### PR TITLE
fix(code): make owner paths collision-resistant

### DIFF
--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -14,6 +14,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 use uuid::Uuid;
 
+use tidebreak_core::db::code::get_repo_by_root_path;
 use tidebreak_core::{OwnerId, RepoId, Store};
 
 use super::bus::{CloneProgress, CodeLiveUpdate};
@@ -21,6 +22,7 @@ use super::gh::{self, resolve_github_clone_url};
 use super::runtime::CodeRuntime;
 use crate::error::ServerError;
 use crate::obo_gateway::{GitCredential, GitForgeAttribution, GitForgeError, GitForgeIdentity};
+use crate::principal::{legacy_owner_path_segment, owner_path_segment};
 use crate::routes::code::{
     CodeCloneDefaults, CodeCloneJobSnapshot, CodeGithubRepositories, CodeRepoSource,
     CodeRepoSources,
@@ -139,31 +141,17 @@ impl CloneJob {
 /// parent, because there is exactly one owner and its paths are the ones users
 /// already have.
 ///
-/// Owner keys are visible ASCII and may contain characters that are not safe
-/// in a path segment, so everything outside a conservative set is replaced.
+/// Only paths created after the collision-resistant encoding use this root.
+/// Existing repositories and worktrees remain reachable through the absolute
+/// paths stored on their rows.
 pub(crate) fn owner_dir(parent: &Path, owner: &OwnerId) -> PathBuf {
-    if owner.is_local() {
-        return parent.to_path_buf();
-    }
-    let segment: String = owner
-        .as_str()
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    // A key of only separators must not resolve to the parent itself, and
-    // must never climb out of it.
-    let segment = segment.trim_matches('.').to_owned();
-    if segment.is_empty() {
-        parent.join("owner")
-    } else {
-        parent.join(segment)
-    }
+    owner_path_segment(owner).map_or_else(|| parent.to_path_buf(), |segment| parent.join(segment))
+}
+
+/// The pre-SEC-6 owner directory, used only for compatibility reads.
+pub(crate) fn legacy_owner_dir(parent: &Path, owner: &OwnerId) -> PathBuf {
+    legacy_owner_path_segment(owner)
+        .map_or_else(|| parent.to_path_buf(), |segment| parent.join(segment))
 }
 
 /// Body fields after the route has rejected an empty or mixed source.
@@ -370,6 +358,15 @@ impl CodeRuntime {
                 format!("destination {} already exists", target.display()),
             ));
         }
+        let legacy_target = legacy_owner_dir(&parent, owner).join(&name);
+        if legacy_target != target
+            && registered_legacy_clone_target(&self.db, owner, &legacy_target).await?
+        {
+            return Err(ServerError::conflict_kind(
+                "clone_target_exists",
+                format!("destination {} already exists", legacy_target.display()),
+            ));
+        }
         write_clone_parent_dir(&*self.db, &parent).await?;
 
         let id = Uuid::new_v4();
@@ -491,6 +488,29 @@ impl CodeRuntime {
         #[cfg(not(test))]
         None
     }
+}
+
+/// Whether an existing live row proves that the legacy target belongs to this
+/// exact owner.
+///
+/// A bare existence check would reintroduce the collision: another owner may
+/// occupy the same lossy legacy directory. The owner-scoped row is the proof
+/// that lets clone setup preserve the old conflict behavior safely.
+pub(crate) async fn registered_legacy_clone_target(
+    store: &tidebreak_core::DbStore,
+    owner: &OwnerId,
+    target: &Path,
+) -> Result<bool, ServerError> {
+    let canonical = match tokio::fs::canonicalize(target).await {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(_) => return Ok(false),
+    };
+    Ok(
+        get_repo_by_root_path(store, owner, &canonical.display().to_string())
+            .await?
+            .is_some(),
+    )
 }
 
 /// Where a clone reads from, plus the GitHub slug when the caller named one.

