### PR TITLE
feat(code): refresh the hosted pull-request digest out of the request path

### DIFF
--- a/crates/tidebreak-server/src/code/pr_fetch.rs
+++ b/crates/tidebreak-server/src/code/pr_fetch.rs
@@ -1,12 +1,18 @@
 //! One conditional REST fetcher for pull-request state (decision 66).
 //!
-//! Every background pull-request read runs through here: one `gh api` read
-//! of the pull request, one of its head's check runs, one of its reviews,
-//! and — only for base branches observed to run a merge queue — one
-//! timeline read for queue membership. Each read sends the stored ETag, so
-//! an unchanged answer is a 304 that GitHub does not count against the
+//! Every background pull-request read runs through here: one read of the
+//! pull request, one of its head's check runs, one of its reviews, and —
+//! only for base branches observed to run a merge queue — one timeline
+//! read for queue membership. Each read sends the stored ETag, so an
+//! unchanged answer is a 304 that GitHub does not count against the
 //! primary rate limit: sustained cost tracks how often pull requests
 //! change, not how often Tidebreak asks.
+//!
+//! The reads ride one of two transports ([`FetchTransport`]): `gh api` on
+//! a machine with an authenticated `gh`, or the forge REST API with a
+//! borrowed credential on a gateway-hosted machine that has none
+//! (decision 65). Both answer in one [`RawHttpResponse`] shape, so the
+//! conditional discipline is a single code path however the host is asked.
 //!
 //! One [`HostGate`] paces every call. It holds a small global concurrency,
 //! spaces requests per host, and treats a secondary-rate-limit answer or a
@@ -20,6 +26,7 @@ use std::time::Duration;
 
 use serde_json::Value;
 
+use crate::obo_gateway::GitCredential;
 use tidebreak_core::{
     CodePullRequestFact, CodePullRequestState, PullRequestCheck, PullRequestCheckBucket,
     PullRequestDigest,
@@ -38,6 +45,33 @@ const DEFAULT_PARK: Duration = Duration::from_secs(60);
 const MAX_PARK: Duration = Duration::from_secs(15 * 60);
 /// Bound on one `gh api` call — the same bound the general runner uses.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Cap on one direct REST response body — the same ceiling the hosted forge
+/// reader applies, so a confused origin cannot grow the process.
+const REST_RESPONSE_LIMIT: usize = 2 * 1024 * 1024;
+
+/// Ceiling on timeline pages one membership read walks. The timeline pages
+/// oldest-first and membership is the last queue transition, so the walk
+/// must reach the end; past this depth the read states nothing rather than
+/// reporting an older transition as current.
+const TIMELINE_PAGE_CAP: u32 = 30;
+
+/// How one gated read reaches the forge: `gh api` where an authenticated
+/// `gh` exists, or the REST API with a borrowed per-operation credential on
+/// a gateway-hosted machine that has none (decision 65). Either way the
+/// answer is the same [`RawHttpResponse`], so ETags, 304s, and parks are
+/// one discipline.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FetchTransport<'a> {
+    /// `gh api --include` run in `cwd` on `binary`.
+    Gh { cwd: &'a Path, binary: &'a Path },
+    /// A direct conditional GET against `api_base` with a borrowed
+    /// credential as the bearer.
+    Rest {
+        api_base: &'a str,
+        credential: &'a GitCredential,
+    },
+}
 
 /// Pace and park GitHub reads, one state per host (decision 66).
 #[derive(Debug)]
@@ -185,11 +219,9 @@ pub(crate) struct BranchRules {
 }
 
 /// GET `repos/{owner}/{name}/pulls/{number}`, conditionally.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn read_pull_request(
     gate: &HostGate,
-    cwd: &Path,
-    binary: &Path,
+    transport: FetchTransport<'_>,
     host: &str,
     owner: &str,
     name: &str,
