### PR TITLE
fix(code): retry failed watch submissions

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/watch.rs
+++ b/crates/tidebreak-core/src/db/ops/code/watch.rs
@@ -1,5 +1,6 @@
 //! Persistence for durable watch tasks.
 
+use chrono::{DateTime, Utc};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
 
 use crate::code::{CodeSessionId, CodeWatch, CodeWatchId, CodeWatchState, WorkspaceId};
@@ -7,6 +8,21 @@ use crate::error::{AgentError, Result};
 use crate::OwnerId;
 
 use super::super::super::{entities, store_err, DbStore};
+
+/// Compare-and-set token for one detached watch submission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WatchSubmissionClaim {
+    /// Watch whose submission owns the reservation.
+    pub watch_id: CodeWatchId,
+    /// Owner scope copied from the reserved watch.
+    pub owner: OwnerId,
+    /// Exact reservation detail used by the compare-and-set update.
+    pub detail: String,
+    /// Exact reservation timestamp used by the compare-and-set update.
+    pub reserved_at: DateTime<Utc>,
+    /// Attempt count before this reservation is accepted.
+    pub cycles: i64,
+}
 
 /// Insert a watch row. The row belongs to `watch.owner`, denormalized from
 /// the workspace it watches.
@@ -84,6 +100,119 @@ pub async fn list_active_watches_all_owners(store: &DbStore) -> Result<Vec<CodeW
         .into_iter()
         .map(watch_from_row)
         .collect()
