### PR TITLE
feat(desktop): right-align prompts and tidy code workspace UX

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -348,6 +348,11 @@ export function AppShell() {
       // workspace page answers it.
       useCodeUiStore.getState().requestTerminal();
     },
+    "code-new-tab": () => {
+      const { pathname } = router.state.location;
+      if (!codeWorkspaceIdFromPath(pathname)) return false;
+      useCodeUiStore.getState().requestNewTabMenu();
+    },
     "code-quick-open": () => {
       const { pathname } = router.state.location;
       if (!codeWorkspaceIdFromPath(pathname)) return false;

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -46,6 +46,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { usePortalOverlayOpen } from "@/lib/usePortalOverlayOpen";
 import { foregroundBrowserScope } from "./code/browser/foregroundBrowserScope";
 import { seedBrowserSession } from "./code/browser/browserPersistence";
+import { MarkdownLinkProvider } from "./MessageMarkdown";
 
 import { friendlyErrorMessage } from "./lib/utils";
 import {
@@ -689,18 +690,21 @@ export function ChatRoute({ chatId }: { chatId: string }) {
    * per chat, seeded with a fresh browser id and a foreground workspace
    * scope the native executor derives identically from the chat id.
    */
-  function openBrowser() {
-    const existingIndex = layout.tabs.findIndex(
-      (tab) => tab.type === "browser",
-    );
-    if (existingIndex !== -1) {
-      openPanel(layout.tabs[existingIndex]);
-      return;
+  function openBrowser(url?: string) {
+    if (!url) {
+      const existingIndex = layout.tabs.findIndex(
+        (tab) => tab.type === "browser",
+      );
+      if (existingIndex !== -1) {
+        openPanel(layout.tabs[existingIndex]);
+        return;
+      }
     }
     const browserId = crypto.randomUUID();
     const session = seedBrowserSession({
       browserId,
       workspaceId: foregroundBrowserScope(chatId),
+      initialUrl: url,
     });
     setBrowserTitles((current) => ({
       ...current,
@@ -1093,14 +1097,20 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         />
         {/* Citations live in the transcript but open into the panel beside it,
             so the way there is provided above both slots. */}
-        <SourceNavProvider value={sourceNav}>
-          <PanelLayout
-            layout={layout}
-            tabLabel={tabLabel}
-            renderChat={renderChat}
-            renderPanel={renderPanel}
-          />
-        </SourceNavProvider>
+        <MarkdownLinkProvider
+          onOpenInApp={
+            hasLocalHostAuthority() ? (url) => openBrowser(url) : undefined
+          }
+        >
+          <SourceNavProvider value={sourceNav}>
+            <PanelLayout
+              layout={layout}
+              tabLabel={tabLabel}
+              renderChat={renderChat}
+              renderPanel={renderPanel}
+            />
+          </SourceNavProvider>
+        </MarkdownLinkProvider>
       </div>
     </RouteFrame>
   );

--- a/crates/tidebreak-desktop/ui/src/MessageMarkdown.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageMarkdown.dom.test.tsx
@@ -1,12 +1,20 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AssistantSource } from "./AssistantSources";
 import { MessageCitationsProvider } from "./InlineCitation";
-import { MessageMarkdown } from "./MessageMarkdown";
+import { MarkdownLinkProvider, MessageMarkdown } from "./MessageMarkdown";
 
-afterEach(cleanup);
+const openInBrowser = vi.hoisted(() => vi.fn());
+vi.mock("./openInBrowser", () => ({
+  openInBrowser: (...args: unknown[]) => openInBrowser(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  openInBrowser.mockReset();
+});
 
 describe("code block copy", () => {
   it("copies the raw source, not the highlighted markup", async () => {
@@ -85,5 +93,52 @@ describe("inline citations", () => {
     expect(screen.queryByRole("button")).toBeNull();
     expect(container).toHaveTextContent("The reef grows slowly.");
     expect(container.textContent).not.toContain("citation_id");
+  });
+});
+
+describe("markdown links", () => {
+  const LOCAL =
+    "Storybook is still at http://127.0.0.1:6031/?path=/story/code-workspace-card--hover-idle-session if you want another look.";
+
+  it("keeps a localhost URL as one link after a model line wrap", () => {
+    render(
+      <MessageMarkdown>
+        {
+          "Storybook is still at http://127.0.0.1:6031/?\npath=/story/code-workspace-card--hover-idle-session if you want another look."
+        }
+      </MessageMarkdown>,
+    );
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "http://127.0.0.1:6031/?path=/story/code-workspace-card--hover-idle-session",
+    );
+    expect(link).toHaveTextContent(
+      "http://127.0.0.1:6031/?path=/story/code-workspace-card--hover-idle-session",
+    );
+  });
+
+  it("opens the in-app browser on click, and the system browser on a command click", async () => {
+    const user = userEvent.setup();
+    const onOpenInApp = vi.fn();
+    render(
+      <MarkdownLinkProvider onOpenInApp={onOpenInApp}>
+        <MessageMarkdown>{LOCAL}</MessageMarkdown>
+      </MarkdownLinkProvider>,
+    );
+    const link = screen.getByRole("link");
+    await user.click(link);
+    expect(onOpenInApp).toHaveBeenCalledWith(
+      "http://127.0.0.1:6031/?path=/story/code-workspace-card--hover-idle-session",
+    );
+    expect(openInBrowser).not.toHaveBeenCalled();
+
+    onOpenInApp.mockClear();
+    const command = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+    fireEvent.click(link, { metaKey: command, ctrlKey: !command });
+    expect(onOpenInApp).not.toHaveBeenCalled();
+    expect(openInBrowser).toHaveBeenCalledWith(
+      "http://127.0.0.1:6031/?path=/story/code-workspace-card--hover-idle-session",
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageMarkdown.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { stripCitationDirectives } from "./citationDirectives";
 import {
   decodeUnicodeEscapes,
+  joinWrappedMarkdownUrls,
   MessageMarkdown,
   preserveLineBreaks,
   safeMarkdownUrl,
@@ -50,16 +51,44 @@ describe("citation directives", () => {
 });
 
 describe("safeMarkdownUrl", () => {
-  it("permits only secure external links", () => {
+  it("permits http and https, and rejects executable or local schemes", () => {
     expect(safeMarkdownUrl("https://tidebreak.io/docs")).toBe(
       "https://tidebreak.io/docs",
     );
-    expect(safeMarkdownUrl("http://tidebreak.io")).toBeUndefined();
+    expect(safeMarkdownUrl("http://127.0.0.1:6031/?path=/story/card")).toBe(
+      "http://127.0.0.1:6031/?path=/story/card",
+    );
     expect(safeMarkdownUrl("javascript:alert(1)")).toBeUndefined();
     expect(safeMarkdownUrl("data:text/html,unsafe")).toBeUndefined();
     expect(
       safeMarkdownUrl("file:///Users/example/private.txt"),
     ).toBeUndefined();
+    expect(
+      safeMarkdownUrl("https://user:secret@tidebreak.io/docs"),
+    ).toBeUndefined();
+  });
+});
+
+describe("joinWrappedMarkdownUrls", () => {
+  it("rejoins a URL the model broke after the query marker", () => {
+    expect(
+      joinWrappedMarkdownUrls(
+        "Storybook is still at http://127.0.0.1:6031/?\npath=/story/code-workspace-card--hover-idle-session if you want another look.",
+      ),
+    ).toBe(
+      "Storybook is still at http://127.0.0.1:6031/?path=/story/code-workspace-card--hover-idle-session if you want another look.",
+    );
+  });
+
+  it("does not join a URL to the next sentence", () => {
+    expect(
+      joinWrappedMarkdownUrls("See http://127.0.0.1:6031/\nThe hover card."),
+    ).toBe("See http://127.0.0.1:6031/\nThe hover card.");
+  });
+
+  it("leaves fenced code untouched", () => {
+    const fenced = "```\nhttp://127.0.0.1:6031/?\npath=/story/x\n```";
+    expect(joinWrappedMarkdownUrls(fenced)).toBe(fenced);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageMarkdown.tsx
@@ -1,8 +1,11 @@
 import {
+  createContext,
   isValidElement,
   memo,
+  useContext,
   useMemo,
   useRef,
+  type MouseEvent,
   type ReactElement,
   type ReactNode,
   type Ref,
@@ -39,13 +42,9 @@ import { InlineCitation } from "./InlineCitation";
 import { splitMarkdownBlocks } from "./markdownBlocks";
 import { escapeLatexText } from "./markdownLatex";
 import { slugify } from "./markdownHeadings";
+import { openInBrowser } from "./openInBrowser";
+import { usesCommandModifier } from "./ShellShortcuts";
 
-/**
- * Keep model-generated navigation deliberately narrow. `react-markdown` does
- * not render raw HTML unless a raw HTML plugin is opted into (we do not), and
- * this allowlist keeps rendered links from opening local files or executable
- * schemes.
- */
 /**
  * Convert single newlines to Markdown hard breaks (two trailing spaces + newline)
  * so a model's intended line breaks render, while double+ newlines stay paragraph
@@ -145,15 +144,114 @@ export function rawCodeText(node: {
     .join("");
 }
 
+/**
+ * Keep model-generated navigation on http(s). `react-markdown` does not render
+ * raw HTML unless a raw HTML plugin is opted into (we do not), and this
+ * allowlist keeps rendered links from opening local files or executable
+ * schemes. Localhost http is allowed so a Storybook or dev-server URL stays a
+ * link.
+ */
 export function safeMarkdownUrl(url: string | undefined): string | undefined {
   if (!url) return undefined;
 
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "https:" ? parsed.href : undefined;
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    if (parsed.username || parsed.password) return undefined;
+    return parsed.href;
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Rejoin an autolink the model broke across a line.
+ *
+ * GFM stops an autolink at a newline, and {@link preserveLineBreaks} would
+ * otherwise turn that newline into a hard break. A URL that wrapped after `?`
+ * would then render as dead text. Fenced code is left alone.
+ */
+export function joinWrappedMarkdownUrls(input: string): string {
+  const parts: string[] = [];
+  for (const segment of input.split(/(```[\s\S]*?(?:```|$))/)) {
+    parts.push(
+      segment.startsWith("```") ? segment : joinUrlLineBreaks(segment),
+    );
+  }
+  return parts.join("");
+}
+
+const URL_LINE_WRAP =
+  /(https?:\/\/[^\s]+)\n(?!\n)([/?#&%][^\s]*|[A-Za-z0-9._~%-]+=[^\s]*)/gi;
+
+function joinUrlLineBreaks(input: string): string {
+  let result = input;
+  for (let i = 0; i < 8; i += 1) {
+    const next = result.replace(URL_LINE_WRAP, "$1$2");
+    if (next === result) break;
+    result = next;
+  }
+  return result;
+}
+
+const MarkdownLinkOpenContext = createContext<((url: string) => void) | null>(
+  null,
+);
+
+/** How transcript links open the in-app browser. Absent, they leave the app. */
+export function MarkdownLinkProvider({
+  onOpenInApp,
+  children,
+}: {
+  onOpenInApp?: (url: string) => void;
+  children: ReactNode;
+}) {
+  return (
+    <MarkdownLinkOpenContext.Provider value={onOpenInApp ?? null}>
+      {children}
+    </MarkdownLinkOpenContext.Provider>
+  );
+}
+
+function isCommandClick(event: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+}): boolean {
+  return usesCommandModifier(
+    typeof navigator === "undefined" ? "" : navigator.userAgent,
+  )
+    ? event.metaKey
+    : event.ctrlKey;
+}
+
+function MarkdownLink({
+  children,
+  href,
+}: {
+  children?: ReactNode;
+  href?: string;
+}) {
+  const openInApp = useContext(MarkdownLinkOpenContext);
+  const safeHref = safeMarkdownUrl(href);
+  if (!safeHref) return <span>{children}</span>;
+  const url = safeHref;
+
+  function onClick(event: MouseEvent<HTMLAnchorElement>) {
+    event.preventDefault();
+    if (isCommandClick(event) || !openInApp) {
+      void openInBrowser(url);
+      return;
+    }
+    openInApp(url);
+  }
+
+  return (
+    <a href={url} rel="noreferrer noopener" onClick={onClick}>
+      {children}
+    </a>
+  );
 }
 
 /**
@@ -218,16 +316,7 @@ const components: Components = {
   h4: ({ children }) => <h4>{children}</h4>,
   h5: ({ children }) => <h5>{children}</h5>,
   h6: ({ children }) => <h6>{children}</h6>,
-  a: ({ children, href }) => {
-    const safeHref = safeMarkdownUrl(href);
-    if (!safeHref) return <span>{children}</span>;
-
-    return (
-      <a href={safeHref} target="_blank" rel="noreferrer noopener">
-        {children}
-      </a>
-    );
-  },
+  a: MarkdownLink,
   // Do not let assistant Markdown initiate unrequested network loads. The alt
   // text remains available as a small, readable indication of omitted media.
   img: ({ alt }) => (
@@ -364,7 +453,9 @@ const rehypePlugins: NonNullable<Options["rehypePlugins"]> = [
  * Markdown twice.
  */
 export function processMarkdownContent(input: string): string {
-  return preserveLineBreaks(escapeLatexText(decodeUnicodeEscapes(input)));
+  return preserveLineBreaks(
+    escapeLatexText(decodeUnicodeEscapes(joinWrappedMarkdownUrls(input))),
+  );
 }
 
 /**
@@ -432,6 +523,7 @@ function blockRehypePlugins(
 ): NonNullable<Options["rehypePlugins"]> {
   if (start == null || end == null || end <= start) return rehypePlugins;
   if (decodeUnicodeEscapes(block) !== block) return rehypePlugins;
+  if (joinWrappedMarkdownUrls(block) !== block) return rehypePlugins;
   if (escapeLatexText(block) !== block) return rehypePlugins;
   // A block carrying a citation is left alone too: the mark would split the
   // text the citation is read out of, leaving the two passes to argue over the

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
@@ -96,6 +96,18 @@ describe("shell shortcut resolution", () => {
     ).toBe("toggle-code-terminal");
     expect(
       resolveShellShortcut(
+        keyEvent({ key: "t", code: "KeyT" }),
+        context({ mode: "code" }),
+      )?.id,
+    ).toBe("code-new-tab");
+    expect(
+      resolveShellShortcut(
+        keyEvent({ key: "p", code: "KeyP" }),
+        context({ mode: "code" }),
+      )?.id,
+    ).toBe("code-quick-open");
+    expect(
+      resolveShellShortcut(
         keyEvent({ key: "i", code: "KeyI" }),
         context({ mode: "chat" }),
       ),

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -16,6 +16,7 @@ export type ShellShortcutAction =
   | "code-new-workspace"
   | "toggle-code-review"
   | "toggle-code-terminal"
+  | "code-new-tab"
   | "code-quick-open"
   | "code-find"
   | "code-prev-tab"
@@ -224,13 +225,12 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     allowInEditable: true,
   },
   {
-    // The tab strip's plus control opens the file picker first, so the chord
-    // that means "new tab" everywhere else opens the same thing here rather
-    // than a blank tab there is nothing to put in.
-    id: "code-quick-open",
+    // The tab strip's plus control offers what a new tab can be, so the chord
+    // that means "new tab" elsewhere opens that menu rather than file search.
+    id: "code-new-tab",
     codes: ["KeyT"],
     mod: true,
-    description: "New tab: open a file by name",
+    description: "New tab",
     group: "Code",
     scope: "code",
     allowInEditable: true,

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -1,4 +1,10 @@
-import { useRef, type KeyboardEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { useDroppable } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -114,6 +120,7 @@ export function CodeCenterTabs({
   onCloseEditorsToRight,
   onCopyPath,
   onNewTab,
+  openMenuRequest = 0,
   onNewBrowser,
   onNewDiff,
   onNewSourceControl,
@@ -150,6 +157,8 @@ export function CodeCenterTabs({
   onCopyPath: (path: string) => void;
   /** Open the file picker; the menu's "Open file" entry. */
   onNewTab: () => void;
+  /** Increment to open the plus menu from the shell keymap (Cmd+T). */
+  openMenuRequest?: number;
   onNewBrowser?: () => void;
   /** Open the all-changes diff as a center tab. */
   onNewDiff?: () => void;
@@ -175,9 +184,13 @@ export function CodeCenterTabs({
   onCloseGroup?: () => void;
 }) {
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [menuOpen, setMenuOpen] = useState(false);
   const { setNodeRef: setStripRef } = useDroppable({
     id: editorStripDropId(region),
   });
+  useEffect(() => {
+    if (openMenuRequest > 0) setMenuOpen(true);
+  }, [openMenuRequest]);
   const tabOffset = conversations.length;
   const panelId =
     region === "primary" ? EDITOR_PANEL_ID : SPLIT_EDITOR_PANEL_ID;
@@ -358,7 +371,7 @@ export function CodeCenterTabs({
       {/* One + for everything the center can open. A bare click must say
           what it will do, so the button offers the choices instead of
           jumping into the file picker. */}
-      <DropdownMenu>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
         <DropdownMenuTrigger asChild>
           <button
             type="button"

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -595,27 +595,27 @@ it("gives the active inspector tab a selected fill idle tabs do not share", asyn
 
   const files = screen.getByRole("tab", { name: "Files" });
   const source = screen.getByRole("tab", { name: "Source control" });
-  const pr = screen.getByRole("tab", { name: "Pull request" });
 
   expect(files).toHaveAttribute("data-state", "active");
   expect(files).toHaveClass("bg-background");
   expect(source).toHaveAttribute("data-state", "inactive");
-  expect(pr).toHaveAttribute("data-state", "inactive");
   expect(source).not.toHaveClass("bg-background");
-  expect(pr).not.toHaveClass("bg-background");
+  expect(
+    screen.queryByRole("tab", { name: "Pull request" }),
+  ).not.toBeInTheDocument();
 
   await userEvent.setup().click(source);
 
   expect(source).toHaveAttribute("data-state", "active");
   expect(source).toHaveClass("bg-background");
   expect(files).not.toHaveClass("bg-background");
-  expect(pr).not.toHaveClass("bg-background");
 
-  // Radix drives the arrows; this pins that the inspector still gets them.
+  // Radix drives the arrows; with no pull request the strip is Files and
+  // Changes, so right from Changes wraps to Files.
   source.focus();
   await userEvent.setup().keyboard("{ArrowRight}");
-  expect(pr).toHaveAttribute("data-state", "active");
-  expect(pr).toHaveFocus();
+  expect(files).toHaveAttribute("data-state", "active");
+  expect(files).toHaveFocus();
 });
 
 it("shows the changed-file count in the Changes tab", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -115,11 +115,7 @@ export function CodeInspector({
   onClose?: () => void;
 }) {
   const digest = useWorkspaceDigest(workspaceId);
-  const pr = prResource
-    ? prResource.data === null
-      ? (digest?.pr_state ?? workspace?.pr)
-      : prResource.data.pr
-    : (digest?.pr_state ?? workspace?.pr);
+  const pr = prResource?.data?.pr ?? digest?.pr_state ?? workspace?.pr;
   const scope = useCodeUiStore((state) => state.inspectorScope);
   const setInspectorScope = useCodeUiStore((state) => state.setInspectorScope);
   const filesSearchPending = useCodeUiStore(
@@ -153,6 +149,10 @@ export function CodeInspector({
   useEffect(() => {
     if (filesSearchPending) setTab("files");
   }, [filesSearchPending]);
+
+  useEffect(() => {
+    if (!pr && tab === "pr") setTab("source");
+  }, [pr, tab]);
 
   function openFile(next: string, line?: number) {
     if (onOpenFile) {
@@ -202,23 +202,23 @@ export function CodeInspector({
             >
               <GitBranch className="size-3.5" />
             </InspectorTabTrigger>
-            <InspectorTabTrigger
-              value="pr"
-              label="Pull request"
-              displayLabel="Review"
-              selected={tab === "pr"}
-            >
-              <GitPullRequest
-                className={cn(
-                  "size-3.5",
-                  pr
-                    ? STATUS_MARK[
-                        PULL_REQUEST_LIFECYCLE_TONE[pullRequestLifecycle(pr)]
-                      ]
-                    : undefined,
-                )}
-              />
-            </InspectorTabTrigger>
+            {pr && (
+              <InspectorTabTrigger
+                value="pr"
+                label="Pull request"
+                displayLabel="Review"
+                selected={tab === "pr"}
+              >
+                <GitPullRequest
+                  className={cn(
+                    "size-3.5",
+                    STATUS_MARK[
+                      PULL_REQUEST_LIFECYCLE_TONE[pullRequestLifecycle(pr)]
+                    ],
+                  )}
+                />
+              </InspectorTabTrigger>
+            )}
           </TabsList>
           <div className="ml-auto flex min-w-0 items-center gap-1">
             {scope && (

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.dom.test.tsx
@@ -20,7 +20,7 @@ type QuickOpenProps = ComponentProps<typeof CodeQuickOpen>;
  * Render the picker with a request counter the test can bump.
  *
  * The chords that reach it live in the shell keymap, so the component's only
- * entry point is this counter — the one the New tab control increments and the
+ * entry point is this counter — the one Open file… increments and the
  * one the keymap raises. `open()` stands in for either.
  */
 function mountQuickOpen(props: Omit<QuickOpenProps, "openRequest">) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
@@ -26,9 +26,10 @@ const VISIBLE_RESULTS = 12;
 /**
  * Centered, keyboard-first filename quick open.
  *
- * The chords that reach it — Cmd+T and Cmd+P — are in the shell keymap rather
- * than a listener here, so they appear in the shortcuts dialog and respect the
- * guard that keeps every shell chord out of an open dialog.
+ * The chord that reaches it — Cmd+P — is in the shell keymap rather than a
+ * listener here, so it appears in the shortcuts dialog and respects the guard
+ * that keeps every shell chord out of an open dialog. Cmd+T opens the New tab
+ * menu instead.
  */
 export function CodeQuickOpen({
   client,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -149,7 +149,9 @@ describe("CodeSidebar", () => {
     // One header over one list: the by-repo group header is a label, and the
     // three actions beside "Workspaces" are the whole toolbar.
     expect(await screen.findByTitle("app")).toBeInTheDocument();
-    expect(screen.getByText("Workspaces")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Workspaces" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Workspace list settings" }),
     ).toBeInTheDocument();
@@ -366,5 +368,18 @@ describe("CodeSidebar", () => {
       });
       expect(router.state.location.search).not.toHaveProperty("task");
     });
+  });
+
+  it("opens the code home from the Workspaces heading", async () => {
+    const { router } = await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code/w/ws-1" },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspaces" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/code"));
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -58,6 +58,9 @@ import type { WorkspaceWorkflowAction } from "./workspaceWorkflow";
  * draws is the reader's `railPrefs` choice; what each card *says* (the
  * aria-label) never shrinks with those choices.
  *
+ * The "Workspaces" heading is the way back to `/code`, the same home that
+ * greets a machine with nothing on the rail yet.
+ *
  * It also hosts code mode's two dialogs. The rail is on screen for every
  * `/code` route, so mounting them here is what makes them reachable from the
  * keyboard anywhere in the mode without a second instance per page.
@@ -126,9 +129,21 @@ export function CodeSidebar() {
       <CodeModeSwitch />
 
       <div className="flex shrink-0 items-center gap-0.5 px-1 pt-1 pb-1.5">
-        <span className="min-w-0 flex-1 px-2 py-1 text-sm font-medium text-muted-foreground">
+        <button
+          type="button"
+          className={cn(
+            "min-w-0 flex-1 cursor-pointer rounded-md px-2 py-1 text-left text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground",
+            FOCUS_RING,
+            HOVER_TINT,
+          )}
+          aria-current={pathname === "/code" ? "page" : undefined}
+          onClick={() => {
+            if (pathname === "/code") return;
+            void navigate({ to: "/code" });
+          }}
+        >
           Workspaces
-        </span>
+        </button>
         <RailSettingsMenu />
         <button
           type="button"

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -360,6 +360,36 @@ describe("CodeTranscript", () => {
     expect(within(seam).queryByText(/in \//)).not.toBeInTheDocument();
   });
 
+  it("omits the diffstat when a completed turn changed no files", () => {
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "turn_boundary",
+            id: "b-empty",
+            turnId: "t-empty",
+            status: "completed",
+            durationMs: 8_000,
+            usage: USAGE,
+            error: null,
+            diffstat: {
+              files: 0,
+              insertions: 0,
+              deletions: 0,
+              truncated: false,
+            },
+          },
+        ]}
+      />,
+    );
+    const seam = screen.getByRole("group", { name: "Turn finished" });
+    expect(within(seam).getByText("· 8.0s")).toBeInTheDocument();
+    expect(within(seam).queryByText("0 files")).not.toBeInTheDocument();
+    expect(
+      within(seam).queryByLabelText("0 files, 0 additions, 0 deletions"),
+    ).not.toBeInTheDocument();
+  });
+
   /**
    * The seam is the fork point: "Fork from here" must hand the host this
    * boundary's turn id, and the affordance must not render at all for a

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -346,9 +346,12 @@ export type CodeUiStore = {
    * what keeps a later remount from repeating it.
    */
   quickOpenPending: boolean;
+  newTabMenuPending: boolean;
   filesSearchPending: boolean;
   requestQuickOpen: () => void;
   takeQuickOpen: () => boolean;
+  requestNewTabMenu: () => void;
+  takeNewTabMenu: () => boolean;
   /** Opens the review sidebar too: search is dead while that rail is hidden. */
   requestFilesSearch: () => void;
   takeFilesSearch: () => boolean;
@@ -425,11 +428,18 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   pendingComposerPrompt: null,
   composerActionScope: null,
   quickOpenPending: false,
+  newTabMenuPending: false,
   filesSearchPending: false,
   requestQuickOpen: () => set({ quickOpenPending: true }),
   takeQuickOpen: () => {
     if (!get().quickOpenPending) return false;
     set({ quickOpenPending: false });
+    return true;
+  },
+  requestNewTabMenu: () => set({ newTabMenuPending: true }),
+  takeNewTabMenu: () => {
+    if (!get().newTabMenuPending) return false;
+    set({ newTabMenuPending: false });
     return true;
   },
   requestFilesSearch: () => {
@@ -584,6 +594,7 @@ export function resetCodeUiHostState(): void {
     pendingComposerPrompt: null,
     composerActionScope: null,
     quickOpenPending: false,
+    newTabMenuPending: false,
     filesSearchPending: false,
     workflowShortcutPending: null,
     archivePending: false,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -666,6 +666,8 @@ afterEach(() => {
     composerActionScope: null,
     workflowShortcutPending: null,
     archivePending: false,
+    newTabMenuPending: false,
+    quickOpenPending: false,
   });
   resetWorkflowPromptStore();
   browserMocks.close.mockClear();
@@ -1328,6 +1330,9 @@ describe("CodeWorkspacePage", () => {
 
     expect(useCodeUiStore.getState().reviewSidebarOpen).toBe(false);
     expect(screen.queryByTestId("code-inspector")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
   });
 
   it("surfaces a quick-action exit code on the result toast", async () => {
@@ -1794,6 +1799,37 @@ describe("CodeWorkspacePage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("opens the next live workspace after archiving the one on screen", async () => {
+    const other: CodeWorkspaceSnapshot = {
+      ...WORKSPACE,
+      id: "ws-2",
+      title: "Fix logout",
+      created_at: "2026-08-16T00:00:00.000Z",
+    };
+    const client = Object.assign(makeClient(), {
+      listCodeRepos: vi.fn(async () => [REPO]),
+      listCodeWorkspaces: vi.fn(async () => [WORKSPACE, other]),
+      getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+    });
+    client.getCodeWorkspace.mockImplementation(async (id: string) =>
+      id === "ws-2" ? other : WORKSPACE,
+    );
+    const { router } = await mountWorkspace(client);
+    const user = userEvent.setup();
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Archive" }));
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-2"),
+    );
+    expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", false);
+  });
+
   it("asks once before discarding changes during archive", async () => {
     const client = makeClient();
     client.archiveCodeWorkspace
@@ -1926,8 +1962,8 @@ describe("CodeWorkspacePage", () => {
       within(inspector).getByRole("tab", { name: "Files" }),
     ).toBeInTheDocument();
     expect(
-      within(inspector).getByRole("tab", { name: "Pull request" }),
-    ).toBeInTheDocument();
+      within(inspector).queryByRole("tab", { name: "Pull request" }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Terminal" }));
 
@@ -1943,10 +1979,9 @@ describe("CodeWorkspacePage", () => {
       }),
     );
 
-    await user.click(screen.getByRole("tab", { name: "Pull request" }));
     expect(
-      within(inspector).getByText("No pull request yet"),
-    ).toBeInTheDocument();
+      within(inspector).queryByText("No pull request yet"),
+    ).not.toBeInTheDocument();
   });
 
   it("does not promote a stale files catalog into the conversation strip", async () => {
@@ -2249,6 +2284,24 @@ describe("CodeWorkspacePage", () => {
       "aria-selected",
       "true",
     );
+  });
+
+  it("opens the New tab menu from the chord instead of the file picker", async () => {
+    const client = makeClient();
+    await mountWorkspace(client);
+    await screen.findByRole("tab", { name: "Main agent" });
+
+    act(() => useCodeUiStore.getState().requestNewTabMenu());
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Open file…" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "New agent" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: "Search files by name" }),
+    ).not.toBeInTheDocument();
   });
 
   it("starts on the main-agent tab and opens a file from the visible new-tab control", async () => {
@@ -2556,34 +2609,31 @@ describe("CodeWorkspacePage", () => {
     expect(client.openCodeEvents.mock.calls[0]?.[0]).toBe(SESSION.id);
   });
 
-  it("opens source control and PR details as center tabs from the + menu", async () => {
+  it("opens source control and the pull request in the review sidebar", async () => {
     const client = makeClient();
     client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: PR });
     const user = userEvent.setup();
     await mountWorkspace(client);
 
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+
     await user.click(screen.getByRole("button", { name: "New tab" }));
     await user.click(
       await screen.findByRole("menuitem", { name: "Source control" }),
     );
-    // The inspector also names a Source control tab; the center's tab is the
-    // one controlling the primary editor panel.
-    const centerTab = (name: string) =>
-      screen
-        .getAllByRole("tab", { name })
-        .find(
-          (tab) =>
-            tab.getAttribute("aria-controls") ===
-            "code-center-panel-editor-primary",
-        );
+    const inspector = screen.getByTestId("code-inspector");
     await waitFor(() =>
-      expect(centerTab("Source control")).toHaveAttribute(
-        "aria-selected",
-        "true",
-      ),
+      expect(
+        within(inspector).getByRole("tab", { name: "Source control" }),
+      ).toHaveAttribute("aria-selected", "true"),
     );
     expect(
-      await screen.findByTestId("source-control-panel"),
+      screen.queryByTestId("source-control-panel"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Send message" }),
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "New tab" }));
@@ -2591,12 +2641,31 @@ describe("CodeWorkspacePage", () => {
       await screen.findByRole("menuitem", { name: "Pull request" }),
     );
     await waitFor(() =>
-      expect(centerTab("Pull request")).toHaveAttribute(
-        "aria-selected",
-        "true",
-      ),
+      expect(
+        within(inspector).getByRole("tab", { name: "Pull request" }),
+      ).toHaveAttribute("aria-selected", "true"),
     );
-    expect(await screen.findByTestId("pr-details-panel")).toBeInTheDocument();
+    expect(screen.queryByTestId("pr-details-panel")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Send message" }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits Pull request from the new-tab menu when there is no pull request", async () => {
+    const client = makeClient();
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "New tab" }));
+    expect(
+      screen.queryByRole("menuitem", { name: "Pull request" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Source control" }),
+    ).toBeInTheDocument();
   });
 
   it("opens, restores, and retitles a browser as a center editor tab", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -65,6 +65,8 @@ import { followScrollBehavior } from "@/ChatScroll";
 import { useStreamStalled } from "@/useStreamStalled";
 import { useTranscriptFollow } from "@/useTranscriptFollow";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
+import { ErrorBoundary } from "@/ErrorBoundary";
+import { MarkdownLinkProvider } from "@/MessageMarkdown";
 import { usePortalOverlayOpen } from "@/lib/usePortalOverlayOpen";
 import {
   SHELL_SHORTCUTS,
@@ -317,6 +319,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     (state) => state.setReviewSidebarOpen,
   );
   const quickOpenPending = useCodeUiStore((state) => state.quickOpenPending);
+  const newTabMenuPending = useCodeUiStore((state) => state.newTabMenuPending);
   const openFilePending = useCodeUiStore((state) => state.openFilePending);
   const archivePending = useCodeUiStore((state) => state.archivePending);
   const terminalPending = useCodeUiStore((state) => state.terminalPending);
@@ -387,6 +390,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const [reloadToken, setReloadToken] = useState(0);
   const [quickOpenRequest, setQuickOpenRequest] = useState(0);
   const [quickOpenTarget, setQuickOpenTarget] =
+    useState<CodeEditorRegion>("primary");
+  const [newTabMenuRequest, setNewTabMenuRequest] = useState(0);
+  const [newTabMenuRegion, setNewTabMenuRegion] =
     useState<CodeEditorRegion>("primary");
   const [inspectorTabRequest, setInspectorTabRequest] = useState<{
     tab: InspectorTab;
@@ -594,7 +600,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         setWorkspace(next);
         const catalogState = useCodeCatalogStore.getState();
         catalogState.upsertWorkspace(next);
-        setSessions(listed);
+        // Create navigates as soon as the workspace exists, so a session the
+        // dialog just started can land in the catalog before this list does.
+        const remembered = catalogState.sessionsByWorkspace[workspaceId];
+        setSessions(
+          remembered && !listed.some((entry) => entry.id === remembered.id)
+            ? [remembered, ...listed]
+            : listed,
+        );
         setSessionsLoaded(true);
         // The card and the rail show one agent per workspace, so the catalog
         // remembers the first — the one the workspace was started with.
@@ -856,6 +869,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     setQuickOpenRequest((request) => request + 1);
   }
 
+  function showNewTabMenu(region: CodeEditorRegion) {
+    setNewTabMenuRegion(region);
+    setNewTabMenuRequest((request) => request + 1);
+  }
+
   // The shell keymap raises the ask above the route; the workspace is what can
   // answer it. Taking the flag is what stops a remount from reopening the
   // picker over whatever the reader moved on to.
@@ -866,6 +884,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     if (!useCodeUiStore.getState().takeQuickOpen()) return;
     requestNewTab(splitFocused ? "secondary" : "primary");
   }, [quickOpenPending, splitFocused]);
+
+  useEffect(() => {
+    if (!newTabMenuPending) return;
+    if (!useCodeUiStore.getState().takeNewTabMenu()) return;
+    showNewTabMenu(splitFocused ? "secondary" : "primary");
+  }, [newTabMenuPending, splitFocused]);
 
   // The palette ranks worktree files but has nowhere to put one; the tabs live
   // here, so it names a path and this opens it.
@@ -1229,6 +1253,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         }
         onCopyPath={copyEditorPath}
         onNewTab={() => requestNewTab("primary")}
+        openMenuRequest={newTabMenuRegion === "primary" ? newTabMenuRequest : 0}
         onNewBrowser={
           canNewBrowser ? () => openBrowser(undefined, "primary") : undefined
         }
@@ -1237,14 +1262,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             openCodeEditor(layout, { type: "diff" }, "primary"),
           )
         }
-        onNewSourceControl={() =>
-          setWorkspaceLayout(
-            openCodeEditor(layout, { type: "source_control" }, "primary"),
-          )
-        }
-        onNewPr={() =>
-          setWorkspaceLayout(openCodeEditor(layout, { type: "pr" }, "primary"))
-        }
+        onNewSourceControl={() => openInspectorTab("source")}
+        onNewPr={pr ? () => openInspectorTab("pr") : undefined}
         onNewTerminal={() => void openTerminal("primary")}
         canNewTerminal={canNewTerminal}
         onMoveEditorToOtherGroup={(index) =>
@@ -1414,6 +1433,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         }
         onCopyPath={copyEditorPath}
         onNewTab={() => requestNewTab("secondary")}
+        openMenuRequest={
+          newTabMenuRegion === "secondary" ? newTabMenuRequest : 0
+        }
         onNewBrowser={
           canNewBrowser ? () => openBrowser(undefined, "secondary") : undefined
         }
@@ -1422,16 +1444,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             openCodeEditor(layout, { type: "diff" }, "secondary"),
           )
         }
-        onNewSourceControl={() =>
-          setWorkspaceLayout(
-            openCodeEditor(layout, { type: "source_control" }, "secondary"),
-          )
-        }
-        onNewPr={() =>
-          setWorkspaceLayout(
-            openCodeEditor(layout, { type: "pr" }, "secondary"),
-          )
-        }
+        onNewSourceControl={() => openInspectorTab("source")}
+        onNewPr={pr ? () => openInspectorTab("pr") : undefined}
         onNewTerminal={() => void openTerminal("secondary")}
         canNewTerminal={canNewTerminal}
         onMoveEditorToOtherGroup={(index) =>
@@ -1511,7 +1525,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   );
 
   return (
-    <>
+    <MarkdownLinkProvider
+      onOpenInApp={canNewBrowser ? (url) => openBrowser(url) : undefined}
+    >
       {dialogs}
       <CodeQuickOpen
         client={client}
@@ -1612,10 +1628,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         </div>
       ) : reviewSidebarOpen ? (
         <ResizablePanelGroup
-          defaultLayout={inspectorLayout.defaultLayout}
+          defaultLayout={usableInspectorLayout(inspectorLayout.defaultLayout)}
           onLayoutChanged={inspectorLayout.onLayoutChanged}
           orientation="horizontal"
-          className="min-h-0 flex-1"
+          className="h-full min-h-0 flex-1"
         >
           <ResizablePanel
             id="workspace"
@@ -1632,19 +1648,29 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             minSize="22"
             className="min-w-0 bg-page-background"
           >
-            <CodeInspector
-              key={workspaceId}
-              client={client}
-              workspaceId={workspaceId}
-              workspace={workspace}
-              contentRevision={contentRevision}
-              prResource={prResource}
-              requestedTab={inspectorTabRequest}
-              onRequestedTabHandled={handleInspectorTabRequest}
-              onOpenFile={openFile}
-              onOpenDiff={openFileDiff}
-              onClose={() => setReviewSidebarOpen(false)}
-            />
+            <ErrorBoundary
+              resetKey={workspaceId}
+              fallback={
+                <p className="text-muted-foreground p-4 text-sm">
+                  The review sidebar could not load. Git and pull-request
+                  details stay here when they are available.
+                </p>
+              }
+            >
+              <CodeInspector
+                key={workspaceId}
+                client={client}
+                workspaceId={workspaceId}
+                workspace={workspace}
+                contentRevision={contentRevision}
+                prResource={prResource}
+                requestedTab={inspectorTabRequest}
+                onRequestedTabHandled={handleInspectorTabRequest}
+                onOpenFile={openFile}
+                onOpenDiff={openFileDiff}
+                onClose={() => setReviewSidebarOpen(false)}
+              />
+            </ErrorBoundary>
           </ResizablePanel>
         </ResizablePanelGroup>
       ) : (
@@ -1652,7 +1678,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           {workspaceMain}
         </div>
       )}
-    </>
+    </MarkdownLinkProvider>
   );
 }
 
@@ -2697,6 +2723,32 @@ function WatchTaskBar({
       </Button>
     </div>
   );
+}
+
+/**
+ * Ignore a stored inspector split that would collapse the conversation.
+ *
+ * react-resizable-panels v4 remembers `{ [panelId]: percent }`. A leftover
+ * v3 payload, or a drag that parked the workspace pane at zero, would hide
+ * the chat the moment the review sidebar opened.
+ */
+function usableInspectorLayout(
+  layout: Record<string, number> | undefined,
+): Record<string, number> | undefined {
+  if (!layout) return undefined;
+  const workspace = layout.workspace;
+  const inspector = layout.inspector;
+  if (
+    typeof workspace !== "number" ||
+    typeof inspector !== "number" ||
+    !Number.isFinite(workspace) ||
+    !Number.isFinite(inspector) ||
+    workspace < 40 ||
+    inspector < 18
+  ) {
+    return undefined;
+  }
+  return { workspace, inspector };
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -234,6 +234,47 @@ describe("NewWorkspaceDialog", () => {
     expect(useCodeCatalogStore.getState().workspaces).toEqual([created]);
   });
 
+  it("opens the workspace as soon as it exists, before the session starts", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const created = workspace(
+      "ws-early",
+      "repo-new",
+      "2026-08-24T12:00:00.000Z",
+    );
+    const sessionStart = deferred<CodeSessionSnapshot>();
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace: vi.fn(async () => created),
+          createCodeSession: vi.fn(() => sessionStart.promise),
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code/w/ws-old" },
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-early"),
+    );
+    sessionStart.resolve(
+      session("ws-early", "claude_code", "2026-08-24T12:00:00.000Z"),
+    );
+  });
+
   it("removes a failed create and retries the captured request", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -88,7 +88,8 @@ const NO_ENGINE_EFFORTS: ReasoningEffort[] = [];
  * dialog keeps the message and name for the next Cmd+N; a create consumes
  * them. "Create more" keeps the dialog open after a create, clearing only
  * the message and name, for firing off several tasks on the same sticky
- * settings.
+ * settings. A create that is not "Create more" opens the workspace as soon
+ * as it exists, so the reader is already on it while the first session starts.
  *
  * The title is optional: left blank, the server generates a two-word name and
  * later replaces it with one derived from the first turn, the same way chats
@@ -153,7 +154,6 @@ type CreateAttempt = {
   fastMode: boolean;
   fastModeByHarness: Partial<Record<HarnessKind, boolean>>;
   createMore: boolean;
-  originPath: string;
 };
 
 export function NewWorkspaceDialog({
@@ -443,7 +443,6 @@ export function NewWorkspaceDialog({
       fastMode: postedFastMode,
       fastModeByHarness: { ...fastByHarness },
       createMore,
-      originPath: pathnameRef.current,
     };
     useCodeUiStore.getState().setNewWorkspaceDraft(EMPTY_NEW_WORKSPACE_DRAFT);
     if (createMore) {
@@ -517,6 +516,7 @@ export function NewWorkspaceDialog({
       return;
     }
     replaceWorkspace(pending.id, workspace);
+    await revealCreatedWorkspace(workspace, attempt);
     const prompt = attempt.startingPrompt.trim();
     try {
       const gateway = gatewayCodeModels(
@@ -575,13 +575,14 @@ export function NewWorkspaceDialog({
         `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
       );
     }
+  }
+
+  async function revealCreatedWorkspace(
+    workspace: CodeWorkspaceSnapshot,
+    attempt: CreateAttempt,
+  ) {
     const workspaceId = workspace.id;
-    const workspacePath = `/code/w/${workspaceId}`;
-    if (
-      attempt.createMore ||
-      (pathnameRef.current !== attempt.originPath &&
-        pathnameRef.current !== workspacePath)
-    ) {
+    if (attempt.createMore) {
       toast.success(`Started ${workspace.title}`, {
         action: {
           label: "Open",
@@ -594,10 +595,10 @@ export function NewWorkspaceDialog({
       });
       return;
     }
-    if (pathnameRef.current === workspacePath) return;
+    if (pathnameRef.current === `/code/w/${workspaceId}`) return;
     await navigate({
       to: "/code/w/$workspaceId",
-      params: { workspaceId: workspace.id },
+      params: { workspaceId },
     });
   }
 

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -75,7 +75,7 @@ export function TurnReviewCard({
   onForkFromTurn?: (turnId: string) => void;
 }) {
   const duration = formatTurnDuration(turn.durationMs);
-  const diffstat = turn.diffstat && (
+  const diffstat = turn.diffstat && hasFileChanges(turn.diffstat) && (
     <TurnDiffstat
       stat={turn.diffstat}
       turnId={turn.turnId}
@@ -230,6 +230,11 @@ function TurnActionsMenu({
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+/** A recorded zero-stat is still a diffstat; the seam only shows real changes. */
+function hasFileChanges(stat: Diffstat): boolean {
+  return stat.files > 0 || stat.insertions > 0 || stat.deletions > 0;
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { stepWorkspaceId } from "./railNavigation";
+import { nextWorkspaceAfterLeaving, stepWorkspaceId } from "./railNavigation";
 
 describe("stepWorkspaceId", () => {
   const rail = ["a", "b", "c"];
@@ -27,5 +27,17 @@ describe("stepWorkspaceId", () => {
   it("has nowhere to go on an empty rail", () => {
     expect(stepWorkspaceId([], undefined, 1)).toBeNull();
     expect(stepWorkspaceId([], "a", -1)).toBeNull();
+  });
+});
+
+describe("nextWorkspaceAfterLeaving", () => {
+  it("opens the next live card, wrapping at the end of the rail", () => {
+    expect(nextWorkspaceAfterLeaving(["a", "b", "c"], "a")).toBe("b");
+    expect(nextWorkspaceAfterLeaving(["a", "b", "c"], "c")).toBe("a");
+  });
+
+  it("falls through to the code home when nothing else is live", () => {
+    expect(nextWorkspaceAfterLeaving(["a"], "a")).toBeNull();
+    expect(nextWorkspaceAfterLeaving([], "a")).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
@@ -49,3 +49,18 @@ export function stepRailWorkspace(
 ): string | null {
   return stepWorkspaceId(railWorkspaceIds(), current, delta);
 }
+
+/**
+ * The workspace to open after `leftId` leaves the rail, or `null` for `/code`.
+ *
+ * Archiving the open workspace must not leave the reader on a page the rail
+ * no longer draws. The next live card is the replacement; an empty rail falls
+ * through to the code home.
+ */
+export function nextWorkspaceAfterLeaving(
+  ids: readonly string[],
+  leftId: string,
+): string | null {
+  const next = stepWorkspaceId(ids, leftId, 1);
+  return next && next !== leftId ? next : null;
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -39,6 +39,8 @@ import {
 } from "./codeWorktreeHost";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
+import { nextWorkspaceAfterLeaving, railWorkspaceIds } from "./railNavigation";
+import { codeWorkspaceIdFromPath } from "./routes";
 import { startUneffMeWorkspace } from "./uneffMe";
 
 /**
@@ -357,16 +359,31 @@ export function useWorkspaceCardCommands(): {
     });
   }
 
-  async function afterArchive(archived: CodeWorkspaceSnapshot) {
+  async function afterArchive(
+    archived: CodeWorkspaceSnapshot,
+    liveIds: readonly string[],
+  ) {
+    const viewing = codeWorkspaceIdFromPath(pathname) === archived.id;
+    const nextId = viewing
+      ? nextWorkspaceAfterLeaving(liveIds, archived.id)
+      : null;
     upsertWorkspace(archived);
     forgetWorkspaceSession(archived.id);
     toast.success("Workspace archived");
-    if (pathname === `/code/w/${archived.id}`) {
-      await navigate({ to: "/code", replace: true });
+    if (!viewing) return;
+    if (nextId) {
+      await navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId: nextId },
+        replace: true,
+      });
+      return;
     }
+    await navigate({ to: "/code", replace: true });
   }
 
   async function runArchive(workspace: CodeWorkspaceSnapshot) {
+    const liveIds = railWorkspaceIds();
     const onOptimisticChange = (archived: boolean) => {
       upsertWorkspace(
         archived
@@ -386,7 +403,7 @@ export function useWorkspaceCardCommands(): {
         onOptimisticChange,
       });
       if (!archived) return;
-      await afterArchive(archived);
+      await afterArchive(archived, liveIds);
     } catch (error) {
       toast.error(friendlyErrorMessage(error, "Could not archive"));
     }
@@ -399,6 +416,7 @@ export function useWorkspaceCardCommands(): {
    * confirmation still stands between the click and the worktree going away.
    */
   async function runForceArchive(workspace: CodeWorkspaceSnapshot) {
+    const liveIds = railWorkspaceIds();
     const ok = await confirm({
       title: "Discard changes and archive?",
       description:
@@ -414,7 +432,10 @@ export function useWorkspaceCardCommands(): {
     };
     upsertWorkspace(optimistic);
     try {
-      await afterArchive(await client.archiveCodeWorkspace(workspace.id, true));
+      await afterArchive(
+        await client.archiveCodeWorkspace(workspace.id, true),
+        liveIds,
+      );
     } catch (error) {
       upsertWorkspace(workspace);
       toast.error(friendlyErrorMessage(error, "Could not archive"));

--- a/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
@@ -234,6 +234,9 @@ export const FirstRepository: Story = {
     await expect(
       await canvas.findByRole("heading", { name: "Start with a repository" }),
     ).toBeVisible();
+    await expect(
+      canvas.getByRole("button", { name: "Workspaces" }),
+    ).toBeVisible();
   },
 };
 

--- a/crates/tidebreak-desktop/ui/src/stories/MessageMarkdown.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/MessageMarkdown.stories.tsx
@@ -54,3 +54,18 @@ export const HighlightedPassage: Story = {
     highlightRange: { start: 4, end: 18 },
   },
 };
+
+/** A localhost URL must stay one link even when the line wraps at the query. */
+export const WrappedLocalUrl: Story = {
+  args: {
+    children:
+      "Storybook is still at http://127.0.0.1:6031/?path=/story/code-workspace-card--hover-idle-session if you want another look.",
+  },
+  decorators: [
+    (Story) => (
+      <article className="message message-assistant mx-auto w-80 rounded-xl bg-background px-4 py-3">
+        <Story />
+      </article>
+    ),
+  ],
+};

--- a/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
@@ -76,9 +76,20 @@ export const CompletedWithRecap: Story = {
   },
 };
 
-/** A turn that changed nothing still says it finished. */
+/** A turn that changed nothing still says it finished, without a zero-stat chip. */
 export const CompletedNoChanges: Story = {
-  args: { turn: boundary({ diffstat: null }) },
+  args: {
+    turn: boundary({
+      diffstat: { files: 0, insertions: 0, deletions: 0, truncated: false },
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("group", { name: "Turn finished" }),
+    ).toBeInTheDocument();
+    await expect(canvas.queryByText("0 files")).not.toBeInTheDocument();
+  },
 };
 
 export const Failed: Story = {

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -780,14 +780,16 @@ body {
   }
 
   .message-user-frame {
+    display: flex;
     width: 100%;
     max-width: 100%;
-    align-self: flex-start;
+    flex-direction: column;
+    align-items: flex-end;
   }
 
   .message-user {
     width: fit-content;
-    max-width: 100%;
+    max-width: min(36rem, 85%);
     border-radius: var(--radius);
     padding: 0.625rem 0.75rem;
     background: var(--muted);
@@ -1444,6 +1446,7 @@ body {
   .message-markdown a {
     color: inherit;
     font-weight: 500;
+    overflow-wrap: anywhere;
     text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
     text-underline-offset: 0.16em;
   }

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1438,6 +1438,20 @@ fn find_gh(search_path: Option<&str>) -> Option<PathBuf> {
             return Some(candidate);
         }
     }
+    if search_path.is_some() {
+        return None;
+    }
+    // Packaged apps inherit a GUI PATH that often omits Homebrew. Login-shell
+    // probing still runs after this; these are the install locations `gh`
+    // actually uses when that probe cannot run.
+    for candidate in [
+        PathBuf::from("/opt/homebrew/bin/gh"),
+        PathBuf::from("/usr/local/bin/gh"),
+    ] {
+        if is_executable(&candidate) {
+            return Some(candidate);
+        }
+    }
     None
 }
 

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1444,15 +1444,12 @@ fn find_gh(search_path: Option<&str>) -> Option<PathBuf> {
     // Packaged apps inherit a GUI PATH that often omits Homebrew. Login-shell
     // probing still runs after this; these are the install locations `gh`
     // actually uses when that probe cannot run.
-    for candidate in [
+    [
         PathBuf::from("/opt/homebrew/bin/gh"),
         PathBuf::from("/usr/local/bin/gh"),
-    ] {
-        if is_executable(&candidate) {
-            return Some(candidate);
-        }
-    }
-    None
+    ]
+    .into_iter()
+    .find(|candidate| is_executable(candidate))
 }
 
 #[cfg(windows)]

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -33,7 +33,7 @@ use tidebreak_core::{
     bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
     CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeSession,
     CodeSessionId, CodeSessionLifecycle, CodeSubagentStatus, CodeSubagentSummary, CodeTurn,
-    CodeTurnId, CodeTurnStatus, CodeUsage, CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind,
+    CodeTurnId, CodeTurnStatus, CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind,
     HarnessNoticeLevel, OwnerId, PermissionMode, ToolOutcome,
 };
 use tidebreak_harness::{
@@ -42,9 +42,6 @@ use tidebreak_harness::{
 };
 
 use super::bus::CodeEventBus;
-
-const HIGH_FIRST_CALL_CONTEXT_TOKENS: u64 = 20_000;
-const SHORT_FIRST_TURN_INPUT_CHARS: usize = 2_000;
 
 pub(crate) enum WorkerCommand {
     RunTurn {
@@ -582,26 +579,6 @@ impl HarnessEventSink for LiveSink {
             return;
         }
         let turn_id = *self.turn_id.lock().unwrap();
-        if let (Some(turn_id), HarnessEvent::TurnCompleted { usage }) = (turn_id, &event) {
-            if let Ok(Some(turn)) =
-                tidebreak_core::db::code::get_turn(&self.db, &self.owner, turn_id).await
-            {
-                if let Some(message) = high_first_call_context_warning(&turn, usage) {
-                    let _ = persist_and_publish(
-                        &self.db,
-                        &self.bus,
-                        &self.owner,
-                        self.session_id,
-                        self.spawn_epoch,
-                        CodeEvent::HarnessNotice {
-                            level: HarnessNoticeLevel::Warning,
-                            message,
-                        },
-                    )
-                    .await;
-                }
-            }
-        }
         let Some(code_event) = map_event(event, turn_id) else {
             return;
         };
@@ -697,20 +674,6 @@ impl HarnessEventSink for LiveSink {
             recap.spawn(self.owner.clone(), self.session_id, turn_id);
         }
     }
-}
-
-fn high_first_call_context_warning(turn: &CodeTurn, usage: &CodeUsage) -> Option<String> {
-    let context_tokens = usage.first_call_context_tokens?;
-    let input_chars = turn.user_input.chars().count();
-    if turn.ordinal != 1
-        || input_chars > SHORT_FIRST_TURN_INPUT_CHARS
-        || context_tokens < HIGH_FIRST_CALL_CONTEXT_TOKENS
-    {
-        return None;
-    }
-    Some(format!(
-        "The first model call used {context_tokens} context tokens for a {input_chars}-character first-turn prompt. Check harness startup instructions and injected context for duplication."
-    ))
 }
 
 /// Start the worker for a session.
@@ -2764,47 +2727,6 @@ mod tests {
             CodeSubagentStatus::Failed
         ));
         assert_eq!(failed[0].status, CodeSubagentStatus::Failed);
-    }
-
-    #[test]
-    fn high_first_call_context_warns_only_for_short_first_turns() {
-        let mut turn = CodeTurn {
-            id: CodeTurnId::new(),
-            session_id: CodeSessionId::new(),
-            ordinal: 1,
-            status: CodeTurnStatus::Completed,
-            model: None,
-            fast_mode: false,
-            user_input: "fix the parser".into(),
-            user_input_blob_id: None,
-            attachments: Vec::new(),
-            checkpoint_ref: None,
-            diffstat: None,
-            usage: None,
-            narrative: None,
-            started_at: Utc::now(),
-            ended_at: Some(Utc::now()),
-        };
-        let usage = CodeUsage {
-            first_call_context_tokens: Some(HIGH_FIRST_CALL_CONTEXT_TOKENS),
-            ..CodeUsage::default()
-        };
-
-        assert!(high_first_call_context_warning(&turn, &usage).is_some());
-        turn.ordinal = 2;
-        assert!(high_first_call_context_warning(&turn, &usage).is_none());
-        turn.ordinal = 1;
-        turn.user_input = "x".repeat(SHORT_FIRST_TURN_INPUT_CHARS + 1);
-        assert!(high_first_call_context_warning(&turn, &usage).is_none());
-        turn.user_input = "short".into();
-        assert!(high_first_call_context_warning(
-            &turn,
-            &CodeUsage {
-                first_call_context_tokens: Some(HIGH_FIRST_CALL_CONTEXT_TOKENS - 1),
-                ..CodeUsage::default()
-            }
-        )
-        .is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Creating a workspace now opens it as soon as it exists. Archiving the one on screen moves you to the next live workspace, or to `/code` if none remain. The Workspaces heading goes to code home.

Cmd+T opens the new-tab menu. File search stays on Cmd+P. Source control and pull request stay in the review sidebar so they do not replace chat. The pull request tab is hidden until a PR exists.

Clicking a transcript link opens it in-app. Command-click opens it in the system browser. A URL that wraps across a line stays one link. User messages sit on the right in Work and Code.

Empty `0 files +0 −0` chips stay off the turn seam. The first-call context harness notice is gone. Packaged apps look for Homebrew `gh` when PATH does not include it.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome format src`
- `pnpm --dir crates/tidebreak-desktop/ui lint`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- focused Vitest on the changed UI files (192 tests)
- `cargo test -p tidebreak-server --lib -- code::session_worker code::gh::tests` (42 tests)
- Storybook screenshots of Conversation/Transcript and Code/Transcript for user-bubble alignment

## Compatibility and risk

None. No wire-format change. Homebrew `gh` lookup only runs when PATH search found nothing.
