### PR TITLE
fix(server): wait out Windows SQLite sharing violations on reset

### DIFF
--- a/crates/tidebreak-desktop/src/voice_transcription.rs
+++ b/crates/tidebreak-desktop/src/voice_transcription.rs
@@ -575,9 +575,12 @@ printf 'TIDEBREAK_WHISPER_BYTES=8\n helper transcript '
         let model = dir.path().join("model.bin");
         std::fs::write(&model, b"model").expect("model");
         let helper = dir.path().join("truncating-whisper-helper");
+        // Drain stdin first. A helper that exits without reading races the
+        // parent's write_all and reports "Could not send audio" instead of
+        // the incomplete-receipt error this test is for.
         std::fs::write(
             &helper,
-            "#!/bin/sh\nprintf 'TIDEBREAK_WHISPER_BYTES=0\\npartial transcript'\n",
+            "#!/bin/sh\ncat >/dev/null\nprintf 'TIDEBREAK_WHISPER_BYTES=0\\npartial transcript'\n",
         )
         .expect("helper");
         std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755))

--- a/crates/tidebreak-server/src/code/worktree_orphans.rs
+++ b/crates/tidebreak-server/src/code/worktree_orphans.rs
@@ -26,7 +26,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
-use sea_orm::{ConnectionTrait, Database, DatabaseBackend, Statement};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseBackend, Statement};
 use serde::{Deserialize, Serialize};
 
 /// Sidecar naming the trees a reset left on disk.
@@ -104,9 +104,12 @@ async fn scan(database: &Path) -> Result<Vec<OrphanedWorktree>, String> {
         return Ok(Vec::new());
     }
     // Read-only, so a scan can never create or migrate the file it is about to
-    // delete.
-    let url = format!("sqlite://{}?mode=ro", database.display());
-    let connection = Database::connect(&url)
+    // delete. One connection, and `immutable=1` so SQLite does not map WAL or
+    // SHM. Windows refuses the caller's delete while those mappings live.
+    let url = format!("sqlite://{}?mode=ro&immutable=1", database.display());
+    let mut options = ConnectOptions::new(url);
+    options.max_connections(1).min_connections(0);
+    let connection = Database::connect(options)
         .await
         .map_err(|error| error.to_string())?;
 
@@ -121,7 +124,14 @@ async fn scan(database: &Path) -> Result<Vec<OrphanedWorktree>, String> {
     };
     // Close before returning either way: Windows refuses to delete a file this
     // process still has open, and the caller deletes this one next.
-    let _ = connection.close().await;
+    if let Err(error) = connection.close().await {
+        tracing::warn!(
+            database = %database.display(),
+            %error,
+            "could not close the doomed database after scanning worktrees; Windows may refuse \
+             the reset delete until the handle is gone"
+        );
+    }
 
     let recorded_at = Utc::now();
     let mut found = Vec::new();

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -242,11 +242,11 @@ fn remove_sqlite_files(database: &Path) -> Result<()> {
 }
 
 /// Delete one reset target. Windows can still hold the SQLite files for a
-/// beat after `close()` returns (WAL mapping), so a sharing violation retries
-/// instead of failing the epoch reset.
+/// beat after `close()` returns (WAL mapping), so a sharing or lock violation
+/// retries instead of failing the epoch reset.
 fn remove_reset_file(path: &Path, kind: &str) -> Result<()> {
     let delays_ms: &[u64] = if cfg!(windows) {
-        &[0, 10, 50, 100, 250]
+        &[0, 10, 50, 100, 250, 500, 1000]
     } else {
         &[0]
     };
@@ -277,7 +277,8 @@ fn remove_reset_file(path: &Path, kind: &str) -> Result<()> {
 }
 
 fn is_windows_sharing_violation(error: &std::io::Error) -> bool {
-    error.raw_os_error() == Some(32)
+    // ERROR_SHARING_VIOLATION, ERROR_LOCK_VIOLATION
+    matches!(error.raw_os_error(), Some(32 | 33))
 }
 
 /// Durable host-broker files that outlive SQLite unless explicitly cleared.
@@ -294,16 +295,7 @@ fn remove_host_broker_durable_state(data_dir: &Path) -> Result<()> {
         "host-broker-audit.previous.jsonl",
     ] {
         let path = data_dir.join(name);
-        match std::fs::remove_file(&path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(AgentError::config(format!(
-                    "failed to reset host-broker durable file {}: {error}",
-                    path.display()
-                )))
-            }
-        }
+        remove_reset_file(&path, "host-broker durable file")?;
     }
     Ok(())
 }
@@ -991,5 +983,56 @@ mod tests {
             Some(expected)
         );
         assert_eq!(std::fs::read(vector).unwrap(), b"current vector state");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_sharing_and_lock_violations_are_retried() {
+        assert!(is_windows_sharing_violation(
+            &std::io::Error::from_raw_os_error(32)
+        ));
+        assert!(is_windows_sharing_violation(
+            &std::io::Error::from_raw_os_error(33)
+        ));
+        assert!(!is_windows_sharing_violation(
+            &std::io::Error::from_raw_os_error(2)
+        ));
+        assert!(!is_windows_sharing_violation(
+            &std::io::Error::from_raw_os_error(5)
+        ));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_unlink_does_not_treat_busy_as_a_sharing_violation() {
+        assert!(!is_windows_sharing_violation(
+            &std::io::Error::from_raw_os_error(16)
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn remove_sqlite_files_retries_after_the_holding_handle_is_dropped() {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+
+        let dir = tempfile::tempdir().unwrap();
+        let database = dir.path().join(DATABASE_FILE);
+        std::fs::write(&database, b"held").unwrap();
+        // SQLite maps WAL without FILE_SHARE_DELETE. Match that so the first
+        // remove_file fails with os error 32 until this handle is dropped.
+        let hold = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ)
+            .open(&database)
+            .unwrap();
+        let database_for_delete = database.clone();
+        let worker = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(40));
+            drop(hold);
+        });
+        remove_sqlite_files(&database_for_delete).unwrap();
+        worker.join().unwrap();
+        assert!(!database.exists());
     }
 }


### PR DESCRIPTION
The Windows cargo-check lane on main was failing in `desktop_schema::tests::legacy_database_and_vectors_are_reset_with_explicit_preservation_policy`. That is not a compile flake. The pre-v1 profile reset reopens the doomed SQLite file to record orphaned worktrees, then deletes it. On Windows, SQLite's WAL mapping still holds the file after `close()`, so `remove_file` returns os error 32.

#2743 already retries that delete for 410ms. This change goes further:
- Opens the orphan scan with one `immutable=1` connection so SQLite does not map WAL or SHM.
- Extends the retry window and treats lock violations the same as sharing violations.
- Uses the same retry for host-broker files the reset also deletes.
- Covers the retry with a Windows-only handle test that drops the lock after the first failed unlink.

`cargo test -p tidebreak-server --lib desktop_schema --locked` passed locally. The new sharing-violation test runs on the Windows lane.