### PR TITLE
feat(voice): extract whisper.cpp into a lazily downloaded helper binary

### DIFF
--- a/.github/workflows/cache-windows.yml
+++ b/.github/workflows/cache-windows.yml
@@ -131,44 +131,6 @@ jobs:
         working-directory: crates/tidebreak-desktop/ui
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      # whisper.cpp refuses MSVC on ARM. The cmake crate honors CMAKE_GENERATOR
-      # from the environment but not CMAKE_GENERATOR_TOOLSET, so Ninja plus
-      # clang-cl is the reliable way to keep aarch64-pc-windows-msvc while
-      # compiling the native C/C++ with Clang. This must match the release
-      # workflow exactly so the warmed CMake trees are reusable there.
-      - name: Use clang-cl for Windows ARM native code
-        if: ${{ matrix.arch == 'aarch64' }}
-        run: |
-          clang_cl=""
-          for candidate in \
-            "$(command -v clang-cl || true)" \
-            "/c/Program Files/LLVM/bin/clang-cl.exe" \
-            "/c/Program Files/LLVM/bin/clang-cl"; do
-            if [[ -n "$candidate" && -x "$candidate" ]]; then
-              clang_cl="$candidate"
-              break
-            fi
-          done
-          if [[ -z "$clang_cl" ]]; then
-            echo "clang-cl is required to compile whisper.cpp on Windows ARM" >&2
-            exit 1
-          fi
-          if ! command -v ninja >/dev/null; then
-            echo "ninja is required to compile whisper.cpp on Windows ARM" >&2
-            exit 1
-          fi
-          clang_cl="$(cygpath -m "$clang_cl")"
-          {
-            echo "CC=$clang_cl"
-            echo "CXX=$clang_cl"
-            echo "CXXFLAGS=/EHsc"
-            echo "CMAKE_GENERATOR=Ninja"
-            echo "CMAKE_C_COMPILER=$clang_cl"
-            echo "CMAKE_CXX_COMPILER=$clang_cl"
-            echo "CMAKE_ASM_COMPILER=$clang_cl"
-          } >> "$GITHUB_ENV"
-          echo "Using $clang_cl with Ninja for Windows ARM native code"
-
       - name: Compile without production credentials or bundles
         id: compile
         continue-on-error: true

--- a/.github/workflows/publish-whisper-helper.yml
+++ b/.github/workflows/publish-whisper-helper.yml
@@ -1,0 +1,283 @@
+name: Publish whisper helper
+
+# Builds and publishes the tidebreak-whisper transcription helper the desktop
+# app downloads on demand (see crates/tidebreak-desktop/src/whisper_install.rs).
+# Run this manually after bumping the version in crates/tidebreak-whisper:
+# the hosted files are immutable, so republishing different bytes under an
+# already-published version fails instead of silently swapping them. Move the
+# desktop's pinned HELPER_VERSION only after this workflow succeeds.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tidebreak-publish-whisper-helper
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: resolve helper version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Read the helper crate version
+        id: version
+        run: |
+          version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -er '.packages[] | select(.name == "tidebreak-whisper") | .version')"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "Unexpected tidebreak-whisper version: $version" >&2
+            exit 1
+          }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: build · ${{ matrix.target }}
+    needs: version
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+          - target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+          # The x86_64 Linux baseline matches the app's: Ubuntu 22.04 keeps
+          # the glibc requirement no newer than the packaged desktop's.
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      # whisper.cpp refuses MSVC on ARM. The cmake crate honors CMAKE_GENERATOR
+      # from the environment but not CMAKE_GENERATOR_TOOLSET, so Ninja plus
+      # clang-cl is the reliable way to keep aarch64-pc-windows-msvc while
+      # compiling the native C/C++ with Clang.
+      - name: Use clang-cl for Windows ARM native code
+        if: ${{ matrix.target == 'aarch64-pc-windows-msvc' }}
+        run: |
+          clang_cl=""
+          for candidate in \
+            "$(command -v clang-cl || true)" \
+            "/c/Program Files/LLVM/bin/clang-cl.exe" \
+            "/c/Program Files/LLVM/bin/clang-cl"; do
+            if [[ -n "$candidate" && -x "$candidate" ]]; then
+              clang_cl="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$clang_cl" ]]; then
+            echo "clang-cl is required to compile whisper.cpp on Windows ARM" >&2
+            exit 1
+          fi
+          if ! command -v ninja >/dev/null; then
+            echo "ninja is required to compile whisper.cpp on Windows ARM" >&2
+            exit 1
+          fi
+          clang_cl="$(cygpath -m "$clang_cl")"
+          {
+            echo "CC=$clang_cl"
+            echo "CXX=$clang_cl"
+            echo "CXXFLAGS=/EHsc"
+            echo "CMAKE_GENERATOR=Ninja"
+            echo "CMAKE_C_COMPILER=$clang_cl"
+            echo "CMAKE_CXX_COMPILER=$clang_cl"
+            echo "CMAKE_ASM_COMPILER=$clang_cl"
+          } >> "$GITHUB_ENV"
+          echo "Using $clang_cl with Ninja for Windows ARM native code"
+
+      - name: Build the helper
+        run: cargo build --release --locked -p tidebreak-whisper --target "${{ matrix.target }}"
+
+      - name: Collect the artifact under its published name
+        env:
+          RELEASE_TARGET: ${{ matrix.target }}
+        run: |
+          extension=""
+          [[ "$RELEASE_TARGET" != *windows* ]] || extension=".exe"
+          built="target/$RELEASE_TARGET/release/tidebreak-whisper$extension"
+          [[ -s "$built" ]] || {
+            echo "Built helper is missing or empty: $built" >&2
+            exit 1
+          }
+          mkdir -p dist
+          cp "$built" "dist/tidebreak-whisper-$RELEASE_TARGET$extension"
+
+      - name: Upload the built helper
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-whisper-${{ matrix.target }}-${{ github.run_id }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: sign and publish
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: desktop-production
+      url: https://downloads.brightwave.io/tidebreak/manifest.json
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      HELPER_VERSION: ${{ needs.version.outputs.version }}
+      AWS_REGION: ${{ vars.DOWNLOADS_AWS_REGION || 'us-east-1' }}
+      AWS_RELEASE_ROLE_ARN: ${{ vars.AWS_RELEASE_ROLE_ARN }}
+      DOWNLOADS_S3_BUCKET: ${{ vars.DOWNLOADS_S3_BUCKET }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate publishing configuration
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          missing=()
+          for name in \
+            AWS_RELEASE_ROLE_ARN \
+            DOWNLOADS_S3_BUCKET \
+            TAURI_SIGNING_PRIVATE_KEY \
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing whisper-helper publishing configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Download the built helpers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: tidebreak-whisper-*-${{ github.run_id }}
+          merge-multiple: true
+          path: dist
+
+      - name: Require every published target
+        run: |
+          expected="$(printf '%s\n' \
+            dist/tidebreak-whisper-aarch64-apple-darwin \
+            dist/tidebreak-whisper-x86_64-apple-darwin \
+            dist/tidebreak-whisper-x86_64-pc-windows-msvc.exe \
+            dist/tidebreak-whisper-aarch64-pc-windows-msvc.exe \
+            dist/tidebreak-whisper-x86_64-unknown-linux-gnu \
+            dist/tidebreak-whisper-aarch64-unknown-linux-gnu \
+            | LC_ALL=C sort)"
+          actual="$(find dist -type f | LC_ALL=C sort)"
+          [[ "$actual" = "$expected" ]] || {
+            echo "Published helper set is incomplete or unexpected:" >&2
+            printf '%s\n' "$actual" >&2
+            exit 1
+          }
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
+      - name: Install pinned Tauri bundler
+        run: |
+          pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts
+          echo "$GITHUB_WORKSPACE/.github/tauri-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      # The desktop verifies the helper with the committed updater public key
+      # before it can run, so these signatures are what make the download
+      # trustworthy — the same authenticity bar as an app update.
+      - name: Sign every helper with the updater key
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          while IFS= read -r -d '' file; do
+            rm -f "$file.sig"
+            tauri signer sign "$file"
+            [[ -s "$file.sig" ]] || {
+              echo "Tauri updater signature is empty: $file.sig" >&2
+              exit 1
+            }
+          done < <(find dist -type f ! -name '*.sig' -print0)
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: ${{ env.AWS_RELEASE_ROLE_ARN }}
+          role-session-name: tidebreak-whisper-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload immutable helper files
+        run: |
+          prefix="tidebreak/tools/whisper-helper/v$HELPER_VERSION"
+          head_error="$RUNNER_TEMP/helper-head-error"
+
+          upload_immutable() {
+            local file="$1"
+            local key="$2"
+            local content_type="$3"
+            local digest remote_digest error
+            digest="$(sha256sum "$file" | cut -d ' ' -f 1)"
+            if remote_digest="$(aws s3api head-object \
+              --bucket "$DOWNLOADS_S3_BUCKET" \
+              --key "$key" \
+              --query Metadata.sha256 \
+              --output text 2>"$head_error")"; then
+              [[ "$remote_digest" = "$digest" ]] || {
+                echo "Refusing to overwrite immutable s3://$DOWNLOADS_S3_BUCKET/$key — bump the tidebreak-whisper version instead" >&2
+                exit 1
+              }
+              echo "Already uploaded with matching digest: $key"
+              return
+            fi
+            error="$(<"$head_error")"
+            case "$error" in
+              *404*|*Not\ Found*) ;;
+              *) printf '%s\n' "$error" >&2; exit 1 ;;
+            esac
+            aws s3 cp "$file" "s3://$DOWNLOADS_S3_BUCKET/$key" \
+              --content-type "$content_type" \
+              --cache-control 'public,max-age=31536000,immutable' \
+              --metadata "sha256=$digest"
+          }
+
+          while IFS= read -r -d '' file; do
+            upload_immutable "$file" "$prefix/${file#dist/}" application/octet-stream
+            upload_immutable "$file.sig" "$prefix/${file#dist/}.sig" text/plain
+          done < <(find dist -type f ! -name '*.sig' -print0)
+
+      - name: Smoke test the hosted helpers
+        run: |
+          base="https://downloads.brightwave.io/tidebreak/tools/whisper-helper/v$HELPER_VERSION"
+          while IFS= read -r -d '' file; do
+            name="${file#dist/}"
+            curl --fail --silent --show-error --head "$base/$name" >/dev/null
+            curl --fail --silent --show-error "$base/$name.sig" \
+              --output "$RUNNER_TEMP/hosted.sig"
+            cmp "$file.sig" "$RUNNER_TEMP/hosted.sig"
+          done < <(find dist -type f ! -name '*.sig' -print0)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1308,43 +1308,6 @@ jobs:
       - name: Verify the third-party notices match the released graph
         run: node scripts/generate-third-party-notices.mjs --check
 
-      # whisper.cpp refuses MSVC on ARM. The cmake crate honors CMAKE_GENERATOR
-      # from the environment but not CMAKE_GENERATOR_TOOLSET, so Ninja plus
-      # clang-cl is the reliable way to keep aarch64-pc-windows-msvc while
-      # compiling the native C/C++ with Clang.
-      - name: Use clang-cl for Windows ARM native code
-        if: ${{ matrix.arch == 'aarch64' }}
-        run: |
-          clang_cl=""
-          for candidate in \
-            "$(command -v clang-cl || true)" \
-            "/c/Program Files/LLVM/bin/clang-cl.exe" \
-            "/c/Program Files/LLVM/bin/clang-cl"; do
-            if [[ -n "$candidate" && -x "$candidate" ]]; then
-              clang_cl="$candidate"
-              break
-            fi
-          done
-          if [[ -z "$clang_cl" ]]; then
-            echo "clang-cl is required to compile whisper.cpp on Windows ARM" >&2
-            exit 1
-          fi
-          if ! command -v ninja >/dev/null; then
-            echo "ninja is required to compile whisper.cpp on Windows ARM" >&2
-            exit 1
-          fi
-          clang_cl="$(cygpath -m "$clang_cl")"
-          {
-            echo "CC=$clang_cl"
-            echo "CXX=$clang_cl"
-            echo "CXXFLAGS=/EHsc"
-            echo "CMAKE_GENERATOR=Ninja"
-            echo "CMAKE_C_COMPILER=$clang_cl"
-            echo "CMAKE_CXX_COMPILER=$clang_cl"
-            echo "CMAKE_ASM_COMPILER=$clang_cl"
-          } >> "$GITHUB_ENV"
-          echo "Using $clang_cl with Ninja for Windows ARM native code"
-
       - name: Compile without production credentials or bundles
         id: compile
         continue-on-error: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,10 @@ changes.
 
 ## Development
 
