### PR TITLE
feat(code): add Uneff me to start a Tidebreak fix from debug JSON

### DIFF
--- a/crates/tidebreak-desktop/ui/src/CommandPaletteDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/CommandPaletteDialog.tsx
@@ -23,6 +23,7 @@ import {
 import { codeWorkspaceIdFromPath, shellShortcutMode } from "./code/routes";
 import { arrangeWorkspaces } from "./code/workspaceCards";
 import { useWorkspaceCardCommands } from "./code/workspaceActions";
+import { tidebreakProductRepo } from "./code/uneffMe";
 import {
   chatNavigationPaletteRows,
   chatPaletteRows,
@@ -70,6 +71,7 @@ export function CommandPaletteDialog() {
 
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
   const repos = useCodeCatalogStore((state) => state.repos);
+  const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
   const digests = useWorkspaceDigests();
   const railPrefs = useCodeUiStore((state) => state.railPrefs);
   const suggestion = useCodeUiStore((state) => state.workflowSuggestion);
@@ -150,14 +152,17 @@ export function CommandPaletteDialog() {
         ? workspaceActionPaletteRows({
             workspace,
             hasPr: Boolean(workspace.pr),
-            hasSession: Boolean(digest),
+            hasSession: Boolean(digest) || Boolean(sessions[workspace.id]),
             attentionPinned: digest?.attention.state.type === "manual",
             quickActions: repo?.quick_actions ?? [],
+            canUneff: Boolean(tidebreakProductRepo(repos)),
             onCommand: (command) =>
               workspaceRunner.run(command.id, {
                 workspace,
                 title: workspace.title,
                 pr: workspace.pr,
+                session: sessions[workspace.id],
+                sessionId: digest?.session,
                 actionName: command.actionName,
               }),
           })
@@ -192,6 +197,7 @@ export function CommandPaletteDialog() {
     workspaceId,
     workspaces,
     repos,
+    sessions,
     digests,
     railPrefs,
     suggestion,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -39,6 +39,7 @@ import {
   useWorkspaceCardCommands,
   workspaceCommands,
 } from "./workspaceActions";
+import { tidebreakProductRepo } from "./uneffMe";
 import { WorkspaceCard } from "./WorkspaceCard";
 import {
   arrangeWorkspaces,
@@ -204,6 +205,7 @@ export function CodeSidebar() {
                               sessions[workspace.id]?.attention
                             )?.state.type === "manual",
                           canOpenWorktree,
+                          canUneff: Boolean(tidebreakProductRepo(repos)),
                         })
                   }
                   childSessions={watchChildren(

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -290,9 +290,9 @@ function deferred<T>() {
 
 function makeClient() {
   return {
-    getCodeWorkspace: vi.fn(async () => WORKSPACE),
+    getCodeWorkspace: vi.fn(async (_id: string) => WORKSPACE),
     listCodeWorkspaceSessions: vi.fn(
-      async (): Promise<(typeof SESSION)[]> => [],
+      async (_id: string): Promise<(typeof SESSION)[]> => [],
     ),
     listCodeSessionTurns: vi.fn(async (_sessionId: string) => [TURN]),
     listCodeApprovals: vi.fn(async () => []),

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -304,6 +304,19 @@ function makeClient() {
       ) => codeEventSocket(onFrame),
     ),
     getCodeRepo: vi.fn(async () => REPO),
+    getCodeSessionDebug: vi.fn(async () => ({
+      session: { id: "sess-1" },
+      turns: [],
+      events: [],
+    })),
+    createCodeWorkspace: vi.fn(async () => ({
+      ...WORKSPACE,
+      id: "ws-uneff",
+      repo_id: "repo-tb",
+      title: "Uneff: Fix login",
+      worktree_path: "/tmp/tidebreak/.worktrees/uneff",
+      branch_name: "tidebreak/uneff-fix-login",
+    })),
     createCodeSession: vi.fn(async () => CREATED_SESSION),
     forkCodeSession: vi.fn(async () => FORK_SOURCE),
     archiveCodeWorkspace: vi.fn(async () => ({
@@ -1782,6 +1795,60 @@ describe("CodeWorkspacePage", () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/code"));
     expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", true);
+  });
+
+  it("starts a Tidebreak fix workspace from Uneff me", async () => {
+    const client = makeClient();
+    const created = {
+      ...WORKSPACE,
+      id: "ws-uneff",
+      repo_id: "repo-tb",
+      title: "Uneff: Fix login",
+      worktree_path: "/tmp/tidebreak/.worktrees/uneff",
+      branch_name: "tidebreak/uneff-fix-login",
+    };
+    const tidebreakRepo = {
+      ...REPO,
+      id: "repo-tb",
+      display_name: "tidebreak",
+      root_path: "/tmp/tidebreak",
+    };
+    client.listCodeRepos.mockResolvedValue([REPO, tidebreakRepo]);
+    client.listCodeWorkspaceSessions.mockImplementation(async (id: string) =>
+      id === WORKSPACE.id ? [SESSION] : [],
+    );
+    client.createCodeWorkspace.mockResolvedValue(created);
+    client.getCodeWorkspace.mockImplementation(async (id: string) =>
+      id === created.id ? created : WORKSPACE,
+    );
+    useCodeCatalogStore.setState({
+      repos: [REPO, tidebreakRepo],
+    });
+    const { router } = await mountWorkspace(client);
+    const user = userEvent.setup();
+
+    await screen.findByRole("heading", { name: /Fix login/ });
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Uneff me" }));
+
+    await waitFor(() =>
+      expect(client.createCodeWorkspace).toHaveBeenCalledWith({
+        repo_id: "repo-tb",
+        title: "Uneff: Fix login",
+      }),
+    );
+    expect(client.getCodeSessionDebug).toHaveBeenCalledWith("sess-1");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe(`/code/w/${created.id}`),
+    );
+    await waitFor(() => {
+      const pending = useCodeUiStore.getState().pendingComposerPrompt;
+      const composer = screen.queryByRole("textbox", {
+        name: "Message",
+      }) as HTMLTextAreaElement | null;
+      const text = pending?.text ?? composer?.value ?? "";
+      expect(text).toContain("Open a pull request against main");
+    });
   });
 
   it("keeps git and comments in the review sidebar, and opens the terminal as a tab", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -168,6 +168,7 @@ import {
   useWorkspaceCardCommands,
   workspaceHeaderCommands,
 } from "./workspaceActions";
+import { tidebreakProductRepo } from "./uneffMe";
 import { sessionActivityLabel, isPutAway } from "./workspaceCards";
 import {
   createPermissionModes,
@@ -743,6 +744,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         // A watch child is the harness's own run, not a conversation to
         // continue, so only an interactive agent offers a fork.
         canFork: session?.kind === "interactive",
+        canUneff: Boolean(tidebreakProductRepo(catalog.repos)),
         quickActions: repo?.quick_actions ?? [],
       })
     : [];

--- a/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
@@ -8,6 +8,7 @@ import {
   Play,
   Plus,
   Terminal,
+  Wrench,
 } from "lucide-react";
 
 import type {
@@ -168,6 +169,7 @@ export function workspaceActionPaletteRows(input: {
   hasSession: boolean;
   attentionPinned: boolean;
   quickActions: readonly { name: string }[];
+  canUneff?: boolean;
   onCommand: (command: WorkspaceCommand) => void;
 }): PaletteRow[] {
   const archived = input.workspace.status === "archived";
@@ -176,6 +178,7 @@ export function workspaceActionPaletteRows(input: {
     archived,
     hasSession: input.hasSession,
     attentionPinned: input.attentionPinned,
+    canUneff: input.canUneff,
   });
   const quick: WorkspaceCommand[] = archived
     ? []
@@ -204,6 +207,7 @@ const ACTION_ICONS: Partial<Record<WorkspaceCommandId, PaletteRow["icon"]>> = {
   "new-session": Plus,
   "toggle-terminal": Terminal,
   "open-pr": GitPullRequest,
+  "uneff-me": Wrench,
   "run-quick-action": Play,
   archive: Archive,
   "force-archive": Archive,

--- a/crates/tidebreak-desktop/ui/src/code/uneffMe.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/uneffMe.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { CodeRepoSnapshot, CodeWorkspaceSnapshot } from "../api/types";
+import {
+  DEBUG_JSON_PROMPT_BUDGET,
+  debugJsonForPrompt,
+  isTidebreakProductRepo,
+  startUneffMeWorkspace,
+  tidebreakProductRepo,
+  uneffMePrompt,
+  uneffMeWorkspaceTitle,
+} from "./uneffMe";
+
+const APP: CodeRepoSnapshot = {
+  id: "repo-app",
+  root_path: "/tmp/app",
+  display_name: "app",
+  default_base_ref: "main",
+  branch_prefix: "tidebreak",
+  quick_actions: [],
+  created_at: "2026-08-15T00:00:00.000Z",
+};
+
+const TIDEBREAK: CodeRepoSnapshot = {
+  ...APP,
+  id: "repo-tb",
+  root_path: "/Users/sam/src/tidebreak",
+  display_name: "tidebreak",
+};
+
+describe("tidebreak product repo", () => {
+  it("matches the product checkout, not a worktree folder", () => {
+    expect(isTidebreakProductRepo(TIDEBREAK)).toBe(true);
+    expect(
+      isTidebreakProductRepo({
+        ...APP,
+        display_name: "notes",
+        root_path: "/Users/sam/Tidebreak/workspaces/tidebreak/ember-orchard",
+      }),
+    ).toBe(false);
+    expect(
+      isTidebreakProductRepo({
+        ...APP,
+        display_name: "brightwave-inc/tidebreak",
+        root_path: "/tmp/clone",
+      }),
+    ).toBe(true);
+  });
+
+  it("prefers the display name tidebreak when several match", () => {
+    const clone: CodeRepoSnapshot = {
+      ...TIDEBREAK,
+      id: "repo-clone",
+      display_name: "tidebreak-src",
+      root_path: "/opt/tidebreak",
+    };
+    expect(tidebreakProductRepo([APP, clone, TIDEBREAK])?.id).toBe("repo-tb");
+  });
+});
+
+describe("uneff me prompt", () => {
+  it("names the source session and includes the debug JSON", () => {
+    const prompt = uneffMePrompt({
+      sourceTitle: "Fix login",
+      sourceBranch: "tidebreak/fix-login",
+      sourceRepo: "app",
+      sessionId: "sess-1",
+      debug: { session: { id: "sess-1" }, turns: [], events: [] },
+    });
+    expect(prompt).toContain("Fix login");
+    expect(prompt).toContain("tidebreak/fix-login");
+    expect(prompt).toContain("sess-1");
+    expect(prompt).toContain("Open a pull request against main");
+    expect(prompt).toContain('"id": "sess-1"');
+    expect(prompt).not.toContain("omitted");
+  });
+
+  it("drops journal events when the dump is too large", () => {
+    const events = Array.from({ length: 80 }, (_, index) => ({
+      seq: index,
+      blob: "x".repeat(2_000),
+    }));
+    const packed = debugJsonForPrompt({
+      session: { id: "sess-1" },
+      turns: [{ id: "turn-1" }],
+      events,
+    });
+    expect(packed.omitted).toBe("events");
+    expect(packed.text).toContain('"sess-1"');
+    expect(packed.text).not.toContain('"blob"');
+    expect(packed.text.length).toBeLessThanOrEqual(DEBUG_JSON_PROMPT_BUDGET);
+
+    const prompt = uneffMePrompt({
+      sourceTitle: "Fix login",
+      sourceBranch: "tidebreak/fix-login",
+      sourceRepo: "app",
+      sessionId: "sess-1",
+      debug: { session: { id: "sess-1" }, turns: [{ id: "turn-1" }], events },
+    });
+    expect(prompt).toContain("Journal events were omitted");
+  });
+
+  it("truncates a title the way a fresh PR-agent workspace does", () => {
+    expect(uneffMeWorkspaceTitle("Fix login")).toBe("Uneff: Fix login");
+    expect(uneffMeWorkspaceTitle("x".repeat(80)).length).toBe(60);
+    expect(uneffMeWorkspaceTitle("x".repeat(80)).endsWith("…")).toBe(true);
+  });
+});
+
+describe("startUneffMeWorkspace", () => {
+  it("creates a Tidebreak workspace and returns the prompt", async () => {
+    const created: CodeWorkspaceSnapshot = {
+      id: "ws-fix",
+      repo_id: TIDEBREAK.id,
+      title: "Uneff: Fix login",
+      worktree_path: "/tmp/tidebreak/.worktrees/uneff",
+      branch_name: "tidebreak/uneff-fix-login",
+      base_ref: "main",
+      status: "active",
+      created_at: "2026-08-26T00:00:00.000Z",
+    };
+    const getDebug = vi.fn(async () => ({ session: { id: "sess-1" } }));
+    const createWorkspace = vi.fn(async () => created);
+
+    const result = await startUneffMeWorkspace({
+      repos: [APP, TIDEBREAK],
+      sessionId: "sess-1",
+      sourceTitle: "Fix login",
+      sourceBranch: "tidebreak/fix-login",
+      sourceRepo: "app",
+      getDebug,
+      createWorkspace,
+    });
+
+    expect(getDebug).toHaveBeenCalledWith("sess-1");
+    expect(createWorkspace).toHaveBeenCalledWith({
+      repo_id: TIDEBREAK.id,
+      title: "Uneff: Fix login",
+    });
+    expect(result.workspace).toEqual(created);
+    expect(result.prompt).toContain("sess-1");
+  });
+
+  it("refuses to start when Tidebreak is not connected", async () => {
+    await expect(
+      startUneffMeWorkspace({
+        repos: [APP],
+        sessionId: "sess-1",
+        sourceTitle: "Fix login",
+        sourceBranch: "tidebreak/fix-login",
+        sourceRepo: "app",
+        getDebug: vi.fn(),
+        createWorkspace: vi.fn(),
+      }),
+    ).rejects.toThrow("Add the Tidebreak repository to Code first.");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/uneffMe.ts
+++ b/crates/tidebreak-desktop/ui/src/code/uneffMe.ts
@@ -1,0 +1,154 @@
+import type { CodeRepoSnapshot, CodeWorkspaceSnapshot } from "../api/types";
+
+/** Pretty JSON that still fits a first turn. Events are the usual overflow. */
+export const DEBUG_JSON_PROMPT_BUDGET = 100_000;
+
+const PRODUCT_REPO_NAMES = new Set(["tidebreak", "brightwave-inc/tidebreak"]);
+
+export function repoPathBasename(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const parts = trimmed.split(/[\\/]/);
+  return parts[parts.length - 1] ?? "";
+}
+
+/**
+ * The Tidebreak source checkout among connected repos.
+ *
+ * Match the folder or display name, not a worktree path: those live under
+ * `workspaces/tidebreak/…` and are not the product repository.
+ */
+export function isTidebreakProductRepo(repo: {
+  display_name: string;
+  root_path: string;
+}): boolean {
+  const name = repo.display_name.trim().toLowerCase();
+  if (PRODUCT_REPO_NAMES.has(name)) return true;
+  return repoPathBasename(repo.root_path).toLowerCase() === "tidebreak";
+}
+
+export function tidebreakProductRepo<
+  T extends { display_name: string; root_path: string },
+>(repos: readonly T[]): T | undefined {
+  const matches = repos.filter(isTidebreakProductRepo);
+  return (
+    matches.find(
+      (repo) => repo.display_name.trim().toLowerCase() === "tidebreak",
+    ) ??
+    matches.find(
+      (repo) => repoPathBasename(repo.root_path).toLowerCase() === "tidebreak",
+    ) ??
+    matches[0]
+  );
+}
+
+export function uneffMeWorkspaceTitle(sourceTitle: string): string {
+  const base = `Uneff: ${sourceTitle.trim() || "session"}`;
+  return base.length > 60 ? `${base.slice(0, 59).trimEnd()}…` : base;
+}
+
+export type DebugJsonOmission = "none" | "events" | "truncated";
+
+export function debugJsonForPrompt(debug: unknown): {
+  text: string;
+  omitted: DebugJsonOmission;
+} {
+  const pretty = stringifyDebug(debug, true);
+  if (pretty.length <= DEBUG_JSON_PROMPT_BUDGET) {
+    return { text: pretty, omitted: "none" };
+  }
+  const record = asRecord(debug);
+  if (record && "events" in record) {
+    const { events: _events, ...rest } = record;
+    const withoutEventsPretty = stringifyDebug(rest, true);
+    if (withoutEventsPretty.length <= DEBUG_JSON_PROMPT_BUDGET) {
+      return { text: withoutEventsPretty, omitted: "events" };
+    }
+    const withoutEventsCompact = stringifyDebug(rest, false);
+    if (withoutEventsCompact.length <= DEBUG_JSON_PROMPT_BUDGET) {
+      return { text: withoutEventsCompact, omitted: "events" };
+    }
+    return {
+      text: truncateDebug(withoutEventsCompact),
+      omitted: "truncated",
+    };
+  }
+  const compact = stringifyDebug(debug, false);
+  if (compact.length <= DEBUG_JSON_PROMPT_BUDGET) {
+    return { text: compact, omitted: "none" };
+  }
+  return { text: truncateDebug(compact), omitted: "truncated" };
+}
+
+export function uneffMePrompt(input: {
+  sourceTitle: string;
+  sourceBranch: string;
+  sourceRepo: string;
+  sessionId: string;
+  debug: unknown;
+}): string {
+  const json = debugJsonForPrompt(input.debug);
+  const omission =
+    json.omitted === "events"
+      ? "Journal events were omitted because the debug dump was too large. Session and turns are included."
+      : json.omitted === "truncated"
+        ? "The debug dump was truncated because it was too large."
+        : null;
+  return [
+    "The user hit a problem in Tidebreak Code. You are in a fresh workspace of the Tidebreak source repository.",
+    "Diagnose the product bug from the debug JSON. Fix it. Open a pull request against main when the fix is ready.",
+    `Source workspace: ${input.sourceTitle}`,
+    `Source branch: ${input.sourceBranch}`,
+    `Source repository: ${input.sourceRepo}`,
+    `Session: ${input.sessionId}`,
+    omission,
+    "The debug JSON follows.",
+    json.text,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n\n");
+}
+
+export async function startUneffMeWorkspace(input: {
+  repos: readonly CodeRepoSnapshot[];
+  sessionId: string;
+  sourceTitle: string;
+  sourceBranch: string;
+  sourceRepo: string;
+  getDebug: (sessionId: string) => Promise<unknown>;
+  createWorkspace: (body: {
+    repo_id: string;
+    title?: string;
+  }) => Promise<CodeWorkspaceSnapshot>;
+}): Promise<{ workspace: CodeWorkspaceSnapshot; prompt: string }> {
+  const repo = tidebreakProductRepo(input.repos);
+  if (!repo) {
+    throw new Error("Add the Tidebreak repository to Code first.");
+  }
+  const debug = await input.getDebug(input.sessionId);
+  const prompt = uneffMePrompt({
+    sourceTitle: input.sourceTitle,
+    sourceBranch: input.sourceBranch,
+    sourceRepo: input.sourceRepo,
+    sessionId: input.sessionId,
+    debug,
+  });
+  const workspace = await input.createWorkspace({
+    repo_id: repo.id,
+    title: uneffMeWorkspaceTitle(input.sourceTitle),
+  });
+  return { workspace, prompt };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringifyDebug(value: unknown, pretty: boolean): string {
+  return pretty ? JSON.stringify(value, null, 2) : JSON.stringify(value);
+}
+
+function truncateDebug(text: string): string {
+  return `${text.slice(0, DEBUG_JSON_PROMPT_BUDGET)}\n…(truncated)`;
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
@@ -67,6 +67,45 @@ describe("workspace worktree actions", () => {
     ).toEqual({ id: "copy-worktree", label: "Copy worktree path" });
   });
 
+  it("offers Uneff me next to Copy debug JSON when Tidebreak is connected", () => {
+    const commands = workspaceCommands({
+      hasPr: false,
+      archived: false,
+      hasSession: true,
+      canUneff: true,
+    });
+    const copy = commands.findIndex(
+      (command) => command.id === "copy-debug-json",
+    );
+    const uneff = commands.findIndex((command) => command.id === "uneff-me");
+    expect(commands[copy]?.label).toBe("Copy debug JSON");
+    expect(commands[uneff]?.label).toBe("Uneff me");
+    expect(uneff).toBe(copy + 1);
+
+    expect(
+      workspaceCommands({
+        hasPr: false,
+        archived: false,
+        hasSession: true,
+      }).some((command) => command.id === "uneff-me"),
+    ).toBe(false);
+
+    const header = workspaceHeaderCommands({
+      archived: false,
+      hasSession: true,
+      attentionPinned: false,
+      quickActions: [],
+      canUneff: true,
+    });
+    const headerCopy = header.findIndex(
+      (command) => command.id === "copy-debug-json",
+    );
+    expect(header[headerCopy + 1]).toEqual({
+      id: "uneff-me",
+      label: "Uneff me",
+    });
+  });
+
   it("turns a typed failure into a recoverable notice", () => {
     expect(
       worktreeOpenFailureNotice({

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -39,6 +39,7 @@ import {
 } from "./codeWorktreeHost";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
+import { startUneffMeWorkspace } from "./uneffMe";
 
 /**
  * Workspace commands shared by the card context menu and the workspace
@@ -52,6 +53,7 @@ export type WorkspaceCommandId =
   | "open-worktree"
   | "copy-worktree"
   | "copy-debug-json"
+  | "uneff-me"
   | "open-pr"
   | "toggle-terminal"
   | "pin-attention"
@@ -78,8 +80,16 @@ export type WorkspaceCommandContext = {
   title: string;
   pr?: PullRequestDigest;
   session?: CodeSessionSnapshot;
+  /** Session id when the snapshot is not loaded — the palette has a digest. */
+  sessionId?: string;
   actionName?: string;
 };
+
+function contextSessionId(
+  context: WorkspaceCommandContext,
+): string | undefined {
+  return context.session?.id ?? context.sessionId;
+}
 
 export function workspaceCommands(input: {
   hasPr: boolean;
@@ -87,6 +97,8 @@ export function workspaceCommands(input: {
   hasSession?: boolean;
   attentionPinned?: boolean;
   canOpenWorktree?: boolean;
+  /** Tidebreak's own checkout is connected, so a debug dump can become a fix. */
+  canUneff?: boolean;
 }): WorkspaceCommand[] {
   // An archived workspace has no worktree: nothing to open a terminal in,
   // no session to steer. What is left is reading, copying the branch that
@@ -117,6 +129,9 @@ export function workspaceCommands(input: {
         : { id: "pin-attention", label: "Pin attention" },
     );
     items.push({ id: "copy-debug-json", label: "Copy debug JSON" });
+    if (input.canUneff) {
+      items.push({ id: "uneff-me", label: "Uneff me" });
+    }
   }
   items.push({
     id: "archive",
@@ -144,6 +159,7 @@ export function workspaceHeaderCommands(input: {
   canOpenWorktree?: boolean;
   /** The shown agent has a transcript worth handing to a sibling. */
   canFork?: boolean;
+  canUneff?: boolean;
 }): WorkspaceCommand[] {
   const items: WorkspaceCommand[] = [
     worktreePathCommand(
@@ -161,6 +177,9 @@ export function workspaceHeaderCommands(input: {
       items.push({ id: "fork-agent", label: "Fork this agent" });
     }
     items.push({ id: "copy-debug-json", label: "Copy debug JSON" });
+    if (input.canUneff) {
+      items.push({ id: "uneff-me", label: "Uneff me" });
+    }
   }
   if (!input.archived) {
     for (const action of input.quickActions) {
@@ -419,6 +438,43 @@ export function useWorkspaceCardCommands(): {
     }
   }
 
+  async function runUneffMe(context: WorkspaceCommandContext) {
+    const sessionId = contextSessionId(context);
+    if (!sessionId) return;
+    if (useCodeUiStore.getState().composerActionScope !== null) {
+      toast.error("Another agent action is already running");
+      return;
+    }
+    const sourceRepo =
+      useCodeCatalogStore
+        .getState()
+        .repos.find((repo) => repo.id === context.workspace.repo_id)
+        ?.display_name ?? context.workspace.repo_id;
+    try {
+      const { workspace, prompt } = await startUneffMeWorkspace({
+        repos: useCodeCatalogStore.getState().repos,
+        sessionId,
+        sourceTitle: context.title,
+        sourceBranch: context.workspace.branch_name,
+        sourceRepo,
+        getDebug: (id) => client.getCodeSessionDebug(id),
+        createWorkspace: (body) => client.createCodeWorkspace(body),
+      });
+      upsertWorkspace(workspace);
+      if (!useCodeUiStore.getState().runComposerPrompt(workspace.id, prompt)) {
+        useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
+      }
+      await navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId: workspace.id },
+      });
+    } catch (error) {
+      toast.error(
+        friendlyErrorMessage(error, "Could not start a Tidebreak fix"),
+      );
+    }
+  }
+
   /**
    * True restore first; when the branch is gone that is impossible, so the
    * fallback offer is a fresh workspace on the same repo. A failed setup
@@ -504,9 +560,10 @@ export function useWorkspaceCardCommands(): {
           .catch(() => toast.error("Could not copy worktree path"));
         return;
       case "copy-debug-json": {
-        if (!context.session) return;
+        const sessionId = contextSessionId(context);
+        if (!sessionId) return;
         void client
-          .getCodeSessionDebug(context.session.id)
+          .getCodeSessionDebug(sessionId)
           .then((bundle) => copyPlainText(JSON.stringify(bundle, null, 2)))
           .then(() =>
             toast.success("Debug JSON copied", {
@@ -519,6 +576,10 @@ export function useWorkspaceCardCommands(): {
               friendlyErrorMessage(error, "Could not copy debug JSON"),
             ),
           );
+        return;
+      }
+      case "uneff-me": {
+        void runUneffMe(context);
         return;
       }
       case "open-pr": {

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { MoreHorizontal } from "lucide-react";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import type {
   Attention,
@@ -9,9 +8,12 @@ import type {
   CodeWorkspacePrSnapshot,
 } from "@/api";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { AttentionBadge } from "@/code/AttentionBadge";
 import { SessionLifecycleIndicator } from "@/code/SessionLifecycleIndicator";
+import {
+  WorkspaceOverflowMenu,
+  workspaceHeaderCommands,
+} from "@/code/workspaceActions";
 import { WorkspaceHeader } from "@/code/WorkspaceHeader";
 import { WorkspaceWorkflowControl } from "@/code/WorkspaceWorkflowControl";
 import type {
@@ -127,15 +129,21 @@ function HeaderState({
       onToggleTerminal={() => setTerminalOpen((open) => !open)}
       onToggleReview={() => setReviewOpen((open) => !open)}
       overflowAction={
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          className="rounded-lg"
-          aria-label="Workspace actions"
-        >
-          <MoreHorizontal />
-        </Button>
+        <WorkspaceOverflowMenu
+          commands={workspaceHeaderCommands({
+            archived: false,
+            hasSession: true,
+            attentionPinned: false,
+            canFork: true,
+            canUneff: true,
+            quickActions: [],
+          })}
+          context={{
+            repoName: "tidebreak",
+            worktreePath: "/Users/sam/tidebreak/worktrees/ui-pane-redesign",
+          }}
+          onCommand={fn()}
+        />
       }
     />
   );
@@ -227,6 +235,23 @@ export const UnrecognizedEngineEvents: Story = {
 
 export const Loading: Story = {
   args: { snapshot: null, loading: true },
+};
+
+/** Session overflow: copy debug JSON, then Uneff me. */
+export const OverflowActions: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Workspace actions" }),
+    );
+    const menu = within(document.body);
+    await expect(
+      await menu.findByRole("menuitem", { name: "Copy debug JSON" }),
+    ).toBeVisible();
+    await expect(
+      await menu.findByRole("menuitem", { name: "Uneff me" }),
+    ).toBeVisible();
+  },
 };
 
 export const ReviewClosed: Story = {


### PR DESCRIPTION
## What changed

Code workspace overflow now offers **Uneff me** next to Copy debug JSON when a connected repo looks like the Tidebreak checkout (`tidebreak` or `brightwave-inc/tidebreak`). The command fetches that session's debug dump, opens a fresh workspace on the Tidebreak repo, and seeds the first turn with a prompt to diagnose the product bug and open a pull request against `main`.

Large dumps drop journal events (and truncate as a last resort) so the first turn still fits. The command palette also passes the session into Copy debug JSON and Uneff me, which previously no-oped from Cmd+K.

## Validation

- `biome format` and `biome lint` on the touched UI files
- `vitest run src/code/uneffMe.test.ts src/code/workspaceActions.test.ts src/code/CodeWorkspacePage.dom.test.tsx` — 68 passed
- Storybook `Code/Workspace header > Overflow actions` reviewed in dark and light

Left to CI: the scoped desktop UI lane and the rest of the required checks.

## Compatibility and risk

None. Client-only. The command is hidden unless Tidebreak is a connected Code repo.