### PR TITLE
feat(cli): agent MCP tools drive code mode

### DIFF
--- a/crates/tidebreak-cli/Cargo.toml
+++ b/crates/tidebreak-cli/Cargo.toml
@@ -52,9 +52,9 @@ url = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-# The scripted model provider the end-to-end print-mode test drives the turn
-# with. Enabling it here compiles it into the `tidebreak` binary the test spawns,
-# and only when the tests are built.
-tidebreak-server = { path = "../tidebreak-server", features = ["scripted-provider"] }
+# The scripted model provider and scripted code-mode engine the end-to-end
+# tests drive. Enabling them here compiles them into the `tidebreak` binary
+# the tests spawn, and only when the tests are built.
+tidebreak-server = { path = "../tidebreak-server", features = ["scripted-provider", "scripted-harness"] }
 tempfile = { workspace = true }
 jsonschema = { workspace = true }

--- a/crates/tidebreak-cli/src/agent_mcp/code.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/code.rs
@@ -1,0 +1,1354 @@
+//! Code-mode MCP tools. Reads are [`ApprovalClass::ReadOnly`]; mutations are
+//! [`ApprovalClass::Sensitive`].
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tidebreak_core::{
+    ApprovalClass, CapLevel, CodeApprovalId, CodeSessionId, CodeTurnId, HarnessKind,
+    PermissionMode, RepoId, Result, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolRegistry,
+    ToolSpec, WorkspaceId,
+};
+use tokio::sync::Mutex;
+
+use super::code_follow::{
+    decide_and_follow, run_turn, wait_turn, CodeFollowState, CodeTurnResult, DEFAULT_TIMEOUT,
+};
+use super::{AgentMcp, TurnStatus};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
+struct CodeTools {
+    state: Arc<AgentMcp>,
+    follows: Mutex<HashMap<CodeSessionId, CodeFollowState>>,
+}
+
+/// Register every code-mode tool on `registry`.
+pub(crate) fn register(registry: &mut ToolRegistry, state: Arc<AgentMcp>) {
+    let tools = Arc::new(CodeTools {
+        state,
+        follows: Mutex::new(HashMap::new()),
+    });
+    registry.register(Box::new(CodeHarnessesTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeRepoAddTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeReposTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeWorkspaceCreateTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeWorkspacesTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeWorkspaceArchiveTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeSessionCreateTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeSessionsTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeSessionSetPermissionModeTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeRunTurnTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeWaitTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeApprovalsTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeDecideTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeInterruptTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeTurnsTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeDiffTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeFilesTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeGitStatusTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeGitCommitTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeGitPushTool {
+        tools: Arc::clone(&tools),
+    }));
+    registry.register(Box::new(CodeGitPrTool { tools }));
+}
+
+fn turn_output(result: &CodeTurnResult) -> ToolOutput {
+    let data = serde_json::to_value(result).unwrap_or(Value::Null);
+    ToolOutput::text(format!(
+        "status: {}{}",
+        result.status.as_str(),
+        if result.assistant_text.is_empty() {
+            String::new()
+        } else {
+            format!("\n{}", result.assistant_text)
+        }
+    ))
+    .with_data(data)
+}
+
+fn fail(message: impl Into<String>) -> Result<ToolOutput> {
+    Ok(ToolOutput::error(message.into()))
+}
+
+fn fail_args(message: impl Into<String>) -> Result<ToolOutput> {
+    Ok(ToolOutput::failed(
+        ToolErrorCategory::InvalidArguments,
+        message.into(),
+    ))
+}
+
+fn object_schema(properties: Value, required: &[&str]) -> Value {
+    let mut schema = json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": false,
+    });
+    if !required.is_empty() {
+        schema["required"] = json!(required);
+    }
+    schema
+}
+
+fn timeout_property() -> Value {
+    json!({
+        "type": "integer",
+        "minimum": 1,
+        "default": DEFAULT_TIMEOUT_SECS,
+        "description": "Seconds to follow the turn before returning status running. The turn keeps going server-side.",
+    })
+}
+
+fn permission_mode_property() -> Value {
+    json!({
+        "type": "string",
+        "enum": ["plan", "ask", "auto", "allow"],
+        "description": "Permission mode stored on the session.",
+    })
+}
+
+fn harness_property() -> Value {
+    json!({
+        "type": "string",
+        "enum": ["claude_code", "codex", "opencode", "grok"],
+        "description": "Engine adapter kind.",
+    })
+}
+
+fn timeout_from(args: &Value) -> std::result::Result<Duration, ToolOutput> {
+    match args.get("timeout_seconds") {
+        None | Some(Value::Null) => Ok(DEFAULT_TIMEOUT),
+        Some(value) => {
+            let Some(seconds) = value.as_u64() else {
+                return Err(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "timeout_seconds must be a positive integer",
+                ));
+            };
+            if seconds == 0 {
+                return Err(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "timeout_seconds must be at least 1",
+                ));
+            }
+            Ok(Duration::from_secs(seconds))
+        }
+    }
+}
+
+fn required_uuid<T: FromStr>(args: &Value, field: &str) -> std::result::Result<T, ToolOutput> {
+    let Some(value) = args.get(field).and_then(Value::as_str) else {
+        return Err(ToolOutput::failed(
+            ToolErrorCategory::InvalidArguments,
+            format!("{field} is required"),
+        ));
+    };
+    T::from_str(value).map_err(|_| {
+        ToolOutput::failed(
+            ToolErrorCategory::InvalidArguments,
+            format!("{field} must be a UUID"),
+        )
+    })
+}
+
+fn optional_uuid<T: FromStr>(
+    args: &Value,
+    field: &str,
+) -> std::result::Result<Option<T>, ToolOutput> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => {
+            let Some(text) = value.as_str() else {
+                return Err(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    format!("{field} must be a UUID"),
+                ));
+            };
+            T::from_str(text).map(Some).map_err(|_| {
+                ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    format!("{field} must be a UUID"),
+                )
+            })
+        }
+    }
+}
+
+fn parse_permission_mode(value: &str) -> std::result::Result<PermissionMode, ToolOutput> {
+    PermissionMode::from_str(value).ok_or_else(|| {
+        ToolOutput::failed(
+            ToolErrorCategory::InvalidArguments,
+            "permission_mode must be plan, ask, auto, or allow",
+        )
+    })
+}
+
+fn parse_harness(value: &str) -> std::result::Result<HarnessKind, ToolOutput> {
+    HarnessKind::from_str(value).ok_or_else(|| {
+        ToolOutput::failed(
+            ToolErrorCategory::InvalidArguments,
+            "harness must be claude_code, codex, opencode, or grok",
+        )
+    })
+}
+
+fn default_create_permission_mode(caps: Option<&tidebreak_core::HarnessCaps>) -> PermissionMode {
+    match caps {
+        Some(caps) if caps.allow_mode == CapLevel::Supported => PermissionMode::Allow,
+        Some(caps) if caps.auto_mode == CapLevel::Supported => PermissionMode::Auto,
+        Some(caps) if caps.structured_approvals == CapLevel::Supported => PermissionMode::Ask,
+        _ => PermissionMode::Plan,
+    }
+}
+
+async fn remember(tools: &CodeTools, session: CodeSessionId, result: &CodeTurnResult) {
+    let Some(turn_id) = result.turn_id else {
+        return;
+    };
+    tools.follows.lock().await.insert(
+        session,
+        CodeFollowState {
+            turn_id,
+            last_seq: result.events_cursor,
+            assistant_text: result.assistant_text.clone(),
+            queued: result.status == TurnStatus::Queued,
+        },
+    );
+}
+
+fn parse_decision(
+    value: &Value,
+) -> std::result::Result<(Option<CodeApprovalId>, bool, Option<String>), ToolOutput> {
+    let approval_id = match value.get("approval_id") {
+        None | Some(Value::Null) => None,
+        Some(id) => {
+            let Some(text) = id.as_str() else {
+                return Err(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "approval_id must be a UUID",
+                ));
+            };
+            Some(CodeApprovalId::from_str(text).map_err(|_| {
+                ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "approval_id must be a UUID",
+                )
+            })?)
+        }
+    };
+    let approve = if let Some(approve) = value.get("approve") {
+        approve.as_bool().ok_or_else(|| {
+            ToolOutput::failed(
+                ToolErrorCategory::InvalidArguments,
+                "approve must be a boolean",
+            )
+        })?
+    } else {
+        match value.get("decision").and_then(Value::as_str) {
+            Some("approve") => true,
+            Some("deny") | Some("reject") => false,
+            Some(other) => {
+                return Err(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    format!("decision must be approve or deny, not {other:?}"),
+                ));
+            }
+            None => {
+                return Err(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    "decision needs approve or decision",
+                ));
+            }
+        }
+    };
+    let feedback = value
+        .get("feedback")
+        .or_else(|| value.get("reason"))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    Ok((approval_id, approve, feedback))
+}
+
+// ---------------------------------------------------------------------------
+// code_harnesses
+// ---------------------------------------------------------------------------
+
+struct CodeHarnessesTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeHarnessesTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_harnesses".into(),
+            description:
+                "Harness doctor report: which engines are found, their tier, and capabilities."
+                    .into(),
+            input_schema: object_schema(json!({}), &[]),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+        let client = self.tools.state.client.lock().await;
+        match client.list_harnesses().await {
+            Ok(report) => Ok(
+                ToolOutput::text(format!("{} harness(es)", report.harnesses.len()))
+                    .with_data(serde_json::to_value(&report).unwrap_or(Value::Null)),
+            ),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// code_repo_add / code_repos
+// ---------------------------------------------------------------------------
+
+struct CodeRepoAddTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeRepoAddTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_repo_add".into(),
+            description: "Register a local git repository as a code-mode repo.".into(),
+            input_schema: object_schema(
+                json!({
+                    "source": {
+                        "type": "string",
+                        "description": "Absolute path to the git checkout.",
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name. Defaults to the directory name.",
+                    },
+                }),
+                &["source"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let Some(source) = args.get("source").and_then(Value::as_str) else {
+            return fail_args("source is required");
+        };
+        let name = args.get("name").and_then(Value::as_str);
+        let client = self.tools.state.client.lock().await;
+        match client.create_repo(source, name, None, None).await {
+            Ok(repo) => Ok(ToolOutput::text(format!("repo {}", repo.id))
+                .with_data(serde_json::to_value(&repo).unwrap_or(Value::Null))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeReposTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeReposTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_repos".into(),
+            description: "List registered code-mode repositories.".into(),
+            input_schema: object_schema(json!({}), &[]),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+        let client = self.tools.state.client.lock().await;
+        match client.list_repos().await {
+            Ok(repos) => Ok(ToolOutput::text(format!("{} repo(s)", repos.len()))
+                .with_data(json!({ "repos": repos }))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// workspaces
+// ---------------------------------------------------------------------------
+
+struct CodeWorkspaceCreateTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeWorkspaceCreateTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_workspace_create".into(),
+            description: "Create an isolated workspace (worktree + branch) on a repo.".into(),
+            input_schema: object_schema(
+                json!({
+                    "repo_id": {
+                        "type": "string",
+                        "description": "Repository UUID.",
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Workspace title.",
+                    },
+                    "base": {
+                        "type": "string",
+                        "description": "Base ref. Defaults to the repo's default_base_ref.",
+                    },
+                }),
+                &["repo_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let repo_id = match required_uuid::<RepoId>(&args, "repo_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let name = args.get("name").and_then(Value::as_str);
+        let base = args.get("base").and_then(Value::as_str);
+        let client = self.tools.state.client.lock().await;
+        match client.create_workspace(repo_id, name, base).await {
+            Ok(workspace) => Ok(ToolOutput::text(format!("workspace {}", workspace.id))
+                .with_data(serde_json::to_value(&workspace).unwrap_or(Value::Null))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeWorkspacesTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeWorkspacesTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_workspaces".into(),
+            description: "List code-mode workspaces, optionally filtered by repo.".into(),
+            input_schema: object_schema(
+                json!({
+                    "repo_id": {
+                        "type": "string",
+                        "description": "Limit the list to this repository UUID.",
+                    },
+                }),
+                &[],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let repo_id = match optional_uuid::<RepoId>(&args, "repo_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        match client.list_workspaces(repo_id).await {
+            Ok(workspaces) => Ok(
+                ToolOutput::text(format!("{} workspace(s)", workspaces.len()))
+                    .with_data(json!({ "workspaces": workspaces })),
+            ),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeWorkspaceArchiveTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeWorkspaceArchiveTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_workspace_archive".into(),
+            description: "Archive a workspace.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                }),
+                &["workspace_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        match client.archive_workspace(workspace_id, false).await {
+            Ok(workspace) => Ok(ToolOutput::text(format!("archived {}", workspace.id))
+                .with_data(serde_json::to_value(&workspace).unwrap_or(Value::Null))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// sessions
+// ---------------------------------------------------------------------------
+
+struct CodeSessionCreateTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeSessionCreateTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_session_create".into(),
+            description: "Start a code-mode session in a workspace.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                    "harness": harness_property(),
+                    "model": {
+                        "type": "string",
+                        "description": "Engine model id to pin on the session.",
+                    },
+                    "permission_mode": permission_mode_property(),
+                }),
+                &["workspace_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let harness = match args.get("harness").and_then(Value::as_str) {
+            Some(value) => match parse_harness(value) {
+                Ok(kind) => kind,
+                Err(output) => return Ok(output),
+            },
+            None => HarnessKind::ClaudeCode,
+        };
+        let model = args.get("model").and_then(Value::as_str);
+        let client = self.tools.state.client.lock().await;
+        let mode = match args.get("permission_mode").and_then(Value::as_str) {
+            Some(value) => match parse_permission_mode(value) {
+                Ok(mode) => mode,
+                Err(output) => return Ok(output),
+            },
+            None => {
+                let caps = match client.list_harnesses().await {
+                    Ok(report) => report
+                        .harnesses
+                        .into_iter()
+                        .find(|entry| entry.kind == harness)
+                        .map(|entry| entry.caps),
+                    Err(error) => return fail(error.to_string()),
+                };
+                default_create_permission_mode(caps.as_ref())
+            }
+        };
+        match client
+            .create_session_with(workspace_id, harness, mode, model)
+            .await
+        {
+            Ok(session) => Ok(ToolOutput::text(format!("session {}", session.id))
+                .with_data(serde_json::to_value(&session).unwrap_or(Value::Null))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeSessionsTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeSessionsTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_sessions".into(),
+            description: "List sessions in a workspace.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                }),
+                &["workspace_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        match client.list_workspace_sessions(workspace_id).await {
+            Ok(sessions) => Ok(ToolOutput::text(format!("{} session(s)", sessions.len()))
+                .with_data(json!({ "sessions": sessions }))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeSessionSetPermissionModeTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeSessionSetPermissionModeTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_session_set_permission_mode".into(),
+            description: "Change a session's permission mode.".into(),
+            input_schema: object_schema(
+                json!({
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session UUID.",
+                    },
+                    "permission_mode": permission_mode_property(),
+                }),
+                &["session_id", "permission_mode"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let session_id = match required_uuid::<CodeSessionId>(&args, "session_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let Some(mode) = args.get("permission_mode").and_then(Value::as_str) else {
+            return fail_args("permission_mode is required");
+        };
+        let mode = match parse_permission_mode(mode) {
+            Ok(mode) => mode,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        match client.set_session_permission_mode(session_id, mode).await {
+            Ok(session) => Ok(ToolOutput::text(format!(
+                "session {} is now {}",
+                session.id,
+                session.permission_mode.as_str()
+            ))
+            .with_data(serde_json::to_value(&session).unwrap_or(Value::Null))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// turns / follow
+// ---------------------------------------------------------------------------
+
+struct CodeRunTurnTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeRunTurnTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_run_turn".into(),
+            description: "Submit a prompt and follow until the turn settles, parks on an approval, queues, or the timeout elapses."
+                .into(),
+            input_schema: object_schema(
+                json!({
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session UUID.",
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "User text to post as this turn.",
+                    },
+                    "timeout_seconds": timeout_property(),
+                }),
+                &["session_id", "prompt"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let session_id = match required_uuid::<CodeSessionId>(&args, "session_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let Some(prompt) = args.get("prompt").and_then(Value::as_str) else {
+            return fail_args("prompt is required");
+        };
+        let timeout = match timeout_from(&args) {
+            Ok(timeout) => timeout,
+            Err(output) => return Ok(output),
+        };
+        let mut client = self.tools.state.client.lock().await;
+        let result = match run_turn(&mut client, session_id, prompt, timeout).await {
+            Ok(result) => result,
+            Err(error) => return fail(error.to_string()),
+        };
+        drop(client);
+        remember(&self.tools, session_id, &result).await;
+        Ok(turn_output(&result))
+    }
+}
+
+struct CodeWaitTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeWaitTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_wait".into(),
+            description: "Re-follow an in-flight or queued turn until it settles, parks, or the timeout elapses."
+                .into(),
+            input_schema: object_schema(
+                json!({
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session UUID.",
+                    },
+                    "timeout_seconds": timeout_property(),
+                }),
+                &["session_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let session_id = match required_uuid::<CodeSessionId>(&args, "session_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let timeout = match timeout_from(&args) {
+            Ok(timeout) => timeout,
+            Err(output) => return Ok(output),
+        };
+        let follow = self.tools.follows.lock().await.get(&session_id).cloned();
+        let Some(follow) = follow else {
+            return fail(format!("no in-flight turn for session {session_id}"));
+        };
+        let mut client = self.tools.state.client.lock().await;
+        let result = match wait_turn(&mut client, session_id, follow, timeout).await {
+            Ok(result) => result,
+            Err(error) => return fail(error.to_string()),
+        };
+        drop(client);
+        remember(&self.tools, session_id, &result).await;
+        Ok(turn_output(&result))
+    }
+}
+
+struct CodeApprovalsTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeApprovalsTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_approvals".into(),
+            description: "List pending approvals for a code session.".into(),
+            input_schema: object_schema(
+                json!({
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session UUID.",
+                    },
+                }),
+                &["session_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let session_id = match required_uuid::<CodeSessionId>(&args, "session_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        match client.list_approvals(Some(session_id), true).await {
+            Ok(approvals) => Ok(ToolOutput::text(format!("{} approval(s)", approvals.len()))
+                .with_data(json!({ "approvals": approvals }))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeDecideTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeDecideTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_decide".into(),
+            description:
+                "Approve or deny a parked code-mode approval, then follow to the next settle point."
+                    .into(),
+            input_schema: object_schema(
+                json!({
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session UUID.",
+                    },
+                    "decision": {
+                        "type": "object",
+                        "description": "Approval decision: {approval_id?, decision:\"approve\"|\"deny\", feedback?} or {approve: true}.",
+                    },
+                    "timeout_seconds": timeout_property(),
+                }),
+                &["session_id", "decision"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let session_id = match required_uuid::<CodeSessionId>(&args, "session_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let Some(decision_value) = args.get("decision") else {
+            return fail_args("decision is required");
+        };
+        let (approval_id, approve, feedback) = match parse_decision(decision_value) {
+            Ok(parsed) => parsed,
+            Err(output) => return Ok(output),
+        };
+        let timeout = match timeout_from(&args) {
+            Ok(timeout) => timeout,
+            Err(output) => return Ok(output),
+        };
+        let follow = self.tools.follows.lock().await.get(&session_id).cloned();
+        let mut client = self.tools.state.client.lock().await;
+        let approval_id = match approval_id {
+            Some(id) => id,
+            None => {
+                let pending = match client.list_approvals(Some(session_id), true).await {
+                    Ok(pending) => pending,
+                    Err(error) => return fail(error.to_string()),
+                };
+                match pending.as_slice() {
+                    [only] => only.id,
+                    [] => return fail(format!("no pending approval on session {session_id}")),
+                    _ => return fail_args(
+                        "decision must include approval_id when more than one approval is pending",
+                    ),
+                }
+            }
+        };
+        let result = match decide_and_follow(
+            &mut client,
+            session_id,
+            approval_id,
+            approve,
+            feedback.as_deref(),
+            follow,
+            timeout,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => return fail(error.to_string()),
+        };
+        drop(client);
+        remember(&self.tools, session_id, &result).await;
+        Ok(turn_output(&result))
+    }
+}
+
+struct CodeInterruptTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeInterruptTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_interrupt".into(),
+            description: "Interrupt the in-flight turn on a session.".into(),
+            input_schema: object_schema(
+                json!({
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session UUID.",
+                    },
+                }),
+                &["session_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let session_id = match required_uuid::<CodeSessionId>(&args, "session_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        if let Err(error) = client.interrupt_session(session_id).await {
+            return fail(error.to_string());
+        }
+        Ok(ToolOutput::text("interrupted").with_data(json!({ "ok": true })))
+    }
+}
+
+struct CodeTurnsTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeTurnsTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_turns".into(),
+            description: "Turn history and the durable session queue.".into(),
+            input_schema: object_schema(
+                json!({
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session UUID.",
+                    },
+                }),
+                &["session_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let session_id = match required_uuid::<CodeSessionId>(&args, "session_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        let turns = match client.list_session_turns(session_id).await {
+            Ok(turns) => turns,
+            Err(error) => return fail(error.to_string()),
+        };
+        let queued = match client.list_queued_code_turns(session_id).await {
+            Ok(queued) => queued,
+            Err(error) => return fail(error.to_string()),
+        };
+        let data = json!({
+            "turns": turns,
+            "queued": queued.queued,
+            "queue_paused": queued.paused,
+        });
+        Ok(ToolOutput::text(format!(
+            "{} turn(s), {} queued",
+            turns.len(),
+            queued.queued.len()
+        ))
+        .with_data(data))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// diff / files / git
+// ---------------------------------------------------------------------------
+
+struct CodeDiffTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeDiffTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_diff".into(),
+            description: "Bounded unified diff for a workspace, optionally one path.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Limit the diff to this worktree-relative path.",
+                    },
+                }),
+                &["workspace_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let path = args.get("path").and_then(Value::as_str);
+        let client = self.tools.state.client.lock().await;
+        match client
+            .workspace_diff(workspace_id, None::<CodeTurnId>, path)
+            .await
+        {
+            Ok(diff) => Ok(ToolOutput::text(if diff.diff.is_empty() {
+                "no diff".into()
+            } else {
+                diff.diff.clone()
+            })
+            .with_data(serde_json::to_value(&diff).unwrap_or(Value::Null))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeFilesTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeFilesTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_files".into(),
+            description: "Changed-file list for a workspace, optionally filtered by path.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Keep files whose path equals or is under this prefix.",
+                    },
+                }),
+                &["workspace_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let path = args.get("path").and_then(Value::as_str);
+        let client = self.tools.state.client.lock().await;
+        let mut files = match client.workspace_files(workspace_id, None).await {
+            Ok(files) => files,
+            Err(error) => return fail(error.to_string()),
+        };
+        if let Some(path) = path {
+            files
+                .files
+                .retain(|file| file.path == path || file.path.starts_with(&format!("{path}/")));
+        }
+        Ok(ToolOutput::text(format!("{} file(s)", files.files.len()))
+            .with_data(serde_json::to_value(&files).unwrap_or(Value::Null)))
+    }
+}
+
+struct CodeGitStatusTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeGitStatusTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_git_status".into(),
+            description: "Local git status and pull-request digest for a workspace.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                }),
+                &["workspace_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        match client.git_status(workspace_id).await {
+            Ok(status) => {
+                let summary = if status.dirty { "dirty" } else { "clean" };
+                Ok(ToolOutput::text(format!("git {summary}"))
+                    .with_data(serde_json::to_value(&status).unwrap_or(Value::Null)))
+            }
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeGitCommitTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeGitCommitTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_git_commit".into(),
+            description: "Stage and commit the workspace worktree.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Commit message.",
+                    },
+                }),
+                &["workspace_id", "message"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let Some(message) = args.get("message").and_then(Value::as_str) else {
+            return fail_args("message is required");
+        };
+        let client = self.tools.state.client.lock().await;
+        match client.git_commit(workspace_id, Some(message)).await {
+            Ok(commit) => Ok(ToolOutput::text(format!("committed {}", commit.sha))
+                .with_data(serde_json::to_value(&commit).unwrap_or(Value::Null))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeGitPushTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeGitPushTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_git_push".into(),
+            description: "Push the workspace branch.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                }),
+                &["workspace_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let client = self.tools.state.client.lock().await;
+        match client.git_push(workspace_id).await {
+            Ok(push) => Ok(
+                ToolOutput::text(format!("pushed {} to {}", push.branch, push.remote))
+                    .with_data(serde_json::to_value(&push).unwrap_or(Value::Null)),
+            ),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}
+
+struct CodeGitPrTool {
+    tools: Arc<CodeTools>,
+}
+
+#[async_trait::async_trait]
+impl Tool for CodeGitPrTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "code_git_pr".into(),
+            description: "Open a pull request for the workspace branch.".into(),
+            input_schema: object_schema(
+                json!({
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Workspace UUID.",
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Pull request title.",
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Pull request body.",
+                    },
+                    "draft": {
+                        "type": "boolean",
+                        "description": "Ignored: the git_pr route has no draft field.",
+                    },
+                }),
+                &["workspace_id"],
+            ),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let workspace_id = match required_uuid::<WorkspaceId>(&args, "workspace_id") {
+            Ok(id) => id,
+            Err(output) => return Ok(output),
+        };
+        let title = args.get("title").and_then(Value::as_str);
+        let body = args.get("body").and_then(Value::as_str);
+        let client = self.tools.state.client.lock().await;
+        match client.git_pr(workspace_id, title, body).await {
+            Ok(pr) => Ok(ToolOutput::text("pull request")
+                .with_data(serde_json::to_value(&pr).unwrap_or(Value::Null))),
+            Err(error) => fail(error.to_string()),
+        }
+    }
+}

--- a/crates/tidebreak-cli/src/agent_mcp/code_follow.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/code_follow.rs
@@ -1,0 +1,554 @@
+//! Follow one code-mode turn over the session event socket until it settles.
+//!
+//! Subscribe before `POST /turns` so a long-lived submit cannot finish in a
+//! window this process is not watching. A timeout returns
+//! [`TurnStatus::Running`]; a `SubmitTurnResponse::Queued` returns
+//! [`TurnStatus::Queued`] without waiting. Reconnect uses
+//! [`crate::event_stream::CodeEventStream`]; a socket that cannot be reopened
+//! is reconciled through `list_session_turns`.
+
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use tidebreak_core::{
+    AgentError, CodeApprovalId, CodeEvent, CodeSessionId, CodeTurnId, CodeTurnStatus, Result,
+};
+
+use crate::api::client::Client;
+use crate::api::code::{
+    is_turn_terminal, CodeApprovalSnapshot, CodeTurnSnapshot, SubmitTurnResponse,
+};
+use crate::event_stream::{CodeEventStream, CodeStreamNext};
+
+use super::TurnStatus;
+
+/// Default `timeout_seconds` for `code_run_turn` / `code_wait` / `code_decide`.
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Per-session follow cursor so `code_wait` / `code_decide` resume the same turn.
+#[derive(Debug, Clone)]
+pub(crate) struct CodeFollowState {
+    pub turn_id: CodeTurnId,
+    pub last_seq: i64,
+    pub assistant_text: String,
+    pub queued: bool,
+}
+
+/// The run-turn / wait / decide return contract, plus queued extras.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CodeTurnResult {
+    pub status: TurnStatus,
+    pub assistant_text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending: Option<Value>,
+    pub events_cursor: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<CodeTurnId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queue_position: Option<i64>,
+}
+
+struct FollowGate {
+    expected: Option<CodeTurnId>,
+    ours: bool,
+    seen_start: bool,
+}
+
+impl FollowGate {
+    fn submit() -> Self {
+        Self {
+            expected: None,
+            ours: false,
+            seen_start: false,
+        }
+    }
+
+    fn attach(turn: CodeTurnId) -> Self {
+        Self {
+            expected: Some(turn),
+            ours: true,
+            seen_start: false,
+        }
+    }
+
+    fn waiting_for(turn: CodeTurnId) -> Self {
+        Self {
+            expected: Some(turn),
+            ours: false,
+            seen_start: false,
+        }
+    }
+
+    fn turn_id(&self) -> Option<CodeTurnId> {
+        self.expected
+    }
+
+    fn on_ran(&mut self, id: CodeTurnId) {
+        if self.ours && self.expected == Some(id) {
+            return;
+        }
+        if self.expected.is_some_and(|bound| bound != id) {
+            self.ours = false;
+            self.seen_start = false;
+        }
+        self.expected = Some(id);
+    }
+
+    fn on_frame(&mut self, replayed: bool, event: &CodeEvent) -> bool {
+        if let CodeEvent::TurnStarted { turn_id } = event {
+            let matches_bound = self.expected == Some(*turn_id);
+            let live_unbound = self.expected.is_none() && !replayed;
+            if matches_bound || live_unbound {
+                self.expected = Some(*turn_id);
+                self.ours = true;
+                self.seen_start = true;
+            }
+        }
+        if self.expected.is_none() || !self.ours {
+            return false;
+        }
+        !(replayed && !self.seen_start)
+    }
+}
+
+fn running(
+    assistant_text: String,
+    events_cursor: i64,
+    turn_id: Option<CodeTurnId>,
+) -> CodeTurnResult {
+    CodeTurnResult {
+        status: TurnStatus::Running,
+        assistant_text,
+        pending: None,
+        events_cursor,
+        turn_id,
+        queue_position: None,
+    }
+}
+
+fn from_turn_status(
+    status: CodeTurnStatus,
+    assistant_text: String,
+    events_cursor: i64,
+    turn_id: CodeTurnId,
+) -> CodeTurnResult {
+    let status = match status {
+        CodeTurnStatus::Completed => TurnStatus::Completed,
+        CodeTurnStatus::Failed => TurnStatus::Failed,
+        CodeTurnStatus::Interrupted => TurnStatus::Cancelled,
+        CodeTurnStatus::Running => TurnStatus::Running,
+    };
+    CodeTurnResult {
+        status,
+        assistant_text,
+        pending: None,
+        events_cursor,
+        turn_id: Some(turn_id),
+        queue_position: None,
+    }
+}
+
+fn pending_approval(approval: &CodeApprovalSnapshot) -> Value {
+    json!({
+        "type": "approval",
+        "approval_id": approval.id,
+        "kind": approval.kind,
+        "turn_id": approval.turn_id,
+        "harness_raw_json": approval.harness_raw_json,
+        "state": approval.state,
+    })
+}
+
+fn reconcile_assistant_text(streamed: &mut String, complete: &str) {
+    if complete.starts_with(streamed.as_str()) || streamed.starts_with(complete) {
+        streamed.clear();
+        streamed.push_str(complete);
+        return;
+    }
+    streamed.clear();
+    streamed.push_str(complete);
+}
+
+async fn pending_for_turn(
+    client: &Client,
+    session: CodeSessionId,
+    turn_id: Option<CodeTurnId>,
+) -> Result<Option<CodeApprovalSnapshot>> {
+    let pending = client.list_approvals(Some(session), true).await?;
+    Ok(pending
+        .into_iter()
+        .find(|approval| turn_id.is_none_or(|id| approval.turn_id == id)))
+}
+
+async fn turn_by_id(
+    client: &Client,
+    session: CodeSessionId,
+    turn_id: CodeTurnId,
+) -> Result<Option<CodeTurnSnapshot>> {
+    let turns = client.list_session_turns(session).await?;
+    Ok(turns.into_iter().find(|turn| turn.id == turn_id))
+}
+
+async fn running_turn_id(client: &Client, session: CodeSessionId) -> Result<Option<CodeTurnId>> {
+    let turns = client.list_session_turns(session).await?;
+    Ok(turns
+        .into_iter()
+        .rev()
+        .find(|turn| turn.status == CodeTurnStatus::Running)
+        .map(|turn| turn.id))
+}
+
+async fn timeout_result(
+    client: &Client,
+    session: CodeSessionId,
+    gate: &FollowGate,
+    assistant_text: String,
+    events_cursor: i64,
+) -> Result<CodeTurnResult> {
+    let turn_id = match gate.turn_id() {
+        Some(id) => Some(id),
+        None => running_turn_id(client, session).await?,
+    };
+    Ok(running(assistant_text, events_cursor, turn_id))
+}
+
+async fn reconcile_lost_socket(
+    client: &Client,
+    session: CodeSessionId,
+    turn_id: Option<CodeTurnId>,
+    assistant_text: String,
+    events_cursor: i64,
+    stream_error: AgentError,
+) -> Result<CodeTurnResult> {
+    let Some(turn_id) = turn_id else {
+        return Err(stream_error);
+    };
+    if let Some(turn) = turn_by_id(client, session, turn_id).await? {
+        if turn.status != CodeTurnStatus::Running {
+            return Ok(from_turn_status(
+                turn.status,
+                assistant_text,
+                events_cursor,
+                turn_id,
+            ));
+        }
+    }
+    if let Some(approval) = pending_for_turn(client, session, Some(turn_id)).await? {
+        return Ok(CodeTurnResult {
+            status: TurnStatus::NeedsApproval,
+            assistant_text,
+            pending: Some(pending_approval(&approval)),
+            events_cursor,
+            turn_id: Some(turn_id),
+            queue_position: None,
+        });
+    }
+    let queued = client.list_queued_code_turns(session).await?;
+    if let Some(row) = queued.queued.iter().find(|row| row.id == turn_id) {
+        return Ok(CodeTurnResult {
+            status: TurnStatus::Queued,
+            assistant_text,
+            pending: None,
+            events_cursor,
+            turn_id: Some(turn_id),
+            queue_position: Some(row.position),
+        });
+    }
+    Ok(running(assistant_text, events_cursor, Some(turn_id)))
+}
+
+async fn apply_ours(
+    client: &Client,
+    session: CodeSessionId,
+    stream: &CodeEventStream,
+    gate: &FollowGate,
+    assistant_text: &mut String,
+    frame: &crate::api::code::SequencedCodeEventFrame,
+) -> Result<Option<CodeTurnResult>> {
+    match &frame.event {
+        CodeEvent::AssistantDelta { text } => {
+            if frame.replacement == Some(true) {
+                reconcile_assistant_text(assistant_text, text);
+            } else {
+                assistant_text.push_str(text);
+            }
+            Ok(None)
+        }
+        CodeEvent::AssistantMessage { text, .. } => {
+            reconcile_assistant_text(assistant_text, text);
+            Ok(None)
+        }
+        CodeEvent::TurnStarted { .. } => {
+            assistant_text.clear();
+            Ok(None)
+        }
+        CodeEvent::ApprovalRequested { approval_id } => {
+            let pending = match pending_for_turn(client, session, gate.turn_id()).await? {
+                Some(pending) => pending_approval(&pending),
+                None => json!({
+                    "type": "approval",
+                    "approval_id": approval_id,
+                    "turn_id": gate.turn_id(),
+                }),
+            };
+            Ok(Some(CodeTurnResult {
+                status: TurnStatus::NeedsApproval,
+                assistant_text: assistant_text.clone(),
+                pending: Some(pending),
+                events_cursor: stream.last_seq(),
+                turn_id: gate.turn_id(),
+                queue_position: None,
+            }))
+        }
+        event if is_turn_terminal(event) => {
+            let status = match event {
+                CodeEvent::TurnCompleted { .. } => TurnStatus::Completed,
+                CodeEvent::TurnInterrupted => TurnStatus::Cancelled,
+                _ => TurnStatus::Failed,
+            };
+            Ok(Some(CodeTurnResult {
+                status,
+                assistant_text: assistant_text.clone(),
+                pending: None,
+                events_cursor: stream.last_seq(),
+                turn_id: gate.turn_id(),
+                queue_position: None,
+            }))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Post `message` after the socket is open, then follow until a settle, a
+/// park, a queue receipt, or `timeout`.
+pub(crate) async fn run_turn(
+    client: &mut Client,
+    session: CodeSessionId,
+    message: &str,
+    timeout: Duration,
+) -> Result<CodeTurnResult> {
+    let mut stream = CodeEventStream::open(client, session).await?;
+    let submit_client = client.clone();
+    let mut submit = std::pin::pin!(submit_client.submit_turn(session, message));
+    let mut submit_done = false;
+    let mut gate = FollowGate::submit();
+    let mut assistant_text = String::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return timeout_result(client, session, &gate, assistant_text, stream.last_seq()).await;
+        }
+        let frame = tokio::select! {
+            biased;
+            frame = stream.next(client, session) => frame,
+            submitted = async {
+                if submit_done {
+                    std::future::pending::<Result<SubmitTurnResponse>>().await
+                } else {
+                    submit.as_mut().await
+                }
+            } => {
+                submit_done = true;
+                match submitted? {
+                    SubmitTurnResponse::Ran(turn) => gate.on_ran(turn.id),
+                    SubmitTurnResponse::Queued(row) => {
+                        return Ok(CodeTurnResult {
+                            status: TurnStatus::Queued,
+                            assistant_text,
+                            pending: None,
+                            events_cursor: stream.last_seq(),
+                            turn_id: Some(row.id),
+                            queue_position: Some(row.position),
+                        });
+                    }
+                }
+                continue;
+            }
+            () = tokio::time::sleep(remaining) => {
+                return timeout_result(client, session, &gate, assistant_text, stream.last_seq())
+                    .await;
+            }
+        };
+        match handle_frame(
+            client,
+            session,
+            &mut stream,
+            &mut gate,
+            &mut assistant_text,
+            frame,
+        )
+        .await?
+        {
+            Some(result) => return Ok(result),
+            None => continue,
+        }
+    }
+}
+
+/// Re-follow an in-flight or queued turn.
+pub(crate) async fn wait_turn(
+    client: &mut Client,
+    session: CodeSessionId,
+    follow: CodeFollowState,
+    timeout: Duration,
+) -> Result<CodeTurnResult> {
+    if let Some(result) = settled_or_parked(client, session, &follow).await? {
+        return Ok(result);
+    }
+    let mut gate = if follow.queued {
+        FollowGate::waiting_for(follow.turn_id)
+    } else {
+        FollowGate::attach(follow.turn_id)
+    };
+    let mut stream = CodeEventStream::open_after(client, session, follow.last_seq).await?;
+    follow_open_stream(
+        client,
+        &mut stream,
+        session,
+        &mut gate,
+        follow.assistant_text,
+        timeout,
+    )
+    .await
+}
+
+/// Apply an approval decision, then follow to the next settle point.
+pub(crate) async fn decide_and_follow(
+    client: &mut Client,
+    session: CodeSessionId,
+    approval_id: CodeApprovalId,
+    approve: bool,
+    feedback: Option<&str>,
+    follow: Option<CodeFollowState>,
+    timeout: Duration,
+) -> Result<CodeTurnResult> {
+    let turn_id = match follow.as_ref() {
+        Some(follow) => follow.turn_id,
+        None => {
+            let pending = client.list_approvals(Some(session), true).await?;
+            pending
+                .into_iter()
+                .find(|row| row.id == approval_id)
+                .map(|row| row.turn_id)
+                .ok_or_else(|| {
+                    AgentError::msg(format!(
+                        "no pending approval {approval_id} on session {session}"
+                    ))
+                })?
+        }
+    };
+    let after_seq = follow.as_ref().map(|follow| follow.last_seq).unwrap_or(0);
+    let assistant_text = follow
+        .as_ref()
+        .map(|follow| follow.assistant_text.clone())
+        .unwrap_or_default();
+    let mut stream = CodeEventStream::open_after(client, session, after_seq).await?;
+    client
+        .decide_code_approval(approval_id, approve, feedback)
+        .await?;
+    let mut gate = FollowGate::attach(turn_id);
+    follow_open_stream(
+        client,
+        &mut stream,
+        session,
+        &mut gate,
+        assistant_text,
+        timeout,
+    )
+    .await
+}
+
+async fn settled_or_parked(
+    client: &Client,
+    session: CodeSessionId,
+    follow: &CodeFollowState,
+) -> Result<Option<CodeTurnResult>> {
+    if let Some(turn) = turn_by_id(client, session, follow.turn_id).await? {
+        if turn.status != CodeTurnStatus::Running {
+            return Ok(Some(from_turn_status(
+                turn.status,
+                follow.assistant_text.clone(),
+                follow.last_seq,
+                follow.turn_id,
+            )));
+        }
+        if let Some(approval) = pending_for_turn(client, session, Some(follow.turn_id)).await? {
+            return Ok(Some(CodeTurnResult {
+                status: TurnStatus::NeedsApproval,
+                assistant_text: follow.assistant_text.clone(),
+                pending: Some(pending_approval(&approval)),
+                events_cursor: follow.last_seq,
+                turn_id: Some(follow.turn_id),
+                queue_position: None,
+            }));
+        }
+        return Ok(None);
+    }
+    let queued = client.list_queued_code_turns(session).await?;
+    if queued.queued.iter().any(|row| row.id == follow.turn_id) {
+        return Ok(None);
+    }
+    Ok(None)
+}
+
+async fn follow_open_stream(
+    client: &mut Client,
+    stream: &mut CodeEventStream,
+    session: CodeSessionId,
+    gate: &mut FollowGate,
+    mut assistant_text: String,
+    timeout: Duration,
+) -> Result<CodeTurnResult> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return timeout_result(client, session, gate, assistant_text, stream.last_seq()).await;
+        }
+        let frame = tokio::select! {
+            biased;
+            frame = stream.next(client, session) => frame,
+            () = tokio::time::sleep(remaining) => {
+                return timeout_result(client, session, gate, assistant_text, stream.last_seq())
+                    .await;
+            }
+        };
+        match handle_frame(client, session, stream, gate, &mut assistant_text, frame).await? {
+            Some(result) => return Ok(result),
+            None => continue,
+        }
+    }
+}
+
+async fn handle_frame(
+    client: &mut Client,
+    session: CodeSessionId,
+    stream: &mut CodeEventStream,
+    gate: &mut FollowGate,
+    assistant_text: &mut String,
+    frame: Result<CodeStreamNext>,
+) -> Result<Option<CodeTurnResult>> {
+    let frame = match frame {
+        Ok(CodeStreamNext::Frame(frame)) => frame,
+        Ok(CodeStreamNext::Ignore) => return Ok(None),
+        Err(error) => {
+            return Ok(Some(
+                reconcile_lost_socket(
+                    client,
+                    session,
+                    gate.turn_id(),
+                    assistant_text.clone(),
+                    stream.last_seq(),
+                    error,
+                )
+                .await?,
+            ));
+        }
+    };
+    if !gate.on_frame(frame.replayed == Some(true), &frame.event) {
+        return Ok(None);
+    }
+    apply_ours(client, session, stream, gate, assistant_text, &frame).await
+}

--- a/crates/tidebreak-cli/src/agent_mcp/mod.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/mod.rs
@@ -10,7 +10,7 @@
 //! `request_folder_access` returns `needs_host_consent` with no decision path.
 //! Standing consent comes from `tidebreak folder connect` or the desktop.
 //!
-//! Later PRs add tool modules (settings, code mode) by adding a file and one
+//! Later surfaces add tool modules by adding a file and one
 //! [`register`] call in [`assemble_registry`].
 
 use std::collections::HashMap;
@@ -24,6 +24,8 @@ use crate::api::client::Client;
 use crate::connect;
 
 mod chat;
+mod code;
+mod code_follow;
 pub(crate) mod follow;
 mod profile;
 
@@ -65,11 +67,12 @@ pub(crate) async fn run(server: connect::Server) -> Result<()> {
 }
 
 /// Assemble the MCP registry. Add a module and one `register` call here to
-/// grow the surface (settings, code mode) without touching the entry point.
+/// grow the surface without touching the entry point.
 fn assemble_registry(state: Arc<AgentMcp>) -> ToolRegistry {
     let mut tools = ToolRegistry::new();
     chat::register(&mut tools, Arc::clone(&state));
-    profile::register(&mut tools, state);
+    profile::register(&mut tools, Arc::clone(&state));
+    code::register(&mut tools, state);
     tools
 }
 
@@ -92,6 +95,7 @@ pub(crate) enum TurnStatus {
     NeedsAnswer,
     NeedsHostConsent,
     Running,
+    Queued,
     Cancelled,
     Failed,
 }
@@ -105,6 +109,7 @@ impl TurnStatus {
             Self::NeedsAnswer => "needs_answer",
             Self::NeedsHostConsent => "needs_host_consent",
             Self::Running => "running",
+            Self::Queued => "queued",
             Self::Cancelled => "cancelled",
             Self::Failed => "failed",
         }
@@ -143,6 +148,27 @@ mod tests {
                 "chat_status",
                 "chat_steer",
                 "chat_wait",
+                "code_approvals",
+                "code_decide",
+                "code_diff",
+                "code_files",
+                "code_git_commit",
+                "code_git_pr",
+                "code_git_push",
+                "code_git_status",
+                "code_harnesses",
+                "code_interrupt",
+                "code_repo_add",
+                "code_repos",
+                "code_run_turn",
+                "code_session_create",
+                "code_session_set_permission_mode",
+                "code_sessions",
+                "code_turns",
+                "code_wait",
+                "code_workspace_archive",
+                "code_workspace_create",
+                "code_workspaces",
                 "exec_select",
                 "model_role_set",
                 "profile_snapshot",

--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -100,6 +100,8 @@ pub struct CodeTurnSnapshot {
 /// A follow-up parked while the session is already running a turn.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueuedCodeTurn {
+    /// Row id, and the turn id the promoted turn is inserted under.
+    pub id: CodeTurnId,
     pub session_id: CodeSessionId,
     pub message: String,
     pub position: i64,
@@ -111,6 +113,14 @@ pub struct QueuedCodeTurn {
 pub enum SubmitTurnResponse {
     Ran(CodeTurnSnapshot),
     Queued(QueuedCodeTurn),
+}
+
+/// Result of `GET /code/sessions/{id}/queued`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueuedCodeTurnsSnapshot {
+    pub queued: Vec<QueuedCodeTurn>,
+    #[serde(default)]
+    pub paused: bool,
 }
 
 /// One event on the per-session WebSocket.
@@ -400,12 +410,27 @@ impl Client {
         harness: HarnessKind,
         permission_mode: PermissionMode,
     ) -> Result<CodeSessionSnapshot> {
+        self.create_session_with(workspace, harness, permission_mode, None)
+            .await
+    }
+
+    pub async fn create_session_with(
+        &self,
+        workspace: WorkspaceId,
+        harness: HarnessKind,
+        permission_mode: PermissionMode,
+        model: Option<&str>,
+    ) -> Result<CodeSessionSnapshot> {
+        let mut body = serde_json::json!({
+            "harness": harness,
+            "permission_mode": permission_mode,
+        });
+        if let Some(model) = model {
+            body["model"] = model.into();
+        }
         self.post_json(
             format!("{}/code/workspaces/{workspace}/sessions", self.base_url()),
-            &serde_json::json!({
-                "harness": harness,
-                "permission_mode": permission_mode,
-            }),
+            &body,
         )
         .await
     }
@@ -428,6 +453,17 @@ impl Client {
     ) -> Result<Vec<CodeTurnSnapshot>> {
         self.get_json(format!("{}/code/sessions/{session}/turns", self.base_url()))
             .await
+    }
+
+    pub async fn list_queued_code_turns(
+        &self,
+        session: CodeSessionId,
+    ) -> Result<QueuedCodeTurnsSnapshot> {
+        self.get_json(format!(
+            "{}/code/sessions/{session}/queued",
+            self.base_url()
+        ))
+        .await
     }
 
     pub async fn interrupt_session(&self, session: CodeSessionId) -> Result<()> {

--- a/crates/tidebreak-cli/src/event_stream.rs
+++ b/crates/tidebreak-cli/src/event_stream.rs
@@ -1,14 +1,16 @@
-//! Shared chat event-socket follow: subscribe, reconnect, durable fallback.
+//! Shared event-socket follow: subscribe, reconnect, durable fallback.
 //!
-//! Print mode and `agent-mcp` both watch one turn over `/chats/{id}/events`.
-//! The reconnect ladder and the durable-transcript fallback live here so those
-//! surfaces stay in lockstep; each caller decides what a frame *means*.
+//! Print mode and `agent-mcp` watch a chat turn over `/chats/{id}/events`.
+//! Code-mode tools watch `/code/sessions/{id}/events`. The reconnect ladder
+//! lives here so those surfaces stay in lockstep; each caller decides what a
+//! frame *means*.
 
 use futures::StreamExt as _;
-use tidebreak_core::{AgentError, ChatId, Result, TurnId};
+use tidebreak_core::{AgentError, ChatId, CodeSessionId, Result, TurnId};
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::api::client::{Client, DurableTurn, EventSocket};
+use crate::api::code::{decode_event_frame, SequencedCodeEventFrame};
 use crate::api::wire::{ChatFrame, ClientEvent};
 
 /// Attempts to re-open the event socket after it closes mid-turn before giving
@@ -123,6 +125,84 @@ impl EventStream {
         }
         Err(AgentError::msg(format!(
             "the event stream closed mid-turn and could not be reopened{}",
+            last.map(|error| format!(": {error}")).unwrap_or_default()
+        )))
+    }
+}
+
+/// The code-mode session event socket plus the cursor a reconnect resumes from.
+pub(crate) struct CodeEventStream {
+    socket: EventSocket,
+    last_seq: i64,
+}
+
+pub(crate) enum CodeStreamNext {
+    Frame(SequencedCodeEventFrame),
+    Ignore,
+}
+
+impl CodeEventStream {
+    pub(crate) async fn open(client: &Client, session: CodeSessionId) -> Result<Self> {
+        Self::open_after(client, session, 0).await
+    }
+
+    pub(crate) async fn open_after(
+        client: &Client,
+        session: CodeSessionId,
+        after: i64,
+    ) -> Result<Self> {
+        Ok(Self {
+            socket: client.open_code_events(session, after).await?,
+            last_seq: after,
+        })
+    }
+
+    pub(crate) fn last_seq(&self) -> i64 {
+        self.last_seq
+    }
+
+    /// The next sequenced frame, or an ignorable payload. A closed socket
+    /// climbs [`RECONNECT_DELAYS`] and resumes from [`Self::last_seq`]. The
+    /// caller reconciles via `list_session_turns` when this returns an error.
+    pub(crate) async fn next(
+        &mut self,
+        client: &mut Client,
+        session: CodeSessionId,
+    ) -> Result<CodeStreamNext> {
+        match self.socket.next().await {
+            Some(Ok(Message::Text(text))) => match decode_event_frame(&text) {
+                Ok(frame) => {
+                    self.last_seq = frame.seq;
+                    Ok(CodeStreamNext::Frame(frame))
+                }
+                Err(_) => Ok(CodeStreamNext::Ignore),
+            },
+            Some(Ok(_)) => Ok(CodeStreamNext::Ignore),
+            Some(Err(_)) | None => {
+                self.reconnect(client, session).await?;
+                Ok(CodeStreamNext::Ignore)
+            }
+        }
+    }
+
+    async fn reconnect(&mut self, client: &mut Client, session: CodeSessionId) -> Result<()> {
+        let mut last = None;
+        for delay in RECONNECT_DELAYS {
+            tokio::time::sleep(delay).await;
+            if let Err(error) = client.refresh_attach_endpoint() {
+                last = Some(error);
+                continue;
+            }
+            match client.open_code_events(session, self.last_seq).await {
+                Ok(socket) => {
+                    self.socket = socket;
+                    return Ok(());
+                }
+                Err(error) => last = Some(error),
+            }
+        }
+        Err(AgentError::msg(format!(
+            "the code event stream closed mid-turn and could not be reopened{}",
             last.map(|error| format!(": {error}")).unwrap_or_default()
         )))
     }

--- a/crates/tidebreak-cli/tests/agent_mcp.rs
+++ b/crates/tidebreak-cli/tests/agent_mcp.rs
@@ -111,6 +111,9 @@ impl Mcp {
             "chat_output_read",
             "agent_runs",
             "agent_run_cancel",
+            "code_run_turn",
+            "code_wait",
+            "code_decide",
         ] {
             assert!(
                 names.contains(&expected),

--- a/crates/tidebreak-cli/tests/agent_mcp_code.rs
+++ b/crates/tidebreak-cli/tests/agent_mcp_code.rs
@@ -1,0 +1,487 @@
+//! End-to-end tests of `tidebreak agent-mcp` code-mode tools over a real
+//! `tidebreak serve` with the feature-gated scripted harness.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+const TURN_TIMEOUT: Duration = Duration::from_secs(60);
+
+struct Reaper(Child);
+
+impl Drop for Reaper {
+    fn drop(&mut self) {
+        self.0.kill().ok();
+        self.0.wait().ok();
+    }
+}
+
+struct Mcp {
+    _reaper: Reaper,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Mcp {
+    fn connect(url: &str, token: &str, data_dir: &Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+            .args(["agent-mcp", "--server", url])
+            .env("TIDEBREAK_SERVER_TOKEN", token)
+            .env("TIDEBREAK_DATA_DIR", data_dir)
+            .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+            .env_remove("TIDEBREAK_SERVER_URL")
+            .env_remove("TIDEBREAK_MCP_CONFIG")
+            .env_remove("ANTHROPIC_API_KEY")
+            .env_remove("HTTP_PROXY")
+            .env_remove("HTTPS_PROXY")
+            .env_remove("http_proxy")
+            .env_remove("https_proxy")
+            .env_remove("ALL_PROXY")
+            .env_remove("all_proxy")
+            .env("NO_PROXY", "*")
+            .env("no_proxy", "*")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn tidebreak agent-mcp");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let stderr = child.stderr.take().expect("stderr");
+        std::thread::spawn(move || {
+            let mut sink = Vec::new();
+            let _ = BufReader::new(stderr).read_to_end(&mut sink);
+        });
+        let mut mcp = Self {
+            _reaper: Reaper(child),
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        mcp.handshake();
+        mcp
+    }
+
+    fn handshake(&mut self) {
+        let listed = self.rpc(
+            "initialize",
+            json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "agent-mcp-code-test", "version": "1"},
+            }),
+        );
+        assert!(
+            listed["result"]["capabilities"]["tools"].is_object(),
+            "initialize: {listed}"
+        );
+        self.notify("notifications/initialized", json!({}));
+        let tools = self.rpc("tools/list", json!({}));
+        let names: Vec<&str> = tools["result"]["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .map(|tool| tool["name"].as_str().expect("name"))
+            .collect();
+        for expected in [
+            "code_harnesses",
+            "code_repo_add",
+            "code_run_turn",
+            "code_wait",
+            "code_decide",
+            "code_diff",
+            "code_git_status",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "missing {expected} in {names:?}\n{tools}"
+            );
+        }
+    }
+
+    fn notify(&mut self, method: &str, params: Value) {
+        let line = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        writeln!(self.stdin, "{line}").expect("write notify");
+        self.stdin.flush().expect("flush notify");
+    }
+
+    fn rpc(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let line = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        writeln!(self.stdin, "{line}").expect("write rpc");
+        self.stdin.flush().expect("flush rpc");
+        let started = Instant::now();
+        let mut response = String::new();
+        loop {
+            response.clear();
+            let n = self.stdout.read_line(&mut response).expect("read rpc");
+            assert!(n > 0, "agent-mcp closed stdout after {method}");
+            assert!(
+                started.elapsed() < TURN_TIMEOUT,
+                "timed out waiting for {method}: {response}"
+            );
+            let parsed: Value =
+                serde_json::from_str(&response).unwrap_or_else(|_| panic!("rpc line: {response}"));
+            if parsed.get("id") == Some(&json!(id)) {
+                return parsed;
+            }
+        }
+    }
+
+    fn call(&mut self, name: &str, arguments: Value) -> Value {
+        let response = self.rpc(
+            "tools/call",
+            json!({
+                "name": name,
+                "arguments": arguments,
+            }),
+        );
+        assert_eq!(
+            response["result"]["isError"], false,
+            "{name} failed: {response}"
+        );
+        response["result"]["structuredContent"].clone()
+    }
+}
+
+fn spawn_serve(dir: &Path, extra_env: &[(&str, &str)]) -> (Reaper, String, String) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_tidebreak"));
+    command
+        .arg("serve")
+        .env("TIDEBREAK_DATA_DIR", dir)
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_MCP_CONFIG")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("HTTP_PROXY")
+        .env_remove("HTTPS_PROXY")
+        .env_remove("http_proxy")
+        .env_remove("https_proxy")
+        .env_remove("ALL_PROXY")
+        .env_remove("all_proxy")
+        .env("NO_PROXY", "*")
+        .env("no_proxy", "*");
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    let mut child = command
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn tidebreak serve");
+    let stdout = child.stdout.take().unwrap();
+    let reaper = Reaper(child);
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+    let url = format!(
+        "http://{}",
+        addr_line.rsplit("http://").next().unwrap().trim()
+    );
+    let token = token_line
+        .strip_prefix("tidebreak: token ")
+        .expect("token line")
+        .trim()
+        .to_owned();
+    (reaper, url, token)
+}
+
+fn init_git_repo(path: &Path) {
+    std::fs::create_dir_all(path).unwrap();
+    assert!(Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+    std::fs::write(path.join("README.md"), "demo\n").unwrap();
+    assert!(Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .args([
+            "-c",
+            "user.name=Tidebreak",
+            "-c",
+            "user.email=tidebreak@example.test",
+            "commit",
+            "-m",
+            "init",
+        ])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+}
+
+fn plain_events() -> Value {
+    json!([
+        {
+            "type": "session_started",
+            "harness_kind": "claude_code",
+            "harness_version": "scripted",
+            "resume_ref": "scripted-session"
+        },
+        {"type": "turn_started"},
+        {"type": "assistant_delta", "text": "hello from the scripted engine"},
+        {"type": "turn_completed", "usage": {}}
+    ])
+}
+
+fn open_session(mcp: &mut Mcp, repo_dir: &Path, permission_mode: &str) -> (String, String) {
+    let repo = mcp.call(
+        "code_repo_add",
+        json!({
+            "source": repo_dir.to_str().unwrap(),
+            "name": "sample",
+        }),
+    );
+    let repo_id = repo["id"].as_str().expect("repo id").to_owned();
+    let workspace = mcp.call(
+        "code_workspace_create",
+        json!({
+            "repo_id": repo_id,
+            "name": "ws",
+        }),
+    );
+    let workspace_id = workspace["id"].as_str().expect("workspace id").to_owned();
+    let session = mcp.call(
+        "code_session_create",
+        json!({
+            "workspace_id": workspace_id,
+            "harness": "claude_code",
+            "permission_mode": permission_mode,
+        }),
+    );
+    (
+        workspace_id,
+        session["id"].as_str().expect("session id").to_owned(),
+    )
+}
+
+/// (a) repo → workspace → session → code_run_turn to completion.
+#[test]
+fn repo_workspace_session_run_to_completion() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = plain_events().to_string();
+    let (_server, url, token) = spawn_serve(dir.path(), &[("TIDEBREAK_SCRIPTED_HARNESS", &script)]);
+    let mut mcp = Mcp::connect(&url, &token, dir.path());
+
+    let repo_dir = dir.path().join("sample-repo");
+    init_git_repo(&repo_dir);
+    let (_workspace_id, session_id) = open_session(&mut mcp, &repo_dir, "plan");
+
+    let turn = mcp.call(
+        "code_run_turn",
+        json!({
+            "session_id": session_id,
+            "prompt": "say hello",
+            "timeout_seconds": 30,
+        }),
+    );
+    assert_eq!(turn["status"], "completed", "{turn}");
+    assert_eq!(
+        turn["assistant_text"], "hello from the scripted engine",
+        "{turn}"
+    );
+}
+
+/// (b) a scripted approval: code_run_turn returns needs_approval, code_decide
+/// approve settles.
+#[test]
+fn approval_then_decide() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = json!({
+        "approvals": true,
+        "events": [
+            {
+                "type": "session_started",
+                "harness_kind": "claude_code",
+                "harness_version": "scripted",
+                "resume_ref": "scripted-session"
+            },
+            {"type": "turn_started"},
+            {
+                "type": "approval_requested",
+                "harness_ref": {"call_id": "toolu_scripted"},
+                "raw": {
+                    "tool_name": "Write",
+                    "input": {
+                        "file_path": "/workspace/probe.txt",
+                        "content": "hello"
+                    },
+                    "tool_use_id": "toolu_scripted"
+                }
+            },
+            {"type": "assistant_delta", "text": "after the decision"},
+            {"type": "turn_completed", "usage": {}}
+        ]
+    })
+    .to_string();
+    let (_server, url, token) = spawn_serve(dir.path(), &[("TIDEBREAK_SCRIPTED_HARNESS", &script)]);
+    let mut mcp = Mcp::connect(&url, &token, dir.path());
+
+    let repo_dir = dir.path().join("sample-repo");
+    init_git_repo(&repo_dir);
+    let (_workspace_id, session_id) = open_session(&mut mcp, &repo_dir, "ask");
+
+    let parked = mcp.call(
+        "code_run_turn",
+        json!({
+            "session_id": session_id,
+            "prompt": "write the file",
+            "timeout_seconds": 30,
+        }),
+    );
+    assert_eq!(parked["status"], "needs_approval", "{parked}");
+    let approval_id = parked["pending"]["approval_id"]
+        .as_str()
+        .expect("pending approval_id")
+        .to_owned();
+
+    let settled = mcp.call(
+        "code_decide",
+        json!({
+            "session_id": session_id,
+            "decision": {
+                "approval_id": approval_id,
+                "decision": "approve",
+            },
+            "timeout_seconds": 30,
+        }),
+    );
+    assert_eq!(settled["status"], "completed", "{settled}");
+    assert_eq!(settled["assistant_text"], "after the decision", "{settled}");
+}
+
+/// (c) submit while a turn runs → status queued, then code_wait drains both.
+#[test]
+fn queued_then_wait_drains_both() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = json!({
+        "turn_delay_ms": 2500,
+        "events": [
+            {
+                "type": "session_started",
+                "harness_kind": "claude_code",
+                "harness_version": "scripted",
+                "resume_ref": "scripted-session"
+            },
+            {"type": "turn_started"},
+            {"type": "assistant_delta", "text": "later"},
+            {"type": "turn_completed", "usage": {}}
+        ]
+    })
+    .to_string();
+    let (_server, url, token) = spawn_serve(dir.path(), &[("TIDEBREAK_SCRIPTED_HARNESS", &script)]);
+    let mut mcp = Mcp::connect(&url, &token, dir.path());
+
+    let repo_dir = dir.path().join("sample-repo");
+    init_git_repo(&repo_dir);
+    let (_workspace_id, session_id) = open_session(&mut mcp, &repo_dir, "plan");
+
+    let running = mcp.call(
+        "code_run_turn",
+        json!({
+            "session_id": session_id,
+            "prompt": "first",
+            "timeout_seconds": 1,
+        }),
+    );
+    assert_eq!(running["status"], "running", "{running}");
+
+    let queued = mcp.call(
+        "code_run_turn",
+        json!({
+            "session_id": session_id,
+            "prompt": "second",
+            "timeout_seconds": 5,
+        }),
+    );
+    assert_eq!(queued["status"], "queued", "{queued}");
+    assert!(queued["turn_id"].is_string(), "{queued}");
+    assert!(queued["queue_position"].is_number(), "{queued}");
+
+    let finished = mcp.call(
+        "code_wait",
+        json!({
+            "session_id": session_id,
+            "timeout_seconds": 30,
+        }),
+    );
+    assert_eq!(finished["status"], "completed", "{finished}");
+    assert_eq!(finished["assistant_text"], "later", "{finished}");
+
+    let turns = mcp.call("code_turns", json!({ "session_id": session_id }));
+    let history = turns["turns"].as_array().expect("turns");
+    assert_eq!(history.len(), 2, "{turns}");
+    assert!(
+        history.iter().all(|turn| turn["status"] == "completed"),
+        "{turns}"
+    );
+}
+
+/// (d) code_diff / code_git_status return sane shapes after a scripted edit.
+#[test]
+fn diff_and_git_status_after_scripted_edit() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = json!({
+        "writes": [{"path": "edited.txt", "contents": "scripted edit\n"}],
+        "events": [
+            {
+                "type": "session_started",
+                "harness_kind": "claude_code",
+                "harness_version": "scripted",
+                "resume_ref": "scripted-session"
+            },
+            {"type": "turn_started"},
+            {"type": "assistant_delta", "text": "edited"},
+            {"type": "turn_completed", "usage": {}}
+        ]
+    })
+    .to_string();
+    let (_server, url, token) = spawn_serve(dir.path(), &[("TIDEBREAK_SCRIPTED_HARNESS", &script)]);
+    let mut mcp = Mcp::connect(&url, &token, dir.path());
+
+    let repo_dir = dir.path().join("sample-repo");
+    init_git_repo(&repo_dir);
+    let (workspace_id, session_id) = open_session(&mut mcp, &repo_dir, "plan");
+
+    let turn = mcp.call(
+        "code_run_turn",
+        json!({
+            "session_id": session_id,
+            "prompt": "edit the file",
+            "timeout_seconds": 30,
+        }),
+    );
+    assert_eq!(turn["status"], "completed", "{turn}");
+
+    let diff = mcp.call("code_diff", json!({ "workspace_id": workspace_id }));
+    let diff_text = diff["diff"].as_str().unwrap_or("");
+    assert!(
+        diff_text.contains("edited.txt") || diff_text.contains("scripted edit"),
+        "{diff}"
+    );
+    assert!(diff["stat"].is_object(), "{diff}");
+
+    let status = mcp.call("code_git_status", json!({ "workspace_id": workspace_id }));
+    assert_eq!(status["dirty"], true, "{status}");
+    assert!(status["suggested_commit_message"].is_string(), "{status}");
+}

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -474,7 +474,7 @@ impl CodeRuntime {
         })
     }
 
-    #[cfg(any(test, feature = "scripted-harness"))]
+    #[cfg(test)]
     pub(crate) fn with_registry(
         db: Arc<DbStore>,
         data_dir: PathBuf,
@@ -483,7 +483,7 @@ impl CodeRuntime {
         Self::with_registry_and_browser_runtime(db, data_dir, adapters, None, None)
     }
 
-    #[cfg(any(test, feature = "scripted-harness"))]
+    #[cfg(test)]
     pub(crate) fn with_registry_and_browser_runtime(
         db: Arc<DbStore>,
         data_dir: PathBuf,
@@ -548,7 +548,7 @@ impl CodeRuntime {
 
     /// Lend gateway git credentials from tests, in place of the on-behalf-of
     /// handle a hosted deployment wires in.
-    #[cfg(any(test, feature = "scripted-harness"))]
+    #[cfg(test)]
     pub(crate) fn with_git_credentials(
         mut self,
         lender: Arc<dyn crate::obo_gateway::GitCredentialLender>,
@@ -2618,17 +2618,31 @@ impl CodeRuntime {
             // which case this is a marker read. It stays on the create path
             // regardless: correctness must not depend on the warm path having
             // run, and a pin installed here is serialized against that one.
-            match self.ensure_pinned_harness(harness, false).await {
-                Ok(binary) => {
-                    self.record_pin_install(harness, Ok(()));
-                    self.invalidate_moved_probe(harness, &binary);
+            // Skip when a CLI e2e has replaced this kind with the scripted
+            // engine: that binary has no pin and must not try to download one.
+            let skip_pin = {
+                #[cfg(feature = "scripted-harness")]
+                {
+                    crate::scripted_harness::env_is_set()
                 }
-                Err(err) => {
-                    self.record_pin_install(harness, Err(err.clone()));
-                    return Err(ServerError::unprocessable_kind(
-                        "harness_not_found",
-                        format!("{harness} could not be installed: {err}"),
-                    ));
+                #[cfg(not(feature = "scripted-harness"))]
+                {
+                    false
+                }
+            };
+            if !skip_pin {
+                match self.ensure_pinned_harness(harness, false).await {
+                    Ok(binary) => {
+                        self.record_pin_install(harness, Ok(()));
+                        self.invalidate_moved_probe(harness, &binary);
+                    }
+                    Err(err) => {
+                        self.record_pin_install(harness, Err(err.clone()));
+                        return Err(ServerError::unprocessable_kind(
+                            "harness_not_found",
+                            format!("{harness} could not be installed: {err}"),
+                        ));
+                    }
                 }
             }
         }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1894,11 +1894,14 @@ async fn bind_inner(
     );
     // A self-host machine owns its filesystem. Clones land under the data
     // directory unless an operator set a destination (decision 70).
-    let runtime = if state.config.profile == Profile::SelfHost {
+    #[allow(unused_mut)]
+    let mut runtime = if state.config.profile == Profile::SelfHost {
         runtime.with_clone_parent_default(state.config.data_dir.join("code").join("src"))
     } else {
         runtime
     };
+    #[cfg(feature = "scripted-harness")]
+    scripted_harness::install_from_env(&mut runtime.adapters)?;
     let code = Arc::new(runtime);
     // Recovery runs after the bind, below: the workers it re-attaches need the
     // bound loopback address to reach their approval endpoint.

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -2,19 +2,25 @@
 //!
 //! Compiled only under the `scripted-harness` feature or in this crate's
 //! tests, matching [`scripted_provider`]: a released binary never contains it.
+//! Test-only helpers stay compiled under the feature so CLI e2e can load the
+//! adapter; they are unused outside this crate's tests.
+#![cfg_attr(not(test), allow(dead_code))]
 
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tidebreak_core::{CapLevel, HarnessCaps, HarnessKind, PermissionMode, ReasoningEffort};
+use serde::Deserialize;
+use tidebreak_core::{
+    AgentError, CapLevel, HarnessCaps, HarnessKind, PermissionMode, ReasoningEffort, Result,
+};
 use tidebreak_harness::child::ChildPid;
 use tidebreak_harness::{
-    ApprovalCompleter, ApprovalDecision, HarnessAdapter, HarnessApprovalRef, HarnessError,
-    HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession, HostEnv, SessionSpec, TurnInput,
-    TurnOutcome,
+    AdapterRegistry, ApprovalCompleter, ApprovalDecision, HarnessAdapter, HarnessApprovalRef,
+    HarnessError, HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession, HostEnv,
+    SessionSpec, TurnInput, TurnOutcome,
 };
 use tokio::sync::{oneshot, watch};
 
@@ -74,9 +80,20 @@ impl ApprovalCompleter for ScriptedApprover {
     }
 }
 
-/// Environment variable carrying a JSON array of [`HarnessEvent`]s.
-#[allow(dead_code)]
+/// Environment variable carrying a scripted-engine script for CLI e2e tests.
 const SCRIPT_VAR: &str = "TIDEBREAK_SCRIPTED_HARNESS";
+
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) fn env_is_set() -> bool {
+    std::env::var_os(SCRIPT_VAR).is_some()
+}
+
+/// One file the scripted engine writes into the session worktree.
+#[derive(Clone, Debug, Deserialize)]
+struct ScriptedWrite {
+    path: String,
+    contents: String,
+}
 
 /// One scripted engine session.
 #[derive(Clone)]
@@ -125,6 +142,11 @@ pub(crate) struct ScriptedAdapter {
     /// Approval endpoint each launch was handed, `None` when it was handed no
     /// channel at all. Lets a test see how a session was wired.
     launched_approvals: Arc<std::sync::Mutex<Vec<Option<String>>>>,
+    /// Files to materialize in the worktree at the start of each turn.
+    writes: Vec<ScriptedWrite>,
+    /// Sleep once at the start of each turn, so a caller can observe Running
+    /// and queue a follow-up before the script plays.
+    turn_delay: Duration,
 }
 
 impl ScriptedAdapter {
@@ -157,6 +179,8 @@ impl ScriptedAdapter {
             approval_ack_delay: Duration::ZERO,
             probes: Arc::new(AtomicU64::new(0)),
             launched_approvals: Arc::new(std::sync::Mutex::new(Vec::new())),
+            writes: Vec::new(),
+            turn_delay: Duration::ZERO,
         }
     }
 
@@ -408,6 +432,9 @@ impl HarnessAdapter for ScriptedAdapter {
             turns: self.turns.clone(),
             modes: self.modes.clone(),
             inputs: self.inputs.clone(),
+            worktree: spec.worktree.clone(),
+            writes: self.writes.clone(),
+            turn_delay: self.turn_delay,
         }))
     }
 }
@@ -440,6 +467,9 @@ struct ScriptedSession {
     turns: Arc<std::sync::Mutex<Vec<Option<ReasoningEffort>>>>,
     modes: Arc<std::sync::Mutex<Vec<PermissionMode>>>,
     inputs: Arc<std::sync::Mutex<Vec<ScriptedTurnInput>>>,
+    worktree: PathBuf,
+    writes: Vec<ScriptedWrite>,
+    turn_delay: Duration,
 }
 
 /// One turn as the engine received it.
@@ -525,6 +555,13 @@ impl HarnessSession for ScriptedSession {
             return Err(HarnessError::ResumeLost(detail.clone()));
         }
         self.interrupt.store(false, Ordering::SeqCst);
+        if !self.turn_delay.is_zero() {
+            tokio::time::sleep(self.turn_delay).await;
+            if self.interrupt.load(Ordering::SeqCst) {
+                return Ok(self.stopped().await);
+            }
+        }
+        apply_scripted_writes(&self.worktree, &self.writes)?;
         self.unrecognized
             .fetch_add(self.unrecognized_per_turn, Ordering::SeqCst);
         // A per-turn child exists only while the turn runs; publish it the way
@@ -613,6 +650,101 @@ impl HarnessSession for ScriptedSession {
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         Ok(())
     }
+}
+
+fn apply_scripted_writes(worktree: &Path, writes: &[ScriptedWrite]) -> Result<(), HarnessError> {
+    for write in writes {
+        let relative = Path::new(&write.path);
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| matches!(component, Component::ParentDir))
+        {
+            return Err(HarnessError::Other(format!(
+                "scripted write path must be worktree-relative: {}",
+                write.path
+            )));
+        }
+        let dest = worktree.join(relative);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                HarnessError::Other(format!("scripted write mkdir failed: {error}"))
+            })?;
+        }
+        std::fs::write(&dest, &write.contents)
+            .map_err(|error| HarnessError::Other(format!("scripted write failed: {error}")))?;
+    }
+    Ok(())
+}
+
+/// Object form of [`SCRIPT_VAR`]: events plus optional delay, writes, and
+/// approval-channel flags. A bare JSON array of [`HarnessEvent`]s is also
+/// accepted so a short successful turn stays one line.
+#[derive(Debug, Deserialize)]
+struct ScriptedHarnessScript {
+    events: Vec<HarnessEvent>,
+    #[serde(default)]
+    delay_ms: u64,
+    #[serde(default)]
+    turn_delay_ms: u64,
+    #[serde(default)]
+    writes: Vec<ScriptedWrite>,
+    #[serde(default)]
+    approvals: bool,
+}
+
+/// The adapter [`SCRIPT_VAR`] asks for, or `None` when it is unset.
+///
+/// A malformed script is an error rather than a silent fall-through to the
+/// real engines: a CLI e2e whose script did not parse would otherwise try to
+/// install pinned harness binaries.
+pub(crate) fn adapter_from_env() -> Result<Option<ScriptedAdapter>> {
+    let Ok(script) = std::env::var(SCRIPT_VAR) else {
+        return Ok(None);
+    };
+    let parsed = parse_script(&script).map_err(|error| {
+        AgentError::config(format!("{SCRIPT_VAR} is not a valid script: {error}"))
+    })?;
+    let mut adapter = ScriptedAdapter::new(parsed.events);
+    if parsed.delay_ms > 0 {
+        adapter = adapter.with_delay(Duration::from_millis(parsed.delay_ms));
+    }
+    if parsed.turn_delay_ms > 0 {
+        adapter.turn_delay = Duration::from_millis(parsed.turn_delay_ms);
+    }
+    if parsed.approvals
+        || adapter
+            .events
+            .iter()
+            .any(|event| matches!(event, HarnessEvent::ApprovalRequested { .. }))
+    {
+        adapter = adapter.with_approvals(CapLevel::Supported);
+    }
+    adapter.writes = parsed.writes;
+    Ok(Some(adapter))
+}
+
+/// Install the env-driven scripted engine in place of the matching built-in,
+/// so a spawned `tidebreak serve` can drive code-mode turns without a real
+/// harness binary.
+pub(crate) fn install_from_env(registry: &mut AdapterRegistry) -> Result<()> {
+    if let Some(adapter) = adapter_from_env()? {
+        registry.register(Arc::new(adapter));
+    }
+    Ok(())
+}
+
+fn parse_script(script: &str) -> std::result::Result<ScriptedHarnessScript, serde_json::Error> {
+    if let Ok(events) = serde_json::from_str::<Vec<HarnessEvent>>(script) {
+        return Ok(ScriptedHarnessScript {
+            events,
+            delay_ms: 0,
+            turn_delay_ms: 0,
+            writes: Vec::new(),
+            approvals: false,
+        });
+    }
+    serde_json::from_str(script)
 }
 
 /// A short successful turn: one assistant delta, then completed.

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -430,6 +430,53 @@ Profile and settings tools inspect and steer the axes a chat turn depends on:
 
 Credentials do not transit this surface. There is no tool for provider, web-search, or exec keys (`set-key` / `remove-key`), and no tool for MCP server config (`put_mcp_servers`). A human sets those in the desktop or the CLI. `profile_snapshot` strips credential material, key fragments, and secret-bearing fields before it returns.
 
+#### Code mode
+
+The same `agent-mcp` process also drives **code mode** on that server: repos,
+workspaces, sessions, turns, approvals, diffs, and git/PR actions. Reads are
+read-only; mutations are sensitive. Possession of the bearer authorizes
+calling them. Harness approvals the engine raises inside a session are never
+auto-approved.
+
+Session lifecycle:
+
+| Tool | What it does |
+| --- | --- |
+| `code_harnesses` | Harness doctor report. |
+| `code_repo_add` | Register a local git checkout (`source`, optional `name`). |
+| `code_repos` | Registered repos. |
+| `code_workspace_create` | Create a worktree + branch (`repo_id`, optional `name`, `base`). |
+| `code_workspaces` | Workspaces, optionally filtered by `repo_id`. |
+| `code_workspace_archive` | Archive a workspace. |
+| `code_session_create` | Start a session (`workspace_id`, optional `harness`, `model`, `permission_mode`). |
+| `code_sessions` | Sessions in a workspace. |
+| `code_session_set_permission_mode` | Change the session's permission mode. |
+| `code_turns` | Turn history plus the durable session queue. |
+| `code_interrupt` | Interrupt the in-flight turn. |
+| `code_diff` / `code_files` | Workspace diff and changed-file list. |
+| `code_git_status` / `code_git_commit` / `code_git_push` / `code_git_pr` | Git and pull-request actions. These are Sensitive tools, not a second approval gate: the bearer already authorizes the workspace. |
+
+The run-turn → decide loop is the chat loop with a code-shaped decision:
+
+```json
+{"approval_id":"…","decision":"approve"}
+{"approval_id":"…","decision":"deny","feedback":"use the fixtures directory"}
+```
+
+`code_run_turn` subscribes the session event socket, then submits. Follow until
+the turn settles, parks on an approval, or `timeout_seconds` (default 300)
+elapses. `code_wait` re-follows an in-flight or queued turn. `code_decide`
+applies the decision and follows to the next settle point. `code_approvals`
+lists what is parked.
+
+`status` is the chat set plus **`queued`**. `POST /code/sessions/{id}/turns`
+waits for the worker to finish or to park the message on the durable session
+queue. A queued receipt returns immediately with the queue position and the
+turn id the promoted turn will run under — it is not a failure. Re-check with
+`code_wait`; one wait drains the running turn and then the queued follow-up.
+
+`run_action` and `reap_session` are not mounted.
+
 ### `rehome-secrets`
 
 macOS ties keychain approvals to a binary's code signature, so credentials

--- a/docs/decisions/0074-agent-mcp-drives-code-mode.md
+++ b/docs/decisions/0074-agent-mcp-drives-code-mode.md
@@ -1,0 +1,105 @@
+# 74. Agent MCP drives code mode over the attach contract
+
+- Status: Proposed
+- Date: 2026-08-26
+- Owners: cli
+- Related: [`0073-agent-mcp-drives-chat-over-attach.md`](0073-agent-mcp-drives-chat-over-attach.md),
+  [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
+  [`0069-durable-code-session-queue.md`](0069-durable-code-session-queue.md),
+  [`docs-site/content/docs/headless.mdx`](../../docs-site/content/docs/headless.mdx)
+- Supersedes: none
+
+## Context
+
+`tidebreak agent-mcp` already drives chat over the attach contract: a
+`ToolRegistry` of schema-discoverable tools, `AutoApproveGate` so possession of
+the bearer is the authorization boundary, and one return shape for run-turn /
+wait / decide (`completed`, `needs_approval`, `running`, …). Code mode has the
+same attach surface — repos, workspaces, sessions, a durable turn queue,
+foreign harness approvals, diffs, and git/PR verbs — but an external agent
+that wants to drive it still has to reverse-engineer `/code/*`.
+
+The chat decision (record 73) already
+said later surfaces add a file and one registration call. This is that call.
+
+## Decision
+
+**1. Code mode is driven through the same `tidebreak agent-mcp` process.**
+A `code.rs` module registers snake_case tools with hand-authored JSON schemas
+(`additionalProperties: false`). Reads are `ReadOnly`; mutations are
+`Sensitive`. The MCP gate still auto-approves *calling our tools*. It does not
+auto-approve the driven session's harness approvals.
+
+**2. The chat return contract extends with `queued`.**
+`code_run_turn`, `code_wait`, and `code_decide` return the chat shape
+`{status, assistant_text, pending?, events_cursor}` with one added status:
+`queued`. `POST /code/sessions/{id}/turns` waits for the worker to finish or
+to park the message (decision 69). A `SubmitTurnResponse::Queued` receipt
+returns immediately with the queue position and the turn id the promoted turn
+will run under. The caller re-checks with `code_wait`. `running` still means
+the follow timeout elapsed while the turn continues server-side.
+
+`code_run_turn` subscribes the session event socket *before* submitting, so a
+live approval cannot hide behind the long POST. Reconnect climbs the shared
+event-stream ladder and resumes from the cursor; a socket that cannot be
+reopened is reconciled through `list_session_turns` (and the durable queue
+when the turn has not been promoted yet).
+
+**3. Harness approvals are interaction points. They are never auto-approved.**
+A turn that parks on `approval_requested` returns `needs_approval` with the
+approval id. `code_decide` is the only path that settles it. This is the same
+stance as chat: the MCP bearer authorizes driving Tidebreak, not bypassing the
+engine's permission system (decision 33).
+
+**4. Git and pull-request actions are plain Sensitive tools.**
+`code_git_commit`, `code_git_push`, and `code_git_pr` are not approval-gated
+beyond the MCP `Sensitive` class. The bearer already authorizes the workspace
+the same way `tidebreak code git …` does. Putting a second consent card on
+those verbs would invent a gate the interactive CLI does not have.
+
+Deliberately skipped: `run_action` (named quick actions) and `reap_session`.
+They do not fall out of the session → turn → decide → diff/git loop.
+
+## Alternatives Considered
+
+**Document the `/code/*` routes and let harnesses call them.** Same rejection
+as chat: there is no OpenAPI document, subscribe-before-post and the durable
+queue are easy to get wrong, and every harness would reimplement them.
+
+**Auto-approve harness approvals from the MCP gate.** That would make
+`agent-mcp` a permission bypass for foreign engines, which decision 33
+forbids.
+
+**Park git/PR behind `code_decide`.** Those verbs are operator actions on a
+workspace the bearer already holds, not harness-requested tool calls. The
+interactive CLI runs them without an approval card.
+
+**Block on a queued submit until it runs.** That would hide queue position
+from the caller and make a second `code_run_turn` look like a hang. Returning
+`queued` and following with `code_wait` keeps the chat contract's "timeout
+means `running`, not `failed`" honesty.
+
+## Consequences
+
+An MCP-speaking harness can drive a code session end to end: register a repo,
+open a workspace, run turns, answer approvals, inspect the diff, and commit or
+open a PR. Callers must handle `queued` in addition to the chat statuses; a
+harness that only reads `completed` will stall on the first follow-up sent
+mid-turn.
+
+Revisit if git/PR should require an extra confirmation even from a bearer that
+already owns the workspace, or if `run_action` / `reap_session` become part of
+the headless loop.
+
+## Validation
+
+`crates/tidebreak-cli/tests/agent_mcp_code.rs` speaks MCP over the real binary
+against `tidebreak serve` with the feature-gated scripted harness: repo →
+workspace → session → `code_run_turn` completes with assistant text; a
+scripted approval returns `needs_approval` and `code_decide` settles it; a
+submit while a turn runs returns `queued` and `code_wait` drains both; after a
+scripted worktree edit, `code_diff` and `code_git_status` return sane shapes.
+The registry unit test compiles every advertised input schema, including the
+new code tools. A plausible wrong implementation — auto-approving the parked
+write, treating a queued submit as `failed`, or diffing before the edit lands
+— fails those tests.


### PR DESCRIPTION
You extend `tidebreak agent-mcp` with code-mode tools so an external agent can drive Tidebreak code sessions end to end: repos, workspaces, sessions, turns, approvals, diffs, and git/PR actions.

The tools are snake_case with hand-authored JSON schemas (`additionalProperties: false`). Reads are ReadOnly; mutations are Sensitive. Possession of the bearer authorizes calling them.

Tool list:
- `code_harnesses` - harness doctor report
- `code_repo_add` / `code_repos` - register and list repos
- `code_workspace_create` / `code_workspaces` / `code_workspace_archive`
- `code_session_create` / `code_sessions` / `code_session_set_permission_mode`
- `code_run_turn` - subscribe to session events, then submit; follow until the turn settles, parks, queues, or times out
- `code_wait` - re-follow an in-flight or queued turn
- `code_approvals` / `code_decide` - list parked approvals; decide, then follow
- `code_interrupt`
- `code_turns` - history plus the durable session queue
- `code_diff` / `code_files`
- `code_git_status` / `code_git_commit` / `code_git_push` / `code_git_pr`

`code_run_turn`, `code_wait`, and `code_decide` return the chat contract `{status, assistant_text, pending?, events_cursor}`. You get one extra status: `queued`. `POST /code/sessions/{id}/turns` waits for the worker to finish or to park the message. A queued receipt returns immediately with the queue position and the turn id the promoted turn will run under. You re-check with `code_wait`; one wait drains the running turn and then the follow-up. `running` still means the follow timeout elapsed while the turn continues server-side.

Harness approvals never auto-approve. A parked turn returns `needs_approval`; you settle it with `code_decide`. Git and PR actions are plain Sensitive tools rather than approval-gated: the bearer already authorizes the workspace.

You skip `run_action` and `reap_session`. They do not fall out of the session -> turn -> decide -> diff/git loop. `code_git_pr` accepts `draft` on the tool schema; the git_pr route has no draft field, so you do not send it.

You test this with `crates/tidebreak-cli/tests/agent_mcp_code.rs` against `tidebreak serve` and the feature-gated scripted harness: (a) repo -> workspace -> session -> `code_run_turn` to completion; (b) a scripted approval returns `needs_approval` and `code_decide` approve settles; (c) a submit while a turn runs returns `queued`, then `code_wait` drains both; (d) after a scripted worktree edit, `code_diff` and `code_git_status` return sane shapes. The registry unit test compiles every advertised input schema, including the new code tools.

CI recovery: Re-ran after the GitHub Actions outage on August 26, 2026.

<!-- gha-outage-retry: 2026-08-26 -->