-Desktop builds require CMake to compile the pinned whisper.cpp local voice engine (`brew install cmake` on macOS; install the `cmake` package on Linux).
+Local voice transcription runs in a separately published `tidebreak-whisper`
+helper the desktop downloads on demand, so building the desktop app itself no
+longer requires CMake. Building the helper (`cargo build -p tidebreak-whisper`)
+does, and so does the `Publish whisper helper` workflow.
 
 ```sh
 # Run the desktop app: installs the UI dependencies, then opens the window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -89,18 +89,18 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -119,9 +119,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -161,7 +161,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
 dependencies = [
  "bytes",
  "half",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -241,15 +241,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 
 [[package]]
 name = "arrow-select"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.1"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -380,7 +380,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -510,7 +510,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -577,18 +577,18 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -614,9 +614,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -684,27 +684,25 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
 dependencies = [
  "bon-macros",
- "rustversion",
 ]
 
 [[package]]
 name = "bon-macros"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "ident_case",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -721,7 +719,7 @@ checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
 ]
 
 [[package]]
@@ -734,7 +732,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -787,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
@@ -831,9 +829,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -881,7 +879,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -896,7 +894,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -917,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -1010,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -1068,9 +1066,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1079,7 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -1141,9 +1139,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -1197,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "time",
  "version_check",
@@ -1237,7 +1235,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -1250,7 +1248,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1266,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1290,9 +1288,9 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1379,7 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1389,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1438,6 +1436,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,7 +1456,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1461,7 +1469,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1472,7 +1493,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1483,14 +1504,25 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbus"
@@ -1522,12 +1554,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1539,7 +1601,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1550,7 +1612,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1571,7 +1633,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1625,7 +1687,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -1633,13 +1695,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1662,7 +1724,7 @@ checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1788,9 +1850,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
 ]
@@ -1813,7 +1875,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -1863,7 +1925,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1905,11 +1967,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1937,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -1983,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flagset"
@@ -2049,13 +2110,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2186,7 +2247,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2428,7 +2489,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2456,7 +2517,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2471,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gobject-sys"
@@ -2535,7 +2596,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2658,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "html-escape"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
+checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
 
 [[package]]
 name = "html5ever"
@@ -2684,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2694,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2704,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2729,18 +2790,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2770,7 +2831,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2808,7 +2869,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2832,9 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2846,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2859,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2873,16 +2934,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2893,15 +2955,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3069,9 +3131,9 @@ checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-docker"
@@ -3140,6 +3202,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,7 +3297,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3210,14 +3325,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3304,7 +3419,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -3456,18 +3571,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3482,9 +3597,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -3497,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -3632,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3678,7 +3793,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -3708,7 +3823,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -3720,9 +3835,9 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "memoffset",
 ]
@@ -3793,9 +3908,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -3850,7 +3965,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3869,7 +3984,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -3882,7 +3997,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3903,7 +4018,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -3914,7 +4029,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3947,7 +4062,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3974,7 +4089,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -3987,7 +4102,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3998,7 +4113,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -4010,7 +4125,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -4022,7 +4137,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -4053,7 +4168,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -4069,9 +4184,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
-version = "5.4.0"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
 dependencies = [
  "dunce",
  "is-wsl",
@@ -4173,7 +4288,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4271,9 +4386,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -4281,9 +4396,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4291,22 +4406,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -4361,7 +4476,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4392,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -4438,7 +4553,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4457,6 +4572,21 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -4482,9 +4612,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -4517,7 +4647,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4546,7 +4686,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4574,32 +4714,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -4612,7 +4730,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -4665,7 +4783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -4680,9 +4798,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
@@ -4706,7 +4824,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
  "socket2",
@@ -4716,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -4743,9 +4861,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4754,9 +4872,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4838,7 +4956,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4854,22 +4972,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4891,9 +5009,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4903,9 +5021,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4972,7 +5090,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -5101,7 +5219,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.8",
  "rkyv",
  "serde",
  "serde_json",
@@ -5129,7 +5247,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5148,9 +5266,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -5174,9 +5292,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5211,9 +5329,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5300,7 +5418,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals 0.29.1",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5312,7 +5430,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals 0.30.0",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5323,15 +5441,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sea-bae"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+checksum = "260bbc7148a8d6818ac5032a1b9970da1a68bdd723d45b12d59f7c1bf3565e24"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5373,9 +5490,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-arrow"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2eee8405f16c1f337fe3a83389361caea83c928d14dbd666a480407072c365"
+checksum = "4c800d9db902534d7d01728faf98e33d13c1d57bb8c57d8e4c518309172bddda"
 dependencies = [
  "arrow",
  "sea-query",
@@ -5412,7 +5529,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -5432,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d190cfb3bcceb8a8d7d04dee5a0c77f60c7627979cdcb47fdcb8934f009badf"
+checksum = "546040c653a705e60ec65ecd3191a809603734bebbc225775916dea9ae409b31"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -5455,7 +5572,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror 2.0.20",
 ]
 
@@ -5491,7 +5608,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5513,7 +5630,7 @@ dependencies = [
  "hkdf 0.12.4",
  "num",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.8",
  "serde",
  "sha2 0.10.9",
  "zbus 4.4.0",
@@ -5525,7 +5642,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5538,7 +5655,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5561,7 +5678,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser 0.36.0",
  "derive_more",
  "log",
@@ -5580,7 +5697,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser 0.37.0",
  "derive_more",
  "log",
@@ -5642,7 +5759,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5653,7 +5770,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5664,7 +5781,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5693,13 +5810,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5734,9 +5851,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5744,6 +5861,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
  "serde_core",
@@ -5754,14 +5872,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5794,7 +5912,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5808,9 +5926,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -5824,7 +5942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5852,7 +5970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5937,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -5995,9 +6113,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6053,9 +6171,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -6110,7 +6228,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -6123,7 +6241,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6146,7 +6264,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
@@ -6157,7 +6275,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -6189,7 +6307,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -6318,7 +6436,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6329,9 +6447,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7"
+checksum = "e45c444e496845d3f2a351146bff59aae4975b2280238df1dfaa0c7d1846f38e"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -6388,7 +6506,7 @@ name = "symphonia-core"
 version = "0.6.0"
 source = "git+https://github.com/pdeljanov/Symphonia?rev=619c6806e5122b3206b8938773a801dd4a8a5950#619c6806e5122b3206b8938773a801dd4a8a5950"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "lazy_static",
  "log",
@@ -6443,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6454,9 +6572,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6480,7 +6598,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6502,7 +6620,7 @@ version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -6538,13 +6656,13 @@ dependencies = [
 
 [[package]]
 name = "tao-macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+checksum = "5f7eeb6d99155545da6150a1795945f16ac9c178deb2a5f2e74d776107bd5849"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6660,7 +6778,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tauri-utils",
  "thiserror 2.0.20",
  "time",
@@ -6678,7 +6796,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -6758,7 +6876,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.20",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "url",
 ]
 
@@ -6797,7 +6915,7 @@ dependencies = [
  "tokio",
  "tracing",
  "windows-sys 0.60.2",
- "zbus 5.17.0",
+ "zbus 5.19.0",
 ]
 
 [[package]]
@@ -6915,7 +7033,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -6930,7 +7048,7 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -6990,7 +7108,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7001,14 +7119,14 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -7110,6 +7228,7 @@ dependencies = [
  "flate2",
  "futures",
  "libc",
+ "minisign-verify",
  "objc2",
  "objc2-foundation",
  "objc2-web-kit",
@@ -7139,7 +7258,6 @@ dependencies = [
  "unicode-general-category",
  "url",
  "uuid",
- "whisper-rs",
  "windows-sys 0.61.2",
  "zip 8.6.0",
 ]
@@ -7314,13 +7432,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tidebreak-whisper"
+version = "0.1.0"
+dependencies = [
+ "whisper-rs",
+]
+
+[[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -7330,15 +7454,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7355,9 +7479,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7365,9 +7489,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7397,13 +7521,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7418,9 +7542,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7497,9 +7621,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -7507,7 +7631,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -7563,30 +7687,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -7610,7 +7734,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -7628,7 +7752,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "http",
  "http-body",
@@ -7671,7 +7795,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7731,9 +7855,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -7777,7 +7901,7 @@ checksum = "38d90eea51bc7988ef9e674bf80a85ba6804739e535e9cab48e4bb34a8b652aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "termcolor",
 ]
 
@@ -7792,8 +7916,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
- "sha1 0.10.6",
+ "rand 0.9.5",
+ "sha1 0.10.7",
  "thiserror 2.0.20",
 ]
 
@@ -8103,9 +8227,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8117,9 +8241,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8127,9 +8251,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8137,22 +8261,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -8185,9 +8309,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8205,9 +8329,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -8274,14 +8398,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8308,7 +8432,7 @@ checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8352,9 +8476,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 
 [[package]]
 name = "winapi"
@@ -8456,7 +8580,20 @@ dependencies = [
  "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -8478,7 +8615,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8489,7 +8626,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8500,7 +8637,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8511,7 +8648,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8544,7 +8681,7 @@ checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -8566,12 +8703,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8840,9 +8995,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -8882,7 +9037,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "windows-sys 0.59.0",
 ]
 
@@ -8894,9 +9049,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wry"
@@ -9017,7 +9172,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -9045,10 +9200,10 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand 0.8.6",
+ "rand 0.8.8",
  "serde",
  "serde_repr",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "static_assertions",
  "tokio",
  "tracing",
@@ -9062,9 +9217,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.17.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -9089,10 +9244,10 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.3",
- "zbus_macros 5.17.0",
- "zbus_names 4.3.3",
- "zvariant 5.13.0",
+ "winnow 1.0.4",
+ "zbus_macros 5.19.0",
+ "zbus_names 4.3.4",
+ "zvariant 5.15.0",
 ]
 
 [[package]]
@@ -9104,23 +9259,23 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "zvariant_utils 2.1.0",
 ]
 
 [[package]]
 name = "zbus_macros"
-version = "5.17.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
- "zbus_names 4.3.3",
- "zvariant 5.13.0",
- "zvariant_utils 3.5.0",
+ "syn 3.0.4",
+ "zbus_names 4.3.4",
+ "zvariant 5.15.0",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -9136,33 +9291,42 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 1.0.3",
- "zvariant 5.13.0",
+ "winnow 1.0.4",
+ "zvariant 5.15.0",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9182,7 +9346,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -9203,14 +9367,14 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9219,9 +9383,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9230,13 +9394,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -9266,15 +9430,15 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-jpeg"
@@ -9300,16 +9464,17 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.13.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.3",
- "zvariant_derive 5.13.0",
- "zvariant_utils 3.5.0",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive 5.15.0",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -9321,21 +9486,21 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "zvariant_utils 2.1.0",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.13.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
- "zvariant_utils 3.5.0",
+ "syn 3.0.4",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -9346,18 +9511,18 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.118",
- "winnow 1.0.3",
+ "syn 3.0.4",
+ "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ symphonia = { version = "=0.6.0", default-features = false, features = ["aac", "
 opus-decoder = "=0.1.1"
 whisper-rs = "=0.16.0"
 base64 = "=0.23.1"
+minisign-verify = "=0.2.5"
 libc = "=0.2.189"
 async-stream = "=0.3.6"
 axum = { version = "=0.8.9", features = ["ws"] }

--- a/crates/tidebreak-desktop/Cargo.toml
+++ b/crates/tidebreak-desktop/Cargo.toml
@@ -36,6 +36,7 @@ cap-fs-ext.workspace = true
 cap-std.workspace = true
 futures.workspace = true
 flate2 = "=1.1.9"
+minisign-verify.workspace = true
 tidebreak-code-execution = { path = "../tidebreak-code-execution" }
 tidebreak-core = { path = "../tidebreak-core", default-features = false, features = ["keychain"] }
 tidebreak-host-broker = { path = "../tidebreak-host-broker" }
@@ -58,7 +59,6 @@ tokio-util = { workspace = true }
 unicode-general-category = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
-whisper-rs = { workspace = true }
 tempfile.workspace = true
 tar = "=0.4.46"
 zip.workspace = true

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -54,6 +54,7 @@ mod skill_import;
 mod trusted_folders;
 mod updater;
 mod voice_transcription;
+mod whisper_install;
 
 /// Connection details the webview needs to reach the API it is attached to.
 #[derive(Clone, Serialize)]

--- a/crates/tidebreak-desktop/src/voice_transcription.rs
+++ b/crates/tidebreak-desktop/src/voice_transcription.rs
@@ -2,11 +2,13 @@
 //!
 //! The renderer sends only recorded bytes to the loopback API. This native
 //! runner owns the pinned model path, download verification, media decoding,
-//! resampling, and whisper.cpp inference.
+//! and resampling. It delegates whisper.cpp inference to a separately
+//! published helper that the desktop verifies before every use.
 
 use std::collections::HashMap;
 use std::io::{Cursor, Read as _};
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt as _;
@@ -23,9 +25,9 @@ use tidebreak_server::voice_transcription::{
 };
 use tidebreak_server::{LocalVoiceError, LocalVoiceRunner, LocalVoiceState, LocalVoiceStatus};
 use tokio::io::AsyncWriteExt as _;
-use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
 const WHISPER_SAMPLE_RATE: u32 = 16_000;
+const HELPER_RESULT_PREFIX: &str = "TIDEBREAK_WHISPER_BYTES=";
 
 fn model_version(model: &LocalVoiceModel) -> String {
     format!("whisper.cpp-{LOCAL_VOICE_REPO_COMMIT}-{}", model.id)
@@ -248,52 +250,99 @@ impl LocalVoiceRunner for DesktopLocalVoiceRunner {
         self.ensure_installed(model)
             .await
             .map_err(LocalVoiceError::Runner)?;
-        let path = self.model_path(model);
+        let model_path = self.model_path(model);
         let language = if model.english_only { "en" } else { "auto" };
         let content_type = content_type.to_owned();
-        tokio::task::spawn_blocking(move || {
-            transcribe_blocking(&path, language, &content_type, audio)
-        })
-        .await
-        .map_err(|_| {
-            LocalVoiceError::Runner(
-                "Local voice transcription worker stopped unexpectedly".to_owned(),
-            )
-        })?
+        let samples = tokio::task::spawn_blocking(move || decode_audio(&content_type, audio))
+            .await
+            .map_err(|_| {
+                LocalVoiceError::Runner("Local voice audio decoder stopped unexpectedly".to_owned())
+            })??;
+        let helper = crate::whisper_install::ensure_helper(&self.data_dir)
+            .await
+            .map_err(LocalVoiceError::Runner)?;
+        transcribe_with_helper(&helper, &model_path, language, &samples).await
     }
 }
 
-fn transcribe_blocking(
+async fn transcribe_with_helper(
+    helper: &Path,
     model: &Path,
     language: &str,
-    content_type: &str,
-    audio: Vec<u8>,
+    samples: &[f32],
 ) -> Result<String, LocalVoiceError> {
-    let samples = decode_audio(content_type, audio)?;
-    let context = WhisperContext::new_with_params(model, WhisperContextParameters::default())
-        .map_err(|_| LocalVoiceError::Runner("Could not load the local voice model".to_owned()))?;
-    let mut state = context.create_state().map_err(|_| {
-        LocalVoiceError::Runner("Could not initialize local voice transcription".to_owned())
+    let input = encode_samples(samples);
+    let input_len = input.len();
+    let mut command = tokio::process::Command::new(helper);
+    command
+        .arg("--model")
+        .arg(model)
+        .arg("--language")
+        .arg(language)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command.spawn().map_err(|_| {
+        LocalVoiceError::Runner("Could not start the local voice helper".to_owned())
     })?;
-    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-    // "auto" asks whisper to detect the language; the English-only models
-    // reject anything else, so the catalog decides which is passed.
-    params.set_language(Some(language));
-    params.set_translate(false);
-    params.set_no_context(true);
-    params.set_print_progress(false);
-    params.set_print_realtime(false);
-    params.set_print_timestamps(false);
-    state
-        .full(params, &samples)
-        .map_err(|_| LocalVoiceError::Runner("Local voice transcription failed".to_owned()))?;
-    let mut text = String::new();
-    for segment in state.as_iter() {
-        text.push_str(&segment.to_str_lossy().map_err(|_| {
-            LocalVoiceError::Runner("Local voice transcription returned invalid text".to_owned())
-        })?);
+    let mut stdin = child.stdin.take().ok_or_else(|| {
+        LocalVoiceError::Runner("Could not open the local voice helper input".to_owned())
+    })?;
+    let write_input = async move {
+        stdin.write_all(&input).await?;
+        stdin.shutdown().await
+    };
+    let (write_result, output_result) = tokio::join!(write_input, child.wait_with_output());
+    let output = output_result.map_err(|_| {
+        LocalVoiceError::Runner("The local voice helper stopped unexpectedly".to_owned())
+    })?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        let detail = detail.trim();
+        let message = if detail.is_empty() {
+            format!("Local voice transcription failed ({})", output.status)
+        } else {
+            format!("Local voice transcription failed: {detail}")
+        };
+        return Err(LocalVoiceError::Runner(message));
+    }
+    write_result.map_err(|_| {
+        LocalVoiceError::Runner("Could not send audio to the local voice helper".to_owned())
+    })?;
+    decode_helper_output(output.stdout, input_len)
+}
+
+fn decode_helper_output(
+    stdout: Vec<u8>,
+    expected_input_bytes: usize,
+) -> Result<String, LocalVoiceError> {
+    let result = String::from_utf8(stdout).map_err(|_| {
+        LocalVoiceError::Runner("Local voice transcription returned invalid text".to_owned())
+    })?;
+    let (receipt, text) = result.split_once('\n').ok_or_else(|| {
+        LocalVoiceError::Runner("Local voice helper returned an invalid result".to_owned())
+    })?;
+    let consumed = receipt
+        .strip_prefix(HELPER_RESULT_PREFIX)
+        .and_then(|value| value.parse::<usize>().ok())
+        .ok_or_else(|| {
+            LocalVoiceError::Runner("Local voice helper returned an invalid result".to_owned())
+        })?;
+    if consumed != expected_input_bytes {
+        return Err(LocalVoiceError::Runner(format!(
+            "Local voice helper consumed {consumed} of {expected_input_bytes} audio bytes"
+        )));
     }
     Ok(text.trim().to_owned())
+}
+
+fn encode_samples(samples: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(std::mem::size_of_val(samples));
+    for sample in samples {
+        bytes.extend_from_slice(&sample.to_le_bytes());
+    }
+    bytes
 }
 
 fn decode_audio(content_type: &str, audio: Vec<u8>) -> Result<Vec<f32>, LocalVoiceError> {
@@ -448,6 +497,102 @@ mod tests {
     }
 
     #[test]
+    fn helper_input_is_little_endian_f32_pcm() {
+        assert_eq!(
+            encode_samples(&[1.0, -0.5]),
+            [0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0xbf]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn helper_process_receives_the_pinned_protocol() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let model = dir.path().join("model.bin");
+        std::fs::write(&model, b"model").expect("model");
+        let helper = dir.path().join("fake-whisper-helper");
+        std::fs::write(
+            &helper,
+            r#"#!/bin/sh
+if [ "$#" -ne 4 ] || [ "$1" != "--model" ] || [ ! -f "$2" ] || [ "$3" != "--language" ] || [ "$4" != "en" ]; then
+  echo "unexpected helper arguments" >&2
+  exit 2
+fi
+hex="$(od -An -tx1 | tr -d '[:space:]')"
+if [ "$hex" != "0000803f000000bf" ]; then
+  echo "unexpected PCM bytes: $hex" >&2
+  exit 3
+fi
+printf 'TIDEBREAK_WHISPER_BYTES=8\n helper transcript '
+"#,
+        )
+        .expect("helper");
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755))
+            .expect("permissions");
+
+        assert_eq!(
+            transcribe_with_helper(&helper, &model, "en", &[1.0, -0.5])
+                .await
+                .expect("transcript"),
+            "helper transcript"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn helper_failure_preserves_stderr_when_stdin_closes_early() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let model = dir.path().join("model.bin");
+        std::fs::write(&model, b"model").expect("model");
+        let helper = dir.path().join("failing-whisper-helper");
+        std::fs::write(
+            &helper,
+            "#!/bin/sh\necho 'could not load the voice model' >&2\nexit 1\n",
+        )
+        .expect("helper");
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755))
+            .expect("permissions");
+
+        let error = transcribe_with_helper(&helper, &model, "en", &[1.0, -0.5])
+            .await
+            .expect_err("helper failure");
+        assert_eq!(
+            error.message(),
+            "Local voice transcription failed: could not load the voice model"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn helper_success_requires_a_complete_input_receipt() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let model = dir.path().join("model.bin");
+        std::fs::write(&model, b"model").expect("model");
+        let helper = dir.path().join("truncating-whisper-helper");
+        std::fs::write(
+            &helper,
+            "#!/bin/sh\nprintf 'TIDEBREAK_WHISPER_BYTES=0\\npartial transcript'\n",
+        )
+        .expect("helper");
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755))
+            .expect("permissions");
+
+        let error = transcribe_with_helper(&helper, &model, "en", &[1.0, -0.5])
+            .await
+            .expect_err("incomplete helper input");
+        assert_eq!(
+            error.message(),
+            "Local voice helper consumed 0 of 8 audio bytes"
+        );
+    }
+
+    #[test]
     fn marker_must_match_the_exact_pinned_model() {
         let dir = tempfile::tempdir().unwrap();
         let runner = DesktopLocalVoiceRunner::new(dir.path().to_owned());
@@ -497,13 +642,13 @@ mod tests {
     }
 
     /// Drives a second catalog entry through the real install path: download,
-    /// SHA-256 verification, marker, and inference on a recording. Ignored
-    /// because it fetches 57 MB; run it when the catalog or the runner's
-    /// per-model layout changes.
+    /// SHA-256 verification, marker, and helper inference on a recording.
+    /// Ignored because it fetches the model and the published helper; run it
+    /// when the catalog or either side of the helper protocol changes.
     ///
     /// `cargo test -p tidebreak-desktop installs_and_transcribes -- --ignored`
     #[tokio::test]
-    #[ignore = "downloads a catalog model over the network"]
+    #[ignore = "downloads a catalog model and the voice helper over the network"]
     async fn installs_and_transcribes_with_a_second_catalog_model() {
         let dir = tempfile::tempdir().unwrap();
         let runner = DesktopLocalVoiceRunner::new(dir.path().to_owned());
@@ -548,20 +693,21 @@ mod tests {
         assert!(runner.install("whisper-imaginary").await.is_err());
     }
 
-    #[test]
+    #[tokio::test]
     #[ignore = "downloads the pinned model and runs real local inference"]
-    fn transcribes_real_webm_and_mp4_fixtures() {
+    async fn transcribes_real_webm_and_mp4_fixtures() {
         let webm = std::env::var("TIDEBREAK_TEST_VOICE_WEBM").expect("webm fixture path");
         let mp4 = std::env::var("TIDEBREAK_TEST_VOICE_MP4").expect("mp4 fixture path");
-        let model = std::env::var("TIDEBREAK_TEST_VOICE_MODEL").expect("model path");
+        let model = PathBuf::from(std::env::var("TIDEBREAK_TEST_VOICE_MODEL").expect("model path"));
+        let helper = PathBuf::from(
+            std::env::var(crate::whisper_install::HELPER_PATH_ENV).expect("helper path"),
+        );
         for (mime, path) in [("audio/webm", webm), ("audio/mp4", mp4)] {
-            let text = transcribe_blocking(
-                Path::new(&model),
-                "en",
-                mime,
-                std::fs::read(path).expect("voice fixture"),
-            )
-            .expect("local transcription");
+            let samples = decode_audio(mime, std::fs::read(path).expect("voice fixture"))
+                .expect("decode fixture");
+            let text = transcribe_with_helper(&helper, &model, "en", &samples)
+                .await
+                .expect("local transcription");
             assert!(!text.is_empty());
         }
     }

--- a/crates/tidebreak-desktop/src/whisper_install.rs
+++ b/crates/tidebreak-desktop/src/whisper_install.rs
@@ -1,0 +1,402 @@
+//! Managed install of the `tidebreak-whisper` transcription helper.
+//!
+//! The desktop no longer links whisper.cpp. Local voice transcription spawns
+//! a small helper binary instead, and this module fetches that helper the
+//! first time it is needed: an exact pinned version from Tidebreak's own
+//! download service, signature-verified before a single byte of it can run,
+//! installed under the app's data directory
+//! (`tools/whisper-helper/<version>/`) with no admin rights and no writes
+//! outside app-owned paths.
+//!
+//! Supply-chain posture: the URL names an exact helper version — never
+//! "latest" — and the downloaded binary must verify against the Tauri
+//! updater public key already committed in `tauri.conf.json`. That is the
+//! same key that authenticates full app updates, so the helper cannot be
+//! swapped by anyone who could not also ship an app update. A pinned SHA-256
+//! would force a two-phase source change on every helper release; the
+//! signature pins the publisher instead of the bytes and needs only the
+//! version constant to move.
+//!
+//! Gatekeeper: a download performed by this process carries no
+//! `com.apple.quarantine` attribute — quarantine is applied by applications
+//! that opt in via `LSFileQuarantineEnabled` (browsers), not by the kernel —
+//! so the helper runs without any Gatekeeper prompt, exactly like the managed
+//! LibreOffice install (see `office_install.rs`).
+//!
+//! Integrity at rest: the install directory carries an `installed.json`
+//! marker recording the version and the SHA-256 of the verified binary.
+//! Resolution re-hashes the binary and trusts the managed install only when
+//! the marker matches both the pinned version and the bytes on disk. A stale,
+//! replaced, or half-written install stays invisible and a fresh install
+//! replaces it.
+
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// The exact published helper version this build downloads and trusts. It is
+/// the `version` of `crates/tidebreak-whisper`; bump both together and run
+/// the **Publish whisper helper** workflow before shipping the app change.
+pub(crate) const HELPER_VERSION: &str = "0.1.0";
+
+/// The Tauri updater public key, byte-identical to
+/// `plugins.updater.pubkey` in `tauri.conf.json` (a test enforces this).
+/// The helper is signed with the matching private key by the publish
+/// workflow, exactly like updater artifacts.
+const UPDATER_PUBKEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUyRjM1NjZGOTQxRUFBNwpSV1NuNmtINVpqVXZEaXY4cVFWZ0RrbThUbHlEZFB1RnVtT01MSGcwRElhcjdtUUpJckJzM2ZjTAo=";
+
+/// The helper is a single static binary in the low tens of megabytes. The
+/// signature gate decides authenticity; this only stops an oversized response
+/// from consuming the user's disk.
+const MAX_HELPER_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Overrides every resolution step, including verification. Development
+/// builds and the ignored end-to-end tests point this at a locally built
+/// `target/release/tidebreak-whisper`.
+pub(crate) const HELPER_PATH_ENV: &str = "TIDEBREAK_WHISPER_HELPER";
+
+fn helper_file_name() -> &'static str {
+    if cfg!(windows) {
+        "tidebreak-whisper.exe"
+    } else {
+        "tidebreak-whisper"
+    }
+}
+
+/// The Rust target triple of this build, which names the published artifact.
+fn target_triple() -> Result<&'static str, String> {
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else {
+        return Err("Local voice transcription is not supported on this processor".into());
+    };
+    Ok(match (std::env::consts::OS, arch) {
+        ("macos", "aarch64") => "aarch64-apple-darwin",
+        ("macos", "x86_64") => "x86_64-apple-darwin",
+        ("windows", "aarch64") => "aarch64-pc-windows-msvc",
+        ("windows", "x86_64") => "x86_64-pc-windows-msvc",
+        ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
+        ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
+        _ => return Err("Local voice transcription is not supported on this platform".into()),
+    })
+}
+
+fn artifact_url(triple: &str) -> String {
+    let extension = if triple.contains("windows") {
+        ".exe"
+    } else {
+        ""
+    };
+    format!(
+        "https://downloads.brightwave.io/tidebreak/tools/whisper-helper/v{HELPER_VERSION}/tidebreak-whisper-{triple}{extension}"
+    )
+}
+
+fn version_dir(data_dir: &Path) -> PathBuf {
+    data_dir
+        .join("tools")
+        .join("whisper-helper")
+        .join(HELPER_VERSION)
+}
+
+fn staging_dir(data_dir: &Path) -> PathBuf {
+    data_dir
+        .join("tools")
+        .join("whisper-helper")
+        .join("staging")
+}
+
+fn marker_path(version_dir: &Path) -> PathBuf {
+    version_dir.join("installed.json")
+}
+
+/// What `installed.json` records: which artifact the directory was verified
+/// against. Written only after the signature check succeeded.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InstallMarker {
+    version: String,
+    binary_sha256: String,
+}
+
+/// The managed helper, if a verified install of the pinned version is
+/// present. Every resolution hashes the binary before returning a path, so a
+/// file replaced after installation never executes behind a stale marker.
+pub(crate) fn managed_helper(data_dir: &Path) -> Option<PathBuf> {
+    if let Ok(overridden) = std::env::var(HELPER_PATH_ENV) {
+        // The override is authoritative: a wrong path fails at spawn time
+        // with the real reason instead of silently downloading the pin.
+        return Some(PathBuf::from(overridden));
+    }
+    verified_managed_helper(data_dir)
+}
+
+fn verified_managed_helper(data_dir: &Path) -> Option<PathBuf> {
+    let version_dir = version_dir(data_dir);
+    let marker = std::fs::read(marker_path(&version_dir)).ok()?;
+    let marker: InstallMarker = serde_json::from_slice(&marker).ok()?;
+    if marker.version != HELPER_VERSION {
+        return None;
+    }
+    let binary = version_dir.join(helper_file_name());
+    if !binary.is_file() || sha256_hex_of_file(&binary).ok()? != marker.binary_sha256 {
+        return None;
+    }
+    Some(binary)
+}
+
+/// Serializes installs; two transcriptions hitting a cold machine at once
+/// produce one download.
+fn install_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
+    &LOCK
+}
+
+/// The one resolution path: an existing verified install, or download,
+/// verify, and install the pinned helper.
+pub(crate) async fn ensure_helper(data_dir: &Path) -> Result<PathBuf, String> {
+    let _serialized = install_lock().lock().await;
+    if let Some(helper) = managed_helper(data_dir) {
+        return Ok(helper);
+    }
+
+    let staging = staging_dir(data_dir);
+    let _ = tokio::fs::remove_dir_all(&staging).await;
+    tokio::fs::create_dir_all(&staging)
+        .await
+        .map_err(|error| format!("Could not prepare the voice helper directory: {error}"))?;
+    let result = install_into(data_dir, &staging).await;
+    // The staging directory never survives: success moved the binary out,
+    // failure leaves only partial artifacts worth reclaiming.
+    let _ = tokio::fs::remove_dir_all(&staging).await;
+    result
+}
+
+async fn install_into(data_dir: &Path, staging: &Path) -> Result<PathBuf, String> {
+    let triple = target_triple()?;
+    let url = artifact_url(triple);
+
+    let binary_bytes = download(&url, MAX_HELPER_BYTES).await?;
+    let signature_bytes = download(&format!("{url}.sig"), 64 * 1024).await?;
+    let signature = String::from_utf8(signature_bytes)
+        .map_err(|_| "The voice helper signature was not valid text".to_owned())?;
+    verify_signature(&binary_bytes, signature.trim())?;
+
+    let staged = staging.join(helper_file_name());
+    tokio::fs::write(&staged, &binary_bytes)
+        .await
+        .map_err(|error| format!("Could not write the voice helper: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        tokio::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))
+            .await
+            .map_err(|error| format!("Could not install the voice helper: {error}"))?;
+    }
+
+    let version_dir = version_dir(data_dir);
+    tokio::fs::create_dir_all(&version_dir)
+        .await
+        .map_err(|error| format!("Could not prepare the voice helper directory: {error}"))?;
+    let installed = version_dir.join(helper_file_name());
+    // A leftover unverified binary (no marker names it) would block the
+    // rename on Windows; replace it.
+    let _ = tokio::fs::remove_file(&installed).await;
+    tokio::fs::rename(&staged, &installed)
+        .await
+        .map_err(|error| format!("Could not install the voice helper: {error}"))?;
+
+    // The marker lands last, so a crash anywhere above leaves an install that
+    // resolution ignores and the next attempt replaces.
+    let marker = serde_json::to_vec_pretty(&InstallMarker {
+        version: HELPER_VERSION.to_owned(),
+        binary_sha256: sha256_hex(&binary_bytes),
+    })
+    .map_err(|error| format!("Could not record the voice helper install: {error}"))?;
+    let marker_file = marker_path(&version_dir);
+    let partial = marker_file.with_extension("json.partial");
+    tokio::fs::write(&partial, marker)
+        .await
+        .map_err(|error| format!("Could not record the voice helper install: {error}"))?;
+    tokio::fs::rename(&partial, &marker_file)
+        .await
+        .map_err(|error| format!("Could not record the voice helper install: {error}"))?;
+
+    managed_helper(data_dir).ok_or_else(|| "The installed voice helper did not verify".to_owned())
+}
+
+/// Fetch one artifact fully into memory with a byte ceiling. The helper and
+/// its signature are small enough that streaming to disk buys nothing.
+async fn download(url: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
+    use futures::StreamExt as _;
+
+    let response = reqwest::Client::new()
+        .get(url)
+        .send()
+        .await
+        .map_err(|_| "Could not download the voice helper".to_owned())?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Could not download the voice helper: server answered {}",
+            response.status()
+        ));
+    }
+    if response
+        .content_length()
+        .is_some_and(|total| total > max_bytes)
+    {
+        return Err("The voice helper download was larger than expected".to_owned());
+    }
+    let mut bytes = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| "The voice helper download was interrupted".to_owned())?;
+        if bytes.len() as u64 + chunk.len() as u64 > max_bytes {
+            return Err("The voice helper download was larger than expected".to_owned());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+/// Verify `bytes` against a Tauri-format signature: base64 wrapping a
+/// minisign signature file, checked with the committed updater public key.
+/// This mirrors what `tauri-plugin-updater` does for app updates.
+fn verify_signature(bytes: &[u8], signature_base64: &str) -> Result<(), String> {
+    fn invalid<E>(_: E) -> String {
+        "The downloaded voice helper failed signature verification".to_owned()
+    }
+    let engine = base64::engine::general_purpose::STANDARD;
+    let pubkey =
+        String::from_utf8(engine.decode(UPDATER_PUBKEY).map_err(invalid)?).map_err(invalid)?;
+    let pubkey = minisign_verify::PublicKey::decode(&pubkey).map_err(invalid)?;
+    let signature =
+        String::from_utf8(engine.decode(signature_base64).map_err(invalid)?).map_err(invalid)?;
+    let signature = minisign_verify::Signature::decode(&signature).map_err(invalid)?;
+    pubkey.verify(bytes, &signature, true).map_err(|_| {
+        "The downloaded voice helper failed signature verification and was discarded".to_owned()
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+fn sha256_hex_of_file(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Ok(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The helper trusts the same publisher as app updates: this constant and
+    /// the updater pubkey in `tauri.conf.json` must never drift apart.
+    #[test]
+    fn pinned_pubkey_matches_the_updater_configuration() {
+        let mut config = String::new();
+        std::fs::File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/tauri.conf.json"))
+            .expect("tauri.conf.json")
+            .read_to_string(&mut config)
+            .expect("read tauri.conf.json");
+        let config: serde_json::Value = serde_json::from_str(&config).expect("parse");
+        assert_eq!(
+            config["plugins"]["updater"]["pubkey"].as_str(),
+            Some(UPDATER_PUBKEY)
+        );
+    }
+
+    /// The signature gate: garbage, truncated, and wrong-key signatures are
+    /// all rejected before any downloaded byte could execute.
+    #[test]
+    fn signature_verification_rejects_invalid_signatures() {
+        assert!(verify_signature(b"binary", "not base64!").is_err());
+        let engine = base64::engine::general_purpose::STANDARD;
+        assert!(verify_signature(b"binary", &engine.encode("not a signature")).is_err());
+        // A well-formed signature file that this key never made. Decoding may
+        // succeed or fail depending on its structure; either way it must not
+        // verify.
+        let foreign = "untrusted comment: signature from minisign secret key\nRUTTNsbNM+FoZOvOTaXYzpFAJ1UMxIqYPB0uMc0bYr5AmMBBTDW1FJ8y4h+8odFT4hOPWXjifV5nHfP1lB1DGBk8g0mgvbnZAAY=\ntrusted comment: timestamp:1700000000\nEqXbnr1VOb5MCRolWjX99cWv/2mBjnpZjbnPCzMTBFXNbG4b2SxmxeoBhCUmimSpRoOAeFHuNjZGVvNP2wnJCQ==\n";
+        assert!(verify_signature(b"binary", &engine.encode(foreign)).is_err());
+    }
+
+    /// At-rest integrity: the managed install resolves only when both the
+    /// pinned version and the recorded binary digest match the bytes on disk.
+    #[test]
+    fn managed_install_resolves_only_with_matching_bytes_and_marker() {
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let version_dir = version_dir(data_dir.path());
+        std::fs::create_dir_all(&version_dir).expect("dirs");
+        let binary = version_dir.join(helper_file_name());
+        std::fs::write(&binary, b"helper").expect("binary");
+
+        // Binary present, no marker: an interrupted install, not trusted.
+        assert_eq!(verified_managed_helper(data_dir.path()), None);
+
+        let write_marker = |version: &str, binary_sha256: String| {
+            std::fs::write(
+                marker_path(&version_dir),
+                serde_json::to_vec(&InstallMarker {
+                    version: version.to_owned(),
+                    binary_sha256,
+                })
+                .expect("marker json"),
+            )
+            .expect("write marker");
+        };
+
+        write_marker("0.0.0-other", sha256_hex(b"helper"));
+        assert_eq!(verified_managed_helper(data_dir.path()), None);
+
+        write_marker(HELPER_VERSION, sha256_hex(b"different bytes"));
+        assert_eq!(verified_managed_helper(data_dir.path()), None);
+
+        write_marker(HELPER_VERSION, sha256_hex(b"helper"));
+        assert_eq!(
+            verified_managed_helper(data_dir.path()),
+            Some(binary.clone())
+        );
+
+        std::fs::write(&binary, b"replaced helper").expect("replace binary");
+        assert_eq!(verified_managed_helper(data_dir.path()), None);
+    }
+
+    #[test]
+    fn every_supported_platform_names_a_published_artifact() {
+        let triple = target_triple().expect("supported test platform");
+        let url = artifact_url(triple);
+        assert!(url.starts_with("https://downloads.brightwave.io/tidebreak/tools/whisper-helper/v"));
+        assert!(url.contains(HELPER_VERSION));
+        assert!(url.contains(triple));
+    }
+}

--- a/crates/tidebreak-desktop/src/whisper_install.rs
+++ b/crates/tidebreak-desktop/src/whisper_install.rs
@@ -54,9 +54,11 @@ const UPDATER_PUBKEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZX
 /// from consuming the user's disk.
 const MAX_HELPER_BYTES: u64 = 128 * 1024 * 1024;
 
-/// Overrides every resolution step, including verification. Development
-/// builds and the ignored end-to-end tests point this at a locally built
-/// `target/release/tidebreak-whisper`.
+/// Overrides every resolution step in test and debug builds. Local development
+/// and ignored end-to-end tests point this at a locally built helper. Release
+/// builds do not read this variable, so every production helper still passes
+/// signature verification and the at-rest digest check.
+#[cfg(any(test, debug_assertions))]
 pub(crate) const HELPER_PATH_ENV: &str = "TIDEBREAK_WHISPER_HELPER";
 
 fn helper_file_name() -> &'static str {
@@ -129,6 +131,7 @@ struct InstallMarker {
 /// present. Every resolution hashes the binary before returning a path, so a
 /// file replaced after installation never executes behind a stale marker.
 pub(crate) fn managed_helper(data_dir: &Path) -> Option<PathBuf> {
+    #[cfg(any(test, debug_assertions))]
     if let Ok(overridden) = std::env::var(HELPER_PATH_ENV) {
         // The override is authoritative: a wrong path fails at spawn time
         // with the real reason instead of silently downloading the pin.

--- a/crates/tidebreak-server/src/logging.rs
+++ b/crates/tidebreak-server/src/logging.rs
@@ -60,7 +60,7 @@ const DEFAULT_DIRECTIVES: &str = "warn,tidebreak_cli=info,tidebreak_code_executi
     tidebreak_core=info,tidebreak_desktop=info,tidebreak_egress=info,\
     tidebreak_harness=info,tidebreak_host_broker=info,tidebreak_mcp=info,\
     tidebreak_router=info,tidebreak_sandbox_agent=info,tidebreak_sandbox_protocol=info,\
-    tidebreak_server=info,tidebreak_shell_policy=info";
+    tidebreak_server=info,tidebreak_shell_policy=info,tidebreak_whisper=info";
 
 /// Keep the structured file focused on purpose-built, payload-free events.
 const DEFAULT_DIAGNOSTIC_DIRECTIVES: &str = "off,tidebreak_diagnostics=info";

--- a/crates/tidebreak-whisper/Cargo.toml
+++ b/crates/tidebreak-whisper/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tidebreak-whisper"
+description = "Tidebreak's whisper.cpp transcription helper: a one-shot binary the desktop app downloads on demand, keeping the C++ inference build out of the app itself."
+# Versioned independently of the workspace: this binary is published to
+# downloads.brightwave.io and pinned by the desktop at runtime, not shipped
+# inside the app bundle. Bump this version, dispatch the "Publish whisper
+# helper" workflow, then move the desktop's pin.
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "tidebreak-whisper"
+path = "src/main.rs"
+
+[dependencies]
+whisper-rs = { workspace = true }

--- a/crates/tidebreak-whisper/src/main.rs
+++ b/crates/tidebreak-whisper/src/main.rs
@@ -1,0 +1,109 @@
+//! One-shot whisper.cpp transcription helper.
+//!
+//! The desktop app spawns this binary per transcription instead of linking
+//! whisper.cpp, so the C++ build stays out of the app, its release pipeline,
+//! and its caches. The contract is deliberately tiny:
+//!
+//! - arguments: `--model <path> --language <en|auto>`
+//! - stdin: mono 16 kHz PCM as little-endian `f32` samples
+//! - stdout: the consumed byte count on the first line, then the UTF-8 transcript
+//! - exit: `0` on success; non-zero with a reason on stderr otherwise
+//!
+//! There is no protocol negotiation. The desktop pins the exact published
+//! helper version and verifies its updater signature before the first spawn,
+//! so both sides of this contract always come from the same source revision.
+
+use std::io::{Read as _, Write as _};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+/// A hard ceiling on stdin, comfortably above any real recording: one hour of
+/// 16 kHz mono f32 audio is about 230 MB. The desktop is the only caller, so
+/// this only guards against a runaway pipe, not a hostile one.
+const MAX_STDIN_BYTES: u64 = 1024 * 1024 * 1024;
+const RESULT_PREFIX: &str = "TIDEBREAK_WHISPER_BYTES=";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("{message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let (model, language) = parse_args()?;
+    let mut raw = Vec::new();
+    std::io::stdin()
+        .lock()
+        .take(MAX_STDIN_BYTES)
+        .read_to_end(&mut raw)
+        .map_err(|error| format!("could not read audio samples from stdin: {error}"))?;
+    if raw.len() % 4 != 0 {
+        return Err("stdin did not contain whole little-endian f32 samples".to_owned());
+    }
+    if raw.is_empty() {
+        return Err("stdin contained no audio samples".to_owned());
+    }
+    let samples: Vec<f32> = raw
+        .chunks_exact(4)
+        .map(|bytes| f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+        .collect();
+
+    let context = WhisperContext::new_with_params(&model, WhisperContextParameters::default())
+        .map_err(|error| format!("could not load the voice model: {error}"))?;
+    let mut state = context
+        .create_state()
+        .map_err(|error| format!("could not initialize transcription: {error}"))?;
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+    // "auto" asks whisper to detect the language; the English-only models
+    // reject anything else, so the caller's catalog decides which is passed.
+    params.set_language(Some(&language));
+    params.set_translate(false);
+    params.set_no_context(true);
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_timestamps(false);
+    state
+        .full(params, &samples)
+        .map_err(|error| format!("transcription failed: {error}"))?;
+
+    let mut text = String::new();
+    for segment in state.as_iter() {
+        text.push_str(
+            &segment
+                .to_str_lossy()
+                .map_err(|error| format!("transcription returned invalid text: {error}"))?,
+        );
+    }
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "{RESULT_PREFIX}{}", raw.len())
+        .and_then(|()| stdout.write_all(text.trim().as_bytes()))
+        .and_then(|()| stdout.flush())
+        .map_err(|error| format!("could not write the transcript: {error}"))
+}
+
+fn parse_args() -> Result<(PathBuf, String), String> {
+    let mut model = None;
+    let mut language = None;
+    let mut args = std::env::args().skip(1);
+    while let Some(flag) = args.next() {
+        let mut value = |name: &str| {
+            args.next()
+                .ok_or_else(|| format!("{name} requires a value"))
+        };
+        match flag.as_str() {
+            "--model" => model = Some(PathBuf::from(value("--model")?)),
+            "--language" => language = Some(value("--language")?),
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    Ok((
+        model.ok_or("--model is required")?,
+        language.ok_or("--language is required")?,
+    ))
+}

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -25,9 +25,9 @@ a stale one.
 
 ## Summary
 
-- Rust crates: 829
+- Rust crates: 845
 - Desktop UI production packages: 515
-- Distinct license texts: 577
+- Distinct license texts: 581
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -78,7 +78,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/tkaitchuck/ahash
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-d03325792f3d](#l-d03325792f3d))
 
-### aho-corasick 1.1.4
+### aho-corasick 1.1.5
 
 - License: `Unlicense OR MIT`
 - Repository: https://github.com/BurntSushi/aho-corasick
@@ -114,13 +114,13 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/sunfishcode/ambient-authority
 - License text: `COPYRIGHT` ([L-b6ca90f6c899](#l-b6ca90f6c899)), `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-Apache-2.0_WITH_LLVM-exception` ([L-23823edf2631](#l-23823edf2631)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### android_system_properties 0.1.5
+### android_system_properties 0.1.6
 
-- License: `MIT/Apache-2.0`
+- License: `MIT OR Apache-2.0`
 - Repository: https://github.com/nical/android_system_properties
 - License text: `LICENSE-APACHE` ([L-dd0815108f8e](#l-dd0815108f8e)), `LICENSE-MIT` ([L-af6e2a74133b](#l-af6e2a74133b))
 
-### anyhow 1.0.103
+### anyhow 1.0.104
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/anyhow
@@ -138,71 +138,71 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/bluss/arrayvec
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-92c666480f81](#l-92c666480f81))
 
-### arrow 57.3.1
+### arrow 58.4.0
 
 - License: `Apache-2.0`
 - Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
 
-### arrow-arith 57.3.1
-
-- License: `Apache-2.0`
-- Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
-
-### arrow-array 57.3.1
+### arrow-arith 58.4.0
 
 - License: `Apache-2.0`
 - Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
 
-### arrow-buffer 57.3.1
+### arrow-array 58.4.0
+
+- License: `Apache-2.0 AND MIT`
+- Repository: https://github.com/apache/arrow-rs
+- License text: `LICENSE-MIT` ([L-bddc4356d6da](#l-bddc4356d6da)), `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
+
+### arrow-buffer 58.4.0
 
 - License: `Apache-2.0`
 - Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
 
