### PR TITLE
fix(code): show opencode's fixed permission mode as locked

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
@@ -59,6 +59,7 @@ const READY_DOCTOR: HarnessDoctorReport = {
       remediation: "",
       stderr: "",
       unrecognized_event_count: 0,
+      relaunch_composes_permission_mode: true,
     } as HarnessDoctorEntry,
   ],
 };

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -212,6 +212,7 @@ const START_HARNESS: HarnessDoctorEntry = {
   remediation: "",
   stderr: "",
   unrecognized_event_count: 0,
+  relaunch_composes_permission_mode: true,
 };
 
 function enableStartHarness(client: ReturnType<typeof makeClient>) {
@@ -1114,6 +1115,66 @@ describe("CodeWorkspacePage", () => {
     );
     expect(screen.getByRole("switch", { name: "Fast mode on" })).toBeEnabled();
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("locks the permission picker once an opencode session has started", async () => {
+    const client = makeClient();
+    const started: CodeSessionSnapshot = {
+      ...SESSION,
+      harness_kind: "opencode",
+      harness_resume_ref: "ses_started",
+    };
+    client.listCodeWorkspaceSessions.mockResolvedValue([started]);
+    const opencodeDoctor = {
+      ...START_HARNESS,
+      kind: "opencode" as const,
+      relaunch_composes_permission_mode: false,
+    };
+    useCodeCatalogStore.setState({
+      doctor: { harnesses: [opencodeDoctor] },
+    });
+    client.getHarnessDoctor.mockResolvedValue({
+      harnesses: [opencodeDoctor],
+    });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    const trigger = await screen.findByRole("button", {
+      name: "Permissions: Ask",
+    });
+    expect(trigger).toBeDisabled();
+    await user.hover(trigger.parentElement!);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Set when the session started — start a new session to change it",
+    );
+    expect(client.setCodeSessionPermissionMode).not.toHaveBeenCalled();
+  });
+
+  it("keeps the permission picker live for a started Claude session", async () => {
+    const client = makeClient();
+    const started: CodeSessionSnapshot = {
+      ...SESSION,
+      harness_resume_ref: "ses_started",
+    };
+    client.listCodeWorkspaceSessions.mockResolvedValue([started]);
+    useCodeCatalogStore.setState({
+      doctor: { harnesses: [START_HARNESS] },
+    });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    const trigger = await screen.findByRole("button", {
+      name: "Permissions: Ask",
+    });
+    expect(trigger).toBeEnabled();
+    await user.click(trigger);
+    await user.click(screen.getByRole("menuitem", { name: /Auto/ }));
+    await waitFor(() =>
+      expect(client.setCodeSessionPermissionMode).toHaveBeenCalledWith(
+        SESSION.id,
+        "auto",
+      ),
+    );
   });
 
   it("rolls back only the failed session setting and clears the shared pending state", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -2416,7 +2416,12 @@ function CodeSessionPane({
                 : undefined
             }
             onModelChange={setModel}
-            onModeChange={changePermissionMode}
+            onModeChange={
+              doctorEntry?.relaunch_composes_permission_mode === false &&
+              session.harness_resume_ref
+                ? undefined
+                : changePermissionMode
+            }
             onEffortChange={
               doctorEntry?.caps.reasoning_levels === "unsupported"
                 ? undefined

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
@@ -104,6 +104,7 @@ describe("DoctorList", () => {
           remediation: "",
           stderr: "",
           unrecognized_event_count: 6,
+          relaunch_composes_permission_mode: true,
         },
       ],
     };
@@ -233,4 +234,5 @@ const notDownloaded: HarnessDoctorEntry = {
   remediation: "",
   stderr: "",
   unrecognized_event_count: 0,
+  relaunch_composes_permission_mode: false,
 };

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -41,6 +41,7 @@ function entry(
     remediation: "",
     stderr: "",
     unrecognized_event_count: 0,
+    relaunch_composes_permission_mode: true,
     ...overrides,
   };
 }

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -76,6 +76,7 @@ function harness(kind: HarnessKind): HarnessDoctorEntry {
     remediation: "",
     stderr: "",
     unrecognized_event_count: 0,
+    relaunch_composes_permission_mode: kind !== "opencode",
   } as HarnessDoctorEntry;
 }
 
@@ -314,6 +315,34 @@ describe("NewWorkspaceDialog", () => {
       reasoningEffortByHarness: {},
       fastModeByHarness: {},
     });
+  });
+
+  it("says the mode is fixed once an opencode session starts", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("opencode")],
+      } as never,
+    });
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          listCodeHarnessModels: vi.fn(async () => ({
+            kind: "opencode" as const,
+            models: [],
+            reasoning_efforts: [],
+          })),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(
+      screen.getByText("Mode is fixed once the session starts"),
+    ).toBeInTheDocument();
   });
 
   // A report that has not landed knows nothing about any engine, so the

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -62,6 +62,7 @@ import {
   harnessUnusableReason,
   preferredCodeModels,
   requiresHarnessModelIds,
+  CREATE_PERMISSION_MODE_FIXED,
   HARNESS_LABELS,
   type CodeModelOption,
 } from "./labels";
