### PR TITLE
fix(code): keep late transcript rows on the finished turn

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AssistantMessageBody.tsx
+++ b/crates/tidebreak-desktop/ui/src/AssistantMessageBody.tsx
@@ -18,6 +18,8 @@ export function AssistantMessageBody({
 }) {
   const displayed = useStreamingTypewriter(text, streaming);
   return (
-    <MessageMarkdown containerRef={containerRef}>{displayed}</MessageMarkdown>
+    <MessageMarkdown containerRef={containerRef}>
+      {streaming ? displayed : text}
+    </MessageMarkdown>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -1848,6 +1848,71 @@ describe("hydrate then replay", () => {
     ]);
   });
 
+  it("inserts a late assistant message before the finished turn's seam", () => {
+    const { state: completed } = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "turn_completed", usage: NO_USAGE },
+    ]);
+    const late = reduceCodeSessionEvent(
+      completed,
+      framed(completed.lastSeq + 1, {
+        type: "assistant_message",
+        text: "Three issues triaged.",
+      }),
+      deps(),
+    );
+
+    expect(late.state.items.map((item) => item.kind)).toEqual([
+      "assistant",
+      "turn_boundary",
+    ]);
+    expect(late.state.items[0]).toMatchObject({
+      kind: "assistant",
+      text: "Three issues triaged.",
+      turnId: "t1",
+      streaming: false,
+    });
+  });
+
+  it("keeps a late assistant message on the turn that just finished after the next prompt is accepted", () => {
+    const { state: completed } = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "turn_completed", usage: NO_USAGE },
+    ]);
+    const accepted = applyAcceptedTurn(completed, {
+      ...SNAPSHOT_TURN,
+      id: "t2",
+      ordinal: 2,
+      status: "running",
+      user_input: "poll for them",
+      ended_at: undefined,
+    });
+    const late = reduceCodeSessionEvent(
+      accepted,
+      framed(accepted.lastSeq + 1, {
+        type: "assistant_message",
+        text: "Three issues triaged.",
+      }),
+      deps(),
+    );
+
+    expect(late.state.items.map((item) => item.kind)).toEqual([
+      "assistant",
+      "turn_boundary",
+      "user",
+    ]);
+    expect(late.state.items[0]).toMatchObject({
+      kind: "assistant",
+      text: "Three issues triaged.",
+      turnId: "t1",
+    });
+    expect(late.state.items[2]).toMatchObject({
+      kind: "user",
+      turnId: "t2",
+      text: "poll for them",
+    });
+  });
+
   it("keeps a later turn's seam from capturing an earlier turn's replay", () => {
     const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
       SNAPSHOT_TURN,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -775,8 +775,7 @@ export function reduceCodeSessionEvent(
   const effects: CodeSessionEffect[] = [];
   // Snapshot activity can be stale across a retained close. Historical rows
   // stay unassigned until replay itself establishes their turn.
-  const attributedTurnId =
-    framed.replayed === true ? state.journalTurnId : state.activeTurnId;
+  const attributedTurnId = activityTurnId(state, framed);
 
   switch (event.type) {
     case "session_started":
@@ -1233,6 +1232,36 @@ function replayFollowsAcceptedTurn(
     state.acceptedTurnFence !== null &&
     framed.seq > state.acceptedTurnFence.afterSeq
   );
+}
+
+/**
+ * Which turn a frame's rows belong on.
+ *
+ * Replay follows the journal's `turn_started`. Live frames follow the active
+ * turn, except in the window after a submit is accepted and before the engine
+ * names that turn: leftover activity from the turn that just finished must
+ * not land on the new prompt. That is what made a delayed first reply appear
+ * under the next user message.
+ */
+function activityTurnId(
+  state: CodeSessionState,
+  framed: SequencedCodeEventFrame,
+): string | null {
+  if (framed.replayed === true) return state.journalTurnId;
+  if (state.acceptedTurnFence !== null && state.journalTurnId === null) {
+    return lastBoundaryTurnId(state.items) ?? state.activeTurnId;
+  }
+  return state.activeTurnId ?? lastBoundaryTurnId(state.items);
+}
+
+function lastBoundaryTurnId(
+  items: readonly CodeTranscriptItem[],
+): string | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item.kind === "turn_boundary" && item.turnId) return item.turnId;
+  }
+  return null;
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -506,7 +506,7 @@ function itemSignature(
     case "turn_boundary":
       return `${item.status}:${item.diffstat?.files ?? -1}`;
     case "assistant":
-      return `${item.streaming}:${ownsCopyAction}`;
+      return `${item.streaming}:${ownsCopyAction}:${item.text.length}`;
     case "reasoning":
       return String(item.streaming);
     case "file_activity":

--- a/crates/tidebreak-desktop/ui/src/useStreamingTypewriter.test.ts
+++ b/crates/tidebreak-desktop/ui/src/useStreamingTypewriter.test.ts
@@ -37,7 +37,7 @@ describe("useStreamingTypewriter", () => {
     expect(result.current).toBe("Searching the web and 1 other task");
   });
 
-  it("drains the remaining buffer smoothly when a live step settles", async () => {
+  it("shows the full text when a live step settles", () => {
     vi.useFakeTimers();
     const { result, rerender } = renderHook(
       ({ text, live }) => useStreamingTypewriter(text, live),
@@ -45,15 +45,8 @@ describe("useStreamingTypewriter", () => {
     );
 
     rerender({ text: "Searching the web and 1 other task", live: true });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(20);
-    });
     rerender({ text: "Searching the web and 1 other task", live: false });
 
-    expect(result.current).not.toBe("Searching the web and 1 other task");
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1_000);
-    });
     expect(result.current).toBe("Searching the web and 1 other task");
   });
 

--- a/crates/tidebreak-desktop/ui/src/useStreamingTypewriter.ts
+++ b/crates/tidebreak-desktop/ui/src/useStreamingTypewriter.ts
@@ -85,7 +85,6 @@ export function useStreamingTypewriter(text: string, live: boolean): string {
 
   useEffect(() => {
     const previousTarget = targetRef.current;
-    const wasLive = liveRef.current;
     targetRef.current = text;
     liveRef.current = live;
 
@@ -97,17 +96,12 @@ export function useStreamingTypewriter(text: string, live: boolean): string {
       return;
     }
     if (!live) {
-      // A stream that just ended may still have a small presentation buffer.
-      // Drain it quickly instead of snapping the final characters into place.
-      // Ordinary historical updates still render immediately.
-      const canFinishSmoothly =
-        wasLive && text.startsWith(displayedRef.current);
-      if (!canFinishSmoothly) {
-        stop();
-        showImmediately(text);
-      } else if (timerRef.current === null) {
-        tick();
-      }
+      // A settled row must not wait on the typewriter timer. If that timer
+      // never fires, the prose stays blank until some later render — a send
+      // was enough to unstick it. Historical updates and a stream that just
+      // ended both render at once.
+      stop();
+      showImmediately(text);
       return;
     }
     if (text === previousTarget) return;

--- a/crates/tidebreak-desktop/ui/src/useTranscriptFollow.ts
+++ b/crates/tidebreak-desktop/ui/src/useTranscriptFollow.ts
@@ -84,6 +84,7 @@ export function useTranscriptFollow({
   const contentObserverRef = useRef<ResizeObserver | null>(null);
   const [scrolledAway, setScrolledAway] = useState(false);
   const [fadeClass, setFadeClass] = useState<string | null>(null);
+  const followPaintRef = useRef<number | null>(null);
 
   // Reflect where the scroll sits onto the edge-fade masks: fade the top once
   // there is content above, the bottom while there is content below.
@@ -109,10 +110,25 @@ export function useTranscriptFollow({
     if (!scroll) return;
     isProgrammaticRef.current = true;
     setScrolledAway(false);
-    scrollToLatest(scroll, "auto");
-    requestAnimationFrame(() => {
-      isProgrammaticRef.current = false;
-    });
+    // Two frames: the first lets newly inserted rows paint, the second
+    // scrolls. A catch-up scroll in the same frame as the insert is what
+    // WKWebView blanks until the next user scroll — a send.
+    if (followPaintRef.current !== null) return;
+    const afterPaint = () => {
+      followPaintRef.current = requestAnimationFrame(() => {
+        followPaintRef.current = null;
+        const latest = scrollRef.current;
+        if (!latest) {
+          isProgrammaticRef.current = false;
+          return;
+        }
+        scrollToLatest(latest, "auto");
+        requestAnimationFrame(() => {
+          isProgrammaticRef.current = false;
+        });
+      });
+    };
+    followPaintRef.current = requestAnimationFrame(afterPaint);
   }, []);
 
   const smoothScrollToBottom = useCallback(() => {
@@ -246,6 +262,15 @@ export function useTranscriptFollow({
     if (visible && followsLatestRef.current) scrollToBottom("auto");
     updateEdges();
   }, [visible, scrollToBottom, updateEdges]);
+
+  useEffect(() => {
+    return () => {
+      if (followPaintRef.current !== null) {
+        cancelAnimationFrame(followPaintRef.current);
+        followPaintRef.current = null;
+      }
+    };
+  }, []);
 
   return {
     scrollRef: attachScrollRef,


### PR DESCRIPTION
A follow-up send was pinning leftover live frames to the new prompt. The first reply stayed blank, then appeared under the second message.

Late live activity now stays on the turn that just finished until the engine starts the next one. Settled assistant text renders immediately instead of waiting on the typewriter timer. Follow waits two frames before scrolling so WKWebView can paint the new rows.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui test`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check` on the touched files

## Compatibility and risk

None. Client-only transcript presentation.
