### PR TITLE
fix(code): preserve hosted delivery action refusals

### DIFF
--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -127,6 +127,10 @@ enum DeliveryApi {
 }
 
 impl DeliveryApi {
+    fn can_mark_pull_request_ready(&self) -> bool {
+        matches!(self, Self::Gh { .. })
+    }
+
     async fn get(&self, endpoint: &str) -> Result<Value, String> {
         match self {
             Self::Gh {
@@ -474,6 +478,29 @@ async fn delivery_api(
             })
         }
     }
+}
+
+/// Build the same transport as reads, while preserving the forge-specific
+/// refusal kind if a credential mint fails after the availability probe.
+///
+/// The probe and mint are separate gateway calls. A disconnect or expired
+/// caller session between them must remain a hosted-forge refusal, not turn
+/// into a generic GitHub request error.
+async fn delivery_action_api(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    reader: &DeliveryReader,
+    target: &CodeGitHubRepositoryTarget,
+) -> Result<DeliveryApi, ServerError> {
+    delivery_api(runtime, owner, reader, target)
+        .await
+        .map_err(|message| {
+            if matches!(reader, DeliveryReader::Forge) {
+                ServerError::conflict_kind("git_forge_not_offered", message)
+            } else {
+                ServerError::bad_request_kind("github", message)
+            }
+        })
 }
 
 async fn resolve_repository_for_api(
@@ -1428,7 +1455,7 @@ pub(crate) async fn pull_request_detail(
 
     let open = summary.state == "open";
     Ok(CodeDeliveryPullRequestDetail {
-        can_mark_ready: open && summary.draft,
+        can_mark_ready: open && summary.draft && api.can_mark_pull_request_ready(),
         can_merge: open && !summary.draft,
         can_rerun_failed: summary.checks.iter().any(|check| {
             check.bucket == PullRequestCheckBucket::Fail && check.workflow_run_id.is_some()
@@ -1583,9 +1610,7 @@ pub(crate) async fn act_on_pull_request(
             _ => {}
         }
     }
-    let api = delivery_api(runtime, owner, &reader, &target.repository)
-        .await
-        .map_err(map_forge_action_error)?;
+    let api = delivery_action_api(runtime, owner, &reader, &target.repository).await?;
     // The canonical URL of the pull request being acted on: the key the
     // workspace-side digest refresh matches on (decision 66).
     let pull_request_url = format!(
@@ -1983,9 +2008,7 @@ pub(crate) async fn act_on_run(
     }
     let access = delivery_access(runtime, owner, false).await;
     let reader = access.require_reader()?;
-    let api = delivery_api(runtime, owner, &reader, &body.target.repository)
-        .await
-        .map_err(map_forge_action_error)?;
+    let api = delivery_action_api(runtime, owner, &reader, &body.target.repository).await?;
     match body.action {
         CodeDeliveryRunAction::Rerun => {
             api.rerun_workflow(&body.target.repository, body.target.id)
@@ -4321,14 +4344,21 @@ fn map_gh_error(error: gh::GhError) -> ServerError {
     }
 }
 
-fn map_forge_action_error(message: String) -> ServerError {
-    let lower = message.to_ascii_lowercase();
-    if lower.contains("head branch was modified") || lower.contains("head sha") {
-        ServerError::conflict_kind("pr_head_changed", message)
-    } else if lower.contains("not mergeable") || lower.contains("merge cannot be performed") {
-        ServerError::conflict_kind("pr_not_mergeable", message)
-    } else {
-        ServerError::bad_request_kind("github", message)
+fn map_forge_action_error(error: super::forge_rest::ForgeActionError) -> ServerError {
+    let message = error.message().to_owned();
+    match error.kind() {
+        super::forge_rest::ForgeActionErrorKind::AuthFailed => {
+            ServerError::conflict_kind("git_auth_failed", message)
+        }
+        super::forge_rest::ForgeActionErrorKind::HeadChanged => {
+            ServerError::conflict_kind("pr_head_changed", message)
+        }
+        super::forge_rest::ForgeActionErrorKind::NotMergeable => {
+            ServerError::conflict_kind("pr_not_mergeable", message)
+        }
+        super::forge_rest::ForgeActionErrorKind::Other => {
+            ServerError::bad_request_kind("github", message)
+        }
     }
 }
 

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -48,6 +48,76 @@ const CHECK_RUN_CONCURRENCY: usize = 4;
 const TIMELINE_PAGE_SIZE: u32 = 100;
 const TIMELINE_PAGE_LIMIT: u32 = 20;
 
+/// Stable action classification kept beside the HTTP response that proves it.
+///
+/// GitHub's merge endpoint assigns meaning to status codes even when an
+/// enterprise host replaces the English response text. Delivery must not
+/// lose `pr_head_changed` or `pr_not_mergeable` merely because that prose
+/// changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ForgeActionErrorKind {
+    AuthFailed,
+    HeadChanged,
+    NotMergeable,
+    Other,
+}
+
+/// One failed forge mutation, with the user-facing host message and the
+/// stable classification Delivery exposes on the wire.
+#[derive(Debug)]
+pub(crate) struct ForgeActionError {
+    kind: ForgeActionErrorKind,
+    message: String,
+}
+
+impl ForgeActionError {
+    fn transport(message: String) -> Self {
+        Self {
+            kind: ForgeActionErrorKind::Other,
+            message,
+        }
+    }
+
+    fn response(status: reqwest::StatusCode, value: &Value) -> Self {
+        let message = forge_message(status, value);
+        let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
+            ForgeActionErrorKind::AuthFailed
+        } else {
+            ForgeActionErrorKind::Other
+        };
+        Self { kind, message }
+    }
+
+    fn merge_response(status: reqwest::StatusCode, value: &Value) -> Self {
+        let message = forge_message(status, value);
+        let lower = message.to_ascii_lowercase();
+        let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
+            ForgeActionErrorKind::AuthFailed
+        } else if status == reqwest::StatusCode::CONFLICT
+            || lower.contains("head branch was modified")
+            || lower.contains("head sha")
+        {
+            ForgeActionErrorKind::HeadChanged
+        } else if status == reqwest::StatusCode::METHOD_NOT_ALLOWED
+            || lower.contains("not mergeable")
+            || lower.contains("merge cannot be performed")
+        {
+            ForgeActionErrorKind::NotMergeable
+        } else {
+            ForgeActionErrorKind::Other
+        };
+        Self { kind, message }
+    }
+
+    pub(crate) fn kind(&self) -> ForgeActionErrorKind {
+        self.kind
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+}
+
 /// The REST base for a forge host: `api.github.com` for github.com, the
 /// GHES `/api/v3/` convention for anything else.
 ///
@@ -337,16 +407,17 @@ pub(crate) async fn create_stack(
     target: &CodeGitHubRepositoryTarget,
     credential: &GitCredential,
     numbers: &[u64],
-) -> Result<(), String> {
+) -> Result<(), ForgeActionError> {
     let (status, value) = request(
         reqwest::Method::POST,
         format!("{api_base}/repos/{}/{}/stacks", target.owner, target.name),
         credential,
         Some(&serde_json::json!({ "pull_requests": numbers })),
     )
-    .await?;
+    .await
+    .map_err(ForgeActionError::transport)?;
     if !status.is_success() {
-        return Err(forge_message(status, &value));
+        return Err(ForgeActionError::response(status, &value));
     }
     Ok(())
 }
@@ -359,7 +430,7 @@ pub(crate) async fn merge_pull_request(
     number: u64,
     method: &str,
     expected_head_sha: &str,
-) -> Result<(), String> {
+) -> Result<(), ForgeActionError> {
     let (status, value) = request(
         reqwest::Method::PUT,
         format!(
@@ -372,9 +443,16 @@ pub(crate) async fn merge_pull_request(
             "merge_method": method,
         })),
     )
-    .await?;
-    if !status.is_success() || value.get("merged").and_then(Value::as_bool) != Some(true) {
-        return Err(forge_message(status, &value));
+    .await
+    .map_err(ForgeActionError::transport)?;
+    if !status.is_success() {
+        return Err(ForgeActionError::merge_response(status, &value));
+    }
+    if value.get("merged").and_then(Value::as_bool) != Some(true) {
+        return Err(ForgeActionError {
+            kind: ForgeActionErrorKind::NotMergeable,
+            message: forge_message(status, &value),
+        });
     }
     Ok(())
 }
@@ -389,7 +467,7 @@ pub(crate) async fn enable_pull_request_auto_merge(
     number: u64,
     method: &str,
     expected_head_sha: &str,
-) -> Result<(), String> {
+) -> Result<(), ForgeActionError> {
     let (status, pull) = request(
         reqwest::Method::GET,
         format!(
@@ -399,16 +477,19 @@ pub(crate) async fn enable_pull_request_auto_merge(
         credential,
         None,
     )
-    .await?;
+    .await
+    .map_err(ForgeActionError::transport)?;
     if !status.is_success() {
-        return Err(forge_message(status, &pull));
+        return Err(ForgeActionError::merge_response(status, &pull));
     }
     let node_id = pull
         .get("node_id")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|id| !id.is_empty())
-        .ok_or_else(|| "the forge pull request did not name a node id".to_owned())?;
+        .ok_or_else(|| {
+            ForgeActionError::transport("the forge pull request did not name a node id".to_owned())
+        })?;
     let merge_method = match method {
         "squash" => "SQUASH",
         "rebase" => "REBASE",
@@ -428,7 +509,8 @@ pub(crate) async fn enable_pull_request_auto_merge(
         credential,
         Some(&body),
     )
-    .await?;
+    .await
+    .map_err(ForgeActionError::transport)?;
     if !status.is_success()
         || value
             .get("errors")
@@ -438,7 +520,7 @@ pub(crate) async fn enable_pull_request_auto_merge(
             .pointer("/data/enablePullRequestAutoMerge")
             .is_none_or(Value::is_null)
     {
-        return Err(forge_message(status, &value));
+        return Err(ForgeActionError::merge_response(status, &value));
     }
     Ok(())
 }
@@ -450,7 +532,7 @@ pub(crate) async fn update_pull_request_state(
     credential: &GitCredential,
     number: u64,
     state: &str,
-) -> Result<(), String> {
+) -> Result<(), ForgeActionError> {
     let (status, value) = request(
         reqwest::Method::PATCH,
         format!(
@@ -460,9 +542,10 @@ pub(crate) async fn update_pull_request_state(
         credential,
         Some(&serde_json::json!({ "state": state })),
     )
-    .await?;
+    .await
+    .map_err(ForgeActionError::transport)?;
     if !status.is_success() {
-        return Err(forge_message(status, &value));
+        return Err(ForgeActionError::response(status, &value));
     }
     Ok(())
 }
@@ -474,7 +557,7 @@ pub(crate) async fn comment_on_pull_request(
     credential: &GitCredential,
     number: u64,
     body: &str,
-) -> Result<(), String> {
+) -> Result<(), ForgeActionError> {
     let (status, value) = request(
         reqwest::Method::POST,
         format!(
@@ -484,9 +567,10 @@ pub(crate) async fn comment_on_pull_request(
         credential,
         Some(&serde_json::json!({ "body": body })),
     )
-    .await?;
+    .await
+    .map_err(ForgeActionError::transport)?;
     if !status.is_success() {
-        return Err(forge_message(status, &value));
+        return Err(ForgeActionError::response(status, &value));
     }
     Ok(())
 }
@@ -497,7 +581,7 @@ pub(crate) async fn rerun_workflow(
     target: &CodeGitHubRepositoryTarget,
     credential: &GitCredential,
     run_id: u64,
-) -> Result<(), String> {
+) -> Result<(), ForgeActionError> {
     rerun(api_base, target, credential, run_id, "rerun").await
 }
 
@@ -507,7 +591,7 @@ pub(crate) async fn rerun_failed_jobs(
     target: &CodeGitHubRepositoryTarget,
     credential: &GitCredential,
     run_id: u64,
-) -> Result<(), String> {
+) -> Result<(), ForgeActionError> {
     rerun(api_base, target, credential, run_id, "rerun-failed-jobs").await
 }
 
@@ -517,7 +601,7 @@ async fn rerun(
     credential: &GitCredential,
     run_id: u64,
     action: &str,
-) -> Result<(), String> {
+) -> Result<(), ForgeActionError> {
     let (status, value) = request(
         reqwest::Method::POST,
         format!(
@@ -527,9 +611,10 @@ async fn rerun(
         credential,
         None,
     )
-    .await?;
+    .await
+    .map_err(ForgeActionError::transport)?;
     if !status.is_success() {
-        return Err(forge_message(status, &value));
+        return Err(ForgeActionError::response(status, &value));
     }
     Ok(())
 }

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -88,23 +88,13 @@ impl ForgeActionError {
         Self { kind, message }
     }
 
-    fn merge_response(status: reqwest::StatusCode, value: &Value) -> Self {
+    fn pull_request_merge_response(status: reqwest::StatusCode, value: &Value) -> Self {
         let message = forge_message(status, value);
-        let lower = message.to_ascii_lowercase();
-        let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
-            ForgeActionErrorKind::AuthFailed
-        } else if status == reqwest::StatusCode::CONFLICT
-            || lower.contains("head branch was modified")
-            || lower.contains("head sha")
-        {
-            ForgeActionErrorKind::HeadChanged
-        } else if status == reqwest::StatusCode::METHOD_NOT_ALLOWED
-            || lower.contains("not mergeable")
-            || lower.contains("merge cannot be performed")
-        {
-            ForgeActionErrorKind::NotMergeable
-        } else {
-            ForgeActionErrorKind::Other
+        let kind = match status {
+            reqwest::StatusCode::UNAUTHORIZED => ForgeActionErrorKind::AuthFailed,
+            reqwest::StatusCode::CONFLICT => ForgeActionErrorKind::HeadChanged,
+            reqwest::StatusCode::METHOD_NOT_ALLOWED => ForgeActionErrorKind::NotMergeable,
+            _ => ForgeActionErrorKind::Other,
         };
         Self { kind, message }
     }
@@ -446,7 +436,9 @@ pub(crate) async fn merge_pull_request(
     .await
     .map_err(ForgeActionError::transport)?;
     if !status.is_success() {
-        return Err(ForgeActionError::merge_response(status, &value));
+        return Err(ForgeActionError::pull_request_merge_response(
+            status, &value,
+        ));
     }
     if value.get("merged").and_then(Value::as_bool) != Some(true) {
         return Err(ForgeActionError {
@@ -480,7 +472,7 @@ pub(crate) async fn enable_pull_request_auto_merge(
     .await
     .map_err(ForgeActionError::transport)?;
     if !status.is_success() {
-        return Err(ForgeActionError::merge_response(status, &pull));
+        return Err(ForgeActionError::response(status, &pull));
     }
     let node_id = pull
         .get("node_id")
@@ -520,7 +512,7 @@ pub(crate) async fn enable_pull_request_auto_merge(
             .pointer("/data/enablePullRequestAutoMerge")
             .is_none_or(Value::is_null)
     {
-        return Err(ForgeActionError::merge_response(status, &value));
+        return Err(ForgeActionError::response(status, &value));
     }
     Ok(())
 }
@@ -1013,23 +1005,32 @@ mod tests {
     #[test]
     fn pull_request_merge_statuses_ignore_rewritten_messages() {
         let kind = |status: reqwest::StatusCode, message: &str| {
-            ForgeActionError::merge_response(status, &serde_json::json!({ "message": message }))
-                .kind()
+            ForgeActionError::pull_request_merge_response(
+                status,
+                &serde_json::json!({ "message": message }),
+            )
+            .kind()
         };
         assert_eq!(
-            kind(reqwest::StatusCode::CONFLICT, "Opaque enterprise response"),
-            ForgeActionErrorKind::HeadChanged
-        );
-        assert_eq!(
-            kind(reqwest::StatusCode::CONFLICT, "Merge conflict"),
+            kind(
+                reqwest::StatusCode::CONFLICT,
+                "Pull Request is not mergeable"
+            ),
             ForgeActionErrorKind::HeadChanged
         );
         assert_eq!(
             kind(
                 reqwest::StatusCode::METHOD_NOT_ALLOWED,
-                "Opaque enterprise response"
+                "Head sha did not match the reviewed revision"
             ),
             ForgeActionErrorKind::NotMergeable
+        );
+        assert_eq!(
+            kind(
+                reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+                "Head branch was modified"
+            ),
+            ForgeActionErrorKind::Other
         );
     }
 

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -50,10 +50,10 @@ const TIMELINE_PAGE_LIMIT: u32 = 20;
 
 /// Stable action classification kept beside the HTTP response that proves it.
 ///
-/// 401 and 405 keep their meaning even when an enterprise host replaces the
-/// English body. 409 does not: GitHub uses it for a stale head and for a
-/// merge conflict, so Delivery reads the body before choosing
-/// `pr_head_changed` or `pr_not_mergeable`.
+/// This module always sends `sha` to GitHub's pull-request merge endpoint,
+/// whose contract defines 409 as a head mismatch and 405 as a merge refusal.
+/// Delivery must not lose `pr_head_changed` or `pr_not_mergeable` merely
+/// because an enterprise host replaces the English response text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ForgeActionErrorKind {
     AuthFailed,
@@ -91,21 +91,16 @@ impl ForgeActionError {
     fn merge_response(status: reqwest::StatusCode, value: &Value) -> Self {
         let message = forge_message(status, value);
         let lower = message.to_ascii_lowercase();
-        let head_changed = lower.contains("head branch was modified")
-            || lower.contains("head sha")
-            || lower.contains("sha didn't match")
-            || lower.contains("sha did not match")
-            || (lower.contains("head commit") && lower.contains("match"))
-            || (lower.contains("expected head") && lower.contains("match"));
         let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
             ForgeActionErrorKind::AuthFailed
-        } else if head_changed {
+        } else if status == reqwest::StatusCode::CONFLICT
+            || lower.contains("head branch was modified")
+            || lower.contains("head sha")
+        {
             ForgeActionErrorKind::HeadChanged
         } else if status == reqwest::StatusCode::METHOD_NOT_ALLOWED
-            || status == reqwest::StatusCode::CONFLICT
             || lower.contains("not mergeable")
             || lower.contains("merge cannot be performed")
-            || lower.contains("merge conflict")
         {
             ForgeActionErrorKind::NotMergeable
         } else {
@@ -1012,40 +1007,27 @@ mod tests {
         );
     }
 
-    /// GitHub's merge endpoint uses 409 for both a stale head and a merge
-    /// conflict. Only a body that names the SHA mismatch is `HeadChanged`.
+    /// The pull-request merge endpoint's status contract is independent of
+    /// response prose: with the `sha` request field, 409 is a stale reviewed
+    /// head and 405 is an unmergeable pull request.
     #[test]
-    fn a_merge_409_is_head_changed_only_when_the_body_names_a_stale_sha() {
+    fn pull_request_merge_statuses_ignore_rewritten_messages() {
         let kind = |status: reqwest::StatusCode, message: &str| {
             ForgeActionError::merge_response(status, &serde_json::json!({ "message": message }))
                 .kind()
         };
         assert_eq!(
-            kind(
-                reqwest::StatusCode::CONFLICT,
-                "Head branch was modified. Review and try the merge again."
-            ),
-            ForgeActionErrorKind::HeadChanged
-        );
-        assert_eq!(
-            kind(
-                reqwest::StatusCode::CONFLICT,
-                "Head sha didn't match current head of this branch."
-            ),
+            kind(reqwest::StatusCode::CONFLICT, "Opaque enterprise response"),
             ForgeActionErrorKind::HeadChanged
         );
         assert_eq!(
             kind(reqwest::StatusCode::CONFLICT, "Merge conflict"),
-            ForgeActionErrorKind::NotMergeable
-        );
-        assert_eq!(
-            kind(reqwest::StatusCode::CONFLICT, ""),
-            ForgeActionErrorKind::NotMergeable
+            ForgeActionErrorKind::HeadChanged
         );
         assert_eq!(
             kind(
                 reqwest::StatusCode::METHOD_NOT_ALLOWED,
-                "Pull Request is not mergeable"
+                "Opaque enterprise response"
             ),
             ForgeActionErrorKind::NotMergeable
         );

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -50,10 +50,10 @@ const TIMELINE_PAGE_LIMIT: u32 = 20;
 
 /// Stable action classification kept beside the HTTP response that proves it.
 ///
-/// GitHub's merge endpoint assigns meaning to status codes even when an
-/// enterprise host replaces the English response text. Delivery must not
-/// lose `pr_head_changed` or `pr_not_mergeable` merely because that prose
-/// changed.
+/// 401 and 405 keep their meaning even when an enterprise host replaces the
+/// English body. 409 does not: GitHub uses it for a stale head and for a
+/// merge conflict, so Delivery reads the body before choosing
+/// `pr_head_changed` or `pr_not_mergeable`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ForgeActionErrorKind {
     AuthFailed,
@@ -91,16 +91,21 @@ impl ForgeActionError {
     fn merge_response(status: reqwest::StatusCode, value: &Value) -> Self {
         let message = forge_message(status, value);
         let lower = message.to_ascii_lowercase();
+        let head_changed = lower.contains("head branch was modified")
+            || lower.contains("head sha")
+            || lower.contains("sha didn't match")
+            || lower.contains("sha did not match")
+            || (lower.contains("head commit") && lower.contains("match"))
+            || (lower.contains("expected head") && lower.contains("match"));
         let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
             ForgeActionErrorKind::AuthFailed
-        } else if status == reqwest::StatusCode::CONFLICT
-            || lower.contains("head branch was modified")
-            || lower.contains("head sha")
-        {
+        } else if head_changed {
             ForgeActionErrorKind::HeadChanged
         } else if status == reqwest::StatusCode::METHOD_NOT_ALLOWED
+            || status == reqwest::StatusCode::CONFLICT
             || lower.contains("not mergeable")
             || lower.contains("merge cannot be performed")
+            || lower.contains("merge conflict")
         {
             ForgeActionErrorKind::NotMergeable
         } else {
@@ -1004,6 +1009,45 @@ mod tests {
         assert_eq!(
             graphql_url("https://ghe.acme.test/api/v3"),
             "https://ghe.acme.test/api/graphql"
+        );
+    }
+
+    /// GitHub's merge endpoint uses 409 for both a stale head and a merge
+    /// conflict. Only a body that names the SHA mismatch is `HeadChanged`.
+    #[test]
+    fn a_merge_409_is_head_changed_only_when_the_body_names_a_stale_sha() {
+        let kind = |status: reqwest::StatusCode, message: &str| {
+            ForgeActionError::merge_response(status, &serde_json::json!({ "message": message }))
+                .kind()
+        };
+        assert_eq!(
+            kind(
+                reqwest::StatusCode::CONFLICT,
+                "Head branch was modified. Review and try the merge again."
+            ),
+            ForgeActionErrorKind::HeadChanged
+        );
+        assert_eq!(
+            kind(
+                reqwest::StatusCode::CONFLICT,
+                "Head sha didn't match current head of this branch."
+            ),
+            ForgeActionErrorKind::HeadChanged
+        );
+        assert_eq!(
+            kind(reqwest::StatusCode::CONFLICT, "Merge conflict"),
+            ForgeActionErrorKind::NotMergeable
+        );
+        assert_eq!(
+            kind(reqwest::StatusCode::CONFLICT, ""),
+            ForgeActionErrorKind::NotMergeable
+        );
+        assert_eq!(
+            kind(
+                reqwest::StatusCode::METHOD_NOT_ALLOWED,
+                "Pull Request is not mergeable"
+            ),
+            ForgeActionErrorKind::NotMergeable
         );
     }
 

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -2717,7 +2717,7 @@ async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
                 Some("old-head") => (
                     axum::http::StatusCode::CONFLICT,
                     axum::Json(serde_json::json!({
-                        "message": "The reviewed revision no longer matches."
+                        "message": "Head branch was modified. Review and try the merge again."
                     })),
                 ),
                 Some("blocked-head") => (
@@ -2799,7 +2799,7 @@ async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
     let (status, kind, message) = error_kind(response).await;
     assert_eq!(status, reqwest::StatusCode::CONFLICT);
     assert_eq!(kind, "pr_head_changed");
-    assert!(message.contains("reviewed revision"), "{message}");
+    assert!(message.contains("Head branch was modified"), "{message}");
 
     let response = client
         .post(format!("http://{addr}/code/delivery/pull-requests/action"))

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -2717,7 +2717,7 @@ async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
                 Some("old-head") => (
                     axum::http::StatusCode::CONFLICT,
                     axum::Json(serde_json::json!({
-                        "message": "Head branch was modified. Review and try the merge again."
+                        "message": "The reviewed revision no longer matches."
                     })),
                 ),
                 Some("blocked-head") => (
@@ -2799,7 +2799,7 @@ async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
     let (status, kind, message) = error_kind(response).await;
     assert_eq!(status, reqwest::StatusCode::CONFLICT);
     assert_eq!(kind, "pr_head_changed");
-    assert!(message.contains("Head branch was modified"), "{message}");
+    assert!(message.contains("reviewed revision"), "{message}");
 
     let response = client
         .post(format!("http://{addr}/code/delivery/pull-requests/action"))

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -2061,7 +2061,9 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
     };
     let pull = |headers: axum::http::HeaderMap| async move {
         assert_borrowed_forge_credential(&headers);
-        axum::Json(pull_request())
+        let mut pull = pull_request();
+        pull["draft"] = serde_json::Value::Bool(true);
+        axum::Json(pull)
     };
     let issue_comments = |headers: axum::http::HeaderMap| async move {
         assert_borrowed_forge_credential(&headers);
@@ -2454,6 +2456,10 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
     assert_eq!(pull_request_detail["summary"]["number"], 17);
     assert_eq!(pull_request_detail["summary"]["in_merge_queue"], true);
     assert_eq!(
+        pull_request_detail["can_mark_ready"], false,
+        "hosted REST details must not advertise the unsupported ready transition"
+    );
+    assert_eq!(
         pull_request_detail["body"],
         "Read the delivery detail over REST."
     );
@@ -2701,17 +2707,40 @@ async fn a_hosted_delivery_page_reads_and_acts_over_forge_rest() {
 async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
     let requests = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let merge_requests = Arc::clone(&requests);
-    let merge = move |headers: axum::http::HeaderMap| {
+    let merge = move |headers: axum::http::HeaderMap,
+                      axum::Json(body): axum::Json<serde_json::Value>| {
         let requests = Arc::clone(&merge_requests);
         async move {
             assert_borrowed_forge_credential(&headers);
             requests.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            (
-                axum::http::StatusCode::CONFLICT,
-                axum::Json(serde_json::json!({
-                    "message": "Head branch was modified. Review and try the merge again."
-                })),
-            )
+            match body["sha"].as_str() {
+                Some("old-head") => (
+                    axum::http::StatusCode::CONFLICT,
+                    axum::Json(serde_json::json!({
+                        "message": "The reviewed revision no longer matches."
+                    })),
+                ),
+                Some("blocked-head") => (
+                    axum::http::StatusCode::METHOD_NOT_ALLOWED,
+                    axum::Json(serde_json::json!({
+                        "message": "Branch protection rejected this operation."
+                    })),
+                ),
+                Some("soft-blocked-head") => (
+                    axum::http::StatusCode::OK,
+                    axum::Json(serde_json::json!({
+                        "merged": false,
+                        "message": "Repository policy rejected this operation."
+                    })),
+                ),
+                Some("expired-credential") => (
+                    axum::http::StatusCode::UNAUTHORIZED,
+                    axum::Json(serde_json::json!({
+                        "message": "The borrowed credential is no longer valid."
+                    })),
+                ),
+                unexpected => panic!("unexpected merge sha: {unexpected:?}"),
+            }
         }
     };
     let forge =
@@ -2741,7 +2770,7 @@ async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
     );
     register_delivery_repository(&client, addr, &token, &root).await;
 
-    let merge_action = |repository: serde_json::Value| {
+    let merge_action = |repository: serde_json::Value, expected_head_sha: &str| {
         serde_json::json!({
             "target": { "repository": repository, "number": 17 },
             "action": {
@@ -2749,27 +2778,87 @@ async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
                 "method": "squash",
                 "auto": false,
                 "admin": false,
-                "expected_head_sha": "old-head"
+                "expected_head_sha": expected_head_sha
             }
         })
     };
     let response = client
         .post(format!("http://{addr}/code/delivery/pull-requests/action"))
         .bearer_auth(&token)
-        .json(&merge_action(serde_json::json!({
-            "host": "github.com",
-            "owner": "acme",
-            "name": "demo"
-        })))
+        .json(&merge_action(
+            serde_json::json!({
+                "host": "github.com",
+                "owner": "acme",
+                "name": "demo"
+            }),
+            "old-head",
+        ))
         .send()
         .await
         .unwrap();
     let (status, kind, message) = error_kind(response).await;
     assert_eq!(status, reqwest::StatusCode::CONFLICT);
     assert_eq!(kind, "pr_head_changed");
-    assert!(message.contains("Head branch was modified"), "{message}");
-    assert_eq!(requests.load(std::sync::atomic::Ordering::SeqCst), 1);
-    assert_eq!(lender.minted(), vec!["acme/demo"]);
+    assert!(message.contains("reviewed revision"), "{message}");
+
+    let response = client
+        .post(format!("http://{addr}/code/delivery/pull-requests/action"))
+        .bearer_auth(&token)
+        .json(&merge_action(
+            serde_json::json!({
+                "host": "github.com",
+                "owner": "acme",
+                "name": "demo"
+            }),
+            "blocked-head",
+        ))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "pr_not_mergeable");
+    assert!(message.contains("Branch protection"), "{message}");
+
+    let response = client
+        .post(format!("http://{addr}/code/delivery/pull-requests/action"))
+        .bearer_auth(&token)
+        .json(&merge_action(
+            serde_json::json!({
+                "host": "github.com",
+                "owner": "acme",
+                "name": "demo"
+            }),
+            "soft-blocked-head",
+        ))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "pr_not_mergeable");
+    assert!(message.contains("Repository policy"), "{message}");
+
+    let response = client
+        .post(format!("http://{addr}/code/delivery/pull-requests/action"))
+        .bearer_auth(&token)
+        .json(&merge_action(
+            serde_json::json!({
+                "host": "github.com",
+                "owner": "acme",
+                "name": "demo"
+            }),
+            "expired-credential",
+        ))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "git_auth_failed");
+    assert!(message.contains("no longer valid"), "{message}");
+    assert_eq!(requests.load(std::sync::atomic::Ordering::SeqCst), 4);
+    assert_eq!(lender.minted(), vec!["acme/demo"; 4]);
 
     for repository in [
         serde_json::json!({
@@ -2786,7 +2875,7 @@ async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
         let response = client
             .post(format!("http://{addr}/code/delivery/pull-requests/action"))
             .bearer_auth(&token)
-            .json(&merge_action(repository))
+            .json(&merge_action(repository, "old-head"))
             .send()
             .await
             .unwrap();
@@ -2794,13 +2883,51 @@ async fn hosted_delivery_actions_propagate_failures_and_pin_the_target() {
     }
     assert_eq!(
         requests.load(std::sync::atomic::Ordering::SeqCst),
-        1,
+        4,
         "unregistered targets never reach the forge"
     );
     assert_eq!(
         lender.minted(),
-        vec!["acme/demo"],
+        vec!["acme/demo"; 4],
         "unregistered targets never mint a credential"
+    );
+    let connect_url = "https://gateway.example/account/apps";
+    *lender.mint_refusal.lock().expect("mint refusal") = Some(GitForgeError::NotConnected {
+        connect_url: Some(connect_url.to_owned()),
+    });
+    let response = client
+        .post(format!("http://{addr}/code/delivery/pull-requests/action"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "target": {
+                "repository": {
+                    "host": "github.com",
+                    "owner": "acme",
+                    "name": "demo"
+                },
+                "number": 17
+            },
+            "action": {
+                "type": "comment",
+                "body": "This must not reach the forge."
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(response).await;
+    assert_eq!(status, reqwest::StatusCode::CONFLICT);
+    assert_eq!(kind, "git_forge_not_offered");
+    assert!(message.contains(connect_url), "{message}");
+    assert_eq!(
+        requests.load(std::sync::atomic::Ordering::SeqCst),
+        4,
+        "a refused credential mint never reaches the forge"
+    );
+    assert_eq!(
+        lender.minted().len(),
+        5,
+        "the failed operation borrows once"
     );
 }
 


### PR DESCRIPTION
## Summary

- keep hosted Delivery actions on the same borrowed-caller forge transport as reads
- hide the unsupported ready transition for hosted draft pull requests while preserving its typed direct-action refusal
- classify REST merge conflicts, non-mergeability, expired credentials, and probe-to-mint refusals with stable error kinds
- retain focused coverage for merge, close, reopen, comment, rerun, rerun-failed, target pinning, and caller credential borrowing

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1 --offline`
- Focused Cargo tests were attempted with both Cargo/libgit2 and Git CLI fetching. This environment cannot fetch the pinned Symphonia Git revision because its outbound GitHub proxy returns HTTP 403; CI is the executable validation lane.
- Generated wire files are unchanged because this patch changes no serialized contract.

## Compatibility and risk

- No persisted or wire-format changes.
- Local and self-hosted machines keep the existing `gh` action path.
- Hosted credentials remain per-caller, in memory, and borrowed once for the repository operation.

Closes #2700