### PR TITLE
fix(code): bound subprocess output while reading

### DIFF
--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -11,7 +11,7 @@ use std::process::{ExitStatus, Output};
 use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 use tokio::sync::watch;
 #[cfg(unix)]
@@ -29,6 +29,101 @@ pub enum RecordedProcessReap {
     Exited,
     /// The recorded process still had the same identity when the wait expired.
     TimedOut,
+}
+
+/// Which end of one subprocess stream survives an output limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputRetention {
+    /// Keep the first bytes and lines that the process wrote.
+    Head,
+    /// Keep the newest bytes and lines that the process wrote.
+    Tail,
+}
+
+/// Memory limits for one piped subprocess stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OutputBudget {
+    /// Maximum retained bytes.
+    pub max_bytes: usize,
+    /// Maximum retained newline-delimited records.
+    pub max_lines: usize,
+    /// Which end survives when either limit is exceeded.
+    pub retention: OutputRetention,
+}
+
+impl OutputBudget {
+    /// Create a budget that keeps the stream's leading bytes and lines.
+    #[must_use]
+    pub const fn head(max_bytes: usize, max_lines: usize) -> Self {
+        Self {
+            max_bytes,
+            max_lines,
+            retention: OutputRetention::Head,
+        }
+    }
+
+    /// Create a budget that keeps the stream's trailing bytes and lines.
+    #[must_use]
+    pub const fn tail(max_bytes: usize, max_lines: usize) -> Self {
+        Self {
+            max_bytes,
+            max_lines,
+            retention: OutputRetention::Tail,
+        }
+    }
+}
+
+/// One subprocess stream captured within its byte and line limits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedOutput {
+    /// Retained bytes from the selected end of the stream.
+    pub bytes: Vec<u8>,
+    /// Whether bytes or lines were discarded.
+    pub truncated: bool,
+    /// Which end of the stream was retained.
+    pub retention: OutputRetention,
+}
+
+impl BoundedOutput {
+    /// Decode the retained bytes and insert an explicit truncation marker at
+    /// the discarded end.
+    #[must_use]
+    pub fn into_marked_text(self) -> String {
+        let text = String::from_utf8_lossy(&self.bytes).into_owned();
+        if !self.truncated {
+            return text;
+        }
+        match self.retention {
+            OutputRetention::Head => {
+                if text.ends_with('\n') {
+                    format!("{text}[output truncated]\n")
+                } else {
+                    format!("{text}\n[output truncated]")
+                }
+            }
+            OutputRetention::Tail => {
+                if text.starts_with('\n') {
+                    format!("[output truncated]{text}")
+                } else {
+                    format!("[output truncated]\n{text}")
+                }
+            }
+        }
+    }
+}
+
+/// Exit status and bounded stdout and stderr from one process tree.
+#[derive(Debug)]
+pub struct BoundedProcessOutput {
+    /// Root process exit status.
+    pub status: ExitStatus,
+    /// Bounded stdout.
+    pub stdout: BoundedOutput,
+    /// Bounded stderr.
+    pub stderr: BoundedOutput,
+    /// Whether the process tree was terminated after either stream exceeded
+    /// its budget.
+    pub terminated_for_output: bool,
 }
 
 /// Return the creation identity captured when this process spawned `pid`.
@@ -362,6 +457,52 @@ impl ProcessTreeChild {
         })
     }
 
