### PR TITLE
feat(code): choose reasoning effort and fast mode at workspace creation

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -2448,6 +2448,7 @@ export class ApiClient {
       permission_mode: PermissionMode;
       model?: string;
       reasoning_effort?: ReasoningEffort;
+      fast_mode?: boolean;
     },
   ): Promise<CodeSessionSnapshot> {
     return requireParsed(

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -1,6 +1,10 @@
 import { create } from "zustand";
 
-import type { HarnessKind, PermissionMode } from "../api/types";
+import type {
+  HarnessKind,
+  PermissionMode,
+  ReasoningEffort,
+} from "../api/types";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import type { StatusTone } from "./statusTone";
 import type { WorkflowShortcut } from "./workspaceWorkflow";
@@ -20,6 +24,15 @@ const HARNESS_KINDS: readonly HarnessKind[] = [
   "codex",
   "opencode",
   "grok",
+];
+const REASONING_EFFORTS: readonly ReasoningEffort[] = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
 ];
 
 /**
@@ -48,6 +61,10 @@ export type CodeCreateDefaults = {
   harness?: HarnessKind;
   modelsByHarness: Partial<Record<HarnessKind, string>>;
   permissionMode?: PermissionMode;
+  /** Last honored reasoning effort per engine; omitted when the engine has none. */
+  reasoningEffortByHarness?: Partial<Record<HarnessKind, ReasoningEffort>>;
+  /** Last fast-mode pick per engine; only restored when the model still serves it. */
+  fastModeByHarness?: Partial<Record<HarnessKind, boolean>>;
 };
 
 /** What one successful create adds to the remembered defaults. */
