### PR TITLE
feat(code): send Create PR into chat and edit action prompts

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -34,6 +34,7 @@ import { toast } from "sonner";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { resetCodeSessionRegistry } from "./CodeSessionRegistry";
 import { useCodeUiStore } from "./CodeUiStore";
+import { resetWorkflowPromptStore } from "./workflowPrompts";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeWorkspacePage } from "./CodeWorkspacePage";
 import {
@@ -652,6 +653,7 @@ afterEach(() => {
     workflowShortcutPending: null,
     archivePending: false,
   });
+  resetWorkflowPromptStore();
   browserMocks.close.mockClear();
   window.localStorage.clear();
   vi.restoreAllMocks();
@@ -1641,8 +1643,9 @@ describe("CodeWorkspacePage", () => {
     expect(toast.error).toHaveBeenCalledWith("worktree is busy");
   });
 
-  it("drafts the Create PR request into the composer for local changes", async () => {
+  it("sends the Create PR request into the workspace chat for local changes", async () => {
     const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
     client.getCodeWorkspacePr.mockResolvedValue({
       dirty: true,
       unpushed: false,
@@ -1664,21 +1667,19 @@ describe("CodeWorkspacePage", () => {
       within(control).getByRole("button", { name: "Create PR" }),
     );
 
-    // Offered, not sent: the request lands as an editable draft and no turn
-    // starts until the reader submits it.
-    const composer = await waitFor(() => {
-      const input = document.querySelector<HTMLTextAreaElement>(
-        "[data-composer-input]",
-      );
-      expect(input?.value).toContain("open a pull request against `main`");
-      return input!;
-    });
-    expect(composer.value).toContain("Do not merge.");
-    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+    await waitFor(() => expect(client.submitCodeTurn).toHaveBeenCalled());
+    expect(client.submitCodeTurn.mock.calls[0]?.[0]).toBe("sess-1");
+    expect(client.submitCodeTurn.mock.calls[0]?.[1]).toContain(
+      "open a pull request against `main`",
+    );
+    expect(client.submitCodeTurn.mock.calls[0]?.[1]).toContain("Do not merge.");
 
-    // Hand review is one step away: the menu still opens Source control, and
-    // the suggested commit message still does not crowd the composer — the
-    // draft stays exactly what Create PR put there.
+    const composer = document.querySelector<HTMLTextAreaElement>(
+      "[data-composer-input]",
+    );
+    expect(composer?.value ?? "").not.toContain("improve login flow");
+    expect(composer?.value ?? "").not.toContain("open a pull request");
+
     await user.click(
       within(control).getByRole("button", { name: "More workspace actions" }),
     );
@@ -1689,7 +1690,6 @@ describe("CodeWorkspacePage", () => {
       "aria-selected",
       "true",
     );
-    expect(composer.value).not.toContain("improve login flow");
 
     await user.click(screen.getByRole("tab", { name: "Files" }));
     await user.click(screen.getByRole("button", { name: "Review sidebar" }));

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.dom.test.tsx
@@ -16,6 +16,10 @@ import type {
 } from "../api/types";
 import { useCodeUiStore } from "./CodeUiStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
+import {
+  resetWorkflowPromptStore,
+  useWorkflowPromptStore,
+} from "./workflowPrompts";
 import { WorkspaceWorkflowControl } from "./WorkspaceWorkflowControl";
 
 vi.mock("sonner", () => ({
@@ -103,9 +107,71 @@ beforeEach(() => {
     pendingComposerPrompt: null,
     composerActionScope: null,
   });
+  resetWorkflowPromptStore();
 });
 
 afterEach(cleanup);
+
+const dirtyLocal: CodeWorkspacePrSnapshot = {
+  dirty: true,
+  unpushed: false,
+  ahead: 0,
+  has_upstream: true,
+  suggested_commit_message: "improve login flow",
+  gh_found: true,
+  gh_authenticated: true,
+  remediation: "",
+};
+
+function renderDirtyControl() {
+  const dirtyResource: CodeWorkspacePrResource = {
+    ...resource(),
+    data: dirtyLocal,
+  };
+  render(
+    <WorkspaceWorkflowControl
+      client={
+        {
+          pushCodeWorkspace: vi.fn(),
+          createCodePullRequest: vi.fn(),
+          markCodePrReady: vi.fn(),
+          mergeCodePr: vi.fn(),
+          startCodeWatch: vi.fn(),
+          stopCodeWatch: vi.fn(),
+          writeCodeCheckLogs: vi.fn(),
+        } as unknown as ApiClient
+      }
+      workspaceId="ws-1"
+      branchName="tidebreak/fix-login"
+      baseRef="main"
+      resource={dirtyResource}
+      onOpenSourceControl={vi.fn()}
+    />,
+  );
+}
+
+describe("Create PR", () => {
+  it("submits the prompt instead of leaving it in the composer", async () => {
+    renderDirtyControl();
+    await userEvent.click(screen.getByRole("button", { name: "Create PR" }));
+    const pending = useCodeUiStore.getState().pendingComposerPrompt;
+    expect(pending?.submit).toBe(true);
+    expect(pending?.scope).toBe("ws-1");
+    expect(pending?.text).toContain("open a pull request against `main`");
+    expect(pending?.text).toContain("Do not merge.");
+  });
+
+  it("sends a prompt edited in settings", async () => {
+    useWorkflowPromptStore
+      .getState()
+      .setPrompt("compose_pr", "Ship this branch to {base}.");
+    renderDirtyControl();
+    await userEvent.click(screen.getByRole("button", { name: "Create PR" }));
+    expect(useCodeUiStore.getState().pendingComposerPrompt?.text).toBe(
+      "Ship this branch to `main`.",
+    );
+  });
+});
 
 describe("Fix CI", () => {
   it("downloads the failing job logs and names them in the prompt", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -95,9 +95,6 @@ export function WorkspaceWorkflowControl({
   const popoverTitleId = useId();
   const { confirm, dialog: confirmDialog } = useConfirm();
   const runComposerPrompt = useCodeUiStore((state) => state.runComposerPrompt);
-  const offerComposerPrompt = useCodeUiStore(
-    (state) => state.offerComposerPrompt,
-  );
   const workflowShortcutPending = useCodeUiStore(
     (state) => state.workflowShortcutPending,
   );
@@ -389,11 +386,10 @@ export function WorkspaceWorkflowControl({
         onOpenSourceControl();
         return;
       case "compose_pr":
-        // A draft, not a turn: the request lands in the composer for the
-        // reader to edit and send, because opening a pull request publishes
-        // the branch.
         setDetailsOpen(false);
-        offerComposerPrompt(workspaceId, composePrPrompt(baseRef));
+        if (!runComposerPrompt(workspaceId, composePrPrompt(baseRef))) {
+          toast.error("Another agent action is already running");
+        }
         return;
       case "open_pr": {
         setDetailsOpen(false);
@@ -748,7 +744,7 @@ export function WorkspaceWorkflowControl({
               primary === "watch_and_fix"
                 ? "Start an agent task that watches this pull request and fixes actionable failures."
                 : primary === "compose_pr"
-                  ? "Draft a request in the composer to commit, push, and open a pull request. You review and send it."
+                  ? "Send a request to commit, push, and open a pull request."
                   : primary === "mark_ready" ||
                       primary === "merge" ||
                       primary === "fix_errors" ||

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { PullRequestDigest } from "../api/types";
 import {
@@ -10,6 +10,11 @@ import {
   prWorkflowStatus,
 } from "./prActions";
 import { prHasConflicts, prIsQueued } from "./prState";
+import { resetWorkflowPromptStore } from "./workflowPrompts";
+
+afterEach(() => {
+  resetWorkflowPromptStore();
+});
 
 function pr(partial: Partial<PullRequestDigest>): PullRequestDigest {
   return {

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -13,6 +13,7 @@ import {
   type CheckCounts,
   type PrGate,
 } from "./prState";
+import { renderWorkflowPrompt } from "./workflowPrompts";
 
 export type PrWorkflowAction =
   | "watch_and_fix"
@@ -288,6 +289,9 @@ export function prFreshAgentPrompt(
  * pull-request state changes, which decision 42 reserves for the user: they
  * run through their own endpoints, and excluding them from this type is what
  * stops a merge prompt from being wired back up by accident.
+ *
+ * Settings can replace the instruction. Live pull-request context is still
+ * appended after it.
  */
 export function prWorkflowPrompt(
   action: PrPromptAction,
@@ -297,24 +301,11 @@ export function prWorkflowPrompt(
   const number = `#${pr.number}`;
   const base = pr.base_branch?.trim() || "the base branch";
   const context = prWorkflowPromptContext(pr);
-  let instruction: string;
-  switch (action) {
-    case "fix_errors":
-      instruction =
-        logs.length > 0
-          ? `Pull request ${number} has failing checks, and their job logs are already downloaded — read them first. Reproduce the cause when practical, make the smallest safe fix in this workspace, run focused validation, commit, and push. Do not merge.`
-          : `Pull request ${number} has failing checks. Inspect the latest failing CI logs for the current head SHA, reproduce the cause when practical, make the smallest safe fix in this workspace, run focused validation, commit, and push. Do not merge.`;
-      break;
-    case "address_feedback":
-      instruction = `Pull request ${number} has requested changes. Inspect the latest unresolved review feedback, implement each actionable request in this workspace, run focused validation, commit, push, and reply where context is useful. Do not merge.`;
-      break;
-    case "update_branch":
-      instruction = `Update pull request ${number} from ${base}. Fetch the latest base branch, rebase this workspace branch onto it, resolve any conflicts, run focused validation, and push the updated head. Do not merge.`;
-      break;
-    case "resolve_conflicts":
-      instruction = `Pull request ${number} has merge conflicts with ${base}. Fetch and rebase onto ${base}, resolve every conflict in this workspace, run focused validation, commit if needed, and push the updated head. Do not merge the pull request.`;
-      break;
-  }
+  const instruction = renderWorkflowPrompt(
+    action,
+    { pr: number, base },
+    { logsAttached: logs.length > 0 },
+  );
   const attached = checkLogSection(logs);
   return `${instruction}\n\n${context}${attached}`;
 }

--- a/crates/tidebreak-desktop/ui/src/code/workflowPrompts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workflowPrompts.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+
+import { prWorkflowPrompt } from "./prActions";
+import { composePrPrompt } from "./workspaceWorkflow";
+import {
+  DEFAULT_WORKFLOW_PROMPTS,
+  interpolateWorkflowPrompt,
+  renderWorkflowPrompt,
+  resetWorkflowPromptStore,
+  useWorkflowPromptStore,
+} from "./workflowPrompts";
+
+afterEach(() => {
+  resetWorkflowPromptStore();
+  window.localStorage.clear();
+});
+
+describe("interpolateWorkflowPrompt", () => {
+  it("fills known placeholders and leaves unknown ones", () => {
+    expect(
+      interpolateWorkflowPrompt("Open against {base} for {pr}.", {
+        base: "`main`",
+        pr: "#41",
+      }),
+    ).toBe("Open against `main` for #41.");
+    expect(interpolateWorkflowPrompt("Keep {other}", { base: "main" })).toBe(
+      "Keep {other}",
+    );
+  });
+});
+
+describe("renderWorkflowPrompt", () => {
+  it("uses the shipped Create PR wording and names the base branch", () => {
+    expect(composePrPrompt("main")).toContain(
+      "open a pull request against `main`",
+    );
+    expect(composePrPrompt(" ")).toContain("the default branch");
+  });
+
+  it("sends a stored Create PR override", () => {
+    useWorkflowPromptStore
+      .getState()
+      .setPrompt("compose_pr", "Ship the branch to {base}. Do not merge.");
+    expect(composePrPrompt("main")).toBe(
+      "Ship the branch to `main`. Do not merge.",
+    );
+  });
+
+  it("keeps the logs-attached Fix CI wording until the prompt is customized", () => {
+    expect(
+      renderWorkflowPrompt("fix_errors", { pr: "#41" }, { logsAttached: true }),
+    ).toContain("already downloaded");
+    useWorkflowPromptStore
+      .getState()
+      .setPrompt("fix_errors", "Fix {pr} from the attached logs.");
+    expect(
+      renderWorkflowPrompt("fix_errors", { pr: "#41" }, { logsAttached: true }),
+    ).toBe("Fix #41 from the attached logs.");
+  });
+
+  it("falls back to the default when the stored prompt is empty", () => {
+    useWorkflowPromptStore.getState().setPrompt("compose_pr", "   ");
+    expect(composePrPrompt("main")).toBe(
+      interpolateWorkflowPrompt(DEFAULT_WORKFLOW_PROMPTS.compose_pr, {
+        base: "`main`",
+      }),
+    );
+  });
+
+  it("persists overrides and forgets a reset prompt", () => {
+    const store = useWorkflowPromptStore.getState();
+    store.setPrompt("compose_pr", "Custom {base}");
+    expect(window.localStorage.getItem("tidebreak.workflowPrompts")).toContain(
+      "Custom {base}",
+    );
+    store.resetPrompt("compose_pr");
+    expect(window.localStorage.getItem("tidebreak.workflowPrompts")).toBeNull();
+  });
+});
+
+describe("prWorkflowPrompt overrides", () => {
+  it("uses the stored instruction and still appends live pull-request state", () => {
+    useWorkflowPromptStore
+      .getState()
+      .setPrompt("update_branch", "Rebase {pr} onto {base}.");
+    const prompt = prWorkflowPrompt("update_branch", {
+      number: 41,
+      state: "open",
+      base_branch: "main",
+      title: "Fix login",
+    });
+    expect(prompt.startsWith("Rebase #41 onto main.")).toBe(true);
+    expect(prompt).toContain("Pull request: #41 - Fix login");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workflowPrompts.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workflowPrompts.ts
@@ -1,0 +1,234 @@
+import { create } from "zustand";
+
+/**
+ * Agent prompts the workspace actions send, plus the settings that edit them.
+ *
+ * Clicking Create PR, Fix CI, and the other prompt actions submits this text
+ * into the workspace chat. Settings stores only the deviations from the
+ * defaults; an empty or matching value is the shipped wording.
+ */
+
+export const WORKFLOW_PROMPT_IDS = [
+  "compose_pr",
+  "fix_errors",
+  "address_feedback",
+  "update_branch",
+  "resolve_conflicts",
+] as const;
+
+export type WorkflowPromptId = (typeof WORKFLOW_PROMPT_IDS)[number];
+
+export const DEFAULT_WORKFLOW_PROMPTS: Record<WorkflowPromptId, string> = {
+  compose_pr: [
+    "Review the uncommitted changes in this workspace, run focused validation,",
+    "commit with a clear message (split unrelated work into separate commits),",
+    "push the branch, and open a pull request against {base}.",
+    "Give the pull request a title and description that summarize what changed",
+    "and why. Do not merge.",
+  ].join(" "),
+  fix_errors: [
+    "Pull request {pr} has failing checks. Inspect the latest failing CI logs",
+    "for the current head SHA, reproduce the cause when practical, make the",
+    "smallest safe fix in this workspace, run focused validation, commit, and",
+    "push. Do not merge.",
+  ].join(" "),
+  address_feedback: [
+    "Pull request {pr} has requested changes. Inspect the latest unresolved",
+    "review feedback, implement each actionable request in this workspace, run",
+    "focused validation, commit, push, and reply where context is useful. Do",
+    "not merge.",
+  ].join(" "),
+  update_branch: [
+    "Update pull request {pr} from {base}. Fetch the latest base branch,",
+    "rebase this workspace branch onto it, resolve any conflicts, run focused",
+    "validation, and push the updated head. Do not merge.",
+  ].join(" "),
+  resolve_conflicts: [
+    "Pull request {pr} has merge conflicts with {base}. Fetch and rebase",
+    "onto {base}, resolve every conflict in this workspace, run focused",
+    "validation, commit if needed, and push the updated head. Do not merge the",
+    "pull request.",
+  ].join(" "),
+};
+
+/** Uncustomized Fix CI wording when job logs are already on disk. */
+export const DEFAULT_FIX_ERRORS_WITH_LOGS = [
+  "Pull request {pr} has failing checks, and their job logs are already",
+  "downloaded — read them first. Reproduce the cause when practical, make the",
+  "smallest safe fix in this workspace, run focused validation, commit, and",
+  "push. Do not merge.",
+].join(" ");
+
+export const WORKFLOW_PROMPT_FIELDS: readonly {
+  id: WorkflowPromptId;
+  label: string;
+  hint: string;
+}[] = [
+  {
+    id: "compose_pr",
+    label: "Create PR",
+    hint: "{base} is the target branch. Sent when the workspace has uncommitted changes.",
+  },
+  {
+    id: "fix_errors",
+    label: "Fix CI",
+    hint: "{pr} is the pull request number. Downloaded job logs are named after this prompt.",
+  },
+  {
+    id: "address_feedback",
+    label: "Address feedback",
+    hint: "{pr} is the pull request number. Live review state is appended after this prompt.",
+  },
+  {
+    id: "update_branch",
+    label: "Update branch",
+    hint: "{pr} is the pull request number. {base} is the base branch.",
+  },
+  {
+    id: "resolve_conflicts",
+    label: "Resolve conflicts",
+    hint: "{pr} is the pull request number. {base} is the base branch.",
+  },
+];
+
+const STORAGE_KEY = "tidebreak.workflowPrompts";
+
+export type WorkflowPromptVars = {
+  base?: string;
+  pr?: string;
+};
+
+export function interpolateWorkflowPrompt(
+  template: string,
+  vars: WorkflowPromptVars,
+): string {
+  return template.replace(/\{(base|pr)\}/g, (match, key: string) => {
+    if (key === "base") return vars.base ?? match;
+    if (key === "pr") return vars.pr ?? match;
+    return match;
+  });
+}
+
+export function isWorkflowPromptId(value: string): value is WorkflowPromptId {
+  return (WORKFLOW_PROMPT_IDS as readonly string[]).includes(value);
+}
+
+function storage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readStoredOverrides(): Partial<Record<WorkflowPromptId, string>> {
+  try {
+    const raw = storage()?.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const overrides: Partial<Record<WorkflowPromptId, string>> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!isWorkflowPromptId(key) || typeof value !== "string") continue;
+      if (value === DEFAULT_WORKFLOW_PROMPTS[key]) continue;
+      overrides[key] = value;
+    }
+    return overrides;
+  } catch {
+    return {};
+  }
+}
+
+function storeOverrides(overrides: Partial<Record<WorkflowPromptId, string>>) {
+  const local = storage();
+  if (!local) return;
+  try {
+    if (Object.keys(overrides).length === 0) {
+      local.removeItem(STORAGE_KEY);
+      return;
+    }
+    local.setItem(STORAGE_KEY, JSON.stringify(overrides));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
+export type WorkflowPromptStore = {
+  overrides: Partial<Record<WorkflowPromptId, string>>;
+  setPrompt: (id: WorkflowPromptId, value: string) => void;
+  resetPrompt: (id: WorkflowPromptId) => void;
+};
+
+export function createWorkflowPromptStore() {
+  return create<WorkflowPromptStore>()((set, get) => ({
+    overrides: readStoredOverrides(),
+    setPrompt: (id, value) => {
+      const overrides = { ...get().overrides };
+      if (value === DEFAULT_WORKFLOW_PROMPTS[id]) {
+        delete overrides[id];
+      } else {
+        overrides[id] = value;
+      }
+      storeOverrides(overrides);
+      set({ overrides });
+    },
+    resetPrompt: (id) => {
+      const overrides = { ...get().overrides };
+      delete overrides[id];
+      storeOverrides(overrides);
+      set({ overrides });
+    },
+  }));
+}
+
+export const useWorkflowPromptStore = createWorkflowPromptStore();
+
+/** The text the settings field shows, default when nothing is stored. */
+export function workflowPromptDraft(
+  id: WorkflowPromptId,
+  overrides: Partial<Record<WorkflowPromptId, string>> = currentOverrides(),
+): string {
+  return overrides[id] ?? DEFAULT_WORKFLOW_PROMPTS[id];
+}
+
+export function workflowPromptIsCustom(
+  id: WorkflowPromptId,
+  overrides: Partial<Record<WorkflowPromptId, string>> = currentOverrides(),
+): boolean {
+  return Object.hasOwn(overrides, id);
+}
+
+function currentOverrides(): Partial<Record<WorkflowPromptId, string>> {
+  return useWorkflowPromptStore.getState().overrides;
+}
+
+/**
+ * The instruction one action sends, after placeholders and any override.
+ *
+ * Uncustomized Fix CI keeps a second default when job logs are already
+ * downloaded, so the agent is told to read them first. A stored override
+ * replaces both wordings; the log paths still follow the instruction.
+ */
+export function renderWorkflowPrompt(
+  id: WorkflowPromptId,
+  vars: WorkflowPromptVars,
+  options?: { logsAttached?: boolean },
+): string {
+  const override = useWorkflowPromptStore.getState().overrides[id];
+  const template =
+    override !== undefined
+      ? override
+      : id === "fix_errors" && options?.logsAttached
+        ? DEFAULT_FIX_ERRORS_WITH_LOGS
+        : DEFAULT_WORKFLOW_PROMPTS[id];
+  const source = template.trim() ? template : DEFAULT_WORKFLOW_PROMPTS[id];
+  return interpolateWorkflowPrompt(source, vars);
+}
+
+/** Test helper: drop overrides without touching unrelated stores. */
+export function resetWorkflowPromptStore(): void {
+  storeOverrides({});
+  useWorkflowPromptStore.setState({ overrides: {} });
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { HttpError } from "../api/client";
 import type { CodeWorkspacePrSnapshot, PullRequestDigest } from "../api/types";
+import { resetWorkflowPromptStore } from "./workflowPrompts";
 import {
   composePrPrompt,
   resolveWorkflowShortcut,
@@ -11,6 +12,10 @@ import {
   workspaceWorkflowModel,
   type WorkflowShortcut,
 } from "./workspaceWorkflow";
+
+afterEach(() => {
+  resetWorkflowPromptStore();
+});
 
 const CLEAN: CodeWorkspacePrSnapshot = {
   dirty: false,
@@ -41,8 +46,8 @@ describe("workspaceWorkflowModel", () => {
     expect(workspaceWorkflowActionLabel(dirty.primary!, dirty.stage)).toBe(
       "Create PR",
     );
-    // Hand review does not vanish behind the drafted request; it moves one
-    // step away into the menu.
+    // Hand review does not vanish behind Create PR; it moves one step away
+    // into the menu.
     expect(dirty.secondary).toEqual(["open_source"]);
     expect(workspaceWorkflowActionLabel("open_source", dirty.stage)).toBe(
       "Review & commit",

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -11,6 +11,7 @@ import {
   type PrWorkflowAction,
 } from "./prActions";
 import { checkSummaryText, type CheckCounts } from "./prState";
+import { renderWorkflowPrompt } from "./workflowPrompts";
 
 export type WorkspaceWorkflowAction =
   | PrWorkflowAction
@@ -153,15 +154,15 @@ export function workspaceWorkflowModel(
       };
     }
     // No pull request yet, so the useful next step is the whole trip: Create
-    // PR drafts the commit-push-open request into the composer for the reader
-    // to send. Hand review stays one step away in the menu.
+    // PR sends the commit-push-open request into the workspace chat. Hand
+    // review stays one step away in the menu.
     return {
       stage: "dirty",
       tone: "warning",
       summary: "Uncommitted changes",
       title: "Changes need a pull request",
       detail:
-        "Create PR drafts a request in the composer to commit, push, and open a pull request.",
+        "Create PR sends a request to commit, push, and open a pull request.",
       primary: "compose_pr",
       secondary: ["open_source"],
     };
@@ -388,7 +389,7 @@ function pullRequestWorkflow(pr: PullRequestDigest): WorkspaceWorkflowModel {
  * A keyboard ask against the workflow.
  *
  * A chord names an intent, not an action: `pull_request` means "get this
- * branch in front of reviewers", which is a drafted commit-and-open request on
+ * branch in front of reviewers", which is a sent commit-and-open request on
  * a dirty worktree, a push on an unpushed branch, a create on a pushed one,
  * and a trip to GitHub once the pull request exists. Binding chords to intents
  * rather than to actions is what lets the reader press the same key at every
@@ -456,7 +457,7 @@ export function resolveWorkflowShortcut(
     case "pull_request":
       // Commit and push come first whether or not a pull request exists, so
       // these stages lead. With no pull request yet, uncommitted work gets the
-      // drafted request that carries it all the way; with one open, new local
+      // sent request that carries it all the way; with one open, new local
       // changes go through the commit box to update it.
       if (model.stage === "dirty") {
         return { run: model.pr ? "open_source" : "compose_pr" };
@@ -588,21 +589,14 @@ export function workspaceWorkflowActionLabel(
 }
 
 /**
- * The request the Create PR control drafts into the composer.
+ * The request Create PR sends into the workspace chat.
  *
- * Offered as a draft rather than run: opening a pull request publishes the
- * branch, so the reader reads, edits, and sends the request instead of the
- * button firing it. The agent it reaches sits in the worktree and can see the
- * diff, so the prompt says what to do with the changes rather than repeating
- * them. Merging stays with the user per decision 42.
+ * The agent sits in the worktree and can see the diff, so the prompt says what
+ * to do with the changes rather than repeating them. Merging stays with the
+ * user per decision 42. Settings can replace the wording; {base} is the
+ * target branch.
  */
 export function composePrPrompt(base?: string): string {
   const target = base?.trim() ? `\`${base.trim()}\`` : "the default branch";
-  return [
-    "Review the uncommitted changes in this workspace, run focused validation,",
-    "commit with a clear message (split unrelated work into separate commits),",
-    `push the branch, and open a pull request against ${target}.`,
-    "Give the pull request a title and description that summarize what changed",
-    "and why. Do not merge.",
-  ].join(" ");
+  return renderWorkflowPrompt("compose_pr", { base: target });
 }

--- a/crates/tidebreak-desktop/ui/src/settings/QuickActionsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/QuickActionsPanel.dom.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_WORKFLOW_PROMPTS,
+  resetWorkflowPromptStore,
+  useWorkflowPromptStore,
+} from "@/code/workflowPrompts";
+import { QuickActionsPanel } from "./QuickActionsPanel";
+
+afterEach(() => {
+  cleanup();
+  resetWorkflowPromptStore();
+  window.localStorage.clear();
+});
+
+describe("QuickActionsPanel", () => {
+  it("edits a prompt and restores the shipped wording", () => {
+    render(<QuickActionsPanel />);
+    const createPr = screen.getByRole("textbox", { name: "Create PR prompt" });
+    expect(createPr).toHaveValue(DEFAULT_WORKFLOW_PROMPTS.compose_pr);
+    expect(
+      screen.queryByRole("button", { name: "Reset Create PR to default" }),
+    ).toBeNull();
+
+    fireEvent.change(createPr, {
+      target: { value: "Open a pull request against {base}." },
+    });
+    expect(useWorkflowPromptStore.getState().overrides.compose_pr).toBe(
+      "Open a pull request against {base}.",
+    );
+    expect(window.localStorage.getItem("tidebreak.workflowPrompts")).toContain(
+      "Open a pull request against {base}.",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reset Create PR to default" }),
+    );
+    expect(createPr).toHaveValue(DEFAULT_WORKFLOW_PROMPTS.compose_pr);
+    expect(
+      screen.queryByRole("button", { name: "Reset Create PR to default" }),
+    ).toBeNull();
+    expect(
+      useWorkflowPromptStore.getState().overrides.compose_pr,
+    ).toBeUndefined();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/settings/QuickActionsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/QuickActionsPanel.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  useWorkflowPromptStore,
+  workflowPromptDraft,
+  workflowPromptIsCustom,
+  WORKFLOW_PROMPT_FIELDS,
+} from "@/code/workflowPrompts";
+import { SettingsField, SettingsPanel, SettingsSection } from "./primitives";
+
+/**
+ * The prompts workspace actions send into chat.
+ *
+ * Create PR, Fix CI, and the other prompt actions submit this text rather
+ * than leaving it in the composer. Each field saves as you type; Reset
+ * restores the shipped wording for that action only.
+ */
+export function QuickActionsPanel() {
+  const overrides = useWorkflowPromptStore((state) => state.overrides);
+  const setPrompt = useWorkflowPromptStore((state) => state.setPrompt);
+  const resetPrompt = useWorkflowPromptStore((state) => state.resetPrompt);
+
+  return (
+    <SettingsPanel
+      title="Quick actions"
+      description="The prompts Tidebreak sends when you click a workspace action such as Create PR. Each one goes into the workspace chat as soon as you click it. {base} is the target branch. {pr} is the pull request number."
+    >
+      <SettingsSection>
+        {WORKFLOW_PROMPT_FIELDS.map((field) => {
+          const customized = workflowPromptIsCustom(field.id, overrides);
+          return (
+            <div key={field.id} className="flex flex-col gap-2">
+              <SettingsField label={field.label} hint={field.hint}>
+                <Textarea
+                  value={workflowPromptDraft(field.id, overrides)}
+                  onChange={(event) => setPrompt(field.id, event.target.value)}
+                  rows={4}
+                  spellCheck
+                  aria-label={`${field.label} prompt`}
+                />
+              </SettingsField>
+              {customized && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="self-start px-0 text-muted-foreground hover:bg-transparent"
+                  aria-label={`Reset ${field.label} to default`}
+                  onClick={() => resetPrompt(field.id)}
+                >
+                  Reset to default
+                </Button>
+              )}
+            </div>
+          );
+        })}
+      </SettingsSection>
+    </SettingsPanel>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/settings/sections.test.ts
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.test.ts
@@ -41,6 +41,14 @@ describe("settings sections", () => {
     }
   });
 
+  it("always exposes quick-action prompts", () => {
+    for (const managed of [false, true]) {
+      expect(
+        settingsSectionsFor(managed).map((section) => section.path),
+      ).toContain("quick-actions");
+    }
+  });
+
   it("keeps a providers deep link to what it can act on", () => {
     // The picker's CTAs address this route; anything else in the URL — a stale
     // link, a hand-edited one — must reach the panel as nothing rather than as

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -14,6 +14,7 @@ import {
   Mic,
   Terminal,
   Waypoints,
+  Zap,
 } from "lucide-react";
 
 import { useApp } from "@/AppContext";
@@ -33,6 +34,7 @@ import { UpdatesPanel } from "./UpdatesPanel";
 import { WebSearchPanel } from "./WebSearchPanel";
 import { VoiceTranscriptionPanel } from "./VoiceTranscriptionPanel";
 import { CodingHarnessesPanel } from "./CodingHarnessesPanel";
+import { QuickActionsPanel } from "./QuickActionsPanel";
 
 /**
  * Each section reads what it needs from the shell context rather than being
@@ -184,6 +186,10 @@ function CodingHarnessesSection() {
   return <CodingHarnessesPanel client={client} />;
 }
 
+function QuickActionsSection() {
+  return <QuickActionsPanel />;
+}
+
 export type SettingsSectionDef = {
   /** The path segment under `/settings`, and its address. */
   path: string;
@@ -291,6 +297,14 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     icon: Terminal,
     iconClass: "text-icon-amber",
     Component: CodingHarnessesSection,
+  },
+  {
+    path: "quick-actions",
+    label: "Quick actions",
+    group: "capabilities",
+    icon: Zap,
+    iconClass: "text-icon-violet",
+    Component: QuickActionsSection,
   },
   {
     path: "connected-apps",

--- a/crates/tidebreak-desktop/ui/src/stories/QuickActionsPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/QuickActionsPanel.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  resetWorkflowPromptStore,
+  useWorkflowPromptStore,
+} from "@/code/workflowPrompts";
+import { QuickActionsPanel } from "@/settings/QuickActionsPanel";
+
+/**
+ * The prompts workspace actions send into chat. Defaults are the shipped
+ * wording; a customized Create PR is the state a reader who has edited one
+ * field actually sees, including a live Reset.
+ */
+const meta = {
+  title: "Settings/Quick actions",
+  component: QuickActionsPanel,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => {
+      resetWorkflowPromptStore();
+      return <Story />;
+    },
+  ],
+} satisfies Meta<typeof QuickActionsPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Defaults: Story = {};
+
+export const CustomCreatePr: Story = {
+  render: () => {
+    useWorkflowPromptStore
+      .getState()
+      .setPrompt(
+        "compose_pr",
+        [
+          "Review the diff, write a focused commit, push, and open a pull",
+          "request against {base}. Keep the description short. Do not merge.",
+        ].join(" "),
+      );
+    return <QuickActionsPanel />;
+  },
+};


### PR DESCRIPTION
Create PR now submits into the workspace chat instead of leaving a draft in the composer. You edit that prompt, and the other pull-request action prompts, in Settings → Quick actions.

Clicking Create PR, Fix CI, Address feedback, Update branch, or Resolve conflicts sends the stored text immediately. `{base}` is the target branch. `{pr}` is the pull request number. Pull-request actions still append the live GitHub state after the instruction. Reset restores one action's shipped wording.

## Validation

- `biome format` and `biome lint` on the changed UI files
- `vitest run` for `workflowPrompts`, `workspaceWorkflow`, `prActions`, `WorkspaceWorkflowControl`, `CodeWorkspacePage`, `QuickActionsPanel`, and settings sections (125 tests)