### PR TITLE
fix(code): emit Codex session start once

### DIFF
--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -52,7 +52,10 @@ impl HarnessAdapter for CodexAdapter {
     async fn probe(&self, host: &HostEnv) -> HarnessProbe {
         match probe_shell(host, "codex").await {
             Ok(capture) => {
-                let version = observe_version(&capture.binary, &capture.env).await.ok();
+                let version = observe_version(&capture.binary, &capture.env)
+                    .await
+                    .ok()
+                    .map(|version| normalize_codex_version(&version));
                 let authenticated = observe_login(&capture.binary, &capture.env).await;
                 HarnessProbe {
                     found: true,
@@ -118,6 +121,20 @@ impl HarnessAdapter for CodexAdapter {
         // 0064), so attaching a session costs no engine runtime.
         Ok(Box::new(CodexSession::new(spec)))
     }
+}
+
+fn normalize_codex_version(version: &str) -> String {
+    version
+        .split_whitespace()
+        .find_map(|candidate| {
+            let candidate = candidate.strip_prefix('v').unwrap_or(candidate);
+            candidate
+                .chars()
+                .next()
+                .is_some_and(|first| first.is_ascii_digit())
+                .then(|| candidate.to_owned())
+        })
+        .unwrap_or_else(|| version.trim().to_owned())
 }
 
 fn supports_native_steering(version: Option<&str>) -> bool {
@@ -756,6 +773,13 @@ mod tests {
     #[test]
     fn adapter_has_a_fixtures_directory_with_a_manifest() {
         assert!(fixture_dir().join("manifest.toml").is_file());
+    }
+
+    #[test]
+    fn codex_versions_use_the_bare_engine_version() {
+        assert_eq!(normalize_codex_version("codex-cli 0.147.0"), "0.147.0");
+        assert_eq!(normalize_codex_version("codex-cli v0.147.0"), "0.147.0");
+        assert_eq!(normalize_codex_version("0.147.0"), "0.147.0");
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -267,10 +267,12 @@ impl CodexStreamParser {
                 }
                 Vec::new()
             }
+            "thread/started" => self.emit_session_started(&params),
             "account/rateLimits/updated"
             | "hook/completed"
             | "hook/started"
             | "item/commandExecution/outputDelta"
+            | "item/commandExecution/terminalInteraction"
             | "item/fileChange/outputDelta"
             | "item/fileChange/patchUpdated"
             | "item/mcpToolCall/progress"
@@ -285,7 +287,6 @@ impl CodexStreamParser {
             | "thread/goal/updated"
             | "thread/queue/changed"
             | "thread/settings/updated"
-            | "thread/started"
             | "thread/status/changed"
             | "thread/goal/cleared"
             | "turn/diff/updated"
@@ -296,7 +297,7 @@ impl CodexStreamParser {
                 Vec::new()
             }
             other => {
-                self.count_unrecognized(other, value);
+                self.count_unrecognized_notification(other, value);
                 Vec::new()
             }
         }
@@ -755,19 +756,22 @@ impl CodexStreamParser {
     }
 
     fn emit_session_started(&mut self, result: &Value) -> Vec<HarnessEvent> {
+        if self.emitted_session {
+            return Vec::new();
+        }
         let thread = result.get("thread").cloned().unwrap_or(Value::Null);
-        if let Some(id) = thread
+        let Some(id) = thread
             .get("id")
             .and_then(Value::as_str)
             .or_else(|| thread.get("sessionId").and_then(Value::as_str))
-        {
-            self.resume_ref = Some(id.to_owned());
-        }
-        if let Some(version) = thread.get("cliVersion").and_then(Value::as_str) {
-            self.version = Some(version.to_owned());
-        }
-        if self.emitted_session {
+            .filter(|id| !id.is_empty())
+        else {
+            self.count_unrecognized("session-start/missing-thread-id", result);
             return Vec::new();
+        };
+        self.resume_ref = Some(id.to_owned());
+        if let Some(version) = thread.get("cliVersion").and_then(Value::as_str) {
+            self.version = Some(super::normalize_codex_version(version));
         }
         self.emitted_session = true;
         vec![HarnessEvent::SessionStarted {
@@ -775,6 +779,24 @@ impl CodexStreamParser {
             harness_version: self.version.clone().unwrap_or_else(|| "unknown".into()),
             resume_ref: self.resume_ref.clone(),
         }]
+    }
+
+    fn count_unrecognized_notification(&mut self, method: &str, payload: &Value) {
+        self.unrecognized += 1;
+        let mut rendered = payload.to_string();
+        crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
+        tracing::info!(
+            target: "tidebreak_harness::codex",
+            unrecognized = self.unrecognized,
+            kind = method,
+            "unrecognized engine event"
+        );
+        tracing::debug!(
+            target: "tidebreak_harness::codex",
+            method = method,
+            payload = %rendered,
+            "unrecognized engine notification payload"
+        );
     }
 
     fn emit_tool_started(
@@ -1331,10 +1353,75 @@ mod tests {
     }
 
     #[test]
+    fn session_started_emits_once_with_the_resume_ref_in_either_start_order() {
+        let cases = [
+            (
+                "result first",
+                r#"
+{"dir":"out","msg":{"id":1,"method":"thread/start","params":{}}}
+{"dir":"in","msg":{"id":1,"result":{"thread":{"id":"abc","cliVersion":"codex-cli 0.147.0"}}}}
+{"dir":"in","msg":{"method":"thread/started","params":{"thread":{"id":"abc","cliVersion":"0.147.0"}}}}
+"#,
+            ),
+            (
+                "notification first",
+                r#"
+{"dir":"in","msg":{"method":"thread/started","params":{"thread":{"id":"abc","cliVersion":"codex-cli 0.147.0"}}}}
+{"dir":"out","msg":{"id":1,"method":"thread/start","params":{}}}
+{"dir":"in","msg":{"id":1,"result":{"thread":{"id":"abc","cliVersion":"0.147.0"}}}}
+"#,
+            ),
+        ];
+
+        for (order, input) in cases {
+            let out = CodexStreamParser::parse_ndjson(input);
+            assert_eq!(out.unrecognized, 0, "{order}");
+            assert_eq!(out.resume_ref.as_deref(), Some("abc"), "{order}");
+            let started = out
+                .events
+                .iter()
+                .filter_map(|event| match event {
+                    HarnessEvent::SessionStarted {
+                        harness_kind,
+                        harness_version,
+                        resume_ref,
+                    } => Some((harness_kind, harness_version, resume_ref)),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(started.len(), 1, "{order}");
+            assert_eq!(*started[0].0, HarnessKind::Codex, "{order}");
+            assert_eq!(started[0].1, "0.147.0", "{order}");
+            assert_eq!(started[0].2.as_deref(), Some("abc"), "{order}");
+        }
+    }
+
+    #[test]
+    fn session_started_waits_for_a_nonempty_thread_id() {
+        let input = r#"
+{"dir":"out","msg":{"id":1,"method":"thread/start","params":{}}}
+{"dir":"in","msg":{"id":1,"result":{"thread":{"id":"","cliVersion":"0.147.0"}}}}
+{"dir":"in","msg":{"method":"thread/started","params":{"thread":{"id":"abc","cliVersion":"0.147.0"}}}}
+"#;
+        let out = CodexStreamParser::parse_ndjson(input);
+
+        assert_eq!(out.unrecognized, 1);
+        assert_eq!(out.resume_ref.as_deref(), Some("abc"));
+        assert_eq!(
+            out.events
+                .iter()
+                .filter(|event| matches!(event, HarnessEvent::SessionStarted { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn known_streaming_telemetry_does_not_count_as_protocol_drift() {
         let input = r#"
 {"method":"item/reasoning/summaryTextDelta","params":{"delta":"thinking"}}
 {"method":"item/commandExecution/outputDelta","params":{"delta":"output"}}
+{"method":"item/commandExecution/terminalInteraction","params":{"itemId":"command-1"}}
 {"method":"turn/diff/updated","params":{"diff":"patch"}}
 {"method":"thread/compacted","params":{}}
 "#;

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -1922,11 +1922,13 @@ async fn session_was_ended(db: &DbStore, session: &mut CodeSession) -> bool {
     }
 }
 
-/// Bump the spawn epoch, record pid/version, and journal SessionStarted.
+/// Bump the spawn epoch and record the process metadata.
 ///
 /// Call this once, before the engine is launched, so the event sink and the
 /// session row share the same epoch. Pass `child_pid` after launch via
-/// [`save_session`] if the adapter only exposes a pid later.
+/// [`save_session`] if the adapter only exposes a pid later. Codex reports
+/// `SessionStarted` after its thread exists, so its parser journals that event
+/// with the resume ref. Other adapters keep the eager event at attachment.
 pub(crate) async fn attach_engine(
     db: &DbStore,
     bus: &CodeEventBus,
@@ -1954,23 +1956,25 @@ pub(crate) async fn attach_engine(
     super::attention::persist_session(db, bus, &session)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;
-    persist_and_publish(
-        db,
-        bus,
-        &session.owner,
-        session_id,
-        epoch,
-        CodeEvent::SessionStarted {
-            harness_kind: kind,
-            harness_version: session
-                .harness_version
-                .clone()
-                .unwrap_or_else(|| "unknown".into()),
-            resume_ref: session.harness_resume_ref.clone(),
-        },
-    )
-    .await
-    .map_err(|err| WorkerError::Failed(err.to_string()))?;
+    if kind != tidebreak_core::HarnessKind::Codex {
+        persist_and_publish(
+            db,
+            bus,
+            &session.owner,
+            session_id,
+            epoch,
+            CodeEvent::SessionStarted {
+                harness_kind: kind,
+                harness_version: session
+                    .harness_version
+                    .clone()
+                    .unwrap_or_else(|| "unknown".into()),
+                resume_ref: session.harness_resume_ref.clone(),
+            },
+        )
+        .await
+        .map_err(|err| WorkerError::Failed(err.to_string()))?;
+    }
     Ok(session)
 }
 
@@ -2415,7 +2419,9 @@ impl From<HarnessError> for WorkerError {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use tidebreak_core::db::code::{get_session, insert_repo, insert_session, insert_workspace};
+    use tidebreak_core::db::code::{
+        get_session, insert_repo, insert_session, insert_workspace, list_events, MAX_REPLAY_EVENTS,
+    };
     use tidebreak_core::{
         CodeRepo, CodeSessionKind, CodeUsage, CodeWorkspace, CodeWorkspaceStatus, HarnessKind,
         ImageMediaType, ImageRef, PermissionMode, RepoId, ToolDetail, WorkspaceId,
@@ -2497,10 +2503,13 @@ mod tests {
         .is_none());
     }
 
-    async fn seeded_sink() -> (
+    async fn seeded_session(
+        harness_kind: HarnessKind,
+        harness_version: Option<&str>,
+    ) -> (
         tempfile::TempDir,
         Arc<DbStore>,
-        Arc<LiveSink>,
+        Arc<CodeEventBus>,
         CodeSessionId,
     ) {
         let directory = tempfile::tempdir().unwrap();
@@ -2566,8 +2575,8 @@ mod tests {
                 owner: owner.clone(),
                 workspace_id,
                 kind: CodeSessionKind::Interactive,
-                harness_kind: HarnessKind::ClaudeCode,
-                harness_version: Some("2.1.237".into()),
+                harness_kind,
+                harness_version: harness_version.map(str::to_owned),
                 harness_resume_ref: None,
                 permission_mode: PermissionMode::Plan,
                 model: None,
@@ -2585,10 +2594,26 @@ mod tests {
         )
         .await
         .unwrap();
+        (
+            directory,
+            store,
+            Arc::new(CodeEventBus::default()),
+            session_id,
+        )
+    }
+
+    async fn seeded_sink() -> (
+        tempfile::TempDir,
+        Arc<DbStore>,
+        Arc<LiveSink>,
+        CodeSessionId,
+    ) {
+        let (directory, store, bus, session_id) =
+            seeded_session(HarnessKind::ClaudeCode, Some("2.1.237")).await;
         let sink = sink_for(
             store.clone(),
-            Arc::new(CodeEventBus::default()),
-            owner,
+            bus,
+            OwnerId::local(),
             session_id,
             1,
             None,
@@ -2597,6 +2622,103 @@ mod tests {
             None,
         );
         (directory, store, sink, session_id)
+    }
+
+    #[tokio::test]
+    async fn codex_attachment_journals_one_start_after_the_thread_is_known() {
+        let (_directory, store, bus, session_id) =
+            seeded_session(HarnessKind::Codex, Some("codex-cli 0.147.0")).await;
+        let attached = attach_engine(
+            &store,
+            &bus,
+            session_id,
+            HarnessKind::Codex,
+            Some("0.147.0".into()),
+            None,
+        )
+        .await
+        .unwrap();
+        let owner = OwnerId::local();
+        assert_eq!(attached.harness_version.as_deref(), Some("0.147.0"));
+
+        assert!(
+            list_events(&store, &owner, session_id, 0, MAX_REPLAY_EVENTS)
+                .await
+                .unwrap()
+                .events
+                .iter()
+                .all(|event| !matches!(&event.event, CodeEvent::SessionStarted { .. }))
+        );
+
+        let sink = sink_for(
+            store.clone(),
+            bus,
+            owner.clone(),
+            session_id,
+            attached.spawn_epoch,
+            None,
+            attached.subagents,
+            None,
+            None,
+        );
+        sink.emit(HarnessEvent::SessionStarted {
+            harness_kind: HarnessKind::Codex,
+            harness_version: "0.147.0".into(),
+            resume_ref: Some("thread-1".into()),
+        })
+        .await;
+
+        let started = list_events(&store, &owner, session_id, 0, MAX_REPLAY_EVENTS)
+            .await
+            .unwrap()
+            .events
+            .into_iter()
+            .filter_map(|event| match event.event {
+                CodeEvent::SessionStarted {
+                    harness_kind,
+                    harness_version,
+                    resume_ref,
+                } => Some((harness_kind, harness_version, resume_ref)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            started,
+            vec![(
+                HarnessKind::Codex,
+                "0.147.0".into(),
+                Some("thread-1".into())
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn non_codex_attachment_keeps_the_eager_session_start() {
+        let (_directory, store, bus, session_id) =
+            seeded_session(HarnessKind::ClaudeCode, Some("2.1.237")).await;
+
+        attach_engine(
+            &store,
+            &bus,
+            session_id,
+            HarnessKind::ClaudeCode,
+            Some("2.1.237".into()),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let events = list_events(&store, &OwnerId::local(), session_id, 0, MAX_REPLAY_EVENTS)
+            .await
+            .unwrap()
+            .events;
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(&event.event, CodeEvent::SessionStarted { .. }))
+                .count(),
+            1
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- Skip the eager server-side `session_started` event for Codex. The Codex parser now emits the event after it receives a non-empty thread ID.
- Accept either `thread/start` result order or `thread/started` notification order while emitting exactly one event with the resume ref.
- Normalize Codex versions to the bare engine version, log unknown notification method names at debug level, and classify `item/commandExecution/terminalInteraction` as known telemetry.

## Compatibility and safety

- Other harnesses keep the existing eager session start behavior.
- Codex keeps the existing resume-ref durability rule: the sink records the ref from startup and persists it after turn activity starts.
- The change does not alter public APIs, storage schemas, or other harness adapters.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Parsed every Codex 0.147.0 NDJSON and expected JSON fixture with `jq`.
- Confirmed matching thread IDs between captured `thread/start` results and `thread/started` notifications.
- Rust build, test, check, and Clippy commands were not run, as required for this issue.

Closes #2655