### PR TITLE
fix(code): coalesce codex transport reconnect notices

### DIFF
--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/manifest.toml
@@ -22,6 +22,11 @@ observed_auth = "Logged in using ChatGPT"
 # `collab-agents` is a later capture (2026-08-25) from the same pinned 0.147.0
 # binary with `[features] multi_agent = true` in the isolated $CODEX_HOME. It
 # is the only capture where one connection carries two threads.
+# `reconnect-storm` is a reconstruction, not a teed capture: the same 0.147.0
+# binary on the hosted machine (the #2613 smoke test) emitted nine
+# error-notification frames of `Reconnecting websocket... attempt N/5` across
+# two retry rounds and then failed the turn with the vendor 401. The frames
+# were rebuilt from that transcript with simplified ids (#2654).
 
 integration_path = "app-server-stdio"
 model = "gpt-5.6-luna"
@@ -37,6 +42,7 @@ scenarios = [
   "error",
   "posture-retry",
   "collab-agents",
+  "reconnect-storm",
 ]
 
 [permission_mode_mapping]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/reconnect-storm.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/reconnect-storm.expected.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "turn_started"
+  },
+  {
+    "type": "harness_notice",
+    "level": "warning",
+    "message": "Reconnecting websocket..."
+  },
+  {
+    "type": "turn_failed",
+    "error": {
+      "message": "Missing bearer or basic authentication in header"
+    }
+  }
+]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/reconnect-storm.ndjson
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/reconnect-storm.ndjson
@@ -1,0 +1,13 @@
+{"dir":"out","msg":{"id":51,"method":"turn/start","params":{"threadId":"thread-1","input":[{"type":"text","text":"hello"}]}}}
+{"dir":"in","msg":{"id":51,"result":{"turn":{"id":"turn-1","status":"inProgress"}}}}
+{"dir":"in","msg":{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"turn-1","status":"inProgress"}}}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 1/5"}},"emittedAtMs":1787222401101}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 2/5"}},"emittedAtMs":1787222402113}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 3/5"}},"emittedAtMs":1787222404126}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 4/5"}},"emittedAtMs":1787222408141}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 5/5"}},"emittedAtMs":1787222416158}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 1/5"}},"emittedAtMs":1787222417163}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 2/5"}},"emittedAtMs":1787222418171}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 3/5"}},"emittedAtMs":1787222420184}}
+{"dir":"in","msg":{"method":"error","params":{"threadId":"thread-1","error":{"message":"Reconnecting websocket... attempt 4/5"}},"emittedAtMs":1787222424199}}
+{"dir":"in","msg":{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","status":"failed","error":{"message":"Missing bearer or basic authentication in header"}}}}}

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -700,6 +700,38 @@ mod tests {
             .any(|event| matches!(event, HarnessEvent::TurnFailed { .. })));
     }
 
+    /// Nine `Reconnecting websocket... attempt N/5` error notifications across
+    /// two retry rounds read as one warning, and the terminal 401 stays the
+    /// error-level row (#2654).
+    #[test]
+    fn fixture_replay_reconnect_storm() {
+        let (events, unrecognized) = replay("reconnect-storm");
+        assert_eq!(unrecognized, 0, "reconnect chatter is recognized protocol");
+        let notices = events
+            .iter()
+            .filter_map(|event| match event {
+                HarnessEvent::HarnessNotice { level, message } => Some((level, message)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            notices.len(),
+            1,
+            "nine reconnect attempts must coalesce into one notice"
+        );
+        assert_eq!(
+            *notices[0].0,
+            tidebreak_core::HarnessNoticeLevel::Warning,
+            "transport retry chatter is degradation, not the failure itself"
+        );
+        assert!(notices[0].1.contains("Reconnecting websocket"));
+        assert!(matches!(
+            events.last(),
+            Some(HarnessEvent::TurnFailed { error })
+                if error.message.contains("Missing bearer or basic authentication")
+        ));
+    }
+
     #[test]
     fn posture_retry_fixture_repeats_the_same_policy_after_rejection() {
         let (events, unrecognized) = replay("posture-retry");

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -50,6 +50,9 @@ pub struct CodexStreamParser {
     outbound_methods: HashMap<String, String>,
     /// itemId → JSON-RPC request id for a parked approval.
     pending_approvals: HashMap<String, Value>,
+    /// Counter-stripped text of the reconnect notice most recently emitted,
+    /// while its retry storm is still the latest thing the engine said.
+    open_reconnect: Option<String>,
 }
 
 /// Result of parsing a whole fixture or a finished stream.
@@ -233,6 +236,7 @@ impl CodexStreamParser {
                     return self.ensure_subagent_started(&params);
                 }
                 self.parent_turn_active = true;
+                self.open_reconnect = None;
                 self.turn_usage_baseline = self.last_usage.clone();
                 self.turn_first_call_context_tokens = None;
                 vec![HarnessEvent::TurnStarted]
@@ -245,6 +249,25 @@ impl CodexStreamParser {
                     .and_then(Value::as_str)
                     .or_else(|| params.pointer("/error/message").and_then(Value::as_str))
                     .unwrap_or(method);
+                // A flapping transport announces every attempt ("Reconnecting
+                // websocket... attempt 3/5"), and a failed round starts over
+                // at 1/5. One flap is one fact; repeat announcements for the
+                // same endpoint drown the terminal failure that follows them
+                // (#2654). Emit the first as a warning — the turn is degraded,
+                // not dead — and swallow the rest until the engine says
+                // something else. Exhaustion and the terminal error carry no
+                // attempt counter, so they pass through at error level.
+                if let Some(stripped) = strip_reconnect_attempt(message) {
+                    if self.open_reconnect.as_deref() == Some(&stripped) {
+                        return Vec::new();
+                    }
+                    self.open_reconnect = Some(stripped.clone());
+                    return vec![HarnessEvent::HarnessNotice {
+                        level: HarnessNoticeLevel::Warning,
+                        message: bound(&stripped, MAX_NOTICE_CHARS),
+                    }];
+                }
+                self.open_reconnect = None;
                 vec![HarnessEvent::HarnessNotice {
                     level: if method == "error" {
                         HarnessNoticeLevel::Error
@@ -969,6 +992,39 @@ fn thread_id(params: &Value) -> Option<&str> {
     params.get("threadId").and_then(Value::as_str)
 }
 
+/// The text of a transport reconnect-attempt notice with its `attempt N/M`
+/// counter removed, or `None` for any other message.
+///
+/// `Reconnecting websocket... attempt 3/5` strips to
+/// `Reconnecting websocket...`, and every attempt against the same endpoint
+/// strips to the same text — including a later round restarting at 1/5 —
+/// which is what lets consecutive attempts coalesce. A gave-up message has
+/// no `N/M` counter and stays untouched.
+fn strip_reconnect_attempt(message: &str) -> Option<String> {
+    let lower = message.to_ascii_lowercase();
+    if !lower.contains("reconnecting") {
+        return None;
+    }
+    let at = lower.rfind("attempt")?;
+    let counter = message[at + "attempt".len()..].trim_start();
+    let made = counter.find(|c: char| !c.is_ascii_digit())?;
+    if made == 0 || !counter[made..].starts_with('/') {
+        return None;
+    }
+    let of = &counter[made + 1..];
+    let of_end = of.find(|c: char| !c.is_ascii_digit()).unwrap_or(of.len());
+    if of_end == 0 {
+        return None;
+    }
+    let prefix = message[..at].trim_end();
+    let suffix = of[of_end..].trim_start();
+    if suffix.is_empty() {
+        Some(prefix.to_owned())
+    } else {
+        Some(format!("{prefix} {suffix}"))
+    }
+}
+
 fn collab_targets(item: &Value) -> Vec<String> {
     item.get("receiverThreadIds")
         .and_then(Value::as_array)
@@ -1532,6 +1588,47 @@ mod tests {
             out.events.last(),
             Some(HarnessEvent::TurnFailed { .. })
         ));
+    }
+
+    /// Attempts against one endpoint collapse into a single warning, but the
+    /// coalescing must not eat a later, separate storm — or the non-retry
+    /// notice that interrupts it, which keeps its own level.
+    #[test]
+    fn reconnect_coalescing_resets_when_the_engine_says_something_else() {
+        let mut parser = CodexStreamParser::new();
+        let mut events = Vec::new();
+        for message in [
+            "Reconnecting websocket... attempt 1/5",
+            "Reconnecting websocket... attempt 2/5",
+            "Gave up reconnecting after 5 attempts",
+            "Reconnecting websocket... attempt 1/5",
+        ] {
+            let line = serde_json::json!({
+                "method": "error",
+                "params": {"error": {"message": message}}
+            });
+            events.extend(parser.push_line(&line.to_string()));
+        }
+
+        assert_eq!(parser.unrecognized(), 0);
+        let notices = events
+            .iter()
+            .filter_map(|event| match event {
+                HarnessEvent::HarnessNotice { level, message } => Some((*level, message.as_str())),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            notices,
+            vec![
+                (HarnessNoticeLevel::Warning, "Reconnecting websocket..."),
+                (
+                    HarnessNoticeLevel::Error,
+                    "Gave up reconnecting after 5 attempts"
+                ),
+                (HarnessNoticeLevel::Warning, "Reconnecting websocket..."),
+            ]
+        );
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -186,6 +186,22 @@ impl CodexStreamParser {
     }
 
     fn push_inbound(&mut self, value: &Value) -> Vec<HarnessEvent> {
+        let events = self.dispatch_inbound(value);
+        // Anything transcript-visible that is not itself a notice proves the
+        // engine got through again, so a later flap is a new degradation
+        // episode and must re-announce. Silent state notifications (token
+        // usage, rate limits) emit nothing and could plausibly interleave a
+        // single storm, so they leave the window open.
+        if events
+            .iter()
+            .any(|event| !matches!(event, HarnessEvent::HarnessNotice { .. }))
+        {
+            self.open_reconnect = None;
+        }
+        events
+    }
+
+    fn dispatch_inbound(&mut self, value: &Value) -> Vec<HarnessEvent> {
         if value.get("error").is_some() && value.get("id").is_some() {
             return self.parse_rpc_error(value);
         }
@@ -236,7 +252,6 @@ impl CodexStreamParser {
                     return self.ensure_subagent_started(&params);
                 }
                 self.parent_turn_active = true;
-                self.open_reconnect = None;
                 self.turn_usage_baseline = self.last_usage.clone();
                 self.turn_first_call_context_tokens = None;
                 vec![HarnessEvent::TurnStarted]
@@ -1629,6 +1644,65 @@ mod tests {
                 (HarnessNoticeLevel::Warning, "Reconnecting websocket..."),
             ]
         );
+    }
+
+    /// A storm that recovers — assistant text streams again — and then flaps
+    /// a second time is two degradation episodes, not one. Every attempt
+    /// strips to the same text, so only real engine activity in between can
+    /// distinguish them; silent telemetry like a token-usage update must not.
+    #[test]
+    fn a_recovered_stream_reannounces_the_next_reconnect_storm() {
+        let reconnect = |attempt: u64| {
+            serde_json::json!({
+                "method": "error",
+                "params": {"error": {
+                    "message": format!("Reconnecting websocket... attempt {attempt}/5")
+                }}
+            })
+            .to_string()
+        };
+        let usage = serde_json::json!({
+            "method": "thread/tokenUsage/updated",
+            "params": {"tokenUsage": {"total": {"inputTokens": 10, "outputTokens": 1}}}
+        })
+        .to_string();
+        let delta = serde_json::json!({
+            "method": "item/agentMessage/delta",
+            "params": {"delta": "back online"}
+        })
+        .to_string();
+
+        let mut parser = CodexStreamParser::new();
+        let mut events = Vec::new();
+        for line in [
+            reconnect(1),
+            usage.clone(),
+            reconnect(2),
+            delta,
+            reconnect(1),
+            reconnect(2),
+        ] {
+            events.extend(parser.push_line(&line));
+        }
+
+        assert_eq!(parser.unrecognized(), 0);
+        let notices = events
+            .iter()
+            .filter(|event| matches!(event, HarnessEvent::HarnessNotice { .. }))
+            .count();
+        assert_eq!(
+            notices, 2,
+            "the storm after recovery must announce itself; the usage update \
+             inside the first storm must not split it"
+        );
+        assert!(matches!(
+            &events[..],
+            [
+                HarnessEvent::HarnessNotice { .. },
+                HarnessEvent::AssistantDelta { .. },
+                HarnessEvent::HarnessNotice { .. },
+            ]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #2654.

## What changed

One failed Codex turn used to produce nine separate error-level notice rows — `Reconnecting websocket... attempt N/5` repeated across two retry rounds — before the terminal 401, so the row that mattered drowned in transport noise.

You now get one row for the whole storm. In the codex parser's `warning`/`error` notification arm, a message carrying a reconnect attempt counter is stripped of that counter, emitted once as a single warning-level notice (`Reconnecting websocket...`), and every consecutive repeat for the same endpoint is swallowed. The coalescing window closes when the engine says anything else or a new turn starts, so a later, separate flap announces itself again. Messages without an `attempt N/M` counter — the gave-up notice, the terminal 401 — pass through untouched and keep their error level.

The new `reconnect-storm` fixture pins it: nine reconnect error notifications in, one warning notice and the `turn_failed` out. The fixture is a reconstruction of the #2613 hosted smoke-test transcript (same pinned 0.147.0 binary) with simplified ids, and the manifest records that provenance. A unit test also pins the reset: a storm interrupted by a non-retry error notice re-announces, and the interrupting notice keeps its own level.

## What you ran

- `cargo fmt --all --check`
- `cargo check -p tidebreak-harness`
- `cargo test -p tidebreak-harness codex` (81 passed, including the new replay test) and `cargo test -p tidebreak-harness reconnect`
- The replay test fails without the parser change (nine error notices instead of one warning), verified before implementing the fix.
- `cargo clippy -p tidebreak-harness --all-targets`: no warnings in the changed files. This sandbox cannot fetch the symphonia git dependency, so workspace resolution for these commands ran against a temporary local stub of that dependency; nothing of it is committed.