@@ -926,18 +927,26 @@ export function NewWorkspaceDialog({
                 }));
               }}
             />
-            <WithTooltip label={`Permissions · ${alt("P")}`}>
-              <span className="inline-flex min-w-0">
-                <PermissionModeMenu
-                  scopeKey="code-create"
-                  value={postedMode}
-                  disabled={availableModes.length === 0}
-                  availableModes={availableModes}
-                  onChange={(mode) => setPermissionMode(mode)}
-                  {...pickerProps("mode")}
-                />
-              </span>
-            </WithTooltip>
+            <div className="flex min-w-0 flex-col">
+              <WithTooltip label={`Permissions · ${alt("P")}`}>
+                <span className="inline-flex min-w-0">
+                  <PermissionModeMenu
+                    scopeKey="code-create"
+                    value={postedMode}
+                    disabled={availableModes.length === 0}
+                    availableModes={availableModes}
+                    onChange={(mode) => setPermissionMode(mode)}
+                    {...pickerProps("mode")}
+                  />
+                </span>
+              </WithTooltip>
+              {selectedHarness?.relaunch_composes_permission_mode === false && (
+                <p className="text-muted-foreground px-2 text-xs">
+                  {CREATE_PERMISSION_MODE_FIXED}
+                </p>
+              )}
+            </div>
+
             <div className="min-w-4 flex-1" />
             <WithTooltip label="Stay here after create to fire off another">
               <label

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -95,6 +95,7 @@ function entry(
     remediation: "",
     stderr: "",
     unrecognized_event_count: 0,
+    relaunch_composes_permission_mode: kind !== "opencode",
   };
 }
 
