### PR TITLE
fix(code): skip local-only checkouts in Delivery refresh warnings

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -183,6 +183,62 @@ describe("delivery pull request list", () => {
     );
   });
 
+  it("does not warn when only local-only repositories were skipped", async () => {
+    renderList({
+      ...storyClient(),
+      getCodeDeliveryRepositories: async () => ({
+        ...deliveryRepositoriesSnapshot,
+        errors: [
+          {
+            kind: "not_github",
+            message:
+              "code-mode-audit-IWF86H: could not read origin remote: error: No such remote 'origin'",
+          },
+          {
+            kind: "not_github",
+            message:
+              "code-mode-audit-fixture: use owner/repo, host/owner/repo, or a GitHub URL",
+          },
+        ],
+      }),
+    } as unknown as ApiClient);
+
+    expect(
+      await screen.findByText("Build the delivery center"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/could not be refreshed/)).toBeNull();
+    expect(screen.queryByText(/code-mode-audit/)).toBeNull();
+  });
+
+  it("still names GitHub repositories that failed to refresh", async () => {
+    renderList({
+      ...storyClient(),
+      getCodeDeliveryRepositories: async () => ({
+        ...deliveryRepositoriesSnapshot,
+        errors: [
+          {
+            kind: "not_github",
+            message: "code-mode-audit-fixture: not a GitHub remote",
+          },
+          {
+            repository: {
+              host: "github.com",
+              owner: "brightwave-inc",
+              name: "docs",
+            },
+            kind: "transient",
+            message: "brightwave-inc/docs did not answer in time.",
+          },
+        ],
+      }),
+    } as unknown as ApiClient);
+
+    expect(
+      await screen.findByText("brightwave-inc/docs did not answer in time."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/code-mode-audit/)).toBeNull();
+  });
+
   it("opens on your own open pull requests, drafts included", async () => {
     const query = vi.fn(async (_body: unknown) => ({
       capability: deliveryRepositoriesSnapshot.capability,

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -457,10 +457,12 @@ function CodeDeliveryBody({
 
   const discovered = repositorySnapshot?.repositories ?? [];
   const capability = repositorySnapshot?.capability ?? null;
-  const repositoryErrors = [
+  // Local-only Tidebreak checkouts are skipped on purpose. They are not
+  // GitHub sources, so they must not look like a failed refresh.
+  const repositoryErrors = deliveryRefreshErrors([
     ...(repositorySnapshot?.errors ?? []),
     ...resolutionErrors,
-  ];
+  ]);
   const repositoriesLoading = repositoryLoading && !repositorySnapshot;
   const routeRepository = useMemo<CodeGitHubRepositoryTarget | undefined>(
     () =>
@@ -3307,6 +3309,27 @@ function FreshnessBar({
   );
 }
 
+function deliveryRefreshErrors(
+  errors: readonly CodeDeliverySourceError[],
+): CodeDeliverySourceError[] {
+  return errors.filter((error) => error.kind !== "not_github");
+}
+
+function refreshErrorSummary(
+  errors: readonly CodeDeliverySourceError[],
+): string {
+  if (errors.length === 1) return errors[0]!.message;
+  const names = errors.flatMap((error) =>
+    error.repository
+      ? [`${error.repository.owner}/${error.repository.name}`]
+      : [],
+  );
+  if (names.length === errors.length) {
+    return `${errors.length} repositories could not be refreshed (${names.join(", ")}). Available results are still shown.`;
+  }
+  return `${errors.length} repositories could not be refreshed. Available results are still shown.`;
+}
+
 function PartialErrorBanner({
   errors,
   compact = false,
@@ -3314,6 +3337,8 @@ function PartialErrorBanner({
   errors: CodeDeliverySourceError[];
   compact?: boolean;
 }) {
+  const visible = deliveryRefreshErrors(errors);
+  if (visible.length === 0) return null;
   return (
     <div
       role="status"
@@ -3323,11 +3348,7 @@ function PartialErrorBanner({
       )}
     >
       <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
-      <span>
-        {errors.length === 1
-          ? errors[0]!.message
-          : `${errors.length} repositories could not be refreshed. Available results are still shown.`}
-      </span>
+      <span>{refreshErrorSummary(visible)}</span>
     </div>
   );
 }

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -580,7 +580,14 @@ pub(crate) async fn discover_repositories(
     let access = delivery_access(runtime, owner, refresh).await;
     let capability = access.capability.clone();
     let catalog = owner_repository_catalog(runtime, owner, refresh).await?;
-    let mut errors = catalog.errors;
+    // Local-only Tidebreak checkouts are not Delivery sources. Keep them off
+    // the snapshot so the page does not treat a skipped origin as a refresh
+    // failure.
+    let mut errors = catalog
+        .errors
+        .into_iter()
+        .filter(|error| error.kind != "not_github")
+        .collect::<Vec<_>>();
 
     let resolved = if let Some(reader) = access.reader.clone() {
         stream::iter(catalog.entries)


### PR DESCRIPTION
## What changed

Delivery listed GitHub repositories correctly, then warned that local Tidebreak checkouts without a GitHub origin could not be refreshed. Those checkouts are not Delivery sources. The repository snapshot and the Delivery banner now skip `not_github` errors. A real GitHub refresh failure still warns, and when more than one repository fails the banner names them.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome check` on the changed UI files
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeDeliveryPage.dom.test.tsx` (27 passed)
- Did not compile or test Rust locally
- Confirmed against the desktop-dev delivery snapshot: the two errors were `code-mode-audit-IWF86H` (no origin) and `code-mode-audit-fixture` (not a GitHub URL)

## Compatibility and risk

None. The public snapshot omits skippable local-only catalog errors. GitHub refresh failures are unchanged.