### PR TITLE
fix(code): refuse unauthenticated sessions at create

### DIFF
--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -71,22 +71,65 @@ pub(crate) fn model_serves_fast_mode(id: &str) -> bool {
         .any(|model| id == *model || id.ends_with(&format!("-{model}")))
 }
 
-fn claude_settings_models(
-    env: &[(std::ffi::OsString, std::ffi::OsString)],
-) -> Vec<crate::ListedHarnessModel> {
+/// The same `~/.claude/settings.json` the engine reads, located through the
+/// captured probe environment. `None` when HOME is unset or the file is
+/// absent or unparseable.
+fn read_settings(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> Option<serde_json::Value> {
     let home = env
         .iter()
         .rev()
         .find(|(key, _)| key.eq_ignore_ascii_case("HOME"))
-        .map(|(_, value)| std::path::PathBuf::from(value.as_os_str()));
-    let Some(home) = home.filter(|home| !home.as_os_str().is_empty()) else {
-        return Vec::new();
+        .map(|(_, value)| std::path::PathBuf::from(value.as_os_str()))
+        .filter(|home| !home.as_os_str().is_empty())?;
+    let raw = std::fs::read_to_string(home.join(".claude").join("settings.json")).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Environment variables that authenticate or reroute Claude Code without
+/// the vendor login [`observe_auth`] observes.
+const AUTH_OVERRIDE_VARS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+];
+
+/// Whether this environment could authenticate Claude Code without the
+/// vendor login [`observe_auth`] observes: an API key, auth token, or
+/// endpoint override in the environment or in the `env` block of the same
+/// `settings.json` the model listing reads, a Bedrock/Vertex switch, or an
+/// `apiKeyHelper`. Gateway-managed machines authenticate this way with no
+/// login at all, so a hit means a session may work even though the probe
+/// saw signed-out — never that credentials are known-good.
+pub(crate) fn auth_override_present(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> bool {
+    if crate::probe::env_sets_any(env, AUTH_OVERRIDE_VARS) {
+        return true;
+    }
+    let Some(settings) = read_settings(env) else {
+        return false;
     };
-    let path = home.join(".claude").join("settings.json");
-    let Ok(raw) = std::fs::read_to_string(&path) else {
-        return Vec::new();
-    };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+    if settings
+        .get("apiKeyHelper")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|helper| !helper.trim().is_empty())
+    {
+        return true;
+    }
+    settings
+        .get("env")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|vars| {
+            AUTH_OVERRIDE_VARS
+                .iter()
+                .any(|name| vars.contains_key(*name))
+        })
+}
+
+fn claude_settings_models(
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
+) -> Vec<crate::ListedHarnessModel> {
+    let Some(value) = read_settings(env) else {
         return Vec::new();
     };
     let current = value
@@ -285,6 +328,38 @@ mod tests {
         );
         assert_eq!(auth_status_from_json(br#"{"authMethod":"oauth"}"#), None);
         assert_eq!(auth_status_from_json(b"not json"), None);
+    }
+
+    #[test]
+    fn auth_override_reads_env_and_settings() {
+        let os = std::ffi::OsString::from;
+        assert!(!auth_override_present(&[]));
+        assert!(auth_override_present(&[(
+            os("ANTHROPIC_API_KEY"),
+            os("sk-ant")
+        )]));
+        assert!(auth_override_present(&[(
+            os("ANTHROPIC_BASE_URL"),
+            os("https://gateway.example")
+        )]));
+        // An empty value is an unset variable, not a credential.
+        assert!(!auth_override_present(&[(os("ANTHROPIC_API_KEY"), os(""))]));
+
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir(home.path().join(".claude")).unwrap();
+        let settings = home.path().join(".claude").join("settings.json");
+        let env = vec![(os("HOME"), home.path().as_os_str().to_owned())];
+        assert!(!auth_override_present(&env));
+        std::fs::write(&settings, r#"{"model":"claude-opus-5"}"#).unwrap();
+        assert!(!auth_override_present(&env));
+        std::fs::write(
+            &settings,
+            r#"{"env":{"ANTHROPIC_BASE_URL":"https://gateway.example"}}"#,
+        )
+        .unwrap();
+        assert!(auth_override_present(&env));
+        std::fs::write(&settings, r#"{"apiKeyHelper":"/usr/local/bin/key.sh"}"#).unwrap();
+        assert!(auth_override_present(&env));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -413,6 +413,41 @@ fn login_status_from_output(stdout: &[u8], stderr: &[u8]) -> Option<bool> {
     None
 }
 
+/// Whether this environment could authenticate Codex without the ChatGPT or
+/// API-key login [`observe_login`] observes: an OpenAI key or endpoint
+/// override in the environment, or a `config.toml` that declares a custom
+/// model provider — the shape a gateway-managed machine uses to point
+/// inference at its own endpoint, which `codex login status` reports as
+/// signed out. A hit means a session may work even though the probe saw
+/// signed-out — never that credentials are known-good.
+pub(crate) fn auth_override_present(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> bool {
+    if crate::probe::env_sets_any(env, &["OPENAI_API_KEY", "OPENAI_BASE_URL"]) {
+        return true;
+    }
+    config_declares_model_provider(env)
+}
+
+/// `$CODEX_HOME/config.toml`, defaulting to `~/.codex/config.toml`, mentions
+/// `model_provider`. A comment mentioning it also matches; that over-reads
+/// toward "may authenticate some other way", which is the safe direction.
+fn config_declares_model_provider(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> bool {
+    let config_dir = crate::probe::env_value(env, std::ffi::OsStr::new("CODEX_HOME"))
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            env.iter()
+                .rev()
+                .find(|(key, _)| key.eq_ignore_ascii_case("HOME"))
+                .map(|(_, value)| std::path::PathBuf::from(value.as_os_str()).join(".codex"))
+                .filter(|dir| !dir.as_os_str().is_empty())
+        });
+    let Some(config_dir) = config_dir else {
+        return false;
+    };
+    std::fs::read_to_string(config_dir.join("config.toml"))
+        .is_ok_and(|raw| raw.contains("model_provider"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -833,6 +868,44 @@ mod tests {
             login_status_from_output(b"something else\n", b"also something\n"),
             None
         );
+    }
+
+    #[test]
+    fn auth_override_reads_env_and_config() {
+        let os = std::ffi::OsString::from;
+        assert!(!auth_override_present(&[]));
+        assert!(auth_override_present(&[(os("OPENAI_API_KEY"), os("sk"))]));
+        assert!(auth_override_present(&[(
+            os("OPENAI_BASE_URL"),
+            os("https://gateway.example/v1")
+        )]));
+        // An empty value is an unset variable, not a credential.
+        assert!(!auth_override_present(&[(os("OPENAI_API_KEY"), os(""))]));
+
+        // CODEX_HOME wins over HOME/.codex, and only a config that mentions
+        // a model provider counts.
+        let codex_home = tempfile::tempdir().unwrap();
+        let env = vec![(os("CODEX_HOME"), codex_home.path().as_os_str().to_owned())];
+        assert!(!auth_override_present(&env));
+        std::fs::write(
+            codex_home.path().join("config.toml"),
+            "model_provider = \"gateway\"\n",
+        )
+        .unwrap();
+        assert!(auth_override_present(&env));
+
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir(home.path().join(".codex")).unwrap();
+        let config = home.path().join(".codex").join("config.toml");
+        let env = vec![(os("HOME"), home.path().as_os_str().to_owned())];
+        std::fs::write(&config, "model = \"gpt-5\"\n").unwrap();
+        assert!(!auth_override_present(&env));
+        std::fs::write(
+            &config,
+            "[model_providers.gateway]\nbase_url = \"https://gateway.example/v1\"\n",
+        )
+        .unwrap();
+        assert!(auth_override_present(&env));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -48,6 +48,26 @@ pub use probe::{
     ListedHarnessModel, ProbeCapture, ProbeError,
 };
 
+/// Whether some auth mode besides the vendor login a probe observes could
+/// carry this engine's inference: an API key or endpoint override in the
+/// captured environment, or engine config pointing inference at a gateway.
+///
+/// `true` grants the benefit of the doubt — a session may work even though
+/// the probe saw signed-out — so callers use it to avoid refusing that
+/// session, never as proof of working credentials. Engines whose override
+/// surfaces are unverified answer `true` for the same reason.
+#[must_use]
+pub fn auth_override_present(
+    kind: HarnessKind,
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
+) -> bool {
+    match kind {
+        HarnessKind::ClaudeCode => claude::auth_override_present(env),
+        HarnessKind::Codex => codex::auth_override_present(env),
+        HarnessKind::Opencode | HarnessKind::Grok => true,
+    }
+}
+
 /// Normalized, unpersisted event. Maps 1:1 onto [`tidebreak_core::CodeEvent`]
 /// minus persistence ids (turn id, approval id).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -365,11 +365,21 @@ fn env_key_eq(left: &std::ffi::OsStr, right: &std::ffi::OsStr, case_insensitive:
     }
 }
 
-fn env_value<'a>(env: &'a [(OsString, OsString)], key: &std::ffi::OsStr) -> Option<&'a OsString> {
+pub(crate) fn env_value<'a>(
+    env: &'a [(OsString, OsString)],
+    key: &std::ffi::OsStr,
+) -> Option<&'a OsString> {
     env.iter()
         .rev()
         .find(|(candidate, _)| env_key_eq(candidate, key, cfg!(windows)))
         .map(|(_, value)| value)
+}
+
+/// Whether the captured environment assigns any of `names` a non-empty value.
+pub(crate) fn env_sets_any(env: &[(OsString, OsString)], names: &[&str]) -> bool {
+    names.iter().any(|name| {
+        env_value(env, std::ffi::OsStr::new(name)).is_some_and(|value| !value.is_empty())
+    })
 }
 
 fn apply_captured_env(command: &mut Command, env: &[(std::ffi::OsString, std::ffi::OsString)]) {

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -40,3 +40,13 @@ pub(crate) mod worktree_root;
 
 pub(crate) use runtime::CodeRuntime;
 pub(crate) use scoped::ScopedCode;
+
+/// The display name the product uses for an engine, wherever copy names one.
+pub(crate) fn harness_label(kind: tidebreak_core::HarnessKind) -> &'static str {
+    match kind {
+        tidebreak_core::HarnessKind::ClaudeCode => "Claude Code",
+        tidebreak_core::HarnessKind::Codex => "Codex CLI",
+        tidebreak_core::HarnessKind::Opencode => "opencode",
+        tidebreak_core::HarnessKind::Grok => "Grok CLI",
+    }
+}

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -1015,6 +1015,8 @@ mod tests {
             session.owner.clone(),
             session_id,
             session.spawn_epoch,
+            session.harness_kind,
+            false,
             None,
             session.subagents.clone(),
             None,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -3049,6 +3049,7 @@ impl CodeRuntime {
                 format!("{harness} has no path"),
             ));
         }
+        self.refuse_signed_out_harness(harness, &probe)?;
         let execution_settings = CodeSessionExecutionSettings {
             model: normalize_model(model),
             reasoning_effort,
@@ -4355,6 +4356,48 @@ impl CodeRuntime {
         Ok(())
     }
 
+    /// Refuse to mint a session that will 401 on its first turn (issue 2653).
+    ///
+    /// Fires only on a definitive signed-out observation with no other auth
+    /// mode in sight: the relay carries covered engines as the caller
+    /// (decision 71), and an API key or gateway endpoint override in the
+    /// environment or engine config authenticates without any vendor login
+    /// (issue 2749). An unobserved sign-in state (`None`) stays allowed — a
+    /// false refusal on a working machine is worse than the first-turn
+    /// failure this replaces, which the worker at least maps to the same
+    /// legible message.
+    fn refuse_signed_out_harness(
+        &self,
+        harness: HarnessKind,
+        probe: &HarnessProbe,
+    ) -> Result<(), ServerError> {
+        Self::signed_out_harness_refusal(self.harness_llm.is_some(), harness, probe)
+    }
+
+    fn signed_out_harness_refusal(
+        relay_active: bool,
+        harness: HarnessKind,
+        probe: &HarnessProbe,
+    ) -> Result<(), ServerError> {
+        if probe.authenticated != Some(false) {
+            return Ok(());
+        }
+        if relay_active && super::harness_llm::relay_covered(harness) {
+            return Ok(());
+        }
+        if tidebreak_harness::auth_override_present(harness, &probe.env) {
+            return Ok(());
+        }
+        let label = super::harness_label(harness);
+        Err(ServerError::unprocessable_kind(
+            "harness_not_authenticated",
+            format!(
+                "{label} is not signed in on this machine. \
+                 Sign in to {label} in your own terminal, then start the session again."
+            ),
+        ))
+    }
+
     pub(crate) async fn mark_session_viewed(
         &self,
         owner: &OwnerId,
@@ -5033,6 +5076,8 @@ impl CodeRuntime {
             session.owner.clone(),
             session.id,
             attached.spawn_epoch,
+            session.harness_kind,
+            self.harness_llm.is_some() && super::harness_llm::relay_covered(session.harness_kind),
             None,
             attached.subagents.clone(),
             self.gh_search_path_owned(),
@@ -6019,6 +6064,94 @@ mod probe_freshness_tests {
         let installed = Path::new("/data/tools/harnesses/codex/0.147.0/node_modules/.bin/codex");
         assert!(!probe_describes(None, installed));
         assert!(!probe_describes(Some(&probe_at(None)), installed));
+    }
+}
+
+#[cfg(test)]
+mod signed_out_refusal_tests {
+    use super::*;
+
+    fn probe(
+        authenticated: Option<bool>,
+        env: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+    ) -> HarnessProbe {
+        HarnessProbe {
+            found: true,
+            binary_path: Some(PathBuf::from("/scripted/engine")),
+            version: Some("1.0.0".into()),
+            authenticated,
+            stderr: String::new(),
+            env,
+            commands: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_definitive_signed_out_observation_refuses_with_the_typed_kind() {
+        let err = CodeRuntime::signed_out_harness_refusal(
+            false,
+            HarnessKind::Codex,
+            &probe(Some(false), Vec::new()),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), "harness_not_authenticated");
+        assert!(
+            err.message()
+                .contains("Codex CLI is not signed in on this machine."),
+            "{}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn an_unverified_or_signed_in_observation_allows_create() {
+        for authenticated in [None, Some(true)] {
+            assert!(CodeRuntime::signed_out_harness_refusal(
+                false,
+                HarnessKind::ClaudeCode,
+                &probe(authenticated, Vec::new()),
+            )
+            .is_ok());
+        }
+    }
+
+    #[test]
+    fn the_relay_carries_covered_engines_past_a_signed_out_probe() {
+        // The #2742 guarantee: a hosted machine with the relay creates freely.
+        assert!(CodeRuntime::signed_out_harness_refusal(
+            true,
+            HarnessKind::Codex,
+            &probe(Some(false), Vec::new()),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn a_credential_override_in_the_environment_allows_create() {
+        // A gateway-managed machine authenticates with no vendor login
+        // (issue 2749); its overrides must beat the signed-out observation.
+        let env = vec![(
+            std::ffi::OsString::from("OPENAI_BASE_URL"),
+            std::ffi::OsString::from("https://gateway.example/v1"),
+        )];
+        assert!(CodeRuntime::signed_out_harness_refusal(
+            false,
+            HarnessKind::Codex,
+            &probe(Some(false), env),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn engines_without_a_verified_override_surface_never_refuse() {
+        // opencode honors provider keys and config shapes the probe cannot
+        // cheaply rule out, so a signed-out observation alone must not block.
+        assert!(CodeRuntime::signed_out_harness_refusal(
+            false,
+            HarnessKind::Opencode,
+            &probe(Some(false), Vec::new()),
+        )
+        .is_ok());
     }
 }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -874,6 +874,38 @@ impl CodeRuntime {
         if let Some(probe) = cached {
             return probe;
         }
+        self.probe_uncached(adapter).await
+    }
+
+    /// The probe for session create: a cached signed-out observation that
+    /// would refuse is stale.
+    ///
+    /// Signing in or adding a provider override does not invalidate the
+    /// doctor's cache. Re-using that answer here would refuse a repaired
+    /// machine — the false refusal this path exists to avoid. A signed-in
+    /// or unverified cache, or a signed-out cache the relay or an override
+    /// already carries, still hits.
+    async fn probe_for_session_create(&self, adapter: &dyn HarnessAdapter) -> HarnessProbe {
+        let kind = adapter.kind();
+        let cached = self
+            .probes
+            .lock()
+            .expect("harness probes")
+            .get(&kind)
+            .cloned();
+        if let Some(probe) = cached {
+            let would_refuse =
+                Self::signed_out_harness_refusal(self.harness_llm.is_some(), kind, &probe).is_err();
+            if !would_refuse {
+                return probe;
+            }
+            self.probes.lock().expect("harness probes").remove(&kind);
+        }
+        self.probe(adapter).await
+    }
+
+    async fn probe_uncached(&self, adapter: &dyn HarnessAdapter) -> HarnessProbe {
+        let kind = adapter.kind();
         let mut host = self.host.clone();
         host.managed_node_root = match self.host_tool_broker.as_deref() {
             Some(broker) => {
@@ -3027,7 +3059,7 @@ impl CodeRuntime {
                 }
             }
         }
-        let probe = self.probe(adapter.as_ref()).await;
+        let probe = self.probe_for_session_create(adapter.as_ref()).await;
         if !probe.found {
             return Err(ServerError::unprocessable_kind(
                 "harness_not_found",

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -33,7 +33,7 @@ use tidebreak_core::{
     bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
     CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeSession,
     CodeSessionId, CodeSessionLifecycle, CodeSubagentStatus, CodeSubagentSummary, CodeTurn,
-    CodeTurnId, CodeTurnStatus, CodeUsage, CodeWorkspaceStatus, DbStore, FenceReason,
+    CodeTurnId, CodeTurnStatus, CodeUsage, CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind,
     HarnessNoticeLevel, OwnerId, PermissionMode, ToolOutcome,
 };
 use tidebreak_harness::{
@@ -229,6 +229,12 @@ pub(crate) struct LiveSink {
     owner: OwnerId,
     session_id: CodeSessionId,
     spawn_epoch: i64,
+    /// Which engine this session runs, for copy that names it.
+    harness: HarnessKind,
+    /// Whether this session's inference rides the on-behalf-of relay
+    /// (decision 71). The relay's refusals are already legible and name the
+    /// gateway, so [`LiveSink::legible_turn_error`] leaves them untouched.
+    relay_wired: bool,
     turn_id: std::sync::Mutex<Option<CodeTurnId>>,
     /// Resume ref reported during engine startup but not yet proven durable.
     ///
@@ -266,6 +272,27 @@ impl LiveSink {
     fn take_unrecognized_delta(&self, total: u64) -> u64 {
         let flushed = self.flushed_unrecognized.swap(total, Ordering::SeqCst);
         total.saturating_sub(flushed)
+    }
+
+    /// The engine's report of a failed turn, made legible when it is a
+    /// provider authentication failure (issue 2653): the vendor's raw 401
+    /// body cannot tell the reader "sign this harness in" from "the
+    /// provider is down", so the sentence the create-time refusal uses
+    /// leads and the engine's own words follow. A turn riding the relay
+    /// keeps its message untouched — the relay's refusals already name the
+    /// gateway, and "sign in in your own terminal" is wrong on a hosted
+    /// machine.
+    fn legible_turn_error(&self, message: String) -> BoundedError {
+        if self.relay_wired || !provider_auth_failure(&message) {
+            return BoundedError { message };
+        }
+        let label = crate::code::harness_label(self.harness);
+        BoundedError {
+            message: format!(
+                "{label} is not signed in on this machine. Sign in to {label} in your own \
+                 terminal, then try again. The engine reported: {message}"
+            ),
+        }
     }
 
     /// Persist a reported resume ref after the engine proves a turn started.
@@ -577,6 +604,15 @@ impl HarnessEventSink for LiveSink {
         }
         let Some(code_event) = map_event(event, turn_id) else {
             return;
+        };
+        // An engine that fails a turn can pass the provider's raw 401 body
+        // straight through. Swap it for the legible sentence before the
+        // journal keeps it.
+        let code_event = match code_event {
+            CodeEvent::TurnFailed { error } => CodeEvent::TurnFailed {
+                error: self.legible_turn_error(error.message),
+            },
+            other => other,
         };
         // Assistant deltas stream and are gone. The `assistant_message` that
         // closes the run repeats them exactly, so a row here would store the
@@ -1706,7 +1742,7 @@ async fn drive_turn_inner(
                     (
                         CodeTurnStatus::Failed,
                         CodeEvent::TurnFailed {
-                            error: BoundedError { message: detail },
+                            error: sink.legible_turn_error(detail),
                         },
                     )
                 } else {
@@ -1739,9 +1775,7 @@ async fn drive_turn_inner(
                 turn.ended_at = Some(Utc::now());
                 let _ = save_turn(db, &session.owner, &turn).await;
                 let event = CodeEvent::TurnFailed {
-                    error: BoundedError {
-                        message: err.to_string(),
-                    },
+                    error: sink.legible_turn_error(err.to_string()),
                 };
                 sink.note_subagent_boundary(&event).await;
                 let _ = persist_and_publish(
@@ -2148,6 +2182,28 @@ pub(crate) async fn attach_engine(
     Ok(session)
 }
 
+/// Whether an engine's failure message reads as the provider refusing its
+/// credentials, as opposed to any other turn failure. Matches the raw 401
+/// bodies and sign-in errors the shipped engines actually print; anything
+/// unrecognized passes through untouched.
+fn provider_auth_failure(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    [
+        // OpenAI's raw 401 body, what a signed-out Codex prints.
+        "missing bearer or basic authentication",
+        // The error type the vendors' 401 bodies carry.
+        "authentication_error",
+        // What a signed-out Claude Code prints in its result line.
+        "invalid api key",
+        "please run /login",
+        // Anthropic's refusal of a rejected bearer.
+        "invalid bearer token",
+        "401 unauthorized",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn sink_for(
     db: Arc<DbStore>,
@@ -2155,6 +2211,8 @@ pub(crate) fn sink_for(
     owner: OwnerId,
     session_id: CodeSessionId,
     spawn_epoch: i64,
+    harness: HarnessKind,
+    relay_wired: bool,
     turn_id: Option<CodeTurnId>,
     subagents: Vec<CodeSubagentSummary>,
     gh_search_path: Option<String>,
@@ -2166,6 +2224,8 @@ pub(crate) fn sink_for(
         owner,
         session_id,
         spawn_epoch,
+        harness,
+        relay_wired,
         turn_id: std::sync::Mutex::new(turn_id),
         pending_resume_ref: std::sync::Mutex::new(None),
         gh_search_path,
@@ -2818,6 +2878,8 @@ mod tests {
             OwnerId::local(),
             session_id,
             1,
+            HarnessKind::ClaudeCode,
+            false,
             None,
             Vec::new(),
             None,
@@ -3092,6 +3154,8 @@ mod tests {
             owner.clone(),
             session_id,
             attached.spawn_epoch,
+            HarnessKind::Codex,
+            false,
             None,
             attached.subagents,
             None,
@@ -3500,5 +3564,66 @@ mod tests {
             message,
             "compare these\n\nimages attached to this message:\n- `first.png`\n- `second.png`"
         );
+    }
+
+    #[test]
+    fn provider_auth_failures_are_recognized_and_other_failures_are_not() {
+        // The vendor bodies the shipped engines actually pass through.
+        assert!(provider_auth_failure(
+            "Missing bearer or basic authentication in header"
+        ));
+        assert!(provider_auth_failure(
+            r#"{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}"#
+        ));
+        assert!(provider_auth_failure("Invalid API key · Please run /login"));
+        assert!(provider_auth_failure("HTTP 401 Unauthorized"));
+        // Everything else keeps the engine's own words.
+        assert!(!provider_auth_failure(
+            "overloaded_error: try again shortly"
+        ));
+        assert!(!provider_auth_failure("engine exited with status 1"));
+    }
+
+    #[tokio::test]
+    async fn a_raw_401_turn_failure_reads_as_a_sign_in_problem() {
+        let (_directory, _store, sink, _session_id) = seeded_sink().await;
+        let mapped =
+            sink.legible_turn_error("Missing bearer or basic authentication in header".into());
+        assert!(
+            mapped
+                .message
+                .starts_with("Claude Code is not signed in on this machine."),
+            "got: {}",
+            mapped.message
+        );
+        // The engine's own words survive for whoever debugs the transcript.
+        assert!(mapped
+            .message
+            .contains("Missing bearer or basic authentication in header"));
+        let untouched = sink.legible_turn_error("engine exited with status 1".into());
+        assert_eq!(untouched.message, "engine exited with status 1");
+    }
+
+    #[tokio::test]
+    async fn a_relay_wired_session_keeps_the_relays_own_refusal() {
+        let (_directory, store, bus, session_id) =
+            seeded_session(HarnessKind::Codex, Some("0.147.0")).await;
+        let sink = sink_for(
+            store,
+            bus,
+            OwnerId::local(),
+            session_id,
+            1,
+            HarnessKind::Codex,
+            true,
+            None,
+            Vec::new(),
+            None,
+            None,
+        );
+        // The relay's refusals already name the gateway; "sign in in your
+        // own terminal" would be wrong on a hosted machine.
+        let kept = sink.legible_turn_error("authentication_error: sign in required".into());
+        assert_eq!(kept.message, "authentication_error: sign in required");
     }
 }

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -8,6 +8,7 @@ use super::types::{
     CodeHarnessInstallSnapshot, HarnessAuthMode, HarnessDoctorEntry, HarnessDoctorReport,
     HarnessModel, HarnessModelList, InstallHarnessQuery,
 };
+use crate::code::harness_label;
 use crate::code::harness_llm::relay_covered;
 use tidebreak_core::HarnessKind;
 
@@ -167,13 +168,4 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
     }))
     .await;
     Ok(HarnessDoctorReport { harnesses })
-}
-
-fn harness_label(kind: HarnessKind) -> &'static str {
-    match kind {
-        HarnessKind::ClaudeCode => "Claude Code",
-        HarnessKind::Codex => "Codex CLI",
-        HarnessKind::Opencode => "opencode",
-        HarnessKind::Grok => "Grok CLI",
-    }
 }

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -150,7 +150,7 @@ pub(crate) struct ScriptedAdapter {
     /// and queue a follow-up before the script plays.
     turn_delay: Duration,
     /// What the probe reports as this engine's local sign-in state.
-    authenticated: Option<bool>,
+    authenticated: Arc<std::sync::Mutex<Option<bool>>>,
 }
 
 impl ScriptedAdapter {
@@ -185,7 +185,7 @@ impl ScriptedAdapter {
             approval_ack_delay: Duration::ZERO,
             probes: Arc::new(AtomicU64::new(0)),
             launched_approvals: Arc::new(std::sync::Mutex::new(Vec::new())),
-            authenticated: Some(true),
+            authenticated: Arc::new(std::sync::Mutex::new(Some(true))),
             writes: Vec::new(),
             turn_delay: Duration::ZERO,
         }
@@ -385,9 +385,16 @@ impl ScriptedAdapter {
     /// Report this local sign-in state from the probe, for surfaces that
     /// branch on it — the doctor's hosted report among them.
     #[allow(dead_code)]
-    pub(crate) fn with_authenticated(mut self, authenticated: Option<bool>) -> Self {
-        self.authenticated = authenticated;
+    pub(crate) fn with_authenticated(self, authenticated: Option<bool>) -> Self {
+        self.set_authenticated(authenticated);
         self
+    }
+
+    /// Flip the sign-in state the next probe reports. Tests use this to
+    /// model a user signing in after the doctor has already cached signed-out.
+    #[allow(dead_code)]
+    pub(crate) fn set_authenticated(&self, authenticated: Option<bool>) {
+        *self.authenticated.lock().expect("scripted auth") = authenticated;
     }
 }
 
@@ -403,7 +410,7 @@ impl HarnessAdapter for ScriptedAdapter {
             found: true,
             binary_path: Some(PathBuf::from("/scripted/engine")),
             version: Some("scripted".into()),
-            authenticated: self.authenticated,
+            authenticated: *self.authenticated.lock().expect("scripted auth"),
             stderr: String::new(),
             env: Vec::new(),
             commands: Vec::new(),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -2420,6 +2420,51 @@ async fn a_signed_out_engine_refuses_at_create_not_on_turn_one() {
     );
 }
 
+/// Signing in after the doctor has cached a signed-out probe must not leave
+/// create stuck on that answer. Create re-probes a cached refusal rather
+/// than waiting for an explicit doctor refresh.
+#[tokio::test]
+async fn create_re_probes_a_cached_signed_out_observation() {
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_authenticated(Some(false));
+    let (router, token, _runtime, dir) = code_app_with(adapter.clone()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+
+    let report = client
+        .get(format!("http://{addr}/code/harnesses"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(report["harnesses"][0]["authenticated"], false);
+    assert_eq!(adapter.probe_count(), 1);
+
+    adapter.set_authenticated(Some(true));
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    assert!(
+        adapter.probe_count() >= 2,
+        "create must re-probe a cached signed-out observation, not reuse it"
+    );
+}
+
 /// Only a definitive signed-out observation refuses. A probe that could not
 /// verify the sign-in state answers `None`, and a false refusal on a working
 /// machine is strictly worse than the first-turn failure it would prevent.

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -2383,6 +2383,132 @@ async fn unsupported_fast_mode_is_refused_on_create_and_live_update() {
     assert_eq!(body["kind"], "fast_mode_unsupported", "{body}");
 }
 
+/// A definitively signed-out engine refuses at create with a message the UI
+/// can show, instead of minting a session that dies on turn one with the
+/// provider's raw 401 (#2653).
+#[tokio::test]
+async fn a_signed_out_engine_refuses_at_create_not_on_turn_one() {
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_authenticated(Some(false));
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "harness_not_authenticated", "{body}");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap()
+            .contains("Claude Code is not signed in on this machine."),
+        "{body}"
+    );
+}
+
+/// Only a definitive signed-out observation refuses. A probe that could not
+/// verify the sign-in state answers `None`, and a false refusal on a working
+/// machine is strictly worse than the first-turn failure it would prevent.
+#[tokio::test]
+async fn an_unverified_sign_in_state_does_not_block_create() {
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_authenticated(None);
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+}
+
+/// The #2742 guarantee holds at create time: on a gateway-hosted machine the
+/// relay authenticates covered engines as the caller, so a signed-out engine
+/// still creates a session freely.
+#[tokio::test]
+async fn a_signed_out_relay_covered_engine_still_creates_on_a_hosted_machine() {
+    let (dir, store) = temp_db_store("code.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(
+        ScriptedAdapter::new(plain_text_script()).with_authenticated(Some(false)),
+    ));
+    let gateway = Arc::new(
+        crate::obo_gateway::OboGateway::new(
+            "https://gateway.example",
+            "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed".to_owned(),
+        )
+        .unwrap(),
+    );
+    let runtime = Arc::new(
+        CodeRuntime::with_registry(db, dir.path().to_path_buf(), registry).with_harness_llm(
+            Arc::new(crate::code::harness_llm::HarnessLlmRelay::new(gateway)),
+        ),
+    );
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime.clone());
+    let token = state.token.clone();
+    let addr = serve(app(state)).await;
+    // Boot publishes the loopback base the relay wiring needs before any
+    // worker attaches; tests serve the router directly, so publish it here.
+    runtime.start(format!("http://{addr}")).await.unwrap();
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+}
+
 /// A model switch keeps the model but clears settings the new row cannot
 /// honor before the turn or its snapshot sees them.
 #[tokio::test]


### PR DESCRIPTION
A definitively signed-out engine now refuses at session create with a typed 422 (`harness_not_authenticated`) and a message the UI can show, instead of minting a session that dies on turn one with the provider's raw 401.

The refusal is deliberately narrow:

- Only a definitive `authenticated: Some(false)` probe observation refuses. An unverified state (`None`) creates freely — a false refusal on a working machine is worse than the first-turn failure this replaces.
- On a hosted machine the relay carries covered engines as the caller (decision 71, #2742), so a signed-out engine still creates.
- An API key or gateway endpoint override in the environment or engine config (Claude `settings.json` env block and `apiKeyHelper`, Codex `config.toml` model providers) authenticates without any vendor login (#2749), so an override beats the signed-out observation.
- opencode and Grok have unverified override surfaces, so they never refuse on the probe alone.

For sessions that still reach a provider 401 mid-turn, the session worker swaps the vendor's raw 401 body for the same legible sign-in sentence, keeping the engine's own words for whoever debugs the transcript. Relay-wired sessions keep the relay's own refusals untouched — "sign in in your own terminal" is wrong on a hosted machine.

Closes #2653