### PR TITLE
fix(code): report gateway-managed credentials in the doctor

### DIFF
--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -167,12 +167,32 @@ pub struct HarnessDoctorEntry {
     pub caps: HarnessCaps,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authenticated: Option<bool>,
+    /// How a session of this engine authenticates on the server's machine.
+    /// A server that predates the field knows only the local sign-in probe.
+    #[serde(default)]
+    pub auth_mode: HarnessAuthMode,
     #[serde(default)]
     pub remediation: String,
     #[serde(default)]
     pub stderr: String,
     #[serde(default)]
     pub unrecognized_event_count: i64,
+}
+
+/// How a session of one engine authenticates on the server's machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessAuthMode {
+    /// The engine's own local sign-in.
+    #[default]
+    LocalSignIn,
+    /// A credential or endpoint override authenticates the engine without a
+    /// vendor login.
+    GatewayManaged,
+    /// The on-behalf-of relay carries turns as the caller.
+    GatewayRelay,
+    /// The relay does not cover this engine on a hosted machine.
+    HostedUnavailable,
 }
 
 /// Bounded changed-file list for `GET /code/workspaces/{id}/files`.

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -23,7 +23,7 @@ use crate::api::client::Client;
 use crate::api::code::{
     decode_event_frame, decode_update_notice, is_turn_terminal, supported_caps_summary,
     turn_exit_code, CodeApprovalSnapshot, CodeSessionDigest, CodeSessionSnapshot, CodeTurnSnapshot,
-    CodeUpdateNotice, CodeWorkspaceSnapshot, SubmitTurnResponse,
+    CodeUpdateNotice, CodeWorkspaceSnapshot, HarnessAuthMode, SubmitTurnResponse,
 };
 use crate::connect::Server;
 use crate::print::OutputFormat;
