### PR TITLE
fix(code): keep scratch operations capability-bound

### DIFF
--- a/crates/tidebreak-server/src/code/ci_logs.rs
+++ b/crates/tidebreak-server/src/code/ci_logs.rs
@@ -120,7 +120,7 @@ fn job_ref_from_check_url(url: &str) -> Option<JobRef> {
 /// Stale files from an earlier fetch are removed once the new set is written,
 /// so the directory only ever describes one head.
 pub(crate) async fn write_failing_check_logs(
-    private_root: &Path,
+    private_root: &super::scratch::ScratchRoot,
     binary: &Path,
     checks: &[PullRequestCheck],
     head_sha: Option<&str>,
@@ -181,6 +181,7 @@ pub(crate) async fn write_failing_check_logs(
         logs.push(WrittenCheckLog {
             check,
             path: private_root
+                .path()
                 .join(CI_LOGS_DIR)
                 .join(&name)
                 .display()
@@ -392,8 +393,10 @@ mod tests {
 
     #[tokio::test]
     async fn a_second_fetch_prunes_the_previous_heads_files() {
-        let root = tempfile::tempdir().expect("temp root");
-        let dir = super::super::scratch::scratch_dir(root.path(), CI_LOGS_DIR).expect("dir");
+        let directory = tempfile::tempdir().expect("temp root");
+        let root = super::super::scratch::ScratchRoot::open_for_test(directory.path())
+            .expect("scratch root");
+        let dir = super::super::scratch::scratch_dir(&root, CI_LOGS_DIR).expect("dir");
         dir.publish(std::ffi::OsStr::new("old-1.log"), b"old")
             .await
             .expect("publish old");

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -139,13 +139,14 @@ pub(crate) struct WrittenTranscript {
 /// directory rather than leaving a partial handoff for the child to trip
 /// over.
 pub(crate) async fn write_transcript(
-    private_root: &Path,
+    private_root: &super::scratch::ScratchRoot,
     blobs: &dyn BlobStore,
     session: &CodeSession,
     cut: ForkCut<'_>,
     events: &[SequencedCodeEvent],
 ) -> std::io::Result<WrittenTranscript> {
-    let write_lock = fork_lock(private_root, session.id);
+    let private_path = private_root.path();
+    let write_lock = fork_lock(private_path, session.id);
     let _write = write_lock.lock().await;
     let generation = uuid::Uuid::new_v4();
     let turns = cut.turns;
@@ -157,7 +158,7 @@ pub(crate) async fn write_transcript(
     materialize_attachments(&scope, blobs, turns, &retained_images).await?;
 
     let records = render_turn_records(
-        private_root,
+        private_path,
         session,
         turns,
         events,
@@ -175,7 +176,7 @@ pub(crate) async fn write_transcript(
     }
 
     let rendered = render_transcript_with_generation(
-        private_root,
+        private_path,
         session,
         turns,
         cut.excluded,
@@ -192,7 +193,7 @@ pub(crate) async fn write_transcript(
         .await?;
     scope.keep();
 
-    let dir = private_root
+    let dir = private_path
         .join(FORKS_DIR)
         .join(session.id.to_string())
         .join(generation.to_string());
@@ -1078,6 +1079,10 @@ mod tests {
             .collect()
     }
 
+    fn test_root(directory: &tempfile::TempDir) -> super::super::scratch::ScratchRoot {
+        super::super::scratch::ScratchRoot::open_for_test(directory.path()).expect("scratch root")
+    }
+
     /// Render the condensed transcript as if every turn had a record file and
     /// every image was retained, which is what most summary tests care about.
     fn render_transcript(
@@ -1547,9 +1552,10 @@ mod tests {
             turn(session.id, 1, "hello"),
             turn(session.id, 2, "and again"),
         ];
+        let private_root = test_root(&private);
 
         let written = write_transcript(
-            private.path(),
+            &private_root,
             &blobs,
             &session,
             ForkCut {
@@ -1587,8 +1593,9 @@ mod tests {
             .map(|ordinal| turn(session.id, ordinal, "work"))
             .collect();
         let cut = cut_at(&turns, Some(turns[0].id)).expect("known turn");
+        let private_root = test_root(&private);
 
-        let written = write_transcript(private.path(), &blobs, &session, cut, &[])
+        let written = write_transcript(&private_root, &blobs, &session, cut, &[])
             .await
             .expect("write");
 
@@ -1616,9 +1623,10 @@ mod tests {
             turn(session.id, 1, "hello"),
             turn(session.id, 2, "more work"),
         ];
+        let private_root = test_root(&private);
 
         let first = write_transcript(
-            private.path(),
+            &private_root,
             &blobs,
             &session,
             ForkCut {
@@ -1630,7 +1638,7 @@ mod tests {
         .await
         .expect("first write");
         let second = write_transcript(
-            private.path(),
+            &private_root,
             &blobs,
             &session,
             ForkCut {
@@ -1684,9 +1692,10 @@ mod tests {
             .unwrap();
         only.attachments = vec![first, second];
         let turns = vec![only];
+        let private_root = test_root(&private);
 
         let written = write_transcript(
-            private.path(),
+            &private_root,
             blobs.as_ref(),
             &session,
             ForkCut {
@@ -1743,9 +1752,10 @@ mod tests {
         let mut new = turn(session.id, 2, "and this");
         new.attachments = vec![real];
         let turns = vec![old, new];
+        let private_root = test_root(&private);
 
         let written = write_transcript(
-            private.path(),
+            &private_root,
             blobs.as_ref(),
             &session,
             ForkCut {

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -675,6 +675,8 @@ mod tests {
         );
         let private_root = _dir.path().join("private");
         std::fs::create_dir(&private_root).unwrap();
+        let private_root =
+            crate::code::scratch::ScratchRoot::open_for_test(&private_root).expect("scratch root");
         let child_pid = i64::from(std::process::id());
         let engine = crate::scripted_harness::ScriptedAdapter::new(vec![
             tidebreak_harness::HarnessEvent::TurnStarted,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -4133,7 +4133,7 @@ impl CodeRuntime {
 
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),
-            allowed_read_roots: vec![private_root.clone()],
+            allowed_read_roots: vec![private_root.path().to_path_buf()],
             permission_mode: session.permission_mode,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort,

--- a/crates/tidebreak-server/src/code/scratch.rs
+++ b/crates/tidebreak-server/src/code/scratch.rs
@@ -7,6 +7,7 @@
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 
 use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt as _};
 use cap_std::ambient_authority;
@@ -16,6 +17,33 @@ use tokio::io::AsyncWriteExt as _;
 
 const CODE_DIR: &str = "code";
 const PRIVATE_DIR: &str = "private";
+
+/// A workspace's private storage root, pinned to the directory that passed
+/// validation.
+///
+/// `path` is only the name that engines receive for reading published files.
+/// Every Tidebreak mutation stays relative to `dir`, so replacing that name or
+/// one of its ancestors cannot redirect the operation.
+#[derive(Clone)]
+pub(crate) struct ScratchRoot {
+    dir: Arc<Dir>,
+    path: PathBuf,
+}
+
+impl ScratchRoot {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_for_test(path: &Path) -> io::Result<Self> {
+        let path = absolute_path(path)?;
+        Ok(Self {
+            dir: Arc::new(open_root(&path)?),
+            path,
+        })
+    }
+}
 
 /// An open scratch directory whose path components were all opened without
 /// following symlinks.
@@ -96,18 +124,24 @@ impl Drop for ScratchScope {
 }
 
 /// Create the private root for one workspace under the profile data directory.
-pub(crate) fn workspace_root(data_dir: &Path, workspace_id: WorkspaceId) -> io::Result<PathBuf> {
+pub(crate) fn workspace_root(
+    data_dir: &Path,
+    workspace_id: WorkspaceId,
+) -> io::Result<ScratchRoot> {
     let data_dir = absolute_path(data_dir)?;
     let root = open_root(&data_dir)?;
     reject_git_indexable_root(&std::fs::canonicalize(&data_dir)?)?;
     let code = ensure_child_dir(&root, OsStr::new(CODE_DIR))?;
     let private = ensure_child_dir(&code, OsStr::new(PRIVATE_DIR))?;
     let workspace_name = workspace_id.to_string();
-    ensure_child_dir(&private, OsStr::new(&workspace_name))?;
-    Ok(data_dir
-        .join(CODE_DIR)
-        .join(PRIVATE_DIR)
-        .join(workspace_name))
+    let workspace = ensure_child_dir(&private, OsStr::new(&workspace_name))?;
+    Ok(ScratchRoot {
+        dir: Arc::new(workspace),
+        path: data_dir
+            .join(CODE_DIR)
+            .join(PRIVATE_DIR)
+            .join(workspace_name),
+    })
 }
 
 fn absolute_path(path: &Path) -> io::Result<PathBuf> {
@@ -140,9 +174,9 @@ fn reject_git_indexable_root(root: &Path) -> io::Result<()> {
 }
 
 /// Open or create one directory below a workspace's private root.
-pub(crate) fn scratch_dir(root: &Path, relative: &str) -> io::Result<ScratchDir> {
+pub(crate) fn scratch_dir(root: &ScratchRoot, relative: &str) -> io::Result<ScratchDir> {
     let components = scratch_components(relative)?;
-    let mut current = open_root(root)?;
+    let mut current = root.dir.try_clone()?;
     for component in components {
         current = ensure_child_dir(&current, &component)?;
     }
@@ -150,9 +184,12 @@ pub(crate) fn scratch_dir(root: &Path, relative: &str) -> io::Result<ScratchDir>
 }
 
 /// Open an existing scratch directory without creating any path component.
-pub(crate) fn scratch_dir_if_exists(root: &Path, relative: &str) -> io::Result<Option<ScratchDir>> {
+pub(crate) fn scratch_dir_if_exists(
+    root: &ScratchRoot,
+    relative: &str,
+) -> io::Result<Option<ScratchDir>> {
     let components = scratch_components(relative)?;
-    let mut current = open_root(root)?;
+    let mut current = root.dir.try_clone()?;
     for component in components {
         let metadata = match current.symlink_metadata(&component) {
             Ok(metadata) => metadata,
@@ -172,7 +209,7 @@ pub(crate) fn scratch_dir_if_exists(root: &Path, relative: &str) -> io::Result<O
 
 /// Create a session-and-turn-specific directory below `relative`.
 pub(crate) fn scratch_scope(
-    root: &Path,
+    root: &ScratchRoot,
     relative: &str,
     session_id: uuid::Uuid,
     turn_id: uuid::Uuid,
@@ -196,7 +233,7 @@ pub(crate) fn scratch_scope(
 /// Only UUID-named session directories and legacy UUID-named image files are
 /// Tidebreak-owned. Unknown entries stay untouched. Symlinks are unlinked,
 /// never followed.
-pub(crate) fn sweep_scopes(root: &Path, relative: &str) -> io::Result<()> {
+pub(crate) fn sweep_scopes(root: &ScratchRoot, relative: &str) -> io::Result<()> {
     let Some(root) = scratch_dir_if_exists(root, relative)? else {
         return Ok(());
     };
@@ -418,6 +455,10 @@ fn is_legacy_attachment_name(name: &OsStr) -> bool {
 mod tests {
     use super::*;
 
+    fn test_root(path: &Path) -> ScratchRoot {
+        ScratchRoot::open_for_test(path).expect("scratch root")
+    }
+
     fn git(worktree: &Path, args: &[&str]) -> std::process::Output {
         std::process::Command::new("git")
             .args(args)
@@ -445,7 +486,7 @@ mod tests {
         let root = parent.path().join("private");
         std::os::unix::fs::symlink(outside.path(), &root).unwrap();
 
-        let result = scratch_dir(&root, "attachments");
+        let result = ScratchRoot::open_for_test(&root);
 
         assert!(result.is_err());
         assert!(std::fs::read_dir(outside.path()).unwrap().next().is_none());
@@ -454,11 +495,12 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn rejects_a_symlinked_nested_directory() {
-        let root = tempfile::tempdir().unwrap();
+        let directory = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
-        std::os::unix::fs::symlink(outside.path(), root.path().join("attachments")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), directory.path().join("attachments")).unwrap();
+        let root = test_root(directory.path());
 
-        let result = scratch_dir(root.path(), "attachments");
+        let result = scratch_dir(&root, "attachments");
 
         assert!(result.is_err());
         assert!(std::fs::read_dir(outside.path()).unwrap().next().is_none());
@@ -508,12 +550,12 @@ mod tests {
             .await
             .unwrap();
 
-        let private_mode = std::fs::metadata(&private_root)
+        let private_mode = std::fs::metadata(private_root.path())
             .unwrap()
             .permissions()
             .mode()
             & 0o777;
-        let attachments = private_root.join("attachments");
+        let attachments = private_root.path().join("attachments");
         let attachment_mode = std::fs::metadata(&attachments)
             .unwrap()
             .permissions()
@@ -573,7 +615,8 @@ mod tests {
 
         let session_id = uuid::Uuid::new_v4();
         let turn_id = uuid::Uuid::new_v4();
-        let scope = scratch_scope(private.path(), "attachments", session_id, turn_id).unwrap();
+        let private_root = test_root(private.path());
+        let scope = scratch_scope(&private_root, "attachments", session_id, turn_id).unwrap();
         scope
             .publish(OsStr::new("image.png"), b"private")
             .await
@@ -609,9 +652,10 @@ mod tests {
     #[tokio::test]
     async fn scope_cleanup_removes_only_its_session_tree() {
         let private = tempfile::tempdir().unwrap();
+        let private_root = test_root(private.path());
         let session_id = uuid::Uuid::new_v4();
         let turn_id = uuid::Uuid::new_v4();
-        let scope = scratch_scope(private.path(), "attachments", session_id, turn_id).unwrap();
+        let scope = scratch_scope(&private_root, "attachments", session_id, turn_id).unwrap();
         scope
             .publish(OsStr::new("image.png"), b"private")
             .await
@@ -640,9 +684,10 @@ mod tests {
         use std::os::unix::fs::PermissionsExt as _;
 
         let private = tempfile::tempdir().unwrap();
+        let private_root = test_root(private.path());
         let session_id = uuid::Uuid::new_v4();
         let turn_id = uuid::Uuid::new_v4();
-        let mut scope = scratch_scope(private.path(), "attachments", session_id, turn_id).unwrap();
+        let mut scope = scratch_scope(&private_root, "attachments", session_id, turn_id).unwrap();
         scope
             .publish(OsStr::new("image.png"), b"private")
             .await
@@ -665,6 +710,7 @@ mod tests {
     #[test]
     fn sweep_unlinks_scoped_symlinks_without_touching_their_targets() {
         let private = tempfile::tempdir().unwrap();
+        let private_root = test_root(private.path());
         let outside = tempfile::tempdir().unwrap();
         std::fs::write(outside.path().join("keep.txt"), b"keep").unwrap();
         let root = private.path().join("attachments");
@@ -672,12 +718,54 @@ mod tests {
         let session_id = uuid::Uuid::new_v4();
         std::os::unix::fs::symlink(outside.path(), root.join(session_id.to_string())).unwrap();
 
-        sweep_scopes(private.path(), "attachments").unwrap();
+        sweep_scopes(&private_root, "attachments").unwrap();
 
         assert!(!root.join(session_id.to_string()).exists());
         assert_eq!(
             std::fs::read(outside.path().join("keep.txt")).unwrap(),
             b"keep"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_root_stays_bound_after_an_ancestor_is_replaced() {
+        let parent = tempfile::tempdir().unwrap();
+        let storage = parent.path().join("storage");
+        let held = parent.path().join("held-storage");
+        let redirected = parent.path().join("redirected-storage");
+        std::fs::create_dir_all(storage.join("data")).unwrap();
+        std::fs::create_dir_all(redirected.join("data")).unwrap();
+        let workspace_id = WorkspaceId::new();
+        let private_root = workspace_root(&storage.join("data"), workspace_id).unwrap();
+
+        std::fs::rename(&storage, &held).unwrap();
+        std::os::unix::fs::symlink(&redirected, &storage).unwrap();
+        let redirected_workspace = redirected
+            .join("data")
+            .join(CODE_DIR)
+            .join(PRIVATE_DIR)
+            .join(workspace_id.to_string());
+        std::fs::create_dir_all(&redirected_workspace).unwrap();
+
+        let session_id = uuid::Uuid::new_v4();
+        let turn_id = uuid::Uuid::new_v4();
+        let scope = scratch_scope(&private_root, "attachments", session_id, turn_id).unwrap();
+        scope
+            .publish(OsStr::new("private.png"), b"private")
+            .await
+            .unwrap();
+        scope.keep();
+
+        let relative = Path::new("data")
+            .join(CODE_DIR)
+            .join(PRIVATE_DIR)
+            .join(workspace_id.to_string())
+            .join("attachments")
+            .join(session_id.to_string())
+            .join(turn_id.to_string())
+            .join("private.png");
+        assert_eq!(std::fs::read(held.join(&relative)).unwrap(), b"private");
+        assert!(!redirected.join(relative).exists());
     }
 }

--- a/crates/tidebreak-server/src/code/scratch.rs
+++ b/crates/tidebreak-server/src/code/scratch.rs
@@ -526,7 +526,9 @@ mod tests {
         let data_dir = worktree.path().join("data");
         std::fs::create_dir(&data_dir).unwrap();
 
-        let error = workspace_root(&data_dir, WorkspaceId::new()).unwrap_err();
+        let error = workspace_root(&data_dir, WorkspaceId::new())
+            .err()
+            .expect("symlinked Git marker should be rejected");
 
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
     }
@@ -591,7 +593,9 @@ mod tests {
         let data_dir = worktree.path().join(".tidebreak");
         std::fs::create_dir(&data_dir).unwrap();
 
-        let error = workspace_root(&data_dir, WorkspaceId::new()).unwrap_err();
+        let error = workspace_root(&data_dir, WorkspaceId::new())
+            .err()
+            .expect("repository-local data directory should be rejected");
 
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
         assert_git_success(worktree.path(), &["add", "-A"]);

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -11,7 +11,6 @@
 //! it: an interrupt's grace period is exactly when the child's stdout most
 //! needs draining.
 
-use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -191,7 +190,7 @@ pub(crate) struct AttachmentStore {
     /// Published bytes, addressed by blob id.
     pub blobs: Option<Arc<dyn BlobStore>>,
     /// Private storage for this workspace, outside every Git worktree.
-    pub private_root: PathBuf,
+    pub private_root: super::scratch::ScratchRoot,
     /// Whether this engine consumes images over its own protocol.
     pub engine_reads_images: bool,
 }
@@ -1708,7 +1707,7 @@ async fn sweep_attachment_leftovers_or_fence(
     db: &DbStore,
     bus: &CodeEventBus,
     session: &mut CodeSession,
-    private_root: &Path,
+    private_root: &super::scratch::ScratchRoot,
 ) -> Result<(), WorkerError> {
     let Err(error) = super::scratch::sweep_scopes(private_root, ATTACHMENTS_DIR) else {
         return Ok(());
@@ -1774,7 +1773,7 @@ struct StagedTurnAttachments {
 /// The session and turn path prevents a later session from inheriting files
 /// from this one. The returned scope removes the directory on every exit.
 async fn write_turn_attachments(
-    private_root: &Path,
+    private_root: &super::scratch::ScratchRoot,
     session_id: CodeSessionId,
     turn_id: CodeTurnId,
     attachments: &[tidebreak_core::ImageRef],
@@ -1794,6 +1793,7 @@ async fn write_turn_attachments(
             .await?;
         written.push(
             private_root
+                .path()
                 .join(ATTACHMENTS_DIR)
                 .join(session_id.to_string())
                 .join(turn_id.to_string())
@@ -2756,8 +2756,11 @@ mod tests {
         use std::os::unix::fs::PermissionsExt as _;
 
         let (directory, store, sink, session_id) = seeded_sink().await;
-        let private_root = directory.path().join("private");
-        let attachment_root = private_root.join(ATTACHMENTS_DIR);
+        let private_path = directory.path().join("private");
+        std::fs::create_dir(&private_path).unwrap();
+        let private_root =
+            super::super::scratch::ScratchRoot::open_for_test(&private_path).expect("scratch root");
+        let attachment_root = private_root.path().join(ATTACHMENTS_DIR);
         let leftover = attachment_root.join(CodeSessionId::new().to_string());
         std::fs::create_dir_all(&leftover).unwrap();
         std::fs::write(leftover.join("private.png"), b"private").unwrap();
@@ -2887,6 +2890,8 @@ mod tests {
     #[tokio::test]
     async fn fallback_images_live_only_in_the_session_turn_scope() {
         let private = tempfile::tempdir().unwrap();
+        let private_root = super::super::scratch::ScratchRoot::open_for_test(private.path())
+            .expect("scratch root");
         let session_id = CodeSessionId::new();
         let turn_id = CodeTurnId::new();
         let attachment = ImageRef {
@@ -2897,7 +2902,7 @@ mod tests {
             byte_len: 4,
         };
         let staged = write_turn_attachments(
-            private.path(),
+            &private_root,
             session_id,
             turn_id,
             std::slice::from_ref(&attachment),


### PR DESCRIPTION
Closes #2671.

## Implementation

- Retain the validated workspace private directory as a cloneable `ScratchRoot` capability.
- Route fork transcripts, CI logs, attachment staging, and attachment cleanup through the retained directory handle.
- Keep the lexical path only for engine-visible file names and allowed read roots.
- Add a deterministic Unix regression that replaces an ancestor after validation and proves the write stays in the originally opened root.

## Backwards compatibility

This change does not alter the HTTP API, stored data, or published path layout. Existing scratch files keep the same absolute paths.

## Safety and risk

The change only narrows filesystem authority. Internal function signatures now require `ScratchRoot`, which prevents later code from reopening an ambient path by mistake. The main risk is platform-specific directory-handle behavior, which CI covers across supported targets.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Per repository guidance, local Cargo build, check, Clippy, and tests were not run.