### PR TITLE
fix(code): make restore ownership-safe

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -261,6 +261,8 @@ pub enum CodeWorkspaceStatus {
     SetupFailed,
     /// Ready for sessions.
     Active,
+    /// Archive owns the checkout and rejects every new writer.
+    Archiving,
     /// Archived; worktree removed, branch kept.
     Archived,
     /// Released; worktree and branch both gone, commits kept as a bundle.
@@ -280,6 +282,7 @@ impl CodeWorkspaceStatus {
             Self::Creating => "creating",
             Self::SetupFailed => "setup_failed",
             Self::Active => "active",
+            Self::Archiving => "archiving",
             Self::Archived => "archived",
             Self::Released => "released",
         }
@@ -293,6 +296,7 @@ impl CodeWorkspaceStatus {
             "creating" => Some(Self::Creating),
             "setup_failed" => Some(Self::SetupFailed),
             "active" => Some(Self::Active),
+            "archiving" => Some(Self::Archiving),
             "archived" => Some(Self::Archived),
             "released" => Some(Self::Released),
             _ => None,

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -55,6 +55,7 @@ impl MigratorTrait for Migrator {
             Box::new(PrePinCodeLifecycleRepair),
             Box::new(CodeApprovalBinding),
             Box::new(CodeSessionProcessIdentity),
+            Box::new(CodeWorkspaceArchiving),
         ]
     }
 }
@@ -65,6 +66,15 @@ struct CodeSessionProcessIdentity;
 impl MigrationName for CodeSessionProcessIdentity {
     fn name(&self) -> &str {
         "m20260826_000017_code_session_process_identity"
+    }
+}
+
+/// Add the transient workspace state that excludes writers during archive.
+struct CodeWorkspaceArchiving;
+
+impl MigrationName for CodeWorkspaceArchiving {
+    fn name(&self) -> &str {
+        "m20260826_000018_code_workspace_archiving"
     }
 }
 
