### PR TITLE
fix(code): show Claude authentication as unverified until proven

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
@@ -38,6 +38,7 @@ const READY_DOCTOR: HarnessDoctorReport = {
       kind: "claude_code",
       found: true,
       installable: true,
+      authenticated: true,
       tier: "reference",
       caps: {
         resume: "supported",

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -30,8 +30,8 @@ import { middleTruncate } from "./workspaceCards";
  *
  * A machine with nothing downloaded yet is not blocked: picking an engine in
  * the New Workspace dialog fetches it. The doctor only takes the page when
- * every engine is signed out or unsupported, which is the one case a reader
- * cannot resolve by starting a workspace.
+ * every engine is signed out, unverified, or unsupported, which is the one
+ * case a reader cannot resolve by starting a workspace.
  */
 
 export function CodeHome() {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -190,6 +190,7 @@ const START_HARNESS: HarnessDoctorEntry = {
   kind: "claude_code",
   found: true,
   installable: true,
+  authenticated: true,
   tier: "reference",
   caps: {
     resume: "supported",

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
@@ -9,6 +9,73 @@ import { DoctorList } from "./DoctorList";
 afterEach(cleanup);
 
 describe("DoctorList", () => {
+  it("labels authenticated, signed-out, and unverified engines distinctly", () => {
+    render(
+      <DoctorList
+        report={{
+          harnesses: [
+            {
+              ...notDownloaded,
+              kind: "claude_code",
+              found: true,
+              authenticated: true,
+            },
+            {
+              ...notDownloaded,
+              kind: "codex",
+              found: true,
+              authenticated: false,
+              remediation: "Sign in to Codex CLI, then re-check.",
+            },
+            {
+              ...notDownloaded,
+              kind: "opencode",
+              found: true,
+              remediation: "Sign in via your terminal, then re-check.",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Signed out")).toBeInTheDocument();
+    expect(screen.getByText("Unverified")).toBeInTheDocument();
+    expect(
+      screen.getByText("Sign in via your terminal, then re-check."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 of 3 engines ready.")).toBeInTheDocument();
+  });
+
+  it("directs an all-installed blocked set to sign in instead of download", () => {
+    render(
+      <DoctorList
+        report={{
+          harnesses: [
+            {
+              ...notDownloaded,
+              kind: "claude_code",
+              found: true,
+              remediation: "Sign in via your terminal, then re-check.",
+            },
+            {
+              ...notDownloaded,
+              kind: "codex",
+              found: true,
+              authenticated: false,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "No engine is ready yet. Sign in to one below, then re-check.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("states that protocol-gap counts include saved session history", async () => {
     const report: HarnessDoctorReport = {
       harnesses: [

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -61,7 +61,9 @@ export function DoctorList({
             // know "can I start work" does not walk every row to find out.
             <p className="text-muted-foreground text-sm">
               {ready === 0
-                ? "No engine is ready yet. Download one, or pick it when you start a workspace."
+                ? report.harnesses.every((entry) => entry.found)
+                  ? "No engine is ready yet. Sign in to one below, then re-check."
+                  : "No engine is ready yet. Download one, or pick it when you start a workspace."
                 : `${ready} of ${total} ${total === 1 ? "engine" : "engines"} ready.`}
             </p>
           )}
@@ -127,7 +129,11 @@ function statusBadge(
   if (install?.error) return { label: "Download failed", variant: "critical" };
   if (isHarnessReady(entry)) return { label: "Ready", variant: "success" };
   // A state, not an instruction — the instruction is the line below it.
-  if (entry.found) return { label: "Signed out", variant: "warning" };
+  if (entry.found) {
+    return entry.authenticated === false
+      ? { label: "Signed out", variant: "warning" }
+      : { label: "Unverified", variant: "warning" };
+  }
   if (harnessNeedsDownload(entry)) {
     return { label: "Not downloaded", variant: "outline" };
   }
@@ -150,6 +156,9 @@ function subtitle(
   }
   if (install?.error) return install.error;
   if (entry.remediation) return entry.remediation;
+  if (entry.found && entry.authenticated !== true) {
+    return "Sign in via your terminal, then re-check.";
+  }
   if (harnessNeedsDownload(entry)) {
     return "Downloads the first time you pick it.";
   }

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -51,8 +51,8 @@ describe("HarnessPicker", () => {
     await renderWithRouter(
       <HarnessPicker
         harnesses={[
-          entry({ kind: "claude_code" }),
-          entry({ kind: "codex" }),
+          entry({ kind: "claude_code", authenticated: true }),
+          entry({ kind: "codex", authenticated: true }),
           entry({ kind: "opencode", found: false, installable: false }),
         ]}
         value="claude_code"
@@ -81,7 +81,7 @@ describe("HarnessPicker", () => {
     await renderWithRouter(
       <HarnessPicker
         harnesses={[
-          entry({ kind: "claude_code" }),
+          entry({ kind: "claude_code", authenticated: true }),
           entry({
             kind: "opencode",
             found: false,
@@ -107,10 +107,15 @@ describe("HarnessPicker", () => {
     await renderWithRouter(
       <HarnessPicker
         harnesses={[
-          entry({ kind: "claude_code", version: "2.1.233" }),
+          entry({
+            kind: "claude_code",
+            version: "2.1.233",
+            authenticated: true,
+          }),
           entry({
             kind: "grok",
             version: "1.0.4",
+            authenticated: true,
             caps: {
               ...CAPS,
               plan_mode: "unsupported",
@@ -131,11 +136,37 @@ describe("HarnessPicker", () => {
     expect(onChange).toHaveBeenCalledWith("grok");
   });
 
+  it("disables an engine whose sign-in status is unverified", async () => {
+    const onChange = vi.fn();
+    await renderWithRouter(
+      <HarnessPicker
+        harnesses={[
+          entry({
+            kind: "claude_code",
+            authenticated: undefined,
+            remediation: "Sign in via your terminal, then re-check.",
+          }),
+          entry({ kind: "codex", authenticated: true }),
+        ]}
+        value="codex"
+        onChange={onChange}
+      />,
+    );
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole("combobox", { name: "Harness" }));
+    const row = screen.getByRole("option", { name: /Claude Code/ });
+    expect(row).toHaveTextContent("Unverified — sign in via your terminal");
+    expect(row).toHaveAttribute("aria-disabled", "true");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("does not add a settings button beside the composer control", async () => {
     await renderWithRouter(
       <HarnessPicker
         harnesses={[
-          entry({ kind: "claude_code" }),
+          entry({ kind: "claude_code", authenticated: true }),
           entry({ kind: "opencode", found: false, installable: false }),
         ]}
         value="claude_code"

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -67,6 +67,7 @@ function harness(kind: HarnessKind): HarnessDoctorEntry {
     kind,
     found: true,
     installable: true,
+    authenticated: true,
     tier: "reference",
     caps: { ...CAPS },
     commands: [],

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -86,6 +86,7 @@ function entry(
     kind,
     found: true,
     installable: true,
+    authenticated: true,
     tier: "reference",
     caps: { ...CAPS, structured_approvals: "supported", ...caps },
     commands: [],

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -12,6 +12,7 @@ import {
   harnessCanStartNow,
   harnessNeedsDownload,
   harnessUnusableReason,
+  isHarnessReady,
   preferredCodeModels,
   sessionLifecycleTooltip,
 } from "./labels";
@@ -105,6 +106,12 @@ describe("create-time permission mode", () => {
 });
 
 describe("harnessUnusableReason", () => {
+  it("requires a positive authentication observation before an engine is ready", () => {
+    expect(isHarnessReady({ found: true, authenticated: true })).toBe(true);
+    expect(isHarnessReady({ found: true, authenticated: false })).toBe(false);
+    expect(isHarnessReady({ found: true })).toBe(false);
+  });
+
   it("names the one reason a picker row cannot be chosen", () => {
     expect(
       harnessUnusableReason({
@@ -125,6 +132,14 @@ describe("harnessUnusableReason", () => {
       harnessUnusableReason({
         found: true,
         installable: true,
+        caps: caps("supported", "supported", "supported"),
+      }),
+    ).toBe("Unverified — sign in via your terminal");
+    expect(
+      harnessUnusableReason({
+        found: true,
+        installable: true,
+        authenticated: true,
         caps: caps("unsupported", "unsupported", "unsupported"),
       }),
     ).toBe("Not available yet");
@@ -132,6 +147,7 @@ describe("harnessUnusableReason", () => {
       harnessUnusableReason({
         found: true,
         installable: true,
+        authenticated: true,
         caps: caps("supported", "unsupported", "unsupported"),
       }),
     ).toBeNull();
@@ -140,6 +156,7 @@ describe("harnessUnusableReason", () => {
       harnessUnusableReason({
         found: true,
         installable: true,
+        authenticated: true,
         caps: caps("unsupported", "unsupported", "supported"),
       }),
     ).toBeNull();

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -119,7 +119,7 @@ export function isHarnessReady(entry: {
   found: boolean;
   authenticated?: boolean;
 }): boolean {
-  return entry.found && entry.authenticated !== false;
+  return entry.found && entry.authenticated === true;
 }
 
 /** True when create can post at least one permission mode this engine honors. */
@@ -151,10 +151,14 @@ export function harnessUnusableReason(entry: {
   found: boolean;
   installable: boolean;
   authenticated?: boolean;
+  remediation?: string;
   caps: ModeCaps;
 }): string | null {
   if (!entry.found && !entry.installable) return "Not installed";
   if (entry.authenticated === false) return "Sign in via your terminal";
+  if (entry.found && entry.authenticated === undefined) {
+    return "Unverified — sign in via your terminal";
+  }
   if (!harnessHonorsAnyCreateMode(entry)) return "Not available yet";
   return null;
 }
@@ -164,6 +168,7 @@ export function harnessCanStartNow(entry: {
   found: boolean;
   installable: boolean;
   authenticated?: boolean;
+  remediation?: string;
   caps: ModeCaps;
 }): boolean {
   return entry.found && !harnessUnusableReason(entry);

--- a/crates/tidebreak-desktop/ui/src/stories/CodingHarnessesPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodingHarnessesPanel.stories.tsx
@@ -76,7 +76,7 @@ export const Downloading: Story = {
   args: { report: harnessDoctorCold, installs: harnessInstallsInFlight },
 };
 
-/** States no download fixes: no pin for one engine, no sign-in for the other. */
+/** States no download fixes: one unverified engine and one signed-out engine. */
 export const NeedsYou: Story = { args: { report: harnessDoctorDegraded } };
 
 /** The first read has not landed. */

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
@@ -60,7 +60,7 @@ export const Downloading: Story = {
   },
 };
 
-/** Nothing a download fixes: an engine with no pin, and one signed out. */
+/** Nothing a download fixes: one unverified engine and one signed-out engine. */
 export const NeedsYou: Story = {
   args: { report: harnessDoctorDegraded },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -481,6 +481,7 @@ function doctorEntry(
   return {
     found: true,
     installable: true,
+    authenticated: true,
     tier: "reference",
     caps: fullCaps,
     commands: [],
@@ -539,17 +540,18 @@ export const harnessDoctorDegraded: HarnessDoctorReport = {
   harnesses: [
     doctorEntry({
       kind: "claude_code",
-      found: false,
-      installable: false,
-      remediation: "This build ships no pinned Claude Code binary to download.",
-      stderr: "claude: command not found",
+      version: "2.1.234 (Claude Code)",
+      path: "~/.local/share/tidebreak/tools/harnesses/claude_code",
+      authenticated: undefined,
+      remediation:
+        "Tidebreak could not verify the Claude Code sign-in. Sign in to Claude Code in your own terminal, then re-check.",
     }),
     doctorEntry({
       kind: "codex",
       version: "codex-cli 0.147.0",
       tier: "secondary",
       authenticated: false,
-      remediation: "Sign in to codex in your own terminal, then re-check.",
+      remediation: "Sign in to Codex CLI in your own terminal, then re-check.",
       caps: { ...fullCaps, mid_turn_steering: "supported" },
     }),
   ],

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -5,12 +5,20 @@ pub mod browser;
 pub mod parse;
 pub mod session;
 
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use tidebreak_core::{CapLevel, HarnessCaps, HarnessKind, ReasoningEffort};
+use tokio::process::Command;
+use tokio::time::timeout;
 
 use crate::claude::session::ClaudeSession;
 use crate::probe::{observe_version, probe_shell, HostEnv};
 use crate::{HarnessAdapter, HarnessError, HarnessProbe, HarnessSession, SessionSpec};
+
+const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Claude Code adapter. Capabilities below are for the captured version
 /// 2.1.233: verified flags are `Supported`/`Unsupported`; anything not
@@ -125,12 +133,12 @@ impl HarnessAdapter for ClaudeCodeAdapter {
         match probe_shell(host, "claude").await {
             Ok(capture) => {
                 let version = observe_version(&capture.binary, &capture.env).await.ok();
-                // Auth observation is not captured for 2.1.233. Do not guess.
+                let authenticated = observe_auth(&capture.binary, &capture.env).await;
                 HarnessProbe {
                     found: true,
                     binary_path: Some(capture.binary),
                     version,
-                    authenticated: None,
+                    authenticated,
                     stderr: capture.stderr,
                     env: capture.env,
                     commands: Vec::new(),
@@ -188,6 +196,36 @@ impl HarnessAdapter for ClaudeCodeAdapter {
     }
 }
 
+/// `claude auth status --json` reports `loggedIn` without exposing a token.
+async fn observe_auth(
+    binary: &Path,
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
+) -> Option<bool> {
+    let mut command = Command::new(binary);
+    command
+        .args(["auth", "status", "--json"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command.env_clear();
+    for (key, value) in crate::filter_child_env(env.iter().cloned()) {
+        command.env(key, value);
+    }
+    let child = crate::spawn_process_tree(&mut command).ok()?;
+    let output = timeout(AUTH_TIMEOUT, child.wait_with_output())
+        .await
+        .ok()?
+        .ok()?;
+    auth_status_from_json(&output.stdout)
+}
+
+fn auth_status_from_json(stdout: &[u8]) -> Option<bool> {
+    serde_json::from_slice::<serde_json::Value>(stdout)
+        .ok()?
+        .get("loggedIn")?
+        .as_bool()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -224,6 +262,24 @@ mod tests {
             );
         }
         (out.events, out.unrecognized)
+    }
+
+    #[test]
+    fn auth_status_reads_authenticated_unauthenticated_and_unknown_states() {
+        assert_eq!(
+            auth_status_from_json(
+                br#"{"loggedIn":true,"authMethod":"oauth","apiProvider":"firstParty"}"#,
+            ),
+            Some(true)
+        );
+        assert_eq!(
+            auth_status_from_json(
+                br#"{"loggedIn":false,"authMethod":"none","apiProvider":"firstParty"}"#,
+            ),
+            Some(false)
+        );
+        assert_eq!(auth_status_from_json(br#"{"authMethod":"oauth"}"#), None);
+        assert_eq!(auth_status_from_json(b"not json"), None);
     }
 
     #[test]

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -109,10 +109,15 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
                 .sum();
             let install_error = code.pin_install_error(*kind);
             let installable = tidebreak_harness::pin_for(*kind).is_some();
+            let label = harness_label(*kind);
             let remediation = if let Some(err) = install_error {
                 format!("could not download the pinned {kind} binary: {err}")
             } else if probe.found && probe.authenticated == Some(false) {
-                format!("sign in to {kind} in your own terminal, then re-check")
+                format!("Sign in to {label} in your own terminal, then re-check.")
+            } else if probe.found && probe.authenticated.is_none() {
+                format!(
+                    "Tidebreak could not verify the {label} sign-in. Sign in to {label} in your own terminal, then re-check."
+                )
             } else if !probe.found && !installable {
                 format!("this build ships no pinned {kind} binary to download")
             } else {
@@ -141,4 +146,13 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
     }))
     .await;
     Ok(HarnessDoctorReport { harnesses })
+}
+
+fn harness_label(kind: HarnessKind) -> &'static str {
+    match kind {
+        HarnessKind::ClaudeCode => "Claude Code",
+        HarnessKind::Codex => "Codex CLI",
+        HarnessKind::Opencode => "opencode",
+        HarnessKind::Grok => "Grok CLI",
+    }
 }


### PR DESCRIPTION
## Summary

- Probe Claude Code with `claude auth status --json` and read only its non-secret `loggedIn` field.
- Require a positive authentication observation before the desktop marks an installed harness Ready.
- Show unknown authentication as Unverified with terminal sign-in remediation.
- Preserve the Ready state for positively authenticated harnesses and the Signed out state for negative observations.
- Add focused parser, readiness, picker, doctor, and Storybook coverage.

## Compatibility and safety

The probe uses Tidebreak’s filtered child environment and a 15-second timeout. A failed command, missing field, or malformed response produces an unknown observation, so the desktop blocks the harness as Unverified instead of guessing. No token or credential value is read, logged, or returned.

## Validation

- 55 focused desktop tests
- TypeScript type check
- Biome check for changed UI files
- Storybook build and visual inspection for the changed states
- `cargo fmt --all -- --check`
- `git diff --check`

Per repository policy, this change does not run Cargo build, test, check, or Clippy locally.

Closes #2683