### PR TITLE
fix(desktop): keep the workspace layout usable with the inspector open

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -37,6 +37,7 @@ import { useCodeUiStore } from "./CodeUiStore";
 import { resetWorkflowPromptStore } from "./workflowPrompts";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeWorkspacePage } from "./CodeWorkspacePage";
+import { MIN_INSPECTOR_PANE_WIDTH_PX } from "./inspectorLayout";
 import {
   forkFraming,
   forkTranscriptFile,
@@ -655,6 +656,35 @@ beforeEach(() => {
   vi.useRealTimers();
 });
 
+/**
+ * Make every observed element report this width.
+ *
+ * jsdom measures nothing, so the shared stub answers with a desktop-sized
+ * box. A test that cares about a narrow pane swaps in its own for the
+ * duration; `vi.stubGlobal` is undone with the other stubs after each test.
+ */
+function stubPaneWidth(width: number) {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+      observe(target: Element) {
+        this.callback(
+          [
+            {
+              target,
+              contentRect: { width, height: 768 },
+            } as unknown as ResizeObserverEntry,
+          ],
+          this as unknown as ResizeObserver,
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+}
+
 afterEach(() => {
   cleanup();
   resetCodeSessionRegistry();
@@ -674,6 +704,7 @@ afterEach(() => {
   browserMocks.close.mockClear();
   window.localStorage.clear();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   vi.clearAllMocks();
 });
 
@@ -1333,6 +1364,27 @@ describe("CodeWorkspacePage", () => {
     expect(screen.queryByTestId("code-inspector")).not.toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("stands the review sidebar down when the pane is too narrow to split", async () => {
+    // The bounds are percentages, so a narrow pane shrinks the workspace and
+    // the inspector together and no drag wins the journal its floor back.
+    stubPaneWidth(MIN_INSPECTOR_PANE_WIDTH_PX - 40);
+    const client = makeClient();
+    await mountWorkspace(client);
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("code-inspector")).not.toBeInTheDocument();
+    // The reader's preference survives; only this window cannot honour it.
+    expect(useCodeUiStore.getState().reviewSidebarOpen).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Review sidebar" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getByRole("textbox", { name: "Message" }),
     ).toBeInTheDocument();
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -174,6 +174,7 @@ import { tidebreakProductRepo } from "./uneffMe";
 import { sessionActivityLabel, isPutAway } from "./workspaceCards";
 import {
   DEFAULT_INSPECTOR_LAYOUT,
+  fitsInspectorSplit,
   INSPECTOR_LAYOUT_STORAGE_ID,
   INSPECTOR_PANEL_IDS,
   MAX_INSPECTOR_SIZE,
@@ -423,15 +424,15 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     [inspectorLayout.defaultLayout],
   );
 
-  useEffect(() => {
-    if (!reviewSidebarOpen) return;
-    const group = inspectorGroupRef.current;
-    if (!group) return;
-    const current = group.getLayout();
-    if (Object.keys(current).length > 0 && !usableInspectorLayout(current)) {
-      group.setLayout({ ...DEFAULT_INSPECTOR_LAYOUT });
-    }
-  }, [inspectorGroupRef, reviewSidebarOpen, workspaceId]);
+  const { paneRef: inspectorPaneRef, width: inspectorPaneWidth } =
+    useMeasuredWidth();
+  const inspectorFits = fitsInspectorSplit(inspectorPaneWidth);
+  /**
+   * The split only appears when the reader asked for it and the pane can
+   * carry it. The stored preference survives a narrow window, so widening
+   * one brings the inspector straight back.
+   */
+  const inspectorOpen = reviewSidebarOpen && inspectorFits;
   const [starting, setStarting] = useState(false);
   const [createMode, setCreateMode] = useState<PermissionMode | null>(null);
   const [fileReveal, setFileReveal] = useState<{
@@ -1628,7 +1629,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           ) : undefined
         }
         terminalOpen={hasTerminal}
-        reviewOpen={reviewSidebarOpen}
+        reviewOpen={inspectorOpen}
+        reviewUnavailableReason={
+          inspectorFits
+            ? undefined
+            : "Too narrow for the review sidebar — open Source control or Pull request as a tab"
+        }
         terminalShortcut={shortcutHints.terminal}
         reviewShortcut={shortcutHints.review}
         onToggleTerminal={toggleTerminal}
@@ -1670,57 +1676,63 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             Retry
           </Button>
         </div>
-      ) : reviewSidebarOpen ? (
-        <ResizablePanelGroup
-          id={INSPECTOR_LAYOUT_STORAGE_ID}
-          groupRef={inspectorGroupRef}
-          defaultLayout={inspectorDefaultLayout}
-          onLayoutChanged={inspectorLayout.onLayoutChanged}
-          orientation="horizontal"
-          className="h-auto min-h-0 max-w-full min-w-0 flex-1 overflow-clip"
-        >
-          <ResizablePanel
-            id="workspace"
-            defaultSize={String(DEFAULT_INSPECTOR_LAYOUT.workspace)}
-            minSize={String(MIN_WORKSPACE_SIZE)}
-            className="h-full min-h-0 min-w-0"
-          >
-            {workspaceMain}
-          </ResizablePanel>
-          <ResizableHandle className="bg-border-subtle transition-colors hover:bg-border" />
-          <ResizablePanel
-            id="inspector"
-            defaultSize={String(DEFAULT_INSPECTOR_LAYOUT.inspector)}
-            minSize={String(MIN_INSPECTOR_SIZE)}
-            maxSize={String(MAX_INSPECTOR_SIZE)}
-            className="h-full min-h-0 min-w-0 bg-page-background"
-          >
-            <ErrorBoundary
-              resetKey={workspaceId}
-              fallback={
-                <p className="text-muted-foreground p-4 text-sm">
-                  The review sidebar could not load. Git and pull-request
-                  details stay here when they are available.
-                </p>
-              }
-            >
-              <CodeInspector
-                key={workspaceId}
-                client={client}
-                workspaceId={workspaceId}
-                workspace={workspace}
-                contentRevision={contentRevision}
-                prResource={prResource}
-                onOpenFile={openFile}
-                onOpenDiff={openFileDiff}
-                onClose={() => setReviewSidebarOpen(false)}
-              />
-            </ErrorBoundary>
-          </ResizablePanel>
-        </ResizablePanelGroup>
       ) : (
-        <div className="flex h-full min-h-0 flex-1 overflow-hidden">
-          {workspaceMain}
+        <div
+          ref={inspectorPaneRef}
+          data-testid="workspace-pane"
+          className="flex h-full min-h-0 flex-1 overflow-hidden"
+        >
+          {inspectorOpen ? (
+            <ResizablePanelGroup
+              id={INSPECTOR_LAYOUT_STORAGE_ID}
+              groupRef={inspectorGroupRef}
+              defaultLayout={inspectorDefaultLayout}
+              onLayoutChanged={inspectorLayout.onLayoutChanged}
+              orientation="horizontal"
+              className="h-auto min-h-0 max-w-full min-w-0 flex-1 overflow-clip"
+            >
+              <ResizablePanel
+                id="workspace"
+                defaultSize={String(DEFAULT_INSPECTOR_LAYOUT.workspace)}
+                minSize={String(MIN_WORKSPACE_SIZE)}
+                className="h-full min-h-0 min-w-0"
+              >
+                {workspaceMain}
+              </ResizablePanel>
+              <ResizableHandle className="bg-border-subtle transition-colors hover:bg-border" />
+              <ResizablePanel
+                id="inspector"
+                defaultSize={String(DEFAULT_INSPECTOR_LAYOUT.inspector)}
+                minSize={String(MIN_INSPECTOR_SIZE)}
+                maxSize={String(MAX_INSPECTOR_SIZE)}
+                className="h-full min-h-0 min-w-0 bg-page-background"
+              >
+                <ErrorBoundary
+                  resetKey={workspaceId}
+                  fallback={
+                    <p className="text-muted-foreground p-4 text-sm">
+                      The review sidebar could not load. Git and pull-request
+                      details stay here when they are available.
+                    </p>
+                  }
+                >
+                  <CodeInspector
+                    key={workspaceId}
+                    client={client}
+                    workspaceId={workspaceId}
+                    workspace={workspace}
+                    contentRevision={contentRevision}
+                    prResource={prResource}
+                    onOpenFile={openFile}
+                    onOpenDiff={openFileDiff}
+                    onClose={() => setReviewSidebarOpen(false)}
+                  />
+                </ErrorBoundary>
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          ) : (
+            workspaceMain
+          )}
         </div>
       )}
     </MarkdownLinkProvider>
@@ -1819,6 +1831,40 @@ function storedBrowserTitles(layout: LayoutState): Record<string, string> {
  * plus menu stops offering another rather than letting the create fail.
  */
 const MAX_WORKSPACE_TERMINALS = 8;
+
+/**
+ * Track one element's width, in CSS pixels.
+ *
+ * The width stays `null` until an observer reports, so a caller can tell
+ * "not measured yet" from "measured and narrow" and avoid deciding on a zero
+ * it read before layout ran. The callback ref re-attaches whenever the
+ * element behind it changes, which is what keeps the reading live across the
+ * split going up and coming down.
+ */
+function useMeasuredWidth(): {
+  paneRef: (element: HTMLElement | null) => void;
+  width: number | null;
+} {
+  const [width, setWidth] = useState<number | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  useEffect(() => () => observerRef.current?.disconnect(), []);
+
+  const paneRef = useCallback((element: HTMLElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    setWidth(element.getBoundingClientRect().width);
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setWidth(entry.contentRect.width);
+    });
+    observer.observe(element);
+    observerRef.current = observer;
+  }, []);
+
+  return { paneRef, width };
+}
 
 /**
  * Give every open shell a tab label, keeping the ones already assigned.

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -210,6 +210,11 @@ describe("NewWorkspaceDialog", () => {
     expect(screen.getByTestId("new-workspace-controls")).toHaveClass(
       "flex-wrap",
     );
+    // A short window scrolls the form rather than clipping the Create row.
+    expect(screen.getByRole("dialog").querySelector("form")).toHaveClass(
+      "min-h-0",
+      "overflow-y-auto",
+    );
   });
 
   it("closes and lists the workspace before creation finishes", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -673,7 +673,14 @@ export function NewWorkspaceDialog({
         }}
       >
         <DialogTitle className="sr-only">New workspace</DialogTitle>
-        <form className="flex min-h-0 min-w-0 flex-col" onSubmit={submit}>
+        {/* The dialog clips what it cannot fit, and the prompt holds a hard
+            floor, so a short window would drop the wrapped footer — the row
+            carrying Create — off the bottom. Scrolling the form instead keeps
+            every control reachable. */}
+        <form
+          className="flex min-h-0 min-w-0 flex-col overflow-y-auto"
+          onSubmit={submit}
+        >
           <div className="flex min-w-0 flex-wrap items-center gap-x-1 gap-y-1 px-3 pt-3">
             <DropdownMenu {...pickerProps("repo")}>
               <WithTooltip label={`Repo · ${command ? "⌘N" : "Ctrl+N"}`}>

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceHeader.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceHeader.tsx
@@ -29,6 +29,7 @@ export function WorkspaceHeader({
   sessionStatus,
   terminalOpen,
   reviewOpen,
+  reviewUnavailableReason,
   terminalShortcut,
   reviewShortcut,
   onToggleTerminal,
@@ -47,6 +48,8 @@ export function WorkspaceHeader({
   sessionStatus?: ReactNode;
   terminalOpen: boolean;
   reviewOpen: boolean;
+  /** Why the review sidebar cannot open here, when it cannot. */
+  reviewUnavailableReason?: string;
   terminalShortcut?: string;
   reviewShortcut?: string;
   onToggleTerminal: () => void;
@@ -130,19 +133,22 @@ export function WorkspaceHeader({
         </WithTooltip>
         <WithTooltip
           label={
-            reviewOpen
-              ? `Hide review sidebar${shortcutSuffix(reviewShortcut)}`
-              : `Review sidebar${shortcutSuffix(reviewShortcut)}`
+            reviewUnavailableReason
+              ? reviewUnavailableReason
+              : reviewOpen
+                ? `Hide review sidebar${shortcutSuffix(reviewShortcut)}`
+                : `Review sidebar${shortcutSuffix(reviewShortcut)}`
           }
         >
           <Button
             type="button"
             variant="ghost"
             size="icon-sm"
-            className="rounded-lg"
+            className="rounded-lg aria-disabled:cursor-default aria-disabled:opacity-50"
             aria-pressed={reviewOpen}
             aria-label="Review sidebar"
-            onClick={onToggleReview}
+            aria-disabled={reviewUnavailableReason ? true : undefined}
+            onClick={reviewUnavailableReason ? undefined : onToggleReview}
           >
             {reviewOpen ? <PanelRightClose /> : <PanelRight />}
           </Button>

--- a/crates/tidebreak-desktop/ui/src/code/inspectorLayout.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/inspectorLayout.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   DEFAULT_INSPECTOR_LAYOUT,
+  fitsInspectorSplit,
+  MIN_INSPECTOR_PANE_WIDTH_PX,
+  MIN_WORKSPACE_SIZE,
+  MIN_WORKSPACE_WIDTH_PX,
   usableInspectorLayout,
 } from "./inspectorLayout";
 
@@ -24,5 +28,22 @@ describe("usableInspectorLayout", () => {
     { workspace: 65, inspector: 30 },
   ])("rejects a layout that can hide or corrupt the workspace", (layout) => {
     expect(usableInspectorLayout(layout)).toBeUndefined();
+  });
+});
+
+describe("fitsInspectorSplit", () => {
+  it("keeps the split only where the workspace still clears its floor", () => {
+    const roomy = MIN_INSPECTOR_PANE_WIDTH_PX;
+    expect(fitsInspectorSplit(roomy)).toBe(true);
+    expect(fitsInspectorSplit(roomy - 1)).toBe(false);
+    expect((roomy * MIN_WORKSPACE_SIZE) / 100).toBeGreaterThanOrEqual(
+      MIN_WORKSPACE_WIDTH_PX,
+    );
+  });
+
+  it("treats an unmeasured pane as roomy", () => {
+    // Deciding on the zero a pane reports before layout runs would flash the
+    // inspector away on every wide-window mount.
+    expect(fitsInspectorSplit(null)).toBe(true);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/inspectorLayout.ts
+++ b/crates/tidebreak-desktop/ui/src/code/inspectorLayout.ts
@@ -10,6 +10,35 @@ export const MIN_WORKSPACE_SIZE = 58;
 export const MIN_INSPECTOR_SIZE = 22;
 export const MAX_INSPECTOR_SIZE = 42;
 
+/**
+ * The narrowest workspace column that still carries its own furniture: the
+ * center tab strip with Source control and Pull request on it, the journal,
+ * and the composer with a readable model pill.
+ */
+export const MIN_WORKSPACE_WIDTH_PX = 480;
+
+/**
+ * The narrowest pane worth splitting at all.
+ *
+ * The bounds above are percentages, so a narrow window shrinks both panels
+ * together and no drag can win the workspace its floor back. Below this the
+ * inspector stands down and the workspace takes the whole pane; Source
+ * control and Pull request stay reachable as center tabs.
+ */
+export const MIN_INSPECTOR_PANE_WIDTH_PX = Math.ceil(
+  (MIN_WORKSPACE_WIDTH_PX * 100) / MIN_WORKSPACE_SIZE,
+);
+
+/**
+ * Whether a pane of this width can carry the split.
+ *
+ * An unmeasured pane counts as roomy, so the first paint on a wide window
+ * never flashes the inspector away before the observer reports.
+ */
+export function fitsInspectorSplit(paneWidth: number | null): boolean {
+  return paneWidth === null || paneWidth >= MIN_INSPECTOR_PANE_WIDTH_PX;
+}
+
 export type InspectorLayout = {
   workspace: number;
   inspector: number;

--- a/crates/tidebreak-desktop/ui/src/components/ui/resizable.test.ts
+++ b/crates/tidebreak-desktop/ui/src/components/ui/resizable.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { RESIZABLE_HANDLE_CLASS } from "./resizable";
+
+/**
+ * `react-resizable-panels` labels a separator by its own axis, not by its
+ * group's: a horizontal group is split by a separator that reports
+ * `aria-orientation="vertical"`. Reading that word as "the group is vertical"
+ * made the handle a full-width row inside every horizontal group, which left
+ * the panels beside it zero pixels wide — the code workspace lost its journal,
+ * composer, and center tabs the moment the inspector opened.
+ */
+describe("resizable handle", () => {
+  it("sizes the bar from the separator's own axis", () => {
+    expect(RESIZABLE_HANDLE_CLASS).toContain(
+      "aria-[orientation=horizontal]:w-full",
+    );
+    expect(RESIZABLE_HANDLE_CLASS).toContain(
+      "aria-[orientation=horizontal]:h-px",
+    );
+  });
+
+  it("never grows a vertical separator to the full width of its group", () => {
+    expect(RESIZABLE_HANDLE_CLASS).not.toContain("aria-[orientation=vertical]");
+    expect(RESIZABLE_HANDLE_CLASS).toContain("w-px");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/components/ui/resizable.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/resizable.tsx
@@ -20,17 +20,28 @@ const ResizablePanelGroup = ({
 
 const ResizablePanel = Panel;
 
+/**
+ * The hairline between two panels, plus a wider invisible grab strip.
+ *
+ * `aria-orientation` describes the separator's own axis, not the group's: a
+ * horizontal group is split by a *vertical* separator. Key the full-width bar
+ * off `horizontal` accordingly. Keying it off `vertical` — which reads as the
+ * matching word — makes the handle a full-width row in every horizontal
+ * group, and the panels beside it collapse to zero.
+ */
+const RESIZABLE_HANDLE_CLASS =
+  "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2";
+
 const ResizableHandle = ({
   className,
   ...props
 }: React.ComponentProps<typeof Separator>) => (
-  <Separator
-    className={cn(
-      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=vertical]:h-px aria-[orientation=vertical]:w-full aria-[orientation=vertical]:after:left-0 aria-[orientation=vertical]:after:h-1 aria-[orientation=vertical]:after:w-full aria-[orientation=vertical]:after:translate-x-0 aria-[orientation=vertical]:after:-translate-y-1/2",
-      className,
-    )}
-    {...props}
-  />
+  <Separator className={cn(RESIZABLE_HANDLE_CLASS, className)} {...props} />
 );
 
-export { ResizablePanelGroup, ResizablePanel, ResizableHandle };
+export {
+  RESIZABLE_HANDLE_CLASS,
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+};

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -32,8 +32,11 @@ import {
 } from "@/code/CodeUpdatesStore";
 import { CodeWorkspacePage } from "@/code/CodeWorkspacePage";
 import {
+  DEFAULT_INSPECTOR_LAYOUT,
   INSPECTOR_LAYOUT_STORAGE_ID,
   INSPECTOR_PANEL_IDS,
+  MAX_INSPECTOR_SIZE,
+  MIN_WORKSPACE_WIDTH_PX,
 } from "@/code/inspectorLayout";
 import type { LayoutState } from "@/panel/panelTypes";
 import {
@@ -1041,9 +1044,52 @@ export const SettingsPending: Story = {
   },
 };
 
+/**
+ * The center tab strip survives the split: it is on screen, and every tab on
+ * it is reachable without scrolling sideways.
+ *
+ * Scrolled-out tabs are how the workspace used to lose Source control and
+ * Pull request whenever the inspector opened.
+ */
+async function expectCenterTabsReachable(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await expect(
+    await canvas.findByRole("tab", { name: "Main agent" }),
+  ).toBeVisible();
+  const strip = canvasElement.querySelector<HTMLElement>(
+    ".workspace-pane-tabs",
+  );
+  await expect(strip).toBeVisible();
+  expect(strip?.scrollWidth ?? 0).toBeLessThanOrEqual(
+    (strip?.clientWidth ?? 0) + 1,
+  );
+}
+
+/** The journal and the composer keep a workable column beside the inspector. */
+async function expectConversationIntact(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  const journal = canvasElement.querySelector<HTMLElement>(".chat-pane");
+  await expect(journal).toBeVisible();
+  await expect(
+    await canvas.findByRole("textbox", { name: "Message" }),
+  ).toBeVisible();
+  expect(journal?.getBoundingClientRect().width ?? 0).toBeGreaterThanOrEqual(
+    MIN_WORKSPACE_WIDTH_PX,
+  );
+}
+
+/** The inspector's share of the pane, as a percentage. */
+function inspectorShare(canvasElement: HTMLElement): number {
+  const canvas = within(canvasElement);
+  const workspace = canvas.getByTestId("workspace").getBoundingClientRect();
+  const inspector = canvas.getByTestId("inspector").getBoundingClientRect();
+  return (inspector.width / (workspace.width + inspector.width)) * 100;
+}
+
 /** Review is an optional working pane, not a replacement for the conversation. */
 export const ConversationWithReview: Story = {
   args: { reviewOpen: true },
+  globals: { viewport: { value: "desktop", isRotated: false } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(
@@ -1061,6 +1107,31 @@ export const ConversationWithReview: Story = {
     expect(workspacePanel.getBoundingClientRect().width).toBeGreaterThan(
       inspectorPanel.getBoundingClientRect().width,
     );
+    expect(inspectorShare(canvasElement)).toBeLessThanOrEqual(
+      MAX_INSPECTOR_SIZE,
+    );
+    await expectCenterTabsReachable(canvasElement);
+    await expectConversationIntact(canvasElement);
+  },
+};
+
+/** A saved split inside the bounds comes back exactly as the reader left it. */
+export const RestoredInspectorSplit: Story = {
+  args: {
+    reviewOpen: true,
+    storedInspectorLayout: { workspace: 60, inspector: 40 },
+  },
+  globals: { viewport: { value: "desktop", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByTestId("inspector"),
+    ).toBeVisible();
+    expect(inspectorShare(canvasElement)).toBeCloseTo(40, 0);
+    expect(inspectorShare(canvasElement)).toBeLessThanOrEqual(
+      MAX_INSPECTOR_SIZE,
+    );
+    await expectCenterTabsReachable(canvasElement);
+    await expectConversationIntact(canvasElement);
   },
 };
 
@@ -1070,6 +1141,7 @@ export const InvalidStoredInspectorLayout: Story = {
     reviewOpen: true,
     storedInspectorLayout: { workspace: 0, inspector: 100 },
   },
+  globals: { viewport: { value: "desktop", isRotated: false } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const workspacePanel = await canvas.findByTestId("workspace");
@@ -1080,6 +1152,13 @@ export const InvalidStoredInspectorLayout: Story = {
     expect(workspacePanel.getBoundingClientRect().width).toBeGreaterThan(
       inspectorPanel.getBoundingClientRect().width,
     );
+    // The rejected payload falls back to the shipped split, not to a clamp.
+    expect(inspectorShare(canvasElement)).toBeCloseTo(
+      DEFAULT_INSPECTOR_LAYOUT.inspector,
+      0,
+    );
+    await expectCenterTabsReachable(canvasElement);
+    await expectConversationIntact(canvasElement);
   },
 };
 
@@ -1095,6 +1174,30 @@ export const SourceControlTab: Story = {
   },
 };
 
+/** Source control and the inspector are two views of the same work, side by side. */
+export const SourceControlTabWithReview: Story = {
+  args: {
+    initialUrl: workspaceUrl({
+      tabs: [{ type: "source_control" }],
+      activeIndex: 0,
+      fullscreen: false,
+    }),
+    reviewOpen: true,
+  },
+  globals: { viewport: { value: "desktop", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("tab", { name: "Source control" }),
+    ).toBeVisible();
+    await expect(await canvas.findByTestId("inspector")).toBeVisible();
+    expect(inspectorShare(canvasElement)).toBeLessThanOrEqual(
+      MAX_INSPECTOR_SIZE,
+    );
+    await expectCenterTabsReachable(canvasElement);
+  },
+};
+
 /** Pull-request status and comments remain a peer center tab. */
 export const PullRequestTab: Story = {
   args: {
@@ -1104,6 +1207,61 @@ export const PullRequestTab: Story = {
       fullscreen: false,
     }),
     reviewOpen: false,
+  },
+};
+
+/** The pull-request tab and the inspector coexist; neither crowds the strip. */
+export const PullRequestTabWithReview: Story = {
+  args: {
+    initialUrl: workspaceUrl({
+      tabs: [{ type: "pr" }],
+      activeIndex: 0,
+      fullscreen: false,
+    }),
+    reviewOpen: true,
+  },
+  globals: { viewport: { value: "desktop", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("tab", { name: "Pull request" }),
+    ).toBeVisible();
+    await expect(await canvas.findByTestId("inspector")).toBeVisible();
+    expect(inspectorShare(canvasElement)).toBeLessThanOrEqual(
+      MAX_INSPECTOR_SIZE,
+    );
+    await expectCenterTabsReachable(canvasElement);
+  },
+};
+
+/**
+ * Too narrow to split: the inspector stands down rather than squeezing the
+ * journal, and the header control says why. Source control and Pull request
+ * stay reachable as center tabs.
+ */
+export const MinimumWindowWithReview: Story = {
+  args: { reviewOpen: true },
+  globals: { viewport: { value: "minimumWindow", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("tab", { name: "Main agent" }),
+    ).toBeVisible();
+    await expect(canvas.queryByTestId("inspector")).toBeNull();
+    await expect(
+      canvas.getByRole("button", { name: "Review sidebar" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    const journal = canvasElement.querySelector<HTMLElement>(".chat-pane");
+    const pane = canvas.getByTestId("workspace-pane");
+    await expect(journal).toBeVisible();
+    await expect(
+      await canvas.findByRole("textbox", { name: "Message" }),
+    ).toBeVisible();
+    // The journal takes the whole pane, not a fraction of it.
+    expect(journal?.getBoundingClientRect().width ?? 0).toBeGreaterThan(
+      pane.getBoundingClientRect().width - 16,
+    );
+    await expectCenterTabsReachable(canvasElement);
   },
 };
 

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -267,6 +267,13 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/** One CSS rem, which the interface zoom moves. Sizes below scale with it. */
+function rem(element: HTMLElement): number {
+  return Number.parseFloat(
+    getComputedStyle(element.ownerDocument.documentElement).fontSize,
+  );
+}
+
 /**
  * Sticky defaults answered, message focused, one Enter from a running task.
  * Every pill has a chord: Cmd+N repo, Alt+E engine, Alt+M model, Alt+P
@@ -277,9 +284,13 @@ export const Default: Story = {
     const page = within(canvasElement.ownerDocument.body);
     const dialog = await page.findByRole("dialog");
     const prompt = page.getByRole("textbox", { name: "First message" });
+    const unit = rem(dialog);
     await expect(dialog).toBeVisible();
-    expect(dialog.getBoundingClientRect().width).toBeGreaterThan(800);
-    expect(prompt.getBoundingClientRect().height).toBeGreaterThanOrEqual(200);
+    // `max-w-4xl` on the dialog and `sm:min-h-52` on the prompt, in pixels.
+    expect(dialog.getBoundingClientRect().width).toBeCloseTo(56 * unit, 0);
+    expect(prompt.getBoundingClientRect().height).toBeGreaterThanOrEqual(
+      13 * unit,
+    );
   },
 };
 
@@ -289,8 +300,56 @@ export const MinimumWindow: Story = {
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
     const dialog = await page.findByRole("dialog");
-    await expect(page.getByRole("button", { name: /Create/ })).toBeVisible();
+    const create = page.getByRole("button", { name: /Create/ });
+    await expect(create).toBeVisible();
     expect(dialog.scrollWidth).toBeLessThanOrEqual(dialog.clientWidth);
+    // The wrapped footer is the row a short window used to cut off.
+    expect(dialog.scrollHeight).toBeLessThanOrEqual(dialog.clientHeight);
+    expect(create.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      dialog.getBoundingClientRect().bottom,
+    );
+  },
+};
+
+/** Picking the repo is the one setting above the message, and it has a chord. */
+export const RepoPicker: Story = {
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await page.findByRole("button", { name: "Repo" }));
+    const menu = await page.findByRole("menu");
+    await expect(within(menu).getByText("toronto")).toBeVisible();
+    await expect(menu.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      window.innerHeight,
+    );
+  },
+};
+
+/** The model list belongs to the engine, so it opens upward from the footer. */
+export const ModelPicker: Story = {
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await page.findByRole("button", { name: /Claude Opus 5/ }),
+    );
+    const menu = await page.findByRole("menu");
+    await expect(within(menu).getByText("Claude Sonnet 5")).toBeVisible();
+    await expect(menu.getBoundingClientRect().top).toBeGreaterThanOrEqual(0);
+  },
+};
+
+/** The base ref is a free-text field, not a branch list: tags and commits count. */
+export const BaseRefPicker: Story = {
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await page.findByRole("button", { name: "Base ref" }),
+    );
+    await expect(
+      await page.findByRole("textbox", { name: "Base ref" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("The branch, tag, or commit the worktree is cut from."),
+    ).toBeVisible();
   },
 };
 
@@ -300,6 +359,15 @@ export const MinimumWindow: Story = {
  */
 export const EnginesNeedSetup: Story = {
   args: { doctor: harnessDoctorDegraded },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await page.findByRole("button", { name: /^Harness:/ }),
+    );
+    const menu = await page.findByRole("menu");
+    await expect(within(menu).getByText("Coding harnesses…")).toBeVisible();
+    await expect(menu.getBoundingClientRect().top).toBeGreaterThanOrEqual(0);
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

The code workspace's resize handle collapsed both panels to zero width, so
every horizontal `ResizablePanelGroup` on the page rendered empty. Opening
the review sidebar blanked the journal, composer, and center tabs; the
editor split blanked both editor panes. That is the failure #2786 reports,
and it reproduces on `main` at a full 1280x800 desktop, not only at narrow
widths.

`react-resizable-panels` labels a separator by its own axis, not its group's:
a horizontal group is split by a separator reporting
`aria-orientation="vertical"`. The handle keyed its full-width bar off that
word, so it claimed the whole row and left the panels beside it nothing.

## What changed

- `resizable.tsx`: key the handle's full-width bar off
  `aria-orientation=horizontal`, with a comment on why the matching word is
  the wrong one. Export the class string so a unit test can pin the mapping.
- `inspectorLayout.ts`: add `MIN_WORKSPACE_WIDTH_PX` and
  `fitsInspectorSplit`. The bounds are percentages, so a narrow pane shrinks
  the workspace and the inspector together and no drag wins the journal its
  floor back. Below the derived pane width the inspector stands down.
- `CodeWorkspacePage.tsx`: measure the pane that carries the split and hide
  the inspector when it cannot hold one. The stored preference survives, so
  widening the window brings it back. Drop the inspector recovery effect —
  the sanitizer runs before the group mounts, so the layout the effect read
  was always valid and the branch never fired.
- `WorkspaceHeader.tsx`: when the pane is too narrow, the review control
  dims and its tooltip points at the Source control and Pull request center
  tabs instead.
- `NewWorkspaceDialog.tsx` (#2777): the form scrolls rather than letting a
  short window clip the wrapped Create row. The sizing PR #2780 shipped is
  unchanged; its Storybook checks asserted 800px wide and 200px tall, which
  a 14px root font size never reaches, so they are now measured against the
  interface's own rem (`max-w-4xl`, `sm:min-h-52`).

## Storybook

New states, all with play assertions that the tab strip does not scroll
sideways, the journal clears its floor, and the inspector stays inside
`MAX_INSPECTOR_SIZE`:

- `RestoredInspectorSplit` — a valid saved 60/40 split comes back exactly.
- `SourceControlTabWithReview`, `PullRequestTabWithReview` — a review center
  tab beside the inspector, which no story covered before.
- `MinimumWindowWithReview` — the inspector stands down at 720x480, the
  journal takes the pane, and the header control reports why.
- `RepoPicker`, `ModelPicker`, `BaseRefPicker`, and an opened engine menu on
  `EnginesNeedSetup` — the composer's picker states (#2777).

Inspector stories now pin the desktop viewport instead of inheriting the
canvas.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome format src` — no fixes
- `pnpm --dir crates/tidebreak-desktop/ui lint` — no fixes
- `npx tsc --noEmit` — clean
- `pnpm --dir crates/tidebreak-desktop/ui test` — 248 files, 2127 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — completed

Screenshots captured through headless Chromium against a local Storybook and
inspected: the review split, restored split, rejected stored layout, Source
control and Pull request beside the inspector, the minimum window, the split
editor pane, and the four composer picker states, in light and dark. Before
and after shots confirm the blank pane and its fix.

Closes #2786
Closes #2777