+}
+
+/// Reserve one watch fix-turn submission without consuming the head's
+/// attempt. The watch snapshot is the compare-and-set token, so duplicate
+/// sweeps cannot both reserve the same transition.
+pub async fn reserve_watch_submission(
+    store: &DbStore,
+    watch: &CodeWatch,
+    detail: &str,
+    reserved_at: DateTime<Utc>,
+) -> Result<Option<WatchSubmissionClaim>> {
+    let mut update = entities::code_watch::Entity::update_many()
+        .col_expr(
+            entities::code_watch::Column::State,
+            sea_orm::sea_query::Expr::value(CodeWatchState::Fixing.as_str()),
+        )
+        .col_expr(
+            entities::code_watch::Column::Detail,
+            sea_orm::sea_query::Expr::value(Some(detail.to_owned())),
+        )
+        .col_expr(
+            entities::code_watch::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(reserved_at),
+        )
+        .filter(entities::code_watch::Column::Id.eq(watch.id.0))
+        .filter(entities::code_watch::Column::Owner.eq(watch.owner.as_str()))
+        .filter(entities::code_watch::Column::State.eq(watch.state.as_str()))
+        .filter(entities::code_watch::Column::UpdatedAt.eq(watch.updated_at));
+    update = match watch.detail.as_deref() {
+        Some(detail) => update.filter(entities::code_watch::Column::Detail.eq(detail)),
+        None => update.filter(entities::code_watch::Column::Detail.is_null()),
+    };
+    update = match watch.last_fix_head.as_deref() {
+        Some(head) => update.filter(entities::code_watch::Column::LastFixHead.eq(head)),
+        None => update.filter(entities::code_watch::Column::LastFixHead.is_null()),
+    };
+    let result = update.exec(&store.conn).await.map_err(store_err)?;
+    Ok((result.rows_affected == 1).then(|| WatchSubmissionClaim {
+        watch_id: watch.id,
+        owner: watch.owner.clone(),
+        detail: detail.to_owned(),
+        reserved_at,
+        cycles: watch.cycles,
+    }))
+}
+
+/// Mark a reserved head attempted after a running turn, queued turn, or
+/// persisted turn proves that the detached submission was durably accepted.
+pub async fn accept_watch_submission(
+    store: &DbStore,
+    claim: &WatchSubmissionClaim,
+    head: Option<&str>,
+    detail: &str,
+    accepted_at: DateTime<Utc>,
+) -> Result<bool> {
+    let result = entities::code_watch::Entity::update_many()
+        .col_expr(
+            entities::code_watch::Column::Detail,
+            sea_orm::sea_query::Expr::value(Some(detail.to_owned())),
+        )
+        .col_expr(
+            entities::code_watch::Column::LastFixHead,
+            sea_orm::sea_query::Expr::value(head.map(str::to_owned)),
+        )
+        .col_expr(
+            entities::code_watch::Column::Cycles,
+            sea_orm::sea_query::Expr::value(claim.cycles.saturating_add(1)),
+        )
+        .col_expr(
+            entities::code_watch::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(accepted_at),
+        )
+        .filter(entities::code_watch::Column::Id.eq(claim.watch_id.0))
+        .filter(entities::code_watch::Column::Owner.eq(claim.owner.as_str()))
+        .filter(entities::code_watch::Column::State.eq(CodeWatchState::Fixing.as_str()))
+        .filter(entities::code_watch::Column::Detail.eq(claim.detail.as_str()))
+        .filter(entities::code_watch::Column::UpdatedAt.eq(claim.reserved_at))
+        .filter(entities::code_watch::Column::Cycles.eq(claim.cycles))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
+/// Release a failed or abandoned submission reservation. The reservation's
+/// timestamp and detail fence a late failure from clearing a newer retry.
+pub async fn release_watch_submission(
+    store: &DbStore,
+    claim: &WatchSubmissionClaim,
+    released_at: DateTime<Utc>,
+) -> Result<bool> {
+    let result = entities::code_watch::Entity::update_many()
+        .col_expr(
+            entities::code_watch::Column::State,
+            sea_orm::sea_query::Expr::value(CodeWatchState::Watching.as_str()),
+        )
+        .col_expr(
+            entities::code_watch::Column::Detail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::code_watch::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(released_at),
+        )
+        .filter(entities::code_watch::Column::Id.eq(claim.watch_id.0))
+        .filter(entities::code_watch::Column::Owner.eq(claim.owner.as_str()))
+        .filter(entities::code_watch::Column::State.eq(CodeWatchState::Fixing.as_str()))
+        .filter(entities::code_watch::Column::Detail.eq(claim.detail.as_str()))
+        .filter(entities::code_watch::Column::UpdatedAt.eq(claim.reserved_at))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
 }
 
 /// Persist mutable watch fields. Identity and `created_at` stay as stored,

--- a/crates/tidebreak-core/src/db/ops/code/watch.rs
+++ b/crates/tidebreak-core/src/db/ops/code/watch.rs
@@ -107,10 +107,14 @@ pub async fn list_active_watches_all_owners(store: &DbStore) -> Result<Vec<CodeW
 /// sweeps cannot both reserve the same transition.
 pub async fn reserve_watch_submission(
     store: &DbStore,
+    owner: &OwnerId,
     watch: &CodeWatch,
     detail: &str,
     reserved_at: DateTime<Utc>,
 ) -> Result<Option<WatchSubmissionClaim>> {
+    if &watch.owner != owner {
+        return Ok(None);
+    }
     let mut update = entities::code_watch::Entity::update_many()
         .col_expr(
             entities::code_watch::Column::State,
@@ -125,7 +129,7 @@ pub async fn reserve_watch_submission(
             sea_orm::sea_query::Expr::value(reserved_at),
         )
         .filter(entities::code_watch::Column::Id.eq(watch.id.0))
-        .filter(entities::code_watch::Column::Owner.eq(watch.owner.as_str()))
+        .filter(entities::code_watch::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_watch::Column::State.eq(watch.state.as_str()))
         .filter(entities::code_watch::Column::UpdatedAt.eq(watch.updated_at));
     update = match watch.detail.as_deref() {
@@ -139,7 +143,7 @@ pub async fn reserve_watch_submission(
     let result = update.exec(&store.conn).await.map_err(store_err)?;
     Ok((result.rows_affected == 1).then(|| WatchSubmissionClaim {
         watch_id: watch.id,
-        owner: watch.owner.clone(),
+        owner: owner.clone(),
         detail: detail.to_owned(),
         reserved_at,
         cycles: watch.cycles,
@@ -150,11 +154,15 @@ pub async fn reserve_watch_submission(
 /// persisted turn proves that the detached submission was durably accepted.
 pub async fn accept_watch_submission(
     store: &DbStore,
+    owner: &OwnerId,
     claim: &WatchSubmissionClaim,
     head: Option<&str>,
     detail: &str,
     accepted_at: DateTime<Utc>,
 ) -> Result<bool> {
+    if &claim.owner != owner {
+        return Ok(false);
+    }
     let result = entities::code_watch::Entity::update_many()
         .col_expr(
             entities::code_watch::Column::Detail,
@@ -173,7 +181,7 @@ pub async fn accept_watch_submission(
             sea_orm::sea_query::Expr::value(accepted_at),
         )
         .filter(entities::code_watch::Column::Id.eq(claim.watch_id.0))
-        .filter(entities::code_watch::Column::Owner.eq(claim.owner.as_str()))
+        .filter(entities::code_watch::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_watch::Column::State.eq(CodeWatchState::Fixing.as_str()))
         .filter(entities::code_watch::Column::Detail.eq(claim.detail.as_str()))
         .filter(entities::code_watch::Column::UpdatedAt.eq(claim.reserved_at))
@@ -188,9 +196,13 @@ pub async fn accept_watch_submission(
 /// timestamp and detail fence a late failure from clearing a newer retry.
 pub async fn release_watch_submission(
     store: &DbStore,
+    owner: &OwnerId,
     claim: &WatchSubmissionClaim,
     released_at: DateTime<Utc>,
 ) -> Result<bool> {
+    if &claim.owner != owner {
+        return Ok(false);
+    }
     let result = entities::code_watch::Entity::update_many()
         .col_expr(
             entities::code_watch::Column::State,
@@ -205,7 +217,7 @@ pub async fn release_watch_submission(
             sea_orm::sea_query::Expr::value(released_at),
         )
         .filter(entities::code_watch::Column::Id.eq(claim.watch_id.0))
-        .filter(entities::code_watch::Column::Owner.eq(claim.owner.as_str()))
+        .filter(entities::code_watch::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_watch::Column::State.eq(CodeWatchState::Fixing.as_str()))
         .filter(entities::code_watch::Column::Detail.eq(claim.detail.as_str()))
         .filter(entities::code_watch::Column::UpdatedAt.eq(claim.reserved_at))

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -2001,12 +2001,13 @@ async fn watch_submission_failure_retries_without_consuming_the_head() {
 
     let first_detail = "submitting failing checks for head abc123";
     let first_reserved_at = created_at + chrono::Duration::seconds(1);
-    let first_claim = reserve_watch_submission(&store, &watch, first_detail, first_reserved_at)
-        .await
-        .unwrap()
-        .expect("first reservation");
+    let first_claim =
+        reserve_watch_submission(&store, &owner, &watch, first_detail, first_reserved_at)
+            .await
+            .unwrap()
+            .expect("first reservation");
     assert!(
-        reserve_watch_submission(&store, &watch, first_detail, first_reserved_at)
+        reserve_watch_submission(&store, &owner, &watch, first_detail, first_reserved_at)
             .await
             .unwrap()
             .is_none(),
@@ -2022,9 +2023,11 @@ async fn watch_submission_failure_retries_without_consuming_the_head() {
     assert_eq!(reserved.cycles, 0);
 
     let released_at = first_reserved_at + chrono::Duration::seconds(1);
-    assert!(release_watch_submission(&store, &first_claim, released_at)
-        .await
-        .unwrap());
+    assert!(
+        release_watch_submission(&store, &owner, &first_claim, released_at)
+            .await
+            .unwrap()
+    );
     let retry = latest_watch_for_workspace(&store, &owner, workspace_id)
         .await
         .unwrap()
@@ -2036,13 +2039,15 @@ async fn watch_submission_failure_retries_without_consuming_the_head() {
 
     let second_detail = "submitting failing checks for head abc123";
     let second_reserved_at = released_at + chrono::Duration::seconds(1);
-    let second_claim = reserve_watch_submission(&store, &retry, second_detail, second_reserved_at)
-        .await
-        .unwrap()
-        .expect("retry reservation");
+    let second_claim =
+        reserve_watch_submission(&store, &owner, &retry, second_detail, second_reserved_at)
+            .await
+            .unwrap()
+            .expect("retry reservation");
     let accepted_at = second_reserved_at + chrono::Duration::seconds(1);
     assert!(accept_watch_submission(
         &store,
+        &owner,
         &second_claim,
         Some("abc123"),
         "fixing failing checks",
@@ -2053,6 +2058,7 @@ async fn watch_submission_failure_retries_without_consuming_the_head() {
     assert!(
         !release_watch_submission(
             &store,
+            &owner,
             &second_claim,
             accepted_at + chrono::Duration::seconds(1),
         )

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -1966,6 +1966,110 @@ async fn latest_watch_for_session_matches_on_the_session_not_the_workspace() {
     );
 }
 
+/// A failed detached submit releases only its own reservation. The retry can
+/// reserve the same head, while a duplicate sweep cannot reserve it twice.
+#[tokio::test]
+async fn watch_submission_failure_retries_without_consuming_the_head() {
+    use crate::code::{CodeWatch, CodeWatchId, CodeWatchState};
+    use crate::db::code::{
+        accept_watch_submission, insert_watch, latest_watch_for_workspace,
+        release_watch_submission, reserve_watch_submission,
+    };
+
+    let (_dir, store, session_id, _turn_id) = seeded_session().await;
+    let owner = OwnerId::local();
+    let workspace_id = get_session(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .workspace_id;
+    let created_at = now() - chrono::Duration::minutes(1);
+    let watch = CodeWatch {
+        id: CodeWatchId::new(),
+        owner: owner.clone(),
+        workspace_id,
+        session_id,
+        pr_number: 42,
+        state: CodeWatchState::Watching,
+        detail: None,
+        last_fix_head: None,
+        cycles: 0,
+        created_at,
+        updated_at: created_at,
+    };
+    insert_watch(&store, &watch).await.unwrap();
+
+    let first_detail = "submitting failing checks for head abc123";
+    let first_reserved_at = created_at + chrono::Duration::seconds(1);
+    let first_claim = reserve_watch_submission(&store, &watch, first_detail, first_reserved_at)
+        .await
+        .unwrap()
+        .expect("first reservation");
+    assert!(
+        reserve_watch_submission(&store, &watch, first_detail, first_reserved_at)
+            .await
+            .unwrap()
+            .is_none(),
+        "a duplicate sweep must not reserve the same transition"
+    );
+    let reserved = latest_watch_for_workspace(&store, &owner, workspace_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reserved.state, CodeWatchState::Fixing);
+    assert_eq!(reserved.detail.as_deref(), Some(first_detail));
+    assert_eq!(reserved.last_fix_head, None);
+    assert_eq!(reserved.cycles, 0);
+
+    let released_at = first_reserved_at + chrono::Duration::seconds(1);
+    assert!(release_watch_submission(&store, &first_claim, released_at)
+        .await
+        .unwrap());
+    let retry = latest_watch_for_workspace(&store, &owner, workspace_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(retry.state, CodeWatchState::Watching);
+    assert_eq!(retry.detail, None);
+    assert_eq!(retry.last_fix_head, None);
+    assert_eq!(retry.cycles, 0);
+
+    let second_detail = "submitting failing checks for head abc123";
+    let second_reserved_at = released_at + chrono::Duration::seconds(1);
+    let second_claim = reserve_watch_submission(&store, &retry, second_detail, second_reserved_at)
+        .await
+        .unwrap()
+        .expect("retry reservation");
+    let accepted_at = second_reserved_at + chrono::Duration::seconds(1);
+    assert!(accept_watch_submission(
+        &store,
+        &second_claim,
+        Some("abc123"),
+        "fixing failing checks",
+        accepted_at,
+    )
+    .await
+    .unwrap());
+    assert!(
+        !release_watch_submission(
+            &store,
+            &second_claim,
+            accepted_at + chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap(),
+        "a late failure must not release an accepted retry"
+    );
+    let accepted = latest_watch_for_workspace(&store, &owner, workspace_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(accepted.state, CodeWatchState::Fixing);
+    assert_eq!(accepted.detail.as_deref(), Some("fixing failing checks"));
+    assert_eq!(accepted.last_fix_head.as_deref(), Some("abc123"));
+    assert_eq!(accepted.cycles, 1);
+}
+
 /// Removing a repository must not take its history with it.
 ///
 /// A hard delete cannot do this. SQLite does not enforce the workspace

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -595,9 +595,14 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
             }
             let reservation_detail = watch_submission_detail(reason, pr.head_sha.as_deref());
             let reserved_at = Utc::now();
-            let Some(claim) =
-                reserve_watch_submission(&runtime.db, watch, &reservation_detail, reserved_at)
-                    .await?
+            let Some(claim) = reserve_watch_submission(
+                &runtime.db,
+                &owner,
+                watch,
+                &reservation_detail,
+                reserved_at,
+            )
+            .await?
             else {
                 return Ok(());
             };
@@ -657,6 +662,7 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
                     Some(true) => {
                         match accept_watch_submission(
                             &task_runtime.db,
+                            &task_owner,
                             &claim,
                             head.as_deref(),
                             &accepted_detail,
@@ -682,7 +688,14 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
                         }
                     }
                     Some(false) => {
-                        match release_watch_submission(&task_runtime.db, &claim, Utc::now()).await {
+                        match release_watch_submission(
+                            &task_runtime.db,
+                            &task_owner,
+                            &claim,
+                            Utc::now(),
+                        )
+                        .await
+                        {
                             Ok(true) => {
                                 emit_workspace_digests(
                                     &task_runtime.db,
@@ -743,6 +756,7 @@ async fn reconcile_watch_submission(
         let reservation_head = reservation.head.map(str::to_owned);
         let changed = accept_watch_submission(
             &runtime.db,
+            &watch.owner,
             &claim,
             reservation_head.as_deref(),
             &detail,
@@ -763,7 +777,7 @@ async fn reconcile_watch_submission(
         return Ok(true);
     }
     let released_at = Utc::now();
-    let changed = release_watch_submission(&runtime.db, &claim, released_at).await?;
+    let changed = release_watch_submission(&runtime.db, &watch.owner, &claim, released_at).await?;
     if !changed {
         return Ok(true);
     }

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -21,8 +21,9 @@ use chrono::Utc;
 use tracing::warn;
 
 use tidebreak_core::db::code::{
-    get_session, insert_watch, latest_watch_for_workspace, list_active_watches_all_owners,
-    list_sessions_for_workspace, save_watch,
+    accept_watch_submission, get_session, insert_watch, latest_watch_for_workspace,
+    list_active_watches_all_owners, list_queued_turns, list_sessions_for_workspace, list_turns,
+    release_watch_submission, reserve_watch_submission, save_watch, WatchSubmissionClaim,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeSessionKind, CodeSessionLifecycle, CodeWatch,
@@ -36,6 +37,15 @@ use crate::error::ServerError;
 
 /// How often the watch sweep walks active watches.
 pub(crate) const WATCH_SWEEP_INTERVAL: Duration = Duration::from_secs(47);
+
+/// How long an unaccepted detached submission may hold its reservation.
+/// Admission normally finishes in one database round trip. The longer lease
+/// tolerates a slow worker mailbox while still recovering after a restart.
+const WATCH_SUBMISSION_RESERVATION_TIMEOUT: Duration = Duration::from_secs(180);
+
+const WATCH_SUBMISSION_PREFIX: &str = "submitting ";
+const WATCH_SUBMISSION_HEAD_MARKER: &str = " for head ";
+const WATCH_SUBMISSION_UNKNOWN_HEAD: &str = "unknown";
 
 /// What one PR digest asks of the watch.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,6 +86,41 @@ impl WatchReason {
             Self::ChangesRequested => "requested changes",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WatchSubmissionReservation<'a> {
+    reason: &'a str,
+    head: Option<&'a str>,
+}
+
+fn watch_submission_detail(reason: WatchReason, head: Option<&str>) -> String {
+    format!(
+        "{WATCH_SUBMISSION_PREFIX}{}{WATCH_SUBMISSION_HEAD_MARKER}{}",
+        reason.describe(),
+        head.unwrap_or(WATCH_SUBMISSION_UNKNOWN_HEAD)
+    )
+}
+
+fn watch_submission_reservation(watch: &CodeWatch) -> Option<WatchSubmissionReservation<'_>> {
+    if watch.state != CodeWatchState::Fixing {
+        return None;
+    }
+    let detail = watch
+        .detail
+        .as_deref()?
+        .strip_prefix(WATCH_SUBMISSION_PREFIX)?;
+    let (reason, head) = detail.rsplit_once(WATCH_SUBMISSION_HEAD_MARKER)?;
+    (!reason.is_empty()).then_some(WatchSubmissionReservation {
+        reason,
+        head: (head != WATCH_SUBMISSION_UNKNOWN_HEAD).then_some(head),
+    })
+}
+
+fn watch_submission_reservation_expired(watch: &CodeWatch, now: chrono::DateTime<Utc>) -> bool {
+    now.signed_duration_since(watch.updated_at)
+        .to_std()
+        .is_ok_and(|age| age >= WATCH_SUBMISSION_RESERVATION_TIMEOUT)
 }
 
 /// Classify one digest the way the workflow control does, minus the actions
@@ -402,6 +447,9 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
         | CodeSessionLifecycle::Created
         | CodeSessionLifecycle::Idle => {}
     }
+    if reconcile_watch_submission(runtime, watch, &session).await? {
+        return Ok(());
+    }
     let workspace = match runtime.get_workspace(&owner, watch.workspace_id).await {
         Ok(workspace) => workspace,
         Err(_) => {
@@ -545,12 +593,19 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
                 )
                 .await;
             }
+            let reservation_detail = watch_submission_detail(reason, pr.head_sha.as_deref());
+            let reserved_at = Utc::now();
+            let Some(claim) =
+                reserve_watch_submission(&runtime.db, watch, &reservation_detail, reserved_at)
+                    .await?
+            else {
+                return Ok(());
+            };
             let settled_attention = settled_watch_block_attention(watch, &session.attention);
             watch.state = CodeWatchState::Fixing;
-            watch.detail = Some(format!("fixing {}", reason.describe()));
-            watch.last_fix_head = pr.head_sha.clone();
-            watch.cycles = watch.cycles.saturating_add(1);
-            persist_watch(runtime.as_ref(), watch).await?;
+            watch.detail = Some(reservation_detail.clone());
+            watch.updated_at = reserved_at;
+            emit_workspace_digests(&runtime.db, &runtime.bus, &owner, watch.workspace_id).await;
             if let Some(attention) = settled_attention {
                 let _ = apply_attention(
                     &runtime.db,
@@ -564,26 +619,172 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
             }
             let instruction = fix_turn_instruction(reason, &pr);
             let session_id = watch.session_id;
+            let watch_id = watch.id;
+            let workspace_id = watch.workspace_id;
+            let head = pr.head_sha.clone();
+            let accepted_detail = format!("fixing {}", reason.describe());
             let task_runtime = Arc::clone(runtime);
             let task_owner = owner.clone();
             // Detached: a fix turn can run for minutes and the sweep must
-            // keep serving other watches. The next sweeps see the session
-            // Running and stand by.
+            // keep serving other watches. The reservation blocks duplicate
+            // sweeps until the worker durably accepts or rejects the turn.
             tokio::spawn(async move {
-                if let Err(err) = task_runtime
+                let result = task_runtime
                     .submit_turn(&task_owner, session_id, instruction, None, None, Vec::new())
+                    .await;
+                let accepted = match &result {
+                    Ok(_) => Some(true),
+                    Err(_) => match watch_submission_was_accepted(
+                        task_runtime.as_ref(),
+                        &task_owner,
+                        session_id,
+                        reserved_at,
+                    )
                     .await
-                {
+                    {
+                        Ok(accepted) => Some(accepted),
+                        Err(err) => {
+                            warn!(
+                                watch = %watch_id,
+                                error = %err.message(),
+                                "code-mode watch could not verify fix-turn acceptance"
+                            );
+                            None
+                        }
+                    },
+                };
+                match accepted {
+                    Some(true) => {
+                        match accept_watch_submission(
+                            &task_runtime.db,
+                            &claim,
+                            head.as_deref(),
+                            &accepted_detail,
+                            Utc::now(),
+                        )
+                        .await
+                        {
+                            Ok(true) => {
+                                emit_workspace_digests(
+                                    &task_runtime.db,
+                                    &task_runtime.bus,
+                                    &task_owner,
+                                    workspace_id,
+                                )
+                                .await;
+                            }
+                            Ok(false) => {}
+                            Err(err) => warn!(
+                                watch = %watch_id,
+                                error = %err,
+                                "code-mode watch could not record an accepted fix turn"
+                            ),
+                        }
+                    }
+                    Some(false) => {
+                        match release_watch_submission(&task_runtime.db, &claim, Utc::now()).await {
+                            Ok(true) => {
+                                emit_workspace_digests(
+                                    &task_runtime.db,
+                                    &task_runtime.bus,
+                                    &task_owner,
+                                    workspace_id,
+                                )
+                                .await;
+                            }
+                            Ok(false) => {}
+                            Err(release_err) => warn!(
+                                watch = %watch_id,
+                                error = %release_err,
+                                "code-mode watch could not release a failed submission"
+                            ),
+                        }
+                    }
+                    None => {}
+                }
+                if let Err(err) = result {
                     warn!(
                         session = %session_id,
                         error = %err.message(),
-                        "code-mode watch fix turn failed to submit"
+                        "code-mode watch fix turn failed"
                     );
                 }
             });
             Ok(())
         }
     }
+}
+
+/// Settle the durable reservation before the sweep judges the pull request.
+/// A running, queued, or persisted watch turn proves admission even when the
+/// detached submit task disappeared during a process restart.
+async fn reconcile_watch_submission(
+    runtime: &CodeRuntime,
+    watch: &mut CodeWatch,
+    session: &tidebreak_core::CodeSession,
+) -> Result<bool, ServerError> {
+    let Some(reservation) = watch_submission_reservation(watch) else {
+        return Ok(false);
+    };
+    let accepted = session.lifecycle == CodeSessionLifecycle::Running
+        || watch_submission_was_accepted(runtime, &watch.owner, watch.session_id, watch.updated_at)
+            .await?;
+    let reservation_detail = watch.detail.clone().unwrap_or_default();
+    let claim = WatchSubmissionClaim {
+        watch_id: watch.id,
+        owner: watch.owner.clone(),
+        detail: reservation_detail,
+        reserved_at: watch.updated_at,
+        cycles: watch.cycles,
+    };
+    if accepted {
+        let accepted_at = Utc::now();
+        let detail = format!("fixing {}", reservation.reason);
+        let changed =
+            accept_watch_submission(&runtime.db, &claim, reservation.head, &detail, accepted_at)
+                .await?;
+        if !changed {
+            return Ok(true);
+        }
+        watch.detail = Some(detail);
+        watch.last_fix_head = reservation.head.map(str::to_owned);
+        watch.cycles = watch.cycles.saturating_add(1);
+        watch.updated_at = accepted_at;
+        emit_workspace_digests(&runtime.db, &runtime.bus, &watch.owner, watch.workspace_id).await;
+        return Ok(false);
+    }
+    if !watch_submission_reservation_expired(watch, Utc::now()) {
+        return Ok(true);
+    }
+    let released_at = Utc::now();
+    let changed = release_watch_submission(&runtime.db, &claim, released_at).await?;
+    if !changed {
+        return Ok(true);
+    }
+    watch.state = CodeWatchState::Watching;
+    watch.detail = None;
+    watch.updated_at = released_at;
+    emit_workspace_digests(&runtime.db, &runtime.bus, &watch.owner, watch.workspace_id).await;
+    Ok(false)
+}
+
+async fn watch_submission_was_accepted(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    session_id: tidebreak_core::CodeSessionId,
+    reserved_at: chrono::DateTime<Utc>,
+) -> Result<bool, ServerError> {
+    if list_queued_turns(&runtime.db, owner, session_id)
+        .await?
+        .iter()
+        .any(|turn| turn.created_at >= reserved_at)
+    {
+        return Ok(true);
+    }
+    Ok(list_turns(&runtime.db, owner, session_id)
+        .await?
+        .iter()
+        .any(|turn| turn.started_at >= reserved_at))
 }
 
 /// The workspace's stored pull-request digest, when the fact row behind it
@@ -930,5 +1131,70 @@ mod tests {
             assert!(text.contains("do not merge"), "{reason:?}");
             assert!(!text.contains("enable auto-merge once"), "{reason:?}");
         }
+    }
+
+    #[test]
+    fn submission_reservation_round_trips_the_reason_and_head() {
+        let now = Utc::now();
+        let watch = CodeWatch {
+            id: CodeWatchId::new(),
+            owner: OwnerId::local(),
+            workspace_id: WorkspaceId::new(),
+            session_id: tidebreak_core::CodeSessionId::new(),
+            pr_number: 12,
+            state: CodeWatchState::Fixing,
+            detail: Some(watch_submission_detail(
+                WatchReason::FailingChecks,
+                Some("abc123"),
+            )),
+            last_fix_head: None,
+            cycles: 0,
+            created_at: now,
+            updated_at: now,
+        };
+        assert_eq!(
+            watch_submission_reservation(&watch),
+            Some(WatchSubmissionReservation {
+                reason: "failing checks",
+                head: Some("abc123"),
+            })
+        );
+
+        let mut unknown_head = watch;
+        unknown_head.detail = Some(watch_submission_detail(WatchReason::Conflicts, None));
+        assert_eq!(
+            watch_submission_reservation(&unknown_head),
+            Some(WatchSubmissionReservation {
+                reason: "merge conflicts",
+                head: None,
+            })
+        );
+    }
+
+    #[test]
+    fn a_recent_reservation_blocks_duplicate_sweeps_until_it_expires() {
+        let now = Utc::now();
+        let mut watch = CodeWatch {
+            id: CodeWatchId::new(),
+            owner: OwnerId::local(),
+            workspace_id: WorkspaceId::new(),
+            session_id: tidebreak_core::CodeSessionId::new(),
+            pr_number: 12,
+            state: CodeWatchState::Fixing,
+            detail: Some(watch_submission_detail(
+                WatchReason::FailingChecks,
+                Some("abc123"),
+            )),
+            last_fix_head: None,
+            cycles: 0,
+            created_at: now,
+            updated_at: now,
+        };
+        assert!(!watch_submission_reservation_expired(
+            &watch,
+            now + chrono::Duration::seconds(179)
+        ));
+        watch.updated_at = now - chrono::Duration::seconds(180);
+        assert!(watch_submission_reservation_expired(&watch, now));
     }
 }

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -740,14 +740,20 @@ async fn reconcile_watch_submission(
     if accepted {
         let accepted_at = Utc::now();
         let detail = format!("fixing {}", reservation.reason);
-        let changed =
-            accept_watch_submission(&runtime.db, &claim, reservation.head, &detail, accepted_at)
-                .await?;
+        let reservation_head = reservation.head.map(str::to_owned);
+        let changed = accept_watch_submission(
+            &runtime.db,
+            &claim,
+            reservation_head.as_deref(),
+            &detail,
+            accepted_at,
+        )
+        .await?;
         if !changed {
             return Ok(true);
         }
         watch.detail = Some(detail);
-        watch.last_fix_head = reservation.head.map(str::to_owned);
+        watch.last_fix_head = reservation_head;
         watch.cycles = watch.cycles.saturating_add(1);
         watch.updated_at = accepted_at;
         emit_workspace_digests(&runtime.db, &runtime.bus, &watch.owner, watch.workspace_id).await;


### PR DESCRIPTION
## What changed

- Reserve a watch fix-turn submission before dispatch without consuming the current head's attempt.
- Mark the head and cycle count only after a running, queued, or persisted turn proves durable acceptance.
- Release failed or stale reservations so the next sweep retries, while compare-and-set claims block duplicate sweeps and late failures.
- Add regression coverage for failed submission, retry, duplicate reservation, and late release behavior.

## Validation

- `cargo fmt --all -- --check`
- `git diff origin/main...HEAD --check`
- Cargo compilation and tests are left to CI under repository policy.

## Compatibility and risk

No database schema or wire format changes. The implementation uses the existing watch state, detail, head, cycle, and timestamp fields. Compare-and-set filters keep terminal watches and newer retries from being overwritten by detached completion races.

## Tracking

Closes #2688

CI recovery: Re-ran after the GitHub Actions outage on August 26, 2026.

<!-- gha-outage-retry: 2026-08-26 -->