### PR TITLE
fix(code): retain complete turns in bounded fork replay

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -1,10 +1,12 @@
+use std::collections::{HashMap, HashSet};
+
 use chrono::Utc;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
     QuerySelect, Set, TransactionTrait,
 };
 
-use crate::code::{CodeEvent, CodeSessionId, SequencedCodeEvent};
+use crate::code::{CodeEvent, CodeSessionId, CodeTurnId, CodeTurnStatus, SequencedCodeEvent};
 use crate::error::{AgentError, Result};
 use crate::OwnerId;
 
@@ -122,6 +124,22 @@ pub struct CodeEventPage {
     pub truncated: bool,
 }
 
+/// A fork-specific journal window made only of complete reconstructable turns.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CodeForkEventPage {
+    /// Kept turn events in ascending sequence order.
+    pub events: Vec<SequencedCodeEvent>,
+    /// Turn ids whose complete event records fit in [`events`].
+    pub complete_turns: HashSet<CodeTurnId>,
+    /// Terminal status observed for the requested fork boundary.
+    ///
+    /// This remains present when that turn is too large to retain, so fork
+    /// settlement does not depend on returning a partial event window.
+    pub boundary_status: Option<CodeTurnStatus>,
+    /// True when one or more whole turns were omitted at the replay boundary.
+    pub truncated: bool,
+}
+
 /// Events for one of the owner's sessions with `seq > after`, in order.
 ///
 /// At most `limit` events come back, and the window keeps the *newest* ones:
@@ -162,6 +180,259 @@ pub async fn list_events(
     Ok(CodeEventPage { events, truncated })
 }
 
+/// Complete reconstructable turn events through `through_turn`, newest first
+/// for budget decisions and ascending in the returned page.
+///
+/// The ordinary replay API keeps an event-count tail. A fork cannot use that
+/// tail directly because its first retained row may sit inside a turn or
+/// inside a nested tool call. This scan walks backwards to each `TurnStarted`
+/// frame, keeps only a contiguous suffix of whole turns that fits `limit`, and
+/// omits the whole boundary turn when that turn alone exceeds the cap.
+/// Events from turns after `through_turn` are scanned but never returned.
+pub async fn list_fork_events(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    through_turn: CodeTurnId,
+    limit: u64,
+) -> Result<CodeForkEventPage> {
+    const MIN_SCAN_BATCH: u64 = 128;
+
+    let mut builder =
+        ForkEventPageBuilder::new(through_turn, usize::try_from(limit).unwrap_or(usize::MAX));
+    let batch = limit.max(MIN_SCAN_BATCH).min(MAX_REPLAY_EVENTS);
+    let mut before = None;
+
+    loop {
+        let mut query = entities::code_event::Entity::find()
+            .filter(entities::code_event::Column::Owner.eq(owner.as_str()))
+            .filter(entities::code_event::Column::SessionId.eq(session_id.0))
+            .order_by_desc(entities::code_event::Column::Seq)
+            .limit(batch);
+        if let Some(seq) = before {
+            query = query.filter(entities::code_event::Column::Seq.lt(seq));
+        }
+        let rows = query.all(&store.conn).await.map_err(store_err)?;
+        if rows.is_empty() {
+            break;
+        }
+        before = rows.last().map(|row| row.seq);
+        let short_batch = rows.len() < usize::try_from(batch).unwrap_or(usize::MAX);
+        for model in rows {
+            builder.push(SequencedCodeEvent {
+                seq: model.seq,
+                event: serde_json::from_value(model.event)?,
+            });
+            if builder.done() {
+                break;
+            }
+        }
+        if builder.done() || short_batch {
+            break;
+        }
+    }
+
+    Ok(builder.finish())
+}
+
+/// Incrementally selects a newest contiguous suffix of complete turns while
+/// the database scan moves from newest events to oldest events.
+struct ForkEventPageBuilder {
+    through_turn: CodeTurnId,
+    limit: usize,
+    used: usize,
+    target_found: bool,
+    done: bool,
+    truncated: bool,
+    boundary_status: Option<CodeTurnStatus>,
+    terminal_status: Option<CodeTurnStatus>,
+    terminal_count: usize,
+    segment_rev: Vec<SequencedCodeEvent>,
+    segment_oversized: bool,
+    kept_rev: Vec<Vec<SequencedCodeEvent>>,
+    complete_turns: HashSet<CodeTurnId>,
+}
+
+impl ForkEventPageBuilder {
+    fn new(through_turn: CodeTurnId, limit: usize) -> Self {
+        Self {
+            through_turn,
+            limit,
+            used: 0,
+            target_found: false,
+            done: false,
+            truncated: false,
+            boundary_status: None,
+            terminal_status: None,
+            terminal_count: 0,
+            segment_rev: Vec::new(),
+            segment_oversized: false,
+            kept_rev: Vec::new(),
+            complete_turns: HashSet::new(),
+        }
+    }
+
+    fn push(&mut self, entry: SequencedCodeEvent) {
+        if self.done {
+            return;
+        }
+        if let CodeEvent::TurnStarted { turn_id } = &entry.event {
+            self.finish_segment(*turn_id, entry.seq);
+            return;
+        }
+
+        if let Some(status) = terminal_status(&entry.event) {
+            self.terminal_count += 1;
+            if self.terminal_status.is_none() {
+                self.terminal_status = Some(status);
+            }
+        } else if self.terminal_status.is_none() {
+            // Session-level rows after a terminal event do not belong to the
+            // turn. Ignore them until the backwards scan reaches its end.
+            return;
+        }
+
+        let remaining = self.limit.saturating_sub(self.used);
+        let max_after_start = remaining.saturating_sub(1);
+        if self.segment_rev.len() < max_after_start {
+            self.segment_rev.push(entry);
+        } else {
+            self.segment_oversized = true;
+        }
+    }
+
+    fn finish_segment(&mut self, turn_id: CodeTurnId, start_seq: i64) {
+        let is_target = turn_id == self.through_turn;
+        if !self.target_found {
+            if !is_target {
+                self.reset_segment();
+                return;
+            }
+            self.target_found = true;
+            self.boundary_status = if self.terminal_count == 1 {
+                self.terminal_status
+            } else {
+                None
+            };
+        }
+
+        let remaining = self.limit.saturating_sub(self.used);
+        if self.terminal_status.is_none()
+            || self.terminal_count != 1
+            || self.segment_oversized
+            || self.segment_rev.len().saturating_add(1) > remaining
+        {
+            self.truncated = true;
+            self.done = true;
+            self.reset_segment();
+            return;
+        }
+
+        let mut events = Vec::with_capacity(self.segment_rev.len() + 1);
+        events.push(SequencedCodeEvent {
+            seq: start_seq,
+            event: CodeEvent::TurnStarted { turn_id },
+        });
+        events.extend(self.segment_rev.drain(..).rev());
+        if !turn_is_reconstructable(turn_id, &events) {
+            self.truncated = true;
+            self.done = true;
+            self.reset_segment();
+            return;
+        }
+
+        self.used += events.len();
+        self.complete_turns.insert(turn_id);
+        self.kept_rev.push(events);
+        self.reset_segment();
+    }
+
+    fn reset_segment(&mut self) {
+        self.terminal_status = None;
+        self.terminal_count = 0;
+        self.segment_rev.clear();
+        self.segment_oversized = false;
+    }
+
+    const fn done(&self) -> bool {
+        self.done
+    }
+
+    fn finish(mut self) -> CodeForkEventPage {
+        self.kept_rev.reverse();
+        CodeForkEventPage {
+            events: self.kept_rev.into_iter().flatten().collect(),
+            complete_turns: self.complete_turns,
+            boundary_status: self.boundary_status,
+            truncated: self.truncated,
+        }
+    }
+}
+
+fn terminal_status(event: &CodeEvent) -> Option<CodeTurnStatus> {
+    match event {
+        CodeEvent::TurnCompleted { .. } => Some(CodeTurnStatus::Completed),
+        CodeEvent::TurnFailed { .. } => Some(CodeTurnStatus::Failed),
+        CodeEvent::TurnInterrupted => Some(CodeTurnStatus::Interrupted),
+        _ => None,
+    }
+}
+
+/// Confirm that every retained child and completion still has the start and
+/// parent frame that gives it meaning.
+fn turn_is_reconstructable(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> bool {
+    let Some((first, rest)) = events.split_first() else {
+        return false;
+    };
+    if !matches!(&first.event, CodeEvent::TurnStarted { turn_id: id } if *id == turn_id)
+        || rest
+            .last()
+            .and_then(|entry| terminal_status(&entry.event))
+            .is_none()
+    {
+        return false;
+    }
+
+    let mut calls: HashMap<&str, Option<&str>> = HashMap::new();
+    let mut completed = HashSet::new();
+    for entry in rest {
+        match &entry.event {
+            CodeEvent::TurnStarted { .. } => return false,
+            CodeEvent::ToolStarted {
+                call_id,
+                parent_call_id,
+                ..
+            } => {
+                if calls.contains_key(call_id.as_str())
+                    || parent_call_id
+                        .as_deref()
+                        .is_some_and(|parent| !calls.contains_key(parent))
+                {
+                    return false;
+                }
+                calls.insert(call_id, parent_call_id.as_deref());
+            }
+            CodeEvent::ToolCompleted {
+                call_id,
+                parent_call_id,
+                ..
+            } => {
+                if calls.get(call_id.as_str()).copied() != Some(parent_call_id.as_deref())
+                    || !completed.insert(call_id.as_str())
+                {
+                    return false;
+                }
+            }
+            CodeEvent::AssistantMessage {
+                parent_call_id: Some(parent),
+                ..
+            } if !calls.contains_key(parent.as_str()) => return false,
+            _ => {}
+        }
+    }
+    true
+}
+
 /// Newest journal events for one session, newest first. Digests use this
 /// bounded tail to identify an unresolved top-level tool without replaying a
 /// long conversation on every updates-socket connection.
@@ -187,4 +458,159 @@ pub async fn list_recent_events(
             })
         })
         .collect()
