### PR TITLE
fix(code): use the shared popover shadow on workspace hover cards

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -244,7 +244,7 @@ export function WorkspaceCard({
             side={compactDetail ? "bottom" : "right"}
             align="start"
             sideOffset={10}
-            className="w-[22rem] overflow-hidden rounded-xl border-border bg-popover p-0 shadow-[0_18px_48px_color-mix(in_oklch,var(--foreground)_16%,transparent)]"
+            className="w-[22rem] overflow-hidden rounded-xl border-border bg-popover p-0"
           >
             <WorkspaceDetailPanel
               workspace={workspace}


### PR DESCRIPTION
## What changed

The workspace hover card used a custom 18px/48px glow that sat well above the rest of the floating surfaces. Drop that override so the card inherits `shadow-lg` from `HoverCardContent`, the same token menus and other popovers already use.

## Validation

- `biome format` and `biome lint` on `WorkspaceCard.tsx`
- `vitest run src/code/WorkspaceCard.dom.test.tsx src/stylesContract.test.ts` — 22 passed
- Storybook `Code/Workspace card > Hover idle session` reviewed in dark and light

Left to CI: the scoped desktop UI lane and the rest of the required checks.

## Compatibility and risk

None. Visual only. No persisted or wire-format change.