### PR TITLE
fix(code): keep conditional PR snapshots coherent

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/pull_request.rs
+++ b/crates/tidebreak-core/src/db/ops/code/pull_request.rs
@@ -207,18 +207,23 @@ pub async fn get_pull_request_fetch_state(
     }))
 }
 
-/// Store the ETags one fetch pass ended with (decision 66). The caller
-/// passes each endpoint's current value — the fresh ETag after a 200, the
-/// one it sent after a 304 — so the row always names what the host holds.
-/// `Ok(false)` when no fact row exists for the identity.
+/// Store one conditional fetch pass atomically (decision 66).
+///
+/// `fresh_fact` carries the representation a pull-request 200 validated; a
+/// 304 passes `None`. The pull snapshot and its ETag must move in one row
+/// update, or concurrent refreshes can pair one response's validator with
+/// another response's snapshot and make the next 304 reconstruct stale
+/// state. Endpoint ETags carry the pass's final values. `Ok(false)` when no
+/// fact row exists for the identity.
 #[allow(clippy::too_many_arguments)]
-pub async fn set_pull_request_etags(
+pub async fn set_pull_request_fetch_state(
     store: &DbStore,
     owner: &OwnerId,
     host: &str,
     repo_owner: &str,
     repo_name: &str,
     number: u64,
+    fresh_fact: Option<&CodePullRequestFact>,
     pull_etag: Option<&str>,
     checks_etag: Option<&str>,
     reviews_etag: Option<&str>,
@@ -229,6 +234,16 @@ pub async fn set_pull_request_etags(
         return Ok(false);
     };
     let mut model: entities::code_pull_request::ActiveModel = row.into();
+    if let Some(fact) = fresh_fact {
+        model.url = Set(fact.url.clone());
+        model.title = Set(fact.title.clone());
+        model.state = Set(fact.state.as_str().to_owned());
+        model.draft = Set(fact.draft);
+        model.head_branch = Set(fact.head_branch.clone());
+        model.base_branch = Set(fact.base_branch.clone());
+        model.head_sha = Set(fact.head_sha.clone());
+        model.last_seen_at = Set(fact.last_seen_at);
+    }
     model.pull_etag = Set(pull_etag.map(ToOwned::to_owned));
     model.checks_etag = Set(checks_etag.map(ToOwned::to_owned));
     model.reviews_etag = Set(reviews_etag.map(ToOwned::to_owned));

--- a/crates/tidebreak-core/src/db/ops/code/pull_request.rs
+++ b/crates/tidebreak-core/src/db/ops/code/pull_request.rs
@@ -54,6 +54,10 @@ pub async fn save_pull_request_fact(
         closed_at: Set(fact.closed_at),
         first_seen_at: Set(fact.first_seen_at),
         last_seen_at: Set(fact.last_seen_at),
+        // This snapshot did not arrive with a pull endpoint validator. Clear
+        // any existing validator in the same upsert so a concurrent refresh
+        // cannot leave its ETag naming this writer's unrelated snapshot.
+        pull_etag: Set(None),
         // The live tier (decision 66) is written by its own setter and never
         // by a snapshot upsert, so a confirmation cannot blank it.
         ..Default::default()
@@ -80,6 +84,7 @@ pub async fn save_pull_request_fact(
             entities::code_pull_request::Column::MergedAt,
             entities::code_pull_request::Column::ClosedAt,
             entities::code_pull_request::Column::LastSeenAt,
+            entities::code_pull_request::Column::PullEtag,
         ])
         .to_owned(),
     )

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -196,6 +196,33 @@ pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Resul
     Ok(result.rows_affected == 1)
 }
 