@@ -89,6 +99,109 @@ impl MigrationTrait for CodeSessionProcessIdentity {
 
     async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
         // Removing the identity would make a recorded pid unsafe to reap.
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CodeWorkspaceArchiving {
+    fn use_transaction(&self) -> Option<bool> {
+        // SQLite must disable foreign-key enforcement while it rebuilds the
+        // table to widen the CHECK constraint. PRAGMA foreign_keys is ignored
+        // inside a transaction.
+        None
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DbBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"
+DO $repair$
+DECLARE
+    old_constraint text;
+BEGIN
+    FOR old_constraint IN
+        SELECT constraint_row.conname
+        FROM pg_constraint AS constraint_row
+        JOIN pg_attribute AS attribute_row
+          ON attribute_row.attrelid = constraint_row.conrelid
+         AND attribute_row.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'code_workspace'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute_row.attname = 'status'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE "code_workspace" DROP CONSTRAINT %I',
+            old_constraint
+        );
+    END LOOP;
+END
+$repair$;
+ALTER TABLE "code_workspace"
+    ADD CONSTRAINT "code_workspace_status_check"
+    CHECK ("status" IN (
+        'creating', 'setup_failed', 'active', 'archiving', 'archived', 'released'
+    ));
+"#,
+                )
+                .await
+                .map(|_| ()),
+            DbBackend::Sqlite => manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"
+PRAGMA foreign_keys = OFF;
+CREATE TABLE "code_workspace_archiving" (
+    "id" text NOT NULL PRIMARY KEY,
+    "owner" text NOT NULL DEFAULT 'local',
+    "repo_id" text NOT NULL,
+    "title" text NOT NULL,
+    "worktree_path" text NOT NULL UNIQUE,
+    "branch_name" text NOT NULL,
+    "base_ref" text NOT NULL,
+    "status" text NOT NULL CHECK ("status" IN (
+        'creating', 'setup_failed', 'active', 'archiving', 'archived', 'released'
+    )),
+    "pr" text,
+    "created_at" text NOT NULL,
+    "archived_at" text,
+    "released_at" text,
+    "released_tip" text,
+    "bundle_bytes" integer,
+    FOREIGN KEY ("repo_id") REFERENCES "code_repo" ("id")
+);
+INSERT INTO "code_workspace_archiving" (
+    "id", "owner", "repo_id", "title", "worktree_path", "branch_name",
+    "base_ref", "status", "pr", "created_at", "archived_at",
+    "released_at", "released_tip", "bundle_bytes"
+)
+SELECT
+    "id", "owner", "repo_id", "title", "worktree_path", "branch_name",
+    "base_ref", "status", "pr", "created_at", "archived_at",
+    "released_at", "released_tip", "bundle_bytes"
+FROM "code_workspace";
+DROP TABLE "code_workspace";
+ALTER TABLE "code_workspace_archiving" RENAME TO "code_workspace";
+CREATE UNIQUE INDEX "idx_code_workspace_repo_branch"
+    ON "code_workspace" ("repo_id", "branch_name");
+CREATE INDEX "idx_code_workspace_owner_created"
+    ON "code_workspace" ("owner", "created_at");
+PRAGMA foreign_keys = ON;
+"#,
+                )
+                .await
+                .map(|_| ()),
+            backend => Err(DbErr::Custom(format!(
+                "unsupported database backend for workspace archiving migration: {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // An interrupted archive can persist this value. Removing it would
+        // make that row unreadable instead of recoverable.
         Ok(())
     }
 }
@@ -2076,6 +2189,7 @@ mod tests {
                 "m20260825_000015_pre_pin_code_lifecycle_repair",
                 "m20260825_000016_code_approval_binding",
                 "m20260826_000017_code_session_process_identity",
+                "m20260826_000018_code_workspace_archiving",
             ]
         );
         assert!(db

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -2240,9 +2240,11 @@ impl MigrationTrait for CodeQueuedTurns {
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
-    use sea_orm_migration::prelude::{PostgresQueryBuilder, SqliteQueryBuilder};
+    use sea_orm_migration::prelude::{PostgresQueryBuilder, SchemaManager, SqliteQueryBuilder};
     use sea_orm_migration::MigratorTrait;
 
+    #[cfg(feature = "sqlite")]
+    use super::rebuild_sqlite_code_workspace_for_archiving_inner;
     use super::Migrator;
 
     /// Every `CREATE TABLE` a fresh database runs comes from `sqlite_master`,

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -187,7 +187,7 @@ async fn rebuild_sqlite_code_workspace_for_archiving_inner(
     manager: &SchemaManager<'_>,
     _fail_after_drop_for_test: bool,
 ) -> Result<(), DbErr> {
-    use sea_orm::sqlx::{Acquire as _, Executor as _};
+    use sea_orm::sqlx::Acquire as _;
     use sea_orm::DatabaseExecutor;
 
     let DatabaseExecutor::Connection(database) = manager.get_connection() else {

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -106,18 +106,21 @@ impl MigrationTrait for CodeSessionProcessIdentity {
 #[async_trait::async_trait]
 impl MigrationTrait for CodeWorkspaceArchiving {
     fn use_transaction(&self) -> Option<bool> {
-        // SQLite must disable foreign-key enforcement while it rebuilds the
-        // table to widen the CHECK constraint. PRAGMA foreign_keys is ignored
-        // inside a transaction.
+        // SQLite needs a connection-bound transaction that starts only after
+        // foreign-key enforcement is disabled on that exact connection. The
+        // SQLite branch owns that transaction manually. PostgreSQL executes
+        // its ALTER statements atomically on its own.
         None
     }
 
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         match manager.get_database_backend() {
-            DbBackend::Postgres => manager
-                .get_connection()
-                .execute_unprepared(
-                    r#"
+            DbBackend::Postgres => {
+                let transaction = manager.begin().await?;
+                transaction
+                    .get_connection()
+                    .execute_unprepared(
+                        r#"
 DO $repair$
 DECLARE
     old_constraint text;
@@ -145,14 +148,71 @@ ALTER TABLE "code_workspace"
         'creating', 'setup_failed', 'active', 'archiving', 'archived', 'released'
     ));
 "#,
-                )
-                .await
-                .map(|_| ()),
-            DbBackend::Sqlite => manager
-                .get_connection()
-                .execute_unprepared(
-                    r#"
-PRAGMA foreign_keys = OFF;
+                    )
+                    .await?;
+                transaction.commit().await
+            }
+            DbBackend::Sqlite => rebuild_sqlite_code_workspace_for_archiving(manager).await,
+            backend => Err(DbErr::Custom(format!(
+                "unsupported database backend for workspace archiving migration: {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // An interrupted archive can persist this value. Removing it would
+        // make that row unreadable instead of recoverable.
+        Ok(())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+async fn rebuild_sqlite_code_workspace_for_archiving(
+    manager: &SchemaManager<'_>,
+) -> Result<(), DbErr> {
+    rebuild_sqlite_code_workspace_for_archiving_inner(manager, false).await
+}
+
+#[cfg(not(feature = "sqlite"))]
+async fn rebuild_sqlite_code_workspace_for_archiving(
+    _manager: &SchemaManager<'_>,
+) -> Result<(), DbErr> {
+    Err(DbErr::Custom(
+        "SQLite workspace migration support is not compiled".to_owned(),
+    ))
+}
+
+#[cfg(feature = "sqlite")]
+async fn rebuild_sqlite_code_workspace_for_archiving_inner(
+    manager: &SchemaManager<'_>,
+    _fail_after_drop_for_test: bool,
+) -> Result<(), DbErr> {
+    use sea_orm::sqlx::{Acquire as _, Executor as _};
+    use sea_orm::DatabaseExecutor;
+
+    let DatabaseExecutor::Connection(database) = manager.get_connection() else {
+        return Err(DbErr::Custom(
+            "SQLite workspace rebuild requires the migration connection".to_owned(),
+        ));
+    };
+    let mut connection = database
+        .get_sqlite_connection_pool()
+        .acquire()
+        .await
+        .map_err(|error| DbErr::Custom(format!("acquire SQLite migration connection: {error}")))?;
+    sea_orm::sqlx::query("PRAGMA foreign_keys = OFF")
+        .execute(&mut *connection)
+        .await
+        .map_err(|error| DbErr::Custom(format!("disable SQLite foreign keys: {error}")))?;
+
+    let mut transaction = connection
+        .begin()
+        .await
+        .map_err(|error| DbErr::Custom(format!("begin SQLite workspace rebuild: {error}")))?;
+    let rebuild = async {
+        for statement in [
+            r#"DROP TABLE IF EXISTS "code_workspace_archiving""#,
+            r#"
 CREATE TABLE "code_workspace_archiving" (
     "id" text NOT NULL PRIMARY KEY,
     "owner" text NOT NULL DEFAULT 'local',
@@ -171,7 +231,8 @@ CREATE TABLE "code_workspace_archiving" (
     "released_tip" text,
     "bundle_bytes" integer,
     FOREIGN KEY ("repo_id") REFERENCES "code_repo" ("id")
-);
+)"#,
+            r#"
 INSERT INTO "code_workspace_archiving" (
     "id", "owner", "repo_id", "title", "worktree_path", "branch_name",
     "base_ref", "status", "pr", "created_at", "archived_at",
@@ -181,28 +242,79 @@ SELECT
     "id", "owner", "repo_id", "title", "worktree_path", "branch_name",
     "base_ref", "status", "pr", "created_at", "archived_at",
     "released_at", "released_tip", "bundle_bytes"
-FROM "code_workspace";
-DROP TABLE "code_workspace";
-ALTER TABLE "code_workspace_archiving" RENAME TO "code_workspace";
-CREATE UNIQUE INDEX "idx_code_workspace_repo_branch"
-    ON "code_workspace" ("repo_id", "branch_name");
-CREATE INDEX "idx_code_workspace_owner_created"
-    ON "code_workspace" ("owner", "created_at");
-PRAGMA foreign_keys = ON;
-"#,
-                )
-                .await
-                .map(|_| ()),
-            backend => Err(DbErr::Custom(format!(
-                "unsupported database backend for workspace archiving migration: {backend:?}"
-            ))),
+FROM "code_workspace""#,
+            r#"DROP TABLE "code_workspace""#,
+        ] {
+            sea_orm::sqlx::query(statement)
+                .execute(&mut *transaction)
+                .await?;
         }
+        #[cfg(test)]
+        if _fail_after_drop_for_test {
+            sea_orm::sqlx::query("SELECT * FROM missing_workspace_rebuild_table")
+                .execute(&mut *transaction)
+                .await?;
+        }
+        for statement in [
+            r#"ALTER TABLE "code_workspace_archiving" RENAME TO "code_workspace""#,
+            r#"CREATE UNIQUE INDEX "idx_code_workspace_repo_branch"
+                ON "code_workspace" ("repo_id", "branch_name")"#,
+            r#"CREATE INDEX "idx_code_workspace_owner_created"
+                ON "code_workspace" ("owner", "created_at")"#,
+        ] {
+            sea_orm::sqlx::query(statement)
+                .execute(&mut *transaction)
+                .await?;
+        }
+        Ok::<(), sea_orm::sqlx::Error>(())
     }
+    .await;
 
-    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
-        // An interrupted archive can persist this value. Removing it would
-        // make that row unreadable instead of recoverable.
-        Ok(())
+    let rebuild = match rebuild {
+        Ok(()) => transaction
+            .commit()
+            .await
+            .map_err(|error| DbErr::Custom(format!("commit SQLite workspace rebuild: {error}"))),
+        Err(error) => {
+            let rollback = transaction.rollback().await;
+            match rollback {
+                Ok(()) => Err(DbErr::Custom(format!(
+                    "rebuild SQLite workspace table: {error}"
+                ))),
+                Err(rollback) => Err(DbErr::Custom(format!(
+                    "rebuild SQLite workspace table: {error}; rollback failed: {rollback}"
+                ))),
+            }
+        }
+    };
+
+    let enable = match sea_orm::sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(&mut *connection)
+        .await
+    {
+        Ok(_) => {
+            sea_orm::sqlx::query_scalar::<_, i64>("PRAGMA foreign_keys")
+                .fetch_one(&mut *connection)
+                .await
+        }
+        Err(error) => Err(error),
+    }
+    .map_err(|error| DbErr::Custom(format!("restore SQLite foreign keys: {error}")))
+    .and_then(|enabled| {
+        if enabled == 1 {
+            Ok(())
+        } else {
+            Err(DbErr::Custom(
+                "restore SQLite foreign keys: PRAGMA remained disabled".to_owned(),
+            ))
+        }
+    });
+    match (rebuild, enable) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(rebuild), Err(enable)) => {
+            Err(DbErr::Custom(format!("{rebuild}; additionally, {enable}")))
+        }
     }
 }
 
@@ -2200,6 +2312,102 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn a_failed_workspace_rebuild_rolls_back_the_live_sqlite_table() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        Migrator::up(&db, Some(16)).await.unwrap();
+        db.execute_unprepared(
+            "INSERT INTO code_repo (
+                id, owner, root_path, display_name, default_base_ref,
+                branch_prefix, quick_actions, created_at
+             ) VALUES (
+                'repo-archive', 'local', '/tmp/archive', 'archive', 'main',
+                'tidebreak/', '[]', '2026-08-26T00:00:00Z'
+             );
+             INSERT INTO code_workspace (
+                id, owner, repo_id, title, worktree_path, branch_name, base_ref,
+                status, created_at
+             ) VALUES (
+                'workspace-archive', 'local', 'repo-archive', 'archive',
+                '/tmp/archive-worktree', 'tidebreak/archive', 'main', 'active',
+                '2026-08-26T00:00:00Z'
+             );
+             INSERT INTO code_session (
+                id, owner, workspace_id, kind, harness_kind, permission_mode,
+                lifecycle, attention_state, attention_source, created_at
+             ) VALUES (
+                'session-archive', 'local', 'workspace-archive', 'interactive',
+                'claude_code', 'plan', 'idle', '{}', 'lifecycle',
+                '2026-08-26T00:00:00Z'
+             )",
+        )
+        .await
+        .unwrap();
+
+        let manager = SchemaManager::new(&db);
+        let error = rebuild_sqlite_code_workspace_for_archiving_inner(&manager, true)
+            .await
+            .expect_err("the injected statement fails after the live table is dropped");
+        assert!(error
+            .to_string()
+            .contains("missing_workspace_rebuild_table"));
+
+        let workspace = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT status FROM code_workspace WHERE id = 'workspace-archive'".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .expect("the original workspace table and row survive");
+        assert_eq!(workspace.try_get::<String>("", "status").unwrap(), "active");
+        assert!(db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT 1 AS present FROM code_session WHERE id = 'session-archive'".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' \
+                 AND name = 'code_workspace_archiving'"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap()
+            .is_none());
+
+        rebuild_sqlite_code_workspace_for_archiving_inner(&manager, false)
+            .await
+            .unwrap();
+        db.execute_unprepared(
+            "UPDATE code_workspace SET status = 'archiving' WHERE id = 'workspace-archive'",
+        )
+        .await
+        .unwrap();
+        assert!(db
+            .query_all_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "PRAGMA foreign_key_check".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .is_empty());
+        let foreign_keys = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "PRAGMA foreign_keys".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(foreign_keys.try_get::<i64>("", "foreign_keys").unwrap(), 1);
     }
 
     /// A database that stopped at the current baseline and later took the rest

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -115,6 +115,33 @@ pub async fn compare_and_set_workspace_status(
     Ok(result.rows_affected == 1)
 }
 
+/// Finish an archive only while the workspace still owns the transient state.
+pub async fn complete_workspace_archive(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: WorkspaceId,
+    archived_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool> {
+    let result = entities::code_workspace::Entity::update_many()
+        .col_expr(
+            entities::code_workspace::Column::Status,
+            sea_orm::sea_query::Expr::value(CodeWorkspaceStatus::Archived.as_str()),
+        )
+        .col_expr(
+            entities::code_workspace::Column::ArchivedAt,
+            sea_orm::sea_query::Expr::value(archived_at),
+        )
+        .filter(entities::code_workspace::Column::Id.eq(id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
+        .filter(
+            entities::code_workspace::Column::Status.eq(CodeWorkspaceStatus::Archiving.as_str()),
+        )
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 /// Persist mutable workspace fields. `id`, `repo_id`, and `created_at` stay as stored.
 pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Result<bool> {
     let result = entities::code_workspace::Entity::update_many()

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -75,6 +75,46 @@ pub async fn list_workspaces(
         .collect()
 }
 
+/// Every workspace in one lifecycle state, across owners.
+///
+/// Boot recovery uses this only for the transient `Archiving` state. Owner
+/// scoping resumes before any caller-facing operation.
+pub async fn list_workspaces_by_status_all_owners(
+    store: &DbStore,
+    status: CodeWorkspaceStatus,
+) -> Result<Vec<CodeWorkspace>> {
+    entities::code_workspace::Entity::find()
+        .filter(entities::code_workspace::Column::Status.eq(status.as_str()))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(workspace_from_row)
+        .collect()
+}
+
+/// Change one workspace lifecycle only when it still has the expected state.
+pub async fn compare_and_set_workspace_status(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: WorkspaceId,
+    expected: CodeWorkspaceStatus,
+    next: CodeWorkspaceStatus,
+) -> Result<bool> {
+    let result = entities::code_workspace::Entity::update_many()
+        .col_expr(
+            entities::code_workspace::Column::Status,
+            sea_orm::sea_query::Expr::value(next.as_str()),
+        )
+        .filter(entities::code_workspace::Column::Id.eq(id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_workspace::Column::Status.eq(expected.as_str()))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 /// Persist mutable workspace fields. `id`, `repo_id`, and `created_at` stay as stored.
 pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Result<bool> {
     let result = entities::code_workspace::Entity::update_many()

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1996,6 +1996,9 @@ describe("archive force kinds", () => {
       archiveForceKind(new HttpError(409, "both", "uncommitted_and_unpushed")),
     ).toBe("uncommitted_and_unpushed");
     expect(
+      archiveForceKind(new HttpError(409, "ignored", "ignored_content")),
+    ).toBe("ignored_content");
+    expect(
       archiveForceKind(new HttpError(409, "busy", "session_running")),
     ).toBeNull();
   });

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -278,6 +278,7 @@ export const ARCHIVE_FORCE_KINDS = new Set([
   "uncommitted",
   "unpushed",
   "uncommitted_and_unpushed",
+  "ignored_content",
 ]);
 
 /** The 409 kinds that mean archive needs an explicit force. */

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -76,6 +76,7 @@ export const WORKSPACE_STATUS_LABELS: Record<CodeWorkspaceStatus, string> = {
   creating: "Creating",
   setup_failed: "Setup failed",
   active: "Active",
+  archiving: "Archiving",
   archived: "Archived",
   released: "Released",
 };

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -244,6 +244,7 @@ const WORKSPACE_STATUSES = new Set<CodeWorkspaceStatus>([
   "creating",
   "setup_failed",
   "active",
+  "archiving",
   "archived",
   "released",
 ]);

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1796,7 +1796,7 @@ bundle_bytes?: number, };
 /**
  * Status of a persisted workspace.
  */
-export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archived" | "released";
+export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archiving" | "archived" | "released";
 
 /**
  * Bounded path listing for `GET /code/workspaces/{id}/tree`.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -11,12 +11,13 @@ use tokio::sync::oneshot;
 use tokio::time::Instant as TokioInstant;
 
 use tidebreak_core::db::code::{
-    abandon_pending_approval, arm_trigger, claim_approval, delete_trigger, delete_workspace,
-    get_approval, get_open_turn, get_repo, get_repo_by_root_path, get_session, get_workspace,
-    insert_repo, insert_session, insert_workspace, list_approvals, list_events, list_fork_events,
-    list_repos, list_sessions, list_sessions_all_owners, list_sessions_for_workspace,
-    list_triggers_for_repo, list_turns, list_workspaces, mark_repo_removed, queued_turn_head,
-    save_repo, save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
+    abandon_pending_approval, arm_trigger, claim_approval, compare_and_set_workspace_status,
+    delete_trigger, delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path,
+    get_session, get_workspace, insert_repo, insert_session, insert_workspace, list_approvals,
+    list_events, list_fork_events, list_repos, list_sessions, list_sessions_all_owners,
+    list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
+    list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head, save_repo,
+    save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
     ClaimedApprovalSettlement, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
@@ -230,6 +231,8 @@ pub(crate) struct CodeRuntime {
     /// reads the model handles the app state owns and this runtime is built
     /// first. `None` until then, and in deployments that install none.
     recap: Mutex<Option<Arc<dyn super::recap::TurnRecap>>>,
+    #[cfg(test)]
+    archive_shutdown_timeout: AtomicBool,
 }
 
 /// How long one base branch's rules answer stands before the next read.
@@ -416,6 +419,8 @@ impl CodeRuntime {
             pr_refresh_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
             recap: Mutex::new(None),
+            #[cfg(test)]
+            archive_shutdown_timeout: AtomicBool::new(false),
         }
     }
 
@@ -544,6 +549,8 @@ impl CodeRuntime {
             pr_refresh_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
             recap: Mutex::new(None),
+            #[cfg(test)]
+            archive_shutdown_timeout: AtomicBool::new(false),
         }
     }
 
@@ -571,6 +578,12 @@ impl CodeRuntime {
     #[cfg(test)]
     pub(crate) fn set_forge_api_base(&self, base: Option<String>) {
         *self.forge_api_base.lock().expect("forge api base") = base;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_archive_shutdown_timeout(&self, enabled: bool) {
+        self.archive_shutdown_timeout
+            .store(enabled, Ordering::SeqCst);
     }
 
     /// The REST base decision 65's pull-request operations drive: the
@@ -642,6 +655,31 @@ impl CodeRuntime {
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
         self.ensure_stall_sweep();
+        for workspace in
+            list_workspaces_by_status_all_owners(&self.db, CodeWorkspaceStatus::Archiving).await?
+        {
+            if !std::path::Path::new(&workspace.worktree_path).exists() {
+                tracing::warn!(
+                    workspace = %workspace.id,
+                    "code-mode: archive recovery left a missing checkout fenced as archiving"
+                );
+                continue;
+            }
+            if !compare_and_set_workspace_status(
+                &self.db,
+                &workspace.owner,
+                workspace.id,
+                CodeWorkspaceStatus::Archiving,
+                CodeWorkspaceStatus::Active,
+            )
+            .await?
+            {
+                tracing::warn!(
+                    workspace = %workspace.id,
+                    "code-mode: archive recovery lost its lifecycle compare-and-set"
+                );
+            }
+        }
         let actions = recovery::recover_running_sessions(&self.db, &self.bus)
             .await
             .map_err(ServerError::from)?;
@@ -1149,18 +1187,25 @@ impl CodeRuntime {
         owner: &OwnerId,
         id: WorkspaceId,
         force: bool,
+        terminals: &super::terminal::TerminalHub,
     ) -> Result<CodeWorkspace, ServerError> {
         let mut workspace = self.get_workspace(owner, id).await?;
         if workspace.status == CodeWorkspaceStatus::Archived {
             return Ok(workspace);
         }
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
         let repo = self.get_repo(owner, workspace.repo_id).await?;
         // Blockers first: a refused archive must leave the workspace exactly as
         // it was, and running the hook script is not "exactly as it was".
         self.refuse_running_sessions(owner, id, force).await?;
-        let path = std::path::Path::new(&workspace.worktree_path);
+        let path = std::path::PathBuf::from(&workspace.worktree_path);
         if path.exists() {
-            if let Some(block) = archive_blockers(path, &workspace.base_ref)
+            if let Some(block) = archive_blockers(&path, &workspace.base_ref)
                 .await
                 .map_err(map_worktree)?
             {
@@ -1171,19 +1216,107 @@ impl CodeRuntime {
                     ));
                 }
             }
+        }
+        if !compare_and_set_workspace_status(
+            &self.db,
+            owner,
+            id,
+            CodeWorkspaceStatus::Active,
+            CodeWorkspaceStatus::Archiving,
+        )
+        .await?
+        {
+            return Err(ServerError::conflict_kind(
+                "workspace_lifecycle_busy",
+                "another workspace lifecycle operation started first",
+            ));
+        }
+        workspace.status = CodeWorkspaceStatus::Archiving;
+
+        let archived = self
+            .archive_workspace_exclusive(owner, workspace, repo, force, terminals)
+            .await;
+        if archived.is_err() && path.exists() {
+            if !compare_and_set_workspace_status(
+                &self.db,
+                owner,
+                id,
+                CodeWorkspaceStatus::Archiving,
+                CodeWorkspaceStatus::Active,
+            )
+            .await?
+            {
+                tracing::warn!(
+                    workspace = %id,
+                    "code-mode: failed to restore Active after a refused archive"
+                );
+            }
+        }
+        archived
+    }
+
+    async fn archive_workspace_exclusive(
+        &self,
+        owner: &OwnerId,
+        mut workspace: CodeWorkspace,
+        repo: CodeRepo,
+        force: bool,
+        terminals: &super::terminal::TerminalHub,
+    ) -> Result<CodeWorkspace, ServerError> {
+        if !terminals.close_workspace_and_wait(workspace.id).await {
+            return Err(ServerError::conflict_kind(
+                "terminal_shutdown_timeout",
+                "a workspace terminal did not stop; the checkout was preserved",
+            ));
+        }
+        let workers_stopped = self.end_workspace_sessions(owner, workspace.id).await?;
+        #[cfg(test)]
+        let workers_stopped =
+            workers_stopped && !self.archive_shutdown_timeout.load(Ordering::SeqCst);
+        if !workers_stopped {
+            return Err(ServerError::conflict_kind(
+                "workspace_shutdown_timeout",
+                "a workspace worker did not stop; the checkout was preserved",
+            ));
+        }
+
+        let turn = self.worktree_turn_lock(workspace.id);
+        let _turn_guard = turn.lock().await;
+        let current = self.get_workspace(owner, workspace.id).await?;
+        if current.status != CodeWorkspaceStatus::Archiving {
+            return Err(ServerError::conflict_kind(
+                "workspace_lifecycle_changed",
+                format!(
+                    "workspace became {} during archive",
+                    current.status.as_str()
+                ),
+            ));
+        }
+
+        let path = std::path::Path::new(&workspace.worktree_path);
+        if path.exists() {
             // Decision 0032: the archive script obeys the same
-            // failure-preserves rule as setup. A script that backs up or
-            // pushes state and exits non-zero must stop the archive, not have
-            // its checkout removed underneath it. A worktree that is already
-            // gone has nothing to run the script against.
+            // failure-preserves rule as setup. Lifecycle exclusion starts
+            // before the hook so no in-process writer can overlap it.
             if let Err(err) = run_archive_script(path, repo.archive_script.as_deref()).await {
                 return Err(ServerError::unprocessable_kind(
                     "archive_script_failed",
                     err.to_string(),
                 ));
             }
+            if let Some(block) = archive_blockers(path, &workspace.base_ref)
+                .await
+                .map_err(map_worktree)?
+            {
+                if !force {
+                    return Err(ServerError::conflict_kind(
+                        block.as_str(),
+                        "workspace changed during archive; the checkout was preserved",
+                    ));
+                }
+            }
         }
-        let workers_stopped = self.end_workspace_sessions(owner, id).await?;
+
         remove_worktree(std::path::Path::new(&repo.root_path), path)
             .await
             .map_err(map_worktree)?;
@@ -1198,24 +1331,17 @@ impl CodeRuntime {
         }
         workspace.status = CodeWorkspaceStatus::Archived;
         workspace.archived_at = Some(Utc::now());
-        save_workspace(&self.db, &workspace).await?;
-        // Drop the turn lock only once every worker confirmed it was gone.
-        // The lock is an `Arc`, so forgetting it here does not disturb a
-        // worker that outlived its shutdown grace — it hands the *next* one a
-        // second lock over the same checkout, which is the one thing this is
-        // supposed to make impossible. Keeping the entry costs a map slot per
-        // archived workspace and keeps restore on the same lock.
-        if workers_stopped {
-            self.worktree_turns
-                .lock()
-                .expect("worktree turn locks")
-                .remove(&workspace.id);
-        } else {
-            tracing::warn!(
-                workspace = %workspace.id,
-                "code-mode: keeping the workspace turn lock; a worker outlived its shutdown"
-            );
+        if !save_workspace(&self.db, &workspace).await? {
+            return Err(ServerError::conflict_kind(
+                "workspace_lifecycle_changed",
+                "the workspace row changed before archive completed",
+            ));
         }
+        drop(_turn_guard);
+        self.worktree_turns
+            .lock()
+            .expect("worktree turn locks")
+            .remove(&workspace.id);
         Ok(workspace)
     }
 
@@ -2536,10 +2662,10 @@ impl CodeRuntime {
         id: WorkspaceId,
     ) -> Result<CodeWorkspace, ServerError> {
         let workspace = self.get_workspace(owner, id).await?;
-        if workspace.status == CodeWorkspaceStatus::Archived {
+        if workspace.status != CodeWorkspaceStatus::Active {
             return Err(ServerError::conflict_kind(
                 "workspace_not_ready",
-                "workspace is archived",
+                format!("workspace is {}", workspace.status.as_str()),
             ));
         }
         if !std::path::Path::new(&workspace.worktree_path).exists() {
@@ -2848,6 +2974,13 @@ impl CodeRuntime {
             }
         }
         let mut session = self.get_session(owner, id).await?;
+        let workspace = self.get_workspace(owner, session.workspace_id).await?;
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
         if session.lifecycle == CodeSessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
                 "session_fenced",
@@ -4465,6 +4598,13 @@ impl CodeRuntime {
             .clone()
     }
 
+    pub(crate) fn workspace_write_lock(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Arc<tokio::sync::Mutex<()>> {
+        self.worktree_turn_lock(workspace_id)
+    }
+
     fn require_worker(&self, id: CodeSessionId) -> Result<WorkerHandle, ServerError> {
         self.workers
             .lock()
@@ -5036,6 +5176,9 @@ fn map_worktree(err: WorktreeError) -> ServerError {
             }
         }
         WorktreeError::Internal(message) => ServerError::internal(message),
+        WorktreeError::ArchiveUncertain(message) => {
+            ServerError::conflict_kind("archive_inspection_uncertain", message)
+        }
     }
 }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -12,12 +12,12 @@ use tokio::time::Instant as TokioInstant;
 
 use tidebreak_core::db::code::{
     abandon_pending_approval, arm_trigger, claim_approval, compare_and_set_workspace_status,
-    delete_trigger, delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path,
-    get_session, get_workspace, insert_repo, insert_session, insert_workspace, list_approvals,
-    list_events, list_fork_events, list_repos, list_sessions, list_sessions_all_owners,
-    list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
-    list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head, save_repo,
-    save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
+    complete_workspace_archive, delete_trigger, delete_workspace, get_approval, get_open_turn,
+    get_repo, get_repo_by_root_path, get_session, get_workspace, insert_repo, insert_session,
+    insert_workspace, list_approvals, list_events, list_fork_events, list_repos, list_sessions,
+    list_sessions_all_owners, list_sessions_for_workspace, list_triggers_for_repo, list_turns,
+    list_workspaces, list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head,
+    save_repo, save_session, save_workspace, settle_approval_claim, update_trigger_enabled,
     ClaimedApprovalSettlement, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
@@ -665,13 +665,6 @@ impl CodeRuntime {
         for workspace in
             list_workspaces_by_status_all_owners(&self.db, CodeWorkspaceStatus::Archiving).await?
         {
-            if !std::path::Path::new(&workspace.worktree_path).exists() {
-                tracing::warn!(
-                    workspace = %workspace.id,
-                    "code-mode: archive recovery left a missing checkout fenced as archiving"
-                );
-                continue;
-            }
             let sessions =
                 list_sessions_for_workspace(&self.db, &workspace.owner, workspace.id).await?;
             if sessions.iter().any(|session| {
@@ -684,6 +677,18 @@ impl CodeRuntime {
                     workspace = %workspace.id,
                     "code-mode: archive recovery kept lifecycle exclusion because a worker may still exist"
                 );
+                continue;
+            }
+            if !std::path::Path::new(&workspace.worktree_path).exists() {
+                let repo = self.get_repo(&workspace.owner, workspace.repo_id).await?;
+                match self.finalize_removed_workspace(workspace, &repo).await {
+                    Ok(workspace) => self.forget_workspace_turn_lock(workspace.id),
+                    Err(error) => {
+                        tracing::warn!(
+                            "code-mode: archive recovery could not finalize a missing checkout: {error}"
+                        );
+                    }
+                }
                 continue;
             }
             if !compare_and_set_workspace_status(
@@ -1223,6 +1228,25 @@ impl CodeRuntime {
         if workspace.status == CodeWorkspaceStatus::Archived {
             return Ok(workspace);
         }
+        let path = std::path::PathBuf::from(&workspace.worktree_path);
+        if workspace.status == CodeWorkspaceStatus::Archiving && !path.exists() {
+            let sessions = list_sessions_for_workspace(&self.db, owner, id).await?;
+            if sessions.iter().any(|session| {
+                matches!(
+                    session.lifecycle,
+                    CodeSessionLifecycle::Running | CodeSessionLifecycle::Fenced
+                )
+            }) {
+                return Err(ServerError::conflict_kind(
+                    "workspace_lifecycle_busy",
+                    "a workspace worker may still be running",
+                ));
+            }
+            let repo = self.get_repo(owner, workspace.repo_id).await?;
+            let archived = self.finalize_removed_workspace(workspace, &repo).await?;
+            self.forget_workspace_turn_lock(archived.id);
+            return Ok(archived);
+        }
         if workspace.status != CodeWorkspaceStatus::Active {
             return Err(ServerError::conflict_kind(
                 "workspace_not_ready",
@@ -1233,7 +1257,6 @@ impl CodeRuntime {
         // Blockers first: a refused archive must leave the workspace exactly as
         // it was, and running the hook script is not "exactly as it was".
         self.refuse_running_sessions(owner, id, force).await?;
-        let path = std::path::PathBuf::from(&workspace.worktree_path);
         if path.exists() {
             if let Some(block) = archive_blockers(&path, &workspace.base_ref)
                 .await
@@ -1363,6 +1386,17 @@ impl CodeRuntime {
         remove_worktree(std::path::Path::new(&repo.root_path), path)
             .await
             .map_err(map_worktree)?;
+        let archived = self.finalize_removed_workspace(workspace, &repo).await?;
+        drop(_turn_guard);
+        self.forget_workspace_turn_lock(archived.id);
+        Ok(archived)
+    }
+
+    async fn finalize_removed_workspace(
+        &self,
+        mut workspace: CodeWorkspace,
+        repo: &CodeRepo,
+    ) -> Result<CodeWorkspace, ServerError> {
         let _ = prune_worktrees(std::path::Path::new(&repo.root_path)).await;
         if let Err(error) =
             delete_workspace_refs(std::path::Path::new(&repo.root_path), workspace.id).await
@@ -1372,20 +1406,36 @@ impl CodeRuntime {
                 "code-mode: could not delete checkpoint refs on archive: {error}"
             );
         }
-        workspace.status = CodeWorkspaceStatus::Archived;
-        workspace.archived_at = Some(Utc::now());
-        if !save_workspace(&self.db, &workspace).await? {
+        let archived_at = workspace.archived_at.unwrap_or_else(Utc::now);
+        if !complete_workspace_archive(&self.db, &workspace.owner, workspace.id, archived_at)
+            .await?
+        {
+            let current = self.get_workspace(&workspace.owner, workspace.id).await?;
+            if current.status == CodeWorkspaceStatus::Archived {
+                return Ok(current);
+            }
             return Err(ServerError::conflict_kind(
                 "workspace_lifecycle_changed",
                 "the workspace row changed before archive completed",
             ));
         }
-        drop(_turn_guard);
+        workspace.status = CodeWorkspaceStatus::Archived;
+        workspace.archived_at = Some(archived_at);
+        super::attention::emit_workspace_digests(
+            &self.db,
+            &self.bus,
+            &workspace.owner,
+            workspace.id,
+        )
+        .await;
+        Ok(workspace)
+    }
+
+    fn forget_workspace_turn_lock(&self, workspace_id: WorkspaceId) {
         self.worktree_turns
             .lock()
             .expect("worktree turn locks")
-            .remove(&workspace.id);
-        Ok(workspace)
+            .remove(&workspace_id);
     }
 
     /// Reactivate an archived workspace at its own path, on its own branch.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -180,6 +180,8 @@ pub(crate) struct CodeRuntime {
     /// Last pin-install failure per kind. Cleared on a successful install.
     pin_install_errors: Mutex<HashMap<HarnessKind, String>>,
     workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
+    /// Serializes writer admission with workspace lifecycle transitions.
+    workspace_lifecycles: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
     /// One turn at a time per worktree, shared by every session in it.
     ///
     /// Sessions in a workspace share one checkout, so their turns cannot
@@ -395,6 +397,7 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            workspace_lifecycles: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: Mutex::new(HashMap::new()),
             delivery_nudges: DeliveryNudgeDebounce::default(),
@@ -525,6 +528,7 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            workspace_lifecycles: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: Mutex::new(HashMap::new()),
             delivery_nudges: DeliveryNudgeDebounce::default(),
@@ -655,6 +659,9 @@ impl CodeRuntime {
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
         self.ensure_stall_sweep();
+        let actions = recovery::recover_running_sessions(&self.db, &self.bus)
+            .await
+            .map_err(ServerError::from)?;
         for workspace in
             list_workspaces_by_status_all_owners(&self.db, CodeWorkspaceStatus::Archiving).await?
         {
@@ -662,6 +669,20 @@ impl CodeRuntime {
                 tracing::warn!(
                     workspace = %workspace.id,
                     "code-mode: archive recovery left a missing checkout fenced as archiving"
+                );
+                continue;
+            }
+            let sessions =
+                list_sessions_for_workspace(&self.db, &workspace.owner, workspace.id).await?;
+            if sessions.iter().any(|session| {
+                matches!(
+                    session.lifecycle,
+                    CodeSessionLifecycle::Running | CodeSessionLifecycle::Fenced
+                )
+            }) {
+                tracing::warn!(
+                    workspace = %workspace.id,
+                    "code-mode: archive recovery kept lifecycle exclusion because a worker may still exist"
                 );
                 continue;
             }
@@ -680,9 +701,6 @@ impl CodeRuntime {
                 );
             }
         }
-        let actions = recovery::recover_running_sessions(&self.db, &self.bus)
-            .await
-            .map_err(ServerError::from)?;
         let recovered_sessions = list_sessions_all_owners(&self.db).await?;
         for session in &recovered_sessions {
             super::approval_sweep::abandon_for_restart(
@@ -1166,6 +1184,18 @@ impl CodeRuntime {
         &self,
         workspace: &CodeWorkspace,
     ) -> Result<(), ServerError> {
+        let lifecycle = self.workspace_lifecycle_lock(workspace.id);
+        let _lifecycle_guard = lifecycle.lock().await;
+        let current = self.get_workspace(&workspace.owner, workspace.id).await?;
+        if current.status != workspace.status {
+            return Err(ServerError::conflict_kind(
+                "workspace_lifecycle_changed",
+                format!(
+                    "workspace became {} before the update was saved",
+                    current.status.as_str()
+                ),
+            ));
+        }
         if !save_workspace(&self.db, workspace).await? {
             return Err(ServerError::not_found(format!(
                 "workspace {} not found",
@@ -1217,26 +1247,41 @@ impl CodeRuntime {
                 }
             }
         }
-        if !compare_and_set_workspace_status(
-            &self.db,
-            owner,
-            id,
-            CodeWorkspaceStatus::Active,
-            CodeWorkspaceStatus::Archiving,
-        )
-        .await?
         {
-            return Err(ServerError::conflict_kind(
-                "workspace_lifecycle_busy",
-                "another workspace lifecycle operation started first",
-            ));
+            let lifecycle = self.workspace_lifecycle_lock(id);
+            let _lifecycle_guard = lifecycle.lock().await;
+            workspace = self.get_workspace(owner, id).await?;
+            if workspace.status != CodeWorkspaceStatus::Active {
+                return Err(ServerError::conflict_kind(
+                    "workspace_lifecycle_busy",
+                    format!("workspace is {}", workspace.status.as_str()),
+                ));
+            }
+            self.refuse_running_sessions(owner, id, force).await?;
+            if !compare_and_set_workspace_status(
+                &self.db,
+                owner,
+                id,
+                CodeWorkspaceStatus::Active,
+                CodeWorkspaceStatus::Archiving,
+            )
+            .await?
+            {
+                return Err(ServerError::conflict_kind(
+                    "workspace_lifecycle_busy",
+                    "another workspace lifecycle operation started first",
+                ));
+            }
         }
         workspace.status = CodeWorkspaceStatus::Archiving;
 
         let archived = self
             .archive_workspace_exclusive(owner, workspace, repo, force, terminals)
             .await;
-        if archived.is_err() && path.exists() {
+        if archived
+            .as_ref()
+            .is_err_and(|error| archive_failure_can_reopen(error) && path.exists())
+        {
             if !compare_and_set_workspace_status(
                 &self.db,
                 owner,
@@ -2719,6 +2764,8 @@ impl CodeRuntime {
             fast_mode,
         }: NewSessionSettings,
     ) -> Result<CodeSession, ServerError> {
+        let lifecycle = self.workspace_lifecycle_lock(workspace_id);
+        let _lifecycle_guard = lifecycle.lock().await;
         let workspace = self.get_workspace(owner, workspace_id).await?;
         if workspace.status != CodeWorkspaceStatus::Active {
             return Err(ServerError::conflict_kind(
@@ -4602,7 +4649,16 @@ impl CodeRuntime {
         &self,
         workspace_id: WorkspaceId,
     ) -> Arc<tokio::sync::Mutex<()>> {
-        self.worktree_turn_lock(workspace_id)
+        self.workspace_lifecycle_lock(workspace_id)
+    }
+
+    fn workspace_lifecycle_lock(&self, workspace_id: WorkspaceId) -> Arc<tokio::sync::Mutex<()>> {
+        self.workspace_lifecycles
+            .lock()
+            .expect("workspace lifecycle locks")
+            .entry(workspace_id)
+            .or_default()
+            .clone()
     }
 
     fn require_worker(&self, id: CodeSessionId) -> Result<WorkerHandle, ServerError> {
@@ -5180,6 +5236,18 @@ fn map_worktree(err: WorktreeError) -> ServerError {
             ServerError::conflict_kind("archive_inspection_uncertain", message)
         }
     }
+}
+
+fn archive_failure_can_reopen(error: &ServerError) -> bool {
+    matches!(
+        error.kind(),
+        "archive_script_failed"
+            | "archive_inspection_uncertain"
+            | "ignored_content"
+            | "uncommitted"
+            | "unpushed"
+            | "uncommitted_and_unpushed"
+    )
 }
 
 fn map_worker(err: WorkerError) -> ServerError {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -235,6 +235,8 @@ pub(crate) struct CodeRuntime {
     recap: Mutex<Option<Arc<dyn super::recap::TurnRecap>>>,
     #[cfg(test)]
     archive_shutdown_timeout: AtomicBool,
+    #[cfg(test)]
+    fail_next_workspace_final_save: AtomicBool,
 }
 
 /// How long one base branch's rules answer stands before the next read.
@@ -424,6 +426,8 @@ impl CodeRuntime {
             recap: Mutex::new(None),
             #[cfg(test)]
             archive_shutdown_timeout: AtomicBool::new(false),
+            #[cfg(test)]
+            fail_next_workspace_final_save: AtomicBool::new(false),
         }
     }
 
@@ -588,6 +592,12 @@ impl CodeRuntime {
     pub(crate) fn set_archive_shutdown_timeout(&self, enabled: bool) {
         self.archive_shutdown_timeout
             .store(enabled, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_workspace_final_save(&self) {
+        self.fail_next_workspace_final_save
+            .store(true, Ordering::SeqCst);
     }
 
     /// The REST base decision 65's pull-request operations drive: the
@@ -1139,13 +1149,16 @@ impl CodeRuntime {
             bundle_bytes: None,
         };
         insert_workspace(&self.db, &workspace).await?;
-        match create_worktree(std::path::Path::new(&repo.root_path), &path, &branch, &base).await {
-            Ok(()) => {}
-            Err(err) => {
-                let _ = delete_workspace(&self.db, owner, id).await;
-                return Err(map_worktree(err));
-            }
-        }
+        let operation =
+            match create_worktree(std::path::Path::new(&repo.root_path), &path, &branch, &base)
+                .await
+            {
+                Ok(operation) => operation,
+                Err(err) => {
+                    let _ = delete_workspace(&self.db, owner, id).await;
+                    return Err(map_worktree(err));
+                }
+            };
         // Before the setup script, which may itself commit: from here on,
         // anything this workspace commits should already carry the right
         // name.
@@ -1153,19 +1166,58 @@ impl CodeRuntime {
         match run_setup_script(&path, repo.setup_script.as_deref()).await {
             Ok(()) => {
                 workspace.status = CodeWorkspaceStatus::Active;
-                save_workspace(&self.db, &workspace).await?;
+                match self.save_workspace_final(&workspace).await {
+                    Ok(true) => operation.complete().await,
+                    Ok(false) => {
+                        operation.rollback().await;
+                        return Err(ServerError::not_found(format!(
+                            "workspace {} not found",
+                            workspace.id
+                        )));
+                    }
+                    Err(error) => {
+                        operation.rollback().await;
+                        return Err(error);
+                    }
+                }
                 gh::run_auto_create_actions(&path, &repo.quick_actions).await;
                 Ok(workspace)
             }
             Err(err) => {
                 workspace.status = CodeWorkspaceStatus::SetupFailed;
-                save_workspace(&self.db, &workspace).await?;
+                match self.save_workspace_final(&workspace).await {
+                    Ok(true) => operation.complete().await,
+                    Ok(false) => {
+                        operation.rollback().await;
+                        return Err(ServerError::not_found(format!(
+                            "workspace {} not found",
+                            workspace.id
+                        )));
+                    }
+                    Err(error) => {
+                        operation.rollback().await;
+                        return Err(error);
+                    }
+                }
                 Err(ServerError::unprocessable_kind(
                     "setup_failed",
                     err.to_string(),
                 ))
             }
         }
+    }
+
+    async fn save_workspace_final(&self, workspace: &CodeWorkspace) -> Result<bool, ServerError> {
+        #[cfg(test)]
+        if self
+            .fail_next_workspace_final_save
+            .swap(false, Ordering::SeqCst)
+        {
+            return Err(ServerError::internal(
+                "injected workspace lifecycle persistence failure",
+            ));
+        }
+        Ok(save_workspace(&self.db, workspace).await?)
     }
 
     pub(crate) async fn list_workspaces(
@@ -1458,16 +1510,20 @@ impl CodeRuntime {
     /// did — usually kilobytes against a checkout measured in gigabytes — so
     /// dropping the ref frees nearly everything and a restore still rebuilds
     /// exactly. The transcript is not touched at any tier.
-    /// Drop a restored workspace's release bookkeeping and its bundle.
+    /// Drop a restored workspace's release bookkeeping.
     ///
-    /// The branch is back in the repository, so the bundle is a second copy of
-    /// commits git already has. Removing it is best-effort: a bundle left
-    /// behind wastes space, while failing the restore over it would strand a
-    /// workspace whose checkout is already on disk.
-    fn clear_release(workspace: &mut CodeWorkspace, data_dir: &std::path::Path) {
+    /// The bundle stays until the row carrying these cleared fields is durable.
+    fn clear_release(workspace: &mut CodeWorkspace) {
         if workspace.released_at.is_none() && workspace.bundle_bytes.is_none() {
             return;
         }
+        workspace.released_at = None;
+        workspace.released_tip = None;
+        workspace.bundle_bytes = None;
+    }
+
+    /// Remove a restored workspace's bundle after its final row is durable.
+    fn remove_release_bundle(workspace: &CodeWorkspace, data_dir: &std::path::Path) {
         let bundle = worktree::bundle_path(data_dir, &workspace.id.0);
         if let Err(error) = std::fs::remove_file(&bundle) {
             if error.kind() != std::io::ErrorKind::NotFound {
@@ -1478,9 +1534,6 @@ impl CodeRuntime {
                 );
             }
         }
-        workspace.released_at = None;
-        workspace.released_tip = None;
-        workspace.bundle_bytes = None;
     }
 
     pub(crate) async fn release_workspace(
@@ -1563,6 +1616,8 @@ impl CodeRuntime {
         owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<CodeWorkspace, ServerError> {
+        let lifecycle = self.workspace_lifecycle_lock(id);
+        let _lifecycle_guard = lifecycle.lock().await;
         let mut workspace = self.get_workspace(owner, id).await?;
         if workspace.status == CodeWorkspaceStatus::Active {
             return Ok(workspace);
@@ -1577,64 +1632,80 @@ impl CodeRuntime {
         let repo = self.get_repo(owner, workspace.repo_id).await?;
         Self::refuse_removed_repo(&repo)?;
         let repo_root = std::path::Path::new(&repo.root_path);
-        // A released workspace has no branch: release bundled its commits and
-        // dropped the ref. Put the branch back from the bundle first, and the
-        // rest of restore is the archived path unchanged.
-        if released
-            && !worktree::branch_exists(repo_root, &workspace.branch_name)
-                .await
-                .map_err(map_worktree)?
-        {
+        let path = std::path::Path::new(&workspace.worktree_path);
+        let operation = if released {
+            let released_tip = workspace.released_tip.as_deref().ok_or_else(|| {
+                ServerError::conflict_kind(
+                    "released_tip_missing",
+                    "the released workspace has no recorded commit; its bundle was preserved",
+                )
+            })?;
             let bundle = worktree::bundle_path(&self.data_dir, &workspace.id.0);
-            worktree::unbundle_branch(repo_root, &bundle, &workspace.branch_name)
-                .await
-                .map_err(map_worktree)?;
-        }
-        if !worktree::branch_exists(repo_root, &workspace.branch_name)
+            worktree::restore_released_worktree(
+                repo_root,
+                path,
+                &workspace.branch_name,
+                &bundle,
+                released_tip,
+            )
             .await
             .map_err(map_worktree)?
-        {
-            return Err(ServerError::conflict_kind(
-                "branch_missing",
-                format!(
-                    "branch {} no longer exists; create a new workspace instead",
-                    workspace.branch_name
-                ),
-            ));
-        }
-        let path = std::path::Path::new(&workspace.worktree_path);
-        if path.exists() {
-            return Err(ServerError::conflict_kind(
-                "worktree_path_occupied",
-                format!("something already exists at {}", workspace.worktree_path),
-            ));
-        }
-        worktree::restore_worktree(repo_root, path, &workspace.branch_name)
-            .await
-            .map_err(map_worktree)?;
+        } else {
+            if !worktree::branch_exists(repo_root, &workspace.branch_name)
+                .await
+                .map_err(map_worktree)?
+            {
+                return Err(ServerError::conflict_kind(
+                    "branch_missing",
+                    format!(
+                        "branch {} no longer exists; create a new workspace instead",
+                        workspace.branch_name
+                    ),
+                ));
+            }
+            worktree::restore_worktree(repo_root, path, &workspace.branch_name)
+                .await
+                .map_err(map_worktree)?
+        };
         // Mirror create's tail exactly: setup decides between Active and
         // SetupFailed, and a failing script preserves the checkout
         // (Decision 0032's failure-preserves rule). One vocabulary for both
         // paths — a reader debugging "setup_failed" should not need to know
         // whether the workspace was created or restored.
-        match run_setup_script(path, repo.setup_script.as_deref()).await {
-            Ok(()) => {
-                workspace.status = CodeWorkspaceStatus::Active;
-                workspace.archived_at = None;
-                Self::clear_release(&mut workspace, &self.data_dir);
-                save_workspace(&self.db, &workspace).await?;
-                Ok(workspace)
+        let setup = run_setup_script(path, repo.setup_script.as_deref()).await;
+        workspace.status = if setup.is_ok() {
+            CodeWorkspaceStatus::Active
+        } else {
+            CodeWorkspaceStatus::SetupFailed
+        };
+        workspace.archived_at = None;
+        if released {
+            Self::clear_release(&mut workspace);
+        }
+        match self.save_workspace_final(&workspace).await {
+            Ok(true) => {}
+            Ok(false) => {
+                operation.rollback().await;
+                return Err(ServerError::not_found(format!(
+                    "workspace {} not found",
+                    workspace.id
+                )));
             }
-            Err(err) => {
-                workspace.status = CodeWorkspaceStatus::SetupFailed;
-                workspace.archived_at = None;
-                Self::clear_release(&mut workspace, &self.data_dir);
-                save_workspace(&self.db, &workspace).await?;
-                Err(ServerError::unprocessable_kind(
-                    "setup_failed",
-                    err.to_string(),
-                ))
+            Err(error) => {
+                operation.rollback().await;
+                return Err(error);
             }
+        }
+        operation.complete().await;
+        if released {
+            Self::remove_release_bundle(&workspace, &self.data_dir);
+        }
+        match setup {
+            Ok(()) => Ok(workspace),
+            Err(error) => Err(ServerError::unprocessable_kind(
+                "setup_failed",
+                error.to_string(),
+            )),
         }
     }
 
@@ -5284,6 +5355,7 @@ fn map_worktree(err: WorktreeError) -> ServerError {
         WorktreeError::ArchiveUncertain(message) => {
             ServerError::conflict_kind("archive_inspection_uncertain", message)
         }
+        WorktreeError::Conflict { kind, message } => ServerError::conflict_kind(kind, message),
     }
 }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1281,8 +1281,7 @@ impl CodeRuntime {
         if archived
             .as_ref()
             .is_err_and(|error| archive_failure_can_reopen(error) && path.exists())
-        {
-            if !compare_and_set_workspace_status(
+            && !compare_and_set_workspace_status(
                 &self.db,
                 owner,
                 id,
@@ -1290,12 +1289,11 @@ impl CodeRuntime {
                 CodeWorkspaceStatus::Active,
             )
             .await?
-            {
-                tracing::warn!(
-                    workspace = %id,
-                    "code-mode: failed to restore Active after a refused archive"
-                );
-            }
+        {
+            tracing::warn!(
+                workspace = %id,
+                "code-mode: failed to restore Active after a refused archive"
+            );
         }
         archived
     }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -685,7 +685,8 @@ impl CodeRuntime {
                     Ok(workspace) => self.forget_workspace_turn_lock(workspace.id),
                     Err(error) => {
                         tracing::warn!(
-                            "code-mode: archive recovery could not finalize a missing checkout: {error}"
+                            "code-mode: archive recovery could not finalize a missing checkout: {}",
+                            error.message()
                         );
                     }
                 }
@@ -1324,7 +1325,7 @@ impl CodeRuntime {
     async fn archive_workspace_exclusive(
         &self,
         owner: &OwnerId,
-        mut workspace: CodeWorkspace,
+        workspace: CodeWorkspace,
         repo: CodeRepo,
         force: bool,
         terminals: &super::terminal::TerminalHub,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -559,6 +559,8 @@ impl CodeRuntime {
             recap: Mutex::new(None),
             #[cfg(test)]
             archive_shutdown_timeout: AtomicBool::new(false),
+            #[cfg(test)]
+            fail_next_workspace_final_save: AtomicBool::new(false),
         }
     }
 

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -316,8 +316,18 @@ impl ScopedCode {
         &self,
         id: WorkspaceId,
         force: bool,
+        terminals: &crate::code::terminal::TerminalHub,
     ) -> Result<CodeWorkspace, ServerError> {
-        self.runtime.archive_workspace(&self.owner, id, force).await
+        self.runtime
+            .archive_workspace(&self.owner, id, force, terminals)
+            .await
+    }
+
+    pub(crate) fn workspace_write_lock(
+        &self,
+        id: WorkspaceId,
+    ) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+        self.runtime.workspace_write_lock(id)
     }
 
     pub(crate) async fn release_workspace(

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -24,17 +24,17 @@ use tracing::{warn, Instrument as _};
 
 use tidebreak_core::db::code::{
     accept_trigger_turn_delivery, append_event, bump_spawn_epoch, delete_queued_turn,
-    get_open_turn, get_session, get_session_all_owners, insert_approval_for_worker, insert_turn,
-    next_turn_ordinal, promote_queued_turn, queue_paused, queued_turn_head, save_session,
-    save_turn, set_queue_paused, set_session_harness_resume_ref, set_session_subagents,
-    CodeJournalError,
+    get_open_turn, get_session, get_session_all_owners, get_workspace, insert_approval_for_worker,
+    insert_turn, next_turn_ordinal, promote_queued_turn, queue_paused, queued_turn_head,
+    save_session, save_turn, set_queue_paused, set_session_harness_resume_ref,
+    set_session_subagents, CodeJournalError,
 };
 use tidebreak_core::{
     bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
     CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeSession,
     CodeSessionId, CodeSessionLifecycle, CodeSubagentStatus, CodeSubagentSummary, CodeTurn,
-    CodeTurnId, CodeTurnStatus, CodeUsage, DbStore, FenceReason, HarnessNoticeLevel, OwnerId,
-    PermissionMode, ReasoningEffort, ToolOutcome,
+    CodeTurnId, CodeTurnStatus, CodeUsage, CodeWorkspaceStatus, DbStore, FenceReason,
+    HarnessNoticeLevel, OwnerId, PermissionMode, ReasoningEffort, ToolOutcome,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
@@ -1272,6 +1272,16 @@ async fn drive_turn_inner(
     // read a session that may be minutes stale by now.
     if session_was_ended(&sink.db, session).await {
         return Err(WorkerError::Conflict("session has ended".into()));
+    }
+    let workspace = get_workspace(&sink.db, &session.owner, session.workspace_id)
+        .await
+        .map_err(|error| WorkerError::Failed(error.to_string()))?
+        .ok_or_else(|| WorkerError::Conflict("workspace no longer exists".into()))?;
+    if workspace.status != CodeWorkspaceStatus::Active {
+        return Err(WorkerError::Conflict(format!(
+            "workspace is {}",
+            workspace.status.as_str()
+        )));
     }
 
     if let Some(model) = model.clone() {

--- a/crates/tidebreak-server/src/code/terminal.rs
+++ b/crates/tidebreak-server/src/code/terminal.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -41,6 +41,7 @@ const DEFAULT_ROWS: u16 = 24;
 const MIN_SIZE: u16 = 1;
 const MAX_SIZE: u16 = 512;
 const NOTICE_BUFFER: usize = 64;
+const TERMINAL_EXIT_GRACE: Duration = Duration::from_secs(5);
 
 /// In-memory process-wide registry of live auxiliary terminals.
 pub(crate) struct TerminalHub {
@@ -76,7 +77,13 @@ struct LiveTerminal {
     writer: Option<Box<dyn Write + Send>>,
     master: Option<Box<dyn MasterPty + Send>>,
     killer: Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
+    exit: Arc<TerminalExit>,
     coalesce: Coalesce,
+}
+
+struct TerminalExit {
+    done: Mutex<bool>,
+    changed: Condvar,
 }
 
 struct Coalesce {
@@ -175,13 +182,19 @@ impl TerminalHub {
             writer: Some(spawned.writer),
             master: Some(spawned.master),
             killer: Some(spawned.killer),
+            exit: Arc::new(TerminalExit::new(false)),
             coalesce: Coalesce::new(),
         };
         let handle = Arc::new(Mutex::new(live));
         self.insert(workspace_id, id, handle.clone());
         let notices = self.notices_sender(owner);
         start_reader(handle.clone(), notices.clone(), spawned.reader);
-        start_reaper(handle.clone(), notices, spawned.child);
+        start_reaper(
+            handle.clone(),
+            notices,
+            spawned.child,
+            handle.lock().expect("terminal").exit.clone(),
+        );
         Ok(lock_snapshot(&handle))
     }
 
@@ -211,6 +224,7 @@ impl TerminalHub {
             writer: None,
             master: None,
             killer: None,
+            exit: Arc::new(TerminalExit::new(true)),
             coalesce: Coalesce::new(),
         };
         let handle = Arc::new(Mutex::new(live));
@@ -367,6 +381,40 @@ impl TerminalHub {
         }
     }
 
+    /// Stop every terminal and prove that each shell process exited.
+    ///
+    /// Archive treats a timeout as uncertainty and preserves the checkout.
+    pub(crate) async fn close_workspace_and_wait(&self, workspace_id: WorkspaceId) -> bool {
+        let handles = {
+            let inner = self.inner.lock().expect("terminal hub");
+            inner
+                .by_workspace
+                .get(&workspace_id)
+                .into_iter()
+                .flatten()
+                .filter_map(|id| inner.by_id.get(id).cloned())
+                .collect::<Vec<_>>()
+        };
+        let exits = handles
+            .iter()
+            .map(|handle| {
+                let mut live = handle.lock().expect("terminal");
+                live.kill_and_end();
+                live.exit.clone()
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            let id = handle.lock().expect("terminal").id;
+            self.remove(workspace_id, id);
+        }
+        tokio::task::spawn_blocking(move || {
+            let deadline = Instant::now() + TERMINAL_EXIT_GRACE;
+            exits.into_iter().all(|exit| exit.wait_until(deadline))
+        })
+        .await
+        .unwrap_or(false)
+    }
+
     /// Append output as if the PTY had produced it. Tests and the reader thread.
     #[cfg(test)]
     pub(crate) fn push_output(&self, id: CodeTerminalId, bytes: &[u8]) {
@@ -450,6 +498,39 @@ impl LiveTerminal {
         self.master = None;
         self.ended = true;
         self.producing = false;
+    }
+}
+
+impl TerminalExit {
+    fn new(done: bool) -> Self {
+        Self {
+            done: Mutex::new(done),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn mark_done(&self) {
+        *self.done.lock().expect("terminal exit") = true;
+        self.changed.notify_all();
+    }
+
+    fn wait_until(&self, deadline: Instant) -> bool {
+        let mut done = self.done.lock().expect("terminal exit");
+        while !*done {
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let waited = self
+                .changed
+                .wait_timeout(done, deadline.saturating_duration_since(now))
+                .expect("terminal exit");
+            done = waited.0;
+            if waited.1.timed_out() && !*done {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -558,11 +639,13 @@ fn start_reaper(
     handle: Arc<Mutex<LiveTerminal>>,
     notices: broadcast::Sender<TerminalNotice>,
     mut child: Box<dyn portable_pty::Child + Send + Sync>,
+    exit: Arc<TerminalExit>,
 ) {
     thread::Builder::new()
         .name("code-terminal-wait".into())
         .spawn(move || {
             let _ = child.wait();
+            exit.mark_done();
             if let Ok(mut live) = handle.lock() {
                 if !live.ended {
                     // The shell is gone, so nothing can be typed at it. Leave

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -564,7 +564,7 @@ pub(crate) async fn restore_worktree(
     branch: &str,
 ) -> Result<WorktreeOperation, WorktreeError> {
     let expected_tip = branch_tip(repo_root, branch).await?;
-    let mut operation =
+    let operation =
         reserve_worktree_target(repo_root, worktree_path, branch, &expected_tip).await?;
     if let Err(err) = require_branch_tip(repo_root, branch, &expected_tip).await {
         operation.rollback().await;

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -26,6 +26,9 @@ pub(crate) const DEFAULT_SEARCH_LIMIT: u32 = 200;
 pub(crate) const MAX_SEARCH_LIMIT: u32 = 500;
 const MAX_SEARCH_QUERY_CHARS: usize = 500;
 const MAX_SEARCH_PREVIEW_CHARS: usize = 500;
+const ARCHIVE_SCAN_MAX_ENTRIES: usize = 10_000;
+const ARCHIVE_SCAN_MAX_PATH_BYTES: usize = 1024 * 1024;
+const ARCHIVE_DISPOSABLE_PATH_KEY: &str = "tidebreak.archiveDisposablePath";
 
 const ADJECTIVES: &[&str] = &[
     "amber", "brave", "calm", "crisp", "dusk", "ember", "faint", "gentle", "hidden", "ivory",
@@ -127,6 +130,7 @@ pub(crate) enum ArchiveBlock {
     Uncommitted,
     Unpushed,
     UncommittedAndUnpushed,
+    IgnoredContent,
 }
 
 impl ArchiveBlock {
@@ -135,6 +139,7 @@ impl ArchiveBlock {
             Self::Uncommitted => "uncommitted",
             Self::Unpushed => "unpushed",
             Self::UncommittedAndUnpushed => "uncommitted_and_unpushed",
+            Self::IgnoredContent => "ignored_content",
         }
     }
 }
@@ -146,6 +151,8 @@ pub(crate) enum WorktreeError {
     User(String),
     #[error("{0}")]
     Internal(String),
+    #[error("{0}")]
+    ArchiveUncertain(String),
 }
 
 impl WorktreeError {
@@ -155,6 +162,10 @@ impl WorktreeError {
 
     fn internal(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
+    }
+
+    fn archive_uncertain(message: impl Into<String>) -> Self {
+        Self::ArchiveUncertain(message.into())
     }
 }
 
@@ -614,11 +625,16 @@ pub(crate) async fn archive_blockers(
 ) -> Result<Option<ArchiveBlock>, WorktreeError> {
     let uncommitted = has_uncommitted_work(worktree_path).await?;
     let unpushed = has_unpushed_work(worktree_path, base_ref).await?;
-    Ok(match (uncommitted, unpushed) {
-        (true, true) => Some(ArchiveBlock::UncommittedAndUnpushed),
-        (true, false) => Some(ArchiveBlock::Uncommitted),
-        (false, true) => Some(ArchiveBlock::Unpushed),
-        (false, false) => None,
+    let ignored = has_non_disposable_ignored_content(worktree_path).await?;
+    Ok(if ignored {
+        Some(ArchiveBlock::IgnoredContent)
+    } else {
+        match (uncommitted, unpushed) {
+            (true, true) => Some(ArchiveBlock::UncommittedAndUnpushed),
+            (true, false) => Some(ArchiveBlock::Uncommitted),
+            (false, true) => Some(ArchiveBlock::Unpushed),
+            (false, false) => None,
+        }
     })
 }
 
@@ -1018,6 +1034,182 @@ async fn has_uncommitted_work(worktree_path: &Path) -> Result<bool, WorktreeErro
         .await
         .map_err(|err| WorktreeError::internal(format!("git status failed: {err}")))?;
     Ok(!status.is_empty())
+}
+
+async fn has_non_disposable_ignored_content(worktree_path: &Path) -> Result<bool, WorktreeError> {
+    let disposable = archive_disposable_paths(worktree_path).await?;
+    let mut stack = vec![worktree_path.to_path_buf()];
+    let mut candidates = Vec::new();
+    let mut entry_count = 0usize;
+    let mut path_bytes = 0usize;
+
+    while let Some(directory) = stack.pop() {
+        let mut entries = tokio::fs::read_dir(&directory).await.map_err(|error| {
+            WorktreeError::archive_uncertain(format!(
+                "archive could not inspect {}: {error}",
+                directory.display()
+            ))
+        })?;
+        while let Some(entry) = entries.next_entry().await.map_err(|error| {
+            WorktreeError::archive_uncertain(format!(
+                "archive could not continue inspecting {}: {error}",
+                directory.display()
+            ))
+        })? {
+            let path = entry.path();
+            let relative = path.strip_prefix(worktree_path).map_err(|_| {
+                WorktreeError::archive_uncertain("archive scan escaped the worktree")
+            })?;
+            if relative == Path::new(".git") || path_is_disposable(relative, &disposable) {
+                continue;
+            }
+            entry_count = entry_count.saturating_add(1);
+            path_bytes = path_bytes.saturating_add(relative.as_os_str().len());
+            if entry_count > ARCHIVE_SCAN_MAX_ENTRIES || path_bytes > ARCHIVE_SCAN_MAX_PATH_BYTES {
+                return Err(WorktreeError::archive_uncertain(format!(
+                    "archive inspection exceeded its {}-entry or {}-byte path budget; configure generated directories with git config --add {ARCHIVE_DISPOSABLE_PATH_KEY} <directory>",
+                    ARCHIVE_SCAN_MAX_ENTRIES, ARCHIVE_SCAN_MAX_PATH_BYTES
+                )));
+            }
+            let file_type = entry.file_type().await.map_err(|error| {
+                WorktreeError::archive_uncertain(format!(
+                    "archive could not inspect {}: {error}",
+                    path.display()
+                ))
+            })?;
+            candidates.push(relative.to_string_lossy().replace('\\', "/"));
+            if file_type.is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+
+    git_check_ignored(worktree_path, &candidates).await
+}
+
+async fn archive_disposable_paths(worktree_path: &Path) -> Result<Vec<PathBuf>, WorktreeError> {
+    let mut command = Command::new("git");
+    command
+        .args(["config", "--null", "--get-all", ARCHIVE_DISPOSABLE_PATH_KEY])
+        .current_dir(worktree_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let child = command
+        .spawn()
+        .map_err(|error| WorktreeError::archive_uncertain(format!("git config failed: {error}")))?;
+    let output = timeout(GIT_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| WorktreeError::archive_uncertain("git config timed out during archive"))?
+        .map_err(|error| WorktreeError::archive_uncertain(format!("git config failed: {error}")))?;
+    if output.status.code() == Some(1) && output.stdout.is_empty() {
+        return Ok(Vec::new());
+    }
+    if !output.status.success() {
+        return Err(WorktreeError::archive_uncertain(format!(
+            "git config failed during archive: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    if output.stdout.len() > ARCHIVE_SCAN_MAX_PATH_BYTES {
+        return Err(WorktreeError::archive_uncertain(
+            "archive disposable-path configuration exceeded its path budget",
+        ));
+    }
+    output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|value| !value.is_empty())
+        .map(|value| validate_disposable_path(&String::from_utf8_lossy(value)))
+        .collect()
+}
+
+fn validate_disposable_path(value: &str) -> Result<PathBuf, WorktreeError> {
+    let path = Path::new(value.trim());
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(WorktreeError::archive_uncertain(format!(
+            "{ARCHIVE_DISPOSABLE_PATH_KEY} must name a relative directory without . or ..: {value}"
+        )));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn path_is_disposable(path: &Path, disposable: &[PathBuf]) -> bool {
+    disposable
+        .iter()
+        .any(|configured| path.starts_with(configured))
+}
+
+async fn git_check_ignored(
+    worktree_path: &Path,
+    candidates: &[String],
+) -> Result<bool, WorktreeError> {
+    if candidates.is_empty() {
+        return Ok(false);
+    }
+    let mut input = Vec::new();
+    for candidate in candidates {
+        input.extend_from_slice(candidate.as_bytes());
+        input.push(0);
+    }
+    let mut command = Command::new("git");
+    command
+        .args(["check-ignore", "--stdin", "-z"])
+        .current_dir(worktree_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let mut child = command.spawn().map_err(|error| {
+        WorktreeError::archive_uncertain(format!("git check-ignore failed: {error}"))
+    })?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| WorktreeError::archive_uncertain("git check-ignore did not open stdin"))?;
+    let writer = tokio::spawn(async move {
+        let result = stdin.write_all(&input).await;
+        drop(stdin);
+        result
+    });
+    let output = timeout(GIT_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| WorktreeError::archive_uncertain("git check-ignore timed out"))?
+        .map_err(|error| {
+            WorktreeError::archive_uncertain(format!("git check-ignore failed: {error}"))
+        })?;
+    writer
+        .await
+        .map_err(|error| {
+            WorktreeError::archive_uncertain(format!("git check-ignore input failed: {error}"))
+        })?
+        .map_err(|error| {
+            WorktreeError::archive_uncertain(format!("git check-ignore input failed: {error}"))
+        })?;
+    match output.status.code() {
+        Some(0) => {
+            if output.stdout.len() > ARCHIVE_SCAN_MAX_PATH_BYTES {
+                Err(WorktreeError::archive_uncertain(
+                    "git check-ignore output exceeded the archive path budget",
+                ))
+            } else {
+                Ok(!output.stdout.is_empty())
+            }
+        }
+        Some(1) if output.stdout.is_empty() => Ok(false),
+        _ => Err(WorktreeError::archive_uncertain(format!(
+            "git check-ignore failed during archive: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))),
+    }
 }
 
 async fn has_unpushed_work(worktree_path: &Path, base_ref: &str) -> Result<bool, WorktreeError> {

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -1038,53 +1038,10 @@ async fn has_uncommitted_work(worktree_path: &Path) -> Result<bool, WorktreeErro
 
 async fn has_non_disposable_ignored_content(worktree_path: &Path) -> Result<bool, WorktreeError> {
     let disposable = archive_disposable_paths(worktree_path).await?;
-    let mut stack = vec![worktree_path.to_path_buf()];
-    let mut candidates = Vec::new();
-    let mut entry_count = 0usize;
-    let mut path_bytes = 0usize;
-
-    while let Some(directory) = stack.pop() {
-        let mut entries = tokio::fs::read_dir(&directory).await.map_err(|error| {
-            WorktreeError::archive_uncertain(format!(
-                "archive could not inspect {}: {error}",
-                directory.display()
-            ))
-        })?;
-        while let Some(entry) = entries.next_entry().await.map_err(|error| {
-            WorktreeError::archive_uncertain(format!(
-                "archive could not continue inspecting {}: {error}",
-                directory.display()
-            ))
-        })? {
-            let path = entry.path();
-            let relative = path.strip_prefix(worktree_path).map_err(|_| {
-                WorktreeError::archive_uncertain("archive scan escaped the worktree")
-            })?;
-            if relative == Path::new(".git") || path_is_disposable(relative, &disposable) {
-                continue;
-            }
-            entry_count = entry_count.saturating_add(1);
-            path_bytes = path_bytes.saturating_add(relative.as_os_str().len());
-            if entry_count > ARCHIVE_SCAN_MAX_ENTRIES || path_bytes > ARCHIVE_SCAN_MAX_PATH_BYTES {
-                return Err(WorktreeError::archive_uncertain(format!(
-                    "archive inspection exceeded its {}-entry or {}-byte path budget; configure generated directories with git config --add {ARCHIVE_DISPOSABLE_PATH_KEY} <directory>",
-                    ARCHIVE_SCAN_MAX_ENTRIES, ARCHIVE_SCAN_MAX_PATH_BYTES
-                )));
-            }
-            let file_type = entry.file_type().await.map_err(|error| {
-                WorktreeError::archive_uncertain(format!(
-                    "archive could not inspect {}: {error}",
-                    path.display()
-                ))
-            })?;
-            candidates.push(relative.to_string_lossy().replace('\\', "/"));
-            if file_type.is_dir() {
-                stack.push(path);
-            }
-        }
-    }
-
-    git_check_ignored(worktree_path, &candidates).await
+    let ignored = list_ignored_paths_bounded(worktree_path).await?;
+    Ok(ignored
+        .iter()
+        .any(|path| !path_is_disposable(Path::new(path), &disposable)))
 }
 
 async fn archive_disposable_paths(worktree_path: &Path) -> Result<Vec<PathBuf>, WorktreeError> {
@@ -1147,69 +1104,73 @@ fn path_is_disposable(path: &Path, disposable: &[PathBuf]) -> bool {
         .any(|configured| path.starts_with(configured))
 }
 
-async fn git_check_ignored(
-    worktree_path: &Path,
-    candidates: &[String],
-) -> Result<bool, WorktreeError> {
-    if candidates.is_empty() {
-        return Ok(false);
-    }
-    let mut input = Vec::new();
-    for candidate in candidates {
-        input.extend_from_slice(candidate.as_bytes());
-        input.push(0);
-    }
+async fn list_ignored_paths_bounded(worktree_path: &Path) -> Result<Vec<String>, WorktreeError> {
     let mut command = Command::new("git");
     command
-        .args(["check-ignore", "--stdin", "-z"])
+        .args([
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+        ])
         .current_dir(worktree_path)
-        .stdin(Stdio::piped())
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)
         .env("GIT_TERMINAL_PROMPT", "0");
     let mut child = command.spawn().map_err(|error| {
-        WorktreeError::archive_uncertain(format!("git check-ignore failed: {error}"))
+        WorktreeError::archive_uncertain(format!("git ls-files failed: {error}"))
     })?;
-    let mut stdin = child
-        .stdin
+    let mut stdout = child
+        .stdout
         .take()
-        .ok_or_else(|| WorktreeError::archive_uncertain("git check-ignore did not open stdin"))?;
-    let writer = tokio::spawn(async move {
-        let result = stdin.write_all(&input).await;
-        drop(stdin);
-        result
-    });
-    let output = timeout(GIT_TIMEOUT, child.wait_with_output())
-        .await
-        .map_err(|_| WorktreeError::archive_uncertain("git check-ignore timed out"))?
-        .map_err(|error| {
-            WorktreeError::archive_uncertain(format!("git check-ignore failed: {error}"))
-        })?;
-    writer
-        .await
-        .map_err(|error| {
-            WorktreeError::archive_uncertain(format!("git check-ignore input failed: {error}"))
-        })?
-        .map_err(|error| {
-            WorktreeError::archive_uncertain(format!("git check-ignore input failed: {error}"))
-        })?;
-    match output.status.code() {
-        Some(0) => {
-            if output.stdout.len() > ARCHIVE_SCAN_MAX_PATH_BYTES {
-                Err(WorktreeError::archive_uncertain(
-                    "git check-ignore output exceeded the archive path budget",
-                ))
-            } else {
-                Ok(!output.stdout.is_empty())
-            }
+        .ok_or_else(|| WorktreeError::archive_uncertain("git ls-files did not open stdout"))?;
+    let mut output = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        let read = timeout(GIT_TIMEOUT, stdout.read(&mut chunk))
+            .await
+            .map_err(|_| WorktreeError::archive_uncertain("git ls-files timed out"))?
+            .map_err(|error| {
+                WorktreeError::archive_uncertain(format!("git ls-files failed: {error}"))
+            })?;
+        if read == 0 {
+            break;
         }
-        Some(1) if output.stdout.is_empty() => Ok(false),
-        _ => Err(WorktreeError::archive_uncertain(format!(
-            "git check-ignore failed during archive: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ))),
+        output.extend_from_slice(&chunk[..read]);
+        if output.len() > ARCHIVE_SCAN_MAX_PATH_BYTES {
+            let _ = child.kill().await;
+            return Err(WorktreeError::archive_uncertain(format!(
+                "ignored-content inspection exceeded its {}-byte path budget; configure generated directories with git config --add {ARCHIVE_DISPOSABLE_PATH_KEY} <directory>",
+                ARCHIVE_SCAN_MAX_PATH_BYTES
+            )));
+        }
     }
+    let status = timeout(GIT_TIMEOUT, child.wait())
+        .await
+        .map_err(|_| WorktreeError::archive_uncertain("git ls-files timed out"))?
+        .map_err(|error| {
+            WorktreeError::archive_uncertain(format!("git ls-files failed: {error}"))
+        })?;
+    if !status.success() {
+        return Err(WorktreeError::archive_uncertain(
+            "git ls-files failed during ignored-content inspection",
+        ));
+    }
+    let paths = output
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| String::from_utf8_lossy(path).into_owned())
+        .collect::<Vec<_>>();
+    if paths.len() > ARCHIVE_SCAN_MAX_ENTRIES {
+        return Err(WorktreeError::archive_uncertain(format!(
+            "ignored-content inspection exceeded its {}-entry budget; configure generated directories with git config --add {ARCHIVE_DISPOSABLE_PATH_KEY} <directory>",
+            ARCHIVE_SCAN_MAX_ENTRIES
+        )));
+    }
+    Ok(paths)
 }
 
 async fn has_unpushed_work(worktree_path: &Path, base_ref: &str) -> Result<bool, WorktreeError> {

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -686,7 +686,7 @@ impl WorktreeOperation {
                             "worktree",
                             "remove",
                             "--force",
-                            &worktree_path.to_string_lossy(),
+                            &registered.path.to_string_lossy(),
                         ],
                         GIT_WORKTREE_TIMEOUT,
                     )
@@ -846,6 +846,7 @@ impl WorktreeOperation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RegisteredWorktree {
+    path: PathBuf,
     head: String,
     branch: Option<String>,
 }
@@ -1115,14 +1116,21 @@ async fn registered_worktree(
     .await
     .map_err(|error| WorktreeError::internal(format!("git worktree list failed: {error}")))?;
     let mut matches_path = false;
+    let mut registered_path = None;
     let mut head = None;
     let mut branch = None;
     for field in fields {
         if let Some(path) = field.strip_prefix("worktree ") {
             if matches_path {
-                return Ok(head.map(|head| RegisteredWorktree { head, branch }));
+                return Ok(head.map(|head| RegisteredWorktree {
+                    path: registered_path.expect("a matched worktree has a path"),
+                    head,
+                    branch,
+                }));
             }
-            matches_path = repo_paths_equivalent(Path::new(path), worktree_path);
+            let path = PathBuf::from(path);
+            matches_path = existing_paths_equivalent(&path, worktree_path);
+            registered_path = matches_path.then_some(path);
             head = None;
             branch = None;
         } else if matches_path {
@@ -1134,9 +1142,23 @@ async fn registered_worktree(
         }
     }
     if matches_path {
-        Ok(head.map(|head| RegisteredWorktree { head, branch }))
+        Ok(head.map(|head| RegisteredWorktree {
+            path: registered_path.expect("a matched worktree has a path"),
+            head,
+            branch,
+        }))
     } else {
         Ok(None)
+    }
+}
+
+fn existing_paths_equivalent(left: &Path, right: &Path) -> bool {
+    if repo_paths_equivalent(left, right) {
+        return true;
+    }
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => repo_paths_equivalent(&left, &right),
+        _ => false,
     }
 }
 

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -525,11 +525,7 @@ pub(crate) async fn create_worktree(
         return Err(err);
     }
     operation.branch_created = true;
-    if let Err(err) = operation.add_existing_branch().await {
-        operation.rollback().await;
-        return Err(err);
-    }
-    Ok(operation)
+    operation.add_existing_branch_or_rollback().await
 }
 
 /// True when `refs/heads/<branch>` exists in the repository.
@@ -574,11 +570,7 @@ pub(crate) async fn restore_worktree(
         operation.rollback().await;
         return Err(err);
     }
-    if let Err(err) = operation.add_existing_branch().await {
-        operation.rollback().await;
-        return Err(err);
-    }
-    Ok(operation)
+    operation.add_existing_branch_or_rollback().await
 }
 
 /// Re-create a released branch from its bundle and check out its exact tip.
@@ -599,14 +591,18 @@ pub(crate) async fn restore_released_worktree(
         }
     };
     operation.branch_created = restored == RestoredBranch::Created;
-    if let Err(err) = operation.add_existing_branch().await {
-        operation.rollback().await;
-        return Err(err);
-    }
-    Ok(operation)
+    operation.add_existing_branch_or_rollback().await
 }
 
 impl WorktreeOperation {
+    async fn add_existing_branch_or_rollback(mut self) -> Result<Self, WorktreeError> {
+        if let Err(err) = self.add_existing_branch().await {
+            self.rollback().await;
+            return Err(err);
+        }
+        Ok(self)
+    }
+
     async fn add_existing_branch(&mut self) -> Result<(), WorktreeError> {
         let repo_root = &self.repo_root;
         let worktree_path = Path::new(&self.marker.worktree_path);
@@ -2200,8 +2196,7 @@ mod tests {
             ],
         );
 
-        assert!(losing.add_existing_branch().await.is_err());
-        losing.rollback().await;
+        assert!(losing.add_existing_branch_or_rollback().await.is_err());
 
         verify_inside_worktree(&path).await.unwrap();
         assert_eq!(resolve_ref(&path, "HEAD").await.unwrap(), winner_tip);

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -3,11 +3,13 @@
 //! Every git call is a bounded, non-interactive subprocess of the user's own
 //! `git` binary. Arguments are an argv array, never a shell string.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -29,6 +31,8 @@ const MAX_SEARCH_PREVIEW_CHARS: usize = 500;
 const ARCHIVE_SCAN_MAX_ENTRIES: usize = 10_000;
 const ARCHIVE_SCAN_MAX_PATH_BYTES: usize = 1024 * 1024;
 const ARCHIVE_DISPOSABLE_PATH_KEY: &str = "tidebreak.archiveDisposablePath";
+const WORKTREE_OPERATION_SUFFIX: &str = ".tidebreak-operation";
+const WORKTREE_REGISTRATION_MARKER: &str = "tidebreak-operation.json";
 
 const ADJECTIVES: &[&str] = &[
     "amber", "brave", "calm", "crisp", "dusk", "ember", "faint", "gentle", "hidden", "ivory",
@@ -66,6 +70,11 @@ pub(crate) fn repo_paths_equivalent(left: &Path, right: &Path) -> bool {
     unsafe {
         CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) == CSTR_EQUAL
     }
+}
+
+#[cfg(not(windows))]
+pub(crate) fn repo_paths_equivalent(left: &Path, right: &Path) -> bool {
+    left == right
 }
 
 #[cfg(windows)]
@@ -153,6 +162,8 @@ pub(crate) enum WorktreeError {
     Internal(String),
     #[error("{0}")]
     ArchiveUncertain(String),
+    #[error("{message}")]
+    Conflict { kind: &'static str, message: String },
 }
 
 impl WorktreeError {
@@ -167,6 +178,41 @@ impl WorktreeError {
     fn archive_uncertain(message: impl Into<String>) -> Self {
         Self::ArchiveUncertain(message.into())
     }
+
+    fn conflict(kind: &'static str, message: impl Into<String>) -> Self {
+        Self::Conflict {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct WorktreeOperationMarker {
+    operation_id: uuid::Uuid,
+    repository: String,
+    worktree_path: String,
+    branch: String,
+    expected_tip: String,
+}
+
+/// A checkout operation that still owns the target reservation.
+///
+/// The caller keeps this value until the workspace's final lifecycle row is
+/// durable. A failed durable write can then remove only the checkout and ref
+/// that still match this operation.
+#[derive(Debug)]
+pub(crate) struct WorktreeOperation {
+    repo_root: PathBuf,
+    marker_path: PathBuf,
+    marker: WorktreeOperationMarker,
+    branch_created: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RestoredBranch {
+    Created,
+    Existing,
 }
 
 /// Name-matched git-tracked and untracked-unignored paths. Never file contents.
@@ -470,39 +516,20 @@ pub(crate) async fn create_worktree(
     worktree_path: &Path,
     branch: &str,
     base_ref: &str,
-) -> Result<(), WorktreeError> {
-    if let Some(parent) = worktree_path.parent() {
-        tokio::fs::create_dir_all(parent).await.map_err(|err| {
-            WorktreeError::internal(format!(
-                "could not create worktree parent {}: {err}",
-                parent.display()
-            ))
-        })?;
+) -> Result<WorktreeOperation, WorktreeError> {
+    let expected_tip = resolve_ref(repo_root, base_ref).await?;
+    let mut operation =
+        reserve_worktree_target(repo_root, worktree_path, branch, &expected_tip).await?;
+    if let Err(err) = create_branch_at(repo_root, branch, &expected_tip).await {
+        operation.rollback().await;
+        return Err(err);
     }
-    let add = git(
-        Some(repo_root),
-        &[
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            &worktree_path.to_string_lossy(),
-            base_ref,
-        ],
-        GIT_WORKTREE_TIMEOUT,
-    )
-    .await;
-    if let Err(err) = add {
-        cleanup_half_created(repo_root, worktree_path).await;
-        return Err(classify_worktree_add(err, branch));
+    operation.branch_created = true;
+    if let Err(err) = operation.add_existing_branch().await {
+        operation.rollback().await;
+        return Err(err);
     }
-    match verify_inside_worktree(worktree_path).await {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            cleanup_half_created(repo_root, worktree_path).await;
-            Err(err)
-        }
-    }
+    Ok(operation)
 }
 
 /// True when `refs/heads/<branch>` exists in the repository.
@@ -532,40 +559,597 @@ pub(crate) async fn branch_exists(repo_root: &Path, branch: &str) -> Result<bool
 /// Re-create a worktree checking out an existing branch.
 ///
 /// The restore counterpart of [`create_worktree`], deliberately a sibling and
-/// not a flag on it: create always mints a branch (`-b`), restore must never
-/// mint one — the branch surviving archive is what makes the workspace worth
-/// restoring. The caller has already verified the branch exists; a race that
-/// deletes it between the check and this call still fails cleanly here.
+/// not a flag on it: create atomically mints a branch, while restore must never
+/// mint one. The branch surviving archive is what makes the workspace worth
+/// restoring.
 pub(crate) async fn restore_worktree(
     repo_root: &Path,
     worktree_path: &Path,
     branch: &str,
-) -> Result<(), WorktreeError> {
-    if let Some(parent) = worktree_path.parent() {
-        tokio::fs::create_dir_all(parent).await.map_err(|err| {
+) -> Result<WorktreeOperation, WorktreeError> {
+    let expected_tip = branch_tip(repo_root, branch).await?;
+    let mut operation =
+        reserve_worktree_target(repo_root, worktree_path, branch, &expected_tip).await?;
+    if let Err(err) = require_branch_tip(repo_root, branch, &expected_tip).await {
+        operation.rollback().await;
+        return Err(err);
+    }
+    if let Err(err) = operation.add_existing_branch().await {
+        operation.rollback().await;
+        return Err(err);
+    }
+    Ok(operation)
+}
+
+/// Re-create a released branch from its bundle and check out its exact tip.
+pub(crate) async fn restore_released_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+    branch: &str,
+    bundle: &Path,
+    released_tip: &str,
+) -> Result<WorktreeOperation, WorktreeError> {
+    let mut operation =
+        reserve_worktree_target(repo_root, worktree_path, branch, released_tip).await?;
+    let restored = match restore_released_branch(&operation, bundle).await {
+        Ok(restored) => restored,
+        Err(err) => {
+            operation.rollback().await;
+            return Err(err);
+        }
+    };
+    operation.branch_created = restored == RestoredBranch::Created;
+    if let Err(err) = operation.add_existing_branch().await {
+        operation.rollback().await;
+        return Err(err);
+    }
+    Ok(operation)
+}
+
+impl WorktreeOperation {
+    async fn add_existing_branch(&mut self) -> Result<(), WorktreeError> {
+        let repo_root = &self.repo_root;
+        let worktree_path = Path::new(&self.marker.worktree_path);
+        let branch = self.marker.branch.as_str();
+        self.require_repository_identity().await?;
+        let add = git(
+            Some(repo_root),
+            &["worktree", "add", &worktree_path.to_string_lossy(), branch],
+            GIT_WORKTREE_TIMEOUT,
+        )
+        .await;
+        if let Err(err) = add {
+            return Err(classify_worktree_add(err, branch));
+        }
+        self.write_registration_marker().await?;
+        verify_worktree_identity(repo_root, worktree_path, branch, &self.marker.expected_tip).await
+    }
+
+    /// Release the reservation after the final workspace row is durable.
+    pub(crate) async fn complete(self) {
+        if let Err(error) = self.remove_registration_marker().await {
+            tracing::warn!(
+                path = %self.marker.worktree_path,
+                operation = %self.marker.operation_id,
+                "code-mode: could not release worktree registration marker: {error}"
+            );
+            return;
+        }
+        if let Err(error) = self.remove_owned_marker().await {
+            tracing::warn!(
+                path = %self.marker_path.display(),
+                operation = %self.marker.operation_id,
+                "code-mode: could not release worktree path marker: {error}"
+            );
+        }
+    }
+
+    /// Remove only the unchanged checkout and branch created by this attempt.
+    pub(crate) async fn rollback(&self) {
+        let owns_marker = match self.owns_marker().await {
+            Ok(owns_marker) => owns_marker,
+            Err(error) => {
+                tracing::warn!(
+                    path = %self.marker_path.display(),
+                    operation = %self.marker.operation_id,
+                    "code-mode: could not verify worktree operation ownership: {error}"
+                );
+                return;
+            }
+        };
+        if !owns_marker {
+            return;
+        }
+
+        if let Err(error) = self.require_repository_identity().await {
+            tracing::warn!(
+                repository = %self.repo_root.display(),
+                operation = %self.marker.operation_id,
+                "code-mode: refused worktree rollback after repository replacement: {error}"
+            );
+            let _ = self.remove_owned_marker().await;
+            return;
+        }
+
+        let repo_root = &self.repo_root;
+        let worktree_path = Path::new(&self.marker.worktree_path);
+        let expected_branch = format!("refs/heads/{}", self.marker.branch);
+        match registered_worktree(repo_root, worktree_path).await {
+            Ok(Some(registered))
+                if registered.head == self.marker.expected_tip
+                    && registered.branch.as_deref() == Some(expected_branch.as_str()) =>
+            {
+                match self.owns_registration_marker().await {
+                    Ok(true) => match git(
+                        Some(repo_root),
+                        &[
+                            "worktree",
+                            "remove",
+                            "--force",
+                            &worktree_path.to_string_lossy(),
+                        ],
+                        GIT_WORKTREE_TIMEOUT,
+                    )
+                    .await
+                    {
+                        Ok(_) => {}
+                        Err(error) => {
+                            tracing::warn!(
+                                path = %worktree_path.display(),
+                                operation = %self.marker.operation_id,
+                                "code-mode: could not roll back owned worktree: {error}"
+                            );
+                        }
+                    },
+                    Ok(false) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            path = %worktree_path.display(),
+                            operation = %self.marker.operation_id,
+                            "code-mode: could not verify worktree registration ownership: {error}"
+                        );
+                    }
+                }
+            }
+            Ok(None) => {}
+            Ok(Some(_)) => {}
+            Err(error) => {
+                tracing::warn!(
+                    path = %worktree_path.display(),
+                    operation = %self.marker.operation_id,
+                    "code-mode: could not inspect failed worktree registration: {error}"
+                );
+            }
+        }
+
+        let _ = prune_worktrees(repo_root).await;
+        if self.branch_created
+            && !branch_is_registered(repo_root, &self.marker.branch)
+                .await
+                .unwrap_or(true)
+        {
+            let branch_ref = format!("refs/heads/{}", self.marker.branch);
+            let _ = git(
+                Some(repo_root),
+                &["update-ref", "-d", &branch_ref, &self.marker.expected_tip],
+                GIT_TIMEOUT,
+            )
+            .await;
+        }
+        if let Err(error) = self.remove_owned_marker().await {
+            tracing::warn!(
+                path = %self.marker_path.display(),
+                operation = %self.marker.operation_id,
+                "code-mode: could not release failed worktree marker: {error}"
+            );
+        }
+    }
+
+    async fn require_repository_identity(&self) -> Result<(), WorktreeError> {
+        let current = repository_identity(&self.repo_root).await?;
+        if current == self.marker.repository {
+            Ok(())
+        } else {
+            Err(WorktreeError::conflict(
+                "worktree_repository_changed",
+                format!(
+                    "repository {} changed during worktree operation {}",
+                    self.repo_root.display(),
+                    self.marker.operation_id
+                ),
+            ))
+        }
+    }
+
+    async fn write_registration_marker(&self) -> Result<(), WorktreeError> {
+        let path = self.registration_marker_path().await?;
+        let bytes = serde_json::to_vec(&self.marker).map_err(|error| {
             WorktreeError::internal(format!(
-                "could not create worktree parent {}: {err}",
+                "could not encode worktree registration marker: {error}"
+            ))
+        })?;
+        let mut options = tokio::fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        let mut file = options.open(&path).await.map_err(|error| {
+            WorktreeError::internal(format!(
+                "could not write worktree registration marker {}: {error}",
+                path.display()
+            ))
+        })?;
+        file.write_all(&bytes).await.map_err(|error| {
+            WorktreeError::internal(format!(
+                "could not write worktree registration marker {}: {error}",
+                path.display()
+            ))
+        })?;
+        file.sync_all().await.map_err(|error| {
+            WorktreeError::internal(format!(
+                "could not sync worktree registration marker {}: {error}",
+                path.display()
+            ))
+        })
+    }
+
+    async fn registration_marker_path(&self) -> Result<PathBuf, WorktreeError> {
+        let git_dir = git_stdout(
+            Some(Path::new(&self.marker.worktree_path)),
+            &["rev-parse", "--path-format=absolute", "--absolute-git-dir"],
+            GIT_TIMEOUT,
+        )
+        .await
+        .map_err(|error| {
+            WorktreeError::internal(format!("could not resolve worktree git directory: {error}"))
+        })?;
+        Ok(PathBuf::from(git_dir.trim()).join(WORKTREE_REGISTRATION_MARKER))
+    }
+
+    async fn owns_registration_marker(&self) -> Result<bool, WorktreeError> {
+        let path = self.registration_marker_path().await?;
+        marker_matches(&path, &self.marker).await
+    }
+
+    async fn remove_registration_marker(&self) -> Result<(), WorktreeError> {
+        let path = self.registration_marker_path().await?;
+        if !marker_matches(&path, &self.marker).await? {
+            return Err(WorktreeError::internal(format!(
+                "worktree registration marker {} no longer belongs to operation {}",
+                path.display(),
+                self.marker.operation_id
+            )));
+        }
+        tokio::fs::remove_file(&path).await.map_err(|error| {
+            WorktreeError::internal(format!(
+                "could not remove worktree registration marker {}: {error}",
+                path.display()
+            ))
+        })
+    }
+
+    async fn owns_marker(&self) -> Result<bool, WorktreeError> {
+        marker_matches(&self.marker_path, &self.marker).await
+    }
+
+    async fn remove_owned_marker(&self) -> Result<(), WorktreeError> {
+        if !self.owns_marker().await? {
+            return Ok(());
+        }
+        match tokio::fs::remove_file(&self.marker_path).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(WorktreeError::internal(format!(
+                "could not remove operation marker {}: {error}",
+                self.marker_path.display()
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RegisteredWorktree {
+    head: String,
+    branch: Option<String>,
+}
+
+async fn reserve_worktree_target(
+    repo_root: &Path,
+    worktree_path: &Path,
+    branch: &str,
+    expected_tip: &str,
+) -> Result<WorktreeOperation, WorktreeError> {
+    let repo_root = repo_root.canonicalize().map_err(|error| {
+        WorktreeError::internal(format!(
+            "could not canonicalize repository {}: {error}",
+            repo_root.display()
+        ))
+    })?;
+    let repository = repository_identity(&repo_root).await?;
+    if let Some(parent) = worktree_path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|error| {
+            WorktreeError::internal(format!(
+                "could not create worktree parent {}: {error}",
                 parent.display()
             ))
         })?;
     }
-    let add = git(
-        Some(repo_root),
-        &["worktree", "add", &worktree_path.to_string_lossy(), branch],
-        GIT_WORKTREE_TIMEOUT,
-    )
-    .await;
-    if let Err(err) = add {
-        cleanup_half_created(repo_root, worktree_path).await;
-        return Err(classify_worktree_add(err, branch));
+    let marker_path = worktree_operation_marker_path(worktree_path)?;
+    let marker = WorktreeOperationMarker {
+        operation_id: uuid::Uuid::new_v4(),
+        repository,
+        worktree_path: worktree_path.display().to_string(),
+        branch: branch.to_owned(),
+        expected_tip: expected_tip.to_owned(),
+    };
+    let bytes = serde_json::to_vec(&marker).map_err(|error| {
+        WorktreeError::internal(format!(
+            "could not encode worktree operation marker: {error}"
+        ))
+    })?;
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    let mut file = match options.open(&marker_path).await {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(WorktreeError::conflict(
+                "worktree_path_busy",
+                format!(
+                    "another worktree operation owns {}",
+                    worktree_path.display()
+                ),
+            ));
+        }
+        Err(error) => {
+            return Err(WorktreeError::internal(format!(
+                "could not reserve worktree path {}: {error}",
+                worktree_path.display()
+            )));
+        }
+    };
+    if let Err(error) = file.write_all(&bytes).await {
+        let _ = tokio::fs::remove_file(&marker_path).await;
+        return Err(WorktreeError::internal(format!(
+            "could not write worktree operation marker {}: {error}",
+            marker_path.display()
+        )));
     }
-    match verify_inside_worktree(worktree_path).await {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            cleanup_half_created(repo_root, worktree_path).await;
-            Err(err)
+    if let Err(error) = file.sync_all().await {
+        let _ = tokio::fs::remove_file(&marker_path).await;
+        return Err(WorktreeError::internal(format!(
+            "could not sync worktree operation marker {}: {error}",
+            marker_path.display()
+        )));
+    }
+    drop(file);
+    let operation = WorktreeOperation {
+        repo_root,
+        marker_path,
+        marker,
+        branch_created: false,
+    };
+    match tokio::fs::symlink_metadata(worktree_path).await {
+        Ok(_) => {
+            operation.remove_owned_marker().await?;
+            Err(WorktreeError::conflict(
+                "worktree_path_occupied",
+                format!("something already exists at {}", worktree_path.display()),
+            ))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(operation),
+        Err(error) => {
+            operation.remove_owned_marker().await?;
+            Err(WorktreeError::internal(format!(
+                "could not inspect worktree path {}: {error}",
+                worktree_path.display()
+            )))
         }
     }
+}
+
+async fn repository_identity(repo_root: &Path) -> Result<String, WorktreeError> {
+    let git_dir = git_stdout(
+        Some(repo_root),
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|error| {
+        WorktreeError::internal(format!("could not resolve repository identity: {error}"))
+    })?;
+    Path::new(git_dir.trim())
+        .canonicalize()
+        .map(|path| path.display().to_string())
+        .map_err(|error| {
+            WorktreeError::internal(format!(
+                "could not canonicalize repository identity {}: {error}",
+                git_dir.trim()
+            ))
+        })
+}
+
+async fn marker_matches(
+    path: &Path,
+    expected: &WorktreeOperationMarker,
+) -> Result<bool, WorktreeError> {
+    match tokio::fs::read(path).await {
+        Ok(bytes) => Ok(serde_json::from_slice::<WorktreeOperationMarker>(&bytes)
+            .map(|marker| &marker == expected)
+            .unwrap_or(false)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(WorktreeError::internal(format!(
+            "could not read operation marker {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn worktree_operation_marker_path(worktree_path: &Path) -> Result<PathBuf, WorktreeError> {
+    let Some(file_name) = worktree_path.file_name() else {
+        return Err(WorktreeError::internal(format!(
+            "worktree path {} has no leaf",
+            worktree_path.display()
+        )));
+    };
+    let mut marker_name = OsString::from(".");
+    marker_name.push(file_name);
+    marker_name.push(WORKTREE_OPERATION_SUFFIX);
+    Ok(worktree_path.with_file_name(marker_name))
+}
+
+async fn resolve_ref(repo_root: &Path, reference: &str) -> Result<String, WorktreeError> {
+    git_stdout(
+        Some(repo_root),
+        &["rev-parse", &format!("{reference}^{{commit}}")],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map(|tip| tip.trim().to_owned())
+    .map_err(|error| WorktreeError::user(format!("could not resolve {reference}: {error}")))
+}
+
+async fn create_branch_at(
+    repo_root: &Path,
+    branch: &str,
+    expected_tip: &str,
+) -> Result<(), WorktreeError> {
+    let branch_ref = format!("refs/heads/{branch}");
+    git(
+        Some(repo_root),
+        &["update-ref", &branch_ref, expected_tip, ""],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map(|_| ())
+    .map_err(|error| {
+        WorktreeError::conflict(
+            "branch_collision",
+            format!("branch {branch} already exists: {error}"),
+        )
+    })
+}
+
+async fn require_branch_tip(
+    repo_root: &Path,
+    branch: &str,
+    expected_tip: &str,
+) -> Result<(), WorktreeError> {
+    let actual_tip = branch_tip(repo_root, branch).await?;
+    if actual_tip == expected_tip {
+        Ok(())
+    } else {
+        Err(WorktreeError::conflict(
+            "branch_tip_changed",
+            format!("branch {branch} moved from {expected_tip} to {actual_tip} during restore"),
+        ))
+    }
+}
+
+async fn verify_worktree_identity(
+    repo_root: &Path,
+    worktree_path: &Path,
+    branch: &str,
+    expected_tip: &str,
+) -> Result<(), WorktreeError> {
+    verify_inside_worktree(worktree_path).await?;
+    let actual_repo = git_stdout(
+        Some(worktree_path),
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|error| {
+        WorktreeError::internal(format!("worktree repository check failed: {error}"))
+    })?;
+    let expected_git_dir = git_stdout(
+        Some(repo_root),
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|error| {
+        WorktreeError::internal(format!("repository identity check failed: {error}"))
+    })?;
+    if !repo_paths_equivalent(
+        Path::new(actual_repo.trim()),
+        Path::new(expected_git_dir.trim()),
+    ) {
+        return Err(WorktreeError::internal(format!(
+            "worktree {} belongs to a different repository",
+            worktree_path.display()
+        )));
+    }
+    let head = resolve_ref(worktree_path, "HEAD").await?;
+    if head != expected_tip {
+        return Err(WorktreeError::conflict(
+            "worktree_tip_changed",
+            format!(
+                "worktree {} checked out {head}, expected {expected_tip}",
+                worktree_path.display()
+            ),
+        ));
+    }
+    let checked_out = git_stdout(
+        Some(worktree_path),
+        &["symbolic-ref", "--quiet", "HEAD"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|error| WorktreeError::internal(format!("worktree branch check failed: {error}")))?;
+    if checked_out.trim() != format!("refs/heads/{branch}") {
+        return Err(WorktreeError::internal(format!(
+            "worktree {} checked out {}, expected {branch}",
+            worktree_path.display(),
+            checked_out.trim()
+        )));
+    }
+    Ok(())
+}
+
+async fn registered_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+) -> Result<Option<RegisteredWorktree>, WorktreeError> {
+    let fields = git_nul_stdout(
+        Some(repo_root),
+        &["worktree", "list", "--porcelain", "-z"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|error| WorktreeError::internal(format!("git worktree list failed: {error}")))?;
+    let mut matches_path = false;
+    let mut head = None;
+    let mut branch = None;
+    for field in fields {
+        if let Some(path) = field.strip_prefix("worktree ") {
+            if matches_path {
+                return Ok(head.map(|head| RegisteredWorktree { head, branch }));
+            }
+            matches_path = repo_paths_equivalent(Path::new(path), worktree_path);
+            head = None;
+            branch = None;
+        } else if matches_path {
+            if let Some(value) = field.strip_prefix("HEAD ") {
+                head = Some(value.to_owned());
+            } else if let Some(value) = field.strip_prefix("branch ") {
+                branch = Some(value.to_owned());
+            }
+        }
+    }
+    if matches_path {
+        Ok(head.map(|head| RegisteredWorktree { head, branch }))
+    } else {
+        Ok(None)
+    }
+}
+
+async fn branch_is_registered(repo_root: &Path, branch: &str) -> Result<bool, WorktreeError> {
+    let expected = format!("branch refs/heads/{branch}");
+    git_nul_stdout(
+        Some(repo_root),
+        &["worktree", "list", "--porcelain", "-z"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map(|fields| fields.iter().any(|field| field == &expected))
+    .map_err(|error| WorktreeError::internal(format!("git worktree list failed: {error}")))
 }
 
 /// Run the setup script, if any. Failure preserves the checkout.
@@ -763,16 +1347,14 @@ pub(crate) async fn create_bundle(
     Ok(size)
 }
 
-/// Restore a branch from its bundle.
-///
-/// Verifies the bundle before fetching: a truncated or corrupt file must fail
-/// here, with the branch still absent, rather than half-populate the object
-/// store and leave a ref pointing at commits whose parents never arrived.
-pub(crate) async fn unbundle_branch(
-    repo_root: &Path,
+/// Restore the exact released branch tip through a temporary Tidebreak ref.
+async fn restore_released_branch(
+    operation: &WorktreeOperation,
     bundle: &Path,
-    branch: &str,
-) -> Result<(), WorktreeError> {
+) -> Result<RestoredBranch, WorktreeError> {
+    let repo_root = &operation.repo_root;
+    let branch = operation.marker.branch.as_str();
+    let expected_tip = operation.marker.expected_tip.as_str();
     if !bundle.exists() {
         return Err(WorktreeError::user(format!(
             "bundle {} is missing; this workspace cannot be restored",
@@ -787,18 +1369,72 @@ pub(crate) async fn unbundle_branch(
     )
     .await
     .map_err(|err| WorktreeError::user(format!("bundle {path} is not usable: {err}")))?;
-    git(
+
+    let temporary_ref = format!(
+        "refs/tidebreak/restores/{}",
+        operation.marker.operation_id.simple()
+    );
+    let result = async {
+        git(
+            Some(repo_root),
+            &[
+                "fetch",
+                path.as_ref(),
+                &format!("refs/heads/{branch}:{temporary_ref}"),
+            ],
+            GIT_WORKTREE_TIMEOUT,
+        )
+        .await
+        .map_err(|err| WorktreeError::user(format!("bundle does not contain {branch}: {err}")))?;
+
+        let bundled_tip = resolve_ref(repo_root, &temporary_ref).await?;
+        if bundled_tip != expected_tip {
+            Err(WorktreeError::conflict(
+                "released_tip_mismatch",
+                format!(
+                    "bundle for {branch} contains {bundled_tip}, expected released tip \
+                         {expected_tip}"
+                ),
+            ))
+        } else if branch_exists(repo_root, branch).await? {
+            require_branch_tip(repo_root, branch, expected_tip)
+                .await
+                .map(|()| RestoredBranch::Existing)
+                .map_err(|_| {
+                    WorktreeError::conflict(
+                        "released_branch_mismatch",
+                        format!(
+                            "branch {branch} exists at a different commit; the released \
+                                 bundle was preserved"
+                        ),
+                    )
+                })
+        } else {
+            match create_branch_at(repo_root, branch, expected_tip).await {
+                Ok(()) => Ok(RestoredBranch::Created),
+                Err(_) => require_branch_tip(repo_root, branch, expected_tip)
+                    .await
+                    .map(|()| RestoredBranch::Existing)
+                    .map_err(|_| {
+                        WorktreeError::conflict(
+                            "released_branch_mismatch",
+                            format!(
+                                "branch {branch} was created at a different commit; the \
+                                     released bundle was preserved"
+                            ),
+                        )
+                    }),
+            }
+        }
+    }
+    .await;
+    let _ = git(
         Some(repo_root),
-        &[
-            "fetch",
-            path.as_ref(),
-            &format!("refs/heads/{branch}:refs/heads/{branch}"),
-        ],
-        GIT_WORKTREE_TIMEOUT,
+        &["update-ref", "-d", &temporary_ref],
+        GIT_TIMEOUT,
     )
-    .await
-    .map_err(|err| WorktreeError::internal(format!("git fetch from bundle failed: {err}")))?;
-    Ok(())
+    .await;
+    result
 }
 
 /// Delete a branch, discarding the ref whether or not it merged.
@@ -1012,20 +1648,6 @@ async fn verify_inside_worktree(path: &Path) -> Result<(), WorktreeError> {
         Err(WorktreeError::internal(
             "worktree verification failed: path is not inside a work tree".to_owned(),
         ))
-    }
-}
-
-async fn cleanup_half_created(repo_root: &Path, worktree_path: &Path) {
-    let path = worktree_path.to_string_lossy();
-    let _ = git(
-        Some(repo_root),
-        &["worktree", "remove", "--force", path.as_ref()],
-        GIT_TIMEOUT,
-    )
-    .await;
-    let _ = git(Some(repo_root), &["worktree", "prune"], GIT_TIMEOUT).await;
-    if worktree_path.exists() {
-        let _ = tokio::fs::remove_dir_all(worktree_path).await;
     }
 }
 
@@ -1338,6 +1960,14 @@ mod tests {
         assert!(status.success(), "{args:?} failed in {}", cwd.display());
     }
 
+    async fn create_ready(repo: &Path, path: &Path, branch: &str, base_ref: &str) {
+        create_worktree(repo, path, branch, base_ref)
+            .await
+            .unwrap()
+            .complete()
+            .await;
+    }
+
     #[tokio::test]
     async fn validate_repo_refuses_bare_and_nested_non_repos() {
         let (dir, repo) = init_repo();
@@ -1363,9 +1993,7 @@ mod tests {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
         let path = scratch_worktree(data.path(), "first");
-        create_worktree(&repo, &path, "tidebreak/first", "main")
-            .await
-            .unwrap();
+        create_ready(&repo, &path, "tidebreak/first", "main").await;
         verify_inside_worktree(&path).await.unwrap();
 
         let err = run_setup_script(&path, Some("exit 7")).await.unwrap_err();
@@ -1403,8 +2031,7 @@ mod tests {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
         let path = scratch_worktree(data.path(), "ghost");
-        // Point at a missing base so `worktree add` fails after creating the branch
-        // attempt; cleanup must not leave a registered worktree.
+        // A missing base fails before branch or checkout creation.
         let err = create_worktree(&repo, &path, "tidebreak/ghost", "no-such-ref")
             .await
             .unwrap_err();
@@ -1424,9 +2051,7 @@ mod tests {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
         let path = scratch_worktree(data.path(), "dirty");
-        create_worktree(&repo, &path, "tidebreak/dirty", "main")
-            .await
-            .unwrap();
+        create_ready(&repo, &path, "tidebreak/dirty", "main").await;
         std::fs::write(path.join("extra.txt"), "uncommitted\n").unwrap();
         assert_eq!(
             archive_blockers(&path, "main").await.unwrap(),
@@ -1438,9 +2063,7 @@ mod tests {
 
         // Already-removed: deleting the directory out of band, then archive.
         let path2 = scratch_worktree(data.path(), "gone");
-        create_worktree(&repo, &path2, "tidebreak/gone", "main")
-            .await
-            .unwrap();
+        create_ready(&repo, &path2, "tidebreak/gone", "main").await;
         std::fs::remove_dir_all(&path2).unwrap();
         remove_worktree(&repo, &path2).await.unwrap();
         let listed = git_stdout(Some(&repo), &["worktree", "list"], GIT_TIMEOUT)
@@ -1457,9 +2080,7 @@ mod tests {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
         let first = scratch_worktree(data.path(), "one");
-        create_worktree(&repo, &first, "tidebreak/same", "main")
-            .await
-            .unwrap();
+        create_ready(&repo, &first, "tidebreak/same", "main").await;
         let second = scratch_worktree(data.path(), "two");
         let err = create_worktree(&repo, &second, "tidebreak/same", "main")
             .await
@@ -1469,6 +2090,102 @@ mod tests {
             "collision must not auto-suffix: {err}"
         );
         assert!(!second.exists());
+    }
+
+    #[tokio::test]
+    async fn occupied_foreign_directory_is_never_removed() {
+        let (_dir, repo) = init_repo();
+        let data = TempDir::new().unwrap();
+        let path = scratch_worktree(data.path(), "foreign");
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("keep.txt"), "foreign\n").unwrap();
+
+        let err = create_worktree(&repo, &path, "tidebreak/foreign", "main")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            WorktreeError::Conflict {
+                kind: "worktree_path_occupied",
+                ..
+            }
+        ));
+        assert_eq!(
+            std::fs::read_to_string(path.join("keep.txt")).unwrap(),
+            "foreign\n"
+        );
+        assert!(!branch_exists(&repo, "tidebreak/foreign").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn concurrent_restores_leave_one_complete_checkout() {
+        let (_dir, repo) = init_repo();
+        run(&repo, &["git", "branch", "tidebreak/archive", "main"]);
+        let data = TempDir::new().unwrap();
+        let path = scratch_worktree(data.path(), "concurrent");
+
+        let (left, right) = tokio::join!(
+            restore_worktree(&repo, &path, "tidebreak/archive"),
+            restore_worktree(&repo, &path, "tidebreak/archive")
+        );
+        let (winner, loser) = match (left, right) {
+            (Ok(winner), Err(loser)) | (Err(loser), Ok(winner)) => (winner, loser),
+            (left, right) => panic!("expected one restore winner, got {left:?} and {right:?}"),
+        };
+        assert!(matches!(
+            loser,
+            WorktreeError::Conflict {
+                kind: "worktree_path_busy" | "worktree_path_occupied",
+                ..
+            }
+        ));
+        verify_inside_worktree(&path).await.unwrap();
+        assert_eq!(
+            branch_tip(&repo, "tidebreak/archive").await.unwrap(),
+            resolve_ref(&path, "HEAD").await.unwrap()
+        );
+        winner.complete().await;
+    }
+
+    #[tokio::test]
+    async fn losing_add_cleanup_preserves_the_concurrent_winner() {
+        let (_dir, repo) = init_repo();
+        let expected_tip = branch_tip(&repo, "main").await.unwrap();
+        let data = TempDir::new().unwrap();
+        let path = scratch_worktree(data.path(), "winner");
+        let mut losing = reserve_worktree_target(&repo, &path, "tidebreak/loser", &expected_tip)
+            .await
+            .unwrap();
+        create_branch_at(&repo, "tidebreak/loser", &expected_tip)
+            .await
+            .unwrap();
+        losing.branch_created = true;
+
+        run(&repo, &["git", "checkout", "-b", "tidebreak/winner"]);
+        std::fs::write(repo.join("winner.txt"), "winner\n").unwrap();
+        run(&repo, &["git", "add", "winner.txt"]);
+        run(&repo, &["git", "commit", "-m", "winner"]);
+        let winner_tip = branch_tip(&repo, "tidebreak/winner").await.unwrap();
+        run(&repo, &["git", "checkout", "main"]);
+        run(
+            &repo,
+            &[
+                "git",
+                "worktree",
+                "add",
+                path.to_str().unwrap(),
+                "tidebreak/winner",
+            ],
+        );
+
+        assert!(losing.add_existing_branch().await.is_err());
+        losing.rollback().await;
+
+        verify_inside_worktree(&path).await.unwrap();
+        assert_eq!(resolve_ref(&path, "HEAD").await.unwrap(), winner_tip);
+        assert!(path.join("winner.txt").is_file());
+        assert!(branch_exists(&repo, "tidebreak/winner").await.unwrap());
+        assert!(!branch_exists(&repo, "tidebreak/loser").await.unwrap());
     }
 
     #[tokio::test]
@@ -1602,9 +2319,7 @@ mod tests {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
         let path = scratch_worktree(data.path(), "blob");
-        create_worktree(&repo, &path, "tidebreak/blob", "main")
-            .await
-            .unwrap();
+        create_ready(&repo, &path, "tidebreak/blob", "main").await;
         std::fs::write(path.join("notes.md"), "hello from blob\n").unwrap();
 
         let blob = read_worktree_file(&path, "notes.md").await.unwrap();
@@ -1622,9 +2337,7 @@ mod tests {
         let (_dir, repo) = init_repo();
         let data = TempDir::new().unwrap();
         let path = scratch_worktree(data.path(), "blob-cap");
-        create_worktree(&repo, &path, "tidebreak/blob-cap", "main")
-            .await
-            .unwrap();
+        create_ready(&repo, &path, "tidebreak/blob-cap", "main").await;
         let huge = format!("hello {}\n", "x".repeat(MAX_BLOB_BYTES + 64));
         std::fs::write(path.join("huge.txt"), &huge).unwrap();
 
@@ -1683,18 +2396,20 @@ mod tests {
         delete_branch(&repo, "tidebreak/work").await.unwrap();
         assert!(!branch_exists(&repo, "tidebreak/work").await.unwrap());
 
-        unbundle_branch(&repo, &bundle, "tidebreak/work")
+        let path = scratch_worktree(dir.path(), "released");
+        restore_released_worktree(&repo, &path, "tidebreak/work", &bundle, &tip)
             .await
-            .unwrap();
+            .unwrap()
+            .complete()
+            .await;
         assert!(branch_exists(&repo, "tidebreak/work").await.unwrap());
         // Same commit, not merely a branch of the same name.
         assert_eq!(branch_tip(&repo, "tidebreak/work").await.unwrap(), tip);
-        run(&repo, &["git", "checkout", "tidebreak/work"]);
         // Normalize: git checks out with CRLF under Windows' default
         // `core.autocrlf`, and the round trip is about the content, not the
         // platform's line endings.
         assert_eq!(
-            std::fs::read_to_string(repo.join("feature.txt"))
+            std::fs::read_to_string(path.join("feature.txt"))
                 .unwrap()
                 .replace("\r\n", "\n"),
             "work\n"
@@ -1753,12 +2468,95 @@ mod tests {
     async fn a_corrupt_bundle_is_refused_and_leaves_no_branch() {
         let (dir, repo) = init_repo();
         let bundle = dir.path().join("broken.bundle");
+        let path = scratch_worktree(dir.path(), "broken");
         std::fs::write(&bundle, b"not a bundle").unwrap();
 
-        let err = unbundle_branch(&repo, &bundle, "tidebreak/nope")
-            .await
-            .unwrap_err();
+        let err = restore_released_worktree(
+            &repo,
+            &path,
+            "tidebreak/nope",
+            &bundle,
+            &branch_tip(&repo, "main").await.unwrap(),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, WorktreeError::User(_)), "{err:?}");
         assert!(!branch_exists(&repo, "tidebreak/nope").await.unwrap());
+        assert!(!path.exists());
+        assert!(bundle.exists());
+    }
+
+    #[tokio::test]
+    async fn released_restore_refuses_a_foreign_same_name_branch() {
+        let (dir, repo) = init_repo();
+        run(&repo, &["git", "checkout", "-b", "tidebreak/released"]);
+        std::fs::write(repo.join("released.txt"), "released\n").unwrap();
+        run(&repo, &["git", "add", "released.txt"]);
+        run(&repo, &["git", "commit", "-m", "released"]);
+        let released_tip = branch_tip(&repo, "tidebreak/released").await.unwrap();
+        run(&repo, &["git", "checkout", "main"]);
+        let bundle = dir.path().join("released.bundle");
+        create_bundle(&repo, "main", "tidebreak/released", &bundle)
+            .await
+            .unwrap();
+        delete_branch(&repo, "tidebreak/released").await.unwrap();
+
+        run(&repo, &["git", "checkout", "-b", "tidebreak/released"]);
+        std::fs::write(repo.join("foreign.txt"), "foreign\n").unwrap();
+        run(&repo, &["git", "add", "foreign.txt"]);
+        run(&repo, &["git", "commit", "-m", "foreign"]);
+        let foreign_tip = branch_tip(&repo, "tidebreak/released").await.unwrap();
+        run(&repo, &["git", "checkout", "main"]);
+
+        let path = scratch_worktree(dir.path(), "foreign-branch");
+        let err =
+            restore_released_worktree(&repo, &path, "tidebreak/released", &bundle, &released_tip)
+                .await
+                .unwrap_err();
+        assert!(matches!(
+            err,
+            WorktreeError::Conflict {
+                kind: "released_branch_mismatch",
+                ..
+            }
+        ));
+        assert_eq!(
+            branch_tip(&repo, "tidebreak/released").await.unwrap(),
+            foreign_tip
+        );
+        assert!(bundle.exists());
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn released_restore_refuses_a_bundle_with_the_wrong_tip() {
+        let (dir, repo) = init_repo();
+        let expected_tip = branch_tip(&repo, "main").await.unwrap();
+        run(&repo, &["git", "checkout", "-b", "tidebreak/released"]);
+        std::fs::write(repo.join("wrong.txt"), "wrong\n").unwrap();
+        run(&repo, &["git", "add", "wrong.txt"]);
+        run(&repo, &["git", "commit", "-m", "wrong tip"]);
+        run(&repo, &["git", "checkout", "main"]);
+        let bundle = dir.path().join("wrong.bundle");
+        create_bundle(&repo, "main", "tidebreak/released", &bundle)
+            .await
+            .unwrap();
+        delete_branch(&repo, "tidebreak/released").await.unwrap();
+
+        let path = scratch_worktree(dir.path(), "wrong-tip");
+        let err =
+            restore_released_worktree(&repo, &path, "tidebreak/released", &bundle, &expected_tip)
+                .await
+                .unwrap_err();
+        assert!(matches!(
+            err,
+            WorktreeError::Conflict {
+                kind: "released_tip_mismatch",
+                ..
+            }
+        ));
+        assert!(!branch_exists(&repo, "tidebreak/released").await.unwrap());
+        assert!(bundle.exists());
+        assert!(!path.exists());
     }
 }

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -103,7 +103,6 @@ impl ServerError {
     }
 
     /// The stable machine-readable `kind` clients branch on.
-    #[cfg(test)]
     pub(crate) fn kind(&self) -> &str {
         &self.info.kind
     }

--- a/crates/tidebreak-server/src/routes/code/terminals.rs
+++ b/crates/tidebreak-server/src/routes/code/terminals.rs
@@ -21,6 +21,8 @@ pub async fn create_terminal(
     Path(id): Path<WorkspaceId>,
     Json(body): Json<CreateTerminalBody>,
 ) -> Result<impl IntoResponse, ServerError> {
+    let workspace = code.get_workspace(id).await?;
+    require_active(&workspace.status)?;
     let write = code.workspace_write_lock(id);
     let _write_guard = write.lock().await;
     let workspace = code.get_workspace(id).await?;
@@ -97,6 +99,8 @@ pub async fn write_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalWriteBody>,
 ) -> Result<StatusCode, ServerError> {
+    let workspace = code.get_workspace(path.id).await?;
+    require_active(&workspace.status)?;
     let write = code.workspace_write_lock(path.id);
     let _write_guard = write.lock().await;
     let workspace = code.get_workspace(path.id).await?;
@@ -115,6 +119,8 @@ pub async fn resize_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalResizeBody>,
 ) -> Result<Json<CodeTerminalSnapshot>, ServerError> {
+    let workspace = code.get_workspace(path.id).await?;
+    require_active(&workspace.status)?;
     let write = code.workspace_write_lock(path.id);
     let _write_guard = write.lock().await;
     let workspace = code.get_workspace(path.id).await?;

--- a/crates/tidebreak-server/src/routes/code/terminals.rs
+++ b/crates/tidebreak-server/src/routes/code/terminals.rs
@@ -21,6 +21,8 @@ pub async fn create_terminal(
     Path(id): Path<WorkspaceId>,
     Json(body): Json<CreateTerminalBody>,
 ) -> Result<impl IntoResponse, ServerError> {
+    let write = code.workspace_write_lock(id);
+    let _write_guard = write.lock().await;
     let workspace = code.get_workspace(id).await?;
     require_active(&workspace.status)?;
     let snap = state
@@ -95,7 +97,10 @@ pub async fn write_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalWriteBody>,
 ) -> Result<StatusCode, ServerError> {
-    let _ = code.get_workspace(path.id).await?;
+    let write = code.workspace_write_lock(path.id);
+    let _write_guard = write.lock().await;
+    let workspace = code.get_workspace(path.id).await?;
+    require_active(&workspace.status)?;
     let bytes = decode_write(&body.bytes)?;
     state
         .terminals
@@ -110,7 +115,10 @@ pub async fn resize_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalResizeBody>,
 ) -> Result<Json<CodeTerminalSnapshot>, ServerError> {
-    let _ = code.get_workspace(path.id).await?;
+    let write = code.workspace_write_lock(path.id);
+    let _write_guard = write.lock().await;
+    let workspace = code.get_workspace(path.id).await?;
+    require_active(&workspace.status)?;
     let snap = state
         .terminals
         .resize(path.id, path.tid, body.cols, body.rows)

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -119,8 +119,9 @@ pub async fn release_workspace(
 /// The worktree comes back at the same path on the kept branch; session rows
 /// and journal history were never deleted, so the conversation is readable
 /// again the moment this returns. 409 kinds: `branch_missing` (the branch was
-/// deleted since archive — fall back to a new workspace), and
-/// `worktree_path_occupied`.
+/// deleted since archive — fall back to a new workspace),
+/// `released_branch_mismatch`, `released_tip_mismatch`,
+/// `worktree_path_busy`, and `worktree_path_occupied`.
 pub async fn restore_workspace(
     code: ScopedCode,
     Path(id): Path<WorkspaceId>,

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -91,8 +91,9 @@ pub async fn archive_workspace(
     Path(id): Path<WorkspaceId>,
     Json(body): Json<ArchiveWorkspaceBody>,
 ) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
-    let archived = code.archive_workspace(id, body.force).await?;
-    state.terminals.close_workspace(id);
+    let archived = code
+        .archive_workspace(id, body.force, state.terminals.as_ref())
+        .await?;
     Ok(Json(CodeWorkspaceSnapshot::from(archived)))
 }
 

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3772,6 +3772,49 @@ async fn archive_shutdown_timeout_preserves_the_checkout() {
 }
 
 #[tokio::test]
+async fn archive_recovery_finishes_after_checkout_removal() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let owner = tidebreak_core::OwnerId::local();
+    let (_registered, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let workspace_id: tidebreak_core::WorkspaceId = json_id(&workspace).parse().unwrap();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    assert!(tidebreak_core::db::code::compare_and_set_workspace_status(
+        &runtime.db,
+        &owner,
+        workspace_id,
+        CodeWorkspaceStatus::Active,
+        CodeWorkspaceStatus::Archiving,
+    )
+    .await
+    .unwrap());
+    let removed = std::process::Command::new("git")
+        .current_dir(&repo)
+        .args(["worktree", "remove", "--force"])
+        .arg(&path)
+        .status()
+        .unwrap();
+    assert!(removed.success());
+    assert!(!path.exists());
+
+    let restarted = CodeRuntime::with_registry(
+        runtime.db.clone(),
+        dir.path().to_path_buf(),
+        scripted_registry(),
+    );
+    restarted.recover().await.unwrap();
+
+    let stored = tidebreak_core::db::code::get_workspace(&runtime.db, &owner, workspace_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.status, CodeWorkspaceStatus::Archived);
+    assert!(stored.archived_at.is_some());
+}
+
+#[tokio::test]
 async fn archive_refuses_ignored_only_content_without_force() {
     let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3637,10 +3637,7 @@ async fn archive_preserves_hook_created_files_without_force() {
     assert_eq!(archived.status(), reqwest::StatusCode::CONFLICT);
     let body: serde_json::Value = archived.json().await.unwrap();
     assert_eq!(body["kind"], "uncommitted");
-    assert_eq!(
-        std::fs::read_to_string(path.join("hook-created.txt")).unwrap(),
-        "kept\n"
-    );
+    assert!(path.join("hook-created.txt").is_file());
     let stored = tidebreak_core::db::code::get_workspace(
         &_runtime.db,
         &tidebreak_core::OwnerId::local(),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -7752,7 +7752,9 @@ async fn legacy_managed_repo_and_worktree_paths_remain_accessible() {
         legacy_worktree_root.join(format!("demo-{}", &workspace_id.to_string()[..8]));
     create_worktree(&repo_root, &worktree_path, "thet/legacy-owner-path", "main")
         .await
-        .unwrap();
+        .unwrap()
+        .complete()
+        .await;
     let workspace = CodeWorkspace {
         id: workspace_id,
         owner: owner.clone(),
@@ -8149,6 +8151,112 @@ async fn release_frees_the_branch_and_restore_rebuilds_it_from_the_bundle() {
             .replace("\r\n", "\n"),
         "survives release\n",
         "the released commit did not come back"
+    );
+}
+
+/// A released restore keeps its only durable recovery material until the
+/// Active row commits. If that write fails after checkout creation, the exact
+/// attempt is removed and the Released row can retry from the same bundle.
+#[tokio::test]
+async fn released_restore_keeps_the_bundle_when_the_final_row_fails() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let workspace_id: WorkspaceId = json_id(&workspace).parse().unwrap();
+    let branch = workspace["branch_name"].as_str().unwrap().to_owned();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    std::fs::write(path.join("kept.txt"), "retry me\n").unwrap();
+    for args in [
+        ["add", "kept.txt"].as_slice(),
+        ["commit", "-m", "keep the released tip"].as_slice(),
+    ] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(&path)
+            .status()
+            .unwrap()
+            .success());
+    }
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/archive"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+    let released = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/release"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(released.status(), reqwest::StatusCode::OK);
+    let released_body: serde_json::Value = released.json().await.unwrap();
+    let released_tip = released_body["released_tip"].as_str().unwrap().to_owned();
+    let bundle = dir
+        .path()
+        .join("code")
+        .join("bundles")
+        .join(format!("{}.bundle", workspace_id.as_uuid()));
+    assert!(bundle.is_file());
+
+    runtime.fail_next_workspace_final_save();
+    let failed = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/restore"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(failed.status(), reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(bundle.is_file(), "a failed final row write lost the bundle");
+    assert!(
+        !path.exists(),
+        "the failed restore left its checkout behind"
+    );
+    assert!(
+        !branch_exists_in(&repo, &branch),
+        "the failed restore left its temporary branch behind"
+    );
+    let still_released = client
+        .get(format!("http://{addr}/code/workspaces/{workspace_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(still_released.status(), reqwest::StatusCode::OK);
+    let still_released: serde_json::Value = still_released.json().await.unwrap();
+    assert_eq!(still_released["status"], "released");
+    assert_eq!(still_released["released_tip"], released_tip);
+
+    let retried = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/restore"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        retried.status(),
+        reqwest::StatusCode::OK,
+        "restore retry failed: {}",
+        retried.text().await.unwrap()
+    );
+    assert!(path.join("kept.txt").is_file());
+    assert!(
+        !bundle.exists(),
+        "the durable Active row should retire the bundle"
     );
 }
 

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3594,6 +3594,255 @@ async fn a_failing_archive_script_preserves_the_worktree() {
 }
 
 #[tokio::test]
+async fn archive_preserves_hook_created_files_without_force() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "path": repo,
+            "archive_script": "echo kept > hook-created.txt",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "hook output",
+        }))
+        .send()
+        .await
+        .unwrap();
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = archived.json().await.unwrap();
+    assert_eq!(body["kind"], "uncommitted");
+    assert_eq!(
+        std::fs::read_to_string(path.join("hook-created.txt")).unwrap(),
+        "kept\n"
+    );
+    let stored = tidebreak_core::db::code::get_workspace(
+        &_runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        json_id(&workspace).parse().unwrap(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(stored.status, CodeWorkspaceStatus::Active);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn archive_rejects_concurrent_writes_after_the_first_check() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let started = dir.path().join("archive-started");
+    let proceed = dir.path().join("archive-proceed");
+    let script = format!(
+        "touch \"{}\"; while [ ! -f \"{}\" ]; do sleep 0.01; done",
+        started.display(),
+        proceed.display()
+    );
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "path": repo,
+            "archive_script": script,
+        }))
+        .send()
+        .await
+        .unwrap();
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "late writer",
+        }))
+        .send()
+        .await
+        .unwrap();
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let workspace_id = json_id(&workspace).to_owned();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let archive_client = client.clone();
+    let archive_token = token.clone();
+    let archive = tokio::spawn(async move {
+        archive_client
+            .post(format!(
+                "http://{addr}/code/workspaces/{workspace_id}/archive"
+            ))
+            .bearer_auth(archive_token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .unwrap()
+    });
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while !started.exists() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "archive hook did not reach its barrier"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let terminal = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/terminals",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(terminal.status(), reqwest::StatusCode::CONFLICT);
+    let terminal_body: serde_json::Value = terminal.json().await.unwrap();
+    assert_eq!(terminal_body["kind"], "workspace_not_ready");
+
+    std::fs::write(path.join("concurrent.txt"), "late\n").unwrap();
+    std::fs::write(&proceed, "go\n").unwrap();
+    let archived = archive.await.unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = archived.json().await.unwrap();
+    assert_eq!(body["kind"], "uncommitted");
+    assert_eq!(
+        std::fs::read_to_string(path.join("concurrent.txt")).unwrap(),
+        "late\n"
+    );
+}
+
+#[tokio::test]
+async fn archive_shutdown_timeout_preserves_the_checkout() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    runtime.set_archive_shutdown_timeout(true);
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = archived.json().await.unwrap();
+    assert_eq!(body["kind"], "workspace_shutdown_timeout");
+    assert!(path.join("README.md").is_file());
+    let stored = tidebreak_core::db::code::get_workspace(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        json_id(&workspace).parse().unwrap(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(stored.status, CodeWorkspaceStatus::Archiving);
+}
+
+#[tokio::test]
+async fn archive_refuses_ignored_only_content_without_force() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    std::fs::write(repo.join(".gitignore"), ".env.local\nbuild/\n").unwrap();
+    for args in [
+        ["add", ".gitignore"].as_slice(),
+        ["commit", "-m", "ignore local files"].as_slice(),
+    ] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .status()
+            .unwrap()
+            .success());
+    }
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    std::fs::write(path.join(".env.local"), "ONLY_COPY=1\n").unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "ignored_content");
+    assert_eq!(
+        std::fs::read_to_string(path.join(".env.local")).unwrap(),
+        "ONLY_COPY=1\n"
+    );
+
+    assert!(std::process::Command::new("git")
+        .args([
+            "config",
+            "--add",
+            "tidebreak.archiveDisposablePath",
+            "build"
+        ])
+        .current_dir(&path)
+        .status()
+        .unwrap()
+        .success());
+    std::fs::remove_file(path.join(".env.local")).unwrap();
+    std::fs::create_dir_all(path.join("build")).unwrap();
+    std::fs::write(path.join("build/cache.bin"), "generated\n").unwrap();
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+    assert!(!path.exists());
+}
+
+#[tokio::test]
 async fn archive_ends_the_session_before_removing_the_worktree() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -120,7 +120,7 @@ describe the current schema, not the frozen baseline.
   which does. Reclaiming the checkout on disk is a separate, explicit act.
 - **`code_workspace`** — `id`, `repo_id`, `title`, `worktree_path`,
   `branch_name`, `base_ref`, `status`
-  (`Creating | SetupFailed | Active | Archived | Released`), `pr` (JSON digest:
+  (`Creating | SetupFailed | Active | Archiving | Archived | Released`), `pr` (JSON digest:
   number, url, state, checks summary; nullable), `created_at`,
   `archived_at`, `released_at`, `released_tip`, `bundle_bytes`.
 
@@ -131,6 +131,11 @@ describe the current schema, not the frozen baseline.
   build output; a branch's own commits are usually kilobytes, which is what
   makes the deeper tier worth the step. Transcripts are untouched at every
   tier — the row and its journal outlive the bytes.
+
+  Non-force archive also protects ignored files. To exclude a generated
+  directory from that scan, configure its exact repository-relative path with
+  `git config --add tidebreak.archiveDisposablePath <directory>`. Archive
+  fails closed when the scan or its configured paths exceed the safety budget.
 - **`code_session`** — `id`, `workspace_id`, `kind`
   (`Interactive | Watch`, per
   [`0050`](decisions/0050-watch-and-fix-is-a-durable-task.md)), `harness_kind`,


### PR DESCRIPTION
## What changed

- Verify released bundles through a unique `refs/tidebreak/restores/*` ref and require the imported tip to match `released_tip` exactly.
- Accept an existing workspace branch only when its tip matches the released commit.
- Reserve worktree targets with operation markers in the target parent and Git registration directory.
- Roll back only registrations, paths, and branches that still match the operation ID, repository, path, branch, and expected tip.
- Keep released bundles until the final Active or SetupFailed workspace row is durable.
- Serialize restore lifecycle transitions without changing the archive behavior from #2707.

## Validation

- `rustfmt --edition 2021 --check` on the changed Rust files.
- `git diff e90b8f875..HEAD --check`.
- Focused source assertions for temporary refs, ownership markers, conflict kinds, and every requested regression.
- No Cargo commands ran, per issue instructions. GitHub CI performs compilation and tests.

## Compatibility and risk

No wire or database schema changes. Restore can now return specific conflict kinds for a foreign released branch, a mismatched bundle tip, an in-flight target reservation, or an occupied target. Cleanup is deliberately conservative when any ownership field differs.

## Tracking

Closes #2721