@@ -58,6 +75,10 @@ export type CodeCreateSelection = {
   /** Picks made before the final harness, kept for the next switch back. */
   modelsByHarness?: Partial<Record<HarnessKind, string>>;
   permissionMode?: PermissionMode;
+  reasoningEffort?: ReasoningEffort | null;
+  reasoningEffortByHarness?: Partial<Record<HarnessKind, ReasoningEffort>>;
+  fastMode?: boolean;
+  fastModeByHarness?: Partial<Record<HarnessKind, boolean>>;
 };
 
 /**
@@ -124,11 +145,39 @@ function readStoredCreateDefaults(): CodeCreateDefaults | null {
     ) {
       modelsByHarness[rememberedHarness] = legacyModel;
     }
+    const reasoningEffortByHarness: Partial<
+      Record<HarnessKind, ReasoningEffort>
+    > = {};
+    const storedEfforts = record.reasoningEffortByHarness;
+    if (storedEfforts && typeof storedEfforts === "object") {
+      const effortRecord = storedEfforts as Record<string, unknown>;
+      for (const kind of HARNESS_KINDS) {
+        const effort = effortRecord[kind];
+        if (
+          typeof effort === "string" &&
+          REASONING_EFFORTS.includes(effort as ReasoningEffort)
+        ) {
+          reasoningEffortByHarness[kind] = effort as ReasoningEffort;
+        }
+      }
+    }
+    const fastModeByHarness: Partial<Record<HarnessKind, boolean>> = {};
+    const storedFast = record.fastModeByHarness;
+    if (storedFast && typeof storedFast === "object") {
+      const fastRecord = storedFast as Record<string, unknown>;
+      for (const kind of HARNESS_KINDS) {
+        if (typeof fastRecord[kind] === "boolean") {
+          fastModeByHarness[kind] = fastRecord[kind];
+        }
+      }
+    }
     return {
       repoId: text(record.repoId),
       harness: rememberedHarness,
       modelsByHarness,
       permissionMode: mode(record.permissionMode),
+      reasoningEffortByHarness,
+      fastModeByHarness,
     };
   } catch {
     return null;
@@ -480,18 +529,37 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
       return { railPrefs };
     }),
   rememberCreate: (selection) => {
+    const previous = get().lastCreate;
     const modelsByHarness = {
-      ...get().lastCreate?.modelsByHarness,
+      ...previous?.modelsByHarness,
       ...selection.modelsByHarness,
     };
     if (selection.model) {
       modelsByHarness[selection.harness] = selection.model;
+    }
+    const reasoningEffortByHarness = {
+      ...previous?.reasoningEffortByHarness,
+      ...selection.reasoningEffortByHarness,
+    };
+    if (selection.reasoningEffort) {
+      reasoningEffortByHarness[selection.harness] = selection.reasoningEffort;
+    } else if (selection.reasoningEffort === null) {
+      delete reasoningEffortByHarness[selection.harness];
+    }
+    const fastModeByHarness = {
+      ...previous?.fastModeByHarness,
+      ...selection.fastModeByHarness,
+    };
+    if (selection.fastMode !== undefined) {
+      fastModeByHarness[selection.harness] = selection.fastMode;
     }
     const defaults: CodeCreateDefaults = {
       repoId: selection.repoId,
       harness: selection.harness,
       modelsByHarness,
       permissionMode: selection.permissionMode,
+      reasoningEffortByHarness,
+      fastModeByHarness,
     };
     storeCreateDefaults(defaults);
     set({ lastCreate: defaults });

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -619,6 +619,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     message: string,
     model?: string,
     draft = message,
+    reasoningEffort?: ReasoningEffort | null,
+    fastMode = false,
   ) {
     const request = startRequestRef.current + 1;
     startRequestRef.current = request;
@@ -650,6 +652,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           harness,
           permission_mode: permissionMode,
           model: posted,
+          ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+          ...(fastMode ? { fast_mode: true } : {}),
         });
       } catch (err) {
         if (isCurrent()) {
@@ -1305,8 +1309,24 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   client={client}
                   catalogModels={models}
                   defaultModelKey={defaultModelKey}
-                  onStart={(harness, mode, message, model, draft) =>
-                    startSession(harness, mode, message, model, draft)
+                  onStart={(
+                    harness,
+                    mode,
+                    message,
+                    model,
+                    draft,
+                    reasoningEffort,
+                    fastMode,
+                  ) =>
+                    startSession(
+                      harness,
+                      mode,
+                      message,
+                      model,
+                      draft,
+                      reasoningEffort,
+                      fastMode,
+                    )
                   }
                   workspaceFiles={
                     forkSource

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -311,6 +311,8 @@ describe("NewWorkspaceDialog", () => {
         opencode: "model-gateway/deepseek-v4-pro",
         claude_code: "claude-opus-5",
       },
+      reasoningEffortByHarness: {},
+      fastModeByHarness: {},
     });
   });
 
@@ -474,6 +476,8 @@ describe("NewWorkspaceDialog", () => {
         harness: "codex",
         modelsByHarness: { codex: "gpt-5.6-sol" },
         permissionMode: "allow",
+        reasoningEffortByHarness: {},
+        fastModeByHarness: { codex: false },
       }),
     );
     expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
@@ -1244,6 +1248,261 @@ describe("NewWorkspaceDialog", () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("menuitem", { name: /GPT 5.6 Sol/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers reasoning effort and fast mode only when the engine and model honor them", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    const efforts: ReasoningEffort[] = ["low", "medium", "high"];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code"), harness("opencode")],
+        notices: [],
+      } as never,
+    });
+    const user = userEvent.setup();
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          listCodeHarnessModels: vi.fn((kind: HarnessKind) =>
+            Promise.resolve(
+              kind === "opencode"
+                ? {
+                    kind: "opencode" as const,
+                    models: [
+                      {
+                        id: "gpt-5.6-sol",
+                        label: "GPT 5.6 Sol",
+                        default: true,
+                        reasoning_efforts: [],
+                        fast_mode: false,
+                      },
+                    ],
+                    reasoning_efforts: [],
+                    fast_mode: false,
+                  }
+                : {
+                    kind: "claude_code" as const,
+                    models: [
+                      {
+                        id: "claude-opus-5",
+                        label: "Claude Opus 5",
+                        default: true,
+                        reasoning_efforts: [],
+                        fast_mode: true,
+                      },
+                      {
+                        id: "claude-sonnet-5",
+                        label: "Claude Sonnet 5",
+                        default: false,
+                        reasoning_efforts: [],
+                        fast_mode: false,
+                      },
+                    ],
+                    reasoning_efforts: efforts,
+                    fast_mode: true,
+                  },
+            ),
+          ),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reasoning: Default" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Fast mode off" }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Model: Claude Opus 5" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Claude Sonnet 5/ }));
+    expect(
+      screen.queryByRole("switch", { name: /Fast mode/ }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Harness: Claude Code" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /opencode/ }));
+    expect(
+      await screen.findByRole("button", { name: "Model: GPT 5.6 Sol" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Reasoning:/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /Fast mode/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("posts the chosen reasoning effort and fast mode on create", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    const efforts: ReasoningEffort[] = ["low", "medium", "high"];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const createCodeWorkspace = vi.fn(async () =>
+      workspace("ws-settings", "repo-new", "2026-08-20T00:00:00.000Z"),
+    );
+    const createCodeSession = vi.fn(async () =>
+      session("ws-settings", "claude_code", "2026-08-20T00:00:00.000Z"),
+    );
+    const user = userEvent.setup();
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace,
+          createCodeSession,
+          listCodeHarnessModels: vi.fn(async () => ({
+            kind: "claude_code" as const,
+            models: [
+              {
+                id: "claude-opus-5",
+                label: "Claude Opus 5",
+                default: true,
+                reasoning_efforts: [],
+                fast_mode: true,
+              },
+            ],
+            reasoning_efforts: efforts,
+            fast_mode: true,
+          })),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Reasoning: Default" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "High" }));
+    await user.click(screen.getByRole("switch", { name: "Fast mode off" }));
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+    await waitFor(() =>
+      expect(createCodeSession).toHaveBeenCalledWith("ws-settings", {
+        harness: "claude_code",
+        permission_mode: "allow",
+        model: "claude-opus-5",
+        reasoning_effort: "high",
+        fast_mode: true,
+      }),
+    );
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().lastCreate).toEqual({
+        repoId: "repo-new",
+        harness: "claude_code",
+        modelsByHarness: { claude_code: "claude-opus-5" },
+        permissionMode: "allow",
+        reasoningEffortByHarness: { claude_code: "high" },
+        fastModeByHarness: { claude_code: true },
+      }),
+    );
+  });
+
+  it("restores lastCreate effort and fast mode only when the engine still honors them", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    const efforts: ReasoningEffort[] = ["low", "medium", "high"];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("grok"), harness("opencode")],
+        notices: [],
+      } as never,
+    });
+    useCodeUiStore.setState({
+      lastCreate: {
+        harness: "grok",
+        modelsByHarness: { grok: "grok-4.6" },
+        reasoningEffortByHarness: { grok: "high", opencode: "high" },
+        fastModeByHarness: { grok: true, opencode: true },
+      },
+    });
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          listCodeHarnessModels: vi.fn((kind: HarnessKind) =>
+            Promise.resolve(
+              kind === "opencode"
+                ? {
+                    kind: "opencode" as const,
+                    models: [
+                      {
+                        id: "gpt-5.6-sol",
+                        label: "GPT 5.6 Sol",
+                        default: true,
+                        reasoning_efforts: [],
+                        fast_mode: false,
+                      },
+                    ],
+                    reasoning_efforts: [],
+                    fast_mode: false,
+                  }
+                : {
+                    kind: "grok" as const,
+                    models: [
+                      {
+                        id: "grok-4.6",
+                        label: "Grok 4.6",
+                        default: true,
+                        reasoning_efforts: efforts,
+                        fast_mode: false,
+                      },
+                    ],
+                    reasoning_efforts: efforts,
+                    fast_mode: false,
+                  },
+            ),
+          ),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Model: Grok 4.6" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reasoning: High" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /Fast mode/ }),
+    ).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Harness: Grok CLI" }));
+    await user.click(screen.getByRole("menuitem", { name: /opencode/ }));
+    expect(
+      await screen.findByRole("button", { name: "Model: GPT 5.6 Sol" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Reasoning:/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /Fast mode/ }),
     ).not.toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -1345,6 +1345,60 @@ describe("NewWorkspaceDialog", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows fast mode on a gateway catalog row the harness listing marks as fast", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const listCodeHarnessModels = vi.fn(async () => ({
+      kind: "claude_code" as const,
+      models: [
+        {
+          id: "claude-opus-5",
+          label: "Claude Opus 5",
+          default: true,
+          reasoning_efforts: [],
+          fast_mode: true,
+        },
+      ],
+      reasoning_efforts: ["low", "medium", "high"] as ReasoningEffort[],
+      fast_mode: true,
+    }));
+    await renderWithRouter(
+      <AppContextProvider
+        value={{
+          ...app({ listCodeHarnessModels }),
+          models: [
+            {
+              key: "model_gateway::claude-opus-5",
+              id: "claude-opus-5",
+              display_name: "Claude Opus 5",
+              provider: "model_gateway",
+              vendor: "anthropic",
+              available: true,
+            } as never,
+          ],
+          defaultModelKey: "model_gateway::claude-opus-5",
+        }}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(listCodeHarnessModels).toHaveBeenCalledWith("claude_code");
+    expect(
+      await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Fast mode off" }),
+    ).toBeInTheDocument();
+  });
+
   it("posts the chosen reasoning effort and fast mode on create", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     const efforts: ReasoningEffort[] = ["low", "medium", "high"];

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -350,13 +350,10 @@ export function NewWorkspaceDialog({
     };
     const gateway = gatewayCodeModels(models, harness, defaultModelKey);
     const native = useCodeCatalogStore.getState().modelsByHarness[harness];
-    const needsNative =
-      requiresHarnessModelIds(harness) || gateway.length === 0;
-    if (!needsNative) {
-      apply(gateway);
-      setModelLoading(false);
-      return;
-    }
+    // Fetch the harness listing even when the gateway catalog already has
+    // display rows: those rows omit `fast_mode`, and the engine's effort
+    // ladder is also stored from this fetch. Join happens in
+    // `preferredCodeModels`.
     if (native !== undefined) {
       apply(preferredCodeModels(harness, native, gateway));
       setModelLoading(false);

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -16,6 +16,7 @@ import type {
   CodeWorkspaceSnapshot,
   HarnessDoctorEntry,
   HarnessKind,
+  ReasoningEffort,
 } from "../api/types";
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
@@ -44,13 +45,18 @@ import {
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
-import { HarnessModelMenu } from "./CodeComposer";
+import {
+  FastModeToggle,
+  HarnessModelMenu,
+  ReasoningEffortMenu,
+} from "./CodeComposer";
 import { HarnessInstallNote } from "./HarnessInstallNote";
 import { useWarmHarnessInstall } from "./useHarnessInstall";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import {
   createPermissionModes,
   defaultCreatePermissionMode,
+  effortLadder,
   gatewayCodeModels,
   harnessCanStartNow,
   harnessUnusableReason,
@@ -60,13 +66,16 @@ import {
   type CodeModelOption,
 } from "./labels";
 
+const NO_ENGINE_EFFORTS: ReasoningEffort[] = [];
+
 /**
  * Create a workspace, its first session, and — when a first message is typed —
  * its first turn, then open it.
  *
  * The dialog is a composer, not a form: the message is the surface, and every
  * setting is a pill that opens on what this reader used last (repo, engine,
- * model, and permission mode stick via `lastCreate`; the catalog covers a
+ * model, permission mode, reasoning effort, and fast mode stick via
+ * `lastCreate`; the catalog covers a
  * fresh window). Enter creates, Shift+Enter breaks a line, and Cmd+Enter
  * creates from anywhere in the dialog, pickers included. Each pill has its own
  * chord — Cmd+N again for the repo, and Alt+E / M / P / B / N for engine,
@@ -138,6 +147,10 @@ type CreateAttempt = {
   permissionMode: PermissionMode;
   model: string | undefined;
   modelsByHarness: Partial<Record<HarnessKind, string>>;
+  reasoningEffort: ReasoningEffort | null;
+  reasoningEffortByHarness: Partial<Record<HarnessKind, ReasoningEffort>>;
+  fastMode: boolean;
+  fastModeByHarness: Partial<Record<HarnessKind, boolean>>;
   createMore: boolean;
   originPath: string;
 };
@@ -186,6 +199,12 @@ export function NewWorkspaceDialog({
   const [modelsByHarness, setModelsByHarness] = useState<
     Partial<Record<HarnessKind, string>>
   >({});
+  const [effortByHarness, setEffortByHarness] = useState<
+    Partial<Record<HarnessKind, ReasoningEffort>>
+  >({});
+  const [fastByHarness, setFastByHarness] = useState<
+    Partial<Record<HarnessKind, boolean>>
+  >({});
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
   const [modelLoading, setModelLoading] = useState(false);
   const [openPicker, setOpenPicker] = useState<PickerId | null>(null);
@@ -210,6 +229,23 @@ export function NewWorkspaceDialog({
     recentHarness(selectableHarnesses, sessions, lastCreate?.harness) ??
     "claude_code";
   const model = modelsByHarness[harness];
+  const engineEfforts =
+    useCodeCatalogStore((state) => state.effortsByHarness[harness]) ??
+    NO_ENGINE_EFFORTS;
+  const selectedOption =
+    modelOptions.find((option) => option.id === model) ??
+    modelOptions.find((option) => option.default) ??
+    modelOptions[0];
+  const effortLevels = effortLadder(selectedOption, engineEfforts);
+  const fastModeAvailable = selectedOption?.fast_mode ?? false;
+  const rememberedEffort = effortByHarness[harness];
+  const postedEffort =
+    rememberedEffort && effortLevels.includes(rememberedEffort)
+      ? rememberedEffort
+      : null;
+  const postedFastMode = fastModeAvailable
+    ? Boolean(fastByHarness[harness])
+    : false;
 
   useEffect(() => {
     if (!open) return;
@@ -238,6 +274,14 @@ export function NewWorkspaceDialog({
     setCreateMore(retry?.createMore ?? false);
     setModelsByHarness(
       retry?.modelsByHarness ?? { ...lastCreate?.modelsByHarness },
+    );
+    setEffortByHarness(
+      retry?.reasoningEffortByHarness ?? {
+        ...lastCreate?.reasoningEffortByHarness,
+      },
+    );
+    setFastByHarness(
+      retry?.fastModeByHarness ?? { ...lastCreate?.fastModeByHarness },
     );
     setModelOptions([]);
     setModelLoading(false);
@@ -396,6 +440,10 @@ export function NewWorkspaceDialog({
       permissionMode: postedMode,
       model,
       modelsByHarness: { ...modelsByHarness },
+      reasoningEffort: postedEffort,
+      reasoningEffortByHarness: { ...effortByHarness },
+      fastMode: postedFastMode,
+      fastModeByHarness: { ...fastByHarness },
       createMore,
       originPath: pathnameRef.current,
     };
@@ -491,6 +539,10 @@ export function NewWorkspaceDialog({
         harness: attempt.harness,
         permission_mode: attempt.permissionMode,
         model: posted,
+        ...(attempt.reasoningEffort
+          ? { reasoning_effort: attempt.reasoningEffort }
+          : {}),
+        ...(attempt.fastMode ? { fast_mode: true } : {}),
       });
       rememberSession(session);
       rememberCreate({
@@ -499,6 +551,10 @@ export function NewWorkspaceDialog({
         model: posted,
         modelsByHarness: attempt.modelsByHarness,
         permissionMode: attempt.permissionMode,
+        reasoningEffort: attempt.reasoningEffort,
+        reasoningEffortByHarness: attempt.reasoningEffortByHarness,
+        fastMode: attempt.fastMode,
+        fastModeByHarness: attempt.fastModeByHarness,
       });
       if (prompt) {
         try {
@@ -849,6 +905,30 @@ export function NewWorkspaceDialog({
                 </span>
               </WithTooltip>
             )}
+            {effortLevels.length > 0 && (
+              <ReasoningEffortMenu
+                levels={effortLevels}
+                value={postedEffort}
+                onChange={(next) => {
+                  setEffortByHarness((current) => {
+                    const nextMap = { ...current };
+                    if (next) nextMap[harness] = next;
+                    else delete nextMap[harness];
+                    return nextMap;
+                  });
+                }}
+              />
+            )}
+            <FastModeToggle
+              available={fastModeAvailable}
+              value={postedFastMode}
+              onChange={(next) => {
+                setFastByHarness((current) => ({
+                  ...current,
+                  [harness]: next,
+                }));
+              }}
+            />
             <WithTooltip label={`Permissions · ${alt("P")}`}>
               <span className="inline-flex min-w-0">
                 <PermissionModeMenu

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -598,6 +598,57 @@ describe("StartSessionPrompt", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows fast mode on a gateway catalog row the harness listing marks as fast", async () => {
+    const client = {
+      listCodeHarnessModels: vi.fn(async () => ({
+        kind: "claude_code" as const,
+        models: [
+          {
+            id: "claude-opus-5",
+            label: "Claude Opus 5",
+            default: true,
+            reasoning_efforts: [],
+            fast_mode: true,
+          },
+        ],
+        reasoning_efforts: ["low", "medium", "high"] as ReasoningEffort[],
+        fast_mode: true,
+      })),
+    };
+    await renderWithRouter(
+      wrap(
+        <StartSessionPrompt
+          workspaceId="workspace-1"
+          harnesses={[entry("claude_code", {})]}
+          starting={false}
+          selectedMode={null}
+          onSelectMode={vi.fn()}
+          onStart={vi.fn()}
+          client={client}
+          catalogModels={[
+            {
+              key: "model_gateway::claude-opus-5",
+              id: "claude-opus-5",
+              display_name: "Claude Opus 5",
+              provider: "model_gateway",
+              vendor: "anthropic",
+              available: true,
+            } as never,
+          ]}
+          defaultModelKey="model_gateway::claude-opus-5"
+        />,
+      ),
+    );
+
+    expect(client.listCodeHarnessModels).toHaveBeenCalledWith("claude_code");
+    expect(
+      await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Fast mode off" }),
+    ).toBeInTheDocument();
+  });
+
   it("posts the chosen reasoning effort and fast mode on start", async () => {
     const user = userEvent.setup();
     const onStart = vi.fn();

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -5,6 +5,7 @@ import {
   createEvent,
   fireEvent,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -166,6 +167,9 @@ describe("StartSessionPrompt", () => {
       "allow",
       "list the files",
       undefined,
+      undefined,
+      null,
+      false,
     );
   });
 
@@ -203,6 +207,9 @@ describe("StartSessionPrompt", () => {
       "plan",
       "list the files",
       undefined,
+      undefined,
+      null,
+      false,
     );
   });
 
@@ -245,6 +252,9 @@ describe("StartSessionPrompt", () => {
       "auto",
       "list the files",
       undefined,
+      undefined,
+      null,
+      false,
     );
   });
 
@@ -293,6 +303,9 @@ describe("StartSessionPrompt", () => {
       "allow",
       "list the files",
       "claude-opus-5",
+      undefined,
+      null,
+      false,
     );
   });
 
@@ -361,6 +374,9 @@ describe("StartSessionPrompt", () => {
       "allow",
       "list the files",
       "model-gateway-model-gateway/grok-4.6",
+      undefined,
+      null,
+      false,
     );
   });
 
@@ -490,5 +506,218 @@ describe("StartSessionPrompt", () => {
     );
     await user.click(screen.getByRole("menuitem", { name: /Ask/ }));
     expect(onSelectMode).toHaveBeenCalledWith("ask");
+  });
+
+  it("offers reasoning effort and fast mode only when the engine and model honor them", async () => {
+    const user = userEvent.setup();
+    const efforts: ReasoningEffort[] = ["low", "medium", "high"];
+    const client = {
+      listCodeHarnessModels: vi.fn((kind: HarnessDoctorEntry["kind"]) =>
+        Promise.resolve(
+          kind === "opencode"
+            ? {
+                kind: "opencode" as const,
+                models: [
+                  {
+                    id: "gpt-5.6-sol",
+                    label: "GPT 5.6 Sol",
+                    default: true,
+                    reasoning_efforts: [],
+                    fast_mode: false,
+                  },
+                ],
+                reasoning_efforts: [],
+                fast_mode: false,
+              }
+            : {
+                kind: "claude_code" as const,
+                models: [
+                  {
+                    id: "claude-opus-5",
+                    label: "Claude Opus 5",
+                    default: true,
+                    reasoning_efforts: [],
+                    fast_mode: true,
+                  },
+                  {
+                    id: "claude-sonnet-5",
+                    label: "Claude Sonnet 5",
+                    default: false,
+                    reasoning_efforts: [],
+                    fast_mode: false,
+                  },
+                ],
+                reasoning_efforts: efforts,
+                fast_mode: true,
+              },
+        ),
+      ),
+    };
+    await renderWithRouter(
+      wrap(
+        <StartSessionPrompt
+          workspaceId="workspace-1"
+          harnesses={[entry("claude_code", {}), entry("opencode", {})]}
+          starting={false}
+          selectedMode={null}
+          onSelectMode={vi.fn()}
+          onStart={vi.fn()}
+          client={client}
+        />,
+      ),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reasoning: Default" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Fast mode off" }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Model: Claude Opus 5" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Claude Sonnet 5/ }));
+    expect(
+      screen.queryByRole("switch", { name: /Fast mode/ }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /opencode/ }));
+    expect(
+      await screen.findByRole("button", { name: "Model: GPT 5.6 Sol" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Reasoning:/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /Fast mode/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("posts the chosen reasoning effort and fast mode on start", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+    const efforts: ReasoningEffort[] = ["low", "medium", "high"];
+    const client = {
+      listCodeHarnessModels: vi.fn(async () => ({
+        kind: "claude_code" as const,
+        models: [
+          {
+            id: "claude-opus-5",
+            label: "Claude Opus 5",
+            default: true,
+            reasoning_efforts: [],
+            fast_mode: true,
+          },
+        ],
+        reasoning_efforts: efforts,
+        fast_mode: true,
+      })),
+    };
+    await renderWithRouter(
+      wrap(
+        <StartSessionPrompt
+          workspaceId="workspace-1"
+          harnesses={[entry("claude_code", {})]}
+          starting={false}
+          selectedMode={null}
+          onSelectMode={vi.fn()}
+          onStart={onStart}
+          client={client}
+        />,
+      ),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Reasoning: Default" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "High" }));
+    await user.click(screen.getByRole("switch", { name: "Fast mode off" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "list the files",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(onStart).toHaveBeenCalledWith(
+      "claude_code",
+      "allow",
+      "list the files",
+      "claude-opus-5",
+      undefined,
+      "high",
+      true,
+    );
+  });
+
+  it("restores lastCreate effort and fast mode only when the engine still honors them", async () => {
+    useCodeUiStore.setState({
+      lastCreate: {
+        harness: "opencode",
+        modelsByHarness: { opencode: "gpt-5.6-sol" },
+        reasoningEffortByHarness: { opencode: "high" },
+        fastModeByHarness: { opencode: true },
+      },
+    });
+    const client = {
+      listCodeHarnessModels: vi.fn(async () => ({
+        kind: "opencode" as const,
+        models: [
+          {
+            id: "gpt-5.6-sol",
+            label: "GPT 5.6 Sol",
+            default: true,
+            reasoning_efforts: [],
+            fast_mode: false,
+          },
+        ],
+        reasoning_efforts: [],
+        fast_mode: false,
+      })),
+    };
+    const onStart = vi.fn();
+    const user = userEvent.setup();
+    await renderWithRouter(
+      wrap(
+        <StartSessionPrompt
+          workspaceId="workspace-1"
+          harnesses={[entry("opencode", {})]}
+          starting={false}
+          selectedMode={null}
+          onSelectMode={vi.fn()}
+          onStart={onStart}
+          client={client}
+        />,
+      ),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Model: GPT 5.6 Sol" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Reasoning:/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /Fast mode/ }),
+    ).not.toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "list the files",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(onStart).toHaveBeenCalledWith(
+      "opencode",
+      "allow",
+      "list the files",
+      "gpt-5.6-sol",
+      undefined,
+      null,
+      false,
+    );
+    await waitFor(() => expect(onStart).toHaveBeenCalled());
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -26,7 +26,6 @@ import {
   harnessCanStartNow,
   harnessUnusableReason,
   preferredCodeModels,
-  requiresHarnessModelIds,
   type CodeModelOption,
 } from "./labels";
 
@@ -176,13 +175,8 @@ export function StartSessionPrompt({
       defaultModelKey,
     );
     const native = useCodeCatalogStore.getState().modelsByHarness[selectedKind];
-    const needsNative =
-      requiresHarnessModelIds(selectedKind) || gateway.length === 0;
-    if (!needsNative) {
-      apply(gateway);
-      setModelLoading(false);
-      return;
-    }
+    // Same as the in-workspace composer: always load the harness listing so
+    // gateway rows can inherit `fast_mode` (and per-model effort ladders).
     if (native !== undefined) {
       apply(preferredCodeModels(selectedKind, native, gateway));
       setModelLoading(false);

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -6,6 +6,7 @@ import type {
   HarnessDoctorEntry,
   HarnessKind,
   ModelInfo,
+  ReasoningEffort,
 } from "../api/types";
 import type { ComposerWorkspaceFiles } from "@/Composer";
 import { CodeComposer } from "./CodeComposer";
@@ -20,6 +21,7 @@ import {
 import {
   createPermissionModes,
   defaultCreatePermissionMode,
+  effortLadder,
   gatewayCodeModels,
   harnessCanStartNow,
   harnessUnusableReason,
@@ -27,6 +29,8 @@ import {
   requiresHarnessModelIds,
   type CodeModelOption,
 } from "./labels";
+
+const NO_ENGINE_EFFORTS: ReasoningEffort[] = [];
 
 const NO_CATALOG_MODELS: ModelInfo[] = [];
 
@@ -70,6 +74,8 @@ export function StartSessionPrompt({
     message: string,
     model?: string,
     draft?: string,
+    reasoningEffort?: ReasoningEffort | null,
+    fastMode?: boolean,
   ) => Promise<void> | void;
   client?: Pick<ApiClient, "listCodeHarnessModels"> &
     Partial<Pick<ApiClient, "startHarnessInstall" | "getHarnessDoctor">>;
@@ -85,6 +91,12 @@ export function StartSessionPrompt({
   const [modelsByHarness, setModelsByHarness] = useState<
     Partial<Record<HarnessKind, string>>
   >({ ...lastCreate?.modelsByHarness });
+  const [effortByHarness, setEffortByHarness] = useState<
+    Partial<Record<HarnessKind, ReasoningEffort>>
+  >({ ...lastCreate?.reasoningEffortByHarness });
+  const [fastByHarness, setFastByHarness] = useState<
+    Partial<Record<HarnessKind, boolean>>
+  >({ ...lastCreate?.fastModeByHarness });
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
   const [modelLoading, setModelLoading] = useState(false);
   const root = useRef<HTMLDivElement>(null);
@@ -109,6 +121,26 @@ export function StartSessionPrompt({
 
   const selectedKind = selected?.kind;
   const model = selectedKind ? modelsByHarness[selectedKind] : undefined;
+  const engineEfforts =
+    useCodeCatalogStore((state) =>
+      selectedKind ? state.effortsByHarness[selectedKind] : undefined,
+    ) ?? NO_ENGINE_EFFORTS;
+  const selectedOption =
+    modelOptions.find((option) => option.id === model) ??
+    modelOptions.find((option) => option.default) ??
+    modelOptions[0];
+  const effortLevels = effortLadder(selectedOption, engineEfforts);
+  const fastModeAvailable = selectedOption?.fast_mode ?? false;
+  const rememberedEffort = selectedKind
+    ? effortByHarness[selectedKind]
+    : undefined;
+  const postedEffort =
+    rememberedEffort && effortLevels.includes(rememberedEffort)
+      ? rememberedEffort
+      : null;
+  const postedFastMode = fastModeAvailable
+    ? Boolean(selectedKind && fastByHarness[selectedKind])
+    : false;
   const installed = Boolean(selected?.found);
   const install = useWarmHarnessInstall(
     canInstallHarnesses(client) ? client : undefined,
@@ -207,6 +239,9 @@ export function StartSessionPrompt({
           model={model}
           modelOptions={modelOptions}
           modelLoading={modelLoading}
+          reasoningEffort={postedEffort}
+          engineEfforts={engineEfforts}
+          fastMode={postedFastMode}
           harnessMenu={
             <HarnessPicker
               harnesses={harnesses}
@@ -230,6 +265,22 @@ export function StartSessionPrompt({
               [selectedKind]: next,
             }));
           }}
+          onEffortChange={(next) => {
+            if (!selectedKind) return;
+            setEffortByHarness((current) => {
+              const nextMap = { ...current };
+              if (next) nextMap[selectedKind] = next;
+              else delete nextMap[selectedKind];
+              return nextMap;
+            });
+          }}
+          onFastModeChange={(next) => {
+            if (!selectedKind) return;
+            setFastByHarness((current) => ({
+              ...current,
+              [selectedKind]: next,
+            }));
+          }}
           onModeChange={onSelectMode}
           onSubmitStart={(draft) => {
             submittedDraft.current = draft;
@@ -239,9 +290,25 @@ export function StartSessionPrompt({
             const draft = submittedDraft.current ?? message;
             try {
               if (draft === message) {
-                await onStart(selected.kind, mode, message, model);
+                await onStart(
+                  selected.kind,
+                  mode,
+                  message,
+                  model,
+                  undefined,
+                  postedEffort,
+                  postedFastMode,
+                );
               } else {
-                await onStart(selected.kind, mode, message, model, draft);
+                await onStart(
+                  selected.kind,
+                  mode,
+                  message,
+                  model,
+                  draft,
+                  postedEffort,
+                  postedFastMode,
+                );
               }
             } finally {
               submittedDraft.current = null;

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -357,6 +357,42 @@ describe("preferredCodeModels", () => {
     expect(preferredCodeModels("codex", native, gateway)).toEqual(gateway);
     expect(preferredCodeModels("claude_code", native, [])).toEqual(native);
   });
+
+  it("copies fast_mode from the harness listing onto matching gateway rows", () => {
+    const listed = [
+      {
+        id: "claude-opus-5",
+        label: "Claude Opus 5",
+        source: "Claude Code",
+        fast_mode: true,
+      },
+    ];
+    const catalog = [
+      {
+        id: "claude-opus-5",
+        label: "Claude Opus 5",
+        source: "Claude Code · model-gateway",
+      },
+      {
+        id: "claude-sonnet-5",
+        label: "Claude Sonnet 5",
+        source: "Claude Code · model-gateway",
+      },
+    ];
+    expect(preferredCodeModels("claude_code", listed, catalog)).toEqual([
+      {
+        id: "claude-opus-5",
+        label: "Claude Opus 5",
+        source: "Claude Code · model-gateway",
+        fast_mode: true,
+      },
+      {
+        id: "claude-sonnet-5",
+        label: "Claude Sonnet 5",
+        source: "Claude Code · model-gateway",
+      },
+    ]);
+  });
 });
 
 describe("groupCodeModelOptions", () => {

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -360,13 +360,41 @@ export function requiresHarnessModelIds(kind: HarnessKind): boolean {
  * engines keep the gateway catalog when it exists because their adapters
  * accept those ids directly and the catalog carries the entitled display rows.
  */
