### PR TITLE
docs: renumber agent MCP decision record to 0073

### DIFF
--- a/docs/decisions/0073-agent-mcp-drives-chat-over-attach.md
+++ b/docs/decisions/0073-agent-mcp-drives-chat-over-attach.md
@@ -1,4 +1,4 @@
-# 71. Agent MCP drives chat over the attach contract
+# 73. Agent MCP drives chat over the attach contract
 
 - Status: Proposed
 - Date: 2026-08-26


### PR DESCRIPTION
PR #2650 took decision number 0071 (hosted engines ride the caller's inference) and 0072 went to the mobile client record before #2666 merged, so the agent MCP record landed as a duplicate 0071. Rename the file to 0073 and update its heading. No content changes.