+    /// Capture stdout and stderr concurrently without exceeding either
+    /// stream's byte or line budget.
+    ///
+    /// If `terminate_on_limit` is true, the first discarded byte terminates
+    /// the owned process tree. The returned buffers still contain the bounded
+    /// head or tail selected by each budget. Cancelling this future keeps the
+    /// ordinary drop behavior and terminates the tree.
+    pub async fn wait_with_bounded_output(
+        mut self,
+        stdout_budget: OutputBudget,
+        stderr_budget: OutputBudget,
+        terminate_on_limit: bool,
+    ) -> io::Result<BoundedProcessOutput> {
+        drop(self.take_stdin());
+        let stdout = self.take_stdout();
+        let stderr = self.take_stderr();
+        let (limit_tx, mut limit_rx) = watch::channel(false);
+        let read_stdout = capture_bounded(stdout, stdout_budget, limit_tx.clone());
+        let read_stderr = capture_bounded(stderr, stderr_budget, limit_tx);
+        let readers = async move { tokio::try_join!(read_stdout, read_stderr) };
+        tokio::pin!(readers);
+
+        let mut terminated_for_output = false;
+        let mut limit_open = true;
+        let (stdout, stderr) = loop {
+            tokio::select! {
+                result = &mut readers => break result?,
+                changed = limit_rx.changed(), if terminate_on_limit && !terminated_for_output && limit_open => {
+                    if changed.is_ok() && *limit_rx.borrow_and_update() {
+                        self.terminate_tree()?;
+                        terminated_for_output = true;
+                    } else if changed.is_err() {
+                        limit_open = false;
+                    }
+                }
+            }
+        };
+        let status = self.wait().await?;
+        Ok(BoundedProcessOutput {
+            status,
+            stdout,
+            stderr,
+            terminated_for_output,
+        })
+    }
+
     /// Ask the process to stop, escalating to tree termination after `grace`.
     ///
     /// Windows has no reliable console-control channel for GUI-spawned batch
@@ -434,6 +575,160 @@ impl ProcessTreeChild {
             self.child_mut().start_kill()
         }
     }
+}
+
+const BOUNDED_OUTPUT_CHUNK_BYTES: usize = 8 * 1_024;
+
+async fn capture_bounded<R>(
+    reader: Option<R>,
+    budget: OutputBudget,
+    limit_tx: watch::Sender<bool>,
+) -> io::Result<BoundedOutput>
+where
+    R: AsyncRead + Unpin,
+{
+    let Some(mut reader) = reader else {
+        return Ok(BoundedOutput {
+            bytes: Vec::new(),
+            truncated: false,
+            retention: budget.retention,
+        });
+    };
+    let mut capture = OutputCapture::new(budget);
+    let mut chunk = [0_u8; BOUNDED_OUTPUT_CHUNK_BYTES];
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        if capture.push(&chunk[..read]) {
+            limit_tx.send_replace(true);
+        }
+    }
+    Ok(capture.finish())
+}
+
+#[derive(Debug)]
+struct OutputCapture {
+    budget: OutputBudget,
+    bytes: Vec<u8>,
+    newline_count: usize,
+    truncated: bool,
+}
+
+impl OutputCapture {
+    fn new(budget: OutputBudget) -> Self {
+        Self {
+            budget,
+            bytes: Vec::with_capacity(budget.max_bytes.min(BOUNDED_OUTPUT_CHUNK_BYTES)),
+            newline_count: 0,
+            truncated: false,
+        }
+    }
+
+    /// Returns true only when this push crosses a limit for the first time.
+    fn push(&mut self, chunk: &[u8]) -> bool {
+        let was_truncated = self.truncated;
+        match self.budget.retention {
+            OutputRetention::Head => self.push_head(chunk),
+            OutputRetention::Tail => self.push_tail(chunk),
+        }
+        !was_truncated && self.truncated
+    }
+
+    fn push_head(&mut self, chunk: &[u8]) {
+        if chunk.is_empty() {
+            return;
+        }
+        let byte_room = self.budget.max_bytes.saturating_sub(self.bytes.len());
+        let mut take = chunk.len().min(byte_room);
+        if self.newline_count >= self.budget.max_lines {
+            take = 0;
+        } else if self.budget.max_lines != usize::MAX {
+            let remaining_lines = self.budget.max_lines - self.newline_count;
+            if let Some(index) = nth_newline(chunk, remaining_lines) {
+                take = take.min(index.saturating_add(1));
+            }
+        }
+        let kept = &chunk[..take];
+        self.newline_count = self
+            .newline_count
+            .saturating_add(kept.iter().filter(|byte| **byte == b'\n').count());
+        self.bytes.extend_from_slice(kept);
+        self.truncated |= take < chunk.len();
+    }
+
+    fn push_tail(&mut self, chunk: &[u8]) {
+        if chunk.is_empty() {
+            return;
+        }
+        if self.budget.max_bytes == 0 || self.budget.max_lines == 0 {
+            self.truncated = true;
+            return;
+        }
+        if chunk.len() >= self.budget.max_bytes {
+            let dropped = !self.bytes.is_empty() || chunk.len() > self.budget.max_bytes;
+            self.bytes.clear();
+            self.bytes
+                .extend_from_slice(&chunk[chunk.len() - self.budget.max_bytes..]);
+            self.truncated |= dropped;
+        } else {
+            let overflow = self
+                .bytes
+                .len()
+                .saturating_add(chunk.len())
+                .saturating_sub(self.budget.max_bytes);
+            if overflow > 0 {
+                self.bytes.drain(..overflow);
+                self.truncated = true;
+            }
+            self.bytes.extend_from_slice(chunk);
+        }
+        self.newline_count = self.bytes.iter().filter(|byte| **byte == b'\n').count();
+        if self.budget.max_lines != usize::MAX {
+            while retained_line_count(&self.bytes, self.newline_count) > self.budget.max_lines {
+                let Some(end) = self.bytes.iter().position(|byte| *byte == b'\n') else {
+                    self.bytes.clear();
+                    self.newline_count = 0;
+                    self.truncated = true;
+                    break;
+                };
+                self.bytes.drain(..=end);
+                self.newline_count -= 1;
+                self.truncated = true;
+            }
+        }
+    }
+
+    fn finish(self) -> BoundedOutput {
+        BoundedOutput {
+            bytes: self.bytes,
+            truncated: self.truncated,
+            retention: self.budget.retention,
+        }
+    }
+}
+
+fn retained_line_count(bytes: &[u8], newline_count: usize) -> usize {
+    newline_count.saturating_add(usize::from(
+        !bytes.is_empty() && bytes.last() != Some(&b'\n'),
+    ))
+}
+
+fn nth_newline(bytes: &[u8], count: usize) -> Option<usize> {
+    if count == 0 {
+        return Some(0);
+    }
+    let mut seen = 0;
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte == b'\n' {
+            seen += 1;
+            if seen == count {
+                return Some(index);
+            }
+        }
+    }
+    None
 }
 
 impl Drop for ProcessTreeChild {
@@ -1003,6 +1298,35 @@ mod tests {
             other => panic!("{other:?}"),
         }
     }
