### PR TITLE
feat(desktop): sandbox agents sidebar section and spawn dialog

### DIFF
--- a/crates/tidebreak-desktop/ui/src/sidebar/SandboxAgentsSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SandboxAgentsSection.tsx
@@ -1,0 +1,339 @@
+import { type ComponentType, useState } from "react";
+import { Bot, ChevronRight, GitBranch, Plus, Square } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { ClaudeIcon, OpenAIIcon, OpenCodeIcon, XaiIcon } from "@/ProviderIcons";
+import { SidebarButton } from "./primitives";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SandboxHarness =
+  | "claude_code"
+  | "codex"
+  | "opencode"
+  | "grok_build"
+  | "custom";
+
+export type SandboxStatus =
+  | "queued"
+  | "provisioning"
+  | "running"
+  | "idle"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type SandboxAgent = {
+  id: string;
+  harness: SandboxHarness;
+  task: string;
+  status: SandboxStatus;
+  repositoryUrl?: string;
+  repositoryRef?: string;
+  profile: string;
+  elapsedLabel?: string;
+  spendMicroUsd?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HARNESS_ICONS: Record<
+  SandboxHarness,
+  ComponentType<{ className?: string }>
+> = {
+  claude_code: ClaudeIcon,
+  codex: OpenAIIcon,
+  opencode: OpenCodeIcon,
+  grok_build: XaiIcon,
+  custom: Bot as ComponentType<{ className?: string }>,
+};
+
+const HARNESS_LABELS: Record<SandboxHarness, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex",
+  opencode: "opencode",
+  grok_build: "Grok",
+  custom: "Custom",
+};
+
+export const SANDBOX_STATUS_LABELS: Record<SandboxStatus, string> = {
+  queued: "Queued",
+  provisioning: "Starting",
+  running: "Running",
+  idle: "Idle",
+  completed: "Completed",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+function sandboxStatusDotClass(status: SandboxStatus): string {
+  switch (status) {
+    case "queued":
+    case "provisioning":
+      return "animate-pulse bg-muted-foreground";
+    case "running":
+      return "animate-pulse bg-live";
+    case "idle":
+      return "bg-warning";
+    case "completed":
+      return "bg-success";
+    case "failed":
+      return "bg-destructive";
+    case "cancelled":
+      return "bg-muted-foreground";
+  }
+}
+
+function sandboxStatusBadgeVariant(
+  status: SandboxStatus,
+): "live" | "info" | "warning" | "success" | "critical" | "outline" {
+  switch (status) {
+    case "running":
+      return "live";
+    case "queued":
+    case "provisioning":
+      return "info";
+    case "idle":
+      return "warning";
+    case "completed":
+      return "success";
+    case "failed":
+      return "critical";
+    case "cancelled":
+      return "outline";
+  }
+}
+
+function isLive(status: SandboxStatus): boolean {
+  return (
+    status === "queued" ||
+    status === "provisioning" ||
+    status === "running" ||
+    status === "idle"
+  );
+}
+
+function repoShortName(url: string): string {
+  const match = url.match(/([^/]+\/[^/]+?)(?:\.git)?$/);
+  return match?.[1] ?? url;
+}
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+export function SandboxAgentsSection({
+  agents,
+  onSpawn,
+  onOpen,
+  onStop,
+}: {
+  agents: readonly SandboxAgent[];
+  onSpawn?: () => void;
+  onOpen?: (id: string) => void;
+  onStop?: (id: string) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+  const liveCount = agents.filter((agent) => isLive(agent.status)).length;
+
+  if (agents.length === 0 && !onSpawn) return null;
+
+  return (
+    <div className="flex shrink-0 flex-col">
+      <div className="flex items-center">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-1 px-2 py-1"
+          onClick={() => setCollapsed((prev) => !prev)}
+          aria-expanded={!collapsed}
+        >
+          <ChevronRight
+            className={cn(
+              "size-3 shrink-0 text-muted-foreground transition-transform",
+              !collapsed && "rotate-90",
+            )}
+            aria-hidden="true"
+          />
+          <span className="text-xs font-medium text-foreground-subtle">
+            Agents
+          </span>
+          {liveCount > 0 && (
+            <Badge variant="live" size="sm" className="ml-auto px-1.5 py-0">
+              {liveCount}
+            </Badge>
+          )}
+          {liveCount === 0 && agents.length > 0 && (
+            <span className="ml-auto text-[10px] text-muted-foreground">
+              {agents.length}
+            </span>
+          )}
+        </button>
+        {onSpawn && (
+          <WithTooltip label="Spawn sandbox agent" side="right">
+            <button
+              type="button"
+              className="mr-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              aria-label="Spawn sandbox agent"
+              onClick={onSpawn}
+            >
+              <Plus className="size-3.5" />
+            </button>
+          </WithTooltip>
+        )}
+      </div>
+
+      {!collapsed && (
+        <div className="flex flex-col gap-0.5">
+          {agents.map((agent) => (
+            <SandboxAgentRow
+              key={agent.id}
+              agent={agent}
+              onOpen={onOpen}
+              onStop={onStop}
+            />
+          ))}
+          {agents.length === 0 && onSpawn && (
+            <SidebarButton className="text-muted-foreground" onClick={onSpawn}>
+              <Bot className="text-icon-violet" />
+              <span className="text-xs">Spawn an agent</span>
+            </SidebarButton>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
+function SandboxAgentRow({
+  agent,
+  onOpen,
+  onStop,
+}: {
+  agent: SandboxAgent;
+  onOpen?: (id: string) => void;
+  onStop?: (id: string) => void;
+}) {
+  const Icon = HARNESS_ICONS[agent.harness];
+  const live = isLive(agent.status);
+
+  return (
+    <div className="group/agent relative">
+      <SidebarButton
+        className="gap-1.5 pr-1.5"
+        onClick={() => onOpen?.(agent.id)}
+        aria-label={`${HARNESS_LABELS[agent.harness]} agent: ${agent.task}`}
+      >
+        <span className="relative flex size-4 shrink-0 items-center justify-center">
+          <Icon className="size-3.5" />
+          <span
+            className={cn(
+              "absolute -right-0.5 -bottom-0.5 size-[6px] rounded-full ring-1 ring-page-background",
+              sandboxStatusDotClass(agent.status),
+            )}
+            aria-hidden="true"
+          />
+        </span>
+        <span className="min-w-0 flex-1 truncate text-xs">{agent.task}</span>
+        {live && agent.elapsedLabel && (
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {agent.elapsedLabel}
+          </span>
+        )}
+        {!live && <SandboxAgentStatusBadge status={agent.status} />}
+      </SidebarButton>
+
+      {live && onStop && (
+        <WithTooltip label="Stop agent" side="right">
+          <button
+            type="button"
+            className="absolute top-1/2 right-1.5 hidden -translate-y-1/2 rounded p-0.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive group-hover/agent:flex"
+            aria-label={`Stop ${HARNESS_LABELS[agent.harness]} agent`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onStop(agent.id);
+            }}
+          >
+            <Square className="size-3 fill-current" />
+          </button>
+        </WithTooltip>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Status badge (inline, minimal)
+// ---------------------------------------------------------------------------
+
+function SandboxAgentStatusBadge({ status }: { status: SandboxStatus }) {
+  const variant = sandboxStatusBadgeVariant(status);
+  return (
+    <Badge variant={variant} size="sm" className="h-4 px-1.5 py-0 text-[10px]">
+      {SANDBOX_STATUS_LABELS[status]}
+    </Badge>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail row (expanded state for hover or panel)
+// ---------------------------------------------------------------------------
+
+export function SandboxAgentDetail({ agent }: { agent: SandboxAgent }) {
+  const Icon = HARNESS_ICONS[agent.harness];
+
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      <div className="flex items-start gap-2.5">
+        <div className="grid size-7 shrink-0 place-items-center">
+          <Icon className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="line-clamp-2 text-sm font-medium leading-5">
+            {agent.task}
+          </p>
+          <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span>{HARNESS_LABELS[agent.harness]}</span>
+            <span>·</span>
+            <span>{agent.profile}</span>
+            {agent.elapsedLabel && (
+              <>
+                <span>·</span>
+                <span>{agent.elapsedLabel}</span>
+              </>
+            )}
+          </div>
+        </div>
+        <SandboxAgentStatusBadge status={agent.status} />
+      </div>
+
+      {agent.repositoryUrl && (
+        <div className="ml-9 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <GitBranch className="size-3 shrink-0" aria-hidden="true" />
+          <span className="truncate">{repoShortName(agent.repositoryUrl)}</span>
+          {agent.repositoryRef && (
+            <>
+              <span>@</span>
+              <span className="truncate font-mono">{agent.repositoryRef}</span>
+            </>
+          )}
+        </div>
+      )}
+
+      {agent.spendMicroUsd !== undefined && agent.spendMicroUsd > 0 && (
+        <div className="ml-9 text-xs text-muted-foreground">
+          ${(agent.spendMicroUsd / 1_000_000).toFixed(2)} spent
+        </div>
+      )}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/sidebar/SandboxAgentsSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SandboxAgentsSection.tsx
@@ -169,7 +169,7 @@ export function SandboxAgentsSection({
             </Badge>
           )}
           {liveCount === 0 && agents.length > 0 && (
-            <span className="ml-auto text-[10px] text-muted-foreground">
+            <span className="ml-auto text-2xs text-muted-foreground">
               {agents.length}
             </span>
           )}
@@ -245,7 +245,7 @@ function SandboxAgentRow({
         </span>
         <span className="min-w-0 flex-1 truncate text-xs">{agent.task}</span>
         {live && agent.elapsedLabel && (
-          <span className="shrink-0 text-[10px] text-muted-foreground">
+          <span className="shrink-0 text-2xs text-muted-foreground">
             {agent.elapsedLabel}
           </span>
         )}
@@ -278,7 +278,7 @@ function SandboxAgentRow({
 function SandboxAgentStatusBadge({ status }: { status: SandboxStatus }) {
   const variant = sandboxStatusBadgeVariant(status);
   return (
-    <Badge variant={variant} size="sm" className="h-4 px-1.5 py-0 text-[10px]">
+    <Badge variant={variant} size="sm" className="h-4 px-1.5 py-0 text-2xs">
       {SANDBOX_STATUS_LABELS[status]}
     </Badge>
   );

--- a/crates/tidebreak-desktop/ui/src/sidebar/SpawnSandboxDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SpawnSandboxDialog.tsx
@@ -1,0 +1,254 @@
+import { type ComponentType, useState } from "react";
+import { Play, Rocket } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { ClaudeIcon, OpenAIIcon, OpenCodeIcon, XaiIcon } from "@/ProviderIcons";
+
+import type { SandboxHarness } from "./SandboxAgentsSection";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SandboxProfile = {
+  id: string;
+  name: string;
+  enabled: boolean;
+};
+
+export type SpawnSandboxRequest = {
+  profile: string;
+  harness: SandboxHarness;
+  task: string;
+  repository?: string;
+  repositoryRef?: string;
+  model?: string;
+  reasoningEffort?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HARNESS_OPTIONS: {
+  value: SandboxHarness;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+}[] = [
+  { value: "claude_code", label: "Claude Code", icon: ClaudeIcon },
+  { value: "codex", label: "Codex", icon: OpenAIIcon },
+  { value: "opencode", label: "opencode", icon: OpenCodeIcon },
+  { value: "grok_build", label: "Grok", icon: XaiIcon },
+];
+
+const EFFORT_OPTIONS = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "Extra high" },
+  { value: "max", label: "Max" },
+];
+
+// ---------------------------------------------------------------------------
+// Dialog
+// ---------------------------------------------------------------------------
+
+export function SpawnSandboxDialog({
+  open,
+  profiles,
+  onSubmit,
+  onClose,
+}: {
+  open: boolean;
+  profiles: readonly SandboxProfile[];
+  onSubmit: (request: SpawnSandboxRequest) => void;
+  onClose: () => void;
+}) {
+  const [profile, setProfile] = useState(
+    profiles.find((p) => p.enabled)?.id ?? "",
+  );
+  const [harness, setHarness] = useState<SandboxHarness>("claude_code");
+  const [task, setTask] = useState("");
+  const [repository, setRepository] = useState("");
+  const [repositoryRef, setRepositoryRef] = useState("");
+  const [model, setModel] = useState("");
+  const [effort, setEffort] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit = profile !== "" && task.trim() !== "" && !submitting;
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    onSubmit({
+      profile,
+      harness,
+      task: task.trim(),
+      repository: repository.trim() || undefined,
+      repositoryRef: repositoryRef.trim() || undefined,
+      model: model.trim() || undefined,
+      reasoningEffort: effort || undefined,
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Rocket className="size-4 text-icon-violet" aria-hidden="true" />
+            Spawn sandbox agent
+          </DialogTitle>
+          <DialogDescription>
+            Launch a detached agent in a Model Gateway sandbox. It keeps working
+            after you close this window.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          {/* Profile */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="spawn-profile">Profile</Label>
+            <Select value={profile} onValueChange={setProfile}>
+              <SelectTrigger id="spawn-profile">
+                <SelectValue placeholder="Select a profile" />
+              </SelectTrigger>
+              <SelectContent>
+                {profiles.map((p) => (
+                  <SelectItem key={p.id} value={p.id} disabled={!p.enabled}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Harness */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="spawn-harness">Harness</Label>
+            <Select
+              value={harness}
+              onValueChange={(v) => setHarness(v as SandboxHarness)}
+            >
+              <SelectTrigger id="spawn-harness">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HARNESS_OPTIONS.map((opt) => {
+                  const Icon = opt.icon;
+                  return (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      <span className="flex items-center gap-2">
+                        <Icon className="size-3.5" />
+                        {opt.label}
+                      </span>
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Task */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="spawn-task">Task</Label>
+            <Textarea
+              id="spawn-task"
+              rows={3}
+              placeholder="Describe what the agent should do…"
+              value={task}
+              onChange={(event) => setTask(event.target.value)}
+            />
+          </div>
+
+          {/* Repository (optional) */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="spawn-repo">
+              Repository
+              <span className="ml-1 text-xs font-normal text-muted-foreground">
+                optional
+              </span>
+            </Label>
+            <div className="flex gap-2">
+              <Input
+                id="spawn-repo"
+                placeholder="owner/repo or full URL"
+                value={repository}
+                onChange={(event) => setRepository(event.target.value)}
+                className="flex-1"
+              />
+              <Input
+                placeholder="branch"
+                value={repositoryRef}
+                onChange={(event) => setRepositoryRef(event.target.value)}
+                className="w-28"
+              />
+            </div>
+          </div>
+
+          {/* Model + effort */}
+          <div className="flex gap-3">
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label htmlFor="spawn-model">
+                Model
+                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  optional
+                </span>
+              </Label>
+              <Input
+                id="spawn-model"
+                placeholder="e.g. claude-sonnet-4"
+                value={model}
+                onChange={(event) => setModel(event.target.value)}
+              />
+            </div>
+            <div className="flex w-36 flex-col gap-1.5">
+              <Label htmlFor="spawn-effort">Effort</Label>
+              <Select value={effort} onValueChange={setEffort}>
+                <SelectTrigger id="spawn-effort">
+                  <SelectValue placeholder="Default" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">Default</SelectItem>
+                  {EFFORT_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit} onClick={handleSubmit}>
+            <Play className="size-3.5" aria-hidden="true" />
+            {submitting ? "Spawning…" : "Spawn"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/SandboxAgents.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SandboxAgents.stories.tsx
@@ -1,0 +1,347 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import {
+  SandboxAgentsSection,
+  SandboxAgentDetail,
+  type SandboxAgent,
+  type SandboxHarness,
+  type SandboxStatus,
+} from "@/sidebar/SandboxAgentsSection";
+import {
+  SpawnSandboxDialog,
+  type SandboxProfile,
+} from "@/sidebar/SpawnSandboxDialog";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// ---------------------------------------------------------------------------
+// Fixture data
+// ---------------------------------------------------------------------------
+
+function sandboxAgent(
+  id: string,
+  harness: SandboxHarness,
+  status: SandboxStatus,
+  task: string,
+  overrides: Partial<SandboxAgent> = {},
+): SandboxAgent {
+  const live = ["queued", "provisioning", "running", "idle"].includes(status);
+  return {
+    id,
+    harness,
+    task,
+    status,
+    profile: "default",
+    elapsedLabel: live ? "2m 34s" : "8m 12s",
+    spendMicroUsd: live ? 45_000 : 320_000,
+    ...overrides,
+  };
+}
+
+const liveAgents: SandboxAgent[] = [
+  sandboxAgent(
+    "sb-1",
+    "claude_code",
+    "running",
+    "Refactor the settings panel to use the new token system",
+    {
+      repositoryUrl: "https://github.com/brightwave-inc/tidebreak",
+      repositoryRef: "feat/settings-tokens",
+      elapsedLabel: "4m 12s",
+      spendMicroUsd: 89_000,
+    },
+  ),
+  sandboxAgent(
+    "sb-2",
+    "codex",
+    "running",
+    "Add integration tests for the webhook handler",
+    {
+      repositoryUrl: "https://github.com/brightwave-inc/model-gateway",
+      repositoryRef: "main",
+      elapsedLabel: "1m 48s",
+      spendMicroUsd: 32_000,
+    },
+  ),
+  sandboxAgent(
+    "sb-3",
+    "grok_build",
+    "provisioning",
+    "Migrate the database schema for user preferences",
+    { elapsedLabel: "12s" },
+  ),
+];
+
+const mixedAgents: SandboxAgent[] = [
+  sandboxAgent(
+    "sb-1",
+    "claude_code",
+    "running",
+    "Audit the permission model for connected apps",
+    {
+      repositoryUrl: "https://github.com/brightwave-inc/tidebreak",
+      repositoryRef: "main",
+      elapsedLabel: "6m 30s",
+      spendMicroUsd: 142_000,
+    },
+  ),
+  sandboxAgent(
+    "sb-2",
+    "opencode",
+    "idle",
+    "Review accessibility compliance across all forms",
+    { elapsedLabel: "3m 15s" },
+  ),
+  sandboxAgent(
+    "sb-3",
+    "codex",
+    "completed",
+    "Fix the rate limiter edge case in batch processing",
+    { elapsedLabel: "12m 45s", spendMicroUsd: 520_000 },
+  ),
+  sandboxAgent(
+    "sb-4",
+    "grok_build",
+    "failed",
+    "Set up E2E test infrastructure for mobile builds",
+    { elapsedLabel: "2m 10s", spendMicroUsd: 28_000 },
+  ),
+  sandboxAgent(
+    "sb-5",
+    "claude_code",
+    "cancelled",
+    "Investigate memory leak in the WebSocket reconnect loop",
+  ),
+];
+
+const singleRunning: SandboxAgent[] = [
+  sandboxAgent(
+    "sb-1",
+    "claude_code",
+    "running",
+    "Ship the sandbox agents sidebar section",
+    {
+      repositoryUrl: "https://github.com/brightwave-inc/tidebreak",
+      repositoryRef: "feat/sandbox-ui",
+      elapsedLabel: "2m 05s",
+      spendMicroUsd: 55_000,
+    },
+  ),
+];
+
+const profiles: SandboxProfile[] = [
+  { id: "default", name: "Default", enabled: true },
+  { id: "high-resource", name: "High resource", enabled: true },
+  { id: "restricted", name: "Restricted (disabled)", enabled: false },
+];
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function SidebarWrapper({
+  children,
+  width = 260,
+}: {
+  children: React.ReactNode;
+  width?: number;
+}) {
+  return (
+    <TooltipProvider>
+      <div
+        className="flex h-[600px] border-r border-border-subtle bg-page-background"
+        style={{ width }}
+      >
+        <div className="flex w-full flex-col overflow-hidden">
+          <div className="mt-2 flex grow flex-col gap-1 overflow-y-auto px-2">
+            {children}
+          </div>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section stories
+// ---------------------------------------------------------------------------
+
+const meta = {
+  title: "Sidebar/Sandbox agents",
+  parameters: { layout: "centered" },
+} satisfies Meta;
+
+export default meta;
+
+export const Empty: StoryObj = {
+  render: () => (
+    <SidebarWrapper>
+      <SandboxAgentsSection agents={[]} onSpawn={fn()} />
+    </SidebarWrapper>
+  ),
+};
+
+export const SingleRunning: StoryObj = {
+  render: () => (
+    <SidebarWrapper>
+      <SandboxAgentsSection
+        agents={singleRunning}
+        onSpawn={fn()}
+        onOpen={fn()}
+        onStop={fn()}
+      />
+    </SidebarWrapper>
+  ),
+};
+
+export const ThreeLive: StoryObj = {
+  name: "3 live agents",
+  render: () => (
+    <SidebarWrapper>
+      <SandboxAgentsSection
+        agents={liveAgents}
+        onSpawn={fn()}
+        onOpen={fn()}
+        onStop={fn()}
+      />
+    </SidebarWrapper>
+  ),
+};
+
+export const MixedStatuses: StoryObj = {
+  name: "Mixed statuses (5 agents)",
+  render: () => (
+    <SidebarWrapper>
+      <SandboxAgentsSection
+        agents={mixedAgents}
+        onSpawn={fn()}
+        onOpen={fn()}
+        onStop={fn()}
+      />
+    </SidebarWrapper>
+  ),
+};
+
+export const NoSpawnButton: StoryObj = {
+  name: "Read-only (no spawn)",
+  render: () => (
+    <SidebarWrapper>
+      <SandboxAgentsSection agents={mixedAgents.slice(0, 2)} onOpen={fn()} />
+    </SidebarWrapper>
+  ),
+};
+
+export const NarrowRail: StoryObj = {
+  name: "Narrow rail (200px)",
+  render: () => (
+    <SidebarWrapper width={200}>
+      <SandboxAgentsSection
+        agents={liveAgents}
+        onSpawn={fn()}
+        onOpen={fn()}
+        onStop={fn()}
+      />
+    </SidebarWrapper>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// Detail stories
+// ---------------------------------------------------------------------------
+
+export const DetailRunning: StoryObj = {
+  name: "Agent detail — running",
+  render: () => (
+    <div className="w-80 rounded-lg border border-border bg-background">
+      <SandboxAgentDetail agent={liveAgents[0]!} />
+    </div>
+  ),
+};
+
+export const DetailCompleted: StoryObj = {
+  name: "Agent detail — completed",
+  render: () => (
+    <div className="w-80 rounded-lg border border-border bg-background">
+      <SandboxAgentDetail agent={mixedAgents[2]!} />
+    </div>
+  ),
+};
+
+export const DetailFailed: StoryObj = {
+  name: "Agent detail — failed",
+  render: () => (
+    <div className="w-80 rounded-lg border border-border bg-background">
+      <SandboxAgentDetail agent={mixedAgents[3]!} />
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// Spawn dialog stories
+// ---------------------------------------------------------------------------
+
+export const SpawnDialog: StoryObj = {
+  name: "Spawn dialog",
+  render: () => (
+    <SpawnSandboxDialog
+      open
+      profiles={profiles}
+      onSubmit={fn()}
+      onClose={fn()}
+    />
+  ),
+};
+
+export const SpawnDialogNoProfiles: StoryObj = {
+  name: "Spawn dialog — no profiles",
+  render: () => (
+    <SpawnSandboxDialog open profiles={[]} onSubmit={fn()} onClose={fn()} />
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// All harnesses
+// ---------------------------------------------------------------------------
+
+export const AllHarnesses: StoryObj = {
+  name: "Every harness type",
+  render: () => {
+    const agents: SandboxAgent[] = [
+      sandboxAgent(
+        "h-1",
+        "claude_code",
+        "running",
+        "Claude Code agent working on auth",
+      ),
+      sandboxAgent("h-2", "codex", "running", "Codex agent building API tests"),
+      sandboxAgent(
+        "h-3",
+        "opencode",
+        "running",
+        "opencode agent reviewing forms",
+      ),
+      sandboxAgent(
+        "h-4",
+        "grok_build",
+        "running",
+        "Grok agent migrating schemas",
+      ),
+      sandboxAgent(
+        "h-5",
+        "custom",
+        "running",
+        "Custom harness processing data",
+      ),
+    ];
+    return (
+      <SidebarWrapper>
+        <SandboxAgentsSection
+          agents={agents}
+          onSpawn={fn()}
+          onOpen={fn()}
+          onStop={fn()}
+        />
+      </SidebarWrapper>
+    );
+  },
+};


### PR DESCRIPTION
## Summary

- Adds a collapsible **Agents** section for the sidebar that shows live Model Gateway sandbox agents with branded harness icons (Claude Code, Codex, opencode, Grok), teal status dots, elapsed time, and status badges for settled states.
- Adds a **spawn dialog** for launching detached sandbox agents with profile, harness, task, repository, model, and reasoning effort configuration.
- Adds a **detail card** component for expanded agent state (task, metadata, repo/branch, spend).
- Adds 12 Storybook stories covering empty, single-agent, multi-agent, mixed-status, all-harness, narrow-rail, detail card, and spawn dialog states.

Components are not wired to live data yet — this is the presentational layer and Storybook mock-up.

## Test plan

- [ ] `pnpm --dir crates/tidebreak-desktop/ui tsc --noEmit` passes
- [ ] `pnpm --dir crates/tidebreak-desktop/ui biome check` passes
- [ ] Storybook stories render correctly at `Sidebar/Sandbox agents`