@@ -197,7 +229,7 @@ pub(crate) async fn read_pull_request(
     etag: Option<&str>,
 ) -> Result<EndpointRead<RestPull>, FetchFailure> {
     let path = format!("repos/{owner}/{name}/pulls/{number}");
-    let response = gated_read(gate, cwd, binary, host, &path, etag).await?;
+    let response = gated_read(gate, transport, host, &path, etag).await?;
     match response.status {
         200 => match rest_pull_from_value(&parse_body(&response)?) {
             Some(pull) => Ok(EndpointRead::Fresh {
@@ -220,15 +252,14 @@ pub(crate) async fn read_pull_request(
 /// `gh pr view` applied to a branch.
 pub(crate) async fn read_pull_request_for_head(
     gate: &HostGate,
-    cwd: &Path,
-    binary: &Path,
+    transport: FetchTransport<'_>,
     host: &str,
     owner: &str,
     name: &str,
     branch: &str,
 ) -> Result<Option<RestPull>, FetchFailure> {
     let path = format!("repos/{owner}/{name}/pulls?head={owner}:{branch}&state=all&per_page=10");
-    let response = gated_read(gate, cwd, binary, host, &path, None).await?;
+    let response = gated_read(gate, transport, host, &path, None).await?;
     match response.status {
         200 => {
             let listed = parse_body(&response)?;
@@ -246,11 +277,9 @@ pub(crate) async fn read_pull_request_for_head(
 }
 
 /// GET `repos/{owner}/{name}/commits/{sha}/check-runs`, conditionally.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn read_check_runs(
     gate: &HostGate,
-    cwd: &Path,
-    binary: &Path,
+    transport: FetchTransport<'_>,
     host: &str,
     owner: &str,
     name: &str,
@@ -258,7 +287,7 @@ pub(crate) async fn read_check_runs(
     etag: Option<&str>,
 ) -> Result<EndpointRead<Vec<PullRequestCheck>>, FetchFailure> {
     let path = format!("repos/{owner}/{name}/commits/{sha}/check-runs?per_page=100");
-    let response = gated_read(gate, cwd, binary, host, &path, etag).await?;
+    let response = gated_read(gate, transport, host, &path, etag).await?;
     match response.status {
         200 => {
             let value = parse_body(&response)?;
@@ -277,11 +306,9 @@ pub(crate) async fn read_check_runs(
 ///
 /// One page of one hundred: a pull request with more reviews than that has
 /// long since answered the only question this read asks.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn read_reviews(
     gate: &HostGate,
-    cwd: &Path,
-    binary: &Path,
+    transport: FetchTransport<'_>,
     host: &str,
     owner: &str,
     name: &str,
@@ -289,7 +316,7 @@ pub(crate) async fn read_reviews(
     etag: Option<&str>,
 ) -> Result<EndpointRead<ReviewTally>, FetchFailure> {
     let path = format!("repos/{owner}/{name}/pulls/{number}/reviews?per_page=100");
-    let response = gated_read(gate, cwd, binary, host, &path, etag).await?;
+    let response = gated_read(gate, transport, host, &path, etag).await?;
     match response.status {
         200 => {
             let value = parse_body(&response)?;
@@ -308,15 +335,14 @@ pub(crate) async fn read_reviews(
 /// this branch requires. `Missing` on hosts that predate rulesets.
 pub(crate) async fn read_branch_rules(
     gate: &HostGate,
-    cwd: &Path,
-    binary: &Path,
+    transport: FetchTransport<'_>,
     host: &str,
     owner: &str,
     name: &str,
     branch: &str,
 ) -> Result<EndpointRead<BranchRules>, FetchFailure> {
     let path = format!("repos/{owner}/{name}/rules/branches/{branch}");
-    let response = gated_read(gate, cwd, binary, host, &path, None).await?;
+    let response = gated_read(gate, transport, host, &path, None).await?;
     match response.status {
         200 => {
             let value = parse_body(&response)?;
@@ -337,13 +363,47 @@ pub(crate) async fn read_branch_rules(
 /// nothing rather than guessing.
 pub(crate) async fn read_merge_queue_membership(
     gate: &HostGate,
-    cwd: &Path,
-    binary: &Path,
+    transport: FetchTransport<'_>,
     host: &str,
     owner: &str,
     name: &str,
     number: u64,
 ) -> Option<bool> {
+    let (cwd, binary) = match transport {
+        FetchTransport::Gh { cwd, binary } => (cwd, binary),
+        FetchTransport::Rest { .. } => {
+            // The timeline pages oldest-first and membership is the last
+            // queue transition, so walk to the end the way the `gh` arm's
+            // `--paginate` does. A short page is the end.
+            let mut membership = None;
+            for page in 1..=TIMELINE_PAGE_CAP {
+                let path = format!(
+                    "repos/{owner}/{name}/issues/{number}/timeline?per_page=100&page={page}"
+                );
+                let response = gated_read(gate, transport, host, &path, None).await.ok()?;
+                if response.status != 200 {
+                    return None;
+                }
+                let value: Value = serde_json::from_str(&response.body).ok()?;
+                let events = value.as_array()?;
+                if let Some(last) = events.iter().rev().find_map(|event| {
+                    match event.get("event").and_then(Value::as_str) {
+                        Some(event @ ("added_to_merge_queue" | "removed_from_merge_queue")) => {
+                            Some(event)
+                        }
+                        _ => None,
+                    }
+                }) {
+                    membership = Some(last == "added_to_merge_queue");
+                }
+                if events.len() < 100 {
+                    return Some(membership.unwrap_or(false));
+                }
+            }
+            // Deeper than the cap: state nothing rather than guessing.
+            return None;
+        }
+    };
     let _permit = gate.admit(host).await.ok()?;
     let path = format!("repos/{owner}/{name}/issues/{number}/timeline?per_page=100");
     let mut args = vec!["api"];
@@ -437,31 +497,103 @@ pub(crate) fn digest_from_parts(
     }
 }
 
-/// One gated conditional GET of `path` on `host`.
+/// One gated conditional GET of `path` on `host`, over either transport.
 async fn gated_read(
     gate: &HostGate,
-    cwd: &Path,
-    binary: &Path,
+    transport: FetchTransport<'_>,
     host: &str,
     path: &str,
     etag: Option<&str>,
 ) -> Result<RawHttpResponse, FetchFailure> {
     let _permit = gate.admit(host).await.map_err(FetchFailure::Parked)?;
-    let mut args = vec!["api", "--include"];
-    let hostname = host_argument(host);
-    if let Some(hostname) = &hostname {
-        args.extend(["--hostname", hostname.as_str()]);
-    }
-    let conditional = etag.map(|etag| format!("If-None-Match: {etag}"));
-    if let Some(conditional) = &conditional {
-        args.extend(["-H", conditional.as_str()]);
-    }
-    args.push(path);
-    let response = run_gh_http(cwd, binary, &args, FETCH_TIMEOUT)
-        .await
-        .map_err(FetchFailure::Transport)?;
+    let response = match transport {
+        FetchTransport::Gh { cwd, binary } => {
+            let mut args = vec!["api", "--include"];
+            let hostname = host_argument(host);
+            if let Some(hostname) = &hostname {
+                args.extend(["--hostname", hostname.as_str()]);
+            }
+            let conditional = etag.map(|etag| format!("If-None-Match: {etag}"));
+            if let Some(conditional) = &conditional {
+                args.extend(["-H", conditional.as_str()]);
+            }
+            args.push(path);
+            run_gh_http(cwd, binary, &args, FETCH_TIMEOUT)
+                .await
+                .map_err(FetchFailure::Transport)?
+        }
+        FetchTransport::Rest {
+            api_base,
+            credential,
+        } => rest_conditional_get(api_base, credential, path, etag).await?,
+    };
     apply_limit_answer(gate, host, &response);
     Ok(response)
+}
+
+/// One conditional GET against the forge REST API with a borrowed
+/// credential (decision 65), answered in the same [`RawHttpResponse`] shape
+/// `gh api --include` produces — status, ETag, pacing headers, body — so
+/// the caller's 304 and park handling never knows which transport ran.
+async fn rest_conditional_get(
+    api_base: &str,
+    credential: &GitCredential,
+    path: &str,
+    etag: Option<&str>,
+) -> Result<RawHttpResponse, FetchFailure> {
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .user_agent(concat!("tidebreak/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|error| {
+            FetchFailure::Transport(format!("the forge REST client could not be built: {error}"))
+        })?;
+    let mut request = client
+        .get(format!("{api_base}/{path}"))
+        .bearer_auth(&credential.secret)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header("x-github-api-version", "2022-11-28");
+    if let Some(etag) = etag {
+        request = request.header(reqwest::header::IF_NONE_MATCH, etag);
+    }
+    let mut response = request.send().await.map_err(|error| {
+        FetchFailure::Transport(format!("the forge could not be reached: {error}"))
+    })?;
+    let header = |response: &reqwest::Response, name: &str| {
+        response
+            .headers()
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .map(ToOwned::to_owned)
+    };
+    let status = response.status().as_u16();
+    let etag = header(&response, "etag");
+    let retry_after_secs = header(&response, "retry-after").and_then(|value| value.parse().ok());
+    let ratelimit_remaining =
+        header(&response, "x-ratelimit-remaining").and_then(|value| value.parse().ok());
+    let ratelimit_reset_epoch =
+        header(&response, "x-ratelimit-reset").and_then(|value| value.parse().ok());
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        FetchFailure::Transport(format!("the forge response broke mid-read: {error}"))
+    })? {
+        if bytes.len() + chunk.len() > REST_RESPONSE_LIMIT {
+            return Err(FetchFailure::Transport(
+                "the forge response passed the size ceiling".to_owned(),
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(RawHttpResponse {
+        status,
+        etag,
+        retry_after_secs,
+        ratelimit_remaining,
+        ratelimit_reset_epoch,
+        body: String::from_utf8_lossy(&bytes).into_owned(),
+    })
 }
 
 /// Park the host when the answer orders it: a `Retry-After`, a secondary
@@ -826,6 +958,205 @@ mod tests {
         assert!(tokio::time::Instant::now() - first >= HOST_SPACING);
     }
 
+    async fn serve_forge(router: axum::Router) -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router).await;
+        });
+        addr
+    }
+
+    /// The hosted transport keeps the same conditional discipline as `gh`
+    /// (decision 65 meets decision 66): the borrowed credential rides as the
+    /// bearer, a stored ETag goes out as `If-None-Match`, and an unchanged
+    /// answer comes back as a 304 rather than a paid re-read.
+    #[tokio::test]
+    async fn the_rest_transport_sends_the_stored_etag_and_reads_the_304() {
+        type Seen = Arc<Mutex<Vec<(Option<String>, Option<String>)>>>;
+        let seen: Seen = Arc::default();
+        let recorded = Arc::clone(&seen);
+        let pull = move |headers: axum::http::HeaderMap| {
+            let recorded = Arc::clone(&recorded);
+            async move {
+                let header = |name: axum::http::HeaderName| {
+                    headers
+                        .get(name)
+                        .and_then(|value| value.to_str().ok())
+                        .map(ToOwned::to_owned)
+                };
+                let conditional = header(axum::http::header::IF_NONE_MATCH);
+                recorded.lock().unwrap().push((
+                    header(axum::http::header::AUTHORIZATION),
+                    conditional.clone(),
+                ));
+                let unchanged = conditional.as_deref() == Some("W/\"pull-1\"");
+                let body = if unchanged {
+                    String::new()
+                } else {
+                    serde_json::json!({
+                        "number": 12,
+                        "html_url": "https://github.com/acme/demo/pull/12",
+                        "state": "open",
+                        "head": { "ref": "feature", "sha": "aaa" },
+                        "base": { "ref": "main" },
+                    })
+                    .to_string()
+                };
+                axum::http::Response::builder()
+                    .status(if unchanged { 304 } else { 200 })
+                    .header("etag", "W/\"pull-1\"")
+                    .body(axum::body::Body::from(body))
+                    .unwrap()
+            }
+        };
+        let api = serve_forge(
+            axum::Router::new().route("/repos/acme/demo/pulls/12", axum::routing::get(pull)),
+        )
+        .await;
+
+        let credential = GitCredential {
+            username: "x-access-token".into(),
+            secret: "ghs_test_borrowed".into(),
+        };
+        let api_base = format!("http://{api}");
+        let transport = FetchTransport::Rest {
+            api_base: &api_base,
+            credential: &credential,
+        };
+        let gate = HostGate::default();
+        let first = read_pull_request(&gate, transport, "github.com", "acme", "demo", 12, None)
+            .await
+            .unwrap();
+        let EndpointRead::Fresh { value, etag } = first else {
+            panic!("expected fresh: {first:?}");
+        };
+        assert_eq!(value.number, 12);
+        let etag = etag.expect("a 200 carries the etag to send next time");
+        let second = read_pull_request(
+            &gate,
+            transport,
+            "github.com",
+            "acme",
+            "demo",
+            12,
+            Some(&etag),
+        )
+        .await
+        .unwrap();
+        assert_eq!(second, EndpointRead::NotModified);
+        let seen = seen.lock().unwrap().clone();
+        assert_eq!(seen.len(), 2);
+        assert_eq!(
+            seen[0],
+            (Some("Bearer ghs_test_borrowed".into()), None),
+            "the first read is unconditional and authenticated"
+        );
+        assert_eq!(
+            seen[1],
+            (
+                Some("Bearer ghs_test_borrowed".into()),
+                Some("W/\"pull-1\"".into())
+            ),
+            "the second read sends the stored ETag"
+        );
+    }
+
+    /// A limit answer over the hosted transport parks the host exactly as
+    /// one over `gh` does: the next read waits out the stated window.
+    #[tokio::test]
+    async fn a_rest_limit_answer_parks_the_host() {
+        let limited = || async {
+            axum::http::Response::builder()
+                .status(403)
+                .header("retry-after", "120")
+                .body(axum::body::Body::from(
+                    r#"{"message":"You have exceeded a secondary rate limit. Please wait."}"#,
+                ))
+                .unwrap()
+        };
+        let api = serve_forge(
+            axum::Router::new().route("/repos/acme/demo/pulls/12", axum::routing::get(limited)),
+        )
+        .await;
+
+        let credential = GitCredential {
+            username: "x-access-token".into(),
+            secret: "ghs_test_borrowed".into(),
+        };
+        let api_base = format!("http://{api}");
+        let transport = FetchTransport::Rest {
+            api_base: &api_base,
+            credential: &credential,
+        };
+        let gate = HostGate::default();
+        let refused =
+            read_pull_request(&gate, transport, "github.com", "acme", "demo", 12, None).await;
+        assert!(
+            matches!(refused, Err(FetchFailure::Refused(403, _))),
+            "{refused:?}"
+        );
+        let parked = gate.admit("github.com").await;
+        assert!(
+            matches!(parked, Err(remaining) if remaining.as_secs() > 100),
+            "{parked:?}"
+        );
+    }
+
+    /// The timeline pages oldest-first, so the membership read walks to the
+    /// last page: a queue entry on page one that a later page removes reads
+    /// as out, exactly as the `gh` arm's `--paginate` reports it.
+    #[tokio::test]
+    async fn the_rest_membership_read_walks_the_timeline_to_its_last_page() {
+        let timeline = |axum::extract::Query(params): axum::extract::Query<
+            std::collections::HashMap<String, String>,
+        >| async move {
+            let page: u32 = params
+                .get("page")
+                .map_or(1, |page| page.parse().expect("a numeric page"));
+            let events = match page {
+                1 => {
+                    let mut events: Vec<serde_json::Value> = (0..99)
+                        .map(|_| serde_json::json!({ "event": "labeled" }))
+                        .collect();
+                    events.push(serde_json::json!({ "event": "added_to_merge_queue" }));
+                    events
+                }
+                2 => vec![
+                    serde_json::json!({ "event": "labeled" }),
+                    serde_json::json!({ "event": "removed_from_merge_queue" }),
+                ],
+                page => panic!("the walk must stop at the short page, read page {page}"),
+            };
+            axum::Json(serde_json::Value::Array(events))
+        };
+        let api = serve_forge(axum::Router::new().route(
+            "/repos/acme/demo/issues/12/timeline",
+            axum::routing::get(timeline),
+        ))
+        .await;
+
+        let credential = GitCredential {
+            username: "x-access-token".into(),
+            secret: "ghs_test_borrowed".into(),
+        };
+        let api_base = format!("http://{api}");
+        let transport = FetchTransport::Rest {
+            api_base: &api_base,
+            credential: &credential,
+        };
+        let gate = HostGate::default();
+        let membership =
+            read_merge_queue_membership(&gate, transport, "github.com", "acme", "demo", 12).await;
+        assert_eq!(
+            membership,
+            Some(false),
+            "the removal on the last page wins over the addition on the first"
+        );
+    }
+
     #[cfg(unix)]
     mod shim {
         use super::*;
@@ -857,18 +1188,13 @@ esac
 "#,
             );
             let gate = HostGate::default();
-            let first = read_pull_request(
-                &gate,
-                dir.path(),
-                &gh,
-                "github.com",
-                "acme",
-                "demo",
-                12,
-                None,
-            )
-            .await
-            .unwrap();
+            let transport = FetchTransport::Gh {
+                cwd: dir.path(),
+                binary: &gh,
+            };
+            let first = read_pull_request(&gate, transport, "github.com", "acme", "demo", 12, None)
+                .await
+                .unwrap();
             let EndpointRead::Fresh { value, etag } = first else {
                 panic!("expected fresh: {first:?}");
             };
@@ -877,8 +1203,7 @@ esac
             let etag = etag.expect("a 200 carries the etag to send next time");
             let second = read_pull_request(
                 &gate,
-                dir.path(),
-                &gh,
+                transport,
                 "github.com",
                 "acme",
                 "demo",
@@ -901,8 +1226,10 @@ esac
             let gate = HostGate::default();
             let refused = read_pull_request(
                 &gate,
-                dir.path(),
-                &gh,
+                FetchTransport::Gh {
+                    cwd: dir.path(),
+                    binary: &gh,
+                },
                 "github.com",
                 "acme",
                 "demo",

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -2033,27 +2033,6 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)?;
-        // On a hosted machine the digest comes from the forge REST API with
-        // a borrowed credential (decision 65) — there is no `gh` here for
-        // the hot refresher to drive, so this read stays in the request
-        // path. Failures leave the persisted digest and the next read asks
-        // again.
-        if self.git_credentials().is_some() {
-            let worktree = std::path::Path::new(&workspace.worktree_path);
-            if let Ok(Some((target, credential))) = self.forge_rest_context(owner, worktree).await {
-                let api_base = self.forge_api_base_for(&target.host);
-                if let Ok(Some(digest)) = super::forge_rest::pull_request_digest(
-                    &api_base,
-                    &target,
-                    &credential,
-                    &workspace.branch_name,
-                )
-                .await
-                {
-                    status.pr = Some(digest);
-                }
-            }
-        }
         // On a hosted machine, say whose identity a push would act as
         // (decisions 63 and 65) — only for a checkout the machine would
         // actually lend an identity to, so the sentence is never wider than
@@ -2105,6 +2084,11 @@ impl CodeRuntime {
     /// and take the new digest as this workspace's column. Quiet on every
     /// failure — the caller's row keeps whatever it had, and the next tick
     /// or sweep corrects.
+    ///
+    /// The fetch rides an authenticated `gh` where one exists; a
+    /// gateway-hosted machine has none (decision 65), so there the same
+    /// refresh drives the forge REST API with a borrowed credential —
+    /// same gate, same stored ETags, same 304-shaped traffic.
     pub(crate) async fn refresh_workspace_pr_row(&self, owner: &OwnerId, id: WorkspaceId) {
         let Ok(mut workspace) = self.get_workspace(owner, id).await else {
             return;
@@ -2113,13 +2097,32 @@ impl CodeRuntime {
             return;
         }
         let gh_path = self.gh_search_path_owned();
-        let Some(binary) = gh::authenticated_gh_binary(gh_path.as_deref()).await else {
-            return;
+        let worktree = std::path::PathBuf::from(&workspace.worktree_path);
+        let digest = match gh::authenticated_gh_binary(gh_path.as_deref()).await {
+            Some(binary) => {
+                let transport = super::pr_fetch::FetchTransport::Gh {
+                    cwd: &worktree,
+                    binary: &binary,
+                };
+                self.fetched_workspace_digest(owner, &workspace, transport)
+                    .await
+            }
+            None => {
+                let Ok(Some((target, credential))) =
+                    self.forge_rest_context(owner, &worktree).await
+                else {
+                    return;
+                };
+                let api_base = self.forge_api_base_for(&target.host);
+                let transport = super::pr_fetch::FetchTransport::Rest {
+                    api_base: &api_base,
+                    credential: &credential,
+                };
+                self.fetched_workspace_digest(owner, &workspace, transport)
+                    .await
+            }
         };
-        let Some(digest) = self
-            .fetched_workspace_digest(owner, &workspace, &binary)
-            .await
-        else {
+        let Some(digest) = digest else {
             return;
         };
         if workspace.pr.as_ref() != Some(&digest) {
@@ -2185,7 +2188,9 @@ impl CodeRuntime {
             .ok()
     }
 
-    /// The workspace's digest through the conditional fetcher (decision 66).
+    /// The workspace's digest through the conditional fetcher (decision 66),
+    /// over whichever transport the caller resolved — `gh` or the hosted
+    /// forge REST API.
     ///
     /// Identity comes from the stored digest's URL, or a head lookup when
     /// the workspace knows no pull request yet. Each endpoint sends the
@@ -2197,11 +2202,10 @@ impl CodeRuntime {
         &self,
         owner: &OwnerId,
         workspace: &CodeWorkspace,
-        binary: &Path,
+        transport: super::pr_fetch::FetchTransport<'_>,
     ) -> Option<PullRequestDigest> {
         use super::pr_fetch::{self, EndpointRead};
 
-        let cwd = std::path::Path::new(&workspace.worktree_path);
         let gate = &self.host_gate;
         let stored_identity = workspace
             .pr
@@ -2214,8 +2218,7 @@ impl CodeRuntime {
                 let target = self.workspace_repository_target(owner, workspace).await?;
                 let found = match pr_fetch::read_pull_request_for_head(
                     gate,
-                    cwd,
-                    binary,
+                    transport,
                     &target.host,
                     &target.owner,
                     &target.name,
@@ -2254,8 +2257,7 @@ impl CodeRuntime {
         };
         let pull = match pr_fetch::read_pull_request(
             gate,
-            cwd,
-            binary,
+            transport,
             &host,
             &repo_owner,
             &repo_name,
@@ -2291,8 +2293,7 @@ impl CodeRuntime {
                 };
                 match pr_fetch::read_check_runs(
                     gate,
-                    cwd,
-                    binary,
+                    transport,
                     &host,
                     &repo_owner,
                     &repo_name,
@@ -2323,8 +2324,7 @@ impl CodeRuntime {
         let open = pull.state == "open";
         let rules = if open {
             self.branch_rules_for(
-                cwd,
-                binary,
+                transport,
                 &host,
                 &repo_owner,
                 &repo_name,
@@ -2337,8 +2337,7 @@ impl CodeRuntime {
         let review_decision = if open {
             match pr_fetch::read_reviews(
                 gate,
-                cwd,
-                binary,
+                transport,
                 &host,
                 &repo_owner,
                 &repo_name,
@@ -2373,8 +2372,7 @@ impl CodeRuntime {
                 _ => {
                     pr_fetch::read_merge_queue_membership(
                         gate,
-                        cwd,
-                        binary,
+                        transport,
                         &host,
                         &repo_owner,
                         &repo_name,
@@ -2410,8 +2408,7 @@ impl CodeRuntime {
     /// The base branch's rules, cached per branch for [`BRANCH_RULES_TTL`].
     async fn branch_rules_for(
         &self,
-        cwd: &Path,
-        binary: &Path,
+        transport: super::pr_fetch::FetchTransport<'_>,
         host: &str,
         repo_owner: &str,
         repo_name: &str,
@@ -2435,8 +2432,7 @@ impl CodeRuntime {
         }
         let rules = match super::pr_fetch::read_branch_rules(
             &self.host_gate,
-            cwd,
-            binary,
+            transport,
             host,
             repo_owner,
             repo_name,

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -907,9 +907,9 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
     let lender = Arc::new(FakeLender::offering("acme-ship[bot]"));
     let (router, token, runtime, dir) =
         code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
-    // Status reads on a forge checkout now refresh the digest over REST
-    // (decision 65); a dead loopback port keeps this test off the network
-    // while the borrow accounting below stays observable.
+    // Status reads answer from the stored row; only the background refresher
+    // fetches over REST. A dead loopback port keeps any stray fetch off the
+    // network while the borrow accounting below stays observable.
     runtime.set_forge_api_base(Some("http://127.0.0.1:9/".to_owned()));
     let addr = serve(router).await;
     let client = reqwest::Client::new();
@@ -975,16 +975,11 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
         body["pushes_as_self"].is_null(),
         "the App's identity is never claimed as the caller's own: {body}"
     );
-    // The forge checkout's status read borrows once for the REST digest
-    // (decision 65); the read fails on the dead port and degrades silently.
-    let digest_borrows = lender.minted().len();
-    assert!(digest_borrows > 0, "the digest read borrows per operation");
+    // The status read serves the stored row and borrows nothing: the
+    // background refresher owns the digest fetch now.
     assert!(
-        lender
-            .minted()
-            .iter()
-            .all(|repository| repository == "acme/demo"),
-        "every borrow names the one forge repository: {:?}",
+        lender.minted().is_empty(),
+        "the status read must not borrow: {:?}",
         lender.minted()
     );
 
@@ -1009,9 +1004,8 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
         .unwrap();
     let body: serde_json::Value = status.json().await.unwrap();
     assert!(body["pushes_as"].is_null(), "{body}");
-    assert_eq!(
-        lender.minted().len(),
-        digest_borrows,
+    assert!(
+        lender.minted().is_empty(),
         "a foreign host must never reach the gateway"
     );
     run(
@@ -1040,8 +1034,8 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
     assert!(message.contains("no git forge"), "{message}");
     assert_eq!(
         lender.minted().len(),
-        digest_borrows + 1,
-        "the refused push asked exactly once more"
+        1,
+        "the refused push asked exactly once"
     );
     assert!(
         lender
@@ -1500,6 +1494,278 @@ exit 3
         .await
         .unwrap();
     assert_eq!(fresh["pr"]["head_sha"], "bbbbbbbb");
+}
+
+/// Decision 65 meets decision 66 on a hosted machine: the request path
+/// answers from the stored row without an inline forge fetch, and the
+/// refresher drives the same conditional fetcher over the forge REST API —
+/// unconditionally the first time, then with `If-None-Match` from the fact
+/// row's stored ETags, keeping the row on the 304.
+#[tokio::test]
+async fn a_hosted_digest_reads_the_row_and_refreshes_conditionally() {
+    use tidebreak_core::db::code::save_pull_request_fact;
+    use tidebreak_core::{CodePullRequestFact, CodePullRequestId, CodePullRequestState};
+
+    type Seen = Arc<std::sync::Mutex<Vec<(&'static str, Option<String>)>>>;
+    let seen: Seen = Arc::default();
+
+    fn conditional_answer(
+        seen: &Seen,
+        endpoint: &'static str,
+        headers: &axum::http::HeaderMap,
+        etag: &str,
+        body: serde_json::Value,
+    ) -> axum::response::Response {
+        let conditional = headers
+            .get(axum::http::header::IF_NONE_MATCH)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
+        let unchanged = conditional.as_deref() == Some(etag);
+        seen.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push((endpoint, conditional));
+        axum::http::Response::builder()
+            .status(if unchanged { 304 } else { 200 })
+            .header("etag", etag)
+            .body(axum::body::Body::from(if unchanged {
+                String::new()
+            } else {
+                body.to_string()
+            }))
+            .unwrap()
+    }
+
+    let pull_seen = Arc::clone(&seen);
+    let pull = move |headers: axum::http::HeaderMap| {
+        let seen = Arc::clone(&pull_seen);
+        async move {
+            conditional_answer(
+                &seen,
+                "pull",
+                &headers,
+                "W/\"pull-1\"",
+                serde_json::json!({
+                    "number": 12,
+                    "html_url": "https://github.com/acme/demo/pull/12",
+                    "title": "Hosted change",
+                    "state": "open",
+                    "draft": false,
+                    "mergeable": true,
+                    "mergeable_state": "clean",
+                    "head": { "ref": "feature", "sha": "feedfeedfeedfeedfeed" },
+                    "base": { "ref": "main" },
+                    "auto_merge": null,
+                }),
+            )
+        }
+    };
+    let checks_seen = Arc::clone(&seen);
+    let checks = move |headers: axum::http::HeaderMap| {
+        let seen = Arc::clone(&checks_seen);
+        async move {
+            conditional_answer(
+                &seen,
+                "checks",
+                &headers,
+                "W/\"checks-1\"",
+                serde_json::json!({
+                    "check_runs": [
+                        { "name": "lint", "status": "completed", "conclusion": "success",
+                          "html_url": "https://github.com/acme/demo/runs/1" },
+                    ]
+                }),
+            )
+        }
+    };
+    let reviews_seen = Arc::clone(&seen);
+    let reviews = move |headers: axum::http::HeaderMap| {
+        let seen = Arc::clone(&reviews_seen);
+        async move {
+            conditional_answer(
+                &seen,
+                "reviews",
+                &headers,
+                "W/\"reviews-1\"",
+                serde_json::json!([]),
+            )
+        }
+    };
+    let timeline = || async { axum::Json(serde_json::json!([])) };
+    let fallback_seen = Arc::clone(&seen);
+    let fallback = move |uri: axum::http::Uri| {
+        let seen = Arc::clone(&fallback_seen);
+        async move {
+            seen.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(("other", Some(uri.path().to_owned())));
+            axum::http::StatusCode::NOT_FOUND
+        }
+    };
+    let forge = axum::Router::new()
+        .route("/repos/acme/demo/pulls/12", axum::routing::get(pull))
+        .route(
+            "/repos/acme/demo/commits/{sha}/check-runs",
+            axum::routing::get(checks),
+        )
+        .route(
+            "/repos/acme/demo/pulls/12/reviews",
+            axum::routing::get(reviews),
+        )
+        .route(
+            "/repos/acme/demo/issues/12/timeline",
+            axum::routing::get(timeline),
+        )
+        .fallback(fallback);
+    let api = serve(forge).await;
+
+    let lender = Arc::new(FakeLender::offering_person("mira-chen"));
+    let (router, token, runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    runtime.set_gh_search_path(Some("/path/with/no/gh".into()));
+    runtime.set_forge_api_base(Some(format!("http://{api}")));
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "hosted digest").await;
+    let id = json_id(&workspace).to_owned();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+
+    // The decision-62 fact row the stored ETags live on.
+    let owner = tidebreak_core::OwnerId::local();
+    let now = chrono::Utc::now();
+    save_pull_request_fact(
+        &runtime.db,
+        &CodePullRequestFact {
+            id: CodePullRequestId::new(),
+            owner: owner.clone(),
+            host: "github.com".into(),
+            repo_owner: "acme".into(),
+            repo_name: "demo".into(),
+            number: 12,
+            url: "https://github.com/acme/demo/pull/12".into(),
+            title: "Hosted change".into(),
+            state: CodePullRequestState::Open,
+            draft: false,
+            author: None,
+            head_branch: "feature".into(),
+            base_branch: "main".into(),
+            head_sha: Some("feedfeedfeedfeedfeed".into()),
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            closed_at: None,
+            first_seen_at: now,
+            last_seen_at: now,
+            live: None,
+        },
+    )
+    .await
+    .unwrap();
+    seed_workspace_pull_request(&runtime, &id, "https://github.com/acme/demo/pull/12", 12).await;
+
+    // The request path answers from the stored row: the seeded digest comes
+    // back untouched, and the forge sees no read at all.
+    let first = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(first["pr"]["number"], 12);
+    assert!(
+        first["pr"]["title"].is_null(),
+        "the request path serves the row, not a fresh fetch: {first}"
+    );
+    assert!(
+        seen.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_empty(),
+        "the request path never reached the forge"
+    );
+
+    // The refresher tick fetches over REST — unconditionally, no ETag is
+    // stored yet — and the result lands on the row the next read serves.
+    let workspace_id: tidebreak_core::WorkspaceId = id.parse().unwrap();
+    runtime.refresh_workspace_pr_row(&owner, workspace_id).await;
+    let refreshed = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(refreshed["pr"]["title"], "Hosted change");
+    assert_eq!(refreshed["pr"]["head_sha"], "feedfeedfeedfeedfeed");
+    assert_eq!(
+        refreshed["pr"]["checks_summary"],
+        "1 passing, 0 pending, 0 failing"
+    );
+
+    // The next tick sends `If-None-Match` from the stored ETags, and the
+    // 304 answers keep the row intact.
+    runtime.refresh_workspace_pr_row(&owner, workspace_id).await;
+    let unchanged = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(unchanged["pr"]["title"], "Hosted change");
+    assert_eq!(
+        unchanged["pr"]["checks_summary"],
+        "1 passing, 0 pending, 0 failing"
+    );
+
+    let seen = seen
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let sent = |endpoint: &str| {
+        seen.iter()
+            .filter(|(name, _)| *name == endpoint)
+            .map(|(_, conditional)| conditional.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        sent("pull"),
+        vec![None, Some("W/\"pull-1\"".to_owned())],
+        "the first pull read is unconditional; the second sends the stored ETag"
+    );
+    assert_eq!(
+        sent("checks"),
+        vec![None, Some("W/\"checks-1\"".to_owned())]
+    );
+    assert_eq!(
+        sent("reviews"),
+        vec![None, Some("W/\"reviews-1\"".to_owned())]
+    );
+    assert!(
+        lender
+            .minted()
+            .iter()
+            .all(|repository| repository == "acme/demo"),
+        "every borrow names the one repository: {:?}",
+        lender.minted()
+    );
 }
 
 /// One host read updates every workspace holding the pull request


### PR DESCRIPTION
Closes #2579

Deferred from decision 66: slice 4 (#2572) took `GET /code/workspaces/{id}/pr` off GitHub for machines with `gh`, but a gateway-hosted machine (decision 65) has no `gh`, so `forge_rest::pull_request_digest` still ran inside the request path — an unconditional one-to-three-second fetch with a borrowed credential on every workspace open.

## What changed

**One fetcher, two transports.** `pr_fetch` grows a `FetchTransport`: the conditional fetcher's reads now run over either `gh api` or a direct REST GET with the borrowed credential as the bearer. The REST arm answers in the same `RawHttpResponse` shape `gh api --include` produces, so ETags, 304s, and the `HostGate` parks (`Retry-After`, secondary-limit answers, exhausted windows) stay one code path however the host is asked. The merge-queue timeline read gets a gated single-page REST arm too.

**The refresher picks the transport.** `refresh_workspace_pr_row` uses an authenticated `gh` where one exists, and otherwise the hosted forge-REST context — the repository target plus one borrowed credential. The hot refresher, the push-dirties-the-row path, and the explicit refresh action all ride it unchanged, and every read sends `If-None-Match` from the fact row's stored ETags.

**The request path stops fetching.** `workspace_pr` drops the inline hosted digest fetch. The hosted read now answers from local git plus the stored row, exactly like the `gh` path, and the 17-second hot tier keeps the row current while you are looking.

## Tests

- `the_rest_transport_sends_the_stored_etag_and_reads_the_304` and `a_rest_limit_answer_parks_the_host` pin the REST arm's conditional discipline and park behavior against a scripted forge.
- `a_hosted_digest_reads_the_row_and_refreshes_conditionally` pins the end-to-end shape: the hosted read serves the stored row with zero forge traffic (a fallback route records any stray request), the refresher's first pass fetches unconditionally and lands on the row, and the next pass sends `If-None-Match` from the stored ETags for the pull, check-runs, and reviews endpoints and keeps the row on the 304s. Stash the source change and it fails at the no-inline-fetch assertion.

## What I ran

`cargo fmt --all --check`, `cargo check -p tidebreak-server --all-targets`, and the focused tests: `cargo test -p tidebreak-server --lib pr_fetch` plus the five pull-request digest and hosted tests in `code_git`. All pass. I did not run the full workspace suite.