+
+    #[test]
+    fn bounded_capture_discards_bytes_beyond_the_cap() {
+        let mut capture = OutputCapture::new(OutputBudget::head(8, usize::MAX));
+        assert!(capture.push(b"0123456789"));
+        let output = capture.finish();
+        assert_eq!(output.bytes, b"01234567");
+        assert!(output.truncated);
+    }
+
+    #[test]
+    fn bounded_capture_does_not_retain_a_very_long_line() {
+        let mut capture = OutputCapture::new(OutputBudget::head(32, 4));
+        assert!(!capture.push(&vec![b'x'; 16]));
+        assert!(capture.push(&vec![b'x'; 64 * 1_024]));
+        let output = capture.finish();
+        assert_eq!(output.bytes.len(), 32);
+        assert!(output.bytes.iter().all(|byte| *byte == b'x'));
+        assert!(output.truncated);
+    }
+
+    #[test]
+    fn bounded_capture_stops_at_the_line_cap() {
+        let mut capture = OutputCapture::new(OutputBudget::head(128, 2));
+        assert!(capture.push(b"one\ntwo\nthree\n"));
+        let output = capture.finish();
+        assert_eq!(output.bytes, b"one\ntwo\n");
+        assert!(output.truncated);
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -1160,6 +1484,69 @@ exit 0
             "output collection unexpectedly ignored the inherited pipe"
         );
         assert_process_exits(descendant).await;
