### PR TITLE
feat(code): read hosted delivery over forge REST

### DIFF
--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1314,7 +1314,10 @@ at_turn_ordinal?: number,
 truncated: boolean, };
 
 /**
- * Whether the local GitHub CLI can serve delivery requests.
+ * Whether this caller's GitHub path can serve Delivery requests.
+ *
+ * Desktops and self-host machines report the local GitHub CLI. A
+ * gateway-authenticated hosted machine reports the caller's connected forge.
  */
 export type CodeGitHubCapability = { found: boolean, authenticated?: boolean, viewer_login?: string, remediation: string, };
 

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -34,6 +34,7 @@ use super::reconcile::{
 };
 use super::runtime::CodeRuntime;
 use crate::error::ServerError;
+use crate::obo_gateway::{GitCredential, GitForgeAttribution};
 use crate::routes::code::types::{
     CodeDeliveryActionResult, CodeDeliveryCheck, CodeDeliveryDeploymentStatus,
     CodeDeliveryPrAttentionReason, CodeDeliveryPullRequestAction,
@@ -66,6 +67,39 @@ const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(700);
 
 const PR_LIST_FIELDS: &str = "number,url,state,title,isDraft,author,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRepository,headRepositoryOwner,headRefName,headRefOid,baseRefName,updatedAt,createdAt,mergedAt,closedAt,labels,comments";
 const PR_LIST_FIELDS_WITH_CHECKS: &str = "number,url,state,title,isDraft,author,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRepository,headRepositoryOwner,headRefName,headRefOid,baseRefName,updatedAt,createdAt,mergedAt,closedAt,labels,comments,statusCheckRollup";
+
+#[derive(Debug, Clone)]
+enum DeliveryReader {
+    Gh(PathBuf),
+    Forge,
+}
+
+impl DeliveryReader {
+    fn cache_scope(&self) -> &'static str {
+        match self {
+            Self::Gh(_) => "gh",
+            Self::Forge => "forge-rest",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DeliveryAccess {
+    capability: CodeGitHubCapability,
+    reader: Option<DeliveryReader>,
+    unavailable_kind: &'static str,
+}
+
+impl DeliveryAccess {
+    fn source_error(&self) -> CodeDeliverySourceError {
+        CodeDeliverySourceError {
+            repository: None,
+            kind: self.unavailable_kind.into(),
+            message: self.capability.remediation.clone(),
+            retry_at: None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PullRequestRemotePlan {
@@ -536,28 +570,20 @@ pub(crate) async fn discover_repositories(
     owner: &OwnerId,
     refresh: bool,
 ) -> Result<CodeDeliveryRepositoriesSnapshot, ServerError> {
-    let search_path = runtime.gh_search_path_owned();
-    let observation = if refresh {
-        gh::refresh_gh_observation(search_path.as_deref()).await
-    } else {
-        gh::observe_gh(search_path.as_deref()).await
-    };
-    let capability = github_capability(&observation);
+    let access = delivery_access(runtime, owner, refresh).await;
+    let capability = access.capability.clone();
     let catalog = owner_repository_catalog(runtime, owner, refresh).await?;
     let mut errors = catalog.errors;
 
-    let resolved = if observation.authenticated == Some(true) {
-        let binary = observation
-            .binary
-            .clone()
-            .expect("authenticated gh has a binary");
+    let resolved = if let Some(reader) = access.reader.clone() {
         stream::iter(catalog.entries)
             .map(|entry| {
-                let binary = binary.clone();
+                let reader = reader.clone();
                 async move {
-                    resolve_repository_cached(
+                    resolve_repository_for_reader(
                         runtime,
-                        &binary,
+                        owner,
+                        &reader,
                         &entry.target,
                         Some(entry.repo.id),
                         refresh,
@@ -626,20 +652,16 @@ pub(crate) async fn resolve_repositories(
     targets = dedupe_targets(targets)?;
     ensure_delivery_targets(runtime, owner, allow_unscoped_delivery, &targets).await?;
 
-    let observation = gh::observe_gh(runtime.gh_search_path_owned().as_deref()).await;
-    let capability = github_capability(&observation);
+    let access = delivery_access(runtime, owner, false).await;
+    let capability = access.capability.clone();
 
     let mut repositories = Vec::new();
-    if observation.authenticated == Some(true) {
-        let binary = observation
-            .binary
-            .clone()
-            .expect("authenticated gh has a binary");
+    if let Some(reader) = access.reader.clone() {
         let results = stream::iter(targets)
             .map(|target| {
-                let binary = binary.clone();
+                let reader = reader.clone();
                 async move {
-                    resolve_repository_cached(runtime, &binary, &target, None, false)
+                    resolve_repository_for_reader(runtime, owner, &reader, &target, None, false)
                         .await
                         .map_err(|message| (target, message))
                 }
@@ -654,10 +676,9 @@ pub(crate) async fn resolve_repositories(
             }
         }
     } else {
-        let kind = observation_error_kind(&observation);
         errors.extend(targets.into_iter().map(|target| CodeDeliverySourceError {
             repository: Some(target),
-            kind: kind.into(),
+            kind: access.unavailable_kind.into(),
             message: capability.remediation.clone(),
             retry_at: None,
         }));
@@ -681,27 +702,22 @@ pub(crate) async fn query_pull_requests(
     let force_refresh = query.refresh && query.cursor.is_none();
     let targets = dedupe_targets(query.repositories.clone())?;
     ensure_delivery_targets(runtime, owner, allow_unscoped_delivery, &targets).await?;
-    let search_path = runtime.gh_search_path_owned();
-    let observation = if force_refresh {
-        gh::refresh_gh_observation(search_path.as_deref()).await
-    } else {
-        gh::observe_gh(search_path.as_deref()).await
-    };
-    let capability = github_capability(&observation);
-    if observation.authenticated != Some(true) {
+    let access = delivery_access(runtime, owner, force_refresh).await;
+    let capability = access.capability.clone();
+    let Some(reader) = access.reader.clone() else {
         return Ok(CodeDeliveryPullRequestsPage {
             capability,
             items: Vec::new(),
             next_cursor: None,
-            errors: vec![observation_source_error(&observation)],
+            errors: vec![access.source_error()],
             fetched_at: Utc::now(),
         });
-    }
+    };
 
     let remote_plan = pull_request_remote_plan(&query);
     let cache_key = aggregate_cache_key(
         owner,
-        &format!("prs:{}", remote_plan.cache_scope()),
+        &format!("prs:{}:{}", reader.cache_scope(), remote_plan.cache_scope()),
         &targets,
     );
     let request_started = Instant::now();
@@ -723,20 +739,17 @@ pub(crate) async fn query_pull_requests(
                     return pull_request_page(capability, cached, &query);
                 }
             }
-            let binary = observation
-                .binary
-                .clone()
-                .expect("authenticated gh has a binary");
             let workspace_index = workspace_index(runtime, owner, force_refresh).await?;
             let remote_plan = &remote_plan;
             let results = stream::iter(targets.clone())
                 .map(|target| {
-                    let binary = binary.clone();
+                    let reader = reader.clone();
                     let workspace_index = workspace_index.clone();
                     async move {
                         fetch_pull_requests(
                             runtime,
-                            &binary,
+                            owner,
+                            &reader,
                             &target,
                             &workspace_index,
                             remote_plan,
@@ -1248,25 +1261,24 @@ pub(crate) async fn query_runs(
     let force_refresh = query.refresh && query.cursor.is_none();
     let targets = dedupe_targets(query.repositories.clone())?;
     ensure_delivery_targets(runtime, owner, allow_unscoped_delivery, &targets).await?;
-    let search_path = runtime.gh_search_path_owned();
-    let observation = if force_refresh {
-        gh::refresh_gh_observation(search_path.as_deref()).await
-    } else {
-        gh::observe_gh(search_path.as_deref()).await
-    };
-    let capability = github_capability(&observation);
-    if observation.authenticated != Some(true) {
+    let access = delivery_access(runtime, owner, force_refresh).await;
+    let capability = access.capability.clone();
+    let Some(reader) = access.reader.clone() else {
         return Ok(CodeDeliveryRunsPage {
             capability,
             items: Vec::new(),
             next_cursor: None,
-            errors: vec![observation_source_error(&observation)],
+            errors: vec![access.source_error()],
             fetched_at: Utc::now(),
         });
-    }
+    };
 
     let (remote_scope, fetch_workflows, fetch_deployments) = run_remote_scope(&query);
-    let cache_key = aggregate_cache_key(owner, &format!("runs:{remote_scope}"), &targets);
+    let cache_key = aggregate_cache_key(
+        owner,
+        &format!("runs:{}:{remote_scope}", reader.cache_scope()),
+        &targets,
+    );
     let request_started = Instant::now();
     let cached = if force_refresh {
         None
@@ -1283,19 +1295,16 @@ pub(crate) async fn query_runs(
                     return run_page(capability, cached, &query);
                 }
             }
-            let binary = observation
-                .binary
-                .clone()
-                .expect("authenticated gh has a binary");
             let workspace_index = workspace_index(runtime, owner, force_refresh).await?;
             let results = stream::iter(targets.clone())
                 .map(|target| {
-                    let binary = binary.clone();
+                    let reader = reader.clone();
                     let workspace_index = workspace_index.clone();
                     async move {
                         fetch_runs(
                             runtime,
-                            &binary,
+                            owner,
+                            &reader,
                             &target,
                             &workspace_index,
                             fetch_workflows,
@@ -1532,6 +1541,87 @@ fn github_capability(observation: &GhObservation) -> CodeGitHubCapability {
         viewer_login: observation.viewer_login.clone(),
         remediation: observation.remediation.clone(),
     }
+}
+
+/// Select Delivery's read path for one caller.
+///
+/// A machine with a gateway lender never consults `gh`: the lender's forge
+/// probe is the source of availability and identity. Every other machine
+/// keeps the existing GitHub CLI observation unchanged.
+async fn delivery_access(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    force_refresh: bool,
+) -> DeliveryAccess {
+    if let Some(lender) = runtime.git_credentials() {
+        return match lender.git_forge_identity(owner).await {
+            Ok(identity) => {
+                let viewer_login = match identity.attribution {
+                    GitForgeAttribution::Person { login, .. } => Some(login),
+                    GitForgeAttribution::Bot { bot_login } => bot_login,
+                };
+                DeliveryAccess {
+                    capability: CodeGitHubCapability {
+                        found: true,
+                        authenticated: Some(true),
+                        viewer_login,
+                        remediation: String::new(),
+                    },
+                    reader: Some(DeliveryReader::Forge),
+                    unavailable_kind: "git_forge_not_offered",
+                }
+            }
+            Err(refusal) => DeliveryAccess {
+                capability: CodeGitHubCapability {
+                    found: !matches!(&refusal, crate::obo_gateway::GitForgeError::NoGitForge),
+                    authenticated: Some(false),
+                    viewer_login: None,
+                    remediation: super::clone::git_forge_refusal_message(&refusal),
+                },
+                reader: None,
+                unavailable_kind: "git_forge_not_offered",
+            },
+        };
+    }
+
+    let search_path = runtime.gh_search_path_owned();
+    let observation = if force_refresh {
+        gh::refresh_gh_observation(search_path.as_deref()).await
+    } else {
+        gh::observe_gh(search_path.as_deref()).await
+    };
+    let unavailable_kind = observation_error_kind(&observation);
+    let reader = (observation.authenticated == Some(true))
+        .then(|| DeliveryReader::Gh(observation.binary.clone().expect("authenticated gh")));
+    DeliveryAccess {
+        capability: github_capability(&observation),
+        reader,
+        unavailable_kind,
+    }
+}
+
+/// Borrow one credential for one repository Delivery read.
+async fn borrow_delivery_credential(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    target: &CodeGitHubRepositoryTarget,
+) -> Result<GitCredential, String> {
+    if !target
+        .host
+        .eq_ignore_ascii_case(gh::GIT_CREDENTIAL_FORGE_HOST)
+    {
+        return Err(format!(
+            "this hosted machine can borrow credentials only for {}",
+            gh::GIT_CREDENTIAL_FORGE_HOST
+        ));
+    }
+    let lender = runtime
+        .git_credentials()
+        .ok_or_else(|| "this machine has no hosted forge lender".to_owned())?;
+    lender
+        .git_credential(owner, &format!("{}/{}", target.owner, target.name))
+        .await
+        .map_err(|refusal| super::clone::git_forge_refusal_message(&refusal))
 }
 
 async fn require_authenticated(runtime: &CodeRuntime) -> Result<GhObservation, ServerError> {
@@ -1802,6 +1892,14 @@ async fn resolve_repository(
 ) -> Result<CodeGitHubRepositoryRef, String> {
     let endpoint = format!("repos/{}/{}", target.owner, target.name);
     let value = run_api_json(binary, &target.host, &endpoint).await?;
+    Ok(repository_ref_from_value(target, tidebreak_repo_id, &value))
+}
+
+fn repository_ref_from_value(
+    target: &CodeGitHubRepositoryTarget,
+    tidebreak_repo_id: Option<tidebreak_core::RepoId>,
+    value: &Value,
+) -> CodeGitHubRepositoryRef {
     let owner = value
         .get("owner")
         .and_then(|owner| owner.get("login"))
@@ -1811,7 +1909,7 @@ async fn resolve_repository(
     let name = text_field(&value, "name").unwrap_or_else(|| target.name.clone());
     let name_with_owner =
         text_field(&value, "full_name").unwrap_or_else(|| format!("{owner}/{name}"));
-    Ok(CodeGitHubRepositoryRef {
+    CodeGitHubRepositoryRef {
         host: target.host.clone(),
         owner,
         name,
@@ -1820,7 +1918,7 @@ async fn resolve_repository(
             .unwrap_or_else(|| format!("https://{}/{}/{}", target.host, target.owner, target.name)),
         default_branch: text_field(&value, "default_branch"),
         tidebreak_repo_id,
-    })
+    }
 }
 
 async fn resolve_repository_cached(
@@ -1847,6 +1945,65 @@ async fn resolve_repository_cached(
     }
 
     let repository = resolve_repository(binary, target, None).await?;
+    runtime
+        .delivery_cache
+        .put_repository(key, repository.clone());
+    Ok(repository_with_id(repository, tidebreak_repo_id))
+}
+
+async fn resolve_repository_for_reader(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    reader: &DeliveryReader,
+    target: &CodeGitHubRepositoryTarget,
+    tidebreak_repo_id: Option<tidebreak_core::RepoId>,
+    force_refresh: bool,
+) -> Result<CodeGitHubRepositoryRef, String> {
+    match reader {
+        DeliveryReader::Gh(binary) => {
+            resolve_repository_cached(runtime, binary, target, tidebreak_repo_id, force_refresh)
+                .await
+        }
+        DeliveryReader::Forge => {
+            let credential = borrow_delivery_credential(runtime, owner, target).await?;
+            resolve_repository_rest_cached(
+                runtime,
+                target,
+                tidebreak_repo_id,
+                force_refresh,
+                &credential,
+            )
+            .await
+        }
+    }
+}
+
+async fn resolve_repository_rest_cached(
+    runtime: &CodeRuntime,
+    target: &CodeGitHubRepositoryTarget,
+    tidebreak_repo_id: Option<tidebreak_core::RepoId>,
+    force_refresh: bool,
+    credential: &GitCredential,
+) -> Result<CodeGitHubRepositoryRef, String> {
+    let key = repository_key(target);
+    let request_started = Instant::now();
+    if !force_refresh {
+        if let Some(cached) = runtime.delivery_cache.repository(&key) {
+            return Ok(repository_with_id(cached.value, tidebreak_repo_id));
+        }
+    }
+
+    let read = runtime.delivery_cache.repository_read(&key);
+    let _guard = read.lock().await;
+    if let Some(cached) = runtime.delivery_cache.repository(&key) {
+        if !force_refresh || cached.fetched_at >= request_started {
+            return Ok(repository_with_id(cached.value, tidebreak_repo_id));
+        }
+    }
+
+    let api_base = runtime.forge_api_base_for(&target.host);
+    let value = super::forge_rest::repository(&api_base, target, credential).await?;
+    let repository = repository_ref_from_value(target, None, &value);
     runtime
         .delivery_cache
         .put_repository(key, repository.clone());
@@ -1979,40 +2136,63 @@ where
 
 async fn fetch_pull_requests(
     runtime: &CodeRuntime,
-    binary: &Path,
+    owner: &OwnerId,
+    reader: &DeliveryReader,
     target: &CodeGitHubRepositoryTarget,
     workspaces: &[WorkspaceIndexEntry],
     plan: &PullRequestRemotePlan,
     force_refresh: bool,
 ) -> Result<Vec<PullRequestObservation>, String> {
-    let repository =
-        resolve_repository_cached(runtime, binary, target, None, force_refresh).await?;
-    let cli_repository = gh::cli_repository(&target.host, &target.owner, &target.name);
-    let limit = MAX_REMOTE_ITEMS_PER_REPO.to_string();
-    let mut args = vec![
-        "pr",
-        "list",
-        "--repo",
-        cli_repository.as_str(),
-        "--state",
-        plan.state,
-        "--limit",
-        limit.as_str(),
-        "--json",
-        plan.fields,
-    ];
-    if let Some(author) = plan.author.as_deref() {
-        args.push("--author");
-        args.push(author);
-    }
-    let raw =
-        with_transient_retry(|| gh::run_gh(Path::new("."), binary, &args, GH_READ_TIMEOUT)).await?;
-    let value: Value = serde_json::from_str(&raw)
-        .map_err(|error| format!("could not parse pull requests: {error}"))?;
-    Ok(value
-        .as_array()
-        .into_iter()
-        .flatten()
+    let (repository, values) = match reader {
+        DeliveryReader::Gh(binary) => {
+            let repository =
+                resolve_repository_cached(runtime, binary, target, None, force_refresh).await?;
+            let cli_repository = gh::cli_repository(&target.host, &target.owner, &target.name);
+            let limit = MAX_REMOTE_ITEMS_PER_REPO.to_string();
+            let mut args = vec![
+                "pr",
+                "list",
+                "--repo",
+                cli_repository.as_str(),
+                "--state",
+                plan.state,
+                "--limit",
+                limit.as_str(),
+                "--json",
+                plan.fields,
+            ];
+            if let Some(author) = plan.author.as_deref() {
+                args.push("--author");
+                args.push(author);
+            }
+            let raw =
+                with_transient_retry(|| gh::run_gh(Path::new("."), binary, &args, GH_READ_TIMEOUT))
+                    .await?;
+            let value: Value = serde_json::from_str(&raw)
+                .map_err(|error| format!("could not parse pull requests: {error}"))?;
+            (repository, value.as_array().cloned().unwrap_or_default())
+        }
+        DeliveryReader::Forge => {
+            let credential = borrow_delivery_credential(runtime, owner, target).await?;
+            let repository =
+                resolve_repository_rest_cached(runtime, target, None, force_refresh, &credential)
+                    .await?;
+            let api_base = runtime.forge_api_base_for(&target.host);
+            let values = with_transient_retry(|| {
+                super::forge_rest::delivery_pull_requests(
+                    &api_base,
+                    target,
+                    &credential,
+                    plan.state,
+                    plan.checks_loaded,
+                )
+            })
+            .await?;
+            (repository, values)
+        }
+    };
+    Ok(values
+        .iter()
         .filter_map(|value| parse_pull_request(&repository, value, workspaces))
         .collect())
 }
@@ -2109,10 +2289,12 @@ fn parse_pull_request(
         .get("autoMergeRequest")
         .is_some_and(|request| !request.is_null());
     let in_merge_queue = (merge_state_status.as_deref() == Some("queued")).then_some(true);
-    let comment_count = value
-        .get("comments")
-        .and_then(Value::as_array)
-        .and_then(|comments| u64::try_from(comments.len()).ok());
+    let comment_count = value.get("comments").and_then(|comments| {
+        comments
+            .as_array()
+            .and_then(|comments| u64::try_from(comments.len()).ok())
+            .or_else(|| comments.as_u64())
+    });
     let merged_at = datetime_field(value, "mergedAt");
     let closed_at = datetime_field(value, "closedAt");
     // `gh` reports MERGED as its own state, but a host that only reports
@@ -2311,36 +2493,69 @@ fn pull_request_attention(
 
 async fn fetch_runs(
     runtime: &CodeRuntime,
-    binary: &Path,
+    owner: &OwnerId,
+    reader: &DeliveryReader,
     target: &CodeGitHubRepositoryTarget,
     workspaces: &[WorkspaceIndexEntry],
     fetch_workflows: bool,
     fetch_deployments: bool,
     force_refresh: bool,
 ) -> Result<FetchedRuns, String> {
-    let repository =
-        resolve_repository_cached(runtime, binary, target, None, force_refresh).await?;
-    let workflow_endpoint = api_endpoint(target, "actions/runs?per_page=100");
-    let deployments_endpoint = api_endpoint(target, "deployments?per_page=100");
-    let workflow_read = async {
-        if fetch_workflows {
-            run_api_json(binary, &target.host, &workflow_endpoint)
-                .await
-                .map(Some)
-        } else {
-            Ok(None)
+    let (repository, workflow_runs, deployments) = match reader {
+        DeliveryReader::Gh(binary) => {
+            let repository =
+                resolve_repository_cached(runtime, binary, target, None, force_refresh).await?;
+            let workflow_endpoint = api_endpoint(target, "actions/runs?per_page=100");
+            let deployments_endpoint = api_endpoint(target, "deployments?per_page=100");
+            let workflow_read = async {
+                if fetch_workflows {
+                    run_api_json(binary, &target.host, &workflow_endpoint)
+                        .await
+                        .map(Some)
+                } else {
+                    Ok(None)
+                }
+            };
+            let deployment_read = async {
+                if fetch_deployments {
+                    run_api_json(binary, &target.host, &deployments_endpoint)
+                        .await
+                        .map(Some)
+                } else {
+                    Ok(None)
+                }
+            };
+            let (workflow_runs, deployments) = tokio::join!(workflow_read, deployment_read);
+            (repository, workflow_runs, deployments)
+        }
+        DeliveryReader::Forge => {
+            let credential = borrow_delivery_credential(runtime, owner, target).await?;
+            let repository =
+                resolve_repository_rest_cached(runtime, target, None, force_refresh, &credential)
+                    .await?;
+            let api_base = runtime.forge_api_base_for(&target.host);
+            let workflow_read = async {
+                if fetch_workflows {
+                    super::forge_rest::workflow_runs(&api_base, target, &credential)
+                        .await
+                        .map(Some)
+                } else {
+                    Ok(None)
+                }
+            };
+            let deployment_read = async {
+                if fetch_deployments {
+                    super::forge_rest::deployments(&api_base, target, &credential)
+                        .await
+                        .map(Some)
+                } else {
+                    Ok(None)
+                }
+            };
+            let (workflow_runs, deployments) = tokio::join!(workflow_read, deployment_read);
+            (repository, workflow_runs, deployments)
         }
     };
-    let deployment_read = async {
-        if fetch_deployments {
-            run_api_json(binary, &target.host, &deployments_endpoint)
-                .await
-                .map(Some)
-        } else {
-            Ok(None)
-        }
-    };
-    let (workflow_runs, deployments) = tokio::join!(workflow_read, deployment_read,);
     Ok(collect_run_sources(
         target,
         &repository,

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -192,6 +192,13 @@ struct FetchedRuns {
     errors: Vec<CodeDeliverySourceError>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct RunFetchOptions {
+    fetch_workflows: bool,
+    fetch_deployments: bool,
+    force_refresh: bool,
+}
+
 /// Short-lived owner/query caches. No GitHub response is durable.
 #[derive(Debug, Default)]
 pub(crate) struct DeliveryCache {
@@ -1274,6 +1281,11 @@ pub(crate) async fn query_runs(
     };
 
     let (remote_scope, fetch_workflows, fetch_deployments) = run_remote_scope(&query);
+    let fetch_options = RunFetchOptions {
+        fetch_workflows,
+        fetch_deployments,
+        force_refresh,
+    };
     let cache_key = aggregate_cache_key(
         owner,
         &format!("runs:{}:{remote_scope}", reader.cache_scope()),
@@ -1307,9 +1319,7 @@ pub(crate) async fn query_runs(
                             &reader,
                             &target,
                             &workspace_index,
-                            fetch_workflows,
-                            fetch_deployments,
-                            force_refresh,
+                            fetch_options,
                         )
                         .await
                         .map_err(|message| (target, message))
@@ -1906,17 +1916,17 @@ fn repository_ref_from_value(
         .and_then(Value::as_str)
         .unwrap_or(&target.owner)
         .to_owned();
-    let name = text_field(&value, "name").unwrap_or_else(|| target.name.clone());
+    let name = text_field(value, "name").unwrap_or_else(|| target.name.clone());
     let name_with_owner =
-        text_field(&value, "full_name").unwrap_or_else(|| format!("{owner}/{name}"));
+        text_field(value, "full_name").unwrap_or_else(|| format!("{owner}/{name}"));
     CodeGitHubRepositoryRef {
         host: target.host.clone(),
         owner,
         name,
         name_with_owner,
-        url: text_field(&value, "html_url")
+        url: text_field(value, "html_url")
             .unwrap_or_else(|| format!("https://{}/{}/{}", target.host, target.owner, target.name)),
-        default_branch: text_field(&value, "default_branch"),
+        default_branch: text_field(value, "default_branch"),
         tidebreak_repo_id,
     }
 }
@@ -2497,18 +2507,17 @@ async fn fetch_runs(
     reader: &DeliveryReader,
     target: &CodeGitHubRepositoryTarget,
     workspaces: &[WorkspaceIndexEntry],
-    fetch_workflows: bool,
-    fetch_deployments: bool,
-    force_refresh: bool,
+    options: RunFetchOptions,
 ) -> Result<FetchedRuns, String> {
     let (repository, workflow_runs, deployments) = match reader {
         DeliveryReader::Gh(binary) => {
             let repository =
-                resolve_repository_cached(runtime, binary, target, None, force_refresh).await?;
+                resolve_repository_cached(runtime, binary, target, None, options.force_refresh)
+                    .await?;
             let workflow_endpoint = api_endpoint(target, "actions/runs?per_page=100");
             let deployments_endpoint = api_endpoint(target, "deployments?per_page=100");
             let workflow_read = async {
-                if fetch_workflows {
+                if options.fetch_workflows {
                     run_api_json(binary, &target.host, &workflow_endpoint)
                         .await
                         .map(Some)
@@ -2517,7 +2526,7 @@ async fn fetch_runs(
                 }
             };
             let deployment_read = async {
-                if fetch_deployments {
+                if options.fetch_deployments {
                     run_api_json(binary, &target.host, &deployments_endpoint)
                         .await
                         .map(Some)
@@ -2530,12 +2539,17 @@ async fn fetch_runs(
         }
         DeliveryReader::Forge => {
             let credential = borrow_delivery_credential(runtime, owner, target).await?;
-            let repository =
-                resolve_repository_rest_cached(runtime, target, None, force_refresh, &credential)
-                    .await?;
+            let repository = resolve_repository_rest_cached(
+                runtime,
+                target,
+                None,
+                options.force_refresh,
+                &credential,
+            )
+            .await?;
             let api_base = runtime.forge_api_base_for(&target.host);
             let workflow_read = async {
-                if fetch_workflows {
+                if options.fetch_workflows {
                     super::forge_rest::workflow_runs(&api_base, target, &credential)
                         .await
                         .map(Some)
@@ -2544,7 +2558,7 @@ async fn fetch_runs(
                 }
             };
             let deployment_read = async {
-                if fetch_deployments {
+                if options.fetch_deployments {
                     super::forge_rest::deployments(&api_base, target, &credential)
                         .await
                         .map(Some)
@@ -3483,15 +3497,6 @@ fn observation_error_kind(observation: &GhObservation) -> &'static str {
         "gh_signed_out"
     } else {
         "gh_unavailable"
-    }
-}
-
-fn observation_source_error(observation: &GhObservation) -> CodeDeliverySourceError {
-    CodeDeliverySourceError {
-        repository: None,
-        kind: observation_error_kind(observation).into(),
-        message: observation.remediation.clone(),
-        retry_at: None,
     }
 }
 

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -459,10 +459,11 @@ async fn check_run_values(
         .filter_map(|run| {
             let name = run.get("name").and_then(Value::as_str)?;
             let conclusion = run.get("conclusion").cloned().unwrap_or(Value::Null);
-            let pending_state = conclusion
-                .is_null()
-                .then(|| Value::String("PENDING".to_owned()))
-                .unwrap_or(Value::Null);
+            let pending_state = if conclusion.is_null() {
+                Value::String("PENDING".to_owned())
+            } else {
+                Value::Null
+            };
             let details_url = run
                 .get("details_url")
                 .filter(|value| value.as_str().is_some())

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -7,14 +7,14 @@
 //! every answer exactly like the `gh --json` payload code mode already
 //! parses — one JSON vocabulary, however the host was asked.
 //!
-//! Deliberately narrow: creation, the PR-card digest, and the fact reads
-//! (decision 62). Merge, ready, close, comments, CI logs, and the
-//! repository-wide delivery panel stay `gh`-only and keep answering exactly
-//! as they do today on machines without it.
+//! Deliberately narrow: creation, the PR-card digest, the fact reads
+//! (decision 62), and the repository-wide Delivery lists. Merge, ready,
+//! close, comments, CI logs, and Delivery detail drawers stay `gh`-only and
+//! keep answering exactly as they do today on machines without it.
 
 use std::time::Duration;
 
-use futures::StreamExt as _;
+use futures::{stream, StreamExt as _};
 use serde_json::Value;
 
 use crate::obo_gateway::GitCredential;
@@ -27,6 +27,9 @@ const REST_TIMEOUT: Duration = Duration::from_secs(30);
 /// Cap on one REST response body. PR and check payloads are kilobytes; the
 /// bound exists so a confused origin cannot grow the process.
 const RESPONSE_LIMIT: usize = 2 * 1024 * 1024;
+
+/// Bound the check-run fan-out within one repository list read.
+const CHECK_RUN_CONCURRENCY: usize = 4;
 
 /// The REST base for a forge host: `api.github.com` for github.com, the
 /// GHES `/api/v3/` convention for anything else.
@@ -102,6 +105,120 @@ fn forge_message(status: reqwest::StatusCode, value: &Value) -> String {
         }
         bounded
     }
+}
+
+/// Read one repository in the same REST shape that `gh api repos/...`
+/// returns. Delivery turns this into its repository reference.
+pub(crate) async fn repository(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+) -> Result<Value, String> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!("{api_base}/repos/{}/{}", target.owner, target.name),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    Ok(value)
+}
+
+/// List one repository's pull requests in the `gh pr list --json`
+/// vocabulary that Delivery already parses.
+///
+/// GitHub REST has no `merged` list state. A merged query reads closed pull
+/// requests and lets Delivery's existing `mergedAt` filter select the rows.
+/// When checks are requested, each pull request carries an explicit
+/// `statusCheckRollup`, including an empty array for a head with no runs.
+pub(crate) async fn delivery_pull_requests(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    state: &str,
+    checks_loaded: bool,
+) -> Result<Vec<Value>, String> {
+    let state = if state == "merged" { "closed" } else { state };
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/pulls?state={state}&per_page=100",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    let pulls = value.as_array().cloned().unwrap_or_default();
+    stream::iter(pulls)
+        .map(|pull| async move {
+            let mut fact = fact_value(&pull);
+            if checks_loaded {
+                let checks = match pull.pointer("/head/sha").and_then(Value::as_str) {
+                    Some(sha) => check_run_values(api_base, target, credential, sha).await?,
+                    None => Vec::new(),
+                };
+                fact.as_object_mut()
+                    .expect("fact values are objects")
+                    .insert("statusCheckRollup".to_owned(), Value::Array(checks));
+            }
+            Ok(fact)
+        })
+        .buffered(CHECK_RUN_CONCURRENCY)
+        .collect::<Vec<Result<Value, String>>>()
+        .await
+        .into_iter()
+        .collect()
+}
+
+/// Read one repository's GitHub Actions runs.
+pub(crate) async fn workflow_runs(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+) -> Result<Value, String> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/actions/runs?per_page=100",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    Ok(value)
+}
+
+/// Read one repository's deployments.
+pub(crate) async fn deployments(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+) -> Result<Value, String> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/deployments?per_page=100",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    Ok(value)
 }
 
 /// Create a pull request and return it in the fact shape.
@@ -282,6 +399,43 @@ async fn check_runs(
     credential: &GitCredential,
     sha: &str,
 ) -> Result<Vec<PullRequestCheck>, String> {
+    Ok(check_run_values(api_base, target, credential, sha)
+        .await?
+        .iter()
+        .filter_map(|run| {
+            let name = run.get("name").and_then(Value::as_str)?.to_owned();
+            let conclusion = run.get("conclusion").and_then(Value::as_str);
+            let bucket = match conclusion {
+                Some("success") => PullRequestCheckBucket::Pass,
+                Some("neutral" | "cancelled" | "skipped") => PullRequestCheckBucket::Skipped,
+                Some(_) => PullRequestCheckBucket::Fail,
+                None => PullRequestCheckBucket::Pending,
+            };
+            let detail = conclusion
+                .or_else(|| run.get("status").and_then(Value::as_str))
+                .map(ToOwned::to_owned);
+            let url = run
+                .get("detailsUrl")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            Some(PullRequestCheck {
+                name,
+                bucket,
+                detail,
+                url,
+            })
+        })
+        .collect())
+}
+
+/// One head's check runs in the `statusCheckRollup` shape that Delivery
+/// already parses from `gh pr list --json`.
+async fn check_run_values(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    sha: &str,
+) -> Result<Vec<Value>, String> {
     let (status, value) = request(
         reqwest::Method::GET,
         format!(
@@ -303,27 +457,25 @@ async fn check_runs(
     Ok(runs
         .iter()
         .filter_map(|run| {
-            let name = run.get("name").and_then(Value::as_str)?.to_owned();
-            let conclusion = run.get("conclusion").and_then(Value::as_str);
-            let bucket = match conclusion {
-                Some("success") => PullRequestCheckBucket::Pass,
-                Some("neutral" | "cancelled" | "skipped") => PullRequestCheckBucket::Skipped,
-                Some(_) => PullRequestCheckBucket::Fail,
-                None => PullRequestCheckBucket::Pending,
-            };
-            let detail = conclusion
-                .or_else(|| run.get("status").and_then(Value::as_str))
-                .map(ToOwned::to_owned);
-            let url = run
-                .get("html_url")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned);
-            Some(PullRequestCheck {
-                name,
-                bucket,
-                detail,
-                url,
-            })
+            let name = run.get("name").and_then(Value::as_str)?;
+            let conclusion = run.get("conclusion").cloned().unwrap_or(Value::Null);
+            let pending_state = conclusion
+                .is_null()
+                .then(|| Value::String("PENDING".to_owned()))
+                .unwrap_or(Value::Null);
+            let details_url = run
+                .get("details_url")
+                .filter(|value| value.as_str().is_some())
+                .or_else(|| run.get("html_url"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            Some(serde_json::json!({
+                "name": name,
+                "status": run.get("status").cloned().unwrap_or(Value::Null),
+                "state": pending_state,
+                "conclusion": conclusion,
+                "detailsUrl": details_url,
+            }))
         })
         .collect())
 }
@@ -365,13 +517,37 @@ async fn merge_queue_state(
 /// however the host was asked. `state` stays REST's own `open`/`closed`;
 /// the parser already reads closed-with-merged-at as merged.
 pub(crate) fn fact_value(pr: &Value) -> Value {
+    let head_repository = pr.pointer("/head/repo").map_or(Value::Null, |repository| {
+        serde_json::json!({
+            "nameWithOwner": repository.get("full_name").cloned().unwrap_or(Value::Null),
+            "name": repository.get("name").cloned().unwrap_or(Value::Null),
+        })
+    });
+    let head_repository_owner = pr
+        .pointer("/head/repo/owner/login")
+        .cloned()
+        .map_or(Value::Null, |login| serde_json::json!({ "login": login }));
+    let mergeable = match pr.get("mergeable") {
+        Some(Value::Bool(true)) => Value::String("MERGEABLE".to_owned()),
+        Some(Value::Bool(false)) => Value::String("CONFLICTING".to_owned()),
+        _ => Value::Null,
+    };
     serde_json::json!({
         "number": pr.get("number").cloned().unwrap_or(Value::Null),
         "url": pr.get("html_url").cloned().unwrap_or(Value::Null),
         "title": pr.get("title").cloned().unwrap_or(Value::Null),
         "state": pr.get("state").cloned().unwrap_or(Value::Null),
         "isDraft": pr.get("draft").cloned().unwrap_or(Value::Null),
-        "author": { "login": pr.pointer("/user/login").cloned().unwrap_or(Value::Null) },
+        "author": {
+            "login": pr.pointer("/user/login").cloned().unwrap_or(Value::Null),
+            "avatarUrl": pr.pointer("/user/avatar_url").cloned().unwrap_or(Value::Null),
+        },
+        "reviewDecision": Value::Null,
+        "mergeable": mergeable,
+        "mergeStateStatus": pr.get("mergeable_state").cloned().unwrap_or(Value::Null),
+        "autoMergeRequest": pr.get("auto_merge").cloned().unwrap_or(Value::Null),
+        "headRepository": head_repository,
+        "headRepositoryOwner": head_repository_owner,
         "headRefName": pr.pointer("/head/ref").cloned().unwrap_or(Value::Null),
         "headRefOid": pr.pointer("/head/sha").cloned().unwrap_or(Value::Null),
         "baseRefName": pr.pointer("/base/ref").cloned().unwrap_or(Value::Null),
@@ -379,6 +555,8 @@ pub(crate) fn fact_value(pr: &Value) -> Value {
         "updatedAt": pr.get("updated_at").cloned().unwrap_or(Value::Null),
         "mergedAt": pr.get("merged_at").cloned().unwrap_or(Value::Null),
         "closedAt": pr.get("closed_at").cloned().unwrap_or(Value::Null),
+        "labels": pr.get("labels").cloned().unwrap_or_else(|| Value::Array(Vec::new())),
+        "comments": pr.get("comments").cloned().unwrap_or(Value::Null),
     })
 }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -565,7 +565,7 @@ impl CodeRuntime {
 
     /// The REST base decision 65's pull-request operations drive: the
     /// forge's own, or a test override.
-    fn forge_api_base_for(&self, host: &str) -> String {
+    pub(crate) fn forge_api_base_for(&self, host: &str) -> String {
         #[cfg(test)]
         {
             if let Some(base) = self.forge_api_base.lock().expect("forge api base").clone() {

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -907,7 +907,10 @@ fn default_github_host() -> String {
     "github.com".to_owned()
 }
 
-/// Whether the local GitHub CLI can serve delivery requests.
+/// Whether this caller's GitHub path can serve Delivery requests.
+///
+/// Desktops and self-host machines report the local GitHub CLI. A
+/// gateway-authenticated hosted machine reports the caller's connected forge.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct CodeGitHubCapability {
     pub found: bool,

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -1292,3 +1292,317 @@ exit 3
     let live = fact.live.expect("the digest read writes the live tier");
     assert_eq!(live.merge_state_status.as_deref(), Some("blocked"));
 }
+
+fn assert_borrowed_forge_credential(headers: &axum::http::HeaderMap) {
+    let bearer = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    assert_eq!(bearer, "Bearer ghs_fake_borrowed");
+}
+
+async fn register_delivery_repository(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    root: &std::path::Path,
+) {
+    let response = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "path": root }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+}
+
+/// Issue #2673: a gateway-authenticated hosted caller reads every Delivery
+/// list through one borrowed credential per repository operation. No `gh`
+/// observation participates, and check runs keep the attention bucket useful.
+#[tokio::test]
+async fn a_hosted_delivery_page_reads_repository_lists_over_forge_rest() {
+    let repository = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!({
+            "name": "demo",
+            "full_name": "acme/demo",
+            "html_url": "https://github.com/acme/demo",
+            "default_branch": "main",
+            "owner": { "login": "acme" },
+        }))
+    };
+    let pulls = |headers: axum::http::HeaderMap,
+                 axum::extract::Query(query): axum::extract::Query<
+        std::collections::HashMap<String, String>,
+    >| async move {
+        assert_borrowed_forge_credential(&headers);
+        assert_eq!(query.get("state").map(String::as_str), Some("open"));
+        axum::Json(serde_json::json!([{
+            "number": 17,
+            "html_url": "https://github.com/acme/demo/pull/17",
+            "title": "Repair hosted delivery",
+            "state": "open",
+            "draft": false,
+            "user": {
+                "login": "mira-chen",
+                "avatar_url": "https://avatars.example/mira"
+            },
+            "head": {
+                "ref": "hosted-delivery",
+                "sha": "feedfeedfeedfeedfeed",
+                "repo": {
+                    "name": "demo",
+                    "full_name": "acme/demo",
+                    "owner": { "login": "acme" }
+                }
+            },
+            "base": { "ref": "main" },
+            "labels": [{ "name": "code" }],
+            "comments": 2,
+            "created_at": "2026-08-25T10:00:00Z",
+            "updated_at": "2026-08-25T11:00:00Z",
+            "merged_at": null,
+            "closed_at": null
+        }]))
+    };
+    let checks = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!({
+            "check_runs": [{
+                "name": "desktop test",
+                "status": "completed",
+                "conclusion": "failure",
+                "details_url": "https://github.com/acme/demo/actions/runs/44"
+            }, {
+                "name": "clippy",
+                "status": "in_progress",
+                "conclusion": null,
+                "html_url": "https://github.com/acme/demo/actions/runs/45"
+            }]
+        }))
+    };
+    let workflow_runs = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!({
+            "workflow_runs": [{
+                "id": 44,
+                "run_attempt": 2,
+                "status": "completed",
+                "conclusion": "failure",
+                "display_title": "Desktop CI",
+                "name": "CI",
+                "html_url": "https://github.com/acme/demo/actions/runs/44",
+                "head_branch": "hosted-delivery",
+                "head_sha": "feedfeedfeedfeedfeed",
+                "event": "pull_request",
+                "actor": { "login": "mira-chen" },
+                "created_at": "2026-08-25T10:00:00Z",
+                "updated_at": "2026-08-25T11:00:00Z"
+            }]
+        }))
+    };
+    let deployments = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!([{
+            "id": 91,
+            "environment": "production",
+            "ref": "hosted-delivery",
+            "sha": "feedfeedfeedfeedfeed",
+            "creator": { "login": "mira-chen" },
+            "created_at": "2026-08-25T10:30:00Z",
+            "updated_at": "2026-08-25T10:30:00Z"
+        }]))
+    };
+    let forge = axum::Router::new()
+        .route("/repos/acme/demo", axum::routing::get(repository))
+        .route("/repos/acme/demo/pulls", axum::routing::get(pulls))
+        .route(
+            "/repos/acme/demo/commits/{sha}/check-runs",
+            axum::routing::get(checks),
+        )
+        .route(
+            "/repos/acme/demo/actions/runs",
+            axum::routing::get(workflow_runs),
+        )
+        .route(
+            "/repos/acme/demo/deployments",
+            axum::routing::get(deployments),
+        );
+    let forge_addr = serve(forge).await;
+
+    let lender = Arc::new(FakeLender::offering_person("mira-chen"));
+    let (router, token, runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    runtime.set_gh_search_path(Some("/path/with/no/gh".into()));
+    runtime.set_forge_api_base(Some(format!("http://{forge_addr}")));
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let root = init_paired_repo(dir.path());
+    run(
+        &root,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+    register_delivery_repository(&client, addr, &token, &root).await;
+
+    let repositories: serde_json::Value = client
+        .get(format!("http://{addr}/code/delivery/repositories"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(repositories["capability"]["authenticated"], true);
+    assert_eq!(repositories["capability"]["viewer_login"], "mira-chen");
+    assert_eq!(
+        repositories["repositories"][0]["name_with_owner"],
+        "acme/demo"
+    );
+    assert_eq!(repositories["repositories"][0]["default_branch"], "main");
+
+    let target = serde_json::json!({
+        "host": "github.com",
+        "owner": "acme",
+        "name": "demo"
+    });
+    let pull_requests: serde_json::Value = client
+        .post(format!("http://{addr}/code/delivery/pull-requests/query"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repositories": [target.clone()],
+            "states": ["open"]
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(pull_requests["items"][0]["number"], 17);
+    assert_eq!(pull_requests["items"][0]["comment_count"], 2);
+    assert_eq!(
+        pull_requests["items"][0]["checks"][0]["name"],
+        "desktop test"
+    );
+    assert_eq!(pull_requests["items"][0]["checks"][0]["bucket"], "fail");
+    assert_eq!(
+        pull_requests["items"][0]["checks"][0]["workflow_run_id"],
+        44
+    );
+    assert_eq!(pull_requests["items"][0]["checks"][1]["bucket"], "pending");
+    assert_eq!(
+        pull_requests["items"][0]["checks"][1]["workflow_run_id"],
+        45
+    );
+    assert_eq!(
+        pull_requests["items"][0]["attention_reasons"][0],
+        "checks_failed"
+    );
+
+    let runs: serde_json::Value = client
+        .post(format!("http://{addr}/code/delivery/runs/query"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "repositories": [target] }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(runs["items"].as_array().unwrap().len(), 2, "{runs}");
+    assert!(runs["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["kind"] == "workflow_run"));
+    assert!(runs["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["kind"] == "deployment"));
+    assert_eq!(
+        lender.minted(),
+        vec![
+            "acme/demo".to_owned(),
+            "acme/demo".to_owned(),
+            "acme/demo".to_owned()
+        ],
+        "each repository read borrows once"
+    );
+}
+
+/// Issue #2673: a hosted caller who has not connected their forge gets the
+/// gateway's connect path. The response never points at a terminal on a
+/// machine where the caller cannot run `gh auth login`.
+#[tokio::test]
+async fn an_unconnected_hosted_delivery_page_never_recommends_gh_login() {
+    let connect_url = "https://gateway.example/account/apps";
+    let lender = Arc::new(FakeLender::refusing(GitForgeError::NotConnected {
+        connect_url: Some(connect_url.to_owned()),
+    }));
+    let (router, token, runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    runtime.set_gh_search_path(Some("/path/with/no/gh".into()));
+    runtime.set_forge_api_base(Some("http://127.0.0.1:9".into()));
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let root = init_paired_repo(dir.path());
+    run(
+        &root,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+    register_delivery_repository(&client, addr, &token, &root).await;
+
+    let repositories: serde_json::Value = client
+        .get(format!("http://{addr}/code/delivery/repositories"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let remediation = repositories["capability"]["remediation"].as_str().unwrap();
+    assert_eq!(repositories["capability"]["authenticated"], false);
+    assert!(remediation.contains(connect_url), "{remediation}");
+    assert!(!remediation.contains("gh auth login"), "{remediation}");
+
+    let pull_requests: serde_json::Value = client
+        .post(format!("http://{addr}/code/delivery/pull-requests/query"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repositories": [{
+                "host": "github.com",
+                "owner": "acme",
+                "name": "demo"
+            }],
+            "states": ["open"]
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(pull_requests["items"].as_array().unwrap().len(), 0);
+    assert_eq!(pull_requests["errors"][0]["kind"], "git_forge_not_offered");
+    assert!(pull_requests["errors"][0]["message"]
+        .as_str()
+        .unwrap()
+        .contains(connect_url));
+    assert!(lender.minted().is_empty());
+}


### PR DESCRIPTION
## Summary

- Probe the gateway forge for Delivery capability on hosted machines instead of consulting `gh`.
- Read tracked repository metadata, open pull requests with check runs, GitHub Actions runs, and deployments over forge REST with one borrowed credential per repository operation.
- Keep desktop and self-host reads, pull request details, run details, and every Delivery mutation on the existing `gh` paths.

## Backwards compatibility

Desktop and self-host machines still select the GitHub CLI reader and preserve the existing payloads and actions. The public Delivery wire shape does not change.

## Safety and risk

Borrowed credentials remain in memory for one operation. The hosted reader refuses targets outside the configured forge host, disables redirects through the existing REST client, bounds response bodies, and never writes credentials to disk or subprocess arguments.

The main risk is REST payload drift from the GitHub CLI vocabulary. Focused server tests cover repository discovery, author identity, check buckets and workflow run IDs, Actions runs, deployments, per-operation mints, and the gateway connect remediation.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Cargo build, check, Clippy, and tests were not run locally under the repository Rust policy. CI owns those lanes.

Closes #2673