### PR TITLE
feat(code): read the delivery panel over forge REST on hosted machines

### DIFF
--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -99,6 +99,126 @@ impl DeliveryAccess {
             retry_at: None,
         }
     }
+
+    /// The reader, or the same refusal the list reads surface as a source
+    /// error — `gh_absent`/`gh_signed_out`/`gh_unavailable` on a local
+    /// machine, `git_forge_not_offered` with the connect path on a hosted
+    /// one.
+    fn require_reader(&self) -> Result<DeliveryReader, ServerError> {
+        self.reader.clone().ok_or_else(|| {
+            ServerError::conflict_kind(self.unavailable_kind, self.capability.remediation.clone())
+        })
+    }
+}
+
+/// One authenticated GET runner for the detail drawers: the same
+/// repository-scoped endpoint strings, answered by `gh api` or by the forge
+/// REST API depending on the reader.
+enum DeliveryEndpointApi {
+    Gh {
+        binary: PathBuf,
+        host: String,
+    },
+    Rest {
+        api_base: String,
+        credential: GitCredential,
+    },
+}
+
+impl DeliveryEndpointApi {
+    async fn get(&self, endpoint: &str) -> Result<Value, String> {
+        match self {
+            Self::Gh { binary, host } => run_api_json(binary, host, endpoint).await,
+            Self::Rest {
+                api_base,
+                credential,
+            } => super::forge_rest::api_get(api_base, credential, endpoint).await,
+        }
+    }
+
+    async fn pull_request(
+        &self,
+        target: &CodeGitHubRepositoryTarget,
+        repository: &CodeGitHubRepositoryRef,
+        number: u64,
+    ) -> Result<Value, String> {
+        match self {
+            Self::Gh { binary, .. } => {
+                let cli_repository =
+                    gh::cli_repository(&repository.host, &repository.owner, &repository.name);
+                let number = number.to_string();
+                let raw = gh::run_gh(
+                    Path::new("."),
+                    binary,
+                    &[
+                        "pr",
+                        "view",
+                        &number,
+                        "--repo",
+                        &cli_repository,
+                        "--json",
+                        PR_LIST_FIELDS_WITH_CHECKS,
+                    ],
+                    GH_READ_TIMEOUT,
+                )
+                .await?;
+                serde_json::from_str(&raw)
+                    .map_err(|error| format!("could not parse pull request: {error}"))
+            }
+            Self::Rest {
+                api_base,
+                credential,
+            } => {
+                super::forge_rest::delivery_pull_request(api_base, target, credential, number).await
+            }
+        }
+    }
+}
+
+async fn delivery_endpoint_api(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    reader: &DeliveryReader,
+    target: &CodeGitHubRepositoryTarget,
+) -> Result<DeliveryEndpointApi, String> {
+    match reader {
+        DeliveryReader::Gh(binary) => Ok(DeliveryEndpointApi::Gh {
+            binary: binary.clone(),
+            host: target.host.clone(),
+        }),
+        DeliveryReader::Forge => {
+            let credential = borrow_delivery_credential(runtime, owner, target).await?;
+            Ok(DeliveryEndpointApi::Rest {
+                api_base: runtime.forge_api_base_for(&target.host),
+                credential,
+            })
+        }
+    }
+}
+
+async fn resolve_repository_for_api(
+    runtime: &CodeRuntime,
+    api: &DeliveryEndpointApi,
+    target: &CodeGitHubRepositoryTarget,
+    tidebreak_repo_id: Option<tidebreak_core::RepoId>,
+    force_refresh: bool,
+) -> Result<CodeGitHubRepositoryRef, String> {
+    match api {
+        DeliveryEndpointApi::Gh { binary, .. } => {
+            resolve_repository_cached(runtime, binary, target, tidebreak_repo_id, force_refresh)
+                .await
+        }
+        DeliveryEndpointApi::Rest { credential, .. } => {
+            resolve_repository_rest_cached(
+                runtime,
+                target,
+                tidebreak_repo_id,
+                force_refresh,
+                credential,
+            )
+            .await
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -476,10 +596,10 @@ pub(crate) async fn query_pull_requests_by_number(
     owner: &OwnerId,
     repositories: Vec<(CodeGitHubRepositoryTarget, Vec<u64>)>,
 ) -> Result<CodeDeliveryPullRequestsPage, ServerError> {
-    let observation = gh::observe_gh(runtime.gh_search_path_owned().as_deref()).await;
-    let capability = github_capability(&observation);
+    let access = delivery_access(runtime, owner, false).await;
+    let capability = access.capability.clone();
     let repositories = dedupe_numbered_targets(repositories)?;
-    if observation.authenticated != Some(true) {
+    let Some(reader) = access.reader.clone() else {
         return Ok(CodeDeliveryPullRequestsPage {
             capability,
             items: Vec::new(),
@@ -487,21 +607,20 @@ pub(crate) async fn query_pull_requests_by_number(
             errors: Vec::new(),
             fetched_at: Utc::now(),
         });
-    }
+    };
 
-    let binary = observation
-        .binary
-        .clone()
-        .expect("authenticated gh has a binary");
     let workspaces = Arc::new(workspace_index(runtime, owner, false).await?);
     let resolved = stream::iter(repositories)
         .map(|(target, numbers)| {
-            let binary = binary.clone();
+            let reader = reader.clone();
             async move {
-                let repository = resolve_repository(&binary, &target, None)
+                let api = delivery_endpoint_api(runtime, owner, &reader, &target)
                     .await
                     .map_err(|message| (target.clone(), message))?;
-                Ok((target, repository, numbers))
+                let repository = resolve_repository_for_api(runtime, &api, &target, None, false)
+                    .await
+                    .map_err(|message| (target.clone(), message))?;
+                Ok((target, Arc::new(api), repository, numbers))
             }
         })
         .buffer_unordered(DELIVERY_CONCURRENCY)
@@ -512,11 +631,11 @@ pub(crate) async fn query_pull_requests_by_number(
     let mut errors = Vec::new();
     for result in resolved {
         match result {
-            Ok((target, repository, numbers)) => {
+            Ok((target, api, repository, numbers)) => {
                 reads.extend(
-                    numbers
-                        .into_iter()
-                        .map(|number| (target.clone(), repository.clone(), number)),
+                    numbers.into_iter().map(|number| {
+                        (target.clone(), Arc::clone(&api), repository.clone(), number)
+                    }),
                 );
             }
             Err((target, message)) => errors.push(source_error(Some(target), message)),
@@ -524,12 +643,11 @@ pub(crate) async fn query_pull_requests_by_number(
     }
 
     let results = stream::iter(reads)
-        .map(|(target, repository, number)| {
-            let binary = binary.clone();
+        .map(|(target, api, repository, number)| {
             let workspaces = Arc::clone(&workspaces);
             async move {
                 with_transient_retry(|| {
-                    fetch_pull_request(&binary, &repository, number, &workspaces)
+                    fetch_pull_request(&api, &target, &repository, number, &workspaces)
                 })
                 .await
                 .map_err(|message| (target, format!("pull request #{number}: {message}")))
@@ -852,18 +970,24 @@ pub(crate) async fn pull_request_detail(
         std::slice::from_ref(&target.repository),
     )
     .await?;
-    let observation = require_authenticated(runtime).await?;
-    let binary = observation
-        .binary
-        .as_ref()
-        .expect("authenticated gh has binary");
-    let repository = resolve_repository_cached(runtime, binary, &target.repository, None, false)
+    let access = delivery_access(runtime, owner, false).await;
+    let reader = access.require_reader()?;
+    let api = delivery_endpoint_api(runtime, owner, &reader, &target.repository)
+        .await
+        .map_err(|message| ServerError::bad_request_kind("github", message))?;
+    let repository = resolve_repository_for_api(runtime, &api, &target.repository, None, false)
         .await
         .map_err(|message| ServerError::bad_request_kind("github", message))?;
     let workspace_index = workspace_index(runtime, owner, false).await?;
-    let mut observation = fetch_pull_request(binary, &repository, target.number, &workspace_index)
-        .await
-        .map_err(|message| ServerError::bad_request_kind("github", message))?;
+    let mut observation = fetch_pull_request(
+        &api,
+        &target.repository,
+        &repository,
+        target.number,
+        &workspace_index,
+    )
+    .await
+    .map_err(|message| ServerError::bad_request_kind("github", message))?;
     let minted = persist_and_augment_pull_request_facts(
         runtime,
         owner,
@@ -895,11 +1019,11 @@ pub(crate) async fn pull_request_detail(
         &format!("pulls/{}/files?per_page=100", target.number),
     );
     let (pull, issue_comments, reviews, inline_comments, changed) = tokio::join!(
-        run_api_json(binary, &target.repository.host, &pull_endpoint),
-        run_api_json(binary, &target.repository.host, &issue_comments_endpoint),
-        run_api_json(binary, &target.repository.host, &reviews_endpoint),
-        run_api_json(binary, &target.repository.host, &inline_endpoint),
-        run_api_json(binary, &target.repository.host, &files_endpoint),
+        api.get(&pull_endpoint),
+        api.get(&issue_comments_endpoint),
+        api.get(&reviews_endpoint),
+        api.get(&inline_endpoint),
+        api.get(&files_endpoint),
     );
     let pull = pull.map_err(|message| ServerError::bad_request_kind("github", message))?;
     let mut comments = Vec::new();
@@ -1391,12 +1515,12 @@ pub(crate) async fn run_detail(
         std::slice::from_ref(&target.repository),
     )
     .await?;
-    let observation = require_authenticated(runtime).await?;
-    let binary = observation
-        .binary
-        .as_ref()
-        .expect("authenticated gh has binary");
-    let repository = resolve_repository_cached(runtime, binary, &target.repository, None, false)
+    let access = delivery_access(runtime, owner, false).await;
+    let reader = access.require_reader()?;
+    let api = delivery_endpoint_api(runtime, owner, &reader, &target.repository)
+        .await
+        .map_err(|message| ServerError::bad_request_kind("github", message))?;
+    let repository = resolve_repository_for_api(runtime, &api, &target.repository, None, false)
         .await
         .map_err(|message| ServerError::bad_request_kind("github", message))?;
     let workspace_index = workspace_index(runtime, owner, false).await?;
@@ -1409,10 +1533,7 @@ pub(crate) async fn run_detail(
                 &target.repository,
                 &format!("actions/runs/{}/jobs?per_page=100", target.id),
             );
-            let (run, jobs) = tokio::join!(
-                run_api_json(binary, &target.repository.host, &run_endpoint),
-                run_api_json(binary, &target.repository.host, &jobs_endpoint),
-            );
+            let (run, jobs) = tokio::join!(api.get(&run_endpoint), api.get(&jobs_endpoint),);
             let run = run.map_err(|message| ServerError::bad_request_kind("github", message))?;
             let summary = parse_workflow_run(&repository, &run, &workspace_index)
                 .ok_or_else(|| ServerError::not_found("workflow run not found"))?;
@@ -1458,10 +1579,8 @@ pub(crate) async fn run_detail(
                 &target.repository,
                 &format!("deployments/{}/statuses?per_page=100", target.id),
             );
-            let (deployment, statuses) = tokio::join!(
-                run_api_json(binary, &target.repository.host, &deployment_endpoint),
-                run_api_json(binary, &target.repository.host, &statuses_endpoint),
-            );
+            let (deployment, statuses) =
+                tokio::join!(api.get(&deployment_endpoint), api.get(&statuses_endpoint),);
             let deployment =
                 deployment.map_err(|message| ServerError::bad_request_kind("github", message))?;
             let mut errors = Vec::new();
@@ -2241,30 +2360,13 @@ fn pull_request_remote_plan(query: &CodeDeliveryPullRequestQuery) -> PullRequest
 }
 
 async fn fetch_pull_request(
-    binary: &Path,
+    api: &DeliveryEndpointApi,
+    target: &CodeGitHubRepositoryTarget,
     repository: &CodeGitHubRepositoryRef,
     number: u64,
     workspaces: &[WorkspaceIndexEntry],
 ) -> Result<PullRequestObservation, String> {
-    let cli_repository = gh::cli_repository(&repository.host, &repository.owner, &repository.name);
-    let number = number.to_string();
-    let raw = gh::run_gh(
-        Path::new("."),
-        binary,
-        &[
-            "pr",
-            "view",
-            &number,
-            "--repo",
-            &cli_repository,
-            "--json",
-            PR_LIST_FIELDS_WITH_CHECKS,
-        ],
-        GH_READ_TIMEOUT,
-    )
-    .await?;
-    let value: Value = serde_json::from_str(&raw)
-        .map_err(|error| format!("could not parse pull request: {error}"))?;
+    let value = api.pull_request(target, repository, number).await?;
     parse_pull_request(repository, &value, workspaces)
         .ok_or_else(|| "GitHub returned an incomplete pull request".into())
 }

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -1196,6 +1196,7 @@ pub(crate) async fn act_on_pull_request(
         std::slice::from_ref(&body.target.repository),
     )
     .await?;
+    require_gh_actions(runtime)?;
     let search_path = runtime.gh_search_path_owned();
     let target = body.target;
     // The canonical URL of the pull request being acted on: the key the
@@ -1636,6 +1637,7 @@ pub(crate) async fn act_on_run(
         std::slice::from_ref(&body.target.repository),
     )
     .await?;
+    require_gh_actions(runtime)?;
     match body.action {
         CodeDeliveryRunAction::RerunFailed => {
             if body.target.kind != CodeDeliveryRunKind::WorkflowRun {
@@ -1751,6 +1753,23 @@ async fn borrow_delivery_credential(
         .git_credential(owner, &format!("{}/{}", target.owner, target.name))
         .await
         .map_err(|refusal| super::clone::git_forge_refusal_message(&refusal))
+}
+
+/// Refuse Delivery actions on a hosted machine, by name.
+///
+/// Reads borrow per-operation credentials, but merge, ready, close, comment,
+/// and rerun still shell out to `gh`. Until those move to the forge REST
+/// API, a hosted caller gets one honest refusal instead of a `gh`
+/// remediation no hosted machine can follow.
+fn require_gh_actions(runtime: &CodeRuntime) -> Result<(), ServerError> {
+    if runtime.git_credentials().is_some() {
+        return Err(ServerError::conflict_kind(
+            "git_forge_actions_unsupported",
+            "This hosted machine cannot act on pull requests or runs yet. \
+             Open the pull request or run on GitHub to act there.",
+        ));
+    }
+    Ok(())
 }
 
 async fn require_authenticated(runtime: &CodeRuntime) -> Result<GhObservation, ServerError> {

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -10,7 +10,8 @@
 //! Deliberately narrow: creation, the PR-card digest, the fact reads
 //! (decision 62), and the Delivery reads — repository lists, by-number
 //! sweeps, and the detail drawers. Mutations (merge, ready, close, comments,
-//! rerun) still shell out to `gh`.
+//! rerun) still shell out to `gh`, so a hosted Delivery action refuses with
+//! its own kind rather than a `gh` remediation no hosted machine can follow.
 
 use std::time::Duration;
 

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -8,9 +8,9 @@
 //! parses — one JSON vocabulary, however the host was asked.
 //!
 //! Deliberately narrow: creation, the PR-card digest, the fact reads
-//! (decision 62), and the repository-wide Delivery lists. Merge, ready,
-//! close, comments, CI logs, and Delivery detail drawers stay `gh`-only and
-//! keep answering exactly as they do today on machines without it.
+//! (decision 62), and the Delivery reads — repository lists, by-number
+//! sweeps, and the detail drawers. Mutations (merge, ready, close, comments,
+//! rerun) still shell out to `gh`.
 
 use std::time::Duration;
 
@@ -125,6 +125,62 @@ pub(crate) async fn repository(
         return Err(forge_message(status, &value));
     }
     Ok(value)
+}
+
+/// One authenticated GET on a repository-scoped endpoint, answered in the
+/// same REST shape `gh api <endpoint>` returns.
+///
+/// The detail drawers already speak endpoint strings; this lets them ask the
+/// forge directly when no `gh` exists.
+pub(crate) async fn api_get(
+    api_base: &str,
+    credential: &GitCredential,
+    endpoint: &str,
+) -> Result<Value, String> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!("{api_base}/{endpoint}"),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    Ok(value)
+}
+
+/// Read one pull request in the `gh pr view --json` vocabulary, checks
+/// included — the single-row read the by-number sweep and the detail
+/// drawer share.
+pub(crate) async fn delivery_pull_request(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    number: u64,
+) -> Result<Value, String> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/pulls/{number}",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    let mut fact = fact_value(&value);
+    let checks = match value.pointer("/head/sha").and_then(Value::as_str) {
+        Some(sha) => check_run_values(api_base, target, credential, sha).await?,
+        None => Vec::new(),
+    };
+    fact.as_object_mut()
+        .expect("fact values are objects")
+        .insert("statusCheckRollup".to_owned(), Value::Array(checks));
+    Ok(fact)
 }
 
 /// List one repository's pull requests in the `gh pr list --json`

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -2087,6 +2087,42 @@ async fn a_hosted_delivery_page_reads_lists_and_details_over_forge_rest() {
         deployment_detail["deployment_statuses"][0]["state"],
         "success"
     );
+
+    for (path, body) in [
+        (
+            "/code/delivery/pull-requests/action",
+            serde_json::json!({
+                "target": { "repository": target.clone(), "number": 17 },
+                "action": { "type": "close" }
+            }),
+        ),
+        (
+            "/code/delivery/runs/action",
+            serde_json::json!({
+                "target": {
+                    "repository": target.clone(),
+                    "kind": "workflow_run",
+                    "id": 44
+                },
+                "action": { "type": "rerun_failed" }
+            }),
+        ),
+    ] {
+        let response = client
+            .post(format!("http://{addr}{path}"))
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+        let error: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(error["kind"], "git_forge_actions_unsupported");
+        assert!(error["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Open the pull request or run on GitHub"));
+    }
     assert_eq!(
         lender.minted(),
         vec![

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -1688,31 +1688,17 @@ async fn register_delivery_repository(
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 }
 
-/// Issue #2673: a gateway-authenticated hosted caller reads every Delivery
-/// list through one borrowed credential per repository operation. No `gh`
-/// observation participates, and check runs keep the attention bucket useful.
+/// Issue #2673: a gateway-authenticated hosted caller reads Delivery lists
+/// and details through one borrowed credential per repository operation. No
+/// `gh` observation participates, and check runs keep attention useful.
 #[tokio::test]
-async fn a_hosted_delivery_page_reads_repository_lists_over_forge_rest() {
-    let repository = |headers: axum::http::HeaderMap| async move {
-        assert_borrowed_forge_credential(&headers);
-        axum::Json(serde_json::json!({
-            "name": "demo",
-            "full_name": "acme/demo",
-            "html_url": "https://github.com/acme/demo",
-            "default_branch": "main",
-            "owner": { "login": "acme" },
-        }))
-    };
-    let pulls = |headers: axum::http::HeaderMap,
-                 axum::extract::Query(query): axum::extract::Query<
-        std::collections::HashMap<String, String>,
-    >| async move {
-        assert_borrowed_forge_credential(&headers);
-        assert_eq!(query.get("state").map(String::as_str), Some("open"));
-        axum::Json(serde_json::json!([{
+async fn a_hosted_delivery_page_reads_lists_and_details_over_forge_rest() {
+    fn pull_request() -> serde_json::Value {
+        serde_json::json!({
             "number": 17,
             "html_url": "https://github.com/acme/demo/pull/17",
             "title": "Repair hosted delivery",
+            "body": "Read the delivery detail over REST.",
             "state": "open",
             "draft": false,
             "user": {
@@ -1730,11 +1716,67 @@ async fn a_hosted_delivery_page_reads_repository_lists_over_forge_rest() {
             },
             "base": { "ref": "main" },
             "labels": [{ "name": "code" }],
+            "assignees": [{ "login": "mira-chen" }],
+            "requested_reviewers": [{ "login": "reviewer" }],
             "comments": 2,
+            "changed_files": 1,
+            "additions": 12,
+            "deletions": 3,
+            "commits": 2,
             "created_at": "2026-08-25T10:00:00Z",
             "updated_at": "2026-08-25T11:00:00Z",
             "merged_at": null,
             "closed_at": null
+        })
+    }
+
+    let repository = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!({
+            "name": "demo",
+            "full_name": "acme/demo",
+            "html_url": "https://github.com/acme/demo",
+            "default_branch": "main",
+            "owner": { "login": "acme" },
+        }))
+    };
+    let pulls = |headers: axum::http::HeaderMap,
+                 axum::extract::Query(query): axum::extract::Query<
+        std::collections::HashMap<String, String>,
+    >| async move {
+        assert_borrowed_forge_credential(&headers);
+        assert_eq!(query.get("state").map(String::as_str), Some("open"));
+        axum::Json(serde_json::json!([pull_request()]))
+    };
+    let pull = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(pull_request())
+    };
+    let issue_comments = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!([{
+            "id": 100,
+            "body": "Please keep the hosted path scoped.",
+            "user": { "login": "reviewer" },
+            "created_at": "2026-08-25T11:05:00Z"
+        }]))
+    };
+    let reviews = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!([]))
+    };
+    let inline_comments = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!([]))
+    };
+    let files = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!([{
+            "filename": "crates/tidebreak-server/src/code/delivery.rs",
+            "status": "modified",
+            "additions": 12,
+            "deletions": 3,
+            "patch": "@@ -1 +1 @@"
         }]))
     };
     let checks = |headers: axum::http::HeaderMap| async move {
@@ -1773,6 +1815,37 @@ async fn a_hosted_delivery_page_reads_repository_lists_over_forge_rest() {
             }]
         }))
     };
+    let workflow_run = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!({
+            "id": 44,
+            "run_attempt": 2,
+            "status": "completed",
+            "conclusion": "failure",
+            "display_title": "Desktop CI",
+            "name": "CI",
+            "html_url": "https://github.com/acme/demo/actions/runs/44",
+            "head_branch": "hosted-delivery",
+            "head_sha": "feedfeedfeedfeedfeed",
+            "event": "pull_request",
+            "actor": { "login": "mira-chen" },
+            "created_at": "2026-08-25T10:00:00Z",
+            "updated_at": "2026-08-25T11:00:00Z"
+        }))
+    };
+    let jobs = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!({
+            "jobs": [{
+                "id": 501,
+                "name": "test",
+                "status": "completed",
+                "conclusion": "failure",
+                "html_url": "https://github.com/acme/demo/actions/runs/44/job/501",
+                "steps": [{ "name": "Run tests", "conclusion": "failure" }]
+            }]
+        }))
+    };
     let deployments = |headers: axum::http::HeaderMap| async move {
         assert_borrowed_forge_credential(&headers);
         axum::Json(serde_json::json!([{
@@ -1785,9 +1858,46 @@ async fn a_hosted_delivery_page_reads_repository_lists_over_forge_rest() {
             "updated_at": "2026-08-25T10:30:00Z"
         }]))
     };
+    let deployment = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!({
+            "id": 91,
+            "environment": "production",
+            "ref": "hosted-delivery",
+            "sha": "feedfeedfeedfeedfeed",
+            "creator": { "login": "mira-chen" },
+            "created_at": "2026-08-25T10:30:00Z",
+            "updated_at": "2026-08-25T10:30:00Z"
+        }))
+    };
+    let deployment_statuses = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!([{
+            "id": 92,
+            "state": "success",
+            "description": "Deployed",
+            "environment_url": "https://demo.example",
+            "log_url": "https://github.com/acme/demo/deployments/91",
+            "created_at": "2026-08-25T10:35:00Z"
+        }]))
+    };
     let forge = axum::Router::new()
         .route("/repos/acme/demo", axum::routing::get(repository))
         .route("/repos/acme/demo/pulls", axum::routing::get(pulls))
+        .route("/repos/acme/demo/pulls/17", axum::routing::get(pull))
+        .route(
+            "/repos/acme/demo/issues/17/comments",
+            axum::routing::get(issue_comments),
+        )
+        .route(
+            "/repos/acme/demo/pulls/17/reviews",
+            axum::routing::get(reviews),
+        )
+        .route(
+            "/repos/acme/demo/pulls/17/comments",
+            axum::routing::get(inline_comments),
+        )
+        .route("/repos/acme/demo/pulls/17/files", axum::routing::get(files))
         .route(
             "/repos/acme/demo/commits/{sha}/check-runs",
             axum::routing::get(checks),
@@ -1797,8 +1907,24 @@ async fn a_hosted_delivery_page_reads_repository_lists_over_forge_rest() {
             axum::routing::get(workflow_runs),
         )
         .route(
+            "/repos/acme/demo/actions/runs/44",
+            axum::routing::get(workflow_run),
+        )
+        .route(
+            "/repos/acme/demo/actions/runs/44/jobs",
+            axum::routing::get(jobs),
+        )
+        .route(
             "/repos/acme/demo/deployments",
             axum::routing::get(deployments),
+        )
+        .route(
+            "/repos/acme/demo/deployments/91",
+            axum::routing::get(deployment),
+        )
+        .route(
+            "/repos/acme/demo/deployments/91/statuses",
+            axum::routing::get(deployment_statuses),
         );
     let forge_addr = serve(forge).await;
 
@@ -1878,10 +2004,34 @@ async fn a_hosted_delivery_page_reads_repository_lists_over_forge_rest() {
         "checks_failed"
     );
 
+    let pull_request_detail: serde_json::Value = client
+        .post(format!("http://{addr}/code/delivery/pull-requests/detail"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repository": target.clone(),
+            "number": 17
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(pull_request_detail["summary"]["number"], 17);
+    assert_eq!(
+        pull_request_detail["body"],
+        "Read the delivery detail over REST."
+    );
+    assert_eq!(pull_request_detail["comments"][0]["author"], "reviewer");
+    assert_eq!(
+        pull_request_detail["files"][0]["path"],
+        "crates/tidebreak-server/src/code/delivery.rs"
+    );
+
     let runs: serde_json::Value = client
         .post(format!("http://{addr}/code/delivery/runs/query"))
         .bearer_auth(&token)
-        .json(&serde_json::json!({ "repositories": [target] }))
+        .json(&serde_json::json!({ "repositories": [target.clone()] }))
         .send()
         .await
         .unwrap()
@@ -1899,9 +2049,50 @@ async fn a_hosted_delivery_page_reads_repository_lists_over_forge_rest() {
         .unwrap()
         .iter()
         .any(|item| item["kind"] == "deployment"));
+
+    let workflow_detail: serde_json::Value = client
+        .post(format!("http://{addr}/code/delivery/runs/detail"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repository": target.clone(),
+            "kind": "workflow_run",
+            "id": 44
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(workflow_detail["summary"]["github_id"], 44);
+    assert_eq!(workflow_detail["jobs"][0]["name"], "test");
+    assert_eq!(workflow_detail["jobs"][0]["failed_steps"][0], "Run tests");
+
+    let deployment_detail: serde_json::Value = client
+        .post(format!("http://{addr}/code/delivery/runs/detail"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repository": target,
+            "kind": "deployment",
+            "id": 91
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(deployment_detail["summary"]["github_id"], 91);
+    assert_eq!(
+        deployment_detail["deployment_statuses"][0]["state"],
+        "success"
+    );
     assert_eq!(
         lender.minted(),
         vec![
+            "acme/demo".to_owned(),
+            "acme/demo".to_owned(),
+            "acme/demo".to_owned(),
             "acme/demo".to_owned(),
             "acme/demo".to_owned(),
             "acme/demo".to_owned()


### PR DESCRIPTION
Supersedes #2698: that PR's CI concurrency group (`CI-refs/pull/2698/merge`) is held by workflow run 32985439271, stranded in GitHub's Actions backend during the 15:30–15:37 UTC incident window. The run refuses cancel, force-cancel, and delete, and `cancel-in-progress` cannot replace it, so no pull-request event can start required lanes on #2698. A fresh pull request gets a clean concurrency group. Same branch, identical tree to the head Shipright passed twice (59e3b4320, 52ed64075).

PR #2680 established hosted Delivery list reads over forge REST. This follow-up keeps that merged implementation and adds only the remaining detail paths.

## Implementation

- Reuse one borrowed forge credential for each repository operation.
- Read exact pull requests, pull-request details, workflow-run details, and deployment details through the selected Delivery transport.
- Keep local machines on the existing `gh` paths.
- Return `git_forge_actions_unsupported` for hosted mutations that still require `gh`.
- Keep `fetch_runs` below Clippy’s argument limit through the merged `RunFetchOptions` scope.

## Backwards compatibility

Desktop and self-hosted machines keep their existing `gh` behavior and public wire shapes. Hosted list behavior remains the implementation merged in #2680.

## Safety and risk

Each hosted detail operation borrows one repository-scoped credential and keeps it in memory for that operation. The existing REST client still rejects redirects, bounds response bodies, and pins hosted credentials to GitHub.

## Validation

- `rustfmt --edition 2021 --check` on the three changed Rust files
- `git diff --check origin/main...HEAD`
- Verified `origin/main` is an ancestor of the submitted head

Cargo build, test, check, and Clippy were not run locally under the repository policy. CI owns those lanes.

The automatic review posted G2G at 559d38a32, this pull request's exact head, at 2026-08-26 16:52 UTC.
