### PR TITLE
feat(code): make repo hooks and quick actions reachable

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -84,6 +84,7 @@ import {
   type TaskPlan,
   type CodeApprovalSnapshot,
   type CodeRepoSnapshot,
+  type QuickAction,
   type CodeSessionSnapshot,
   type CodeTurnSnapshot,
   type CodeActionSnapshot,
@@ -2090,6 +2091,7 @@ export class ApiClient {
     branch_prefix?: string;
     setup_script?: string;
     archive_script?: string;
+    quick_actions?: QuickAction[];
   }): Promise<CodeRepoSnapshot> {
     return requireParsed(
       parseCodeRepo(
@@ -2122,6 +2124,8 @@ export class ApiClient {
       branch_prefix?: string;
       setup_script?: string | null;
       archive_script?: string | null;
+      /** The whole list, replaced. Omit to leave the stored list alone. */
+      quick_actions?: QuickAction[];
     },
   ): Promise<CodeRepoSnapshot> {
     return requireParsed(
@@ -2421,6 +2425,29 @@ export class ApiClient {
       parseCodeWorkspace(
         await this.json(
           `/code/workspaces/${encodeURIComponent(workspaceId)}/restore`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+          },
+        ),
+      ),
+      "code workspace",
+    );
+  }
+
+  /**
+   * Run the repo's setup script again on a workspace that is `setup_failed`.
+   * The worktree is the one it already has, so a success takes the workspace
+   * Active without cutting a second checkout. A second failure comes back as
+   * 422 `setup_failed`.
+   */
+  async retryCodeWorkspaceSetup(
+    workspaceId: string,
+  ): Promise<CodeWorkspaceSnapshot> {
+    return requireParsed(
+      parseCodeWorkspace(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/retry-setup`,
           {
             method: "POST",
             headers: this.headers(true),

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -148,6 +148,7 @@ import {
   type CodeApprovalState as WireCodeApprovalState,
   type CodeEvent as WireCodeEvent,
   type CodeRepoSnapshot as WireCodeRepoSnapshot,
+  type QuickAction as WireQuickAction,
   type CodeSessionId as WireCodeSessionId,
   type CodeSessionKind as WireCodeSessionKind,
   type CodeSessionLifecycle as WireCodeSessionLifecycle,
@@ -1144,6 +1145,8 @@ export type FileDownloadProgress = {
 
 /** A registered local git repository. */
 export type CodeRepoSnapshot = WireCodeRepoSnapshot;
+/** A named command a workspace of that repository can run. */
+export type QuickAction = WireQuickAction;
 export type RepoId = WireRepoId;
 
 /** Local code activity and cost estimates. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -87,6 +87,8 @@ import {
 } from "./CodeDeliveryStore";
 import { CodeSidebar } from "./CodeSidebar";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { RepositorySettings } from "./RepositorySettings";
 import { RepositoryTriggerRules } from "./RepositoryTriggerRules";
 import { GithubAvatar } from "./GithubAvatar";
 import {
@@ -3011,6 +3013,8 @@ function DeliveryRepositoriesDialog({
   const [error, setError] = useState<string | null>(null);
   const [triggerRepository, setTriggerRepository] =
     useState<CodeGitHubRepositoryRef | null>(null);
+  const [settingsRepository, setSettingsRepository] =
+    useState<CodeGitHubRepositoryRef | null>(null);
 
   const add = async () => {
     const repositories = input
@@ -3099,11 +3103,28 @@ function DeliveryRepositoriesDialog({
                           ? () => setTriggerRepository(repository)
                           : undefined
                       }
+                      onManageSettings={
+                        repository.tidebreak_repo_id
+                          ? () => setSettingsRepository(repository)
+                          : undefined
+                      }
                     />
                   );
                 })
               )}
             </div>
+            {settingsRepository && (
+              <div className="mt-4">
+                <RepositorySettings
+                  client={client}
+                  repoId={settingsRepository.tidebreak_repo_id ?? null}
+                  repoLabel={settingsRepository.name_with_owner}
+                  onSaved={(repo) =>
+                    useCodeCatalogStore.getState().upsertRepo(repo)
+                  }
+                />
+              </div>
+            )}
             {triggerRepository && (
               <div className="mt-4">
                 <RepositoryTriggerRules
@@ -3193,6 +3214,7 @@ function RepositorySettingRow({
   onPinnedChange,
   onRemove,
   onManageTriggers,
+  onManageSettings,
 }: {
   repository: CodeGitHubRepositoryRef;
   enabled: boolean;
@@ -3202,6 +3224,7 @@ function RepositorySettingRow({
   onPinnedChange: (pinned: boolean) => void;
   onRemove?: () => void;
   onManageTriggers?: () => void;
+  onManageSettings?: () => void;
 }) {
   return (
     <div className="flex items-center gap-3 border-b border-border-subtle px-3 py-2.5 last:border-b-0">
@@ -3229,6 +3252,16 @@ function RepositorySettingRow({
       >
         {pinned ? <PinOff /> : <Pin />}
       </Button>
+      {onManageSettings && (
+        <Button
+          type="button"
+          size="xs"
+          variant="outline"
+          onClick={onManageSettings}
+        >
+          Settings
+        </Button>
+      )}
       {onManageTriggers && (
         <Button
           type="button"

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -382,4 +382,37 @@ describe("CodeSidebar", () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/code"));
   });
+
+  /**
+   * Without this, a workspace whose setup script failed reads exactly like an
+   * idle one: the card has no session row and nothing else names the status.
+   */
+  it("says Setup failed on a card whose setup script did not finish", async () => {
+    client.listCodeWorkspaces.mockResolvedValueOnce([
+      {
+        id: "ws-broken",
+        repo_id: "repo-1",
+        title: "Broken setup",
+        worktree_path: "/tmp/app/.worktrees/broken",
+        branch_name: "tidebreak/broken",
+        base_ref: "main",
+        status: "setup_failed" as const,
+        created_at: "2026-08-15T00:00:00.000Z",
+      },
+    ] as never);
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(await screen.findByText("Setup failed")).toBeInTheDocument();
+    // The status reaches a screen reader too, not just the ink.
+    expect(
+      screen.getByRole("button", {
+        name: "Broken setup · Setup failed · app · tidebreak/broken",
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -216,6 +216,7 @@ export function CodeSidebar() {
                             )?.state.type === "manual",
                           canOpenWorktree,
                           canUneff: Boolean(tidebreakProductRepo(repos)),
+                          setupFailed: workspace.status === "setup_failed",
                         })
                   }
                   childSessions={watchChildren(

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -795,6 +795,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         canFork: session?.kind === "interactive",
         canUneff: Boolean(tidebreakProductRepo(catalog.repos)),
         quickActions: repo?.quick_actions ?? [],
+        setupFailed: workspace.status === "setup_failed",
       })
     : [];
 

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -10,6 +10,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import { HttpError } from "../api/client";
 import { renderWithRouter } from "@/test/router";
 import type {
   CodeRepoSnapshot,
@@ -371,6 +372,60 @@ describe("NewWorkspaceDialog", () => {
     await waitFor(() =>
       expect(useCodeCatalogStore.getState().workspaces).toEqual([created]),
     );
+  });
+
+  /**
+   * A failed setup script still cut the worktree, so "Try again" would create
+   * a second one for work the user already has.
+   */
+  it("keeps the card and opens the workspace when setup fails", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const broken = {
+      ...workspace("ws-broken", "repo-new", "2026-08-24T12:00:00.000Z"),
+      status: "setup_failed",
+    } as CodeWorkspaceSnapshot;
+    const createCodeWorkspace = vi
+      .fn()
+      .mockRejectedValue(
+        new HttpError(422, "setup script exited 3", "setup_failed"),
+      );
+    const listCodeWorkspaces = vi.fn(async () => [broken]);
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace,
+          listCodeWorkspaces,
+          createCodeSession: vi.fn(),
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledOnce());
+    // No retry action: creating again would cut a second worktree.
+    expect(toastError.mock.calls[0]?.[1]).toBeUndefined();
+    await waitFor(() =>
+      expect(useCodeCatalogStore.getState().workspaces).toEqual([broken]),
+    );
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-broken"),
+    );
+    expect(createCodeWorkspace).toHaveBeenCalledTimes(1);
   });
 
   it("keeps remembered models keyed by harness", () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -18,6 +18,7 @@ import type {
   HarnessKind,
   ReasoningEffort,
 } from "../api/types";
+import { HttpError } from "../api/client";
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -495,6 +496,34 @@ export function NewWorkspaceDialog({
     void finishCreate(attempt, pending);
   }
 
+  /**
+   * Find the row `POST /code/workspaces` wrote before its setup script failed.
+   *
+   * The response carried the error, not the workspace, so the id has to come
+   * back off the list. Every row already in the catalog is one we know about,
+   * so the newest row that is not is the one this attempt created.
+   */
+  async function findCreatedWorkspace(
+    attempt: CreateAttempt,
+    pending: CodeWorkspaceSnapshot,
+  ): Promise<CodeWorkspaceSnapshot | null> {
+    const known = new Set(
+      useCodeCatalogStore
+        .getState()
+        .workspaces.map((workspace) => workspace.id),
+    );
+    known.delete(pending.id);
+    try {
+      const listed = await client.listCodeWorkspaces(attempt.repoId);
+      const fresh = listed
+        .filter((workspace) => !known.has(workspace.id))
+        .sort((left, right) => right.created_at.localeCompare(left.created_at));
+      return fresh[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   async function finishCreate(
     attempt: CreateAttempt,
     pending: CodeWorkspaceSnapshot,
@@ -507,6 +536,25 @@ export function NewWorkspaceDialog({
         base_ref: attempt.baseRef.trim() || undefined,
       });
     } catch (error) {
+      // A failed setup script still cut the worktree and wrote the workspace
+      // row (Decision 0032). Deleting the card and offering "Try again" would
+      // create a second worktree for work the user already has, so keep the
+      // card, refetch the row the server wrote, and open it.
+      if (error instanceof HttpError && error.kind === "setup_failed") {
+        const created = await findCreatedWorkspace(attempt, pending);
+        toast.error(
+          friendlyErrorMessage(error, "Created, but the setup script failed"),
+        );
+        // No "Try again" either way: the worktree exists, and creating again
+        // would cut a second one.
+        if (created) {
+          replaceWorkspace(pending.id, created);
+          await revealCreatedWorkspace(created, attempt);
+        } else {
+          removeWorkspace(pending.id);
+        }
+        return;
+      }
       removeWorkspace(pending.id);
       retryAttempt.current = attempt;
       if (!attempt.createMore) {

--- a/crates/tidebreak-desktop/ui/src/code/RepositorySettings.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositorySettings.dom.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CodeRepoSnapshot } from "@/api/types";
+import { RepositorySettings } from "./RepositorySettings";
+
+afterEach(cleanup);
+
+function repo(overrides: Partial<CodeRepoSnapshot> = {}): CodeRepoSnapshot {
+  return {
+    id: "repo-1",
+    root_path: "/tmp/tidebreak",
+    display_name: "tidebreak",
+    default_base_ref: "main",
+    branch_prefix: "tidebreak/",
+    setup_script: "pnpm install",
+    quick_actions: [
+      { name: "Test", command: "cargo test", auto_run_on_create: false },
+    ],
+    created_at: "2026-08-22T12:00:00Z",
+    ...overrides,
+  } as CodeRepoSnapshot;
+}
+
+describe("RepositorySettings", () => {
+  it("saves an edited setup script when the field is committed", async () => {
+    const user = userEvent.setup();
+    const stored = repo();
+    const client = {
+      getCodeRepo: vi.fn(async () => stored),
+      patchCodeRepo: vi.fn(async () => ({
+        ...stored,
+        setup_script: "pnpm install --frozen-lockfile",
+      })),
+    };
+    render(
+      <RepositorySettings
+        client={client}
+        repoId="repo-1"
+        repoLabel="brightwave-inc/tidebreak"
+      />,
+    );
+
+    const setup = await screen.findByLabelText("Setup script");
+    expect(setup).toHaveValue("pnpm install");
+    await user.clear(setup);
+    await user.type(setup, "pnpm install --frozen-lockfile");
+    await user.tab();
+
+    await waitFor(() =>
+      expect(client.patchCodeRepo).toHaveBeenCalledWith(
+        "repo-1",
+        expect.objectContaining({
+          setup_script: "pnpm install --frozen-lockfile",
+        }),
+      ),
+    );
+  });
+
+  it("writes quick actions, which had no write path at all before", async () => {
+    const user = userEvent.setup();
+    const stored = repo({ quick_actions: [] });
+    const client = {
+      getCodeRepo: vi.fn(async () => stored),
+      patchCodeRepo: vi.fn(async (_id: string, body: unknown) => ({
+        ...stored,
+        ...(body as object),
+      })),
+    };
+    render(
+      <RepositorySettings
+        client={client}
+        repoId="repo-1"
+        repoLabel="brightwave-inc/tidebreak"
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Add" }));
+    await user.type(screen.getByLabelText("Quick action 1 name"), "Lint");
+    await user.type(
+      screen.getByLabelText("Quick action 1 command"),
+      "cargo clippy",
+    );
+    await user.click(
+      screen.getByRole("switch", { name: "Run quick action 1 on create" }),
+    );
+
+    await waitFor(() =>
+      expect(client.patchCodeRepo).toHaveBeenCalledWith(
+        "repo-1",
+        expect.objectContaining({
+          quick_actions: [
+            { name: "Lint", command: "cargo clippy", auto_run_on_create: true },
+          ],
+        }),
+      ),
+    );
+  });
+
+  it("does not write a field that only lost focus", async () => {
+    const user = userEvent.setup();
+    const client = {
+      getCodeRepo: vi.fn(async () => repo()),
+      patchCodeRepo: vi.fn(),
+    };
+    render(
+      <RepositorySettings
+        client={client}
+        repoId="repo-1"
+        repoLabel="brightwave-inc/tidebreak"
+      />,
+    );
+
+    await user.click(await screen.findByLabelText("Base ref"));
+    await user.tab();
+
+    expect(client.patchCodeRepo).not.toHaveBeenCalled();
+  });
+
+  it("says what to do when the repository is not registered", async () => {
+    const client = { getCodeRepo: vi.fn(), patchCodeRepo: vi.fn() };
+    render(
+      <RepositorySettings
+        client={client}
+        repoId={null}
+        repoLabel="brightwave-inc/tidebreak"
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        "Register this repository in Tidebreak before editing hooks.",
+      ),
+    ).toBeInTheDocument();
+    expect(client.getCodeRepo).not.toHaveBeenCalled();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
@@ -1,0 +1,453 @@
+import { useEffect, useRef, useState } from "react";
+import { CircleAlert, LoaderCircle, Plus, X } from "lucide-react";
+
+import type { ApiClient } from "@/api/client";
+import type { CodeRepoSnapshot, QuickAction } from "@/api/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { friendlyErrorMessage } from "@/lib/utils";
+
+type RepoSettingsClient = Pick<ApiClient, "getCodeRepo" | "patchCodeRepo">;
+
+/**
+ * How many quick actions a repository takes. Mirrors the server's cap in
+ * `routes/code/repos.rs` so the editor stops at the limit rather than letting
+ * the user type a 33rd row and learn about it from a 400.
+ */
+const MAX_QUICK_ACTIONS = 32;
+
+/** The editable half of a repo record, held while the user types. */
+type RepoSettingsDraft = {
+  default_base_ref: string;
+  branch_prefix: string;
+  setup_script: string;
+  archive_script: string;
+  quick_actions: QuickAction[];
+};
+
+function draftOf(repo: CodeRepoSnapshot): RepoSettingsDraft {
+  return {
+    default_base_ref: repo.default_base_ref,
+    branch_prefix: repo.branch_prefix,
+    setup_script: repo.setup_script ?? "",
+    archive_script: repo.archive_script ?? "",
+    quick_actions: repo.quick_actions.map((action) => ({ ...action })),
+  };
+}
+
+/** Exactly what a draft puts on the wire. */
+type RepoSettingsPayload = {
+  default_base_ref?: string;
+  branch_prefix?: string;
+  setup_script: string | null;
+  archive_script: string | null;
+  quick_actions: QuickAction[];
+};
+
+/**
+ * Trim a draft into a body the server will accept.
+ *
+ * A quick action the user is still filling in has no name or no command yet,
+ * and the server rejects either. Those rows stay on screen and off the wire
+ * until they are complete, so adding one never blocks saving the rest.
+ */
+function payloadOf(draft: RepoSettingsDraft): RepoSettingsPayload {
+  return {
+    default_base_ref: draft.default_base_ref.trim() || undefined,
+    branch_prefix: draft.branch_prefix.trim() || undefined,
+    setup_script: draft.setup_script.trim() || null,
+    archive_script: draft.archive_script.trim() || null,
+    quick_actions: draft.quick_actions
+      .map((action) => ({
+        name: action.name.trim(),
+        command: action.command.trim(),
+        auto_run_on_create: action.auto_run_on_create,
+      }))
+      .filter((action) => action.name && action.command),
+  };
+}
+
+/**
+ * True when the draft is worth sending. Every field is optional on the wire,
+ * so a no-op blur would otherwise PATCH the repo on every focus change.
+ */
+function changed(draft: RepoSettingsDraft, repo: CodeRepoSnapshot): boolean {
+  return (
+    JSON.stringify(payloadOf(draft)) !==
+    JSON.stringify(payloadOf(draftOf(repo)))
+  );
+}
+
+/**
+ * Repo lifecycle hooks: the base a workspace branches from, the prefix its
+ * branch carries, the scripts that run around the worktree, and the named
+ * commands a workspace can run.
+ *
+ * The server has run all four since code mode shipped; this is the only place
+ * that writes them. Text commits on blur and switches commit on change, so
+ * there is no Save button to forget.
+ */
+export function RepositorySettings({
+  client,
+  repoId,
+  repoLabel,
+  onSaved,
+}: {
+  client: RepoSettingsClient;
+  repoId: string | null;
+  repoLabel: string;
+  onSaved?: (repo: CodeRepoSnapshot) => void;
+}) {
+  const [draft, setDraft] = useState<RepoSettingsDraft | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const generation = useRef(0);
+  const busyRef = useRef(false);
+  /**
+   * The stored record. A ref, not state: nothing renders it, and the commit
+   * that queues behind an in-flight write has to compare against what the
+   * server just returned rather than the value its closure captured.
+   */
+  const repoRef = useRef<CodeRepoSnapshot | null>(null);
+  /** A draft that arrived while a write was in flight; it goes next. */
+  const queued = useRef<RepoSettingsDraft | null>(null);
+
+  const remember = (next: CodeRepoSnapshot | null) => {
+    repoRef.current = next;
+  };
+
+  const load = async () => {
+    const token = ++generation.current;
+    if (!repoId) {
+      remember(null);
+      setDraft(null);
+      setLoading(false);
+      setError("Register this repository in Tidebreak before editing hooks.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await client.getCodeRepo(repoId);
+      if (token !== generation.current) return;
+      remember(next);
+      setDraft(draftOf(next));
+    } catch (caught) {
+      if (token === generation.current) {
+        setError(friendlyErrorMessage(caught, "Could not load the repo."));
+      }
+    } finally {
+      if (token === generation.current) setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    busyRef.current = false;
+    queued.current = null;
+    setBusy(false);
+    remember(null);
+    setDraft(null);
+    void load();
+    return () => {
+      generation.current += 1;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, repoId]);
+
+  /**
+   * Send one draft. A rejected write leaves the draft as typed so the user can
+   * fix the field the server named instead of retyping the whole form.
+   *
+   * Edits land faster than the round trip — a blur and the switch beside it
+   * are one gesture — so a draft that arrives mid-write is held and sent when
+   * the write returns rather than dropped.
+   */
+  const commit = async (next: RepoSettingsDraft) => {
+    const stored = repoRef.current;
+    if (!repoId || !stored) return;
+    if (busyRef.current) {
+      queued.current = next;
+      return;
+    }
+    if (!changed(next, stored)) return;
+    const token = generation.current;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const saved = await client.patchCodeRepo(repoId, payloadOf(next));
+      if (token !== generation.current) return;
+      remember(saved);
+      // Keep the list on screen as the user has it: the rows the server just
+      // echoed, plus any row still being filled in.
+      setDraft({ ...draftOf(saved), quick_actions: next.quick_actions });
+      onSaved?.(saved);
+    } catch (caught) {
+      if (token === generation.current) {
+        setError(friendlyErrorMessage(caught, "Could not save the repo."));
+      }
+    } finally {
+      if (token === generation.current) {
+        busyRef.current = false;
+        setBusy(false);
+        const held = queued.current;
+        queued.current = null;
+        if (held) void commit(held);
+      }
+    }
+  };
+
+  const editActions = (
+    apply: (actions: QuickAction[]) => QuickAction[],
+    save: boolean,
+  ) => {
+    if (!draft) return;
+    const next = { ...draft, quick_actions: apply(draft.quick_actions) };
+    setDraft(next);
+    if (save) void commit(next);
+  };
+
+  return (
+    <div className="rounded-lg border border-border-subtle bg-background p-4">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-medium text-muted-foreground">
+            {repoLabel}
+          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Scripts run in the worktree. A failing setup script leaves the
+            checkout in place and marks the workspace Setup failed.
+          </p>
+        </div>
+        {(loading || busy) && <LoaderCircle className="size-4 animate-spin" />}
+      </div>
+      {error && (
+        <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-critical-border bg-critical-background px-3 py-2 text-xs text-critical-foreground-muted">
+          <span className="flex items-start gap-2">
+            <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
+            {error}
+          </span>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            disabled={loading}
+            onClick={() => void load()}
+          >
+            Try again
+          </Button>
+        </div>
+      )}
+      {!loading && draft && (
+        <div className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label
+                htmlFor="repo-settings-base-ref"
+                className="text-xs text-muted-foreground"
+              >
+                Base ref
+              </Label>
+              <Input
+                id="repo-settings-base-ref"
+                className="font-mono"
+                value={draft.default_base_ref}
+                placeholder="main"
+                onChange={(event) =>
+                  setDraft({ ...draft, default_base_ref: event.target.value })
+                }
+                onBlur={() => void commit(draft)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label
+                htmlFor="repo-settings-branch-prefix"
+                className="text-xs text-muted-foreground"
+              >
+                Branch prefix
+              </Label>
+              <Input
+                id="repo-settings-branch-prefix"
+                className="font-mono"
+                value={draft.branch_prefix}
+                placeholder="tidebreak/"
+                onChange={(event) =>
+                  setDraft({ ...draft, branch_prefix: event.target.value })
+                }
+                onBlur={() => void commit(draft)}
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label
+              htmlFor="repo-settings-setup-script"
+              className="text-xs text-muted-foreground"
+            >
+              Setup script
+            </Label>
+            <Textarea
+              id="repo-settings-setup-script"
+              className="min-h-16 font-mono"
+              rows={3}
+              value={draft.setup_script}
+              placeholder="pnpm install"
+              onChange={(event) =>
+                setDraft({ ...draft, setup_script: event.target.value })
+              }
+              onBlur={() => void commit(draft)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Runs after a worktree is created or restored.
+            </p>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label
+              htmlFor="repo-settings-archive-script"
+              className="text-xs text-muted-foreground"
+            >
+              Archive script
+            </Label>
+            <Textarea
+              id="repo-settings-archive-script"
+              className="min-h-16 font-mono"
+              rows={3}
+              value={draft.archive_script}
+              placeholder="./scripts/back-up.sh"
+              onChange={(event) =>
+                setDraft({ ...draft, archive_script: event.target.value })
+              }
+              onBlur={() => void commit(draft)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Runs before the worktree is removed. A failure stops the archive.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs text-muted-foreground">
+                Quick actions
+              </span>
+              <Button
+                type="button"
+                size="xs"
+                variant="outline"
+                disabled={draft.quick_actions.length >= MAX_QUICK_ACTIONS}
+                onClick={() =>
+                  editActions(
+                    (actions) => [
+                      ...actions,
+                      { name: "", command: "", auto_run_on_create: false },
+                    ],
+                    false,
+                  )
+                }
+              >
+                <Plus />
+                Add
+              </Button>
+            </div>
+            {draft.quick_actions.length >= MAX_QUICK_ACTIONS && (
+              <p className="text-xs text-muted-foreground">
+                A repository takes at most {MAX_QUICK_ACTIONS} quick actions.
+              </p>
+            )}
+            {draft.quick_actions.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No quick actions yet. Add one to run a named command in any
+                workspace of this repo.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {draft.quick_actions.map((action, index) => (
+                  <div
+                    // Names are still being typed here, so the row's position
+                    // is the only stable identity it has.
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={index}
+                    className="flex items-center gap-2"
+                  >
+                    <Input
+                      className="w-36"
+                      value={action.name}
+                      placeholder="Test"
+                      aria-label={`Quick action ${index + 1} name`}
+                      onChange={(event) =>
+                        editActions(
+                          (actions) =>
+                            actions.map((item, at) =>
+                              at === index
+                                ? { ...item, name: event.target.value }
+                                : item,
+                            ),
+                          false,
+                        )
+                      }
+                      onBlur={() => draft && void commit(draft)}
+                    />
+                    <Input
+                      className="flex-1 font-mono"
+                      value={action.command}
+                      placeholder="cargo test"
+                      aria-label={`Quick action ${index + 1} command`}
+                      onChange={(event) =>
+                        editActions(
+                          (actions) =>
+                            actions.map((item, at) =>
+                              at === index
+                                ? { ...item, command: event.target.value }
+                                : item,
+                            ),
+                          false,
+                        )
+                      }
+                      onBlur={() => draft && void commit(draft)}
+                    />
+                    <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+                      <Switch
+                        className="h-4 w-7"
+                        thumbClassName="size-3 data-[state=checked]:translate-x-3"
+                        checked={action.auto_run_on_create}
+                        aria-label={`Run quick action ${index + 1} on create`}
+                        onCheckedChange={(checked) =>
+                          editActions(
+                            (actions) =>
+                              actions.map((item, at) =>
+                                at === index
+                                  ? { ...item, auto_run_on_create: checked }
+                                  : item,
+                              ),
+                            true,
+                          )
+                        }
+                      />
+                      On create
+                    </label>
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="ghost-destructive"
+                      aria-label={`Remove quick action ${index + 1}`}
+                      onClick={() =>
+                        editActions(
+                          (actions) =>
+                            actions.filter((_item, at) => at !== index),
+                          true,
+                        )
+                      }
+                    >
+                      <X />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -44,7 +44,11 @@ import type {
 import { AttentionBadge } from "./AttentionBadge";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import { FOCUS_RING_INSET, HOVER_TINT } from "./interactive";
-import { HARNESS_LABELS, LIFECYCLE_LABELS } from "./labels";
+import {
+  HARNESS_LABELS,
+  LIFECYCLE_LABELS,
+  WORKSPACE_STATUS_LABELS,
+} from "./labels";
 import type { WorkspaceCommand } from "./workspaceActions";
 import {
   workspaceWorkflowActionLabel,
@@ -679,6 +683,23 @@ function WorkspaceActivityLine({
       >
         <LoaderCircle className="size-3 shrink-0 animate-spin" aria-hidden />
         <span className="min-w-0 flex-1 truncate">Creating workspace</span>
+      </div>
+    );
+  }
+  // The checkout survived, so the workspace is usable — but the setup script
+  // never finished, and nothing else on the card would say so.
+  if (workspace.status === "setup_failed") {
+    return (
+      <div
+        className={cn(
+          "flex min-w-0 items-center gap-1.5 px-2.5 pb-2 pl-7 text-xs",
+          STATUS_TEXT.critical,
+        )}
+      >
+        <CircleAlert className="size-3 shrink-0" aria-hidden />
+        <span className="min-w-0 flex-1 truncate">
+          {WORKSPACE_STATUS_LABELS.setup_failed}
+        </span>
       </div>
     );
   }

--- a/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
@@ -7,6 +7,7 @@ import {
   MessageSquare,
   Play,
   Plus,
+  RefreshCw,
   Terminal,
   Wrench,
 } from "lucide-react";
@@ -182,6 +183,7 @@ export function workspaceActionPaletteRows(input: {
     attentionPinned: input.attentionPinned,
     canUneff: input.canUneff,
     canOpenInEditor: input.canOpenInEditor,
+    setupFailed: input.workspace.status === "setup_failed",
   });
   const quick: WorkspaceCommand[] = archived
     ? []
@@ -216,6 +218,7 @@ const ACTION_ICONS: Partial<Record<WorkspaceCommandId, PaletteRow["icon"]>> = {
   archive: Archive,
   "force-archive": Archive,
   restore: Archive,
+  "retry-setup": RefreshCw,
 };
 
 /** The commands a chord already reaches, so the row can teach it. */

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -70,7 +70,8 @@ export type WorkspaceCommandId =
   | "run-quick-action"
   | "archive"
   | "force-archive"
-  | "restore";
+  | "restore"
+  | "retry-setup";
 
 export type WorkspaceCommand = {
   id: WorkspaceCommandId;
@@ -108,6 +109,8 @@ export function workspaceCommands(input: {
   canOpenInEditor?: boolean;
   /** Tidebreak's own checkout is connected, so a debug dump can become a fix. */
   canUneff?: boolean;
+  /** The setup script failed, so the workspace has a worktree but no session. */
+  setupFailed?: boolean;
 }): WorkspaceCommand[] {
   // An archived workspace has no worktree: nothing to open a terminal in,
   // no session to steer. What is left is reading, copying the branch that
@@ -129,6 +132,12 @@ export function workspaceCommands(input: {
   ];
   const editor = editorCommand(input.canOpenInEditor);
   if (editor) items.push(editor);
+  // The checkout is there and the branch is cut; only the script fell over.
+  // Running it again is the way back, and it is the only command here a
+  // setup-failed workspace can currently complete.
+  if (input.setupFailed) {
+    items.splice(1, 0, { id: "retry-setup", label: "Retry setup" });
+  }
   if (input.hasPr) {
     items.push({ id: "open-pr", label: "Open pull request" });
   }
@@ -172,6 +181,8 @@ export function workspaceHeaderCommands(input: {
   /** The shown agent has a transcript worth handing to a sibling. */
   canFork?: boolean;
   canUneff?: boolean;
+  /** The setup script failed, so the workspace has a worktree but no session. */
+  setupFailed?: boolean;
 }): WorkspaceCommand[] {
   const items: WorkspaceCommand[] = [
     worktreePathCommand(
@@ -183,6 +194,12 @@ export function workspaceHeaderCommands(input: {
     ? undefined
     : editorCommand(input.canOpenInEditor);
   if (editor) items.splice(1, 0, editor);
+  // A broken setup leads the menu: it is the one command that changes the
+  // workspace's state, and everything below it acts on a checkout the script
+  // never finished preparing.
+  if (input.setupFailed) {
+    items.unshift({ id: "retry-setup", label: "Retry setup" });
+  }
   if (input.hasSession) {
     items.push(
       input.attentionPinned
@@ -585,6 +602,25 @@ export function useWorkspaceCardCommands(): {
     }
   }
 
+  /**
+   * Run the repo's setup script again on the worktree the workspace already
+   * has. A second failure leaves the workspace exactly where it was, so the
+   * user can edit the script and try again without losing the checkout.
+   */
+  async function runRetrySetup(workspace: CodeWorkspaceSnapshot) {
+    try {
+      const revived = await client.retryCodeWorkspaceSetup(workspace.id);
+      upsertWorkspace(revived);
+      toast.success("Setup finished");
+      await navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId: workspace.id },
+      });
+    } catch (error) {
+      toast.error(friendlyErrorMessage(error, "The setup script failed again"));
+    }
+  }
+
   function run(
     command: WorkspaceCommandId,
     context: WorkspaceCommandContext,
@@ -730,6 +766,9 @@ export function useWorkspaceCardCommands(): {
         return;
       case "restore":
         void runRestore(context.workspace);
+        return;
+      case "retry-setup":
+        void runRetrySetup(context.workspace);
         return;
     }
   }

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -20,6 +20,7 @@ import {
   workspacePrChipSummary,
   workspaceStackParent,
   workspaceStatusRank,
+  WORKSPACE_STATUS_RANK_ORDER,
 } from "./workspaceCards";
 import {
   prCompactStatusLabel,
@@ -303,6 +304,24 @@ describe("workspaceStatusRank", () => {
         digest("ws-a", { lifecycle: "running" }),
       ),
     ).toBe("archived");
+  });
+
+  it("ranks a failed setup above idle so the card says the script broke", () => {
+    expect(
+      workspaceStatusRank(workspace("ws-a", "app", "setup_failed"), undefined),
+    ).toBe("setup_failed");
+    expect(WORKSPACE_STATUS_RANK_ORDER.indexOf("setup_failed")).toBeLessThan(
+      WORKSPACE_STATUS_RANK_ORDER.indexOf("idle"),
+    );
+  });
+
+  it("keeps live work ahead of a failed setup", () => {
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app", "setup_failed"),
+        digest("ws-a", { lifecycle: "running" }),
+      ),
+    ).toBe("running");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -101,6 +101,7 @@ export type WorkspaceStatusRank =
   | "running"
   | "pr_open"
   | "done_unreviewed"
+  | "setup_failed"
   | "idle"
   | "archived";
 
@@ -109,6 +110,7 @@ export const WORKSPACE_STATUS_RANK_ORDER: readonly WorkspaceStatusRank[] = [
   "running",
   "pr_open",
   "done_unreviewed",
+  "setup_failed",
   "idle",
   "archived",
 ];
@@ -119,14 +121,20 @@ export const WORKSPACE_STATUS_RANK_LABELS: Record<WorkspaceStatusRank, string> =
     running: "Running",
     pr_open: "PR open",
     done_unreviewed: "Done",
+    setup_failed: "Setup failed",
     idle: "Idle",
     archived: "Archived",
   };
 
 /**
  * Rank a workspace for the by-status rail. Needs-you wins, then a running
- * engine, then an open PR, then done-unreviewed, then idle. Archived is last.
- * A digest may change the rank; viewing or selecting never does.
+ * engine, then an open PR, then done-unreviewed, then a workspace whose setup
+ * script failed, then idle. Archived is last. A digest may change the rank;
+ * viewing or selecting never does.
+ *
+ * A failed setup ranks below live work because the checkout survives and the
+ * engine can still run in it — but above idle, because nothing else on the
+ * card says the script never finished.
  */
 export function workspaceStatusRank(
   workspace: CodeWorkspaceSnapshot,
@@ -143,6 +151,7 @@ export function workspaceStatusRank(
   if (digest?.attention.state.type === "done_unreviewed") {
     return "done_unreviewed";
   }
+  if (workspace.status === "setup_failed") return "setup_failed";
   return "idle";
 }
 
@@ -415,6 +424,7 @@ export function workspaceCardLabel(input: {
 }): string {
   const parts = [input.title];
   if (input.workspaceStatus === "creating") parts.push("Creating workspace");
+  if (input.workspaceStatus === "setup_failed") parts.push("Setup failed");
   if (
     input.attention &&
     input.attention.state.type !== "working" &&

--- a/crates/tidebreak-desktop/ui/src/stories/RepositorySettings.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/RepositorySettings.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import type { CodeRepoSnapshot } from "@/api/types";
+import { RepositorySettings } from "@/code/RepositorySettings";
+import { codeRepositories } from "./fixtures";
+
+const stored: CodeRepoSnapshot = {
+  ...codeRepositories[0],
+  setup_script: "pnpm install --frozen-lockfile",
+  archive_script: "./scripts/back-up-worktree.sh",
+  quick_actions: [
+    {
+      name: "Test",
+      command: "cargo test -p tidebreak-server",
+      auto_run_on_create: false,
+    },
+    { name: "Install", command: "pnpm install", auto_run_on_create: true },
+  ],
+};
+
+function client(repo: CodeRepoSnapshot | null, delayMs = 0) {
+  return {
+    getCodeRepo: async () => {
+      if (delayMs) await new Promise((done) => setTimeout(done, delayMs));
+      if (!repo) throw new Error("repo 404");
+      return repo;
+    },
+    patchCodeRepo: async (
+      _id: string,
+      body: Partial<CodeRepoSnapshot>,
+    ): Promise<CodeRepoSnapshot> => ({ ...(repo ?? stored), ...body }),
+  };
+}
+
+/**
+ * The only surface that writes a repo's lifecycle hooks: the base a workspace
+ * branches from, its branch prefix, the setup and archive scripts, and the
+ * named commands a workspace can run. Fields commit on blur; switches commit
+ * on change.
+ */
+const meta = {
+  title: "Code/Repository settings",
+  component: RepositorySettings,
+  args: {
+    client: client(stored) as never,
+    repoId: "repo-tidebreak",
+    repoLabel: "brightwave-inc/tidebreak",
+    onSaved: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-2xl px-5 py-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RepositorySettings>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Both scripts set and two quick actions, one of them auto-run on create. */
+export const Configured: Story = {};
+
+/** A fresh registration: defaults for the refs, no scripts, no actions. */
+export const Empty: Story = {
+  args: {
+    client: client({
+      ...stored,
+      setup_script: undefined,
+      archive_script: undefined,
+      quick_actions: [],
+    }) as never,
+  },
+};
+
+/** The read is still in flight; the spinner is the only chrome that moves. */
+export const Loading: Story = {
+  args: { client: client(stored, 100_000) as never },
+};
+
+/** The repository is tracked on GitHub but never registered in Tidebreak. */
+export const NotRegistered: Story = {
+  args: { repoId: null },
+};
+
+/** The read failed. The error names a retry rather than an empty form. */
+export const LoadFailed: Story = {
+  args: { client: client(null) as never },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -85,6 +85,28 @@ export const Creating: Story = {
   },
 };
 
+/**
+ * The setup script failed. The checkout and branch survived, so the row keeps
+ * its commands and offers the retry — the critical line is the only thing that
+ * says the script never finished.
+ */
+export const SetupFailed: Story = {
+  args: {
+    workspace: {
+      ...codeWorkspace,
+      id: "ws-setup-failed",
+      title: "Rework the credential exchange",
+      status: "setup_failed",
+    },
+    visibleMeta: { repoChip: true, branch: true },
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      setupFailed: true,
+    }),
+  },
+};
+
 /** A green pull request with the hover detail held open for visual review. */
 export const HoverPullRequestReady: Story = {
   args: {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -30,8 +30,8 @@ use tidebreak_core::{
     CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeRepo, CodeSession, CodeSessionId,
     CodeSessionKind, CodeSessionLifecycle, CodeTrigger, CodeTriggerAction, CodeTriggerCondition,
     CodeTriggerId, CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore, Diffstat,
-    FenceReason, HarnessKind, OwnerId, PermissionMode, PullRequestDigest, ReasoningEffort, RepoId,
-    WorkspaceId,
+    FenceReason, HarnessKind, OwnerId, PermissionMode, PullRequestDigest, QuickAction,
+    ReasoningEffort, RepoId, WorkspaceId,
 };
 use tidebreak_harness::{
     builtin_registry, AdapterRegistry, ApprovalChannelSpec, ApprovalDecision, HarnessAdapter,
@@ -128,6 +128,8 @@ pub(crate) struct RepoRegistration {
     pub branch_prefix: Option<String>,
     pub setup_script: Option<String>,
     pub archive_script: Option<String>,
+    /// Named commands workspaces of this repo offer. Validated by the caller.
+    pub quick_actions: Vec<QuickAction>,
 }
 
 /// Result of `POST /code/sessions/{id}/turns`.
@@ -1015,6 +1017,7 @@ impl CodeRuntime {
             branch_prefix,
             setup_script,
             archive_script,
+            quick_actions,
         } = metadata;
         let validated = validate_repo_path(&root_path).await.map_err(map_worktree)?;
         let toplevel = validated.toplevel.display().to_string();
@@ -1063,7 +1066,7 @@ impl CodeRuntime {
                 .unwrap_or_else(|| "tidebreak/".into()),
             setup_script,
             archive_script,
-            quick_actions: Vec::new(),
+            quick_actions,
             created_at: Utc::now(),
             removed_at: None,
             cloned_from,
@@ -1818,6 +1821,60 @@ impl CodeRuntime {
         }
         match setup {
             Ok(()) => Ok(workspace),
+            Err(error) => Err(ServerError::unprocessable_kind(
+                "setup_failed",
+                error.to_string(),
+            )),
+        }
+    }
+
+    /// Re-run the setup script on a worktree that already exists.
+    ///
+    /// A failed setup keeps the checkout (Decision 0032), but every other
+    /// route refuses a `setup_failed` workspace, so the state has no exit
+    /// short of archiving the work. This is that exit: fix the script, run it
+    /// again, and the workspace goes Active without cutting a second worktree.
+    ///
+    /// Both outcomes match create's tail — Active on success, still
+    /// `SetupFailed` and a 422 `setup_failed` on failure.
+    pub(crate) async fn retry_workspace_setup(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+    ) -> Result<CodeWorkspace, ServerError> {
+        let lifecycle = self.workspace_lifecycle_lock(id);
+        let _lifecycle_guard = lifecycle.lock().await;
+        let mut workspace = self.get_workspace(owner, id).await?;
+        if workspace.status == CodeWorkspaceStatus::Active {
+            return Ok(workspace);
+        }
+        if workspace.status != CodeWorkspaceStatus::SetupFailed {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
+        let path = std::path::PathBuf::from(&workspace.worktree_path);
+        if !path.exists() {
+            return Err(ServerError::conflict_kind(
+                "worktree_missing",
+                "the worktree is gone; archive this workspace and restore it instead",
+            ));
+        }
+        let repo = self.get_repo(owner, workspace.repo_id).await?;
+        Self::refuse_removed_repo(&repo)?;
+        match run_setup_script(&path, repo.setup_script.as_deref()).await {
+            Ok(()) => {
+                workspace.status = CodeWorkspaceStatus::Active;
+                if !self.save_workspace_final(&workspace).await? {
+                    return Err(ServerError::not_found(format!(
+                        "workspace {} not found",
+                        workspace.id
+                    )));
+                }
+                gh::run_auto_create_actions(&path, &repo.quick_actions).await;
+                Ok(workspace)
+            }
             Err(error) => Err(ServerError::unprocessable_kind(
                 "setup_failed",
                 error.to_string(),

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -345,6 +345,13 @@ impl ScopedCode {
         self.runtime.restore_workspace(&self.owner, id).await
     }
 
+    pub(crate) async fn retry_workspace_setup(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<CodeWorkspace, ServerError> {
+        self.runtime.retry_workspace_setup(&self.owner, id).await
+    }
+
     pub(crate) async fn workspace_tree(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -908,6 +908,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::restore_workspace),
         )
         .route(
+            "/code/workspaces/{id}/retry-setup",
+            post(routes::code::retry_workspace_setup),
+        )
+        .route(
             "/code/workspaces/{id}/files",
             get(routes::code::list_workspace_files),
         )

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -101,7 +101,8 @@ pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
     get_worktree_root, list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace,
-    release_workspace, restore_workspace, search_workspace, set_worktree_root,
+    release_workspace, restore_workspace, retry_workspace_setup, search_workspace,
+    set_worktree_root,
 };
 
 // Nothing here reaches `AppState.code` directly. Every handler in this module

--- a/crates/tidebreak-server/src/routes/code/repos.rs
+++ b/crates/tidebreak-server/src/routes/code/repos.rs
@@ -12,12 +12,87 @@ use super::types::{
     CloneRepoBody, CodeCloneDefaults, CodeCloneJobSnapshot, CodeGithubRepositories,
     CodeRepoSnapshot, CodeRepoSources, CreateRepoBody, PatchRepoBody, RemoveRepoQuery,
 };
-use tidebreak_core::RepoId;
+use tidebreak_core::{QuickAction, RepoId};
+
+/// How many quick actions one repository may carry.
+///
+/// Every entry renders in the workspace header menu and the command palette,
+/// so a list past this is unusable before it is expensive. The cap also keeps
+/// the request body from sizing anything the server allocates.
+const MAX_QUICK_ACTIONS: usize = 32;
+
+/// Longest quick-action name. It is a menu label, not prose.
+const MAX_QUICK_ACTION_NAME: usize = 64;
+
+/// Longest quick-action command. A quick action is one short command in the
+/// worktree, bounded by `ACTION_TIMEOUT`; anything longer belongs in a script
+/// the command calls.
+const MAX_QUICK_ACTION_COMMAND: usize = 1024;
+
+/// Trim a submitted quick-action list and refuse one a workspace could not run.
+///
+/// `run_named_action` looks an action up by name, so two actions sharing a name
+/// make one of them unreachable. Reject the pair here rather than store a list
+/// whose second entry never runs.
+///
+/// Lengths are counted in `char`s, so a limit means the same thing to a reader
+/// as it does to the check.
+fn normalize_quick_actions(actions: Vec<QuickAction>) -> Result<Vec<QuickAction>, ServerError> {
+    if actions.len() > MAX_QUICK_ACTIONS {
+        return Err(ServerError::bad_request(format!(
+            "a repository takes at most {MAX_QUICK_ACTIONS} quick actions; got {}",
+            actions.len()
+        )));
+    }
+    // Neither vector takes a capacity hint from the body. The cap above bounds
+    // the list, and growing a vector of at most 32 entries costs nothing worth
+    // sizing from untrusted input.
+    let mut seen: Vec<String> = Vec::new();
+    let mut normalized = Vec::new();
+    for action in actions {
+        let name = action.name.trim().to_owned();
+        let command = action.command.trim().to_owned();
+        if name.is_empty() {
+            return Err(ServerError::bad_request(
+                "quick action name must not be empty",
+            ));
+        }
+        if name.chars().count() > MAX_QUICK_ACTION_NAME {
+            return Err(ServerError::bad_request(format!(
+                "quick action name must be at most {MAX_QUICK_ACTION_NAME} characters"
+            )));
+        }
+        if command.is_empty() {
+            return Err(ServerError::bad_request(format!(
+                "quick action {name} must have a command"
+            )));
+        }
+        if command.chars().count() > MAX_QUICK_ACTION_COMMAND {
+            return Err(ServerError::bad_request(format!(
+                "quick action {name} must have a command of at most \
+                 {MAX_QUICK_ACTION_COMMAND} characters"
+            )));
+        }
+        if seen.iter().any(|existing| existing == &name) {
+            return Err(ServerError::bad_request(format!(
+                "quick action {name} is listed twice"
+            )));
+        }
+        seen.push(name.clone());
+        normalized.push(QuickAction {
+            name,
+            command,
+            auto_run_on_create: action.auto_run_on_create,
+        });
+    }
+    Ok(normalized)
+}
 
 pub async fn create_repo(
     code: ScopedCode,
     Json(body): Json<CreateRepoBody>,
 ) -> Result<impl IntoResponse, ServerError> {
+    let quick_actions = normalize_quick_actions(body.quick_actions.unwrap_or_default())?;
     let repo = code
         .register_repo(
             PathBuf::from(body.path),
@@ -31,6 +106,7 @@ pub async fn create_repo(
                 branch_prefix: body.branch_prefix,
                 setup_script: body.setup_script,
                 archive_script: body.archive_script,
+                quick_actions,
             },
         )
         .await?;
@@ -85,6 +161,9 @@ pub async fn patch_repo(
     }
     if let Some(script) = body.archive_script {
         repo.archive_script = script.filter(|value| !value.trim().is_empty());
+    }
+    if let Some(actions) = body.quick_actions {
+        repo.quick_actions = normalize_quick_actions(actions)?;
     }
     code.save_repo(&repo).await?;
     Ok(Json(CodeRepoSnapshot::from(repo)))

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -646,6 +646,9 @@ pub struct CreateRepoBody {
     pub setup_script: Option<String>,
     #[serde(default)]
     pub archive_script: Option<String>,
+    /// Named commands the workspace surface offers. Omitted means none.
+    #[serde(default)]
+    pub quick_actions: Option<Vec<QuickAction>>,
 }
 
 /// Body of `PATCH /code/repos/{id}`.
@@ -662,6 +665,10 @@ pub struct PatchRepoBody {
     pub setup_script: Option<Option<String>>,
     #[serde(default)]
     pub archive_script: Option<Option<String>>,
+    /// The whole list, replaced. An empty list clears every quick action;
+    /// omitting the field leaves the stored list alone.
+    #[serde(default)]
+    pub quick_actions: Option<Vec<QuickAction>>,
 }
 
 /// Body of `POST /code/workspaces`.

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -130,6 +130,19 @@ pub async fn restore_workspace(
     Ok(Json(CodeWorkspaceSnapshot::from(restored)))
 }
 
+/// `POST /code/workspaces/{id}/retry-setup` — run the setup script again on the
+/// worktree this workspace already has.
+///
+/// The only way out of `setup_failed` that keeps the checkout. Success returns
+/// the now-Active workspace; another failure returns 422 `setup_failed`.
+pub async fn retry_workspace_setup(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
+    let workspace = code.retry_workspace_setup(id).await?;
+    Ok(Json(CodeWorkspaceSnapshot::from(workspace)))
+}
+
 pub async fn list_workspace_tree(
     code: ScopedCode,
     Path(id): Path<WorkspaceId>,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1069,6 +1069,302 @@ async fn workspace_setup_failure_preserves_the_checkout() {
     assert!(std::path::Path::new(path).join("README.md").is_file());
 }
 
+/// Quick actions are only reachable if a client can write them. `create`
+/// stores the list, `patch` replaces it whole, and an empty list clears it.
+#[tokio::test]
+async fn quick_actions_round_trip_through_create_and_patch() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "path": repo,
+            "quick_actions": [
+                { "name": "  Test  ", "command": " cargo test ", "auto_run_on_create": false },
+                { "name": "Install", "command": "pnpm install", "auto_run_on_create": true },
+            ],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let repo_id = json_id(&repo_body);
+    assert_eq!(repo_body["quick_actions"][0]["name"], "Test");
+    assert_eq!(repo_body["quick_actions"][0]["command"], "cargo test");
+    assert_eq!(repo_body["quick_actions"][1]["auto_run_on_create"], true);
+
+    let patched = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "quick_actions": [
+                { "name": "Lint", "command": "cargo clippy", "auto_run_on_create": false },
+            ],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(patched.status(), reqwest::StatusCode::OK);
+    let patched: serde_json::Value = patched.json().await.unwrap();
+    assert_eq!(patched["quick_actions"].as_array().unwrap().len(), 1);
+    assert_eq!(patched["quick_actions"][0]["name"], "Lint");
+
+    // Two actions under one name would make the second unreachable, because
+    // running one looks it up by name.
+    let duplicate = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "quick_actions": [
+                { "name": "Lint", "command": "cargo clippy", "auto_run_on_create": false },
+                { "name": "Lint", "command": "biome lint", "auto_run_on_create": false },
+            ],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(duplicate.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let blank = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "quick_actions": [{ "name": "Lint", "command": "   ", "auto_run_on_create": false }],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(blank.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    // Nothing the server allocates is sized from the body. Every entry also
+    // renders in the header menu and the palette, so the list is bounded.
+    let over_cap: Vec<serde_json::Value> = (0..33)
+        .map(|index| {
+            serde_json::json!({
+                "name": format!("Action {index}"),
+                "command": "true",
+                "auto_run_on_create": false,
+            })
+        })
+        .collect();
+    let too_many = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "quick_actions": over_cap }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(too_many.status(), reqwest::StatusCode::BAD_REQUEST);
+    let refusal: serde_json::Value = too_many.json().await.unwrap();
+    // The refusal names the limit, so a client can fix the body without guessing.
+    assert!(
+        refusal["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("32")),
+        "refusal should name the cap, got {refusal}"
+    );
+
+    // Exactly the cap is still accepted.
+    let at_cap: Vec<serde_json::Value> = (0..32)
+        .map(|index| {
+            serde_json::json!({
+                "name": format!("Action {index}"),
+                "command": "true",
+                "auto_run_on_create": false,
+            })
+        })
+        .collect();
+    let accepted = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "quick_actions": at_cap }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(accepted.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        accepted.json::<serde_json::Value>().await.unwrap()["quick_actions"]
+            .as_array()
+            .unwrap()
+            .len(),
+        32
+    );
+
+    let long_name = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "quick_actions": [{
+                "name": "n".repeat(65),
+                "command": "true",
+                "auto_run_on_create": false,
+            }],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(long_name.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let long_command = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "quick_actions": [{
+                "name": "Lint",
+                "command": "x".repeat(1025),
+                "auto_run_on_create": false,
+            }],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(long_command.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    // Back to one so the clear-vs-omit checks below read against a known list.
+    let reset = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "quick_actions": [
+                { "name": "Lint", "command": "cargo clippy", "auto_run_on_create": false },
+            ],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(reset.status(), reqwest::StatusCode::OK);
+
+    // Omitting the field leaves the stored list alone; an empty list clears it.
+    let renamed = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "display_name": "renamed" }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(renamed["quick_actions"].as_array().unwrap().len(), 1);
+    let cleared = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "quick_actions": [] }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert!(cleared["quick_actions"].as_array().unwrap().is_empty());
+}
+
+/// A failed setup keeps the checkout, so the way out is to fix the script and
+/// run it again — not to cut a second worktree. Retrying takes the workspace
+/// Active on the same path.
+#[tokio::test]
+async fn retry_setup_revives_a_setup_failed_workspace_in_place() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let repo_body: serde_json::Value = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo, "setup_script": "exit 3" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let repo_id = json_id(&repo_body).to_owned();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "repo_id": repo_id, "title": "broken setup" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let listed = client
+        .get(format!("http://{addr}/code/workspaces?repo_id={repo_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .unwrap();
+    let workspace_id = json_id(&listed[0]).to_owned();
+    let worktree_path = listed[0]["worktree_path"].as_str().unwrap().to_owned();
+
+    // Still broken: the retry fails the same way and the status holds.
+    let again = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/retry-setup"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(again.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(
+        again.json::<serde_json::Value>().await.unwrap()["kind"],
+        "setup_failed"
+    );
+
+    let fixed = client
+        .patch(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "setup_script": "echo ok > .setup-ran" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(fixed.status(), reqwest::StatusCode::OK);
+    let revived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/retry-setup"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(revived.status(), reqwest::StatusCode::OK);
+    let revived: serde_json::Value = revived.json().await.unwrap();
+    assert_eq!(revived["status"], "active");
+    // The same worktree, not a second one.
+    assert_eq!(revived["worktree_path"], worktree_path);
+    assert!(std::path::Path::new(&worktree_path)
+        .join(".setup-ran")
+        .is_file());
+    let listed = client
+        .get(format!("http://{addr}/code/workspaces?repo_id={repo_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+
+    // An already-active workspace is a no-op, not a re-run.
+    let repeat = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/retry-setup"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(repeat.status(), reqwest::StatusCode::OK);
+}
+
 #[tokio::test]
 async fn archive_requires_force_when_the_tree_is_dirty() {
     let (router, token, _runtime, dir) = code_app(plain_text_script()).await;

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -361,6 +361,7 @@ POST/GET        /code/workspaces           {repo_id, base_ref?, title?}
 GET/PATCH       /code/workspaces/{id}
 POST            /code/workspaces/{id}/archive | /release            {force?}
 POST            /code/workspaces/{id}/restore        back from a reclaim tier (0059)
+POST            /code/workspaces/{id}/retry-setup    run setup again on the same worktree
 POST            /code/workspaces/{id}/sessions       {harness, permission_mode,
                                                      model?, reasoning_effort?, fast_mode?}
 POST/GET        /code/sessions/{id}/turns            {message}  (queued while running —


### PR DESCRIPTION
The repo lifecycle hooks — setup script, archive script, quick actions — ran
server-side but nothing could write them and their failures never showed.
This closes that loop.

## Quick actions had no write path

`quick_actions` was absent from both `CreateRepoBody` and `PatchRepoBody`,
and `deny_unknown_fields` turned a client that sent one into a 422. The
subsystem was unreachable in production. Both bodies now take the field, and
`normalize_quick_actions` trims it and refuses what a workspace could not
run: a blank name, a blank command, or two actions under one name — the
second of a duplicate pair is unreachable, because `run_named_action` looks
an action up by name.

On patch the list is replaced whole. Omitting the field leaves the stored
list alone; an empty list clears it.

The list is bounded: at most 32 actions, names to 64 characters, commands to
1024. Every entry renders in the workspace header menu and the command
palette, so a list past that is unusable before it is expensive, and the
refusal names the limit so a client can fix the body without guessing. The
editor disables Add at the cap rather than letting a 33rd row earn a 400.
Bounding the list is also what lets the normalizer grow its vectors instead
of sizing them from `actions.len()` — CodeQL flagged those two
`Vec::with_capacity` calls as allocations derived from a request body
(alerts 190 and 191).

## A repo settings surface

`patchCodeRepo` had zero callers. `RepositorySettings` is the one place that
writes a repo's base ref, branch prefix, setup script, archive script, and
quick actions. It sits beside the trigger rules in the tracked-repositories
dialog, behind a Settings button on each registered row.

Text commits on blur, switches commit on change, so there is no Save button
to forget. A row still being typed stays on screen and off the wire until it
has both a name and a command, so adding one never blocks saving the rest. A
write that lands mid-flight queues behind the one in progress rather than
being dropped.

## `setup_failed` is visible

The "Setup failed" label had no consumers and the card fell through to idle,
so a workspace whose setup script broke read as an ordinary quiet one. The
card now carries a critical line, the accessible name says it too, and the
by-status rail gets a rank between done-unreviewed and idle: below live work,
because the checkout survived, but above idle, because nothing else says the
script never finished.

## The dialog no longer cuts a second worktree

On `setup_failed` the new-workspace dialog deleted the optimistic card and
offered "Try again", which created a second worktree for work the user
already had. It now keeps the card, finds the row the server wrote, and opens
it — the shape `runRestore` already used.

## `POST /code/workspaces/{id}/retry-setup`

`require_live_workspace` refuses a `setup_failed` workspace for everything,
so the state had no exit short of archiving the work. This runs the script
again on the worktree the workspace already has: Active on success, still
`setup_failed` and a 422 on another failure. It is offered as "Retry setup"
on the card menu, the workspace header, and the command palette.

## Tests

Server: `quick_actions_round_trip_through_create_and_patch` covers create,
patch, trimming, the duplicate and blank-command refusals, the 32-action cap
(over, and exactly at), the name and command length caps, and clear-vs-omit.
`retry_setup_revives_a_setup_failed_workspace_in_place` covers the failing
retry, the fixed retry, the same worktree path, and the no-op on an active
workspace. `workspace_setup_failure_preserves_the_checkout` still passes.

UI: `RepositorySettings.dom.test.tsx` (blur save, quick-action write, no
write on a bare focus change, unregistered repo), the `setup_failed` card
branch in `CodeSidebar.dom.test.tsx`, the rank in `workspaceCards.test.ts`,
and the dialog branch in `NewWorkspaceDialog.dom.test.tsx`.

Storybook: `Code/Repository settings` (configured, empty, loading, not
registered, load failed) and `Code/Workspace card` → `Setup failed`.

## Ran

`cargo check -p tidebreak-server`, `cargo clippy -p tidebreak-server
--all-targets` (only pre-existing `scripted_harness.rs` dead-code warnings),
`cargo fmt --all --check`, the three server tests above, `pnpm format`,
`pnpm lint`, `tsc --noEmit`, the full `pnpm test` (248 files, 2130 tests),
and `pnpm storybook:build`. `UPDATE_WIRE_TYPES=1` produced no wire diff —
the request bodies are `Deserialize`-only and not TS-exported — and both
`wire.ts` copies are untouched.

I could not screenshot the new stories: no Playwright package or browser MCP
is available in this environment, so the visual review is unverified.

Closes #2798

