### PR TITLE
fix(code): keep the session relay key in the codex child environment

### DIFF
--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -2786,6 +2786,34 @@ done
     }
 
     #[test]
+    fn session_relay_key_survives_the_reserved_namespace_strip() {
+        // Decision 71 hands the codex child its per-session relay key by env
+        // (the provider config spawn_wiring emits reads it through
+        // env_key=TIDEBREAK_LLM_KEY); stripping it as a reserved key left
+        // hosted codex sessions with no credential at all.
+        let plan = compose_app_server_plan(
+            std::path::Path::new("/usr/bin/codex"),
+            &[],
+            std::path::Path::new("/workspace"),
+            &[
+                ("TIDEBREAK_LLM_KEY".into(), "tbreak_hl_test".into()),
+                ("TIDEBREAK_BROWSER_CAPFILE".into(), "/evil/cap.json".into()),
+            ],
+            None,
+        )
+        .unwrap();
+        let relay = plan.env.iter().find(|(key, _)| key == "TIDEBREAK_LLM_KEY");
+        assert_eq!(
+            relay.map(|(_, value)| value.as_str()),
+            Some("tbreak_hl_test")
+        );
+        assert!(!plan
+            .env
+            .iter()
+            .any(|(key, _)| key == "TIDEBREAK_BROWSER_CAPFILE"));
+    }
+
+    #[test]
     fn bridge_command_with_spaces_remains_one_command_value() {
         let spec = BrowserChannelSpec::new(
             std::path::PathBuf::from("/tmp/browser-cap.json"),

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -417,9 +417,16 @@ impl BrowserChannelSpec {
 
     /// Whether a settings environment key belongs to Tidebreak rather than
     /// the user. Adapters must reject these keys before composing a launch.
+    ///
+    /// The session relay key (decision 71) is the one exception: the server
+    /// itself hands an engine child `TIDEBREAK_LLM_KEY`, and codex resolves
+    /// its provider credential from exactly that name, so it must survive
+    /// the reserved-namespace strip. Every other key in the namespace still
+    /// belongs to Tidebreak, not the user.
     #[must_use]
     pub fn is_reserved_env_key(key: &str) -> bool {
-        key.to_ascii_uppercase().starts_with("TIDEBREAK_")
+        let key = key.to_ascii_uppercase();
+        key.starts_with("TIDEBREAK_") && key != "TIDEBREAK_LLM_KEY"
     }
 
     /// Inject the capability-file path as the final environment value on a


### PR DESCRIPTION
## What changed

Decision 71 hands the codex child its per-session relay key through the environment — `spawn_wiring` emits `TIDEBREAK_LLM_KEY` and codex's provider config resolves its credential from that name. But `is_reserved_env_key` rejects the whole `TIDEBREAK_` namespace, and every adapter's session composer runs that strip before building the launch plan, so the server's own relay key was removed and **hosted codex sessions have launched with no credential since #2650 landed**. Found while tracing env flow for #2750; the hosted loop never reached a post-#2650 codex session to catch it.

`TIDEBREAK_LLM_KEY` is now the one sanctioned exception — the only `TIDEBREAK_` value the server itself hands an engine child — so it survives the strip in all four adapters' composers. Every other reserved key is still rejected; the existing browser-capfile strip test passes unchanged, and a new regression test pins that the codex plan keeps the relay key while stripping `TIDEBREAK_BROWSER_CAPFILE`.

A user-supplied `TIDEBREAK_LLM_KEY` gains nothing: on a hosted machine the server's wiring value is authoritative for the session, and locally nothing reads the name.

## Verification

- `cargo fmt` run; the new test and the untouched existing strip tests left to CI (cold worktree — a full build is not a cheap subset).
- The bug and fix are both purely mechanical on the env composition path: the composer's retain is the only place the wiring key could disappear, and the exemption is the minimal change to it.

Closes #2751.