### PR TITLE
feat(cli): agent MCP server drives chat over attach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7022,6 +7022,7 @@ dependencies = [
  "chrono",
  "futures",
  "image",
+ "jsonschema",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/tidebreak-cli/Cargo.toml
+++ b/crates/tidebreak-cli/Cargo.toml
@@ -57,3 +57,4 @@ uuid = { workspace = true }
 # and only when the tests are built.
 tidebreak-server = { path = "../tidebreak-server", features = ["scripted-provider"] }
 tempfile = { workspace = true }
+jsonschema = { workspace = true }

--- a/crates/tidebreak-cli/src/agent_mcp/chat.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/chat.rs
@@ -1,0 +1,860 @@
+//! Chat-mode MCP tools. Reads are [`ApprovalClass::ReadOnly`]; mutations are
+//! [`ApprovalClass::Sensitive`].
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tidebreak_core::{
+    ApprovalClass, ChatId, Result, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolRegistry,
+    ToolSpec, TurnId,
+};
+
+use crate::event_stream::EventStream;
+
+use super::follow::{
+    apply_decision, collect_events, follow_open_stream, follow_turn, turn_id_for_decision,
+    Decision, DEFAULT_TIMEOUT,
+};
+use super::{AgentMcp, FollowState, TurnResult};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+const MAX_EVENTS: usize = 200;
+const MESSAGE_TAIL: usize = 8;
+
+/// Register every chat tool on `registry`.
+pub(crate) fn register(registry: &mut ToolRegistry, state: Arc<AgentMcp>) {
+    registry.register(Box::new(ChatCreateTool {
+        state: Arc::clone(&state),
+    }));
+    registry.register(Box::new(ChatListTool {
+        state: Arc::clone(&state),
+    }));
+    registry.register(Box::new(ChatStatusTool {
+        state: Arc::clone(&state),
+    }));
+    registry.register(Box::new(ChatRunTurnTool {
+        state: Arc::clone(&state),
+    }));
+    registry.register(Box::new(ChatWaitTool {
+        state: Arc::clone(&state),
+    }));
+    registry.register(Box::new(ChatDecideTool {
+        state: Arc::clone(&state),
+    }));
+    registry.register(Box::new(ChatEventsTool {
+        state: Arc::clone(&state),
+    }));
+    registry.register(Box::new(ChatSteerTool {
+        state: Arc::clone(&state),
+    }));
+    registry.register(Box::new(ChatCancelTool { state }));
+}
+
+fn turn_output(result: &TurnResult) -> ToolOutput {
+    let data = serde_json::to_value(result).unwrap_or(Value::Null);
+    ToolOutput::text(format!(
+        "status: {}{}",
+        result.status.as_str(),
+        if result.assistant_text.is_empty() {
+            String::new()
+        } else {
+            format!("\n{}", result.assistant_text)
+        }
+    ))
+    .with_data(data)
+}
+
+fn fail(message: impl Into<String>) -> Result<ToolOutput> {
+    Ok(ToolOutput::error(message.into()))
+}
+
+fn fail_args(message: impl Into<String>) -> Result<ToolOutput> {
+    Ok(ToolOutput::failed(
+        ToolErrorCategory::InvalidArguments,
+        message.into(),
+    ))
+}
+
+fn required_chat_id(args: &Value) -> std::result::Result<ChatId, ToolOutput> {
+    let Some(value) = args.get("chat_id").and_then(Value::as_str) else {
+        return Err(ToolOutput::failed(
+            ToolErrorCategory::InvalidArguments,
+            "chat_id is required",
+        ));
+    };
+    ChatId::from_str(value).map_err(|_| {
+        ToolOutput::failed(
+            ToolErrorCategory::InvalidArguments,
+            "chat_id must be a UUID",
+        )
+    })
+}
+
+fn timeout_from(args: &Value) -> std::result::Result<Duration, ToolOutput> {
+    match args.get("timeout_seconds") {
+        None | Some(Value::Null) => Ok(DEFAULT_TIMEOUT),
+        Some(value) => {
+            let Some(seconds) = value.as_u64() else {
+                return Err(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "timeout_seconds must be a positive integer",
+                ));
+            };
+            if seconds == 0 {
+                return Err(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "timeout_seconds must be at least 1",
+                ));
+            }
+            Ok(Duration::from_secs(seconds))
+        }
+    }
+}
+
+async fn remember(state: &AgentMcp, chat: ChatId, turn_id: TurnId, result: &TurnResult) {
+    state.follows.lock().await.insert(
+        chat,
+        FollowState {
+            turn_id,
+            last_seq: result.events_cursor,
+            assistant_text: result.assistant_text.clone(),
+        },
+    );
+}
+
+fn object_schema(properties: Value, required: &[&str]) -> Value {
+    let mut schema = json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": false,
+    });
+    if !required.is_empty() {
+        schema["required"] = json!(required);
+    }
+    schema
+}
+
+fn chat_id_property() -> Value {
+    json!({
+        "type": "string",
+        "description": "Chat UUID.",
+    })
+}
+
+fn timeout_property() -> Value {
+    json!({
+        "type": "integer",
+        "minimum": 1,
+        "default": DEFAULT_TIMEOUT_SECS,
+        "description": "Seconds to follow the turn before returning status running. The turn keeps going server-side.",
+    })
+}
+
+// ---------------------------------------------------------------------------
+// chat_create
+// ---------------------------------------------------------------------------
+
+struct ChatCreateTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_create_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_create".into(),
+        description: "Create a chat. Optionally pin a catalog model and a permission mode (plan, ask, auto, or allow)."
+            .into(),
+        input_schema: object_schema(
+            json!({
+                "model": {
+                    "type": "string",
+                    "description": "Catalog key to pin on the new chat.",
+                },
+                "permission_mode": {
+                    "type": "string",
+                    "enum": ["plan", "ask", "auto", "allow"],
+                    "description": "Permission mode stored on the chat.",
+                },
+            }),
+            &[],
+        ),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatCreateTool {
+    fn spec(&self) -> ToolSpec {
+        chat_create_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let model = args.get("model").and_then(Value::as_str);
+        let permission_mode = args.get("permission_mode").and_then(Value::as_str);
+        if let Some(mode) = permission_mode {
+            if !matches!(mode, "plan" | "ask" | "auto" | "allow") {
+                return fail_args("permission_mode must be plan, ask, auto, or allow");
+            }
+        }
+        let client = self.state.client.lock().await;
+        let chat = match client.create_chat().await {
+            Ok(chat) => chat,
+            Err(error) => return fail(error.to_string()),
+        };
+        if let Some(model) = model {
+            if let Err(error) = client.set_chat_model(chat, Some(model)).await {
+                return fail(error.to_string());
+            }
+        }
+        if let Some(mode) = permission_mode {
+            if let Err(error) = client.set_chat_permission_mode(chat, Some(mode)).await {
+                return fail(error.to_string());
+            }
+        }
+        let data = json!({ "chat_id": chat });
+        Ok(ToolOutput::text(format!("chat {chat}")).with_data(data))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chat_list
+// ---------------------------------------------------------------------------
+
+struct ChatListTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_list_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_list".into(),
+        description: "List chats, most recently active first.".into(),
+        input_schema: object_schema(json!({}), &[]),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatListTool {
+    fn spec(&self) -> ToolSpec {
+        chat_list_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+        let client = self.state.client.lock().await;
+        let chats = match client.list_chats().await {
+            Ok(chats) => chats,
+            Err(error) => return fail(error.to_string()),
+        };
+        let summaries: Vec<Value> = chats
+            .iter()
+            .map(|chat| {
+                json!({
+                    "chat_id": chat.id,
+                    "title": chat.title,
+                    "model": chat.model,
+                    "permission_mode": chat.permission_mode,
+                    "created_at": chat.created_at,
+                })
+            })
+            .collect();
+        let data = json!({ "chats": summaries });
+        Ok(ToolOutput::text(format!("{} chat(s)", summaries.len())).with_data(data))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chat_status
+// ---------------------------------------------------------------------------
+
+struct ChatStatusTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_status_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_status".into(),
+        description:
+            "Run state, a tail of recent messages, and pending approvals, plans, and questions."
+                .into(),
+        input_schema: object_schema(json!({ "chat_id": chat_id_property() }), &["chat_id"]),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatStatusTool {
+    fn spec(&self) -> ToolSpec {
+        chat_status_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let chat = match required_chat_id(&args) {
+            Ok(chat) => chat,
+            Err(output) => return Ok(output),
+        };
+        let client = self.state.client.lock().await;
+        let summary = match client.get_chat(chat).await {
+            Ok(summary) => summary,
+            Err(error) => return fail(error.to_string()),
+        };
+        let transcript = match client.chat_transcript(chat).await {
+            Ok(transcript) => transcript,
+            Err(error) => return fail(error.to_string()),
+        };
+        let approvals = match client.list_pending_approvals(chat).await {
+            Ok(approvals) => approvals,
+            Err(error) => return fail(error.to_string()),
+        };
+        let plans = match client.list_pending_plans(chat).await {
+            Ok(plans) => plans
+                .into_iter()
+                .map(|plan| {
+                    json!({
+                        "call_id": plan.call_id,
+                        "title": plan.title,
+                        "plan": plan.plan,
+                    })
+                })
+                .collect::<Vec<Value>>(),
+            Err(error) => return fail(error.to_string()),
+        };
+        let questions = match client.list_pending_questions(chat).await {
+            Ok(questions) => questions
+                .into_iter()
+                .map(|block| {
+                    json!({
+                        "call_id": block.call_id,
+                        "questions": block.questions.into_iter().map(|question| {
+                            json!({
+                                "id": question.id,
+                                "header": question.header,
+                                "question": question.question,
+                                "question_type": question.question_type,
+                                "allow_free_form": question.allow_free_form,
+                                "options": question.options.into_iter().map(|option| {
+                                    json!({
+                                        "id": option.id,
+                                        "label": option.label,
+                                        "description": option.description,
+                                    })
+                                }).collect::<Vec<Value>>(),
+                            })
+                        }).collect::<Vec<Value>>(),
+                    })
+                })
+                .collect::<Vec<Value>>(),
+            Err(error) => return fail(error.to_string()),
+        };
+        let folder = match client.list_pending_folder_access(chat).await {
+            Ok(folder) => folder,
+            Err(error) => return fail(error.to_string()),
+        };
+        drop(client);
+
+        let messages = transcript
+            .get("messages")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let tail: Vec<Value> = messages
+            .iter()
+            .rev()
+            .take(MESSAGE_TAIL)
+            .rev()
+            .map(|message| {
+                json!({
+                    "id": message.get("id"),
+                    "role": message.get("role"),
+                    "content": message.get("content"),
+                })
+            })
+            .collect();
+
+        let follow = self.state.follows.lock().await.get(&chat).cloned();
+        let terminal = transcript
+            .get("terminal_turns")
+            .and_then(Value::as_array)
+            .and_then(|turns| turns.last());
+        let run_state = if !approvals.is_empty() {
+            "needs_approval"
+        } else if !plans.is_empty() {
+            "needs_plan_decision"
+        } else if !questions.is_empty() {
+            "needs_answer"
+        } else if !folder.is_empty() {
+            "needs_host_consent"
+        } else if let Some(follow) = &follow {
+            let finished = transcript
+                .get("terminal_turns")
+                .and_then(Value::as_array)
+                .is_some_and(|turns| {
+                    turns.iter().any(|turn| {
+                        turn.get("turn_id")
+                            .and_then(Value::as_str)
+                            .is_some_and(|id| id == follow.turn_id.to_string())
+                    })
+                });
+            if finished {
+                terminal
+                    .and_then(|turn| turn.get("status"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("idle")
+            } else {
+                "running"
+            }
+        } else {
+            terminal
+                .and_then(|turn| turn.get("status"))
+                .and_then(Value::as_str)
+                .unwrap_or("idle")
+        };
+
+        let data = json!({
+            "chat_id": chat,
+            "title": summary.title,
+            "model": summary.model,
+            "permission_mode": summary.permission_mode,
+            "run_state": run_state,
+            "messages": tail,
+            "pending_approvals": approvals,
+            "pending_plans": plans,
+            "pending_questions": questions,
+            "pending_host_consent": folder,
+        });
+        Ok(ToolOutput::text(format!("run_state: {run_state}")).with_data(data))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chat_run_turn
+// ---------------------------------------------------------------------------
+
+struct ChatRunTurnTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_run_turn_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_run_turn".into(),
+        description: "Post a user prompt and follow the turn until it settles, parks on an interaction, or the timeout elapses."
+            .into(),
+        input_schema: object_schema(
+            json!({
+                "chat_id": chat_id_property(),
+                "prompt": {
+                    "type": "string",
+                    "description": "User text to post as this turn.",
+                },
+                "timeout_seconds": timeout_property(),
+            }),
+            &["chat_id", "prompt"],
+        ),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatRunTurnTool {
+    fn spec(&self) -> ToolSpec {
+        chat_run_turn_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let chat = match required_chat_id(&args) {
+            Ok(chat) => chat,
+            Err(output) => return Ok(output),
+        };
+        let Some(prompt) = args.get("prompt").and_then(Value::as_str) else {
+            return fail_args("prompt is required");
+        };
+        let timeout = match timeout_from(&args) {
+            Ok(timeout) => timeout,
+            Err(output) => return Ok(output),
+        };
+        let turn_id = TurnId::new();
+        let mut client = self.state.client.lock().await;
+        let mut stream = match EventStream::open(&client, chat).await {
+            Ok(stream) => stream,
+            Err(error) => return fail(error.to_string()),
+        };
+        if let Err(error) = client.post_message(chat, turn_id, prompt, &[], &[]).await {
+            return fail(error.to_string());
+        }
+        let result = match follow_open_stream(
+            &mut client,
+            &mut stream,
+            chat,
+            turn_id,
+            false,
+            String::new(),
+            timeout,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => return fail(error.to_string()),
+        };
+        drop(client);
+        remember(&self.state, chat, turn_id, &result).await;
+        Ok(turn_output(&result))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chat_wait
+// ---------------------------------------------------------------------------
+
+struct ChatWaitTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_wait_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_wait".into(),
+        description: "Re-follow an in-flight turn until it settles, parks, or the timeout elapses."
+            .into(),
+        input_schema: object_schema(
+            json!({
+                "chat_id": chat_id_property(),
+                "timeout_seconds": timeout_property(),
+            }),
+            &["chat_id"],
+        ),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatWaitTool {
+    fn spec(&self) -> ToolSpec {
+        chat_wait_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let chat = match required_chat_id(&args) {
+            Ok(chat) => chat,
+            Err(output) => return Ok(output),
+        };
+        let timeout = match timeout_from(&args) {
+            Ok(timeout) => timeout,
+            Err(output) => return Ok(output),
+        };
+        let follow = self.state.follows.lock().await.get(&chat).cloned();
+        let Some(follow) = follow else {
+            return fail(format!("no in-flight turn for chat {chat}"));
+        };
+        let mut client = self.state.client.lock().await;
+        let result = match follow_turn(
+            &mut client,
+            chat,
+            follow.turn_id,
+            follow.last_seq,
+            follow.assistant_text,
+            timeout,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => return fail(error.to_string()),
+        };
+        drop(client);
+        remember(&self.state, chat, follow.turn_id, &result).await;
+        Ok(turn_output(&result))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chat_decide
+// ---------------------------------------------------------------------------
+
+struct ChatDecideTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_decide_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_decide".into(),
+        description: "Apply an approval, plan, or questions decision, then follow to the next settle point. Decision objects mirror the print stdin protocol."
+            .into(),
+        input_schema: object_schema(
+            json!({
+                "chat_id": chat_id_property(),
+                "decision": {
+                    "type": "object",
+                    "description": "Print-protocol decision: {type:\"approval\", call_id, approve, feedback?} or {type:\"plan\", call_id, ...} or {type:\"questions\", call_id, answers}.",
+                },
+                "timeout_seconds": timeout_property(),
+            }),
+            &["chat_id", "decision"],
+        ),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatDecideTool {
+    fn spec(&self) -> ToolSpec {
+        chat_decide_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let chat = match required_chat_id(&args) {
+            Ok(chat) => chat,
+            Err(output) => return Ok(output),
+        };
+        let Some(decision_value) = args.get("decision") else {
+            return fail_args("decision is required");
+        };
+        let decision = match Decision::parse(decision_value) {
+            Ok(decision) => decision,
+            Err(message) => return fail_args(message),
+        };
+        let timeout = match timeout_from(&args) {
+            Ok(timeout) => timeout,
+            Err(output) => return Ok(output),
+        };
+
+        let stored = self.state.follows.lock().await.get(&chat).cloned();
+        let mut client = self.state.client.lock().await;
+        let turn_id = match stored.as_ref() {
+            Some(follow) => follow.turn_id,
+            None => match turn_id_for_decision(&client, chat, &decision).await {
+                Ok(turn_id) => turn_id,
+                Err(error) => return fail(error.to_string()),
+            },
+        };
+        let after_seq = stored.as_ref().map(|follow| follow.last_seq).unwrap_or(0);
+        let assistant_text = stored
+            .as_ref()
+            .map(|follow| follow.assistant_text.clone())
+            .unwrap_or_default();
+
+        let mut stream = match EventStream::open_after(&client, chat, after_seq).await {
+            Ok(stream) => stream,
+            Err(error) => return fail(error.to_string()),
+        };
+        if let Err(error) = apply_decision(&client, chat, &decision).await {
+            return fail(error.to_string());
+        }
+        let result = match follow_open_stream(
+            &mut client,
+            &mut stream,
+            chat,
+            turn_id,
+            after_seq > 0,
+            assistant_text,
+            timeout,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => return fail(error.to_string()),
+        };
+        drop(client);
+        remember(&self.state, chat, turn_id, &result).await;
+        Ok(turn_output(&result))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chat_events
+// ---------------------------------------------------------------------------
+
+struct ChatEventsTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_events_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_events".into(),
+        description: "Raw journal frames after a cursor, for auditing. Capped at 200 events."
+            .into(),
+        input_schema: object_schema(
+            json!({
+                "chat_id": chat_id_property(),
+                "after_seq": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Return frames with seq greater than this cursor.",
+                },
+                "max_events": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_EVENTS,
+                    "default": MAX_EVENTS,
+                    "description": "Maximum frames to return (capped at 200).",
+                },
+            }),
+            &["chat_id"],
+        ),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatEventsTool {
+    fn spec(&self) -> ToolSpec {
+        chat_events_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let chat = match required_chat_id(&args) {
+            Ok(chat) => chat,
+            Err(output) => return Ok(output),
+        };
+        let after_seq = match args.get("after_seq") {
+            None | Some(Value::Null) => 0,
+            Some(value) => match value.as_i64() {
+                Some(seq) if seq >= 0 => seq,
+                _ => return fail_args("after_seq must be a non-negative integer"),
+            },
+        };
+        let max_events = match args.get("max_events") {
+            None | Some(Value::Null) => MAX_EVENTS,
+            Some(value) => match value.as_u64() {
+                Some(n) if n >= 1 => (n as usize).min(MAX_EVENTS),
+                _ => return fail_args("max_events must be an integer from 1 to 200"),
+            },
+        };
+        let mut client = self.state.client.lock().await;
+        let (events, cursor) = match collect_events(&mut client, chat, after_seq, max_events).await
+        {
+            Ok(result) => result,
+            Err(error) => return fail(error.to_string()),
+        };
+        let data = json!({
+            "events": events,
+            "events_cursor": cursor,
+        });
+        Ok(ToolOutput::text(format!("{} event(s)", events.len())).with_data(data))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chat_steer
+// ---------------------------------------------------------------------------
+
+struct ChatSteerTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_steer_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_steer".into(),
+        description: "Steer the in-flight turn with more user text.".into(),
+        input_schema: object_schema(
+            json!({
+                "chat_id": chat_id_property(),
+                "text": {
+                    "type": "string",
+                    "description": "User text to inject into the active turn.",
+                },
+            }),
+            &["chat_id", "text"],
+        ),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatSteerTool {
+    fn spec(&self) -> ToolSpec {
+        chat_steer_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let chat = match required_chat_id(&args) {
+            Ok(chat) => chat,
+            Err(output) => return Ok(output),
+        };
+        let Some(text) = args.get("text").and_then(Value::as_str) else {
+            return fail_args("text is required");
+        };
+        let follow = self.state.follows.lock().await.get(&chat).cloned();
+        let Some(follow) = follow else {
+            return fail(format!("no in-flight turn for chat {chat}"));
+        };
+        let client = self.state.client.lock().await;
+        if let Err(error) = client
+            .steer(chat, follow.turn_id, TurnId::new(), text)
+            .await
+        {
+            return fail(error.to_string());
+        }
+        Ok(ToolOutput::text("steered").with_data(json!({ "ok": true })))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chat_cancel
+// ---------------------------------------------------------------------------
+
+struct ChatCancelTool {
+    state: Arc<AgentMcp>,
+}
+
+fn chat_cancel_spec() -> ToolSpec {
+    ToolSpec {
+        name: "chat_cancel".into(),
+        description: "Cancel the in-flight turn.".into(),
+        input_schema: object_schema(
+            json!({
+                "chat_id": chat_id_property(),
+            }),
+            &["chat_id"],
+        ),
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for ChatCancelTool {
+    fn spec(&self) -> ToolSpec {
+        chat_cancel_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let chat = match required_chat_id(&args) {
+            Ok(chat) => chat,
+            Err(output) => return Ok(output),
+        };
+        let follow = self.state.follows.lock().await.get(&chat).cloned();
+        let Some(follow) = follow else {
+            return fail(format!("no in-flight turn for chat {chat}"));
+        };
+        let client = self.state.client.lock().await;
+        if let Err(error) = client.cancel_turn(chat, follow.turn_id).await {
+            return fail(error.to_string());
+        }
+        Ok(ToolOutput::text("cancelled").with_data(json!({ "ok": true })))
+    }
+}

--- a/crates/tidebreak-cli/src/agent_mcp/follow.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/follow.rs
@@ -1,0 +1,558 @@
+//! Follow one chat turn over the event journal until it settles.
+//!
+//! Given a chat and a turn that has already been posted (or is already in
+//! flight), subscribe the events socket and watch until the turn completes,
+//! fails, cancels, parks on an interaction, or the caller's timeout elapses.
+//! A timeout returns [`TurnStatus::Running`]: the turn is durable on the
+//! server and the caller re-checks with `chat_wait` or `chat_status`.
+//!
+//! Reconnect and durable-transcript fallback come from [`crate::event_stream`],
+//! the same path print mode uses.
+
+use std::time::Duration;
+
+use serde_json::json;
+use tidebreak_core::{AgentError, CallId, ChatId, Result, TurnId, REQUEST_FOLDER_ACCESS_TOOL};
+
+use crate::api::client::{Client, DurableTurn, DurableTurnStatus};
+use crate::api::wire::ClientEvent;
+use crate::event_stream::{EventStream, StreamNext};
+use crate::print::protocol::Interaction;
+
+use super::{TurnResult, TurnStatus};
+
+/// Default `timeout_seconds` for `chat_run_turn` / `chat_wait` / `chat_decide`.
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// How often a folder-access watch asks whether the call has parked.
+const FOLDER_POLL: Duration = Duration::from_millis(100);
+
+/// Follow `turn_id` on `chat` until a settle point or `timeout`.
+///
+/// `after_seq` is the journal cursor to resume from (`0` to replay from the
+/// start). `assistant_text` is text already collected on an earlier follow of
+/// the same turn; new `TextDelta`s append. A terminal durable record short-
+/// circuits the socket.
+pub(crate) async fn follow_turn(
+    client: &mut Client,
+    chat: ChatId,
+    turn_id: TurnId,
+    after_seq: i64,
+    assistant_text: String,
+    timeout: Duration,
+) -> Result<TurnResult> {
+    if let Some(turn) = client.durable_turn(chat, turn_id).await? {
+        return Ok(from_durable(turn, assistant_text));
+    }
+    let mut stream = EventStream::open_after(client, chat, after_seq).await?;
+    follow_open_stream(
+        client,
+        &mut stream,
+        chat,
+        turn_id,
+        after_seq > 0,
+        assistant_text,
+        timeout,
+    )
+    .await
+}
+
+/// Follow an already-open socket. The caller subscribes before posting so the
+/// turn cannot start in a window this process is not watching.
+pub(crate) async fn follow_open_stream(
+    client: &mut Client,
+    stream: &mut EventStream,
+    chat: ChatId,
+    turn_id: TurnId,
+    mut ours: bool,
+    mut assistant_text: String,
+    timeout: Duration,
+) -> Result<TurnResult> {
+    let mut folder_watch: Option<CallId> = None;
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Ok(running(assistant_text, stream.last_seq()));
+        }
+
+        let frame = tokio::select! {
+            biased;
+            frame = stream.next(client, chat, turn_id) => frame?,
+            () = tokio::time::sleep(remaining) => {
+                return Ok(running(assistant_text, stream.last_seq()));
+            }
+            () = tokio::time::sleep(FOLDER_POLL), if folder_watch.is_some() => {
+                if let Some(call_id) = folder_watch {
+                    if folder_access_parked(client, chat, call_id).await? {
+                        return Ok(TurnResult {
+                            status: TurnStatus::NeedsHostConsent,
+                            assistant_text,
+                            pending: Some(json!({
+                                "type": "host_consent",
+                                "tool": REQUEST_FOLDER_ACCESS_TOOL,
+                                "call_id": call_id,
+                            })),
+                            events_cursor: stream.last_seq(),
+                        });
+                    }
+                }
+                continue;
+            }
+        };
+
+        let event = match frame {
+            StreamNext::Frame(_raw, event) => event,
+            StreamNext::Ignore => continue,
+            StreamNext::Durable(turn) => {
+                return Ok(from_durable(turn, assistant_text));
+            }
+        };
+
+        if !ours {
+            if !matches!(&event, ClientEvent::TurnStarted { turn_id: id } if *id == turn_id) {
+                continue;
+            }
+            ours = true;
+        }
+
+        match event {
+            ClientEvent::TextDelta { text } => assistant_text.push_str(&text),
+            ClientEvent::ToolCallStarted { call_id, name } => {
+                if name == REQUEST_FOLDER_ACCESS_TOOL {
+                    folder_watch = Some(call_id);
+                }
+            }
+            ClientEvent::ToolCallCompleted { call_id, .. } => {
+                if folder_watch == Some(call_id) {
+                    folder_watch = None;
+                }
+            }
+            ClientEvent::ApprovalRequired {
+                call_id,
+                action,
+                approval,
+                grant_rungs,
+                preview,
+                ..
+            } => {
+                return Ok(TurnResult {
+                    status: TurnStatus::NeedsApproval,
+                    assistant_text,
+                    pending: Some(pending_approval(
+                        call_id,
+                        action,
+                        approval,
+                        grant_rungs,
+                        preview,
+                    )),
+                    events_cursor: stream.last_seq(),
+                });
+            }
+            ClientEvent::PlanProposed { call_id } => {
+                if let Some(interaction) = pending_plan(client, chat, call_id).await? {
+                    return Ok(TurnResult {
+                        status: TurnStatus::NeedsPlanDecision,
+                        assistant_text,
+                        pending: Some(pending_from_interaction(&interaction)),
+                        events_cursor: stream.last_seq(),
+                    });
+                }
+            }
+            ClientEvent::UserQuestionsAsked { call_id } => {
+                if let Some(interaction) = pending_questions(client, chat, call_id).await? {
+                    return Ok(TurnResult {
+                        status: TurnStatus::NeedsAnswer,
+                        assistant_text,
+                        pending: Some(pending_from_interaction(&interaction)),
+                        events_cursor: stream.last_seq(),
+                    });
+                }
+            }
+            ClientEvent::TurnCompleted { .. } => {
+                return Ok(TurnResult {
+                    status: TurnStatus::Completed,
+                    assistant_text,
+                    pending: None,
+                    events_cursor: stream.last_seq(),
+                });
+            }
+            ClientEvent::TurnFailed { .. } | ClientEvent::TurnRefused { .. } => {
+                return Ok(TurnResult {
+                    status: TurnStatus::Failed,
+                    assistant_text,
+                    pending: None,
+                    events_cursor: stream.last_seq(),
+                });
+            }
+            ClientEvent::TurnCancelled { .. } => {
+                return Ok(TurnResult {
+                    status: TurnStatus::Cancelled,
+                    assistant_text,
+                    pending: None,
+                    events_cursor: stream.last_seq(),
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+fn running(assistant_text: String, events_cursor: i64) -> TurnResult {
+    TurnResult {
+        status: TurnStatus::Running,
+        assistant_text,
+        pending: None,
+        events_cursor,
+    }
+}
+
+fn from_durable(turn: DurableTurn, assistant_text: String) -> TurnResult {
+    let status = match turn.status {
+        DurableTurnStatus::Completed => TurnStatus::Completed,
+        DurableTurnStatus::Failed => TurnStatus::Failed,
+        DurableTurnStatus::Cancelled => TurnStatus::Cancelled,
+    };
+    let assistant_text = if turn.content.is_empty() {
+        assistant_text
+    } else {
+        turn.content
+    };
+    TurnResult {
+        status,
+        assistant_text,
+        pending: None,
+        events_cursor: turn.last_event_seq,
+    }
+}
+
+fn pending_approval(
+    call_id: CallId,
+    action: String,
+    approval: String,
+    grant_rungs: Vec<crate::api::wire::GrantRung>,
+    preview: Option<serde_json::Value>,
+) -> serde_json::Value {
+    json!({
+        "type": "approval",
+        "call_id": call_id,
+        "action": action,
+        "approval": approval,
+        "grant_rungs": grant_rungs,
+        "preview": preview,
+    })
+}
+
+fn pending_from_interaction(interaction: &Interaction) -> serde_json::Value {
+    match interaction {
+        Interaction::Approval {
+            call_id,
+            action,
+            approval,
+            grant_rungs,
+            preview,
+        } => pending_approval(
+            *call_id,
+            action.clone(),
+            approval.clone(),
+            grant_rungs.clone(),
+            preview.clone(),
+        ),
+        Interaction::Plan {
+            call_id,
+            title,
+            plan,
+        } => json!({
+            "type": "plan",
+            "call_id": call_id,
+            "title": title,
+            "plan": plan,
+        }),
+        Interaction::Questions { call_id, questions } => json!({
+            "type": "questions",
+            "call_id": call_id,
+            "questions": questions,
+        }),
+    }
+}
+
+async fn pending_plan(
+    client: &Client,
+    chat: ChatId,
+    call_id: Option<CallId>,
+) -> Result<Option<Interaction>> {
+    let pending = client.list_pending_plans(chat).await?;
+    Ok(pending
+        .into_iter()
+        .find(|plan| call_id.is_none_or(|id| plan.call_id == id))
+        .map(Interaction::from_plan))
+}
+
+async fn pending_questions(
+    client: &Client,
+    chat: ChatId,
+    call_id: Option<CallId>,
+) -> Result<Option<Interaction>> {
+    let pending = client.list_pending_questions(chat).await?;
+    Ok(pending
+        .into_iter()
+        .find(|block| call_id.is_none_or(|id| block.call_id == id))
+        .map(Interaction::from_questions))
+}
+
+async fn folder_access_parked(client: &Client, chat: ChatId, call_id: CallId) -> Result<bool> {
+    let pending = client.list_pending_folder_access(chat).await?;
+    let want = call_id.to_string();
+    Ok(pending.iter().any(|row| {
+        row.get("call_id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|id| id == want)
+    }))
+}
+
+/// Collect raw journal frames after `after_seq`, up to `max_events`.
+///
+/// Replay is drained, then a short idle ends the read so a live socket does
+/// not hang the tool. Failures to open the socket surface as errors; a socket
+/// that closes mid-read returns whatever was collected.
+pub(crate) async fn collect_events(
+    client: &mut Client,
+    chat: ChatId,
+    after_seq: i64,
+    max_events: usize,
+) -> Result<(Vec<serde_json::Value>, i64)> {
+    let transcript = client.chat_transcript(chat).await?;
+    let end = transcript
+        .get("last_event_seq")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+    if after_seq >= end || max_events == 0 {
+        return Ok((Vec::new(), after_seq.max(end)));
+    }
+    let mut stream = EventStream::open_after(client, chat, after_seq).await?;
+    let mut events = Vec::new();
+    let idle = Duration::from_secs(2);
+    loop {
+        if events.len() >= max_events || stream.last_seq() >= end {
+            break;
+        }
+        let raw = tokio::select! {
+            raw = stream.recv() => raw,
+            () = tokio::time::sleep(idle) => break,
+        };
+        let Some(raw) = raw else {
+            break;
+        };
+        match serde_json::from_str::<serde_json::Value>(&raw) {
+            Ok(value) if value.get("seq").is_some() => events.push(value),
+            Ok(_) => {}
+            Err(_) => events.push(json!({ "raw": raw })),
+        }
+        if stream.last_seq() >= end {
+            break;
+        }
+    }
+    Ok((events, stream.last_seq()))
+}
+
+/// Apply a print-protocol decision over HTTP. The caller follows afterwards.
+pub(crate) async fn apply_decision(
+    client: &Client,
+    chat: ChatId,
+    decision: &Decision,
+) -> Result<()> {
+    match decision {
+        Decision::Approval {
+            call_id,
+            approve,
+            reason,
+            grant,
+        } => {
+            client
+                .decide_approval(chat, *call_id, *approve, reason, *grant)
+                .await
+        }
+        Decision::Plan {
+            call_id,
+            accept,
+            feedback,
+            permission_mode,
+        } => {
+            client
+                .decide_plan(
+                    chat,
+                    *call_id,
+                    *accept,
+                    feedback.as_deref(),
+                    permission_mode.as_deref(),
+                )
+                .await
+        }
+        Decision::Questions { call_id, body } => {
+            client.answer_questions(chat, *call_id, body.clone()).await
+        }
+    }
+}
+
+/// A decision object as `chat_decide` accepts it.
+///
+/// Mirrors the print stdin protocol (`type` + `decision`/`answers`) and also
+/// the compact `{type:"approval", call_id, approve, feedback?}` shape.
+pub(crate) enum Decision {
+    Approval {
+        call_id: CallId,
+        approve: bool,
+        reason: String,
+        grant: Option<crate::api::wire::GrantRung>,
+    },
+    Plan {
+        call_id: CallId,
+        accept: bool,
+        feedback: Option<String>,
+        permission_mode: Option<String>,
+    },
+    Questions {
+        call_id: CallId,
+        body: serde_json::Value,
+    },
+}
+
+impl Decision {
+    pub(crate) fn parse(value: &serde_json::Value) -> std::result::Result<Self, String> {
+        let kind = value
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "decision must include type".to_owned())?;
+        let call_id = value
+            .get("call_id")
+            .ok_or_else(|| "decision must include call_id".to_owned())
+            .and_then(|id| {
+                serde_json::from_value::<CallId>(id.clone())
+                    .map_err(|error| format!("call_id is not a UUID: {error}"))
+            })?;
+        match kind {
+            "approval" => {
+                let approve = parse_approve(value)?;
+                let reason = value
+                    .get("feedback")
+                    .or_else(|| value.get("reason"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("rejected by the driver")
+                    .to_owned();
+                let grant = value
+                    .get("grant")
+                    .cloned()
+                    .filter(|grant| !grant.is_null())
+                    .map(serde_json::from_value)
+                    .transpose()
+                    .map_err(|error| format!("grant is not a known rung: {error}"))?;
+                Ok(Self::Approval {
+                    call_id,
+                    approve,
+                    reason,
+                    grant,
+                })
+            }
+            "plan" => {
+                let accept = parse_plan_accept(value)?;
+                let feedback = value
+                    .get("feedback")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned);
+                let permission_mode = value
+                    .get("permission_mode")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned);
+                Ok(Self::Plan {
+                    call_id,
+                    accept,
+                    feedback,
+                    permission_mode,
+                })
+            }
+            "questions" => {
+                let answers = value
+                    .get("answers")
+                    .cloned()
+                    .ok_or_else(|| "a questions decision must include answers".to_owned())?;
+                Ok(Self::Questions {
+                    call_id,
+                    body: json!({ "answers": answers }),
+                })
+            }
+            other => Err(format!("unknown decision type {other:?}")),
+        }
+    }
+}
+
+fn parse_approve(value: &serde_json::Value) -> std::result::Result<bool, String> {
+    if let Some(approve) = value.get("approve") {
+        return approve
+            .as_bool()
+            .ok_or_else(|| "approve must be a boolean".to_owned());
+    }
+    match value.get("decision").and_then(serde_json::Value::as_str) {
+        Some("approve") => Ok(true),
+        Some("reject") => Ok(false),
+        Some(other) => Err(format!(
+            "approval decision must be approve or reject, not {other:?}"
+        )),
+        None => Err("an approval decision needs approve or decision".to_owned()),
+    }
+}
+
+fn parse_plan_accept(value: &serde_json::Value) -> std::result::Result<bool, String> {
+    if let Some(accept) = value.get("accept") {
+        return accept
+            .as_bool()
+            .ok_or_else(|| "accept must be a boolean".to_owned());
+    }
+    match value.get("decision").and_then(serde_json::Value::as_str) {
+        Some("accept") => Ok(true),
+        Some("reject") => Ok(false),
+        Some(other) => Err(format!(
+            "plan decision must be accept or reject, not {other:?}"
+        )),
+        None => Err("a plan decision needs accept or decision".to_owned()),
+    }
+}
+
+/// Look up the turn a parked interaction belongs to when this process has not
+/// followed it yet.
+pub(crate) async fn turn_id_for_decision(
+    client: &Client,
+    chat: ChatId,
+    decision: &Decision,
+) -> Result<TurnId> {
+    let call_id = match decision {
+        Decision::Approval { call_id, .. }
+        | Decision::Plan { call_id, .. }
+        | Decision::Questions { call_id, .. } => *call_id,
+    };
+    let want = call_id.to_string();
+    let approvals = client.list_pending_approvals(chat).await?;
+    if let Some(row) = approvals.iter().find(|row| {
+        row.get("call_id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|id| id == want)
+    }) {
+        if let Some(turn_id) = row
+            .get("turn_id")
+            .and_then(|value| serde_json::from_value::<TurnId>(value.clone()).ok())
+        {
+            return Ok(turn_id);
+        }
+    }
+    let plans = client.list_pending_plans(chat).await?;
+    if let Some(plan) = plans.into_iter().find(|plan| plan.call_id == call_id) {
+        return Ok(plan.turn_id);
+    }
+    let questions = client.list_pending_questions(chat).await?;
+    if let Some(block) = questions.into_iter().find(|block| block.call_id == call_id) {
+        return Ok(block.turn_id);
+    }
+    Err(AgentError::msg(format!(
+        "no pending interaction named {call_id} on chat {chat}"
+    )))
+}

--- a/crates/tidebreak-cli/src/agent_mcp/mod.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/mod.rs
@@ -1,0 +1,152 @@
+//! `tidebreak agent-mcp` — a stdio MCP server that drives chat over attach.
+//!
+//! Possession of the server bearer is the authorization boundary. The registry
+//! is wired with [`AutoApproveGate`] so every tool is listed and callable; the
+//! *driven chat's* own approvals, plans, and questions are never auto-approved.
+//! Those park as interaction points and come back as `needs_approval` /
+//! `needs_plan_decision` / `needs_answer` for `chat_decide` to answer.
+//!
+//! Host folder consent is not drivable. A turn that parks on
+//! `request_folder_access` returns `needs_host_consent` with no decision path.
+//! Standing consent comes from `tidebreak folder connect` or the desktop.
+//!
+//! Later PRs add tool modules (settings, code mode) by adding a file and one
+//! [`register`] call in [`assemble_registry`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tidebreak_core::{AgentError, AutoApproveGate, ChatId, Result, ToolCtx, ToolRegistry, TurnId};
+use tokio::sync::Mutex;
+
+use crate::api::client::Client;
+use crate::connect;
+
+mod chat;
+pub(crate) mod follow;
+
+/// Per-chat follow cursor so `chat_wait` / `chat_decide` resume the same turn.
+#[derive(Debug, Clone)]
+struct FollowState {
+    turn_id: TurnId,
+    last_seq: i64,
+    assistant_text: String,
+}
+
+/// Shared process state for every mounted tool.
+struct AgentMcp {
+    client: Mutex<Client>,
+    follows: Mutex<HashMap<ChatId, FollowState>>,
+}
+
+/// Serve `tidebreak agent-mcp`: resolve the attach (or embed) endpoint, build
+/// the chat tool registry, and run MCP over stdio. stdout is JSON-RPC only.
+pub(crate) async fn run(server: connect::Server) -> Result<()> {
+    let session = connect::Session::open(&server).await?;
+    let state = Arc::new(AgentMcp {
+        client: Mutex::new(session.client().clone()),
+        follows: Mutex::new(HashMap::new()),
+    });
+
+    let tools = Arc::new(assemble_registry(state));
+    let ctx = ToolCtx::without_private_scratch(ChatId::new(), None);
+    let mcp =
+        tidebreak_mcp::McpServer::new(tools, ctx).with_approval_gate(Arc::new(AutoApproveGate));
+
+    let outcome = tidebreak_mcp::serve_stdio(mcp)
+        .await
+        .map_err(|error| AgentError::msg(format!("MCP stdio error: {error}")));
+    // Keep the embedded accept loop alive until stdio ends; dropping `session`
+    // earlier would abort an in-process server mid-call.
+    drop(session);
+    outcome
+}
+
+/// Assemble the MCP registry. Add a module and one `register` call here to
+/// grow the surface (settings, code mode) without touching the entry point.
+fn assemble_registry(state: Arc<AgentMcp>) -> ToolRegistry {
+    let mut tools = ToolRegistry::new();
+    chat::register(&mut tools, state);
+    tools
+}
+
+/// The run-turn / wait / decide return contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct TurnResult {
+    pub status: TurnStatus,
+    pub assistant_text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending: Option<serde_json::Value>,
+    pub events_cursor: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TurnStatus {
+    Completed,
+    NeedsApproval,
+    NeedsPlanDecision,
+    NeedsAnswer,
+    NeedsHostConsent,
+    Running,
+    Cancelled,
+    Failed,
+}
+
+impl TurnStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::NeedsApproval => "needs_approval",
+            Self::NeedsPlanDecision => "needs_plan_decision",
+            Self::NeedsAnswer => "needs_answer",
+            Self::NeedsHostConsent => "needs_host_consent",
+            Self::Running => "running",
+            Self::Cancelled => "cancelled",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_registered_tool_schema_is_valid_json_schema() {
+        let client = Client::attach("http://127.0.0.1:9".into(), "token").expect("client");
+        let registry = assemble_registry(Arc::new(AgentMcp {
+            client: Mutex::new(client),
+            follows: Mutex::new(HashMap::new()),
+        }));
+        let specs = registry.specs();
+        let names: Vec<&str> = specs.iter().map(|spec| spec.name.as_str()).collect();
+        assert_eq!(
+            names,
+            [
+                "chat_cancel",
+                "chat_create",
+                "chat_decide",
+                "chat_events",
+                "chat_list",
+                "chat_run_turn",
+                "chat_status",
+                "chat_steer",
+                "chat_wait",
+            ],
+            "an invalid schema is dropped from advertisement; names must stay complete"
+        );
+        for spec in &specs {
+            jsonschema::options()
+                .with_draft(jsonschema::Draft::Draft202012)
+                .build(&spec.input_schema)
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "{} input schema is not valid JSON Schema: {error}\n{}",
+                        spec.name, spec.input_schema
+                    )
+                });
+        }
+    }
+}

--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -136,12 +136,15 @@ impl Client {
             .map_err(|error| AgentError::msg(format!("invalid server token: {error}")))?;
         value.set_sensitive(true);
         headers.insert(reqwest::header::AUTHORIZATION, value);
-        let http = reqwest::Client::builder()
-            .default_headers(headers)
-            .build()
-            .map_err(|error| {
-                AgentError::msg(format!("could not build the HTTP client: {error}"))
-            })?;
+        let mut http = reqwest::Client::builder().default_headers(headers);
+        if loopback_http_base(&base) {
+            // Ambient HTTP_PROXY must not intercept loopback: a proxy that
+            // claims 127.0.0.1 black-holes `serve` and `--attach`.
+            http = http.no_proxy();
+        }
+        let http = http.build().map_err(|error| {
+            AgentError::msg(format!("could not build the HTTP client: {error}"))
+        })?;
         Ok(Self {
             http,
             base,
@@ -457,6 +460,30 @@ impl Client {
             .map_err(request_error)?;
         Self::expect_success(response).await?;
         Ok(())
+    }
+
+    /// Tool-call approvals awaiting a decision on this chat.
+    pub async fn list_pending_approvals(&self, chat: ChatId) -> Result<Vec<serde_json::Value>> {
+        self.get_json(format!("{}/chats/{chat}/approvals", self.base))
+            .await
+    }
+
+    /// Host-folder access requests awaiting operator consent on this chat.
+    ///
+    /// This is the renderer-facing pending set (bearer auth), not the native
+    /// executor's raw claim list. A call appears here only after it has parked.
+    pub async fn list_pending_folder_access(&self, chat: ChatId) -> Result<Vec<serde_json::Value>> {
+        self.get_json(format!(
+            "{}/chats/{chat}/client-executions/pending",
+            self.base
+        ))
+        .await
+    }
+
+    /// The durable transcript plus terminal turns and the journal watermark.
+    pub async fn chat_transcript(&self, chat: ChatId) -> Result<serde_json::Value> {
+        self.get_json(format!("{}/chats/{chat}/messages", self.base))
+            .await
     }
 
     /// Plans awaiting review on this chat.
@@ -1184,6 +1211,16 @@ impl Client {
             Err(error) => Err(ClientExecutionError::Failed(error)),
         }
     }
+}
+
+/// True when `base` names a loopback HTTP origin.
+fn loopback_http_base(base: &str) -> bool {
+    let rest = base
+        .strip_prefix("http://")
+        .or_else(|| base.strip_prefix("https://"))
+        .unwrap_or(base);
+    let host = rest.split(['/', ':']).next().unwrap_or(rest);
+    matches!(host, "127.0.0.1" | "localhost" | "[::1]" | "::1")
 }
 
 /// reqwest's `Display` already strips nothing for loopback URLs, but keep the

--- a/crates/tidebreak-cli/src/api/wire.rs
+++ b/crates/tidebreak-cli/src/api/wire.rs
@@ -293,7 +293,6 @@ pub struct AgentActivityItem {
 pub struct PendingPlan {
     pub call_id: CallId,
     /// The turn that proposed it; part of the wire contract, not rendered.
-    #[allow(dead_code)]
     pub turn_id: TurnId,
     pub title: String,
     pub plan: String,
@@ -305,7 +304,6 @@ pub struct PendingPlan {
 pub struct PendingQuestions {
     pub call_id: CallId,
     /// The turn that asked; part of the wire contract, not rendered.
-    #[allow(dead_code)]
     pub turn_id: TurnId,
     #[serde(default)]
     pub questions: Vec<UserQuestion>,

--- a/crates/tidebreak-cli/src/event_stream.rs
+++ b/crates/tidebreak-cli/src/event_stream.rs
@@ -1,0 +1,129 @@
+//! Shared chat event-socket follow: subscribe, reconnect, durable fallback.
+//!
+//! Print mode and `agent-mcp` both watch one turn over `/chats/{id}/events`.
+//! The reconnect ladder and the durable-transcript fallback live here so those
+//! surfaces stay in lockstep; each caller decides what a frame *means*.
+
+use futures::StreamExt as _;
+use tidebreak_core::{AgentError, ChatId, Result, TurnId};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::api::client::{Client, DurableTurn, EventSocket};
+use crate::api::wire::{ChatFrame, ClientEvent};
+
+/// Attempts to re-open the event socket after it closes mid-turn before giving
+/// up. The retries cover a transient hiccup — an accept-loop stumble when the
+/// server is in-process, a dropped connection when it is not.
+pub(crate) const RECONNECT_DELAYS: [std::time::Duration; 8] = [
+    std::time::Duration::from_millis(250),
+    std::time::Duration::from_millis(500),
+    std::time::Duration::from_secs(1),
+    std::time::Duration::from_secs(2),
+    std::time::Duration::from_secs(4),
+    std::time::Duration::from_secs(5),
+    std::time::Duration::from_secs(6),
+    std::time::Duration::from_secs(6),
+];
+
+/// The event socket plus the cursor a reconnect resumes from.
+pub(crate) struct EventStream {
+    socket: EventSocket,
+    last_seq: i64,
+}
+
+pub(crate) enum StreamNext {
+    Frame(String, ClientEvent),
+    Durable(DurableTurn),
+    Ignore,
+}
+
+impl EventStream {
+    pub(crate) async fn open(client: &Client, chat: ChatId) -> Result<Self> {
+        Self::open_after(client, chat, 0).await
+    }
+
+    pub(crate) async fn open_after(client: &Client, chat: ChatId, after: i64) -> Result<Self> {
+        Ok(Self {
+            socket: client.open_events(chat, after).await?,
+            last_seq: after,
+        })
+    }
+
+    pub(crate) fn last_seq(&self) -> i64 {
+        self.last_seq
+    }
+
+    /// One journaled frame, or `None` if the socket closed or produced a
+    /// non-text payload. Does not reconnect — callers that are draining a
+    /// replay (not following a live turn) stop here rather than climbing the
+    /// reconnect ladder.
+    pub(crate) async fn recv(&mut self) -> Option<String> {
+        match self.socket.next().await {
+            Some(Ok(Message::Text(text))) => {
+                if let Ok(ChatFrame::Event(frame)) = serde_json::from_str::<ChatFrame>(&text) {
+                    self.last_seq = frame.seq;
+                }
+                Some(text.to_string())
+            }
+            _ => None,
+        }
+    }
+
+    /// The next journaled frame, a durable terminal fallback, or an ignorable
+    /// payload such as metadata, a ping, or undecodable text.
+    pub(crate) async fn next(
+        &mut self,
+        client: &mut Client,
+        chat: ChatId,
+        turn_id: TurnId,
+    ) -> Result<StreamNext> {
+        match self.socket.next().await {
+            Some(Ok(Message::Text(text))) => {
+                let Ok(ChatFrame::Event(frame)) = serde_json::from_str::<ChatFrame>(&text) else {
+                    return Ok(StreamNext::Ignore);
+                };
+                self.last_seq = frame.seq;
+                Ok(StreamNext::Frame(text.to_string(), frame.event))
+            }
+            Some(Ok(_)) => Ok(StreamNext::Ignore),
+            Some(Err(_)) | None => match self.reconnect(client, chat, turn_id).await? {
+                Some(turn) => Ok(StreamNext::Durable(turn)),
+                None => Ok(StreamNext::Ignore),
+            },
+        }
+    }
+
+    async fn reconnect(
+        &mut self,
+        client: &mut Client,
+        chat: ChatId,
+        turn_id: TurnId,
+    ) -> Result<Option<DurableTurn>> {
+        let mut last = None;
+        for delay in RECONNECT_DELAYS {
+            tokio::time::sleep(delay).await;
+            if let Err(error) = client.refresh_attach_endpoint() {
+                last = Some(error);
+                continue;
+            }
+            match client.open_events(chat, self.last_seq).await {
+                Ok(socket) => {
+                    self.socket = socket;
+                    return Ok(None);
+                }
+                Err(error) => last = Some(error),
+            }
+        }
+        if client.refresh_attach_endpoint().is_ok() {
+            match client.durable_turn(chat, turn_id).await {
+                Ok(Some(turn)) => return Ok(Some(turn)),
+                Ok(None) => {}
+                Err(error) => last = Some(error),
+            }
+        }
+        Err(AgentError::msg(format!(
+            "the event stream closed mid-turn and could not be reopened{}",
+            last.map(|error| format!(": {error}")).unwrap_or_default()
+        )))
+    }
+}

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -70,6 +70,11 @@
 //! stdio so any MCP-speaking host can observe and navigate browser sessions.
 //! See [`browser`].
 //!
+//! `tidebreak agent-mcp` serves chat-mode tools over MCP stdio so an external
+//! agent can drive a running Tidebreak over the attach contract. Unlike `mcp`
+//! and `browser-mcp` it accepts `--server` / `--attach`: it is a client, the
+//! same way `-p` is. See [`agent_mcp`].
+//!
 //! Every client command above embeds its own server by default. `--server
 //! <url>` (or `TIDEBREAK_SERVER_URL`) makes it a pure client of one that is
 //! already running instead, with the bearer token coming from
@@ -94,11 +99,13 @@ use tidebreak_core::{
     AgentError, ChatId, Config, ListDir, Profile, ReadFile, Result, ToolCtx, ToolRegistry, TurnId,
 };
 
+mod agent_mcp;
 mod api;
 mod browser;
 mod code;
 mod connect;
 mod diagnostics;
+mod event_stream;
 mod folder;
 mod folder_executor;
 mod outputs;
@@ -175,6 +182,7 @@ usage: tidebreak serve
        tidebreak browser screenshot --browser-id <id> --snapshot-id <id> \
               --document-epoch <n> [--max-width <px>] [--max-height <px>] --json
        tidebreak browser-mcp
+       tidebreak agent-mcp
 
        tidebreak folder connect <path> --chat <id> [--output-format text|json]
        tidebreak folder list [--chat <id>] [--output-format text|json]
@@ -213,11 +221,11 @@ A key is read from stdin, or from the environment variable named by
 --from-env — never from an argument, which every process on the machine
 can read.
 
--p, output, attach, diagnostics, the setup commands, and the code family also take
---server <url> [--server-token-env <var>] or --attach, which talks to a
-server that is already running instead of embedding one. --attach reads
-{TIDEBREAK_DATA_DIR}/listen.json (written by serve and the desktop). With
---server the token comes from TIDEBREAK_SERVER_TOKEN, or from the named
+-p, output, attach, diagnostics, agent-mcp, the setup commands, and the code
+family also take --server <url> [--server-token-env <var>] or --attach, which
+talks to a server that is already running instead of embedding one. --attach
+reads {TIDEBREAK_DATA_DIR}/listen.json (written by serve and the desktop).
+With --server the token comes from TIDEBREAK_SERVER_TOKEN, or from the named
 variable; it is never an argument either. The folder commands do not take
 --server/--attach: they provision local host consent in this machine's own
 broker and product store, and they can run while serve or the desktop
@@ -453,6 +461,14 @@ async fn run() -> Result<i32> {
                 usage_error("browser-mcp accepts no arguments");
             }
             crate::browser::run_browser_mcp().await.map(|()| 0)
+        }
+        Some(command) if command == OsStr::new("agent-mcp") => {
+            if args.next().is_some() {
+                usage_error("agent-mcp accepts no arguments beyond --server/--attach");
+            }
+            crate::agent_mcp::run(server_flags.resolve()?)
+                .await
+                .map(|()| 0)
         }
         Some(command) if command == OsStr::new("code") => {
             match crate::code::parse(text_args(args)) {

--- a/crates/tidebreak-cli/src/print.rs
+++ b/crates/tidebreak-cli/src/print.rs
@@ -38,17 +38,14 @@ use std::collections::HashMap;
 use std::future::Future as _;
 use std::io::{IsTerminal as _, Write as _};
 
-use futures::StreamExt as _;
 use tidebreak_core::{
     AgentError, CallId, ChatId, RequestFolderAccessResult, Result, TurnId,
     REQUEST_FOLDER_ACCESS_TOOL,
 };
-use tokio_tungstenite::tungstenite::Message;
 
-use crate::api::client::{
-    Client, ClientExecutionOutcome, DurableTurn, DurableTurnStatus, EventSocket,
-};
-use crate::api::wire::{ChatFrame, ClientEvent, ToolCallStatus};
+use crate::api::client::{Client, ClientExecutionOutcome, DurableTurn, DurableTurnStatus};
+use crate::api::wire::{ClientEvent, ToolCallStatus};
+use crate::event_stream::{EventStream as Stream, StreamNext};
 
 mod driver;
 pub mod protocol;
@@ -67,20 +64,6 @@ const EXIT_DECISION_FAILED: i32 = 4;
 /// Exit status for interruption by SIGINT, following the shell's 128+signal
 /// convention.
 const EXIT_INTERRUPTED: i32 = 130;
-
-/// Attempts to re-open the event socket after it closes mid-turn before giving
-/// up. The retries cover a transient hiccup — an accept-loop stumble when the
-/// server is in-process, a dropped connection when it is not.
-const RECONNECT_DELAYS: [std::time::Duration; 8] = [
-    std::time::Duration::from_millis(250),
-    std::time::Duration::from_millis(500),
-    std::time::Duration::from_secs(1),
-    std::time::Duration::from_secs(2),
-    std::time::Duration::from_secs(4),
-    std::time::Duration::from_secs(5),
-    std::time::Duration::from_secs(6),
-    std::time::Duration::from_secs(6),
-];
 
 /// How often a folder refusal asks whether its call has become claimable, and
 /// the ceiling that interval backs off to.
@@ -894,85 +877,6 @@ async fn resolve_declined(
         Ok(()) => ResolveDeclined::Declined,
         Err(error) if error.is_conflict() => ResolveDeclined::HandledElsewhere,
         Err(error) => ResolveDeclined::Failed(error.into()),
-    }
-}
-
-/// The event socket plus the cursor a reconnect resumes from.
-struct Stream {
-    socket: EventSocket,
-    last_seq: i64,
-}
-
-enum StreamNext {
-    Frame(String, ClientEvent),
-    Durable(DurableTurn),
-    Ignore,
-}
-
-impl Stream {
-    async fn open(client: &Client, chat: ChatId) -> Result<Self> {
-        Ok(Self {
-            socket: client.open_events(chat, 0).await?,
-            last_seq: 0,
-        })
-    }
-
-    /// The next journaled frame, a durable terminal fallback, or an ignorable
-    /// payload such as metadata, a ping, or undecodable text.
-    async fn next(
-        &mut self,
-        client: &mut Client,
-        chat: ChatId,
-        turn_id: TurnId,
-    ) -> Result<StreamNext> {
-        match self.socket.next().await {
-            Some(Ok(Message::Text(text))) => {
-                let Ok(ChatFrame::Event(frame)) = serde_json::from_str::<ChatFrame>(&text) else {
-                    return Ok(StreamNext::Ignore);
-                };
-                self.last_seq = frame.seq;
-                Ok(StreamNext::Frame(text.to_string(), frame.event))
-            }
-            Some(Ok(_)) => Ok(StreamNext::Ignore),
-            Some(Err(_)) | None => match self.reconnect(client, chat, turn_id).await? {
-                Some(turn) => Ok(StreamNext::Durable(turn)),
-                None => Ok(StreamNext::Ignore),
-            },
-        }
-    }
-
-    async fn reconnect(
-        &mut self,
-        client: &mut Client,
-        chat: ChatId,
-        turn_id: TurnId,
-    ) -> Result<Option<DurableTurn>> {
-        let mut last = None;
-        for delay in RECONNECT_DELAYS {
-            tokio::time::sleep(delay).await;
-            if let Err(error) = client.refresh_attach_endpoint() {
-                last = Some(error);
-                continue;
-            }
-            match client.open_events(chat, self.last_seq).await {
-                Ok(socket) => {
-                    self.socket = socket;
-                    return Ok(None);
-                }
-                Err(error) => last = Some(error),
-            }
-        }
-        if client.refresh_attach_endpoint().is_ok() {
-            match client.durable_turn(chat, turn_id).await {
-                Ok(Some(turn)) => return Ok(Some(turn)),
-                Ok(None) => {}
-                Err(error) => last = Some(error),
-            }
-        }
-        Err(AgentError::msg(format!(
-            "the event stream closed mid-turn and could not be reopened{}",
-            last.map(|error| format!(": {error}")).unwrap_or_default()
-        )))
     }
 }
 

--- a/crates/tidebreak-cli/tests/agent_mcp.rs
+++ b/crates/tidebreak-cli/tests/agent_mcp.rs
@@ -1,0 +1,354 @@
+//! End-to-end tests of `tidebreak agent-mcp` over a real `tidebreak serve`.
+//!
+//! The child speaks MCP on stdio (initialize → initialized → tools/list →
+//! tools/call). The server is the production engine with the feature-gated
+//! scripted provider, so the attach contract is the real one.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+const TURN_TIMEOUT: Duration = Duration::from_secs(60);
+
+struct Reaper(Child);
+
+impl Drop for Reaper {
+    fn drop(&mut self) {
+        self.0.kill().ok();
+        self.0.wait().ok();
+    }
+}
+
+struct Mcp {
+    _reaper: Reaper,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Mcp {
+    fn connect(url: &str, token: &str, data_dir: &Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+            .args(["agent-mcp", "--server", url])
+            .env("TIDEBREAK_SERVER_TOKEN", token)
+            .env("TIDEBREAK_DATA_DIR", data_dir)
+            .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+            .env_remove("TIDEBREAK_SERVER_URL")
+            .env_remove("TIDEBREAK_MCP_CONFIG")
+            .env_remove("ANTHROPIC_API_KEY")
+            .env_remove("HTTP_PROXY")
+            .env_remove("HTTPS_PROXY")
+            .env_remove("http_proxy")
+            .env_remove("https_proxy")
+            .env_remove("ALL_PROXY")
+            .env_remove("all_proxy")
+            .env("NO_PROXY", "*")
+            .env("no_proxy", "*")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn tidebreak agent-mcp");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let stderr = child.stderr.take().expect("stderr");
+        std::thread::spawn(move || {
+            let mut sink = Vec::new();
+            let _ = BufReader::new(stderr).read_to_end(&mut sink);
+        });
+        let mut mcp = Self {
+            _reaper: Reaper(child),
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        mcp.handshake();
+        mcp
+    }
+
+    fn handshake(&mut self) {
+        let listed = self.rpc(
+            "initialize",
+            json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "agent-mcp-test", "version": "1"},
+            }),
+        );
+        assert!(
+            listed["result"]["capabilities"]["tools"].is_object(),
+            "initialize: {listed}"
+        );
+        self.notify("notifications/initialized", json!({}));
+        let tools = self.rpc("tools/list", json!({}));
+        let names: Vec<&str> = tools["result"]["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .map(|tool| tool["name"].as_str().expect("name"))
+            .collect();
+        for expected in [
+            "chat_create",
+            "chat_list",
+            "chat_status",
+            "chat_run_turn",
+            "chat_wait",
+            "chat_decide",
+            "chat_events",
+            "chat_steer",
+            "chat_cancel",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "missing {expected} in {names:?}\n{tools}"
+            );
+        }
+    }
+
+    fn notify(&mut self, method: &str, params: Value) {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        writeln!(self.stdin, "{line}").expect("write notify");
+        self.stdin.flush().expect("flush notify");
+    }
+
+    fn rpc(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let line = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        writeln!(self.stdin, "{line}").expect("write rpc");
+        self.stdin.flush().expect("flush rpc");
+        let started = Instant::now();
+        let mut response = String::new();
+        loop {
+            response.clear();
+            let n = self.stdout.read_line(&mut response).expect("read rpc");
+            assert!(n > 0, "agent-mcp closed stdout after {method}");
+            assert!(
+                started.elapsed() < TURN_TIMEOUT,
+                "timed out waiting for {method}: {response}"
+            );
+            let parsed: Value =
+                serde_json::from_str(&response).unwrap_or_else(|_| panic!("rpc line: {response}"));
+            if parsed.get("id") == Some(&json!(id)) {
+                return parsed;
+            }
+        }
+    }
+
+    fn call(&mut self, name: &str, arguments: Value) -> Value {
+        let response = self.rpc(
+            "tools/call",
+            json!({
+                "name": name,
+                "arguments": arguments,
+            }),
+        );
+        assert_eq!(
+            response["result"]["isError"], false,
+            "{name} failed: {response}"
+        );
+        response["result"]["structuredContent"].clone()
+    }
+}
+
+fn spawn_serve(dir: &Path, extra_env: &[(&str, &str)]) -> (Reaper, String, String) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_tidebreak"));
+    command
+        .arg("serve")
+        .env("TIDEBREAK_DATA_DIR", dir)
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_MCP_CONFIG")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("HTTP_PROXY")
+        .env_remove("HTTPS_PROXY")
+        .env_remove("http_proxy")
+        .env_remove("https_proxy")
+        .env_remove("ALL_PROXY")
+        .env_remove("all_proxy")
+        .env("NO_PROXY", "*")
+        .env("no_proxy", "*");
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    let mut child = command
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn tidebreak serve");
+    let stdout = child.stdout.take().unwrap();
+    let reaper = Reaper(child);
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+    let url = format!(
+        "http://{}",
+        addr_line.rsplit("http://").next().unwrap().trim()
+    );
+    let token = token_line
+        .strip_prefix("tidebreak: token ")
+        .expect("token line")
+        .trim()
+        .to_owned();
+    (reaper, url, token)
+}
+
+/// (a) chat_create then chat_run_turn to completion with assistant text.
+/// (c) chat_events returns frames after a cursor.
+#[test]
+fn create_run_and_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = json!([{"text": "hello from the script"}]).to_string();
+    let (_server, url, token) =
+        spawn_serve(dir.path(), &[("TIDEBREAK_SCRIPTED_PROVIDER", &script)]);
+    let mut mcp = Mcp::connect(&url, &token, dir.path());
+
+    let created = mcp.call("chat_create", json!({}));
+    let chat_id = created["chat_id"].as_str().expect("chat_id").to_owned();
+
+    let turn = mcp.call(
+        "chat_run_turn",
+        json!({
+            "chat_id": chat_id,
+            "prompt": "say hello",
+        }),
+    );
+    assert_eq!(turn["status"], "completed", "{turn}");
+    assert_eq!(turn["assistant_text"], "hello from the script", "{turn}");
+    let cursor = turn["events_cursor"].as_i64().expect("cursor");
+    assert!(cursor > 0, "{turn}");
+
+    let events = mcp.call(
+        "chat_events",
+        json!({
+            "chat_id": chat_id,
+            "after_seq": 0,
+        }),
+    );
+    let frames = events["events"].as_array().expect("events");
+    assert!(
+        frames.iter().any(|frame| {
+            frame.pointer("/event/type").and_then(Value::as_str) == Some("turn_completed")
+        }),
+        "{events}"
+    );
+    let mid = frames[0]["seq"].as_i64().expect("first seq");
+    let later = mcp.call(
+        "chat_events",
+        json!({
+            "chat_id": chat_id,
+            "after_seq": mid,
+            "max_events": 50,
+        }),
+    );
+    let later_frames = later["events"].as_array().expect("later events");
+    assert!(
+        later_frames
+            .iter()
+            .all(|frame| frame["seq"].as_i64().is_some_and(|seq| seq > mid)),
+        "{later}"
+    );
+    assert!(
+        later_frames.len() < frames.len(),
+        "after_seq must drop earlier frames: first={} later={}",
+        frames.len(),
+        later_frames.len()
+    );
+}
+
+/// (b) a scripted exec approval: chat_run_turn returns needs_approval with the
+/// call_id, chat_decide approve settles the turn.
+#[test]
+fn approval_then_decide() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = json!([
+        {
+            "tool": "exec",
+            "input": {"summary": "Run a command", "command": "true"}
+        },
+        {"text": "ran it"}
+    ])
+    .to_string();
+    let (_server, url, token) =
+        spawn_serve(dir.path(), &[("TIDEBREAK_SCRIPTED_PROVIDER", &script)]);
+    let mut mcp = Mcp::connect(&url, &token, dir.path());
+
+    let created = mcp.call("chat_create", json!({ "permission_mode": "ask" }));
+    let chat_id = created["chat_id"].as_str().expect("chat_id").to_owned();
+
+    let parked = mcp.call(
+        "chat_run_turn",
+        json!({
+            "chat_id": chat_id,
+            "prompt": "run the command",
+        }),
+    );
+    assert_eq!(parked["status"], "needs_approval", "{parked}");
+    let call_id = parked["pending"]["call_id"]
+        .as_str()
+        .expect("pending call_id")
+        .to_owned();
+
+    let settled = mcp.call(
+        "chat_decide",
+        json!({
+            "chat_id": chat_id,
+            "decision": {
+                "type": "approval",
+                "call_id": call_id,
+                "decision": "approve",
+            },
+        }),
+    );
+    assert_eq!(settled["status"], "completed", "{settled}");
+    assert_eq!(settled["assistant_text"], "ran it", "{settled}");
+}
+
+/// (d) a short timeout returns status running and a later chat_wait completes
+/// the same turn.
+#[test]
+fn short_timeout_then_wait() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = json!([{
+        "text": "later",
+        "delay_ms": 2500
+    }])
+    .to_string();
+    let (_server, url, token) =
+        spawn_serve(dir.path(), &[("TIDEBREAK_SCRIPTED_PROVIDER", &script)]);
+    let mut mcp = Mcp::connect(&url, &token, dir.path());
+
+    let created = mcp.call("chat_create", json!({}));
+    let chat_id = created["chat_id"].as_str().expect("chat_id").to_owned();
+
+    let running = mcp.call(
+        "chat_run_turn",
+        json!({
+            "chat_id": chat_id,
+            "prompt": "take your time",
+            "timeout_seconds": 1,
+        }),
+    );
+    assert_eq!(running["status"], "running", "{running}");
+
+    let finished = mcp.call(
+        "chat_wait",
+        json!({
+            "chat_id": chat_id,
+            "timeout_seconds": 15,
+        }),
+    );
+    assert_eq!(finished["status"], "completed", "{finished}");
+    assert_eq!(finished["assistant_text"], "later", "{finished}");
+}

--- a/crates/tidebreak-server/src/scripted_provider.rs
+++ b/crates/tidebreak-server/src/scripted_provider.rs
@@ -49,9 +49,17 @@ enum Step {
         tool: String,
         #[serde(default)]
         input: serde_json::Value,
+        /// Hold this completion before streaming the call, so a follower can
+        /// observe an in-flight turn.
+        #[serde(default)]
+        delay_ms: u64,
     },
     /// Answer with `text` and end the turn.
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(default)]
+        delay_ms: u64,
+    },
 }
 
 /// Replays [`Step`]s, one per completion.
@@ -68,8 +76,15 @@ impl ModelProvider for ScriptedProvider {
 
     async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let step = self.calls.fetch_add(1, Ordering::SeqCst);
+        let delay_ms = match self.steps.get(step) {
+            Some(Step::Tool { delay_ms, .. } | Step::Text { delay_ms, .. }) => *delay_ms,
+            None => 0,
+        };
+        if delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        }
         let events = match self.steps.get(step) {
-            Some(Step::Tool { tool, input }) => vec![
+            Some(Step::Tool { tool, input, .. }) => vec![
                 ProviderEvent::ToolCallStarted {
                     index: 0,
                     id: format!("scripted_{step}"),
@@ -83,7 +98,7 @@ impl ModelProvider for ScriptedProvider {
                     reason: StopReason::ToolUse,
                 },
             ],
-            Some(Step::Text { text }) => vec![
+            Some(Step::Text { text, .. }) => vec![
                 ProviderEvent::TextDelta { text: text.clone() },
                 ProviderEvent::Stop {
                     reason: StopReason::EndTurn,

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -48,6 +48,7 @@ tidebreak mcp-server add <name> (--command <cmd> [--arg <a>]… | --url <url>)
 tidebreak mcp-server remove <name>
 tidebreak chat list
 tidebreak chat create
+tidebreak agent-mcp
 
 tidebreak code doctor [--refresh]
 tidebreak code repo add <path> [--name <name>] [--base-ref <ref>] [--branch-prefix <p>]
@@ -78,7 +79,7 @@ tidebreak code watch [--once] [--timeout <secs>]
 
 A bare `tidebreak` with no arguments runs `serve`.
 
-`-p`, `output`, `attach`, the setup commands, and the code family additionally take
+`-p`, `output`, `attach`, `agent-mcp`, the setup commands, and the code family additionally take
 `--server <url>` / `--server-token-env <var>`, or `--attach` — see
 [Attaching to a running server](#attaching-to-a-running-server).
 Every `tidebreak code` command also accepts `--json` (one object, or NDJSON
@@ -348,6 +349,69 @@ It exposes `read_file` and `list_dir`, and only after a proper MCP initialize
 handshake. This is Tidebreak acting as an MCP *server* for some other client —
 it is unrelated to [connecting MCP servers to Tidebreak](/mcp-servers).
 
+### Agent MCP
+
+`tidebreak agent-mcp` is the other direction: an MCP *server* that lets an
+external agent drive **chat** on a Tidebreak that is already running. It is an
+attach client, the same way `-p` is — pass `--server` / `--attach` (and
+`TIDEBREAK_SERVER_TOKEN` or `TIDEBREAK_DATA_DIR` for `--attach`). `mcp` and
+`browser-mcp` refuse those flags; this command requires them in practice,
+because the tools talk to the attach contract, not to a workspace directory.
+
+```sh
+export TIDEBREAK_SERVER_TOKEN=<the token that server printed>
+cargo run -p tidebreak-cli -- agent-mcp --server http://127.0.0.1:53421
+```
+
+stdout is JSON-RPC only. Diagnostics go to stderr.
+
+The tools are schema-discoverable (`tools/list`). Reads are read-only;
+mutations are sensitive. Possession of the bearer is what authorizes calling
+them — the driven chat's own approvals are never auto-approved.
+
+| Tool | What it does |
+| --- | --- |
+| `chat_create` | Create a chat. Optional `model` and `permission_mode` (`plan`, `ask`, `auto`, `allow`). Returns `{chat_id}`. |
+| `chat_list` | Chat summaries. |
+| `chat_status` | Run state, a tail of recent messages, pending approvals / plans / questions. |
+| `chat_run_turn` | Post a prompt with a fresh turn id and follow until the turn settles, parks, or `timeout_seconds` (default 300) elapses. |
+| `chat_wait` | Re-follow an in-flight turn. Same return shape as `chat_run_turn`. |
+| `chat_decide` | Apply a print-protocol decision, then follow to the next settle point. |
+| `chat_events` | Raw journal frames after `after_seq`, at most `max_events` (capped at 200). |
+| `chat_steer` | Inject more user text into the in-flight turn. |
+| `chat_cancel` | Cancel the in-flight turn. |
+
+`chat_run_turn`, `chat_wait`, and `chat_decide` return the same object:
+
+```json
+{
+  "status": "completed",
+  "assistant_text": "…",
+  "pending": null,
+  "events_cursor": 42
+}
+```
+
+`status` is one of `completed`, `needs_approval`, `needs_plan_decision`,
+`needs_answer`, `needs_host_consent`, `running`, `cancelled`, `failed`.
+`running` means the timeout elapsed while the turn continues on the server —
+turns are durable — so you re-check with `chat_wait` or `chat_status`.
+
+The loop is run-turn, then decide, until `completed` (or `failed` /
+`cancelled`):
+
+```json
+{"type":"approval","call_id":"…","decision":"approve"}
+{"type":"plan","call_id":"…","decision":"accept","permission_mode":"auto"}
+{"type":"questions","call_id":"…","answers":[{"question_id":"target","selected_option_ids":["staging"]}]}
+```
+
+Those objects are the same ones `-p --output-format json` reads on stdin. Host
+folder consent is not in that vocabulary: if a turn parks on
+`request_folder_access`, status is `needs_host_consent` and there is no
+decision path. Standing consent still comes from `tidebreak folder connect`
+or the desktop.
+
 ### `rehome-secrets`
 
 macOS ties keychain approvals to a binary's code signature, so credentials
@@ -398,7 +462,7 @@ export TIDEBREAK_SERVER_TOKEN=<the token that server printed>
 cargo run -p tidebreak-cli -- --server http://127.0.0.1:53421 provider list
 ```
 
-`--server` / `--attach` work on `-p` and every setup command.
+`--server` / `--attach` work on `-p`, `agent-mcp`, and every setup command.
 `TIDEBREAK_SERVER_URL` sets the same thing as `--server` for a whole shell, and
 the flag wins over it. After the endpoint is resolved, an attached command
 writes no log file and touches no keychain — it is only an HTTP+WebSocket

--- a/docs/decisions/0071-agent-mcp-drives-chat-over-attach.md
+++ b/docs/decisions/0071-agent-mcp-drives-chat-over-attach.md
@@ -1,0 +1,114 @@
+# 71. Agent MCP drives chat over the attach contract
+
+- Status: Proposed
+- Date: 2026-08-26
+- Owners: cli
+- Related: [`0007-cli-headless-feature-parity.md`](0007-cli-headless-feature-parity.md),
+  [`0012-data-dir-listen-endpoint.md`](0012-data-dir-listen-endpoint.md),
+  [`0048-one-interaction-model.md`](0048-one-interaction-model.md),
+  [`docs-site/content/docs/headless.mdx`](../../docs-site/content/docs/headless.mdx)
+- Supersedes: none
+
+## Context
+
+Tidebreak already exposes chat as HTTP + WebSocket (the same attach contract
+`-p` and the desktop use) and already serves MCP over stdio (`tidebreak mcp`
+for filesystem tools, `tidebreak browser-mcp` for the browser). An external
+agent that wants to drive a running Tidebreak today has to reverse-engineer
+those routes: there is no OpenAPI document, the event journal is a WebSocket,
+and a turn parks on approvals, plans, and questions that a raw HTTP client has
+to notice and answer.
+
+`browser-mcp` is the pattern to copy: a `ToolRegistry` of tools whose
+`execute()` calls a loopback client, mounted into `tidebreak_mcp::McpServer`
+with an `AutoApproveGate`, served over stdio. Chat needs the same face, with
+one difference: it is an attach client like `-p`, so it accepts `--server` /
+`--attach` instead of refusing them.
+
+## Decision
+
+**1. Chat is driven through `tidebreak agent-mcp`, not by documenting raw HTTP.**
+The subcommand resolves the attach endpoint, builds `api::client::Client`,
+assembles a `ToolRegistry`, and serves MCP over stdio. stdout carries only
+JSON-RPC; diagnostics go to stderr. Later surfaces (settings, code mode) add a
+file and one registration call.
+
+MCP is the right face because any harness that already mounts MCP tools gets
+schema-discoverable operations without an OpenAPI document we do not publish,
+and because it reuses the `tidebreak-mcp` server face and the `browser-mcp`
+precedent rather than inventing a second protocol.
+
+**2. Bearer possession is the authorization boundary for the MCP tools.**
+The registry is wired with `AutoApproveGate`, so ReadOnly and Sensitive tools
+are listed and callable. That gate is *not* the driven chat's approval gate.
+Approvals, plans, and questions the model raises inside the chat are never
+auto-approved: they surface as interaction points on the run-turn contract.
+
+**3. `chat_run_turn`, `chat_wait`, and `chat_decide` share one return shape.**
+
+```json
+{
+  "status": "completed|needs_approval|needs_plan_decision|needs_answer|needs_host_consent|running|cancelled|failed",
+  "assistant_text": "…",
+  "pending": { "type": "approval", "call_id": "…" },
+  "events_cursor": 42
+}
+```
+
+`chat_run_turn` posts with a client-chosen idempotent `turn_id` after
+subscribing the events socket, then follows until a settle, a park, or the
+timeout. `running` means the timeout elapsed while the turn continues
+server-side (turns are durable); the caller re-checks with `chat_wait` or
+`chat_status`. `chat_decide` takes a print-protocol decision object, applies it
+over HTTP, and follows to the next settle point.
+
+**4. Host folder consent is not drivable.**
+If a turn parks on `request_folder_access`, the tools return
+`needs_host_consent` and offer no decision path. Standing folder consent comes
+only from `tidebreak folder connect` or the desktop. This matches print mode:
+the driving protocol's closed vocabulary is approval, plan, and questions.
+
+## Alternatives Considered
+
+**Document the HTTP + WebSocket routes and let harnesses call them.** There is
+no OpenAPI document, and there will not be one: the route table is the
+specification. Every harness would reimplement subscribe-before-post, the
+reconnect ladder, durable-turn reconciliation, and the interaction vocabulary.
+MCP tools carry those rules once.
+
+**Extend `tidebreak -p` instead of a long-lived MCP server.** Print mode is
+one turn and one process. An external agent that wants to create chats, run
+several turns, answer an approval, and inspect the journal needs a session,
+not a fresh argv each time.
+
+**Auto-approve the driven chat's tool calls from the MCP gate.** That would
+make `agent-mcp` a permission bypass. The MCP gate authorizes *calling our
+tools*; the chat's own approvals stay interaction points.
+
+**Let `chat_decide` grant `request_folder_access`.** Folder access is
+host-machine consent, not a chat decision. Print mode already refuses to treat
+it as an `Interaction`. Opening a grant path here would mint standing consent
+from a bearer token.
+
+## Consequences
+
+An MCP-speaking harness can drive chat on a running Tidebreak without learning
+the attach routes. The tool list will grow (settings, code mode) through the
+same registry. Callers must handle `running` and the three interaction
+statuses; a harness that only reads `completed` will stall on the first
+approval.
+
+Revisit if we publish a real OpenAPI surface, if folder consent gains a
+headless grant path that is not `tidebreak folder connect`, or if MCP itself
+is the wrong face for long-running follow.
+
+## Validation
+
+`crates/tidebreak-cli/tests/agent_mcp.rs` speaks MCP over the real binary
+against `tidebreak serve` with the scripted provider: a turn completes with
+assistant text; an exec approval returns `needs_approval` and `chat_decide`
+settles it; `chat_events` returns frames after a cursor; a short timeout
+returns `running` and `chat_wait` completes the same turn. A unit test
+compiles every registered `ToolSpec` input schema as JSON Schema. A plausible
+wrong implementation — auto-approving the parked exec, treating timeout as
+`failed`, or skipping the event cursor — fails those tests.


### PR DESCRIPTION
Add `tidebreak agent-mcp`, a stdio MCP server that lets you drive chat on a running Tidebreak over the attach contract.

You launch it with `--server` or `--attach`, the same flags `-p` takes. stdout carries only JSON-RPC; diagnostics go to stderr.

The tools are:

- `chat_create` `{model?, permission_mode?}` → `{chat_id}`
- `chat_list` → chat summaries
- `chat_status` `{chat_id}` → run state, recent messages, pending approvals/plans/questions
- `chat_run_turn` `{chat_id, prompt, timeout_seconds?}` → post a turn and follow it
- `chat_wait` `{chat_id, timeout_seconds?}` → re-follow an in-flight turn
- `chat_decide` `{chat_id, decision}` → apply a print-protocol decision and follow to the next settle
- `chat_events` `{chat_id, after_seq?, max_events?}` → raw journal frames (capped at 200)
- `chat_steer` `{chat_id, text}` and `chat_cancel` `{chat_id}`

`chat_run_turn`, `chat_wait`, and `chat_decide` return `{status, assistant_text, pending?, events_cursor}`. `status` is one of `completed`, `needs_approval`, `needs_plan_decision`, `needs_answer`, `needs_host_consent`, `running`, `cancelled`, `failed`. `running` means the timeout elapsed while the turn continues on the server; you re-check with `chat_wait` or `chat_status`.

The driven chat's own approvals are never auto-approved. Host folder consent is not drivable: if a turn parks on `request_folder_access`, you get `needs_host_consent` and no decision path. Standing consent still comes from `tidebreak folder connect` or the desktop.

Later tool modules (settings, code mode) register by adding a file and one call.

How it was tested: `cargo fmt --all`, `cargo clippy -p tidebreak-cli -p tidebreak-mcp --all-targets -- -D warnings`, a unit test that compiles every registered `ToolSpec` as JSON Schema, and e2e tests in `crates/tidebreak-cli/tests/agent_mcp.rs` that spawn `tidebreak serve` with the scripted provider and speak MCP over `agent-mcp` stdio — create then run to completion, exec approval then `chat_decide` approve, `chat_events` after a cursor, and a short timeout then `chat_wait`.