### PR TITLE
fix(code): probe login-shell gh before Homebrew paths

### DIFF
--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1205,13 +1205,19 @@ async fn resolve_gh_binary(search_path: Option<&str>) -> Option<PathBuf> {
             binary,
             login_env: None,
         },
-        None => {
-            let capture = probe_shell(&HostEnv::from_process(), "gh").await.ok()?;
-            GhLaunch {
+        None => match probe_shell(&HostEnv::from_process(), "gh").await {
+            Ok(capture) => GhLaunch {
                 binary: capture.binary,
                 login_env: Some(Arc::new(capture.env)),
-            }
-        }
+            },
+            // Homebrew installs after PATH and login-shell probing. GitHub's
+            // macOS runners ship `/opt/homebrew/bin/gh`; looking there first
+            // skips the probe the packaged-app smoke test exists to prove.
+            Err(_) => GhLaunch {
+                binary: well_known_gh()?,
+                login_env: None,
+            },
+        },
     };
     let _ = GH_LAUNCH.set(launch);
     GH_LAUNCH.get().map(|launch| launch.binary.clone())
@@ -1438,18 +1444,23 @@ fn find_gh(search_path: Option<&str>) -> Option<PathBuf> {
             return Some(candidate);
         }
     }
-    if search_path.is_some() {
-        return None;
+    None
+}
+
+fn well_known_gh() -> Option<PathBuf> {
+    #[cfg(not(windows))]
+    {
+        [
+            PathBuf::from("/opt/homebrew/bin/gh"),
+            PathBuf::from("/usr/local/bin/gh"),
+        ]
+        .into_iter()
+        .find(|candidate| is_executable(candidate))
     }
-    // Packaged apps inherit a GUI PATH that often omits Homebrew. Login-shell
-    // probing still runs after this; these are the install locations `gh`
-    // actually uses when that probe cannot run.
-    [
-        PathBuf::from("/opt/homebrew/bin/gh"),
-        PathBuf::from("/usr/local/bin/gh"),
-    ]
-    .into_iter()
-    .find(|candidate| is_executable(candidate))
+    #[cfg(windows)]
+    {
+        None
+    }
 }
 
 #[cfg(windows)]

--- a/scripts/smoke-packaged-gh-discovery.sh
+++ b/scripts/smoke-packaged-gh-discovery.sh
@@ -136,6 +136,7 @@ jq -e '.capability.authenticated == false' "$response" >/dev/null
 
 [[ -s "$fake_log" ]] || {
   echo "The packaged app reported gh without invoking the login-shell binary." >&2
+  echo "Discovery must probe the login shell before /opt/homebrew/bin/gh or /usr/local/bin/gh." >&2
   exit 1
 }
 if grep -Fvx 'auth status --json hosts' "$fake_log" >/dev/null; then


### PR DESCRIPTION
## What changed

Staging desktop publishes fail on the packaged GitHub CLI smoke test. GitHub macOS runners ship `/opt/homebrew/bin/gh`, and discovery used that path before the login-shell probe, so the fake login-shell binary never ran.

Discovery now uses PATH, then the login shell, then Homebrew locations. Packaged apps still find Homebrew `gh` when the login shell does not have it.

## Validation

- `cargo test -p tidebreak-server --lib -- code::gh::tests::resolve_github_uses_gh_url_when_signed_in`

The packaged-app smoke test itself runs only in the staging publish workflow after this lands on `main`.

## Compatibility and risk

None. No wire-format change. Homebrew lookup still runs when PATH and login-shell probing find nothing.