@@ -171,6 +172,31 @@ describe("StartSessionPrompt", () => {
       null,
       false,
     );
+    expect(
+      screen.queryByText("Mode is fixed once the session starts"),
+    ).toBeNull();
+  });
+
+  it("says opencode's mode is fixed once the session starts", async () => {
+    await renderWithRouter(
+      wrap(
+        <StartSessionPrompt
+          workspaceId="workspace-1"
+          harnesses={[entry("opencode", {})]}
+          starting={false}
+          selectedMode={null}
+          onSelectMode={vi.fn()}
+          onStart={vi.fn()}
+        />,
+      ),
+    );
+
+    expect(
+      screen.getByText("Mode is fixed once the session starts"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Permissions: Allow all" }),
+    ).toBeEnabled();
   });
 
   it("falls back to Plan when structured approvals are not supported", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -19,6 +19,7 @@ import {
   useWarmHarnessInstall,
 } from "./useHarnessInstall";
 import {
+  CREATE_PERMISSION_MODE_FIXED,
   createPermissionModes,
   defaultCreatePermissionMode,
   effortLadder,
@@ -249,7 +250,16 @@ export function StartSessionPrompt({
               }}
             />
           }
-          footerNote={<HarnessInstallNote install={install} />}
+          footerNote={
+            <>
+              {selected?.relaunch_composes_permission_mode === false && (
+                <p className="text-muted-foreground text-xs">
+                  {CREATE_PERMISSION_MODE_FIXED}
+                </p>
+              )}
+              <HarnessInstallNote install={install} />
+            </>
+          }
           promptScope={workspaceId}
           workspaceFiles={workspaceFiles}
           onModelChange={(next) => {

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -95,11 +95,15 @@ export const PERMISSION_MODE_UNAVAILABLE_REASON =
 
 /**
  * Shown where the mode is fixed for the life of the surface — a create form
- * that has already posted, a read-only view of someone else's session. A live
- * session's picker is not locked: `POST /code/sessions/{id}/mode` moves it.
+ * that has already posted, a read-only view of someone else's session, or a
+ * live engine that fixes its posture when the session starts (opencode).
  */
 export const SESSION_PERMISSION_MODE_LOCKED =
   "Set when the session started — start a new session to change it";
+
+/** Create-time hint when the selected engine cannot change mode after start. */
+export const CREATE_PERMISSION_MODE_FIXED =
+  "Mode is fixed once the session starts";
 
 /** The capability flags the mode policy reads. */
 export type ModeCaps = Pick<

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -3066,6 +3066,7 @@ export function parseHarnessDoctorEntry(
       "remediation",
       "stderr",
       "unrecognized_event_count",
+      "relaunch_composes_permission_mode",
     ]) ||
     !isMember(value.kind, HARNESS_KINDS) ||
     typeof value.found !== "boolean" ||
@@ -3078,7 +3079,9 @@ export function parseHarnessDoctorEntry(
       !isMember(value.auth_mode, HARNESS_AUTH_MODES)) ||
     typeof value.remediation !== "string" ||
     typeof value.stderr !== "string" ||
-    !isFiniteNumber(value.unrecognized_event_count)
+    !isFiniteNumber(value.unrecognized_event_count) ||
+    (value.relaunch_composes_permission_mode !== undefined &&
+      typeof value.relaunch_composes_permission_mode !== "boolean")
   ) {
     return null;
   }
@@ -3095,6 +3098,10 @@ export function parseHarnessDoctorEntry(
     // Ditto the hosted doctor: a server that predates it knows only the
     // local sign-in probe, and that is the local answer.
     auth_mode: value.auth_mode ?? "local_sign_in",
+    // Engines historically recomposed the mode on relaunch; a server that
+    // predates the field still behaves that way.
+    relaunch_composes_permission_mode:
+      value.relaunch_composes_permission_mode !== false,
     tier: value.tier,
     caps,
     remediation: value.remediation,

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2590,7 +2590,13 @@ installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: 
  * observation, which on a hosted machine is not what a session
  * authenticates with.
  */
-auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, };
+auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, 
+/**
+ * Whether relaunching a session applies a permission mode chosen after
+ * it started. False for engines that fix the mode on session create
+ * (opencode); true where a relaunch rebuilds the launch plan.
+ */
+relaunch_composes_permission_mode: boolean, };
 
 /**
  * Doctor report for every registered engine adapter.

--- a/crates/tidebreak-desktop/ui/src/stories/PermissionModePicker.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/PermissionModePicker.stories.tsx
@@ -47,9 +47,13 @@ export const LockedAfterStart: Story = {
 
 /** Create-time hint next to a still-live picker. */
 export const FixedAtCreate: Story = {
-  render: () => (
+  args: {
+    value: "allow",
+    onChange: () => {},
+  },
+  render: (args) => (
     <div className="flex min-w-0 flex-col">
-      <PermissionModePicker value="allow" onChange={() => {}} />
+      <PermissionModePicker {...args} />
       <p className="text-muted-foreground px-2 text-xs">
         {CREATE_PERMISSION_MODE_FIXED}
       </p>

--- a/crates/tidebreak-desktop/ui/src/stories/PermissionModePicker.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/PermissionModePicker.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PermissionModePicker } from "@/code/CodeComposer";
+import { CREATE_PERMISSION_MODE_FIXED } from "@/code/labels";
+
+/**
+ * Permission mode in the composer footer.
+ *
+ * Most engines take a new mode on the next turn. opencode fixes its posture
+ * when the session is created, so after the first turn the trigger stays
+ * visible, disabled, with the locked-mode tooltip. Create surfaces keep the
+ * picker live and add a short hint so Plan vs Allow is an informed choice.
+ */
+const meta = {
+  title: "Composer/Permission mode",
+  component: PermissionModePicker,
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-3 p-10">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PermissionModePicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A live session whose engine can still change mode. */
+export const Live: Story = {
+  args: {
+    value: "ask",
+    onChange: () => {},
+  },
+};
+
+/**
+ * After opencode has started: the current mode is shown, the trigger is
+ * disabled, and the tooltip explains that a new session is the way to
+ * pick a different one.
+ */
+export const LockedAfterStart: Story = {
+  args: {
+    value: "allow",
+  },
+};
+
+/** Create-time hint next to a still-live picker. */
+export const FixedAtCreate: Story = {
+  render: () => (
+    <div className="flex min-w-0 flex-col">
+      <PermissionModePicker value="allow" onChange={() => {}} />
+      <p className="text-muted-foreground px-2 text-xs">
+        {CREATE_PERMISSION_MODE_FIXED}
+      </p>
+    </div>
+  ),
+};

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -489,6 +489,7 @@ function doctorEntry(
     remediation: "",
     stderr: "",
     unrecognized_event_count: 0,
+    relaunch_composes_permission_mode: true,
     ...overrides,
   };
 }
@@ -518,6 +519,7 @@ export const harnessDoctor: HarnessDoctorReport = {
       version: "1.18.18",
       tier: "tertiary",
       authenticated: true,
+      relaunch_composes_permission_mode: false,
       caps: { ...fullCaps, allow_mode: "unknown", reasoning_levels: "unknown" },
     }),
     doctorEntry({

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -813,6 +813,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn claude_codex_and_grok_recompose_permission_mode_on_relaunch() {
+        assert!(claude::ClaudeCodeAdapter::new().relaunch_composes_permission_mode());
+        assert!(codex::CodexAdapter::new().relaunch_composes_permission_mode());
+        assert!(grok::GrokAdapter::new().relaunch_composes_permission_mode());
+        assert!(!opencode::OpencodeAdapter::new().relaunch_composes_permission_mode());
+    }
+
+    #[test]
     fn harness_crate_does_not_depend_on_a_pty() {
         // Structural: the harness crate's own manifest must not name a
         // pseudo-terminal package. Auxiliary terminals live in the server.

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -163,6 +163,8 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
                 remediation,
                 stderr: probe.stderr,
                 unrecognized_event_count,
+                relaunch_composes_permission_mode: adapter
+                    .relaunch_composes_permission_mode(),
             }
         })
     }))

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -410,6 +410,10 @@ pub struct HarnessDoctorEntry {
     pub remediation: String,
     pub stderr: String,
     pub unrecognized_event_count: i64,
+    /// Whether relaunching a session applies a permission mode chosen after
+    /// it started. False for engines that fix the mode on session create
+    /// (opencode); true where a relaunch rebuilds the launch plan.
+    pub relaunch_composes_permission_mode: bool,
 }
 
 /// One model a harness CLI listed.

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -7764,6 +7764,74 @@ async fn the_doctor_caches_probes_and_refresh_re_probes() {
     );
 }
 
