### PR TITLE
fix(desktop): keep parked agents visible on workspace cards

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -325,6 +325,49 @@ describe("WorkspaceCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("announces Done when parked attention is already idle", () => {
+    const digest: CodeSessionDigest = {
+      workspace: workspace.id,
+      session: "sess-1",
+      kind: "interactive",
+      harness_kind: "grok",
+      lifecycle: "idle",
+      attention: { state: { type: "idle" }, source: "lifecycle" },
+      title: workspace.title,
+      turn_count: 4,
+      recap: "Folded the backoff into refresh.",
+    };
+    render(
+      <WorkspaceCard
+        workspace={workspace}
+        digest={digest}
+        session={undefined}
+        repoName="app"
+        active={false}
+        terminalOpen={false}
+        density="detailed"
+        visibleMeta={{ repoChip: true, branch: false }}
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          hasSession: true,
+        })}
+        onOpen={vi.fn()}
+        onCommand={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("Done")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Fix login · Done · app · tidebreak/fix-login",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Idle/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not show live motion when an older idle digest still says Working", () => {
     const digest: CodeSessionDigest = {
       workspace: workspace.id,

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -260,7 +260,26 @@ describe("WorkspaceCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps idle lifecycle detail off the non-hover card", () => {
+  it("keeps a workspace without a session looking empty", () => {
+    renderCard();
+
+    expect(screen.queryByText("Idle")).not.toBeInTheDocument();
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Claude Code")).not.toBeInTheDocument();
+  });
+
+  it("keeps a parked agent visible as a completed turn", () => {
+    const digest: CodeSessionDigest = {
+      workspace: workspace.id,
+      session: "sess-1",
+      kind: "interactive",
+      harness_kind: "claude_code",
+      lifecycle: "idle",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      title: workspace.title,
+      turn_count: 1,
+      recap: "Folded the backoff into refresh.",
+    };
     const session: CodeSessionSnapshot = {
       id: "sess-1",
       workspace_id: workspace.id,
@@ -276,21 +295,34 @@ describe("WorkspaceCard", () => {
     render(
       <WorkspaceCard
         workspace={workspace}
-        digest={undefined}
+        digest={digest}
         session={session}
         repoName="app"
-        active={false}
+        active
         terminalOpen={false}
         density="detailed"
-        visibleMeta={{ repoChip: true, branch: false }}
-        commands={workspaceCommands({ hasPr: false, archived: false })}
+        visibleMeta={{ repoChip: true, branch: true }}
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          hasSession: true,
+        })}
         onOpen={vi.fn()}
         onCommand={vi.fn()}
       />,
     );
 
-    expect(screen.queryByText("Idle")).not.toBeInTheDocument();
-    expect(screen.queryByTitle("Claude Code")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Working")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Done")).toBeInTheDocument();
+    expect(screen.getByTitle("Claude Code")).toBeInTheDocument();
+    expect(
+      screen.getByText("Folded the backoff into refresh."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Fix login · Done · app · tidebreak/fix-login",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("does not show live motion when an older idle digest still says Working", () => {
@@ -325,10 +357,10 @@ describe("WorkspaceCard", () => {
     );
 
     expect(screen.queryByLabelText("Working")).not.toBeInTheDocument();
-    expect(screen.getByText("Idle · 1 turn")).toBeInTheDocument();
+    expect(screen.getAllByText("Done · 1 turn").length).toBeGreaterThan(0);
     expect(
       screen.getByRole("button", {
-        name: "Fix login · Idle · app · tidebreak/fix-login",
+        name: "Fix login · Done · app · tidebreak/fix-login",
       }),
     ).toBeInTheDocument();
   });

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -68,7 +68,7 @@ import {
   isPutAway,
   middleTruncate,
   repoAccentClass,
-  sessionRowLabel,
+  sessionActivityLineLabel,
   watchRowLabel,
   workspaceCardLabel,
   workspacePrChipSummary,
@@ -765,23 +765,17 @@ function workspaceActivitySummary(
   const worthyDigest =
     digest && isSessionRowWorthy(digest) ? digest : undefined;
   const statusLabel = worthyDigest
-    ? sessionRowLabel(worthyDigest)
+    ? sessionActivityLineLabel(worthyDigest)
     : digest
       ? LIFECYCLE_LABELS[digest.lifecycle]
       : session
         ? LIFECYCLE_LABELS[session.lifecycle]
         : null;
-  const turnCount = digest?.turn_count;
-  const turnLabel =
-    turnCount !== undefined
-      ? `${turnCount} ${turnCount === 1 ? "turn" : "turns"}`
-      : null;
-  const sessionLine = [statusLabel, turnLabel].filter(Boolean).join(" · ");
-  const terminalOnly = terminalOpen && !sessionLine;
-  if (!sessionLine && !terminalOnly) return null;
+  const terminalOnly = terminalOpen && !statusLabel;
+  if (!statusLabel && !terminalOnly) return null;
 
   return {
-    label: sessionLine || "Terminal open",
+    label: statusLabel || "Terminal open",
     tone: digestStatusTone(digest),
     needsYou: false,
     terminalOnly,

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -174,7 +174,7 @@ export function WorkspaceCard({
                   title,
                   repoName,
                   branchName: workspace.branch_name,
-                  attention: digest?.attention,
+                  attention: attentionMark,
                   session: digest,
                   pr,
                   terminalOpen,

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.test.ts
@@ -11,10 +11,12 @@ import {
 function digest(
   attention: Attention["state"],
   lifecycle: CodeSessionDigest["lifecycle"],
+  turnCount = 0,
 ): CodeSessionDigest {
   return {
     attention: { state: attention, source: "lifecycle" },
     lifecycle,
+    turn_count: turnCount,
   } as CodeSessionDigest;
 }
 
@@ -85,7 +87,7 @@ describe("attentionMarkForDigest", () => {
     ).toBeUndefined();
   });
 
-  it("keeps attention that outranks lifecycle and leaves idle unmarked", () => {
+  it("keeps attention that outranks lifecycle and leaves a never-started idle unmarked", () => {
     const needsYou = digest(
       { type: "needs_you", prompt: "Approve this?", source: "structured" },
       "idle",
@@ -94,5 +96,18 @@ describe("attentionMarkForDigest", () => {
     expect(
       attentionMarkForDigest(digest({ type: "idle" }, "idle")),
     ).toBeUndefined();
+  });
+
+  it("marks a parked turn as Done so the card still reads as an agent", () => {
+    const done = {
+      state: { type: "done_unreviewed" as const },
+      source: "lifecycle" as const,
+    };
+    expect(
+      attentionMarkForDigest(digest({ type: "working" }, "idle", 1)),
+    ).toEqual(done);
+    expect(attentionMarkForDigest(digest({ type: "idle" }, "idle", 3))).toEqual(
+      done,
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.ts
@@ -143,17 +143,28 @@ export function digestStatusTone(
  *
  * Older rows can still carry `Working` after their lifecycle settles. Motion
  * must agree with lifecycle, or the same workspace reads as live in one place
- * and idle in another. Idle itself has no mark because it asks for nothing.
+ * and idle in another. A parked turn with work behind it takes the quiet
+ * Done mark so the card still reads as an agent, not an empty workspace.
  */
 export function attentionMarkForDigest(
-  digest: Pick<CodeSessionDigest, "attention" | "lifecycle"> | undefined,
+  digest:
+    | Pick<CodeSessionDigest, "attention" | "lifecycle" | "turn_count">
+    | undefined,
 ): Attention | undefined {
-  if (!digest || digest.attention.state.type === "idle") return undefined;
+  if (!digest) return undefined;
   if (
     digest.attention.state.type === "working" &&
     digest.lifecycle !== "running"
   ) {
-    return undefined;
+    return digest.turn_count > 0 ? COMPLETED_TURN_MARK : undefined;
+  }
+  if (digest.attention.state.type === "idle") {
+    return digest.turn_count > 0 ? COMPLETED_TURN_MARK : undefined;
   }
   return digest.attention;
 }
+
+const COMPLETED_TURN_MARK: Attention = {
+  state: { type: "done_unreviewed" },
+  source: "lifecycle",
+};

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -474,6 +474,35 @@ describe("workspaceCardLabel", () => {
     ).toBe("Fix login · Idle · app · tidebreak/fix-login");
   });
 
+  it("announces Done for a parked idle session, matching the complete mark", () => {
+    const session = digest("ws-a", {
+      lifecycle: "idle",
+      attention: { state: { type: "idle" }, source: "lifecycle" },
+      turn_count: 4,
+    });
+    expect(
+      workspaceCardLabel({
+        title: "Fix login",
+        repoName: "app",
+        branchName: "tidebreak/fix-login",
+        attention: {
+          state: { type: "done_unreviewed" },
+          source: "lifecycle",
+        },
+        session,
+      }),
+    ).toBe("Fix login · Done · app · tidebreak/fix-login");
+    expect(
+      workspaceCardLabel({
+        title: "Fix login",
+        repoName: "app",
+        branchName: "tidebreak/fix-login",
+        attention: session.attention,
+        session,
+      }),
+    ).toBe("Fix login · Done · app · tidebreak/fix-login");
+  });
+
   it("announces queue membership instead of the open lifecycle", () => {
     expect(
       workspaceCardLabel({

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -12,7 +12,10 @@ import {
   groupWorkspacesByRepo,
   listArchivedWorkspaces,
   middleTruncate,
+  isSessionRowWorthy,
   sessionActivityLabel,
+  sessionActivityLineLabel,
+  sessionRowLabel,
   workspaceCardLabel,
   workspacePrChipSummary,
   workspaceStackParent,
@@ -329,6 +332,58 @@ describe("formatCompactAge", () => {
     expect(formatCompactAge("2026-08-18T11:48:00.000Z", now)).toBe("12m");
     expect(formatCompactAge("2026-08-18T09:00:00.000Z", now)).toBe("3h");
     expect(formatCompactAge("2026-08-16T12:00:00.000Z", now)).toBe("2d");
+  });
+});
+
+describe("isSessionRowWorthy", () => {
+  it("keeps a parked idle agent on the rail", () => {
+    expect(isSessionRowWorthy(digest("ws-a", { turn_count: 2 }))).toBe(true);
+    expect(
+      isSessionRowWorthy(
+        digest("ws-a", { lifecycle: "created", turn_count: 0 }),
+      ),
+    ).toBe(false);
+    expect(isSessionRowWorthy(undefined)).toBe(false);
+  });
+});
+
+describe("sessionRowLabel", () => {
+  it("calls a parked turn Done once it has finished work", () => {
+    expect(sessionRowLabel(digest("ws-a", { turn_count: 2 }))).toBe("Done");
+    expect(
+      sessionRowLabel(digest("ws-a", { lifecycle: "created", turn_count: 0 })),
+    ).toBe("Created");
+  });
+});
+
+describe("sessionActivityLineLabel", () => {
+  it("prefers the recap on a parked turn", () => {
+    expect(
+      sessionActivityLineLabel(
+        digest("ws-a", {
+          turn_count: 4,
+          recap: "Folded the backoff into refresh.",
+        }),
+      ),
+    ).toBe("Folded the backoff into refresh.");
+  });
+
+  it("keeps live activity and the turn count together", () => {
+    expect(
+      sessionActivityLineLabel(
+        digest("ws-a", {
+          lifecycle: "running",
+          activity: "shell",
+          turn_count: 3,
+        }),
+      ),
+    ).toBe("Shell running · 3 turns");
+  });
+
+  it("falls back to Done and the turn count without a recap", () => {
+    expect(sessionActivityLineLabel(digest("ws-a", { turn_count: 2 }))).toBe(
+      "Done · 2 turns",
+    );
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -415,12 +415,20 @@ export function workspaceCardLabel(input: {
 }): string {
   const parts = [input.title];
   if (input.workspaceStatus === "creating") parts.push("Creating workspace");
-  if (input.attention && input.attention.state.type !== "working") {
+  if (
+    input.attention &&
+    input.attention.state.type !== "working" &&
+    input.attention.state.type !== "idle"
+  ) {
     parts.push(attentionLabel(input.attention));
   }
   if (input.session?.lifecycle === "running") {
     parts.push(sessionActivityLabel(input.session));
-  } else if (input.session && input.attention?.state.type === "working") {
+  } else if (
+    input.session &&
+    (input.attention?.state.type === "working" ||
+      input.attention?.state.type === "idle")
+  ) {
     parts.push(sessionRowLabel(input.session));
   }
   if (input.pr) {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -278,11 +278,13 @@ export function isSessionRowWorthy(
   digest: CodeSessionDigest | undefined,
 ): digest is CodeSessionDigest {
   if (!digest) return false;
-  if (digest.lifecycle === "running" || digest.lifecycle === "fenced") {
-    return true;
+  // A created session with no turns and no engine is still an empty
+  // workspace. Everything else belongs to an agent, including a parked
+  // idle one — hiding that row makes the card look unused.
+  if (digest.lifecycle === "created" && digest.turn_count === 0) {
+    return digest.harness_kind !== undefined;
   }
-  const type = digest.attention.state.type;
-  return type === "needs_you" || type === "stalled";
+  return true;
 }
 
 /** Short lifecycle word for the nested session row. */
@@ -299,8 +301,36 @@ export function sessionRowLabel(digest: CodeSessionDigest): string {
     case "manual":
       return "Pinned";
     default:
+      if (
+        (digest.lifecycle === "idle" || digest.lifecycle === "ended") &&
+        digest.turn_count > 0
+      ) {
+        return "Done";
+      }
       return LIFECYCLE_LABELS[digest.lifecycle];
   }
+}
+
+/**
+ * Copy for the workspace card's session line.
+ *
+ * A live turn names the activity and the turn count. A parked turn prefers
+ * the recap when one exists — that is the complete-state read — and falls
+ * back to the short lifecycle word so the agent is still visible.
+ */
+export function sessionActivityLineLabel(digest: CodeSessionDigest): string {
+  if (digest.attention.state.type === "needs_you") {
+    return digest.attention.state.prompt || "Needs you";
+  }
+  const recap = digest.recap?.trim();
+  if (recap && digest.lifecycle !== "running") return recap;
+  const status =
+    digest.lifecycle === "running"
+      ? sessionActivityLabel(digest)
+      : sessionRowLabel(digest);
+  const turns =
+    digest.turn_count === 1 ? "1 turn" : `${digest.turn_count} turns`;
+  return `${status} · ${turns}`;
 }
 
 /** Precise running-state copy for a workspace row. */
@@ -391,7 +421,7 @@ export function workspaceCardLabel(input: {
   if (input.session?.lifecycle === "running") {
     parts.push(sessionActivityLabel(input.session));
   } else if (input.session && input.attention?.state.type === "working") {
-    parts.push(LIFECYCLE_LABELS[input.session.lifecycle]);
+    parts.push(sessionRowLabel(input.session));
   }
   if (input.pr) {
     parts.push(

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -16,6 +16,10 @@ import {
   codeWorkspace,
   doneDigest,
   draftPrDigest,
+  grokIdleSession,
+  idleCompleteDigest,
+  idleDigest,
+  idleSession,
   mergedPrDigest,
   monitorDigest,
   needsYouDigest,
@@ -323,15 +327,10 @@ export const HoverIdleSession: Story = {
       branch_name: "tidebreak/idle-workspace",
     },
     digest: {
-      ...runningDigest,
+      ...idleDigest,
       title: "Idle workspace",
-      lifecycle: "idle",
-      turn_count: 1,
     },
-    session: {
-      ...codeSession,
-      lifecycle: "idle",
-    },
+    session: idleSession,
     active: true,
     visibleMeta: { repoChip: true, branch: true },
     commands: workspaceCommands({
@@ -340,6 +339,50 @@ export const HoverIdleSession: Story = {
       hasSession: true,
     }),
     detailDefaultOpen: true,
+  },
+};
+
+/**
+ * A parked agent still owns the row. The quiet Done mark and the harness
+ * keep it from looking like an empty workspace after the turn completes.
+ */
+export const ParkedComplete: Story = {
+  args: {
+    workspace: {
+      ...codeWorkspace,
+      title: "Parked exploration",
+      branch_name: "tidebreak/parked-exploration",
+    },
+    digest: {
+      ...idleCompleteDigest,
+      title: "Parked exploration",
+    },
+    session: grokIdleSession,
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      hasSession: true,
+    }),
+  },
+};
+
+/** Parked without a recap still names the agent and the completed turn. */
+export const ParkedIdle: Story = {
+  args: {
+    workspace: {
+      ...codeWorkspace,
+      title: "Product direction hypotheses",
+    },
+    digest: {
+      ...idleDigest,
+      title: "Product direction hypotheses",
+    },
+    session: idleSession,
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      hasSession: true,
+    }),
   },
 };
 
@@ -541,22 +584,24 @@ export const PullRequestTones: Story = {
 /**
  * The status ramp on one screen, which is the only way to catch a tone drawn
  * at the wrong strength. Read down the glyph rail: working moves, needs-you is
- * the one red, stalled is amber, done is quiet, and merged is purple rather
- * than a second shade of green. Check this in both themes.
+ * the one red, stalled is amber, done is quiet, parked still shows the agent,
+ * and merged is purple rather than a second shade of green. Check this in both
+ * themes.
  */
 export const StatusTones: Story = {
   render: (args) => (
     <div className="flex flex-col gap-0.5">
       {(
         [
-          ["Working", runningDigest, undefined],
-          ["Needs you", needsYouDigest, undefined],
-          ["Stalled", stalledDigest, undefined],
-          ["Done, unreviewed", doneDigest, undefined],
-          ["PR merged", undefined, mergedPrDigest],
-          ["Idle", undefined, undefined],
+          ["Working", runningDigest, codeSession, undefined],
+          ["Needs you", needsYouDigest, codeSession, undefined],
+          ["Stalled", stalledDigest, codeSession, undefined],
+          ["Done, unreviewed", doneDigest, idleSession, undefined],
+          ["Parked, complete", idleCompleteDigest, grokIdleSession, undefined],
+          ["PR merged", undefined, undefined, mergedPrDigest],
+          ["No session", undefined, undefined, undefined],
         ] as const
-      ).map(([label, digest, pr]) => (
+      ).map(([label, digest, session, pr]) => (
         <WorkspaceCard
           {...args}
           key={label}
@@ -567,7 +612,7 @@ export const StatusTones: Story = {
             pr,
           }}
           digest={digest && { ...digest, title: label }}
-          session={digest ? codeSession : undefined}
+          session={session}
           commands={workspaceCommands({
             hasPr: Boolean(pr),
             archived: false,
@@ -630,6 +675,13 @@ export const Rail: Story = {
           title: "Parked exploration",
           branch_name: "tidebreak/parked-exploration",
         }}
+        digest={{ ...idleCompleteDigest, title: "Parked exploration" }}
+        session={grokIdleSession}
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          hasSession: true,
+        })}
       />
     </div>
   ),

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -294,6 +294,11 @@ export const attentionDoneUnreviewed: Attention = {
   source: "lifecycle",
 };
 
+export const attentionIdle: Attention = {
+  state: { type: "idle" },
+  source: "lifecycle",
+};
+
 export const attentionFenced: Attention = {
   state: { type: "fenced", reason: { type: "orphan_alive" } },
   source: "lifecycle",
@@ -702,6 +707,32 @@ export const doneDigest: CodeSessionDigest = codeDigest({
   attention: attentionDoneUnreviewed,
   turn_count: 6,
 });
+
+/** Parked after a turn, still carrying Working from an older digest. */
+export const idleDigest: CodeSessionDigest = codeDigest({
+  lifecycle: "idle",
+  turn_count: 2,
+});
+
+/** Parked after a turn, with the recap the rail uses as the complete read. */
+export const idleCompleteDigest: CodeSessionDigest = codeDigest({
+  lifecycle: "idle",
+  attention: attentionIdle,
+  harness_kind: "grok",
+  turn_count: 4,
+  recap: "Folded the backoff into refresh and left the retry passing.",
+});
+
+export const idleSession: CodeSessionSnapshot = {
+  ...codeSession,
+  lifecycle: "idle",
+};
+
+export const grokIdleSession: CodeSessionSnapshot = {
+  ...codeSession,
+  harness_kind: "grok",
+  lifecycle: "idle",
+};
 
 /** A watch-and-fix task riding under the workspace (decision 50). */
 export const watchDigest: CodeSessionDigest = codeDigest({


### PR DESCRIPTION
A parked idle session dropped the rail activity line, so a workspace that already had an agent looked empty.

After a turn completes, the card keeps the harness icon and a quiet Done mark. When a recap exists, that is the status line. A workspace with no session stays title-only.

Storybook: `Code/Workspace card` — Parked complete, Parked idle, Status tones, Rail.

## Validation

`pnpm --dir crates/tidebreak-desktop/ui test src/code/WorkspaceCard.dom.test.tsx src/code/workspaceCards.test.ts src/code/statusTone.test.ts`

## Compatibility and risk

None. Presentation-only.