--- a/crates/tidebreak-server/src/code/worktree_root.rs
+++ b/crates/tidebreak-server/src/code/worktree_root.rs
@@ -41,7 +41,8 @@ impl CodeRuntime {
     /// The setting is one deployment-wide path, so a multi-user machine needs
     /// the same per-owner segment clones take ([`owner_dir`]) — otherwise two
     /// users' repositories of the same name share a folder. The local profile
-    /// has exactly one owner and keeps the root itself.
+    /// has exactly one owner and keeps the root itself. Existing workspaces do
+    /// not use this derivation: they keep the absolute path stored on the row.
     pub(crate) async fn owner_worktree_root(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/principal.rs
+++ b/crates/tidebreak-server/src/principal.rs
@@ -22,13 +22,16 @@
 //! [`crate::auth::require_admin`] over the role resolved here — see
 //! `docs/decisions/0006-self-host-deployment-plane-authorization.md`.
 
-use std::fmt;
+use std::fmt::{self, Write as _};
 use std::sync::Arc;
 
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
+use sha2::{Digest as _, Sha256};
 use tidebreak_core::{AgentError, OwnerId, Result};
+
+const OWNER_PATH_SEGMENT_PREFIX: &str = "owner-v2-";
 
 /// What a principal is permitted to reach.
 ///
@@ -96,6 +99,56 @@ impl Principal {
             Self::User { role, .. } => *role == Role::Admin,
         }
     }
+}
+
+/// Stable filesystem identity for a non-local owner's exact durable key.
+///
+/// The segment is lowercase hexadecimal so a case-insensitive filesystem
+/// cannot fold two generated representations together. Hashing the exact key
+/// also keeps punctuation significant without placing path syntax in the
+/// segment. The version prefix leaves room for an explicit migration if this
+/// encoding ever changes.
+#[must_use]
+pub(crate) fn owner_path_segment(owner: &OwnerId) -> Option<String> {
+    if owner.is_local() {
+        return None;
+    }
+    let digest = Sha256::digest(owner.as_str().as_bytes());
+    let mut segment = String::with_capacity(OWNER_PATH_SEGMENT_PREFIX.len() + digest.len() * 2);
+    segment.push_str(OWNER_PATH_SEGMENT_PREFIX);
+    for byte in digest {
+        write!(&mut segment, "{byte:02x}").expect("writing to a string cannot fail");
+    }
+    Some(segment)
+}
+
+/// Filesystem segment used before [`owner_path_segment`].
+///
+/// Keep this only for finding a same-owner managed checkout that predates the
+/// collision-resistant encoding. New repositories and worktrees must never
+/// use it because distinct owner keys can map to the same segment.
+#[must_use]
+pub(crate) fn legacy_owner_path_segment(owner: &OwnerId) -> Option<String> {
+    if owner.is_local() {
+        return None;
+    }
+    let segment: String = owner
+        .as_str()
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let segment = segment.trim_matches('.');
+    Some(if segment.is_empty() {
+        "owner".to_owned()
+    } else {
+        segment.to_owned()
+    })
 }
 
 /// The operator-assigned identifier of a named user on a shared deployment.