+/// opencode fixes permission mode at session create; Claude and Codex
+/// recompose it on relaunch. The doctor carries that so the picker can lock.
+#[tokio::test]
+async fn the_doctor_reports_whether_relaunch_composes_permission_mode() {
+    let (dir, store) = temp_db_store("code.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(
+        ScriptedAdapter::new(plain_text_script()).with_kind(HarnessKind::ClaudeCode),
+    ));
+    registry.register(Arc::new(
+        ScriptedAdapter::new(plain_text_script()).with_kind(HarnessKind::Codex),
+    ));
+    registry.register(Arc::new(
+        ScriptedAdapter::new(plain_text_script())
+            .with_kind(HarnessKind::Opencode)
+            .with_posture_fixed_at_session_start(),
+    ));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db,
+        dir.path().to_path_buf(),
+        registry,
+    ));
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime);
+    let token = state.token.clone();
+    let addr = serve(app(state)).await;
+    let client = reqwest::Client::new();
+
+    let report = client
+        .get(format!("http://{addr}/code/harnesses"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    let by_kind: std::collections::BTreeMap<String, bool> = report["harnesses"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| {
+            (
+                row["kind"].as_str().unwrap().to_owned(),
+                row["relaunch_composes_permission_mode"]
+                    .as_bool()
+                    .expect("doctor must send relaunch_composes_permission_mode"),
+            )
+        })
+        .collect();
+    assert_eq!(by_kind.get("claude_code"), Some(&true));
+    assert_eq!(by_kind.get("codex"), Some(&true));
+    assert_eq!(by_kind.get("opencode"), Some(&false));
+}
+
 /// Decision 71's doctor half: on a gateway-hosted machine the relay-covered
 /// engines are ready without a local sign-in — nobody can open a terminal
 /// there — and the uncovered ones say they are not available hosted yet,

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2831,6 +2831,8 @@ allow_local_mcp_servers: boolean, };
  */
 export type ManagedPolicySource = "os" | "provisioned" | "unmanaged";
 
