### PR TITLE
ci(release): warm Windows/Linux caches, single notarization, faster publish tail

### DIFF
--- a/.github/workflows/cache-linux.yml
+++ b/.github/workflows/cache-linux.yml
@@ -1,0 +1,186 @@
+name: Warm Linux release cache
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .cargo/**
+      - .github/workflows/cache-linux.yml
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - rust-toolchain.toml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Let the active main-tip compilation finish so a later release can consume
+  # its compiler outputs. GitHub retains at most one newer pending run.
+  group: tidebreak-linux-release-cache
+  cancel-in-progress: false
+
+jobs:
+  cargo-downloads:
+    name: Cargo dependency downloads
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: linux-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+
+      - name: Fetch Cargo dependency downloads
+        run: |
+          cargo fetch --locked --target x86_64-unknown-linux-gnu
+          cargo fetch --locked --target aarch64-unknown-linux-gnu
+
+  warm:
+    name: Linux cache · ${{ matrix.arch }}
+    needs: cargo-downloads
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+          - arch: aarch64
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04-arm
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      # GitHub throttles sccache's many small writes. Retain its existing
+      # object cache as a read-only fallback and persist build outputs below
+      # with one cache archive per architecture.
+      SCCACHE_GHA_RW_MODE: READ_ONLY
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Linux packaging dependencies
+        timeout-minutes: 8
+        run: |
+          scripts/install-linux-apt-packages.sh \
+            build-essential \
+            cmake \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            xdg-utils
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      - name: Restore unsigned Rust build cache
+        id: rust-build-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/tidebreak
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}
+          key: linux-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+          restore-keys: |
+            linux-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            linux-release-target-v1-${{ matrix.arch }}-
+
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: linux-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install UI dependencies
+        working-directory: crates/tidebreak-desktop/ui
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Compile without production credentials or bundles
+        id: compile
+        continue-on-error: true
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
+        with:
+          projectPath: crates/tidebreak-desktop
+          args: --target ${{ matrix.target }} --no-bundle --ci
+
+      - name: Report unsigned Rust build cache size
+        if: ${{ !cancelled() }}
+        run: |
+          du -ch \
+            target/release/{.cargo-lock,.fingerprint,build,deps} \
+            target/${{ matrix.target }}/release/{.cargo-lock,.fingerprint,build,deps} \
+            target/${{ matrix.target }}/release/tidebreak-desktop \
+            target/${{ matrix.target }}/release/tidebreak-host-broker \
+            target/${{ matrix.target }}/release/tidebreak \
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.* \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }} \
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }} \
+            2>/dev/null | tail -1 || true
+
+      - name: Save unsigned Rust build cache
+        if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/tidebreak
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}
+          key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
+
+      - name: Require a successful cache-warm compilation
+        if: ${{ steps.compile.outcome != 'success' }}
+        run: exit 1

--- a/.github/workflows/cache-windows.yml
+++ b/.github/workflows/cache-windows.yml
@@ -1,0 +1,217 @@
+name: Warm Windows release cache
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .cargo/**
+      - .github/workflows/cache-windows.yml
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - rust-toolchain.toml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Let the active main-tip compilation finish so a later release can consume
+  # its compiler outputs. GitHub retains at most one newer pending run.
+  group: tidebreak-windows-release-cache
+  cancel-in-progress: false
+
+jobs:
+  cargo-downloads:
+    name: Cargo dependency downloads
+    runs-on: windows-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+
+      - name: Fetch Cargo dependency downloads
+        run: |
+          cargo fetch --locked --target x86_64-pc-windows-msvc
+          cargo fetch --locked --target aarch64-pc-windows-msvc
+
+  warm:
+    name: Windows cache · ${{ matrix.arch }}
+    needs: cargo-downloads
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-pc-windows-msvc
+            runner: windows-latest
+          - arch: aarch64
+            target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      # GitHub throttles sccache's many small writes. Retain its existing
+      # object cache as a read-only fallback and persist build outputs below
+      # with one cache archive per architecture.
+      SCCACHE_GHA_RW_MODE: READ_ONLY
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      - name: Restore unsigned Rust build cache
+        id: rust-build-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop.exe
+            target/${{ matrix.target }}/release/tidebreak-host-broker.exe
+            target/${{ matrix.target }}/release/tidebreak.exe
+            target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
+          key: windows-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+          restore-keys: |
+            windows-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            windows-release-target-v1-${{ matrix.arch }}-
+
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/tidebreak-desktop/ui
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # whisper.cpp refuses MSVC on ARM. The cmake crate honors CMAKE_GENERATOR
+      # from the environment but not CMAKE_GENERATOR_TOOLSET, so Ninja plus
+      # clang-cl is the reliable way to keep aarch64-pc-windows-msvc while
+      # compiling the native C/C++ with Clang. This must match the release
+      # workflow exactly so the warmed CMake trees are reusable there.
+      - name: Use clang-cl for Windows ARM native code
+        if: ${{ matrix.arch == 'aarch64' }}
+        run: |
+          clang_cl=""
+          for candidate in \
+            "$(command -v clang-cl || true)" \
+            "/c/Program Files/LLVM/bin/clang-cl.exe" \
+            "/c/Program Files/LLVM/bin/clang-cl"; do
+            if [[ -n "$candidate" && -x "$candidate" ]]; then
+              clang_cl="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$clang_cl" ]]; then
+            echo "clang-cl is required to compile whisper.cpp on Windows ARM" >&2
+            exit 1
+          fi
+          if ! command -v ninja >/dev/null; then
+            echo "ninja is required to compile whisper.cpp on Windows ARM" >&2
+            exit 1
+          fi
+          clang_cl="$(cygpath -m "$clang_cl")"
+          {
+            echo "CC=$clang_cl"
+            echo "CXX=$clang_cl"
+            echo "CXXFLAGS=/EHsc"
+            echo "CMAKE_GENERATOR=Ninja"
+            echo "CMAKE_C_COMPILER=$clang_cl"
+            echo "CMAKE_CXX_COMPILER=$clang_cl"
+            echo "CMAKE_ASM_COMPILER=$clang_cl"
+          } >> "$GITHUB_ENV"
+          echo "Using $clang_cl with Ninja for Windows ARM native code"
+
+      - name: Compile without production credentials or bundles
+        id: compile
+        continue-on-error: true
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
+        with:
+          projectPath: crates/tidebreak-desktop
+          args: --target ${{ matrix.target }} --no-bundle --ci
+
+      - name: Report unsigned Rust build cache size
+        if: ${{ !cancelled() }}
+        run: |
+          du -ch \
+            target/release/{.cargo-lock,.fingerprint,build,deps} \
+            target/${{ matrix.target }}/release/{.cargo-lock,.fingerprint,build,deps} \
+            target/${{ matrix.target }}/release/tidebreak-desktop.exe \
+            target/${{ matrix.target }}/release/tidebreak-host-broker.exe \
+            target/${{ matrix.target }}/release/tidebreak.exe \
+            target/${{ matrix.target }}/release/tidebreak_desktop_lib.* \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe \
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe \
+            2>/dev/null | tail -1 || true
+
+      - name: Save unsigned Rust build cache
+        if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop.exe
+            target/${{ matrix.target }}/release/tidebreak-host-broker.exe
+            target/${{ matrix.target }}/release/tidebreak.exe
+            target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
+          key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
+
+      - name: Require a successful cache-warm compilation
+        if: ${{ steps.compile.outcome != 'success' }}
+        run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -925,16 +925,6 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare App Store Connect key
-        env:
-          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
-        run: |
-          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          echo "APPLE_API_KEY=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
-          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
-
       - name: Import Developer ID certificate
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -993,7 +983,11 @@ jobs:
             fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify(config));
           '
 
-      - name: Bundle, sign, and notarize the prepared Tauri app
+      # The App Store Connect key is deliberately not in the environment yet:
+      # without notary credentials, Tauri signs the app and DMG but skips its
+      # own notarization submission. One submission of the DMG below covers
+      # the nested app too, halving the Apple round trips.
+      - name: Bundle and sign the prepared Tauri app
         working-directory: crates/tidebreak-desktop
         run: |
           tauri bundle \
@@ -1002,7 +996,19 @@ jobs:
             --bundles app,dmg \
             --ci
 
-      - name: Notarize and staple the DMG
+      - name: Prepare App Store Connect key
+        env:
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          echo "APPLE_API_KEY=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
+          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      # Notarizing the DMG registers tickets for the DMG and the identically
+      # signed app inside it, so both staples come from this one submission.
+      - name: Notarize the DMG, then staple the DMG and app
         env:
           RELEASE_TARGET: universal-apple-darwin
         run: |
@@ -1013,6 +1019,12 @@ jobs:
             exit 1
           }
           dmg_path="${dmg_paths[0]}"
+          app_paths=("$target_dir/$RELEASE_TARGET/release/bundle/macos/"*.app)
+          (( ${#app_paths[@]} == 1 )) && [[ -d "${app_paths[0]}" ]] || {
+            echo "Expected exactly one app bundle to staple for $RELEASE_TARGET" >&2
+            exit 1
+          }
+          app_path="${app_paths[0]}"
 
           submission_output="$(xcrun notarytool submit "$dmg_path" \
             --key "$APPLE_API_KEY_PATH" \
@@ -1036,6 +1048,8 @@ jobs:
 
           xcrun stapler staple "$dmg_path"
           xcrun stapler validate "$dmg_path"
+          xcrun stapler staple "$app_path"
+          xcrun stapler validate "$app_path"
 
       - name: Verify and collect signed artifacts
         env:
@@ -1244,6 +1258,9 @@ jobs:
           key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
             windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            windows-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+            windows-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            windows-release-target-v1-${{ matrix.arch }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -1258,8 +1275,10 @@ jobs:
           add-rust-environment-hash-key: "false"
           cache-bin: false
           cache-targets: false
-          # No cache-warming workflow exists for Windows, so this
-          # credential-free prerequisite is the registry cache's single writer.
+          # The Warm Windows release cache workflow writes this registry cache
+          # on pushes to main. This credential-free prerequisite stays a
+          # fallback writer for releases cut before the warm run finishes;
+          # a duplicate save against an existing key is skipped harmlessly.
           save-if: true
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -1644,6 +1663,45 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.validate.outputs.sha }}
+
+      # This credentialed job never saves a cache (a default-branch cache
+      # writer must not run code from a manually dispatched release), but it
+      # restores the archive the Warm Linux release cache workflow saved from
+      # main so the packaging build recompiles as little as possible.
+      - name: Restore unsigned Rust build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/tidebreak
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}
+          key: linux-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+          restore-keys: |
+            linux-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            linux-release-target-v1-${{ matrix.arch }}-
+
+      # The shipped binaries must be produced by this job, not lifted from a
+      # cache archive; only intermediate compiler outputs are worth keeping.
+      - name: Discard restored product binaries
+        run: |
+          rm -rf \
+            target/${{ matrix.target }}/release/tidebreak-desktop \
+            target/${{ matrix.target }}/release/tidebreak-host-broker \
+            target/${{ matrix.target }}/release/tidebreak \
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.* \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }} \
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}
 
       - name: Install Linux packaging dependencies
         timeout-minutes: 8
@@ -2111,7 +2169,7 @@ jobs:
         if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
         run: |
           release_prefix="tidebreak/releases/v$TIDEBREAK_VERSION"
-          head_error="$RUNNER_TEMP/release-head-error"
+          export release_prefix
 
           content_type() {
             case "$1" in
@@ -2128,9 +2186,11 @@ jobs:
           }
 
           upload_immutable() {
+            set -euo pipefail
             local file="$1"
             local key="$2"
-            local digest remote_digest error
+            local head_error digest remote_digest error
+            head_error="$(mktemp)"
             digest="$(sha256sum "$file" | cut -d ' ' -f 1)"
             if remote_digest="$(aws s3api head-object \
               --bucket "$DOWNLOADS_S3_BUCKET" \
@@ -2154,11 +2214,14 @@ jobs:
               --cache-control 'public,max-age=31536000,immutable' \
               --metadata "sha256=$digest"
           }
+          export -f content_type upload_immutable
 
-          while IFS= read -r -d '' file; do
-            relative="${file#dist/}"
-            upload_immutable "$file" "$release_prefix/$relative"
-          done < <(find dist -type f ! -name manifest.json ! -name latest.json -print0)
+          # Upload the payload files in parallel; a failure in any child fails
+          # this step through xargs. The versioned manifest.json still uploads
+          # last and alone, so the resume preflight can only ever see a
+          # complete immutable prefix behind an existing manifest.
+          find dist -type f ! -name manifest.json ! -name latest.json -print0 \
+            | xargs -0 -n 1 -P 8 bash -c 'upload_immutable "$1" "$release_prefix/${1#dist/}"' _
           upload_immutable dist/manifest.json "$release_prefix/manifest.json"
 
       - name: Publish latest release metadata
@@ -2172,6 +2235,9 @@ jobs:
             --content-type application/json \
             --cache-control 'no-cache, max-age=0'
 
+      # Do not wait for the invalidation to complete: propagation takes 5-15
+      # minutes, the smoke test below cache-busts its own reads, and real
+      # clients only ever race a short no-cache TTL on these two objects.
       - name: Invalidate release metadata
         id: invalidate
         run: |
@@ -2181,9 +2247,6 @@ jobs:
             --query Invalidation.Id \
             --output text)"
           echo "id=$invalidation_id" >> "$GITHUB_OUTPUT"
-          aws cloudfront wait invalidation-completed \
-            --distribution-id "$DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID" \
-            --id "$invalidation_id"
 
       - name: Smoke test hosted release
         run: |

--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -323,16 +323,6 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare App Store Connect key
-        env:
-          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
-        run: |
-          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          echo "APPLE_API_KEY=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
-          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
-
       - name: Import Developer ID certificate
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -401,7 +391,11 @@ jobs:
             fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify(overlay));
           '
 
-      - name: Build, sign, and notarize the staging app
+      # The App Store Connect key is deliberately not in the environment yet:
+      # without notary credentials, Tauri signs the app and DMG but skips its
+      # own notarization submission. One submission of the DMG below covers
+      # the nested app too, halving the Apple round trips.
+      - name: Build and sign the staging app
         id: tauri
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
@@ -411,7 +405,19 @@ jobs:
             --config ${{ runner.temp }}/tidebreak-staging.json
             --bundles app,dmg
 
-      - name: Notarize and staple the DMG
+      - name: Prepare App Store Connect key
+        env:
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          echo "APPLE_API_KEY=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
+          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      # Notarizing the DMG registers tickets for the DMG and the identically
+      # signed app inside it, so both staples come from this one submission.
+      - name: Notarize the DMG, then staple the DMG and app
         env:
           RELEASE_TARGET: universal-apple-darwin
         run: |
@@ -422,6 +428,12 @@ jobs:
             exit 1
           }
           dmg_path="${dmg_paths[0]}"
+          app_paths=("$target_dir/$RELEASE_TARGET/release/bundle/macos/"*.app)
+          (( ${#app_paths[@]} == 1 )) && [[ -d "${app_paths[0]}" ]] || {
+            echo "Expected exactly one app bundle to staple for $RELEASE_TARGET" >&2
+            exit 1
+          }
+          app_path="${app_paths[0]}"
 
           submission_output="$(xcrun notarytool submit "$dmg_path" \
             --key "$APPLE_API_KEY_PATH" \
@@ -445,6 +457,8 @@ jobs:
 
           xcrun stapler staple "$dmg_path"
           xcrun stapler validate "$dmg_path"
+          xcrun stapler staple "$app_path"
+          xcrun stapler validate "$app_path"
 
       - name: Verify and collect signed artifacts
         env:
@@ -750,6 +764,9 @@ jobs:
             --cache-control 'no-cache, max-age=0'
           echo "advance=true" >> "$GITHUB_OUTPUT"
 
+      # Do not wait for the invalidation to complete: propagation takes 5-15
+      # minutes, the smoke test below cache-busts its own reads, and staging
+      # clients only ever race a short no-cache TTL on these two objects.
       - name: Invalidate staging metadata
         if: ${{ steps.advance.outputs.advance == 'true' }}
         id: invalidate
@@ -760,9 +777,6 @@ jobs:
             --query Invalidation.Id \
             --output text)"
           echo "id=$invalidation_id" >> "$GITHUB_OUTPUT"
-          aws cloudfront wait invalidation-completed \
-            --distribution-id "$DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID" \
-            --id "$invalidation_id"
 
       - name: Smoke test hosted staging
         if: ${{ steps.advance.outputs.advance == 'true' }}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -170,7 +170,8 @@ automatic.
 7. The macOS and Windows production jobs verify those archives before loading
    signing material, then run `tauri bundle` against the prepared binaries.
    They do not compile Rust or rebuild the frontend. The macOS job signs the app
-   with the Developer ID identity, notarizes and staples the app and DMG,
+   with the Developer ID identity, submits the DMG to Apple's notary service
+   once, staples the resulting ticket to both the DMG and the app,
    verifies them with Apple tooling, and creates a signed Tauri updater archive.
    Parallel Windows and Linux jobs produce x86_64 and ARM64 NSIS, AppImage, and
    Debian packages; every package is signed with the Tauri updater key after
@@ -201,8 +202,9 @@ automatic.
     frozen title and notes and publish the draft. GitHub then locks the release
     tag and assets. The workflow uses GitHub's resulting publication timestamp
     to create and attest the hosted manifest, uploads immutable versioned files,
-    advances the public manifests, invalidates their CDN paths, and smoke-tests
-    the hosted release. If a prior attempt already uploaded the complete
+    advances the public manifests, requests CDN invalidation of their paths
+    without waiting for propagation, and smoke-tests
+    the hosted release with cache-busting reads. If a prior attempt already uploaded the complete
     immutable prefix, a new dispatch validates and reuses those bytes, skips the
     desktop build, and resumes only mutable metadata publication, CDN
     invalidation, and smoke testing. If GitHub publication succeeded but hosted
@@ -255,14 +257,15 @@ installer itself, so no separate updater archive exists on Windows. Release
 builds check that authenticated feed and ask before restarting into the new
 installer.
 
-Unlike macOS, no cache-warming workflow exists for Windows: the credential-free
-`prepare_windows` job compiles the tag from scratch (or from an earlier
-release's prepared cache) and is the single writer of the Windows Cargo
-registry and prepared-build caches. The Windows ARM job keeps the
-`aarch64-pc-windows-msvc` Rust target and compiles whisper.cpp with Ninja plus
-`clang-cl`, because ggml refuses MSVC on ARM. The credential-free prepare job
-restores only caches for the same commit SHA, so a failed MSVC CMake tree from
-an earlier attempt cannot be reused after that compiler switch. After the
+Like macOS, Windows has a cache-warming workflow: **Warm Windows release
+cache** compiles each architecture on pushes to `main` and saves the compiler
+outputs, so the credential-free `prepare_windows` job usually restores a warm
+archive instead of compiling the tag from scratch. That prepare job remains a
+fallback writer of the Windows Cargo registry cache and saves the
+release-specific prepared cache. The Windows ARM jobs keep the
+`aarch64-pc-windows-msvc` Rust target and compile whisper.cpp with Ninja plus
+`clang-cl`, because ggml refuses MSVC on ARM; the warm workflow uses the same
+compiler setup so its CMake trees stay reusable in the release. After the
 compile, the job transfers only the final binary, sidecars, and Tauri
 configuration to the production job. The production job verifies and bundles
 those files without installing a compiler or rebuilding the frontend.
@@ -291,7 +294,10 @@ capability checks; packaging the desktop does not claim those features on
 Linux.
 
 The Linux packaging job uses compiler and Cargo download caches in read-only
-mode and does not enable pnpm caching. It builds both formats from the validated
+mode and does not enable pnpm caching. It restores the unsigned build archive
+that **Warm Linux release cache** saves from `main`, discards any restored
+product binaries so the shipped bytes are always produced by the release job,
+and never saves a cache of its own. It builds both formats from the validated
 release tag before the updater private key enters the step environment, then
 signs and collects only the completed package bytes. This avoids exposing a
 default-branch cache writer to code executed during a manually dispatched
@@ -364,9 +370,10 @@ older installed binaries have no updater and therefore cannot discover it.
 Users must install that first updater-enabled release manually; subsequent
 releases can advance automatically.
 
-**Warm macOS release cache** runs independently after relevant changes land on
-`main`. A short prerequisite job saves Cargo dependency downloads before the
-build job compiles the desktop app with `--no-bundle`. This keeps a later UI
+**Warm macOS release cache**, **Warm Windows release cache**, and **Warm Linux
+release cache** run independently after relevant changes land on `main`. In
+each workflow a short prerequisite job saves Cargo dependency downloads before
+the build job compiles the desktop app with `--no-bundle`. This keeps a later UI
 setup or compilation failure from also losing newly downloaded Cargo
 dependencies. Each architecture then saves one unsigned archive containing
 Cargo fingerprints, build-script outputs, compiled dependency files, and the
@@ -376,16 +383,18 @@ those final unsigned products lets an exact-source build skip the otherwise
 expensive desktop relink. The archive is saved before a failed compile is
 reported, so successful partial work remains reusable. None of these jobs load
 the `desktop-production` environment, sign, or publish. Because cache warming
-has its own workflow and failure boundary, a later signing, notarization, or
+has its own workflows and failure boundary, a later signing, notarization, or
 publication failure cannot prevent that main-tip cache run from finishing. If
-the shared cache is empty or has been evicted, manually run **Warm macOS release
-cache** from `main`; the production release workflow also compiles the exact tag
+a shared cache is empty or has been evicted, manually run the matching warm
+workflow from `main`; the production release workflow also compiles the exact tag
 and product version in a credential-free prerequisite. That prerequisite saves
 its release-specific unsigned cache before reporting a compile failure. After a
 successful compile, it uploads the final binary, universal sidecars, and Tauri
 configuration in a one-day, run-scoped artifact. The `desktop-production` job
 verifies that artifact before it loads signing material, then packages those
-exact binaries without compiling again.
+exact binaries without compiling again. Six warm archives plus the
+release-specific ones compete for the repository's shared cache budget, so an
+evicted archive costs a slower release, never a broken one.
 
 To use a larger macOS runner for production compiles, set the repository
 variable `PRODUCTION_MACOS_RUNNER` to a provisioned ARM64 organization runner
@@ -524,12 +533,12 @@ Treat the release workflow as public even while the repository is private:
   Apple key files. `sccache` remains a read-only fallback because GitHub
   throttles its many small writes; the separate Cargo download cache retains
   `cache-targets: false`.
-- The independent cache-warm workflow runs only for relevant pushes to `main`
-  or an explicit manual dispatch. It has no production environment and receives
-  no Apple, Tauri, or AWS credentials. It fetches Cargo dependencies early and
-  stops after compiling with `--no-bundle`; it cannot sign or publish a
-  release. Signing, notarization, or publication failures therefore do not
-  cancel or roll back the separate main-tip cache run.
+- The independent cache-warm workflows run only for relevant pushes to `main`
+  or an explicit manual dispatch. They have no production environment and
+  receive no Apple, Tauri, or AWS credentials. Each fetches Cargo dependencies
+  early and stops after compiling with `--no-bundle`; none can sign or publish
+  a release. Signing, notarization, or publication failures therefore do not
+  cancel or roll back the separate main-tip cache runs.
 - Production artifacts are collected only after code-signing, notarization,
   stapling, and local verification succeed. The temporary App Store Connect key
   is removed even when the build fails.
@@ -539,9 +548,12 @@ Treat the release workflow as public even while the repository is private:
   can skip rebuilding. The publisher then derives `latest.json` from that
   authoritative manifest and reruns metadata publication, CloudFront
   invalidation, and the complete hosted smoke test.
-- Tauri notarizes and staples the app bundle. The workflow separately submits
-  the signed DMG to Apple's notary service, requires an accepted result, and
-  staples its ticket before artifact verification or upload.
+- Notarization happens once per build: Tauri signs the app and DMG without
+  notary credentials, then the workflow submits the signed DMG to Apple's
+  notary service, requires an accepted result, and staples that one ticket to
+  both the DMG and the identically signed app bundle before artifact
+  verification or upload. The App Store Connect key reaches the job
+  environment only after bundling.
 
 Public source does not eliminate the need for operational controls. Restrict
 who can publish releases and change Actions configuration, protect `main`, and


### PR DESCRIPTION
## What changed

This change adds credential-free Windows and Linux cache warmers, splits compilation from release packaging, notarizes the signed disk image once, and shortens the publish tail without changing the manifest-last rule. It also makes the final policy test require the new packaging layout.

## Validation

`TIDEBREAK_SKIP_DOCKER_CONTEXT_PROBE=1 node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs` passes 82 tests and skips the two Docker-daemon probes. GitHub Actions runs the full suite.

## Compatibility and risk

Release artifact names and the updater contract stay unchanged. Production credentials remain isolated to packaging and publish jobs.