### PR TITLE
fix(code): make archive deletion race-safe

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -261,6 +261,8 @@ pub enum CodeWorkspaceStatus {
     SetupFailed,
     /// Ready for sessions.
     Active,
+    /// Archive owns the checkout and rejects every new writer.
+    Archiving,
     /// Archived; worktree removed, branch kept.
     Archived,
     /// Released; worktree and branch both gone, commits kept as a bundle.
@@ -280,6 +282,7 @@ impl CodeWorkspaceStatus {
             Self::Creating => "creating",
             Self::SetupFailed => "setup_failed",
             Self::Active => "active",
+            Self::Archiving => "archiving",
             Self::Archived => "archived",
             Self::Released => "released",
         }
@@ -293,6 +296,7 @@ impl CodeWorkspaceStatus {
             "creating" => Some(Self::Creating),
             "setup_failed" => Some(Self::SetupFailed),
             "active" => Some(Self::Active),
+            "archiving" => Some(Self::Archiving),
             "archived" => Some(Self::Archived),
             "released" => Some(Self::Released),
             _ => None,

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -55,6 +55,7 @@ impl MigratorTrait for Migrator {
             Box::new(PrePinCodeLifecycleRepair),
             Box::new(CodeApprovalBinding),
             Box::new(CodeSessionProcessIdentity),
+            Box::new(CodeWorkspaceArchiving),
         ]
     }
 }
@@ -65,6 +66,15 @@ struct CodeSessionProcessIdentity;
 impl MigrationName for CodeSessionProcessIdentity {
     fn name(&self) -> &str {
         "m20260826_000017_code_session_process_identity"
+    }
+}
+
+/// Add the transient workspace state that excludes writers during archive.
+struct CodeWorkspaceArchiving;
+
+impl MigrationName for CodeWorkspaceArchiving {
+    fn name(&self) -> &str {
+        "m20260826_000018_code_workspace_archiving"
     }
 }
 