+/**
+ * Copy engine-owned caps from the harness listing onto gateway display rows.
+ *
+ * Gateway catalog rows never carry `fast_mode` (or a code-engine effort
+ * ladder). The in-workspace picker still fetches the harness listing for
+ * those fields and joins by model id, so a gateway-selected claude-opus-5
+ * can show the fast toggle.
+ */
+function overlayHarnessModelCaps(
+  gateway: readonly CodeModelOption[],
+  native: readonly CodeModelOption[],
+): CodeModelOption[] {
+  if (native.length === 0) return [...gateway];
+  const byId = new Map(native.map((option) => [option.id, option]));
+  return gateway.map((row) => {
+    const listed = byId.get(row.id);
+    if (!listed) return row;
+    return {
+      ...row,
+      ...(listed.reasoning_efforts && listed.reasoning_efforts.length > 0
+        ? { reasoning_efforts: listed.reasoning_efforts }
+        : {}),
+      ...(listed.fast_mode ? { fast_mode: true } : {}),
+    };
+  });
+}
+
 export function preferredCodeModels(
   kind: HarnessKind,
   native: readonly CodeModelOption[],
   gateway: readonly CodeModelOption[],
 ): CodeModelOption[] {
   if (requiresHarnessModelIds(kind) && native.length > 0) return [...native];
-  return gateway.length > 0 ? [...gateway] : [...native];
+  if (gateway.length > 0) return overlayHarnessModelCaps(gateway, native);
+  return [...native];
 }
 
 /** One rail section of the code-mode picker: a vendor and its rows. */

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -10,7 +10,11 @@ import {
 } from "@tanstack/react-router";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