+export type MarkNotificationsReadResult = { marked: number, };
+
 /**
  * The curated-registry entry a configured server matched, projected to the
  * renderer beside the server's health.
@@ -3135,6 +3137,24 @@ export type ModelVisibility = "show" | "hide";
  * sandbox. Open access still excludes local, private, and link-local targets.
  */
 export type NetworkPolicy = { "mode": "off" } | { "mode": "package_managers" } | { "mode": "allowed_hosts", allowed_hosts: Array<string>, package_managers: boolean, } | { "mode": "open" };
+
+/**
+ * Where opening the row takes the reader.
+ */
+export type NotificationContextSnapshot = { "surface": "chat", chat_id: ChatId, } | { "surface": "code", session_id: CodeSessionId, workspace_id: WorkspaceId, };
+
+/**
+ * Identifies one durable agent-finished notification.
+ */
+export type NotificationId = string;
+
+export type NotificationKindSnapshot = "agent_completed" | "agent_failed";
+
+export type NotificationPage = { notifications: Array<NotificationSnapshot>, next_cursor?: string, };
+
+export type NotificationSnapshot = { id: NotificationId, kind: NotificationKindSnapshot, title: string, context: NotificationContextSnapshot, created_at: string, read_at?: string, };
+
+export type NotificationUnreadCount = { unread: number, };
 
 /**
  * Identifies one conversation-owned output across all of its revisions.

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2590,7 +2590,13 @@ installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: 
  * observation, which on a hosted machine is not what a session
  * authenticates with.
  */
-auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, };
+auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, 
+/**
+ * Whether relaunching a session applies a permission mode chosen after
+ * it started. False for engines that fix the mode on session create
+ * (opencode); true where a relaunch rebuilds the launch plan.
+ */
+relaunch_composes_permission_mode: boolean, };
 
 /**
  * Doctor report for every registered engine adapter.


### PR DESCRIPTION
## Why

You click the permission mode picker on a started opencode session and the request 409s. Opencode fixes its mode when the HTTP session is created; resume does not re-apply it. The server already refuses that change (`permission_mode_fixed`). The workspace picker still looked live because the UI always wired `onModeChange`.

## What you get

- The harness doctor now sends `relaunch_composes_permission_mode`. Opencode is false. Claude, Codex, and Grok are true (they recompose the launch plan per turn / on relaunch).
- After an opencode session has a resume ref, the in-workspace picker shows the current mode, stays disabled, and uses the existing locked-mode tooltip. Before the first turn the picker stays live.
- Create surfaces (`NewWorkspaceDialog`, `StartSessionPrompt`) add a short hint when the selected engine fixes its mode at start: "Mode is fixed once the session starts".

## Tests

- `cargo check -p tidebreak-server -p tidebreak-harness` (local git pin for Symphonia is 403 here; check ran against crates.io 0.6.0)
- `cargo test -p tidebreak-harness --lib claude_codex_and_grok_recompose_permission_mode_on_relaunch`
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --lib wire_types` — generated `wire.ts` only added this field (desktop + mobile copies)
- `the_doctor_reports_whether_relaunch_composes_permission_mode` compiled; the HTTP probe hung on loopback in this environment (connect timeout). CI should run it.
- `pnpm`/`biome`/`vitest` on focused UI files: CodeWorkspacePage (lock vs Claude live), StartSessionPrompt, NewWorkspaceDialog, CodeComposer locked tooltip, `stylesContract.test.ts` green
- `cargo fmt` via `rustfmt --edition 2024` on the touched server/harness files

Do not merge.