### PR TITLE
fix(code): recover browser state transitions

### DIFF
--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -1374,6 +1374,34 @@ impl BrowserRegistry {
         })
     }
 
+    /// Record a validated same-document URL change without advancing the
+    /// document epoch. The instance and epoch fence prevents a late observer
+    /// from writing into a replacement view or a later document.
+    pub(crate) fn same_document_navigation(
+        &self,
+        browser_id: &str,
+        workspace_id: &str,
+        instance_id: u64,
+        document_epoch: u64,
+        url: String,
+    ) -> Option<BrowserSnapshot> {
+        let mut state = self.lock();
+        {
+            let record = state.records.get_mut(browser_id)?;
+            if record.workspace_id != workspace_id
+                || record.instance_id != instance_id
+                || record.document_epoch != document_epoch
+                || record.url.as_deref() == Some(url.as_str())
+            {
+                return None;
+            }
+            record.url = Some(url);
+            record.load_state = BrowserLoadState::Ready;
+        }
+        let record = state.records.get(browser_id)?;
+        Some(record.snapshot(browser_id, agent_access_for_record(&state, record)))
+    }
+
     pub(crate) fn title_changed(
         &self,
         browser_id: &str,
@@ -2188,6 +2216,140 @@ mod tests {
         assert_eq!(first.document_epoch, Some(1));
         assert_eq!(first.load_state, Some(BrowserLoadState::Loading));
         assert_eq!(second.document_epoch, Some(2));
+    }
+
+    #[test]
+    fn same_document_navigation_updates_every_registry_projection_without_advancing_epoch() {
+        let registry = BrowserRegistry::default();
+        let instance = registry
+            .register(
+                "browser-1",
+                "workspace-1",
+                "https://example.com/".to_owned(),
+                true,
+            )
+            .unwrap();
+        let ready = registry
+            .page_started(
+                "browser-1",
+                "workspace-1",
+                instance,
+                "https://example.com/".to_owned(),
+            )
+            .and_then(|_| {
+                registry.page_finished(
+                    "browser-1",
+                    "workspace-1",
+                    instance,
+                    "https://example.com/".to_owned(),
+                )
+            })
+            .unwrap();
+        let epoch = ready.document_epoch.unwrap();
+        registry
+            .record_semantic_snapshot(
+                "browser-1",
+                "workspace-1",
+                epoch,
+                "snapshot-1".to_owned(),
+                HashMap::from([("@e1".to_owned(), target("Continue"))]),
+            )
+            .unwrap();
+        registry
+            .record_screenshot_epoch("browser-1", "workspace-1", epoch)
+            .unwrap();
+
+        for url in [
+            "https://example.com/?view=details",
+            "https://example.com/?view=replaced",
+            "https://example.com/?view=replaced#summary",
+            "https://example.com/?view=details",
+            "https://example.com/?view=replaced#summary",
+        ] {
+            let snapshot = registry
+                .same_document_navigation(
+                    "browser-1",
+                    "workspace-1",
+                    instance,
+                    epoch,
+                    url.to_owned(),
+                )
+                .unwrap();
+            assert_eq!(snapshot.url.as_deref(), Some(url));
+            assert_eq!(snapshot.document_epoch, Some(epoch));
+            assert_eq!(snapshot.load_state, Some(BrowserLoadState::Ready));
+            assert_eq!(
+                registry.list_for_workspace("workspace-1")[0].url.as_deref(),
+                Some(url)
+            );
+            registry
+                .validate_snapshot_id("browser-1", "workspace-1", "snapshot-1", epoch)
+                .expect("same-document navigation keeps semantic targets live");
+            assert_eq!(
+                registry
+                    .lock()
+                    .records
+                    .get("browser-1")
+                    .and_then(|record| record.screenshot_epoch),
+                Some(epoch)
+            );
+        }
+
+        registry
+            .page_started(
+                "browser-1",
+                "workspace-1",
+                instance,
+                "https://example.com/full-navigation".to_owned(),
+            )
+            .unwrap();
+        assert!(registry
+            .validate_snapshot_id("browser-1", "workspace-1", "snapshot-1", epoch)
+            .is_err());
+        assert_eq!(
+            registry
+                .lock()
+                .records
+                .get("browser-1")
+                .and_then(|record| record.screenshot_epoch),
+            None
+        );
+    }
+
+    #[test]
+    fn stale_same_document_observers_cannot_update_a_later_document() {
+        let (registry, instance) = ready_registry(true);
+        let epoch = registry
+            .snapshot("browser-1", "workspace-1")
+            .unwrap()
+            .document_epoch
+            .unwrap();
+        registry
+            .page_started(
+                "browser-1",
+                "workspace-1",
+                instance,
+                "https://example.com/full-navigation".to_owned(),
+            )
+            .unwrap();
+
+        assert!(registry
+            .same_document_navigation(
+                "browser-1",
+                "workspace-1",
+                instance,
+                epoch,
+                "https://example.com/stale".to_owned(),
+            )
+            .is_none());
+        assert_eq!(
+            registry
+                .snapshot("browser-1", "workspace-1")
+                .unwrap()
+                .url
+                .as_deref(),
+            Some("https://example.com/full-navigation")
+        );
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -2800,9 +2800,11 @@ mod tests {
         assert!(inspect.contains("const MAX_SCANNED_NODES = 5000"));
         assert!(inspect.contains("createTreeWalker(root, 1)"));
         assert!(inspect.contains("budget.nodes -= 1"));
-        assert!(inspect.contains("observed.win.addEventListener(\"scroll\""));
-        assert!(inspect.contains("observed.win.addEventListener(\"resize\""));
-        assert!(inspect.contains("state.listeners.push([observedDocument, \"fullscreenchange\"]"));
+        assert!(inspect.contains("target.addEventListener(type, schedule, true)"));
+        assert!(inspect.contains("state.listeners.push([target, type])"));
+        assert!(inspect.contains("listen(observed.win, \"scroll\")"));
+        assert!(inspect.contains("listen(observed.win, \"resize\")"));
+        assert!(inspect.contains("listen(observedDocument, \"fullscreenchange\")"));
         assert!(inspect.contains("target.removeEventListener(type, state.schedule, true)"));
         assert!(inspect.contains("addMask(entries, frameRect"));
         assert!(inspect.contains("Sensitive content · human takeover"));

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -166,6 +166,54 @@ struct RawTextProbe {
     uninspectable_regions: usize,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SameDocumentNavigationObservation {
+    pub(crate) sequence: u64,
+    pub(crate) url: String,
+}
+
+pub(crate) async fn browser_install_same_document_navigation_observer(
+    webview: &Webview,
+) -> Result<SameDocumentNavigationObservation, String> {
+    #[cfg(target_os = "macos")]
+    {
+        evaluate_json(webview, same_document_navigation_observer_script()).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        webview
+            .eval(same_document_navigation_observer_script())
+            .map_err(|error| format!("browser host: {error}"))?;
+        let url = webview
+            .url()
+            .map_err(|error| format!("browser host: {error}"))?;
+        Ok(SameDocumentNavigationObservation {
+            sequence: 0,
+            url: url.to_string(),
+        })
+    }
+}
+
+pub(crate) async fn browser_read_same_document_navigation_observer(
+    webview: &Webview,
+) -> Result<Option<SameDocumentNavigationObservation>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        evaluate_json(webview, same_document_navigation_observer_read_script()).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let url = webview
+            .url()
+            .map_err(|error| format!("browser host: {error}"))?;
+        Ok(Some(SameDocumentNavigationObservation {
+            sequence: 0,
+            url: url.to_string(),
+        }))
+    }
+}
+
 pub(crate) async fn browser_semantic_snapshot(
     app: &AppHandle,
     registry: &BrowserRegistry,
@@ -797,15 +845,34 @@ async fn evaluate_wait_condition(
 ) -> bool {
     use tidebreak_core::BrowserWaitCondition;
 
+    if let Some(satisfied) = registry_wait_condition(condition, snapshot, start_url) {
+        return satisfied;
+    }
+
     match condition {
-        BrowserWaitCondition::LoadState { state } => snapshot.load_state == Some(*state),
-        BrowserWaitCondition::UrlChanged => snapshot.url.as_deref() != start_url,
         BrowserWaitCondition::TextPresent { text } => {
             page_contains_text(webview, text).await.unwrap_or(false)
         }
         BrowserWaitCondition::TextAbsent { text } => {
             !page_contains_text(webview, text).await.unwrap_or(true)
         }
+        BrowserWaitCondition::LoadState { .. } | BrowserWaitCondition::UrlChanged => {
+            unreachable!("registry-only waits returned above")
+        }
+    }
+}
+
+fn registry_wait_condition(
+    condition: &tidebreak_core::BrowserWaitCondition,
+    snapshot: &BrowserSnapshot,
+    start_url: Option<&str>,
+) -> Option<bool> {
+    use tidebreak_core::BrowserWaitCondition;
+
+    match condition {
+        BrowserWaitCondition::LoadState { state } => Some(snapshot.load_state == Some(*state)),
+        BrowserWaitCondition::UrlChanged => Some(snapshot.url.as_deref() != start_url),
+        BrowserWaitCondition::TextPresent { .. } | BrowserWaitCondition::TextAbsent { .. } => None,
     }
 }
 
@@ -1356,6 +1423,14 @@ fn inspect_overlay_script() -> String {
     INSPECT_OVERLAY_SCRIPT.replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY)
 }
 
+fn same_document_navigation_observer_script() -> &'static str {
+    SAME_DOCUMENT_NAVIGATION_OBSERVER_SCRIPT
+}
+
+fn same_document_navigation_observer_read_script() -> &'static str {
+    SAME_DOCUMENT_NAVIGATION_OBSERVER_READ_SCRIPT
+}
+
 fn screenshot_privacy_script(watch_key: &str, finish: bool) -> Result<String, String> {
     let watch_key = serde_json::to_string(watch_key).map_err(|error| error.to_string())?;
     Ok(SCREENSHOT_PRIVACY_SCRIPT
@@ -1903,7 +1978,22 @@ const INSPECT_OVERLAY_SCRIPT: &str = r##"
     .slice(0, limit);
   __SENSITIVE_FIELD_POLICY__
 
-  const state = { cancelled: false, frame: null, host: null, observers: [], schedule: null };
+  const MAX_OVERLAY_ENTRIES = 500;
+  const MAX_OBSERVED_ROOTS = 64;
+  const MAX_SCANNED_NODES = 5000;
+  const OBSERVED_ATTRIBUTES = [
+    "aria-describedby", "aria-hidden", "aria-label", "aria-labelledby", "autocomplete",
+    "class", "contenteditable", "disabled", "hidden", "href", "id", "inputmode",
+    "name", "open", "placeholder", "readonly", "role", "style", "tabindex", "type",
+  ];
+  const state = {
+    cancelled: false,
+    frame: null,
+    host: null,
+    listeners: [],
+    observers: [],
+    schedule: null,
+  };
   window[STATE_KEY] = state;
 
   const isVisible = (element, win) => {
@@ -1931,42 +2021,58 @@ const INSPECT_OVERLAY_SCRIPT: &str = r##"
       ? "." + element.className.split(" ").filter(Boolean).slice(0, 2).join(".")
       : "");
   const addMask = (entries, rect, label = "Sensitive region · human takeover") => {
+    if (entries.length >= MAX_OVERLAY_ENTRIES) return;
     entries.push({ rect, sensitive: true, label });
   };
 
-  const scanRoot = (root, doc, win, offsetX, offsetY, entries, roots) => {
+  const scanRoot = (root, doc, win, offsetX, offsetY, entries, roots, budget) => {
+    if (
+      roots.length >= MAX_OBSERVED_ROOTS
+      || entries.length >= MAX_OVERLAY_ENTRIES
+      || budget.nodes <= 0
+    ) {
+      return true;
+    }
     roots.push({ root, win });
     let containsSensitive = false;
-    for (const element of root.querySelectorAll(FIELD_SELECTOR)) {
-      if (tidebreakIsSensitiveField(element, doc)) containsSensitive = true;
-    }
-    for (const element of root.querySelectorAll(INTERACTIVE_SELECTOR)) {
-      const sensitive = tidebreakIsSensitiveField(element, doc);
-      if (!isVisible(element, win)) continue;
-      entries.push({
-        rect: absoluteRect(element.getBoundingClientRect(), offsetX, offsetY),
-        sensitive,
-        label: sensitive ? "Sensitive field · human takeover" : ordinaryLabel(element),
-      });
-    }
+    const treeDocument = root.nodeType === 9 ? root : root.ownerDocument;
+    if (!treeDocument) return true;
+    const walker = treeDocument.createTreeWalker(root, 1);
+    while (walker.nextNode()) {
+      if (budget.nodes <= 0) return true;
+      budget.nodes -= 1;
+      const element = walker.currentNode;
+      if (element.matches?.(FIELD_SELECTOR) && tidebreakIsSensitiveField(element, doc)) {
+        containsSensitive = true;
+      }
+      if (element.matches?.(INTERACTIVE_SELECTOR)) {
+        if (entries.length >= MAX_OVERLAY_ENTRIES) return true;
+        const sensitive = tidebreakIsSensitiveField(element, doc);
+        if (isVisible(element, win)) {
+          entries.push({
+            rect: absoluteRect(element.getBoundingClientRect(), offsetX, offsetY),
+            sensitive,
+            label: sensitive ? "Sensitive field · human takeover" : ordinaryLabel(element),
+          });
+        }
+      }
 
-    for (const element of root.querySelectorAll("*")) {
       if (element.shadowRoot) {
-        const shadowEntries = [];
+        const entryStart = entries.length;
         const shadowSensitive = scanRoot(
           element.shadowRoot,
           doc,
           win,
           offsetX,
           offsetY,
-          shadowEntries,
+          entries,
           roots,
+          budget,
         );
         if (shadowSensitive) {
+          entries.splice(entryStart);
           addMask(entries, absoluteRect(element.getBoundingClientRect(), offsetX, offsetY));
           containsSensitive = true;
-        } else {
-          entries.push(...shadowEntries);
         }
       } else if (element.localName?.includes("-")) {
         if (isVisible(element, win)) {
@@ -1974,35 +2080,34 @@ const INSPECT_OVERLAY_SCRIPT: &str = r##"
         }
         containsSensitive = true;
       }
-    }
-
-    for (const frame of root.querySelectorAll("iframe")) {
-      const frameRect = absoluteRect(frame.getBoundingClientRect(), offsetX, offsetY);
-      try {
-        const childDoc = frame.contentDocument;
-        const childWin = frame.contentWindow;
-        if (!childDoc || !childWin) throw new Error("frame unavailable");
-        const childEntries = [];
-        const childSensitive = scanRoot(
-          childDoc,
-          childDoc,
-          childWin,
-          frameRect.left,
-          frameRect.top,
-          childEntries,
-          roots,
-        );
-        if (childSensitive) {
-          addMask(entries, frameRect);
+      if (element.localName === "iframe") {
+        const frameRect = absoluteRect(element.getBoundingClientRect(), offsetX, offsetY);
+        try {
+          const childDoc = element.contentDocument;
+          const childWin = element.contentWindow;
+          if (!childDoc || !childWin) throw new Error("frame unavailable");
+          const entryStart = entries.length;
+          const childSensitive = scanRoot(
+            childDoc,
+            childDoc,
+            childWin,
+            frameRect.left,
+            frameRect.top,
+            entries,
+            roots,
+            budget,
+          );
+          if (childSensitive) {
+            entries.splice(entryStart);
+            addMask(entries, frameRect);
+            containsSensitive = true;
+          }
+        } catch (_) {
+          if (isVisible(element, win)) {
+            addMask(entries, frameRect, "Uninspectable frame · human takeover");
+          }
           containsSensitive = true;
-        } else {
-          entries.push(...childEntries);
         }
-      } catch (_) {
-        if (isVisible(frame, win)) {
-          addMask(entries, frameRect, "Uninspectable frame · human takeover");
-        }
-        containsSensitive = true;
       }
     }
     return containsSensitive;
@@ -2061,7 +2166,17 @@ const INSPECT_OVERLAY_SCRIPT: &str = r##"
     if (state.cancelled) return;
     const entries = [];
     const roots = [];
-    const takeoverRequired = scanRoot(document, document, window, 0, 0, entries, roots);
+    const budget = { nodes: MAX_SCANNED_NODES };
+    const takeoverRequired = scanRoot(
+      document,
+      document,
+      window,
+      0,
+      0,
+      entries,
+      roots,
+      budget,
+    );
     if (takeoverRequired) {
       entries.splice(0, entries.length, {
         rect: { left: 0, top: 0, width: window.innerWidth, height: window.innerHeight },
@@ -2086,6 +2201,10 @@ const INSPECT_OVERLAY_SCRIPT: &str = r##"
 
     for (const observer of state.observers) observer.disconnect();
     state.observers = [];
+    for (const [target, type] of state.listeners) {
+      target.removeEventListener(type, schedule, true);
+    }
+    state.listeners = [];
     if (state.host?.isConnected) state.host.replaceWith(host);
     else document.documentElement.appendChild(host);
     if (typeof host.showPopover === "function") {
@@ -2094,21 +2213,34 @@ const INSPECT_OVERLAY_SCRIPT: &str = r##"
     }
     state.host = host;
 
+    const listen = (target, type) => {
+      if (state.listeners.some(([activeTarget, activeType]) => (
+        activeTarget === target && activeType === type
+      ))) return;
+      target.addEventListener(type, schedule, true);
+      state.listeners.push([target, type]);
+    };
     for (const observed of roots) {
-      const observer = new observed.win.MutationObserver(schedule);
+      const observer = new observed.win.MutationObserver(() => schedule());
       observer.observe(observed.root, {
         subtree: true,
         childList: true,
         characterData: true,
         attributes: true,
+        attributeFilter: OBSERVED_ATTRIBUTES,
       });
       state.observers.push(observer);
+      listen(observed.win, "scroll");
+      listen(observed.win, "resize");
+      const observedDocument = observed.root.nodeType === 9
+        ? observed.root
+        : observed.root.ownerDocument;
+      if (observedDocument) {
+        listen(observedDocument, "fullscreenchange");
+      }
     }
   };
 
-  window.addEventListener("scroll", schedule, true);
-  window.addEventListener("resize", schedule, true);
-  document.addEventListener("fullscreenchange", schedule, true);
   render();
   return "injected";
 })()
@@ -2121,9 +2253,9 @@ const REMOVE_INSPECT_OVERLAY_SCRIPT: &str = r#"
     state.cancelled = true;
     if (state.frame !== null) window.cancelAnimationFrame(state.frame);
     for (const observer of state.observers || []) observer.disconnect();
-    window.removeEventListener("scroll", state.schedule, true);
-    window.removeEventListener("resize", state.schedule, true);
-    document.removeEventListener("fullscreenchange", state.schedule, true);
+    for (const [target, type] of state.listeners || []) {
+      target.removeEventListener(type, state.schedule, true);
+    }
     state.host?.remove();
     delete window.__tidebreak_inspect_state__;
   }
@@ -2131,6 +2263,62 @@ const REMOVE_INSPECT_OVERLAY_SCRIPT: &str = r#"
   document.getElementById("__tidebreak_inspect_style__")?.remove();
   delete window.__tidebreak_highlight_inspect__;
   return "removed";
+})()
+"#;
+
+const SAME_DOCUMENT_NAVIGATION_OBSERVER_SCRIPT: &str = r#"
+(() => {
+  const STATE_KEY = "__tidebreak_same_document_navigation__";
+  const active = window[STATE_KEY];
+  if (active && !active.cancelled) {
+    active.capture("reconcile");
+    return JSON.stringify({ sequence: active.sequence, url: active.url });
+  }
+
+  const state = {
+    cancelled: false,
+    interval: null,
+    sequence: 0,
+    url: String(location.href),
+    capture: null,
+  };
+  const capture = () => {
+    if (state.cancelled) return;
+    const next = String(location.href);
+    if (next === state.url) return;
+    state.url = next;
+    state.sequence += 1;
+  };
+  state.capture = capture;
+
+  for (const method of ["pushState", "replaceState"]) {
+    const original = history[method].bind(history);
+    history[method] = (...args) => {
+      const result = original(...args);
+      capture(method);
+      return result;
+    };
+  }
+  addEventListener("popstate", capture, true);
+  addEventListener("hashchange", capture, true);
+  state.interval = setInterval(capture, 100);
+  addEventListener("pagehide", () => {
+    state.cancelled = true;
+    clearInterval(state.interval);
+    removeEventListener("popstate", capture, true);
+    removeEventListener("hashchange", capture, true);
+  }, { once: true });
+  window[STATE_KEY] = state;
+  return JSON.stringify({ sequence: state.sequence, url: state.url });
+})()
+"#;
+
+const SAME_DOCUMENT_NAVIGATION_OBSERVER_READ_SCRIPT: &str = r#"
+(() => {
+  const state = window.__tidebreak_same_document_navigation__;
+  if (!state || state.cancelled) return "null";
+  state.capture("native_read");
+  return JSON.stringify({ sequence: state.sequence, url: state.url });
 })()
 "#;
 
@@ -2557,6 +2745,36 @@ mod tests {
     }
 
     #[test]
+    fn same_document_navigation_observer_covers_history_and_location_events() {
+        let script = same_document_navigation_observer_script();
+        assert!(script.contains("[\"pushState\", \"replaceState\"]"));
+        assert!(script.contains("addEventListener(\"popstate\""));
+        assert!(script.contains("addEventListener(\"hashchange\""));
+        assert!(script.contains("setInterval(capture, 100)"));
+        assert!(script.contains("clearInterval(state.interval)"));
+        assert!(!script.contains("__TAURI_INTERNALS__"));
+        assert!(!script.contains("window.ipc"));
+    }
+
+    #[test]
+    fn same_document_url_changes_satisfy_registry_waits_without_advancing_epoch() {
+        let mut snapshot = BrowserSnapshot::missing("browser-1", "workspace-1");
+        snapshot.url = Some("https://example.com/?view=details#summary".to_owned());
+        snapshot.load_state = Some(BrowserLoadState::Ready);
+        snapshot.document_epoch = Some(7);
+
+        assert_eq!(
+            registry_wait_condition(
+                &tidebreak_core::BrowserWaitCondition::UrlChanged,
+                &snapshot,
+                Some("https://example.com/"),
+            ),
+            Some(true)
+        );
+        assert_eq!(snapshot.document_epoch, Some(7));
+    }
+
+    #[test]
     fn sensitive_snapshot_nodes_hide_values_labels_and_actions() {
         let script = snapshot_script(25, "__marker");
         assert!(script.contains("const tidebreakTextWithoutFieldDescendants"));
@@ -2575,7 +2793,17 @@ mod tests {
         let screenshot = screenshot_privacy_script("__watch", false).unwrap();
         assert!(inspect.contains("attachShadow({ mode: \"closed\" })"));
         assert!(inspect.contains("window.requestAnimationFrame(() =>"));
-        assert!(inspect.contains("new observed.win.MutationObserver(schedule)"));
+        assert!(inspect.contains("new observed.win.MutationObserver(() => schedule())"));
+        assert!(inspect.contains("attributeFilter: OBSERVED_ATTRIBUTES"));
+        assert!(inspect.contains("const MAX_OVERLAY_ENTRIES = 500"));
+        assert!(inspect.contains("const MAX_OBSERVED_ROOTS = 64"));
+        assert!(inspect.contains("const MAX_SCANNED_NODES = 5000"));
+        assert!(inspect.contains("createTreeWalker(root, 1)"));
+        assert!(inspect.contains("budget.nodes -= 1"));
+        assert!(inspect.contains("observed.win.addEventListener(\"scroll\""));
+        assert!(inspect.contains("observed.win.addEventListener(\"resize\""));
+        assert!(inspect.contains("state.listeners.push([observedDocument, \"fullscreenchange\"]"));
+        assert!(inspect.contains("target.removeEventListener(type, state.schedule, true)"));
         assert!(inspect.contains("addMask(entries, frameRect"));
         assert!(inspect.contains("Sensitive content · human takeover"));
         assert!(screenshot.contains("tidebreakIsSensitiveField(element, doc)"));

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -2805,7 +2805,7 @@ mod tests {
         assert!(inspect.contains("listen(observed.win, \"scroll\")"));
         assert!(inspect.contains("listen(observed.win, \"resize\")"));
         assert!(inspect.contains("listen(observedDocument, \"fullscreenchange\")"));
-        assert!(inspect.contains("target.removeEventListener(type, state.schedule, true)"));
+        assert!(inspect.contains("target.removeEventListener(type, schedule, true)"));
         assert!(inspect.contains("addMask(entries, frameRect"));
         assert!(inspect.contains("Sensitive content · human takeover"));
         assert!(screenshot.contains("tidebreakIsSensitiveField(element, doc)"));

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -26,7 +26,10 @@ use crate::browser_control::{
     BrowserAgentAccess, BrowserController, BrowserDispatchEffect, BrowserLoadState,
     BrowserNavigationDecision, BrowserRegistry, BrowserSnapshot,
 };
-use crate::browser_semantics::{browser_inject_inspect_overlay, browser_remove_inspect_overlay};
+use crate::browser_semantics::{
+    browser_inject_inspect_overlay, browser_install_same_document_navigation_observer,
+    browser_read_same_document_navigation_observer, browser_remove_inspect_overlay,
+};
 
 const BROWSER_LABEL_PREFIX: &str = "code-browser-";
 const CODE_BROWSER_EVENT: &str = "code-browser:event";
@@ -35,6 +38,8 @@ const MAX_WORKSPACE_ID_CHARS: usize = 200;
 const MAX_BROWSER_URL_CHARS: usize = 8_192;
 const AGENT_NAVIGATION_START_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const AGENT_NAVIGATION_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
+const SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(100);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -175,13 +180,13 @@ pub(crate) async fn code_browser_command(
                 .await?;
                 registry.set_inspect(&request.browser_id, &request.workspace_id, true)?;
             } else {
-                let _ = browser_remove_inspect_overlay(
+                browser_remove_inspect_overlay(
                     &app,
                     &registry,
                     &request.browser_id,
                     &request.workspace_id,
                 )
-                .await;
+                .await?;
                 registry.set_inspect(&request.browser_id, &request.workspace_id, false)?;
             }
             registry.snapshot(&request.browser_id, &request.workspace_id)
@@ -191,13 +196,13 @@ pub(crate) async fn code_browser_command(
                 registry.remove(&request.browser_id, &request.workspace_id)?;
                 return Err("browser session is not open".to_owned());
             }
-            let _ = browser_remove_inspect_overlay(
+            browser_remove_inspect_overlay(
                 &app,
                 &registry,
                 &request.browser_id,
                 &request.workspace_id,
             )
-            .await;
+            .await?;
             registry.clear_inspect(&request.browser_id, &request.workspace_id)?;
             registry.snapshot(&request.browser_id, &request.workspace_id)
         }
@@ -509,7 +514,7 @@ fn create_browser(
             );
             NewWindowResponse::Deny
         })
-        .on_page_load(move |_webview, payload| {
+        .on_page_load(move |webview, payload| {
             let snapshot = match payload.event() {
                 PageLoadEvent::Started => load_registry.page_started(
                     &load_browser,
@@ -546,6 +551,19 @@ fn create_browser(
                     origin: None,
                 },
             );
+            if matches!(payload.event(), PageLoadEvent::Finished) {
+                if let Some(document_epoch) = snapshot.document_epoch {
+                    start_same_document_navigation_observer(
+                        load_main.clone(),
+                        load_registry.clone(),
+                        load_browser.clone(),
+                        load_workspace.clone(),
+                        instance_id,
+                        document_epoch,
+                        webview,
+                    );
+                }
+            }
         })
         .on_document_title_changed(move |webview, title| {
             let url = webview.url().ok().map(|url| url.to_string());
@@ -617,6 +635,98 @@ fn create_browser(
         }
     }
     registry.snapshot(browser_id, workspace_id)
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the observer fence keeps native view, workspace, and document identity explicit"
+)]
+fn start_same_document_navigation_observer(
+    main: Webview,
+    registry: BrowserRegistry,
+    browser_id: String,
+    workspace_id: String,
+    instance_id: u64,
+    document_epoch: u64,
+    webview: Webview,
+) {
+    tauri::async_runtime::spawn(async move {
+        let Ok(snapshot) = registry.snapshot(&browser_id, &workspace_id) else {
+            return;
+        };
+        if snapshot.document_epoch != Some(document_epoch) {
+            return;
+        }
+        let Some(expected_origin) = snapshot.url.as_deref().and_then(BrowserOrigin::from_url)
+        else {
+            return;
+        };
+        let renderer_url = main.url().ok();
+        let Ok(initial) = browser_install_same_document_navigation_observer(&webview).await else {
+            return;
+        };
+        let mut last_sequence = initial.sequence;
+        let mut interval = tokio::time::interval(SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+            let Ok(snapshot) = registry.snapshot(&browser_id, &workspace_id) else {
+                return;
+            };
+            if snapshot.document_epoch != Some(document_epoch) {
+                return;
+            }
+
+            let observation = match browser_read_same_document_navigation_observer(&webview).await {
+                Ok(Some(observation)) => observation,
+                Ok(None) => match browser_install_same_document_navigation_observer(&webview).await
+                {
+                    Ok(observation) => observation,
+                    Err(_) => return,
+                },
+                Err(_) => return,
+            };
+            if observation.sequence == last_sequence
+                && snapshot.url.as_deref() == Some(observation.url.as_str())
+            {
+                continue;
+            }
+            last_sequence = observation.sequence;
+            let Ok(url) = validated_same_document_url(
+                &observation.url,
+                renderer_url.as_ref(),
+                &expected_origin,
+            ) else {
+                continue;
+            };
+            let Some(snapshot) = registry.same_document_navigation(
+                &browser_id,
+                &workspace_id,
+                instance_id,
+                document_epoch,
+                url.to_string(),
+            ) else {
+                continue;
+            };
+            emit_event(
+                &main,
+                CodeBrowserEvent {
+                    workspace_id: workspace_id.clone(),
+                    browser_id: browser_id.clone(),
+                    kind: "same_document_navigation",
+                    url: snapshot.url,
+                    title: snapshot.title,
+                    message: None,
+                    load_state: snapshot.load_state,
+                    document_epoch: snapshot.document_epoch,
+                    controller: snapshot.controller,
+                    agent_access: snapshot.agent_access,
+                    origin: None,
+                },
+            );
+        }
+    });
 }
 
 async fn share_browser_with_agent(
@@ -794,6 +904,20 @@ fn validated_url(value: &str, renderer_url: Option<&Url>) -> Result<Url, String>
     Ok(url)
 }
 
+fn validated_same_document_url(
+    value: &str,
+    renderer_url: Option<&Url>,
+    expected_origin: &BrowserOrigin,
+) -> Result<Url, String> {
+    let url = validated_url(value, renderer_url)?;
+    let observed_origin = BrowserOrigin::from_url(url.as_str())
+        .ok_or_else(|| "browser same-document address has no HTTP origin".to_owned())?;
+    if &observed_origin != expected_origin {
+        return Err("browser same-document address changed origin".to_owned());
+    }
+    Ok(url)
+}
+
 fn same_app_origin(left: &Url, right: &Url) -> bool {
     if left.scheme() != right.scheme()
         || left.port_or_known_default() != right.port_or_known_default()
@@ -928,6 +1052,24 @@ mod tests {
         assert!(browser_label("").is_err());
         assert!(browser_label("has/slash").is_err());
         assert!(browser_label(&"a".repeat(MAX_BROWSER_ID_CHARS + 1)).is_err());
+    }
+
+    #[test]
+    fn same_document_observer_accepts_only_valid_urls_on_the_loaded_origin() {
+        let origin = BrowserOrigin::from_url("https://example.com/start").unwrap();
+        assert_eq!(
+            validated_same_document_url(
+                "https://example.com/next?view=details#summary",
+                None,
+                &origin,
+            )
+            .unwrap()
+            .as_str(),
+            "https://example.com/next?view=details#summary"
+        );
+        assert!(validated_same_document_url("not a url", None, &origin).is_err());
+        assert!(validated_same_document_url("javascript:alert(1)", None, &origin).is_err());
+        assert!(validated_same_document_url("https://other.example/", None, &origin).is_err());
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -662,10 +662,8 @@ fn start_same_document_navigation_observer(
             return;
         };
         let renderer_url = main.url().ok();
-        let Ok(initial) = browser_install_same_document_navigation_observer(&webview).await else {
-            return;
-        };
-        let mut last_sequence = initial.sequence;
+        let mut observer_installed = false;
+        let mut last_sequence = None;
         let mut interval = tokio::time::interval(SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -678,21 +676,33 @@ fn start_same_document_navigation_observer(
                 return;
             }
 
-            let observation = match browser_read_same_document_navigation_observer(&webview).await {
-                Ok(Some(observation)) => observation,
-                Ok(None) => match browser_install_same_document_navigation_observer(&webview).await
-                {
-                    Ok(observation) => observation,
-                    Err(_) => return,
-                },
-                Err(_) => return,
+            let observation = if observer_installed {
+                match browser_read_same_document_navigation_observer(&webview).await {
+                    Ok(Some(observation)) => Some(observation),
+                    Ok(None) | Err(_) => {
+                        observer_installed = false;
+                        None
+                    }
+                }
+            } else {
+                None
             };
-            if observation.sequence == last_sequence
+            let observation = match observation {
+                Some(observation) => observation,
+                None => match browser_install_same_document_navigation_observer(&webview).await {
+                    Ok(observation) => {
+                        observer_installed = true;
+                        observation
+                    }
+                    Err(_) => continue,
+                },
+            };
+            if last_sequence == Some(observation.sequence)
                 && snapshot.url.as_deref() == Some(observation.url.as_str())
             {
                 continue;
             }
-            last_sequence = observation.sequence;
+            last_sequence = Some(observation.sequence);
             let Ok(url) = validated_same_document_url(
                 &observation.url,
                 renderer_url.as_ref(),

--- a/crates/tidebreak-desktop/tests/browser-fixture/index.html
+++ b/crates/tidebreak-desktop/tests/browser-fixture/index.html
@@ -141,6 +141,12 @@
         <a href="/?view=details" data-route="details">SPA details</a>
         <a href="/redirect">Server redirect</a>
       </nav>
+      <div class="actions" aria-label="Same-document navigation controls">
+        <button id="replace-route" type="button">Replace route</button>
+        <button id="hash-route" type="button">Change hash</button>
+        <button id="route-back" type="button">Route back</button>
+        <button id="route-forward" type="button">Route forward</button>
+      </div>
       <p id="route-state" aria-live="polite">Route: home</p>
     </header>
 
@@ -308,7 +314,7 @@
 
       function renderRoute() {
         const view = new URL(location.href).searchParams.get("view") ?? "home";
-        routeState.textContent = `Route: ${view}`;
+        routeState.textContent = `Route: ${view}${location.hash}`;
       }
 
       document.querySelectorAll("[data-route]").forEach((link) => {
@@ -319,6 +325,20 @@
         });
       });
       addEventListener("popstate", renderRoute);
+      addEventListener("hashchange", renderRoute);
+      document.querySelector("#replace-route").addEventListener("click", () => {
+        history.replaceState({}, "", "/?view=replaced");
+        renderRoute();
+      });
+      document.querySelector("#hash-route").addEventListener("click", () => {
+        location.hash = location.hash === "#summary" ? "#details" : "#summary";
+      });
+      document.querySelector("#route-back").addEventListener("click", () => {
+        history.back();
+      });
+      document.querySelector("#route-forward").addEventListener("click", () => {
+        history.forward();
+      });
 
       document.querySelector("#add-item-form").addEventListener("submit", async (event) => {
         event.preventDefault();

--- a/crates/tidebreak-desktop/tests/browser-fixture/server.test.mjs
+++ b/crates/tidebreak-desktop/tests/browser-fixture/server.test.mjs
@@ -41,6 +41,18 @@ test("the primary page covers verification privacy and ordinary numeric controls
   assert.match(source, /name="search" inputmode="numeric"/);
 });
 
+test("the primary page exposes every same-document navigation sequence", async () => {
+  const source = await fetch(fixture.origin).then((response) => response.text());
+
+  assert.match(source, /history\.pushState\(\{\}, "", link\.href\)/);
+  assert.match(source, /history\.replaceState\(\{\}, "", "\/\?view=replaced"\)/);
+  assert.match(source, /location\.hash = location\.hash === "#summary"/);
+  assert.match(source, /addEventListener\("popstate", renderRoute\)/);
+  assert.match(source, /addEventListener\("hashchange", renderRoute\)/);
+  assert.match(source, /history\.back\(\)/);
+  assert.match(source, /history\.forward\(\)/);
+});
+
 test("the item API is deterministic and resettable", async () => {
   const initial = await fetch(`${fixture.origin}/api/items`).then((response) =>
     response.json(),

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -279,7 +279,7 @@ export function BrowserToolbar({
                 variant={inspectEnabled ? "secondary" : "ghost"}
                 size={compactToolbar ? "icon-xs" : "icon-sm"}
                 onClick={onToggleInspect}
-                aria-pressed={inspectEnabled || undefined}
+                aria-pressed={inspectEnabled}
                 aria-label={
                   inspectEnabled
                     ? "Hide inspect highlights"

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -451,6 +451,73 @@ describe("CodeBrowserTab", () => {
     );
   });
 
+  it("navigates to the newest address entered while native creation is in flight", async () => {
+    let releaseCreate: (() => void) | undefined;
+    const createGate = new Promise<void>((resolve) => {
+      releaseCreate = resolve;
+    });
+    const runtime = browserHost({ createGate });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/first"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(1),
+    );
+
+    const input = screen.getByRole("textbox", { name: "Address or search" });
+    await userEvent.clear(input);
+    await userEvent.type(input, "example.com/second{enter}");
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/first",
+        documentEpoch: 1,
+      });
+    });
+    expect(input).toHaveValue("example.com/second");
+    releaseCreate?.();
+
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: {
+          type: "navigate",
+          url: "https://example.com/second",
+        },
+      }),
+    );
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "create"),
+    ).toHaveLength(1);
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_started",
+        url: "https://example.com/second",
+        documentEpoch: 2,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/first",
+        documentEpoch: 1,
+      });
+    });
+    expect(input).toHaveValue("example.com/second");
+  });
+
   it.each([
     { label: "newly created", existing: false },
     { label: "restored", existing: true },

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -18,7 +18,10 @@ import type {
   BrowserHostSnapshot,
   CodeBrowserHost,
 } from "./browserHost";
-import { writeStoredBrowserSession } from "./browserPersistence";
+import {
+  readStoredBrowserSession,
+  writeStoredBrowserSession,
+} from "./browserPersistence";
 import { beginBrowserNavigation, createBrowserSession } from "./browserSession";
 import { CodeBrowserTab } from "./CodeBrowserTab";
 
@@ -59,8 +62,10 @@ function agentAccess(
 function browserHost(options?: {
   createGate?: Promise<void>;
   createError?: string;
+  createErrors?: Array<string | null>;
   existing?: boolean;
   snapshotGate?: Promise<void>;
+  actionErrors?: Partial<Record<BrowserHostAction["type"], string>>;
   runtime?: Partial<BrowserHostSnapshot>;
 }): {
   host: CodeBrowserHost;
@@ -69,6 +74,8 @@ function browserHost(options?: {
   openExternal: ReturnType<typeof vi.fn>;
 } {
   const calls: CommandCall[] = [];
+  let createAttempt = 0;
+  let inspectEnabled = options?.runtime?.inspectEnabled ?? false;
   let handler: ((event: BrowserHostEvent) => void) | null = null;
   const openExternal = vi.fn().mockResolvedValue(undefined);
   const host: CodeBrowserHost = {
@@ -79,36 +86,50 @@ function browserHost(options?: {
         handler = null;
       };
     }),
-    command: vi.fn(async (workspaceId, browserId, action) => {
-      calls.push({ workspaceId, browserId, action });
-      if (action.type === "snapshot") {
-        if (options?.snapshotGate) await options.snapshotGate;
-        return options?.existing
-          ? {
-              exists: true,
-              ...options.runtime,
-              workspaceId,
-              browserId,
-              url: "https://example.com/restored",
-              title: "Restored page",
-              loadState: "ready" as const,
-            }
-          : { exists: false, workspaceId, browserId };
-      }
-      if (action.type === "create" && options?.createError) {
-        throw new Error(options.createError);
-      }
-      if (action.type === "create" && options?.createGate) {
-        await options.createGate;
-      }
-      return {
-        exists: true,
-        ...options?.runtime,
-        workspaceId,
-        browserId,
-        url: "url" in action ? action.url : options?.runtime?.url,
-      } satisfies BrowserHostSnapshot;
-    }),
+    command: vi.fn(
+      async (
+        workspaceId: string,
+        browserId: string,
+        action: BrowserHostAction,
+      ) => {
+        calls.push({ workspaceId, browserId, action });
+        if (action.type === "snapshot") {
+          if (options?.snapshotGate) await options.snapshotGate;
+          return options?.existing
+            ? {
+                exists: true,
+                ...options.runtime,
+                workspaceId,
+                browserId,
+                url: "https://example.com/restored",
+                title: "Restored page",
+                loadState: "ready" as const,
+              }
+            : { exists: false, workspaceId, browserId };
+        }
+        const actionError = options?.actionErrors?.[action.type];
+        if (actionError) throw new Error(actionError);
+        if (action.type === "create") {
+          const createError =
+            options?.createErrors?.[createAttempt] ?? options?.createError;
+          createAttempt += 1;
+          if (createError) throw new Error(createError);
+        }
+        if (action.type === "create" && options?.createGate) {
+          await options.createGate;
+        }
+        if (action.type === "set_inspect") inspectEnabled = action.enabled;
+        if (action.type === "remove_inspect") inspectEnabled = false;
+        return {
+          exists: true,
+          ...options?.runtime,
+          workspaceId,
+          browserId,
+          inspectEnabled,
+          url: "url" in action ? action.url : options?.runtime?.url,
+        } satisfies BrowserHostSnapshot;
+      },
+    ),
     openExternal,
   };
   return {
@@ -209,6 +230,49 @@ describe("CodeBrowserTab", () => {
         action: { type: "back" },
       }),
     );
+  });
+
+  it("updates the toolbar and persisted session for same-document navigation", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(
+        true,
+      ),
+    );
+
+    for (const url of [
+      "https://example.com/?view=details",
+      "https://example.com/?view=replaced",
+      "https://example.com/?view=replaced#summary",
+      "https://example.com/?view=details",
+      "https://example.com/?view=replaced#summary",
+    ]) {
+      await act(async () => {
+        runtime.emit({
+          workspaceId: "workspace-1",
+          browserId: "browser-1",
+          type: "same_document_navigation",
+          url,
+          documentEpoch: 4,
+        });
+      });
+
+      expect(
+        screen.getByRole("textbox", { name: "Address or search" }),
+      ).toHaveValue(url.replace("https://", ""));
+      await waitFor(() =>
+        expect(readStoredBrowserSession("browser-1")?.url).toBe(url),
+      );
+    }
   });
 
   it("keeps invalid input in the omnibox and reports the precise error", async () => {
@@ -1011,6 +1075,95 @@ describe("CodeBrowserTab", () => {
     });
   });
 
+  it("creates exactly once after a zero-sized mount receives a nonzero measurement", async () => {
+    let width = 0;
+    const observerCallbacks: ResizeObserverCallback[] = [];
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      () => ({
+        x: 120,
+        y: 180,
+        width,
+        height: width === 0 ? 0 : 560,
+        top: 180,
+        right: 120 + width,
+        bottom: width === 0 ? 180 : 740,
+        left: 120,
+        toJSON: () => ({}),
+      }),
+    );
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          observerCallbacks.push(callback);
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.some(({ action }) => action.type === "snapshot"),
+      ).toBe(true),
+    );
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "create"),
+    ).toHaveLength(0);
+
+    width = 840;
+    const entry = {
+      target: document.body,
+      contentRect: {
+        width: 840,
+        height: 560,
+        top: 180,
+        left: 120,
+        right: 960,
+        bottom: 740,
+        x: 120,
+        y: 180,
+      },
+    } as unknown as ResizeObserverEntry;
+    await act(async () => {
+      for (const callback of observerCallbacks) {
+        callback([entry], {} as ResizeObserver);
+      }
+      await new Promise<void>((resolve) =>
+        window.requestAnimationFrame(() => resolve()),
+      );
+    });
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(1),
+    );
+
+    await act(async () => {
+      for (const callback of observerCallbacks) {
+        callback([entry], {} as ResizeObserver);
+      }
+      await new Promise<void>((resolve) =>
+        window.requestAnimationFrame(() => resolve()),
+      );
+    });
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "create"),
+    ).toHaveLength(1);
+    vi.unstubAllGlobals();
+  });
+
   it("renders a retryable failure without losing the requested address", async () => {
     const runtime = browserHost({ createError: "native view failed" });
     render(
@@ -1030,6 +1183,118 @@ describe("CodeBrowserTab", () => {
       screen.getByRole("textbox", { name: "Address or search" }),
     ).toHaveValue("example.com/docs");
     expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+  });
+
+  it("keeps the failure visible when toolbar Reload creation fails again", async () => {
+    const runtime = browserHost({
+      createErrors: ["native create failed", "native retry failed"],
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/docs"
+        host={runtime.host}
+      />,
+    );
+
+    expect(await screen.findByText("native create failed")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+
+    expect(await screen.findByText("native retry failed")).toBeVisible();
+    expect(screen.getByText("This page did not open")).toBeVisible();
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "create"),
+    ).toHaveLength(2);
+  });
+
+  it("recreates and reconciles a missing view through toolbar Reload", async () => {
+    const runtime = browserHost({
+      createErrors: ["native create failed", null],
+      runtime: {
+        engine: inspectEngine,
+        controller: {
+          kind: "agent",
+          label: "Review agent",
+          action: "Checking the recovered page",
+        },
+        agentAccess: agentAccess({
+          shared: true,
+          scope: "origin",
+          canObserve: true,
+          canControl: true,
+        }),
+      },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/docs"
+        host={runtime.host}
+      />,
+    );
+
+    expect(await screen.findByText("native create failed")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(2),
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      }),
+    );
+    expect(screen.queryByText("This page did not open")).toBeNull();
+    expect(
+      await screen.findByText("Review agent is using this tab"),
+    ).toBeVisible();
+    expect(screen.getByText("example.com shared")).toBeVisible();
+
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/docs",
+      });
+    });
+    expect(screen.getByRole("button", { name: "Reload" })).toBeEnabled();
+  });
+
+  it("uses native Reload when the browser view already exists", async () => {
+    const runtime = browserHost({ existing: true });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.some(({ action }) => action.type === "snapshot"),
+      ).toBe(true),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "reload" },
+      }),
+    );
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "create"),
+    ).toHaveLength(0);
   });
 
   it("does not create an iframe fallback outside the native desktop", async () => {
@@ -1687,6 +1952,62 @@ describe("BrowserToolbar inspect mode", () => {
     expect(
       screen.queryByRole("button", { name: "Inspect page elements" }),
     ).toBeNull();
+  });
+
+  it("keeps inspect disabled when native injection fails", async () => {
+    const runtime = browserHost({
+      existing: true,
+      actionErrors: { set_inspect: "inspect injection failed" },
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess(),
+        inspectEnabled: false,
+      },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+
+    const inspect = await screen.findByRole("button", {
+      name: "Inspect page elements",
+    });
+    await userEvent.click(inspect);
+
+    expect(await screen.findByText("inspect injection failed")).toBeVisible();
+    expect(inspect).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("keeps inspect enabled when native removal fails", async () => {
+    const runtime = browserHost({
+      existing: true,
+      actionErrors: { remove_inspect: "inspect removal failed" },
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess(),
+        inspectEnabled: true,
+      },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+
+    const inspect = await screen.findByRole("button", {
+      name: "Hide inspect highlights",
+    });
+    await userEvent.click(inspect);
+
+    expect(await screen.findByText("inspect removal failed")).toBeVisible();
+    expect(inspect).toHaveAttribute("aria-pressed", "true");
   });
 
   it("remains usable in compact toolbar layouts", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -113,6 +113,9 @@ function CodeBrowserTabSession({
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const mountedRef = useRef(true);
   const nativeReady = useRef(false);
+  const nativePresence = useRef<"unknown" | "missing" | "present">("unknown");
+  const nativeCreateInFlight = useRef<Promise<void> | null>(null);
+  const resizeCreateAttempted = useRef(false);
   const nativeHistoryAvailable = useRef(false);
   const lastNativeBounds = useRef<BrowserBounds | null>(null);
   const nativeRevealFrame = useRef<number | null>(null);
@@ -213,15 +216,7 @@ function CodeBrowserTabSession({
     nativeRevealFrame.current = frame;
   }, [browserId, cancelNativeReveal, host, workspaceId]);
 
-  /**
-   * Shared post-ready reconciliation for create and existing-view paths.
-   *
-   * Reads the live viewport-surface bounds (not a stale pre-await capture),
-   * applies them, then reveals the native surface through the existing
-   * cancellable one-animation-frame mechanism so an in-flight overlay
-   * handoff is never overpainted.  Hides immediately when the tab is
-   * unmounted or obscured.
-   */
+  /** Reconcile live bounds and visibility after a native view becomes ready. */
   const reconcileAfterNativeReady = useCallback(async () => {
     if (!mountedRef.current) {
       nativeReady.current = false;
@@ -263,6 +258,56 @@ function CodeBrowserTabSession({
     scheduleNativeReveal,
     workspaceId,
   ]);
+
+  const createAndReconcileNative = useCallback(
+    async (url: string): Promise<boolean> => {
+      if (!host.available()) return false;
+      if (nativeReady.current) {
+        await reconcileAfterNativeReady();
+        return true;
+      }
+      const pending = nativeCreateInFlight.current;
+      if (pending) {
+        await pending;
+        return nativeReady.current;
+      }
+      const bounds = readBrowserBounds(viewportSurfaceRef.current);
+      if (!bounds) return false;
+
+      resizeCreateAttempted.current = true;
+      const operation = (async () => {
+        try {
+          recordRuntime(
+            await host.command(workspaceId, browserId, {
+              type: "create",
+              url,
+              bounds,
+              visible: false,
+            }),
+          );
+          nativePresence.current = "present";
+          lastNativeBounds.current = bounds;
+          await reconcileAfterNativeReady();
+          nativeHistoryAvailable.current =
+            sessionRef.current.history.length <= 1;
+        } catch (error) {
+          nativeReady.current = false;
+          nativePresence.current = "missing";
+          throw error;
+        }
+      })();
+      nativeCreateInFlight.current = operation;
+      try {
+        await operation;
+        return true;
+      } finally {
+        if (nativeCreateInFlight.current === operation) {
+          nativeCreateInFlight.current = null;
+        }
+      }
+    },
+    [browserId, host, reconcileAfterNativeReady, recordRuntime, workspaceId],
+  );
 
   useEffect(() => {
     mountedRef.current = true;
@@ -371,8 +416,6 @@ function CodeBrowserTabSession({
       }
 
       if (!current.url) return;
-      const bounds = readBrowserBounds(viewportSurfaceRef.current);
-      if (!bounds) return;
 
       try {
         const snapshot = await host.command(workspaceId, browserId, {
@@ -389,6 +432,7 @@ function CodeBrowserTabSession({
         }
         recordRuntime(snapshot);
         if (snapshot.exists) {
+          nativePresence.current = "present";
           nativeReady.current = true;
           nativeHistoryAvailable.current = true;
           if (snapshot.url) {
@@ -404,17 +448,8 @@ function CodeBrowserTabSession({
           }
           await reconcileAfterNativeReady();
         } else {
-          recordRuntime(
-            await host.command(workspaceId, browserId, {
-              type: "create",
-              url: current.url,
-              bounds,
-              visible: false,
-            }),
-          );
-          lastNativeBounds.current = bounds;
-          await reconcileAfterNativeReady();
-          nativeHistoryAvailable.current = current.history.length <= 1;
+          nativePresence.current = "missing";
+          await createAndReconcileNative(current.url);
         }
       } catch (error) {
         if (!cancelled) {
@@ -441,6 +476,12 @@ function CodeBrowserTabSession({
           finishBrowserNavigation(current, event.url!),
         );
         setAddress(browserDisplayAddress(event.url));
+      } else if (event.type === "same_document_navigation" && event.url) {
+        updateSession((current) =>
+          observeBrowserNavigation(current, event.url!, "ready"),
+        );
+        setAddress(browserDisplayAddress(event.url));
+        setAddressError(null);
       } else if (event.type === "title_changed" && event.title) {
         updateSession((current) =>
           event.url && event.url !== current.url
@@ -505,6 +546,7 @@ function CodeBrowserTabSession({
     };
   }, [
     browserId,
+    createAndReconcileNative,
     host,
     recordRuntime,
     reconcileAfterNativeReady,
@@ -522,13 +564,40 @@ function CodeBrowserTabSession({
       frame = window.requestAnimationFrame(() => {
         frame = null;
         const bounds = readBrowserBounds(surface);
-        if (
-          !bounds ||
-          !nativeReady.current ||
-          sameBrowserBounds(lastNativeBounds.current, bounds)
-        ) {
+        if (!bounds) return;
+        if (!nativeReady.current) {
+          const url = sessionRef.current.url;
+          if (
+            nativePresence.current === "missing" &&
+            !resizeCreateAttempted.current &&
+            url
+          ) {
+            resizeCreateAttempted.current = true;
+            void createAndReconcileNative(url)
+              .then((created) => {
+                if (!created || !mountedRef.current) return;
+                updateSession((current) => ({
+                  ...current,
+                  loadState: "loading",
+                  error: null,
+                }));
+              })
+              .catch((error) => {
+                if (!mountedRef.current) return;
+                updateSession((current) =>
+                  failBrowserSession(
+                    current,
+                    friendlyErrorMessage(
+                      error,
+                      "Could not open the in-app browser",
+                    ),
+                  ),
+                );
+              });
+          }
           return;
         }
+        if (sameBrowserBounds(lastNativeBounds.current, bounds)) return;
         lastNativeBounds.current = bounds;
         void host
           .command(workspaceId, browserId, { type: "set_bounds", bounds })
@@ -549,7 +618,7 @@ function CodeBrowserTabSession({
       window.removeEventListener("resize", sync);
       if (frame !== null) window.cancelAnimationFrame(frame);
     };
-  }, [browserId, host, workspaceId]);
+  }, [browserId, createAndReconcileNative, host, updateSession, workspaceId]);
 
   useEffect(() => {
     if (!nativeReady.current || !host.available()) return;
@@ -594,19 +663,8 @@ function CodeBrowserTabSession({
         );
         return;
       }
-      const bounds = readBrowserBounds(viewportSurfaceRef.current);
-      if (!bounds) throw new Error("The browser surface is not ready");
-      recordRuntime(
-        await host.command(workspaceId, browserId, {
-          type: "create",
-          url: target.url,
-          bounds,
-          visible: false,
-        }),
-      );
-      lastNativeBounds.current = bounds;
-      await reconcileAfterNativeReady();
-      nativeHistoryAvailable.current = sessionRef.current.history.length <= 1;
+      const created = await createAndReconcileNative(target.url);
+      if (!created) throw new Error("The browser surface is not ready");
     } catch (error) {
       if (mountedRef.current) {
         updateSession((current) =>
@@ -680,12 +738,66 @@ function CodeBrowserTabSession({
 
   async function reload() {
     if (!session.url) return;
+    if (!nativeReady.current) {
+      await retryNativeCreate();
+      return;
+    }
     updateSession((current) => ({
       ...current,
       loadState: "loading",
       error: null,
     }));
     await runHostCommand("reload");
+  }
+
+  async function retryNativeCreate() {
+    const url = sessionRef.current.url;
+    if (!url || !host.available()) return;
+    try {
+      const created = await createAndReconcileNative(url);
+      if (!created) return;
+      updateSession((current) => ({
+        ...current,
+        loadState: "loading",
+        error: null,
+      }));
+    } catch (error) {
+      if (!mountedRef.current) return;
+      updateSession((current) =>
+        failBrowserSession(
+          current,
+          friendlyErrorMessage(error, "Could not open the in-app browser"),
+        ),
+      );
+    }
+  }
+
+  async function toggleInspect() {
+    if (!host.available() || !nativeReady.current) return;
+    const next = !sessionRef.current.inspectEnabled;
+    try {
+      recordRuntime(
+        await host.command(
+          workspaceId,
+          browserId,
+          next
+            ? { type: "set_inspect", enabled: true }
+            : { type: "remove_inspect" },
+        ),
+      );
+    } catch (error) {
+      updateSession((current) =>
+        setBrowserNotice(current, {
+          kind: "blocked",
+          message: friendlyErrorMessage(
+            error,
+            next
+              ? "Could not show inspect highlights"
+              : "Could not hide inspect highlights",
+          ),
+        }),
+      );
+    }
   }
 
   async function stop() {
@@ -768,15 +880,7 @@ function CodeBrowserTabSession({
         onOverlayOpenChange={setHistoryOpen}
         onAgentAccessOpenChange={setAgentAccessOpen}
         agentAccessOpen={agentAccessOpen}
-        onToggleInspect={() => {
-          const next = !session.inspectEnabled;
-          updateSession((current) => ({ ...current, inspectEnabled: next }));
-          void runHostAction(
-            next
-              ? { type: "set_inspect", enabled: true }
-              : { type: "remove_inspect" },
-          );
-        }}
+        onToggleInspect={() => void toggleInspect()}
         inspectEnabled={session.inspectEnabled}
         viewportControl={
           <BrowserViewportControl
@@ -819,7 +923,7 @@ function CodeBrowserTabSession({
             <BrowserFallback
               error={session.error}
               hasUrl={Boolean(session.url)}
-              onRetry={session.url ? () => void navigate() : undefined}
+              onRetry={session.url ? () => void retryNativeCreate() : undefined}
               onOpenExternal={
                 session.url ? () => void openExternal() : undefined
               }

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -115,6 +115,9 @@ function CodeBrowserTabSession({
   const nativeReady = useRef(false);
   const nativePresence = useRef<"unknown" | "missing" | "present">("unknown");
   const nativeCreateInFlight = useRef<Promise<void> | null>(null);
+  const nativeCreateRequestedUrl = useRef<string | null>(null);
+  const nativeExpectedNavigationUrl = useRef<string | null>(null);
+  const nativeDocumentEpoch = useRef(0);
   const resizeCreateAttempted = useRef(false);
   const nativeHistoryAvailable = useRef(false);
   const lastNativeBounds = useRef<BrowserBounds | null>(null);
@@ -169,6 +172,12 @@ function CodeBrowserTabSession({
         snapshot.workspaceId === workspaceId
       ) {
         setRuntime(snapshot);
+        if (snapshot.documentEpoch !== undefined) {
+          nativeDocumentEpoch.current = Math.max(
+            nativeDocumentEpoch.current,
+            snapshot.documentEpoch,
+          );
+        }
         if (snapshot.inspectEnabled !== undefined) {
           updateSession((current) => ({
             ...current,
@@ -266,8 +275,10 @@ function CodeBrowserTabSession({
         await reconcileAfterNativeReady();
         return true;
       }
+      nativeCreateRequestedUrl.current = url;
       const pending = nativeCreateInFlight.current;
       if (pending) {
+        nativeExpectedNavigationUrl.current = url;
         await pending;
         return nativeReady.current;
       }
@@ -293,7 +304,24 @@ function CodeBrowserTabSession({
         } catch (error) {
           nativeReady.current = false;
           nativePresence.current = "missing";
+          if (nativeExpectedNavigationUrl.current === url) {
+            nativeExpectedNavigationUrl.current = null;
+          }
           throw error;
+        }
+
+        let deliveredUrl = url;
+        while (mountedRef.current && nativeReady.current) {
+          const requestedUrl = nativeCreateRequestedUrl.current;
+          if (!requestedUrl || requestedUrl === deliveredUrl) break;
+          recordRuntime(
+            await host.command(workspaceId, browserId, {
+              type: "navigate",
+              url: requestedUrl,
+            }),
+          );
+          deliveredUrl = requestedUrl;
+          nativeHistoryAvailable.current = false;
         }
       })();
       nativeCreateInFlight.current = operation;
@@ -303,6 +331,7 @@ function CodeBrowserTabSession({
       } finally {
         if (nativeCreateInFlight.current === operation) {
           nativeCreateInFlight.current = null;
+          nativeCreateRequestedUrl.current = null;
         }
       }
     },
@@ -464,6 +493,29 @@ function CodeBrowserTabSession({
     }
 
     function handleHostEvent(event: BrowserHostEvent) {
+      if (
+        event.documentEpoch !== undefined &&
+        event.documentEpoch < nativeDocumentEpoch.current
+      ) {
+        return;
+      }
+      if (
+        (event.type === "navigation_started" ||
+          event.type === "navigation_finished") &&
+        event.url
+      ) {
+        const expectedUrl = nativeExpectedNavigationUrl.current;
+        if (expectedUrl && event.url !== expectedUrl) return;
+        if (event.url === expectedUrl) {
+          nativeExpectedNavigationUrl.current = null;
+        }
+      }
+      if (event.documentEpoch !== undefined) {
+        nativeDocumentEpoch.current = Math.max(
+          nativeDocumentEpoch.current,
+          event.documentEpoch,
+        );
+      }
       if (event.type === "navigation_started" && event.url) {
         updateSession((current) =>
           observeBrowserNavigation(current, event.url!, "loading"),
@@ -666,6 +718,9 @@ function CodeBrowserTabSession({
       const created = await createAndReconcileNative(target.url);
       if (!created) throw new Error("The browser surface is not ready");
     } catch (error) {
+      if (nativeExpectedNavigationUrl.current === target.url) {
+        nativeExpectedNavigationUrl.current = null;
+      }
       if (mountedRef.current) {
         updateSession((current) =>
           failBrowserSession(

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
@@ -96,6 +96,7 @@ export type BrowserHostEvent = {
   type:
     | "navigation_started"
     | "navigation_finished"
+    | "same_document_navigation"
     | "title_changed"
     | "popup_blocked"
     | "download_blocked"

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -35,6 +35,9 @@ type BrowserScenario =
   | "viewport-tablet"
   | "viewport-mobile"
   | "viewport-custom"
+  | "same-document"
+  | "inspect-enable-failure"
+  | "inspect-remove-failure"
   | "inspect-off"
   | "inspect-on";
 
@@ -148,12 +151,38 @@ function BrowserStory({
         : scenario === "failure"
           ? "failed"
           : "ready";
-  const session = browserSession(loadState);
+  const baseSession = browserSession(loadState);
+  const sameDocumentUrl =
+    "http://localhost:4173/review/browser?view=replaced#summary";
+  const session =
+    scenario === "same-document"
+      ? {
+          ...baseSession,
+          url: sameDocumentUrl,
+          address: "localhost:4173/review/browser?view=replaced#summary",
+          title: "Browser review — summary",
+          history: [
+            ...baseSession.history,
+            {
+              url: sameDocumentUrl,
+              title: "Browser review — summary",
+            },
+          ],
+          historyIndex: baseSession.history.length,
+        }
+      : baseSession;
   const [address, setAddress] = useState(session.address);
   const [viewportState, setViewportState] = useState<BrowserViewport>(
     viewport ?? { preset: "fit", customWidth: 1024 },
   );
-  const inspectEnabled = scenario === "inspect-on";
+  const inspectEnabled =
+    scenario === "inspect-on" || scenario === "inspect-remove-failure";
+  const inspectFailure =
+    scenario === "inspect-enable-failure"
+      ? "Could not show inspect highlights"
+      : scenario === "inspect-remove-failure"
+        ? "Could not hide inspect highlights"
+        : null;
   const controller =
     scenario === "agent"
       ? activeAgent
@@ -244,6 +273,13 @@ function BrowserStory({
             message="Downloads stay blocked until Tidebreak has a bounded destination"
             actionLabel="Open externally"
             onAction={fn()}
+            onDismiss={fn()}
+          />
+        )}
+        {inspectFailure && (
+          <BrowserNoticeRow
+            tone="critical"
+            message={inspectFailure}
             onDismiss={fn()}
           />
         )}
@@ -552,7 +588,16 @@ export const HumanTakeoverRequired: Story = { args: { scenario: "takeover" } };
 
 export const SlowPage: Story = { args: { scenario: "slow" } };
 
-export const Failure: Story = { args: { scenario: "failure" } };
+export const Failure: Story = {
+  args: { scenario: "failure" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", { name: "Reload" })).toBeVisible();
+    await expect(
+      canvas.getByRole("button", { name: "Try again" }),
+    ).toBeVisible();
+  },
+};
 
 export const PopupBlocked: Story = { args: { scenario: "popup" } };
 
@@ -664,6 +709,42 @@ export const InspectOn: Story = {
     ).toBeVisible();
     const btn = canvas.getByRole("button", { name: "Hide inspect highlights" });
     await expect(btn).toHaveAttribute("aria-pressed", "true");
+  },
+};
+
+export const SameDocumentNavigation: Story = {
+  args: { scenario: "same-document" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("textbox", { name: "Address or search" }),
+    ).toHaveValue("localhost:4173/review/browser?view=replaced#summary");
+  },
+};
+
+export const InspectEnableFailure: Story = {
+  args: { scenario: "inspect-enable-failure" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("Could not show inspect highlights"),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole("button", { name: "Inspect page elements" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  },
+};
+
+export const InspectRemovalFailure: Story = {
+  args: { scenario: "inspect-remove-failure" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("Could not hide inspect highlights"),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole("button", { name: "Hide inspect highlights" }),
+    ).toHaveAttribute("aria-pressed", "true");
   },
 };
 


### PR DESCRIPTION
Fixes #2659

## Implementation

- Observe validated same-document navigation from `pushState`, `replaceState`, `popstate`, and `hashchange`, then update the registry, toolbar, persistence, list output, and `url_changed` waits without advancing the document epoch.
- Retry native browser creation through the shared create-and-reconcile path when Reload follows a creation failure. Keep the failure visible until creation succeeds.
- Commit inspect state only after native injection or removal succeeds. Keep overlays aligned after scroll, resize, fullscreen changes, and bounded DOM mutations.
- Let the first nonzero `ResizeObserver` measurement create the native browser exactly once.
- Add browser fixture, Rust, UI, and Storybook coverage for each recovery sequence.

## Compatibility

The host event addition is additive. Full-document navigation keeps the existing epoch and semantic-target retirement behavior. Existing browser sessions and persisted history remain compatible.

## Safety

The injected observer validates same-document URLs before emitting them. Native creation is serialized to prevent duplicate views. Mutation-driven overlay refreshes are bounded, and failed inspect operations leave the last confirmed state active.

## Validation

- Browser fixture: 15 tests passed.
- Browser UI suite: 88 tests passed.
- Focused browser Vitest suite: 40 tests passed.
- TypeScript `--noEmit` passed.
- Focused Biome format and lint checks passed.
- Storybook build passed.
- Direct `rustfmt --check` passed.
- `git diff --check` passed.
- Storybook states were captured and inspected at 1200px and 390px in supported light and dark themes.

No local Cargo build, check, Clippy, or test command was run.