### PR TITLE
fix(desktop): spin the progress glyph around its center

### DIFF
--- a/crates/tidebreak-desktop/ui/src/components/ui/spinner.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/spinner.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
@@ -10,22 +9,42 @@ import { cn } from "@/lib/utils";
  * instead of the muted default. Callers own the accessible name — pass
  * `aria-hidden` when adjacent text already says what is happening, or an
  * `aria-label` when the glyph is the only signal.
+ *
+ * The arc is a circle centred on the 24 viewBox. Lucide's Loader2 writes
+ * width/height="24" and uses an open path, so WebKit's `animate-spin`
+ * origin falls on the C's ink box and the glyph orbits at badge size.
+ * `transform-box: view-box` pins rotation to the viewBox centre.
  */
-const Spinner = React.forwardRef<
-  SVGSVGElement,
-  React.ComponentProps<typeof Loader2>
->(({ className, ...props }, ref) => {
-  return (
-    <Loader2
-      className={cn("size-4 animate-spin text-muted-foreground", className)}
-      // An `svg` is not an element that takes a name, so a caller's
-      // `aria-label` would be dropped without a role that does.
-      role={props["aria-label"] ? "img" : undefined}
-      ref={ref}
-      {...props}
-    />
-  );
-});
+const Spinner = React.forwardRef<SVGSVGElement, React.SVGProps<SVGSVGElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <svg
+        ref={ref}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        // An `svg` is not an element that takes a name, so a caller's
+        // `aria-label` would be dropped without a role that does.
+        role={props["aria-label"] ? "img" : undefined}
+        {...props}
+        className={cn(
+          "inline-block size-4 shrink-0 origin-center animate-spin text-muted-foreground [transform-box:view-box]",
+          className,
+        )}
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeDasharray="42 14.5"
+        />
+      </svg>
+    );
+  },
+);
 Spinner.displayName = "Spinner";
 
 export { Spinner };

--- a/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
@@ -115,6 +115,20 @@ type Story = StoryObj<typeof meta>;
 /** One agent alone; the `+` menu is the whole affordance. */
 export const ConversationOnly: Story = {};
 
+/** The live mark on the agent the reader is looking at. */
+export const WorkingConversation: Story = {
+  args: {
+    conversations: [
+      {
+        id: "session-1",
+        label: "Main agent",
+        harness: "claude_code",
+        attention: attentionWorking,
+      },
+    ],
+  },
+};
+
 /**
  * The `+` menu, open. The top group starts something the workspace can hold
  * many of; the group under it opens the one view there is of the worktree.

--- a/crates/tidebreak-desktop/ui/src/stories/Spinner.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Spinner.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Spinner } from "@/components/ui/spinner";
+import { AttentionBadge } from "@/code/AttentionBadge";
+import { HARNESS_ICONS } from "@/code/HarnessPicker";
+
+import { attentionWorking } from "./fixtures";
+
+const ClaudeIcon = HARNESS_ICONS.claude_code;
+
+/**
+ * Indeterminate progress. The arc is centred on the viewBox so it rotates
+ * in place at every size, including the compact mark on an agent tab.
+ */
+const meta = {
+  title: "Foundations/Spinner",
+  component: Spinner,
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Spinner className="size-3" />
+      <Spinner className="size-3.5" />
+      <Spinner className="size-4" />
+      <Spinner className="size-6" />
+    </div>
+  ),
+};
+
+/** The compact working mark as the Main agent tab wears it. */
+export const OnAgentTab: Story = {
+  render: () => (
+    <div className="flex h-8 w-fit items-center rounded-lg bg-background px-2.5 shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_7%,transparent),inset_0_0_0_1px_var(--border-subtle)]">
+      <span className="flex items-center gap-1.5 text-xs font-medium">
+        <ClaudeIcon className="size-3.5 shrink-0" />
+        <span>Main agent</span>
+        <AttentionBadge attention={attentionWorking} compact />
+      </span>
+    </div>
+  ),
+};
+
+/**
+ * The same glyph at 90° steps, pinned to a crosshair. The gap should orbit
+ * the intersection, not drag the whole C around it.
+ */
+export const RotatesOnCenter: Story = {
+  render: () => (
+    <div className="flex items-center gap-6">
+      {[0, 90, 180, 270].map((deg) => (
+        <div key={deg} className="grid size-16 place-items-center">
+          <div className="relative size-8">
+            <span className="absolute inset-x-0 top-1/2 h-px -translate-y-px bg-critical/40" />
+            <span className="absolute inset-y-0 left-1/2 w-px -translate-x-px bg-critical/40" />
+            <Spinner
+              className="size-8 animate-none text-live"
+              style={{ transform: `rotate(${deg}deg)` }}
+              aria-label={`${deg} degrees`}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
Lucide's Loader2 is an open path with a 24px width attribute, so WebKit rotates around the C's ink box. The working mark on agent tabs then orbits instead of spinning in place.

Spinner now draws a circle centred on the 24 viewBox and sets `transform-box: view-box` so `animate-spin` turns around that centre.

Stories: Foundations/Spinner (`Rotates on center`, `On agent tab`) and Code/Center tabs / Working conversation.

Ran `biome check` on the three files and vitest on AttentionBadge, AgentRunTaskPlan, TaskPlanCard, and stylesContract.