### PR TITLE
fix(desktop): count skipped checks as terminal

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
@@ -197,12 +197,34 @@ describe("PullRequestDetailSheet", () => {
 
   it("lists every check, failures first", async () => {
     await renderPanel(2251);
-    await userEvent.click(screen.getByRole("tab", { name: /Checks/ }));
+    const checksTab = screen.getByRole("tab", { name: /Checks/ });
+    expect(checksTab).toHaveTextContent("2/2");
+    await userEvent.click(checksTab);
     expect(
       await screen.findByText("1 of 2 passed, 1 failed"),
     ).toBeInTheDocument();
     const rows = screen.getAllByRole("button", { name: /desktop \// });
     expect(rows[0]).toHaveTextContent("desktop / storybook");
+  });
+
+  it("counts skipped checks as terminal tab progress", async () => {
+    await renderPanel(2240);
+    const checksTab = await screen.findByRole("tab", { name: /Checks/ });
+    expect(checksTab).toHaveTextContent("3/3");
+    await userEvent.click(checksTab);
+    expect(
+      await screen.findByText("2 of 3 passed, 1 skipped"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps pending checks out of progress and uses the running mark", async () => {
+    await renderPanel(2229);
+    const checksTab = await screen.findByRole("tab", { name: /Checks/ });
+    expect(checksTab).toHaveTextContent("1/2");
+    await userEvent.click(checksTab);
+    const pending = screen.getByRole("button", { name: /desktop \/ lint/ });
+    expect(pending.querySelector(".lucide-circle-dashed")).not.toBeNull();
+    expect(pending.querySelector(".lucide-play")).toBeNull();
   });
 
   it("posts a comment and clears the box", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -16,7 +16,6 @@ import {
   GitPullRequestDraft,
   LoaderCircle,
   MoreHorizontal,
-  Play,
   RefreshCw,
   ShieldAlert,
   X,
@@ -500,7 +499,7 @@ export function PullRequestDetailSheet({
                             : STATUS_TEXT.ready,
                       )}
                     >
-                      {counts.passing}/{counts.total}
+                      {counts.total - counts.pending}/{counts.total}
                     </span>
                   )}
                 </TabsTrigger>
@@ -1903,7 +1902,9 @@ export function CheckTone({
     return <X className={cn("size-3.5 shrink-0", STATUS_MARK.critical)} />;
   }
   if (bucket === "pending") {
-    return <Play className={cn("size-3.5 shrink-0", STATUS_MARK.pending)} />;
+    return (
+      <CircleDashed className={cn("size-3.5 shrink-0", STATUS_MARK.pending)} />
+    );
   }
   return <CircleDot className={cn("size-3.5 shrink-0", STATUS_MARK.neutral)} />;
 }

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -505,10 +505,16 @@ export const PullRequestRunningCheckDetail: Story = {
     await expect(
       body.queryByText(/required review|review approval/i),
     ).not.toBeInTheDocument();
-    await userEvent.click(await body.findByRole("tab", { name: /Checks/ }));
+    const checksTab = await body.findByRole("tab", { name: /Checks/ });
+    await expect(checksTab).toHaveTextContent("0/1");
+    await userEvent.click(checksTab);
     await expect(
       await body.findByText("0 of 1 passed, 1 pending"),
     ).toBeVisible();
+    const pending = await body.findByRole("button", {
+      name: /Preview \/ Build preview image/,
+    });
+    await expect(pending.querySelector(".lucide-circle-dashed")).not.toBeNull();
   },
 };
 
@@ -820,6 +826,23 @@ export const PullRequestDetailChecks: Story = {
     await openPullRequest(canvasElement, "Build the delivery center");
     await userEvent.click(await body.findByRole("tab", { name: /Checks/ }));
     await expect(await body.findByText(/1 of 2 passed/)).toBeVisible();
+  },
+};
+
+/** Skipped checks are terminal, so a settled run reads complete in the tab. */
+export const PullRequestTerminalChecks: Story = {
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await openPullRequest(
+      canvasElement,
+      "Cache the workspace digest between polls",
+    );
+    const checksTab = await body.findByRole("tab", { name: /Checks/ });
+    await expect(checksTab).toHaveTextContent("3/3");
+    await userEvent.click(checksTab);
+    await expect(
+      await body.findByText("2 of 3 passed, 1 skipped"),
+    ).toBeVisible();
   },
 };
 


### PR DESCRIPTION
## What changed

- Show the circular dashed status icon for checks that are still running.
- Count skipped checks as terminal progress so a settled run shows the full numerator.
- Cover running, skipped, passing, and failing check progress in focused tests and Storybook.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/PullRequestDetail.dom.test.tsx` — 25 passed.
- `pnpm --dir crates/tidebreak-desktop/ui typecheck` — passed.
- `pnpm --dir crates/tidebreak-desktop/ui lint` — 773 files passed.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — passed.
- `git diff --check` — passed.
- Storybook image capture is pending because no connected browser instance is available.

## Compatibility and risk

None. This changes display-only progress accounting and status iconography.

## Tracking

Closes #2787