### PR TITLE
feat(desktop): scroll and avatar the GitHub repo picker

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -1111,6 +1111,12 @@ describe("AddRepoPalette on a hosted machine that acts as the person", () => {
     expect(
       await screen.findByRole("option", { name: /mira-chen\/notes/ }),
     ).toBeInTheDocument();
+    const names = screen
+      .getAllByRole("option")
+      .map((option) => option.textContent ?? "");
+    expect(
+      names.findIndex((name) => /brightwave-inc\/tidebreak/.test(name)),
+    ).toBeLessThan(names.findIndex((name) => /mira-chen\/notes/.test(name)));
     await user.click(screen.getByRole("option", { name: /mira-chen\/notes/ }));
     expect(
       screen.getByRole("combobox", { name: "Repository" }),

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -49,6 +49,7 @@ import {
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { usesCommandModifier } from "@/ShellShortcuts";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { GithubAvatar } from "./GithubAvatar";
 import { useCodeUiStore } from "./CodeUiStore";
 import { STATUS_TEXT } from "./statusTone";
 import {
@@ -1342,13 +1343,15 @@ function GithubRepoField({
   const emptySuccess =
     !listFailed && listed.length === 0 && repositories !== null;
   const needle = query.trim().toLowerCase();
-  const matches = listed.filter((repository) => {
-    if (!needle) return true;
-    return (
-      repository.full_name.toLowerCase().includes(needle) ||
-      (repository.description ?? "").toLowerCase().includes(needle)
-    );
-  });
+  const matches = listed
+    .filter((repository) => {
+      if (!needle) return true;
+      return (
+        repository.full_name.toLowerCase().includes(needle) ||
+        (repository.description ?? "").toLowerCase().includes(needle)
+      );
+    })
+    .sort(compareGithubRepositories);
   const typed = query.trim();
   const typedIsNew =
     typed.includes("/") &&
@@ -1370,6 +1373,7 @@ function GithubRepoField({
         />
       ) : (
         <Popover
+          modal
           open={open}
           onOpenChange={(next) => {
             setOpen(next);
@@ -1389,22 +1393,38 @@ function GithubRepoField({
                 !value && "text-muted-foreground",
               )}
             >
-              <span className="truncate">{value || "Select a repository"}</span>
+              <span className="flex min-w-0 items-center gap-2">
+                {value && <GithubAvatar login={githubRepoOwner(value)} />}
+                <span className="truncate">
+                  {value || "Select a repository"}
+                </span>
+              </span>
               <ChevronDown className="size-4 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>
           <PopoverContent
             align="start"
-            className="w-[var(--radix-popover-trigger-width)] p-0"
+            collisionPadding={12}
+            className="w-[var(--radix-popover-trigger-width)] overflow-hidden p-0"
           >
-            <Command shouldFilter={false} label="Repositories">
+            <Command
+              shouldFilter={false}
+              label="Repositories"
+              className="h-auto"
+            >
               <CommandInput
                 value={query}
                 onValueChange={setQuery}
                 placeholder="Search or type owner/repo"
                 aria-label="Search repositories"
               />
-              <CommandList className="max-h-56">
+              <CommandList
+                className="max-h-64 overflow-y-auto overscroll-contain"
+                style={{
+                  maxHeight:
+                    "min(16rem, calc(var(--radix-popover-content-available-height, 100vh) - 3.25rem))",
+                }}
+              >
                 <CommandEmpty className="px-3 py-2 text-xs text-muted-foreground">
                   {listFailed
                     ? "Suggestions did not load. Type owner/repo to clone."
@@ -1421,6 +1441,7 @@ function GithubRepoField({
                         setOpen(false);
                       }}
                     >
+                      <GithubAvatar login={githubRepoOwner(typed)} />
                       <span className="truncate">{typed}</span>
                     </CommandItem>
                   </CommandGroup>
@@ -1436,6 +1457,9 @@ function GithubRepoField({
                           setOpen(false);
                         }}
                       >
+                        <GithubAvatar
+                          login={githubRepoOwner(repository.full_name)}
+                        />
                         <span className="flex min-w-0 flex-col">
                           <span className="truncate">
                             {repository.full_name}
@@ -1698,6 +1722,28 @@ function ProbeFailure({
         {busy ? "Retrying…" : action}
       </Button>
     </div>
+  );
+}
+
+function githubRepoOwner(fullName: string): string | undefined {
+  const owner = fullName.split("/")[0]?.trim();
+  return owner || undefined;
+}
+
+function compareGithubRepositories(
+  left: CodeGithubRepository,
+  right: CodeGithubRepository,
+): number {
+  const [leftOwner = "", leftName = ""] = left.full_name
+    .toLowerCase()
+    .split("/");
+  const [rightOwner = "", rightName = ""] = right.full_name
+    .toLowerCase()
+    .split("/");
+  return (
+    leftOwner.localeCompare(rightOwner) ||
+    leftName.localeCompare(rightName) ||
+    left.full_name.localeCompare(right.full_name)
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -86,6 +86,7 @@ import {
 } from "./CodeDeliveryStore";
 import { CodeSidebar } from "./CodeSidebar";
 import { RepositoryTriggerRules } from "./RepositoryTriggerRules";
+import { GithubAvatar } from "./GithubAvatar";
 import {
   CheckTone,
   DetailSheet,
@@ -97,7 +98,6 @@ import {
 import {
   checkCounts,
   checkSummary,
-  githubAvatarUrl,
   pullRequestLifecycle,
   pullRequestListStatus,
   type PullRequestListGroup,
@@ -1952,7 +1952,7 @@ function PullRequestRow({
             // avatars line up as their own strip down the list, and the table
             // keeps the width it has.
             <>
-              <AuthorAvatar
+              <GithubAvatar
                 login={item.author}
                 url={item.author_avatar_url}
                 className="size-4"
@@ -2790,7 +2790,7 @@ function AuthorFilterOptions({
                   toggle(author.login, checked === true)
                 }
               />
-              <AuthorAvatar login={author.login} url={author.avatarUrl} />
+              <GithubAvatar login={author.login} url={author.avatarUrl} />
               <span className="min-w-0 truncate">{author.login}</span>
             </label>
           ))}
@@ -2809,41 +2809,6 @@ function AuthorFilterOptions({
         </button>
       )}
     </div>
-  );
-}
-
-/** A login's face at list scale, with initials when there is no image. */
-function AuthorAvatar({
-  login,
-  url,
-  className,
-}: {
-  login: string;
-  url?: string;
-  className?: string;
-}) {
-  const [failed, setFailed] = useState(false);
-  const source = url ?? githubAvatarUrl(login);
-  if (!source || failed) {
-    return (
-      <span
-        className={cn(
-          "grid size-5 shrink-0 place-items-center rounded-full bg-muted text-2xs font-semibold uppercase text-muted-foreground",
-          className,
-        )}
-        aria-hidden
-      >
-        {login.slice(0, 2)}
-      </span>
-    );
-  }
-  return (
-    <img
-      src={source}
-      alt=""
-      className={cn("size-5 shrink-0 rounded-full object-cover", className)}
-      onError={() => setFailed(true)}
-    />
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/GithubAvatar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/GithubAvatar.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { githubAvatarUrl } from "./pullRequestPresentation";
+
+/**
+ * A GitHub login's face at list scale. Initials stand in when there is no
+ * image, or when the image fails to load.
+ */
+export function GithubAvatar({
+  login,
+  url,
+  className,
+}: {
+  login: string | undefined;
+  url?: string;
+  className?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const source = url ?? githubAvatarUrl(login);
+  if (!source || failed) {
+    return (
+      <span
+        className={cn(
+          "grid size-5 shrink-0 place-items-center rounded-full bg-muted text-2xs font-semibold uppercase text-muted-foreground",
+          className,
+        )}
+        aria-hidden
+      >
+        {(login ?? "?").slice(0, 2)}
+      </span>
+    );
+  }
+  return (
+    <img
+      src={source}
+      alt=""
+      className={cn("size-5 shrink-0 rounded-full object-cover", className)}
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/PrCommentCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCommentCard.tsx
@@ -1,13 +1,11 @@
-import { useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { CircleCheck } from "lucide-react";
 
 import type { PullRequestComment } from "../api/types";
 import { MessageMarkdown } from "@/MessageMarkdown";
 import { cn } from "@/lib/utils";
-import {
-  expandGithubEmojiShortcodes,
-  githubAvatarUrl,
-} from "./pullRequestPresentation";
+import { GithubAvatar } from "./GithubAvatar";
+import { expandGithubEmojiShortcodes } from "./pullRequestPresentation";
 
 /**
  * One pull-request comment, drawn the way GitHub draws it: avatar, author,
@@ -30,7 +28,6 @@ export function PrCommentCard({
   actions?: ReactNode;
   className?: string;
 }) {
-  const [avatarFailed, setAvatarFailed] = useState(false);
   const when = comment.created_at
     ? new Date(comment.created_at).toLocaleString(undefined, {
         month: "short",
@@ -40,7 +37,6 @@ export function PrCommentCard({
       })
     : null;
   const author = comment.author ?? "Unknown";
-  const avatar = comment.avatar_url ?? githubAvatarUrl(comment.author);
   const anchor =
     comment.kind === "inline" && comment.path
       ? `${comment.path}${comment.line !== undefined ? `:${comment.line}` : ""}`
@@ -55,18 +51,11 @@ export function PrCommentCard({
       )}
     >
       <div className="flex min-w-0 items-start gap-2">
-        <span className="bg-muted text-muted-foreground grid size-7 shrink-0 place-items-center overflow-hidden rounded-full text-2xs font-semibold uppercase">
-          {avatar && !avatarFailed ? (
-            <img
-              src={avatar}
-              alt=""
-              className="size-full object-cover"
-              onError={() => setAvatarFailed(true)}
-            />
-          ) : (
-            author.slice(0, 2)
-          )}
-        </span>
+        <GithubAvatar
+          login={comment.author}
+          url={comment.avatar_url}
+          className="size-7"
+        />
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-1.5">
             <span className="text-foreground min-w-0 truncate text-xs font-medium">

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -72,13 +72,13 @@ import {
   prWorkflowPrompt,
   type PrPromptAction,
 } from "./prActions";
+import { GithubAvatar } from "./GithubAvatar";
 import { PrCommentCard } from "./PrCommentCard";
 import {
   checkCounts,
   expandGithubEmojiShortcodes,
   fileStatusLabel,
   fileStatusTone,
-  githubAvatarUrl,
   mergeBlockedReason,
   orderPullRequestComments,
   pullRequestLifecycle,
@@ -579,7 +579,7 @@ function PrDetailHeader({
       </div>
 
       <p className="mt-2 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-muted-foreground">
-        <Avatar
+        <GithubAvatar
           login={summary.author}
           url={summary.author_avatar_url}
           className="size-4"
@@ -621,7 +621,7 @@ function PrDetailHeader({
               key={`assignee:${login}`}
               className="flex items-center gap-1 text-xs text-muted-foreground"
             >
-              <Avatar login={login} className="size-4" />
+              <GithubAvatar login={login} className="size-4" />
               {login}
             </span>
           ))}
@@ -631,7 +631,7 @@ function PrDetailHeader({
               className="flex items-center gap-1 text-xs text-muted-foreground"
               title={`Review requested from ${login}`}
             >
-              <Avatar login={login} className="size-4" />
+              <GithubAvatar login={login} className="size-4" />
               {login}
               <span className="text-2xs">(review requested)</span>
             </span>
@@ -1320,40 +1320,6 @@ export function CheckTone({
     return <Play className={cn("size-3.5 shrink-0", STATUS_MARK.pending)} />;
   }
   return <CircleDot className={cn("size-3.5 shrink-0", STATUS_MARK.neutral)} />;
-}
-
-function Avatar({
-  login,
-  url,
-  className,
-}: {
-  login: string | undefined;
-  url?: string;
-  className?: string;
-}) {
-  const [failed, setFailed] = useState(false);
-  const source = url ?? githubAvatarUrl(login);
-  if (!source || failed) {
-    return (
-      <span
-        className={cn(
-          "grid shrink-0 place-items-center rounded-full bg-muted text-2xs font-semibold uppercase text-muted-foreground",
-          className,
-        )}
-        aria-hidden
-      >
-        {(login ?? "?").slice(0, 2)}
-      </span>
-    );
-  }
-  return (
-    <img
-      src={source}
-      alt=""
-      className={cn("shrink-0 rounded-full object-cover", className)}
-      onError={() => setFailed(true)}
-    />
-  );
 }
 
 function InlineDetailError({

--- a/crates/tidebreak-desktop/ui/src/stories/GithubAvatar.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/GithubAvatar.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { GithubAvatar } from "@/code/GithubAvatar";
+
+const meta = {
+  title: "Code/GitHub avatar",
+  component: GithubAvatar,
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-3 p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof GithubAvatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Image: Story = {
+  args: { login: "github" },
+};
+
+export const Initials: Story = {
+  args: { login: "mira-chen", url: "https://invalid.example/missing.png" },
+};
+
+export const MissingLogin: Story = {
+  args: { login: undefined },
+};
+
+export const Sizes: Story = {
+  args: { login: "github" },
+  render: () => (
+    <div className="flex items-center gap-3">
+      <GithubAvatar login="github" className="size-4" />
+      <GithubAvatar login="github" className="size-5" />
+      <GithubAvatar login="github" className="size-7" />
+    </div>
+  ),
+};

--- a/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
@@ -76,14 +76,50 @@ function setupClient(scenario: SetupScenario): ApiClient {
         ? {
             repositories: [
               {
+                full_name: "brightwave-inc/tidebreak",
+                private: true,
+                description:
+                  "Open-source, local-first desktop for AI coding agents and documents",
+              },
+              {
                 full_name: "mira-chen/notes",
                 private: true,
                 description: "scratch",
               },
               {
-                full_name: "brightwave-inc/tidebreak",
+                full_name: "brightwave-inc/shipright",
                 private: true,
-                description: "the product",
+                description: "Review bots for pull requests",
+              },
+              {
+                full_name: "mira-chen/dotfiles",
+                private: true,
+                description: "machine setup",
+              },
+              {
+                full_name: "brightwave-inc/model-gateway",
+                private: true,
+                description: "Self-hosted LLM and MCP aggregation gateway",
+              },
+              {
+                full_name: "brightwave-inc/clawdbot",
+                private: true,
+                description: "",
+              },
+              {
+                full_name: "brightwave-inc/terraform-main",
+                private: true,
+                description: "All things terraform related",
+              },
+              {
+                full_name: "brightwave-inc/tidebreak-site",
+                private: true,
+                description: "Marketing site",
+              },
+              {
+                full_name: "brightwave-inc/orca",
+                private: true,
+                description: "Internal agent workspace tooling",
               },
             ],
           }
@@ -445,6 +481,11 @@ export const HostedGitHubPicker: Story = {
     await expect(
       await body.findByRole("option", { name: /mira-chen\/notes/ }),
     ).toBeVisible();
+    const last = await body.findByRole("option", {
+      name: /mira-chen\/notes/,
+    });
+    last.scrollIntoView();
+    await expect(last).toBeVisible();
     await expect(body.queryByText("Destination folder")).toBeNull();
   },
 };


### PR DESCRIPTION
The add-repository GitHub dropdown grew past the window, so later rows were unreachable. The list now stays inside the remaining height and scrolls.

Each row shows the owner's GitHub avatar. Repositories sort by owner, then name, so the same face sits together. Pull request and comment faces use the same `GithubAvatar` component.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome format` on the touched files
- `pnpm --dir crates/tidebreak-desktop/ui exec biome lint` on the touched files
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/AddRepoPalette.dom.test.tsx`
- Storybook: Code/Repository setup / Hosted GitHub picker, and Code/GitHub avatar

Did not compile Rust locally.

## Compatibility and risk

None. Presentation only; no wire-format change.