+}
+
+#[cfg(test)]
+mod fork_replay_tests {
+    use super::*;
+    use crate::code::{ToolDetail, ToolOutcome};
+
+    fn sequenced(events: Vec<CodeEvent>) -> Vec<SequencedCodeEvent> {
+        events
+            .into_iter()
+            .enumerate()
+            .map(|(index, event)| SequencedCodeEvent {
+                seq: index as i64 + 1,
+                event,
+            })
+            .collect()
+    }
+
+    fn completed_turn(turn_id: CodeTurnId, middle: Vec<CodeEvent>) -> Vec<CodeEvent> {
+        let mut events = Vec::with_capacity(middle.len() + 2);
+        events.push(CodeEvent::TurnStarted { turn_id });
+        events.extend(middle);
+        events.push(CodeEvent::TurnCompleted {
+            usage: Default::default(),
+            checkpoint: None,
+        });
+        events
+    }
+
+    fn select(events: Vec<CodeEvent>, through_turn: CodeTurnId, limit: usize) -> CodeForkEventPage {
+        let mut builder = ForkEventPageBuilder::new(through_turn, limit);
+        for entry in sequenced(events).into_iter().rev() {
+            builder.push(entry);
+        }
+        builder.finish()
+    }
+
+    #[test]
+    fn omits_one_oversized_newest_turn_as_a_whole() {
+        let newest = CodeTurnId::new();
+        let events = completed_turn(
+            newest,
+            (0..5)
+                .map(|index| CodeEvent::ReasoningDelta {
+                    text: format!("step {index}"),
+                })
+                .collect(),
+        );
+
+        let page = select(events, newest, 4);
+
+        assert_eq!(page.boundary_status, Some(CodeTurnStatus::Completed));
+        assert!(page.events.is_empty());
+        assert!(page.complete_turns.is_empty());
+        assert!(page.truncated);
+    }
+
+    #[test]
+    fn keeps_nested_tool_events_with_their_parent_and_start_frames() {
+        let newest = CodeTurnId::new();
+        let events = completed_turn(
+            newest,
+            vec![
+                CodeEvent::ToolStarted {
+                    call_id: "task-1".to_owned(),
+                    name: "Task".to_owned(),
+                    detail: ToolDetail::Other {
+                        summary: "inspect".to_owned(),
+                    },
+                    parent_call_id: None,
+                },
+                CodeEvent::ToolStarted {
+                    call_id: "read-1".to_owned(),
+                    name: "Read".to_owned(),
+                    detail: ToolDetail::Other {
+                        summary: "src/lib.rs".to_owned(),
+                    },
+                    parent_call_id: Some("task-1".to_owned()),
+                },
+                CodeEvent::AssistantMessage {
+                    text: "found the boundary".to_owned(),
+                    parent_call_id: Some("task-1".to_owned()),
+                },
+                CodeEvent::ToolCompleted {
+                    call_id: "read-1".to_owned(),
+                    outcome: ToolOutcome::Succeeded,
+                    preview: "contents".to_owned(),
+                    detail: None,
+                    parent_call_id: Some("task-1".to_owned()),
+                },
+                CodeEvent::ToolCompleted {
+                    call_id: "task-1".to_owned(),
+                    outcome: ToolOutcome::Succeeded,
+                    preview: "done".to_owned(),
+                    detail: None,
+                    parent_call_id: None,
+                },
+            ],
+        );
+        let limit = events.len();
+
+        let page = select(events, newest, limit);
+
+        assert_eq!(page.events.len(), limit);
+        assert_eq!(page.complete_turns, HashSet::from([newest]));
+        assert!(!page.truncated);
+    }
+
+    #[test]
+    fn omits_a_turn_whose_nested_event_has_no_parent_frame() {
+        let newest = CodeTurnId::new();
+        let events = completed_turn(
+            newest,
+            vec![CodeEvent::ToolStarted {
+                call_id: "read-1".to_owned(),
+                name: "Read".to_owned(),
+                detail: ToolDetail::Other {
+                    summary: "src/lib.rs".to_owned(),
+                },
+                parent_call_id: Some("missing-task".to_owned()),
+            }],
+        );
+
+        let page = select(events, newest, 3);
+
+        assert_eq!(page.boundary_status, Some(CodeTurnStatus::Completed));
+        assert!(page.events.is_empty());
+        assert!(page.complete_turns.is_empty());
+        assert!(page.truncated);
+    }
+
+    #[test]
+    fn keeps_only_complete_turns_that_fit_around_the_cap() {
+        let oldest = CodeTurnId::new();
+        let middle = CodeTurnId::new();
+        let newest = CodeTurnId::new();
+        let mut events = Vec::new();
+        for (turn_id, text) in [(oldest, "oldest"), (middle, "middle"), (newest, "newest")] {
+            events.extend(completed_turn(
+                turn_id,
+                vec![CodeEvent::AssistantMessage {
+                    text: text.to_owned(),
+                    parent_call_id: None,
+                }],
+            ));
+        }
+
+        let page = select(events, newest, 6);
+
+        assert_eq!(page.events.len(), 6);
+        assert_eq!(page.events.first().map(|event| event.seq), Some(4));
+        assert_eq!(page.events.last().map(|event| event.seq), Some(9));
+        assert_eq!(page.complete_turns, HashSet::from([middle, newest]));
+        assert!(page.truncated);
+    }
 }

