### PR TITLE
fix(dev): stage sidecars before Tauri startup

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -18,6 +18,7 @@ desktop_dir="$repo_root/crates/tidebreak-desktop"
 ui_dir="$desktop_dir/ui"
 
 missing=()
+command -v node >/dev/null || missing+=("Node.js — https://nodejs.org/")
 command -v pnpm >/dev/null || missing+=("pnpm — https://pnpm.io/installation")
 cargo tauri --version >/dev/null 2>&1 ||
   missing+=("Tauri CLI 2 — cargo install tauri-cli --version \"^2\"")
@@ -28,11 +29,40 @@ if ((${#missing[@]})); then
   exit 1
 fi
 
+assert_dev_port_available() {
+  command -v lsof >/dev/null || return 0
+  local dev_server_pids
+  dev_server_pids="$(lsof -nP -iTCP:1420 -sTCP:LISTEN -t 2>/dev/null | paste -sd, - || true)"
+  [[ -z "$dev_server_pids" ]] || {
+    echo "Tidebreak's dev port 1420 is already in use by PID(s): $dev_server_pids" >&2
+    echo "Stop the existing dev server, then run scripts/dev.sh again." >&2
+    return 1
+  }
+}
+
+assert_dev_port_available
+
 echo "==> Installing UI dependencies"
 pnpm --dir "$ui_dir" install
 
+echo "==> Preparing desktop sidecars"
+# Resolve the same target directory that Cargo will use. This matters when a
+# local Cargo wrapper assigns one target directory per worktree.
+cargo_metadata="$(
+  cd "$repo_root"
+  cargo metadata --format-version 1 --no-deps
+)"
+cargo_target_dir="$(
+  printf '%s' "$cargo_metadata" |
+    node -e 'process.stdout.write(JSON.parse(require("node:fs").readFileSync(0, "utf8")).target_directory)'
+)"
+export CARGO_TARGET_DIR="$cargo_target_dir"
+node "$desktop_dir/scripts/prepare-sidecar.mjs"
+
 echo "==> Starting the desktop app"
-# tauri.conf.json lives here, and its before-dev hook stages the broker sidecar
-# and starts Vite.
+# Keep sidecar compilation outside Tauri's frontend wait loop. Direct
+# `cargo tauri dev` still uses the repository's standard preparation hook.
+assert_dev_port_available
+dev_config='{"build":{"beforeDevCommand":{"script":"pnpm dev","cwd":"ui"}}}'
 cd "$desktop_dir"
-exec cargo tauri dev "$@"
+exec cargo tauri dev --config "$dev_config" "$@"

--- a/scripts/dev.test.mjs
+++ b/scripts/dev.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const devScript = join(repositoryRoot, "scripts", "dev.sh");
+function writeExecutable(path, source) {
+  writeFileSync(path, source);
+  chmodSync(path, 0o755);
+}
+
+function fakeTools() {
+  const root = mkdtempSync(join(tmpdir(), "tidebreak-dev-test-"));
+  const bin = join(root, "bin");
+  const log = join(root, "calls.log");
+  const preparedMarker = join(root, "sidecars-prepared");
+  const target = join(root, "target");
+  writeFileSync(log, "");
+  mkdirSync(bin);
+
+  writeExecutable(
+    join(bin, "cargo"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'cargo|%s|%s\n' "$*" "\${CARGO_TARGET_DIR-}" >> "$FAKE_LOG"
+if [[ "\${1-}" == "metadata" ]]; then
+  printf '{"target_directory":"%s"}\n' "$FAKE_TARGET_DIR"
+fi
+`,
+  );
+  writeExecutable(
+    join(bin, "pnpm"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'pnpm|%s\n' "$*" >> "$FAKE_LOG"
+`,
+  );
+  writeExecutable(
+    join(bin, "node"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'node|%s\n' "$*" >> "$FAKE_LOG"
+if [[ "\${1-}" == "-e" ]]; then
+  cat >/dev/null
+  printf '%s' "$FAKE_TARGET_DIR"
+else
+  touch "$FAKE_PREPARED_MARKER"
+fi
+`,
+  );
+  writeExecutable(
+    join(bin, "lsof"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ -n "\${FAKE_DEV_SERVER_PID-}" ]]; then
+  printf '%s\n' "$FAKE_DEV_SERVER_PID"
+  exit 0
+fi
+if [[ -n "\${FAKE_DEV_SERVER_PID_AFTER_PREP-}" && -e "$FAKE_PREPARED_MARKER" ]]; then
+  printf '%s\n' "$FAKE_DEV_SERVER_PID_AFTER_PREP"
+  exit 0
+fi
+exit 1
+`,
+  );
+
+  return {
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    env: {
+      ...process.env,
+      FAKE_LOG: log,
+      FAKE_PREPARED_MARKER: preparedMarker,
+      FAKE_TARGET_DIR: target,
+      PATH: `${bin}:/usr/bin:/bin`,
+    },
+    log,
+    target,
+  };
+}
+
+test("scripts/dev.sh prepares sidecars before Tauri starts", () => {
+  const tools = fakeTools();
+  try {
+    const result = spawnSync("bash", [devScript, "--no-watch"], {
+      encoding: "utf8",
+      env: tools.env,
+    });
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const calls = readFileSync(tools.log, "utf8").trim().split("\n");
+    const install = calls.findIndex((call) => call.startsWith("pnpm|"));
+    const prepare = calls.findIndex((call) =>
+      call.includes("prepare-sidecar.mjs"),
+    );
+    const tauri = calls.findIndex((call) => call.startsWith("cargo|tauri dev"));
+
+    assert.ok(install >= 0, calls.join("\n"));
+    assert.ok(prepare > install, calls.join("\n"));
+    assert.ok(tauri > prepare, calls.join("\n"));
+    assert.match(calls[tauri], /--config .*beforeDevCommand.*pnpm dev/);
+    assert.match(calls[tauri], /--no-watch/);
+    assert.match(calls[tauri], new RegExp(`\\|${tools.target}$`));
+  } finally {
+    tools.cleanup();
+  }
+});
+
+test("scripts/dev.sh stops before building when port 1420 is busy", () => {
+  const tools = fakeTools();
+  try {
+    const result = spawnSync("bash", [devScript], {
+      encoding: "utf8",
+      env: { ...tools.env, FAKE_DEV_SERVER_PID: "4242" },
+    });
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /dev port 1420 is already in use by PID\(s\): 4242/,
+    );
+    assert.doesNotMatch(readFileSync(tools.log, "utf8"), /pnpm|metadata/);
+  } finally {
+    tools.cleanup();
+  }
+});
+
+test("scripts/dev.sh rechecks port 1420 after preparing sidecars", () => {
+  const tools = fakeTools();
+  try {
+    const result = spawnSync("bash", [devScript], {
+      encoding: "utf8",
+      env: { ...tools.env, FAKE_DEV_SERVER_PID_AFTER_PREP: "4343" },
+    });
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /dev port 1420 is already in use by PID\(s\): 4343/,
+    );
+    const calls = readFileSync(tools.log, "utf8");
+    assert.match(calls, /prepare-sidecar\.mjs/);
+    assert.doesNotMatch(calls, /cargo\|tauri dev/);
+  } finally {
+    tools.cleanup();
+  }
+});


### PR DESCRIPTION
## What changed

- Stage the host broker and Tidebreak CLI sidecars before Tauri starts its frontend wait loop.
- Reuse those prepared sidecars inside `beforeDevCommand` so Cargo lock contention cannot surface as a Vite lifecycle failure.
- Stop duplicate launches before installation or after sidecar preparation when port 1420 becomes occupied.
- Resolve Cargo’s effective target directory so worktree-specific target wrappers remain supported.

## Validation

- `node --test scripts/dev.test.mjs scripts/workflow-security.test.mjs` — 48 tests passed.
- `shellcheck scripts/dev.sh`
- `bash -n scripts/dev.sh`
- `node --check crates/tidebreak-desktop/scripts/prepare-sidecar.mjs`
- `git diff --check`
- Real startup reached sidecar completion; a concurrent main-checkout launch then claimed port 1420, and the new guard reported its PID without entering Tauri.

## Compatibility and risk

No persisted data, wire format, or packaged release behavior changes. Direct `cargo tauri dev` still prepares sidecars through the existing hook.