### PR TITLE
fix(code): bind workspace merges to exact heads

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1824,6 +1824,102 @@ describe("code workspace git flow", () => {
       "http://127.0.0.1/code/workspaces/ws-1/pr",
     );
   });
+
+  it("posts the exact pull request target and reconciles the accepted head", async () => {
+    const head = "abcdef1234567890";
+    const digest = {
+      dirty: false,
+      unpushed: false,
+      ahead: 1,
+      has_upstream: true,
+      suggested_commit_message: "",
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+      pr: {
+        number: 41,
+        url: "https://github.com/acme/app/pull/41",
+        state: "open",
+        head_branch: "thet/exact-merge",
+        head_sha: head,
+      },
+    };
+    const merged = {
+      ...digest,
+      pr: { ...digest.pr, state: "merged", merged: true },
+    };
+    const target = {
+      repository: { host: "github.com", owner: "acme", name: "app" },
+      number: 41,
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(digest), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            target,
+            accepted_head_sha: head,
+            status: merged,
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.getCodeWorkspacePr("ws-1");
+    await expect(
+      client.mergeCodePr("ws-1", { method: "squash", auto: true }),
+    ).resolves.toEqual(merged);
+
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1/code/workspaces/ws-1/pr/merge");
+    expect(JSON.parse(String(init.body))).toEqual({
+      target,
+      expected_head_sha: head,
+      method: "squash",
+      auto: true,
+    });
+  });
+
+  it("refuses a merge response for a different target or accepted head", async () => {
+    const target = {
+      repository: { host: "github.com", owner: "acme", name: "app" },
+      number: 41,
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          target: { ...target, number: 42 },
+          accepted_head_sha: "different",
+          status: {
+            dirty: false,
+            unpushed: false,
+            ahead: 0,
+            has_upstream: true,
+            suggested_commit_message: "",
+            gh_found: true,
+            gh_authenticated: true,
+            remediation: "",
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await expect(
+      client.mergeCodePr("ws-1", {
+        target,
+        expected_head_sha: "abcdef1234567890",
+        method: "squash",
+      }),
+    ).rejects.toThrow("merge response contains invalid data");
+  });
 });
 
 describe("archive force kinds", () => {

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -97,6 +97,7 @@ import {
   type CodeWorkspaceTree,
   type CodeWorkspacePrSnapshot,
   type CodeWorkspacePullRequests,
+  type PullRequestDigest,
   type CodeTriggerAction,
   type CodeTriggerCondition,
   type CodeTriggerSnapshot,
@@ -206,6 +207,19 @@ export type DeliveryRequestOptions = {
   refreshAuth?: boolean;
 };
 
+export type CodeWorkspaceMergeRequest = {
+  target: CodeDeliveryPullRequestTarget;
+  expected_head_sha: string;
+  method: CodePrMergeMethod;
+  auto?: boolean;
+};
+
+type CodeWorkspaceMergeResult = {
+  target: CodeDeliveryPullRequestTarget;
+  accepted_head_sha: string;
+  status: CodeWorkspacePrSnapshot;
+};
+
 /**
  * The size below which a transfer is not worth reporting on.
  *
@@ -289,6 +303,10 @@ async function throwIfNotOk(response: Response): Promise<void> {
 
 export class ApiClient {
   private accessToken: string;
+  private readonly workspaceMergeTargets = new Map<
+    string,
+    Pick<CodeWorkspaceMergeRequest, "target" | "expected_head_sha">
+  >();
 
   constructor(
     readonly baseUrl: string,
@@ -2728,7 +2746,7 @@ export class ApiClient {
     workspaceId: string,
     body: { title?: string; body?: string } = {},
   ): Promise<CodeWorkspacePrSnapshot> {
-    return requireParsed(
+    const snapshot = requireParsed(
       parseCodeWorkspacePr(
         await this.json(
           `/code/workspaces/${encodeURIComponent(workspaceId)}/git/pr`,
@@ -2741,12 +2759,14 @@ export class ApiClient {
       ),
       "code pull request",
     );
+    this.rememberWorkspaceMergeTarget(workspaceId, snapshot);
+    return snapshot;
   }
 
   async getCodeWorkspacePr(
     workspaceId: string,
   ): Promise<CodeWorkspacePrSnapshot> {
-    return requireParsed(
+    const snapshot = requireParsed(
       parseCodeWorkspacePr(
         await this.json(
           `/code/workspaces/${encodeURIComponent(workspaceId)}/pr`,
@@ -2757,6 +2777,8 @@ export class ApiClient {
       ),
       "code pull request",
     );
+    this.rememberWorkspaceMergeTarget(workspaceId, snapshot);
+    return snapshot;
   }
 
   /** Every pull request attributed to the workspace (decision 62). */
@@ -2780,7 +2802,7 @@ export class ApiClient {
   async refreshCodeWorkspacePr(
     workspaceId: string,
   ): Promise<CodeWorkspacePrSnapshot> {
-    return requireParsed(
+    const snapshot = requireParsed(
       parseCodeWorkspacePr(
         await this.json(
           `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/refresh`,
@@ -2789,6 +2811,8 @@ export class ApiClient {
       ),
       "code pull request",
     );
+    this.rememberWorkspaceMergeTarget(workspaceId, snapshot);
+    return snapshot;
   }
 
   /**
@@ -2922,7 +2946,7 @@ export class ApiClient {
    * prompt. Returns the post-change snapshot.
    */
   async markCodePrReady(workspaceId: string): Promise<CodeWorkspacePrSnapshot> {
-    return requireParsed(
+    const snapshot = requireParsed(
       parseCodeWorkspacePr(
         await this.json(
           `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/ready`,
@@ -2931,6 +2955,8 @@ export class ApiClient {
       ),
       "code pull request",
     );
+    this.rememberWorkspaceMergeTarget(workspaceId, snapshot);
+    return snapshot;
   }
 
   /**
@@ -2939,24 +2965,51 @@ export class ApiClient {
    */
   async mergeCodePr(
     workspaceId: string,
-    body: { method: CodePrMergeMethod; auto?: boolean },
+    body:
+      | CodeWorkspaceMergeRequest
+      | { method: CodePrMergeMethod; auto?: boolean },
   ): Promise<CodeWorkspacePrSnapshot> {
-    return requireParsed(
-      parseCodeWorkspacePr(
-        await this.json(
-          `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/merge`,
-          {
-            method: "POST",
-            headers: this.headers(true),
-            body: JSON.stringify({
-              method: body.method,
-              auto: body.auto ?? false,
-            }),
-          },
-        ),
+    const exact =
+      "target" in body && "expected_head_sha" in body
+        ? {
+            target: body.target,
+            expected_head_sha: body.expected_head_sha,
+          }
+        : this.workspaceMergeTargets.get(workspaceId);
+    if (!exact) {
+      throw new HttpError(
+        409,
+        "409: Refresh the pull request before merging it.",
+        "pr_identity_missing",
+      );
+    }
+    const request: CodeWorkspaceMergeRequest = {
+      ...exact,
+      method: body.method,
+      auto: body.auto ?? false,
+    };
+    const result = parseCodeWorkspaceMergeResult(
+      await this.json(
+        `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/merge`,
+        {
+          method: "POST",
+          headers: this.headers(true),
+          body: JSON.stringify(request),
+        },
       ),
-      "code pull request",
+      request,
     );
+    this.rememberWorkspaceMergeTarget(workspaceId, result.status);
+    return result.status;
+  }
+
+  private rememberWorkspaceMergeTarget(
+    workspaceId: string,
+    snapshot: CodeWorkspacePrSnapshot,
+  ): void {
+    const exact = snapshot.pr ? mergeTargetFromDigest(snapshot.pr) : null;
+    if (exact) this.workspaceMergeTargets.set(workspaceId, exact);
+    else this.workspaceMergeTargets.delete(workspaceId);
   }
 
   async runCodeWorkspaceAction(
@@ -3218,6 +3271,94 @@ export class ApiClient {
 function requireParsed<T>(value: T | null, label: string): T {
   if (!value) throw new Error(`${label} response contains invalid data`);
   return value;
+}
+
+function mergeTargetFromDigest(
+  pr: PullRequestDigest,
+): Pick<CodeWorkspaceMergeRequest, "target" | "expected_head_sha"> | null {
+  if (!pr.url || !pr.head_sha) return null;
+  let url: URL;
+  try {
+    url = new URL(pr.url);
+  } catch {
+    return null;
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (
+    parts.length !== 4 ||
+    parts[2] !== "pull" ||
+    Number(parts[3]) !== pr.number ||
+    !url.hostname
+  ) {
+    return null;
+  }
+  return {
+    target: {
+      repository: {
+        host: url.hostname,
+        owner: parts[0],
+        name: parts[1],
+      },
+      number: pr.number,
+    },
+    expected_head_sha: pr.head_sha,
+  };
+}
+
+function parseCodeWorkspaceMergeResult(
+  value: unknown,
+  expected: CodeWorkspaceMergeRequest,
+): CodeWorkspaceMergeResult {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("code pull request merge response contains invalid data");
+  }
+  const record = value as Record<string, unknown>;
+  const target = record.target as
+    | {
+        repository?: { host?: unknown; owner?: unknown; name?: unknown };
+        number?: unknown;
+      }
+    | undefined;
+  const repository = target?.repository;
+  const acceptedHead = record.accepted_head_sha;
+  const status = parseCodeWorkspacePr(record.status);
+  if (
+    !repository ||
+    typeof repository.host !== "string" ||
+    typeof repository.owner !== "string" ||
+    typeof repository.name !== "string" ||
+    typeof target.number !== "number" ||
+    typeof acceptedHead !== "string" ||
+    !status ||
+    !sameRepository(repository, expected.target.repository) ||
+    target.number !== expected.target.number ||
+    acceptedHead !== expected.expected_head_sha
+  ) {
+    throw new Error("code pull request merge response contains invalid data");
+  }
+  return {
+    target: {
+      repository: {
+        host: repository.host,
+        owner: repository.owner,
+        name: repository.name,
+      },
+      number: target.number,
+    },
+    accepted_head_sha: acceptedHead,
+    status,
+  };
+}
+
+function sameRepository(
+  left: { host: string; owner: string; name: string },
+  right: { host: string; owner: string; name: string },
+): boolean {
+  return (
+    left.host.toLowerCase() === right.host.toLowerCase() &&
+    left.owner.toLowerCase() === right.owner.toLowerCase() &&
+    left.name.toLowerCase() === right.name.toLowerCase()
+  );
 }
 
 function encodeUtf8Base64(text: string): string {

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -3320,17 +3320,20 @@ function parseCodeWorkspaceMergeResult(
       }
     | undefined;
   const repository = target?.repository;
+  const host = repository?.host;
+  const owner = repository?.owner;
+  const name = repository?.name;
   const acceptedHead = record.accepted_head_sha;
   const status = parseCodeWorkspacePr(record.status);
   if (
     !repository ||
-    typeof repository.host !== "string" ||
-    typeof repository.owner !== "string" ||
-    typeof repository.name !== "string" ||
+    typeof host !== "string" ||
+    typeof owner !== "string" ||
+    typeof name !== "string" ||
     typeof target.number !== "number" ||
     typeof acceptedHead !== "string" ||
     !status ||
-    !sameRepository(repository, expected.target.repository) ||
+    !sameRepository({ host, owner, name }, expected.target.repository) ||
     target.number !== expected.target.number ||
     acceptedHead !== expected.expected_head_sha
   ) {
@@ -3339,9 +3342,9 @@ function parseCodeWorkspaceMergeResult(
   return {
     target: {
       repository: {
-        host: repository.host,
-        owner: repository.owner,
-        name: repository.name,
+        host,
+        owner,
+        name,
       },
       number: target.number,
     },

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -248,6 +248,7 @@ const PR: PullRequestDigest = {
   url: "https://github.com/acme/app/pull/41",
   draft: true,
   head_branch: "tidebreak/fix-login",
+  head_sha: "abcdef1234567890",
   base_branch: "main",
   checks: [
     { name: "ci / rust", bucket: "pass" as const },
@@ -1294,6 +1295,15 @@ describe("CodeWorkspacePage", () => {
 
     await waitFor(() =>
       expect(client.mergeCodePr).toHaveBeenCalledWith("ws-1", {
+        target: {
+          repository: {
+            host: "github.com",
+            owner: "acme",
+            name: "app",
+          },
+          number: 41,
+        },
+        expected_head_sha: "abcdef1234567890",
         method: "squash",
         auto: false,
       }),
@@ -1415,6 +1425,15 @@ describe("CodeWorkspacePage", () => {
 
     await waitFor(() =>
       expect(client.mergeCodePr).toHaveBeenCalledWith("ws-1", {
+        target: {
+          repository: {
+            host: "github.com",
+            owner: "acme",
+            name: "app",
+          },
+          number: 41,
+        },
+        expected_head_sha: "abcdef1234567890",
         method: "squash",
         auto: true,
       }),

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.dom.test.tsx
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ApiClient } from "../api/client";
+import { HttpError, type ApiClient } from "../api/client";
 import type {
   CodeCheckLogsSnapshot,
   CodeWorkspacePrSnapshot,
@@ -171,5 +177,120 @@ describe("Fix CI", () => {
     const pending = useCodeUiStore.getState().pendingComposerPrompt;
     expect(pending?.text).toContain("Inspect the latest failing CI logs");
     expect(pending?.text).not.toContain("already downloaded");
+  });
+});
+
+const readyPr: CodeWorkspacePrSnapshot = {
+  ...failingPr,
+  pr: {
+    number: 184,
+    url: "https://github.com/example/app/pull/184",
+    state: "open",
+    title: "Fix login",
+    head_branch: "tidebreak/fix-login",
+    base_branch: "main",
+    head_sha: "abcdef1234567890",
+    mergeable: "mergeable",
+    merge_state_status: "clean",
+    checks: [{ name: "ci", bucket: "pass" }],
+  },
+};
+
+function renderMergeControl(error?: HttpError) {
+  const mergeCodePr = vi.fn(async () => {
+    if (error) throw error;
+    return {
+      ...readyPr,
+      pr: { ...readyPr.pr!, state: "merged", merged: true },
+    };
+  });
+  const refresh = vi.fn(async () => {});
+  const adopt = vi.fn();
+  const setMutationError = vi.fn();
+  const mergeResource: CodeWorkspacePrResource = {
+    data: readyPr,
+    error: null,
+    refreshing: false,
+    refresh,
+    adopt,
+    busy: null,
+    mutationError: null,
+    setMutationError,
+    refreshFromHost: async () => undefined,
+    runMutation: async (_mutation, operation) => operation(),
+  };
+  render(
+    <WorkspaceWorkflowControl
+      client={
+        {
+          pushCodeWorkspace: vi.fn(),
+          createCodePullRequest: vi.fn(),
+          markCodePrReady: vi.fn(),
+          mergeCodePr,
+          startCodeWatch: vi.fn(),
+          stopCodeWatch: vi.fn(),
+          writeCodeCheckLogs: vi.fn(),
+        } as unknown as ApiClient
+      }
+      workspaceId="ws-1"
+      branchName="tidebreak/fix-login"
+      baseRef="main"
+      resource={mergeResource}
+      onOpenSourceControl={vi.fn()}
+    />,
+  );
+  return { mergeCodePr, refresh, adopt, setMutationError };
+}
+
+describe("Merge", () => {
+  it("submits the pull request and head shown in the confirmation", async () => {
+    const { mergeCodePr, adopt } = renderMergeControl();
+    await userEvent.click(screen.getByRole("button", { name: "Merge" }));
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Merge" }),
+    );
+
+    await waitFor(() =>
+      expect(mergeCodePr).toHaveBeenCalledWith("ws-1", {
+        target: {
+          repository: {
+            host: "github.com",
+            owner: "example",
+            name: "app",
+          },
+          number: 184,
+        },
+        expected_head_sha: "abcdef1234567890",
+        method: "squash",
+        auto: false,
+      }),
+    );
+    expect(adopt).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "workspace_dirty",
+    "workspace_unpushed",
+    "pr_head_changed",
+    "pr_target_changed",
+  ])("keeps refresh available after %s", async (kind) => {
+    const { refresh, setMutationError } = renderMergeControl(
+      new HttpError(409, `409: ${kind}`, kind),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Merge" }));
+    const dialog = await screen.findByRole("alertdialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Merge" }),
+    );
+
+    const refreshButton = await screen.findByRole("button", {
+      name: "Refresh workspace status",
+    });
+    expect(setMutationError).toHaveBeenCalledWith(
+      expect.stringContaining("Refresh workspace status"),
+    );
+    await userEvent.click(refreshButton);
+    expect(refresh).toHaveBeenCalledOnce();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -44,6 +44,8 @@ import {
   checkSummary,
   composePrPrompt,
   resolveWorkflowShortcut,
+  workspaceMergeConflictMessage,
+  workspaceMergeIdentity,
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
   type WorkspaceWorkflowAction,
@@ -120,6 +122,10 @@ export function WorkspaceWorkflowControl({
   const statusLabel = model.pr
     ? model.summary.replace(/^#\d+\s*·\s*/, "")
     : model.summary;
+  const detailsTitle =
+    model.pr && resource.mutationError?.includes("Refresh workspace status")
+      ? `Pull request #${model.pr.number} changed`
+      : model.title;
   const activeChecks =
     model.pr?.checks?.filter(
       (check) => check.bucket === "fail" || check.bucket === "pending",
@@ -261,6 +267,14 @@ export function WorkspaceWorkflowControl({
   async function mergePr(auto = false, method: CodePrMergeMethod = "squash") {
     const pr = model.pr;
     if (!pr) return;
+    const exact = workspaceMergeIdentity(pr);
+    if (!exact) {
+      setDetailsOpen(true);
+      resource.setMutationError(
+        "Refresh workspace status before merging. The pull request identity or head commit is incomplete.",
+      );
+      return;
+    }
     setDetailsOpen(false);
     const base = pr.base_branch ?? "its base branch";
     // Two forms of the same verb: the immediate merge reads as something done
@@ -292,17 +306,17 @@ export function WorkspaceWorkflowControl({
             : `Merge #${pr.number}?`,
       description:
         kind === "merge"
-          ? `The pull request is ${landed} into ${base} on GitHub.`
+          ? `The pull request is ${landed} into ${base} on GitHub. Tidebreak checks the workspace and pull request again before it sends the merge.`
           : kind === "merge_when_ready"
-            ? `GitHub adds the pull request to the merge queue and ${lands} it into ${base} once the remaining requirements pass.`
-            : `GitHub ${lands} the pull request into ${base} once the remaining requirements pass.`,
+            ? `GitHub adds the pull request to the merge queue and ${lands} it into ${base} once the remaining requirements pass. Tidebreak checks the workspace and pull request again first.`
+            : `GitHub ${lands} the pull request into ${base} once the remaining requirements pass. Tidebreak checks the workspace and pull request again first.`,
       confirmLabel,
     });
     if (!ok) return;
     try {
       const next = await resource.runMutation(
         auto ? "auto_merge" : "merge",
-        () => client.mergeCodePr(workspaceId, { method, auto }),
+        () => client.mergeCodePr(workspaceId, { ...exact, method, auto }),
       );
       if (!next) return;
       resource.adopt(next);
@@ -314,10 +328,13 @@ export function WorkspaceWorkflowControl({
             : "Merged",
       );
     } catch (err) {
-      // The host's own refusal is the useful sentence here, so it goes to the
-      // status line rather than being flattened into a generic failure.
-      const message =
-        err instanceof HttpError && err.kind === "pr_not_mergeable"
+      const refreshable = workspaceMergeConflictMessage(err);
+      // Keep the pull request context and refresh control visible when local
+      // or host state changed after confirmation.
+      if (refreshable) setDetailsOpen(true);
+      const message = refreshable
+        ? refreshable
+        : err instanceof HttpError && err.kind === "pr_not_mergeable"
           ? err.message
           : friendlyErrorMessage(err, "Could not merge");
       resource.setMutationError(message);
@@ -514,7 +531,7 @@ export function WorkspaceWorkflowControl({
                   id={popoverTitleId}
                   className="text-md font-semibold leading-5"
                 >
-                  {model.title}
+                  {detailsTitle}
                 </h2>
                 <p className="text-foreground-subtle mt-0.5 text-xs leading-4">
                   {resource.mutationError ?? resource.error ?? model.detail}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import { HttpError } from "../api/client";
 import type { CodeWorkspacePrSnapshot, PullRequestDigest } from "../api/types";
 import {
   composePrPrompt,
   resolveWorkflowShortcut,
+  workspaceMergeConflictMessage,
+  workspaceMergeIdentity,
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
   type WorkflowShortcut,
@@ -21,7 +24,13 @@ const CLEAN: CodeWorkspacePrSnapshot = {
 };
 
 function pr(partial: Partial<PullRequestDigest>): PullRequestDigest {
-  return { number: 41, state: "open", ...partial };
+  return {
+    number: 41,
+    state: "open",
+    url: "https://github.com/acme/app/pull/41",
+    head_sha: "abc123456789",
+    ...partial,
+  };
 }
 
 describe("workspaceWorkflowModel", () => {
@@ -172,7 +181,10 @@ describe("workspaceWorkflowModel", () => {
   });
 
   it("does not call an incomplete PR ready", () => {
-    const model = workspaceWorkflowModel({ ...CLEAN, pr: pr({}) });
+    const model = workspaceWorkflowModel({
+      ...CLEAN,
+      pr: pr({ url: undefined, head_sha: undefined }),
+    });
     expect(model.summary).toBe("#41 · Checking");
     expect(model.stage).toBe("checking");
     expect(model.secondary).not.toContain("merge");
@@ -419,5 +431,40 @@ describe("composePrPrompt", () => {
     expect(prompt).toContain("Do not merge.");
     // A workspace without a recorded base still gets a sendable request.
     expect(composePrPrompt(" ")).toContain("the default branch");
+  });
+});
+
+describe("workspace merge identity", () => {
+  it("binds the request to the repository, number, and displayed head", () => {
+    expect(workspaceMergeIdentity(pr({}))).toEqual({
+      target: {
+        repository: { host: "github.com", owner: "acme", name: "app" },
+        number: 41,
+      },
+      expected_head_sha: "abc123456789",
+    });
+    expect(
+      workspaceMergeIdentity(
+        pr({ url: "https://github.com/acme/other/pull/42" }),
+      ),
+    ).toBeNull();
+    expect(workspaceMergeIdentity(pr({ head_sha: undefined }))).toBeNull();
+  });
+
+  it("marks mutable precondition failures as refreshable", () => {
+    const changedHead = workspaceMergeConflictMessage(
+      new HttpError(
+        409,
+        "409: pull request head changed from abc12345 to def67890",
+        "pr_head_changed",
+      ),
+    );
+    expect(changedHead).toContain("Refresh workspace status");
+    expect(changedHead).not.toContain("409:");
+    expect(
+      workspaceMergeConflictMessage(
+        new HttpError(409, "409: branch protection", "pr_not_mergeable"),
+      ),
+    ).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -1,4 +1,9 @@
-import type { CodeWorkspacePrSnapshot, PullRequestDigest } from "../api/types";
+import { HttpError } from "../api/client";
+import type {
+  CodeDeliveryPullRequestTarget,
+  CodeWorkspacePrSnapshot,
+  PullRequestDigest,
+} from "../api/types";
 import {
   prDirectMergeAction,
   prMergeControls,
@@ -53,6 +58,68 @@ export type WorkspaceWorkflowModel = {
   pr?: PullRequestDigest;
   checks?: PrCheckCounts;
 };
+
+export type WorkspaceMergeIdentity = {
+  target: CodeDeliveryPullRequestTarget;
+  expected_head_sha: string;
+};
+
+const REFRESHABLE_MERGE_CONFLICTS = new Set([
+  "pr_head_changed",
+  "pr_identity_missing",
+  "pr_target_changed",
+  "workspace_branch_changed",
+  "workspace_dirty",
+  "workspace_repository_changed",
+  "workspace_unpushed",
+  "workspace_upstream_missing",
+]);
+
+/** Exact pull request identity shown by the workspace UI. */
+export function workspaceMergeIdentity(
+  pr: PullRequestDigest,
+): WorkspaceMergeIdentity | null {
+  if (!pr.url || !pr.head_sha) return null;
+  let url: URL;
+  try {
+    url = new URL(pr.url);
+  } catch {
+    return null;
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (
+    parts.length !== 4 ||
+    parts[2] !== "pull" ||
+    Number(parts[3]) !== pr.number ||
+    !url.hostname
+  ) {
+    return null;
+  }
+  return {
+    target: {
+      repository: {
+        host: url.hostname,
+        owner: parts[0],
+        name: parts[1],
+      },
+      number: pr.number,
+    },
+    expected_head_sha: pr.head_sha,
+  };
+}
+
+/** A server merge rejection that needs a fresh local and host snapshot. */
+export function workspaceMergeConflictMessage(error: unknown): string | null {
+  if (
+    !(error instanceof HttpError) ||
+    !error.kind ||
+    !REFRESHABLE_MERGE_CONFLICTS.has(error.kind)
+  ) {
+    return null;
+  }
+  const message = error.message.replace(/^\d{3}:\s*/, "");
+  return `${message} Refresh workspace status, then review the merge again.`;
+}
 
 /** One compact model for the local Git path and the hosted PR path. */
 export function workspaceWorkflowModel(
@@ -278,14 +345,17 @@ function pullRequestWorkflow(pr: PullRequestDigest): WorkspaceWorkflowModel {
         secondary: withOpenPr(pr, []),
       };
     case "ready":
+      const exact = workspaceMergeIdentity(pr);
       return {
         ...common,
         stage: "ready",
         tone: "ready",
         summary: `#${pr.number} · Ready`,
         title: `Pull request #${pr.number} is ready`,
-        detail: checkSummary(status.checks) || "No blockers reported.",
-        primary: "merge",
+        detail: exact
+          ? checkSummary(status.checks) || "No blockers reported."
+          : "Refresh the pull request before merging it.",
+        primary: exact ? "merge" : pr.url ? "open_pr" : "watch_and_fix",
         secondary: withOpenPr(pr, ["watch_and_fix"]),
       };
     case "merged":
@@ -446,6 +516,12 @@ function mergeIfGreen(
   }
   const pr = model.pr;
   if (!pr) return { blocked: "No pull request yet" };
+  if (!workspaceMergeIdentity(pr)) {
+    return {
+      blocked:
+        "Refresh the pull request before merging it. Its repository or head commit is incomplete.",
+    };
+  }
   const action = prDirectMergeAction(pr);
   if (action?.kind === "merge") return { run: "merge" };
   if (action) return { autoMerge: true };

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2908,7 +2908,15 @@ export type McpViewSession = { frame_path: string, };
 /**
  * Body of `POST /code/workspaces/{id}/pr/merge`.
  */
-export type MergeCodePrBody = { method: CodePrMergeMethod, 
+export type MergeCodePrBody = {
+/**
+ * The repository and pull request shown in the confirmation.
+ */
+target: CodeDeliveryPullRequestTarget,
+/**
+ * The pull request head shown in the confirmation.
+ */
+expected_head_sha: string, method: CodePrMergeMethod,
 /**
  * True arms host auto-merge instead of merging immediately.
  */

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2908,15 +2908,15 @@ export type McpViewSession = { frame_path: string, };
 /**
  * Body of `POST /code/workspaces/{id}/pr/merge`.
  */
-export type MergeCodePrBody = {
+export type MergeCodePrBody = { 
 /**
  * The repository and pull request shown in the confirmation.
  */
-target: CodeDeliveryPullRequestTarget,
+target: CodeDeliveryPullRequestTarget, 
 /**
  * The pull request head shown in the confirmation.
  */
-expected_head_sha: string, method: CodePrMergeMethod,
+expected_head_sha: string, method: CodePrMergeMethod, 
 /**
  * True arms host auto-merge instead of merging immediately.
  */

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -1,7 +1,8 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn, userEvent, within } from "storybook/test";
 
-import type { CodeWorkspacePrSnapshot } from "@/api";
+import { HttpError, type CodeWorkspacePrSnapshot } from "@/api";
 import { WorkspaceWorkflowControl } from "@/code/WorkspaceWorkflowControl";
 import type {
   CodeWorkspacePrMutation,
@@ -22,6 +23,8 @@ import {
 function resourceFor(
   snapshot: CodeWorkspacePrSnapshot | null,
   busy: CodeWorkspacePrMutation | null = null,
+  mutationError: string | null = null,
+  setMutationError: (error: string | null) => void = () => {},
 ): CodeWorkspacePrResource {
   return {
     data: snapshot,
@@ -30,10 +33,10 @@ function resourceFor(
     refresh: async () => {},
     adopt: () => {},
     busy,
-    mutationError: null,
-    setMutationError: () => {},
+    mutationError,
+    setMutationError,
     refreshFromHost: async () => undefined,
-    runMutation: async () => undefined,
+    runMutation: async (_mutation, operation) => operation(),
   };
 }
 
@@ -42,6 +45,7 @@ function WorkflowState({
   busy = null,
   watchTaskLink = false,
   checkLogsHang = false,
+  mergeConflict = false,
 }: {
   snapshot: CodeWorkspacePrSnapshot | null;
   busy?: CodeWorkspacePrMutation | null;
@@ -49,14 +53,25 @@ function WorkflowState({
   watchTaskLink?: boolean;
   /** Leave the check-log download in flight, to hold the reading state. */
   checkLogsHang?: boolean;
+  /** Reject merge after confirmation because the pull request head moved. */
+  mergeConflict?: boolean;
 }) {
+  const [mutationError, setMutationError] = useState<string | null>(null);
   return (
     <WorkspaceWorkflowControl
       client={{
         pushCodeWorkspace: fn(),
         createCodePullRequest: fn(),
         markCodePrReady: fn(),
-        mergeCodePr: fn(),
+        mergeCodePr: mergeConflict
+          ? fn(async () => {
+              throw new HttpError(
+                409,
+                "409: pull request head changed from 8a1f2240 to d94e0301",
+                "pr_head_changed",
+              );
+            })
+          : fn(),
         startCodeWatch: fn(),
         stopCodeWatch: fn(),
         writeCodeCheckLogs: checkLogsHang
@@ -66,7 +81,7 @@ function WorkflowState({
       workspaceId="ws-1"
       branchName="tidebreak/scoped-ui-workshop"
       baseRef="main"
-      resource={resourceFor(snapshot, busy)}
+      resource={resourceFor(snapshot, busy, mutationError, setMutationError)}
       onOpenSourceControl={fn()}
       onOpenWatchTask={watchTaskLink ? fn() : undefined}
     />
@@ -102,6 +117,38 @@ export const ReadyForPullRequest: Story = {
 };
 
 export const PullRequestOpen: Story = {};
+
+/** The server rechecked the confirmed merge and found a replacement head. */
+export const MergePreconditionChanged: Story = {
+  args: {
+    snapshot: {
+      ...openPrGit,
+      ahead: 0,
+      pr: {
+        ...openPrGit.pr!,
+        head_branch: "tidebreak/scoped-ui-workshop",
+        base_branch: "main",
+        head_sha: "8a1f2240e66d32a8",
+        mergeable: "mergeable",
+        merge_state_status: "clean",
+        checks_summary: "9 passing, 0 pending, 0 failing",
+        checks: [{ name: "required checks", bucket: "pass" }],
+      },
+    },
+    mergeConflict: true,
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      within(canvasElement).getByRole("button", { name: "Merge" }),
+    );
+    const dialog = await body.findByRole("alertdialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Merge" }),
+    );
+    await body.findByRole("button", { name: "Refresh workspace status" });
+  },
+};
 
 /** GitHub's merge queue uses the shared orange status treatment. */
 export const MergeQueued: Story = {

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -20,6 +20,7 @@ use tidebreak_harness::{filter_child_env, probe_shell, HostEnv};
 
 use super::setup_script::spawn_workspace_script;
 use crate::obo_gateway::GitCredential;
+use crate::routes::code::types::CodeGitHubRepositoryTarget;
 
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const GIT_PUSH_TIMEOUT: Duration = Duration::from_secs(120);
@@ -203,6 +204,27 @@ pub(crate) struct WorkspaceGitStatus {
     /// `Some(true)` when `pushes_as` is the caller's own account
     /// (decision 65) rather than the deployment's App.
     pub pushes_as_self: Option<bool>,
+}
+
+/// Mutable local facts that must still hold when a workspace merge reaches
+/// the host. The runtime reads them while it owns the workspace turn lock.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceMergeLocalState {
+    pub current_branch: Option<String>,
+    pub head_sha: String,
+    pub dirty: bool,
+    pub upstream: Option<String>,
+    pub ahead_of_upstream: u64,
+}
+
+/// The pull request `gh` resolves from the locked workspace branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspacePullRequestIdentity {
+    pub target: CodeGitHubRepositoryTarget,
+    pub number: u64,
+    pub state: String,
+    pub head_branch: String,
+    pub head_sha: String,
 }
 
 /// Outcome of one named quick action.
@@ -546,28 +568,6 @@ impl MergeMethod {
             Self::Rebase => "--rebase",
         }
     }
-}
-
-/// Merge the workspace PR, or enable auto-merge on it. This is the only path
-/// allowed to run `gh pr merge`, and it exists solely for the user-initiated
-/// merge endpoint — agent and automation paths go through [`run_gh`], which
-/// refuses merge argv outright.
-pub(crate) async fn merge_pull_request(
-    worktree: &Path,
-    method: MergeMethod,
-    auto: bool,
-    gh_search_path: Option<&str>,
-) -> Result<(), GhError> {
-    let gh = observe_gh(gh_search_path).await;
-    let binary = require_gh_binary(&gh)?;
-    let mut args = vec!["pr", "merge", method.flag()];
-    if auto {
-        args.push("--auto");
-    }
-    run_gh_user_merge(worktree, &binary, &args, GH_TIMEOUT)
-        .await
-        .map_err(classify_merge_error)?;
-    Ok(())
 }
 
 /// Mark the workspace's own draft pull request ready for review.
@@ -927,6 +927,52 @@ struct GitInspect {
     suggested_commit_message: String,
     suggested_pr_body: String,
     diffstat: Diffstat,
+}
+
+/// Read the local preconditions for merging a workspace pull request.
+///
+/// The caller owns the workspace turn lock for this read and the host action
+/// that follows. A missing upstream and a detached head stay distinct so the
+/// route can return a specific typed conflict.
+pub(crate) async fn inspect_workspace_merge_local_state(
+    worktree: &Path,
+) -> Result<WorkspaceMergeLocalState, GhError> {
+    let current_branch = git(
+        worktree,
+        &["symbolic-ref", "--quiet", "--short", "HEAD"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .ok()
+    .filter(|branch| !branch.is_empty());
+    let head_sha = git(worktree, &["rev-parse", "HEAD"], GIT_TIMEOUT).await?;
+    let dirty = has_uncommitted_work(worktree).await?;
+    let upstream = git(
+        worktree,
+        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .ok()
+    .filter(|upstream| !upstream.is_empty());
+    let ahead_of_upstream = match upstream {
+        Some(_) => parse_count(
+            &git(
+                worktree,
+                &["rev-list", "--count", "@{u}..HEAD"],
+                GIT_TIMEOUT,
+            )
+            .await?,
+        ),
+        None => 0,
+    };
+    Ok(WorkspaceMergeLocalState {
+        current_branch,
+        head_sha,
+        dirty,
+        upstream,
+        ahead_of_upstream,
+    })
 }
 
 async fn inspect_git(worktree: &Path, base_ref: &str, title: &str) -> Result<GitInspect, GhError> {
@@ -1821,6 +1867,70 @@ pub(crate) fn cli_repository(host: &str, owner: &str, repo: &str) -> String {
 /// delivery list fields: no checks, review, or mergeability — those stay
 /// live-only.
 pub(crate) const PR_FACT_FIELDS: &str = "number,url,title,state,isDraft,author,headRefName,headRefOid,baseRefName,createdAt,updatedAt,mergedAt,closedAt";
+
+/// Resolve the pull request attached to the workspace's current branch.
+///
+/// This read deliberately carries no repository or pull request selector. The
+/// runtime compares the returned URL, number, branch, and head with the exact
+/// target the desktop confirmed before it calls the repository-qualified
+/// merge helper.
+pub(crate) async fn view_workspace_pull_request(
+    worktree: &Path,
+    search_path: Option<&str>,
+) -> Result<WorkspacePullRequestIdentity, GhError> {
+    let observation = observe_gh(search_path).await;
+    let binary = require_gh_binary(&observation)?;
+    let raw = run_gh(
+        worktree,
+        &binary,
+        &["pr", "view", "--json", PR_FACT_FIELDS],
+        GH_TIMEOUT,
+    )
+    .await
+    .map_err(|error| classify_observed_gh(error, &observation))?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|error| GhError::Internal(format!("could not parse pull request: {error}")))?;
+    let number = value
+        .get("number")
+        .and_then(serde_json::Value::as_u64)
+        .filter(|number| *number > 0)
+        .ok_or_else(|| GhError::user("the pull request response did not name a pull request"))?;
+    let url = value
+        .get("url")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| GhError::user("the pull request response did not name its repository"))?;
+    let (host, owner, name, url_number) = super::pr_facts::pull_request_identity_from_url(url)
+        .ok_or_else(|| GhError::user("the pull request response had an invalid URL"))?;
+    if number != url_number {
+        return Err(GhError::user(format!(
+            "the pull request response named both #{number} and #{url_number}"
+        )));
+    }
+    let state = value
+        .get("state")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| GhError::user("the pull request response did not name its state"))?;
+    let head_branch = value
+        .get("headRefName")
+        .and_then(serde_json::Value::as_str)
+        .filter(|branch| !branch.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| GhError::user("the pull request response did not name its head branch"))?;
+    let head_sha = value
+        .get("headRefOid")
+        .and_then(serde_json::Value::as_str)
+        .filter(|sha| !sha.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| GhError::user("the pull request response did not name its head commit"))?;
+    Ok(WorkspacePullRequestIdentity {
+        target: CodeGitHubRepositoryTarget { host, owner, name },
+        number,
+        state,
+        head_branch,
+        head_sha,
+    })
+}
 
 /// Read one repository-qualified pull request's fact fields, as raw JSON.
 pub(crate) async fn view_pull_request_raw(
@@ -2723,25 +2833,44 @@ exit 3
         assert!(!log.exists(), "a refused argv must never spawn gh");
 
         // The dedicated merge operation is the one path that runs it.
-        merge_pull_request(
-            dir.path(),
+        merge_pull_request_target(
+            "github.com",
+            "acme",
+            "app",
+            42,
             MergeMethod::Squash,
             false,
+            false,
+            "abcdef123456",
             Some(shim_dir.path().to_str().unwrap()),
         )
         .await
         .unwrap();
-        merge_pull_request(
-            dir.path(),
+        merge_pull_request_target(
+            "github.com",
+            "acme",
+            "app",
+            42,
             MergeMethod::Merge,
             true,
+            false,
+            "abcdef123456",
             Some(shim_dir.path().to_str().unwrap()),
         )
         .await
         .unwrap();
         let logged = std::fs::read_to_string(&log).unwrap();
-        assert!(logged.contains("pr merge --squash"), "{logged}");
-        assert!(logged.contains("pr merge --merge --auto"), "{logged}");
+        assert!(
+            logged
+                .contains("pr merge 42 --repo acme/app --squash --match-head-commit abcdef123456"),
+            "{logged}"
+        );
+        assert!(
+            logged.contains(
+                "pr merge 42 --repo acme/app --merge --match-head-commit abcdef123456 --auto"
+            ),
+            "{logged}"
+        );
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -57,6 +57,7 @@ use super::worktree::{
     run_archive_script, run_setup_script, slugify, validate_repo_path, worktree_dir, WorktreeError,
 };
 use crate::error::ServerError;
+use crate::routes::code::types::{CodeDeliveryPullRequestTarget, CodeGitHubRepositoryTarget};
 
 const MANAGED_NODE_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
 const MANAGED_NODE_STARTUP_GRACE: Duration = Duration::from_secs(2);
@@ -246,6 +247,14 @@ const DELIVERY_NUDGE_DEBOUNCE: Duration = Duration::from_secs(3);
 #[derive(Default)]
 struct DeliveryNudgeDebounce {
     owners: Arc<Mutex<HashMap<OwnerId, DeliveryNudgeState>>>,
+}
+
+/// The exact merge target the runtime accepted plus the refreshed workspace
+/// status after the host action.
+pub(crate) struct WorkspaceMergeOutcome {
+    pub target: CodeDeliveryPullRequestTarget,
+    pub accepted_head_sha: String,
+    pub status: WorkspaceGitStatus,
 }
 
 struct DeliveryNudgeState {
@@ -1414,6 +1423,8 @@ impl CodeRuntime {
         id: WorkspaceId,
         message: Option<String>,
     ) -> Result<CommitOutcome, ServerError> {
+        let turn = self.worktree_turn_lock(id);
+        let _turn_guard = turn.lock().await;
         let workspace = self.require_live_workspace(owner, id).await?;
         gh::commit_all(
             std::path::Path::new(&workspace.worktree_path),
@@ -1429,6 +1440,8 @@ impl CodeRuntime {
         owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<PushOutcome, ServerError> {
+        let turn = self.worktree_turn_lock(id);
+        let _turn_guard = turn.lock().await;
         let workspace = self.require_live_workspace(owner, id).await?;
         let worktree = std::path::PathBuf::from(&workspace.worktree_path);
         let credential = self.borrow_git_credential(owner, &worktree).await?;
@@ -2210,30 +2223,166 @@ impl CodeRuntime {
         Ok(facts)
     }
 
-    /// User-initiated merge (or auto-merge arming) of the workspace PR, then a
-    /// fresh status read so the caller and the updates channel both see the
-    /// result. This is the only route to `gh pr merge`.
+    /// Merge the exact pull request head the desktop confirmed.
+    ///
+    /// The workspace turn lock covers every mutable local and host preflight
+    /// plus the repository-qualified merge invocation. The final helper also
+    /// sends `--match-head-commit`, so a force push after the live read fails
+    /// at GitHub instead of changing what this request lands.
     pub(crate) async fn merge_workspace_pr(
         &self,
         owner: &OwnerId,
         id: WorkspaceId,
+        target: CodeDeliveryPullRequestTarget,
+        expected_head_sha: String,
         method: gh::MergeMethod,
         auto: bool,
-    ) -> Result<WorkspaceGitStatus, ServerError> {
+    ) -> Result<WorkspaceMergeOutcome, ServerError> {
+        validate_workspace_merge_request(&target, &expected_head_sha)?;
+        let turn = self.worktree_turn_lock(id);
+        let _turn_guard = turn.lock().await;
         let workspace = self.require_live_workspace(owner, id).await?;
+        let worktree = std::path::Path::new(&workspace.worktree_path);
+        let local = gh::inspect_workspace_merge_local_state(worktree)
+            .await
+            .map_err(map_gh)?;
+        let current_branch = local.current_branch.ok_or_else(|| {
+            ServerError::conflict_kind(
+                "workspace_branch_changed",
+                format!(
+                    "the workspace is detached; check out {} and refresh before merging",
+                    workspace.branch_name
+                ),
+            )
+        })?;
+        if current_branch != workspace.branch_name {
+            return Err(ServerError::conflict_kind(
+                "workspace_branch_changed",
+                format!(
+                    "the workspace branch changed from {} to {current_branch}; refresh before merging",
+                    workspace.branch_name
+                ),
+            ));
+        }
+        if local.dirty {
+            return Err(ServerError::conflict_kind(
+                "workspace_dirty",
+                "the workspace now has uncommitted changes; review them before merging",
+            ));
+        }
+        let upstream = local.upstream.ok_or_else(|| {
+            ServerError::conflict_kind(
+                "workspace_upstream_missing",
+                "the workspace branch no longer has an upstream; push it and refresh before merging",
+            )
+        })?;
+        let expected_upstream = format!("origin/{}", workspace.branch_name);
+        if upstream != expected_upstream {
+            return Err(ServerError::conflict_kind(
+                "workspace_branch_changed",
+                format!(
+                    "the workspace branch now tracks {upstream} instead of {expected_upstream}; refresh before merging"
+                ),
+            ));
+        }
+        if local.ahead_of_upstream > 0 {
+            return Err(ServerError::conflict_kind(
+                "workspace_unpushed",
+                format!(
+                    "the workspace now has {} unpushed commit{}; push and refresh before merging",
+                    local.ahead_of_upstream,
+                    if local.ahead_of_upstream == 1 {
+                        ""
+                    } else {
+                        "s"
+                    }
+                ),
+            ));
+        }
+
+        let local_target = super::delivery::repository_target_from_path(worktree)
+            .await
+            .map_err(|message| {
+                ServerError::conflict_kind(
+                    "workspace_repository_changed",
+                    format!("the workspace repository could not be verified: {message}"),
+                )
+            })?;
+        if !same_repository(&local_target, &target.repository) {
+            return Err(ServerError::conflict_kind(
+                "workspace_repository_changed",
+                format!(
+                    "the workspace repository changed from {} to {}; refresh before merging",
+                    repository_label(&target.repository),
+                    repository_label(&local_target)
+                ),
+            ));
+        }
+
         let gh_path = self.gh_search_path_owned();
-        gh::merge_pull_request(
-            std::path::Path::new(&workspace.worktree_path),
+        let live = gh::view_workspace_pull_request(worktree, gh_path.as_deref())
+            .await
+            .map_err(map_gh)?;
+        if !same_repository(&live.target, &target.repository) || live.number != target.number {
+            return Err(ServerError::conflict_kind(
+                "pr_target_changed",
+                format!(
+                    "the workspace now resolves to {}#{} instead of {}#{}; refresh before merging",
+                    repository_label(&live.target),
+                    live.number,
+                    repository_label(&target.repository),
+                    target.number
+                ),
+            ));
+        }
+        if live.head_branch != workspace.branch_name {
+            return Err(ServerError::conflict_kind(
+                "pr_target_changed",
+                format!(
+                    "pull request #{} now uses branch {} instead of {}; refresh before merging",
+                    target.number, live.head_branch, workspace.branch_name
+                ),
+            ));
+        }
+        if live.state != "open" {
+            return Err(ServerError::conflict_kind(
+                "pr_not_mergeable",
+                format!(
+                    "pull request #{} is {}; refresh before merging",
+                    target.number, live.state
+                ),
+            ));
+        }
+        if local.head_sha != expected_head_sha {
+            return Err(pr_head_changed(&expected_head_sha, &local.head_sha));
+        }
+        if live.head_sha != expected_head_sha {
+            return Err(pr_head_changed(&expected_head_sha, &live.head_sha));
+        }
+
+        gh::merge_pull_request_target(
+            &target.repository.host,
+            &target.repository.owner,
+            &target.repository.name,
+            target.number,
             method,
             auto,
+            false,
+            &expected_head_sha,
             gh_path.as_deref(),
         )
         .await
         .map_err(map_gh)?;
+        drop(_turn_guard);
         // A merge dirties the row (decision 66); the delivery lists hold the
         // pre-merge row.
         self.delivery_cache.invalidate();
-        self.refresh_workspace_pr(owner, id).await
+        let status = self.refresh_workspace_pr(owner, id).await?;
+        Ok(WorkspaceMergeOutcome {
+            target,
+            accepted_head_sha: expected_head_sha,
+            status,
+        })
     }
 
     /// Take the workspace's pull request out of draft and return a fresh
@@ -2245,6 +2394,8 @@ impl CodeRuntime {
         owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<WorkspaceGitStatus, ServerError> {
+        let turn = self.worktree_turn_lock(id);
+        let _turn_guard = turn.lock().await;
         let workspace = self.require_live_workspace(owner, id).await?;
         let gh_path = self.gh_search_path_owned();
         gh::mark_workspace_pull_request_ready(
@@ -2264,6 +2415,8 @@ impl CodeRuntime {
         title: Option<String>,
         body: Option<String>,
     ) -> Result<WorkspaceGitStatus, ServerError> {
+        let turn = self.worktree_turn_lock(id);
+        let _turn_guard = turn.lock().await;
         let mut workspace = self.require_live_workspace(owner, id).await?;
         let worktree = std::path::PathBuf::from(&workspace.worktree_path);
         // On a hosted machine the pull request rides the forge REST API with
@@ -2363,6 +2516,8 @@ impl CodeRuntime {
         id: WorkspaceId,
         name: &str,
     ) -> Result<ActionOutcome, ServerError> {
+        let turn = self.worktree_turn_lock(id);
+        let _turn_guard = turn.lock().await;
         let workspace = self.require_live_workspace(owner, id).await?;
         let repo = self.get_repo(owner, workspace.repo_id).await?;
         gh::run_named_action(
@@ -4708,7 +4863,11 @@ fn map_gh(err: GhError) -> ServerError {
         }
         GhError::MergeBlocked(message) => ServerError::conflict_kind("pr_not_mergeable", message),
         GhError::User(message) => {
-            if message.contains("no quick action") {
+            if let Some(message) = message.strip_prefix(gh::PR_HEAD_CHANGED_PREFIX) {
+                ServerError::conflict_kind("pr_head_changed", message)
+            } else if let Some(message) = message.strip_prefix(gh::GH_UNAVAILABLE_PREFIX) {
+                ServerError::conflict_kind("gh_unavailable", message)
+            } else if message.contains("no quick action") {
                 ServerError::not_found(message)
             } else {
                 ServerError::bad_request_kind("git", message)
@@ -4716,6 +4875,53 @@ fn map_gh(err: GhError) -> ServerError {
         }
         GhError::Internal(message) => ServerError::internal(message),
     }
+}
+
+fn validate_workspace_merge_request(
+    target: &CodeDeliveryPullRequestTarget,
+    expected_head_sha: &str,
+) -> Result<(), ServerError> {
+    if target.number == 0
+        || target.repository.host.trim().is_empty()
+        || target.repository.owner.trim().is_empty()
+        || target.repository.name.trim().is_empty()
+        || expected_head_sha.trim().is_empty()
+    {
+        return Err(ServerError::bad_request_kind(
+            "workspace_merge_target",
+            "repository, pull request number, and expected head commit are required",
+        ));
+    }
+    Ok(())
+}
+
+fn same_repository(left: &CodeGitHubRepositoryTarget, right: &CodeGitHubRepositoryTarget) -> bool {
+    left.host.eq_ignore_ascii_case(&right.host)
+        && left.owner.eq_ignore_ascii_case(&right.owner)
+        && left.name.eq_ignore_ascii_case(&right.name)
+}
+
+fn repository_label(target: &CodeGitHubRepositoryTarget) -> String {
+    if target.host.eq_ignore_ascii_case("github.com") {
+        format!("{}/{}", target.owner, target.name)
+    } else {
+        format!("{}/{}/{}", target.host, target.owner, target.name)
+    }
+}
+
+fn pr_head_changed(expected: &str, current: &str) -> ServerError {
+    ServerError::conflict_kind(
+        "pr_head_changed",
+        format!(
+            "pull request head changed from {} to {}; refresh before merging",
+            short_sha(expected),
+            short_sha(current)
+        ),
+    )
+}
+
+fn short_sha(sha: &str) -> &str {
+    sha.get(..sha.len().min(8)).unwrap_or(sha)
 }
 
 /// The origin a hosted machine may lend the forge's App identity to: a

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -506,11 +506,13 @@ impl ScopedCode {
     pub(crate) async fn merge_workspace_pr(
         &self,
         id: WorkspaceId,
+        target: CodeDeliveryPullRequestTarget,
+        expected_head_sha: String,
         method: gh::MergeMethod,
         auto: bool,
-    ) -> Result<WorkspaceGitStatus, ServerError> {
+    ) -> Result<super::runtime::WorkspaceMergeOutcome, ServerError> {
         self.runtime
-            .merge_workspace_pr(&self.owner, id, method, auto)
+            .merge_workspace_pr(&self.owner, id, target, expected_head_sha, method, auto)
             .await
     }
 

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -10,8 +10,8 @@ use crate::extract::{Json, Path};
 use super::types::{
     CodeActionSnapshot, CodeCheckLog, CodeCheckLogError, CodeCheckLogsSnapshot, CodeCommitSnapshot,
     CodePrCommentsSnapshot, CodePrMergeMethod, CodePushSnapshot, CodeWatchSnapshot,
-    CodeWorkspacePrSnapshot, CodeWorkspacePullRequestFact, CodeWorkspacePullRequests,
-    CommitWorkspaceBody, CreatePullRequestBody, MergeCodePrBody,
+    CodeWorkspaceMergeResult, CodeWorkspacePrSnapshot, CodeWorkspacePullRequestFact,
+    CodeWorkspacePullRequests, CommitWorkspaceBody, CreatePullRequestBody, MergeCodePrBody,
 };
 use crate::code::gh::{ActionOutcome, CommitOutcome, MergeMethod, PushOutcome, WorkspaceGitStatus};
 use tidebreak_core::WorkspaceId;
@@ -165,15 +165,21 @@ pub async fn merge_workspace_pr(
     code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Json(body): Json<MergeCodePrBody>,
-) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
+) -> Result<Json<CodeWorkspaceMergeResult>, ServerError> {
     let method = match body.method {
         CodePrMergeMethod::Squash => MergeMethod::Squash,
         CodePrMergeMethod::Merge => MergeMethod::Merge,
         CodePrMergeMethod::Rebase => MergeMethod::Rebase,
     };
-    let status = code.merge_workspace_pr(id, method, body.auto).await?;
+    let outcome = code
+        .merge_workspace_pr(id, body.target, body.expected_head_sha, method, body.auto)
+        .await?;
     let watch = code.latest_watch(id).await?;
-    Ok(Json(pr_snapshot(status, watch)))
+    Ok(Json(CodeWorkspaceMergeResult {
+        target: outcome.target,
+        accepted_head_sha: outcome.accepted_head_sha,
+        status: pr_snapshot(outcome.status, watch),
+    }))
 }
 
 pub async fn mark_workspace_pr_ready(

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -805,10 +805,24 @@ impl From<CodeWatch> for CodeWatchSnapshot {
 #[derive(Debug, Deserialize, Serialize, TS)]
 #[serde(deny_unknown_fields)]
 pub struct MergeCodePrBody {
+    /// The repository and pull request shown in the confirmation.
+    pub target: CodeDeliveryPullRequestTarget,
+    /// The pull request head shown in the confirmation.
+    pub expected_head_sha: String,
     pub method: CodePrMergeMethod,
     /// True arms host auto-merge instead of merging immediately.
     #[serde(default)]
     pub auto: bool,
+}
+
+/// Accepted exact target plus the refreshed workspace status after a merge
+/// request. The desktop uses the echoed identity to reconcile the result with
+/// the confirmation it showed instead of inferring identity from the branch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CodeWorkspaceMergeResult {
+    pub target: CodeDeliveryPullRequestTarget,
+    pub accepted_head_sha: String,
+    pub status: CodeWorkspacePrSnapshot,
 }
 
 /// Merge strategy for a user-initiated PR merge.

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -372,7 +372,7 @@ async fn workspace_merge_requires_the_exact_reviewed_target() {
         .send()
         .await
         .unwrap();
-    assert_eq!(response.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -143,6 +143,106 @@ async fn seed_workspace_pull_request(runtime: &CodeRuntime, id: &str, url: &str,
     runtime.save_workspace(&workspace).await.unwrap();
 }
 
+struct MergeFixture {
+    client: reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: Arc<str>,
+    runtime: Arc<CodeRuntime>,
+    _data: tempfile::TempDir,
+    _shim: tempfile::TempDir,
+    id: String,
+    repo_id: RepoId,
+    path: std::path::PathBuf,
+    branch: String,
+    head: String,
+    log: std::path::PathBuf,
+}
+
+async fn merge_fixture(
+    live_repository: &str,
+    live_number: u64,
+    live_head: Option<&str>,
+) -> MergeFixture {
+    let (router, token, runtime, data) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(data.path());
+    let (repo_body, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "exact merge").await;
+    let repo_id: RepoId = json_id(&repo_body).parse().unwrap();
+    let id = json_id(&workspace).to_owned();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    let branch = workspace["branch_name"].as_str().unwrap().to_owned();
+    run(&path, &["git", "push", "-u", "origin", &branch]);
+    let head = run_stdout(&path, &["git", "rev-parse", "HEAD"]);
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/example/demo.git",
+        ],
+    );
+    seed_workspace_pull_request(&runtime, &id, "https://github.com/example/demo/pull/12", 12).await;
+
+    let shim = tempfile::TempDir::new().unwrap();
+    let log = shim.path().join("log");
+    let live_head = live_head.unwrap_or(&head);
+    let (live_owner, live_name) = live_repository.split_once('/').unwrap();
+    write_executable(
+        &shim.path().join("gh"),
+        &format!(
+            r#"#!/bin/sh
+echo "$@" >> {log}
+if [ "$1" = auth ]; then
+  echo '{{"hosts":{{"github.com":[{{"active":true,"state":"success","login":"tester"}}]}}}}'
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = view ]; then
+  echo '{{"number":{live_number},"url":"https://github.com/{live_owner}/{live_name}/pull/{live_number}","state":"OPEN","headRefName":"{branch}","headRefOid":"{live_head}"}}'
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = merge ]; then exit 0; fi
+exit 3
+"#,
+            log = log.display(),
+        ),
+    );
+    runtime.set_gh_search_path(Some(shim.path().display().to_string()));
+    MergeFixture {
+        client,
+        addr,
+        token,
+        runtime,
+        _data: data,
+        _shim: shim,
+        id,
+        repo_id,
+        path,
+        branch,
+        head,
+        log,
+    }
+}
+
+fn exact_merge_body(head: &str) -> serde_json::Value {
+    serde_json::json!({
+        "target": {
+            "repository": {
+                "host": "github.com",
+                "owner": "example",
+                "name": "demo"
+            },
+            "number": 12
+        },
+        "expected_head_sha": head,
+        "method": "squash",
+        "auto": false
+    })
+}
+
 async fn register_and_workspace(
     client: &reqwest::Client,
     addr: std::net::SocketAddr,
@@ -254,6 +354,277 @@ async fn commit_and_push_use_a_bare_origin_and_refuse_a_clean_tree() {
     assert_eq!(pr["dirty"], false);
     assert_eq!(pr["unpushed"], false);
     assert!(pr["ahead"].as_u64().unwrap() >= 1);
+}
+
+#[tokio::test]
+async fn workspace_merge_requires_the_exact_reviewed_target() {
+    let (router, token, _runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "exact merge body").await;
+    let id = json_id(&workspace);
+    let response = client
+        .post(format!("http://{addr}/code/workspaces/{id}/pr/merge"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "method": "squash", "auto": false }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn workspace_merge_rechecks_and_uses_the_repository_qualified_head() {
+    let fixture = merge_fixture("example/demo", 12, None).await;
+    let response = fixture
+        .client
+        .post(format!(
+            "http://{}/code/workspaces/{}/pr/merge",
+            fixture.addr, fixture.id
+        ))
+        .bearer_auth(&fixture.token)
+        .json(&exact_merge_body(&fixture.head))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["target"]["repository"]["host"], "github.com");
+    assert_eq!(body["target"]["repository"]["owner"], "example");
+    assert_eq!(body["target"]["repository"]["name"], "demo");
+    assert_eq!(body["target"]["number"], 12);
+    assert_eq!(body["accepted_head_sha"], fixture.head);
+    assert!(body["status"].is_object(), "{body}");
+
+    let logged = std::fs::read_to_string(&fixture.log).unwrap();
+    assert!(logged.contains("pr view --json"), "{logged}");
+    assert!(
+        logged.contains(&format!(
+            "pr merge 12 --repo example/demo --squash --match-head-commit {}",
+            fixture.head
+        )),
+        "{logged}"
+    );
+}
+
+#[tokio::test]
+async fn workspace_merge_returns_typed_local_and_remote_conflicts() {
+    let dirty = merge_fixture("example/demo", 12, None).await;
+    std::fs::write(dirty.path.join("dirty.txt"), "changed\n").unwrap();
+    let response = dirty
+        .client
+        .post(format!(
+            "http://{}/code/workspaces/{}/pr/merge",
+            dirty.addr, dirty.id
+        ))
+        .bearer_auth(&dirty.token)
+        .json(&exact_merge_body(&dirty.head))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, _) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "workspace_dirty");
+    assert!(!dirty.log.exists(), "dirty work must fail before gh runs");
+
+    let unpushed = merge_fixture("example/demo", 12, None).await;
+    std::fs::write(unpushed.path.join("ahead.txt"), "ahead\n").unwrap();
+    run(&unpushed.path, &["git", "add", "ahead.txt"]);
+    run(&unpushed.path, &["git", "commit", "-m", "ahead"]);
+    let response = unpushed
+        .client
+        .post(format!(
+            "http://{}/code/workspaces/{}/pr/merge",
+            unpushed.addr, unpushed.id
+        ))
+        .bearer_auth(&unpushed.token)
+        .json(&exact_merge_body(&unpushed.head))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, _) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "workspace_unpushed");
+    assert!(
+        !unpushed.log.exists(),
+        "unpushed work must fail before gh runs"
+    );
+
+    let no_upstream = merge_fixture("example/demo", 12, None).await;
+    run(&no_upstream.path, &["git", "branch", "--unset-upstream"]);
+    let response = no_upstream
+        .client
+        .post(format!(
+            "http://{}/code/workspaces/{}/pr/merge",
+            no_upstream.addr, no_upstream.id
+        ))
+        .bearer_auth(&no_upstream.token)
+        .json(&exact_merge_body(&no_upstream.head))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, _) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "workspace_upstream_missing");
+
+    let changed_branch = merge_fixture("example/demo", 12, None).await;
+    run(
+        &changed_branch.path,
+        &["git", "switch", "-c", "other-branch"],
+    );
+    let response = changed_branch
+        .client
+        .post(format!(
+            "http://{}/code/workspaces/{}/pr/merge",
+            changed_branch.addr, changed_branch.id
+        ))
+        .bearer_auth(&changed_branch.token)
+        .json(&exact_merge_body(&changed_branch.head))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, _) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "workspace_branch_changed");
+
+    let moved_head = merge_fixture("example/demo", 12, Some("bbbbbbbbbbbbbbbb")).await;
+    let response = moved_head
+        .client
+        .post(format!(
+            "http://{}/code/workspaces/{}/pr/merge",
+            moved_head.addr, moved_head.id
+        ))
+        .bearer_auth(&moved_head.token)
+        .json(&exact_merge_body(&moved_head.head))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "pr_head_changed");
+    assert!(message.contains(&moved_head.head[..8]), "{message}");
+    assert!(message.contains("bbbbbbbb"), "{message}");
+    let logged = std::fs::read_to_string(&moved_head.log).unwrap();
+    assert!(!logged.contains("pr merge"), "{logged}");
+
+    let moved_target = merge_fixture("example/other", 19, None).await;
+    let response = moved_target
+        .client
+        .post(format!(
+            "http://{}/code/workspaces/{}/pr/merge",
+            moved_target.addr, moved_target.id
+        ))
+        .bearer_auth(&moved_target.token)
+        .json(&exact_merge_body(&moved_target.head))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "pr_target_changed");
+    assert!(message.contains("example/other#19"), "{message}");
+    let logged = std::fs::read_to_string(&moved_target.log).unwrap();
+    assert!(!logged.contains("pr merge"), "{logged}");
+}
+
+#[tokio::test]
+async fn workspace_merge_holds_the_turn_lock_through_the_host_action() {
+    let fixture = merge_fixture("example/demo", 12, None).await;
+    let entered = fixture._shim.path().join("view-entered");
+    let release = fixture._shim.path().join("release-view");
+    write_executable(
+        &fixture._shim.path().join("gh"),
+        &format!(
+            r#"#!/bin/sh
+echo "$@" >> {log}
+if [ "$1" = auth ]; then
+  echo '{{"hosts":{{"github.com":[{{"active":true,"state":"success","login":"tester"}}]}}}}'
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = view ]; then
+  : > {entered}
+  while [ ! -f {release} ]; do sleep 0.02; done
+  echo '{{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN","headRefName":"{branch}","headRefOid":"{head}"}}'
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = merge ]; then exit 0; fi
+exit 3
+"#,
+            log = fixture.log.display(),
+            entered = entered.display(),
+            release = release.display(),
+            branch = fixture.branch,
+            head = fixture.head,
+        ),
+    );
+    let mut repo = fixture
+        .runtime
+        .get_repo(&tidebreak_core::OwnerId::local(), fixture.repo_id)
+        .await
+        .unwrap();
+    repo.quick_actions = vec![QuickAction {
+        name: "mutate".into(),
+        command: "printf 'changed\\n' > action.txt".into(),
+        auto_run_on_create: false,
+    }];
+    fixture.runtime.save_repo(&repo).await.unwrap();
+
+    let merge_client = fixture.client.clone();
+    let merge_token = fixture.token.clone();
+    let merge_url = format!(
+        "http://{}/code/workspaces/{}/pr/merge",
+        fixture.addr, fixture.id
+    );
+    let merge_body = exact_merge_body(&fixture.head);
+    let merge = tokio::spawn(async move {
+        merge_client
+            .post(merge_url)
+            .bearer_auth(merge_token)
+            .json(&merge_body)
+            .send()
+            .await
+            .unwrap()
+    });
+    for _ in 0..100 {
+        if entered.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(
+        entered.exists(),
+        "the merge did not reach its locked host read"
+    );
+
+    let action_client = fixture.client.clone();
+    let action_token = fixture.token.clone();
+    let action_url = format!(
+        "http://{}/code/workspaces/{}/actions/mutate",
+        fixture.addr, fixture.id
+    );
+    let action = tokio::spawn(async move {
+        action_client
+            .post(action_url)
+            .bearer_auth(action_token)
+            .send()
+            .await
+            .unwrap()
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(
+        !fixture.path.join("action.txt").exists(),
+        "another workspace action ran inside the merge preflight"
+    );
+
+    std::fs::write(&release, "go\n").unwrap();
+    assert_eq!(merge.await.unwrap().status(), reqwest::StatusCode::OK);
+    assert_eq!(action.await.unwrap().status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        std::fs::read_to_string(fixture.path.join("action.txt")).unwrap(),
+        "changed\n"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

- The desktop sends the exact host, repository owner and name, pull request number, displayed head SHA, merge method, and auto-merge choice.
- The server holds the workspace action lock while it rechecks the local branch, upstream, dirty state, unpushed commits, repository identity, pull request identity and state, and local and hosted heads.
- The final merge uses the repository-qualified helper with the exact pull request number and head commit.
- Typed conflicts cover changed worktree and pull request preconditions. The desktop keeps the conflict popover open, shows a clear error, and lets you refresh.
- Commit, push, ready, pull request creation, and quick actions now share the same workspace lock.

## Compatibility

The request and response types change together in the server and generated desktop client. Mixed-version clients fail safely because the server requires the exact merge identity instead of falling back to an unverified target. Existing repositories and pull requests require no migration.

## Safety and risk

The server rejects stale or mismatched state before it starts a merge. The shared action lock closes races with other workspace mutations, and the exact-head merge call prevents a changed pull request from landing. The stricter checks can reject a valid request after the branch or pull request changes; refresh and retry with the current state.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- Focused Biome checks for every changed TypeScript and Storybook file
- 176 focused Vitest tests across five files
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- Storybook screenshots inspected in light, dark, high-contrast light, and high-contrast dark at 900×520 and 390×520 with 2× device scale

Per repository policy, no local Cargo build, check, Clippy, or tests ran.

Fixes #2656