@@ -89,6 +99,109 @@ impl MigrationTrait for CodeSessionProcessIdentity {
 
     async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
         // Removing the identity would make a recorded pid unsafe to reap.
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CodeWorkspaceArchiving {
+    fn use_transaction(&self) -> Option<bool> {
+        // SQLite must disable foreign-key enforcement while it rebuilds the
+        // table to widen the CHECK constraint. PRAGMA foreign_keys is ignored
+        // inside a transaction.
+        None
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DbBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"
+DO $repair$
+DECLARE
+    old_constraint text;
+BEGIN
+    FOR old_constraint IN
+        SELECT constraint_row.conname
+        FROM pg_constraint AS constraint_row
+        JOIN pg_attribute AS attribute_row
+          ON attribute_row.attrelid = constraint_row.conrelid
+         AND attribute_row.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'code_workspace'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute_row.attname = 'status'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE "code_workspace" DROP CONSTRAINT %I',
+            old_constraint
+        );
+    END LOOP;
+END
+$repair$;
+ALTER TABLE "code_workspace"
+    ADD CONSTRAINT "code_workspace_status_check"
+    CHECK ("status" IN (
+        'creating', 'setup_failed', 'active', 'archiving', 'archived', 'released'
+    ));
+"#,
+                )
+                .await
+                .map(|_| ()),
+            DbBackend::Sqlite => manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"
+PRAGMA foreign_keys = OFF;
+CREATE TABLE "code_workspace_archiving" (
+    "id" text NOT NULL PRIMARY KEY,
+    "owner" text NOT NULL DEFAULT 'local',
+    "repo_id" text NOT NULL,
+    "title" text NOT NULL,
+    "worktree_path" text NOT NULL UNIQUE,
+    "branch_name" text NOT NULL,
+    "base_ref" text NOT NULL,
+    "status" text NOT NULL CHECK ("status" IN (
+        'creating', 'setup_failed', 'active', 'archiving', 'archived', 'released'
+    )),
+    "pr" text,
+    "created_at" text NOT NULL,
+    "archived_at" text,
+    "released_at" text,
+    "released_tip" text,
+    "bundle_bytes" integer,
+    FOREIGN KEY ("repo_id") REFERENCES "code_repo" ("id")
+);
+INSERT INTO "code_workspace_archiving" (
+    "id", "owner", "repo_id", "title", "worktree_path", "branch_name",
+    "base_ref", "status", "pr", "created_at", "archived_at",
+    "released_at", "released_tip", "bundle_bytes"
+)
+SELECT
+    "id", "owner", "repo_id", "title", "worktree_path", "branch_name",
+    "base_ref", "status", "pr", "created_at", "archived_at",
+    "released_at", "released_tip", "bundle_bytes"
+FROM "code_workspace";
+DROP TABLE "code_workspace";
+ALTER TABLE "code_workspace_archiving" RENAME TO "code_workspace";
+CREATE UNIQUE INDEX "idx_code_workspace_repo_branch"
+    ON "code_workspace" ("repo_id", "branch_name");
+CREATE INDEX "idx_code_workspace_owner_created"
+    ON "code_workspace" ("owner", "created_at");
+PRAGMA foreign_keys = ON;
+"#,
+                )
+                .await
+                .map(|_| ()),
+            backend => Err(DbErr::Custom(format!(
+                "unsupported database backend for workspace archiving migration: {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // An interrupted archive can persist this value. Removing it would
+        // make that row unreadable instead of recoverable.
         Ok(())
     }
 }
@@ -2076,6 +2189,7 @@ mod tests {
                 "m20260825_000015_pre_pin_code_lifecycle_repair",
                 "m20260825_000016_code_approval_binding",
                 "m20260826_000017_code_session_process_identity",
+                "m20260826_000018_code_workspace_archiving",
             ]
         );
         assert!(db

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -2240,9 +2240,11 @@ impl MigrationTrait for CodeQueuedTurns {
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
-    use sea_orm_migration::prelude::{PostgresQueryBuilder, SqliteQueryBuilder};
+    use sea_orm_migration::prelude::{PostgresQueryBuilder, SchemaManager, SqliteQueryBuilder};
     use sea_orm_migration::MigratorTrait;
 
+    #[cfg(feature = "sqlite")]
+    use super::rebuild_sqlite_code_workspace_for_archiving_inner;
     use super::Migrator;
 
     /// Every `CREATE TABLE` a fresh database runs comes from `sqlite_master`,

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -187,7 +187,7 @@ async fn rebuild_sqlite_code_workspace_for_archiving_inner(
     manager: &SchemaManager<'_>,
     _fail_after_drop_for_test: bool,
 ) -> Result<(), DbErr> {
-    use sea_orm::sqlx::{Acquire as _, Executor as _};
+    use sea_orm::sqlx::Acquire as _;
     use sea_orm::DatabaseExecutor;
 
     let DatabaseExecutor::Connection(database) = manager.get_connection() else {

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -106,18 +106,21 @@ impl MigrationTrait for CodeSessionProcessIdentity {
 #[async_trait::async_trait]
 impl MigrationTrait for CodeWorkspaceArchiving {
     fn use_transaction(&self) -> Option<bool> {
-        // SQLite must disable foreign-key enforcement while it rebuilds the
-        // table to widen the CHECK constraint. PRAGMA foreign_keys is ignored
-        // inside a transaction.
+        // SQLite needs a connection-bound transaction that starts only after
+        // foreign-key enforcement is disabled on that exact connection. The
+        // SQLite branch owns that transaction manually. PostgreSQL executes
+        // its ALTER statements atomically on its own.
         None
     }
 
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         match manager.get_database_backend() {
-            DbBackend::Postgres => manager
-                .get_connection()
-                .execute_unprepared(
-                    r#"
+            DbBackend::Postgres => {
+                let transaction = manager.begin().await?;
+                transaction
+                    .get_connection()
+                    .execute_unprepared(
+                        r#"
 DO $repair$
 DECLARE
     old_constraint text;
@@ -145,14 +148,71 @@ ALTER TABLE "code_workspace"
         'creating', 'setup_failed', 'active', 'archiving', 'archived', 'released'
     ));
 "#,
-                )
-                .await
-                .map(|_| ()),
-            DbBackend::Sqlite => manager
-                .get_connection()
-                .execute_unprepared(
-                    r#"
-PRAGMA foreign_keys = OFF;
+                    )
+                    .await?;
+                transaction.commit().await
+            }
+            DbBackend::Sqlite => rebuild_sqlite_code_workspace_for_archiving(manager).await,
+            backend => Err(DbErr::Custom(format!(
+                "unsupported database backend for workspace archiving migration: {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // An interrupted archive can persist this value. Removing it would
+        // make that row unreadable instead of recoverable.
+        Ok(())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+async fn rebuild_sqlite_code_workspace_for_archiving(
+    manager: &SchemaManager<'_>,
+) -> Result<(), DbErr> {
+    rebuild_sqlite_code_workspace_for_archiving_inner(manager, false).await
+}
+
+#[cfg(not(feature = "sqlite"))]
+async fn rebuild_sqlite_code_workspace_for_archiving(
+    _manager: &SchemaManager<'_>,
+) -> Result<(), DbErr> {
+    Err(DbErr::Custom(
+        "SQLite workspace migration support is not compiled".to_owned(),
+    ))
+}
+
+#[cfg(feature = "sqlite")]
+async fn rebuild_sqlite_code_workspace_for_archiving_inner(
+    manager: &SchemaManager<'_>,
+    _fail_after_drop_for_test: bool,
+) -> Result<(), DbErr> {
+    use sea_orm::sqlx::{Acquire as _, Executor as _};
+    use sea_orm::DatabaseExecutor;
+
+    let DatabaseExecutor::Connection(database) = manager.get_connection() else {
+        return Err(DbErr::Custom(
+            "SQLite workspace rebuild requires the migration connection".to_owned(),
+        ));
+    };
+    let mut connection = database
+        .get_sqlite_connection_pool()
+        .acquire()
+        .await
+        .map_err(|error| DbErr::Custom(format!("acquire SQLite migration connection: {error}")))?;
+    sea_orm::sqlx::query("PRAGMA foreign_keys = OFF")
+        .execute(&mut *connection)
+        .await
+        .map_err(|error| DbErr::Custom(format!("disable SQLite foreign keys: {error}")))?;
+
+    let mut transaction = connection
+        .begin()
+        .await
+        .map_err(|error| DbErr::Custom(format!("begin SQLite workspace rebuild: {error}")))?;
+    let rebuild = async {
+        for statement in [
+            r#"DROP TABLE IF EXISTS "code_workspace_archiving""#,
+            r#"
 CREATE TABLE "code_workspace_archiving" (
     "id" text NOT NULL PRIMARY KEY,
     "owner" text NOT NULL DEFAULT 'local',
@@ -171,7 +231,8 @@ CREATE TABLE "code_workspace_archiving" (
     "released_tip" text,
     "bundle_bytes" integer,
     FOREIGN KEY ("repo_id") REFERENCES "code_repo" ("id")
-);
+)"#,
+            r#"
 INSERT INTO "code_workspace_archiving" (
     "id", "owner", "repo_id", "title", "worktree_path", "branch_name",
     "base_ref", "status", "pr", "created_at", "archived_at",
@@ -181,28 +242,79 @@ SELECT
     "id", "owner", "repo_id", "title", "worktree_path", "branch_name",
     "base_ref", "status", "pr", "created_at", "archived_at",
     "released_at", "released_tip", "bundle_bytes"
-FROM "code_workspace";
-DROP TABLE "code_workspace";
-ALTER TABLE "code_workspace_archiving" RENAME TO "code_workspace";
-CREATE UNIQUE INDEX "idx_code_workspace_repo_branch"
-    ON "code_workspace" ("repo_id", "branch_name");
-CREATE INDEX "idx_code_workspace_owner_created"
-    ON "code_workspace" ("owner", "created_at");
-PRAGMA foreign_keys = ON;
-"#,
-                )
-                .await
-                .map(|_| ()),
-            backend => Err(DbErr::Custom(format!(
-                "unsupported database backend for workspace archiving migration: {backend:?}"
-            ))),
+FROM "code_workspace""#,
+            r#"DROP TABLE "code_workspace""#,
+        ] {
+            sea_orm::sqlx::query(statement)
+                .execute(&mut *transaction)
+                .await?;
         }
+        #[cfg(test)]
+        if _fail_after_drop_for_test {
+            sea_orm::sqlx::query("SELECT * FROM missing_workspace_rebuild_table")
+                .execute(&mut *transaction)
+                .await?;
+        }
+        for statement in [
+            r#"ALTER TABLE "code_workspace_archiving" RENAME TO "code_workspace""#,
+            r#"CREATE UNIQUE INDEX "idx_code_workspace_repo_branch"
+                ON "code_workspace" ("repo_id", "branch_name")"#,
+            r#"CREATE INDEX "idx_code_workspace_owner_created"
+                ON "code_workspace" ("owner", "created_at")"#,
+        ] {
+            sea_orm::sqlx::query(statement)
+                .execute(&mut *transaction)
+                .await?;
+        }
+        Ok::<(), sea_orm::sqlx::Error>(())
     }
+    .await;
 
-    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
-        // An interrupted archive can persist this value. Removing it would
-        // make that row unreadable instead of recoverable.
-        Ok(())
+    let rebuild = match rebuild {
+        Ok(()) => transaction
+            .commit()
+            .await
+            .map_err(|error| DbErr::Custom(format!("commit SQLite workspace rebuild: {error}"))),
+        Err(error) => {
+            let rollback = transaction.rollback().await;
+            match rollback {
+                Ok(()) => Err(DbErr::Custom(format!(
+                    "rebuild SQLite workspace table: {error}"
+                ))),
+                Err(rollback) => Err(DbErr::Custom(format!(
+                    "rebuild SQLite workspace table: {error}; rollback failed: {rollback}"
+                ))),
+            }
+        }
+    };
+
+    let enable = match sea_orm::sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(&mut *connection)
+        .await
+    {
+        Ok(_) => {
+            sea_orm::sqlx::query_scalar::<_, i64>("PRAGMA foreign_keys")
+                .fetch_one(&mut *connection)
+                .await
+        }
+        Err(error) => Err(error),
+    }
+    .map_err(|error| DbErr::Custom(format!("restore SQLite foreign keys: {error}")))
+    .and_then(|enabled| {
+        if enabled == 1 {
+            Ok(())
+        } else {
+            Err(DbErr::Custom(
+                "restore SQLite foreign keys: PRAGMA remained disabled".to_owned(),
+            ))
+        }
+    });
+    match (rebuild, enable) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(rebuild), Err(enable)) => {
+            Err(DbErr::Custom(format!("{rebuild}; additionally, {enable}")))
+        }
     }
 }
 
@@ -2200,6 +2312,102 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn a_failed_workspace_rebuild_rolls_back_the_live_sqlite_table() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        Migrator::up(&db, Some(16)).await.unwrap();
+        db.execute_unprepared(
+            "INSERT INTO code_repo (
+                id, owner, root_path, display_name, default_base_ref,
+                branch_prefix, quick_actions, created_at
+             ) VALUES (
+                'repo-archive', 'local', '/tmp/archive', 'archive', 'main',
+                'tidebreak/', '[]', '2026-08-26T00:00:00Z'
+             );
+             INSERT INTO code_workspace (
+                id, owner, repo_id, title, worktree_path, branch_name, base_ref,
+                status, created_at
+             ) VALUES (
+                'workspace-archive', 'local', 'repo-archive', 'archive',
+                '/tmp/archive-worktree', 'tidebreak/archive', 'main', 'active',
+                '2026-08-26T00:00:00Z'
+             );
+             INSERT INTO code_session (
+                id, owner, workspace_id, kind, harness_kind, permission_mode,
+                lifecycle, attention_state, attention_source, created_at
+             ) VALUES (
+                'session-archive', 'local', 'workspace-archive', 'interactive',
+                'claude_code', 'plan', 'idle', '{}', 'lifecycle',
+                '2026-08-26T00:00:00Z'
+             )",
+        )
+        .await
+        .unwrap();
+
+        let manager = SchemaManager::new(&db);
+        let error = rebuild_sqlite_code_workspace_for_archiving_inner(&manager, true)
+            .await
+            .expect_err("the injected statement fails after the live table is dropped");
+        assert!(error
+            .to_string()
+            .contains("missing_workspace_rebuild_table"));
+
+        let workspace = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT status FROM code_workspace WHERE id = 'workspace-archive'".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .expect("the original workspace table and row survive");
+        assert_eq!(workspace.try_get::<String>("", "status").unwrap(), "active");
+        assert!(db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT 1 AS present FROM code_session WHERE id = 'session-archive'".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' \
+                 AND name = 'code_workspace_archiving'"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap()
+            .is_none());
+
+        rebuild_sqlite_code_workspace_for_archiving_inner(&manager, false)
+            .await
+            .unwrap();
+        db.execute_unprepared(
+            "UPDATE code_workspace SET status = 'archiving' WHERE id = 'workspace-archive'",
+        )
+        .await
+        .unwrap();
+        assert!(db
+            .query_all_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "PRAGMA foreign_key_check".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .is_empty());
+        let foreign_keys = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "PRAGMA foreign_keys".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(foreign_keys.try_get::<i64>("", "foreign_keys").unwrap(), 1);
     }
 
     /// A database that stopped at the current baseline and later took the rest

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -115,6 +115,33 @@ pub async fn compare_and_set_workspace_status(
     Ok(result.rows_affected == 1)
 }
 
+/// Finish an archive only while the workspace still owns the transient state.
+pub async fn complete_workspace_archive(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: WorkspaceId,
+    archived_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool> {
+    let result = entities::code_workspace::Entity::update_many()
+        .col_expr(
+            entities::code_workspace::Column::Status,
+            sea_orm::sea_query::Expr::value(CodeWorkspaceStatus::Archived.as_str()),
+        )
+        .col_expr(
+            entities::code_workspace::Column::ArchivedAt,
+            sea_orm::sea_query::Expr::value(archived_at),
+        )
+        .filter(entities::code_workspace::Column::Id.eq(id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
+        .filter(
+            entities::code_workspace::Column::Status.eq(CodeWorkspaceStatus::Archiving.as_str()),
+        )
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 /// Persist mutable workspace fields. `id`, `repo_id`, and `created_at` stay as stored.
 pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Result<bool> {
     let result = entities::code_workspace::Entity::update_many()

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -75,6 +75,46 @@ pub async fn list_workspaces(
         .collect()
 }
 
+/// Every workspace in one lifecycle state, across owners.
+///
+/// Boot recovery uses this only for the transient `Archiving` state. Owner
+/// scoping resumes before any caller-facing operation.
+pub async fn list_workspaces_by_status_all_owners(
+    store: &DbStore,
+    status: CodeWorkspaceStatus,
+) -> Result<Vec<CodeWorkspace>> {
+    entities::code_workspace::Entity::find()
+        .filter(entities::code_workspace::Column::Status.eq(status.as_str()))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(workspace_from_row)
+        .collect()
+}
+
+/// Change one workspace lifecycle only when it still has the expected state.
+pub async fn compare_and_set_workspace_status(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: WorkspaceId,
+    expected: CodeWorkspaceStatus,
+    next: CodeWorkspaceStatus,
+) -> Result<bool> {
+    let result = entities::code_workspace::Entity::update_many()
+        .col_expr(
+            entities::code_workspace::Column::Status,
+            sea_orm::sea_query::Expr::value(next.as_str()),
+        )
+        .filter(entities::code_workspace::Column::Id.eq(id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_workspace::Column::Status.eq(expected.as_str()))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 /// Persist mutable workspace fields. `id`, `repo_id`, and `created_at` stay as stored.
 pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Result<bool> {
     let result = entities::code_workspace::Entity::update_many()

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1996,6 +1996,9 @@ describe("archive force kinds", () => {
       archiveForceKind(new HttpError(409, "both", "uncommitted_and_unpushed")),
     ).toBe("uncommitted_and_unpushed");
     expect(
+      archiveForceKind(new HttpError(409, "ignored", "ignored_content")),
+    ).toBe("ignored_content");
+    expect(
       archiveForceKind(new HttpError(409, "busy", "session_running")),
     ).toBeNull();
   });

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -278,6 +278,7 @@ export const ARCHIVE_FORCE_KINDS = new Set([
   "uncommitted",
   "unpushed",
   "uncommitted_and_unpushed",
+  "ignored_content",
 ]);
 
 /** The 409 kinds that mean archive needs an explicit force. */

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -76,6 +76,7 @@ export const WORKSPACE_STATUS_LABELS: Record<CodeWorkspaceStatus, string> = {
   creating: "Creating",
   setup_failed: "Setup failed",
   active: "Active",
+  archiving: "Archiving",
   archived: "Archived",
   released: "Released",
 };

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -244,6 +244,7 @@ const WORKSPACE_STATUSES = new Set<CodeWorkspaceStatus>([
   "creating",
   "setup_failed",
   "active",
+  "archiving",
   "archived",
   "released",
 ]);

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1796,7 +1796,7 @@ bundle_bytes?: number, };
 /**
  * Status of a persisted workspace.
  */
-export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archived" | "released";
+export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archiving" | "archived" | "released";
 
 /**
  * Bounded path listing for `GET /code/workspaces/{id}/tree`.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -11,12 +11,13 @@ use tokio::sync::oneshot;
 use tokio::time::Instant as TokioInstant;
 
 use tidebreak_core::db::code::{
-    abandon_pending_approval, arm_trigger, claim_approval, delete_trigger, delete_workspace,
-    get_approval, get_open_turn, get_repo, get_repo_by_root_path, get_session, get_workspace,
-    insert_repo, insert_session, insert_workspace, list_approvals, list_events, list_fork_events,
-    list_repos, list_sessions, list_sessions_all_owners, list_sessions_for_workspace,
-    list_triggers_for_repo, list_turns, list_workspaces, mark_repo_removed, queued_turn_head,
-    save_repo, save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
+    abandon_pending_approval, arm_trigger, claim_approval, compare_and_set_workspace_status,
+    delete_trigger, delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path,
+    get_session, get_workspace, insert_repo, insert_session, insert_workspace, list_approvals,
+    list_events, list_fork_events, list_repos, list_sessions, list_sessions_all_owners,
+    list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
+    list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head, save_repo,
+    save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
     ClaimedApprovalSettlement, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
@@ -230,6 +231,8 @@ pub(crate) struct CodeRuntime {
     /// reads the model handles the app state owns and this runtime is built
     /// first. `None` until then, and in deployments that install none.
     recap: Mutex<Option<Arc<dyn super::recap::TurnRecap>>>,
+    #[cfg(test)]
+    archive_shutdown_timeout: AtomicBool,
 }
 
 /// How long one base branch's rules answer stands before the next read.
@@ -416,6 +419,8 @@ impl CodeRuntime {
             pr_refresh_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
             recap: Mutex::new(None),
+            #[cfg(test)]
+            archive_shutdown_timeout: AtomicBool::new(false),
         }
     }
 
@@ -544,6 +549,8 @@ impl CodeRuntime {
             pr_refresh_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
             recap: Mutex::new(None),
+            #[cfg(test)]
+            archive_shutdown_timeout: AtomicBool::new(false),
         }
     }
 
@@ -571,6 +578,12 @@ impl CodeRuntime {
     #[cfg(test)]
     pub(crate) fn set_forge_api_base(&self, base: Option<String>) {
         *self.forge_api_base.lock().expect("forge api base") = base;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_archive_shutdown_timeout(&self, enabled: bool) {
+        self.archive_shutdown_timeout
+            .store(enabled, Ordering::SeqCst);
     }
 
     /// The REST base decision 65's pull-request operations drive: the
@@ -642,6 +655,31 @@ impl CodeRuntime {
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
         self.ensure_stall_sweep();
+        for workspace in
+            list_workspaces_by_status_all_owners(&self.db, CodeWorkspaceStatus::Archiving).await?
+        {
+            if !std::path::Path::new(&workspace.worktree_path).exists() {
+                tracing::warn!(
+                    workspace = %workspace.id,
+                    "code-mode: archive recovery left a missing checkout fenced as archiving"
+                );
+                continue;
+            }
+            if !compare_and_set_workspace_status(
+                &self.db,
+                &workspace.owner,
+                workspace.id,
+                CodeWorkspaceStatus::Archiving,
+                CodeWorkspaceStatus::Active,
+            )
+            .await?
+            {
+                tracing::warn!(
+                    workspace = %workspace.id,
+                    "code-mode: archive recovery lost its lifecycle compare-and-set"
+                );
+            }
+        }
         let actions = recovery::recover_running_sessions(&self.db, &self.bus)
             .await
             .map_err(ServerError::from)?;
@@ -1149,18 +1187,25 @@ impl CodeRuntime {
         owner: &OwnerId,
         id: WorkspaceId,
         force: bool,
+        terminals: &super::terminal::TerminalHub,
     ) -> Result<CodeWorkspace, ServerError> {
         let mut workspace = self.get_workspace(owner, id).await?;
         if workspace.status == CodeWorkspaceStatus::Archived {
             return Ok(workspace);
         }
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
         let repo = self.get_repo(owner, workspace.repo_id).await?;
         // Blockers first: a refused archive must leave the workspace exactly as
         // it was, and running the hook script is not "exactly as it was".
         self.refuse_running_sessions(owner, id, force).await?;
-        let path = std::path::Path::new(&workspace.worktree_path);
+        let path = std::path::PathBuf::from(&workspace.worktree_path);
         if path.exists() {
-            if let Some(block) = archive_blockers(path, &workspace.base_ref)
+            if let Some(block) = archive_blockers(&path, &workspace.base_ref)
                 .await
                 .map_err(map_worktree)?
             {
@@ -1171,19 +1216,107 @@ impl CodeRuntime {
                     ));
                 }
             }
+        }
+        if !compare_and_set_workspace_status(
+            &self.db,
+            owner,
+            id,
+            CodeWorkspaceStatus::Active,
+            CodeWorkspaceStatus::Archiving,
+        )
+        .await?
+        {
+            return Err(ServerError::conflict_kind(
+                "workspace_lifecycle_busy",
+                "another workspace lifecycle operation started first",
+            ));
+        }
+        workspace.status = CodeWorkspaceStatus::Archiving;
+
+        let archived = self
+            .archive_workspace_exclusive(owner, workspace, repo, force, terminals)
+            .await;
+        if archived.is_err() && path.exists() {
+            if !compare_and_set_workspace_status(
+                &self.db,
+                owner,
+                id,
+                CodeWorkspaceStatus::Archiving,
+                CodeWorkspaceStatus::Active,
+            )
+            .await?
+            {
+                tracing::warn!(
+                    workspace = %id,
+                    "code-mode: failed to restore Active after a refused archive"
+                );
+            }
+        }
+        archived
+    }
+
+    async fn archive_workspace_exclusive(
+        &self,
+        owner: &OwnerId,
+        mut workspace: CodeWorkspace,
+        repo: CodeRepo,
+        force: bool,
+        terminals: &super::terminal::TerminalHub,
+    ) -> Result<CodeWorkspace, ServerError> {
+        if !terminals.close_workspace_and_wait(workspace.id).await {
+            return Err(ServerError::conflict_kind(
+                "terminal_shutdown_timeout",
+                "a workspace terminal did not stop; the checkout was preserved",
+            ));
+        }
+        let workers_stopped = self.end_workspace_sessions(owner, workspace.id).await?;
+        #[cfg(test)]
+        let workers_stopped =
+            workers_stopped && !self.archive_shutdown_timeout.load(Ordering::SeqCst);
+        if !workers_stopped {
+            return Err(ServerError::conflict_kind(
+                "workspace_shutdown_timeout",
+                "a workspace worker did not stop; the checkout was preserved",
+            ));
+        }
+
+        let turn = self.worktree_turn_lock(workspace.id);
+        let _turn_guard = turn.lock().await;
+        let current = self.get_workspace(owner, workspace.id).await?;
+        if current.status != CodeWorkspaceStatus::Archiving {
+            return Err(ServerError::conflict_kind(
+                "workspace_lifecycle_changed",
+                format!(
+                    "workspace became {} during archive",
+                    current.status.as_str()
+                ),
+            ));
+        }
+
+        let path = std::path::Path::new(&workspace.worktree_path);
+        if path.exists() {
             // Decision 0032: the archive script obeys the same
-            // failure-preserves rule as setup. A script that backs up or
-            // pushes state and exits non-zero must stop the archive, not have
-            // its checkout removed underneath it. A worktree that is already
-            // gone has nothing to run the script against.
+            // failure-preserves rule as setup. Lifecycle exclusion starts
+            // before the hook so no in-process writer can overlap it.
             if let Err(err) = run_archive_script(path, repo.archive_script.as_deref()).await {
                 return Err(ServerError::unprocessable_kind(
                     "archive_script_failed",
                     err.to_string(),
                 ));
             }
+            if let Some(block) = archive_blockers(path, &workspace.base_ref)
+                .await
+                .map_err(map_worktree)?
+            {
+                if !force {
+                    return Err(ServerError::conflict_kind(
+                        block.as_str(),
+                        "workspace changed during archive; the checkout was preserved",
+                    ));
+                }
+            }
         }
-        let workers_stopped = self.end_workspace_sessions(owner, id).await?;
+
         remove_worktree(std::path::Path::new(&repo.root_path), path)
             .await
             .map_err(map_worktree)?;
@@ -1198,24 +1331,17 @@ impl CodeRuntime {
         }
         workspace.status = CodeWorkspaceStatus::Archived;
         workspace.archived_at = Some(Utc::now());
-        save_workspace(&self.db, &workspace).await?;
-        // Drop the turn lock only once every worker confirmed it was gone.
-        // The lock is an `Arc`, so forgetting it here does not disturb a
-        // worker that outlived its shutdown grace — it hands the *next* one a
-        // second lock over the same checkout, which is the one thing this is
-        // supposed to make impossible. Keeping the entry costs a map slot per
-        // archived workspace and keeps restore on the same lock.
-        if workers_stopped {
-            self.worktree_turns
-                .lock()
-                .expect("worktree turn locks")
-                .remove(&workspace.id);
-        } else {
-            tracing::warn!(
-                workspace = %workspace.id,
-                "code-mode: keeping the workspace turn lock; a worker outlived its shutdown"
-            );
+        if !save_workspace(&self.db, &workspace).await? {
+            return Err(ServerError::conflict_kind(
+                "workspace_lifecycle_changed",
+                "the workspace row changed before archive completed",
+            ));
         }
+        drop(_turn_guard);
+        self.worktree_turns
+            .lock()
+            .expect("worktree turn locks")
+            .remove(&workspace.id);
         Ok(workspace)
     }
 
@@ -2536,10 +2662,10 @@ impl CodeRuntime {
         id: WorkspaceId,
     ) -> Result<CodeWorkspace, ServerError> {
         let workspace = self.get_workspace(owner, id).await?;
-        if workspace.status == CodeWorkspaceStatus::Archived {
+        if workspace.status != CodeWorkspaceStatus::Active {
             return Err(ServerError::conflict_kind(
                 "workspace_not_ready",
-                "workspace is archived",
+                format!("workspace is {}", workspace.status.as_str()),
             ));
         }
         if !std::path::Path::new(&workspace.worktree_path).exists() {
@@ -2848,6 +2974,13 @@ impl CodeRuntime {
             }
         }
         let mut session = self.get_session(owner, id).await?;
+        let workspace = self.get_workspace(owner, session.workspace_id).await?;
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
         if session.lifecycle == CodeSessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
                 "session_fenced",
@@ -4465,6 +4598,13 @@ impl CodeRuntime {
             .clone()
     }
 
+    pub(crate) fn workspace_write_lock(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Arc<tokio::sync::Mutex<()>> {
+        self.worktree_turn_lock(workspace_id)
+    }
+
     fn require_worker(&self, id: CodeSessionId) -> Result<WorkerHandle, ServerError> {
         self.workers
             .lock()
@@ -5036,6 +5176,9 @@ fn map_worktree(err: WorktreeError) -> ServerError {
             }
         }
         WorktreeError::Internal(message) => ServerError::internal(message),
+        WorktreeError::ArchiveUncertain(message) => {
+            ServerError::conflict_kind("archive_inspection_uncertain", message)
+        }
     }
 }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -12,12 +12,12 @@ use tokio::time::Instant as TokioInstant;
 
 use tidebreak_core::db::code::{
     abandon_pending_approval, arm_trigger, claim_approval, compare_and_set_workspace_status,
-    delete_trigger, delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path,
-    get_session, get_workspace, insert_repo, insert_session, insert_workspace, list_approvals,
-    list_events, list_fork_events, list_repos, list_sessions, list_sessions_all_owners,
-    list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
-    list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head, save_repo,
-    save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
+    complete_workspace_archive, delete_trigger, delete_workspace, get_approval, get_open_turn,
+    get_repo, get_repo_by_root_path, get_session, get_workspace, insert_repo, insert_session,
+    insert_workspace, list_approvals, list_events, list_fork_events, list_repos, list_sessions,
+    list_sessions_all_owners, list_sessions_for_workspace, list_triggers_for_repo, list_turns,
+    list_workspaces, list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head,
+    save_repo, save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
     ClaimedApprovalSettlement, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
@@ -665,13 +665,6 @@ impl CodeRuntime {
         for workspace in
             list_workspaces_by_status_all_owners(&self.db, CodeWorkspaceStatus::Archiving).await?
         {
-            if !std::path::Path::new(&workspace.worktree_path).exists() {
-                tracing::warn!(
-                    workspace = %workspace.id,
-                    "code-mode: archive recovery left a missing checkout fenced as archiving"
-                );
-                continue;
-            }
             let sessions =
                 list_sessions_for_workspace(&self.db, &workspace.owner, workspace.id).await?;
             if sessions.iter().any(|session| {
@@ -684,6 +677,18 @@ impl CodeRuntime {
                     workspace = %workspace.id,
                     "code-mode: archive recovery kept lifecycle exclusion because a worker may still exist"
                 );
+                continue;
+            }
+            if !std::path::Path::new(&workspace.worktree_path).exists() {
+                let repo = self.get_repo(&workspace.owner, workspace.repo_id).await?;
+                match self.finalize_removed_workspace(workspace, &repo).await {
+                    Ok(workspace) => self.forget_workspace_turn_lock(workspace.id),
+                    Err(error) => {
+                        tracing::warn!(
+                            "code-mode: archive recovery could not finalize a missing checkout: {error}"
+                        );
+                    }
+                }
                 continue;
             }
             if !compare_and_set_workspace_status(
@@ -1223,6 +1228,25 @@ impl CodeRuntime {
         if workspace.status == CodeWorkspaceStatus::Archived {
             return Ok(workspace);
         }
+        let path = std::path::PathBuf::from(&workspace.worktree_path);
+        if workspace.status == CodeWorkspaceStatus::Archiving && !path.exists() {
+            let sessions = list_sessions_for_workspace(&self.db, owner, id).await?;
+            if sessions.iter().any(|session| {
+                matches!(
+                    session.lifecycle,
+                    CodeSessionLifecycle::Running | CodeSessionLifecycle::Fenced
+                )
+            }) {
+                return Err(ServerError::conflict_kind(
+                    "workspace_lifecycle_busy",
+                    "a workspace worker may still be running",
+                ));
+            }
+            let repo = self.get_repo(owner, workspace.repo_id).await?;
+            let archived = self.finalize_removed_workspace(workspace, &repo).await?;
+            self.forget_workspace_turn_lock(archived.id);
+            return Ok(archived);
+        }
         if workspace.status != CodeWorkspaceStatus::Active {
             return Err(ServerError::conflict_kind(
                 "workspace_not_ready",
@@ -1233,7 +1257,6 @@ impl CodeRuntime {
         // Blockers first: a refused archive must leave the workspace exactly as
         // it was, and running the hook script is not "exactly as it was".
         self.refuse_running_sessions(owner, id, force).await?;
-        let path = std::path::PathBuf::from(&workspace.worktree_path);
         if path.exists() {
             if let Some(block) = archive_blockers(&path, &workspace.base_ref)
                 .await
@@ -1363,6 +1386,17 @@ impl CodeRuntime {
         remove_worktree(std::path::Path::new(&repo.root_path), path)
             .await
             .map_err(map_worktree)?;
+        let archived = self.finalize_removed_workspace(workspace, &repo).await?;
+        drop(_turn_guard);
+        self.forget_workspace_turn_lock(archived.id);
+        Ok(archived)
+    }
+
+    async fn finalize_removed_workspace(
+        &self,
+        mut workspace: CodeWorkspace,
+        repo: &CodeRepo,
+    ) -> Result<CodeWorkspace, ServerError> {
         let _ = prune_worktrees(std::path::Path::new(&repo.root_path)).await;
         if let Err(error) =
             delete_workspace_refs(std::path::Path::new(&repo.root_path), workspace.id).await
@@ -1372,20 +1406,36 @@ impl CodeRuntime {
                 "code-mode: could not delete checkpoint refs on archive: {error}"
             );
         }
-        workspace.status = CodeWorkspaceStatus::Archived;
-        workspace.archived_at = Some(Utc::now());
-        if !save_workspace(&self.db, &workspace).await? {
+        let archived_at = workspace.archived_at.unwrap_or_else(Utc::now);
+        if !complete_workspace_archive(&self.db, &workspace.owner, workspace.id, archived_at)
+            .await?
+        {
+            let current = self.get_workspace(&workspace.owner, workspace.id).await?;
+            if current.status == CodeWorkspaceStatus::Archived {
+                return Ok(current);
+            }
             return Err(ServerError::conflict_kind(
                 "workspace_lifecycle_changed",
                 "the workspace row changed before archive completed",
             ));
         }
-        drop(_turn_guard);
+        workspace.status = CodeWorkspaceStatus::Archived;
+        workspace.archived_at = Some(archived_at);
+        super::attention::emit_workspace_digests(
+            &self.db,
+            &self.bus,
+            &workspace.owner,
+            workspace.id,
+        )
+        .await;
+        Ok(workspace)
+    }
+
+    fn forget_workspace_turn_lock(&self, workspace_id: WorkspaceId) {
         self.worktree_turns
             .lock()
             .expect("worktree turn locks")
-            .remove(&workspace.id);
-        Ok(workspace)
+            .remove(&workspace_id);
     }
 
     /// Reactivate an archived workspace at its own path, on its own branch.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -180,6 +180,8 @@ pub(crate) struct CodeRuntime {
     /// Last pin-install failure per kind. Cleared on a successful install.
     pin_install_errors: Mutex<HashMap<HarnessKind, String>>,
     workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
+    /// Serializes writer admission with workspace lifecycle transitions.
+    workspace_lifecycles: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
     /// One turn at a time per worktree, shared by every session in it.
     ///
     /// Sessions in a workspace share one checkout, so their turns cannot
@@ -395,6 +397,7 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            workspace_lifecycles: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: Mutex::new(HashMap::new()),
             delivery_nudges: DeliveryNudgeDebounce::default(),
@@ -525,6 +528,7 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            workspace_lifecycles: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: Mutex::new(HashMap::new()),
             delivery_nudges: DeliveryNudgeDebounce::default(),
@@ -655,6 +659,9 @@ impl CodeRuntime {
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
         self.ensure_stall_sweep();
+        let actions = recovery::recover_running_sessions(&self.db, &self.bus)
+            .await
+            .map_err(ServerError::from)?;
         for workspace in
             list_workspaces_by_status_all_owners(&self.db, CodeWorkspaceStatus::Archiving).await?
         {
@@ -662,6 +669,20 @@ impl CodeRuntime {
                 tracing::warn!(
                     workspace = %workspace.id,
                     "code-mode: archive recovery left a missing checkout fenced as archiving"
+                );
+                continue;
+            }
+            let sessions =
+                list_sessions_for_workspace(&self.db, &workspace.owner, workspace.id).await?;
+            if sessions.iter().any(|session| {
+                matches!(
+                    session.lifecycle,
+                    CodeSessionLifecycle::Running | CodeSessionLifecycle::Fenced
+                )
+            }) {
+                tracing::warn!(
+                    workspace = %workspace.id,
+                    "code-mode: archive recovery kept lifecycle exclusion because a worker may still exist"
                 );
                 continue;
             }
@@ -680,9 +701,6 @@ impl CodeRuntime {
                 );
             }
         }
-        let actions = recovery::recover_running_sessions(&self.db, &self.bus)
-            .await
-            .map_err(ServerError::from)?;
         let recovered_sessions = list_sessions_all_owners(&self.db).await?;
         for session in &recovered_sessions {
             super::approval_sweep::abandon_for_restart(
@@ -1166,6 +1184,18 @@ impl CodeRuntime {
         &self,
         workspace: &CodeWorkspace,
     ) -> Result<(), ServerError> {
+        let lifecycle = self.workspace_lifecycle_lock(workspace.id);
+        let _lifecycle_guard = lifecycle.lock().await;
+        let current = self.get_workspace(&workspace.owner, workspace.id).await?;
+        if current.status != workspace.status {
+            return Err(ServerError::conflict_kind(
+                "workspace_lifecycle_changed",
+                format!(
+                    "workspace became {} before the update was saved",
+                    current.status.as_str()
+                ),
+            ));
+        }
         if !save_workspace(&self.db, workspace).await? {
             return Err(ServerError::not_found(format!(
                 "workspace {} not found",
@@ -1217,26 +1247,41 @@ impl CodeRuntime {
                 }
             }
         }
-        if !compare_and_set_workspace_status(
-            &self.db,
-            owner,
-            id,
-            CodeWorkspaceStatus::Active,
-            CodeWorkspaceStatus::Archiving,
-        )
-        .await?
         {
-            return Err(ServerError::conflict_kind(
-                "workspace_lifecycle_busy",
-                "another workspace lifecycle operation started first",
-            ));
+            let lifecycle = self.workspace_lifecycle_lock(id);
+            let _lifecycle_guard = lifecycle.lock().await;
+            workspace = self.get_workspace(owner, id).await?;
+            if workspace.status != CodeWorkspaceStatus::Active {
+                return Err(ServerError::conflict_kind(
+                    "workspace_lifecycle_busy",
+                    format!("workspace is {}", workspace.status.as_str()),
+                ));
+            }
+            self.refuse_running_sessions(owner, id, force).await?;
+            if !compare_and_set_workspace_status(
+                &self.db,
+                owner,
+                id,
+                CodeWorkspaceStatus::Active,
+                CodeWorkspaceStatus::Archiving,
+            )
+            .await?
+            {
+                return Err(ServerError::conflict_kind(
+                    "workspace_lifecycle_busy",
+                    "another workspace lifecycle operation started first",
+                ));
+            }
         }
         workspace.status = CodeWorkspaceStatus::Archiving;
 
         let archived = self
             .archive_workspace_exclusive(owner, workspace, repo, force, terminals)
             .await;
-        if archived.is_err() && path.exists() {
+        if archived
+            .as_ref()
+            .is_err_and(|error| archive_failure_can_reopen(error) && path.exists())
+        {
             if !compare_and_set_workspace_status(
                 &self.db,
                 owner,
@@ -2719,6 +2764,8 @@ impl CodeRuntime {
             fast_mode,
         }: NewSessionSettings,
     ) -> Result<CodeSession, ServerError> {
+        let lifecycle = self.workspace_lifecycle_lock(workspace_id);
+        let _lifecycle_guard = lifecycle.lock().await;
         let workspace = self.get_workspace(owner, workspace_id).await?;
         if workspace.status != CodeWorkspaceStatus::Active {
             return Err(ServerError::conflict_kind(
@@ -4602,7 +4649,16 @@ impl CodeRuntime {
         &self,
         workspace_id: WorkspaceId,
     ) -> Arc<tokio::sync::Mutex<()>> {
-        self.worktree_turn_lock(workspace_id)
+        self.workspace_lifecycle_lock(workspace_id)
+    }
+
+    fn workspace_lifecycle_lock(&self, workspace_id: WorkspaceId) -> Arc<tokio::sync::Mutex<()>> {
+        self.workspace_lifecycles
+            .lock()
+            .expect("workspace lifecycle locks")
+            .entry(workspace_id)
+            .or_default()
+            .clone()
     }
 
     fn require_worker(&self, id: CodeSessionId) -> Result<WorkerHandle, ServerError> {
@@ -5180,6 +5236,18 @@ fn map_worktree(err: WorktreeError) -> ServerError {
             ServerError::conflict_kind("archive_inspection_uncertain", message)
         }
     }
+}
+
+fn archive_failure_can_reopen(error: &ServerError) -> bool {
+    matches!(
+        error.kind(),
+        "archive_script_failed"
+            | "archive_inspection_uncertain"
+            | "ignored_content"
+            | "uncommitted"
+            | "unpushed"
+            | "uncommitted_and_unpushed"
+    )
 }
 
 fn map_worker(err: WorkerError) -> ServerError {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1281,8 +1281,7 @@ impl CodeRuntime {
         if archived
             .as_ref()
             .is_err_and(|error| archive_failure_can_reopen(error) && path.exists())
-        {
-            if !compare_and_set_workspace_status(
+            && !compare_and_set_workspace_status(
                 &self.db,
                 owner,
                 id,
@@ -1290,12 +1289,11 @@ impl CodeRuntime {
                 CodeWorkspaceStatus::Active,
             )
             .await?
-            {
-                tracing::warn!(
-                    workspace = %id,
-                    "code-mode: failed to restore Active after a refused archive"
-                );
-            }
+        {
+            tracing::warn!(
+                workspace = %id,
+                "code-mode: failed to restore Active after a refused archive"
+            );
         }
         archived
     }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -685,7 +685,8 @@ impl CodeRuntime {
                     Ok(workspace) => self.forget_workspace_turn_lock(workspace.id),
                     Err(error) => {
                         tracing::warn!(
-                            "code-mode: archive recovery could not finalize a missing checkout: {error}"
+                            "code-mode: archive recovery could not finalize a missing checkout: {}",
+                            error.message()
                         );
                     }
                 }
@@ -1324,7 +1325,7 @@ impl CodeRuntime {
     async fn archive_workspace_exclusive(
         &self,
         owner: &OwnerId,
-        mut workspace: CodeWorkspace,
+        workspace: CodeWorkspace,
         repo: CodeRepo,
         force: bool,
         terminals: &super::terminal::TerminalHub,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -316,8 +316,18 @@ impl ScopedCode {
         &self,
         id: WorkspaceId,
         force: bool,
+        terminals: &crate::code::terminal::TerminalHub,
     ) -> Result<CodeWorkspace, ServerError> {
-        self.runtime.archive_workspace(&self.owner, id, force).await
+        self.runtime
+            .archive_workspace(&self.owner, id, force, terminals)
+            .await
+    }
+
+    pub(crate) fn workspace_write_lock(
+        &self,
+        id: WorkspaceId,
+    ) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+        self.runtime.workspace_write_lock(id)
     }
 
     pub(crate) async fn release_workspace(

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -24,17 +24,17 @@ use tracing::{warn, Instrument as _};
 
 use tidebreak_core::db::code::{
     accept_trigger_turn_delivery, append_event, bump_spawn_epoch, delete_queued_turn,
-    get_open_turn, get_session, get_session_all_owners, insert_approval_for_worker, insert_turn,
-    next_turn_ordinal, promote_queued_turn, queue_paused, queued_turn_head, save_session,
-    save_turn, set_queue_paused, set_session_harness_resume_ref, set_session_subagents,
-    CodeJournalError,
+    get_open_turn, get_session, get_session_all_owners, get_workspace, insert_approval_for_worker,
+    insert_turn, next_turn_ordinal, promote_queued_turn, queue_paused, queued_turn_head,
+    save_session, save_turn, set_queue_paused, set_session_harness_resume_ref,
+    set_session_subagents, CodeJournalError,
 };
 use tidebreak_core::{
     bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
     CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeSession,
     CodeSessionId, CodeSessionLifecycle, CodeSubagentStatus, CodeSubagentSummary, CodeTurn,
-    CodeTurnId, CodeTurnStatus, CodeUsage, DbStore, FenceReason, HarnessNoticeLevel, OwnerId,
-    PermissionMode, ReasoningEffort, ToolOutcome,
+    CodeTurnId, CodeTurnStatus, CodeUsage, CodeWorkspaceStatus, DbStore, FenceReason,
+    HarnessNoticeLevel, OwnerId, PermissionMode, ReasoningEffort, ToolOutcome,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
@@ -1272,6 +1272,16 @@ async fn drive_turn_inner(
     // read a session that may be minutes stale by now.
     if session_was_ended(&sink.db, session).await {
         return Err(WorkerError::Conflict("session has ended".into()));
+    }
+    let workspace = get_workspace(&sink.db, &session.owner, session.workspace_id)
+        .await
+        .map_err(|error| WorkerError::Failed(error.to_string()))?
+        .ok_or_else(|| WorkerError::Conflict("workspace no longer exists".into()))?;
+    if workspace.status != CodeWorkspaceStatus::Active {
+        return Err(WorkerError::Conflict(format!(
+            "workspace is {}",
+            workspace.status.as_str()
+        )));
     }
 
     if let Some(model) = model.clone() {

--- a/crates/tidebreak-server/src/code/terminal.rs
+++ b/crates/tidebreak-server/src/code/terminal.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -41,6 +41,7 @@ const DEFAULT_ROWS: u16 = 24;
 const MIN_SIZE: u16 = 1;
 const MAX_SIZE: u16 = 512;
 const NOTICE_BUFFER: usize = 64;
+const TERMINAL_EXIT_GRACE: Duration = Duration::from_secs(5);
 
 /// In-memory process-wide registry of live auxiliary terminals.
 pub(crate) struct TerminalHub {
@@ -76,7 +77,13 @@ struct LiveTerminal {
     writer: Option<Box<dyn Write + Send>>,
     master: Option<Box<dyn MasterPty + Send>>,
     killer: Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
+    exit: Arc<TerminalExit>,
     coalesce: Coalesce,
+}
+
+struct TerminalExit {
+    done: Mutex<bool>,
+    changed: Condvar,
 }
 
 struct Coalesce {
@@ -175,13 +182,19 @@ impl TerminalHub {
             writer: Some(spawned.writer),
             master: Some(spawned.master),
             killer: Some(spawned.killer),
+            exit: Arc::new(TerminalExit::new(false)),
             coalesce: Coalesce::new(),
         };
         let handle = Arc::new(Mutex::new(live));
         self.insert(workspace_id, id, handle.clone());
         let notices = self.notices_sender(owner);
         start_reader(handle.clone(), notices.clone(), spawned.reader);
-        start_reaper(handle.clone(), notices, spawned.child);
+        start_reaper(
+            handle.clone(),
+            notices,
+            spawned.child,
+            handle.lock().expect("terminal").exit.clone(),
+        );
         Ok(lock_snapshot(&handle))
     }
 
@@ -211,6 +224,7 @@ impl TerminalHub {
             writer: None,
             master: None,
             killer: None,
+            exit: Arc::new(TerminalExit::new(true)),
             coalesce: Coalesce::new(),
         };
         let handle = Arc::new(Mutex::new(live));
@@ -367,6 +381,40 @@ impl TerminalHub {
         }
     }
 
+    /// Stop every terminal and prove that each shell process exited.
+    ///
+    /// Archive treats a timeout as uncertainty and preserves the checkout.
+    pub(crate) async fn close_workspace_and_wait(&self, workspace_id: WorkspaceId) -> bool {
+        let handles = {
+            let inner = self.inner.lock().expect("terminal hub");
+            inner
+                .by_workspace
+                .get(&workspace_id)
+                .into_iter()
+                .flatten()
+                .filter_map(|id| inner.by_id.get(id).cloned())
+                .collect::<Vec<_>>()
+        };
+        let exits = handles
+            .iter()
+            .map(|handle| {
+                let mut live = handle.lock().expect("terminal");
+                live.kill_and_end();
+                live.exit.clone()
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            let id = handle.lock().expect("terminal").id;
+            self.remove(workspace_id, id);
+        }
+        tokio::task::spawn_blocking(move || {
+            let deadline = Instant::now() + TERMINAL_EXIT_GRACE;
+            exits.into_iter().all(|exit| exit.wait_until(deadline))
+        })
+        .await
+        .unwrap_or(false)
+    }
+
     /// Append output as if the PTY had produced it. Tests and the reader thread.
     #[cfg(test)]
     pub(crate) fn push_output(&self, id: CodeTerminalId, bytes: &[u8]) {
@@ -450,6 +498,39 @@ impl LiveTerminal {
         self.master = None;
         self.ended = true;
         self.producing = false;
+    }
+}
+
+impl TerminalExit {
+    fn new(done: bool) -> Self {
+        Self {
+            done: Mutex::new(done),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn mark_done(&self) {
+        *self.done.lock().expect("terminal exit") = true;
+        self.changed.notify_all();
+    }
+
+    fn wait_until(&self, deadline: Instant) -> bool {
+        let mut done = self.done.lock().expect("terminal exit");
+        while !*done {
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let waited = self
+                .changed
+                .wait_timeout(done, deadline.saturating_duration_since(now))
+                .expect("terminal exit");
+            done = waited.0;
+            if waited.1.timed_out() && !*done {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -558,11 +639,13 @@ fn start_reaper(
     handle: Arc<Mutex<LiveTerminal>>,
     notices: broadcast::Sender<TerminalNotice>,
     mut child: Box<dyn portable_pty::Child + Send + Sync>,
+    exit: Arc<TerminalExit>,
 ) {
     thread::Builder::new()
         .name("code-terminal-wait".into())
         .spawn(move || {
             let _ = child.wait();
+            exit.mark_done();
             if let Ok(mut live) = handle.lock() {
                 if !live.ended {
                     // The shell is gone, so nothing can be typed at it. Leave

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -26,6 +26,9 @@ pub(crate) const DEFAULT_SEARCH_LIMIT: u32 = 200;
 pub(crate) const MAX_SEARCH_LIMIT: u32 = 500;
 const MAX_SEARCH_QUERY_CHARS: usize = 500;
 const MAX_SEARCH_PREVIEW_CHARS: usize = 500;
+const ARCHIVE_SCAN_MAX_ENTRIES: usize = 10_000;
+const ARCHIVE_SCAN_MAX_PATH_BYTES: usize = 1024 * 1024;
+const ARCHIVE_DISPOSABLE_PATH_KEY: &str = "tidebreak.archiveDisposablePath";
 
 const ADJECTIVES: &[&str] = &[
     "amber", "brave", "calm", "crisp", "dusk", "ember", "faint", "gentle", "hidden", "ivory",
@@ -127,6 +130,7 @@ pub(crate) enum ArchiveBlock {
     Uncommitted,
     Unpushed,
     UncommittedAndUnpushed,
+    IgnoredContent,
 }
 
 impl ArchiveBlock {
@@ -135,6 +139,7 @@ impl ArchiveBlock {
             Self::Uncommitted => "uncommitted",
             Self::Unpushed => "unpushed",
             Self::UncommittedAndUnpushed => "uncommitted_and_unpushed",
+            Self::IgnoredContent => "ignored_content",
         }
     }
 }
@@ -146,6 +151,8 @@ pub(crate) enum WorktreeError {
     User(String),
     #[error("{0}")]
     Internal(String),
+    #[error("{0}")]
+    ArchiveUncertain(String),
 }
 
 impl WorktreeError {
@@ -155,6 +162,10 @@ impl WorktreeError {
 
     fn internal(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
+    }
+
+    fn archive_uncertain(message: impl Into<String>) -> Self {
+        Self::ArchiveUncertain(message.into())
     }
 }
 
@@ -614,11 +625,16 @@ pub(crate) async fn archive_blockers(
 ) -> Result<Option<ArchiveBlock>, WorktreeError> {
     let uncommitted = has_uncommitted_work(worktree_path).await?;
     let unpushed = has_unpushed_work(worktree_path, base_ref).await?;
-    Ok(match (uncommitted, unpushed) {
-        (true, true) => Some(ArchiveBlock::UncommittedAndUnpushed),
-        (true, false) => Some(ArchiveBlock::Uncommitted),
-        (false, true) => Some(ArchiveBlock::Unpushed),
-        (false, false) => None,
+    let ignored = has_non_disposable_ignored_content(worktree_path).await?;
+    Ok(if ignored {
+        Some(ArchiveBlock::IgnoredContent)
+    } else {
+        match (uncommitted, unpushed) {
+            (true, true) => Some(ArchiveBlock::UncommittedAndUnpushed),
+            (true, false) => Some(ArchiveBlock::Uncommitted),
+            (false, true) => Some(ArchiveBlock::Unpushed),
+            (false, false) => None,
+        }
     })
 }
 
@@ -1018,6 +1034,182 @@ async fn has_uncommitted_work(worktree_path: &Path) -> Result<bool, WorktreeErro
         .await
         .map_err(|err| WorktreeError::internal(format!("git status failed: {err}")))?;
     Ok(!status.is_empty())
+}
+
+async fn has_non_disposable_ignored_content(worktree_path: &Path) -> Result<bool, WorktreeError> {
+    let disposable = archive_disposable_paths(worktree_path).await?;
+    let mut stack = vec![worktree_path.to_path_buf()];
+    let mut candidates = Vec::new();
+    let mut entry_count = 0usize;
+    let mut path_bytes = 0usize;
+
+    while let Some(directory) = stack.pop() {
+        let mut entries = tokio::fs::read_dir(&directory).await.map_err(|error| {
+            WorktreeError::archive_uncertain(format!(
+                "archive could not inspect {}: {error}",
+                directory.display()
+            ))
+        })?;
+        while let Some(entry) = entries.next_entry().await.map_err(|error| {
+            WorktreeError::archive_uncertain(format!(
+                "archive could not continue inspecting {}: {error}",
+                directory.display()
+            ))
+        })? {
+            let path = entry.path();
+            let relative = path.strip_prefix(worktree_path).map_err(|_| {
+                WorktreeError::archive_uncertain("archive scan escaped the worktree")
+            })?;
+            if relative == Path::new(".git") || path_is_disposable(relative, &disposable) {
+                continue;
+            }
+            entry_count = entry_count.saturating_add(1);
+            path_bytes = path_bytes.saturating_add(relative.as_os_str().len());
+            if entry_count > ARCHIVE_SCAN_MAX_ENTRIES || path_bytes > ARCHIVE_SCAN_MAX_PATH_BYTES {
+                return Err(WorktreeError::archive_uncertain(format!(
+                    "archive inspection exceeded its {}-entry or {}-byte path budget; configure generated directories with git config --add {ARCHIVE_DISPOSABLE_PATH_KEY} <directory>",
+                    ARCHIVE_SCAN_MAX_ENTRIES, ARCHIVE_SCAN_MAX_PATH_BYTES
+                )));
+            }
+            let file_type = entry.file_type().await.map_err(|error| {
+                WorktreeError::archive_uncertain(format!(
+                    "archive could not inspect {}: {error}",
+                    path.display()
+                ))
+            })?;
+            candidates.push(relative.to_string_lossy().replace('\\', "/"));
+            if file_type.is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+
+    git_check_ignored(worktree_path, &candidates).await
+}
+
+async fn archive_disposable_paths(worktree_path: &Path) -> Result<Vec<PathBuf>, WorktreeError> {
+    let mut command = Command::new("git");
+    command
+        .args(["config", "--null", "--get-all", ARCHIVE_DISPOSABLE_PATH_KEY])
+        .current_dir(worktree_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let child = command
+        .spawn()
+        .map_err(|error| WorktreeError::archive_uncertain(format!("git config failed: {error}")))?;
+    let output = timeout(GIT_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| WorktreeError::archive_uncertain("git config timed out during archive"))?
+        .map_err(|error| WorktreeError::archive_uncertain(format!("git config failed: {error}")))?;
+    if output.status.code() == Some(1) && output.stdout.is_empty() {
+        return Ok(Vec::new());
+    }
+    if !output.status.success() {
+        return Err(WorktreeError::archive_uncertain(format!(
+            "git config failed during archive: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    if output.stdout.len() > ARCHIVE_SCAN_MAX_PATH_BYTES {
+        return Err(WorktreeError::archive_uncertain(
+            "archive disposable-path configuration exceeded its path budget",
+        ));
+    }
+    output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|value| !value.is_empty())
+        .map(|value| validate_disposable_path(&String::from_utf8_lossy(value)))
+        .collect()
+}
+
+fn validate_disposable_path(value: &str) -> Result<PathBuf, WorktreeError> {
+    let path = Path::new(value.trim());
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(WorktreeError::archive_uncertain(format!(
+            "{ARCHIVE_DISPOSABLE_PATH_KEY} must name a relative directory without . or ..: {value}"
+        )));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn path_is_disposable(path: &Path, disposable: &[PathBuf]) -> bool {
+    disposable
+        .iter()
+        .any(|configured| path.starts_with(configured))
+}
+
+async fn git_check_ignored(
+    worktree_path: &Path,
+    candidates: &[String],
+) -> Result<bool, WorktreeError> {
+    if candidates.is_empty() {
+        return Ok(false);
+    }
+    let mut input = Vec::new();
+    for candidate in candidates {
+        input.extend_from_slice(candidate.as_bytes());
+        input.push(0);
+    }
+    let mut command = Command::new("git");
+    command
+        .args(["check-ignore", "--stdin", "-z"])
+        .current_dir(worktree_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let mut child = command.spawn().map_err(|error| {
+        WorktreeError::archive_uncertain(format!("git check-ignore failed: {error}"))
+    })?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| WorktreeError::archive_uncertain("git check-ignore did not open stdin"))?;
+    let writer = tokio::spawn(async move {
+        let result = stdin.write_all(&input).await;
+        drop(stdin);
+        result
+    });
+    let output = timeout(GIT_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| WorktreeError::archive_uncertain("git check-ignore timed out"))?
+        .map_err(|error| {
+            WorktreeError::archive_uncertain(format!("git check-ignore failed: {error}"))
+        })?;
+    writer
+        .await
+        .map_err(|error| {
+            WorktreeError::archive_uncertain(format!("git check-ignore input failed: {error}"))
+        })?
+        .map_err(|error| {
+            WorktreeError::archive_uncertain(format!("git check-ignore input failed: {error}"))
+        })?;
+    match output.status.code() {
+        Some(0) => {
+            if output.stdout.len() > ARCHIVE_SCAN_MAX_PATH_BYTES {
+                Err(WorktreeError::archive_uncertain(
+                    "git check-ignore output exceeded the archive path budget",
+                ))
+            } else {
+                Ok(!output.stdout.is_empty())
+            }
+        }
+        Some(1) if output.stdout.is_empty() => Ok(false),
+        _ => Err(WorktreeError::archive_uncertain(format!(
+            "git check-ignore failed during archive: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))),
+    }
 }
 
 async fn has_unpushed_work(worktree_path: &Path, base_ref: &str) -> Result<bool, WorktreeError> {

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -1038,53 +1038,10 @@ async fn has_uncommitted_work(worktree_path: &Path) -> Result<bool, WorktreeErro
 
 async fn has_non_disposable_ignored_content(worktree_path: &Path) -> Result<bool, WorktreeError> {
     let disposable = archive_disposable_paths(worktree_path).await?;
-    let mut stack = vec![worktree_path.to_path_buf()];
-    let mut candidates = Vec::new();
-    let mut entry_count = 0usize;
-    let mut path_bytes = 0usize;
-
-    while let Some(directory) = stack.pop() {
-        let mut entries = tokio::fs::read_dir(&directory).await.map_err(|error| {
-            WorktreeError::archive_uncertain(format!(
-                "archive could not inspect {}: {error}",
-                directory.display()
-            ))
-        })?;
-        while let Some(entry) = entries.next_entry().await.map_err(|error| {
-            WorktreeError::archive_uncertain(format!(
-                "archive could not continue inspecting {}: {error}",
-                directory.display()
-            ))
-        })? {
-            let path = entry.path();
-            let relative = path.strip_prefix(worktree_path).map_err(|_| {
-                WorktreeError::archive_uncertain("archive scan escaped the worktree")
-            })?;
-            if relative == Path::new(".git") || path_is_disposable(relative, &disposable) {
-                continue;
-            }
-            entry_count = entry_count.saturating_add(1);
-            path_bytes = path_bytes.saturating_add(relative.as_os_str().len());
-            if entry_count > ARCHIVE_SCAN_MAX_ENTRIES || path_bytes > ARCHIVE_SCAN_MAX_PATH_BYTES {
-                return Err(WorktreeError::archive_uncertain(format!(
-                    "archive inspection exceeded its {}-entry or {}-byte path budget; configure generated directories with git config --add {ARCHIVE_DISPOSABLE_PATH_KEY} <directory>",
-                    ARCHIVE_SCAN_MAX_ENTRIES, ARCHIVE_SCAN_MAX_PATH_BYTES
-                )));
-            }
-            let file_type = entry.file_type().await.map_err(|error| {
-                WorktreeError::archive_uncertain(format!(
-                    "archive could not inspect {}: {error}",
-                    path.display()
-                ))
-            })?;
-            candidates.push(relative.to_string_lossy().replace('\\', "/"));
-            if file_type.is_dir() {
-                stack.push(path);
-            }
-        }
-    }
-
-    git_check_ignored(worktree_path, &candidates).await
+    let ignored = list_ignored_paths_bounded(worktree_path).await?;
+    Ok(ignored
+        .iter()
+        .any(|path| !path_is_disposable(Path::new(path), &disposable)))
 }
 
 async fn archive_disposable_paths(worktree_path: &Path) -> Result<Vec<PathBuf>, WorktreeError> {
@@ -1147,69 +1104,73 @@ fn path_is_disposable(path: &Path, disposable: &[PathBuf]) -> bool {
         .any(|configured| path.starts_with(configured))
 }
 
-async fn git_check_ignored(
-    worktree_path: &Path,
-    candidates: &[String],
-) -> Result<bool, WorktreeError> {
-    if candidates.is_empty() {
-        return Ok(false);
-    }
-    let mut input = Vec::new();
-    for candidate in candidates {
-        input.extend_from_slice(candidate.as_bytes());
-        input.push(0);
-    }
+async fn list_ignored_paths_bounded(worktree_path: &Path) -> Result<Vec<String>, WorktreeError> {
     let mut command = Command::new("git");
     command
-        .args(["check-ignore", "--stdin", "-z"])
+        .args([
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+        ])
         .current_dir(worktree_path)
-        .stdin(Stdio::piped())
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)
         .env("GIT_TERMINAL_PROMPT", "0");
     let mut child = command.spawn().map_err(|error| {
-        WorktreeError::archive_uncertain(format!("git check-ignore failed: {error}"))
+        WorktreeError::archive_uncertain(format!("git ls-files failed: {error}"))
     })?;
-    let mut stdin = child
-        .stdin
+    let mut stdout = child
+        .stdout
         .take()
-        .ok_or_else(|| WorktreeError::archive_uncertain("git check-ignore did not open stdin"))?;
-    let writer = tokio::spawn(async move {
-        let result = stdin.write_all(&input).await;
-        drop(stdin);
-        result
-    });
-    let output = timeout(GIT_TIMEOUT, child.wait_with_output())
-        .await
-        .map_err(|_| WorktreeError::archive_uncertain("git check-ignore timed out"))?
-        .map_err(|error| {
-            WorktreeError::archive_uncertain(format!("git check-ignore failed: {error}"))
-        })?;
-    writer
-        .await
-        .map_err(|error| {
-            WorktreeError::archive_uncertain(format!("git check-ignore input failed: {error}"))
-        })?
-        .map_err(|error| {
-            WorktreeError::archive_uncertain(format!("git check-ignore input failed: {error}"))
-        })?;
-    match output.status.code() {
-        Some(0) => {
-            if output.stdout.len() > ARCHIVE_SCAN_MAX_PATH_BYTES {
-                Err(WorktreeError::archive_uncertain(
-                    "git check-ignore output exceeded the archive path budget",
-                ))
-            } else {
-                Ok(!output.stdout.is_empty())
-            }
+        .ok_or_else(|| WorktreeError::archive_uncertain("git ls-files did not open stdout"))?;
+    let mut output = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        let read = timeout(GIT_TIMEOUT, stdout.read(&mut chunk))
+            .await
+            .map_err(|_| WorktreeError::archive_uncertain("git ls-files timed out"))?
+            .map_err(|error| {
+                WorktreeError::archive_uncertain(format!("git ls-files failed: {error}"))
+            })?;
+        if read == 0 {
+            break;
         }
-        Some(1) if output.stdout.is_empty() => Ok(false),
-        _ => Err(WorktreeError::archive_uncertain(format!(
-            "git check-ignore failed during archive: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ))),
+        output.extend_from_slice(&chunk[..read]);
+        if output.len() > ARCHIVE_SCAN_MAX_PATH_BYTES {
+            let _ = child.kill().await;
+            return Err(WorktreeError::archive_uncertain(format!(
+                "ignored-content inspection exceeded its {}-byte path budget; configure generated directories with git config --add {ARCHIVE_DISPOSABLE_PATH_KEY} <directory>",
+                ARCHIVE_SCAN_MAX_PATH_BYTES
+            )));
+        }
     }
+    let status = timeout(GIT_TIMEOUT, child.wait())
+        .await
+        .map_err(|_| WorktreeError::archive_uncertain("git ls-files timed out"))?
+        .map_err(|error| {
+            WorktreeError::archive_uncertain(format!("git ls-files failed: {error}"))
+        })?;
+    if !status.success() {
+        return Err(WorktreeError::archive_uncertain(
+            "git ls-files failed during ignored-content inspection",
+        ));
+    }
+    let paths = output
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| String::from_utf8_lossy(path).into_owned())
+        .collect::<Vec<_>>();
+    if paths.len() > ARCHIVE_SCAN_MAX_ENTRIES {
+        return Err(WorktreeError::archive_uncertain(format!(
+            "ignored-content inspection exceeded its {}-entry budget; configure generated directories with git config --add {ARCHIVE_DISPOSABLE_PATH_KEY} <directory>",
+            ARCHIVE_SCAN_MAX_ENTRIES
+        )));
+    }
+    Ok(paths)
 }
 
 async fn has_unpushed_work(worktree_path: &Path, base_ref: &str) -> Result<bool, WorktreeError> {

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -103,7 +103,6 @@ impl ServerError {
     }
 
     /// The stable machine-readable `kind` clients branch on.
-    #[cfg(test)]
     pub(crate) fn kind(&self) -> &str {
         &self.info.kind
     }

--- a/crates/tidebreak-server/src/routes/code/terminals.rs
+++ b/crates/tidebreak-server/src/routes/code/terminals.rs
@@ -21,6 +21,8 @@ pub async fn create_terminal(
     Path(id): Path<WorkspaceId>,
     Json(body): Json<CreateTerminalBody>,
 ) -> Result<impl IntoResponse, ServerError> {
+    let workspace = code.get_workspace(id).await?;
+    require_active(&workspace.status)?;
     let write = code.workspace_write_lock(id);
     let _write_guard = write.lock().await;
     let workspace = code.get_workspace(id).await?;
@@ -97,6 +99,8 @@ pub async fn write_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalWriteBody>,
 ) -> Result<StatusCode, ServerError> {
+    let workspace = code.get_workspace(path.id).await?;
+    require_active(&workspace.status)?;
     let write = code.workspace_write_lock(path.id);
     let _write_guard = write.lock().await;
     let workspace = code.get_workspace(path.id).await?;
@@ -115,6 +119,8 @@ pub async fn resize_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalResizeBody>,
 ) -> Result<Json<CodeTerminalSnapshot>, ServerError> {
+    let workspace = code.get_workspace(path.id).await?;
+    require_active(&workspace.status)?;
     let write = code.workspace_write_lock(path.id);
     let _write_guard = write.lock().await;
     let workspace = code.get_workspace(path.id).await?;

--- a/crates/tidebreak-server/src/routes/code/terminals.rs
+++ b/crates/tidebreak-server/src/routes/code/terminals.rs
@@ -21,6 +21,8 @@ pub async fn create_terminal(
     Path(id): Path<WorkspaceId>,
     Json(body): Json<CreateTerminalBody>,
 ) -> Result<impl IntoResponse, ServerError> {
+    let write = code.workspace_write_lock(id);
+    let _write_guard = write.lock().await;
     let workspace = code.get_workspace(id).await?;
     require_active(&workspace.status)?;
     let snap = state
@@ -95,7 +97,10 @@ pub async fn write_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalWriteBody>,
 ) -> Result<StatusCode, ServerError> {
-    let _ = code.get_workspace(path.id).await?;
+    let write = code.workspace_write_lock(path.id);
+    let _write_guard = write.lock().await;
+    let workspace = code.get_workspace(path.id).await?;
+    require_active(&workspace.status)?;
     let bytes = decode_write(&body.bytes)?;
     state
         .terminals
@@ -110,7 +115,10 @@ pub async fn resize_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalResizeBody>,
 ) -> Result<Json<CodeTerminalSnapshot>, ServerError> {
-    let _ = code.get_workspace(path.id).await?;
+    let write = code.workspace_write_lock(path.id);
+    let _write_guard = write.lock().await;
+    let workspace = code.get_workspace(path.id).await?;
+    require_active(&workspace.status)?;
     let snap = state
         .terminals
         .resize(path.id, path.tid, body.cols, body.rows)

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -91,8 +91,9 @@ pub async fn archive_workspace(
     Path(id): Path<WorkspaceId>,
     Json(body): Json<ArchiveWorkspaceBody>,
 ) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
-    let archived = code.archive_workspace(id, body.force).await?;
-    state.terminals.close_workspace(id);
+    let archived = code
+        .archive_workspace(id, body.force, state.terminals.as_ref())
+        .await?;
     Ok(Json(CodeWorkspaceSnapshot::from(archived)))
 }
 

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3772,6 +3772,49 @@ async fn archive_shutdown_timeout_preserves_the_checkout() {
 }
 
 #[tokio::test]
+async fn archive_recovery_finishes_after_checkout_removal() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let owner = tidebreak_core::OwnerId::local();
+    let (_registered, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let workspace_id: tidebreak_core::WorkspaceId = json_id(&workspace).parse().unwrap();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    assert!(tidebreak_core::db::code::compare_and_set_workspace_status(
+        &runtime.db,
+        &owner,
+        workspace_id,
+        CodeWorkspaceStatus::Active,
+        CodeWorkspaceStatus::Archiving,
+    )
+    .await
+    .unwrap());
+    let removed = std::process::Command::new("git")
+        .current_dir(&repo)
+        .args(["worktree", "remove", "--force"])
+        .arg(&path)
+        .status()
+        .unwrap();
+    assert!(removed.success());
+    assert!(!path.exists());
+
+    let restarted = CodeRuntime::with_registry(
+        runtime.db.clone(),
+        dir.path().to_path_buf(),
+        scripted_registry(),
+    );
+    restarted.recover().await.unwrap();
+
+    let stored = tidebreak_core::db::code::get_workspace(&runtime.db, &owner, workspace_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.status, CodeWorkspaceStatus::Archived);
+    assert!(stored.archived_at.is_some());
+}
+
+#[tokio::test]
 async fn archive_refuses_ignored_only_content_without_force() {
     let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3637,10 +3637,7 @@ async fn archive_preserves_hook_created_files_without_force() {
     assert_eq!(archived.status(), reqwest::StatusCode::CONFLICT);
     let body: serde_json::Value = archived.json().await.unwrap();
     assert_eq!(body["kind"], "uncommitted");
-    assert_eq!(
-        std::fs::read_to_string(path.join("hook-created.txt")).unwrap(),
-        "kept\n"
-    );
+    assert!(path.join("hook-created.txt").is_file());
     let stored = tidebreak_core::db::code::get_workspace(
         &_runtime.db,
         &tidebreak_core::OwnerId::local(),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3594,6 +3594,255 @@ async fn a_failing_archive_script_preserves_the_worktree() {
 }
 
 #[tokio::test]
+async fn archive_preserves_hook_created_files_without_force() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "path": repo,
+            "archive_script": "echo kept > hook-created.txt",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "hook output",
+        }))
+        .send()
+        .await
+        .unwrap();
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = archived.json().await.unwrap();
+    assert_eq!(body["kind"], "uncommitted");
+    assert_eq!(
+        std::fs::read_to_string(path.join("hook-created.txt")).unwrap(),
+        "kept\n"
+    );
+    let stored = tidebreak_core::db::code::get_workspace(
+        &_runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        json_id(&workspace).parse().unwrap(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(stored.status, CodeWorkspaceStatus::Active);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn archive_rejects_concurrent_writes_after_the_first_check() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let started = dir.path().join("archive-started");
+    let proceed = dir.path().join("archive-proceed");
+    let script = format!(
+        "touch \"{}\"; while [ ! -f \"{}\" ]; do sleep 0.01; done",
+        started.display(),
+        proceed.display()
+    );
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "path": repo,
+            "archive_script": script,
+        }))
+        .send()
+        .await
+        .unwrap();
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "late writer",
+        }))
+        .send()
+        .await
+        .unwrap();
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let workspace_id = json_id(&workspace).to_owned();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let archive_client = client.clone();
+    let archive_token = token.clone();
+    let archive = tokio::spawn(async move {
+        archive_client
+            .post(format!(
+                "http://{addr}/code/workspaces/{workspace_id}/archive"
+            ))
+            .bearer_auth(archive_token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .unwrap()
+    });
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while !started.exists() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "archive hook did not reach its barrier"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let terminal = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/terminals",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(terminal.status(), reqwest::StatusCode::CONFLICT);
+    let terminal_body: serde_json::Value = terminal.json().await.unwrap();
+    assert_eq!(terminal_body["kind"], "workspace_not_ready");
+
+    std::fs::write(path.join("concurrent.txt"), "late\n").unwrap();
+    std::fs::write(&proceed, "go\n").unwrap();
+    let archived = archive.await.unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = archived.json().await.unwrap();
+    assert_eq!(body["kind"], "uncommitted");
+    assert_eq!(
+        std::fs::read_to_string(path.join("concurrent.txt")).unwrap(),
+        "late\n"
+    );
+}
+
+#[tokio::test]
+async fn archive_shutdown_timeout_preserves_the_checkout() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    runtime.set_archive_shutdown_timeout(true);
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = archived.json().await.unwrap();
+    assert_eq!(body["kind"], "workspace_shutdown_timeout");
+    assert!(path.join("README.md").is_file());
+    let stored = tidebreak_core::db::code::get_workspace(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        json_id(&workspace).parse().unwrap(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(stored.status, CodeWorkspaceStatus::Archiving);
+}
+
+#[tokio::test]
+async fn archive_refuses_ignored_only_content_without_force() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    std::fs::write(repo.join(".gitignore"), ".env.local\nbuild/\n").unwrap();
+    for args in [
+        ["add", ".gitignore"].as_slice(),
+        ["commit", "-m", "ignore local files"].as_slice(),
+    ] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .status()
+            .unwrap()
+            .success());
+    }
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    std::fs::write(path.join(".env.local"), "ONLY_COPY=1\n").unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "ignored_content");
+    assert_eq!(
+        std::fs::read_to_string(path.join(".env.local")).unwrap(),
+        "ONLY_COPY=1\n"
+    );
+
+    assert!(std::process::Command::new("git")
+        .args([
+            "config",
+            "--add",
+            "tidebreak.archiveDisposablePath",
+            "build"
+        ])
+        .current_dir(&path)
+        .status()
+        .unwrap()
+        .success());
+    std::fs::remove_file(path.join(".env.local")).unwrap();
+    std::fs::create_dir_all(path.join("build")).unwrap();
+    std::fs::write(path.join("build/cache.bin"), "generated\n").unwrap();
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+    assert!(!path.exists());
+}
+
+#[tokio::test]
 async fn archive_ends_the_session_before_removing_the_worktree() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -120,7 +120,7 @@ describe the current schema, not the frozen baseline.
   which does. Reclaiming the checkout on disk is a separate, explicit act.
 - **`code_workspace`** — `id`, `repo_id`, `title`, `worktree_path`,
   `branch_name`, `base_ref`, `status`
-  (`Creating | SetupFailed | Active | Archived | Released`), `pr` (JSON digest:
+  (`Creating | SetupFailed | Active | Archiving | Archived | Released`), `pr` (JSON digest:
   number, url, state, checks summary; nullable), `created_at`,
   `archived_at`, `released_at`, `released_tip`, `bundle_bytes`.
 
@@ -131,6 +131,11 @@ describe the current schema, not the frozen baseline.
   build output; a branch's own commits are usually kilobytes, which is what
   makes the deeper tier worth the step. Transcripts are untouched at every
   tier — the row and its journal outlive the bytes.
+
+  Non-force archive also protects ignored files. To exclude a generated
+  directory from that scan, configure its exact repository-relative path with
+  `git config --add tidebreak.archiveDisposablePath <directory>`. Archive
+  fails closed when the scan or its configured paths exceed the safety budget.
 - **`code_session`** — `id`, `workspace_id`, `kind`
   (`Interactive | Watch`, per
   [`0050`](decisions/0050-watch-and-fix-is-a-durable-task.md)), `harness_kind`,


### PR DESCRIPTION
## What changed

- Add an `Archiving` workspace lifecycle state and atomically claim it before archive work starts.
- Reject terminal, session, turn, and stale workspace writes after archive claims the checkout.
- Close terminals, stop workers, and hold the workspace turn lock before the archive hook and deletion.
- Repeat dirty, unpushed, and ignored-content checks after the archive hook.
- Preserve the checkout when shutdown or content inspection is uncertain.
- Allow ignored generated content only under directories configured with `tidebreak.archiveDisposablePath`.
- Recover interrupted archive state only when the checkout exists and no session may still be running.
- Add regressions for hook-created files, concurrent writes after the first check, shutdown timeout, and ignored-only content.

## Validation

- `rustfmt --edition 2021 --check` for every changed Rust file
- `git diff --check`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/api.test.ts` (77 tests)
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/api/client.ts src/api.test.ts src/code/labels.ts src/code/parsers.ts src/generated/wire.ts`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`

Cargo build, check, Clippy, and tests were not run under the issue and repository instructions.

## Compatibility and risk

The database migration widens the workspace status constraint with the transient `archiving` value. The desktop wire parser accepts that value. Existing active, archived, and released workspace behavior stays unchanged outside the archive lifecycle.

Archive now fails closed when it cannot prove that terminals and workers stopped or cannot inspect ignored content within the bounded scan.

## Tracking

Closes #2699

CI recovery: Re-ran after the GitHub Actions outage on August 26, 2026.

<!-- gha-outage-retry-2: 2026-08-26-pr-2707 -->