@@ -282,10 +282,18 @@ async fn execute(client: &Client, command: Command) -> Result<i32> {
                 let found = if entry.found { "yes" } else { "no" };
                 let path = entry.path.as_deref().unwrap_or("-");
                 let version = entry.version.as_deref().unwrap_or("-");
-                let auth = match entry.authenticated {
-                    Some(true) => "yes",
-                    Some(false) => "no",
-                    None => "-",
+                let auth = match entry.auth_mode {
+                    // The vendor login is one mode of three. A machine whose
+                    // engines run on gateway credentials has no login to
+                    // report, and printing "no" there reads as broken.
+                    HarnessAuthMode::GatewayManaged => "gw",
+                    HarnessAuthMode::GatewayRelay => "relay",
+                    HarnessAuthMode::HostedUnavailable => "n/a",
+                    HarnessAuthMode::LocalSignIn => match entry.authenticated {
+                        Some(true) => "yes",
+                        Some(false) => "no",
+                        None => "-",
+                    },
                 };
                 let tier = format!("{:?}", entry.tier).to_ascii_lowercase();
                 println!(

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
@@ -188,6 +188,43 @@ describe("DoctorList", () => {
       screen.queryByText("Sign in via your terminal, then re-check."),
     ).not.toBeInTheDocument();
   });
+  it("names a gateway-managed engine instead of demanding a sign-in", async () => {
+    render(
+      <DoctorList
+        report={{
+          harnesses: [
+            {
+              ...notDownloaded,
+              kind: "claude_code",
+              found: true,
+              // A machine pointed at the gateway has no vendor login, and
+              // the engine's own check says so (issue 2749).
+              authenticated: false,
+              auth_mode: "gateway_managed",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Gateway-managed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Credentials are managed for this machine."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 of 1 engine ready.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Sign in via your terminal, then re-check."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Signed out")).toBeNull();
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Details for Claude Code" }));
+    expect(
+      screen.getByText("not needed — credentials are managed here"),
+    ).toBeInTheDocument();
+  });
+
   /** An engine still downloading offers no second Download button. */
   it("reports a download in flight instead of offering another", () => {
     render(

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -127,6 +127,10 @@ function statusBadge(
     return { label: "Downloading", variant: "info" };
   }
   if (install?.error) return { label: "Download failed", variant: "critical" };
+  // Ready, and worth naming why: nobody signed in here, and nobody has to.
+  if (entry.auth_mode === "gateway_managed" && entry.found) {
+    return { label: "Gateway-managed", variant: "success" };
+  }
   if (isHarnessReady(entry)) return { label: "Ready", variant: "success" };
   if (entry.auth_mode === "hosted_unavailable") {
     return { label: "Unavailable", variant: "warning" };
@@ -159,11 +163,13 @@ function subtitle(
   }
   if (install?.error) return install.error;
   if (entry.remediation) return entry.remediation;
-  // A relay-covered engine on a hosted machine needs no sign-in, so the
-  // fallback below must not demand one; say where its turns run instead.
+  // Neither a relay-covered engine on a hosted machine nor a gateway-managed
+  // one needs a sign-in, so the fallback below must not demand one; say what
+  // carries its turns instead.
   if (
     entry.found &&
     entry.auth_mode !== "gateway_relay" &&
+    entry.auth_mode !== "gateway_managed" &&
     entry.authenticated !== true
   ) {
     return "Sign in via your terminal, then re-check.";
@@ -173,6 +179,9 @@ function subtitle(
   }
   if (entry.auth_mode === "gateway_relay") {
     return "Turns run as you through the Model Gateway.";
+  }
+  if (entry.auth_mode === "gateway_managed") {
+    return "Credentials are managed for this machine.";
   }
   return TIER_NOTES[entry.tier];
 }
@@ -282,11 +291,13 @@ function DoctorRow({
           <Detail label="Signed in">
             {entry.auth_mode === "gateway_relay"
               ? "as you, through the gateway"
-              : entry.authenticated === undefined
-                ? "not observed"
-                : entry.authenticated
-                  ? "yes"
-                  : "no"}
+              : entry.auth_mode === "gateway_managed"
+                ? "not needed — credentials are managed here"
+                : entry.authenticated === undefined
+                  ? "not observed"
+                  : entry.authenticated
+                    ? "yes"
+                    : "no"}
           </Detail>
           {entry.path && (
             <Detail label="Path">

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -135,6 +135,34 @@ describe("harnessUnusableReason", () => {
     ).toBe(false);
   });
 
+  it("reads a gateway-managed engine as ready without a sign-in", () => {
+    // The machine's credentials are wired outside the engine's own login, so
+    // its login check reports signed out on a working machine (issue 2749).
+    expect(
+      isHarnessReady({
+        found: true,
+        authenticated: false,
+        auth_mode: "gateway_managed",
+      }),
+    ).toBe(true);
+    expect(isHarnessReady({ found: true, auth_mode: "gateway_managed" })).toBe(
+      true,
+    );
+    // The binary still has to be there.
+    expect(isHarnessReady({ found: false, auth_mode: "gateway_managed" })).toBe(
+      false,
+    );
+    expect(
+      harnessUnusableReason({
+        found: true,
+        installable: true,
+        authenticated: false,
+        auth_mode: "gateway_managed",
+        caps: caps("supported", "supported", "supported"),
+      }),
+    ).toBeNull();
+  });
+
   it("gates hosted rows on relay coverage, not a terminal sign-in", () => {
     expect(
       harnessUnusableReason({

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -125,8 +125,10 @@ export function fenceReasonText(reason: FenceReason): string {
  * True when this engine can serve a session right now.
  *
  * On a gateway-hosted machine the relay-covered engines are ready without a
- * local sign-in (decision 71), and the uncovered ones can never be; the
- * `auth_mode` the server reports decides, and `authenticated` — the local
+ * local sign-in (decision 71), and the uncovered ones can never be. A
+ * gateway-managed machine holds credentials the engine's own login check
+ * cannot see, so it is ready as soon as the binary is there (issue 2749).
+ * The `auth_mode` the server reports decides, and `authenticated` — the local
  * probe observation — does not.
  */
 export function isHarnessReady(entry: {
@@ -135,7 +137,8 @@ export function isHarnessReady(entry: {
   auth_mode?: HarnessAuthMode;
 }): boolean {
   const mode = entry.auth_mode ?? "local_sign_in";
-  if (mode === "gateway_relay") return entry.found;
+  if (mode === "gateway_relay" || mode === "gateway_managed")
+    return entry.found;
   if (mode === "hosted_unavailable") return false;
   return entry.found && entry.authenticated === true;
 }
@@ -178,8 +181,9 @@ export function harnessUnusableReason(entry: {
     return "Not available on hosted machines yet";
   }
   if (!entry.found && !entry.installable) return "Not installed";
-  // A relay-covered engine needs no sign-in on a hosted machine, so the
-  // local probe observation is not a gate there either.
+  // A relay-covered engine needs no sign-in on a hosted machine, and a
+  // gateway-managed one holds credentials its login check cannot see, so the
+  // local probe observation is not a gate in either case.
   if (mode === "local_sign_in") {
     if (entry.authenticated === false) return "Sign in via your terminal";
     if (entry.found && entry.authenticated === undefined) {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -199,6 +199,7 @@ const HARNESS_TIERS = new Set<HarnessTier>([
 ]);
 const HARNESS_AUTH_MODES = new Set<HarnessAuthMode>([
   "local_sign_in",
+  "gateway_managed",
   "gateway_relay",
   "hosted_unavailable",
 ]);

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2485,7 +2485,7 @@ export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "sc
 /**
  * How a session of one engine authenticates on this machine.
  */
-export type HarnessAuthMode = "local_sign_in" | "gateway_relay" | "hosted_unavailable";
+export type HarnessAuthMode = "local_sign_in" | "gateway_managed" | "gateway_relay" | "hosted_unavailable";
 
 /**
  * Capability vector for one probed engine version.
@@ -2584,11 +2584,12 @@ export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean,
 installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, 
 /**
  * How a session of this engine authenticates here: the engine's own
- * local sign-in, the on-behalf-of relay on a gateway-hosted machine
+ * local sign-in, a credential override that authenticates without one
+ * (issue 2749), the on-behalf-of relay on a gateway-hosted machine
  * (decision 71), or nothing where the relay does not cover the engine
  * yet. Readiness follows this — `authenticated` stays the local probe
- * observation, which on a hosted machine is not what a session
- * authenticates with.
+ * observation, which on a hosted or gateway-managed machine is not what
+ * a session authenticates with.
  */
 auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, 
 /**

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
@@ -6,6 +6,7 @@ import {
   harnessDoctor,
   harnessDoctorCold,
   harnessDoctorDegraded,
+  harnessDoctorGatewayManaged,
   harnessDoctorHosted,
   harnessDoctorMixed,
   harnessInstallsInFlight,
@@ -73,6 +74,16 @@ export const NeedsYou: Story = {
  */
 export const Hosted: Story = {
   args: { report: harnessDoctorHosted },
+};
+
+/**
+ * A gateway-managed machine: the credentials each engine runs on are wired
+ * outside its own login, so its sign-in check reports signed out on a machine
+ * that works. The rows say who holds the credentials rather than sending the
+ * reader after a login nothing here needs.
+ */
+export const GatewayManaged: Story = {
+  args: { report: harnessDoctorGatewayManaged },
 };
 
 /** The re-probe is running. */

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -647,6 +647,56 @@ export const harnessDoctorHosted: HarnessDoctorReport = {
   ],
 };
 
+/**
+ * A machine whose engines are pointed at a Model Gateway: no vendor login
+ * anywhere, and every engine that reads a credential override works. The two
+ * engines whose override surfaces Tidebreak does not read stay on the local
+ * sign-in they actually have.
+ */
+export const harnessDoctorGatewayManaged: HarnessDoctorReport = {
+  harnesses: [
+    doctorEntry({
+      kind: "claude_code",
+      version: "2.1.234 (Claude Code)",
+      path: "~/.local/share/tidebreak/tools/harnesses/claude_code",
+      authenticated: false,
+      auth_mode: "gateway_managed",
+    }),
+    doctorEntry({
+      kind: "codex",
+      version: "codex-cli 0.147.0",
+      tier: "secondary",
+      authenticated: false,
+      auth_mode: "gateway_managed",
+      caps: {
+        ...fullCaps,
+        mid_turn_steering: "supported",
+        image_input: "unknown",
+      },
+    }),
+    doctorEntry({
+      kind: "opencode",
+      version: "1.18.18",
+      tier: "tertiary",
+      authenticated: true,
+      caps: { ...fullCaps, allow_mode: "unknown", reasoning_levels: "unknown" },
+    }),
+    doctorEntry({
+      kind: "grok",
+      version: "grok 1.0.5",
+      tier: "best_effort",
+      authenticated: false,
+      remediation: "Sign in to Grok CLI in your own terminal, then re-check.",
+      caps: {
+        ...fullCaps,
+        mid_turn_steering: "unsupported",
+        plan_mode: "unsupported",
+        structured_approvals: "unsupported",
+      },
+    }),
+  ],
+};
+
 /** One engine mid-download, one that failed, for the doctor's live states. */
 export const harnessInstallsInFlight: Partial<
   Record<HarnessKind, CodeHarnessInstallSnapshot>

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -103,18 +103,24 @@ const AUTH_OVERRIDE_VARS: &[&str] = &[
 /// login at all, so a hit means a session may work even though the probe
 /// saw signed-out — never that credentials are known-good.
 pub(crate) fn auth_override_present(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> bool {
+    observe_auth_override(env).is_some()
+}
+
+/// The same detection, reported with the surface it came from, for the
+/// doctor's display of how this machine authenticates.
+pub(crate) fn observe_auth_override(
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
+) -> Option<crate::AuthOverrideSignal> {
     if crate::probe::env_sets_any(env, AUTH_OVERRIDE_VARS) {
-        return true;
+        return Some(crate::AuthOverrideSignal::Environment);
     }
-    let Some(settings) = read_settings(env) else {
-        return false;
-    };
+    let settings = read_settings(env)?;
     if settings
         .get("apiKeyHelper")
         .and_then(serde_json::Value::as_str)
         .is_some_and(|helper| !helper.trim().is_empty())
     {
-        return true;
+        return Some(crate::AuthOverrideSignal::EngineConfig);
     }
     settings
         .get("env")
@@ -124,6 +130,7 @@ pub(crate) fn auth_override_present(env: &[(std::ffi::OsString, std::ffi::OsStri
                 .iter()
                 .any(|name| vars.contains_key(*name))
         })
+        .then_some(crate::AuthOverrideSignal::EngineConfig)
 }
 
 fn claude_settings_models(
@@ -360,6 +367,46 @@ mod tests {
         assert!(auth_override_present(&env));
         std::fs::write(&settings, r#"{"apiKeyHelper":"/usr/local/bin/key.sh"}"#).unwrap();
         assert!(auth_override_present(&env));
+    }
+
+    #[test]
+    fn auth_observation_names_the_surface_it_read() {
+        use crate::AuthOverrideSignal;
+        let os = std::ffi::OsString::from;
+        assert_eq!(observe_auth_override(&[]), None);
+        assert_eq!(
+            observe_auth_override(&[(os("ANTHROPIC_AUTH_TOKEN"), os("tok"))]),
+            Some(AuthOverrideSignal::Environment)
+        );
+
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir(home.path().join(".claude")).unwrap();
+        let settings = home.path().join(".claude").join("settings.json");
+        let env = vec![(os("HOME"), home.path().as_os_str().to_owned())];
+        std::fs::write(&settings, r#"{"model":"claude-opus-5"}"#).unwrap();
+        assert_eq!(observe_auth_override(&env), None);
+        std::fs::write(
+            &settings,
+            r#"{"env":{"ANTHROPIC_BASE_URL":"https://gateway.example"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            observe_auth_override(&env),
+            Some(AuthOverrideSignal::EngineConfig)
+        );
+        std::fs::write(&settings, r#"{"apiKeyHelper":"/usr/local/bin/key.sh"}"#).unwrap();
+        assert_eq!(
+            observe_auth_override(&env),
+            Some(AuthOverrideSignal::EngineConfig)
+        );
+        // The environment is the nearer surface, so it names itself even when
+        // the settings file would also answer.
+        let mut both = env.clone();
+        both.push((os("ANTHROPIC_API_KEY"), os("sk-ant")));
+        assert_eq!(
+            observe_auth_override(&both),
+            Some(AuthOverrideSignal::Environment)
+        );
     }
 
     #[tokio::test]

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -421,10 +421,18 @@ fn login_status_from_output(stdout: &[u8], stderr: &[u8]) -> Option<bool> {
 /// signed out. A hit means a session may work even though the probe saw
 /// signed-out — never that credentials are known-good.
 pub(crate) fn auth_override_present(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> bool {
+    observe_auth_override(env).is_some()
+}
+
+/// The same detection, reported with the surface it came from, for the
+/// doctor's display of how this machine authenticates.
+pub(crate) fn observe_auth_override(
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
+) -> Option<crate::AuthOverrideSignal> {
     if crate::probe::env_sets_any(env, &["OPENAI_API_KEY", "OPENAI_BASE_URL"]) {
-        return true;
+        return Some(crate::AuthOverrideSignal::Environment);
     }
-    config_declares_model_provider(env)
+    config_declares_model_provider(env).then_some(crate::AuthOverrideSignal::EngineConfig)
 }
 
 /// `$CODEX_HOME/config.toml`, defaulting to `~/.codex/config.toml`, mentions
@@ -938,6 +946,39 @@ mod tests {
         )
         .unwrap();
         assert!(auth_override_present(&env));
+    }
+
+    #[test]
+    fn auth_observation_names_the_surface_it_read() {
+        use crate::AuthOverrideSignal;
+        let os = std::ffi::OsString::from;
+        assert_eq!(observe_auth_override(&[]), None);
+        assert_eq!(
+            observe_auth_override(&[(os("OPENAI_BASE_URL"), os("https://gateway.example/v1"))]),
+            Some(AuthOverrideSignal::Environment)
+        );
+
+        let codex_home = tempfile::tempdir().unwrap();
+        let env = vec![(os("CODEX_HOME"), codex_home.path().as_os_str().to_owned())];
+        std::fs::write(codex_home.path().join("config.toml"), "model = \"gpt-5\"\n").unwrap();
+        assert_eq!(observe_auth_override(&env), None);
+        std::fs::write(
+            codex_home.path().join("config.toml"),
+            "[model_providers.gateway]\nbase_url = \"https://gateway.example/v1\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            observe_auth_override(&env),
+            Some(AuthOverrideSignal::EngineConfig)
+        );
+        // The environment is the nearer surface, so it names itself even when
+        // the config file would also answer.
+        let mut both = env.clone();
+        both.push((os("OPENAI_API_KEY"), os("sk")));
+        assert_eq!(
+            observe_auth_override(&both),
+            Some(AuthOverrideSignal::Environment)
+        );
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -68,6 +68,71 @@ pub fn auth_override_present(
     }
 }
 
+/// Which surface carried the credential override Tidebreak observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthOverrideSignal {
+    /// An API key, auth token, or endpoint override in the captured shell
+    /// environment.
+    Environment,
+    /// The engine's own configuration file points inference at an endpoint
+    /// the vendor login does not cover.
+    EngineConfig,
+}
+
+/// What Tidebreak observed about how one engine authenticates on this
+/// machine, beyond the vendor login the probe reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HarnessAuthObservation {
+    /// Nothing observed: the surfaces Tidebreak reads carry no override, or
+    /// it reads none for this engine.
+    Unknown,
+    /// A credential or endpoint override is present, carried by this signal.
+    Override(AuthOverrideSignal),
+}
+
+impl HarnessAuthObservation {
+    /// Whether an override is present. `false` means unobserved, not absent.
+    #[must_use]
+    pub fn is_override(self) -> bool {
+        matches!(self, Self::Override(_))
+    }
+
+    /// The signal that carried the override, when one is present.
+    #[must_use]
+    pub fn signal(self) -> Option<AuthOverrideSignal> {
+        match self {
+            Self::Unknown => None,
+            Self::Override(signal) => Some(signal),
+        }
+    }
+}
+
+/// Observe how this engine authenticates here, for a caller that displays
+/// the answer rather than one that decides whether to refuse a session.
+///
+/// Unlike [`auth_override_present`], this never grants the benefit of the
+/// doubt: an engine whose override surfaces Tidebreak does not read answers
+/// [`HarnessAuthObservation::Unknown`], because claiming a machine is
+/// gateway-managed on no evidence would tell the reader their engine works
+/// when nothing says it does. Claude Code and Codex read the same
+/// environment and engine config the create path reads; opencode and Grok
+/// answer `Unknown`.
+#[must_use]
+pub fn observe_auth_mode(
+    kind: HarnessKind,
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
+) -> HarnessAuthObservation {
+    let signal = match kind {
+        HarnessKind::ClaudeCode => claude::observe_auth_override(env),
+        HarnessKind::Codex => codex::observe_auth_override(env),
+        HarnessKind::Opencode | HarnessKind::Grok => None,
+    };
+    signal.map_or(
+        HarnessAuthObservation::Unknown,
+        HarnessAuthObservation::Override,
+    )
+}
+
 /// Normalized, unpersisted event. Maps 1:1 onto [`tidebreak_core::CodeEvent`]
 /// minus persistence ids (turn id, approval id).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -117,13 +117,7 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
             let install_error = code.pin_install_error(*kind);
             let installable = tidebreak_harness::pin_for(*kind).is_some();
             let label = harness_label(*kind);
-            let auth_mode = if !hosted {
-                HarnessAuthMode::LocalSignIn
-            } else if relay_covered(*kind) {
-                HarnessAuthMode::GatewayRelay
-            } else {
-                HarnessAuthMode::HostedUnavailable
-            };
+            let auth_mode = resolve_auth_mode(hosted, *kind, &probe);
             let remediation = if let Some(err) = install_error {
                 format!("could not download the pinned {kind} binary: {err}")
             } else if auth_mode == HarnessAuthMode::HostedUnavailable {
@@ -134,6 +128,11 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
                 // The relay carries each turn as the caller, so no local
                 // sign-in stands between the reader and a session. A missing
                 // binary is the lazy pin's download, not a fault.
+                String::new()
+            } else if auth_mode == HarnessAuthMode::GatewayManaged {
+                // Credentials are already wired on this machine. Asking the
+                // reader to sign in would send them after a login that
+                // nothing here needs (issue 2749).
                 String::new()
             } else if probe.found && probe.authenticated == Some(false) {
                 format!("Sign in to {label} in your own terminal, then re-check.")
@@ -170,4 +169,121 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
     }))
     .await;
     Ok(HarnessDoctorReport { harnesses })
+}
+
+/// How a session of this engine authenticates on this machine.
+///
+/// The vendor login is one mode of three, not the question. A hosted machine
+/// runs every covered engine through the relay (decision 71). Elsewhere, a
+/// machine whose engines are pointed at a gateway carries inference on a
+/// credential nobody logged in for: the engine's own login check reports
+/// signed out, and the machine works. Reading that as "signed out" told
+/// every picker to disable the engine (issue 2749), so a confirmed vendor
+/// login answers first and an observed credential override answers next.
+///
+/// The observation is deliberately narrower than the one the create path
+/// consults: engines whose override surfaces Tidebreak does not read stay on
+/// `LocalSignIn` rather than claim a credential the reader cannot see.
+fn resolve_auth_mode(
+    hosted: bool,
+    kind: HarnessKind,
+    probe: &tidebreak_harness::HarnessProbe,
+) -> HarnessAuthMode {
+    if hosted {
+        return if relay_covered(kind) {
+            HarnessAuthMode::GatewayRelay
+        } else {
+            HarnessAuthMode::HostedUnavailable
+        };
+    }
+    if probe.authenticated != Some(true)
+        && tidebreak_harness::observe_auth_mode(kind, &probe.env).is_override()
+    {
+        return HarnessAuthMode::GatewayManaged;
+    }
+    HarnessAuthMode::LocalSignIn
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use tidebreak_harness::HarnessProbe;
+
+    fn probe(authenticated: Option<bool>, env: Vec<(OsString, OsString)>) -> HarnessProbe {
+        HarnessProbe {
+            found: true,
+            binary_path: None,
+            version: None,
+            authenticated,
+            stderr: String::new(),
+            env,
+            commands: Vec::new(),
+        }
+    }
+
+    fn gateway_env() -> Vec<(OsString, OsString)> {
+        vec![(
+            OsString::from("ANTHROPIC_BASE_URL"),
+            OsString::from("https://gateway.example"),
+        )]
+    }
+
+    #[test]
+    fn a_credential_override_reads_as_gateway_managed() {
+        assert_eq!(
+            resolve_auth_mode(
+                false,
+                HarnessKind::ClaudeCode,
+                &probe(Some(false), gateway_env())
+            ),
+            HarnessAuthMode::GatewayManaged
+        );
+        // The unverified case is the one the doctor used to call "Unverified"
+        // and disable.
+        assert_eq!(
+            resolve_auth_mode(false, HarnessKind::ClaudeCode, &probe(None, gateway_env())),
+            HarnessAuthMode::GatewayManaged
+        );
+    }
+
+    #[test]
+    fn a_confirmed_vendor_login_stays_local() {
+        assert_eq!(
+            resolve_auth_mode(
+                false,
+                HarnessKind::ClaudeCode,
+                &probe(Some(true), gateway_env())
+            ),
+            HarnessAuthMode::LocalSignIn
+        );
+        assert_eq!(
+            resolve_auth_mode(false, HarnessKind::ClaudeCode, &probe(Some(false), vec![])),
+            HarnessAuthMode::LocalSignIn
+        );
+    }
+
+    #[test]
+    fn engines_with_no_override_surface_stay_local() {
+        // `auth_override_present` answers `true` for these to avoid refusing a
+        // session; the doctor must not turn that into a credential claim.
+        for kind in [HarnessKind::Opencode, HarnessKind::Grok] {
+            assert_eq!(
+                resolve_auth_mode(false, kind, &probe(Some(false), gateway_env())),
+                HarnessAuthMode::LocalSignIn
+            );
+        }
+    }
+
+    #[test]
+    fn a_hosted_machine_still_reports_the_relay() {
+        assert_eq!(
+            resolve_auth_mode(
+                true,
+                HarnessKind::ClaudeCode,
+                &probe(Some(false), gateway_env())
+            ),
+            HarnessAuthMode::GatewayRelay
+        );
+    }
 }

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -368,6 +368,13 @@ pub struct HarnessDoctorReport {
 pub enum HarnessAuthMode {
     /// The engine's own local sign-in — the probe result decides readiness.
     LocalSignIn,
+    /// A credential or endpoint override on this machine authenticates the
+    /// engine without any vendor login (issue 2749): an API key or gateway
+    /// base URL in the environment, or engine config pointing inference at a
+    /// gateway. The engine's own login check reports signed out on such a
+    /// machine, and it is still working, so readiness is the binary being
+    /// there and there is nothing to remediate.
+    GatewayManaged,
     /// The on-behalf-of relay (decision 71): a gateway-hosted machine, where
     /// turns run as the caller through the gateway and no local sign-in is
     /// needed.
@@ -401,11 +408,12 @@ pub struct HarnessDoctorEntry {
     #[ts(optional)]
     pub authenticated: Option<bool>,
     /// How a session of this engine authenticates here: the engine's own
-    /// local sign-in, the on-behalf-of relay on a gateway-hosted machine
+    /// local sign-in, a credential override that authenticates without one
+    /// (issue 2749), the on-behalf-of relay on a gateway-hosted machine
     /// (decision 71), or nothing where the relay does not cover the engine
     /// yet. Readiness follows this — `authenticated` stays the local probe
-    /// observation, which on a hosted machine is not what a session
-    /// authenticates with.
+    /// observation, which on a hosted or gateway-managed machine is not what
+    /// a session authenticates with.
     pub auth_mode: HarnessAuthMode,
     pub remediation: String,
     pub stderr: String,

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2485,7 +2485,7 @@ export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "sc
 /**
  * How a session of one engine authenticates on this machine.
  */
-export type HarnessAuthMode = "local_sign_in" | "gateway_relay" | "hosted_unavailable";
+export type HarnessAuthMode = "local_sign_in" | "gateway_managed" | "gateway_relay" | "hosted_unavailable";
 
 /**
  * Capability vector for one probed engine version.
@@ -2584,11 +2584,12 @@ export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean,
 installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, 
 /**
  * How a session of this engine authenticates here: the engine's own
- * local sign-in, the on-behalf-of relay on a gateway-hosted machine
+ * local sign-in, a credential override that authenticates without one
+ * (issue 2749), the on-behalf-of relay on a gateway-hosted machine
  * (decision 71), or nothing where the relay does not cover the engine
  * yet. Readiness follows this — `authenticated` stays the local probe
- * observation, which on a hosted machine is not what a session
- * authenticates with.
+ * observation, which on a hosted or gateway-managed machine is not what
+ * a session authenticates with.
  */
 auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, 
 /**


### PR DESCRIPTION
Closes #2749

## What changed

The doctor's only sign-in signal was the engine's vendor login, so a machine whose engines are pointed at a Model Gateway read as "Signed out" or "Unverified" — and every picker disabled the engine, on a machine that works.

- **Harness crate.** `observe_auth_mode(kind, env)` returns a `HarnessAuthObservation`: either `Unknown`, or an override with the surface that carried it (captured environment, or the engine's own config). Claude Code and Codex reuse the detection the create path already runs — `ANTHROPIC_*` env plus `~/.claude/settings.json` `apiKeyHelper`/`env`, and `OPENAI_*` env plus `$CODEX_HOME/config.toml` `model_provider`. opencode and Grok answer `Unknown`: `auth_override_present` gives them the benefit of the doubt to avoid refusing a session, and the doctor must not turn that into a credential claim. `auth_override_present` keeps its semantics; the per-engine bodies now delegate to the observation.
- **Server.** `resolve_auth_mode` decides the doctor's mode. A hosted machine still reports the relay. Elsewhere, a confirmed vendor login stays `local_sign_in`; no confirmed login plus an observed override reports the new `HarnessAuthMode::GatewayManaged`, whose readiness is `probe.found` and whose remediation is empty — nobody should be sent after a login this machine does not need.
- **Wire + UI.** `gateway_managed` joins the generated wire types (regenerated, both the desktop and mobile copies). `isHarnessReady` treats it as ready when the binary is there, so pickers, `NewWorkspaceDialog`, `StartSessionPrompt`, `HarnessPicker`, and `CodeHome` all follow. The doctor row leads with a Gateway-managed badge, reads "Credentials are managed for this machine." instead of "Sign in via your terminal", and its Details disclosure says the sign-in is not needed.
- **CLI.** `tidebreak code doctor`'s AUTH column reports the mode — `gw`, `relay`, `n/a` — instead of printing `no` for every machine that has no vendor login.

## What I ran

- `cargo check -p tidebreak-harness -p tidebreak-server -p tidebreak-cli` — clean.
- `cargo test -p tidebreak-harness --lib auth_` — 9 passed, including the two new tests that pin which surface the observation names for claude settings/env and for codex `config.toml`.
- `cargo test -p tidebreak-server --lib routes::code::harnesses` — 4 new tests: an env override yields `gateway_managed` on both the signed-out and unobserved probes, a confirmed login stays local, opencode and Grok stay local, and a hosted machine still reports the relay.
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server` — full crate suite green, wire types regenerated.
- `pnpm --dir crates/tidebreak-desktop/ui lint`, `biome format`, and `pnpm --dir crates/tidebreak-desktop/ui test` — 247 files, 2124 tests passed, including the new `labels.ts` readiness test and the `DoctorList` row test.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — succeeded; the new `Code/Harness doctor → Gateway managed` story was captured and reviewed in light and dark.

## Scope

This covers mode 2 on local machines. Mode 3's doctor semantics stay with #2741, and the codex not-observed case stays with #2746.