+/// Write only the pull-request compatibility column of an active workspace.
+///
+/// Background refreshes hold their workspace snapshot across host I/O. A
+/// full-row save from that snapshot could erase a title or other field a
+/// concurrent request changed; this targeted write leaves every unrelated
+/// column untouched and loses cleanly if the workspace left the active tier.
+pub async fn set_active_workspace_pull_request(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: WorkspaceId,
+    pull_request: &PullRequestDigest,
+) -> Result<bool> {
+    let encoded = serde_json::to_value(pull_request)?;
+    let result = entities::code_workspace::Entity::update_many()
+        .col_expr(
+            entities::code_workspace::Column::Pr,
+            sea_orm::sea_query::Expr::value(Some(encoded)),
+        )
+        .filter(entities::code_workspace::Column::Id.eq(id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_workspace::Column::Status.eq(CodeWorkspaceStatus::Active.as_str()))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 /// Set a workspace's title only while it still reads `expected`.
 ///
 /// The compare half is what lets background naming lose to a rename: a derived

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4,7 +4,7 @@ use crate::code::{
     CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeQueuedTurn,
     CodeRepo, CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle,
     CodeSubagentStatus, CodeSubagentSummary, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace,
-    CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
+    CodeWorkspaceStatus, HarnessKind, PullRequestDigest, RepoId, WorkspaceId,
 };
 use crate::db::code::{
     abandon_pending_approval, abandon_pending_approvals_for_stopped_session, append_event,
@@ -18,9 +18,10 @@ use crate::db::code::{
     list_queued_turns, list_repos, list_sessions, list_turn_metrics, list_turns, mark_repo_removed,
     promote_queued_turn, queue_paused, queued_turn_head, recover_interrupted_session,
     replace_session_attention, replace_session_execution_settings, save_session, save_turn,
-    set_queue_paused, set_session_harness_resume_ref, set_session_subagents, set_turn_narrative,
-    set_workspace_title_if, settle_approval_claim, update_queued_turn, ClaimedApprovalSettlement,
-    CodeJournalError, CodeSessionExecutionSettings, MAX_REPLAY_EVENTS,
+    set_active_workspace_pull_request, set_queue_paused, set_session_harness_resume_ref,
+    set_session_subagents, set_turn_narrative, set_workspace_title_if, settle_approval_claim,
+    update_queued_turn, ClaimedApprovalSettlement, CodeJournalError, CodeSessionExecutionSettings,
+    MAX_REPLAY_EVENTS,
 };
 use crate::{
     BlobRetirementStatus, ImageMediaType, ImageRef, OwnerId, PermissionMode, ReasoningEffort, Store,
@@ -651,6 +652,63 @@ async fn workspace_title_swap_replaces_only_the_expected_title() {
             .title,
         "Derived name"
     );
+}
+
+/// A pull-request refresh holds its workspace snapshot across host I/O. Its
+/// eventual PR-column write must not erase a title changed in the meantime.
+#[tokio::test]
+async fn pull_request_write_preserves_a_concurrent_workspace_rename() {
+    let (_dir, store, session_id, _turn) = seeded_session().await;
+    let owner = OwnerId::local();
+    let workspace_id = get_session(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .workspace_id;
+    let refresh_snapshot = get_workspace(&store, &owner, workspace_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(refresh_snapshot.title, "first");
+
+    assert!(set_workspace_title_if(
+        &store,
+        &owner,
+        workspace_id,
+        "first",
+        "Renamed while refresh waited"
+    )
+    .await
+    .unwrap());
+    let digest = PullRequestDigest {
+        number: 42,
+        url: Some("https://github.com/acme/demo/pull/42".into()),
+        state: "open".into(),
+        title: Some("PR title".into()),
+        checks_summary: None,
+        checks: None,
+        draft: Some(false),
+        merged: Some(false),
+        review_decision: None,
+        mergeable: None,
+        merge_state_status: None,
+        head_branch: Some("feature".into()),
+        base_branch: Some("main".into()),
+        head_sha: Some("feedfeed".into()),
+        auto_merge_enabled: Some(false),
+        in_merge_queue: Some(false),
+    };
+    assert!(
+        set_active_workspace_pull_request(&store, &owner, refresh_snapshot.id, &digest)
+            .await
+            .unwrap()
+    );
+    let stored = get_workspace(&store, &owner, workspace_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.title, "Renamed while refresh waited");
+    assert_eq!(stored.pr.as_ref(), Some(&digest));
 }
 
 #[tokio::test]
@@ -3488,9 +3546,10 @@ async fn pull_request_facts_upsert_claim_and_promote() {
         PullRequestCheck, PullRequestCheckBucket,
     };
     use crate::db::code::{
-        count_attributed_prs_for_workspace, get_pull_request_fact, insert_pull_request_attribution,
-        list_attributed_facts_for_workspace, list_fact_repo_identities,
-        promote_attribution_to_authored, save_pull_request_fact, set_pull_request_live_state,
+        count_attributed_prs_for_workspace, get_pull_request_fact, get_pull_request_fetch_state,
+        insert_pull_request_attribution, list_attributed_facts_for_workspace,
+        list_fact_repo_identities, promote_attribution_to_authored, save_pull_request_fact,
+        set_pull_request_fetch_state, set_pull_request_live_state,
     };
 
     let (_dir, store) = temp_store().await;
@@ -3554,6 +3613,31 @@ async fn pull_request_facts_upsert_claim_and_promote() {
     assert_eq!(stored.head_sha.as_deref(), Some("bbb222"));
     assert_eq!(stored.first_seen_at, first_seen);
     assert_eq!(stored.last_seen_at, later);
+
+    assert!(set_pull_request_fetch_state(
+        &store,
+        &owner,
+        "github.com",
+        "acme",
+        "tools",
+        412,
+        Some(&refreshed),
+        Some("W/\"pull-2\""),
+        Some("W/\"checks-2\""),
+        Some("W/\"reviews-2\""),
+    )
+    .await
+    .unwrap());
+    let fetch_state =
+        get_pull_request_fetch_state(&store, &owner, "github.com", "acme", "tools", 412)
+            .await
+            .unwrap()
+            .unwrap();
+    assert_eq!(fetch_state.fact.title, "First, retitled");
+    assert_eq!(fetch_state.fact.head_sha.as_deref(), Some("bbb222"));
+    assert_eq!(fetch_state.pull_etag.as_deref(), Some("W/\"pull-2\""));
+    assert_eq!(fetch_state.checks_etag.as_deref(), Some("W/\"checks-2\""));
+    assert_eq!(fetch_state.reviews_etag.as_deref(), Some("W/\"reviews-2\""));
 
     // The live tier (decision 66): the first write reports change, an
     // identical write does not, and a snapshot upsert never blanks it.

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -3763,6 +3763,72 @@ async fn pull_request_facts_upsert_claim_and_promote() {
         .is_empty());
 }
 
+#[tokio::test]
+async fn snapshot_upsert_invalidates_a_concurrent_fetch_validator() {
+    use crate::code::{CodePullRequestFact, CodePullRequestId, CodePullRequestState};
+    use crate::db::code::{
+        get_pull_request_fetch_state, save_pull_request_fact, set_pull_request_fetch_state,
+    };
+
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let observed = now();
+    let stale = CodePullRequestFact {
+        id: CodePullRequestId::new(),
+        owner: owner.clone(),
+        host: "github.com".into(),
+        repo_owner: "acme".into(),
+        repo_name: "tools".into(),
+        number: 99,
+        url: "https://github.com/acme/tools/pull/99".into(),
+        title: "Stale".into(),
+        state: CodePullRequestState::Open,
+        draft: false,
+        author: None,
+        head_branch: "feature".into(),
+        base_branch: "main".into(),
+        head_sha: Some("old".into()),
+        created_at: observed,
+        updated_at: observed,
+        merged_at: None,
+        closed_at: None,
+        first_seen_at: observed,
+        last_seen_at: observed,
+        live: None,
+    };
+    save_pull_request_fact(&store, &stale).await.unwrap();
+
+    let fresh = CodePullRequestFact {
+        title: "Fresh".into(),
+        head_sha: Some("new".into()),
+        ..stale.clone()
+    };
+    assert!(set_pull_request_fetch_state(
+        &store,
+        &owner,
+        "github.com",
+        "acme",
+        "tools",
+        99,
+        Some(&fresh),
+        Some("W/\"fresh\""),
+        None,
+        None,
+    )
+    .await
+    .unwrap());
+
+    save_pull_request_fact(&store, &stale).await.unwrap();
+
+    let stored = get_pull_request_fetch_state(&store, &owner, "github.com", "acme", "tools", 99)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.fact.title, "Stale");
+    assert_eq!(stored.fact.head_sha.as_deref(), Some("old"));
+    assert_eq!(stored.pull_etag, None);
+}
+
 /// A whole-row turn save cannot blank a recap that landed while it was held.
 ///
 /// The two writers genuinely overlap. A recap is derived after the turn ends

--- a/crates/tidebreak-server/src/code/pr_fetch.rs
+++ b/crates/tidebreak-server/src/code/pr_fetch.rs
@@ -652,6 +652,38 @@ fn bounded_body(response: &RawHttpResponse) -> String {
     bounded
 }
 
+/// Advance the durable fact snapshot after a fresh pull read, before its new
+/// ETag is stored. A later 304 reconstructs these fields from the fact, so
+/// persisting the validator without the representation it validates would
+/// roll title, lifecycle, or head state back to the previous slow-sweep
+/// snapshot.
+pub(crate) fn apply_fresh_pull_to_fact(
+    fact: &mut CodePullRequestFact,
+    pull: &RestPull,
+    observed_at: chrono::DateTime<chrono::Utc>,
+) {
+    if let Some(url) = &pull.url {
+        fact.url.clone_from(url);
+    }
+    if let Some(title) = &pull.title {
+        fact.title.clone_from(title);
+    }
+    if let Some(state) = CodePullRequestState::from_str(&pull.state) {
+        fact.state = state;
+    }
+    if let Some(draft) = pull.draft {
+        fact.draft = draft;
+    }
+    if let Some(head_branch) = &pull.head_branch {
+        fact.head_branch.clone_from(head_branch);
+    }
+    if let Some(base_branch) = &pull.base_branch {
+        fact.base_branch.clone_from(base_branch);
+    }
+    fact.head_sha.clone_from(&pull.head_sha);
+    fact.last_seen_at = observed_at;
+}
+
 /// The same digest-relevant fields, projected from a stored fact row when a
 /// 304 says nothing moved since the row was written.
 pub(crate) fn rest_pull_from_fact(fact: &CodePullRequestFact) -> RestPull {
@@ -854,6 +886,56 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(merged.state, "merged");
+    }
+
+    #[test]
+    fn a_304_must_reuse_the_snapshot_advanced_by_the_fresh_pull() {
+        let now = chrono::Utc::now();
+        let mut fact = CodePullRequestFact {
+            id: tidebreak_core::CodePullRequestId::new(),
+            owner: tidebreak_core::OwnerId::local(),
+            host: "github.com".into(),
+            repo_owner: "acme".into(),
+            repo_name: "demo".into(),
+            number: 12,
+            url: "https://github.com/acme/demo/pull/12".into(),
+            title: "Stale title".into(),
+            state: CodePullRequestState::Open,
+            draft: false,
+            author: None,
+            head_branch: "feature".into(),
+            base_branch: "main".into(),
+            head_sha: Some("deadbeef".into()),
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            closed_at: None,
+            first_seen_at: now,
+            last_seen_at: now,
+            live: None,
+        };
+        let fresh = rest_pull_from_value(&serde_json::json!({
+            "number": 12,
+            "html_url": "https://github.com/acme/demo/pull/12",
+            "state": "open",
+            "title": "Fresh title",
+            "draft": false,
+            "head": { "ref": "feature", "sha": "feedfeed" },
+            "base": { "ref": "main" },
+        }))
+        .unwrap();
+
+        apply_fresh_pull_to_fact(&mut fact, &fresh, now);
+
+        let after_304 = rest_pull_from_fact(&fact);
+        assert_eq!(
+            after_304.title, fresh.title,
+            "a 304 must not roll the title back to the pre-200 fact snapshot"
+        );
+        assert_eq!(
+            after_304.head_sha, fresh.head_sha,
+            "a 304 must not reuse the pre-200 head SHA"
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -20,9 +20,10 @@ use tidebreak_core::db::code::{
     list_pending_permission_mode_changes, list_repos, list_sessions, list_sessions_all_owners,
     list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
     list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head,
-    replace_session_execution_settings, save_repo, save_workspace, settle_approval_claim,
-    update_trigger_enabled, ClaimedApprovalSettlement, CodeSessionExecutionSettings,
-    PermissionModeChangeIntent, MAX_REPLAY_EVENTS,
+    replace_session_execution_settings, save_repo, save_workspace,
+    set_active_workspace_pull_request, settle_approval_claim, update_trigger_enabled,
+    ClaimedApprovalSettlement, CodeSessionExecutionSettings, PermissionModeChangeIntent,
+    MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
@@ -2090,7 +2091,7 @@ impl CodeRuntime {
     /// refresh drives the forge REST API with a borrowed credential —
     /// same gate, same stored ETags, same 304-shaped traffic.
     pub(crate) async fn refresh_workspace_pr_row(&self, owner: &OwnerId, id: WorkspaceId) {
-        let Ok(mut workspace) = self.get_workspace(owner, id).await else {
+        let Ok(workspace) = self.get_workspace(owner, id).await else {
             return;
         };
         if workspace.status != CodeWorkspaceStatus::Active {
@@ -2126,8 +2127,21 @@ impl CodeRuntime {
             return;
         };
         if workspace.pr.as_ref() != Some(&digest) {
-            workspace.pr = Some(digest);
-            let _ = self.save_workspace(&workspace).await;
+            match set_active_workspace_pull_request(&self.db, owner, workspace.id, &digest).await {
+                Ok(true) => {
+                    super::attention::emit_workspace_digests(
+                        &self.db,
+                        &self.bus,
+                        owner,
+                        workspace.id,
+                    )
+                    .await;
+                }
+                Ok(false) => {}
+                Err(err) => {
+                    tracing::debug!(error = %err, "code-mode: workspace digest write failed");
+                }
+            }
         }
     }
 
@@ -2255,7 +2269,7 @@ impl CodeRuntime {
             ),
             None => (None, None, None, None),
         };
-        let pull = match pr_fetch::read_pull_request(
+        let (pull, fresh_pull) = match pr_fetch::read_pull_request(
             gate,
             transport,
             &host,
@@ -2268,9 +2282,11 @@ impl CodeRuntime {
         {
             Ok(EndpointRead::Fresh { value, etag }) => {
                 pull_etag = etag;
-                value
+                (value, true)
             }
-            Ok(EndpointRead::NotModified) => pr_fetch::rest_pull_from_fact(stored_fact.as_ref()?),
+            Ok(EndpointRead::NotModified) => {
+                (pr_fetch::rest_pull_from_fact(stored_fact.as_ref()?), false)
+            }
             Ok(EndpointRead::Missing) => return None,
             Err(failure) => {
                 tracing::debug!(error = %failure, "code-mode: pull-request read skipped");
@@ -2384,23 +2400,33 @@ impl CodeRuntime {
         } else {
             Some(false)
         };
+        let fresh_fact = if fresh_pull {
+            stored_fact.clone().map(|mut fact| {
+                pr_fetch::apply_fresh_pull_to_fact(&mut fact, &pull, Utc::now());
+                fact
+            })
+        } else {
+            None
+        };
+
         let digest = pr_fetch::digest_from_parts(&pull, &checks, review_decision, in_merge_queue);
         self.record_pull_request_live_state(owner, Some(workspace.id), &digest)
             .await;
-        if let Err(err) = tidebreak_core::db::code::set_pull_request_etags(
+        if let Err(err) = tidebreak_core::db::code::set_pull_request_fetch_state(
             &self.db,
             owner,
             &host,
             &repo_owner,
             &repo_name,
             number,
+            fresh_fact.as_ref(),
             pull_etag.as_deref(),
             checks_etag.as_deref(),
             reviews_etag.as_deref(),
         )
         .await
         {
-            tracing::debug!(error = %err, "code-mode: etag write failed");
+            tracing::debug!(error = %err, "code-mode: fetch-state write failed");
         }
         Some(digest)
     }
@@ -2563,7 +2589,7 @@ impl CodeRuntime {
             Ok(workspaces) => workspaces,
             Err(_) => return,
         };
-        for mut workspace in workspaces {
+        for workspace in workspaces {
             if source == Some(workspace.id) || workspace.status != CodeWorkspaceStatus::Active {
                 continue;
             }
@@ -2575,13 +2601,24 @@ impl CodeRuntime {
             if !holds || workspace.pr.as_ref() == Some(digest) {
                 continue;
             }
-            workspace.pr = Some(digest.clone());
-            if let Err(err) = self.save_workspace(&workspace).await {
-                tracing::warn!(
-                    workspace = %workspace.id,
-                    error = %err.message(),
-                    "code-mode: pull-request write-through failed"
-                );
+            match set_active_workspace_pull_request(&self.db, owner, workspace.id, digest).await {
+                Ok(true) => {
+                    super::attention::emit_workspace_digests(
+                        &self.db,
+                        &self.bus,
+                        owner,
+                        workspace.id,
+                    )
+                    .await;
+                }
+                Ok(false) => {}
+                Err(err) => {
+                    tracing::warn!(
+                        workspace = %workspace.id,
+                        error = %err,
+                        "code-mode: pull-request write-through failed"
+                    );
+                }
             }
         }
     }

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -1654,13 +1654,13 @@ async fn a_hosted_digest_reads_the_row_and_refreshes_conditionally() {
             repo_name: "demo".into(),
             number: 12,
             url: "https://github.com/acme/demo/pull/12".into(),
-            title: "Hosted change".into(),
+            title: "Stale hosted change".into(),
             state: CodePullRequestState::Open,
             draft: false,
             author: None,
             head_branch: "feature".into(),
             base_branch: "main".into(),
-            head_sha: Some("feedfeedfeedfeedfeed".into()),
+            head_sha: Some("deadbeefdeadbeefdead".into()),
             created_at: now,
             updated_at: now,
             merged_at: None,
@@ -1730,6 +1730,7 @@ async fn a_hosted_digest_reads_the_row_and_refreshes_conditionally() {
         .await
         .unwrap();
     assert_eq!(unchanged["pr"]["title"], "Hosted change");
+    assert_eq!(unchanged["pr"]["head_sha"], "feedfeedfeedfeedfeed");
     assert_eq!(
         unchanged["pr"]["checks_summary"],
         "1 passing, 0 pending, 0 failing"


### PR DESCRIPTION
Follow-up to #2760.

## What changed

- Advance the durable pull-request snapshot in the same row update that stores the fresh pull ETag, so a later 304 reconstructs the representation that validator actually names.
- Replace background full-workspace saves with a targeted active-workspace PR-column update, preserving concurrent title and unrelated workspace changes.
- Invalidate a pull ETag when an unrelated snapshot writer wins the race, so the next refresh cannot accept a 304 against that snapshot.
- Extend the hosted conditional-refresh scenario so a stale fact receives a fresh 200 and the following 304 must retain the fresh title and head SHA.

## Regression coverage

- `code::pr_fetch::tests::a_304_must_reuse_the_snapshot_advanced_by_the_fresh_pull`
- `db::tests::code::pull_request_facts_upsert_claim_and_promote`
- `db::tests::code::pull_request_write_preserves_a_concurrent_workspace_rename`
- `db::tests::code::snapshot_upsert_invalidates_a_concurrent_fetch_validator`
- `a_hosted_digest_reads_the_row_and_refreshes_conditionally`

## Local checks

- `cargo fmt --all --check`
- `cargo check -p tidebreak-server --all-targets`
- `cargo check -p tidebreak-core --all-targets`
- the three focused unit/database regressions above
- the non-loopback `pr_fetch` unit and shim tests

Loopback TCP is blocked in the review sandbox, so the Axum/REST integration cases are left to CI.