### PR TITLE
fix(code): reset host-scoped state on client changes

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { APP_MODE_STORAGE_KEY, restoreStoredAppMode } from "./appMode";
 import { useChatListStore } from "./ChatListStore";
 import { useCodeCatalogStore } from "./code/CodeCatalogStore";
+import { resetCodeClientGenerationForTests } from "./code/CodeClientGeneration";
 import { useCodeUiStore } from "./code/CodeUiStore";
 import { usePendingPrompts } from "./PendingPrompts";
 import { useProjectListStore } from "./ProjectListStore";
@@ -201,6 +202,11 @@ vi.mock("./api", () => ({
     getHarnessDoctor = getHarnessDoctor;
     getCodeWorktreeRoot = getCodeWorktreeRoot;
     listCodeHarnessModels = listCodeHarnessModels;
+    getCodeSubscriptionUsage = vi.fn(async () => ({
+      source: "unavailable" as const,
+      providers: [],
+      diagnostics: [],
+    }));
     getCodeDeliveryRepositories = vi.fn(async () => ({
       capability: {
         found: false,
@@ -417,6 +423,7 @@ beforeEach(() => {
   listCodeRepos.mockClear();
   listCodeWorkspaces.mockClear();
   listCodeHarnessModels.mockClear();
+  resetCodeClientGenerationForTests();
   useCodeCatalogStore.getState().reset();
   useCodeUiStore.setState({
     newWorkspaceOpen: false,
@@ -493,6 +500,69 @@ describe("app shell", () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/code"));
     expect(await screen.findByRole("radio", { name: "Code" })).toBeChecked();
+  });
+
+  it("resets Code host state before mounting routes for a client", async () => {
+    let resolveRepos!: (
+      value: Awaited<ReturnType<typeof listCodeRepos>>,
+    ) => void;
+    listCodeRepos.mockImplementationOnce(
+      () =>
+        new Promise<Awaited<ReturnType<typeof listCodeRepos>>>((resolve) => {
+          resolveRepos = resolve;
+        }),
+    );
+    useCodeCatalogStore.setState({
+      repos: [
+        {
+          id: "repo-old",
+          root_path: "/tmp/old",
+          display_name: "Old authority",
+          default_base_ref: "main",
+          branch_prefix: "tidebreak",
+          quick_actions: [],
+          created_at: "2026-08-25T00:00:00.000Z",
+        },
+      ],
+      workspaces: [
+        {
+          id: "ws-old",
+          repo_id: "repo-old",
+          title: "Old authority workspace",
+          worktree_path: "/tmp/old/ws-old",
+          branch_name: "tidebreak/old",
+          base_ref: "main",
+          status: "active",
+          created_at: "2026-08-25T00:00:00.000Z",
+        },
+      ],
+      loaded: true,
+    });
+    useCodeUiStore.setState({
+      addRepoOpen: true,
+      workflowShortcutPending: {
+        workspaceId: "ws-old",
+        shortcut: "merge",
+      },
+    });
+
+    await mountApp({ at: "/code" });
+    expect(await screen.findByRole("radio", { name: "Code" })).toBeChecked();
+    expect(useCodeCatalogStore.getState()).toMatchObject({
+      repos: [],
+      workspaces: [],
+      loaded: false,
+    });
+    expect(useCodeUiStore.getState()).toMatchObject({
+      addRepoOpen: false,
+      workflowShortcutPending: null,
+    });
+    expect(screen.queryByText("Old authority workspace")).toBeNull();
+
+    resolveRepos([]);
+    await waitFor(() =>
+      expect(useCodeCatalogStore.getState().loaded).toBe(true),
+    );
   });
 
   it("remembers each app mode selection", async () => {

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -41,6 +41,7 @@ import {
   stepCenterTab,
 } from "./code/codeChrome";
 import { CodeDeliveryMonitor } from "./code/CodeDeliveryMonitor";
+import { activateCodeClient } from "./code/CodeClientScope";
 import { useCodeUiStore } from "./code/CodeUiStore";
 import { stepRailWorkspace } from "./code/railNavigation";
 import {
@@ -447,7 +448,12 @@ export function AppShell() {
         // three host callers that sit outside React read this flag rather
         // than a hook. See `host.ts`.
         setAttachedRemotely(server.attachment === "remote");
-        setClient(new ApiClient(server.baseUrl, server.token));
+        const nextClient = new ApiClient(server.baseUrl, server.token);
+        // Reset host-scoped Code state before React can mount routes against
+        // the replacement authority. Every pending store write also checks
+        // the generation activated here.
+        activateCodeClient(nextClient);
+        setClient(nextClient);
         // Outputs are read over the same API; their module holds the
         // connection because they are called from places with no client.
         connectOutputs(server.baseUrl, server.token);

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
@@ -1,12 +1,34 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { CodeWorkspaceSnapshot } from "../api/types";
+import type { CodeRepoSnapshot, CodeWorkspaceSnapshot } from "../api/types";
 import {
   OPTIMISTIC_WORKSPACE_ID_PREFIX,
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
+import { resetCodeClientGenerationForTests } from "./CodeClientGeneration";
+import { activateCodeClient } from "./CodeClientScope";
 import type { ReasoningEffort } from "../api/types";
 import type { ParsedHarnessModel } from "./parsers";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function repo(id: string): CodeRepoSnapshot {
+  return {
+    id,
+    root_path: `/tmp/${id}`,
+    display_name: id,
+    default_base_ref: "main",
+    branch_prefix: "tidebreak",
+    quick_actions: [],
+    created_at: "2026-08-26T00:00:00.000Z",
+  };
+}
 
 function workspace(
   id: string,
@@ -27,6 +49,7 @@ function workspace(
 
 afterEach(() => {
   useCodeCatalogStore.getState().reset();
+  resetCodeClientGenerationForTests();
 });
 
 describe("CodeCatalogStore.upsertWorkspace", () => {
@@ -61,6 +84,61 @@ describe("CodeCatalogStore.upsertWorkspace", () => {
 });
 
 describe("CodeCatalogStore.ensureHarnessModels", () => {
+  it("ignores a model result from a replaced client generation", async () => {
+    const staleModels = deferred<{
+      kind: "codex";
+      models: ParsedHarnessModel[];
+      reasoning_efforts: ReasoningEffort[];
+    }>();
+    const first = {
+      listCodeHarnessModels: vi.fn(() => staleModels.promise),
+    };
+    activateCodeClient(first);
+    const stale = useCodeCatalogStore
+      .getState()
+      .ensureHarnessModels(first, "codex");
+
+    const replacement = {
+      listCodeHarnessModels: vi.fn(async () => ({
+        kind: "codex" as const,
+        models: [
+          {
+            id: "gpt-new",
+            label: "New model",
+            default: true,
+            reasoning_efforts: [],
+            fast_mode: false,
+          },
+        ],
+        reasoning_efforts: [],
+      })),
+    };
+    activateCodeClient(replacement);
+    await useCodeCatalogStore
+      .getState()
+      .ensureHarnessModels(replacement, "codex");
+
+    staleModels.resolve({
+      kind: "codex",
+      models: [
+        {
+          id: "gpt-old",
+          label: "Old model",
+          default: true,
+          reasoning_efforts: [],
+          fast_mode: false,
+        },
+      ],
+      reasoning_efforts: [],
+    });
+    await stale;
+
+    expect(replacement.listCodeHarnessModels).toHaveBeenCalledOnce();
+    expect(useCodeCatalogStore.getState().modelsByHarness.codex).toEqual([
+      expect.objectContaining({ id: "gpt-new" }),
+    ]);
+  });
+
   it("caches an empty native model catalog", async () => {
     const client = {
       listCodeHarnessModels: vi.fn(async () => ({
@@ -182,6 +260,42 @@ describe("CodeCatalogStore.ensureHarnessModels", () => {
 });
 
 describe("CodeCatalogStore.refresh", () => {
+  it("does not let an old catalog populate or block a replacement", async () => {
+    const staleRepos = deferred<CodeRepoSnapshot[]>();
+    const first = {
+      listCodeRepos: vi.fn(() => staleRepos.promise),
+      listCodeWorkspaces: vi.fn(async () => []),
+      getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+      listCodeHarnessModels: vi.fn(async (kind: string) => ({
+        kind,
+        models: [],
+      })),
+    };
+    activateCodeClient(first);
+    const stale = useCodeCatalogStore.getState().refresh(first as never);
+
+    const replacement = {
+      listCodeRepos: vi.fn(async () => [repo("repo-new")]),
+      listCodeWorkspaces: vi.fn(async () => []),
+      getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+      listCodeHarnessModels: vi.fn(async (kind: string) => ({
+        kind,
+        models: [],
+      })),
+    };
+    activateCodeClient(replacement);
+    const fresh = useCodeCatalogStore.getState().refresh(replacement as never);
+    await fresh;
+
+    expect(replacement.listCodeRepos).toHaveBeenCalledOnce();
+    expect(useCodeCatalogStore.getState().repos).toEqual([repo("repo-new")]);
+
+    staleRepos.resolve([repo("repo-old")]);
+    await stale;
+
+    expect(useCodeCatalogStore.getState().repos).toEqual([repo("repo-new")]);
+  });
+
   it("shares one catalog request across the sidebar and route body", async () => {
     const client = {
       listCodeRepos: vi.fn(async () => []),

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -9,6 +9,10 @@ import type {
   HarnessKind,
   ReasoningEffort,
 } from "../api/types";
+import {
+  codeClientGeneration,
+  isCodeClientGenerationActive,
+} from "./CodeClientGeneration";
 import { harnessCodeModels, type CodeModelOption } from "./labels";
 
 const HARNESS_KINDS: HarnessKind[] = [
@@ -19,9 +23,23 @@ const HARNESS_KINDS: HarnessKind[] = [
 ];
 
 /** One native model probe per harness, shared by every open picker. */
-const modelRequests = new Map<HarnessKind, Promise<CodeModelOption[]>>();
+type CatalogRequestContext = {
+  clientGeneration: number;
+  storeGeneration: number;
+};
+
+type ModelRequest = CatalogRequestContext & {
+  promise: Promise<CodeModelOption[]>;
+};
+
+type CatalogRefresh = CatalogRequestContext & {
+  promise: Promise<void>;
+};
+
+const modelRequests = new Map<HarnessKind, ModelRequest>();
 /** Sidebar and route bodies mount together; they share one catalog refresh. */
-let catalogRefresh: Promise<void> | null = null;
+let catalogRefresh: CatalogRefresh | null = null;
+let storeGeneration = 0;
 
 /**
  * Repos, workspaces, and the last session each workspace opened.
@@ -93,27 +111,56 @@ function loadHarnessModels(
   kind: HarnessKind,
   get: () => CodeCatalogStore,
   force: boolean,
+  context = requestContext(client),
 ): Promise<CodeModelOption[]> {
+  if (!requestIsCurrent(context)) return Promise.resolve([]);
   const cached = get().modelsByHarness[kind];
   // An empty array is a finished probe: this engine advertised no models.
   // Treating it as a cache miss makes every picker open run the CLI again.
   if (!force && cached !== undefined) return Promise.resolve(cached);
   const pending = modelRequests.get(kind);
-  if (pending) return pending;
+  if (pending && sameRequestContext(pending, context)) return pending.promise;
 
   const request = client
     .listCodeHarnessModels(kind)
     .then((listed) => {
+      if (!requestIsCurrent(context)) return [];
       const models = harnessCodeModels(listed.models, kind);
       get().rememberHarnessModels(kind, models, listed.reasoning_efforts);
       return models;
     })
     .catch(() => [])
     .finally(() => {
-      if (modelRequests.get(kind) === request) modelRequests.delete(kind);
+      if (modelRequests.get(kind)?.promise === request) {
+        modelRequests.delete(kind);
+      }
     });
-  modelRequests.set(kind, request);
+  modelRequests.set(kind, { ...context, promise: request });
   return request;
+}
+
+function requestContext(client: object): CatalogRequestContext {
+  return {
+    clientGeneration: codeClientGeneration(client),
+    storeGeneration,
+  };
+}
+
+function sameRequestContext(
+  left: CatalogRequestContext,
+  right: CatalogRequestContext,
+): boolean {
+  return (
+    left.clientGeneration === right.clientGeneration &&
+    left.storeGeneration === right.storeGeneration
+  );
+}
+
+function requestIsCurrent(context: CatalogRequestContext): boolean {
+  return (
+    context.storeGeneration === storeGeneration &&
+    isCodeClientGenerationActive(context.clientGeneration)
+  );
 }
 
 export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
@@ -126,7 +173,11 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
   loaded: false,
   error: null,
   refresh: (client) => {
-    if (catalogRefresh) return catalogRefresh;
+    const context = requestContext(client);
+    if (!requestIsCurrent(context)) return Promise.resolve();
+    if (catalogRefresh && sameRequestContext(catalogRefresh, context)) {
+      return catalogRefresh.promise;
+    }
     const workspaceIdsAtStart = new Set(
       get().workspaces.map((workspace) => workspace.id),
     );
@@ -137,6 +188,7 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
           client.listCodeRepos(),
           client.listCodeWorkspaces(),
         ]);
+        if (!requestIsCurrent(context)) return;
         const localCreates = get().workspaces.filter(
           (workspace) =>
             isOptimisticWorkspace(workspace) ||
@@ -157,17 +209,22 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
           error: null,
         });
       } catch (error) {
+        if (!requestIsCurrent(context)) return;
         set({
           loaded: true,
           error: error instanceof Error ? error.message : String(error),
         });
         return;
       }
+      if (!requestIsCurrent(context)) return;
       const extras: Promise<void>[] = [
         client
           .getHarnessDoctor()
-          .then((doctor) => set({ doctor }))
+          .then((doctor) => {
+            if (requestIsCurrent(context)) set({ doctor });
+          })
           .catch(() => {
+            if (!requestIsCurrent(context)) return;
             // Home waits on a settled report. An empty one leaves the loading
             // empty and shows the install section instead of spinning forever.
             if (get().doctor === null) {
@@ -177,26 +234,33 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
       ];
       for (const kind of HARNESS_KINDS) {
         extras.push(
-          loadHarnessModels(client, kind, get, true).then(() => undefined),
+          loadHarnessModels(client, kind, get, true, context).then(
+            () => undefined,
+          ),
         );
       }
       await Promise.all(extras);
     })().finally(() => {
-      if (catalogRefresh === request) catalogRefresh = null;
+      if (catalogRefresh?.promise === request) catalogRefresh = null;
     });
-    catalogRefresh = request;
+    catalogRefresh = { ...context, promise: request };
     return request;
   },
   refreshDoctor: async (client) => {
+    const context = requestContext(client);
+    if (!requestIsCurrent(context)) return;
     const doctor = await client.refreshHarnessDoctor();
-    set({ doctor });
+    if (requestIsCurrent(context)) set({ doctor });
   },
   // The memoized read, for picking up an engine a download just put on disk.
   // `refreshDoctor` is the doctor's own button: it drops every memoized probe
   // and takes them all cold, which is far more than reading one result that
   // already exists.
   reloadDoctor: async (client) => {
-    set({ doctor: await client.getHarnessDoctor() });
+    const context = requestContext(client);
+    if (!requestIsCurrent(context)) return;
+    const doctor = await client.getHarnessDoctor();
+    if (requestIsCurrent(context)) set({ doctor });
   },
   ensureHarnessModels: (client, kind) =>
     loadHarnessModels(client, kind, get, false),
@@ -269,6 +333,7 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     });
   },
   reset: () => {
+    storeGeneration += 1;
     catalogRefresh = null;
     modelRequests.clear();
     set({

--- a/crates/tidebreak-desktop/ui/src/code/CodeClientGeneration.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeClientGeneration.ts
@@ -1,0 +1,37 @@
+let clientGenerations = new WeakMap<object, number>();
+let nextClientGeneration = 0;
+let activeClientGeneration: number | null = null;
+
+/** A stable identity for one ApiClient object. */
+export function codeClientGeneration(client: object): number {
+  const existing = clientGenerations.get(client);
+  if (existing !== undefined) return existing;
+  nextClientGeneration += 1;
+  clientGenerations.set(client, nextClientGeneration);
+  return nextClientGeneration;
+}
+
+/** Mark one ApiClient generation as the only Code authority allowed to write. */
+export function activateCodeClientGeneration(client: object): {
+  generation: number;
+  changed: boolean;
+} {
+  const generation = codeClientGeneration(client);
+  const changed = activeClientGeneration !== generation;
+  activeClientGeneration = generation;
+  return { generation, changed };
+}
+
+/** Standalone stores accept calls before AppShell establishes an authority. */
+export function isCodeClientGenerationActive(generation: number): boolean {
+  return (
+    activeClientGeneration === null || activeClientGeneration === generation
+  );
+}
+
+/** Test-only: restore the module to its pre-AppShell state. */
+export function resetCodeClientGenerationForTests(): void {
+  clientGenerations = new WeakMap<object, number>();
+  nextClientGeneration = 0;
+  activeClientGeneration = null;
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeClientScope.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeClientScope.ts
@@ -1,0 +1,29 @@
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { activateCodeClientGeneration } from "./CodeClientGeneration";
+import { resetCodeDeliveryHostState } from "./CodeDeliveryStore";
+import { resetCodeSessionRegistry } from "./CodeSessionRegistry";
+import { resetCodeUiHostState } from "./CodeUiStore";
+import {
+  activateCodeCloneClient,
+  disconnectCodeUpdates,
+  useCodeUpdatesStore,
+} from "./CodeUpdatesStore";
+import { resetCodeSubscriptionUsageStore } from "./useCodeSubscriptionUsage";
+
+/**
+ * Move every host-scoped Code store to one ApiClient before routes can mount.
+ */
+export function activateCodeClient(client: object): number {
+  const activation = activateCodeClientGeneration(client);
+  if (!activation.changed) return activation.generation;
+
+  disconnectCodeUpdates();
+  resetCodeSessionRegistry();
+  useCodeCatalogStore.getState().reset();
+  resetCodeDeliveryHostState();
+  resetCodeSubscriptionUsageStore();
+  resetCodeUiHostState();
+  useCodeUpdatesStore.getState().reset();
+  activateCodeCloneClient(client);
+  return activation.generation;
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
@@ -9,6 +9,10 @@ import type {
 } from "../api/types";
 import { requestUserAttention } from "../host";
 import {
+  codeClientGeneration,
+  isCodeClientGenerationActive,
+} from "./CodeClientGeneration";
+import {
   codeDeliveryRepositoryTarget,
   trackedCodeDeliveryRepositories,
   useCodeDeliveryStore,
@@ -52,11 +56,14 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
   }, [pathname, deliveryRevision]);
 
   useEffect(() => {
+    const clientGeneration = codeClientGeneration(client);
     let cancelled = false;
     let running = false;
     let rerunRequested = false;
     let timer: number | null = null;
     let queryController: AbortController | null = null;
+    const isCurrent = () =>
+      !cancelled && isCodeClientGenerationActive(clientGeneration);
 
     const interval = () => {
       if (document.hidden) return HIDDEN_POLL_MS;
@@ -64,7 +71,7 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
     };
 
     const schedule = (delay = interval()) => {
-      if (cancelled) return;
+      if (!isCurrent()) return;
       if (running) {
         rerunRequested = true;
         return;
@@ -77,7 +84,7 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
     };
 
     const poll = async () => {
-      if (cancelled) return;
+      if (!isCurrent()) return;
       if (running) {
         rerunRequested = true;
         return;
@@ -89,7 +96,7 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
       initial.setPollState(true, null);
       try {
         const discovered = await initial.loadRepositories(client);
-        if (cancelled) return;
+        if (!isCurrent()) return;
         const current = useCodeDeliveryStore.getState();
         if (
           !discovered.capability.found ||
@@ -157,7 +164,7 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
           runCursor = runBatch.nextCursor;
         }
 
-        if (cancelled) return;
+        if (!isCurrent()) return;
         const added = useCodeDeliveryStore
           .getState()
           .completeDeliveryPoll(pullRequests, runs, startedAt);
@@ -167,14 +174,14 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
           });
         }
       } catch (error) {
-        if (cancelled || isAbortError(error)) return;
+        if (!isCurrent() || isAbortError(error)) return;
         useCodeDeliveryStore
           .getState()
           .setPollState(false, deliveryErrorMessage(error));
       } finally {
         queryController = null;
         running = false;
-        if (!cancelled) schedule(rerunRequested ? 0 : interval());
+        if (isCurrent()) schedule(rerunRequested ? 0 : interval());
       }
     };
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   codeDeliveryRepositoryKey,
   mergeKnownAuthors,
+  resetCodeDeliveryHostState,
   trackedCodeDeliveryRepositories,
   unreadCodeDeliveryNotifications,
   useCodeDeliveryStore,
@@ -93,6 +94,36 @@ afterEach(() => {
 });
 
 describe("trackedCodeDeliveryRepositories", () => {
+  it("clears host data without deleting Delivery preferences", () => {
+    const manual = repository("other-org", "manual");
+    useCodeDeliveryStore.getState().rememberManualRepositories([manual]);
+    useCodeDeliveryStore.setState({
+      polling: true,
+      monitorError: "old host failed",
+      repositorySnapshot: {
+        capability: { found: true, authenticated: true, remediation: "" },
+        repositories: [repository("brightwave-inc", "old", "repo-old")],
+        errors: [],
+        fetched_at: NOW,
+      },
+      repositoryLoading: true,
+      repositoryError: "stale",
+      repositoryFetchedAt: Date.now(),
+    });
+
+    resetCodeDeliveryHostState();
+
+    expect(useCodeDeliveryStore.getState()).toMatchObject({
+      manualRepositories: [manual],
+      polling: false,
+      monitorError: null,
+      repositorySnapshot: null,
+      repositoryLoading: false,
+      repositoryError: null,
+      repositoryFetchedAt: null,
+    });
+  });
+
   it("combines registered and manual repositories, excludes opted-out rows, and pins first", () => {
     const alpha = repository("brightwave-inc", "alpha", "repo-alpha");
     const zeta = repository("brightwave-inc", "zeta", "repo-zeta");

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.ts
@@ -474,6 +474,21 @@ export const useCodeDeliveryStore = create<CodeDeliveryStore>()((set, get) => {
   };
 });
 
+/** Clear server-derived Delivery data without deleting reader preferences. */
+export function resetCodeDeliveryHostState(): void {
+  repositoryGeneration += 1;
+  repositoryRequest = null;
+  useCodeDeliveryStore.setState({
+    polling: false,
+    monitorError: null,
+    lastSuccessfulPollAt: null,
+    repositorySnapshot: null,
+    repositoryLoading: false,
+    repositoryError: null,
+    repositoryFetchedAt: null,
+  });
+}
+
 function buildDeliveryPoll(
   state: Pick<
     CodeDeliveryStore,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -2,11 +2,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CodeTurnSnapshot, SequencedCodeEventFrame } from "../api/types";
 import {
   acquireCodeSession,
+  acquireCodeSessionFromClient,
   MAX_RETAINED_CODE_SESSIONS,
   peekCodeSession,
   releaseCodeSession,
   resetCodeSessionRegistry,
 } from "./CodeSessionRegistry";
+import { resetCodeClientGenerationForTests } from "./CodeClientGeneration";
+import { activateCodeClient } from "./CodeClientScope";
 import { userItemId } from "./CodeSessionReducer";
 
 class FakeSocket {
@@ -66,9 +69,78 @@ function turnSnapshot(
 afterEach(() => {
   vi.useRealTimers();
   resetCodeSessionRegistry();
+  resetCodeClientGenerationForTests();
 });
 
 describe("CodeSessionRegistry", () => {
+  it("does not let old session hydration populate a replacement client", async () => {
+    const staleTurns = deferred<CodeTurnSnapshot[]>();
+    const oldSockets: FakeSocket[] = [];
+    const first = {
+      listCodeSessionTurns: vi.fn(() => staleTurns.promise),
+      openCodeEvents: vi.fn(
+        (
+          _sessionId: string,
+          after: number,
+          onFrame: (frame: SequencedCodeEventFrame) => void,
+        ) => {
+          const socket = new FakeSocket(after, onFrame);
+          oldSockets.push(socket);
+          return socket as unknown as WebSocket;
+        },
+      ),
+    };
+    activateCodeClient(first);
+    const oldStore = acquireCodeSessionFromClient("s1", first as never);
+
+    const newSockets: FakeSocket[] = [];
+    const replacement = {
+      listCodeSessionTurns: vi.fn(async () => [
+        turnSnapshot(
+          "t2",
+          "completed",
+          "2026-08-26T12:00:00.000Z",
+          "2026-08-26T12:00:01.000Z",
+        ),
+      ]),
+      openCodeEvents: vi.fn(
+        (
+          _sessionId: string,
+          after: number,
+          onFrame: (frame: SequencedCodeEventFrame) => void,
+        ) => {
+          const socket = new FakeSocket(after, onFrame);
+          newSockets.push(socket);
+          return socket as unknown as WebSocket;
+        },
+      ),
+    };
+    activateCodeClient(replacement);
+    const newStore = acquireCodeSessionFromClient("s1", replacement as never);
+    await flushMicrotasks();
+
+    staleTurns.resolve([
+      turnSnapshot(
+        "t1",
+        "completed",
+        "2026-08-25T12:00:00.000Z",
+        "2026-08-25T12:00:01.000Z",
+      ),
+    ]);
+    await flushMicrotasks();
+
+    expect(oldSockets).toHaveLength(0);
+    expect(newSockets).toHaveLength(1);
+    expect(peekCodeSession("s1")?.store).toBe(newStore);
+    expect(oldStore.getState().items).toEqual([]);
+    expect(newStore.getState().items).toContainEqual(
+      expect.objectContaining({ kind: "user", turnId: "t2" }),
+    );
+    expect(newStore.getState().items).not.toContainEqual(
+      expect.objectContaining({ kind: "user", turnId: "t1" }),
+    );
+  });
+
   it("marks the session hydrated even when the snapshot cannot be read", async () => {
     vi.useFakeTimers();
     const sockets: FakeSocket[] = [];

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -1,5 +1,6 @@
 import type { ApiClient } from "../api/client";
 import type { CodeTurnSnapshot, SequencedCodeEventFrame } from "../api/types";
+import { codeClientGeneration } from "./CodeClientGeneration";
 import { CodeSessionController } from "./CodeSessionController";
 import {
   createCodeSessionStore,
@@ -31,6 +32,7 @@ export type CodeSessionEntry = {
   controller: CodeSessionController | null;
   refCount: number;
   turnsHydrated: boolean;
+  clientGeneration: number | null;
 };
 
 const registry = new Map<string, CodeSessionEntry>();
@@ -146,8 +148,15 @@ export function acquireCodeSession(
   openSocket: CodeSessionOpenSocket,
   deps: CodeSessionDeps = defaultDeps,
   hydrateTurns?: () => Promise<CodeTurnSnapshot[]>,
+  clientGeneration: number | null = null,
 ): ReturnType<typeof createCodeSessionStore> {
-  const existing = registry.get(sessionId);
+  let existing = registry.get(sessionId);
+  if (existing && existing.clientGeneration !== clientGeneration) {
+    existing.controller?.dispose();
+    retainedSessionIds.delete(sessionId);
+    registry.delete(sessionId);
+    existing = undefined;
+  }
   if (existing) {
     if (existing.refCount === 0) {
       retainedSessionIds.delete(sessionId);
@@ -176,6 +185,7 @@ export function acquireCodeSession(
     controller: null,
     refCount: 1,
     turnsHydrated: hydrateTurns === undefined,
+    clientGeneration,
   };
   registry.set(sessionId, entry);
   entry.controller = createController(
@@ -202,6 +212,7 @@ export function acquireCodeSessionFromClient(
     (after, onFrame) => client.openCodeEvents(sessionId, after, onFrame),
     deps,
     () => client.listCodeSessionTurns(sessionId),
+    codeClientGeneration(client),
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -481,3 +481,22 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
     return true;
   },
 }));
+
+/** Clear Code actions that refer to the authority AppShell just replaced. */
+export function resetCodeUiHostState(): void {
+  useCodeUiStore.setState({
+    newWorkspaceOpen: false,
+    newWorkspaceRepoId: undefined,
+    addRepoOpen: false,
+    inspectorScope: null,
+    terminalPending: false,
+    pendingComposerPrompt: null,
+    composerActionScope: null,
+    quickOpenPending: false,
+    filesSearchPending: false,
+    workflowShortcutPending: null,
+    archivePending: false,
+    workflowSuggestion: null,
+    openFilePending: null,
+  });
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -14,6 +14,10 @@ import type {
   PullRequestDigest,
 } from "../api/types";
 import {
+  codeClientGeneration,
+  isCodeClientGenerationActive,
+} from "./CodeClientGeneration";
+import {
   INITIAL_RECONNECT_DELAY_MS,
   MAX_RECONNECT_DELAY_MS,
   nextReconnectDelay,
@@ -483,18 +487,9 @@ export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
   reset: () => set({ ...EMPTY }),
 }));
 
-const clientGenerations = new WeakMap<object, number>();
-let nextClientGeneration = 0;
 let nextCloneOrder = 0;
 
-/** A stable identity for one ApiClient object. */
-export function codeClientGeneration(client: object): number {
-  const existing = clientGenerations.get(client);
-  if (existing !== undefined) return existing;
-  nextClientGeneration += 1;
-  clientGenerations.set(client, nextClientGeneration);
-  return nextClientGeneration;
-}
+export { codeClientGeneration };
 
 /**
  * Move clone state to one client authority. A job ID from another machine or
@@ -502,6 +497,7 @@ export function codeClientGeneration(client: object): number {
  */
 export function activateCodeCloneClient(client: object): number {
   const clientGeneration = codeClientGeneration(client);
+  if (!isCodeClientGenerationActive(clientGeneration)) return clientGeneration;
   useCodeUpdatesStore.setState((state) => {
     if (state.cloneClientGeneration === clientGeneration) return state;
     return {
@@ -833,9 +829,17 @@ export function disconnectCodeUpdates(): void {
 }
 
 function open(client: CloneUpdatesClient, born: number): void {
-  if (born !== generation) return;
+  const clientGeneration = codeClientGeneration(client);
+  if (born !== generation || !isCodeClientGenerationActive(clientGeneration)) {
+    return;
+  }
   const next = client.openCodeUpdates((notice) => {
-    if (born !== generation) return;
+    if (
+      born !== generation ||
+      !isCodeClientGenerationActive(clientGeneration)
+    ) {
+      return;
+    }
     const action = noticeToAction(notice);
     if (
       action?.type === "clone_progress" &&
@@ -848,12 +852,22 @@ function open(client: CloneUpdatesClient, born: number): void {
   });
   socket = next;
   next.onopen = () => {
-    if (born !== generation) return;
+    if (
+      born !== generation ||
+      !isCodeClientGenerationActive(clientGeneration)
+    ) {
+      return;
+    }
     reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
     reconcileTrackedClones(client, born);
   };
   next.onclose = () => {
-    if (born !== generation) return;
+    if (
+      born !== generation ||
+      !isCodeClientGenerationActive(clientGeneration)
+    ) {
+      return;
+    }
     socket = null;
     scheduleReconnect(client, born);
   };
@@ -863,7 +877,12 @@ function open(client: CloneUpdatesClient, born: number): void {
 }
 
 function scheduleReconnect(client: CloneUpdatesClient, born: number): void {
-  if (born !== generation) return;
+  if (
+    born !== generation ||
+    !isCodeClientGenerationActive(codeClientGeneration(client))
+  ) {
+    return;
+  }
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
     open(client, born);

--- a/crates/tidebreak-desktop/ui/src/code/useCodeSubscriptionUsage.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useCodeSubscriptionUsage.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CodeSubscriptionUsage } from "../api/types";
+import { resetCodeClientGenerationForTests } from "./CodeClientGeneration";
+import { activateCodeClient } from "./CodeClientScope";
+import {
+  resetCodeSubscriptionUsageStore,
+  useCodeSubscriptionUsageStore,
+} from "./useCodeSubscriptionUsage";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function usage(providerId: string): CodeSubscriptionUsage {
+  return {
+    source: "model_gateway",
+    diagnostics: [],
+    providers: [
+      {
+        id: providerId,
+        label: providerId,
+        accounts: [],
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  resetCodeSubscriptionUsageStore();
+  resetCodeClientGenerationForTests();
+});
+
+describe("Code subscription usage client generation", () => {
+  it("starts the replacement refresh and ignores the old result", async () => {
+    const staleUsage = deferred<CodeSubscriptionUsage>();
+    const first = {
+      getCodeSubscriptionUsage: vi.fn(() => staleUsage.promise),
+    };
+    activateCodeClient(first);
+    const stale = useCodeSubscriptionUsageStore
+      .getState()
+      .refresh(first as never);
+
+    const freshUsage = deferred<CodeSubscriptionUsage>();
+    const replacement = {
+      getCodeSubscriptionUsage: vi.fn(() => freshUsage.promise),
+    };
+    activateCodeClient(replacement);
+    const fresh = useCodeSubscriptionUsageStore
+      .getState()
+      .refresh(replacement as never);
+
+    await Promise.resolve();
+    expect(replacement.getCodeSubscriptionUsage).toHaveBeenCalledOnce();
+    staleUsage.resolve(usage("old"));
+    await stale;
+    expect(useCodeSubscriptionUsageStore.getState()).toMatchObject({
+      report: null,
+      refreshing: true,
+      refreshInFlight: true,
+    });
+
+    freshUsage.resolve(usage("new"));
+    await fresh;
+    expect(useCodeSubscriptionUsageStore.getState()).toMatchObject({
+      report: usage("new"),
+      refreshing: false,
+      refreshInFlight: false,
+      error: null,
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/useCodeSubscriptionUsage.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useCodeSubscriptionUsage.ts
@@ -4,6 +4,10 @@ import { create } from "zustand";
 import { useApp } from "@/AppContext";
 import type { ApiClient } from "@/api/client";
 import type { CodeSubscriptionUsage } from "@/api/types";
+import {
+  codeClientGeneration,
+  isCodeClientGenerationActive,
+} from "./CodeClientGeneration";
 
 const REFRESH_INTERVAL_MS = 60_000;
 
@@ -15,23 +19,68 @@ type CodeSubscriptionUsageState = {
   refresh: (client: ApiClient) => Promise<void>;
 };
 
+type SubscriptionRequest = {
+  clientGeneration: number;
+  storeGeneration: number;
+  promise: Promise<void>;
+};
+
+let storeGeneration = 0;
+let refreshRequest: SubscriptionRequest | null = null;
+
+function requestIsCurrent(
+  clientGeneration: number,
+  requestStoreGeneration: number,
+): boolean {
+  return (
+    requestStoreGeneration === storeGeneration &&
+    isCodeClientGenerationActive(clientGeneration)
+  );
+}
+
 export const useCodeSubscriptionUsageStore = create<CodeSubscriptionUsageState>(
-  (set, get) => ({
+  (set) => ({
     report: null,
     refreshing: false,
     error: null,
     refreshInFlight: false,
-    refresh: async (client) => {
-      if (get().refreshInFlight) return;
-      set({ refreshInFlight: true, refreshing: true });
-      try {
-        const report = await client.getCodeSubscriptionUsage();
-        set({ report, error: null });
-      } catch {
-        set({ error: "Usage could not be refreshed." });
-      } finally {
-        set({ refreshInFlight: false, refreshing: false });
+    refresh: (client) => {
+      const clientGeneration = codeClientGeneration(client);
+      const requestStoreGeneration = storeGeneration;
+      if (!requestIsCurrent(clientGeneration, requestStoreGeneration)) {
+        return Promise.resolve();
       }
+      if (
+        refreshRequest?.clientGeneration === clientGeneration &&
+        refreshRequest.storeGeneration === requestStoreGeneration
+      ) {
+        return refreshRequest.promise;
+      }
+      set({ refreshInFlight: true, refreshing: true });
+      const promise = Promise.resolve()
+        .then(() => client.getCodeSubscriptionUsage())
+        .then((report) => {
+          if (requestIsCurrent(clientGeneration, requestStoreGeneration)) {
+            set({ report, error: null });
+          }
+        })
+        .catch(() => {
+          if (requestIsCurrent(clientGeneration, requestStoreGeneration)) {
+            set({ error: "Usage could not be refreshed." });
+          }
+        })
+        .finally(() => {
+          if (refreshRequest?.promise === promise) refreshRequest = null;
+          if (requestIsCurrent(clientGeneration, requestStoreGeneration)) {
+            set({ refreshInFlight: false, refreshing: false });
+          }
+        });
+      refreshRequest = {
+        clientGeneration,
+        storeGeneration: requestStoreGeneration,
+        promise,
+      };
+      return promise;
     },
   }),
 );
@@ -58,6 +107,8 @@ export function useCodeSubscriptionUsage() {
 }
 
 export function resetCodeSubscriptionUsageStore() {
+  storeGeneration += 1;
+  refreshRequest = null;
   useCodeSubscriptionUsageStore.setState({
     report: null,
     refreshing: false,


### PR DESCRIPTION
## What changed

- Activate one Code client generation before `AppShell` exposes a replacement `ApiClient`.
- Reset host-scoped catalog, subscription, session, delivery, updates, clone, and transient UI state when the authority changes.
- Fence in-flight catalog, model, subscription, session, delivery, and update writes so an old client cannot populate or block the replacement client.
- Add deterministic race tests for client replacement during catalog, model, subscription, and session work.

## Validation

- Focused Vitest: 93 tests passed across seven suites.
- TypeScript: `tsc --noEmit --incremental false` passed.
- Biome check passed.
- `git diff --check` passed.
- No local Cargo commands were run.

## Compatibility and risk

No wire-format or persisted-data changes. The reset keeps persistent reader preferences and clears only state tied to the replaced host authority.

## Tracking

Closes #2670