--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -200,7 +200,7 @@ pub async fn list_fork_events(
 
     let mut builder =
         ForkEventPageBuilder::new(through_turn, usize::try_from(limit).unwrap_or(usize::MAX));
-    let batch = limit.max(MIN_SCAN_BATCH).min(MAX_REPLAY_EVENTS);
+    let batch = limit.clamp(MIN_SCAN_BATCH, MAX_REPLAY_EVENTS);
     let mut before = None;
 
     loop {

--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -463,7 +463,7 @@ pub async fn list_recent_events(
 #[cfg(test)]
 mod fork_replay_tests {
     use super::*;
-    use crate::code::{ToolDetail, ToolOutcome};
+    use crate::code::{Diffstat, HarnessNoticeLevel, ToolDetail, ToolOutcome};
 
     fn sequenced(events: Vec<CodeEvent>) -> Vec<SequencedCodeEvent> {
         events
@@ -564,6 +564,45 @@ mod fork_replay_tests {
         assert_eq!(page.events.len(), limit);
         assert_eq!(page.complete_turns, HashSet::from([newest]));
         assert!(!page.truncated);
+    }
+
+    #[test]
+    fn keeps_a_complete_turn_when_checkpoint_work_follows_its_terminal_event() {
+        for checkpoint_event in [
+            CodeEvent::CheckpointRecorded {
+                turn_id: CodeTurnId::new(),
+                diffstat: Diffstat {
+                    files: 1,
+                    insertions: 2,
+                    deletions: 0,
+                    truncated: false,
+                },
+            },
+            CodeEvent::HarnessNotice {
+                level: HarnessNoticeLevel::Warning,
+                message: "checkpoint failed".to_owned(),
+            },
+        ] {
+            let turn_id = match &checkpoint_event {
+                CodeEvent::CheckpointRecorded { turn_id, .. } => *turn_id,
+                _ => CodeTurnId::new(),
+            };
+            let mut events = completed_turn(
+                turn_id,
+                vec![CodeEvent::AssistantMessage {
+                    text: "done".to_owned(),
+                    parent_call_id: None,
+                }],
+            );
+            events.push(checkpoint_event);
+
+            let page = select(events, turn_id, 3);
+
+            assert_eq!(page.events.len(), 3);
+            assert_eq!(page.complete_turns, HashSet::from([turn_id]));
+            assert_eq!(page.boundary_status, Some(CodeTurnStatus::Completed));
+            assert!(!page.truncated);
+        }
     }
 
     #[test]

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1295,7 +1295,7 @@ at_turn?: CodeTurnId, };
  */
 export type CodeForkTranscript = { path: string, dir: string, byte_len: number, 
 /**
- * Turns the condensed transcript renders in full.
+ * Complete turn histories the condensed transcript renders in full.
  */
 turns: number, 
 /**
@@ -1308,8 +1308,8 @@ total_turns: number,
  */
 at_turn_ordinal?: number, 
 /**
- * True when anything was left out to fit the size cap: the oldest
- * turns, or the end of a turn too large on its own.
+ * True when bounded replay omitted whole turn histories or the file size
+ * cap reduced the oldest turns or the end of one oversized turn.
  */
 truncated: boolean, };
 

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -5,10 +5,11 @@
 //! is the condensed conversation — tool calls as one-line entries, subagent
 //! work summarized by its `Task` call — and stays deliberately small so the
 //! child spends its context on the work rather than on history. Next to it,
-//! one full record per turn (`turn-0007.md` for turn 7) holds what the
-//! summary leaves out: complete tool output previews, subagent activity, and
-//! the engine's reasoning. The child reads the summary first and opens a
-//! record only when the summary is not enough.
+//! one record per turn (`turn-0007.md` for turn 7) holds what the summary
+//! leaves out: complete tool output previews, subagent activity, and the
+//! engine's reasoning when bounded replay retained that whole turn. An
+//! omitted turn keeps its request and an explicit marker. The child reads the
+//! summary first and opens a record only when the summary is not enough.
 //!
 //! Pure serialization of what the journal already holds. No model call and no
 //! generated summary — that would be a second thing to be wrong; the point of
@@ -167,7 +168,7 @@ pub(crate) fn cut_at(turns: &[CodeTurn], at_turn: Option<CodeTurnId>) -> Option<
 /// queued work behind because the reader selected that earlier seam.
 pub(crate) fn cut_at_settled_boundary<'a>(
     turns: &'a [CodeTurn],
-    events: &[SequencedCodeEvent],
+    boundary_status: Option<CodeTurnStatus>,
     pending_approval_turns: &HashSet<CodeTurnId>,
     has_queued_follow_up: bool,
     at_turn: Option<CodeTurnId>,
@@ -195,80 +196,15 @@ pub(crate) fn cut_at_settled_boundary<'a>(
     if at_turn.is_none() && has_queued_follow_up {
         return Err(ForkBoundaryError::QueuedFollowUp);
     }
-    // A later turn row proves that the selected earlier turn crossed its
-    // terminal boundary. The newest turn needs its matching journal event:
-    // the worker writes the terminal row before that event, and accepting the
-    // short gap would preserve an incomplete immutable transcript.
-    let boundary_status = match turn_boundary_evidence(events, boundary.id) {
-        TurnBoundaryEvidence::Settled(status) => Some(status),
-        TurnBoundaryEvidence::Open => None,
-        TurnBoundaryEvidence::StartNotVisible => latest_turn_boundary(events),
-    };
-    if cut.excluded == 0 && boundary_status != Some(boundary.status) {
+    // The worker writes the terminal row before its final journal event. The
+    // fork-specific replay scan reports that exact event even when the turn
+    // itself is too large to retain in the transcript window.
+    if boundary_status != Some(boundary.status) {
         return Err(ForkBoundaryError::Settling {
             ordinal: boundary.ordinal,
         });
     }
     Ok(cut)
-}
-
-/// What the bounded journal proves about one turn's final boundary.
-enum TurnBoundaryEvidence {
-    /// The turn start fell before the replay window.
-    StartNotVisible,
-    /// The start is visible without its terminal event.
-    Open,
-    /// The matching terminal event is visible.
-    Settled(CodeTurnStatus),
-}
-
-fn turn_boundary_evidence(
-    events: &[SequencedCodeEvent],
-    turn_id: CodeTurnId,
-) -> TurnBoundaryEvidence {
-    let mut inside = false;
-    let mut found = false;
-    for entry in events {
-        match &entry.event {
-            CodeEvent::TurnStarted { turn_id: started } => {
-                if inside {
-                    return TurnBoundaryEvidence::Open;
-                }
-                inside = *started == turn_id;
-                found |= inside;
-            }
-            CodeEvent::TurnCompleted { .. } if inside => {
-                return TurnBoundaryEvidence::Settled(CodeTurnStatus::Completed);
-            }
-            CodeEvent::TurnFailed { .. } if inside => {
-                return TurnBoundaryEvidence::Settled(CodeTurnStatus::Failed);
-            }
-            CodeEvent::TurnInterrupted if inside => {
-                return TurnBoundaryEvidence::Settled(CodeTurnStatus::Interrupted);
-            }
-            _ => {}
-        }
-    }
-    if found {
-        TurnBoundaryEvidence::Open
-    } else {
-        TurnBoundaryEvidence::StartNotVisible
-    }
-}
-
-/// Terminal status of the newest turn whose boundary is visible in `events`.
-///
-/// Looking at boundary events in reverse also works when a long turn pushed
-/// its `TurnStarted` event out of the bounded replay window. If the newest
-/// visible boundary is a start, the turn is still running.
-fn latest_turn_boundary(events: &[SequencedCodeEvent]) -> Option<CodeTurnStatus> {
-    events.iter().rev().find_map(|entry| match &entry.event {
-        CodeEvent::TurnCompleted { .. } => Some(Some(CodeTurnStatus::Completed)),
-        CodeEvent::TurnFailed { .. } => Some(Some(CodeTurnStatus::Failed)),
-        CodeEvent::TurnInterrupted => Some(Some(CodeTurnStatus::Interrupted)),
-        CodeEvent::TurnStarted { .. } => Some(None),
-        _ => None,
-    })?
 }
 
 /// A written fork, as the route reports it.
@@ -281,15 +217,14 @@ pub(crate) struct WrittenTranscript {
     pub(crate) dir: String,
     /// Bytes of the condensed transcript on disk.
     pub(crate) byte_len: u64,
-    /// Turns the condensed transcript renders in full.
+    /// Complete turn histories the condensed transcript renders in full.
     pub(crate) turns: u32,
     /// Turns the fork covers, up to and including the fork point.
     pub(crate) total_turns: u32,
     /// The fork point's ordinal, when the conversation continued past it.
     pub(crate) at_turn_ordinal: Option<i64>,
-    /// True when anything was left out of the condensed transcript to fit
-    /// [`MAX_TRANSCRIPT_BYTES`]: turns reduced to stubs or dropped, or the
-    /// end of a turn too large on its own.
+    /// True when bounded replay omitted whole turn histories or the condensed
+    /// transcript reduced content to fit [`MAX_TRANSCRIPT_BYTES`].
     pub(crate) truncated: bool,
 }
 
@@ -307,6 +242,7 @@ pub(crate) async fn write_transcript(
     session: &CodeSession,
     cut: ForkCut<'_>,
     events: &[SequencedCodeEvent],
+    complete_turns: &HashSet<CodeTurnId>,
 ) -> std::io::Result<WrittenTranscript> {
     let private_path = private_root.path();
     let write_lock = fork_lock(private_path, session.id);
@@ -328,6 +264,7 @@ pub(crate) async fn write_transcript(
         engine,
         generation,
         &retained_images,
+        complete_turns,
     );
     for (ordinal, markdown) in &records.files {
         scope
@@ -347,6 +284,7 @@ pub(crate) async fn write_transcript(
         generation,
         &records.ordinals,
         &retained_images,
+        complete_turns,
     );
     scope
         .publish(
@@ -402,6 +340,7 @@ fn render_transcript_with_generation(
     generation: uuid::Uuid,
     record_ordinals: &HashSet<i64>,
     retained_images: &HashSet<CodeTurnId>,
+    complete_turns: &HashSet<CodeTurnId>,
 ) -> RenderedTranscript {
     let engine = harness_label(session.harness_kind);
     let mut sections: Vec<String> = Vec::with_capacity(turns.len());
@@ -414,6 +353,7 @@ fn render_transcript_with_generation(
             engine,
             generation,
             retained_images.contains(&turn.id),
+            complete_turns.contains(&turn.id),
         ));
     }
 
@@ -427,6 +367,7 @@ fn render_transcript_with_generation(
         turns.len(),
         record_ordinals,
         engine,
+        complete_turns,
     )
     .len();
     let budget = MAX_TRANSCRIPT_BYTES.saturating_sub(reserved);
@@ -455,7 +396,13 @@ fn render_transcript_with_generation(
     // asked, and where the full record is — newest first, while they fit.
     let stubs: Vec<String> = turns[..dropped]
         .iter()
-        .map(|turn| render_stub(turn, record_ordinals.contains(&turn.ordinal)))
+        .map(|turn| {
+            render_stub(
+                turn,
+                record_ordinals.contains(&turn.ordinal),
+                complete_turns.contains(&turn.id),
+            )
+        })
         .collect();
     let mut stub_from = dropped;
     for (at, stub) in stubs.iter().enumerate().rev() {
@@ -474,6 +421,7 @@ fn render_transcript_with_generation(
         dropped,
         record_ordinals,
         engine,
+        complete_turns,
     ));
     for stub in &stubs[stub_from..] {
         out.push('\n');
@@ -484,10 +432,17 @@ fn render_transcript_with_generation(
         out.push_str(section);
     }
 
+    let complete = turns
+        .iter()
+        .filter(|turn| complete_turns.contains(&turn.id))
+        .count();
     RenderedTranscript {
         markdown: out,
-        turns: kept as u32,
-        truncated: dropped > 0 || clipped,
+        turns: turns[dropped..]
+            .iter()
+            .filter(|turn| complete_turns.contains(&turn.id))
+            .count() as u32,
+        truncated: dropped > 0 || clipped || complete < turns.len(),
     }
 }
 
@@ -601,6 +556,7 @@ fn header(
     reduced: usize,
     record_ordinals: &HashSet<i64>,
     engine: &str,
+    complete_turns: &HashSet<CodeTurnId>,
 ) -> String {
     let total = turns.len();
     let mut out = String::new();
@@ -633,6 +589,17 @@ fn header(
             if reduced == 1 { "s" } else { "" },
         );
     }
+    let omitted = turns
+        .iter()
+        .filter(|turn| !complete_turns.contains(&turn.id))
+        .count();
+    if omitted > 0 {
+        let _ = writeln!(
+            out,
+            "The bounded journal replay omitted the engine events for {omitted} turn{} as a whole because it could not retain every framing record required to reconstruct them.",
+            if omitted == 1 { "" } else { "s" },
+        );
+    }
     out.push('\n');
     out.push_str(
         "Messages and tool calls are as the engine reported them, condensed: a \
@@ -642,10 +609,11 @@ fn header(
     if !record_ordinals.is_empty() {
         out.push('\n');
         out.push_str(
-            "Each turn also has a full record in this file's directory — \
-             `turn-0007.md` for turn 7 — holding complete tool output and \
-             subagent activity. Read a full record only when this summary is \
-             not enough.\n",
+            "Each retained turn record sits in this file's directory — \
+             `turn-0007.md` for turn 7. A complete record holds tool output \
+             and subagent activity; a turn omitted from bounded replay keeps \
+             its request and an explicit omission marker. Read a record only \
+             when this summary is not enough.\n",
         );
         let missing = turns
             .iter()
@@ -687,7 +655,7 @@ fn clip(section: &mut String, budget: usize) {
 ///
 /// The heading deliberately differs from a full section's `— you`, so the
 /// child can tell a stub from a turn it can read here.
-fn render_stub(turn: &CodeTurn, has_record: bool) -> String {
+fn render_stub(turn: &CodeTurn, has_record: bool, events_complete: bool) -> String {
     let asked = turn.user_input.trim();
     let asked = if asked.is_empty() {
         "_(empty)_".to_owned()
@@ -697,11 +665,16 @@ fn render_stub(turn: &CodeTurn, has_record: bool) -> String {
     };
     let mut out = String::new();
     let _ = writeln!(out, "## Turn {} (condensed)\n", turn.ordinal);
+    if !events_complete {
+        out.push_str(
+            "The engine events for this turn were omitted as a whole from bounded replay. ",
+        );
+    }
     let _ = writeln!(
         out,
         "Asked: {asked}. {}",
         if has_record {
-            format!("Full record: `{}`.", record_name(turn.ordinal))
+            format!("Turn record: `{}`.", record_name(turn.ordinal))
         } else {
             "No record file was retained for this turn.".to_owned()
         }
@@ -710,6 +683,7 @@ fn render_stub(turn: &CodeTurn, has_record: bool) -> String {
 }
 
 /// One turn: what the reader asked, then what the engine said and did.
+#[allow(clippy::too_many_arguments)]
 fn render_turn(
     private_root: &Path,
     session_id: tidebreak_core::CodeSessionId,
@@ -718,6 +692,7 @@ fn render_turn(
     engine: &str,
     generation: uuid::Uuid,
     images_retained: bool,
+    events_complete: bool,
 ) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "## Turn {} — you\n", turn.ordinal);
@@ -735,6 +710,14 @@ fn render_turn(
         "{}\n",
         if asked.is_empty() { "_(empty)_" } else { asked }
     );
+
+    if !events_complete {
+        let _ = writeln!(out, "## Turn {} — {engine}\n", turn.ordinal);
+        out.push_str(
+            "_This turn's engine events were omitted as a whole because the bounded journal replay could not retain every framing record required to reconstruct them._\n",
+        );
+        return out;
+    }
 
     let lines = turn_lines(turn.id, events);
     if lines.is_empty() {
@@ -872,6 +855,7 @@ struct RenderedRecords {
 
 /// Render every turn's full record, kept from the newest back within
 /// [`MAX_RECORD_TOTAL_BYTES`], each clipped to [`MAX_RECORD_FILE_BYTES`].
+#[allow(clippy::too_many_arguments)]
 fn render_turn_records(
     private_root: &Path,
     session: &CodeSession,
@@ -880,15 +864,8 @@ fn render_turn_records(
     engine: &str,
     generation: uuid::Uuid,
     retained_images: &HashSet<CodeTurnId>,
+    complete_turns: &HashSet<CodeTurnId>,
 ) -> RenderedRecords {
-    let started: HashSet<CodeTurnId> = events
-        .iter()
-        .filter_map(|entry| match &entry.event {
-            CodeEvent::TurnStarted { turn_id } => Some(*turn_id),
-            _ => None,
-        })
-        .collect();
-
     let mut files: Vec<(i64, String)> = Vec::with_capacity(turns.len());
     let mut total = 0usize;
     for turn in turns.iter().rev() {
@@ -900,7 +877,7 @@ fn render_turn_records(
             engine,
             generation,
             retained_images.contains(&turn.id),
-            started.contains(&turn.id),
+            complete_turns.contains(&turn.id),
         );
         clip(&mut record, MAX_RECORD_FILE_BYTES);
         if total + record.len() > MAX_RECORD_TOTAL_BYTES {
@@ -926,10 +903,15 @@ fn render_turn_record(
     engine: &str,
     generation: uuid::Uuid,
     images_retained: bool,
-    events_in_window: bool,
+    events_complete: bool,
 ) -> String {
     let mut out = String::new();
-    let _ = writeln!(out, "# Turn {} — full record\n", turn.ordinal);
+    let _ = writeln!(
+        out,
+        "# Turn {} — {} record\n",
+        turn.ordinal,
+        if events_complete { "full" } else { "request" }
+    );
     let _ = writeln!(out, "## Turn {} — you\n", turn.ordinal);
     render_attachment_list(
         &mut out,
@@ -946,11 +928,10 @@ fn render_turn_record(
         if asked.is_empty() { "_(empty)_" } else { asked }
     );
 
-    if !events_in_window {
+    if !events_complete {
         let _ = writeln!(
             out,
-            "_The journal's replay window no longer holds this turn's events; \
-             only the request above survives._",
+            "_The bounded journal replay omitted this turn's engine events as a whole because it could not retain every framing record required to reconstruct them; only the request above survives._",
         );
         return out;
     }
@@ -1243,14 +1224,8 @@ mod tests {
             .collect()
     }
 
-    fn completed_events(turn_id: CodeTurnId) -> Vec<SequencedCodeEvent> {
-        seq(vec![
-            CodeEvent::TurnStarted { turn_id },
-            CodeEvent::TurnCompleted {
-                usage: Default::default(),
-                checkpoint: None,
-            },
-        ])
+    fn all_turn_ids(turns: &[CodeTurn]) -> HashSet<CodeTurnId> {
+        turns.iter().map(|turn| turn.id).collect()
     }
 
     fn test_root(directory: &tempfile::TempDir) -> super::super::scratch::ScratchRoot {
@@ -1274,6 +1249,7 @@ mod tests {
             events,
             uuid::Uuid::nil(),
             &records,
+            &retained,
             &retained,
         )
     }
@@ -1416,30 +1392,23 @@ mod tests {
         let completed = turn(session.id, 1, "first");
         let mut running = turn(session.id, 2, "keep working");
         running.status = CodeTurnStatus::Running;
-        let events = seq(vec![
-            CodeEvent::TurnStarted {
-                turn_id: completed.id,
-            },
-            CodeEvent::TurnCompleted {
-                usage: Default::default(),
-                checkpoint: None,
-            },
-            CodeEvent::TurnStarted {
-                turn_id: running.id,
-            },
-        ]);
         let turns = [completed.clone(), running];
 
-        let result = cut_at_settled_boundary(&turns, &events, &HashSet::new(), false, None);
+        let result = cut_at_settled_boundary(&turns, None, &HashSet::new(), false, None);
 
         assert!(matches!(
             result,
             Err(ForkBoundaryError::Running { ordinal: 2 })
         ));
 
-        let earlier =
-            cut_at_settled_boundary(&turns, &events, &HashSet::new(), false, Some(completed.id))
-                .expect("earlier completed boundary");
+        let earlier = cut_at_settled_boundary(
+            &turns,
+            Some(CodeTurnStatus::Completed),
+            &HashSet::new(),
+            false,
+            Some(completed.id),
+        )
+        .expect("earlier completed boundary");
         assert_eq!(earlier.turns.len(), 1);
         assert_eq!(earlier.excluded, 1);
     }
@@ -1451,10 +1420,15 @@ mod tests {
         let session = session();
         let completed = turn(session.id, 1, "run the command");
         let pending = HashSet::from([completed.id]);
-        let events = completed_events(completed.id);
         let turns = [completed];
 
-        let result = cut_at_settled_boundary(&turns, &events, &pending, false, None);
+        let result = cut_at_settled_boundary(
+            &turns,
+            Some(CodeTurnStatus::Completed),
+            &pending,
+            false,
+            None,
+        );
 
         assert!(matches!(
             result,
@@ -1469,11 +1443,9 @@ mod tests {
     fn queued_follow_up_requires_an_explicit_turn_boundary() {
         let session = session();
         let completed = turn(session.id, 1, "first");
-        let events = completed_events(completed.id);
-
         let ordinary = cut_at_settled_boundary(
             std::slice::from_ref(&completed),
-            &events,
+            Some(CodeTurnStatus::Completed),
             &HashSet::new(),
             true,
             None,
@@ -1482,7 +1454,7 @@ mod tests {
 
         let explicit = cut_at_settled_boundary(
             std::slice::from_ref(&completed),
-            &events,
+            Some(CodeTurnStatus::Completed),
             &HashSet::new(),
             true,
             Some(completed.id),
@@ -1499,12 +1471,9 @@ mod tests {
         let session = session();
         let mut stale = turn(session.id, 1, "finish while forking");
         stale.status = CodeTurnStatus::Running;
-        let started = seq(vec![CodeEvent::TurnStarted { turn_id: stale.id }]);
-        let completed = completed_events(stale.id);
-
         let mixed = cut_at_settled_boundary(
             std::slice::from_ref(&stale),
-            &completed,
+            Some(CodeTurnStatus::Completed),
             &HashSet::new(),
             false,
             None,
@@ -1517,16 +1486,20 @@ mod tests {
         let mut settled = stale;
         settled.status = CodeTurnStatus::Completed;
         let settled_turns = [settled];
-        let row_ahead =
-            cut_at_settled_boundary(&settled_turns, &started, &HashSet::new(), false, None);
+        let row_ahead = cut_at_settled_boundary(&settled_turns, None, &HashSet::new(), false, None);
         assert!(matches!(
             row_ahead,
             Err(ForkBoundaryError::Settling { ordinal: 1 })
         ));
 
-        let retry =
-            cut_at_settled_boundary(&settled_turns, &completed, &HashSet::new(), false, None)
-                .expect("fresh settled snapshot");
+        let retry = cut_at_settled_boundary(
+            &settled_turns,
+            Some(CodeTurnStatus::Completed),
+            &HashSet::new(),
+            false,
+            None,
+        )
+        .expect("fresh settled snapshot");
         assert_eq!(retry.turns.len(), 1);
     }
 
@@ -1540,6 +1513,7 @@ mod tests {
             .map(|ordinal| turn(session.id, ordinal, "work"))
             .collect();
         let records: HashSet<i64> = turns.iter().map(|turn| turn.ordinal).collect();
+        let complete = all_turn_ids(&turns);
 
         let markdown = render_transcript_with_generation(
             Path::new("/private"),
@@ -1550,6 +1524,7 @@ mod tests {
             uuid::Uuid::nil(),
             &records,
             &HashSet::new(),
+            &complete,
         )
         .markdown;
 
@@ -1590,6 +1565,7 @@ mod tests {
             .map(|ordinal| turn(session.id, ordinal, &bulk))
             .collect();
         let records: HashSet<i64> = [3].into_iter().collect();
+        let complete = all_turn_ids(&turns);
 
         let markdown = render_transcript_with_generation(
             Path::new("/private"),
@@ -1600,6 +1576,7 @@ mod tests {
             uuid::Uuid::nil(),
             &records,
             &HashSet::new(),
+            &complete,
         )
         .markdown;
 
@@ -1785,10 +1762,10 @@ mod tests {
         assert_eq!(opens, 2, "the wrapping fence must outgrow the content");
     }
 
-    /// A turn whose events fell out of the bounded replay window still gets a
-    /// record for its ask, and the record says why the rest is missing.
+    /// A turn omitted from bounded replay still gets a request record that
+    /// says why its engine events are missing.
     #[test]
-    fn a_record_says_when_the_journal_window_dropped_its_events() {
+    fn an_omitted_turn_record_says_why_its_events_are_missing() {
         let session = session();
         let old = turn(session.id, 1, "the first ask");
         let record = render_turn_record(
@@ -1803,7 +1780,37 @@ mod tests {
         );
 
         assert!(record.contains("the first ask"));
-        assert!(record.contains("replay window no longer holds"));
+        assert!(record.contains("# Turn 1 — request record"));
+        assert!(record.contains("omitted this turn's engine events as a whole"));
+    }
+
+    /// The condensed transcript must not make an omitted newest turn look as
+    /// though the engine produced no work.
+    #[test]
+    fn marks_a_whole_turn_omitted_from_bounded_replay() {
+        let session = session();
+        let only = turn(session.id, 1, "inspect the failing run");
+
+        let rendered = render_transcript_with_generation(
+            Path::new("/private"),
+            &session,
+            std::slice::from_ref(&only),
+            0,
+            &[],
+            uuid::Uuid::nil(),
+            &HashSet::from([only.ordinal]),
+            &HashSet::new(),
+            &HashSet::new(),
+        );
+
+        assert_eq!(rendered.turns, 0);
+        assert!(rendered.truncated);
+        assert!(rendered
+            .markdown
+            .contains("omitted the engine events for 1 turn as a whole"));
+        assert!(rendered
+            .markdown
+            .contains("This turn's engine events were omitted as a whole"));
     }
 
     /// Records are kept from the newest turn back within the total budget, so
@@ -1815,6 +1822,7 @@ mod tests {
         let turns: Vec<CodeTurn> = (1..=40)
             .map(|ordinal| turn(session.id, ordinal, &bulk))
             .collect();
+        let complete = all_turn_ids(&turns);
 
         let records = render_turn_records(
             Path::new("/private"),
@@ -1824,6 +1832,7 @@ mod tests {
             "Claude Code",
             uuid::Uuid::nil(),
             &HashSet::new(),
+            &complete,
         );
 
         assert!(records.files.len() < turns.len());
@@ -1848,6 +1857,7 @@ mod tests {
             turn(session.id, 1, "hello"),
             turn(session.id, 2, "and again"),
         ];
+        let complete = all_turn_ids(&turns);
         let private_root = test_root(&private);
 
         let written = write_transcript(
@@ -1859,6 +1869,7 @@ mod tests {
                 excluded: 0,
             },
             &[],
+            &complete,
         )
         .await
         .expect("write");
@@ -1889,9 +1900,10 @@ mod tests {
             .map(|ordinal| turn(session.id, ordinal, "work"))
             .collect();
         let cut = cut_at(&turns, Some(turns[0].id)).expect("known turn");
+        let complete = all_turn_ids(cut.turns);
         let private_root = test_root(&private);
 
-        let written = write_transcript(&private_root, &blobs, &session, cut, &[])
+        let written = write_transcript(&private_root, &blobs, &session, cut, &[], &complete)
             .await
             .expect("write");
 
@@ -1919,6 +1931,8 @@ mod tests {
             turn(session.id, 1, "hello"),
             turn(session.id, 2, "more work"),
         ];
+        let first_complete = all_turn_ids(&first_turns);
+        let second_complete = all_turn_ids(&second_turns);
         let private_root = test_root(&private);
 
         let first = write_transcript(
@@ -1930,6 +1944,7 @@ mod tests {
                 excluded: 0,
             },
             &[],
+            &first_complete,
         )
         .await
         .expect("first write");
@@ -1942,6 +1957,7 @@ mod tests {
                 excluded: 0,
             },
             &[],
+            &second_complete,
         )
         .await
         .expect("second write");
@@ -1988,6 +2004,7 @@ mod tests {
             .unwrap();
         only.attachments = vec![first, second];
         let turns = vec![only];
+        let complete = all_turn_ids(&turns);
         let private_root = test_root(&private);
 
         let written = write_transcript(
@@ -1999,6 +2016,7 @@ mod tests {
                 excluded: 0,
             },
             &[],
+            &complete,
         )
         .await
         .unwrap();
@@ -2048,6 +2066,7 @@ mod tests {
         let mut new = turn(session.id, 2, "and this");
         new.attachments = vec![real];
         let turns = vec![old, new];
+        let complete = all_turn_ids(&turns);
         let private_root = test_root(&private);
 
         let written = write_transcript(
@@ -2059,6 +2078,7 @@ mod tests {
                 excluded: 0,
             },
             &[],
+            &complete,
         )
         .await
         .unwrap();

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -13,11 +13,11 @@ use tokio::time::Instant as TokioInstant;
 use tidebreak_core::db::code::{
     abandon_pending_approval, arm_trigger, claim_approval, delete_trigger, delete_workspace,
     get_approval, get_open_turn, get_repo, get_repo_by_root_path, get_session, get_workspace,
-    insert_repo, insert_session, insert_workspace, list_approvals, list_events, list_repos,
-    list_sessions, list_sessions_all_owners, list_sessions_for_workspace, list_triggers_for_repo,
-    list_turns, list_workspaces, mark_repo_removed, queued_turn_head, save_repo, save_session,
-    save_workspace, settle_approval_claim, update_trigger_enabled, ClaimedApprovalSettlement,
-    MAX_REPLAY_EVENTS,
+    insert_repo, insert_session, insert_workspace, list_approvals, list_events, list_fork_events,
+    list_repos, list_sessions, list_sessions_all_owners, list_sessions_for_workspace,
+    list_triggers_for_repo, list_turns, list_workspaces, mark_repo_removed, queued_turn_head,
+    save_repo, save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
+    ClaimedApprovalSettlement, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
@@ -3951,7 +3951,6 @@ impl CodeRuntime {
             .transpose()?;
 
         let turns = list_turns(&self.db, owner, session_id).await?;
-        let events = list_events(&self.db, owner, session_id, 0, MAX_REPLAY_EVENTS).await?;
         let pending_approval_turns: HashSet<CodeTurnId> = list_approvals(
             &self.db,
             owner,
@@ -3966,9 +3965,20 @@ impl CodeRuntime {
             && queued_turn_head(&self.db, owner, session_id)
                 .await?
                 .is_some();
+        let Some(prepared_cut) = fork::cut_at(&turns, at_turn) else {
+            return Err(ServerError::bad_request(
+                "that turn is not part of this session",
+            ));
+        };
+        let Some(boundary) = prepared_cut.turns.last() else {
+            let error = fork::ForkBoundaryError::NoTurns;
+            return Err(ServerError::conflict_kind(error.kind(), error.message()));
+        };
+        let replay =
+            list_fork_events(&self.db, owner, session_id, boundary.id, MAX_REPLAY_EVENTS).await?;
         let cut = fork::cut_at_settled_boundary(
             &turns,
-            &events.events,
+            replay.boundary_status,
             &pending_approval_turns,
             has_queued_follow_up,
             at_turn,
@@ -3984,7 +3994,8 @@ impl CodeRuntime {
             self.blobs.as_ref(),
             &session,
             cut,
-            &events.events,
+            &replay.events,
+            &replay.complete_turns,
         )
         .await
         .map_err(|err| ServerError::internal(format!("could not write the fork transcript: {err}")))

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -542,7 +542,7 @@ pub struct CodeForkTranscript {
     pub path: String,
     pub dir: String,
     pub byte_len: u64,
-    /// Turns the condensed transcript renders in full.
+    /// Complete turn histories the condensed transcript renders in full.
     pub turns: u32,
     /// Turns the fork covers, up to and including the fork point.
     pub total_turns: u32,
@@ -551,8 +551,8 @@ pub struct CodeForkTranscript {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub at_turn_ordinal: Option<i64>,
-    /// True when anything was left out to fit the size cap: the oldest
-    /// turns, or the end of a turn too large on its own.
+    /// True when bounded replay omitted whole turn histories or the file size
+    /// cap reduced the oldest turns or the end of one oversized turn.
     pub truncated: bool,
 }
 


### PR DESCRIPTION
Closes #2718

## What changed

- Read fork journal history backwards and retain only a contiguous suffix of complete turns within the event cap.
- Keep each retained turn’s start, terminal event, tool starts, completions, and parent frames together.
- Preserve the selected turn’s terminal status when one oversized turn cannot fit, so PR #2716’s settled-boundary check stays exact.
- Mark omitted turn histories in the condensed transcript, stubs, and request records instead of showing an empty or partial turn.
- Add focused regressions for an oversized newest turn, nested tool events, missing parent framing, and several complete turns around the cap.

## Validation

- `rustfmt --edition 2021 --check` on the four changed Rust files.
- `git diff --check`.
- Semantic pull request title check.
- No Cargo commands ran, as required by the issue.

## Compatibility and risk

The fork response shape, event cap, journal schema, and existing settled-boundary behavior stay unchanged. Forks may now report fewer complete turns when the prior event-tail behavior would have returned partial history. Every database scan remains scoped by owner and session. The main risk is the stricter framing validation omitting a malformed turn; the transcript names that omission rather than presenting incomplete history.

## Stack

This pull request is stacked directly after #2716.

CI recovery: Re-ran after the GitHub Actions outage on August 26, 2026.