### PR TITLE
fix(code): serialize session setting updates

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -11,6 +11,7 @@ import {
   ChevronDown,
   Gauge,
   List,
+  LoaderCircle,
   Search,
   Sparkles,
   Zap,
@@ -106,12 +107,16 @@ function appendRecoveredDraft(current: string, recovered: string): string {
 export function PermissionModePicker({
   value,
   availableModes = MODES,
+  disabled,
+  pending,
   onChange,
   scopeKey = "code-create",
 }: {
   value: PermissionMode;
   availableModes?: readonly PermissionMode[];
   unavailableReason?: string;
+  disabled?: boolean;
+  pending?: boolean;
   onChange?: (mode: PermissionMode) => void;
   scopeKey?: string;
 }) {
@@ -120,7 +125,7 @@ export function PermissionModePicker({
     <PermissionModeMenu
       scopeKey={scopeKey}
       value={value}
-      disabled={locked}
+      disabled={locked || disabled || pending}
       availableModes={availableModes}
       onChange={async (mode: PermissionMode) => {
         if (!availableModes.includes(mode)) {
@@ -130,6 +135,15 @@ export function PermissionModePicker({
       }}
     />
   );
+  if (pending) {
+    return (
+      <WithTooltip label="Saving session settings">
+        <span className="inline-flex" aria-busy="true">
+          {menu}
+        </span>
+      </WithTooltip>
+    );
+  }
   if (!locked) return menu;
   // Disabled buttons drop pointer events, so the tooltip has to sit on a
   // wrapper the reader can still hover and focus.
@@ -512,11 +526,13 @@ export function FastModeToggle({
   available,
   value,
   disabled,
+  pending,
   onChange,
 }: {
   available: boolean;
   value: boolean;
   disabled?: boolean;
+  pending?: boolean;
   onChange: (fastMode: boolean) => void;
 }) {
   if (!available) return null;
@@ -529,16 +545,23 @@ export function FastModeToggle({
       aria-checked={value}
       className={cn("h-8 gap-2 px-2", value && FAST_TRIGGER_CLASS)}
       disabled={disabled}
+      aria-busy={pending}
       aria-label={label}
       title={
-        value
-          ? "Fast mode on: faster output, higher price per token"
-          : "Fast mode off: the engine's usual speed and price"
+        pending
+          ? "Saving session settings"
+          : value
+            ? "Fast mode on: faster output, higher price per token"
+            : "Fast mode off: the engine's usual speed and price"
       }
       data-fast={value ? "on" : undefined}
       onClick={() => onChange(!value)}
     >
-      <Zap className={cn("size-4", !value && "opacity-50")} />
+      {pending ? (
+        <LoaderCircle className="size-4 animate-spin" />
+      ) : (
+        <Zap className={cn("size-4", !value && "opacity-50")} />
+      )}
     </Button>
   );
 }
@@ -547,11 +570,13 @@ export function ReasoningEffortMenu({
   levels,
   value,
   disabled,
+  pending,
   onChange,
 }: {
   levels: readonly ReasoningEffort[];
   value: ReasoningEffort | null;
   disabled?: boolean;
+  pending?: boolean;
   onChange: (effort: ReasoningEffort | null) => void;
 }) {
   const options = reasoningEffortOptions(levels);
@@ -573,11 +598,14 @@ export function ReasoningEffortMenu({
             topSelected && ULTRA_TRIGGER_CLASS,
           )}
           disabled={disabled}
+          aria-busy={pending}
           aria-label={`Reasoning: ${label}`}
-          title={`Reasoning: ${label}`}
+          title={pending ? "Saving session settings" : `Reasoning: ${label}`}
           data-ultra={topSelected ? "on" : undefined}
         >
-          {topSelected ? (
+          {pending ? (
+            <LoaderCircle className="size-4 animate-spin" />
+          ) : topSelected ? (
             <Sparkles className="size-4" />
           ) : (
             <Gauge className="size-4" />
@@ -641,6 +669,7 @@ export function CodeComposer({
   reasoningEffort = null,
   engineEfforts = [],
   fastMode = false,
+  settingsPending = false,
   onModelChange,
   onModeChange,
   onEffortChange,
@@ -677,6 +706,8 @@ export function CodeComposer({
   reasoningEffort?: ReasoningEffort | null;
   /** Whether the session is armed for fast mode. */
   fastMode?: boolean;
+  /** Whether a permission, reasoning, or fast-mode write is active. */
+  settingsPending?: boolean;
   /**
    * The engine's own ladder, used for a model row that states none of its
    * own — a gateway catalog row, or a model the engine no longer lists.
@@ -1080,6 +1111,7 @@ export function CodeComposer({
             <FastModeToggle
               available={fastModeAvailable}
               value={selectedFastMode}
+              pending={settingsPending}
               onChange={(next) => {
                 setSelectedFastMode(next);
                 onFastModeChange(next);
@@ -1092,6 +1124,7 @@ export function CodeComposer({
             <ReasoningEffortMenu
               levels={effortLevels}
               value={selectedEffort}
+              pending={settingsPending}
               onChange={(next) => {
                 setSelectedEffort(next);
                 onEffortChange(next);
@@ -1103,6 +1136,7 @@ export function CodeComposer({
           <PermissionModePicker
             value={permissionMode}
             availableModes={availableModes}
+            pending={settingsPending}
             onChange={onModeChange}
             scopeKey={sessionId ?? "code-create"}
           />

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -313,6 +313,21 @@ function makeClient() {
       title: body.title,
     })),
     setCodeAttention: vi.fn(async () => SESSION),
+    setCodeSessionPermissionMode: vi.fn(
+      async (
+        _sessionId: string,
+        permissionMode: "plan" | "ask" | "auto" | "allow",
+      ) => ({
+        ...SESSION,
+        permission_mode: permissionMode,
+      }),
+    ),
+    setCodeSessionFastMode: vi.fn(
+      async (_sessionId: string, fastMode: boolean) => ({
+        ...SESSION,
+        fast_mode: fastMode,
+      }),
+    ),
     runCodeWorkspaceAction: vi.fn(async () => ({
       name: "lint",
       success: false,
@@ -987,6 +1002,143 @@ describe("CodeWorkspacePage", () => {
       ),
     );
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("serializes session settings without letting an older response erase a newer choice", async () => {
+    const client = makeClient();
+    const permissionWrite = deferred<CodeSessionSnapshot>();
+    const fastModeWrite = deferred<CodeSessionSnapshot>();
+    const configurableSession: CodeSessionSnapshot = {
+      ...SESSION,
+      harness_kind: "codex",
+      model: "gpt-5.4",
+    };
+    client.listCodeWorkspaceSessions.mockResolvedValue([configurableSession]);
+    client.listCodeHarnessModels.mockResolvedValue({
+      kind: "codex",
+      models: [
+        {
+          id: "gpt-5.4",
+          label: "GPT-5.4",
+          reasoning_efforts: ["low", "high"],
+          fast_mode: true,
+        },
+      ],
+      reasoning_efforts: ["low", "high"],
+    } as never);
+    client.setCodeSessionPermissionMode.mockReturnValue(
+      permissionWrite.promise,
+    );
+    client.setCodeSessionFastMode.mockReturnValue(fastModeWrite.promise);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    const permission = await screen.findByRole("button", {
+      name: "Permissions: Ask",
+    });
+    const fastMode = await screen.findByRole("switch", {
+      name: "Fast mode off",
+    });
+    await user.click(permission);
+    const auto = await screen.findByRole("menuitem", { name: /Auto/ });
+
+    await user.click(auto);
+    await user.click(fastMode);
+
+    await waitFor(() =>
+      expect(client.setCodeSessionPermissionMode).toHaveBeenCalledWith(
+        SESSION.id,
+        "auto",
+      ),
+    );
+    expect(client.setCodeSessionFastMode).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Permissions: Auto" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("switch", { name: "Fast mode on" }),
+    ).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.getByRole("button", { name: "Reasoning: Default" }),
+    ).toHaveAttribute("aria-busy", "true");
+
+    permissionWrite.resolve({
+      ...configurableSession,
+      permission_mode: "auto",
+      fast_mode: false,
+    });
+
+    await waitFor(() =>
+      expect(client.setCodeSessionFastMode).toHaveBeenCalledWith(
+        SESSION.id,
+        true,
+      ),
+    );
+    expect(
+      screen.getByRole("switch", { name: "Fast mode on" }),
+    ).toHaveAttribute("aria-checked", "true");
+
+    fastModeWrite.resolve({
+      ...configurableSession,
+      permission_mode: "auto",
+      fast_mode: true,
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Permissions: Auto" }),
+      ).toBeEnabled(),
+    );
+    expect(screen.getByRole("switch", { name: "Fast mode on" })).toBeEnabled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("rolls back only the failed session setting and clears the shared pending state", async () => {
+    const client = makeClient();
+    const fastModeWrite = deferred<CodeSessionSnapshot>();
+    const configurableSession: CodeSessionSnapshot = {
+      ...SESSION,
+      harness_kind: "codex",
+      model: "gpt-5.4",
+    };
+    client.listCodeWorkspaceSessions.mockResolvedValue([configurableSession]);
+    client.listCodeHarnessModels.mockResolvedValue({
+      kind: "codex",
+      models: [
+        {
+          id: "gpt-5.4",
+          label: "GPT-5.4",
+          reasoning_efforts: ["low", "high"],
+          fast_mode: true,
+        },
+      ],
+      reasoning_efforts: ["low", "high"],
+    } as never);
+    client.setCodeSessionFastMode.mockReturnValue(fastModeWrite.promise);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    await user.click(
+      await screen.findByRole("switch", { name: "Fast mode off" }),
+    );
+    expect(
+      screen.getByRole("switch", { name: "Fast mode on" }),
+    ).toHaveAttribute("aria-busy", "true");
+
+    fastModeWrite.reject(new Error("fast mode is unavailable"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Fast mode off" }),
+      ).toBeEnabled(),
+    );
+    expect(
+      screen.getByRole("button", { name: "Permissions: Ask" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Reasoning: Default" }),
+    ).toBeEnabled();
+    expect(toast.error).toHaveBeenCalledWith("fast mode is unavailable");
   });
 
   it("keeps the Codex session model selectable before its catalog loads", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1975,38 +1975,114 @@ function CodeSessionPane({
   // channel rather than the journal, so the transcript reads it from here
   // instead of from an item the reducer built.
   const sessionDigest = useSessionDigest(workspaceId, session.id);
-  // The row the server last answered with, so the pickers follow a switch the
-  // route made rather than the list this page loaded the workspace with.
-  const [settings, setSettings] = useState({
+  type SessionSettings = {
+    permissionMode: PermissionMode;
+    reasoningEffort: ReasoningEffort | null;
+    fastMode: boolean;
+  };
+  const settingsFromSession = useCallback(
+    (snapshot: CodeSessionSnapshot): SessionSettings => ({
+      permissionMode: snapshot.permission_mode,
+      reasoningEffort: snapshot.reasoning_effort ?? null,
+      fastMode: snapshot.fast_mode,
+    }),
+    [],
+  );
+  const initialSettings: SessionSettings = {
     permissionMode: session.permission_mode,
     reasoningEffort: session.reasoning_effort ?? null,
     fastMode: session.fast_mode,
-  });
+  };
+  // One confirmed baseline plus ordered optimistic patches keeps a full
+  // response from an older write from erasing a choice that is still queued.
+  const [settings, setSettings] = useState(initialSettings);
+  const settingsRef = useRef(initialSettings);
+  const confirmedSettingsRef = useRef(initialSettings);
+  const pendingSettingsWritesRef = useRef(
+    new Map<number, Partial<SessionSettings>>(),
+  );
+  const settingsWriteQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const settingsWriteGenerationRef = useRef(0);
+  const settingsScopeRef = useRef(session.id);
+  const [settingsPending, setSettingsPending] = useState(false);
   const pendingReasoningEffortRef = useRef<{
     value: ReasoningEffort | null;
   } | null>(null);
+  const reconcileSettings = useCallback(() => {
+    let next = { ...confirmedSettingsRef.current };
+    for (const patch of pendingSettingsWritesRef.current.values()) {
+      next = { ...next, ...patch };
+    }
+    const pendingReasoningEffort = pendingReasoningEffortRef.current;
+    if (pendingReasoningEffort) {
+      next.reasoningEffort = pendingReasoningEffort.value;
+    }
+    settingsRef.current = next;
+    setSettings(next);
+  }, []);
+
+  function queueSettingsWrite(
+    patch: Partial<SessionSettings>,
+    write: () => Promise<CodeSessionSnapshot>,
+    failureMessage: string,
+  ) {
+    const scope = session.id;
+    const generation = ++settingsWriteGenerationRef.current;
+    pendingSettingsWritesRef.current.set(generation, patch);
+    reconcileSettings();
+    setSettingsPending(true);
+
+    const result = settingsWriteQueueRef.current.then(() => {
+      if (settingsScopeRef.current !== scope) return null;
+      return write();
+    });
+    settingsWriteQueueRef.current = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    void result.then(
+      (updated) => {
+        if (!updated || settingsScopeRef.current !== scope) return;
+        confirmedSettingsRef.current = settingsFromSession(updated);
+        pendingSettingsWritesRef.current.delete(generation);
+        reconcileSettings();
+        setSettingsPending(pendingSettingsWritesRef.current.size > 0);
+      },
+      (err) => {
+        if (settingsScopeRef.current !== scope) return;
+        pendingSettingsWritesRef.current.delete(generation);
+        reconcileSettings();
+        setSettingsPending(pendingSettingsWritesRef.current.size > 0);
+        toast.error(friendlyErrorMessage(err, failureMessage));
+      },
+    );
+  }
 
   useEffect(() => {
     setModel(session.model ?? inferred);
   }, [inferred, session.model]);
 
   useEffect(() => {
+    if (settingsScopeRef.current !== session.id) {
+      settingsScopeRef.current = session.id;
+      settingsWriteGenerationRef.current += 1;
+      pendingSettingsWritesRef.current.clear();
+      settingsWriteQueueRef.current = Promise.resolve();
+      pendingReasoningEffortRef.current = null;
+      setSettingsPending(false);
+    }
     // A refreshed row can still carry the stored effort while a mid-turn
-    // choice waits for its first submission. Keep that choice until an
-    // accepted submission clears it; changing sessions remounts this pane.
-    const pendingReasoningEffort = pendingReasoningEffortRef.current;
-    setSettings({
-      permissionMode: session.permission_mode,
-      reasoningEffort: pendingReasoningEffort
-        ? pendingReasoningEffort.value
-        : (session.reasoning_effort ?? null),
-      fastMode: session.fast_mode,
-    });
+    // choice waits for its first submission. Reconciliation keeps that choice
+    // and any queued writes on top of the confirmed row.
+    confirmedSettingsRef.current = settingsFromSession(session);
+    reconcileSettings();
   }, [
+    reconcileSettings,
     session.id,
     session.permission_mode,
     session.reasoning_effort,
     session.fast_mode,
+    settingsFromSession,
   ]);
 
   useEffect(() => {
@@ -2154,71 +2230,37 @@ function CodeSessionPane({
     });
   }
 
-  async function changePermissionMode(mode: PermissionMode) {
-    const previous = settings.permissionMode;
-    setSettings((current) => ({ ...current, permissionMode: mode }));
-    try {
-      const updated = await client.setCodeSessionPermissionMode(
-        session.id,
-        mode,
-      );
-      const pendingReasoningEffort = pendingReasoningEffortRef.current;
-      setSettings({
-        permissionMode: updated.permission_mode,
-        reasoningEffort: pendingReasoningEffort
-          ? pendingReasoningEffort.value
-          : (updated.reasoning_effort ?? null),
-        fastMode: updated.fast_mode,
-      });
-    } catch (err) {
-      setSettings((current) => ({ ...current, permissionMode: previous }));
-      toast.error(friendlyErrorMessage(err, "Could not change the mode"));
-    }
+  function changePermissionMode(mode: PermissionMode) {
+    queueSettingsWrite(
+      { permissionMode: mode },
+      () => client.setCodeSessionPermissionMode(session.id, mode),
+      "Could not change the mode",
+    );
   }
 
-  async function changeReasoningEffort(effort: ReasoningEffort | null) {
-    const previous = settings.reasoningEffort;
-    setSettings((current) => ({ ...current, reasoningEffort: effort }));
+  function changeReasoningEffort(effort: ReasoningEffort | null) {
     // A running turn keeps the effort it started with. The selected level
     // rides on the next submission, where the server also makes it sticky.
     if (turnRunning) {
       pendingReasoningEffortRef.current = { value: effort };
+      settingsRef.current = { ...settingsRef.current, reasoningEffort: effort };
+      setSettings(settingsRef.current);
       return;
     }
     pendingReasoningEffortRef.current = null;
-    try {
-      const updated = await client.setCodeSessionReasoningEffort(
-        session.id,
-        effort,
-      );
-      setSettings({
-        permissionMode: updated.permission_mode,
-        reasoningEffort: updated.reasoning_effort ?? null,
-        fastMode: updated.fast_mode,
-      });
-    } catch (err) {
-      setSettings((current) => ({ ...current, reasoningEffort: previous }));
-      toast.error(friendlyErrorMessage(err, "Could not change the reasoning"));
-    }
+    queueSettingsWrite(
+      { reasoningEffort: effort },
+      () => client.setCodeSessionReasoningEffort(session.id, effort),
+      "Could not change the reasoning",
+    );
   }
 
-  async function changeFastMode(fastMode: boolean) {
-    const previous = settings.fastMode;
-    setSettings((current) => ({ ...current, fastMode }));
-    try {
-      const updated = await client.setCodeSessionFastMode(session.id, fastMode);
-      const pendingReasoningEffort = pendingReasoningEffortRef.current;
-      setSettings({
-        permissionMode: updated.permission_mode,
-        reasoningEffort: pendingReasoningEffort
-          ? pendingReasoningEffort.value
-          : (updated.reasoning_effort ?? null),
-        fastMode: updated.fast_mode,
-      });
-    } catch (err) {
-      setSettings((current) => ({ ...current, fastMode: previous }));
-      toast.error(friendlyErrorMessage(err, "Could not change fast mode"));
-    }
+  function changeFastMode(fastMode: boolean) {
+    queueSettingsWrite(
+      { fastMode },
+      () => client.setCodeSessionFastMode(session.id, fastMode),
+      "Could not change fast mode",
+    );
   }
 
   async function steer(message: string) {
@@ -2311,6 +2353,7 @@ function CodeSessionPane({
             availableModes={availableModes}
             reasoningEffort={settings.reasoningEffort}
             fastMode={settings.fastMode}
+            settingsPending={settingsPending}
             engineEfforts={engineEfforts}
             harness={session.harness_kind}
             model={model ?? undefined}

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -64,6 +64,7 @@ type WorkspaceScenario =
   | "session-create-failure"
   | "first-turn-failure"
   | "fork-first-turn-failure"
+  | "settings-pending"
   | "loading"
   | "failure"
   | SubagentScenario;
@@ -603,12 +604,24 @@ function storyClient(scenario: WorkspaceScenario): ApiClient {
     listCodeRepos: async () => [repo],
     listCodeWorkspaces: async () => [workspace, ...otherWorkspaces],
     getHarnessDoctor: async () => harnessDoctor,
-    listCodeHarnessModels: async (
-      kind: CodeSessionSnapshot["harness_kind"],
-    ) => ({
-      kind,
-      models: [],
-    }),
+    listCodeHarnessModels: async (kind: CodeSessionSnapshot["harness_kind"]) =>
+      scenario === "settings-pending"
+        ? {
+            kind,
+            models: [
+              {
+                id: "claude-opus-5",
+                label: "Claude Opus 5",
+                reasoning_efforts: ["low", "medium", "high"],
+                fast_mode: true,
+              },
+            ],
+            reasoning_efforts: ["low", "medium", "high"],
+          }
+        : {
+            kind,
+            models: [],
+          },
     openCodeUpdates: (onNotice: (notice: unknown) => void) =>
       socketAfterOpen(() =>
         onNotice({ type: "snapshot", sessions: updateDigests(scenario) }),
@@ -691,6 +704,26 @@ function storyClient(scenario: WorkspaceScenario): ApiClient {
     },
     decideCodeApproval: async () => ({}) as never,
     setCodeAttention: async () => session,
+    setCodeSessionPermissionMode: async (
+      _sessionId: string,
+      permissionMode: CodeSessionSnapshot["permission_mode"],
+    ) => ({ ...session, permission_mode: permissionMode }),
+    setCodeSessionReasoningEffort: async (
+      _sessionId: string,
+      reasoningEffort: CodeSessionSnapshot["reasoning_effort"] | null,
+    ) =>
+      scenario === "settings-pending"
+        ? pending<CodeSessionSnapshot>()
+        : {
+            ...session,
+            ...(reasoningEffort === null
+              ? { reasoning_effort: undefined }
+              : { reasoning_effort: reasoningEffort }),
+          },
+    setCodeSessionFastMode: async (_sessionId: string, fastMode: boolean) =>
+      scenario === "settings-pending"
+        ? pending<CodeSessionSnapshot>()
+        : { ...session, fast_mode: fastMode },
     reapCodeSession: async () => session,
     steerCodeSession: async () => undefined,
     interruptCodeSession: async () => undefined,
@@ -965,6 +998,26 @@ type Story = StoryObj<typeof meta>;
 
 /** The default: one stable conversation, with workflow state always in reach. */
 export const ConversationAlone: Story = {};
+
+/** One setting write marks the full related control cluster until it settles. */
+export const SettingsPending: Story = {
+  args: { scenario: "settings-pending", reviewOpen: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("switch", { name: "Fast mode off" }),
+    );
+    await expect(
+      await canvas.findByRole("switch", { name: "Fast mode on" }),
+    ).toHaveAttribute("aria-busy", "true");
+    await expect(
+      canvas.getByRole("button", { name: "Reasoning: Default" }),
+    ).toHaveAttribute("aria-busy", "true");
+    await expect(
+      canvas.getByRole("button", { name: "Permissions: Ask" }),
+    ).toBeDisabled();
+  },
+};
 
 /** Review is an optional working pane, not a replacement for the conversation. */
 export const ConversationWithReview: Story = {


### PR DESCRIPTION
## What changed

- Serialize permission, reasoning, and fast-mode session writes through one shared queue.
- Keep a confirmed settings snapshot plus ordered optimistic patches so an older full response cannot overwrite a newer choice.
- Remove only the failed patch, then reconcile the remaining choices against the last confirmed settings.
- Show the shared pending state across the related controls.
- Add DOM coverage for ordered responses and failed-write recovery.
- Add a Storybook pending-state example for the workspace settings controls.

## Compatibility

This change keeps the existing API client and server contracts. It changes only desktop UI coordination and presentation.

## Safety and risk

The queue sends one settings write at a time. Optimistic state remains responsive for follow-up reasoning and fast-mode choices, while the permission control stays disabled during a write. A failed write rolls back its own change without erasing later queued choices.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeWorkspacePage.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/code/CodeComposer.tsx src/code/CodeWorkspacePage.tsx src/code/CodeWorkspacePage.dom.test.tsx src/stories/CodeWorkspacePage.stories.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- Storybook screenshots inspected in light, dark, high-contrast light, and high-contrast dark at desktop and compact widths
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2692