### PR TITLE
fix(code): reject late conditional PR writes

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/pull_request.rs
+++ b/crates/tidebreak-core/src/db/ops/code/pull_request.rs
@@ -6,7 +6,7 @@
 //! to a pull request it authored or contributed to (decision 62). GitHub
 //! stays authoritative; these rows record what was observed and when.
 
-use sea_orm::sea_query::OnConflict;
+use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
     QuerySelect, Set,
@@ -187,6 +187,15 @@ pub struct PullRequestFetchState {
     pub reviews_etag: Option<String>,
 }
 
+/// The condition that protects one pull-request fetch-state write.
+#[derive(Debug, Clone, Copy)]
+pub enum PullRequestFetchCondition<'a> {
+    /// A fresh 200 response replaces the snapshot and validator together.
+    Unconditional,
+    /// A 304 response writes only if the row still holds the validator sent.
+    PullEtag(Option<&'a str>),
+}
+
 /// Load one observed pull request with its stored fetch ETags.
 pub async fn get_pull_request_fetch_state(
     store: &DbStore,
@@ -218,8 +227,10 @@ pub async fn get_pull_request_fetch_state(
 /// 304 passes `None`. The pull snapshot and its ETag must move in one row
 /// update, or concurrent refreshes can pair one response's validator with
 /// another response's snapshot and make the next 304 reconstruct stale
-/// state. Endpoint ETags carry the pass's final values. `Ok(false)` when no
-/// fact row exists for the identity.
+/// state. A 304 also compares the stored pull ETag in this update. If another
+/// writer changed or cleared that validator, the stale response updates zero
+/// rows. Endpoint ETags carry the pass's final values. `Ok(false)` when no
+/// fact row matches the identity and condition.
 #[allow(clippy::too_many_arguments)]
 pub async fn set_pull_request_fetch_state(
     store: &DbStore,
@@ -229,31 +240,74 @@ pub async fn set_pull_request_fetch_state(
     repo_name: &str,
     number: u64,
     fresh_fact: Option<&CodePullRequestFact>,
+    condition: PullRequestFetchCondition<'_>,
     pull_etag: Option<&str>,
     checks_etag: Option<&str>,
     reviews_etag: Option<&str>,
 ) -> Result<bool> {
     let number = i64::try_from(number)
         .map_err(|_| AgentError::Store(format!("pull request number {number} overflows")))?;
-    let Some(row) = find_fact_row(store, owner, host, repo_owner, repo_name, number).await? else {
-        return Ok(false);
-    };
-    let mut model: entities::code_pull_request::ActiveModel = row.into();
+    let mut update = entities::code_pull_request::Entity::update_many()
+        .col_expr(
+            entities::code_pull_request::Column::PullEtag,
+            Expr::value(pull_etag.map(ToOwned::to_owned)),
+        )
+        .col_expr(
+            entities::code_pull_request::Column::ChecksEtag,
+            Expr::value(checks_etag.map(ToOwned::to_owned)),
+        )
+        .col_expr(
+            entities::code_pull_request::Column::ReviewsEtag,
+            Expr::value(reviews_etag.map(ToOwned::to_owned)),
+        )
+        .filter(entities::code_pull_request::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_pull_request::Column::Host.eq(host))
+        .filter(entities::code_pull_request::Column::RepoOwner.eq(repo_owner))
+        .filter(entities::code_pull_request::Column::RepoName.eq(repo_name))
+        .filter(entities::code_pull_request::Column::Number.eq(number));
     if let Some(fact) = fresh_fact {
-        model.url = Set(fact.url.clone());
-        model.title = Set(fact.title.clone());
-        model.state = Set(fact.state.as_str().to_owned());
-        model.draft = Set(fact.draft);
-        model.head_branch = Set(fact.head_branch.clone());
-        model.base_branch = Set(fact.base_branch.clone());
-        model.head_sha = Set(fact.head_sha.clone());
-        model.last_seen_at = Set(fact.last_seen_at);
+        update = update
+            .col_expr(
+                entities::code_pull_request::Column::Url,
+                Expr::value(fact.url.clone()),
+            )
+            .col_expr(
+                entities::code_pull_request::Column::Title,
+                Expr::value(fact.title.clone()),
+            )
+            .col_expr(
+                entities::code_pull_request::Column::State,
+                Expr::value(fact.state.as_str().to_owned()),
+            )
+            .col_expr(
+                entities::code_pull_request::Column::Draft,
+                Expr::value(fact.draft),
+            )
+            .col_expr(
+                entities::code_pull_request::Column::HeadBranch,
+                Expr::value(fact.head_branch.clone()),
+            )
+            .col_expr(
+                entities::code_pull_request::Column::BaseBranch,
+                Expr::value(fact.base_branch.clone()),
+            )
+            .col_expr(
+                entities::code_pull_request::Column::HeadSha,
+                Expr::value(fact.head_sha.clone()),
+            )
+            .col_expr(
+                entities::code_pull_request::Column::LastSeenAt,
+                Expr::value(fact.last_seen_at),
+            );
     }
-    model.pull_etag = Set(pull_etag.map(ToOwned::to_owned));
-    model.checks_etag = Set(checks_etag.map(ToOwned::to_owned));
-    model.reviews_etag = Set(reviews_etag.map(ToOwned::to_owned));
-    model.update(&store.conn).await.map_err(store_err)?;
-    Ok(true)
+    if let PullRequestFetchCondition::PullEtag(expected) = condition {
+        update = match expected {
+            Some(etag) => update.filter(entities::code_pull_request::Column::PullEtag.eq(etag)),
+            None => update.filter(entities::code_pull_request::Column::PullEtag.is_null()),
+        };
+    }
+    let result = update.exec(&store.conn).await.map_err(store_err)?;
+    Ok(result.rows_affected == 1)
 }
 
 /// Every observed pull request on one repository identity.

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -3549,7 +3549,7 @@ async fn pull_request_facts_upsert_claim_and_promote() {
         count_attributed_prs_for_workspace, get_pull_request_fact, get_pull_request_fetch_state,
         insert_pull_request_attribution, list_attributed_facts_for_workspace,
         list_fact_repo_identities, promote_attribution_to_authored, save_pull_request_fact,
-        set_pull_request_fetch_state, set_pull_request_live_state,
+        set_pull_request_fetch_state, set_pull_request_live_state, PullRequestFetchCondition,
     };
 
     let (_dir, store) = temp_store().await;
@@ -3622,6 +3622,7 @@ async fn pull_request_facts_upsert_claim_and_promote() {
         "tools",
         412,
         Some(&refreshed),
+        PullRequestFetchCondition::Unconditional,
         Some("W/\"pull-2\""),
         Some("W/\"checks-2\""),
         Some("W/\"reviews-2\""),
@@ -3768,6 +3769,7 @@ async fn snapshot_upsert_invalidates_a_concurrent_fetch_validator() {
     use crate::code::{CodePullRequestFact, CodePullRequestId, CodePullRequestState};
     use crate::db::code::{
         get_pull_request_fetch_state, save_pull_request_fact, set_pull_request_fetch_state,
+        PullRequestFetchCondition,
     };
 
     let (_dir, store) = temp_store().await;
@@ -3811,6 +3813,7 @@ async fn snapshot_upsert_invalidates_a_concurrent_fetch_validator() {
         "tools",
         99,
         Some(&fresh),
+        PullRequestFetchCondition::Unconditional,
         Some("W/\"fresh\""),
         None,
         None,
@@ -3827,6 +3830,95 @@ async fn snapshot_upsert_invalidates_a_concurrent_fetch_validator() {
     assert_eq!(stored.fact.title, "Stale");
     assert_eq!(stored.fact.head_sha.as_deref(), Some("old"));
     assert_eq!(stored.pull_etag, None);
+}
+
+#[tokio::test]
+async fn late_304_cannot_restore_an_invalidated_pull_validator() {
+    use crate::code::{CodePullRequestFact, CodePullRequestId, CodePullRequestState};
+    use crate::db::code::{
+        get_pull_request_fetch_state, save_pull_request_fact, set_pull_request_fetch_state,
+        PullRequestFetchCondition,
+    };
+
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let observed = now();
+    let snapshot_a = CodePullRequestFact {
+        id: CodePullRequestId::new(),
+        owner: owner.clone(),
+        host: "github.com".into(),
+        repo_owner: "acme".into(),
+        repo_name: "tools".into(),
+        number: 100,
+        url: "https://github.com/acme/tools/pull/100".into(),
+        title: "Snapshot A".into(),
+        state: CodePullRequestState::Open,
+        draft: false,
+        author: None,
+        head_branch: "feature".into(),
+        base_branch: "main".into(),
+        head_sha: Some("aaa".into()),
+        created_at: observed,
+        updated_at: observed,
+        merged_at: None,
+        closed_at: None,
+        first_seen_at: observed,
+        last_seen_at: observed,
+        live: None,
+    };
+    save_pull_request_fact(&store, &snapshot_a).await.unwrap();
+    assert!(set_pull_request_fetch_state(
+        &store,
+        &owner,
+        "github.com",
+        "acme",
+        "tools",
+        100,
+        Some(&snapshot_a),
+        PullRequestFetchCondition::Unconditional,
+        Some("W/\"snapshot-a\""),
+        Some("W/\"checks-a\""),
+        Some("W/\"reviews-a\""),
+    )
+    .await
+    .unwrap());
+
+    let refresh = get_pull_request_fetch_state(&store, &owner, "github.com", "acme", "tools", 100)
+        .await
+        .unwrap()
+        .unwrap();
+    let snapshot_c = CodePullRequestFact {
+        title: "Snapshot C".into(),
+        head_sha: Some("ccc".into()),
+        ..snapshot_a.clone()
+    };
+    save_pull_request_fact(&store, &snapshot_c).await.unwrap();
+
+    assert!(!set_pull_request_fetch_state(
+        &store,
+        &owner,
+        "github.com",
+        "acme",
+        "tools",
+        100,
+        None,
+        PullRequestFetchCondition::PullEtag(refresh.pull_etag.as_deref()),
+        refresh.pull_etag.as_deref(),
+        Some("W/\"late-checks\""),
+        Some("W/\"late-reviews\""),
+    )
+    .await
+    .unwrap());
+
+    let stored = get_pull_request_fetch_state(&store, &owner, "github.com", "acme", "tools", 100)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.fact.title, "Snapshot C");
+    assert_eq!(stored.fact.head_sha.as_deref(), Some("ccc"));
+    assert_eq!(stored.pull_etag, None);
+    assert_eq!(stored.checks_etag.as_deref(), Some("W/\"checks-a\""));
+    assert_eq!(stored.reviews_etag.as_deref(), Some("W/\"reviews-a\""));
 }
 
 /// A whole-row turn save cannot blank a recap that landed while it was held.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -2269,6 +2269,7 @@ impl CodeRuntime {
             ),
             None => (None, None, None, None),
         };
+        let sent_pull_etag = pull_etag.clone();
         let (pull, fresh_pull) = match pr_fetch::read_pull_request(
             gate,
             transport,
@@ -2408,6 +2409,11 @@ impl CodeRuntime {
         } else {
             None
         };
+        let condition = if fresh_pull {
+            tidebreak_core::db::code::PullRequestFetchCondition::Unconditional
+        } else {
+            tidebreak_core::db::code::PullRequestFetchCondition::PullEtag(sent_pull_etag.as_deref())
+        };
 
         let digest = pr_fetch::digest_from_parts(&pull, &checks, review_decision, in_merge_queue);
         self.record_pull_request_live_state(owner, Some(workspace.id), &digest)
@@ -2420,6 +2426,7 @@ impl CodeRuntime {
             &repo_name,
             number,
             fresh_fact.as_ref(),
+            condition,
             pull_etag.as_deref(),
             checks_etag.as_deref(),
             reviews_etag.as_deref(),


### PR DESCRIPTION
## What changed

- Guard 304 fetch-state writes with the exact pull ETag sent by that request.
- Keep fresh 200 responses unconditional so the snapshot and validators still advance together.
- Prevent a late 304 from restoring an invalidated pull validator or replacing newer endpoint ETags.
- Add the exact late-response interleaving as a database regression.

## Validation

- `cargo test -p tidebreak-core --lib late_304_cannot_restore_an_invalidated_pull_validator` — 1 passed.
- `cargo test -p tidebreak-core --lib snapshot_upsert_invalidates_a_concurrent_fetch_validator` — 1 passed.
- `cargo test -p tidebreak-server --lib a_hosted_digest_reads_the_row_and_refreshes_conditionally` — 1 passed.
- `cargo check -p tidebreak-core --all-targets` — passed.
- `cargo check -p tidebreak-server --all-targets` — passed with existing scripted-harness dead-code warnings.
- `cargo fmt --all --check` — passed.
- `git diff --check` — passed.

## Compatibility and risk

No schema or wire-format changes. The guarded update can reject stale 304 writes, which forces a later refresh instead of accepting mismatched cached state.

## Tracking

Closes #2789
Follow-up to #2781.