### PR TITLE
fix(code): preserve first prompt after failed first turn

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -505,6 +505,38 @@ describe("CodeComposer", () => {
     expect(box).toHaveValue("list the files");
   });
 
+  it("admits one send while the first request is pending", async () => {
+    let resolveSend!: () => void;
+    const onSend = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = resolve;
+        }),
+    );
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "send this once" } });
+    const send = screen.getByRole("button", { name: "Send message" });
+
+    fireEvent.click(send);
+    fireEvent.click(send);
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+    expect(send).toBeDisabled();
+
+    resolveSend();
+    await act(async () => Promise.resolve());
+    fireEvent.change(box, { target: { value: "send another message" } });
+    expect(send).toBeEnabled();
+  });
+
   it("changes the selected harness model", async () => {
     const user = userEvent.setup();
     const onModelChange = vi.fn();

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -95,6 +95,14 @@ function appendComposerPrompt(current: string, prompt: string): string {
   return `${existing}\n\n${offered}`;
 }
 
+function appendRecoveredDraft(current: string, recovered: string): string {
+  if (!current) return recovered;
+  if (current === recovered || current.endsWith(`\n\n${recovered}`)) {
+    return current;
+  }
+  return `${current.trimEnd()}\n\n${recovered}`;
+}
+
 export function PermissionModePicker({
   value,
   availableModes = MODES,
@@ -641,6 +649,8 @@ export function CodeComposer({
   slashCommands,
   searchPaths,
   workspaceFiles,
+  recovery,
+  onSubmitStart,
   onSend,
   onSteer,
   onInterrupt,
@@ -692,6 +702,13 @@ export function CodeComposer({
    * message. A fork's transcript arrives this way.
    */
   workspaceFiles?: ComposerWorkspaceFiles;
+  /** A refused first turn restored after the start composer has unmounted. */
+  recovery?: {
+    id: string;
+    draft: string;
+  };
+  /** Capture the exact editable draft before workspace-file paths are added. */
+  onSubmitStart?: (draft: string) => void;
   onSend: (
     message: string,
     attachments?: readonly { blob_id: string; media_type: string }[],
@@ -717,11 +734,18 @@ export function CodeComposer({
   );
   const [selectedFastMode, setSelectedFastMode] = useState(fastMode);
   const [notice, setNotice] = useState<{ text: string } | null>(null);
+  const [submitPending, setSubmitPending] = useState(false);
   const [steerPending, setSteerPending] = useState(false);
   const [steerError, setSteerError] = useState<string | null>(null);
   const [steerStatus, setSteerStatus] = useState<string | null>(null);
   const draftRef = useRef("");
   const pastedTextsRef = useRef<PastedTextAttachment[]>([]);
+  const appliedRecoveryRef = useRef<{
+    id: string;
+    draft: string;
+  } | null>(null);
+  const mountedRef = useRef(true);
+  const submitPendingRef = useRef(false);
   const steerRequestRef = useRef(0);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const images = useImageAttachments(
@@ -773,10 +797,44 @@ export function CodeComposer({
       : undefined;
 
   const pendingPrompt = useCodeUiStore((state) => state.pendingComposerPrompt);
+  const recoveryId = recovery?.id;
+  const recoveryDraft = recovery?.draft;
 
   useEffect(() => {
     draftRef.current = draft;
   }, [draft]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const applied = appliedRecoveryRef.current;
+    if (!recoveryId || recoveryDraft === undefined) {
+      if (!applied) return;
+      appliedRecoveryRef.current = null;
+      setDraft((current) => {
+        if (current !== applied.draft) return current;
+        draftRef.current = "";
+        return "";
+      });
+      return;
+    }
+    setDraft((current) => {
+      const next = appendRecoveredDraft(current, recoveryDraft);
+      draftRef.current = next;
+      return next;
+    });
+    appliedRecoveryRef.current = { id: recoveryId, draft: recoveryDraft };
+    window.requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLTextAreaElement>("[data-composer-input]")
+        ?.focus();
+    });
+  }, [recoveryDraft, recoveryId]);
 
   function updatePastedTexts(
     update: (
@@ -830,6 +888,7 @@ export function CodeComposer({
   }, [fastMode, sessionId]);
 
   async function submit() {
+    if (submitPendingRef.current) return;
     const submittedDraft = draft;
     const submittedPastedTexts = pastedTextsRef.current;
     const typed = messageWithPastedText(submittedDraft, submittedPastedTexts);
@@ -863,6 +922,9 @@ export function CodeComposer({
       },
     );
     const held = images.attachments;
+    submitPendingRef.current = true;
+    setSubmitPending(true);
+    onSubmitStart?.(submittedDraft);
     draftRef.current = "";
     setDraft("");
     pastedTextsRef.current = [];
@@ -901,6 +963,9 @@ export function CodeComposer({
         draftRef.current = submittedDraft;
         return submittedDraft;
       });
+    } finally {
+      submitPendingRef.current = false;
+      if (mountedRef.current) setSubmitPending(false);
     }
   }
 
@@ -988,7 +1053,7 @@ export function CodeComposer({
         busy={running}
         cancelError={null}
         cancelPending={false}
-        disabled={Boolean(disabled)}
+        disabled={Boolean(disabled || submitPending)}
         draft={draft}
         history={history}
         harnessMenu={harnessMenu}

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import {
   act,
   cleanup,
@@ -25,6 +25,7 @@ import type {
   CodeSessionSnapshot,
   CodeWorkspacePrSnapshot,
   CodeWorkspaceSnapshot,
+  HarnessDoctorEntry,
   PullRequestDigest,
   SequencedCodeEventFrame,
 } from "@/api/types";
@@ -35,6 +36,11 @@ import { resetCodeSessionRegistry } from "./CodeSessionRegistry";
 import { useCodeUiStore } from "./CodeUiStore";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeWorkspacePage } from "./CodeWorkspacePage";
+import {
+  forkFraming,
+  forkTranscriptFile,
+  messageWithWorkspaceFiles,
+} from "./fork";
 import {
   readStoredBrowserSession,
   seedBrowserSession,
@@ -164,6 +170,56 @@ const SESSION: CodeSessionSnapshot = {
   created_at: "2026-08-15T00:00:00.000Z",
 };
 
+const CREATED_SESSION: CodeSessionSnapshot = {
+  ...SESSION,
+  id: "sess-created",
+  permission_mode: "allow",
+  attention: { state: { type: "working" }, source: "lifecycle" },
+};
+
+const FORK_SOURCE = {
+  path: "/private/forks/sess-1/turn-1/transcript.md",
+  dir: "/private/forks/sess-1/turn-1",
+  byte_len: 2_048,
+  turns: 1,
+  total_turns: 1,
+  truncated: false,
+};
+
+const START_HARNESS: HarnessDoctorEntry = {
+  kind: "claude_code",
+  found: true,
+  installable: true,
+  tier: "reference",
+  caps: {
+    resume: "supported",
+    streaming_deltas: "supported",
+    mid_turn_steering: "unsupported",
+    plan_mode: "supported",
+    structured_approvals: "supported",
+    auto_mode: "supported",
+    allow_mode: "supported",
+    reasoning_levels: "unknown",
+    native_file_change_events: "unsupported",
+    native_interrupt: "supported",
+    image_input: "unknown",
+    slash_commands: "unknown",
+  },
+  commands: [],
+  remediation: "",
+  stderr: "",
+  unrecognized_event_count: 0,
+};
+
+function enableStartHarness(client: ReturnType<typeof makeClient>) {
+  useCodeCatalogStore.setState({
+    doctor: { harnesses: [START_HARNESS] },
+  });
+  client.getHarnessDoctor.mockResolvedValue({
+    harnesses: [START_HARNESS],
+  });
+}
+
 const TURN = {
   id: "turn-1",
   session_id: "sess-1",
@@ -244,6 +300,8 @@ function makeClient() {
       ) => codeEventSocket(onFrame),
     ),
     getCodeRepo: vi.fn(async () => REPO),
+    createCodeSession: vi.fn(async () => CREATED_SESSION),
+    forkCodeSession: vi.fn(async () => FORK_SOURCE),
     archiveCodeWorkspace: vi.fn(async () => ({
       ...WORKSPACE,
       status: "archived" as const,
@@ -342,7 +400,11 @@ function makeClient() {
     })),
     listCodeRepos: vi.fn(async () => [REPO]),
     listCodeWorkspaces: vi.fn(async () => [WORKSPACE]),
-    getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+    getHarnessDoctor: vi.fn(
+      async (): Promise<{ harnesses: HarnessDoctorEntry[] }> => ({
+        harnesses: [],
+      }),
+    ),
     listCodeHarnessModels: vi.fn(async () => ({
       kind: "claude_code" as const,
       models: [],
@@ -522,6 +584,37 @@ async function mountWorkspace(
   return { ...result, router };
 }
 
+async function mountWorkspaceWithClientSwap(
+  first: ReturnType<typeof makeClient>,
+  second: ReturnType<typeof makeClient>,
+) {
+  const rootRoute = createRootRoute();
+  const codeWorkspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code/w/$workspaceId",
+    validateSearch: (search: Record<string, unknown>): PanelSearch =>
+      panelSearchFrom(search),
+    component: function WorkspaceRoute() {
+      const { workspaceId } = codeWorkspaceRoute.useParams();
+      const [client, setClient] = useState(first);
+      return (
+        <AppContextProvider value={appContext(client)}>
+          <button type="button" onClick={() => setClient(second)}>
+            Switch client
+          </button>
+          <CodeWorkspacePage workspaceId={workspaceId} />
+        </AppContextProvider>
+      );
+    },
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([codeWorkspaceRoute]),
+    history: createMemoryHistory({ initialEntries: ["/code/w/ws-1"] }),
+  });
+  await router.load();
+  return render(<RouterProvider router={router as never} />);
+}
+
 afterEach(() => {
   cleanup();
   resetCodeSessionRegistry();
@@ -593,6 +686,165 @@ describe("CodeWorkspacePage", () => {
     // The start prompt is a flex child of the pane so `mt-auto` on the
     // composer can consume the empty region under the header.
     expect(pane?.firstElementChild?.className).toMatch(/flex-1/);
+  });
+
+  it("restores the start draft when session creation fails", async () => {
+    const client = makeClient();
+    enableStartHarness(client);
+    client.createCodeSession.mockRejectedValue(
+      new Error("Claude Code sign-in expired"),
+    );
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    const message = await screen.findByRole("textbox", { name: "Message" });
+    await user.type(message, "Fix the exact failing test.");
+    const send = screen.getByRole("button", { name: "Send message" });
+    await waitFor(() => expect(send).toBeEnabled());
+    await user.click(send);
+
+    await waitFor(() =>
+      expect(client.createCodeSession).toHaveBeenCalledOnce(),
+    );
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+    expect(message).toHaveValue("Fix the exact failing test.");
+    expect(
+      screen.getByText("Start a session on this workspace."),
+    ).toBeInTheDocument();
+    expect(toast.error).toHaveBeenCalledWith("Claude Code sign-in expired");
+  });
+
+  it("keeps the created session and restores the exact first prompt after the start composer unmounts", async () => {
+    const client = makeClient();
+    enableStartHarness(client);
+    client.listCodeSessionTurns.mockResolvedValue([]);
+    client.submitCodeTurn
+      .mockRejectedValueOnce(new Error("The harness stopped before admission"))
+      .mockResolvedValueOnce({
+        kind: "ran",
+        turn: { ...TURN, session_id: CREATED_SESSION.id },
+      });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    const message = await screen.findByRole("textbox", { name: "Message" });
+    await user.type(message, "Fix the exact failing test.");
+    const send = screen.getByRole("button", { name: "Send message" });
+    await waitFor(() => expect(send).toBeEnabled());
+    await user.click(send);
+
+    expect(
+      await screen.findByText(/The first message was not sent/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Start a session on this workspace."),
+    ).not.toBeInTheDocument();
+    const recovered = screen.getByRole("textbox", { name: "Message" });
+    expect(recovered).toHaveValue("Fix the exact failing test.");
+    expect(client.createCodeSession).toHaveBeenCalledOnce();
+    expect(client.submitCodeTurn).toHaveBeenNthCalledWith(
+      1,
+      CREATED_SESSION.id,
+      "Fix the exact failing test.",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => expect(client.submitCodeTurn).toHaveBeenCalledTimes(2));
+    expect(client.submitCodeTurn).toHaveBeenNthCalledWith(
+      2,
+      CREATED_SESSION.id,
+      "Fix the exact failing test.",
+      undefined,
+      undefined,
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/The first message was not sent/),
+      ).not.toBeInTheDocument(),
+    );
+    expect(recovered).toHaveValue("");
+    expect(client.createCodeSession).toHaveBeenCalledOnce();
+  });
+
+  it("binds a failed fork prompt to its created session when selection changes", async () => {
+    const client = makeClient();
+    enableStartHarness(client);
+    const firstTurn =
+      deferred<Awaited<ReturnType<typeof client.submitCodeTurn>>>();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.listCodeSessionTurns.mockImplementation(async (sessionId) =>
+      sessionId === SESSION.id ? [TURN] : [],
+    );
+    client.submitCodeTurn.mockReturnValueOnce(firstTurn.promise);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    await screen.findByRole("heading", { name: /Fix login/ });
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Fork this agent" }),
+    );
+    const draft = forkFraming(FORK_SOURCE);
+    expect(await screen.findByRole("textbox", { name: "Message" })).toHaveValue(
+      draft,
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await screen.findByRole("tab", { name: "Claude Code" });
+    await user.click(screen.getByRole("tab", { name: "Main agent" }));
+    await act(async () => {
+      firstTurn.reject(new Error("The first turn was refused"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+    expect(
+      screen.queryByText(/The first message was not sent/),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Claude Code" }));
+    expect(
+      await screen.findByText(/The first message was not sent/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(draft);
+    expect(screen.getByLabelText("Attached workspace files")).toHaveTextContent(
+      "transcript.md",
+    );
+    expect(client.submitCodeTurn).toHaveBeenCalledWith(
+      CREATED_SESSION.id,
+      messageWithWorkspaceFiles(draft, [forkTranscriptFile(FORK_SOURCE)]),
+    );
+  });
+
+  it("rejects a stale client start before it can select or submit the created session", async () => {
+    const first = makeClient();
+    const second = makeClient();
+    enableStartHarness(first);
+    enableStartHarness(second);
+    const create = deferred<CodeSessionSnapshot>();
+    first.createCodeSession.mockReturnValue(create.promise);
+    const user = userEvent.setup();
+    await mountWorkspaceWithClientSwap(first, second);
+
+    const message = await screen.findByRole("textbox", { name: "Message" });
+    await user.type(message, "Keep this prompt on the active client.");
+    const send = screen.getByRole("button", { name: "Send message" });
+    await waitFor(() => expect(send).toBeEnabled());
+    await user.click(send);
+    await waitFor(() => expect(first.createCodeSession).toHaveBeenCalledOnce());
+
+    await user.click(screen.getByRole("button", { name: "Switch client" }));
+    await act(async () => create.resolve(CREATED_SESSION));
+
+    expect(first.submitCodeTurn).not.toHaveBeenCalled();
+    expect(second.createCodeSession).not.toHaveBeenCalled();
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "Keep this prompt on the active client.",
+    );
+    expect(
+      screen.getByText("Start a session on this workspace."),
+    ).toBeInTheDocument();
   });
 
   it("shows header skeleton bars instead of Workspace and a repo UUID", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -19,6 +19,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
@@ -203,8 +204,83 @@ export function CodeWorkspacePage({ workspaceId }: { workspaceId: string }) {
  */
 const EMPTY_EFFORTS: readonly ReasoningEffort[] = [];
 
+type FirstTurnRecovery = {
+  id: string;
+  sessionId: string;
+  draft: string;
+  forkSource: CodeForkTranscript | null;
+  message: string;
+  status: "sending" | "failed";
+};
+
+const firstTurnRecoveryByClient = new WeakMap<
+  ApiClient,
+  Map<string, FirstTurnRecovery>
+>();
+const firstTurnRecoveryListeners = new Set<() => void>();
+
+function readFirstTurnRecovery(
+  client: ApiClient,
+  sessionId: string,
+): FirstTurnRecovery | null {
+  return firstTurnRecoveryByClient.get(client)?.get(sessionId) ?? null;
+}
+
+function writeFirstTurnRecovery(
+  client: ApiClient,
+  recovery: FirstTurnRecovery,
+): void {
+  let recoveries = firstTurnRecoveryByClient.get(client);
+  if (!recoveries) {
+    recoveries = new Map();
+    firstTurnRecoveryByClient.set(client, recoveries);
+  }
+  recoveries.set(recovery.sessionId, recovery);
+  for (const listener of firstTurnRecoveryListeners) listener();
+}
+
+function clearFirstTurnRecovery(
+  client: ApiClient,
+  sessionId: string,
+  recoveryId: string,
+): void {
+  const recoveries = firstTurnRecoveryByClient.get(client);
+  if (recoveries?.get(sessionId)?.id !== recoveryId) return;
+  recoveries.delete(sessionId);
+  for (const listener of firstTurnRecoveryListeners) listener();
+}
+
+function updateFirstTurnRecovery(
+  client: ApiClient,
+  sessionId: string,
+  recoveryId: string,
+  update: (current: FirstTurnRecovery) => FirstTurnRecovery,
+): void {
+  const current = readFirstTurnRecovery(client, sessionId);
+  if (!current || current.id !== recoveryId) return;
+  writeFirstTurnRecovery(client, update(current));
+}
+
+function useFirstTurnRecovery(
+  client: ApiClient,
+  sessionId: string,
+): FirstTurnRecovery | null {
+  return useSyncExternalStore(
+    (listener) => {
+      firstTurnRecoveryListeners.add(listener);
+      return () => {
+        firstTurnRecoveryListeners.delete(listener);
+      };
+    },
+    () => readFirstTurnRecovery(client, sessionId),
+    () => null,
+  );
+}
+
 function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const { client, models, defaultModelKey } = useApp();
+  const clientRef = useRef(client);
+  clientRef.current = client;
   const catalog = useCodeCatalogStore();
   const { run, dialogs } = useWorkspaceCardCommands();
   const layout = useLayoutState();
@@ -218,6 +294,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     region: CodeEditorRegion;
     index: number;
   } | null>(null);
+  const mountedRef = useRef(true);
+  const selectionRevisionRef = useRef(0);
+  const startRequestRef = useRef(0);
   const workspaceBrowserIdsRef = useRef(new Set<string>());
   const chrome = splitCodeChromeLayout(layout);
   const workspaceOverlayOpen = usePortalOverlayOpen();
@@ -353,6 +432,19 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   );
 
   layoutRef.current = layout;
+
+  useEffect(() => {
+    startRequestRef.current += 1;
+    setStarting(false);
+  }, [client]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      startRequestRef.current += 1;
+    };
+  }, []);
 
   const closeBrowserPanels = useCallback(
     (browserIds: readonly string[]) => {
@@ -525,35 +617,101 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     permissionMode: PermissionMode,
     message: string,
     model?: string,
+    draft = message,
   ) {
+    const request = startRequestRef.current + 1;
+    startRequestRef.current = request;
+    const startedWithClient = client;
+    const startedAtSelection = selectionRevisionRef.current;
+    const startedWithFork = forkSource;
+    const isCurrent = () =>
+      mountedRef.current &&
+      startRequestRef.current === request &&
+      clientRef.current === startedWithClient;
     setStarting(true);
     try {
-      const gateway = gatewayCodeModels(models, harness, defaultModelKey);
-      const native =
-        requiresHarnessModelIds(harness) || gateway.length === 0
-          ? await catalog.ensureHarnessModels(client, harness)
-          : [];
-      const listed = preferredCodeModels(harness, native, gateway);
-      const posted =
-        model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
-      const created = await client.createCodeSession(workspaceId, {
-        harness,
-        permission_mode: permissionMode,
-        model: posted,
-      });
+      let created: CodeSessionSnapshot;
+      try {
+        const gateway = gatewayCodeModels(models, harness, defaultModelKey);
+        const native =
+          requiresHarnessModelIds(harness) || gateway.length === 0
+            ? await catalog.ensureHarnessModels(startedWithClient, harness)
+            : [];
+        if (!isCurrent()) {
+          throw new Error(
+            "The Code connection changed before the session started. Send the message again.",
+          );
+        }
+        const listed = preferredCodeModels(harness, native, gateway);
+        const posted =
+          model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
+        created = await startedWithClient.createCodeSession(workspaceId, {
+          harness,
+          permission_mode: permissionMode,
+          model: posted,
+        });
+      } catch (err) {
+        if (isCurrent()) {
+          toast.error(friendlyErrorMessage(err, "Could not start a session"));
+        }
+        throw err;
+      }
+
+      const recovery: FirstTurnRecovery = {
+        id: `${created.id}:${request}`,
+        sessionId: created.id,
+        draft,
+        forkSource: startedWithFork,
+        message: "Sending your first message…",
+        status: "sending",
+      };
+      if (!isCurrent()) {
+        const message =
+          "The Code connection changed after the session was created. Send the message again.";
+        writeFirstTurnRecovery(startedWithClient, {
+          ...recovery,
+          message,
+          status: "failed",
+        });
+        throw new Error(message);
+      }
+      writeFirstTurnRecovery(startedWithClient, recovery);
+
       if (conversations.length === 0) catalog.rememberSession(created);
-      setSessions((current) => [...current, created]);
-      setActiveSessionId(created.id);
-      setDraftAgent(false);
-      setForkSource(null);
-      // The first agent stays at a clean URL; a sibling names itself so a
-      // reload comes back to the tab the reader was on.
-      if (conversations.length > 0) openWorkspaceTask(created.id);
-      await client.submitCodeTurn(created.id, message);
-    } catch (err) {
-      toast.error(friendlyErrorMessage(err, "Could not start a session"));
+      setSessions((current) =>
+        current.some((entry) => entry.id === created.id)
+          ? current
+          : [...current, created],
+      );
+      setForkSource((current) =>
+        current === startedWithFork ? null : current,
+      );
+      if (selectionRevisionRef.current === startedAtSelection) {
+        setActiveSessionId(created.id);
+        setDraftAgent(false);
+        // The first agent stays at a clean URL; a sibling names itself so a
+        // reload comes back to the tab the reader was on.
+        if (conversations.length > 0) openWorkspaceTask(created.id);
+      }
+
+      try {
+        await startedWithClient.submitCodeTurn(created.id, message);
+        clearFirstTurnRecovery(startedWithClient, created.id, recovery.id);
+      } catch (err) {
+        const detail = friendlyErrorMessage(err, "Try sending it again.");
+        writeFirstTurnRecovery(startedWithClient, {
+          ...recovery,
+          message: `The first message was not sent. Review it, then choose Send to try again. ${detail}`,
+          status: "failed",
+        });
+        if (isCurrent()) {
+          toast.error(
+            `Session started, but the first message was not sent. ${detail}`,
+          );
+        }
+      }
     } finally {
-      setStarting(false);
+      if (isCurrent()) setStarting(false);
     }
   }
 
@@ -773,6 +931,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
    * same agent. The first one is the workspace's default, so it stays unnamed.
    */
   function selectConversation(sessionId: string | null) {
+    selectionRevisionRef.current += 1;
     setWorkspaceLayout(focusConversation(layout));
     if (sessionId === null) {
       setDraftAgent(true);
@@ -1144,8 +1303,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   client={client}
                   catalogModels={models}
                   defaultModelKey={defaultModelKey}
-                  onStart={(harness, mode, message, model) =>
-                    startSession(harness, mode, message, model)
+                  onStart={(harness, mode, message, model, draft) =>
+                    startSession(harness, mode, message, model, draft)
                   }
                   workspaceFiles={
                     forkSource
@@ -1720,6 +1879,7 @@ function CodeSessionPane({
 }) {
   const follow = useTranscriptFollow();
   const store = useRegisteredCodeSession(session.id, client);
+  const firstTurnRecovery = useFirstTurnRecovery(client, session.id);
   const items = store((state) => state.items);
   const busy = store((state) => state.busy);
   const hydrated = store((state) => state.hydrated);
@@ -1959,6 +2119,7 @@ function CodeSessionPane({
     attachments?: readonly { blob_id: string; media_type: string }[],
   ) {
     const pendingReasoningEffort = pendingReasoningEffortRef.current;
+    const recoveryAtSend = firstTurnRecovery;
     // Sending is a deliberate return to the tail: whatever the reader was
     // reading, they now want to watch their own turn run.
     follow.armFollow();
@@ -1985,6 +2146,9 @@ function CodeSessionPane({
     ).then((outcome) => {
       if (pendingReasoningEffortRef.current === pendingReasoningEffort) {
         pendingReasoningEffortRef.current = null;
+      }
+      if (recoveryAtSend?.status === "failed") {
+        clearFirstTurnRecovery(client, session.id, recoveryAtSend.id);
       }
       return outcome;
     });
@@ -2142,7 +2306,7 @@ function CodeSessionPane({
           </div>
           <CodeComposer
             running={turnRunning}
-            disabled={disabled}
+            disabled={disabled || firstTurnRecovery?.status === "sending"}
             permissionMode={settings.permissionMode}
             availableModes={availableModes}
             reasoningEffort={settings.reasoningEffort}
@@ -2163,6 +2327,28 @@ function CodeSessionPane({
               client
                 .listCodeWorkspaceTree(workspaceId, { query })
                 .then((tree) => tree.paths)
+            }
+            workspaceFiles={
+              firstTurnRecovery?.forkSource
+                ? {
+                    items: [forkTranscriptFile(firstTurnRecovery.forkSource)],
+                    onRemove: () =>
+                      updateFirstTurnRecovery(
+                        client,
+                        session.id,
+                        firstTurnRecovery.id,
+                        (current) => ({ ...current, forkSource: null }),
+                      ),
+                  }
+                : undefined
+            }
+            recovery={
+              firstTurnRecovery
+                ? {
+                    id: firstTurnRecovery.id,
+                    draft: firstTurnRecovery.draft,
+                  }
+                : undefined
             }
             onModelChange={setModel}
             onModeChange={changePermissionMode}
@@ -2201,6 +2387,19 @@ function CodeSessionPane({
             onSteer={steeringSupported ? steer : undefined}
             onInterrupt={interrupt}
           />
+          {firstTurnRecovery && (
+            <p
+              role={firstTurnRecovery.status === "failed" ? "alert" : "status"}
+              className={cn(
+                "mx-auto w-full max-w-3xl px-2 pt-1 text-xs",
+                firstTurnRecovery.status === "failed"
+                  ? "text-critical-foreground"
+                  : "text-muted-foreground",
+              )}
+            >
+              {firstTurnRecovery.message}
+            </p>
+          )}
         </>
       )}
     </div>

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -69,6 +69,7 @@ export function StartSessionPrompt({
     mode: PermissionMode,
     message: string,
     model?: string,
+    draft?: string,
   ) => Promise<void> | void;
   client?: Pick<ApiClient, "listCodeHarnessModels"> &
     Partial<Pick<ApiClient, "startHarnessInstall" | "getHarnessDoctor">>;
@@ -87,6 +88,7 @@ export function StartSessionPrompt({
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
   const [modelLoading, setModelLoading] = useState(false);
   const root = useRef<HTMLDivElement>(null);
+  const submittedDraft = useRef<string | null>(null);
   const ensureHarnessModels = useCodeCatalogStore(
     (state) => state.ensureHarnessModels,
   );
@@ -229,9 +231,21 @@ export function StartSessionPrompt({
             }));
           }}
           onModeChange={onSelectMode}
+          onSubmitStart={(draft) => {
+            submittedDraft.current = draft;
+          }}
           onSend={async (message) => {
             if (!selected) return;
-            await onStart(selected.kind, mode, message, model);
+            const draft = submittedDraft.current ?? message;
+            try {
+              if (draft === message) {
+                await onStart(selected.kind, mode, message, model);
+              } else {
+                await onStart(selected.kind, mode, message, model, draft);
+              }
+            } finally {
+              submittedDraft.current = null;
+            }
           }}
           onInterrupt={() => undefined}
         />

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -13,6 +13,7 @@ import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { ApiClient } from "@/api/client";
 import type {
   CodeRepoSnapshot,
+  CodeForkTranscript,
   CodeSessionDigest,
   CodeSessionSnapshot,
   CodeSubagentStatus,
@@ -60,6 +61,9 @@ type WorkspaceScenario =
   | "active"
   | "nested"
   | "start"
+  | "session-create-failure"
+  | "first-turn-failure"
+  | "fork-first-turn-failure"
   | "loading"
   | "failure"
   | SubagentScenario;
@@ -191,6 +195,22 @@ const session: CodeSessionSnapshot = {
   lifecycle: "idle",
   attention: { state: { type: "done_unreviewed" }, source: "lifecycle" },
   model: "claude-opus-5",
+};
+
+const recoverySession: CodeSessionSnapshot = {
+  ...session,
+  id: "sess-first-turn-recovery",
+  lifecycle: "idle",
+  attention: attentionNeedsYou,
+};
+
+const forkSource: CodeForkTranscript = {
+  path: "/Users/sam/tidebreak/private/forks/sess-pane-redesign/turn-drag/transcript.md",
+  dir: "/Users/sam/tidebreak/private/forks/sess-pane-redesign/turn-drag",
+  byte_len: 3_842,
+  turns: 2,
+  total_turns: 2,
+  truncated: false,
 };
 
 const usage = {
@@ -547,9 +567,16 @@ function updateDigests(scenario: WorkspaceScenario): CodeSessionDigest[] {
 
 function storyClient(scenario: WorkspaceScenario): ApiClient {
   const sessions =
-    scenario === "start" || scenario === "loading" || scenario === "failure"
+    scenario === "start" ||
+    scenario === "session-create-failure" ||
+    scenario === "first-turn-failure" ||
+    scenario === "loading" ||
+    scenario === "failure"
       ? []
       : [session];
+  const firstTurnFails =
+    scenario === "first-turn-failure" || scenario === "fork-first-turn-failure";
+  const sessionCreateFails = scenario === "session-create-failure";
   const loadWorkspace =
     scenario === "loading"
       ? () => pending<CodeWorkspaceSnapshot>()
@@ -560,14 +587,16 @@ function storyClient(scenario: WorkspaceScenario): ApiClient {
   return {
     getCodeWorkspace: loadWorkspace,
     listCodeWorkspaceSessions: async () => sessions,
-    listCodeSessionTurns: async () => turns,
+    listCodeSessionTurns: async (sessionId: string) =>
+      sessionId === recoverySession.id ? [] : turns,
     listCodeApprovals: async () => [],
     openCodeEvents: (
-      _sessionId: string,
+      sessionId: string,
       _after: number,
       onFrame: (frame: SequencedCodeEventFrame) => void,
     ) =>
       socketAfterOpen(() => {
+        if (sessionId === recoverySession.id) return;
         for (const frame of transcriptFrames(scenario)) onFrame(frame);
       }),
     getCodeRepo: async () => repo,
@@ -642,11 +671,24 @@ function storyClient(scenario: WorkspaceScenario): ApiClient {
       gh_authenticated: true,
       gh_remediation: "",
     }),
-    createCodeSession: async () => session,
-    submitCodeTurn: async (_sessionId: string, message: string) => ({
-      kind: "ran",
-      turn: { ...turns[1], id: "turn-story", user_input: message },
-    }),
+    createCodeSession: async () => {
+      if (sessionCreateFails) {
+        throw new Error(
+          "Claude Code sign-in expired before the session could start.",
+        );
+      }
+      return firstTurnFails ? recoverySession : session;
+    },
+    forkCodeSession: async () => forkSource,
+    submitCodeTurn: async (_sessionId: string, message: string) => {
+      if (firstTurnFails) {
+        throw new Error("The harness stopped before it accepted the message.");
+      }
+      return {
+        kind: "ran",
+        turn: { ...turns[1], id: "turn-story", user_input: message },
+      };
+    },
     decideCodeApproval: async () => ({}) as never,
     setCodeAttention: async () => session,
     reapCodeSession: async () => session,
@@ -1082,6 +1124,80 @@ export const EmptySubagentTranscript: Story = {
 /** A workspace with no session keeps the first prompt calm and centered. */
 export const StartSession: Story = {
   args: { scenario: "start", reviewOpen: false },
+};
+
+/** A creation failure leaves the start surface mounted and restores its draft. */
+export const FailedSessionCreation: Story = {
+  args: { scenario: "session-create-failure", reviewOpen: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const message = await canvas.findByRole("textbox", { name: "Message" });
+    await userEvent.type(
+      message,
+      "Keep this draft when the session cannot be created.",
+    );
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Send message" }),
+    );
+    await expect(
+      await canvas.findByText(
+        "Claude Code sign-in expired before the session could start.",
+      ),
+    ).toBeVisible();
+    await expect(
+      canvas.getByText("Start a session on this workspace."),
+    ).toBeVisible();
+    await expect(canvas.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "Keep this draft when the session cannot be created.",
+    );
+  },
+};
+
+/** A failed first turn keeps the created session and restores the exact draft. */
+export const FailedFirstMessage: Story = {
+  args: { scenario: "first-turn-failure", reviewOpen: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const message = await canvas.findByRole("textbox", { name: "Message" });
+    await userEvent.type(
+      message,
+      "Fix the retry path without changing this exact request.",
+    );
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Send message" }),
+    );
+    await expect(
+      await canvas.findByText(/The first message was not sent/),
+    ).toBeVisible();
+    await expect(canvas.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "Fix the retry path without changing this exact request.",
+    );
+  },
+};
+
+/** A failed fork keeps both its editable framing and transcript source. */
+export const FailedForkFirstMessage: Story = {
+  args: { scenario: "fork-first-turn-failure", reviewOpen: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Workspace actions" }),
+    );
+    await userEvent.click(
+      await within(document.body).findByRole("menuitem", {
+        name: "Fork this agent",
+      }),
+    );
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Send message" }),
+    );
+    await expect(
+      await canvas.findByText(/The first message was not sent/),
+    ).toBeVisible();
+    await expect(
+      canvas.getByLabelText("Attached workspace files"),
+    ).toHaveTextContent("transcript.md");
+  },
 };
 
 export const Loading: Story = {


### PR DESCRIPTION
## What changed

- Keep first-turn recovery bound to the exact API client and created session across composer and workspace unmounts.
- If session creation succeeds but the first turn fails, keep the session and restore the exact editable draft in its composer. Restore the fork transcript chip when the start came from a fork.
- If session creation fails, reject the start request so the start composer restores its draft.
- Fence stale client and session selections, prevent duplicate sends while submission is pending, and clear recovery only after an accepted retry or successful first turn.
- Add Storybook coverage for session creation failure, first-turn recovery, and fork first-turn recovery.

## Compatibility and risk

This change is desktop UI-only. It does not change server routes, wire formats, persisted data, or workspace merge behavior.

Recovery stays in memory and is scoped by API client and session ID. Stale results cannot select or submit through a replacement client. A failed retry keeps the recovery state available.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeWorkspacePage.dom.test.tsx src/code/CodeComposer.dom.test.tsx src/code/StartSessionPrompt.dom.test.tsx src/stylesContract.test.ts` — 97 tests passed.
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/code/CodeWorkspacePage.tsx src/code/CodeComposer.tsx src/code/StartSessionPrompt.tsx src/code/CodeWorkspacePage.dom.test.tsx src/code/CodeComposer.dom.test.tsx src/stories/CodeWorkspacePage.stories.tsx` — passed.
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit --pretty false` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — passed.
- Inspected session creation failure, first-turn recovery, and fork recovery in Storybook at 1440×900 and 720×900 in the supported light and dark themes.

## Tracking

Fixes #2658