### PR TITLE
feat(code): open local worktree folders

### DIFF
--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -26,6 +26,7 @@
 server_info: hands the renderer the embedded server's address and per-launch token — the handshake that makes every HTTP route reachable, so it cannot itself be one.
 request_user_attention: native window attention hint when a parked question needs the user.
 code_browser_command: creates and controls sandboxed native child webviews whose bounds and lifecycle exist only in the desktop shell.
+open_code_worktree: opens a local Code worktree through this operating system's folder handler; a headless server cannot open desktop UI.
 
 # Attaching this client to a machine it does not host (ADR 0047)
 remote_machine_state: reports which machine this client is attached to, from shell-held state that exists before any machine is reachable.

--- a/crates/tidebreak-desktop/src/code_worktree.rs
+++ b/crates/tidebreak-desktop/src/code_worktree.rs
@@ -1,0 +1,256 @@
+//! Native open action for a Code workspace's local worktree.
+//!
+//! The server owns workspace creation and stores the path. The desktop owns
+//! the one thing a headless server cannot do: ask this operating system to
+//! open that directory in its normal file manager. The renderer can propose a
+//! path, but this command refuses remote attachments, relative paths, missing
+//! paths, and non-directories before it starts a fixed platform launcher.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use tidebreak_core::{CodeWorkspaceStatus, WorkspaceId};
+
+use crate::remote::RemoteAttachment;
+use crate::{wait_server_info, AppState};
+
+pub(crate) const REASON_AUTHORITY_UNAVAILABLE: &str = "code_worktree_authority_unavailable";
+pub(crate) const REASON_PATH_INVALID: &str = "code_worktree_path_invalid";
+pub(crate) const REASON_WORKSPACE_UNAVAILABLE: &str = "code_worktree_workspace_unavailable";
+pub(crate) const REASON_WORKSPACE_INACTIVE: &str = "code_worktree_workspace_inactive";
+pub(crate) const REASON_PATH_NOT_FOUND: &str = "code_worktree_path_not_found";
+pub(crate) const REASON_NOT_DIRECTORY: &str = "code_worktree_not_directory";
+pub(crate) const REASON_LAUNCHER_UNAVAILABLE: &str = "code_worktree_launcher_unavailable";
+pub(crate) const REASON_OPEN_FAILED: &str = "code_worktree_open_failed";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CodeWorktreeOpenError {
+    /// Stable reason code that the renderer turns into user-facing copy.
+    reason: &'static str,
+    /// Native diagnostic for logs and support. The renderer does not display it.
+    detail: Option<String>,
+}
+
+impl CodeWorktreeOpenError {
+    fn new(reason: &'static str) -> Self {
+        Self {
+            reason,
+            detail: None,
+        }
+    }
+
+    fn detailed(reason: &'static str, detail: impl std::fmt::Display) -> Self {
+        Self {
+            reason,
+            detail: Some(detail.to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CodeWorktreeOpenStatus {
+    Opened,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CodeWorktreeOpenResult {
+    status: CodeWorktreeOpenStatus,
+}
+
+/// Open one local worktree with this operating system's normal folder handler.
+#[tauri::command]
+pub(crate) async fn open_code_worktree(
+    attachment: State<'_, Arc<RemoteAttachment>>,
+    app_state: State<'_, Arc<AppState>>,
+    workspace_id: String,
+) -> Result<CodeWorktreeOpenResult, CodeWorktreeOpenError> {
+    if attachment.current().await.is_some() {
+        return Err(CodeWorktreeOpenError::new(REASON_AUTHORITY_UNAVAILABLE));
+    }
+    let workspace_id: WorkspaceId = workspace_id
+        .parse()
+        .map_err(|_| CodeWorktreeOpenError::new(REASON_WORKSPACE_UNAVAILABLE))?;
+    let info = wait_server_info(app_state.inner())
+        .await
+        .map_err(|error| CodeWorktreeOpenError::detailed(REASON_WORKSPACE_UNAVAILABLE, error))?;
+    let workspace = read_workspace(&info, workspace_id).await?;
+    if !matches!(
+        workspace.status,
+        CodeWorkspaceStatus::Active | CodeWorkspaceStatus::SetupFailed
+    ) {
+        return Err(CodeWorktreeOpenError::new(REASON_WORKSPACE_INACTIVE));
+    }
+    open_directory(PathBuf::from(workspace.worktree_path))
+}
+
+#[derive(Deserialize)]
+struct CodeWorktreeSnapshot {
+    worktree_path: String,
+    status: CodeWorkspaceStatus,
+}
+
+async fn read_workspace(
+    info: &crate::NativeServerInfo,
+    workspace_id: WorkspaceId,
+) -> Result<CodeWorktreeSnapshot, CodeWorktreeOpenError> {
+    let response = crate::documents::local_client()
+        .get(format!("{}/code/workspaces/{workspace_id}", info.base_url))
+        .bearer_auth(&info.token)
+        .send()
+        .await
+        .map_err(|error| CodeWorktreeOpenError::detailed(REASON_WORKSPACE_UNAVAILABLE, error))?;
+    if !response.status().is_success() {
+        return Err(CodeWorktreeOpenError::detailed(
+            REASON_WORKSPACE_UNAVAILABLE,
+            response.status(),
+        ));
+    }
+    response
+        .json()
+        .await
+        .map_err(|error| CodeWorktreeOpenError::detailed(REASON_WORKSPACE_UNAVAILABLE, error))
+}
+
+fn open_directory(path: PathBuf) -> Result<CodeWorktreeOpenResult, CodeWorktreeOpenError> {
+    validate_directory(&path)?;
+    let plan = launcher_plan(current_platform(), &path)
+        .ok_or_else(|| CodeWorktreeOpenError::new(REASON_LAUNCHER_UNAVAILABLE))?;
+    let mut command = tokio::process::Command::new(plan.program);
+    command
+        .args(plan.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(false);
+    let mut child = command.spawn().map_err(|error| {
+        let reason = if error.kind() == std::io::ErrorKind::NotFound {
+            REASON_LAUNCHER_UNAVAILABLE
+        } else {
+            REASON_OPEN_FAILED
+        };
+        CodeWorktreeOpenError::detailed(reason, error)
+    })?;
+    tauri::async_runtime::spawn(async move {
+        let _ = child.wait().await;
+    });
+    Ok(CodeWorktreeOpenResult {
+        status: CodeWorktreeOpenStatus::Opened,
+    })
+}
+
+fn validate_directory(path: &Path) -> Result<(), CodeWorktreeOpenError> {
+    if !path.is_absolute() {
+        return Err(CodeWorktreeOpenError::new(REASON_PATH_INVALID));
+    }
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => Err(CodeWorktreeOpenError::new(REASON_NOT_DIRECTORY)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Err(CodeWorktreeOpenError::new(REASON_PATH_NOT_FOUND))
+        }
+        Err(error) => Err(CodeWorktreeOpenError::detailed(REASON_OPEN_FAILED, error)),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DesktopPlatform {
+    Macos,
+    Windows,
+    Linux,
+    Unsupported,
+}
+
+struct LauncherPlan {
+    program: &'static str,
+    args: Vec<OsString>,
+}
+
+fn launcher_plan(platform: DesktopPlatform, path: &Path) -> Option<LauncherPlan> {
+    let (program, args) = match platform {
+        DesktopPlatform::Macos => ("/usr/bin/open", vec![path.as_os_str().to_owned()]),
+        DesktopPlatform::Windows => ("explorer.exe", vec![path.as_os_str().to_owned()]),
+        DesktopPlatform::Linux => ("xdg-open", vec![path.as_os_str().to_owned()]),
+        DesktopPlatform::Unsupported => return None,
+    };
+    Some(LauncherPlan { program, args })
+}
+
+const fn current_platform() -> DesktopPlatform {
+    #[cfg(target_os = "macos")]
+    {
+        return DesktopPlatform::Macos;
+    }
+    #[cfg(windows)]
+    {
+        return DesktopPlatform::Windows;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return DesktopPlatform::Linux;
+    }
+    #[allow(unreachable_code)]
+    DesktopPlatform::Unsupported
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_validation_refuses_relative_missing_and_file_targets() {
+        assert_eq!(
+            validate_directory(Path::new("relative/worktree"))
+                .unwrap_err()
+                .reason,
+            REASON_PATH_INVALID
+        );
+
+        let directory = tempfile::TempDir::new().unwrap();
+        let missing = directory.path().join("missing");
+        assert_eq!(
+            validate_directory(&missing).unwrap_err().reason,
+            REASON_PATH_NOT_FOUND
+        );
+
+        let file = directory.path().join("file");
+        std::fs::write(&file, "not a worktree").unwrap();
+        assert_eq!(
+            validate_directory(&file).unwrap_err().reason,
+            REASON_NOT_DIRECTORY
+        );
+        assert!(validate_directory(directory.path()).is_ok());
+    }
+
+    #[test]
+    fn every_supported_platform_uses_a_fixed_folder_launcher() {
+        let path = Path::new("/tmp/work tree");
+        for (platform, program) in [
+            (DesktopPlatform::Macos, "/usr/bin/open"),
+            (DesktopPlatform::Windows, "explorer.exe"),
+            (DesktopPlatform::Linux, "xdg-open"),
+        ] {
+            let plan = launcher_plan(platform, path).unwrap();
+            assert_eq!(plan.program, program);
+            assert_eq!(plan.args, vec![path.as_os_str().to_owned()]);
+        }
+        assert!(launcher_plan(DesktopPlatform::Unsupported, path).is_none());
+    }
+
+    #[test]
+    fn failures_serialize_as_stable_reason_and_private_detail() {
+        let value = serde_json::to_value(CodeWorktreeOpenError::detailed(
+            REASON_OPEN_FAILED,
+            "native detail",
+        ))
+        .unwrap();
+        assert_eq!(value["reason"], REASON_OPEN_FAILED);
+        assert_eq!(value["detail"], "native detail");
+    }
+}

--- a/crates/tidebreak-desktop/src/code_worktree.rs
+++ b/crates/tidebreak-desktop/src/code_worktree.rs
@@ -161,8 +161,11 @@ fn validate_directory(path: &Path) -> Result<(), CodeWorktreeOpenError> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DesktopPlatform {
+    #[cfg(any(target_os = "macos", test))]
     Macos,
+    #[cfg(any(target_os = "windows", test))]
     Windows,
+    #[cfg(any(target_os = "linux", test))]
     Linux,
     Unsupported,
 }
@@ -174,8 +177,11 @@ struct LauncherPlan {
 
 fn launcher_plan(platform: DesktopPlatform, path: &Path) -> Option<LauncherPlan> {
     let (program, args) = match platform {
+        #[cfg(any(target_os = "macos", test))]
         DesktopPlatform::Macos => ("/usr/bin/open", vec![path.as_os_str().to_owned()]),
+        #[cfg(any(target_os = "windows", test))]
         DesktopPlatform::Windows => ("explorer.exe", vec![path.as_os_str().to_owned()]),
+        #[cfg(any(target_os = "linux", test))]
         DesktopPlatform::Linux => ("xdg-open", vec![path.as_os_str().to_owned()]),
         DesktopPlatform::Unsupported => return None,
     };

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -34,6 +34,7 @@ mod channel;
 mod chat_debug;
 mod client_execution;
 mod code_browser;
+mod code_worktree;
 #[cfg(test)]
 mod command_parity;
 mod deep_link;
@@ -810,6 +811,7 @@ pub fn run() {
             put_native_mcp_servers,
             request_user_attention,
             code_browser::code_browser_command,
+            code_worktree::open_code_worktree,
             attachments::attach_chat_files,
             attachments::attach_dropped_chat_files,
             image_attachments::publish_chat_image,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -32,6 +32,7 @@ import {
 } from "./CodeUpdatesStore";
 import { FOCUS_RING, HOVER_TINT, RAIL_ICON_BUTTON } from "./interactive";
 import { findCodeTerminalTab } from "./codeChrome";
+import { canOpenLocalCodeWorktree } from "./codeWorktreeHost";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import { RailSettingsMenu } from "./RailSettingsMenu";
 import {
@@ -109,6 +110,7 @@ export function CodeSidebar() {
   useEffect(() => connectCodeUpdates(client), [client]);
 
   const groups = arrangeWorkspaces(prefs.sortMode, repos, workspaces, digests);
+  const canOpenWorktree = canOpenLocalCodeWorktree();
 
   return (
     <SidebarFrame
@@ -201,6 +203,7 @@ export function CodeSidebar() {
                               digest?.attention ??
                               sessions[workspace.id]?.attention
                             )?.state.type === "manual",
+                          canOpenWorktree,
                         })
                   }
                   childSessions={watchChildren(

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -38,6 +38,7 @@ function renderCard(overrides?: {
   density?: "compact" | "detailed";
   visibleMeta?: { repoChip: boolean; branch: boolean };
   detailDefaultOpen?: boolean;
+  canOpenWorktree?: boolean;
 }) {
   const onOpen = vi.fn();
   const onCommand = vi.fn();
@@ -59,6 +60,7 @@ function renderCard(overrides?: {
       commands={workspaceCommands({
         hasPr: Boolean(overrides?.pr),
         archived: merged.status === "archived",
+        canOpenWorktree: overrides?.canOpenWorktree,
       })}
       detailDefaultOpen={overrides?.detailDefaultOpen}
       onOpen={onOpen}
@@ -110,6 +112,33 @@ describe("WorkspaceCard", () => {
     expect(menu).toHaveTextContent("Archive");
     await user.click(screen.getByRole("menuitem", { name: "Toggle terminal" }));
     expect(onCommand).toHaveBeenCalledWith("toggle-terminal");
+  });
+
+  it("opens a local worktree from the hover detail and context menu", async () => {
+    const user = userEvent.setup();
+    const { onCommand } = renderCard({
+      canOpenWorktree: true,
+      detailDefaultOpen: true,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Open folder" }));
+    expect(onCommand).toHaveBeenCalledWith("open-worktree");
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: /^Fix login/ }));
+    expect(
+      await screen.findByRole("menuitem", { name: "Open worktree folder" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Copy worktree path" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps Copy path as the unsupported or remote fallback", async () => {
+    const user = userEvent.setup();
+    const { onCommand } = renderCard({ detailDefaultOpen: true });
+
+    await user.click(screen.getByRole("button", { name: "Copy path" }));
+    expect(onCommand).toHaveBeenCalledWith("copy-worktree");
   });
 
   it("announces a queued pull request and uses its orange chip", () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -1,13 +1,15 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import {
   Archive,
   Bot,
   CheckCircle2,
   CircleAlert,
+  Copy,
   CornerDownRight,
   ExternalLink,
   Eye,
   FileCode2,
+  FolderOpen,
   GitBranch,
   GitPullRequest,
   LoaderCircle,
@@ -131,6 +133,7 @@ export function WorkspaceCard({
   const creating = workspace.status === "creating";
   const attentionMark = attentionMarkForDigest(digest);
   const [detailOpen, setDetailOpen] = useState(detailDefaultOpen);
+  const compactDetail = useCompactWorkspaceDetail();
   const watchActive = childSessions.some(
     (child) =>
       child.watch_state === "watching" ||
@@ -236,7 +239,7 @@ export function WorkspaceCard({
           </ContextMenuTrigger>
 
           <HoverCardContent
-            side="right"
+            side={compactDetail ? "bottom" : "right"}
             align="start"
             sideOffset={10}
             className="w-[22rem] overflow-hidden rounded-xl border-border bg-popover p-0 shadow-[0_18px_48px_color-mix(in_oklch,var(--foreground)_16%,transparent)]"
@@ -251,6 +254,7 @@ export function WorkspaceCard({
               archived={archived}
               watchActive={watchActive}
               terminalOpen={terminalOpen}
+              commands={commands}
               onCommand={onCommand}
               onWorkflowAction={onWorkflowAction}
             />
@@ -316,6 +320,32 @@ export function WorkspaceCard({
   );
 }
 
+function useCompactWorkspaceDetail(): boolean {
+  const query = "(max-width: 639px)";
+  const [compact, setCompact] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+    const media = window.matchMedia(query);
+    const update = () => setCompact(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return compact;
+}
+
 const SUBAGENT_STATUS_LABELS: Record<CodeSubagentStatus, string> = {
   running: "Running",
   done: "Done",
@@ -338,6 +368,7 @@ function WorkspaceDetailPanel({
   archived,
   watchActive,
   terminalOpen,
+  commands,
   onCommand,
   onWorkflowAction,
 }: {
@@ -350,6 +381,7 @@ function WorkspaceDetailPanel({
   archived: boolean;
   watchActive: boolean;
   terminalOpen: boolean;
+  commands: readonly WorkspaceCommand[];
   onCommand: (command: WorkspaceCommand["id"]) => void;
   onWorkflowAction?: (action: WorkspaceWorkflowAction) => void;
 }) {
@@ -391,6 +423,10 @@ function WorkspaceDetailPanel({
   const putAwayLabel =
     workspace.status === "released" ? "Released" : "Archived";
   const prCountLabel = workspacePrChipSummary(digest?.pr_count);
+  const worktreeCommand = commands.find(
+    (command) =>
+      command.id === "open-worktree" || command.id === "copy-worktree",
+  );
 
   return (
     <div data-testid="workspace-hover-card">
@@ -541,6 +577,24 @@ function WorkspaceDetailPanel({
       </div>
 
       <div className="flex items-center gap-2 border-t border-border-subtle bg-muted/25 px-3 py-2">
+        {worktreeCommand && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 px-2 text-xs"
+            onClick={() => onCommand(worktreeCommand.id)}
+          >
+            {worktreeCommand.id === "open-worktree" ? (
+              <FolderOpen className="size-3" aria-hidden />
+            ) : (
+              <Copy className="size-3" aria-hidden />
+            )}
+            {worktreeCommand.id === "open-worktree"
+              ? "Open folder"
+              : "Copy path"}
+          </Button>
+        )}
         <Button
           type="button"
           variant="ghost"

--- a/crates/tidebreak-desktop/ui/src/code/codeWorktreeHost.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeWorktreeHost.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({ invoke, isTauri: () => true }));
+
+import {
+  CodeWorktreeOpenError,
+  codeWorktreeOpenFailureMessage,
+  codeWorktreePlatform,
+  openCodeWorktree,
+  parseCodeWorktreeOpenError,
+} from "./codeWorktreeHost";
+
+beforeEach(() => invoke.mockReset());
+
+describe("code worktree host", () => {
+  it("uses the narrow native command and validates its result", async () => {
+    invoke.mockResolvedValue({ status: "opened" });
+
+    await openCodeWorktree("e777ae2f-619c-4ed7-ad1f-8c9dfd179a90");
+
+    expect(invoke).toHaveBeenCalledWith("open_code_worktree", {
+      workspaceId: "e777ae2f-619c-4ed7-ad1f-8c9dfd179a90",
+    });
+    invoke.mockResolvedValue({ status: "unexpected" });
+    await expect(
+      openCodeWorktree("e777ae2f-619c-4ed7-ad1f-8c9dfd179a90"),
+    ).rejects.toMatchObject({ reason: "code_worktree_open_failed" });
+  });
+
+  it("keeps native failures typed and keeps their detail out of user copy", () => {
+    const error = parseCodeWorktreeOpenError({
+      reason: "code_worktree_path_not_found",
+      detail: "private native diagnostic",
+    });
+
+    expect(error).toBeInstanceOf(CodeWorktreeOpenError);
+    expect(error.reason).toBe("code_worktree_path_not_found");
+    expect(error.detail).toBe("private native diagnostic");
+    expect(
+      codeWorktreeOpenFailureMessage({
+        reason: "code_worktree_path_not_found",
+        detail: "private native diagnostic",
+      }),
+    ).toBe(
+      "The worktree folder no longer exists. Refresh or restore the workspace, then try again.",
+    );
+  });
+
+  it("falls back to a typed generic failure for malformed rejections", () => {
+    expect(parseCodeWorktreeOpenError("native stack trace")).toMatchObject({
+      reason: "code_worktree_open_failed",
+      detail: null,
+    });
+  });
+
+  it("recognizes only the desktop platforms with a native folder launcher", () => {
+    expect(
+      codeWorktreePlatform("Mozilla/5.0 (Macintosh; Intel Mac OS X)"),
+    ).toBe("macos");
+    expect(codeWorktreePlatform("Mozilla/5.0 (Windows NT 10.0; Win64)")).toBe(
+      "windows",
+    );
+    expect(codeWorktreePlatform("Mozilla/5.0 (X11; Linux x86_64)")).toBe(
+      "linux",
+    );
+    expect(codeWorktreePlatform("Tidebreak mobile")).toBe("unsupported");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/codeWorktreeHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeWorktreeHost.ts
@@ -1,0 +1,120 @@
+import { invoke } from "@tauri-apps/api/core";
+
+import { hasLocalHostAuthority } from "@/host";
+
+export type CodeWorktreeOpenReason =
+  | "code_worktree_authority_unavailable"
+  | "code_worktree_workspace_unavailable"
+  | "code_worktree_workspace_inactive"
+  | "code_worktree_path_invalid"
+  | "code_worktree_path_not_found"
+  | "code_worktree_not_directory"
+  | "code_worktree_launcher_unavailable"
+  | "code_worktree_open_failed";
+
+const OPEN_REASONS = new Set<CodeWorktreeOpenReason>([
+  "code_worktree_authority_unavailable",
+  "code_worktree_workspace_unavailable",
+  "code_worktree_workspace_inactive",
+  "code_worktree_path_invalid",
+  "code_worktree_path_not_found",
+  "code_worktree_not_directory",
+  "code_worktree_launcher_unavailable",
+  "code_worktree_open_failed",
+]);
+
+export class CodeWorktreeOpenError extends Error {
+  readonly reason: CodeWorktreeOpenReason;
+  readonly detail: string | null;
+
+  constructor(reason: CodeWorktreeOpenReason, detail: string | null = null) {
+    super(reason);
+    this.name = "CodeWorktreeOpenError";
+    this.reason = reason;
+    this.detail = detail;
+  }
+}
+
+export type CodeWorktreePlatform =
+  | "macos"
+  | "windows"
+  | "linux"
+  | "unsupported";
+
+export function codeWorktreePlatform(userAgent: string): CodeWorktreePlatform {
+  if (userAgent.includes("Mac OS")) return "macos";
+  if (userAgent.includes("Windows")) return "windows";
+  if (userAgent.includes("Linux")) return "linux";
+  return "unsupported";
+}
+
+/** Whether this window can open paths that belong to the active Code server. */
+export function canOpenLocalCodeWorktree(
+  userAgent = globalThis.navigator?.userAgent ?? "",
+): boolean {
+  return (
+    hasLocalHostAuthority() && codeWorktreePlatform(userAgent) !== "unsupported"
+  );
+}
+
+/** Ask the native shell to open one local worktree in the system file manager. */
+export async function openCodeWorktree(workspaceId: string): Promise<void> {
+  try {
+    const result: unknown = await invoke("open_code_worktree", { workspaceId });
+    if (!isExactOpenedResult(result)) {
+      throw new CodeWorktreeOpenError("code_worktree_open_failed");
+    }
+  } catch (error) {
+    if (error instanceof CodeWorktreeOpenError) throw error;
+    throw parseCodeWorktreeOpenError(error);
+  }
+}
+
+export function codeWorktreeOpenFailureMessage(error: unknown): string {
+  switch (parseCodeWorktreeOpenError(error).reason) {
+    case "code_worktree_authority_unavailable":
+      return "This worktree is on the attached machine. Copy the path and open it there.";
+    case "code_worktree_workspace_unavailable":
+      return "Tidebreak could not verify this local workspace. Refresh it, then try again.";
+    case "code_worktree_workspace_inactive":
+      return "This workspace no longer has a local worktree. Restore it, or copy the saved path.";
+    case "code_worktree_path_invalid":
+      return "The saved worktree path is invalid. Copy the path and check the workspace.";
+    case "code_worktree_path_not_found":
+      return "The worktree folder no longer exists. Refresh or restore the workspace, then try again.";
+    case "code_worktree_not_directory":
+      return "The worktree path no longer points to a folder. Copy the path and check the workspace.";
+    case "code_worktree_launcher_unavailable":
+      return "This computer has no file manager command Tidebreak can use. Copy the path and open it manually.";
+    case "code_worktree_open_failed":
+      return "The file manager could not open this worktree. Copy the path and try again.";
+  }
+}
+
+export function parseCodeWorktreeOpenError(
+  error: unknown,
+): CodeWorktreeOpenError {
+  if (error instanceof CodeWorktreeOpenError) return error;
+  if (
+    isRecord(error) &&
+    OPEN_REASONS.has(error.reason as CodeWorktreeOpenReason)
+  ) {
+    return new CodeWorktreeOpenError(
+      error.reason as CodeWorktreeOpenReason,
+      typeof error.detail === "string" ? error.detail : null,
+    );
+  }
+  return new CodeWorktreeOpenError("code_worktree_open_failed");
+}
+
+function isExactOpenedResult(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length === 1 &&
+    value.status === "opened"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  workspaceCommands,
+  workspaceHeaderCommands,
+  worktreeOpenFailureNotice,
+} from "./workspaceActions";
+
+describe("workspace worktree actions", () => {
+  it("offers a native folder action only for an active local workspace", () => {
+    const local = workspaceCommands({
+      hasPr: false,
+      archived: false,
+      canOpenWorktree: true,
+    });
+    expect(local).toContainEqual({
+      id: "open-worktree",
+      label: "Open worktree folder",
+    });
+    expect(local.some((command) => command.id === "copy-worktree")).toBe(false);
+
+    const fallback = workspaceCommands({
+      hasPr: false,
+      archived: false,
+      canOpenWorktree: false,
+    });
+    expect(fallback).toContainEqual({
+      id: "copy-worktree",
+      label: "Copy worktree path",
+    });
+    expect(fallback.some((command) => command.id === "open-worktree")).toBe(
+      false,
+    );
+
+    const archived = workspaceCommands({
+      hasPr: false,
+      archived: true,
+      canOpenWorktree: true,
+    });
+    expect(archived.some((command) => command.id === "open-worktree")).toBe(
+      false,
+    );
+    expect(archived.some((command) => command.id === "copy-worktree")).toBe(
+      true,
+    );
+  });
+
+  it("puts the same truthful action in the workspace header overflow", () => {
+    const common = {
+      archived: false,
+      hasSession: false,
+      attentionPinned: false,
+      quickActions: [],
+    };
+    expect(
+      workspaceHeaderCommands({ ...common, canOpenWorktree: true })[0],
+    ).toEqual({ id: "open-worktree", label: "Open worktree folder" });
+    expect(
+      workspaceHeaderCommands({ ...common, canOpenWorktree: false })[0],
+    ).toEqual({ id: "copy-worktree", label: "Copy worktree path" });
+    expect(
+      workspaceHeaderCommands({
+        ...common,
+        archived: true,
+        canOpenWorktree: true,
+      })[0],
+    ).toEqual({ id: "copy-worktree", label: "Copy worktree path" });
+  });
+
+  it("turns a typed failure into a recoverable notice", () => {
+    expect(
+      worktreeOpenFailureNotice({
+        reason: "code_worktree_path_not_found",
+        detail: "/private/native/detail",
+      }),
+    ).toEqual({
+      title: "Could not open worktree folder",
+      description:
+        "The worktree folder no longer exists. Refresh or restore the workspace, then try again.",
+      actionLabel: "Copy path",
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -32,6 +32,11 @@ import { Input } from "@/components/ui/input";
 import { ToolOutputPreview } from "@/ToolOutputPreview";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { openInBrowser } from "@/openInBrowser";
+import {
+  canOpenLocalCodeWorktree,
+  codeWorktreeOpenFailureMessage,
+  openCodeWorktree,
+} from "./codeWorktreeHost";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 
@@ -44,6 +49,7 @@ export type WorkspaceCommandId =
   | "new-session"
   | "rename"
   | "copy-branch"
+  | "open-worktree"
   | "copy-worktree"
   | "copy-debug-json"
   | "open-pr"
@@ -80,6 +86,7 @@ export function workspaceCommands(input: {
   archived: boolean;
   hasSession?: boolean;
   attentionPinned?: boolean;
+  canOpenWorktree?: boolean;
 }): WorkspaceCommand[] {
   // An archived workspace has no worktree: nothing to open a terminal in,
   // no session to steer. What is left is reading, copying the branch that
@@ -97,7 +104,7 @@ export function workspaceCommands(input: {
     { id: "new-session", label: "New session" },
     { id: "rename", label: "Rename…" },
     { id: "copy-branch", label: "Copy branch name" },
-    { id: "copy-worktree", label: "Copy worktree path" },
+    worktreePathCommand(input.canOpenWorktree ?? canOpenLocalCodeWorktree()),
   ];
   if (input.hasPr) {
     items.push({ id: "open-pr", label: "Open pull request" });
@@ -126,18 +133,24 @@ export function workspaceCommands(input: {
 }
 
 /**
- * Header overflow: rename, pin/clear, repo quick actions, then archive.
- * Card-only items (open, copy, terminal) stay off this surface.
+ * Header overflow: worktree access, rename, pin/clear, repo quick actions,
+ * then archive. Opening the workspace and its terminal remain card-only.
  */
 export function workspaceHeaderCommands(input: {
   archived: boolean;
   hasSession: boolean;
   attentionPinned: boolean;
   quickActions: readonly { name: string }[];
+  canOpenWorktree?: boolean;
   /** The shown agent has a transcript worth handing to a sibling. */
   canFork?: boolean;
 }): WorkspaceCommand[] {
-  const items: WorkspaceCommand[] = [{ id: "rename", label: "Rename…" }];
+  const items: WorkspaceCommand[] = [
+    worktreePathCommand(
+      !input.archived && (input.canOpenWorktree ?? canOpenLocalCodeWorktree()),
+    ),
+    { id: "rename", label: "Rename…" },
+  ];
   if (input.hasSession) {
     items.push(
       input.attentionPinned
@@ -172,6 +185,12 @@ export function workspaceHeaderCommands(input: {
     items.push({ id: "restore", label: "Restore workspace", separated: true });
   }
   return items;
+}
+
+function worktreePathCommand(canOpenWorktree: boolean): WorkspaceCommand {
+  return canOpenWorktree
+    ? { id: "open-worktree", label: "Open worktree folder" }
+    : { id: "copy-worktree", label: "Copy worktree path" };
 }
 
 export function WorkspaceOverflowMenu({
@@ -463,6 +482,22 @@ export function useWorkspaceCardCommands(): {
           .then(() => toast.success("Branch name copied"))
           .catch(() => toast.error("Could not copy branch name"));
         return;
+      case "open-worktree":
+        void openCodeWorktree(context.workspace.id).catch((error) => {
+          const notice = worktreeOpenFailureNotice(error);
+          toast.error(notice.title, {
+            description: notice.description,
+            action: {
+              label: notice.actionLabel,
+              onClick: () => {
+                void copyPlainText(context.workspace.worktree_path)
+                  .then(() => toast.success("Worktree path copied"))
+                  .catch(() => toast.error("Could not copy worktree path"));
+              },
+            },
+          });
+        });
+        return;
       case "copy-worktree":
         void copyPlainText(context.workspace.worktree_path)
           .then(() => toast.success("Worktree path copied"))
@@ -648,6 +683,18 @@ export function useWorkspaceCardCommands(): {
         {outputDialog}
       </>
     ),
+  };
+}
+
+export function worktreeOpenFailureNotice(error: unknown): {
+  title: string;
+  description: string;
+  actionLabel: string;
+} {
+  return {
+    title: "Could not open worktree folder",
+    description: codeWorktreeOpenFailureMessage(error),
+    actionLabel: "Copy path",
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -1,8 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import { toast } from "sonner";
 
-import { workspaceCommands } from "@/code/workspaceActions";
+import {
+  workspaceCommands,
+  worktreeOpenFailureNotice,
+} from "@/code/workspaceActions";
 import { WorkspaceCard } from "@/code/WorkspaceCard";
+import { Toaster } from "@/components/ui/sonner";
 import {
   archivedWorkspace,
   releasedWorkspace,
@@ -628,4 +633,81 @@ export const Rail: Story = {
       />
     </div>
   ),
+};
+
+/** A local workspace leads with the file manager action in its hover detail. */
+export const LocalWorktreeAction: Story = {
+  args: {
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      canOpenWorktree: true,
+    }),
+    detailDefaultOpen: true,
+  },
+};
+
+/** A remote or unsupported client keeps the path-copy fallback in the same place. */
+export const RemoteWorktreeFallback: Story = {
+  args: {
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      canOpenWorktree: false,
+    }),
+    detailDefaultOpen: true,
+  },
+};
+
+function RecoverableWorktreeFailure() {
+  const notice = worktreeOpenFailureNotice({
+    reason: "code_worktree_path_not_found",
+    detail: "/private/native/detail",
+  });
+  return (
+    <>
+      <WorkspaceCard
+        workspace={codeWorkspace}
+        digest={undefined}
+        session={undefined}
+        repoName="tidebreak"
+        active={false}
+        terminalOpen={false}
+        density="detailed"
+        visibleMeta={{ repoChip: true, branch: false }}
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          canOpenWorktree: true,
+        })}
+        detailDefaultOpen
+        onOpen={fn()}
+        onCommand={(command) => {
+          if (command !== "open-worktree") return;
+          toast.error(notice.title, {
+            description: notice.description,
+            action: { label: notice.actionLabel, onClick: fn() },
+          });
+        }}
+      />
+      <Toaster richColors duration={Number.POSITIVE_INFINITY} />
+    </>
+  );
+}
+
+/** A failed native open leaves a clear recovery action instead of disappearing. */
+export const WorktreeOpenFailure: Story = {
+  render: () => <RecoverableWorktreeFailure />,
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await body.findByRole("button", { name: "Open folder" }),
+    );
+    await waitFor(() =>
+      expect(body.getByText("Could not open worktree folder")).toBeVisible(),
+    );
+    await waitFor(() =>
+      expect(body.getByRole("button", { name: "Copy path" })).toBeVisible(),
+    );
+  },
 };


### PR DESCRIPTION
## What changed

- Add a desktop-only `open_code_worktree` command that accepts a workspace ID, verifies local authority, resolves the stored worktree, validates the directory, and launches the platform file manager without a shell.
- Show **Open worktree folder** for supported local desktop workspaces. Keep **Copy worktree path** for remote, archived, browser-only, and unsupported clients.
- Return stable typed failures and show a recoverable error toast with a **Copy path** action.
- Add focused native and UI tests plus Storybook states for local open, fallback copy, and open failure. Keep the hover detail inside compact viewports.

## Compatibility and risk

This change does not alter server routes, wire formats, or persisted data. The native command re-reads the workspace from the embedded server and rejects remote authority, inactive workspaces, relative paths, missing paths, and non-directory targets before it starts a fixed platform launcher.

Existing Copy path behavior remains the fallback whenever the client cannot truthfully open the local folder.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/codeWorktreeHost.test.ts src/code/workspaceActions.test.ts src/code/WorkspaceCard.dom.test.tsx src/stylesContract.test.ts` — 29 tests passed.
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit --pretty false` — passed.
- Focused Biome checks for all changed UI files — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — passed.
- Captured and inspected all three changed stories in light and dark themes at 1280×800 and 420×760 with 2× device scale. No story errors or clipped detail panels remain.

Per repository guidance, no local Cargo build, check, Clippy, or tests ran.

Fixes #2664