+    }
+
+    #[tokio::test]
+    async fn bounded_output_drains_stdout_and_stderr_concurrently() {
+        let script = r#"
+i=0
+while [ $i -lt 300 ]; do
+  printf 'stdout-%04d\n' "$i"
+  printf 'stderr-%04d\n' "$i" >&2
+  i=$((i+1))
+done
+"#;
+        let mut command = Command::new("/bin/sh");
+        command
+            .args(["-c", script])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child = spawn_process_tree(&mut command).unwrap();
+        let output = timeout(
+            ASSERTION_TIMEOUT,
+            child.wait_with_bounded_output(
+                super::OutputBudget::head(1_024, 64),
+                super::OutputBudget::head(1_024, 64),
+                false,
+            ),
+        )
+        .await
+        .expect("bounded output completed")
+        .unwrap();
+
+        assert!(output.status.success());
+        assert!(output.stdout.truncated);
+        assert!(output.stderr.truncated);
+        assert!(String::from_utf8_lossy(&output.stdout.bytes).starts_with("stdout-0000"));
+        assert!(String::from_utf8_lossy(&output.stderr.bytes).starts_with("stderr-0000"));
+    }
+
+    #[tokio::test]
+    async fn bounded_output_terminates_a_producer_that_continues_after_the_cap() {
+        let mut command = Command::new("/bin/sh");
+        command
+            .args(["-c", "while :; do printf '0123456789abcdef'; done"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child = spawn_process_tree(&mut command).unwrap();
+        let output = timeout(
+            ASSERTION_TIMEOUT,
+            child.wait_with_bounded_output(
+                super::OutputBudget::head(128, 8),
+                super::OutputBudget::tail(128, 8),
+                true,
+            ),
+        )
+        .await
+        .expect("output limit terminated the producer")
+        .unwrap();
+
+        assert!(output.terminated_for_output);
+        assert!(output.stdout.truncated);
+        assert_eq!(output.stdout.bytes.len(), 128);
+        assert!(!output.status.success());
     }
 
     async fn spawn_shell_tree() -> (ProcessTreeChild, BufReader<ChildStdout>) {

--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -595,7 +595,10 @@ where
         });
     };
     let mut capture = OutputCapture::new(budget);
