### PR TITLE
fix(code): keep PR state writes behind the fetch-state validator

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -35,10 +35,12 @@ import {
   codeDeliverySearchFrom,
 } from "./CodeDeliveryPage";
 import { useCodeDeliveryStore } from "./CodeDeliveryStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 
 afterEach(() => {
   cleanup();
   useCodeDeliveryStore.getState().reset();
+  useCodeUpdatesStore.getState().reset();
 });
 
 vi.mock("@/openInBrowser", () => ({ openInBrowser: vi.fn() }));
@@ -157,6 +159,31 @@ async function rowFor(title: string): Promise<HTMLElement> {
 }
 
 describe("delivery pull request list", () => {
+  it("re-reads when the server nudges the delivery channel", async () => {
+    // The server says when the pull-request store moved (decision 66). The
+    // list is a projection of that nudge, not a clock of its own: without
+    // the subscription a fix turn's result waits for the reader to press
+    // Refresh (issue 2799).
+    const queryCodeDeliveryPullRequests = vi.fn(async () => ({
+      capability: deliveryRepositoriesSnapshot.capability,
+      items: deliveryPullRequests,
+      errors: [],
+      fetched_at: "2026-08-20T15:20:00.000Z",
+    }));
+    renderList({
+      ...storyClient(),
+      queryCodeDeliveryPullRequests,
+    } as unknown as ApiClient);
+
+    await waitFor(() =>
+      expect(queryCodeDeliveryPullRequests).toHaveBeenCalledTimes(1),
+    );
+    useCodeUpdatesStore.getState().apply({ type: "delivery" });
+    await waitFor(() =>
+      expect(queryCodeDeliveryPullRequests).toHaveBeenCalledTimes(2),
+    );
+  });
+
   it("opens repository-scoped trigger rules from the production dialog", async () => {
     const user = userEvent.setup();
     const listCodeTriggers = vi.fn(async () => []);

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -86,6 +86,7 @@ import {
   type CodeDeliverySurface,
 } from "./CodeDeliveryStore";
 import { CodeSidebar } from "./CodeSidebar";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { RepositoryTriggerRules } from "./RepositoryTriggerRules";
 import { GithubAvatar } from "./GithubAvatar";
 import {
@@ -828,6 +829,13 @@ function PullRequestsSurface({
   const [targetDetailState, setTargetDetailState] =
     useState<TargetDetailState<CodeDeliveryPullRequestDetail> | null>(null);
   const [revision, setRevision] = useState(0);
+  // The server nudges `delivery` whenever the pull-request store moves
+  // (decision 66). This list is a projection of that nudge, not a clock of
+  // its own: a fix turn, a watch, or another window's action reaches the
+  // page through the broadcast rather than waiting for a Refresh.
+  const deliveryRevision = useCodeUpdatesStore(
+    (state) => state.deliveryRevision,
+  );
   // Set by Refresh and by a completed action; consumed by the next query that
   // actually runs. Only those two reach past the server's short list cache —
   // a filter change reruns against it, which is the whole point of caching a
@@ -1048,7 +1056,14 @@ function PullRequestsSurface({
       generation.current += 1;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, selectedRepositories, filters, revision, targetKey]);
+  }, [
+    client,
+    selectedRepositories,
+    filters,
+    revision,
+    deliveryRevision,
+    targetKey,
+  ]);
 
   if (loadingRepositories) return <DeliveryListSkeleton />;
   if (!repositoryLoaded && repositoryError) {

--- a/crates/tidebreak-server/src/code/pr_facts.rs
+++ b/crates/tidebreak-server/src/code/pr_facts.rs
@@ -73,11 +73,17 @@ struct PushAct {
 /// Never returns an error and never touches the turn: every failure is a
 /// debug log. Runs after the turn's terminal event is journaled, so the
 /// tail walk finds the whole turn above its `TurnStarted` marker.
+///
+/// A confirmed act marks the workspace hot (issue 2799). The agent's own
+/// push moves the head the watch assesses, and nothing else dirties the row
+/// for it: without the mark the next assessment reads a pre-push head, calls
+/// its own fix turn a repeat, and parks the watch.
 pub(crate) async fn sweep_turn_for_pull_request_acts(
     db: &DbStore,
     session: &CodeSession,
     turn_id: CodeTurnId,
     gh_search_path: Option<&str>,
+    hot: Option<&super::pr_refresh::HotPullRequests>,
 ) {
     let events =
         match list_recent_events(db, &session.owner, session.id, DETECTOR_EVENT_WINDOW).await {
@@ -148,6 +154,7 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
     recorded.sort_by_key(|(_, command)| command.seq);
 
     let mut confirms = 0usize;
+    let mut confirmed_any = false;
     let mut seen_creates: HashSet<String> = HashSet::new();
     let mut seen_pushes: HashSet<String> = HashSet::new();
     let mut pushes: Vec<(RecordedCommand, PushAct)> = Vec::new();
@@ -179,7 +186,7 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
                     continue;
                 }
                 confirms += 1;
-                confirm_create(
+                confirmed_any |= confirm_create(
                     db,
                     session,
                     &command,
@@ -217,11 +224,23 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
             break;
         }
         confirms += 1;
-        confirm_push(db, session, &command, &push, gh_search_path).await;
+        confirmed_any |= confirm_push(db, session, &command, &push, gh_search_path).await;
+    }
+
+    // The turn moved this workspace's pull request. Nothing else marks it:
+    // route mutations dirty the row for the user's own actions, and the
+    // agent's push is neither. Left unmarked, the watch's next assessment
+    // reads the head from before the fix turn pushed (issue 2799).
+    if confirmed_any {
+        if let Some(hot) = hot {
+            hot.mark(&session.owner, session.workspace_id);
+        }
     }
 }
 
 /// Confirm one `gh pr create` against the host and mint an authored fact.
+///
+/// Reports whether a fact landed, so the caller can mark the workspace hot.
 async fn confirm_create(
     db: &DbStore,
     session: &CodeSession,
@@ -229,13 +248,13 @@ async fn confirm_create(
     create: &CreateAct,
     preview: Option<&str>,
     gh_search_path: Option<&str>,
-) {
+) -> bool {
     let sniffed = preview.and_then(sniff_pull_request_url);
     let target = match resolve_create_target(create, sniffed.as_ref(), &command.cwd).await {
         Some(target) => target,
         None => {
             debug!("pr fact detector could not resolve a repository for a create");
-            return;
+            return false;
         }
     };
     let value = if let Some((_, number)) = &sniffed {
@@ -261,7 +280,7 @@ async fn confirm_create(
         };
         let Some(head) = head else {
             debug!("pr fact detector could not resolve the created head branch");
-            return;
+            return false;
         };
         match list_pull_requests_for_head_raw(
             &target.host,
@@ -279,7 +298,7 @@ async fn confirm_create(
             }
         }
     };
-    let Some(value) = value else { return };
+    let Some(value) = value else { return false };
     record_confirmed_fact(
         db,
         &session.owner,
@@ -291,18 +310,21 @@ async fn confirm_create(
         CodePullRequestRelation::Authored,
         CodePullRequestDiscovery::Command,
     )
-    .await;
+    .await
+    .is_some()
 }
 
 /// Confirm one `git push` against the host and mint a contributed fact when
 /// the pushed branch is a pull request's head.
+///
+/// Reports whether a fact landed, so the caller can mark the workspace hot.
 async fn confirm_push(
     db: &DbStore,
     session: &CodeSession,
     command: &RecordedCommand,
     push: &PushAct,
     gh_search_path: Option<&str>,
-) {
+) -> bool {
     let cwd = push
         .cwd_override
         .clone()
@@ -312,7 +334,7 @@ async fn confirm_push(
         Some(target) => target,
         None => {
             debug!("pr fact detector could not resolve a repository for a push");
-            return;
+            return false;
         }
     };
     let branch = match &push.branch {
@@ -321,7 +343,7 @@ async fn confirm_push(
     };
     let Some(branch) = branch else {
         debug!("pr fact detector could not resolve the pushed branch");
-        return;
+        return false;
     };
     let values = match list_pull_requests_for_head_raw(
         &target.host,
@@ -335,7 +357,7 @@ async fn confirm_push(
         Ok(values) => values,
         Err(err) => {
             debug!("pr fact detector could not list pull requests for a push: {err}");
-            return;
+            return false;
         }
     };
     let matching: Vec<Value> = values
@@ -357,7 +379,7 @@ async fn confirm_push(
         Some(value) => Some(value.clone()),
         None => newest_by_created(matching),
     };
-    let Some(value) = value else { return };
+    let Some(value) = value else { return false };
     record_confirmed_fact(
         db,
         &session.owner,
@@ -369,7 +391,8 @@ async fn confirm_push(
         CodePullRequestRelation::Contributed,
         CodePullRequestDiscovery::Command,
     )
-    .await;
+    .await
+    .is_some()
 }
 
 /// Write one confirmed observation: upsert the fact, claim the attribution,

--- a/crates/tidebreak-server/src/code/pr_refresh.rs
+++ b/crates/tidebreak-server/src/code/pr_refresh.rs
@@ -8,16 +8,48 @@
 //! unconditional one: the request path reads the stored row, and this
 //! sweep is what keeps the row current while anyone watches.
 
-use std::sync::{Arc, Weak};
-use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, Weak};
+use std::time::{Duration, Instant};
 
 use tidebreak_core::db::code::list_active_watches_all_owners;
+use tidebreak_core::{OwnerId, WorkspaceId};
 
 use super::runtime::CodeRuntime;
 
 /// Coprime with the 47s watch, 53s trigger, and 61s reconcile sweeps, so
 /// the four background readers never land on the same tick.
 pub(crate) const HOT_REFRESH_INTERVAL: Duration = Duration::from_secs(17);
+
+/// How long one mark keeps a workspace on the hot tier.
+const HOT_WINDOW: Duration = Duration::from_secs(120);
+
+/// The workspaces on the hot tier, with the owner each belongs to.
+///
+/// Held by handle rather than owned outright, so a writer that has no
+/// runtime can still mark a workspace: the post-turn fact detector is the
+/// one that knows the agent just pushed, and a row nobody marks stays on
+/// its pre-push head until a route mutation or the reconcile sweep moves it.
+#[derive(Clone, Default)]
+pub(crate) struct HotPullRequests(Arc<Mutex<HashMap<WorkspaceId, (OwnerId, Instant)>>>);
+
+impl HotPullRequests {
+    /// Keep this workspace on the hot tier for [`HOT_WINDOW`].
+    pub(crate) fn mark(&self, owner: &OwnerId, id: WorkspaceId) {
+        let mut hot = self.0.lock().expect("hot prs");
+        hot.retain(|_, (_, marked)| marked.elapsed() <= HOT_WINDOW);
+        hot.insert(id, (owner.clone(), Instant::now()));
+    }
+
+    /// The workspaces still inside their window.
+    pub(crate) fn live(&self) -> Vec<(OwnerId, WorkspaceId)> {
+        let mut hot = self.0.lock().expect("hot prs");
+        hot.retain(|_, (_, marked)| marked.elapsed() <= HOT_WINDOW);
+        hot.iter()
+            .map(|(id, (owner, _))| (owner.clone(), *id))
+            .collect()
+    }
+}
 
 /// Abort the hot refresher when the runtime is dropped. The loop holds a
 /// [`Weak`] handle for the same reason every sweep does: an `Arc` would

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -1021,6 +1021,7 @@ mod tests {
             session.subagents.clone(),
             None,
             None,
+            crate::code::pr_refresh::HotPullRequests::default(),
         );
         let private_root = _dir.path().join("private");
         std::fs::create_dir(&private_root).unwrap();

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -207,8 +207,9 @@ pub(crate) struct CodeRuntime {
     /// sibling's turn starts after this one ends. See record 55.
     worktree_turns: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
     /// Workspaces whose digest was requested recently, with the owner each
-    /// belongs to: the hot tier the refresher walks (decision 66).
-    hot_prs: Mutex<HashMap<WorkspaceId, (OwnerId, Instant)>>,
+    /// belongs to: the hot tier the refresher walks (decision 66). Shared by
+    /// handle so the post-turn fact detector marks its own pushes hot.
+    hot_prs: super::pr_refresh::HotPullRequests,
     /// Per-owner delivery nudge debounce, including one pending trailing edge.
     delivery_nudges: DeliveryNudgeDebounce,
     /// Paces and parks every conditional GitHub read (decision 66).
@@ -258,11 +259,6 @@ pub(crate) struct CodeRuntime {
 /// How long one base branch's rules answer stands before the next read.
 /// Rules change on the order of releases, not pushes.
 const BRANCH_RULES_TTL: Duration = Duration::from_secs(3600);
-
-/// How long one digest request keeps a workspace on the hot refresh tier
-/// (decision 66). The UI asks again while a workspace stays open, so the
-/// window only needs to outlive its poll spacing with room to spare.
-const HOT_WINDOW: Duration = Duration::from_secs(120);
 
 /// Floor between two delivery nudges to one owner (decision 66): a sweep
 /// updating many rows collapses to one re-read on the other side.
@@ -443,7 +439,7 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             workspace_lifecycles: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
-            hot_prs: Mutex::new(HashMap::new()),
+            hot_prs: super::pr_refresh::HotPullRequests::default(),
             delivery_nudges: DeliveryNudgeDebounce::default(),
             host_gate: super::pr_fetch::HostGate::default(),
             branch_rules: Mutex::new(HashMap::new()),
@@ -576,7 +572,7 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             workspace_lifecycles: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
-            hot_prs: Mutex::new(HashMap::new()),
+            hot_prs: super::pr_refresh::HotPullRequests::default(),
             delivery_nudges: DeliveryNudgeDebounce::default(),
             host_gate: super::pr_fetch::HostGate::default(),
             branch_rules: Mutex::new(HashMap::new()),
@@ -2145,11 +2141,16 @@ impl CodeRuntime {
         }
     }
 
-    /// Keep this workspace on the hot refresh tier for [`HOT_WINDOW`].
+    /// Keep this workspace on the hot refresh tier.
     fn mark_workspace_pr_hot(&self, owner: &OwnerId, id: WorkspaceId) {
-        let mut hot = self.hot_prs.lock().expect("hot prs");
-        hot.retain(|_, (_, marked)| marked.elapsed() <= HOT_WINDOW);
-        hot.insert(id, (owner.clone(), Instant::now()));
+        self.hot_prs.mark(owner, id);
+    }
+
+    /// The hot tier itself, for a writer that outlives no runtime reference:
+    /// the post-turn fact detector marks the workspace whose head it just
+    /// watched move (issue 2799).
+    pub(super) fn hot_pull_requests(&self) -> super::pr_refresh::HotPullRequests {
+        self.hot_prs.clone()
     }
 
     /// One delivery nudge on the updates channel, debounced per owner
@@ -2161,11 +2162,7 @@ impl CodeRuntime {
 
     /// The workspaces the hot refresher walks this tick.
     pub(super) fn hot_pull_request_workspaces(&self) -> Vec<(OwnerId, WorkspaceId)> {
-        let mut hot = self.hot_prs.lock().expect("hot prs");
-        hot.retain(|_, (_, marked)| marked.elapsed() <= HOT_WINDOW);
-        hot.iter()
-            .map(|(id, (owner, _))| (owner.clone(), *id))
-            .collect()
+        self.hot_prs.live()
     }
 
     /// Start the hot pull-request refresher once (decision 66).
@@ -2211,7 +2208,8 @@ impl CodeRuntime {
     /// row's stored ETag: a 304 answers from the row for free, and a 200
     /// carries new state. The result lands on the row — live tier, fanout,
     /// and the ETags for next time. `None` leaves the caller's persisted
-    /// digest standing: no pull request, a parked host, or a failed read.
+    /// digest standing: no pull request, a parked host, a failed read, or a
+    /// conditional read whose row moved under it.
     async fn fetched_workspace_digest(
         &self,
         owner: &OwnerId,
@@ -2416,9 +2414,14 @@ impl CodeRuntime {
         };
 
         let digest = pr_fetch::digest_from_parts(&pull, &checks, review_decision, in_merge_queue);
-        self.record_pull_request_live_state(owner, Some(workspace.id), &digest)
-            .await;
-        if let Err(err) = tidebreak_core::db::code::set_pull_request_fetch_state(
+        // The validator gates every write this read produces, not just the
+        // fetch state (issue 2799). A 304 reconstructs its digest from the
+        // stored snapshot, so a row that moved under the read leaves that
+        // reconstruction describing a pull request that no longer exists.
+        // Write the transport hints first: if the row refuses them, the
+        // digest never reaches the live tier, the workspace column, or the
+        // caller's broadcast.
+        let accepted = match tidebreak_core::db::code::set_pull_request_fetch_state(
             &self.db,
             owner,
             &host,
@@ -2433,8 +2436,22 @@ impl CodeRuntime {
         )
         .await
         {
-            tracing::debug!(error = %err, "code-mode: fetch-state write failed");
+            Ok(accepted) => accepted,
+            Err(err) => {
+                tracing::debug!(error = %err, "code-mode: fetch-state write failed");
+                false
+            }
+        };
+        if !fresh_pull && !accepted {
+            tracing::debug!(
+                host = %host,
+                number = number,
+                "code-mode: a conditional pull-request read lost its validator; dropping it"
+            );
+            return None;
         }
+        self.record_pull_request_live_state(owner, Some(workspace.id), &digest)
+            .await;
         Some(digest)
     }
 
@@ -5154,6 +5171,7 @@ impl CodeRuntime {
             attached.subagents.clone(),
             self.gh_search_path_owned(),
             self.recap_hook(),
+            self.hot_pull_requests(),
         );
         let approval = self.approval_channel(
             &attached.owner,

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -256,6 +256,10 @@ pub(crate) struct LiveSink {
     /// Derives the turn's recap once it completes. `None` in headless
     /// deployments and tests that install none, which simply have no recaps.
     recap: Option<Arc<dyn super::recap::TurnRecap>>,
+    /// The runtime's hot pull-request tier (decision 66). A turn whose fact
+    /// detector confirms a push or a create marks this workspace, so the
+    /// next hot pass reads the head the turn just moved (issue 2799).
+    hot_prs: super::pr_refresh::HotPullRequests,
 }
 
 impl LiveSink {
@@ -1794,6 +1798,7 @@ async fn drive_turn_inner(
                 session,
                 turn.id,
                 sink.gh_search_path.as_deref(),
+                Some(&sink.hot_prs),
             )
             .await;
             if let Some(detail) = attachment_cleanup_error.as_ref() {
@@ -1846,6 +1851,7 @@ async fn drive_turn_inner(
         session,
         turn.id,
         sink.gh_search_path.as_deref(),
+        Some(&sink.hot_prs),
     )
     .await;
     if let Some(detail) = attachment_cleanup_error {
@@ -2214,6 +2220,7 @@ pub(crate) fn sink_for(
     subagents: Vec<CodeSubagentSummary>,
     gh_search_path: Option<String>,
     recap: Option<Arc<dyn super::recap::TurnRecap>>,
+    hot_prs: super::pr_refresh::HotPullRequests,
 ) -> Arc<LiveSink> {
     Arc::new(LiveSink {
         db,
@@ -2229,6 +2236,7 @@ pub(crate) fn sink_for(
         flushed_unrecognized: AtomicU64::new(0),
         subagents: std::sync::Mutex::new(subagents),
         recap,
+        hot_prs,
     })
 }
 
@@ -2877,6 +2885,7 @@ mod tests {
             Vec::new(),
             None,
             None,
+            crate::code::pr_refresh::HotPullRequests::default(),
         );
         (directory, store, sink, session_id)
     }
@@ -3153,6 +3162,7 @@ mod tests {
             attached.subagents,
             None,
             None,
+            crate::code::pr_refresh::HotPullRequests::default(),
         );
         sink.emit(HarnessEvent::SessionStarted {
             harness_kind: HarnessKind::Codex,
@@ -3613,6 +3623,7 @@ mod tests {
             Vec::new(),
             None,
             None,
+            crate::code::pr_refresh::HotPullRequests::default(),
         );
         // The relay's refusals already name the gateway; "sign in in your
         // own terminal" would be wrong on a hosted machine.

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -807,10 +807,11 @@ async fn watch_submission_was_accepted(
         .any(|turn| turn.started_at >= reserved_at))
 }
 
-/// The workspace's stored pull-request digest, when the fact row behind it
-/// confirms the live tier is fresh (decision 66). `None` sends the caller to
-/// a host read: no stored digest, no joinable URL, no fact row, or a tier
-/// older than the reconcile cadence promises.
+/// The workspace's pull request as its fact row holds it, when that row's
+/// live tier is fresh (decision 66). The workspace column supplies the
+/// identity to join on. `None` sends the caller to a host read: no stored
+/// digest, no joinable URL, no fact row, or a tier older than the reconcile
+/// cadence promises.
 async fn fresh_stored_digest(
     runtime: &CodeRuntime,
     owner: &OwnerId,
@@ -833,19 +834,34 @@ async fn fresh_stored_digest(
     fresh_workspace_digest(stored, &fact, Utc::now())
 }
 
-/// Return the workspace's write-through digest when the fact row confirms
-/// that its live tier is fresh.
+/// Return the digest the fact row's live tier certifies, when that tier is
+/// fresh.
 ///
-/// The hot refresher can observe a merge before the slower reconcile pass
-/// updates the fact snapshot. Rebuilding from that snapshot would reopen the
-/// pull request for the watch until the next reconcile tick.
+/// The certificate and the fields it certifies must come from the same row
+/// (issue 2799). `observed_at` says when the fact row's live tier was
+/// written; the workspace column is a second row whose write can be dropped
+/// on its own, so reading checks, mergeability, and the head off the column
+/// dates one row's staleness by another row's clock.
+///
+/// A terminal state the column already holds still wins. The snapshot tier
+/// moves on its own writes, and reopening a merged pull request for the
+/// watch would cost a fix turn against a head nobody can push.
 fn fresh_workspace_digest(
     stored: &PullRequestDigest,
     fact: &tidebreak_core::CodePullRequestFact,
     now: chrono::DateTime<Utc>,
 ) -> Option<PullRequestDigest> {
     let live = fact.live.as_ref()?;
-    super::reconcile::live_tier_is_fresh(live, now).then(|| stored.clone())
+    if !super::reconcile::live_tier_is_fresh(live, now) {
+        return None;
+    }
+    let mut digest = super::pr_facts::digest_from_fact(fact);
+    let stored_state = stored.state.trim().to_ascii_lowercase();
+    if stored.merged == Some(true) || stored_state == "merged" || stored_state == "closed" {
+        digest.state = stored.state.clone();
+        digest.merged = stored.merged;
+    }
+    Some(digest)
 }
 
 /// Clear only the `NeedsYou` marker that this watch's previous blocked state
@@ -1026,6 +1042,55 @@ mod tests {
         };
 
         assert_eq!(fresh_workspace_digest(&stored, &fact, now), Some(stored));
+    }
+
+    #[test]
+    fn fresh_workspace_digest_reads_the_row_that_dates_it() {
+        // The workspace column and the fact row are two rows with two
+        // writes. When the column's write is dropped, `observed_at` still
+        // says the pull request was read a second ago — of the fact row.
+        // Assessing the column against that certificate judges a head the
+        // agent has already pushed past (issue 2799).
+        let now = Utc::now();
+        let mut stored = base_pr();
+        stored.head_sha = Some("stale".to_owned());
+        stored.checks = None;
+        stored.merge_state_status = Some("clean".to_owned());
+        let mut observed = base_pr();
+        observed.head_sha = Some("pushed".to_owned());
+        observed.checks = Some(vec![check(PullRequestCheckBucket::Fail)]);
+        observed.merge_state_status = Some("blocked".to_owned());
+        let fact = CodePullRequestFact {
+            id: CodePullRequestId::new(),
+            owner: OwnerId::local(),
+            host: "github.com".to_owned(),
+            repo_owner: "example".to_owned(),
+            repo_name: "demo".to_owned(),
+            number: observed.number,
+            url: observed.url.clone().unwrap(),
+            title: observed.title.clone().unwrap(),
+            state: CodePullRequestState::Open,
+            draft: false,
+            author: None,
+            head_branch: "feature".to_owned(),
+            base_branch: "main".to_owned(),
+            head_sha: observed.head_sha.clone(),
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            closed_at: None,
+            first_seen_at: now,
+            last_seen_at: now,
+            live: Some(CodePullRequestLiveState::from_digest(&observed, now)),
+        };
+
+        let digest = fresh_workspace_digest(&stored, &fact, now).expect("the tier is fresh");
+        assert_eq!(digest.head_sha.as_deref(), Some("pushed"));
+        assert_eq!(digest.merge_state_status.as_deref(), Some("blocked"));
+        assert_eq!(
+            assess(&digest),
+            WatchAssessment::Actionable(WatchReason::FailingChecks)
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -1769,6 +1769,306 @@ async fn a_hosted_digest_reads_the_row_and_refreshes_conditionally() {
     );
 }
 
+/// A conditional read that loses its validator writes nothing (issue 2799).
+///
+/// Two refreshes overlap: this one sends the ETag the row held when it
+/// started, and a fresher 200 lands on the row while the request is in
+/// flight. The 304 comes back and rebuilds a digest from the snapshot it
+/// read before that write — a pull request that no longer exists. Decision
+/// 66's validator already refuses the fetch-state write; the live tier, the
+/// workspace column, and the caller's broadcast must refuse it too, or the
+/// state every surface renders is the one the row rejected.
+#[tokio::test]
+async fn a_conditional_read_that_lost_its_validator_writes_nothing() {
+    use tidebreak_core::db::code::{
+        get_pull_request_fact, save_pull_request_fact, set_active_workspace_pull_request,
+        set_pull_request_fetch_state, set_pull_request_live_state, PullRequestFetchCondition,
+    };
+    use tidebreak_core::{
+        CodePullRequestFact, CodePullRequestId, CodePullRequestLiveState, CodePullRequestState,
+        DbStore, PullRequestDigest,
+    };
+
+    /// Where the overlapping fetch writes, once the runtime exists.
+    type Competing = Arc<std::sync::Mutex<Option<(Arc<DbStore>, tidebreak_core::WorkspaceId)>>>;
+
+    let competing: Competing = Arc::default();
+    let pull_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let pull_competing = Arc::clone(&competing);
+    let pull_seen = Arc::clone(&pull_calls);
+    let pull = move |headers: axum::http::HeaderMap| {
+        let competing = Arc::clone(&pull_competing);
+        let calls = Arc::clone(&pull_seen);
+        async move {
+            let conditional = headers
+                .get(axum::http::header::IF_NONE_MATCH)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned);
+            let unchanged = conditional.as_deref() == Some("W/\"pull-1\"");
+            let armed = competing
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            if let (true, Some((db, workspace_id))) = (unchanged, armed) {
+                // The fresher fetch wins the row while this request is still
+                // open: new snapshot, new live tier, new column, new ETag.
+                let owner = tidebreak_core::OwnerId::local();
+                let now = chrono::Utc::now();
+                let winner = PullRequestDigest {
+                    number: 12,
+                    url: Some("https://github.com/acme/demo/pull/12".to_owned()),
+                    state: "open".to_owned(),
+                    title: Some("Newer hosted change".to_owned()),
+                    checks_summary: Some("2 passing, 0 pending, 0 failing".to_owned()),
+                    checks: None,
+                    draft: Some(false),
+                    merged: Some(false),
+                    review_decision: None,
+                    mergeable: Some("mergeable".to_owned()),
+                    merge_state_status: Some("clean".to_owned()),
+                    head_branch: Some("feature".to_owned()),
+                    base_branch: Some("main".to_owned()),
+                    head_sha: Some("cafecafecafecafecafe".to_owned()),
+                    auto_merge_enabled: Some(false),
+                    in_merge_queue: Some(false),
+                };
+                let fact = CodePullRequestFact {
+                    id: CodePullRequestId::new(),
+                    owner: owner.clone(),
+                    host: "github.com".into(),
+                    repo_owner: "acme".into(),
+                    repo_name: "demo".into(),
+                    number: 12,
+                    url: "https://github.com/acme/demo/pull/12".into(),
+                    title: "Newer hosted change".into(),
+                    state: CodePullRequestState::Open,
+                    draft: false,
+                    author: None,
+                    head_branch: "feature".into(),
+                    base_branch: "main".into(),
+                    head_sha: Some("cafecafecafecafecafe".into()),
+                    created_at: now,
+                    updated_at: now,
+                    merged_at: None,
+                    closed_at: None,
+                    first_seen_at: now,
+                    last_seen_at: now,
+                    live: None,
+                };
+                set_pull_request_fetch_state(
+                    &db,
+                    &owner,
+                    "github.com",
+                    "acme",
+                    "demo",
+                    12,
+                    Some(&fact),
+                    PullRequestFetchCondition::Unconditional,
+                    Some("W/\"pull-2\""),
+                    Some("W/\"checks-1\""),
+                    Some("W/\"reviews-1\""),
+                )
+                .await
+                .unwrap();
+                set_pull_request_live_state(
+                    &db,
+                    &owner,
+                    "github.com",
+                    "acme",
+                    "demo",
+                    12,
+                    &CodePullRequestLiveState::from_digest(&winner, now),
+                )
+                .await
+                .unwrap();
+                set_active_workspace_pull_request(&db, &owner, workspace_id, &winner)
+                    .await
+                    .unwrap();
+            }
+            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            axum::http::Response::builder()
+                .status(if unchanged { 304 } else { 200 })
+                .header("etag", "W/\"pull-1\"")
+                .body(axum::body::Body::from(if unchanged {
+                    String::new()
+                } else {
+                    serde_json::json!({
+                        "number": 12,
+                        "html_url": "https://github.com/acme/demo/pull/12",
+                        "title": "Hosted change",
+                        "state": "open",
+                        "draft": false,
+                        "mergeable": true,
+                        "mergeable_state": "clean",
+                        "head": { "ref": "feature", "sha": "feedfeedfeedfeedfeed" },
+                        "base": { "ref": "main" },
+                        "auto_merge": null,
+                    })
+                    .to_string()
+                }))
+                .unwrap()
+        }
+    };
+    let answer = |headers: axum::http::HeaderMap, etag: &'static str, body: String| {
+        let conditional = headers
+            .get(axum::http::header::IF_NONE_MATCH)
+            .and_then(|value| value.to_str().ok());
+        let unchanged = conditional == Some(etag);
+        axum::http::Response::builder()
+            .status(if unchanged { 304 } else { 200 })
+            .header("etag", etag)
+            .body(axum::body::Body::from(if unchanged {
+                String::new()
+            } else {
+                body
+            }))
+            .unwrap()
+    };
+    let checks = move |headers: axum::http::HeaderMap| async move {
+        answer(
+            headers,
+            "W/\"checks-1\"",
+            serde_json::json!({
+                "check_runs": [
+                    { "name": "lint", "status": "completed", "conclusion": "success",
+                      "html_url": "https://github.com/acme/demo/runs/1" },
+                ]
+            })
+            .to_string(),
+        )
+    };
+    let reviews = move |headers: axum::http::HeaderMap| async move {
+        answer(headers, "W/\"reviews-1\"", "[]".to_owned())
+    };
+    let timeline = || async { axum::Json(serde_json::json!([])) };
+    let forge = axum::Router::new()
+        .route("/repos/acme/demo/pulls/12", axum::routing::get(pull))
+        .route(
+            "/repos/acme/demo/commits/{sha}/check-runs",
+            axum::routing::get(checks),
+        )
+        .route(
+            "/repos/acme/demo/pulls/12/reviews",
+            axum::routing::get(reviews),
+        )
+        .route(
+            "/repos/acme/demo/issues/12/timeline",
+            axum::routing::get(timeline),
+        )
+        .fallback(|| async { axum::http::StatusCode::NOT_FOUND });
+    let api = serve(forge).await;
+
+    let lender = Arc::new(FakeLender::offering_person("mira-chen"));
+    let (router, token, runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    runtime.set_gh_search_path(Some("/path/with/no/gh".into()));
+    runtime.set_forge_api_base(Some(format!("http://{api}")));
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "interleaved digest").await;
+    let id = json_id(&workspace).to_owned();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+
+    let owner = tidebreak_core::OwnerId::local();
+    let workspace_id: tidebreak_core::WorkspaceId = id.parse().unwrap();
+    let now = chrono::Utc::now();
+    save_pull_request_fact(
+        &runtime.db,
+        &CodePullRequestFact {
+            id: CodePullRequestId::new(),
+            owner: owner.clone(),
+            host: "github.com".into(),
+            repo_owner: "acme".into(),
+            repo_name: "demo".into(),
+            number: 12,
+            url: "https://github.com/acme/demo/pull/12".into(),
+            title: "Stale hosted change".into(),
+            state: CodePullRequestState::Open,
+            draft: false,
+            author: None,
+            head_branch: "feature".into(),
+            base_branch: "main".into(),
+            head_sha: Some("deadbeefdeadbeefdead".into()),
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            closed_at: None,
+            first_seen_at: now,
+            last_seen_at: now,
+            live: None,
+        },
+    )
+    .await
+    .unwrap();
+    seed_workspace_pull_request(&runtime, &id, "https://github.com/acme/demo/pull/12", 12).await;
+
+    // The first refresh is unconditional: it stores `W/"pull-1"` and the
+    // snapshot the late 304 will later rebuild from.
+    runtime.refresh_workspace_pr_row(&owner, workspace_id).await;
+    let first = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "demo", 12)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.head_sha.as_deref(), Some("feedfeedfeedfeedfeed"));
+    assert_eq!(
+        first.live.as_ref().unwrap().checks_summary.as_deref(),
+        Some("1 passing, 0 pending, 0 failing")
+    );
+
+    // Arm the overlap and refresh again. This read sends `W/"pull-1"`, the
+    // fresher fetch lands `W/"pull-2"` mid-request, and the 304 comes back
+    // describing the pull request as it was before that.
+    *competing
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) =
+        Some((Arc::clone(&runtime.db), workspace_id));
+    runtime.refresh_workspace_pr_row(&owner, workspace_id).await;
+    assert_eq!(pull_calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+
+    let after = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "demo", 12)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        after.head_sha.as_deref(),
+        Some("cafecafecafecafecafe"),
+        "the fresher snapshot stands"
+    );
+    assert_eq!(
+        after.live.as_ref().unwrap().checks_summary.as_deref(),
+        Some("2 passing, 0 pending, 0 failing"),
+        "the rejected digest never reached the live tier"
+    );
+    let column = runtime
+        .get_workspace(&owner, workspace_id)
+        .await
+        .unwrap()
+        .pr
+        .unwrap();
+    assert_eq!(
+        column.head_sha.as_deref(),
+        Some("cafecafecafecafecafe"),
+        "the rejected digest never reached the workspace column"
+    );
+    assert_eq!(
+        column.checks_summary.as_deref(),
+        Some("2 passing, 0 pending, 0 failing")
+    );
+}
+
 /// One host read updates every workspace holding the pull request
 /// (decision 66): a digest change lands on the fact row's live tier, and the
 /// other holder takes the same snapshot — column and digest cache — with no

--- a/crates/tidebreak-server/src/tests/code_pr_facts.rs
+++ b/crates/tidebreak-server/src/tests/code_pr_facts.rs
@@ -266,7 +266,8 @@ async fn a_journaled_create_mints_an_authored_fact() {
     .await;
 
     let search_path = shim.display().to_string();
-    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path)).await;
+    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
+        .await;
 
     let owner = OwnerId::local();
     let fact = get_pull_request_fact(&store, &owner, "github.com", "acme", "tools", 412)
@@ -284,7 +285,8 @@ async fn a_journaled_create_mints_an_authored_fact() {
     assert_eq!(attributed[0].1, CodePullRequestRelation::Authored);
 
     // Re-running the sweep is idempotent: one row, first_seen_at holds.
-    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path)).await;
+    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
+        .await;
     let attributed = list_attributed_facts_for_workspace(&store, &owner, session.workspace_id)
         .await
         .unwrap();
@@ -318,7 +320,8 @@ async fn a_journaled_push_mints_a_contributed_fact() {
     .await;
 
     let search_path = shim.display().to_string();
-    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path)).await;
+    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
+        .await;
 
     let owner = OwnerId::local();
     let attributed = list_attributed_facts_for_workspace(&store, &owner, session.workspace_id)
@@ -327,6 +330,84 @@ async fn a_journaled_push_mints_a_contributed_fact() {
     assert_eq!(attributed.len(), 1);
     assert_eq!(attributed[0].1, CodePullRequestRelation::Contributed);
     assert_eq!(attributed[0].0.number, 412);
+}
+
+#[tokio::test]
+async fn a_confirmed_push_marks_the_workspace_hot() {
+    // The agent's own push moves the head, and nothing else dirties the row
+    // for it: route mutations cover the user's actions, not the engine's.
+    // Left unmarked, the watch reads a pre-push head, calls its own fix turn
+    // a repeat, and parks (issue 2799).
+    let (dir, store) = temp_db_store("pr-facts-hot.db").await;
+    let work = init_github_shaped_repo(dir.path());
+    let shim = dir.path().join("bin");
+    std::fs::create_dir_all(&shim).unwrap();
+    write_gh_shim(&shim, &dir.path().join("gh.log"));
+    let (session, turn_id) = seeded(&store, &work).await;
+
+    journal_command(
+        &store,
+        &session,
+        "call-1",
+        "git push -u origin feat/x",
+        &work,
+        ToolOutcome::Succeeded,
+        "branch pushed",
+        None,
+    )
+    .await;
+
+    let hot = crate::code::pr_refresh::HotPullRequests::default();
+    let search_path = shim.display().to_string();
+    pr_facts::sweep_turn_for_pull_request_acts(
+        &store,
+        &session,
+        turn_id,
+        Some(&search_path),
+        Some(&hot),
+    )
+    .await;
+
+    assert_eq!(
+        hot.live(),
+        vec![(OwnerId::local(), session.workspace_id)],
+        "the confirmed push puts the workspace on the hot refresh tier"
+    );
+}
+
+#[tokio::test]
+async fn a_turn_that_pushed_nothing_leaves_the_hot_tier_alone() {
+    let (dir, store) = temp_db_store("pr-facts-not-hot.db").await;
+    let work = init_github_shaped_repo(dir.path());
+    let shim = dir.path().join("bin");
+    std::fs::create_dir_all(&shim).unwrap();
+    write_gh_shim(&shim, &dir.path().join("gh.log"));
+    let (session, turn_id) = seeded(&store, &work).await;
+
+    journal_command(
+        &store,
+        &session,
+        "call-1",
+        "gh pr view 412",
+        &work,
+        ToolOutcome::Succeeded,
+        "done",
+        None,
+    )
+    .await;
+
+    let hot = crate::code::pr_refresh::HotPullRequests::default();
+    let search_path = shim.display().to_string();
+    pr_facts::sweep_turn_for_pull_request_acts(
+        &store,
+        &session,
+        turn_id,
+        Some(&search_path),
+        Some(&hot),
+    )
+    .await;
+
+    assert!(hot.live().is_empty());
 }
 
 #[tokio::test]
@@ -372,7 +453,8 @@ async fn reads_comments_and_failures_mint_nothing() {
     .await;
 
     let search_path = shim.display().to_string();
-    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path)).await;
+    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
+        .await;
 
     let owner = OwnerId::local();
     assert!(
@@ -420,7 +502,8 @@ async fn a_signed_out_gh_mints_nothing() {
     .await;
 
     let search_path = shim.display().to_string();
-    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path)).await;
+    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
+        .await;
 
     let owner = OwnerId::local();
     assert!(


### PR DESCRIPTION
Follow-through on #2781 and #2791: the fetch-state write is guarded, but the state the UI renders was not.

**The live tier and the workspace column now ride the same validator.** `fetched_workspace_digest` wrote the live tier and returned the digest before the guarded `set_pull_request_fetch_state` call, and both of those writes were unconditional. The exact late-304 interleaving #2791 rejects still landed its reconstructed digest on the fact row's live tier, on the workspace column, and on every surface that reads them. The fetch-state write now goes first, and a conditional read whose row moved under it returns `None` — the callers then skip the column write and the broadcast.

**The watch reads the row that dates it.** `fresh_workspace_digest` certified the workspace *column* with the fact *row*'s `observed_at`, so a dropped column write left the watch assessing a stale head and stale checks against a fresh clock. It now derives the digest from the fact row, keeping the terminal state the column already holds so a merged pull request never reopens for the watch.

**A fix turn's own push marks the workspace hot.** Only route mutations dirtied the row; the post-turn detector neither refreshed nor marked. The watch therefore compared `last_fix_head` against a pre-push head, decided its own fix turn was a repeat, and parked with "a fix attempt did not resolve the problem". The detector now marks the workspace hot when it confirms a push or a create, so the next hot pass reads the head the turn just moved. The hot tier moved into `pr_refresh` as a shared handle to make that reachable without a runtime reference.

**The delivery list is a projection of the `delivery` broadcast.** It refetched only on a local revision bump or a user action. Its effect now depends on `deliveryRevision`.

Routing the delivery aggregate through the fact row — `LIST_CACHE_TTL` and `pull_etag` clearing — stays out of scope and is filed as #2800.

## Tests

Each fails without its fix:

- `a_conditional_read_that_lost_its_validator_writes_nothing` (`code_git.rs`) drives the real interleaving: the forge shim lands a fresher 200 on the row while the conditional request is open, then answers 304. Asserts the rejected digest reaches neither the live tier nor the workspace column.
- `fresh_workspace_digest_reads_the_row_that_dates_it` (`watch.rs`) pins the head and the checks to the fact row.
- `a_confirmed_push_marks_the_workspace_hot` and `a_turn_that_pushed_nothing_leaves_the_hot_tier_alone` (`code_pr_facts.rs`) pin the detector's mark.
- `re-reads when the server nudges the delivery channel` (`CodeDeliveryPage.dom.test.tsx`).

Closes #2799
