### PR TITLE
feat(desktop): shimmer live status labels

### DIFF
--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -194,6 +194,14 @@ It shows live work first, outputs otherwise, and collapses to a compact
 pill when a side panel is using the canvas. Do not build a second activity
 summary that duplicates outputs, folders, permissions, or agents.
 
+### Live labels
+
+While a status line is live — Thinking, an in-progress tool phase — the
+label keeps muted ink and a highlight of `--foreground` sweeps across the
+glyphs (`.live-label-shimmer`). Do not pulse the label's opacity, do not
+cycle invented statuses, and do not paint the text with `live` teal. The
+sweep stops under `prefers-reduced-motion`.
+
 ### Empty states and welcome surfaces
 
 `Empty` is the canonical null-state container, and `EmptyMedia variant="icon"`

--- a/crates/tidebreak-desktop/ui/src/LiveLabel.tsx
+++ b/crates/tidebreak-desktop/ui/src/LiveLabel.tsx
@@ -1,0 +1,30 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+type LiveLabelProps = {
+  children: string;
+  /** Sweep a highlight across the glyphs while work is happening. */
+  live?: boolean;
+} & Omit<ComponentPropsWithoutRef<"span">, "children">;
+
+/**
+ * Status copy that can shimmer. The highlight is a second copy of the
+ * string in `data-text`, so keep `children` a plain string.
+ */
+export function LiveLabel({
+  children,
+  live = false,
+  className,
+  ...props
+}: LiveLabelProps) {
+  return (
+    <span
+      {...props}
+      className={cn(live && "live-label-shimmer", className)}
+      data-text={live ? children : undefined}
+    >
+      {children}
+    </span>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/ThinkingAccordion.tsx
+++ b/crates/tidebreak-desktop/ui/src/ThinkingAccordion.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ChevronDown, Lightbulb } from "lucide-react";
 
+import { LiveLabel } from "./LiveLabel";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,7 +37,7 @@ export function ThinkingAccordion({
    * A surface that pauses to think several times in one turn — code mode does,
    * between every pair of tool calls — would otherwise stack open blocks until
    * they are the whole viewport. It passes false: the line still says
-   * "Thinking" and still pulses, so the work is legible, but the text is one
+   * "Thinking" and still shimmers, so the work is legible, but the text is one
    * click away rather than in the way.
    */
   expandWhileStreaming?: boolean;
@@ -67,9 +68,9 @@ export function ThinkingAccordion({
           className="text-muted-foreground h-auto px-0 py-1"
         >
           <Lightbulb className="size-4" />
-          <span className={cn(streaming && "animate-pulse")}>
+          <LiveLabel live={streaming}>
             {streaming ? "Thinking" : "Thought"}
-          </span>
+          </LiveLabel>
           <ChevronDown
             className={cn(
               "size-4 transition-transform",

--- a/crates/tidebreak-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolActivityGroup.tsx
@@ -7,6 +7,7 @@ import { ToolEntriesList } from "./ToolEntriesList";
 import { ToolIcon } from "./ToolIcon";
 import { toolPreviewHeadline } from "./ToolPreview";
 import { ToolStatusIcon } from "./ToolStatusIcon";
+import { LiveLabel } from "./LiveLabel";
 import { useTypewriterOnce } from "./useTypewriterOnce";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -173,9 +174,10 @@ function ToolActivityRail({
           aria-live="polite"
           aria-atomic="true"
           aria-label={summary.label}
-          className={cn(summary.inProgress && "animate-pulse")}
         >
-          <span aria-hidden="true">{displayedSummary}</span>
+          <LiveLabel live={summary.inProgress} aria-hidden="true">
+            {displayedSummary}
+          </LiveLabel>
         </span>
         <ChevronDown
           className={cn(
@@ -294,14 +296,11 @@ function ToolActivityRow({ activity }: { activity: ToolActivity }) {
         </div>
         <ToolStatusIcon tone={presentation.tone} />
         {/* Row titles do not type — only the phase line does. A running row
-            keeps the pulse so the rail still shows where the work is. */}
-        <p
-          className={cn(
-            "whitespace-nowrap",
-            presentation.tone === "running" && "animate-pulse",
-          )}
-        >
-          {presentation.title}
+            keeps the shimmer so the rail still shows where the work is. */}
+        <p className="whitespace-nowrap">
+          <LiveLabel live={presentation.tone === "running"}>
+            {presentation.title}
+          </LiveLabel>
         </p>
       </div>
       {headline !== null && (

--- a/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
@@ -140,6 +140,39 @@ const streamingMessages: ChatMessage[] = [
   },
 ];
 
+const streamingReasoningMessages: ChatMessage[] = [
+  streamingMessages[0],
+  {
+    id: "stream-reasoning",
+    role: "assistant",
+    reasoning:
+      "I am comparing the dense tool phase with the compact transcript and checking which details should stay collapsed.",
+    text: "",
+    sources: [],
+    createdAt: "2026-08-24T14:02:06.000Z",
+  },
+];
+
+const runningToolMessages: ChatMessage[] = [
+  {
+    id: "run-user",
+    role: "user",
+    text: "Review the current Storybook coverage, run the focused checks, and summarize the gaps.",
+    createdAt: "2026-08-24T14:10:00.000Z",
+  },
+  {
+    id: "run-search",
+    role: "tool",
+    callId: "call-search",
+    name: "search",
+    status: "running",
+    preview: {
+      tool: "search",
+      query: "title: Conversation/ OR title: Composer/ OR title: Chat/",
+    },
+  },
+];
+
 const toolHeavyMessages: ChatMessage[] = [
   {
     id: "tools-user",
@@ -330,6 +363,20 @@ export const LoadingHistory: Story = {
 
 export const StreamingResponse: Story = {
   args: { messages: streamingMessages, busy: true, pinLastTurn: true },
+};
+
+/** Reasoning is still arriving, so Thinking shimmers and the body stays open. */
+export const StreamingReasoning: Story = {
+  args: {
+    messages: streamingReasoningMessages,
+    busy: true,
+    pinLastTurn: true,
+  },
+};
+
+/** A live tool phase shimmers on the folded line until the call settles. */
+export const RunningTools: Story = {
+  args: { messages: runningToolMessages, busy: true, pinLastTurn: true },
 };
 
 export const StalledStream: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/ThinkingAccordion.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ThinkingAccordion.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ThinkingAccordion } from "@/ThinkingAccordion";
+
+/**
+ * The model's reasoning for one step, behind a disclosure. While the
+ * reasoning is still arriving the label says Thinking and shimmers; once the
+ * answer starts it says Thought and sits still.
+ */
+const meta = {
+  title: "Conversation/Thinking accordion",
+  component: ThinkingAccordion,
+  args: {
+    text: "I am comparing the dense tool phase with the compact transcript and checking which details should stay collapsed.",
+    streaming: true,
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-prose pt-12">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ThinkingAccordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Reasoning is still arriving, so the line is open and the label shimmers. */
+export const Streaming: Story = {};
+
+/** The answer has started. The line is closed and the label is still. */
+export const Settled: Story = {
+  args: { streaming: false },
+};
+
+/**
+ * Code mode pauses to think between tool calls. The label still shimmers, but
+ * the body stays closed so stacked thoughts do not fill the viewport.
+ */
+export const FoldedWhileStreaming: Story = {
+  args: { expandWhileStreaming: false },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/ToolActivityGroup.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ToolActivityGroup.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+
+import { ToolActivityGroup, type ToolActivity } from "@/ToolActivityGroup";
+
+const runningSearch: ToolActivity = {
+  id: "search",
+  name: "web_search",
+  status: "running",
+  preview: {
+    tool: "search",
+    query: "title: Conversation/ OR title: Composer/",
+  },
+};
+
+const settledSearch: ToolActivity = {
+  ...runningSearch,
+  status: "completed",
+};
+
+const runningRead: ToolActivity = {
+  id: "read",
+  name: "read_file",
+  status: "running",
+};
+
+/**
+ * One phase of tool work behind a single line. While the phase is live the
+ * label shimmers; a settled phase is quiet. `animate` is off so the label is
+ * complete and only the shimmer moves.
+ */
+const meta = {
+  title: "Conversation/Tool activity",
+  component: ToolActivityGroup,
+  args: {
+    groupIndex: 0,
+    animate: false,
+    activities: [runningSearch],
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-prose pt-12">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ToolActivityGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The phase line names the live call and shimmers. */
+export const Running: Story = {};
+
+/** The phase has settled. The label is still and the wording is past tense. */
+export const Settled: Story = {
+  args: { activities: [settledSearch] },
+};
+
+/** Expanded rows keep the shimmer on the call that is still running. */
+export const RunningExpanded: Story = {
+  args: { activities: [runningSearch, runningRead] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button"));
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -1280,6 +1280,54 @@ body {
     }
   }
 
+  /* Live status labels (Thinking, an in-progress tool phase). Solid muted
+     glyphs, plus a second copy that carries only the highlight band. The
+     band is a slice of a 400%-wide gradient, so it is off-screen at both
+     ends of the loop and the restart does not snap. */
+  .live-label-shimmer {
+    position: relative;
+    display: inline-block;
+    color: var(--muted-foreground);
+  }
+
+  .live-label-shimmer::before {
+    content: attr(data-text);
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: linear-gradient(
+      90deg,
+      transparent 0%,
+      transparent 40%,
+      var(--foreground) 50%,
+      transparent 60%,
+      transparent 100%
+    );
+    background-size: 400% 100%;
+    background-repeat: no-repeat;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    animation: live-label-shimmer 2s linear infinite;
+  }
+
+  @keyframes live-label-shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: 0% 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .live-label-shimmer::before {
+      animation: none !important;
+      display: none !important;
+    }
+  }
+
   @keyframes code-reveal {
     from {
       opacity: 0;

--- a/crates/tidebreak-desktop/ui/src/useTypewriterOnce.test.ts
+++ b/crates/tidebreak-desktop/ui/src/useTypewriterOnce.test.ts
@@ -9,7 +9,7 @@ afterEach(() => vi.useRealTimers());
 
 describe("phase label typing", () => {
   it("never renders a blank frame", () => {
-    // The row it labels also pulses while its phase is live, so an empty frame
+    // The row it labels also shimmers while its phase is live, so an empty frame
     // does not read as text arriving — it reads as something that failed to
     // load. This was visible for most of a second on a real phase line.
     const { result } = renderHook(() =>


### PR DESCRIPTION
Live Thinking and in-progress tool labels used `animate-pulse`. That reads as a skeleton, not as work in progress.

`LiveLabel` keeps muted ink and sweeps a `--foreground` highlight across a second copy of the glyphs, the same overlay as transitions.dev shimmer text. The band is a slice of a 400%-wide gradient, so it is off-screen at both ends of the loop and the restart does not snap. The sweep stops under `prefers-reduced-motion`. The text is not painted with `live` teal.

Storybook: Conversation/Thinking accordion, Conversation/Tool activity, and the Streaming reasoning / Running tools transcript stories.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome format` on the touched files
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run` on `UiFoundations.dom.test.tsx`, `ToolActivityGroup.dom.test.tsx`, `ToolActivityGroup.test.tsx`, `useTypewriterOnce.test.ts`, and `stylesContract.test.ts`
- Visual review in Storybook (light and dark) for the stories above

Did not run `storybook:build` or a Cargo build. CI covers those.

## Compatibility and risk

None. Renderer-only CSS and markup. No wire or persist changes.