-    let mut chunk = [0_u8; BOUNDED_OUTPUT_CHUNK_BYTES];
+    // Keep the read buffer off the async future's stack. Callers can nest this
+    // future through several git helpers, and two inline 8 KiB buffers per
+    // process can overflow the small stack used by Rust's test threads.
+    let mut chunk = vec![0_u8; BOUNDED_OUTPUT_CHUNK_BYTES];
     loop {
         let read = reader.read(&mut chunk).await?;
         if read == 0 {
@@ -1311,7 +1314,7 @@ mod tests {
     #[test]
     fn bounded_capture_does_not_retain_a_very_long_line() {
         let mut capture = OutputCapture::new(OutputBudget::head(32, 4));
-        assert!(!capture.push(&vec![b'x'; 16]));
+        assert!(!capture.push(&[b'x'; 16]));
         assert!(capture.push(&vec![b'x'; 64 * 1_024]));
         let output = capture.finish();
         assert_eq!(output.bytes.len(), 32);

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -35,7 +35,8 @@ mod text;
 pub use budget::{BudgetTick, StreamBudget, StreamLineBuffer};
 pub use child::{
     current_process_identity, spawn_process_tree, spawned_process_identity,
-    terminate_recorded_process, ChildPid, ProcessTreeChild, RecordedProcessReap,
+    terminate_recorded_process, BoundedOutput, BoundedProcessOutput, ChildPid, OutputBudget,
+    OutputRetention, ProcessTreeChild, RecordedProcessReap,
 };
 pub use launch::{
     validate_launch_plan, validate_launch_plan_with, BypassFlagError, BypassPolicy, LaunchPlan,

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -33,6 +33,7 @@ use std::time::Duration;
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
+use tidebreak_harness::{spawn_process_tree, BoundedProcessOutput, OutputBudget};
 use tokio::process::Command;
 use tokio::time::timeout;
 use tracing::warn;
@@ -49,6 +50,11 @@ use super::bus::CodeEventBus;
 
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const GIT_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(120);
+const GIT_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+const GIT_OUTPUT_LINES: usize = 200_000;
+const GIT_ERROR_BYTES: usize = 64 * 1024;
+const GIT_ERROR_LINES: usize = 2_048;
+const MAX_DIFF_LINES: usize = 32_768;
 
 /// Default bound on a unified-diff body.
 pub(crate) const MAX_DIFF_BYTES: usize = 256 * 1024;
@@ -404,15 +410,17 @@ pub(crate) async fn produce_diff(
     if let Some(path) = file {
         let path = GitPath::from_wire(path)?;
         let paths = std::slice::from_ref(&path);
-        let raw = git_bytes_with_literal_paths(
+        let (raw, read_truncated) = git_bytes_with_literal_paths_bounded(
             worktree,
             &["diff", "--find-renames", from, to, "--"],
             paths,
             GIT_SNAPSHOT_TIMEOUT,
+            OutputBudget::head(bounds.max_bytes, MAX_DIFF_LINES),
         )
         .await
         .map_err(CheckpointError::internal)?;
-        let (diff, body_truncated) = truncate_bytes(&raw, bounds.max_bytes);
+        let (diff, decode_truncated) = truncate_bytes(&raw, bounds.max_bytes);
+        let body_truncated = read_truncated || decode_truncated;
         let selected = collect_changes_for_paths(worktree, from, to, paths).await?;
         let stat = Diffstat {
             files: selected.stat.files.max(u32::from(!diff.is_empty())),
@@ -449,15 +457,17 @@ pub(crate) async fn produce_diff(
         .iter()
         .map(|entry| entry.path.clone())
         .collect();
-    let raw = git_bytes_with_literal_paths(
+    let (raw, read_truncated) = git_bytes_with_literal_paths_bounded(
         worktree,
         &["diff", "--find-renames", from, to, "--"],
         &paths,
         GIT_SNAPSHOT_TIMEOUT,
+        OutputBudget::head(bounds.max_bytes, MAX_DIFF_LINES),
     )
     .await
     .map_err(CheckpointError::internal)?;
-    let (body, body_truncated) = truncate_bytes(&raw, bounds.max_bytes);
+    let (body, decode_truncated) = truncate_bytes(&raw, bounds.max_bytes);
+    let body_truncated = read_truncated || decode_truncated;
     truncated |= body_truncated;
     Ok(BoundedDiff {
         diff: body,
@@ -1074,6 +1084,32 @@ async fn git_bytes_with_literal_paths(
     .await
 }
 
+async fn git_bytes_with_literal_paths_bounded(
+    cwd: &Path,
+    args: &[&str],
+    paths: &[GitPath],
+    limit: Duration,
+    stdout_budget: OutputBudget,
+) -> Result<(Vec<u8>, bool), String> {
+    let mut command = git_command(cwd);
+    command.arg("--literal-pathspecs").args(args);
+    for path in paths {
+        command.arg(path.to_os_string()?);
+    }
+    run_git_command_bounded(
+        command,
+        format!(
+            "--literal-pathspecs {} <{} paths>",
+            args.join(" "),
+            paths.len()
+        ),
+        limit,
+        stdout_budget,
+        true,
+    )
+    .await
+}
+
 fn git_command(cwd: &Path) -> Command {
     let mut command = Command::new("git");
     command
@@ -1091,24 +1127,83 @@ fn git_command(cwd: &Path) -> Command {
 }
 
 async fn run_git_command(
-    mut command: Command,
+    command: Command,
     description: String,
     limit: Duration,
 ) -> Result<Vec<u8>, String> {
-    let child = command
-        .spawn()
-        .map_err(|err| format!("failed to spawn git: {err}"))?;
-    let output = timeout(limit, child.wait_with_output())
-        .await
-        .map_err(|_| format!("git {description} timed out"))?
-        .map_err(|err| format!("git {description} failed: {err}"))?;
-    if output.status.success() {
-        Ok(output.stdout)
+    let (stdout, truncated) = run_git_command_bounded(
+        command,
+        description.clone(),
+        limit,
+        OutputBudget::head(GIT_OUTPUT_BYTES, GIT_OUTPUT_LINES),
+        false,
+    )
+    .await?;
+    if truncated {
+        Err(format!("git {description} output exceeded its limit"))
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-        Err(if stderr.is_empty() { stdout } else { stderr })
+        Ok(stdout)
     }
+}
+
+async fn run_git_command_bounded(
+    mut command: Command,
+    description: String,
+    limit: Duration,
+    stdout_budget: OutputBudget,
+    accept_truncated_stdout: bool,
+) -> Result<(Vec<u8>, bool), String> {
+    let child =
+        spawn_process_tree(&mut command).map_err(|err| format!("failed to spawn git: {err}"))?;
+    let output = timeout(
+        limit,
+        child.wait_with_bounded_output(
+            stdout_budget,
+            OutputBudget::tail(GIT_ERROR_BYTES, GIT_ERROR_LINES),
+            true,
+        ),
+    )
+    .await
+    .map_err(|_| format!("git {description} timed out"))?
+    .map_err(|err| format!("git {description} failed: {err}"))?;
+    finish_git_output(output, &description, accept_truncated_stdout)
+}
+
+fn finish_git_output(
+    output: BoundedProcessOutput,
+    description: &str,
+    accept_truncated_stdout: bool,
+) -> Result<(Vec<u8>, bool), String> {
+    let stdout_truncated = output.stdout.truncated;
+    let stderr_truncated = output.stderr.truncated;
+    let stderr_empty = output.stderr.bytes.is_empty();
+    if output.status.success() && !output.terminated_for_output {
+        return if stdout_truncated && !accept_truncated_stdout {
+            Err(format!("git {description} output exceeded its limit"))
+        } else {
+            Ok((output.stdout.bytes, stdout_truncated))
+        };
+    }
+    if output.terminated_for_output
+        && stdout_truncated
+        && !stderr_truncated
+        && stderr_empty
+        && accept_truncated_stdout
+    {
+        return Ok((output.stdout.bytes, true));
+    }
+
+    let stdout = output.stdout.into_marked_text().trim().to_owned();
+    let stderr = output.stderr.into_marked_text().trim().to_owned();
+    if output.terminated_for_output {
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(if detail.is_empty() {
+            format!("git {description} output exceeded its limit")
+        } else {
+            format!("git {description} output exceeded its limit: {detail}")
+        });
+    }
+    Err(if stderr.is_empty() { stdout } else { stderr })
 }
 
 /// Fingerprint of the user's `HEAD` and index, used to prove a checkpoint
@@ -1688,7 +1783,7 @@ mod tests {
             .await
             .unwrap();
         assert!(diff.truncated);
-        assert!(diff.diff.len() <= 80, "{}", diff.diff.len());
+        assert!(diff.diff.len() <= tight.max_bytes, "{}", diff.diff.len());
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -16,7 +16,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 
 use tidebreak_core::{Diffstat, PullRequestDigest, QuickAction};
-use tidebreak_harness::{filter_child_env, probe_shell, HostEnv};
+use tidebreak_harness::{filter_child_env, probe_shell, HostEnv, OutputBudget};
 
 use super::setup_script::spawn_workspace_script;
 use crate::obo_gateway::GitCredential;
@@ -27,6 +27,8 @@ const GIT_PUSH_TIMEOUT: Duration = Duration::from_secs(120);
 const GH_TIMEOUT: Duration = Duration::from_secs(30);
 const ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_OUTPUT_CHARS: usize = 4_096;
+const MAX_ACTION_OUTPUT_BYTES: usize = 4_096;
+const MAX_ACTION_OUTPUT_LINES: usize = 256;
 const GH_OBSERVATION_TTL: Duration = Duration::from_secs(30);
 pub(crate) const GH_UNAVAILABLE_PREFIX: &str = "gh_unavailable: ";
 pub(crate) const PR_HEAD_CHANGED_PREFIX: &str = "pr_head_changed: ";
@@ -1529,13 +1531,22 @@ async fn run_action(worktree: &Path, action: &QuickAction) -> ActionOutcome {
             };
         }
     };
-    match timeout(ACTION_TIMEOUT, child.wait_with_output()).await {
+    match timeout(
+        ACTION_TIMEOUT,
+        child.wait_with_bounded_output(
+            OutputBudget::head(MAX_ACTION_OUTPUT_BYTES, MAX_ACTION_OUTPUT_LINES),
+            OutputBudget::head(MAX_ACTION_OUTPUT_BYTES, MAX_ACTION_OUTPUT_LINES),
+            true,
+        ),
+    )
+    .await
+    {
         Ok(Ok(output)) => ActionOutcome {
             name: action.name.clone(),
-            success: output.status.success(),
+            success: output.status.success() && !output.terminated_for_output,
             exit_code: output.status.code(),
-            stdout: bound_text(&String::from_utf8_lossy(&output.stdout)),
-            stderr: bound_text(&String::from_utf8_lossy(&output.stderr)),
+            stdout: output.stdout.into_marked_text(),
+            stderr: output.stderr.into_marked_text(),
             timed_out: false,
         },
         Ok(Err(err)) => ActionOutcome {
@@ -3073,12 +3084,13 @@ exit 3
         let dir = TempDir::new().unwrap();
         let long = QuickAction {
             name: "noise".into(),
-            command: format!("printf '%{}s' '' | tr ' ' x", MAX_OUTPUT_CHARS + 80),
+            command: "while :; do printf '0123456789abcdef'; done".into(),
             auto_run_on_create: false,
         };
         let noisy = run_action(dir.path(), &long).await;
-        assert!(noisy.success, "{}", noisy.stderr);
-        assert_eq!(noisy.stdout.chars().count(), MAX_OUTPUT_CHARS);
+        assert!(!noisy.success, "an over-limit producer must be terminated");
+        assert!(noisy.stdout.starts_with("0123456789abcdef"));
+        assert!(noisy.stdout.contains("[output truncated]"));
         assert!(!noisy.timed_out);
 
         let sleeper = QuickAction {

--- a/crates/tidebreak-server/src/code/setup_script.rs
+++ b/crates/tidebreak-server/src/code/setup_script.rs
@@ -14,11 +14,13 @@ use std::time::Duration;
 #[cfg(windows)]
 use std::os::windows::ffi::OsStringExt;
 
-use tidebreak_harness::ProcessTreeChild;
+use tidebreak_harness::{OutputBudget, ProcessTreeChild};
 use tokio::process::Command;
 use tokio::time::timeout;
 
 const SCRIPT_TIMEOUT: Duration = Duration::from_secs(120);
+const SCRIPT_OUTPUT_BYTES: usize = 4_096;
+const SCRIPT_OUTPUT_LINES: usize = 256;
 
 /// Outcome of running a user-authored setup or archive script.
 #[derive(Debug)]
@@ -27,6 +29,7 @@ pub(crate) struct ScriptRun {
     pub status: Option<i32>,
     pub stdout: String,
     pub stderr: String,
+    pub output_truncated: bool,
 }
 
 /// Spawn a user-authored script in the platform-native non-interactive shell.
@@ -56,19 +59,29 @@ pub(crate) async fn run_workspace_script(
             status: Some(0),
             stdout: String::new(),
             stderr: String::new(),
+            output_truncated: false,
         });
     }
     let child = spawn_workspace_script(worktree, script)
         .map_err(|err| format!("failed to spawn workspace script: {err}"))?;
-    let output = timeout(SCRIPT_TIMEOUT, child.wait_with_output())
-        .await
-        .map_err(|_| "workspace script timed out".to_owned())?
-        .map_err(|err| format!("workspace script failed: {err}"))?;
+    let output = timeout(
+        SCRIPT_TIMEOUT,
+        child.wait_with_bounded_output(
+            OutputBudget::head(SCRIPT_OUTPUT_BYTES, SCRIPT_OUTPUT_LINES),
+            OutputBudget::head(SCRIPT_OUTPUT_BYTES, SCRIPT_OUTPUT_LINES),
+            true,
+        ),
+    )
+    .await
+    .map_err(|_| "workspace script timed out".to_owned())?
+    .map_err(|err| format!("workspace script failed: {err}"))?;
+    let output_truncated = output.stdout.truncated || output.stderr.truncated;
     Ok(ScriptRun {
-        success: output.status.success(),
+        success: output.status.success() && !output.terminated_for_output,
         status: output.status.code(),
-        stdout: bound_text(&output.stdout),
-        stderr: bound_text(&output.stderr),
+        stdout: output.stdout.into_marked_text(),
+        stderr: output.stderr.into_marked_text(),
+        output_truncated,
     })
 }
 
@@ -141,15 +154,6 @@ fn system_windows_powershell() -> io::Result<PathBuf> {
     }
 }
 
-fn bound_text(bytes: &[u8]) -> String {
-    const MAX: usize = 4_096;
-    let mut text = String::from_utf8_lossy(bytes).into_owned();
-    if text.chars().count() > MAX {
-        text = text.chars().take(MAX).collect();
-    }
-    text
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -165,6 +169,20 @@ mod tests {
             args,
             [OsString::from("-lc"), OsString::from("printf ready")]
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_scripts_mark_output_truncated_at_the_read_limit() {
+        let directory = tempfile::tempdir().expect("worktree");
+        let script = format!("printf '%{}s' '' | tr ' ' x", SCRIPT_OUTPUT_BYTES + 128);
+        let run = run_workspace_script(directory.path(), &script)
+            .await
+            .expect("run noisy script");
+
+        assert!(run.stdout.starts_with(&"x".repeat(SCRIPT_OUTPUT_BYTES)));
+        assert!(run.stdout.contains("[output truncated]"));
+        assert!(run.output_truncated);
     }
 
     #[cfg(windows)]

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -1230,7 +1230,14 @@ mod tests {
             .await
             .unwrap();
 
-        let error = run_setup_script(&path, Some("while :; do printf '0123456789abcdef'; done"))
+        // Windows runs workspace scripts through PowerShell, which cannot
+        // parse the POSIX loop, so each platform floods from its own syntax.
+        let noisy_script = if cfg!(windows) {
+            "while ($true) { Write-Output '0123456789abcdef' }"
+        } else {
+            "while :; do printf '0123456789abcdef'; done"
+        };
+        let error = run_setup_script(&path, Some(noisy_script))
             .await
             .unwrap_err();
 

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -590,8 +590,13 @@ async fn run_hook_script(
     if run.success {
         Ok(())
     } else {
+        let truncation = if run.output_truncated {
+            " [output truncated]"
+        } else {
+            ""
+        };
         Err(WorktreeError::user(format!(
-            "{label} script failed (exit {}): {}",
+            "{label} script failed (exit {}): {}{truncation}",
             run.status
                 .map(|code| code.to_string())
                 .unwrap_or_else(|| "signal".into()),
@@ -1214,6 +1219,23 @@ mod tests {
         assert!(err.to_string().contains("setup script failed"), "{err}");
         assert!(path.join("README.md").is_file());
         verify_inside_worktree(&path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn setup_failure_reports_when_its_output_was_truncated() {
+        let (_dir, repo) = init_repo();
+        let data = TempDir::new().unwrap();
+        let path = scratch_worktree(data.path(), "noisy-setup");
+        create_worktree(&repo, &path, "tidebreak/noisy-setup", "main")
+            .await
+            .unwrap();
+
+        let error = run_setup_script(&path, Some("while :; do printf '0123456789abcdef'; done"))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("[output truncated]"), "{error}");
+        assert!(path.join("README.md").is_file());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #2708 and audit finding DATA-4.

This change enforces output byte and line budgets while child processes are still running. It applies bounded capture to harness children, checkpoint and Git helpers, setup scripts, and worktree commands. Responses retain the existing useful head or tail shape and report truncation explicitly.

The implementation builds on #2705 so it preserves the process-identity and termination fence. Existing callers keep the same successful behavior for output under the cap. Large or non-terminating producers now consume bounded memory and are stopped where the operation can safely terminate them.

Validation: Rustfmt and diff checks pass. Focused regression coverage covers oversized output, long lines, concurrent stdout and stderr, and producers that continue after the cap. CI remains authoritative for Rust compilation and tests.