### PR TITLE
fix(code): enable hosted auto-merge and detect merge-queue membership

### DIFF
--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -155,13 +155,29 @@ impl DeliveryApi {
         number: u64,
     ) -> Option<bool> {
         match self {
-            Self::Gh { .. } => {
+            Self::Gh {
+                observation, host, ..
+            } => {
+                let binary = observation.binary.as_deref()?;
                 let endpoint = format!(
                     "repos/{}/{}/issues/{number}/timeline?per_page=100",
                     target.owner, target.name
                 );
-                let value = self.get(&endpoint).await.ok()?;
-                super::forge_rest::queue_membership_from_timeline(&value)
+                let mut args = vec!["api".to_owned()];
+                if host != "github.com" {
+                    args.extend(["--hostname".to_owned(), host.clone()]);
+                }
+                args.extend([
+                    endpoint,
+                    "--paginate".to_owned(),
+                    "--jq".to_owned(),
+                    ".[] | select(.event == \"added_to_merge_queue\" or .event == \"removed_from_merge_queue\") | .event".to_owned(),
+                ]);
+                let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
+                let raw = gh::run_gh(Path::new("."), binary, &borrowed, GH_READ_TIMEOUT)
+                    .await
+                    .ok()?;
+                Some(super::pr_fetch::queue_membership_from_events(&raw))
             }
             Self::Rest {
                 api_base,

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -149,6 +149,27 @@ impl DeliveryApi {
         }
     }
 
+    async fn merge_queue_membership(
+        &self,
+        target: &CodeGitHubRepositoryTarget,
+        number: u64,
+    ) -> Option<bool> {
+        match self {
+            Self::Gh { .. } => {
+                let endpoint = format!(
+                    "repos/{}/{}/issues/{number}/timeline?per_page=100",
+                    target.owner, target.name
+                );
+                let value = self.get(&endpoint).await.ok()?;
+                super::forge_rest::queue_membership_from_timeline(&value)
+            }
+            Self::Rest {
+                api_base,
+                credential,
+            } => super::forge_rest::merge_queue_state(api_base, target, credential, number).await,
+        }
+    }
+
     async fn pull_request(
         &self,
         target: &CodeGitHubRepositoryTarget,
@@ -241,10 +262,16 @@ impl DeliveryApi {
                 credential,
             } => {
                 if auto {
-                    return Err(ServerError::conflict_kind(
-                        "git_forge_auto_merge_unsupported",
-                        "This hosted machine cannot enable auto-merge through GitHub's stable REST API. Open the pull request on GitHub to enable auto-merge.",
-                    ));
+                    return super::forge_rest::enable_pull_request_auto_merge(
+                        api_base,
+                        target,
+                        credential,
+                        number,
+                        rest_merge_method(method),
+                        expected_head_sha,
+                    )
+                    .await
+                    .map_err(map_forge_action_error);
                 }
                 if admin {
                     return Err(ServerError::conflict_kind(
@@ -1531,12 +1558,6 @@ pub(crate) async fn act_on_pull_request(
                     "This hosted machine cannot mark a draft pull request ready because GitHub's pinned REST API does not expose that transition. Open the pull request on GitHub to mark it ready.",
                 ));
             }
-            CodeDeliveryPullRequestAction::Merge { auto: true, .. } => {
-                return Err(ServerError::conflict_kind(
-                    "git_forge_auto_merge_unsupported",
-                    "This hosted machine cannot enable auto-merge through GitHub's stable REST API. Open the pull request on GitHub to enable auto-merge.",
-                ));
-            }
             CodeDeliveryPullRequestAction::Merge { admin: true, .. } => {
                 return Err(ServerError::conflict_kind(
                     "git_forge_admin_merge_unsupported",
@@ -2697,6 +2718,8 @@ async fn fetch_pull_requests(
         .as_ref()
         .map(parse_stack_memberships)
         .unwrap_or_default();
+    let mut values = values;
+    attach_merge_queue_membership(&api, target, &mut values).await;
     Ok(values
         .iter()
         .filter_map(|value| parse_pull_request(&repository, value, workspaces))
@@ -2747,9 +2770,50 @@ async fn fetch_pull_request(
     number: u64,
     workspaces: &[WorkspaceIndexEntry],
 ) -> Result<PullRequestObservation, String> {
-    let value = api.pull_request(target, repository, number).await?;
+    let mut value = api.pull_request(target, repository, number).await?;
+    attach_merge_queue_membership(api, target, std::slice::from_mut(&mut value)).await;
     parse_pull_request(repository, &value, workspaces)
         .ok_or_else(|| "GitHub returned an incomplete pull request".into())
+}
+
+/// REST `mergeable_state` never reports `queued`. Membership comes from the
+/// issue timeline both readers already share.
+async fn attach_merge_queue_membership(
+    api: &DeliveryApi,
+    target: &CodeGitHubRepositoryTarget,
+    values: &mut [Value],
+) {
+    let jobs = values
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| {
+            Some((
+                index,
+                u64_field(value, "number")?,
+                text_field(value, "state").is_some_and(|state| state.eq_ignore_ascii_case("open")),
+            ))
+        })
+        .collect::<Vec<_>>();
+    let memberships = stream::iter(jobs)
+        .map(|(index, number, open)| async move {
+            let queued = if open {
+                api.merge_queue_membership(target, number).await
+            } else {
+                Some(false)
+            };
+            (index, queued)
+        })
+        .buffered(DELIVERY_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+    for (index, queued) in memberships {
+        let Some(queued) = queued else {
+            continue;
+        };
+        if let Some(object) = values[index].as_object_mut() {
+            object.insert("inMergeQueue".to_owned(), Value::Bool(queued));
+        }
+    }
 }
 
 fn parse_pull_request(
@@ -2781,7 +2845,10 @@ fn parse_pull_request(
     let auto_merge_enabled = value
         .get("autoMergeRequest")
         .is_some_and(|request| !request.is_null());
-    let in_merge_queue = (merge_state_status.as_deref() == Some("queued")).then_some(true);
+    let in_merge_queue = match bool_field(value, "inMergeQueue") {
+        Some(queued) => Some(queued),
+        None => (merge_state_status.as_deref() == Some("queued")).then_some(true),
+    };
     let comment_count = value.get("comments").and_then(|comments| {
         comments
             .as_array()
@@ -4847,6 +4914,53 @@ mod tests {
         assert_eq!(parsed.summary.state, "open");
         assert!(parsed.summary.merged_at.is_none());
         assert!(parsed.summary.closed_at.is_none());
+    }
+
+    #[test]
+    fn merge_queue_membership_prefers_the_timeline_flag() {
+        let queued = serde_json::json!({
+            "number": 2740,
+            "title": "Queued change",
+            "state": "OPEN",
+            "url": "https://github.com/brightwave-inc/tidebreak/pull/2740",
+            "headRefName": "thet/fix",
+            "baseRefName": "main",
+            "mergeStateStatus": "BLOCKED",
+            "inMergeQueue": true,
+            "statusCheckRollup": [{
+                "name": "CI",
+                "status": "IN_PROGRESS",
+                "state": "PENDING",
+                "conclusion": null
+            }]
+        });
+        let parsed = parse_pull_request(&repository_ref(), &queued, &[]).unwrap();
+        assert_eq!(parsed.summary.in_merge_queue, Some(true));
+
+        let unqueued = serde_json::json!({
+            "number": 2740,
+            "title": "Open change",
+            "state": "OPEN",
+            "url": "https://github.com/brightwave-inc/tidebreak/pull/2740",
+            "headRefName": "thet/fix",
+            "baseRefName": "main",
+            "mergeStateStatus": "BLOCKED",
+            "inMergeQueue": false
+        });
+        let parsed = parse_pull_request(&repository_ref(), &unqueued, &[]).unwrap();
+        assert_eq!(parsed.summary.in_merge_queue, Some(false));
+
+        let host_queued = serde_json::json!({
+            "number": 2740,
+            "title": "Host queued",
+            "state": "OPEN",
+            "url": "https://github.com/brightwave-inc/tidebreak/pull/2740",
+            "headRefName": "thet/fix",
+            "baseRefName": "main",
+            "mergeStateStatus": "queued"
+        });
+        let parsed = parse_pull_request(&repository_ref(), &host_queued, &[]).unwrap();
+        assert_eq!(parsed.summary.in_merge_queue, Some(true));
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -42,6 +42,12 @@ mutation($id: ID!, $oid: GitObjectID!, $method: PullRequestMergeMethod!) {\
 /// Bound the check-run fan-out within one repository list read.
 const CHECK_RUN_CONCURRENCY: usize = 4;
 
+/// Timeline pages GitHub returns at once, and the ceiling on how many this
+/// path will fetch. Membership is the last queue event, so a truncated read
+/// would report the wrong state.
+const TIMELINE_PAGE_SIZE: u32 = 100;
+const TIMELINE_PAGE_LIMIT: u32 = 20;
+
 /// The REST base for a forge host: `api.github.com` for github.com, the
 /// GHES `/api/v3/` convention for anything else.
 ///
@@ -761,29 +767,44 @@ async fn check_run_values(
 }
 
 /// Whether the pull request currently sits in a merge queue, from the same
-/// timeline events the `gh` loader reads. `None` when the read fails — the
-/// digest states nothing rather than guessing.
+/// timeline events the `gh` loader reads. Pages until GitHub stops, because
+/// membership is the last queue event and the first page is the oldest.
+/// `None` when the read fails — the digest states nothing rather than guessing.
 pub(crate) async fn merge_queue_state(
     api_base: &str,
     target: &CodeGitHubRepositoryTarget,
     credential: &GitCredential,
     number: u64,
 ) -> Option<bool> {
-    let (status, value) = request(
-        reqwest::Method::GET,
-        format!(
-            "{api_base}/repos/{}/{}/issues/{number}/timeline?per_page=100",
-            target.owner, target.name
-        ),
-        credential,
-        None,
-    )
-    .await
-    .ok()?;
-    if !status.is_success() {
-        return None;
+    let mut events = Vec::new();
+    for page in 1..=TIMELINE_PAGE_LIMIT {
+        let (status, value) = request(
+            reqwest::Method::GET,
+            format!(
+                "{api_base}/repos/{}/{}/issues/{number}/timeline?per_page={TIMELINE_PAGE_SIZE}&page={page}",
+                target.owner, target.name
+            ),
+            credential,
+            None,
+        )
+        .await
+        .ok()?;
+        if !status.is_success() {
+            return None;
+        }
+        let Some(page_events) = value.as_array() else {
+            return None;
+        };
+        let page_len = page_events.len();
+        events.extend(page_events.iter().cloned());
+        if page_len < TIMELINE_PAGE_SIZE as usize {
+            break;
+        }
+        if page == TIMELINE_PAGE_LIMIT {
+            return None;
+        }
     }
-    queue_membership_from_timeline(&value)
+    queue_membership_from_timeline(&Value::Array(events))
 }
 
 /// Latest queue transition wins: added after removed is in, the reverse is
@@ -931,5 +952,15 @@ mod tests {
             Some(false)
         );
         assert_eq!(queue_membership_from_timeline(&Value::Null), None);
+        let across_pages = {
+            let mut events = vec![serde_json::json!({ "event": "added_to_merge_queue" })];
+            events.extend(std::iter::repeat_n(
+                serde_json::json!({ "event": "committed" }),
+                100,
+            ));
+            events.push(serde_json::json!({ "event": "removed_from_merge_queue" }));
+            queue_membership_from_timeline(&Value::Array(events))
+        };
+        assert_eq!(across_pages, Some(false));
     }
 }

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -792,9 +792,7 @@ pub(crate) async fn merge_queue_state(
         if !status.is_success() {
             return None;
         }
-        let Some(page_events) = value.as_array() else {
-            return None;
-        };
+        let page_events = value.as_array()?;
         let page_len = page_events.len();
         events.extend(page_events.iter().cloned());
         if page_len < TIMELINE_PAGE_SIZE as usize {

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -8,10 +8,11 @@
 //! parses — one JSON vocabulary, however the host was asked.
 //!
 //! Deliberately narrow: creation, the PR-card digest, the fact reads
-//! (decision 62), and Delivery's repository-scoped reads and actions. The
-//! stable REST API still has no ready-for-review transition, so that one
-//! hosted action remains an explicit refusal. Host stacks ride the same
-//! generic GET the rest of Delivery uses.
+//! (decision 62), and Delivery's repository-scoped reads and actions. Auto-merge
+//! (and merge-queue enqueue) rides one pinned GitHub mutation because the
+//! REST merge endpoint cannot arm it. Mark-ready and admin merge stay
+//! explicit refusals. Host stacks ride the same generic GET the rest of
+//! Delivery uses.
 
 use std::time::Duration;
 
@@ -29,6 +30,15 @@ const REST_TIMEOUT: Duration = Duration::from_secs(30);
 /// bound exists so a confused origin cannot grow the process.
 const RESPONSE_LIMIT: usize = 2 * 1024 * 1024;
 
+/// Pinned mutation that arms auto-merge, or enqueues when the repository
+/// uses a merge queue. Not a general GraphQL runner.
+const ENABLE_AUTO_MERGE_MUTATION: &str = "\
+mutation($id: ID!, $oid: GitObjectID!, $method: PullRequestMergeMethod!) {\
+  enablePullRequestAutoMerge(input: {\
+    pullRequestId: $id, expectedHeadOid: $oid, mergeMethod: $method\
+  }) { pullRequest { number } }\
+}";
+
 /// Bound the check-run fan-out within one repository list read.
 const CHECK_RUN_CONCURRENCY: usize = 4;
 
@@ -42,6 +52,14 @@ pub(crate) fn default_api_base(host: &str) -> String {
         "https://api.github.com".to_owned()
     } else {
         format!("https://{host}/api/v3")
+    }
+}
+
+/// GraphQL origin for the same forge `api_base` REST talks to.
+fn graphql_url(api_base: &str) -> String {
+    match api_base.strip_suffix("/api/v3") {
+        Some(root) => format!("{root}/api/graphql"),
+        None => format!("{api_base}/graphql"),
     }
 }
 
@@ -350,6 +368,70 @@ pub(crate) async fn merge_pull_request(
     )
     .await?;
     if !status.is_success() || value.get("merged").and_then(Value::as_bool) != Some(true) {
+        return Err(forge_message(status, &value));
+    }
+    Ok(())
+}
+
+/// Arm auto-merge for one pull request, or add it to the merge queue when
+/// the repository uses one. REST cannot do this; GitHub only exposes the
+/// transition as [`ENABLE_AUTO_MERGE_MUTATION`].
+pub(crate) async fn enable_pull_request_auto_merge(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    number: u64,
+    method: &str,
+    expected_head_sha: &str,
+) -> Result<(), String> {
+    let (status, pull) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/pulls/{number}",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &pull));
+    }
+    let node_id = pull
+        .get("node_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| "the forge pull request did not name a node id".to_owned())?;
+    let merge_method = match method {
+        "squash" => "SQUASH",
+        "rebase" => "REBASE",
+        _ => "MERGE",
+    };
+    let body = serde_json::json!({
+        "query": ENABLE_AUTO_MERGE_MUTATION,
+        "variables": {
+            "id": node_id,
+            "oid": expected_head_sha,
+            "method": merge_method,
+        }
+    });
+    let (status, value) = request(
+        reqwest::Method::POST,
+        graphql_url(api_base),
+        credential,
+        Some(&body),
+    )
+    .await?;
+    if !status.is_success()
+        || value
+            .get("errors")
+            .and_then(Value::as_array)
+            .is_some_and(|errors| !errors.is_empty())
+        || value
+            .pointer("/data/enablePullRequestAutoMerge")
+            .is_none_or(Value::is_null)
+    {
         return Err(forge_message(status, &value));
     }
     Ok(())
@@ -681,7 +763,7 @@ async fn check_run_values(
 /// Whether the pull request currently sits in a merge queue, from the same
 /// timeline events the `gh` loader reads. `None` when the read fails — the
 /// digest states nothing rather than guessing.
-async fn merge_queue_state(
+pub(crate) async fn merge_queue_state(
     api_base: &str,
     target: &CodeGitHubRepositoryTarget,
     credential: &GitCredential,
@@ -701,6 +783,12 @@ async fn merge_queue_state(
     if !status.is_success() {
         return None;
     }
+    queue_membership_from_timeline(&value)
+}
+
+/// Latest queue transition wins: added after removed is in, the reverse is
+/// out. An empty timeline is out, not unknown.
+pub(crate) fn queue_membership_from_timeline(value: &Value) -> Option<bool> {
     let last = value.as_array()?.iter().rev().find_map(|event| {
         match event.get("event").and_then(Value::as_str) {
             Some(event @ ("added_to_merge_queue" | "removed_from_merge_queue")) => Some(event),
@@ -801,5 +889,47 @@ mod tests {
             default_api_base("ghe.acme.test"),
             "https://ghe.acme.test/api/v3"
         );
+    }
+
+    #[test]
+    fn the_graphql_origin_follows_the_rest_base() {
+        assert_eq!(
+            graphql_url("https://api.github.com"),
+            "https://api.github.com/graphql"
+        );
+        assert_eq!(
+            graphql_url("https://ghe.acme.test/api/v3"),
+            "https://ghe.acme.test/api/graphql"
+        );
+    }
+
+    #[test]
+    fn merge_queue_membership_follows_the_latest_timeline_event() {
+        assert_eq!(
+            queue_membership_from_timeline(&serde_json::json!([
+                { "event": "added_to_merge_queue" }
+            ])),
+            Some(true)
+        );
+        assert_eq!(
+            queue_membership_from_timeline(&serde_json::json!([
+                { "event": "added_to_merge_queue" },
+                { "event": "removed_from_merge_queue" }
+            ])),
+            Some(false)
+        );
+        assert_eq!(
+            queue_membership_from_timeline(&serde_json::json!([
+                { "event": "removed_from_merge_queue" },
+                { "event": "committed" },
+                { "event": "added_to_merge_queue" }
+            ])),
+            Some(true)
+        );
+        assert_eq!(
+            queue_membership_from_timeline(&serde_json::json!([{ "event": "committed" }])),
+            Some(false)
+        );
+        assert_eq!(queue_membership_from_timeline(&Value::Null), None);
     }
 }

--- a/crates/tidebreak-server/src/code/pr_fetch.rs
+++ b/crates/tidebreak-server/src/code/pr_fetch.rs
@@ -373,7 +373,7 @@ pub(crate) async fn read_merge_queue_membership(
 
 /// The latest queue transition wins: a pull request added and then removed
 /// is out, whatever order history reports the rest in.
-fn queue_membership_from_events(events: &str) -> bool {
+pub(crate) fn queue_membership_from_events(events: &str) -> bool {
     events
         .lines()
         .map(str::trim)

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,6 +33,7 @@ use std::fs::{File, OpenOptions};
 use std::future::Future;
 use std::io::{ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
@@ -235,18 +236,48 @@ async fn reset_pre_v1_state(database: &Path) -> Result<()> {
 
 fn remove_sqlite_files(database: &Path) -> Result<()> {
     for path in sqlite_files(database) {
-        match std::fs::remove_file(&path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == ErrorKind::NotFound => {}
+        remove_reset_file(&path, "local SQLite database file")?;
+    }
+    Ok(())
+}
+
+/// Delete one reset target. Windows can still hold the SQLite files for a
+/// beat after `close()` returns (WAL mapping), so a sharing violation retries
+/// instead of failing the epoch reset.
+fn remove_reset_file(path: &Path, kind: &str) -> Result<()> {
+    let delays_ms: &[u64] = if cfg!(windows) {
+        &[0, 10, 50, 100, 250]
+    } else {
+        &[0]
+    };
+    let mut last_error = None;
+    for (attempt, delay_ms) in delays_ms.iter().enumerate() {
+        if *delay_ms > 0 {
+            std::thread::sleep(Duration::from_millis(*delay_ms));
+        }
+        match std::fs::remove_file(path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(error) if attempt + 1 < delays_ms.len() && is_windows_sharing_violation(&error) => {
+                last_error = Some(error);
+            }
             Err(error) => {
                 return Err(AgentError::config(format!(
-                    "failed to reset local SQLite database file {}: {error}",
+                    "failed to reset {kind} {}: {error}",
                     path.display()
                 )))
             }
         }
     }
-    Ok(())
+    Err(AgentError::config(format!(
+        "failed to reset {kind} {}: {}",
+        path.display(),
+        last_error.expect("a sharing-violation retry keeps the last error")
+    )))
+}
+
+fn is_windows_sharing_violation(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(32)
 }
 
 /// Durable host-broker files that outlive SQLite unless explicitly cleared.

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -1749,7 +1749,8 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
             "created_at": "2026-08-25T10:00:00Z",
             "updated_at": "2026-08-25T11:00:00Z",
             "merged_at": null,
-            "closed_at": null
+            "closed_at": null,
+            "node_id": "PR_kwDOTEST17"
         })
     }
 
@@ -1904,6 +1905,32 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
             "created_at": "2026-08-25T10:35:00Z"
         }]))
     };
+    let timeline = |headers: axum::http::HeaderMap| async move {
+        assert_borrowed_forge_credential(&headers);
+        axum::Json(serde_json::json!([
+            { "event": "committed" },
+            { "event": "added_to_merge_queue" }
+        ]))
+    };
+    let graphql_actions = Arc::clone(&recorded_actions);
+    let graphql = move |headers: axum::http::HeaderMap,
+                        axum::Json(body): axum::Json<serde_json::Value>| {
+        let recorded = Arc::clone(&graphql_actions);
+        async move {
+            assert_borrowed_forge_credential(&headers);
+            recorded
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(serde_json::json!({ "action": "graphql", "body": body }));
+            axum::Json(serde_json::json!({
+                "data": {
+                    "enablePullRequestAutoMerge": {
+                        "pullRequest": { "number": 17 }
+                    }
+                }
+            }))
+        }
+    };
     let merge_actions = Arc::clone(&recorded_actions);
     let merge = move |headers: axum::http::HeaderMap,
                       axum::Json(body): axum::Json<serde_json::Value>| {
@@ -1987,6 +2014,11 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
             axum::routing::get(pull).patch(update_pull),
         )
         .route("/repos/acme/demo/pulls/17/merge", axum::routing::put(merge))
+        .route("/graphql", axum::routing::post(graphql))
+        .route(
+            "/repos/acme/demo/issues/17/timeline",
+            axum::routing::get(timeline),
+        )
         .route(
             "/repos/acme/demo/issues/17/comments",
             axum::routing::get(issue_comments).post(comment),
@@ -2094,6 +2126,7 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
         .await
         .unwrap();
     assert_eq!(pull_requests["items"][0]["number"], 17);
+    assert_eq!(pull_requests["items"][0]["in_merge_queue"], true);
     assert_eq!(pull_requests["items"][0]["comment_count"], 2);
     assert_eq!(
         pull_requests["items"][0]["checks"][0]["name"],
@@ -2109,9 +2142,12 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
         pull_requests["items"][0]["checks"][1]["workflow_run_id"],
         45
     );
-    assert_eq!(
-        pull_requests["items"][0]["attention_reasons"][0],
-        "checks_failed"
+    assert!(
+        pull_requests["items"][0]["attention_reasons"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "a queued pull request leaves the attention list"
     );
 
     let pull_request_detail: serde_json::Value = client
@@ -2128,6 +2164,7 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
         .await
         .unwrap();
     assert_eq!(pull_request_detail["summary"]["number"], 17);
+    assert_eq!(pull_request_detail["summary"]["in_merge_queue"], true);
     assert_eq!(
         pull_request_detail["body"],
         "Read the delivery detail over REST."
@@ -2211,6 +2248,16 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
         }),
         serde_json::json!({
             "target": { "repository": target.clone(), "number": 17 },
+            "action": {
+                "type": "merge",
+                "method": "squash",
+                "auto": true,
+                "admin": false,
+                "expected_head_sha": "feedfeedfeedfeedfeed"
+            }
+        }),
+        serde_json::json!({
+            "target": { "repository": target.clone(), "number": 17 },
             "action": { "type": "close" }
         }),
         serde_json::json!({
@@ -2267,16 +2314,6 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
             serde_json::json!({
                 "type": "merge",
                 "method": "squash",
-                "auto": true,
-                "admin": false,
-                "expected_head_sha": "feedfeedfeedfeedfeed"
-            }),
-            "git_forge_auto_merge_unsupported",
-        ),
-        (
-            serde_json::json!({
-                "type": "merge",
-                "method": "squash",
                 "auto": false,
                 "admin": true,
                 "expected_head_sha": "feedfeedfeedfeedfeed"
@@ -2319,6 +2356,25 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
             "merge_method": "squash"
         }
     })));
+    let auto_merge = actions
+        .iter()
+        .find(|action| action["action"] == "graphql")
+        .expect("hosted auto-merge posts the pinned mutation");
+    assert_eq!(
+        auto_merge["body"]["variables"],
+        serde_json::json!({
+            "id": "PR_kwDOTEST17",
+            "oid": "feedfeedfeedfeedfeed",
+            "method": "SQUASH"
+        })
+    );
+    assert!(
+        auto_merge["body"]["query"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("enablePullRequestAutoMerge"),
+        "{auto_merge}"
+    );
     assert!(actions.contains(&serde_json::json!({
         "action": "state",
         "body": { "state": "closed" }
@@ -2345,7 +2401,7 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
     );
     assert_eq!(
         lender.minted(),
-        vec!["acme/demo".to_owned(); 13],
+        vec!["acme/demo".to_owned(); 14],
         "every read and action borrows only for the registered repository"
     );
 }


### PR DESCRIPTION
Hosted Enable auto-merge returned 409 because GitHub REST cannot arm it. Delivery now posts GitHub’s pinned `enablePullRequestAutoMerge` mutation, which also enqueues when the repository uses a merge queue. Mark-ready and admin merge stay refused on hosted machines.

Queued pull requests rendered as checks running because Delivery treated `mergeable_state == queued` as membership, and GitHub never sends that. Both readers now read the issue timeline (`added_to_merge_queue` / `removed_from_merge_queue`), so a queued pull request shows In merge queue and drops the auto-merge button.

The follow-up Windows CI fix retries SQLite reset deletes when Windows reports a sharing violation after `close()`. Other platforms keep the single-attempt behavior, and Windows still returns the final error after bounded retries.

## Validation

- `cargo test -p tidebreak-server a_hosted_delivery_page_reads_and_acts_over_forge_rest`
- `cargo test -p tidebreak-server merge_queue`
- `cargo test -p tidebreak-server --lib the_graphql_origin_follows_the_rest_base`
- `cargo test -p tidebreak-server --lib hosted_delivery_actions_propagate`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- Windows behavior is verified by GitHub Actions.

## Compatibility and risk

Hosted auto-merge uses one pinned mutation on the existing borrowed credential. The SQLite reset retry is Windows-only, bounded to 410 milliseconds total, and changes no wire or persisted format.