-import type { CodeRepoSnapshot, HarnessKind } from "@/api/types";
+import type {
+  CodeRepoSnapshot,
+  HarnessKind,
+  ReasoningEffort,
+} from "@/api/types";
 import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "@/code/CodeUiStore";
 import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
@@ -24,8 +28,9 @@ import {
 
 /**
  * The new-workspace composer: the first message is the surface, and every
- * setting — repo, name, base ref, engine, model, permissions — is a pill with
- * its own chord. Enter creates; "Create more" keeps it open for the next one.
+ * setting — repo, name, base ref, engine, model, reasoning, fast mode,
+ * permissions — is a pill with its own chord. Enter creates; "Create more"
+ * keeps it open for the next one.
  */
 
 const repos: CodeRepoSnapshot[] = [
@@ -59,20 +64,76 @@ const repos: CodeRepoSnapshot[] = [
 ];
 
 const MODELS: Partial<
-  Record<HarnessKind, { id: string; label: string; default?: boolean }[]>
+  Record<
+    HarnessKind,
+    {
+      id: string;
+      label: string;
+      default?: boolean;
+      reasoning_efforts: ReasoningEffort[];
+      fast_mode: boolean;
+    }[]
+  >
 > = {
   claude_code: [
-    { id: "claude-opus-5", label: "Claude Opus 5", default: true },
-    { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+    {
+      id: "claude-opus-5",
+      label: "Claude Opus 5",
+      default: true,
+      reasoning_efforts: [],
+      fast_mode: true,
+    },
+    {
+      id: "claude-sonnet-5",
+      label: "Claude Sonnet 5",
+      reasoning_efforts: [],
+      fast_mode: false,
+    },
   ],
   codex: [
-    { id: "gpt-5.6-sol", label: "GPT 5.6 Sol", default: true },
-    { id: "gpt-5.6-luna", label: "GPT 5.6 Luna" },
+    {
+      id: "gpt-5.6-sol",
+      label: "GPT 5.6 Sol",
+      default: true,
+      reasoning_efforts: ["low", "medium", "high"],
+      fast_mode: true,
+    },
+    {
+      id: "gpt-5.6-luna",
+      label: "GPT 5.6 Luna",
+      reasoning_efforts: ["low", "medium", "high"],
+      fast_mode: false,
+    },
   ],
   opencode: [
-    { id: "gpt-5.6-sol", label: "GPT 5.6 Sol", default: true },
-    { id: "claude-opus-5", label: "Claude Opus 5" },
-    { id: "grok-4.5", label: "Grok 4.5" },
+    {
+      id: "gpt-5.6-sol",
+      label: "GPT 5.6 Sol",
+      default: true,
+      reasoning_efforts: [],
+      fast_mode: false,
+    },
+    {
+      id: "claude-opus-5",
+      label: "Claude Opus 5",
+      reasoning_efforts: [],
+      fast_mode: false,
+    },
+    {
+      id: "grok-4.5",
+      label: "Grok 4.5",
+      reasoning_efforts: [],
+      fast_mode: false,
+    },
+  ],
+  grok: [
+    {
+      id: "grok-4.6",
+      label: "Grok 4.6",
+      default: true,
+      reasoning_efforts: ["low", "medium", "high", "xhigh"],
+      fast_mode: false,
+    },
   ],
 };
 
@@ -81,6 +142,15 @@ function appContext(): AppContextValue {
     listCodeHarnessModels: async (kind: HarnessKind) => ({
       kind,
       models: MODELS[kind] ?? [],
+      reasoning_efforts:
+        kind === "claude_code"
+          ? (["low", "medium", "high"] as ReasoningEffort[])
+          : kind === "codex"
+            ? (["low", "medium", "high"] as ReasoningEffort[])
+            : kind === "grok"
+              ? (["low", "medium", "high", "xhigh"] as ReasoningEffort[])
+              : [],
+      fast_mode: kind === "claude_code" || kind === "codex",
     }),
     startHarnessInstall: async (kind: HarnessKind) => ({
       kind,

--- a/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
@@ -18,8 +18,10 @@ import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
 
 /**
  * The session-start surface: harness picker, caps-driven permission modes,
- * and the first message. Mode lists must follow each engine's declared
- * capabilities — Grok's honest refusals leave it Auto-only.
+ * reasoning effort, fast mode, and the first message. Mode lists follow each
+ * engine's declared capabilities — Grok's honest refusals leave it Auto-only.
+ * Effort chrome appears only when the engine lists a ladder; fast mode only
+ * when the selected model serves it.
  */
 const models: Partial<Record<HarnessKind, ParsedHarnessModel[]>> = {
   claude_code: [
@@ -28,7 +30,7 @@ const models: Partial<Record<HarnessKind, ParsedHarnessModel[]>> = {
       label: "Claude Fable 5",
       default: true,
       reasoning_efforts: [],
-      fast_mode: false,
+      fast_mode: true,
     },
   ],
   codex: [
@@ -36,8 +38,8 @@ const models: Partial<Record<HarnessKind, ParsedHarnessModel[]>> = {
       id: "gpt-5.6",
       label: "GPT 5.6",
       default: true,
-      reasoning_efforts: [],
-      fast_mode: false,
+      reasoning_efforts: ["low", "medium", "high"],
+      fast_mode: true,
     },
   ],
   opencode: [
@@ -54,17 +56,27 @@ const models: Partial<Record<HarnessKind, ParsedHarnessModel[]>> = {
       id: "grok-4.6",
       label: "Grok 4.6",
       default: true,
-      reasoning_efforts: [],
+      reasoning_efforts: ["low", "medium", "high", "xhigh"],
       fast_mode: false,
     },
   ],
+};
+
+const ENGINE_EFFORTS: Partial<
+  Record<HarnessKind, ParsedHarnessModel["reasoning_efforts"]>
+> = {
+  claude_code: ["low", "medium", "high"],
+  codex: ["low", "medium", "high"],
+  grok: ["low", "medium", "high", "xhigh"],
+  opencode: [],
 };
 
 const client = {
   listCodeHarnessModels: async (kind: HarnessKind) => ({
     kind,
     models: models[kind] ?? [],
-    reasoning_efforts: [],
+    reasoning_efforts: ENGINE_EFFORTS[kind] ?? [],
+    fast_mode: kind === "claude_code" || kind === "codex",
   }),
 };
 


### PR DESCRIPTION
## Summary

You can now choose reasoning effort and fast mode when you create a workspace, not only after a session exists.

The new-workspace dialog and the empty-workspace start composer reuse `ReasoningEffortMenu` and `FastModeToggle`. Effort shows only when the engine lists a ladder (OpenCode stays without it). Fast mode shows only when the selected model row serves it.

Create posts `reasoning_effort` and `fast_mode` on the session body. Sticky `lastCreate` memory stores those picks per engine and restores them only when the current engine and model still honor them. A 422 from create still lands in the existing error toast, which already shows the server message.

The server create path is unchanged.

## Verification

- `biome check` / `biome lint` on the UI files you touched (passed)
- focused vitest: `NewWorkspaceDialog.dom.test.tsx` and `StartSessionPrompt.dom.test.tsx` (33 tests passed)
- `storybook:build` did not finish here: pnpm install could not fetch the SheetJS tarball from cdn.sheetjs.com (403), so the preview build hit a missing `@univerjs/themes` from that incomplete install. CI should run `pnpm --dir crates/tidebreak-desktop/ui storybook:build` on a full install.

Do not merge this PR from this session.