### PR TITLE
chore(desktop): default Storybook to dark mode

### DIFF
--- a/crates/tidebreak-desktop/ui/.storybook/preview.tsx
+++ b/crates/tidebreak-desktop/ui/.storybook/preview.tsx
@@ -36,7 +36,7 @@ const preview: Preview = {
     },
   },
   initialGlobals: {
-    theme: "light",
+    theme: "dark",
   },
   parameters: {
     controls: {


### PR DESCRIPTION
## What changed

Storybook now opens in the dark Tidebreak theme by default. The toolbar still lets you switch to light, high-contrast light, and high-contrast dark themes.

## Validation

- The desktop UI check passed on the pull request head.
- The full CI workflow is running against the same head because the scoped pull request run skips non-UI required lanes.

## Compatibility and risk

This change affects Storybook only. It does not change the desktop application or persisted data.