@@ -186,6 +239,54 @@ mod tests {
     use axum::routing::get;
     use axum::Router;
     use tower::ServiceExt;
+
+    #[test]
+    fn owner_path_segments_are_stable_and_case_fold_safe() {
+        let exact = OwnerId::new("user:alice@example").unwrap();
+        let punctuation_peer = OwnerId::new("user:alice_example").unwrap();
+        let upper = OwnerId::new("user:Alice").unwrap();
+        let lower = OwnerId::new("user:alice").unwrap();
+
+        assert_eq!(
+            owner_path_segment(&exact).as_deref(),
+            Some("owner-v2-40538e821f0efa90f443e3e237769498a96716b377c40394d23f1f455cc24576")
+        );
+        assert_ne!(
+            owner_path_segment(&exact),
+            owner_path_segment(&punctuation_peer)
+        );
+        assert_ne!(owner_path_segment(&upper), owner_path_segment(&lower));
+        assert!(owner_path_segment(&exact)
+            .unwrap()
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'));
+        assert_eq!(owner_path_segment(&OwnerId::local()), None);
+    }
+
+    #[test]
+    fn legacy_owner_path_segments_pin_the_compatibility_lookup() {
+        let punctuation_left = OwnerId::new("user:alice@example").unwrap();
+        let punctuation_right = OwnerId::new("user:alice_example").unwrap();
+        let case_left = OwnerId::new("user:Alice").unwrap();
+        let case_right = OwnerId::new("user:alice").unwrap();
+
+        assert_eq!(
+            legacy_owner_path_segment(&punctuation_left).as_deref(),
+            Some("user_alice_example")
+        );
+        assert_eq!(
+            legacy_owner_path_segment(&punctuation_left),
+            legacy_owner_path_segment(&punctuation_right)
+        );
+        assert!(legacy_owner_path_segment(&case_left)
+            .unwrap()
+            .eq_ignore_ascii_case(&legacy_owner_path_segment(&case_right).unwrap()));
+        assert_eq!(
+            legacy_owner_path_segment(&OwnerId::new("..").unwrap()).as_deref(),
+            Some("owner")
+        );
+        assert_eq!(legacy_owner_path_segment(&OwnerId::local()), None);
+    }
 
     /// The boundary contract: a route the auth middleware does not cover
     /// cannot observe an identity — the extractors fail closed instead of

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -20,9 +20,10 @@ use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, BlobStore, BrowserListResult, BrowserNavigateArgs,
     BrowserNavigateResult, BrowserPageSnapshot, BrowserScreenshotArgs, BrowserScreenshotResult,
-    BrowserSnapshotArgs, BrowserWaitArgs, BrowserWaitResult, CapLevel, CodeEvent, CodeSessionId,
-    CodeSessionLifecycle, CodeTurnId, CodeTurnStatus, CodeWorkspaceStatus, DbStore, FenceReason,
-    HarnessKind, PermissionMode, ReasoningEffort, Store, WorkspaceId,
+    BrowserSnapshotArgs, BrowserWaitArgs, BrowserWaitResult, CapLevel, CodeEvent, CodeRepo,
+    CodeSessionId, CodeSessionLifecycle, CodeTurnId, CodeTurnStatus, CodeWorkspace,
+    CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind, PermissionMode, ReasoningEffort,
+    RepoId, Store, WorkspaceId,
 };
 use tidebreak_harness::{AdapterRegistry, ApprovalDecision, HarnessApprovalRef, HarnessEvent};
 
@@ -7376,7 +7377,7 @@ async fn a_self_host_member_cannot_use_ambient_github_credentials_for_unowned_ta
 /// the second clone from landing on the first one's checkout.
 #[test]
 fn clone_targets_are_keyed_by_owner() {
-    use crate::code::clone::owner_dir;
+    use crate::code::clone::{legacy_owner_dir, owner_dir};
     let parent = std::path::Path::new("/srv/checkouts");
     // The local profile is single-user and keeps the paths people already have.
     assert_eq!(
@@ -7386,9 +7387,14 @@ fn clone_targets_are_keyed_by_owner() {
     let alice = owner_dir(parent, &tidebreak_core::OwnerId::new("alice").unwrap());
     let bob = owner_dir(parent, &tidebreak_core::OwnerId::new("bob").unwrap());
     assert_ne!(alice, bob);
-    assert_eq!(alice, parent.join("alice"));
-    // An owner key is visible ASCII, so it may carry separators and dots that
-    // must not escape the parent or resolve to it.
+    assert_eq!(alice.parent(), Some(parent));
+    assert!(alice.starts_with(parent));
+    // The compatibility path remains available for identifying existing rows,
+    // but new paths never use it.
+    assert_eq!(
+        legacy_owner_dir(parent, &tidebreak_core::OwnerId::new("alice").unwrap()),
+        parent.join("alice")
+    );
     let hostile = owner_dir(
         parent,
         &tidebreak_core::OwnerId::new("../../etc/passwd").unwrap(),
@@ -7396,7 +7402,114 @@ fn clone_targets_are_keyed_by_owner() {
     assert_eq!(hostile.parent(), Some(parent));
     assert!(hostile.starts_with(parent));
     let dots = owner_dir(parent, &tidebreak_core::OwnerId::new("..").unwrap());
-    assert_eq!(dots, parent.join("owner"));
+    assert_eq!(dots.parent(), Some(parent));
+    assert_ne!(dots, parent);
+}
+
+/// Rows created with the legacy owner directory keep their exact absolute
+/// paths. The new namespace applies only to later clones and worktrees.
+#[tokio::test]
+async fn legacy_managed_repo_and_worktree_paths_remain_accessible() {
+    use crate::code::clone::{legacy_owner_dir, owner_dir, registered_legacy_clone_target};
+    use crate::code::worktree::create_worktree;
+
+    let (dir, store) = temp_db_store("code-owner-path-compat.db").await;
+    let db = Arc::new(store);
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    let runtime = CodeRuntime::with_registry(db.clone(), dir.path().to_path_buf(), registry);
+    let owner = tidebreak_core::OwnerId::new("user:alice@example").unwrap();
+
+    let clone_parent = dir.path().join("clones");
+    let legacy_repo_root = legacy_owner_dir(&clone_parent, &owner).join("demo");
+    let repo_root = init_git_repo_named(legacy_repo_root.parent().unwrap(), "demo");
+    let repo = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: repo_root.canonicalize().unwrap().display().to_string(),
+        display_name: "demo".to_owned(),
+        default_base_ref: "main".to_owned(),
+        branch_prefix: "thet/".to_owned(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: chrono::Utc::now(),
+        removed_at: None,
+        cloned_from: Some("https://example.com/acme/demo.git".to_owned()),
+        origin_host: None,
+        origin_owner: None,
+        origin_name: None,
+    };
+    tidebreak_core::db::code::insert_repo(&db, &repo)
+        .await
+        .unwrap();
+    assert!(registered_legacy_clone_target(&db, &owner, &repo_root)
+        .await
+        .unwrap());
+    let colliding_owner = tidebreak_core::OwnerId::new("user:alice_example").unwrap();
+    assert_eq!(
+        legacy_owner_dir(&clone_parent, &colliding_owner),
+        legacy_repo_root.parent().unwrap()
+    );
+    assert!(
+        !registered_legacy_clone_target(&db, &colliding_owner, &repo_root)
+            .await
+            .unwrap()
+    );
+
+    let legacy_worktree_root = legacy_owner_dir(&runtime.default_worktree_root(), &owner);
+    let workspace_id = WorkspaceId::new();
+    let worktree_path =
+        legacy_worktree_root.join(format!("demo-{}", &workspace_id.to_string()[..8]));
+    create_worktree(&repo_root, &worktree_path, "thet/legacy-owner-path", "main")
+        .await
+        .unwrap();
+    let workspace = CodeWorkspace {
+        id: workspace_id,
+        owner: owner.clone(),
+        repo_id: repo.id,
+        title: "Legacy owner path".to_owned(),
+        worktree_path: worktree_path.display().to_string(),
+        branch_name: "thet/legacy-owner-path".to_owned(),
+        base_ref: "main".to_owned(),
+        status: CodeWorkspaceStatus::Active,
+        pr: None,
+        created_at: chrono::Utc::now(),
+        archived_at: None,
+        released_at: None,
+        released_tip: None,
+        bundle_bytes: None,
+    };
+    tidebreak_core::db::code::insert_workspace(&db, &workspace)
+        .await
+        .unwrap();
+
+    assert_ne!(
+        owner_dir(&clone_parent, &owner),
+        legacy_repo_root.parent().unwrap()
+    );
+    let new_worktree_root = runtime.owner_worktree_root(&owner).await.unwrap();
+    assert_ne!(new_worktree_root, legacy_worktree_root);
+    let reread_repo = runtime.get_repo(&owner, repo.id).await.unwrap();
+    assert_eq!(reread_repo.root_path, repo.root_path);
+    let next_workspace = runtime
+        .create_workspace(
+            &owner,
+            repo.id,
+            Some("New owner namespace".to_owned()),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(std::path::Path::new(&next_workspace.worktree_path).starts_with(new_worktree_root));
+    let reread_workspace = runtime.get_workspace(&owner, workspace_id).await.unwrap();
+    assert_eq!(reread_workspace.worktree_path, workspace.worktree_path);
+    let (paths, truncated) = runtime
+        .workspace_tree(&owner, workspace_id, "README", Some(10))
+        .await
+        .unwrap();
+    assert_eq!(paths, vec!["README.md"]);
+    assert!(!truncated);
 }
 
 /// The `/code/*` routes reach the store only through the owner-scoped view.


### PR DESCRIPTION
## What changed

- Derive each non-local managed path namespace from a versioned, lowercase SHA-256 digest of the exact owner key.
- Keep the local-owner directory layout unchanged.
- Preserve existing managed repositories and worktrees through their stored absolute paths. A legacy clone target counts as occupied only when an owner-scoped live repository row proves that it belongs to the exact caller.
- Add regression coverage for punctuation collisions, case-only identifiers, stable encoding, colliding legacy owners, legacy path access, and later worktree creation under the new namespace.

## Validation

- `cargo fmt --all -- --check`
- Stable owner digest fixture checked with `shasum -a 256`
- Protected-file overlap check against open PR #2663
- `git diff --check`

Cargo build, check, Clippy, and tests were not run, as required by the issue instructions.

## Compatibility and risk

No database migration moves existing paths. Repository and workspace rows already store absolute paths, so existing checkouts remain in place and accessible. Only later clones and worktrees use the new namespace. The compatibility lookup requires an exact owner-scoped row and does not trust a colliding legacy directory by existence alone.

## Tracking

Closes #2665.