### PR TITLE
feat(code): show the permission mode and enforce the managed ceiling

### DIFF
--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { afterEach, expect, it, vi } from "vitest";
 import type { ManagedPolicy, PermissionMode } from "./api";
 import { ManagedPolicyContext } from "./managedPolicy";
-import { PermissionModeMenu } from "./PermissionModeMenu";
+import { clampPermissionMode, PermissionModeMenu } from "./PermissionModeMenu";
 import { useFirstTaskGuide } from "./FirstTaskWalkthrough";
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
@@ -77,6 +77,44 @@ it("locks modes above a managed ceiling", async () => {
 
   await userEvent.click(locked);
   expect(onChange).not.toHaveBeenCalled();
+});
+
+it("clamps a requested mode down to a managed ceiling", () => {
+  expect(clampPermissionMode("allow", "ask")).toBe("ask");
+  expect(clampPermissionMode("auto", "ask")).toBe("ask");
+  expect(clampPermissionMode("ask", "ask")).toBe("ask");
+  expect(clampPermissionMode("plan", "ask")).toBe("plan");
+  expect(clampPermissionMode("allow", null)).toBe("allow");
+  expect(clampPermissionMode("allow", undefined)).toBe("allow");
+});
+
+/**
+ * A code session has no turn-gate clamp, so the picker shows the stored
+ * mode the engine launched with rather than the ceiling the chat menu
+ * would display.
+ */
+it("shows a stored over-ceiling mode when display clamping is off", async () => {
+  const capped: ManagedPolicy = {
+    managed: false,
+    source: "unmanaged",
+    misconfigured: false,
+    allow_local_mcp_servers: false,
+    permission_mode_ceiling: "ask",
+  };
+  render(
+    <ManagedPolicyContext.Provider value={capped}>
+      <PermissionModeMenu
+        scopeKey="code-1"
+        value="allow"
+        clampDisplay={false}
+        onChange={vi.fn()}
+      />
+    </ManagedPolicyContext.Provider>,
+  );
+
+  expect(
+    screen.getByRole("button", { name: "Permissions: Allow all" }),
+  ).toBeInTheDocument();
 });
 
 it("lets a new chat save while an old chat write is still settling", async () => {

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -79,10 +79,13 @@ export function permissionModeOption(mode: PermissionMode | null) {
  *
  * A managed profile may assert a permission-mode ceiling. Modes above it
  * render locked — decided elsewhere rather than silently missing — and the
- * server enforces the same ceiling at the chat routes and the turn gate, so
- * this is legibility, not the lockdown itself. A stored mode already above
- * the ceiling displays as the ceiling, matching what the turn actually runs
- * under.
+ * server enforces the same ceiling at the chat routes, the turn gate, and the
+ * code session routes, so this is legibility, not the lockdown itself. A
+ * stored mode already above the ceiling displays as the ceiling, matching
+ * what the turn actually runs under.
+ *
+ * The rows carry no posture descriptions. What an unsupervised mode will do
+ * is stated once, under the control, by the surface that offers it.
  */
 export function PermissionModeMenu({
   scopeKey,

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -59,6 +59,20 @@ function autonomyRank(mode: PermissionMode): number {
   return PERMISSION_MODE_SCALE.findIndex((option) => option.value === mode);
 }
 
+/**
+ * The mode a create or start should post under a managed ceiling: the
+ * requested posture when it is at or below the ceiling, otherwise the
+ * ceiling itself. Chat create already seeds this way server-side; code
+ * posts an explicit mode, so the client has to clamp before the request.
+ */
+export function clampPermissionMode(
+  mode: PermissionMode,
+  ceiling: PermissionMode | null | undefined,
+): PermissionMode {
+  if (ceiling == null) return mode;
+  return autonomyRank(mode) > autonomyRank(ceiling) ? ceiling : mode;
+}
+
 export function permissionModeOption(mode: PermissionMode | null) {
   const value = mode ?? DEFAULT_PERMISSION_MODE;
   return (
@@ -80,9 +94,14 @@ export function permissionModeOption(mode: PermissionMode | null) {
  * A managed profile may assert a permission-mode ceiling. Modes above it
  * render locked — decided elsewhere rather than silently missing — and the
  * server enforces the same ceiling at the chat routes, the turn gate, and the
- * code session routes, so this is legibility, not the lockdown itself. A
- * stored mode already above the ceiling displays as the ceiling, matching
- * what the turn actually runs under.
+ * code session routes, so this is legibility, not the lockdown itself.
+ *
+ * Chat's turn gate clamps an over-ceiling stored mode, so the trigger
+ * displays the ceiling to match what the turn actually runs under. A code
+ * session has no such clamp: pass `clampDisplay={false}` so the picker
+ * shows the stored mode the engine launched with. Create surfaces clamp
+ * the posted value themselves (`clampPermissionMode`) so the label and
+ * the request agree without relying on this display remap.
  *
  * The rows carry no posture descriptions. What an unsupervised mode will do
  * is stated once, under the control, by the surface that offers it.
@@ -93,6 +112,7 @@ export function PermissionModeMenu({
   disabled,
   onChange,
   availableModes,
+  clampDisplay = true,
   open: controlledOpen,
   onOpenChange,
 }: {
@@ -107,6 +127,12 @@ export function PermissionModeMenu({
    * disabled, so what an engine cannot do is stated rather than missing.
    */
   availableModes?: readonly PermissionMode[];
+  /**
+   * When true (chat), an over-ceiling stored mode displays as the ceiling
+   * the turn actually runs under. When false (a live code session), the
+   * trigger shows `value` so it matches the engine launch posture.
+   */
+  clampDisplay?: boolean;
   /** Open the menu from outside — a surface's keyboard shortcut. */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -157,9 +183,10 @@ export function PermissionModeMenu({
   const ceilingRank = ceiling === null ? null : autonomyRank(ceiling);
   const overCeiling = (mode: PermissionMode) =>
     ceilingRank !== null && autonomyRank(mode) > ceilingRank;
-  const effective = overCeiling(value ?? DEFAULT_PERMISSION_MODE)
-    ? ceiling
-    : value;
+  const effective =
+    clampDisplay && overCeiling(value ?? DEFAULT_PERMISSION_MODE)
+      ? ceiling
+      : value;
   const current = permissionModeOption(effective);
   const CurrentIcon = current.icon;
   const controlsDisabled = disabled || saving;

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -126,6 +126,7 @@ export function PermissionModePicker({
     <PermissionModeMenu
       scopeKey={scopeKey}
       value={value}
+      clampDisplay={false}
       disabled={locked || disabled || pending}
       availableModes={availableModes}
       onChange={async (mode: PermissionMode) => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -62,6 +62,7 @@ import {
   codeModelVendor,
   effortLadder,
   groupCodeModelOptions,
+  unsupervisedModeStatement,
   type CodeModelOption,
   PERMISSION_MODE_UNAVAILABLE_REASON,
   SESSION_PERMISSION_MODE_LOCKED,
@@ -1077,6 +1078,18 @@ export function CodeComposer({
     }
   }
 
+  // The posture is never silent: a mode that runs with nobody to ask says so
+  // under the control that picked it (decisions 0038, 0039). An engine that
+  // offers Auto but not Ask has no approval channel, so its Auto escalates
+  // nothing. Start states it once, where the choice is made; a live session
+  // carries it in the workspace header instead of under every draft.
+  const unsupervisedNote = sessionId
+    ? null
+    : unsupervisedModeStatement(
+        permissionMode,
+        availableModes.includes("auto") && !availableModes.includes("ask"),
+      );
+
   return (
     <div className="relative shrink-0 px-[clamp(0.5rem,4%,5rem)] pb-2">
       <Composer
@@ -1199,7 +1212,16 @@ export function CodeComposer({
         steerError={steerError}
         steerPending={steerPending}
         steerStatus={steerStatus}
-        footerNote={footerNote}
+        footerNote={
+          <>
+            {unsupervisedNote && (
+              <p className="text-muted-foreground text-xs">
+                {unsupervisedNote}
+              </p>
+            )}
+            {footerNote}
+          </>
+        }
       />
       {sessionId && (
         <input

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -164,6 +164,7 @@ import { TerminalPane } from "./TerminalPane";
 import { useCodeWorkspacePr } from "./useCodeWorkspacePr";
 import { useCodeContentRevision } from "./useLiveContent";
 import { SessionLifecycleIndicator } from "./SessionLifecycleIndicator";
+import { SessionPermissionIndicator } from "./SessionPermissionIndicator";
 import { WorkspaceHeader } from "./WorkspaceHeader";
 import {
   WorkspaceOverflowMenu,
@@ -1624,6 +1625,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                     : undefined
                 }
               />
+              <span className="text-border" aria-hidden>
+                ·
+              </span>
+              <SessionPermissionIndicator mode={session.permission_mode} />
             </>
           ) : undefined
         }

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -17,7 +17,9 @@ import type {
   CodeWorkspaceSnapshot,
   HarnessDoctorEntry,
   HarnessKind,
+  ManagedPolicy,
 } from "../api/types";
+import { ManagedPolicyContext } from "../managedPolicy";
 import {
   OPTIMISTIC_WORKSPACE_ID_PREFIX,
   useCodeCatalogStore,
@@ -583,6 +585,69 @@ describe("NewWorkspaceDialog", () => {
       }),
     );
     expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+  });
+
+  it("posts the managed ceiling instead of the engine's Allow default", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    useCodeUiStore.setState({
+      lastCreate: { modelsByHarness: {}, permissionMode: "allow" },
+    });
+    const createCodeWorkspace = vi.fn(async () =>
+      workspace("ws-ceiling", "repo-new", "2026-08-20T00:00:00.000Z"),
+    );
+    const createCodeSession = vi.fn(async () =>
+      session("ws-ceiling", "claude_code", "2026-08-20T00:00:00.000Z"),
+    );
+    const capped: ManagedPolicy = {
+      managed: false,
+      source: "unmanaged",
+      misconfigured: false,
+      allow_local_mcp_servers: false,
+      permission_mode_ceiling: "ask",
+    };
+    await renderWithRouter(
+      <ManagedPolicyContext.Provider value={capped}>
+        <AppContextProvider
+          value={app({
+            createCodeWorkspace,
+            createCodeSession,
+            listCodeHarnessModels: claudeModels(),
+          })}
+        >
+          <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+        </AppContextProvider>
+      </ManagedPolicyContext.Provider>,
+      { initialUrl: "/code" },
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Model: Sonnet" }),
+      ).toBeEnabled(),
+    );
+    expect(
+      screen.getByRole("button", { name: "Permissions: Ask" }),
+    ).toBeEnabled();
+    expect(screen.queryByText(ALLOW_ALL_NOTE)).not.toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+    await waitFor(() =>
+      expect(createCodeSession).toHaveBeenCalledWith("ws-ceiling", {
+        harness: "claude_code",
+        permission_mode: "ask",
+        model: "sonnet",
+      }),
+    );
   });
 
   it("creates on Enter in the message; Shift+Enter stays a newline", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -23,6 +23,7 @@ import {
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
+import { ALLOW_ALL_NOTE } from "./labels";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import type { ReasoningEffort } from "../api/types";
 import type { CodeTurnSubmission, ParsedHarnessModel } from "./parsers";
@@ -549,11 +550,11 @@ describe("NewWorkspaceDialog", () => {
         screen.getByRole("button", { name: "Model: GPT 5.6 Sol" }),
       ).toBeEnabled(),
     );
-    // Allow is the default where the engine honors it.
+    // Allow is the default where the engine honors it, and it says so.
     expect(
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeEnabled();
-    expect(screen.queryByText(/runs without asking/)).toBeNull();
+    expect(screen.getByText(ALLOW_ALL_NOTE)).toBeInTheDocument();
 
     fireEvent.keyDown(screen.getByRole("dialog"), {
       key: "Enter",

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -38,7 +38,8 @@ import {
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { shouldSubmitComposerKey } from "../Composer";
-import { PermissionModeMenu } from "../PermissionModeMenu";
+import { clampPermissionMode, PermissionModeMenu } from "../PermissionModeMenu";
+import { useManagedPolicy } from "../managedPolicy";
 import { usesCommandModifier } from "@/ShellShortcuts";
 import {
   OPTIMISTIC_WORKSPACE_ID_PREFIX,
@@ -314,12 +315,15 @@ export function NewWorkspaceDialog({
     : [];
   const honors = (mode: PermissionMode | null | undefined) =>
     mode && availableModes.includes(mode) ? mode : undefined;
-  const postedMode =
+  const ceiling = useManagedPolicy().permission_mode_ceiling;
+  const postedMode = clampPermissionMode(
     honors(permissionMode) ??
-    honors(lastCreate?.permissionMode) ??
-    (selectedHarness
-      ? defaultCreatePermissionMode(selectedHarness.caps)
-      : "plan");
+      honors(lastCreate?.permissionMode) ??
+      (selectedHarness
+        ? defaultCreatePermissionMode(selectedHarness.caps)
+        : "plan"),
+    ceiling,
+  );
   // The posture create is about to post is never silent: a mode that runs
   // with nobody to ask says so next to the control (decisions 0038, 0039).
   const unsupervisedNote = selectedHarness
@@ -949,6 +953,7 @@ export function NewWorkspaceDialog({
                     <PermissionModeMenu
                       scopeKey="code-create"
                       value={postedMode}
+                      clampDisplay={false}
                       disabled={availableModes.length === 0}
                       availableModes={availableModes}
                       onChange={(mode) => setPermissionMode(mode)}

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -54,6 +54,7 @@ import { HarnessInstallNote } from "./HarnessInstallNote";
 import { useWarmHarnessInstall } from "./useHarnessInstall";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import {
+  autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   effortLadder,
@@ -62,6 +63,7 @@ import {
   harnessUnusableReason,
   preferredCodeModels,
   requiresHarnessModelIds,
+  unsupervisedModeStatement,
   CREATE_PERMISSION_MODE_FIXED,
   HARNESS_LABELS,
   type CodeModelOption,
@@ -318,6 +320,14 @@ export function NewWorkspaceDialog({
     (selectedHarness
       ? defaultCreatePermissionMode(selectedHarness.caps)
       : "plan");
+  // The posture create is about to post is never silent: a mode that runs
+  // with nobody to ask says so next to the control (decisions 0038, 0039).
+  const unsupervisedNote = selectedHarness
+    ? unsupervisedModeStatement(
+        postedMode,
+        autoIsUnsupervised(selectedHarness.caps),
+      )
+    : null;
   // An engine still downloading is a legal pick, not a legal start: create
   // would sit on the same npm install with nothing but a spinner. The install
   // note under the pills says what the wait is, and any engine already on
@@ -950,6 +960,11 @@ export function NewWorkspaceDialog({
                   false && (
                   <p className="text-muted-foreground px-2 text-xs">
                     {CREATE_PERMISSION_MODE_FIXED}
+                  </p>
+                )}
+                {unsupervisedNote && (
+                  <p className="text-muted-foreground px-2 text-xs">
+                    {unsupervisedNote}
                   </p>
                 )}
               </div>

--- a/crates/tidebreak-desktop/ui/src/code/SessionPermissionIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionPermissionIndicator.tsx
@@ -1,0 +1,44 @@
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+import type { PermissionMode } from "../api/types";
+import { permissionModeOption } from "../PermissionModeMenu";
+import { FOCUS_RING } from "./interactive";
+import { PERMISSION_MODE_LABELS, sessionPermissionModeTooltip } from "./labels";
+
+/**
+ * The permission mode a code session is running under, in the workspace
+ * header.
+ *
+ * Create picks the most autonomous posture the engine honors (decision 0039,
+ * amended 2026-08-18), so outside the composer the mode was invisible and a
+ * reader could not tell an asking session from an allow-all one. The chip
+ * states it wherever the session is.
+ *
+ * It reads as metadata, not as a warning: same muted size and weight as the
+ * lifecycle text beside it. A higher posture is a normal operating mode, not
+ * an alarm, and the icon carries the recognition.
+ */
+export function SessionPermissionIndicator({ mode }: { mode: PermissionMode }) {
+  const Icon = permissionModeOption(mode).icon;
+  return (
+    <WithTooltip label={sessionPermissionModeTooltip(mode)}>
+      {/*
+       * The tooltip is the only place the posture is spelled out, and a span
+       * cannot be tabbed to, so the tab stop keeps it reachable without a
+       * pointer.
+       */}
+      <span
+        data-testid="session-permission-indicator"
+        tabIndex={0}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-sm text-xs text-muted-foreground",
+          FOCUS_RING,
+        )}
+      >
+        <Icon className="size-3 shrink-0" aria-hidden="true" />
+        <span className="truncate">{PERMISSION_MODE_LABELS[mode]}</span>
+      </span>
+    </WithTooltip>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -12,7 +12,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ReactNode } from "react";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
-import type { HarnessDoctorEntry } from "../api/types";
+import type { HarnessDoctorEntry, ManagedPolicy } from "../api/types";
+import { ManagedPolicyContext } from "../managedPolicy";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
@@ -177,6 +178,50 @@ describe("StartSessionPrompt", () => {
     expect(
       screen.queryByText("Mode is fixed once the session starts"),
     ).toBeNull();
+  });
+
+  it("starts under the managed ceiling instead of the engine's Allow default", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+    const capped: ManagedPolicy = {
+      managed: false,
+      source: "unmanaged",
+      misconfigured: false,
+      allow_local_mcp_servers: false,
+      permission_mode_ceiling: "ask",
+    };
+    await renderWithRouter(
+      wrap(
+        <ManagedPolicyContext.Provider value={capped}>
+          <StartSessionPrompt
+            workspaceId="workspace-1"
+            harnesses={[entry("claude_code", {})]}
+            starting={false}
+            selectedMode={null}
+            onSelectMode={vi.fn()}
+            onStart={onStart}
+          />
+        </ManagedPolicyContext.Provider>,
+      ),
+    );
+    expect(
+      screen.getByRole("button", { name: "Permissions: Ask" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(ALLOW_ALL_NOTE)).not.toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "list the files",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(onStart).toHaveBeenCalledWith(
+      "claude_code",
+      "ask",
+      "list the files",
+      undefined,
+      undefined,
+      null,
+      false,
+    );
   });
 
   it("says opencode's mode is fixed once the session starts", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -16,6 +16,7 @@ import type { HarnessDoctorEntry } from "../api/types";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
+import { ALLOW_ALL_NOTE, UNSUPERVISED_AUTO_NOTE } from "./labels";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 import type { ReasoningEffort } from "../api/types";
 import type { ParsedHarnessModel } from "./parsers";
@@ -156,7 +157,8 @@ describe("StartSessionPrompt", () => {
     expect(
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/runs without asking/)).toBeNull();
+    // The default posture is never silent: it says what it will do.
+    expect(screen.getByText(ALLOW_ALL_NOTE)).toBeInTheDocument();
     expect(
       screen.getByRole("combobox", { name: "Harness" }).closest("form"),
     ).toHaveClass("chat-composer");
@@ -239,7 +241,7 @@ describe("StartSessionPrompt", () => {
     );
   });
 
-  it("switches an Auto-only engine to Auto without extra permission copy", async () => {
+  it("switches an Auto-only engine to Auto and states that it never asks", async () => {
     const user = userEvent.setup();
     const onStart = vi.fn();
     await renderWithRouter(
@@ -267,7 +269,8 @@ describe("StartSessionPrompt", () => {
     expect(
       screen.getByRole("button", { name: "Permissions: Auto" }),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/runs without asking/)).toBeNull();
+    // Grok's Auto has no approval channel behind it, and the composer says so.
+    expect(screen.getByText(UNSUPERVISED_AUTO_NOTE)).toBeInTheDocument();
     await user.type(
       screen.getByRole("textbox", { name: "Message" }),
       "list the files",

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -9,6 +9,8 @@ import type {
   ReasoningEffort,
 } from "../api/types";
 import type { ComposerWorkspaceFiles } from "@/Composer";
+import { clampPermissionMode } from "../PermissionModeMenu";
+import { useManagedPolicy } from "../managedPolicy";
 import { CodeComposer } from "./CodeComposer";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
@@ -112,12 +114,15 @@ export function StartSessionPrompt({
     selectable.find((entry) => harnessCanStartNow(entry)) ??
     selectable[0];
   const availableModes = selected ? createPermissionModes(selected.caps) : [];
-  const mode: PermissionMode =
+  const ceiling = useManagedPolicy().permission_mode_ceiling;
+  const mode: PermissionMode = clampPermissionMode(
     selectedMode && availableModes.includes(selectedMode)
       ? selectedMode
       : selected
         ? defaultCreatePermissionMode(selected.caps)
-        : "plan";
+        : "plan",
+    ceiling,
+  );
 
   const selectedKind = selected?.kind;
   const model = selectedKind ? modelsByHarness[selectedKind] : undefined;

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import type { ReasoningEffort } from "../api/types";
 import type { ModeCaps } from "./labels";
 import {
+  ALLOW_ALL_NOTE,
+  PERMISSION_MODE_POSTURES,
+  UNSUPERVISED_AUTO_NOTE,
   autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
@@ -15,6 +18,8 @@ import {
   isHarnessReady,
   preferredCodeModels,
   sessionLifecycleTooltip,
+  sessionPermissionModeTooltip,
+  unsupervisedModeStatement,
 } from "./labels";
 
 function caps(
@@ -88,20 +93,49 @@ describe("create-time permission mode", () => {
     ).toEqual(["plan"]);
   });
 
-  it("offers only unsupervised Auto for a grok-shaped engine", () => {
-    const grok = caps("unsupported", "unsupported", "supported");
-    expect(createPermissionModes(grok)).toEqual(["auto"]);
-    expect(
-      createPermissionModes(
-        caps("unsupported", "unsupported", "supported", "supported"),
-      ),
-    ).toEqual(["auto", "allow"]);
-    expect(defaultCreatePermissionMode(grok)).toBe("auto");
+  it("offers unsupervised Auto and Allow for a grok-shaped engine", () => {
+    // Grok: no plan mode, no approval channel, both autonomous postures
+    // (`crates/tidebreak-harness/src/grok/mod.rs`).
+    const grok = caps("unsupported", "unsupported", "supported", "supported");
+    expect(createPermissionModes(grok)).toEqual(["auto", "allow"]);
+    expect(defaultCreatePermissionMode(grok)).toBe("allow");
     expect(autoIsUnsupervised(grok)).toBe(true);
+    // An engine with an auto posture and no allow-all still lands on Auto.
+    const autoOnly = caps("unsupported", "unsupported", "supported");
+    expect(createPermissionModes(autoOnly)).toEqual(["auto"]);
+    expect(defaultCreatePermissionMode(autoOnly)).toBe("auto");
+    expect(autoIsUnsupervised(autoOnly)).toBe(true);
     // Supervised Auto rides the approval channel and needs no statement.
     expect(
       autoIsUnsupervised(caps("supported", "supported", "supported")),
     ).toBe(false);
+  });
+});
+
+describe("unsupervisedModeStatement", () => {
+  it("states a posture that runs with nobody to ask", () => {
+    // Allow all never asks, whatever the engine can do.
+    expect(unsupervisedModeStatement("allow", false)).toBe(ALLOW_ALL_NOTE);
+    expect(unsupervisedModeStatement("allow", true)).toBe(ALLOW_ALL_NOTE);
+    // Auto only when the engine has no approval channel to escalate through.
+    expect(unsupervisedModeStatement("auto", true)).toBe(
+      UNSUPERVISED_AUTO_NOTE,
+    );
+    expect(unsupervisedModeStatement("auto", false)).toBeNull();
+    // A posture that escalates needs no statement.
+    expect(unsupervisedModeStatement("ask", true)).toBeNull();
+    expect(unsupervisedModeStatement("plan", true)).toBeNull();
+  });
+});
+
+describe("sessionPermissionModeTooltip", () => {
+  it("names the posture and spells out what it does", () => {
+    expect(sessionPermissionModeTooltip("allow")).toBe(
+      `Permissions: Allow all\n${PERMISSION_MODE_POSTURES.allow}`,
+    );
+    expect(sessionPermissionModeTooltip("plan")).toBe(
+      `Permissions: Plan\n${PERMISSION_MODE_POSTURES.plan}`,
+    );
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -105,6 +105,46 @@ export const SESSION_PERMISSION_MODE_LOCKED =
 export const CREATE_PERMISSION_MODE_FIXED =
   "Mode is fixed once the session starts";
 
+/** What each posture does, in one line, for the surfaces that state it. */
+export const PERMISSION_MODE_POSTURES: Record<PermissionMode, string> = {
+  plan: "Plans the work and writes nothing",
+  ask: "Asks before every tool that changes something",
+  // No claim about escalation: whether Auto has anywhere to ask is the
+  // engine's capability, not the mode's (see [`autoIsUnsupervised`]).
+  auto: "Decides for itself as it works",
+  allow: "Runs every tool without asking",
+};
+
+/** Stated wherever unsupervised Auto is offered (decision 0038). */
+export const UNSUPERVISED_AUTO_NOTE =
+  "This engine has no approval channel: in Auto, every action runs without asking.";
+
+/** Stated wherever Allow is offered (decision 0039). */
+export const ALLOW_ALL_NOTE =
+  "This engine's permission system is off: every action runs without asking.";
+
+/**
+ * The statement a surface shows next to the permission control when the
+ * posture on offer runs with nobody to ask (decisions 0038, 0039).
+ *
+ * `null` for a posture that escalates, so the statement appears only where it
+ * changes what the reader should expect: Allow all anywhere, and Auto on an
+ * engine whose Auto is unsupervised.
+ */
+export function unsupervisedModeStatement(
+  mode: PermissionMode,
+  autoUnsupervised: boolean,
+): string | null {
+  if (mode === "allow") return ALLOW_ALL_NOTE;
+  if (mode === "auto" && autoUnsupervised) return UNSUPERVISED_AUTO_NOTE;
+  return null;
+}
+
+/** The header chip's tooltip: the posture, named and spelled out. */
+export function sessionPermissionModeTooltip(mode: PermissionMode): string {
+  return `Permissions: ${PERMISSION_MODE_LABELS[mode]}\n${PERMISSION_MODE_POSTURES[mode]}`;
+}
+
 /** The capability flags the mode policy reads. */
 export type ModeCaps = Pick<
   HarnessCaps,

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -6,10 +6,12 @@ import type {
   Attention,
   CodeSessionSnapshot,
   CodeWorkspacePrSnapshot,
+  PermissionMode,
 } from "@/api";
 import { Badge } from "@/components/ui/badge";
 import { AttentionBadge } from "@/code/AttentionBadge";
 import { SessionLifecycleIndicator } from "@/code/SessionLifecycleIndicator";
+import { SessionPermissionIndicator } from "@/code/SessionPermissionIndicator";
 import {
   WorkspaceOverflowMenu,
   workspaceHeaderCommands,
@@ -59,6 +61,7 @@ function HeaderState({
   lifecycle = "running",
   pendingApprovals = 0,
   unrecognizedEventCount = 0,
+  permissionMode = "allow",
 }: {
   snapshot: CodeWorkspacePrSnapshot | null;
   loading?: boolean;
@@ -68,6 +71,7 @@ function HeaderState({
   lifecycle?: CodeSessionSnapshot["lifecycle"];
   pendingApprovals?: number;
   unrecognizedEventCount?: number;
+  permissionMode?: PermissionMode;
 }) {
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [reviewOpen, setReviewOpen] = useState(initialReviewOpen);
@@ -119,6 +123,10 @@ function HeaderState({
               unrecognizedEventCount={unrecognizedEventCount}
               runningLabel={lifecycle === "running" ? activityLabel : undefined}
             />
+            <span className="text-border" aria-hidden>
+              ·
+            </span>
+            <SessionPermissionIndicator mode={permissionMode} />
           </>
         )
       }
@@ -230,6 +238,28 @@ export const UnrecognizedEngineEvents: Story = {
     snapshot: openPrGit,
     activityLabel: "Shell running",
     unrecognizedEventCount: 3,
+  },
+};
+
+/**
+ * The posture the session runs under, next to its lifecycle. Create picks the
+ * most autonomous mode the engine honors, so the header is where a reader
+ * learns which one they got.
+ */
+export const AsksBeforeEachTool: Story = {
+  args: { snapshot: openPrGit, permissionMode: "ask" },
+};
+
+export const RunsOnItsOwn: Story = {
+  args: { snapshot: openPrGit, permissionMode: "auto" },
+};
+
+export const PlansOnly: Story = {
+  args: {
+    snapshot: openPrGit,
+    permissionMode: "plan",
+    lifecycle: "idle",
+    activityLabel: "Idle",
   },
 };
 

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -4,6 +4,7 @@ use crate::extract::{Json, Path, RawBytes};
 use crate::routes::image_attachment::{
     inspect_image_bytes, require_declared_type_matches, PublishedImageAttachment,
 };
+use crate::routes::providers_models::refuse_permission_mode_over_ceiling;
 use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
 use axum::body::Body;
@@ -21,10 +22,12 @@ use crate::code::runtime::{NewSessionSettings, SubmitTurnOutcome};
 use tidebreak_core::{CodeSessionId, TurnSteer, WorkspaceId};
 
 pub async fn create_session(
+    State(state): State<AppState>,
     code: ScopedCode,
     Path(workspace_id): Path<WorkspaceId>,
     Json(body): Json<CreateSessionBody>,
 ) -> Result<impl IntoResponse, ServerError> {
+    refuse_permission_mode_over_ceiling(&state, Some(body.permission_mode)).await?;
     let session = code
         .create_session(
             workspace_id,
@@ -286,12 +289,15 @@ pub async fn reap_session(
 ///
 /// The engine is relaunched against the new posture, so this is refused
 /// while a turn is running and while the session has ended. A mode the
-/// engine cannot honor is refused here rather than approximated.
+/// engine cannot honor is refused here rather than approximated, and so is
+/// a mode above the ceiling a managed profile asserts.
 pub async fn set_session_permission_mode(
+    State(state): State<AppState>,
     code: ScopedCode,
     Path(id): Path<CodeSessionId>,
     Json(body): Json<SetPermissionModeBody>,
 ) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
+    refuse_permission_mode_over_ceiling(&state, Some(body.permission_mode)).await?;
     let session = code.set_permission_mode(id, body.permission_mode).await?;
     Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
 }

--- a/crates/tidebreak-server/src/routes/providers_models.rs
+++ b/crates/tidebreak-server/src/routes/providers_models.rs
@@ -241,10 +241,12 @@ pub(super) async fn has_api_key(secrets: &dyn SecretProvider) -> bool {
 
 /// Refuse selecting a permission mode above the managed ceiling.
 ///
-/// The picker-facing half of the lockdown: the authoritative clamp lives at
-/// the turn gate, which also catches chats whose stored mode predates the
-/// policy. Selecting a mode at or below the ceiling stays open — the policy
-/// names a maximum, not a fixed mode.
+/// The picker-facing half of the lockdown: for chat the authoritative clamp
+/// lives at the turn gate, which also catches chats whose stored mode
+/// predates the policy. A code session has no such clamp — its posture is
+/// composed into the engine's launch, so the ceiling binds where the mode is
+/// chosen: session create and the mode route. Selecting a mode at or below
+/// the ceiling stays open — the policy names a maximum, not a fixed mode.
 pub(super) async fn refuse_permission_mode_over_ceiling(
     state: &AppState,
     requested: Option<PermissionMode>,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -115,6 +115,19 @@ async fn code_app(
     code_app_with(ScriptedAdapter::new(events)).await
 }
 
+/// An OS policy that asserts one permission-mode ceiling and nothing else.
+struct CappedOsPolicy(PermissionMode);
+
+impl crate::managed_policy::OsPolicySource for CappedOsPolicy {
+    fn gateway_url(&self) -> tidebreak_core::Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn permission_mode_ceiling(&self) -> tidebreak_core::Result<Option<PermissionMode>> {
+        Ok(Some(self.0))
+    }
+}
+
 async fn code_app_with(
     adapter: ScriptedAdapter,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
@@ -132,20 +145,29 @@ async fn code_app_with_optional_browser(
     adapter: ScriptedAdapter,
     browser_runtime: Option<Arc<RecordingBrowserRuntime>>,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
-    code_app_with_options(adapter, browser_runtime, None).await
+    code_app_with_options(adapter, browser_runtime, None, None).await
 }
 
 async fn code_app_with_put_gate(
     adapter: ScriptedAdapter,
     gate: Arc<PutGate>,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
-    code_app_with_options(adapter, None, Some(gate)).await
+    code_app_with_options(adapter, None, Some(gate), None).await
+}
+
+/// A code app whose OS policy asserts a permission-mode ceiling.
+async fn code_app_with_ceiling(
+    adapter: ScriptedAdapter,
+    ceiling: PermissionMode,
+) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    code_app_with_options(adapter, None, None, Some(ceiling)).await
 }
 
 async fn code_app_with_options(
     adapter: ScriptedAdapter,
     browser_runtime: Option<Arc<RecordingBrowserRuntime>>,
     put_gate: Option<Arc<PutGate>>,
+    permission_mode_ceiling: Option<PermissionMode>,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
     let (dir, store) = temp_db_store("code.db").await;
     let db = Arc::new(store);
@@ -180,6 +202,9 @@ async fn code_app_with_options(
             inner: runtime.blobs.clone(),
             gate,
         });
+    }
+    if let Some(ceiling) = permission_mode_ceiling {
+        state.os_policy = Arc::new(CappedOsPolicy(ceiling));
     }
     state.code = Some(runtime.clone());
     let token = state.token.clone();
@@ -679,6 +704,82 @@ async fn allow_stands_on_its_own_capability_flag() {
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let session: serde_json::Value = created.json().await.unwrap();
     assert_eq!(session["permission_mode"], "allow");
+}
+
+/// A managed profile's `permission_mode_ceiling` binds code sessions the way
+/// it binds chats: an over-ceiling posture is refused where it is chosen —
+/// session create and the mode route — while a stricter one stays the
+/// reader's choice. The UI lock is legibility; this is the enforcement.
+#[tokio::test]
+async fn a_managed_ceiling_refuses_over_ceiling_code_session_modes() {
+    let adapter = ScriptedAdapter::new(plain_text_script())
+        .with_approvals(CapLevel::Supported)
+        .with_auto_mode(CapLevel::Supported)
+        .with_allow_mode(CapLevel::Supported);
+    let (router, token, _runtime, dir) = code_app_with_ceiling(adapter, PermissionMode::Ask).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let sessions_url = format!(
+        "http://{addr}/code/workspaces/{}/sessions",
+        json_id(&workspace)
+    );
+
+    // Create: the engine honors Allow, the policy does not.
+    let refused = client
+        .post(&sessions_url)
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "allow",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "permission_mode_locked", "{body}");
+
+    let created = client
+        .post(&sessions_url)
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(session["permission_mode"], "ask", "{session}");
+    let session = json_id(&session).to_owned();
+
+    // The mode route carries the same ceiling.
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "permission_mode": "auto" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "permission_mode_locked", "{body}");
+
+    // A ceiling names a maximum, so dialing down stays open.
+    let allowed = client
+        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "permission_mode": "plan" }))
+        .send()
+        .await
+        .unwrap();
+    let status = allowed.status();
+    let body: serde_json::Value = allowed.json().await.unwrap();
+    assert_eq!(status, reqwest::StatusCode::OK, "{body}");
+    assert_eq!(body["permission_mode"], "plan", "{body}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

A code session's permission mode was invisible outside the create composer, and the managed `permission_mode_ceiling` bound chat only.

**Visibility.** The workspace header now shows the session's mode as a muted chip beside the lifecycle text (`SessionPermissionIndicator`), with a tooltip that names the posture and says what it does. Create picks the most autonomous mode the engine honors, so the header is where a reader learns which one they got.

**The statement.** `autoIsUnsupervised()` had no caller since #2601 trimmed the permission copy, which left the requirement in decision 0039's amendment unmet — the posture is supposed to be stated next to the control. Both create composers state it again, using the same words #2601 removed: `ALLOW_ALL_NOTE` under Allow all, `UNSUPERVISED_AUTO_NOTE` under Auto on an engine with no approval channel. It appears only at create; a live session carries the header chip instead of a line under every draft, and the menu rows stay free of posture descriptions.

**Enforcement.** `POST /code/workspaces/{id}/sessions` and `POST /code/sessions/{id}/mode` now call `refuse_permission_mode_over_ceiling`, the same refusal the chat routes use (409 `permission_mode_locked`). Until now the code paths validated harness capabilities only and the picker's lock was display-only, so any client could post an over-ceiling mode. A stricter mode stays the reader's choice — the policy names a maximum.

**Fixture fix.** `labels.test.ts` asserted a Grok-shaped engine offers only Auto. The Grok adapter has supported `allow_mode` since the captured 1.0.4 probe, so the create default there is Allow. The fixture now matches the adapter.

Out of scope: the Allow-by-default create behavior, which is a recorded amendment to decision 0039 with its own revisit condition.

## Validation

- `cargo check -p tidebreak-server`
- `cargo test -p tidebreak-server --lib tests::code::` — 112 passed, including the new `a_managed_ceiling_refuses_over_ceiling_code_session_modes` (over-ceiling create and mode change refused, at-or-below accepted)
- `cargo fmt --check -p tidebreak-server`
- `pnpm --dir crates/tidebreak-desktop/ui lint`, `biome format src`, `tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui test` — 2124 passed
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`

No screenshot pass: this environment has no controllable browser. The `Code/Workspace header` story gained `AsksBeforeEachTool`, `RunsOnItsOwn`, and `PlansOnly` so the chip states can be reviewed there.

Closes #2795
