### PR TITLE
fix(desktop): keep code workspace visible

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -727,9 +727,10 @@ it("keys the attributed set on full identity, not the number", async () => {
       workspaceId="ws-1"
       workspace={{ ...WORKSPACE, pr: OPEN_PR } as never}
       contentRevision={0}
-      requestedTab={{ tab: "pr", revision: 1 }}
     />,
   );
+
+  await userEvent.click(screen.getByRole("tab", { name: "Pull request" }));
 
   const list = await screen.findByRole("navigation", {
     name: "Pull requests this workspace worked on",

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -97,8 +97,7 @@ export function CodeInspector({
   workspace,
   contentRevision,
   prResource,
-  requestedTab,
-  onRequestedTabHandled,
+  initialTab,
   onOpenFile,
   onOpenDiff,
   onClose,
@@ -108,8 +107,7 @@ export function CodeInspector({
   workspace: CodeWorkspaceSnapshot | null;
   contentRevision: number;
   prResource?: CodeWorkspacePrResource;
-  requestedTab?: { tab: InspectorTab; revision: number } | null;
-  onRequestedTabHandled?: (revision: number) => void;
+  initialTab?: InspectorTab;
   onOpenFile?: (path: string, line?: number) => void;
   onOpenDiff?: (path: string) => void;
   onClose?: () => void;
@@ -121,7 +119,9 @@ export function CodeInspector({
   const filesSearchPending = useCodeUiStore(
     (state) => state.filesSearchPending,
   );
-  const [tab, setTab] = useState<InspectorTab>(scope ? "source" : "files");
+  const [tab, setTab] = useState<InspectorTab>(
+    initialTab ?? (scope ? "source" : "files"),
+  );
   const [file, setFile] = useState<string | undefined>();
   const turnId = scope?.turnId;
   const changedFiles = useChangedFilesResource({
@@ -136,12 +136,6 @@ export function CodeInspector({
     setTab("source");
     setFile(undefined);
   }, [scope]);
-
-  useEffect(() => {
-    if (!requestedTab) return;
-    setTab(requestedTab.tab);
-    onRequestedTabHandled?.(requestedTab.revision);
-  }, [onRequestedTabHandled, requestedTab]);
 
   // Search lives on the Files tab, so the find chord has to land there first.
   // The panel itself clears the flag once it has the caret; this only moves

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -128,6 +128,7 @@ vi.mock("react-resizable-panels", () => ({
     onLayoutChange: () => {},
     onLayoutChanged: () => {},
   }),
+  useGroupRef: () => ({ current: null }),
 }));
 
 const WORKSPACE: CodeWorkspaceSnapshot = {
@@ -1765,10 +1766,11 @@ describe("CodeWorkspacePage", () => {
     await user.click(
       await screen.findByRole("menuitem", { name: "Review & commit" }),
     );
-    expect(screen.getByRole("tab", { name: "Source control" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    expect(
+      within(
+        screen.getByRole("tablist", { name: "Workspace center" }),
+      ).getByRole("tab", { name: "Source control" }),
+    ).toHaveAttribute("aria-selected", "true");
 
     await user.click(screen.getByRole("tab", { name: "Files" }));
     await user.click(screen.getByRole("button", { name: "Review sidebar" }));
@@ -2609,7 +2611,7 @@ describe("CodeWorkspacePage", () => {
     expect(client.openCodeEvents.mock.calls[0]?.[0]).toBe(SESSION.id);
   });
 
-  it("opens source control and the pull request in the review sidebar", async () => {
+  it("opens source control and the pull request as center tabs", async () => {
     const client = makeClient();
     client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: PR });
     const user = userEvent.setup();
@@ -2623,18 +2625,20 @@ describe("CodeWorkspacePage", () => {
     await user.click(
       await screen.findByRole("menuitem", { name: "Source control" }),
     );
-    const inspector = screen.getByTestId("code-inspector");
     await waitFor(() =>
       expect(
-        within(inspector).getByRole("tab", { name: "Source control" }),
+        within(
+          screen.getByRole("tablist", { name: "Workspace center" }),
+        ).getByRole("tab", { name: "Source control" }),
       ).toHaveAttribute("aria-selected", "true"),
     );
-    expect(
-      screen.queryByTestId("source-control-panel"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Send message" }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("source-control-panel")).toBeInTheDocument();
+    await user.click(
+      within(
+        screen.getByRole("tablist", { name: "Workspace center" }),
+      ).getByRole("tab", { name: "Main agent" }),
+    );
+    expect(screen.getByRole("button", { name: "Send message" })).toBeVisible();
 
     await user.click(screen.getByRole("button", { name: "New tab" }));
     await user.click(
@@ -2642,13 +2646,18 @@ describe("CodeWorkspacePage", () => {
     );
     await waitFor(() =>
       expect(
-        within(inspector).getByRole("tab", { name: "Pull request" }),
+        within(
+          screen.getByRole("tablist", { name: "Workspace center" }),
+        ).getByRole("tab", { name: "Pull request" }),
       ).toHaveAttribute("aria-selected", "true"),
     );
-    expect(screen.queryByTestId("pr-details-panel")).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Send message" }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("pr-details-panel")).toBeInTheDocument();
+    await user.click(
+      within(
+        screen.getByRole("tablist", { name: "Workspace center" }),
+      ).getByRole("tab", { name: "Main agent" }),
+    );
+    expect(screen.getByRole("button", { name: "Send message" })).toBeVisible();
   });
 
   it("omits Pull request from the new-tab menu when there is no pull request", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -24,7 +24,7 @@ import {
   type ReactNode,
 } from "react";
 import { ArrowDown, Bot, CircleDotDashed } from "lucide-react";
-import { useDefaultLayout } from "react-resizable-panels";
+import { useDefaultLayout, useGroupRef } from "react-resizable-panels";
 import { toast } from "sonner";
 
 import type { ApiClient } from "../api/client";
@@ -126,7 +126,7 @@ const CodeBrowserTab = lazy(async () => {
   return { default: module.CodeBrowserTab };
 });
 import { useCodeCatalogStore } from "./CodeCatalogStore";
-import { CodeInspector, PrTab, type InspectorTab } from "./CodeInspector";
+import { CodeInspector, PrTab } from "./CodeInspector";
 import { DiffOverview } from "./DiffOverview";
 import { useCodeUiStore } from "./CodeUiStore";
 import { forkFraming, forkTranscriptFile } from "./fork";
@@ -172,6 +172,15 @@ import {
 } from "./workspaceActions";
 import { tidebreakProductRepo } from "./uneffMe";
 import { sessionActivityLabel, isPutAway } from "./workspaceCards";
+import {
+  DEFAULT_INSPECTOR_LAYOUT,
+  INSPECTOR_LAYOUT_STORAGE_ID,
+  INSPECTOR_PANEL_IDS,
+  MAX_INSPECTOR_SIZE,
+  MIN_INSPECTOR_SIZE,
+  MIN_WORKSPACE_SIZE,
+  usableInspectorLayout,
+} from "./inspectorLayout";
 import {
   createPermissionModes,
   fenceReasonText,
@@ -310,7 +319,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   };
   const taskParam = workspaceSearch.task;
   const subagentParam = workspaceSearch.subagent;
-  const inspectorLayout = useDefaultLayout({ id: "code-inspector" });
+  const inspectorLayout = useDefaultLayout({
+    id: INSPECTOR_LAYOUT_STORAGE_ID,
+    panelIds: INSPECTOR_PANEL_IDS,
+    onlySaveAfterUserInteractions: true,
+  });
+  const inspectorGroupRef = useGroupRef();
   const reviewSidebarOpen = useCodeUiStore((state) => state.reviewSidebarOpen);
   const toggleReviewSidebar = useCodeUiStore(
     (state) => state.toggleReviewSidebar,
@@ -394,16 +408,30 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const [newTabMenuRequest, setNewTabMenuRequest] = useState(0);
   const [newTabMenuRegion, setNewTabMenuRegion] =
     useState<CodeEditorRegion>("primary");
-  const [inspectorTabRequest, setInspectorTabRequest] = useState<{
-    tab: InspectorTab;
-    revision: number;
-  } | null>(null);
   const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
   const tabDragSensors = useSensors(
     // Four pixels of travel before a press becomes a drag, so a click still
     // selects the tab it landed on.
     useSensor(TabPointerSensor, { activationConstraint: { distance: 4 } }),
   );
+
+  const inspectorDefaultLayout = useMemo(
+    () =>
+      usableInspectorLayout(inspectorLayout.defaultLayout) ?? {
+        ...DEFAULT_INSPECTOR_LAYOUT,
+      },
+    [inspectorLayout.defaultLayout],
+  );
+
+  useEffect(() => {
+    if (!reviewSidebarOpen) return;
+    const group = inspectorGroupRef.current;
+    if (!group) return;
+    const current = group.getLayout();
+    if (Object.keys(current).length > 0 && !usableInspectorLayout(current)) {
+      group.setLayout({ ...DEFAULT_INSPECTOR_LAYOUT });
+    }
+  }, [inspectorGroupRef, reviewSidebarOpen, workspaceId]);
   const [starting, setStarting] = useState(false);
   const [createMode, setCreateMode] = useState<PermissionMode | null>(null);
   const [fileReveal, setFileReveal] = useState<{
@@ -1033,20 +1061,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     });
   }
 
-  function openInspectorTab(tab: InspectorTab) {
-    setReviewSidebarOpen(true);
-    setInspectorTabRequest((request) => ({
-      tab,
-      revision: (request?.revision ?? 0) + 1,
-    }));
-  }
-
-  const handleInspectorTabRequest = useCallback((revision: number) => {
-    setInspectorTabRequest((request) =>
-      request?.revision === revision ? null : request,
-    );
-  }, []);
-
   function finishTabDrag(event: DragEndEvent) {
     setDraggedTabId(null);
     const next = dropEditorTab(
@@ -1262,8 +1276,19 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             openCodeEditor(layout, { type: "diff" }, "primary"),
           )
         }
-        onNewSourceControl={() => openInspectorTab("source")}
-        onNewPr={pr ? () => openInspectorTab("pr") : undefined}
+        onNewSourceControl={() =>
+          setWorkspaceLayout(
+            openCodeEditor(layout, { type: "source_control" }, "primary"),
+          )
+        }
+        onNewPr={
+          pr
+            ? () =>
+                setWorkspaceLayout(
+                  openCodeEditor(layout, { type: "pr" }, "primary"),
+                )
+            : undefined
+        }
         onNewTerminal={() => void openTerminal("primary")}
         canNewTerminal={canNewTerminal}
         onMoveEditorToOtherGroup={(index) =>
@@ -1444,8 +1469,19 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             openCodeEditor(layout, { type: "diff" }, "secondary"),
           )
         }
-        onNewSourceControl={() => openInspectorTab("source")}
-        onNewPr={pr ? () => openInspectorTab("pr") : undefined}
+        onNewSourceControl={() =>
+          setWorkspaceLayout(
+            openCodeEditor(layout, { type: "source_control" }, "secondary"),
+          )
+        }
+        onNewPr={
+          pr
+            ? () =>
+                setWorkspaceLayout(
+                  openCodeEditor(layout, { type: "pr" }, "secondary"),
+                )
+            : undefined
+        }
         onNewTerminal={() => void openTerminal("secondary")}
         canNewTerminal={canNewTerminal}
         onMoveEditorToOtherGroup={(index) =>
@@ -1551,7 +1587,15 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               baseRef={workspace.base_ref}
               fallbackPr={pr}
               resource={prResource}
-              onOpenSourceControl={() => openInspectorTab("source")}
+              onOpenSourceControl={() =>
+                setWorkspaceLayout(
+                  openCodeEditor(
+                    layoutRef.current,
+                    { type: "source_control" },
+                    splitFocused ? "secondary" : "primary",
+                  ),
+                )
+              }
               onOpenWatchTask={
                 prResource.data?.watch
                   ? () => openWorkspaceTask(prResource.data?.watch?.session_id)
@@ -1628,15 +1672,17 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         </div>
       ) : reviewSidebarOpen ? (
         <ResizablePanelGroup
-          defaultLayout={usableInspectorLayout(inspectorLayout.defaultLayout)}
+          id={INSPECTOR_LAYOUT_STORAGE_ID}
+          groupRef={inspectorGroupRef}
+          defaultLayout={inspectorDefaultLayout}
           onLayoutChanged={inspectorLayout.onLayoutChanged}
           orientation="horizontal"
-          className="h-full min-h-0 flex-1"
+          className="h-auto min-h-0 max-w-full min-w-0 flex-1 overflow-clip"
         >
           <ResizablePanel
             id="workspace"
-            defaultSize="68"
-            minSize="42"
+            defaultSize={String(DEFAULT_INSPECTOR_LAYOUT.workspace)}
+            minSize={String(MIN_WORKSPACE_SIZE)}
             className="h-full min-h-0 min-w-0"
           >
             {workspaceMain}
@@ -1644,9 +1690,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           <ResizableHandle className="bg-border-subtle transition-colors hover:bg-border" />
           <ResizablePanel
             id="inspector"
-            defaultSize="32"
-            minSize="22"
-            className="min-w-0 bg-page-background"
+            defaultSize={String(DEFAULT_INSPECTOR_LAYOUT.inspector)}
+            minSize={String(MIN_INSPECTOR_SIZE)}
+            maxSize={String(MAX_INSPECTOR_SIZE)}
+            className="h-full min-h-0 min-w-0 bg-page-background"
           >
             <ErrorBoundary
               resetKey={workspaceId}
@@ -1664,8 +1711,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                 workspace={workspace}
                 contentRevision={contentRevision}
                 prResource={prResource}
-                requestedTab={inspectorTabRequest}
-                onRequestedTabHandled={handleInspectorTabRequest}
                 onOpenFile={openFile}
                 onOpenDiff={openFileDiff}
                 onClose={() => setReviewSidebarOpen(false)}
@@ -2723,32 +2768,6 @@ function WatchTaskBar({
       </Button>
     </div>
   );
-}
-
-/**
- * Ignore a stored inspector split that would collapse the conversation.
- *
- * react-resizable-panels v4 remembers `{ [panelId]: percent }`. A leftover
- * v3 payload, or a drag that parked the workspace pane at zero, would hide
- * the chat the moment the review sidebar opened.
- */
-function usableInspectorLayout(
-  layout: Record<string, number> | undefined,
-): Record<string, number> | undefined {
-  if (!layout) return undefined;
-  const workspace = layout.workspace;
-  const inspector = layout.inspector;
-  if (
-    typeof workspace !== "number" ||
-    typeof inspector !== "number" ||
-    !Number.isFinite(workspace) ||
-    !Number.isFinite(inspector) ||
-    workspace < 40 ||
-    inspector < 18
-  ) {
-    return undefined;
-  }
-  return { workspace, inspector };
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/inspectorLayout.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/inspectorLayout.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_INSPECTOR_LAYOUT,
+  usableInspectorLayout,
+} from "./inspectorLayout";
+
+describe("usableInspectorLayout", () => {
+  it("keeps a bounded workspace-first split", () => {
+    expect(usableInspectorLayout(DEFAULT_INSPECTOR_LAYOUT)).toEqual({
+      workspace: 70,
+      inspector: 30,
+    });
+  });
+
+  it.each([
+    undefined,
+    [70, 30],
+    { workspace: 0, inspector: 100 },
+    { workspace: 40, inspector: 60 },
+    { workspace: 70, inspector: 30, stale: 0 },
+    { workspace: 70, inspector: Number.NaN },
+    { workspace: 70, inspector: 20 },
+    { workspace: 65, inspector: 30 },
+  ])("rejects a layout that can hide or corrupt the workspace", (layout) => {
+    expect(usableInspectorLayout(layout)).toBeUndefined();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/inspectorLayout.ts
+++ b/crates/tidebreak-desktop/ui/src/code/inspectorLayout.ts
@@ -1,0 +1,57 @@
+export const INSPECTOR_LAYOUT_STORAGE_ID = "code-workspace-inspector-v2";
+export const INSPECTOR_PANEL_IDS = ["workspace", "inspector"];
+
+export const DEFAULT_INSPECTOR_LAYOUT = {
+  workspace: 70,
+  inspector: 30,
+};
+
+export const MIN_WORKSPACE_SIZE = 58;
+export const MIN_INSPECTOR_SIZE = 22;
+export const MAX_INSPECTOR_SIZE = 42;
+
+export type InspectorLayout = {
+  workspace: number;
+  inspector: number;
+};
+
+/**
+ * Accept only a complete, bounded split that leaves the workspace dominant.
+ *
+ * The panel library stores arbitrary JSON in local storage. Older payloads,
+ * interrupted writes, and layouts saved before the inspector had a maximum
+ * size must not be allowed to hide the journal on the next open.
+ */
+export function usableInspectorLayout(
+  value: unknown,
+): InspectorLayout | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const layout = value as Record<string, unknown>;
+  const keys = Object.keys(layout);
+  if (
+    keys.length !== INSPECTOR_PANEL_IDS.length ||
+    !INSPECTOR_PANEL_IDS.every((id) => keys.includes(id))
+  ) {
+    return undefined;
+  }
+
+  const workspace = layout.workspace;
+  const inspector = layout.inspector;
+  if (
+    typeof workspace !== "number" ||
+    typeof inspector !== "number" ||
+    !Number.isFinite(workspace) ||
+    !Number.isFinite(inspector) ||
+    Math.abs(workspace + inspector - 100) > 0.01 ||
+    workspace < MIN_WORKSPACE_SIZE ||
+    inspector < MIN_INSPECTOR_SIZE ||
+    inspector > MAX_INSPECTOR_SIZE
+  ) {
+    return undefined;
+  }
+
+  return { workspace, inspector };
+}

--- a/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
@@ -336,7 +336,7 @@ function InspectorStory({
             ? { ...prSnapshot, dirty: false, ahead: 0, pr: undefined }
             : storySnapshot,
         )}
-        requestedTab={{ tab, revision: 1 }}
+        initialTab={tab}
         onOpenFile={fn()}
         onOpenDiff={fn()}
         onClose={fn()}

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -31,6 +31,10 @@ import {
   useCodeUpdatesStore,
 } from "@/code/CodeUpdatesStore";
 import { CodeWorkspacePage } from "@/code/CodeWorkspacePage";
+import {
+  INSPECTOR_LAYOUT_STORAGE_ID,
+  INSPECTOR_PANEL_IDS,
+} from "@/code/inspectorLayout";
 import type { LayoutState } from "@/panel/panelTypes";
 import {
   panelSearchFrom,
@@ -850,7 +854,11 @@ function storyRouter(client: ApiClient, initialUrl: string) {
   });
 }
 
-function resetStoryState(reviewOpen: boolean, sidebarCollapsed: boolean) {
+function resetStoryState(
+  reviewOpen: boolean,
+  sidebarCollapsed: boolean,
+  storedInspectorLayout?: Record<string, number>,
+) {
   resetCodeSessionRegistry();
   disconnectCodeUpdates();
   useCodeCatalogStore.getState().reset();
@@ -864,6 +872,15 @@ function resetStoryState(reviewOpen: boolean, sidebarCollapsed: boolean) {
     addRepoOpen: false,
   });
   useUiStore.setState({ sidebarCollapsed, sidebarWidth: 280 });
+  const storageKey = `react-resizable-panels:${[
+    INSPECTOR_LAYOUT_STORAGE_ID,
+    ...INSPECTOR_PANEL_IDS,
+  ].join(":")}`;
+  if (storedInspectorLayout) {
+    localStorage.setItem(storageKey, JSON.stringify(storedInspectorLayout));
+  } else {
+    localStorage.removeItem(storageKey);
+  }
 }
 
 function WorkspacePageStory({
@@ -871,14 +888,16 @@ function WorkspacePageStory({
   initialUrl,
   reviewOpen,
   sidebarCollapsed = false,
+  storedInspectorLayout,
 }: {
   scenario: WorkspaceScenario;
   initialUrl: string;
   reviewOpen: boolean;
   sidebarCollapsed?: boolean;
+  storedInspectorLayout?: Record<string, number>;
 }) {
   const [state] = useState(() => {
-    resetStoryState(reviewOpen, sidebarCollapsed);
+    resetStoryState(reviewOpen, sidebarCollapsed, storedInspectorLayout);
     const client = storyClient(scenario);
     return { client, router: storyRouter(client, initialUrl) };
   });
@@ -985,11 +1004,12 @@ const meta = {
     initialUrl: conversationUrl,
     reviewOpen: false,
     sidebarCollapsed: false,
+    storedInspectorLayout: undefined,
   },
   parameters: { layout: "fullscreen" },
   render: (args) => (
     <WorkspacePageStory
-      key={`${args.scenario}:${args.initialUrl}:${args.reviewOpen}:${args.sidebarCollapsed}`}
+      key={`${args.scenario}:${args.initialUrl}:${args.reviewOpen}:${args.sidebarCollapsed}:${JSON.stringify(args.storedInspectorLayout)}`}
       {...args}
     />
   ),
@@ -1034,6 +1054,56 @@ export const ConversationWithReview: Story = {
         "Rework the code workspace around persistent conversation",
       ),
     ).toBeVisible();
+    const workspacePanel = canvas.getByTestId("workspace");
+    const inspectorPanel = canvas.getByTestId("inspector");
+    await expect(workspacePanel).toBeVisible();
+    await expect(inspectorPanel).toBeVisible();
+    expect(workspacePanel.getBoundingClientRect().width).toBeGreaterThan(
+      inspectorPanel.getBoundingClientRect().width,
+    );
+  },
+};
+
+/** A stale full-width inspector resets before it can hide the journal. */
+export const InvalidStoredInspectorLayout: Story = {
+  args: {
+    reviewOpen: true,
+    storedInspectorLayout: { workspace: 0, inspector: 100 },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const workspacePanel = await canvas.findByTestId("workspace");
+    const inspectorPanel = canvas.getByTestId("inspector");
+    await expect(
+      canvas.findByRole("tab", { name: "Main agent" }),
+    ).resolves.toBeVisible();
+    expect(workspacePanel.getBoundingClientRect().width).toBeGreaterThan(
+      inspectorPanel.getBoundingClientRect().width,
+    );
+  },
+};
+
+/** Source control remains a peer center tab and keeps the inspector optional. */
+export const SourceControlTab: Story = {
+  args: {
+    initialUrl: workspaceUrl({
+      tabs: [{ type: "source_control" }],
+      activeIndex: 0,
+      fullscreen: false,
+    }),
+    reviewOpen: false,
+  },
+};
+
+/** Pull-request status and comments remain a peer center tab. */
+export const PullRequestTab: Story = {
+  args: {
+    initialUrl: workspaceUrl({
+      tabs: [{ type: "pr" }],
+      activeIndex: 0,
+      fullscreen: false,
+    }),
+    reviewOpen: false,
   },
 };
 


### PR DESCRIPTION
## What changed

- Restore Source control and Pull request as center tabs, so the review inspector stays optional.
- Default the inspector split to 70/30 and keep the workspace between 58% and 78% of the available width.
- Reject stale or corrupt saved layouts before they can hide the journal, composer, or center tabs.
- Add focused tests and Storybook states for invalid persistence, the open inspector, Source control, and Pull request.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/inspectorLayout.test.ts src/code/CodeInspector.dom.test.tsx src/code/CodeWorkspacePage.dom.test.tsx` — 94 tests passed.
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit` — passed.
- `pnpm --dir crates/tidebreak-desktop/ui lint` — passed.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — passed.
- `git diff --check` — passed.
- Screenshot inspection could not run because no in-app or extension browser is connected to this session.

## Compatibility and risk

The inspector uses a versioned local layout key, so existing saved inspector widths reset once. No wire or persisted server format changes.

## Tracking

Closes #2776