-### arrow-cast 57.3.1
-
-- License: `Apache-2.0`
-- Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
-
-### arrow-data 57.3.1
+### arrow-cast 58.4.0
 
 - License: `Apache-2.0`
 - Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
 
-### arrow-ord 57.3.1
-
-- License: `Apache-2.0`
-- Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
-
-### arrow-row 57.3.1
+### arrow-data 58.4.0
 
 - License: `Apache-2.0`
 - Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
 
-### arrow-schema 57.3.1
-
-- License: `Apache-2.0`
-- Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
-
-### arrow-select 57.3.1
+### arrow-ord 58.4.0
 
 - License: `Apache-2.0`
 - Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
 
-### arrow-string 57.3.1
+### arrow-row 58.4.0
 
 - License: `Apache-2.0`
 - Repository: https://github.com/apache/arrow-rs
-- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-81399416f00b](#l-81399416f00b))
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
+
+### arrow-schema 58.4.0
+
+- License: `Apache-2.0`
+- Repository: https://github.com/apache/arrow-rs
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
+
+### arrow-select 58.4.0
+
+- License: `Apache-2.0`
+- Repository: https://github.com/apache/arrow-rs
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
+
+### arrow-string 58.4.0
+
+- License: `Apache-2.0`
+- Repository: https://github.com/apache/arrow-rs
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-5018b4040991](#l-5018b4040991))
 
 ### async-broadcast 0.7.2
 
@@ -372,7 +372,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/bitflags/bitflags
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-14435fbcd271](#l-14435fbcd271))
 
-### bitflags 2.13.0
+### bitflags 2.13.1
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/bitflags/bitflags
@@ -408,19 +408,19 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/madsmtm/objc2
 - License text: not distributed with this package
 
-### blocking 1.6.2
+### blocking 1.7.0
 
 - License: `Apache-2.0 OR MIT`
 - Repository: https://github.com/smol-rs/blocking
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### bon 3.9.3
+### bon 3.10.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/elastio/bon
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-b319bdb49677](#l-b319bdb49677))
 
-### bon-macros 3.9.3
+### bon-macros 3.10.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/elastio/bon
@@ -468,7 +468,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/Nullus157/bs58-rs
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-67047503c71f](#l-67047503c71f))
 
-### bstr 1.13.0
+### bstr 1.13.1
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/BurntSushi/bstr
@@ -498,7 +498,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/llogiq/bytecount
 - License text: `LICENSE.Apache2` ([L-c5accbbd8546](#l-c5accbbd8546)), `LICENSE.MIT` ([L-3dda214a46ef](#l-3dda214a46ef))
 
-### bytemuck 1.25.0
+### bytemuck 1.25.2
 
 - License: `Zlib OR Apache-2.0 OR MIT`
 - Repository: https://github.com/Lokathor/bytemuck
@@ -552,7 +552,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/gtk-rs/gtk-rs-core
 - License text: `LICENSE` ([L-21a2121221d2](#l-21a2121221d2))
 
-### camino 1.2.4
+### camino 1.2.5
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/camino-rs/camino
@@ -600,7 +600,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/RustCrypto/block-modes
 - License text: `LICENSE-APACHE` ([L-59013a5c8d3a](#l-59013a5c8d3a)), `LICENSE-MIT` ([L-f3bd9e2e7745](#l-f3bd9e2e7745))
 
-### cc 1.2.66
+### cc 1.4.4
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-lang/cc-rs
@@ -642,7 +642,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/katharostech/cfg_aliases
 - License text: `LICENSE` ([L-48513346d335](#l-48513346d335))
 
-### cfg_aliases 0.2.1
+### cfg_aliases 0.2.2
 
 - License: `MIT`
 - Repository: https://github.com/katharostech/cfg_aliases
@@ -690,7 +690,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/image-rs/color_quant.git
 - License text: `LICENSE` ([L-a24abca538cd](#l-a24abca538cd))
 
-### combine 4.6.7
+### combine 4.6.8
 
 - License: `MIT`
 - Repository: https://github.com/Marwes/combine
@@ -726,7 +726,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/tkaitchuck/constrandom
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-ae9791f02f2b](#l-ae9791f02f2b))
 
-### cookie 0.18.1
+### cookie 0.18.2
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/SergioBenitez/cookie-rs
@@ -768,11 +768,11 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/RustCrypto/utils
 - License text: `LICENSE-APACHE` ([L-59013a5c8d3a](#l-59013a5c8d3a)), `LICENSE-MIT` ([L-6334e52844d6](#l-6334e52844d6))
 
-### cpufeatures 0.3.0
+### cpufeatures 0.3.1
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/RustCrypto/utils
-- License text: `LICENSE-APACHE` ([L-59013a5c8d3a](#l-59013a5c8d3a)), `LICENSE-MIT` ([L-6334e52844d6](#l-6334e52844d6))
+- License text: `LICENSE-APACHE` ([L-59013a5c8d3a](#l-59013a5c8d3a)), `LICENSE-MIT` ([L-ea753cf1e3ec](#l-ea753cf1e3ec))
 
 ### crc 3.4.0
 
@@ -786,7 +786,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/akhilles/crc-catalog.git
 - License text: not distributed with this package
 
-### crc32fast 1.5.0
+### crc32fast 1.5.1
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/srijs/rust-crc32fast
@@ -882,6 +882,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/TedDriggs/darling
 - License text: `LICENSE` ([L-cc8f3c8ab396](#l-cc8f3c8ab396))
 
+### darling 0.24.1
+
+- License: `MIT`
+- Repository: https://github.com/TedDriggs/darling
+- License text: `LICENSE` ([L-cc8f3c8ab396](#l-cc8f3c8ab396))
+
 ### darling_core 0.20.11
 
 - License: `MIT`
@@ -889,6 +895,12 @@ License identifiers named across all declared expressions:
 - License text: `LICENSE` ([L-cc8f3c8ab396](#l-cc8f3c8ab396))
 
 ### darling_core 0.23.0
+
+- License: `MIT`
+- Repository: https://github.com/TedDriggs/darling
+- License text: `LICENSE` ([L-cc8f3c8ab396](#l-cc8f3c8ab396))
+
+### darling_core 0.24.1
 
 - License: `MIT`
 - Repository: https://github.com/TedDriggs/darling
@@ -906,7 +918,13 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/TedDriggs/darling
 - License text: `LICENSE` ([L-cc8f3c8ab396](#l-cc8f3c8ab396))
 
-### data-encoding 2.11.0
+### darling_macro 0.24.1
+
+- License: `MIT`
+- Repository: https://github.com/TedDriggs/darling
+- License text: `LICENSE` ([L-cc8f3c8ab396](#l-cc8f3c8ab396))
+
+### data-encoding 2.11.1
 
 - License: `MIT`
 - Repository: https://github.com/ia0/data-encoding
@@ -923,6 +941,24 @@ License identifiers named across all declared expressions:
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/brotskydotcom/dbus-secret-service.git
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-cef8c2ddacb4](#l-cef8c2ddacb4))
+
+### defmt 1.1.1
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/knurling-rs/defmt
+- License text: `LICENSE-APACHE` ([L-c144680885b2](#l-c144680885b2)), `LICENSE-MIT` ([L-2710a622a896](#l-2710a622a896))
+
+### defmt-macros 1.1.1
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/knurling-rs/defmt
+- License text: `LICENSE-APACHE` ([L-c144680885b2](#l-c144680885b2)), `LICENSE-MIT` ([L-2710a622a896](#l-2710a622a896))
+
+### defmt-parser 1.0.0
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/knurling-rs/defmt
+- License text: not distributed with this package
 
 ### deranged 0.5.8
 
@@ -984,7 +1020,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/madsmtm/objc2
 - License text: not distributed with this package
 
-### displaydoc 0.2.6
+### displaydoc 0.2.7
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/yaahc/displaydoc
@@ -1080,7 +1116,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dtolnay/dyn-clone
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### either 1.16.0
+### either 1.18.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rayon-rs/either
@@ -1158,7 +1194,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/lunacookies/etcetera
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### event-listener 5.4.1
+### event-listener 5.4.2
 
 - License: `Apache-2.0 OR MIT`
 - Repository: https://github.com/smol-rs/event-listener
@@ -1176,7 +1212,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/fancy-regex/fancy-regex
 - License text: `LICENSE` ([L-ffaf97e3da9e](#l-ffaf97e3da9e))
 
-### fastrand 2.4.1
+### fastrand 2.5.0
 
 - License: `Apache-2.0 OR MIT`
 - Repository: https://github.com/smol-rs/fastrand
@@ -1206,7 +1242,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/alexcrichton/filetime
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
 
-### find-msvc-tools 0.1.9
+### find-msvc-tools 0.1.11
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-lang/cc-rs
@@ -1254,7 +1290,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/sfackler/foreign-types
 - License text: `LICENSE-APACHE` ([L-c5accbbd8546](#l-c5accbbd8546)), `LICENSE-MIT` ([L-c9067b1cc20b](#l-c9067b1cc20b))
 
-### foreign-types-macros 0.2.3
+### foreign-types-macros 0.2.4
 
 - License: `MIT/Apache-2.0`
 - Repository: https://github.com/sfackler/foreign-types
@@ -1476,7 +1512,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/gtk-rs/gtk-rs-core
 - License text: `LICENSE` ([L-21a2121221d2](#l-21a2121221d2))
 
-### glob 0.3.3
+### glob 0.3.4
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-lang/glob
@@ -1590,7 +1626,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/RustCrypto/MACs
 - License text: `LICENSE-APACHE` ([L-59013a5c8d3a](#l-59013a5c8d3a)), `LICENSE-MIT` ([L-9c5127ab88e8](#l-9c5127ab88e8))
 
-### html-escape 0.2.14
+### html-escape 0.2.15
 
 - License: `MIT`
 - Repository: https://github.com/magiclen/html-escape
@@ -1608,23 +1644,23 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/servo/html5ever
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-35af0fd88338](#l-35af0fd88338))
 
-### http 1.4.2
+### http 1.5.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/hyperium/http
 - License text: `LICENSE-APACHE` ([L-a7e117f398da](#l-a7e117f398da)), `LICENSE-MIT` ([L-f47894ff9c86](#l-f47894ff9c86))
 
-### http-body 1.0.1
+### http-body 1.1.0
 
 - License: `MIT`
 - Repository: https://github.com/hyperium/http-body
-- License text: `LICENSE` ([L-ae61683b7dd6](#l-ae61683b7dd6))
+- License text: `LICENSE` ([L-57f841bc9767](#l-57f841bc9767))
 
-### http-body-util 0.1.3
+### http-body-util 0.1.5
 
 - License: `MIT`
 - Repository: https://github.com/hyperium/http-body
-- License text: `LICENSE` ([L-4bddfb319e32](#l-4bddfb319e32))
+- License text: `LICENSE` ([L-57f841bc9767](#l-57f841bc9767))
 
 ### httparse 1.10.1
 
@@ -1638,13 +1674,13 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/pyfisch/httpdate
 - License text: `LICENSE-APACHE` ([L-793b7448f5be](#l-793b7448f5be)), `LICENSE-MIT` ([L-8ee77b53f701](#l-8ee77b53f701))
 
-### hybrid-array 0.4.13
+### hybrid-array 0.4.14
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/RustCrypto/hybrid-array
 - License text: `LICENSE-APACHE` ([L-59013a5c8d3a](#l-59013a5c8d3a)), `LICENSE-MIT` ([L-a1aa15c3898d](#l-a1aa15c3898d))
 
-### hyper 1.10.1
+### hyper 1.11.0
 
 - License: `MIT`
 - Repository: https://github.com/hyperium/hyper
@@ -1680,43 +1716,43 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/mdsteele/rust-ico
 - License text: `LICENSE` ([L-95573f040b56](#l-95573f040b56))
 
-### icu_collections 2.2.0
+### icu_collections 2.3.0
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### icu_locale_core 2.2.0
+### icu_locale_core 2.3.0
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### icu_normalizer 2.2.0
+### icu_normalizer 2.3.0
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### icu_normalizer_data 2.2.0
+### icu_normalizer_data 2.3.0
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### icu_properties 2.2.0
+### icu_properties 2.3.0
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### icu_properties_data 2.2.0
+### icu_properties_data 2.3.0
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### icu_provider 2.2.0
+### icu_provider 2.3.1
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
@@ -1818,7 +1854,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/sunfishcode/io-lifetimes
 - License text: `COPYRIGHT` ([L-ced9d1e3612f](#l-ced9d1e3612f)), `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-Apache-2.0_WITH_LLVM-exception` ([L-23823edf2631](#l-23823edf2631)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### ipnet 2.12.0
+### ipnet 2.12.1
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/krisprice/ipnet
@@ -1866,6 +1902,36 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/tauri-apps/javascriptcore-rs
 - License text: `LICENSE` ([L-4603441e4a5a](#l-4603441e4a5a))
 
+### jiff 0.2.35
+
+- License: `Unlicense OR MIT`
+- Repository: https://github.com/BurntSushi/jiff
+- License text: `COPYING` ([L-65314a6c9668](#l-65314a6c9668)), `LICENSE-MIT` ([L-154c1af2b38e](#l-154c1af2b38e)), `UNLICENSE` ([L-ca2abdf69588](#l-ca2abdf69588))
+
+### jiff-core 0.1.0
+
+- License: `Unlicense OR MIT`
+- Repository: https://github.com/BurntSushi/jiff
+- License text: `COPYING` ([L-65314a6c9668](#l-65314a6c9668)), `LICENSE-MIT` ([L-154c1af2b38e](#l-154c1af2b38e)), `UNLICENSE` ([L-ca2abdf69588](#l-ca2abdf69588))
+
+### jiff-static 0.2.35
+
+- License: `Unlicense OR MIT`
+- Repository: https://github.com/BurntSushi/jiff
+- License text: `COPYING` ([L-65314a6c9668](#l-65314a6c9668)), `LICENSE-MIT` ([L-154c1af2b38e](#l-154c1af2b38e)), `UNLICENSE` ([L-ca2abdf69588](#l-ca2abdf69588))
+
+### jiff-tzdb 0.1.8
+
+- License: `Unlicense OR MIT`
+- Repository: https://github.com/BurntSushi/jiff
+- License text: `COPYING` ([L-65314a6c9668](#l-65314a6c9668)), `LICENSE-MIT` ([L-154c1af2b38e](#l-154c1af2b38e)), `UNLICENSE` ([L-ca2abdf69588](#l-ca2abdf69588))
+
+### jiff-tzdb-platform 0.1.3
+
+- License: `Unlicense OR MIT`
+- Repository: https://github.com/BurntSushi/jiff
+- License text: `COPYING` ([L-65314a6c9668](#l-65314a6c9668)), `LICENSE-MIT` ([L-154c1af2b38e](#l-154c1af2b38e)), `UNLICENSE` ([L-ca2abdf69588](#l-ca2abdf69588))
+
 ### jni 0.21.1
 
 - License: `MIT/Apache-2.0`
@@ -1902,7 +1968,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/jni-rs/jni-sys
 - License text: not distributed with this package
 
-### js-sys 0.3.103
+### js-sys 0.3.104
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys
@@ -2032,17 +2098,17 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/rust-lang/compiler-builtins
 - License text: `LICENSE.txt` ([L-5f5535fee8ec](#l-5f5535fee8ec))
 
-### libredox 0.1.18
+### libredox 0.1.20
 
 - License: `MIT`
 - Repository: https://gitlab.redox-os.org/redox-os/libredox.git
 - License text: `LICENSE` ([L-7dbbefcddfaa](#l-7dbbefcddfaa))
 
-### libsqlite3-sys 0.30.1
+### libsqlite3-sys 0.37.0
 
 - License: `MIT`
 - Repository: https://github.com/rusqlite/rusqlite
-- License text: `LICENSE` ([L-1b22c7467645](#l-1b22c7467645))
+- License text: `LICENSE` ([L-6061b8ea5b16](#l-6061b8ea5b16))
 
 ### linux-raw-sys 0.12.1
 
@@ -2050,7 +2116,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/sunfishcode/linux-raw-sys
 - License text: `COPYRIGHT` ([L-7813bacdaa2b](#l-7813bacdaa2b)), `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-Apache-2.0_WITH_LLVM-exception` ([L-23823edf2631](#l-23823edf2631)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### litemap 0.8.2
+### litemap 0.8.3
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
@@ -2062,7 +2128,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/Amanieu/parking_lot
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-8d1f81ea4e87](#l-8d1f81ea4e87))
 
-### log 0.4.33
+### log 0.4.34
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-lang/log
@@ -2164,7 +2230,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide
 - License text: `LICENSE` ([L-7427abc63036](#l-7427abc63036)), `LICENSE-APACHE.md` ([L-0cec06e0e55f](#l-0cec06e0e55f)), `LICENSE-MIT.md` ([L-ac9859ce4e9a](#l-ac9859ce4e9a)), `LICENSE-ZLIB.md` ([L-eac3911cc3d4](#l-eac3911cc3d4))
 
-### mio 1.2.1
+### mio 1.2.2
 
 - License: `MIT`
 - Repository: https://github.com/tokio-rs/mio
@@ -2254,7 +2320,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/jhpratt/num-conv
 - License text: `LICENSE-Apache` ([L-0cec06e0e55f](#l-0cec06e0e55f)), `LICENSE-MIT` ([L-4d83b119f786](#l-4d83b119f786))
 
-### num-integer 0.1.46
+### num-integer 0.1.47
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-num/num-integer
@@ -2404,7 +2470,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/matklad/once_cell
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### open 5.4.0
+### open 5.4.2
 
 - License: `MIT`
 - Repository: https://github.com/Byron/open-rs
@@ -2530,25 +2596,25 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/servo/rust-url/
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-7a8093fb4a93](#l-7a8093fb4a93))
 
-### pest 2.8.8
+### pest 2.9.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/pest-parser/pest
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### pest_derive 2.8.8
+### pest_derive 2.9.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/pest-parser/pest
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### pest_generator 2.8.8
+### pest_generator 2.9.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/pest-parser/pest
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### pest_meta 2.8.8
+### pest_meta 2.9.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/pest-parser/pest
@@ -2602,7 +2668,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/smol-rs/piper
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### pkg-config 0.3.33
+### pkg-config 0.3.34
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-lang/pkg-config-rs
@@ -2638,13 +2704,25 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/smol-rs/polling
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
+### portable-atomic 1.15.0
+
+- License: `Apache-2.0 OR MIT`
+- Repository: https://github.com/taiki-e/portable-atomic
+- License text: `LICENSE-APACHE` ([L-0cec06e0e55f](#l-0cec06e0e55f)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
+
+### portable-atomic-util 0.2.7
+
+- License: `Apache-2.0 OR MIT`
+- Repository: https://github.com/taiki-e/portable-atomic-util
+- License text: `LICENSE-APACHE` ([L-0cec06e0e55f](#l-0cec06e0e55f)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
+
 ### portable-pty 0.9.0
 
 - License: `MIT`
 - Repository: https://github.com/wezterm/wezterm
 - License text: `LICENSE.md` ([L-0f5e2ba844a4](#l-0f5e2ba844a4))
 
-### potential_utf 0.1.5
+### potential_utf 0.1.6
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
@@ -2669,6 +2747,12 @@ License identifiers named across all declared expressions:
 - License text: `LICENSE` ([L-695de7436b47](#l-695de7436b47))
 
 ### prettyplease 0.2.37
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/dtolnay/prettyplease
+- License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
+
+### prettyplease 0.3.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/prettyplease
@@ -2704,19 +2788,7 @@ License identifiers named across all declared expressions:
 - Repository: https://gitlab.com/CreepySkeleton/proc-macro-error
 - License text: `LICENSE-APACHE` ([L-ca5105e39772](#l-ca5105e39772)), `LICENSE-MIT` ([L-c7495b7b3a52](#l-c7495b7b3a52))
 
-### proc-macro-error-attr2 2.0.0
-
-- License: `MIT OR Apache-2.0`
-- Repository: https://github.com/GnomedDev/proc-macro-error-2
-- License text: `LICENSE-APACHE` ([L-ca5105e39772](#l-ca5105e39772)), `LICENSE-MIT` ([L-c7495b7b3a52](#l-c7495b7b3a52))
-
-### proc-macro-error2 2.0.1
-
-- License: `MIT OR Apache-2.0`
-- Repository: https://github.com/GnomedDev/proc-macro-error-2
-- License text: `LICENSE-APACHE` ([L-ca5105e39772](#l-ca5105e39772)), `LICENSE-MIT` ([L-c7495b7b3a52](#l-c7495b7b3a52))
-
-### proc-macro2 1.0.106
+### proc-macro2 1.0.107
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/proc-macro2
@@ -2764,7 +2836,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/quinn-rs/quinn
 - License text: `LICENSE-APACHE` ([L-43070e2d4e53](#l-43070e2d4e53)), `LICENSE-MIT` ([L-05fa1ba3228a](#l-05fa1ba3228a))
 
-### quinn-proto 0.11.16
+### quinn-proto 0.11.17
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/quinn-rs/quinn
@@ -2776,7 +2848,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/quinn-rs/quinn
 - License text: `LICENSE-APACHE` ([L-43070e2d4e53](#l-43070e2d4e53)), `LICENSE-MIT` ([L-05fa1ba3228a](#l-05fa1ba3228a))
 
-### quote 1.0.46
+### quote 1.0.47
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/quote
@@ -2806,13 +2878,13 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/rust-random/rand
 - License text: `COPYRIGHT` ([L-2411d70acb18](#l-2411d70acb18)), `LICENSE-APACHE` ([L-6508cf9942b4](#l-6508cf9942b4)), `LICENSE-MIT` ([L-cc367a7134c2](#l-cc367a7134c2))
 
-### rand 0.8.6
+### rand 0.8.8
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-random/rand
 - License text: `COPYRIGHT` ([L-2411d70acb18](#l-2411d70acb18)), `LICENSE-APACHE` ([L-6508cf9942b4](#l-6508cf9942b4)), `LICENSE-MIT` ([L-cc367a7134c2](#l-cc367a7134c2))
 
-### rand 0.9.4
+### rand 0.9.5
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-random/rand
@@ -2872,13 +2944,13 @@ License identifiers named across all declared expressions:
 - Repository: https://gitlab.redox-os.org/redox-os/users
 - License text: `LICENSE` ([L-157e9bc5ce84](#l-157e9bc5ce84))
 
-### ref-cast 1.0.25
+### ref-cast 1.0.27
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/ref-cast
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### ref-cast-impl 1.0.25
+### ref-cast-impl 1.0.27
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/ref-cast
@@ -2890,13 +2962,13 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/Stranger6667/jsonschema
 - License text: `LICENSE` ([L-19c8b10a10ca](#l-19c8b10a10ca))
 
-### regex 1.12.4
+### regex 1.13.1
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-lang/regex
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-14435fbcd271](#l-14435fbcd271))
 
-### regex-automata 0.4.16
+### regex-automata 0.4.18
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-lang/regex
@@ -2992,7 +3064,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/sunfishcode/rustix-linux-procfs
 - License text: `COPYRIGHT` ([L-adda0c416b03](#l-adda0c416b03)), `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-Apache-2.0_WITH_LLVM-exception` ([L-23823edf2631](#l-23823edf2631)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### rustls 0.23.41
+### rustls 0.23.43
 
 - License: `Apache-2.0 OR ISC OR MIT`
 - Repository: https://github.com/rustls/rustls
@@ -3004,7 +3076,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/rustls/rustls-native-certs
 - License text: `LICENSE` ([L-29fbc81a3f88](#l-29fbc81a3f88)), `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-ISC` ([L-af6da3f3f6b4](#l-af6da3f3f6b4)), `LICENSE-MIT` ([L-a3320aa8d192](#l-a3320aa8d192))
 
-### rustls-pki-types 1.15.0
+### rustls-pki-types 1.15.1
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rustls/pki-types
@@ -3022,7 +3094,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/rustls/rustls-platform-verifier
 - License text: not distributed with this package
 
-### rustls-webpki 0.103.13
+### rustls-webpki 0.103.15
 
 - License: `ISC`
 - Repository: https://github.com/rustls/webpki
@@ -3088,7 +3160,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/bluss/scopeguard
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-1a6aa2616e74](#l-1a6aa2616e74))
 
-### sea-bae 0.2.1
+### sea-bae 0.2.2
 
 - License: `MIT`
 - Repository: https://github.com/SeaQL/sea-bae.git
@@ -3100,7 +3172,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/SeaQL/sea-orm
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-b937e4dc7e27](#l-b937e4dc7e27))
 
-### sea-orm-arrow 2.0.0-rc.3
+### sea-orm-arrow 2.0.0-rc.4
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/SeaQL/sea-orm
@@ -3124,7 +3196,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/SeaQL/sea-orm
 - License text: not distributed with this package
 
-### sea-query 1.0.1
+### sea-query 1.0.2
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/SeaQL/sea-query
@@ -3250,7 +3322,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dtolnay/path-to-error
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### serde_repr 0.1.20
+### serde_repr 0.1.21
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/serde-repr
@@ -3274,13 +3346,13 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/nox/serde_urlencoded
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-b5dae9532426](#l-b5dae9532426))
 
-### serde_with 3.21.0
+### serde_with 3.22.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/jonasbb/serde_with/
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-fdd1c2117bcf](#l-fdd1c2117bcf))
 
-### serde_with_macros 3.21.0
+### serde_with_macros 3.22.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/jonasbb/serde_with/
@@ -3310,7 +3382,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/servo/stylo
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### sha1 0.10.6
+### sha1 0.10.7
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/RustCrypto/hashes
@@ -3394,7 +3466,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/vorner/signal-hook
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-aaac889d0a4a](#l-aaac889d0a4a))
 
-### simd-adler32 0.3.9
+### simd-adler32 0.3.10
 
 - License: `MIT`
 - Repository: https://github.com/mcountryman/simd-adler32
@@ -3442,7 +3514,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/servo/rust-smallvec
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-7f194ae45c25](#l-7f194ae45c25))
 
-### socket2 0.6.4
+### socket2 0.6.5
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/rust-lang/socket2
@@ -3466,7 +3538,7 @@ License identifiers named across all declared expressions:
 - Repository: https://gitlab.gnome.org/World/Rust/soup3-rs
 - License text: `LICENSE` ([L-4603441e4a5a](#l-4603441e4a5a))
 
-### spin 0.9.8
+### spin 0.9.9
 
 - License: `MIT`
 - Repository: https://github.com/mvdnes/spin-rs.git
@@ -3568,7 +3640,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dalek-cryptography/subtle
 - License text: `LICENSE` ([L-24fa06d8eae3](#l-24fa06d8eae3))
 
-### swift-rs 1.0.7
+### swift-rs 1.0.8
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/Brendonovich/swift-rs
@@ -3628,13 +3700,13 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dtolnay/syn
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### syn 2.0.118
+### syn 2.0.119
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/syn
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### syn 3.0.2
+### syn 3.0.4
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/dtolnay/syn
@@ -3664,11 +3736,11 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/tauri-apps/tao
 - License text: `LICENSE` ([L-6dc0e068dcf3](#l-6dc0e068dcf3)), `LICENSE.spdx` ([L-28694f36acab](#l-28694f36acab))
 
-### tao-macros 0.1.3
+### tao-macros 0.1.4
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/tauri-apps/tao
-- License text: not distributed with this package
+- License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-26e6f69cf1f6](#l-26e6f69cf1f6)), `LICENSE.spdx` ([L-1d5680a70055](#l-1d5680a70055))
 
 ### tap 1.0.1
 
@@ -3820,25 +3892,25 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dtolnay/thiserror
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### thread_local 1.1.9
+### thread_local 1.1.10
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/Amanieu/thread_local-rs
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-8d1f81ea4e87](#l-8d1f81ea4e87))
 
-### time 0.3.47
+### time 0.3.55
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/time-rs/time
 - License text: `LICENSE-Apache` ([L-0cec06e0e55f](#l-0cec06e0e55f)), `LICENSE-MIT` ([L-7fdbca77dec6](#l-7fdbca77dec6))
 
-### time-core 0.1.8
+### time-core 0.1.9
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/time-rs/time
 - License text: `LICENSE-Apache` ([L-0cec06e0e55f](#l-0cec06e0e55f)), `LICENSE-MIT` ([L-7fdbca77dec6](#l-7fdbca77dec6))
 
-### time-macros 0.2.27
+### time-macros 0.2.32
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/time-rs/time
@@ -3849,13 +3921,13 @@ License identifiers named across all declared expressions:
 - License: `CC0-1.0`
 - License text: `LICENSE` ([L-6d489af62926](#l-6d489af62926))
 
-### tinystr 0.8.3
+### tinystr 0.8.4
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### tinyvec 1.11.0
+### tinyvec 1.12.0
 
 - License: `Zlib OR Apache-2.0 OR MIT`
 - Repository: https://github.com/Lokathor/tinyvec
@@ -3873,7 +3945,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/tokio-rs/tokio
 - License text: `LICENSE` ([L-3e1bef82aa0d](#l-3e1bef82aa0d))
 
-### tokio-macros 2.7.0
+### tokio-macros 2.7.2
 
 - License: `MIT`
 - Repository: https://github.com/tokio-rs/tokio
@@ -3885,7 +3957,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/rustls/tokio-rustls
 - License text: `LICENSE-APACHE` ([L-720304e6515d](#l-720304e6515d)), `LICENSE-MIT` ([L-1b0258c48739](#l-1b0258c48739))
 
-### tokio-stream 0.1.18
+### tokio-stream 0.1.19
 
 - License: `MIT`
 - Repository: https://github.com/tokio-rs/tokio
@@ -3921,7 +3993,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/toml-rs/toml
 - License text: `LICENSE-APACHE` ([L-c5accbbd8546](#l-c5accbbd8546)), `LICENSE-MIT` ([L-4498464c2864](#l-4498464c2864))
 
-### toml 1.1.2+spec-1.1.0
+### toml 1.1.4+spec-1.1.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/toml-rs/toml
@@ -3957,19 +4029,19 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/toml-rs/toml
 - License text: `LICENSE-APACHE` ([L-c5accbbd8546](#l-c5accbbd8546)), `LICENSE-MIT` ([L-4498464c2864](#l-4498464c2864))
 
-### toml_edit 0.25.12+spec-1.1.0
+### toml_edit 0.25.13+spec-1.1.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/toml-rs/toml
 - License text: `LICENSE-APACHE` ([L-c5accbbd8546](#l-c5accbbd8546)), `LICENSE-MIT` ([L-4498464c2864](#l-4498464c2864))
 
-### toml_parser 1.1.2+spec-1.1.0
+### toml_parser 1.1.3+spec-1.1.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/toml-rs/toml
 - License text: `LICENSE-APACHE` ([L-c5accbbd8546](#l-c5accbbd8546)), `LICENSE-MIT` ([L-4498464c2864](#l-4498464c2864))
 
-### toml_writer 1.1.1+spec-1.1.0
+### toml_writer 1.1.2+spec-1.1.0
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/toml-rs/toml
@@ -4041,7 +4113,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/ArturKovacs/trash
 - License text: `LICENSE.txt` ([L-2e5096718c28](#l-2e5096718c28))
 
-### tray-icon 0.24.1
+### tray-icon 0.24.2
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/tauri-apps/tray-icon
@@ -4299,31 +4371,31 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/bytecodealliance/wasi-rs
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-Apache-2.0_WITH_LLVM-exception` ([L-23823edf2631](#l-23823edf2631)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### wasm-bindgen 0.2.126
+### wasm-bindgen 0.2.127
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/wasm-bindgen/wasm-bindgen
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
 
-### wasm-bindgen-futures 0.4.76
+### wasm-bindgen-futures 0.4.77
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
 
-### wasm-bindgen-macro 0.2.126
+### wasm-bindgen-macro 0.2.127
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
 
-### wasm-bindgen-macro-support 0.2.126
+### wasm-bindgen-macro-support 0.2.127
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
 
-### wasm-bindgen-shared 0.2.126
+### wasm-bindgen-shared 0.2.127
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared
@@ -4341,7 +4413,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/MattiasBuelens/wasm-streams/
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### web-sys 0.3.103
+### web-sys 0.3.104
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys
@@ -4353,7 +4425,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/daxpedda/web-time
 - License text: `LICENSE-APACHE` ([L-ca028ef321c3](#l-ca028ef321c3)), `LICENSE-MIT` ([L-32ae0b6c9e4c](#l-32ae0b6c9e4c))
 
-### web_atoms 0.2.5
+### web_atoms 0.2.6
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/servo/html5ever
@@ -4383,7 +4455,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/rustls/webpki-roots
 - License text: `LICENSE` ([L-d30183ec6610](#l-d30183ec6610))
 
-### webpki-roots 1.0.8
+### webpki-roots 1.0.9
 
 - License: `CDLA-Permissive-2.0`
 - Repository: https://github.com/rustls/webpki-roots
@@ -4425,7 +4497,7 @@ License identifiers named across all declared expressions:
 - Repository: https://codeberg.org/tazz4843/whisper-rs
 - License text: not distributed with this package
 
-### whoami 2.1.2
+### whoami 2.1.3
 
 - License: `Apache-2.0 OR BSL-1.0 OR MIT`
 - Repository: https://github.com/ardaku/whoami
@@ -4486,6 +4558,12 @@ License identifiers named across all declared expressions:
 - License text: `license-apache-2.0` ([L-72de958052e4](#l-72de958052e4)), `license-mit` ([L-d9a1b1e30d63](#l-d9a1b1e30d63))
 
 ### windows-core 0.61.2
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/microsoft/windows-rs
+- License text: `license-apache-2.0` ([L-72de958052e4](#l-72de958052e4)), `license-mit` ([L-d9a1b1e30d63](#l-d9a1b1e30d63))
+
+### windows-core 0.62.2
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/microsoft/windows-rs
@@ -4557,7 +4635,19 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/microsoft/windows-rs
 - License text: `license-apache-2.0` ([L-72de958052e4](#l-72de958052e4)), `license-mit` ([L-d9a1b1e30d63](#l-d9a1b1e30d63))
 
+### windows-result 0.4.1
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/microsoft/windows-rs
+- License text: `license-apache-2.0` ([L-72de958052e4](#l-72de958052e4)), `license-mit` ([L-d9a1b1e30d63](#l-d9a1b1e30d63))
+
 ### windows-strings 0.4.2
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/microsoft/windows-rs
+- License text: `license-apache-2.0` ([L-72de958052e4](#l-72de958052e4)), `license-mit` ([L-d9a1b1e30d63](#l-d9a1b1e30d63))
+
+### windows-strings 0.5.1
 
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/microsoft/windows-rs
@@ -4773,7 +4863,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/winnow-rs/winnow
 - License text: `LICENSE-MIT` ([L-8793aa4141de](#l-8793aa4141de))
 
-### winnow 1.0.3
+### winnow 1.0.4
 
 - License: `MIT`
 - Repository: https://github.com/winnow-rs/winnow
@@ -4809,7 +4899,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/bytecodealliance/wit-bindgen
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-Apache-2.0_WITH_LLVM-exception` ([L-23823edf2631](#l-23823edf2631)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### writeable 0.6.3
+### writeable 0.6.4
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
@@ -4875,7 +4965,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dbus2/zbus/
 - License text: `LICENSE` ([L-a0e7d0739e03](#l-a0e7d0739e03))
 
-### zbus 5.17.0
+### zbus 5.19.0
 
 - License: `MIT`
 - Repository: https://github.com/z-galaxy/zbus/
@@ -4887,7 +4977,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dbus2/zbus/
 - License text: `LICENSE` ([L-a0e7d0739e03](#l-a0e7d0739e03))
 
-### zbus_macros 5.17.0
+### zbus_macros 5.19.0
 
 - License: `MIT`
 - Repository: https://github.com/z-galaxy/zbus/
@@ -4899,19 +4989,25 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dbus2/zbus/
 - License text: `LICENSE` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### zbus_names 4.3.3
+### zbus_names 4.3.4
 
 - License: `MIT`
 - Repository: https://github.com/z-galaxy/zbus/
 - License text: `LICENSE` ([L-a0e7d0739e03](#l-a0e7d0739e03))
 
-### zerocopy 0.8.53
+### zcheapstr 1.1.0
+
+- License: `MIT`
+- Repository: https://github.com/z-galaxy/zcheapstr/
+- License text: `LICENSE` ([L-36c68b249eb6](#l-36c68b249eb6))
+
+### zerocopy 0.8.56
 
 - License: `BSD-2-Clause OR Apache-2.0 OR MIT`
 - Repository: https://github.com/google/zerocopy
 - License text: `LICENSE-APACHE` ([L-75a373c5dfcd](#l-75a373c5dfcd)), `LICENSE-BSD` ([L-47248d1ec833](#l-47248d1ec833)), `LICENSE-MIT` ([L-a03d4daa4f46](#l-a03d4daa4f46))
 
-### zerocopy-derive 0.8.53
+### zerocopy-derive 0.8.56
 
 - License: `BSD-2-Clause OR Apache-2.0 OR MIT`
 - Repository: https://github.com/google/zerocopy
@@ -4941,19 +5037,19 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/RustCrypto/utils
 - License text: `LICENSE-APACHE` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `LICENSE-MIT` ([L-1038b7737a0a](#l-1038b7737a0a))
 
-### zerotrie 0.2.4
+### zerotrie 0.2.5
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### zerovec 0.11.6
+### zerovec 0.11.8
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
 - License text: `LICENSE` ([L-cde87abe221f](#l-cde87abe221f))
 
-### zerovec-derive 0.11.3
+### zerovec-derive 0.11.6
 
 - License: `Unicode-3.0`
 - Repository: https://github.com/unicode-org/icu4x
@@ -4971,13 +5067,13 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/zip-rs/zip2
 - License text: `LICENSE` ([L-6ac8711fb340](#l-6ac8711fb340))
 
-### zmij 1.0.21
+### zmij 1.0.23
 
 - License: `MIT`
 - Repository: https://github.com/dtolnay/zmij
 - License text: `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### zune-core 0.5.1
+### zune-core 0.5.3
 
 - License: `MIT OR Apache-2.0 OR Zlib`
 - Repository: https://github.com/etemesi254/zune-image
@@ -4995,7 +5091,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dbus2/zbus/
 - License text: `LICENSE` ([L-a0e7d0739e03](#l-a0e7d0739e03))
 
-### zvariant 5.13.0
+### zvariant 5.15.0
 
 - License: `MIT`
 - Repository: https://github.com/z-galaxy/zbus/
@@ -5007,7 +5103,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dbus2/zbus/
 - License text: `LICENSE` ([L-a0e7d0739e03](#l-a0e7d0739e03))
 
-### zvariant_derive 5.13.0
+### zvariant_derive 5.15.0
 
 - License: `MIT`
 - Repository: https://github.com/z-galaxy/zbus/
@@ -5019,7 +5115,7 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/dbus2/zbus/
 - License text: `LICENSE` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
-### zvariant_utils 3.5.0
+### zvariant_utils 4.2.0
 
 - License: `MIT`
 - Repository: https://github.com/z-galaxy/zbus/
@@ -10305,30 +10401,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-### L-1b22c7467645
-
-```
-Copyright (c) 2014-2021 The rusqlite developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-```
-
 ### L-1b66e3be6894
 
 ```
@@ -10463,6 +10535,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### L-1d5680a70055
+
+```
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+PackageName: tao-macros
+DataFormat: SPDXRef-1
+PackageSupplier: Organization: The Tauri Programme in the Commons Conservancy
+PackageHomePage: https://tauri.app
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseDeclared: MIT
+PackageCopyrightText: 2020-2023, The Tauri Programme in the Commons Conservancy
+PackageSummary: <text>tao-macros is part of Tao, the official, rust-based window manager for Wry.
+                </text>
+PackageComment: <text>The package includes the following libraries; see
+Relationship information.
+                </text>
+Created: 2020-05-20T09:00:00Z
+PackageDownloadLocation: git://github.com/tauri-apps/tao
+PackageDownloadLocation: git+https://github.com/tauri-apps/tao.git
+PackageDownloadLocation: git+ssh://github.com/tauri-apps/tao.git
+Creator: Person: Daniel Thompson-Yvetot
 ```
 
 ### L-1ddb39b2b497
@@ -11446,6 +11542,62 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### L-26e6f69cf1f6
+
+```
+MIT License
+
+Copyright (c) 2022 - Present Tauri Apps Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### L-2710a622a896
+
+```
+Copyright (c) Ferrous Systems
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ### L-277d2a8e4597
@@ -12759,6 +12911,36 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+```
+
+### L-36c68b249eb6
+
+```
+Copyright (c) 2026 Zeeshan Ali Khan & zcheapstr contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ### L-37412fff76e3
@@ -14873,36 +15055,6 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 ```
 
-### L-4bddfb319e32
-
-```
-Copyright (c) 2019-2025 Sean McArthur & Hyper Contributors
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-```
-
 ### L-4be46afa7981
 
 ```
@@ -15414,6 +15566,24 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 """
+```
+
+### L-5018b4040991
+
+```
+Apache Arrow
+Copyright 2016-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the chronoutil crate (MIT)
+ * Copyright (c) 2020-2022 Oliver Margetts
+ * https://github.com/olliemath/chronoutil
+
+This product includes software from the compact-thrift project (Apache 2.0)
+ * Copyright Jörn Horstmann
+ * https://github.com/jhorstmann/compact-thrift
 ```
 
 ### L-516b24e051bf
@@ -16070,6 +16240,36 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### L-57f841bc9767
+
+```
+Copyright (c) 2019-2026 Sean McArthur & Hyper Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ### L-583e9c5fd9a9
@@ -18453,6 +18653,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### L-6061b8ea5b16
+
+```
+Copyright (c) 2014 The rusqlite developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 ```
 
 ### L-60fd4b5e1281
@@ -24156,95 +24380,6 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ```
 
-### L-81399416f00b
-
-```
-Apache Arrow
-Copyright 2016-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-This product includes software from the SFrame project (BSD, 3-clause).
-* Copyright (C) 2015 Dato, Inc.
-* Copyright (c) 2009 Carnegie Mellon University.
-
-This product includes software from the Feather project (Apache 2.0)
-https://github.com/wesm/feather
-
-This product includes software from the DyND project (BSD 2-clause)
-https://github.com/libdynd
-
-This product includes software from the LLVM project
- * distributed under the University of Illinois Open Source
-
-This product includes software from the google-lint project
- * Copyright (c) 2009 Google Inc. All rights reserved.
-
-This product includes software from the mman-win32 project
- * Copyright https://code.google.com/p/mman-win32/
- * Licensed under the MIT License;
-
-This product includes software from the LevelDB project
- * Copyright (c) 2011 The LevelDB Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * Moved from Kudu http://github.com/cloudera/kudu
-
-This product includes software from the CMake project
- * Copyright 2001-2009 Kitware, Inc.
- * Copyright 2012-2014 Continuum Analytics, Inc.
- * All rights reserved.
-
-This product includes software from https://github.com/matthew-brett/multibuild (BSD 2-clause)
- * Copyright (c) 2013-2016, Matt Terry and Matthew Brett; all rights reserved.
-
-This product includes software from the Ibis project (Apache 2.0)
- * Copyright (c) 2015 Cloudera, Inc.
- * https://github.com/cloudera/ibis
-
-This product includes software from Dremio (Apache 2.0)
-  * Copyright (C) 2017-2018 Dremio Corporation
-  * https://github.com/dremio/dremio-oss
-
-This product includes software from Google Guava (Apache 2.0)
-  * Copyright (C) 2007 The Guava Authors
-  * https://github.com/google/guava
-
-This product include software from CMake (BSD 3-Clause)
-  * CMake - Cross Platform Makefile Generator
-  * Copyright 2000-2019 Kitware, Inc. and Contributors
-
-The web site includes files generated by Jekyll.
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Kudu, which includes the following in
-its NOTICE file:
-
-  Apache Kudu
-  Copyright 2016 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  Portions of this software were developed at
-  Cloudera, Inc (http://www.cloudera.com/).
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache ORC, which includes the following in
-its NOTICE file:
-
-  Apache ORC
-  Copyright 2013-2019 The Apache Software Foundation
-
-  This product includes software developed by The Apache Software
-  Foundation (http://www.apache.org/).
-
-  This product includes software developed by Hewlett-Packard:
-  (c) Copyright [2014-2015] Hewlett-Packard Development Company, L.P
-```
-
 ### L-81976b4834c3
 
 ```
@@ -29452,36 +29587,6 @@ is licensed under:
 at your option.
 ```
 
-### L-ae61683b7dd6
-
-```
-Copyright (c) 2019-2024 Sean McArthur & Hyper Contributors
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-```
-
 ### L-ae8de7e1b783
 
 ```
@@ -31178,6 +31283,32 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+### L-bddc4356d6da
+
+```
+MIT License
+
+Copyright (c) 2020-2022 Oliver Margetts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### L-bde59a7e336f

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -34,6 +34,8 @@ const fixturePaths = [
   "crates/tidebreak-desktop/src/lib.rs",
   "crates/tidebreak-desktop/src/updater.rs",
   "crates/tidebreak-desktop/src/broker.rs",
+  "crates/tidebreak-desktop/src/voice_transcription.rs",
+  "crates/tidebreak-desktop/src/whisper_install.rs",
   "crates/tidebreak-desktop/scripts/prepare-sidecar.mjs",
   "crates/tidebreak-server/build.rs",
   "deploy/self-host/Dockerfile",

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -55,6 +55,24 @@ const desktopBroker = readFileSync(
   repositoryFile("crates", "tidebreak-desktop", "src", "broker.rs"),
   "utf8",
 );
+const desktopVoice = readFileSync(
+  repositoryFile(
+    "crates",
+    "tidebreak-desktop",
+    "src",
+    "voice_transcription.rs",
+  ),
+  "utf8",
+);
+const desktopWhisperInstall = readFileSync(
+  repositoryFile(
+    "crates",
+    "tidebreak-desktop",
+    "src",
+    "whisper_install.rs",
+  ),
+  "utf8",
+);
 const dockerIgnore = readFileSync(
   repositoryFile("deploy", "self-host", "Dockerfile.dockerignore"),
   "utf8",
@@ -851,6 +869,36 @@ test("production secrets remain isolated to the release workflow", () => {
     /\.github\/e2b-cli\/node_modules\/\.bin\/e2b --version/,
   );
   assert.doesNotMatch(publishJob, /npm install|@latest/);
+});
+
+test("desktop voice delegates whisper.cpp to the verified helper", () => {
+  assert.match(desktopHost, /^mod whisper_install;$/m);
+  assert.match(
+    desktopVoice,
+    /crate::whisper_install::ensure_helper\(&self\.data_dir\)/,
+  );
+  assert.match(desktopVoice, /tokio::process::Command::new\(helper\)/);
+  assert.doesNotMatch(desktopVoice, /\bWhisperContext\b|whisper_rs/);
+  assert.doesNotMatch(desktopCargo, /^whisper-rs\s*=/m);
+  assert.match(desktopCargo, /^minisign-verify\.workspace = true$/m);
+  assert.match(
+    desktopWhisperInstall,
+    /sha256_hex_of_file\(&binary\).*marker\.binary_sha256/s,
+  );
+
+  const releaseWindows = workflowJob(workflows["release.yml"], "build_windows");
+  const warmWindows = workflows["cache-windows.yml"];
+  for (const job of [releaseWindows, warmWindows]) {
+    assert.doesNotMatch(job, /Use clang-cl for Windows ARM native code/);
+    assert.doesNotMatch(job, /CMAKE_GENERATOR=Ninja/);
+  }
+
+  const helperBuild = workflowJob(
+    workflows["publish-whisper-helper.yml"],
+    "build",
+  );
+  assert.match(helperBuild, /Use clang-cl for Windows ARM native code/);
+  assert.match(helperBuild, /CMAKE_GENERATOR=Ninja/);
 });
 
 test("dependency policy covers advisories, licenses, sources, and the locked graph", () => {


### PR DESCRIPTION
## What changed

- Route desktop local transcription through the managed `tidebreak-whisper` helper instead of linking whisper.cpp into the desktop.
- Verify the installed helper bytes against the marker SHA-256 before returning or executing the helper.
- Remove the desktop `whisper-rs` dependency and keep the Windows ARM clang-cl setup only in the helper publishing workflow.
- Add focused helper protocol, integrity, dependency-graph, and release-policy contracts.

## Validation

- `cargo fmt --all --check`
- `git diff --check ac34e4833a8a5ce781267d3d634b7ceec8150cae..HEAD`
- `TIDEBREAK_SKIP_DOCKER_CONTEXT_PROBE=1 node --test scripts/workflow-security.test.mjs` (41 passed, 2 Docker probes skipped because the local daemon was unavailable)
- `node scripts/generate-third-party-notices.mjs --check`

Per repository policy, local Cargo build, check, test, and Clippy commands were not run. CI provides those results.

## Compatibility and risk

The helper protocol remains pinned to version `0.1.0`. The desktop sends mono 16 kHz little-endian `f32` PCM over stdin and reads UTF-8 text from stdout. Existing model storage and API behavior remain unchanged. The main risk is platform-specific child-process behavior, which the Windows and desktop CI lanes cover.

## Tracking

This replaces the closed Graphite stack PR #2734 after the stack was recreated as #2739.