### PR TITLE
fix(code): report relay-backed engines as ready on hosted machines

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -207,6 +207,7 @@ import {
   type CodeWorkspaceStatus as WireCodeWorkspaceStatus,
   type FenceReason as WireFenceReason,
   type HarnessCaps as WireHarnessCaps,
+  type HarnessAuthMode as WireHarnessAuthMode,
   type HarnessDoctorEntry as WireHarnessDoctorEntry,
   type HarnessDoctorReport as WireHarnessDoctorReport,
   type HarnessKind as WireHarnessKind,
@@ -1292,6 +1293,7 @@ export type HarnessNoticeLevel = WireHarnessNoticeLevel;
 /** Doctor report for every registered engine. */
 export type HarnessDoctorReport = WireHarnessDoctorReport;
 export type HarnessDoctorEntry = WireHarnessDoctorEntry;
+export type HarnessAuthMode = WireHarnessAuthMode;
 export type HarnessKind = WireHarnessKind;
 export type HarnessTier = WireHarnessTier;
 export type HarnessCaps = WireHarnessCaps;

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
@@ -55,6 +55,7 @@ const READY_DOCTOR: HarnessDoctorReport = {
         slash_commands: "unknown",
       },
       commands: [],
+      auth_mode: "local_sign_in",
       remediation: "",
       stderr: "",
       unrecognized_event_count: 0,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -207,6 +207,7 @@ const START_HARNESS: HarnessDoctorEntry = {
     slash_commands: "unknown",
   },
   commands: [],
+  auth_mode: "local_sign_in",
   remediation: "",
   stderr: "",
   unrecognized_event_count: 0,

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
@@ -100,6 +100,7 @@ describe("DoctorList", () => {
             slash_commands: "unknown",
           },
           commands: [],
+          auth_mode: "local_sign_in",
           remediation: "",
           stderr: "",
           unrecognized_event_count: 6,
@@ -141,6 +142,51 @@ describe("DoctorList", () => {
     expect(onInstall).toHaveBeenCalledWith("opencode");
   });
 
+  it("reads relay-covered engines as ready on a hosted machine", () => {
+    render(
+      <DoctorList
+        report={{
+          harnesses: [
+            {
+              ...notDownloaded,
+              kind: "claude_code",
+              found: true,
+              // The hosted machine's own probe sees no sign-in, and that is
+              // no longer the verdict: the relay carries the turn.
+              authenticated: false,
+              auth_mode: "gateway_relay",
+            },
+            {
+              ...notDownloaded,
+              kind: "opencode",
+              found: true,
+              authenticated: false,
+              auth_mode: "hosted_unavailable",
+              remediation: "opencode is not available on hosted machines yet.",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(
+      screen.getByText("Turns run as you through the Model Gateway."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText("opencode is not available on hosted machines yet."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 of 2 engines ready.")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "No engine is ready yet. Sign in to one below, then re-check.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Sign in via your terminal, then re-check."),
+    ).not.toBeInTheDocument();
+  });
   /** An engine still downloading offers no second Download button. */
   it("reports a download in flight instead of offering another", () => {
     render(
@@ -183,6 +229,7 @@ const notDownloaded: HarnessDoctorEntry = {
     slash_commands: "unknown",
   },
   commands: [],
+  auth_mode: "local_sign_in",
   remediation: "",
   stderr: "",
   unrecognized_event_count: 0,

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -128,6 +128,9 @@ function statusBadge(
   }
   if (install?.error) return { label: "Download failed", variant: "critical" };
   if (isHarnessReady(entry)) return { label: "Ready", variant: "success" };
+  if (entry.auth_mode === "hosted_unavailable") {
+    return { label: "Unavailable", variant: "warning" };
+  }
   // A state, not an instruction — the instruction is the line below it.
   if (entry.found) {
     return entry.authenticated === false
@@ -156,11 +159,20 @@ function subtitle(
   }
   if (install?.error) return install.error;
   if (entry.remediation) return entry.remediation;
-  if (entry.found && entry.authenticated !== true) {
+  // A relay-covered engine on a hosted machine needs no sign-in, so the
+  // fallback below must not demand one; say where its turns run instead.
+  if (
+    entry.found &&
+    entry.auth_mode !== "gateway_relay" &&
+    entry.authenticated !== true
+  ) {
     return "Sign in via your terminal, then re-check.";
   }
   if (harnessNeedsDownload(entry)) {
     return "Downloads the first time you pick it.";
+  }
+  if (entry.auth_mode === "gateway_relay") {
+    return "Turns run as you through the Model Gateway.";
   }
   return TIER_NOTES[entry.tier];
 }
@@ -188,7 +200,13 @@ function DoctorRow({
   const downloading = Boolean(install && !install.done && !install.error);
   const failed = Boolean(install?.error);
   const canDownload =
-    Boolean(onInstall) && !entry.found && entry.installable && !downloading;
+    Boolean(onInstall) &&
+    !entry.found &&
+    entry.installable &&
+    !downloading &&
+    // Downloading an engine the relay cannot carry would hand the reader a
+    // binary that still cannot run here.
+    entry.auth_mode !== "hosted_unavailable";
   const detailId = `harness-detail-${entry.kind}`;
 
   return (
@@ -262,11 +280,13 @@ function DoctorRow({
         >
           <Detail label="Tier">{HARNESS_TIER_LABELS[entry.tier]}</Detail>
           <Detail label="Signed in">
-            {entry.authenticated === undefined
-              ? "not observed"
-              : entry.authenticated
-                ? "yes"
-                : "no"}
+            {entry.auth_mode === "gateway_relay"
+              ? "as you, through the gateway"
+              : entry.authenticated === undefined
+                ? "not observed"
+                : entry.authenticated
+                  ? "yes"
+                  : "no"}
           </Detail>
           {entry.path && (
             <Detail label="Path">

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -37,6 +37,7 @@ function entry(
     tier: "reference",
     caps: { ...CAPS },
     commands: [],
+    auth_mode: "local_sign_in",
     remediation: "",
     stderr: "",
     unrecognized_event_count: 0,

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -71,6 +71,7 @@ function harness(kind: HarnessKind): HarnessDoctorEntry {
     tier: "reference",
     caps: { ...CAPS },
     commands: [],
+    auth_mode: "local_sign_in",
     remediation: "",
     stderr: "",
     unrecognized_event_count: 0,

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -90,6 +90,7 @@ function entry(
     tier: "reference",
     caps: { ...CAPS, structured_approvals: "supported", ...caps },
     commands: [],
+    auth_mode: "local_sign_in",
     remediation: "",
     stderr: "",
     unrecognized_event_count: 0,

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -112,6 +112,50 @@ describe("harnessUnusableReason", () => {
     expect(isHarnessReady({ found: true })).toBe(false);
   });
 
+  it("reads a relay-covered engine as ready on a hosted machine", () => {
+    // The local probe observation is not the verdict there: the relay
+    // carries the turn (decision 71), signed out or not.
+    expect(
+      isHarnessReady({
+        found: true,
+        authenticated: false,
+        auth_mode: "gateway_relay",
+      }),
+    ).toBe(true);
+    expect(isHarnessReady({ found: false, auth_mode: "gateway_relay" })).toBe(
+      false,
+    );
+    // An engine the relay does not cover can never be ready hosted.
+    expect(
+      isHarnessReady({
+        found: true,
+        authenticated: true,
+        auth_mode: "hosted_unavailable",
+      }),
+    ).toBe(false);
+  });
+
+  it("gates hosted rows on relay coverage, not a terminal sign-in", () => {
+    expect(
+      harnessUnusableReason({
+        found: true,
+        installable: true,
+        authenticated: false,
+        auth_mode: "gateway_relay",
+        caps: caps("supported", "supported", "supported"),
+      }),
+    ).toBeNull();
+    expect(
+      harnessUnusableReason({
+        found: true,
+        installable: true,
+        authenticated: true,
+        auth_mode: "hosted_unavailable",
+        caps: caps("supported", "supported", "supported"),
+      }),
+    ).toBe("Not available on hosted machines yet");
+  });
+
   it("names the one reason a picker row cannot be chosen", () => {
     expect(
       harnessUnusableReason({

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -4,6 +4,7 @@ import type {
   CodeSessionLifecycle,
   CodeWorkspaceStatus,
   FenceReason,
+  HarnessAuthMode,
   HarnessCaps,
   HarnessKind,
   HarnessTier,
@@ -116,10 +117,22 @@ export function fenceReasonText(reason: FenceReason): string {
   return reason.detail;
 }
 
+/**
+ * True when this engine can serve a session right now.
+ *
+ * On a gateway-hosted machine the relay-covered engines are ready without a
+ * local sign-in (decision 71), and the uncovered ones can never be; the
+ * `auth_mode` the server reports decides, and `authenticated` — the local
+ * probe observation — does not.
+ */
 export function isHarnessReady(entry: {
   found: boolean;
   authenticated?: boolean;
+  auth_mode?: HarnessAuthMode;
 }): boolean {
+  const mode = entry.auth_mode ?? "local_sign_in";
+  if (mode === "gateway_relay") return entry.found;
+  if (mode === "hosted_unavailable") return false;
   return entry.found && entry.authenticated === true;
 }
 
@@ -152,13 +165,22 @@ export function harnessUnusableReason(entry: {
   found: boolean;
   installable: boolean;
   authenticated?: boolean;
+  auth_mode?: HarnessAuthMode;
   remediation?: string;
   caps: ModeCaps;
 }): string | null {
+  const mode = entry.auth_mode ?? "local_sign_in";
+  if (mode === "hosted_unavailable") {
+    return "Not available on hosted machines yet";
+  }
   if (!entry.found && !entry.installable) return "Not installed";
-  if (entry.authenticated === false) return "Sign in via your terminal";
-  if (entry.found && entry.authenticated === undefined) {
-    return "Unverified — sign in via your terminal";
+  // A relay-covered engine needs no sign-in on a hosted machine, so the
+  // local probe observation is not a gate there either.
+  if (mode === "local_sign_in") {
+    if (entry.authenticated === false) return "Sign in via your terminal";
+    if (entry.found && entry.authenticated === undefined) {
+      return "Unverified — sign in via your terminal";
+    }
   }
   if (!harnessHonorsAnyCreateMode(entry)) return "Not available yet";
   return null;
@@ -169,6 +191,7 @@ export function harnessCanStartNow(entry: {
   found: boolean;
   installable: boolean;
   authenticated?: boolean;
+  auth_mode?: HarnessAuthMode;
   remediation?: string;
   caps: ModeCaps;
 }): boolean {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -38,6 +38,7 @@ import type {
   CodeWorkspaceStatus,
   FenceReason,
   HarnessCaps,
+  HarnessAuthMode,
   HarnessDoctorEntry,
   HarnessDoctorReport,
   HarnessKind,
@@ -195,6 +196,11 @@ const HARNESS_TIERS = new Set<HarnessTier>([
   "secondary",
   "tertiary",
   "best_effort",
+]);
+const HARNESS_AUTH_MODES = new Set<HarnessAuthMode>([
+  "local_sign_in",
+  "gateway_relay",
+  "hosted_unavailable",
 ]);
 const CAP_LEVELS = new Set<CapLevel>(["supported", "unsupported", "unknown"]);
 const PERMISSION_MODES = new Set<PermissionMode>([
@@ -3056,6 +3062,7 @@ export function parseHarnessDoctorEntry(
       "caps",
       "commands",
       "authenticated",
+      "auth_mode",
       "remediation",
       "stderr",
       "unrecognized_event_count",
@@ -3067,6 +3074,8 @@ export function parseHarnessDoctorEntry(
     !isMember(value.tier, HARNESS_TIERS) ||
     (value.authenticated !== undefined &&
       typeof value.authenticated !== "boolean") ||
+    (value.auth_mode !== undefined &&
+      !isMember(value.auth_mode, HARNESS_AUTH_MODES)) ||
     typeof value.remediation !== "string" ||
     typeof value.stderr !== "string" ||
     !isFiniteNumber(value.unrecognized_event_count)
@@ -3083,6 +3092,9 @@ export function parseHarnessDoctorEntry(
     // A server that predates the field offers no on-demand download, which
     // is what this build did before the pin became lazy.
     installable: value.installable === true,
+    // Ditto the hosted doctor: a server that predates it knows only the
+    // local sign-in probe, and that is the local answer.
+    auth_mode: value.auth_mode ?? "local_sign_in",
     tier: value.tier,
     caps,
     remediation: value.remediation,

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2483,6 +2483,11 @@ export type GrantLevel = { "level": "chat", chat_id: ChatId, } | { "level": "pro
 export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "command_prefix", tokens: Array<string>, } | { "scope": "path_subtree", prefix: string, } | { "scope": "whole_tool" };
 
 /**
+ * How a session of one engine authenticates on this machine.
+ */
+export type HarnessAuthMode = "local_sign_in" | "gateway_relay" | "hosted_unavailable";
+
+/**
  * Capability vector for one probed engine version.
  *
  * Constructed exhaustively — there is no [`Default`] — so a new flag is a
@@ -2576,7 +2581,16 @@ export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean,
  * the download starts; the doctor is not a gate the reader must clear
  * first.
  */
-installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, remediation: string, stderr: string, unrecognized_event_count: number, };
+installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, 
+/**
+ * How a session of this engine authenticates here: the engine's own
+ * local sign-in, the on-behalf-of relay on a gateway-hosted machine
+ * (decision 71), or nothing where the relay does not cover the engine
+ * yet. Readiness follows this — `authenticated` stays the local probe
+ * observation, which on a hosted machine is not what a session
+ * authenticates with.
+ */
+auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, };
 
 /**
  * Doctor report for every registered engine adapter.

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
@@ -6,6 +6,7 @@ import {
   harnessDoctor,
   harnessDoctorCold,
   harnessDoctorDegraded,
+  harnessDoctorHosted,
   harnessDoctorMixed,
   harnessInstallsInFlight,
 } from "./fixtures";
@@ -63,6 +64,15 @@ export const Downloading: Story = {
 /** Nothing a download fixes: one unverified engine and one signed-out engine. */
 export const NeedsYou: Story = {
   args: { report: harnessDoctorDegraded },
+};
+
+/**
+ * A gateway-hosted machine: the relay engines are ready with no sign-in to
+ * perform — turns run as the caller through the Model Gateway — and the
+ * engines the relay does not cover yet say so.
+ */
+export const Hosted: Story = {
+  args: { report: harnessDoctorHosted },
 };
 
 /** The re-probe is running. */

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -482,6 +482,7 @@ function doctorEntry(
     found: true,
     installable: true,
     authenticated: true,
+    auth_mode: "local_sign_in",
     tier: "reference",
     caps: fullCaps,
     commands: [],
@@ -585,6 +586,58 @@ export const harnessDoctorMixed: HarnessDoctorReport = {
           version: undefined,
         },
   ),
+};
+
+/**
+ * A gateway-hosted machine (decision 71): the relay engines are ready with no
+ * sign-in to perform, and the ones the relay does not cover yet say so
+ * instead of demanding a terminal nobody can open.
+ */
+export const harnessDoctorHosted: HarnessDoctorReport = {
+  harnesses: [
+    doctorEntry({
+      kind: "claude_code",
+      version: "2.1.234 (Claude Code)",
+      path: "~/.local/share/tidebreak/tools/harnesses/claude_code",
+      authenticated: false,
+      auth_mode: "gateway_relay",
+    }),
+    doctorEntry({
+      kind: "codex",
+      version: "codex-cli 0.147.0",
+      tier: "secondary",
+      authenticated: false,
+      auth_mode: "gateway_relay",
+      caps: {
+        ...fullCaps,
+        mid_turn_steering: "supported",
+        image_input: "unknown",
+      },
+    }),
+    doctorEntry({
+      kind: "opencode",
+      version: "1.18.18",
+      tier: "tertiary",
+      authenticated: false,
+      auth_mode: "hosted_unavailable",
+      remediation: "opencode is not available on hosted machines yet.",
+      caps: { ...fullCaps, allow_mode: "unknown", reasoning_levels: "unknown" },
+    }),
+    doctorEntry({
+      kind: "grok",
+      version: "grok 1.0.5",
+      tier: "best_effort",
+      authenticated: false,
+      auth_mode: "hosted_unavailable",
+      remediation: "Grok CLI is not available on hosted machines yet.",
+      caps: {
+        ...fullCaps,
+        mid_turn_steering: "unsupported",
+        plan_mode: "unsupported",
+        structured_approvals: "unsupported",
+      },
+    }),
+  ],
 };
 
 /** One engine mid-download, one that failed, for the doctor's live states. */

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -282,6 +282,16 @@ pub(crate) fn spawn_wiring(
     }
 }
 
+/// Whether the on-behalf-of relay can carry this engine's inference.
+///
+/// Exactly the engines [`spawn_wiring`] points at the relay. The doctor reads
+/// this on a gateway-hosted machine, where a covered engine needs no local
+/// sign-in and an uncovered one cannot run at all; everywhere else the local
+/// probe decides, and this answer does not matter.
+pub(crate) fn relay_covered(kind: HarnessKind) -> bool {
+    matches!(kind, HarnessKind::ClaudeCode | HarnessKind::Codex)
+}
+
 fn generate_key() -> String {
     format!("tbreak_hl_{}", uuid::Uuid::new_v4())
 }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -616,6 +616,17 @@ impl CodeRuntime {
         self
     }
 
+    /// Wire the engine inference relay from tests, standing in for the
+    /// on-behalf-of handle a hosted deployment constructs.
+    #[cfg(test)]
+    pub(crate) fn with_harness_llm(
+        mut self,
+        relay: Arc<super::harness_llm::HarnessLlmRelay>,
+    ) -> Self {
+        self.harness_llm = Some(relay);
+        self
+    }
+
     pub(crate) fn with_clone_parent_default(mut self, parent: PathBuf) -> Self {
         self.clone_parent_default = Some(parent);
         self

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -833,6 +833,14 @@ impl ScopedCode {
         self.runtime.invalidate_probes();
     }
 
+    /// Whether the on-behalf-of inference relay is active (decision 71):
+    /// true only on a gateway-authenticated hosted machine, whose engines
+    /// carry no provider credentials of their own. The doctor reads this to
+    /// decide whether the local sign-in probe answers the right question.
+    pub(crate) fn harness_llm_relay_active(&self) -> bool {
+        self.runtime.harness_llm().is_some()
+    }
+
     /// Warm the pinned install of one engine. See
     /// [`CodeRuntime::start_harness_install`].
     ///

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -5,9 +5,10 @@ use crate::error::ServerError;
 use crate::extract::Json;
 
 use super::types::{
-    CodeHarnessInstallSnapshot, HarnessDoctorEntry, HarnessDoctorReport, HarnessModel,
-    HarnessModelList, InstallHarnessQuery,
+    CodeHarnessInstallSnapshot, HarnessAuthMode, HarnessDoctorEntry, HarnessDoctorReport,
+    HarnessModel, HarnessModelList, InstallHarnessQuery,
 };
+use crate::code::harness_llm::relay_covered;
 use tidebreak_core::HarnessKind;
 
 /// The doctor surface, served from the memoized probes (decision 0034).
@@ -94,6 +95,11 @@ pub async fn list_harness_models(
 async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
     let sessions = code.list_sessions().await?;
     let sessions = &sessions;
+    // On a gateway-hosted machine, engine inference rides the on-behalf-of
+    // relay (decision 71) and the local sign-in probe answers the wrong
+    // question: nobody can open a terminal there, and a signed-out engine is
+    // a ready one. Everywhere else the probe decides, exactly as before.
+    let hosted = code.harness_llm_relay_active();
     // Probe the kinds concurrently. A cold probe is a login shell plus a
     // version and an authentication subprocess, so a serial walk over the
     // harnesses is most of what this route costs on a cache miss.
@@ -110,16 +116,30 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
             let install_error = code.pin_install_error(*kind);
             let installable = tidebreak_harness::pin_for(*kind).is_some();
             let label = harness_label(*kind);
+            let auth_mode = if !hosted {
+                HarnessAuthMode::LocalSignIn
+            } else if relay_covered(*kind) {
+                HarnessAuthMode::GatewayRelay
+            } else {
+                HarnessAuthMode::HostedUnavailable
+            };
             let remediation = if let Some(err) = install_error {
                 format!("could not download the pinned {kind} binary: {err}")
+            } else if auth_mode == HarnessAuthMode::HostedUnavailable {
+                format!("{label} is not available on hosted machines yet.")
+            } else if !probe.found && !installable {
+                format!("this build ships no pinned {kind} binary to download")
+            } else if auth_mode == HarnessAuthMode::GatewayRelay {
+                // The relay carries each turn as the caller, so no local
+                // sign-in stands between the reader and a session. A missing
+                // binary is the lazy pin's download, not a fault.
+                String::new()
             } else if probe.found && probe.authenticated == Some(false) {
                 format!("Sign in to {label} in your own terminal, then re-check.")
             } else if probe.found && probe.authenticated.is_none() {
                 format!(
                     "Tidebreak could not verify the {label} sign-in. Sign in to {label} in your own terminal, then re-check."
                 )
-            } else if !probe.found && !installable {
-                format!("this build ships no pinned {kind} binary to download")
             } else {
                 // A missing but installable engine has nothing for the reader
                 // to repair: picking it downloads it.
@@ -138,6 +158,7 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
                 caps,
                 commands: probe.commands,
                 authenticated: probe.authenticated,
+                auth_mode,
                 remediation,
                 stderr: probe.stderr,
                 unrecognized_event_count,

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -362,6 +362,21 @@ pub struct HarnessDoctorReport {
     pub harnesses: Vec<HarnessDoctorEntry>,
 }
 
+/// How a session of one engine authenticates on this machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessAuthMode {
+    /// The engine's own local sign-in — the probe result decides readiness.
+    LocalSignIn,
+    /// The on-behalf-of relay (decision 71): a gateway-hosted machine, where
+    /// turns run as the caller through the gateway and no local sign-in is
+    /// needed.
+    GatewayRelay,
+    /// The relay does not cover this engine yet, so it cannot run on a
+    /// hosted machine.
+    HostedUnavailable,
+}
+
 /// One engine's probe, capabilities, and remediation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct HarnessDoctorEntry {
@@ -385,6 +400,13 @@ pub struct HarnessDoctorEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub authenticated: Option<bool>,
+    /// How a session of this engine authenticates here: the engine's own
+    /// local sign-in, the on-behalf-of relay on a gateway-hosted machine
+    /// (decision 71), or nothing where the relay does not cover the engine
+    /// yet. Readiness follows this — `authenticated` stays the local probe
+    /// observation, which on a hosted machine is not what a session
+    /// authenticates with.
+    pub auth_mode: HarnessAuthMode,
     pub remediation: String,
     pub stderr: String,
     pub unrecognized_event_count: i64,

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -382,14 +382,6 @@ impl ScriptedAdapter {
         self
     }
 
-    /// Stand in for a different engine, so a surface that walks every kind —
-    /// the doctor — can be exercised with more than one row.
-    #[allow(dead_code)]
-    pub(crate) fn with_kind(mut self, kind: HarnessKind) -> Self {
-        self.kind = kind;
-        self
-    }
-
     /// Report this local sign-in state from the probe, for surfaces that
     /// branch on it — the doctor's hosted report among them.
     #[allow(dead_code)]

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -149,6 +149,8 @@ pub(crate) struct ScriptedAdapter {
     /// Sleep once at the start of each turn, so a caller can observe Running
     /// and queue a follow-up before the script plays.
     turn_delay: Duration,
+    /// What the probe reports as this engine's local sign-in state.
+    authenticated: Option<bool>,
 }
 
 impl ScriptedAdapter {
@@ -183,6 +185,7 @@ impl ScriptedAdapter {
             approval_ack_delay: Duration::ZERO,
             probes: Arc::new(AtomicU64::new(0)),
             launched_approvals: Arc::new(std::sync::Mutex::new(Vec::new())),
+            authenticated: Some(true),
             writes: Vec::new(),
             turn_delay: Duration::ZERO,
         }
@@ -378,6 +381,22 @@ impl ScriptedAdapter {
         self.silent_interrupt = true;
         self
     }
+
+    /// Stand in for a different engine, so a surface that walks every kind —
+    /// the doctor — can be exercised with more than one row.
+    #[allow(dead_code)]
+    pub(crate) fn with_kind(mut self, kind: HarnessKind) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    /// Report this local sign-in state from the probe, for surfaces that
+    /// branch on it — the doctor's hosted report among them.
+    #[allow(dead_code)]
+    pub(crate) fn with_authenticated(mut self, authenticated: Option<bool>) -> Self {
+        self.authenticated = authenticated;
+        self
+    }
 }
 
 #[async_trait]
@@ -392,7 +411,7 @@ impl HarnessAdapter for ScriptedAdapter {
             found: true,
             binary_path: Some(PathBuf::from("/scripted/engine")),
             version: Some("scripted".into()),
-            authenticated: Some(true),
+            authenticated: self.authenticated,
             stderr: String::new(),
             env: Vec::new(),
             commands: Vec::new(),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -7593,6 +7593,80 @@ async fn the_doctor_caches_probes_and_refresh_re_probes() {
     );
 }
 
+/// Decision 71's doctor half: on a gateway-hosted machine the relay-covered
+/// engines are ready without a local sign-in — nobody can open a terminal
+/// there — and the uncovered ones say they are not available hosted yet,
+/// rather than demanding that terminal sign-in.
+#[tokio::test]
+async fn the_doctor_reports_relay_engines_ready_on_a_hosted_machine() {
+    let (dir, store) = temp_db_store("code.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(
+        ScriptedAdapter::new(plain_text_script()).with_authenticated(Some(false)),
+    ));
+    registry.register(Arc::new(
+        ScriptedAdapter::new(plain_text_script())
+            .with_kind(HarnessKind::Opencode)
+            .with_authenticated(Some(false)),
+    ));
+    let gateway = Arc::new(
+        crate::obo_gateway::OboGateway::new(
+            "https://gateway.example",
+            "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed".to_owned(),
+        )
+        .unwrap(),
+    );
+    let runtime = Arc::new(
+        CodeRuntime::with_registry(db, dir.path().to_path_buf(), registry).with_harness_llm(
+            Arc::new(crate::code::harness_llm::HarnessLlmRelay::new(gateway)),
+        ),
+    );
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime);
+    let token = state.token.clone();
+    let addr = serve(app(state)).await;
+    let client = reqwest::Client::new();
+
+    let report = client
+        .get(format!("http://{addr}/code/harnesses"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    let claude = &report["harnesses"][0];
+    assert_eq!(claude["kind"], "claude_code");
+    assert_eq!(claude["auth_mode"], "gateway_relay");
+    assert_eq!(
+        claude["authenticated"], false,
+        "the local probe observation stays on the row; it is just no longer the verdict"
+    );
+    assert_eq!(claude["remediation"], "");
+
+    let opencode = &report["harnesses"][1];
+    assert_eq!(opencode["kind"], "opencode");
+    assert_eq!(opencode["auth_mode"], "hosted_unavailable");
+    assert_eq!(
+        opencode["remediation"],
+        "opencode is not available on hosted machines yet."
+    );
+}
+
 /// A session restored at boot comes back supervised. Recovery re-attaches its
 /// worker, and that worker's approval endpoint is minted from the bound
 /// loopback address — so recovery has to run after the address is published.

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -1632,7 +1632,7 @@ export type CodeTurnId = string;
 /**
  * One user→engine turn.
  */
-export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, user_input: string, attachments: Array<ImageRef>, usage?: CodeUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string, };
+export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: CodeUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string, };
 
 /**
  * Status of one user→engine turn.

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -979,7 +979,12 @@ export type CodeDeliveryPrAttentionReason = "changes_requested" | "checks_failed
  * User-initiated global PR action. Code-changing actions deliberately do not
  * exist here; they remain workspace-scoped agent prompts.
  */
-export type CodeDeliveryPullRequestAction = { "type": "mark_ready" } | { "type": "merge", method: CodePrMergeMethod, auto: boolean, admin: boolean, expected_head_sha: string, } | { "type": "rerun_failed", workflow_run_ids: Array<number>, } | { "type": "close" } | { "type": "reopen" } | { "type": "comment", body: string, };
+export type CodeDeliveryPullRequestAction = { "type": "mark_ready" } | { "type": "merge", method: CodePrMergeMethod, auto: boolean, admin: boolean, expected_head_sha: string, } | { "type": "create_stack", 
+/**
+ * The chain to register, bottom to top. Every pull request's base
+ * ref must match the previous one's head ref.
+ */
+numbers: Array<number>, } | { "type": "rerun_failed", workflow_run_ids: Array<number>, } | { "type": "close" } | { "type": "reopen" } | { "type": "comment", body: string, };
 
 export type CodeDeliveryPullRequestActionBody = { target: CodeDeliveryPullRequestTarget, action: CodeDeliveryPullRequestAction, };
 
@@ -987,7 +992,13 @@ export type CodeDeliveryPullRequestActionBody = { target: CodeDeliveryPullReques
  * Full PR drawer payload. Conversation entries retain the existing bounded
  * comment contract used by workspace PRs.
  */
-export type CodeDeliveryPullRequestDetail = { summary: CodeDeliveryPullRequestSummary, body: string, labels: Array<string>, assignees: Array<string>, requested_reviewers: Array<string>, changed_files: number, additions: number, deletions: number, commits: number, merged_by?: string, 
+export type CodeDeliveryPullRequestDetail = { summary: CodeDeliveryPullRequestSummary, body: string, labels: Array<string>, assignees: Array<string>, requested_reviewers: Array<string>, changed_files: number, additions: number, deletions: number, 
+/**
+ * The full stack chain this pull request belongs to, bottom to top,
+ * when the host reported one. Absent on hosts without stacked pull
+ * requests.
+ */
+stack?: Array<CodeDeliveryStackMember>, commits: number, merged_by?: string, 
 /**
  * Empty when the diff could not be read. Truncated by `files_truncated`
  * rather than paged: the panel is a review aid, not a diff viewer.
@@ -1038,13 +1049,32 @@ in_merge_queue?: boolean,
  */
 comment_count?: number, checks: Array<CodeDeliveryCheck>, attention_reasons: Array<CodeDeliveryPrAttentionReason>, ready_to_merge: boolean, workspace_links: Array<CodeDeliveryWorkspaceLink>, 
 /**
- * The open pull request this one is stacked on: its base branch is that
- * pull request's head branch in the same repository (decision 62).
- * Derived from the durable fact set, so a parent outside the current
- * page or filter still resolves. Absent when the base is the default
- * branch or nothing tracked owns it.
+ * The host stack this pull request belongs to (GitHub stacked pull
+ * requests), when the host reported one. Identifies the stack, not the
+ * PR.
  */
-stack_parent_number?: number, labels: Array<string>, created_at: string, updated_at: string, 
+stack_number?: number, 
+/**
+ * Total layers in that stack, bottom to top, including merged ones.
+ */
+stack_size?: number, 
+/**
+ * The pull request this one is stacked on. Host stack order wins when
+ * the host reported a stack; branch inference from the durable fact set
+ * is the fallback (decision 62), so a parent outside the current page
+ * or filter still resolves. Absent when the base is the default branch
+ * or nothing tracked owns it.
+ */
+stack_parent_number?: number, 
+/**
+ * A stack-shaped chain of inferred edges the host has no stack for,
+ * bottom to top, when one resolves gaplessly around this pull request
+ * and no member is host-registered. Creating the stack on GitHub makes
+ * the host own the ordering, the retargeting, and the whole-chain merge
+ * — without it, merging a layer lands it into the branch below rather
+ * than the default branch, which is easy to do by accident.
+ */
+unregistered_stack_numbers?: Array<number>, labels: Array<string>, created_at: string, updated_at: string, 
 /**
  * Set only once the pull request merged. `state` alone cannot separate a
  * merged pull request from a closed one on every host response, and the
@@ -1106,6 +1136,23 @@ export type CodeDeliveryRunsPage = { capability: CodeGitHubCapability, items: Ar
  * One repository-level failure in an otherwise usable aggregate response.
  */
 export type CodeDeliverySourceError = { repository?: CodeGitHubRepositoryTarget, kind: string, message: string, retry_at?: string, };
+
+/**
+ * One layer of a pull-request stack, in bottom-to-top order.
+ */
+export type CodeDeliveryStackMember = { number: number, 
+/**
+ * Host state token (open, closed).
+ */
+state: string, draft: boolean, 
+/**
+ * Set once this layer merged.
+ */
+merged_at?: string, 
+/**
+ * Head branch name.
+ */
+head_branch: string, head_sha?: string, };
 
 export type CodeDeliveryWorkflowJob = { id: number, name: string, status: string, conclusion?: string, url: string, started_at: string | null, completed_at: string | null, failed_steps: Array<string>, };
 
@@ -1295,7 +1342,7 @@ at_turn?: CodeTurnId, };
  */
 export type CodeForkTranscript = { path: string, dir: string, byte_len: number, 
 /**
- * Turns the condensed transcript renders in full.
+ * Complete turn histories the condensed transcript renders in full.
  */
 turns: number, 
 /**
@@ -1308,8 +1355,8 @@ total_turns: number,
  */
 at_turn_ordinal?: number, 
 /**
- * True when anything was left out to fit the size cap: the oldest
- * turns, or the end of a turn too large on its own.
+ * True when bounded replay omitted whole turn histories or the file size
+ * cap reduced the oldest turns or the end of one oversized turn.
  */
 truncated: boolean, };
 
@@ -1796,7 +1843,7 @@ bundle_bytes?: number, };
 /**
  * Status of a persisted workspace.
  */
-export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archived" | "released";
+export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archiving" | "archived" | "released";
 
 /**
  * Bounded path listing for `GET /code/workspaces/{id}/tree`.
@@ -2436,6 +2483,11 @@ export type GrantLevel = { "level": "chat", chat_id: ChatId, } | { "level": "pro
 export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "command_prefix", tokens: Array<string>, } | { "scope": "path_subtree", prefix: string, } | { "scope": "whole_tool" };
 
 /**
+ * How a session of one engine authenticates on this machine.
+ */
+export type HarnessAuthMode = "local_sign_in" | "gateway_relay" | "hosted_unavailable";
+
+/**
  * Capability vector for one probed engine version.
  *
  * Constructed exhaustively — there is no [`Default`] — so a new flag is a
@@ -2529,7 +2581,16 @@ export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean,
  * the download starts; the doctor is not a gate the reader must clear
  * first.
  */
-installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, remediation: string, stderr: string, unrecognized_event_count: number, };
+installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, 
+/**
+ * How a session of this engine authenticates here: the engine's own
+ * local sign-in, the on-behalf-of relay on a gateway-hosted machine
+ * (decision 71), or nothing where the relay does not cover the engine
+ * yet. Readiness follows this — `authenticated` stays the local probe
+ * observation, which on a hosted machine is not what a session
+ * authenticates with.
+ */
+auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, };
 
 /**
  * Doctor report for every registered engine adapter.


### PR DESCRIPTION
## What changed

On a gateway-hosted machine the harness doctor listed every engine as unusable and told the reader to sign in at a terminal nobody can open. Since decision 71, Claude Code and Codex turns run on the per-caller inference relay there, so a signed-out engine is a ready engine.

- `doctor()` now asks whether the on-behalf-of relay is active (`ScopedCode::harness_llm_relay_active`, backed by the runtime's existing `harness_llm` handle) and reports each engine's `auth_mode` on the wire: `local_sign_in`, `gateway_relay`, or `hosted_unavailable`.
- `relay_covered(kind)` in `harness_llm.rs` sits beside `spawn_wiring` and covers exactly the engines it wires today — Claude Code and Codex. Opencode and Grok are #2652 and stay out.
- On a hosted machine: relay-covered engines carry no sign-in remediation and the desktop renders them Ready with "Turns run as you through the Model Gateway."; uncovered engines get "{label} is not available on hosted machines yet." and no Download button (the binary could not run there anyway).
- On a local machine (relay absent): every branch is unchanged — `auth_mode` is `local_sign_in` and the existing sign-in remediation, badges, banner, and picker gating behave exactly as before.
- The desktop derives readiness (`isHarnessReady`), picker gating (`harnessUnusableReason`), the banner count, and row copy from the new `auth_mode` field rather than overloading `authenticated`, which stays the honest local probe observation. Wire types regenerated through the ts-rs path (`UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server`) and synced to `mobile/src/generated/wire.ts`.

## How it was verified

- New server test `the_doctor_reports_relay_engines_ready_on_a_hosted_machine` (scripts a signed-out Claude Code and a signed-out opencode against a runtime wired with the relay): asserts `auth_mode: gateway_relay` with empty remediation for Claude Code, `auth_mode: hosted_unavailable` with the not-available-hosted remediation for opencode, and that the local `authenticated: false` observation survives on the row. The two pre-existing doctor tests still pass.
- `cargo check` and `cargo clippy -p tidebreak-server --tests` clean; `cargo fmt` run.
- Full desktop UI suite: 240 files, 2032 tests pass, including new `DoctorList` and `labels` cases for the hosted states; `tsc`, `biome format`, `biome lint` clean.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` succeeds; new `Code/Harness doctor > Hosted` story renders "2 of 4 engines ready." with the gateway copy on the relay rows and the not-available copy on the others, and the local stories render unchanged.
- Left to CI: the workspace-wide test matrix and the wire-types freshness check.

Closes #2741.
