### PR TITLE
fix(code): keep the new-workspace composer draft after dismiss

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -60,6 +60,20 @@ export type CodeCreateSelection = {
   permissionMode?: PermissionMode;
 };
 
+/**
+ * Unsent first message and name in the new-workspace composer. Closing the
+ * dialog keeps them; the next Cmd+N restores them. A create consumes them.
+ */
+export type NewWorkspaceDraft = {
+  startingPrompt: string;
+  title: string;
+};
+
+export const EMPTY_NEW_WORKSPACE_DRAFT: NewWorkspaceDraft = {
+  startingPrompt: "",
+  title: "",
+};
+
 /** Inspector filter for one turn's files and diff. `label` is the ordinal, never the id. */
 export type InspectorScope = {
   turnId: string;
@@ -223,6 +237,12 @@ export type CodeUiStore = {
   newWorkspaceOpen: boolean;
   /** The repo the dialog opens on, when it was opened from one. */
   newWorkspaceRepoId: string | undefined;
+  /**
+   * Typed words still sitting in the new-workspace composer after a dismiss.
+   * Settings stick via `lastCreate`; this is only the message and name.
+   */
+  newWorkspaceDraft: NewWorkspaceDraft;
+  setNewWorkspaceDraft: (draft: NewWorkspaceDraft) => void;
   addRepoOpen: boolean;
   reviewSidebarOpen: boolean;
   /** Files and diff scoped to one turn, or the whole worktree when null. */
@@ -346,6 +366,7 @@ export type WorkflowSuggestion = {
 export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   newWorkspaceOpen: false,
   newWorkspaceRepoId: undefined,
+  newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT,
   addRepoOpen: false,
   reviewSidebarOpen: readStoredReviewSidebarOpen(),
   inspectorScope: null,
@@ -439,6 +460,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
     set({ newWorkspaceOpen: true, newWorkspaceRepoId: known });
   },
   setNewWorkspaceOpen: (open) => set({ newWorkspaceOpen: open }),
+  setNewWorkspaceDraft: (newWorkspaceDraft) => set({ newWorkspaceDraft }),
   setAddRepoOpen: (open) => set({ addRepoOpen: open }),
   toggleReviewSidebar: () =>
     set((state) => {
@@ -487,6 +509,7 @@ export function resetCodeUiHostState(): void {
   useCodeUiStore.setState({
     newWorkspaceOpen: false,
     newWorkspaceRepoId: undefined,
+    newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT,
     addRepoOpen: false,
     inspectorScope: null,
     terminalPending: false,

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -22,7 +22,7 @@ import {
   OPTIMISTIC_WORKSPACE_ID_PREFIX,
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
-import { useCodeUiStore } from "./CodeUiStore";
+import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import type { ReasoningEffort } from "../api/types";
 import type { CodeTurnSubmission, ParsedHarnessModel } from "./parsers";
@@ -42,6 +42,7 @@ afterEach(() => {
   useCodeUiStore.setState({
     lastCreate: null,
     pendingComposerPrompt: null,
+    newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT,
   });
   toastError.mockReset();
   toastSuccess.mockReset();
@@ -516,6 +517,39 @@ describe("NewWorkspaceDialog", () => {
     await waitFor(() => expect(createCodeWorkspace).toHaveBeenCalled());
   });
 
+  it("keeps the first message after the dialog is dismissed", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const value = app({ listCodeHarnessModels: claudeModels() });
+
+    await renderWithRouter(
+      <AppContextProvider value={value}>
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "First message" }), {
+      target: { value: "keep this task" },
+    });
+    cleanup();
+
+    await renderWithRouter(
+      <AppContextProvider value={value}>
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    expect(screen.getByRole("textbox", { name: "First message" })).toHaveValue(
+      "keep this task",
+    );
+  });
+
   it("sends the first message as the session's first turn", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({
@@ -565,6 +599,9 @@ describe("NewWorkspaceDialog", () => {
     );
     // Sent, not parked: nothing left for the workspace composer to take.
     expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+    expect(useCodeUiStore.getState().newWorkspaceDraft).toEqual(
+      EMPTY_NEW_WORKSPACE_DRAFT,
+    );
   });
 
   it("hands the message to the workspace composer when the turn cannot be sent", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -43,7 +43,7 @@ import {
   OPTIMISTIC_WORKSPACE_ID_PREFIX,
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
-import { useCodeUiStore } from "./CodeUiStore";
+import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
 import { HarnessModelMenu } from "./CodeComposer";
 import { HarnessInstallNote } from "./HarnessInstallNote";
 import { useWarmHarnessInstall } from "./useHarnessInstall";
@@ -74,9 +74,11 @@ import {
  *
  * A typed message is posted as the session's first turn once the session
  * exists. If the session or the turn fails, the text is handed to the
- * workspace composer as a draft instead — never dropped. "Create more" keeps
- * the dialog open after a create, clearing only the message and name, for
- * firing off several tasks on the same sticky settings.
+ * workspace composer as a draft instead — never dropped. Dismissing the
+ * dialog keeps the message and name for the next Cmd+N; a create consumes
+ * them. "Create more" keeps the dialog open after a create, clearing only
+ * the message and name, for firing off several tasks on the same sticky
+ * settings.
  *
  * The title is optional: left blank, the server generates a two-word name and
  * later replaces it with one derived from the first turn, the same way chats
@@ -171,9 +173,10 @@ export function NewWorkspaceDialog({
   );
   const lastCreate = useCodeUiStore((state) => state.lastCreate);
   const rememberCreate = useCodeUiStore((state) => state.rememberCreate);
+  const draft = useCodeUiStore((state) => state.newWorkspaceDraft);
+  const startingPrompt = draft.startingPrompt;
+  const title = draft.title;
   const [repoId, setRepoId] = useState("");
-  const [startingPrompt, setStartingPrompt] = useState("");
-  const [title, setTitle] = useState("");
   const [baseRef, setBaseRef] = useState("");
   const [pickedHarness, setPickedHarness] = useState<HarnessKind | null>(null);
   const [permissionMode, setPermissionMode] = useState<PermissionMode | null>(
@@ -219,8 +222,12 @@ export function NewWorkspaceDialog({
       defaultRepoId ??
       recentRepoId(repos, known, lastCreate?.repoId);
     setRepoId(nextRepo);
-    setStartingPrompt(retry?.startingPrompt ?? "");
-    setTitle(retry?.title ?? "");
+    if (retry) {
+      useCodeUiStore.getState().setNewWorkspaceDraft({
+        startingPrompt: retry.startingPrompt,
+        title: retry.title,
+      });
+    }
     setBaseRef(
       retry?.baseRef ??
         repos.find((repo) => repo.id === nextRepo)?.default_base_ref ??
@@ -392,9 +399,8 @@ export function NewWorkspaceDialog({
       createMore,
       originPath: pathnameRef.current,
     };
+    useCodeUiStore.getState().setNewWorkspaceDraft(EMPTY_NEW_WORKSPACE_DRAFT);
     if (createMore) {
-      setStartingPrompt("");
-      setTitle("");
       focusPrompt();
       queueMicrotask(() => {
         createLocked.current = false;
@@ -444,6 +450,12 @@ export function NewWorkspaceDialog({
     } catch (error) {
       removeWorkspace(pending.id);
       retryAttempt.current = attempt;
+      if (!attempt.createMore) {
+        useCodeUiStore.getState().setNewWorkspaceDraft({
+          startingPrompt: attempt.startingPrompt,
+          title: attempt.title,
+        });
+      }
       toast.error(
         friendlyErrorMessage(error, "Could not create the workspace"),
         {
@@ -672,7 +684,13 @@ export function NewWorkspaceDialog({
                 <span className="text-xs font-medium">Name</span>
                 <Input
                   value={title}
-                  onChange={(event) => setTitle(event.target.value)}
+                  onChange={(event) => {
+                    const current = useCodeUiStore.getState().newWorkspaceDraft;
+                    useCodeUiStore.getState().setNewWorkspaceDraft({
+                      ...current,
+                      title: event.target.value,
+                    });
+                  }}
                   placeholder="Named automatically"
                   aria-label="Name"
                   onKeyDown={(event) => {
@@ -730,7 +748,13 @@ export function NewWorkspaceDialog({
           <textarea
             ref={promptInput}
             value={startingPrompt}
-            onChange={(event) => setStartingPrompt(event.target.value)}
+            onChange={(event) => {
+              const current = useCodeUiStore.getState().newWorkspaceDraft;
+              useCodeUiStore.getState().setNewWorkspaceDraft({
+                ...current,
+                startingPrompt: event.target.value,
+              });
+            }}
             aria-label="First message"
             placeholder="Describe the first task (optional)"
             className="placeholder:text-muted-foreground max-h-[45vh] min-h-36 w-full resize-none bg-transparent px-4 py-3 text-base outline-none"

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -12,8 +12,9 @@ import {
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { CodeRepoSnapshot, HarnessKind } from "@/api/types";
 import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
-import { NewWorkspaceDialog } from "@/code/NewWorkspaceDialog";
+import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "@/code/CodeUiStore";
 import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
+import { NewWorkspaceDialog } from "@/code/NewWorkspaceDialog";
 import {
   harnessDoctor,
   harnessDoctorCold,
@@ -175,6 +176,7 @@ function NewWorkspace({
       workspaces: [],
     });
     useCodeUpdatesStore.setState({ harnessInstalls: installs ?? {} });
+    useCodeUiStore.setState({ newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT });
     setSeeded(true);
   }, [doctor, installs]);
   if (!seeded) return null;


### PR DESCRIPTION
## What changed

Dismissing the Cmd+N new-workspace composer no longer throws away the first message. The next Cmd+N restores the typed message and name. Creating a workspace still clears that draft. If create fails, the draft comes back so you can try again.

The dialog was resetting the message to empty every time it opened. The unsent text now lives in the code UI store with the rest of that dialog's chrome, the same way a failed first turn already hands the words to the workspace composer instead of dropping them.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome check` on the four changed files
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/NewWorkspaceDialog.dom.test.tsx` (20 passed), including dismiss-and-reopen and a successful create wiping the draft

Did not click through the running desktop app.

## Compatibility and risk

None. In-memory only for this session. No wire, persistence, or host-authority change.