### PR TITLE
feat(desktop): open workspace files in an external editor

### DIFF
--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -29,6 +29,8 @@ is_window_focused: reports main-window focus; document.hidden is the tab, not th
 present_native_notification: posts an OS banner and asks for notification permission on first unfocused present.
 code_browser_command: creates and controls sandboxed native child webviews whose bounds and lifecycle exist only in the desktop shell.
 open_code_worktree: opens a local Code worktree through this operating system's folder handler; a headless server cannot open desktop UI.
+open_in_editor: starts the editor installed on the machine the reader is sitting at, on one file inside a local worktree; the server may be that machine or another, and neither can raise a desktop editor here.
+detect_external_editors: probes this computer's PATH and application folders for installed editors, which only the client machine can see.
 
 # Attaching this client to a machine it does not host (ADR 0047)
 remote_machine_state: reports which machine this client is attached to, from shell-held state that exists before any machine is reachable.

--- a/crates/tidebreak-desktop/src/code_editor.rs
+++ b/crates/tidebreak-desktop/src/code_editor.rs
@@ -1,0 +1,589 @@
+//! Native open-in-editor for one file inside a Code workspace's worktree.
+//!
+//! The sibling `code_worktree` module hands a whole worktree to the operating
+//! system's folder handler. This one goes a step further: it opens a single
+//! file, at a line, in the editor the reader already uses. The renderer never
+//! supplies a path to run — it names a workspace and a path relative to that
+//! workspace, and this module re-reads the worktree root from the embedded
+//! server, resolves the file inside it, and refuses anything that lands
+//! outside. The editor comes from a closed set of launcher plans, so no part
+//! of the renderer's input reaches a shell.
+
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use tidebreak_core::{CodeWorkspaceStatus, WorkspaceId};
+
+use crate::remote::RemoteAttachment;
+use crate::{wait_server_info, AppState};
+
+pub(crate) const REASON_AUTHORITY_UNAVAILABLE: &str = "code_editor_authority_unavailable";
+pub(crate) const REASON_WORKSPACE_UNAVAILABLE: &str = "code_editor_workspace_unavailable";
+pub(crate) const REASON_WORKSPACE_INACTIVE: &str = "code_editor_workspace_inactive";
+pub(crate) const REASON_PATH_INVALID: &str = "code_editor_path_invalid";
+pub(crate) const REASON_PATH_OUTSIDE_WORKTREE: &str = "code_editor_path_outside_worktree";
+pub(crate) const REASON_PATH_NOT_FOUND: &str = "code_editor_path_not_found";
+pub(crate) const REASON_EDITOR_UNKNOWN: &str = "code_editor_editor_unknown";
+pub(crate) const REASON_EDITOR_UNAVAILABLE: &str = "code_editor_editor_unavailable";
+pub(crate) const REASON_OPEN_FAILED: &str = "code_editor_open_failed";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CodeEditorOpenError {
+    /// Stable reason code that the renderer turns into user-facing copy.
+    reason: &'static str,
+    /// Native diagnostic for logs and support. The renderer does not display it.
+    detail: Option<String>,
+}
+
+impl CodeEditorOpenError {
+    fn new(reason: &'static str) -> Self {
+        Self {
+            reason,
+            detail: None,
+        }
+    }
+
+    fn detailed(reason: &'static str, detail: impl std::fmt::Display) -> Self {
+        Self {
+            reason,
+            detail: Some(detail.to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CodeEditorOpenStatus {
+    Opened,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CodeEditorOpenResult {
+    status: CodeEditorOpenStatus,
+}
+
+/// The editors this desktop knows how to start.
+///
+/// A closed set, not a command string: each variant carries its own program
+/// candidates and its own way of spelling "this file, at this line", so the
+/// renderer chooses an editor rather than composing a command line. `Custom`
+/// is the one escape hatch, and it still takes an absolute program path that
+/// is spawned directly — never a shell string.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ExternalEditorKind {
+    Vscode,
+    Cursor,
+    Zed,
+    Jetbrains,
+    Custom,
+}
+
+impl ExternalEditorKind {
+    /// The kinds the settings panel probes, in the order it shows them.
+    const DETECTED: [Self; 4] = [Self::Vscode, Self::Cursor, Self::Zed, Self::Jetbrains];
+
+    fn id(self) -> &'static str {
+        match self {
+            Self::Vscode => "vscode",
+            Self::Cursor => "cursor",
+            Self::Zed => "zed",
+            Self::Jetbrains => "jetbrains",
+            Self::Custom => "custom",
+        }
+    }
+
+    /// Program names looked up on `PATH`, most specific first.
+    fn commands(self) -> &'static [&'static str] {
+        match self {
+            Self::Vscode => &["code"],
+            Self::Cursor => &["cursor"],
+            Self::Zed => &["zed"],
+            Self::Jetbrains => &["idea", "pycharm", "webstorm", "rustrover", "goland"],
+            Self::Custom => &[],
+        }
+    }
+
+    /// Absolute locations to try when the command-line launcher is not on
+    /// `PATH`. A desktop app started from Finder or a launcher inherits a
+    /// minimal `PATH`, so the installed-editor probe cannot rely on it alone.
+    fn fallbacks(self) -> &'static [&'static str] {
+        match self {
+            Self::Vscode => &[
+                "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+                "/usr/share/code/bin/code",
+                "/snap/bin/code",
+            ],
+            Self::Cursor => &[
+                "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+                "/usr/share/cursor/bin/cursor",
+            ],
+            Self::Zed => &["/Applications/Zed.app/Contents/MacOS/cli", "/snap/bin/zed"],
+            Self::Jetbrains => &[
+                "/Applications/IntelliJ IDEA.app/Contents/MacOS/idea",
+                "/Applications/IntelliJ IDEA CE.app/Contents/MacOS/idea",
+                "/snap/bin/intellij-idea-community",
+            ],
+            Self::Custom => &[],
+        }
+    }
+}
+
+/// One editor's availability on this computer, as the settings panel shows it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ExternalEditorProbe {
+    /// The stable id the renderer stores as the reader's preference.
+    id: &'static str,
+    /// The launcher this probe found, for the panel's caption. Absent when the
+    /// editor is not installed.
+    program: Option<String>,
+}
+
+/// What this computer has installed, so the settings panel can say so.
+#[tauri::command]
+pub(crate) async fn detect_external_editors(
+) -> Result<Vec<ExternalEditorProbe>, CodeEditorOpenError> {
+    let search_path = std::env::var_os("PATH");
+    Ok(ExternalEditorKind::DETECTED
+        .iter()
+        .map(|kind| ExternalEditorProbe {
+            id: kind.id(),
+            program: resolve_program(*kind, search_path.as_deref())
+                .map(|program| program.display().to_string()),
+        })
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OpenInEditorRequest {
+    workspace_id: String,
+    /// A path relative to the worktree root. Absent opens the worktree itself.
+    #[serde(default)]
+    relative_path: Option<String>,
+    #[serde(default)]
+    line: Option<u32>,
+    editor: ExternalEditorKind,
+    /// Absolute program path, required when `editor` is `custom`.
+    #[serde(default)]
+    custom_program: Option<String>,
+}
+
+/// Open one file from a local worktree in the reader's own editor.
+#[tauri::command]
+pub(crate) async fn open_in_editor(
+    attachment: State<'_, Arc<RemoteAttachment>>,
+    app_state: State<'_, Arc<AppState>>,
+    request: OpenInEditorRequest,
+) -> Result<CodeEditorOpenResult, CodeEditorOpenError> {
+    if attachment.current().await.is_some() {
+        return Err(CodeEditorOpenError::new(REASON_AUTHORITY_UNAVAILABLE));
+    }
+    let workspace_id: WorkspaceId = request
+        .workspace_id
+        .parse()
+        .map_err(|_| CodeEditorOpenError::new(REASON_WORKSPACE_UNAVAILABLE))?;
+    let info = wait_server_info(app_state.inner())
+        .await
+        .map_err(|error| CodeEditorOpenError::detailed(REASON_WORKSPACE_UNAVAILABLE, error))?;
+    let workspace = read_workspace(&info, workspace_id).await?;
+    if !matches!(
+        workspace.status,
+        CodeWorkspaceStatus::Active | CodeWorkspaceStatus::SetupFailed
+    ) {
+        return Err(CodeEditorOpenError::new(REASON_WORKSPACE_INACTIVE));
+    }
+    let target = resolve_target(
+        Path::new(&workspace.worktree_path),
+        request.relative_path.as_deref(),
+    )?;
+    let program = match request.editor {
+        ExternalEditorKind::Custom => custom_program(request.custom_program.as_deref())?,
+        kind => resolve_program(kind, std::env::var_os("PATH").as_deref())
+            .ok_or_else(|| CodeEditorOpenError::new(REASON_EDITOR_UNAVAILABLE))?,
+    };
+    let plan = launcher_plan(request.editor, &program, &target, request.line);
+    spawn(plan)
+}
+
+#[derive(Deserialize)]
+struct CodeWorktreeSnapshot {
+    worktree_path: String,
+    status: CodeWorkspaceStatus,
+}
+
+async fn read_workspace(
+    info: &crate::NativeServerInfo,
+    workspace_id: WorkspaceId,
+) -> Result<CodeWorktreeSnapshot, CodeEditorOpenError> {
+    let response = crate::documents::local_client()
+        .get(format!("{}/code/workspaces/{workspace_id}", info.base_url))
+        .bearer_auth(&info.token)
+        .send()
+        .await
+        .map_err(|error| CodeEditorOpenError::detailed(REASON_WORKSPACE_UNAVAILABLE, error))?;
+    if !response.status().is_success() {
+        return Err(CodeEditorOpenError::detailed(
+            REASON_WORKSPACE_UNAVAILABLE,
+            response.status(),
+        ));
+    }
+    response
+        .json()
+        .await
+        .map_err(|error| CodeEditorOpenError::detailed(REASON_WORKSPACE_UNAVAILABLE, error))
+}
+
+/// The absolute file (or folder) to open, proven to sit inside the worktree.
+///
+/// Both sides are canonicalized before they are compared, so a symlink inside
+/// the worktree that points elsewhere is refused the same way `../` is. That
+/// also means the target has to exist: an editor cannot open a file the
+/// worktree no longer has, and inventing the path would defeat the check.
+fn resolve_target(worktree: &Path, relative: Option<&str>) -> Result<PathBuf, CodeEditorOpenError> {
+    if !worktree.is_absolute() {
+        return Err(CodeEditorOpenError::new(REASON_PATH_INVALID));
+    }
+    let root = canonical(worktree)?;
+    let Some(relative) = relative else {
+        return Ok(root);
+    };
+    let relative = Path::new(relative);
+    if relative.as_os_str().is_empty() || relative.is_absolute() {
+        return Err(CodeEditorOpenError::new(REASON_PATH_INVALID));
+    }
+    // Refuse traversal in the request itself rather than relying on the
+    // canonical comparison alone: a `..` that happens to stay inside is still
+    // the renderer reaching past the path it was given.
+    if relative
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(CodeEditorOpenError::new(REASON_PATH_INVALID));
+    }
+    let target = canonical(&root.join(relative))?;
+    if !target.starts_with(&root) {
+        return Err(CodeEditorOpenError::new(REASON_PATH_OUTSIDE_WORKTREE));
+    }
+    Ok(target)
+}
+
+fn canonical(path: &Path) -> Result<PathBuf, CodeEditorOpenError> {
+    std::fs::canonicalize(path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            CodeEditorOpenError::new(REASON_PATH_NOT_FOUND)
+        } else {
+            CodeEditorOpenError::detailed(REASON_OPEN_FAILED, error)
+        }
+    })
+}
+
+/// The reader's own `$EDITOR`-style program, held to the same shape as the
+/// built-in launchers: one absolute executable, spawned directly.
+fn custom_program(program: Option<&str>) -> Result<PathBuf, CodeEditorOpenError> {
+    let program = program.map(str::trim).filter(|value| !value.is_empty());
+    let Some(program) = program else {
+        return Err(CodeEditorOpenError::new(REASON_EDITOR_UNKNOWN));
+    };
+    let path = PathBuf::from(program);
+    if !path.is_absolute() {
+        return Err(CodeEditorOpenError::new(REASON_EDITOR_UNKNOWN));
+    }
+    if !path.is_file() {
+        return Err(CodeEditorOpenError::new(REASON_EDITOR_UNAVAILABLE));
+    }
+    Ok(path)
+}
+
+/// The first program for `kind` that exists, searching `PATH` then the known
+/// install locations.
+fn resolve_program(
+    kind: ExternalEditorKind,
+    search_path: Option<&std::ffi::OsStr>,
+) -> Option<PathBuf> {
+    for command in kind.commands() {
+        for directory in search_path.iter().flat_map(std::env::split_paths) {
+            let candidate = directory.join(command);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    kind.fallbacks()
+        .iter()
+        .map(PathBuf::from)
+        .find(|candidate| candidate.is_file())
+}
+
+struct LauncherPlan {
+    program: PathBuf,
+    args: Vec<OsString>,
+}
+
+/// How each editor spells "open this file at this line".
+///
+/// VS Code and its forks take `--goto path:line`; Zed takes `path:line`;
+/// JetBrains takes `--line <n> <path>`. A custom program gets the path alone,
+/// because nothing here knows its flags.
+fn launcher_plan(
+    kind: ExternalEditorKind,
+    program: &Path,
+    target: &Path,
+    line: Option<u32>,
+) -> LauncherPlan {
+    let line = line.filter(|line| *line >= 1);
+    let args = match (kind, line) {
+        (ExternalEditorKind::Vscode | ExternalEditorKind::Cursor, Some(line)) => {
+            vec![OsString::from("--goto"), suffixed(target, line)]
+        }
+        (ExternalEditorKind::Zed, Some(line)) => vec![suffixed(target, line)],
+        (ExternalEditorKind::Jetbrains, Some(line)) => vec![
+            OsString::from("--line"),
+            OsString::from(line.to_string()),
+            target.as_os_str().to_owned(),
+        ],
+        _ => vec![target.as_os_str().to_owned()],
+    };
+    LauncherPlan {
+        program: program.to_path_buf(),
+        args,
+    }
+}
+
+/// `path:line`, built on the raw bytes so a path that is not valid UTF-8 keeps
+/// its own spelling instead of being lossily rewritten.
+fn suffixed(target: &Path, line: u32) -> OsString {
+    let mut value = target.as_os_str().to_owned();
+    value.push(format!(":{line}"));
+    value
+}
+
+fn spawn(plan: LauncherPlan) -> Result<CodeEditorOpenResult, CodeEditorOpenError> {
+    let mut command = tokio::process::Command::new(&plan.program);
+    command
+        .args(plan.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(false);
+    let mut child = command.spawn().map_err(|error| {
+        let reason = if error.kind() == std::io::ErrorKind::NotFound {
+            REASON_EDITOR_UNAVAILABLE
+        } else {
+            REASON_OPEN_FAILED
+        };
+        CodeEditorOpenError::detailed(reason, error)
+    })?;
+    tauri::async_runtime::spawn(async move {
+        let _ = child.wait().await;
+    });
+    Ok(CodeEditorOpenResult {
+        status: CodeEditorOpenStatus::Opened,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worktree() -> tempfile::TempDir {
+        let directory = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(directory.path().join("src")).unwrap();
+        std::fs::write(directory.path().join("src/main.rs"), "fn main() {}").unwrap();
+        directory
+    }
+
+    #[test]
+    fn resolves_a_file_inside_the_worktree_and_nothing_outside_it() {
+        let directory = worktree();
+        let root = std::fs::canonicalize(directory.path()).unwrap();
+
+        assert_eq!(
+            resolve_target(directory.path(), Some("src/main.rs")).unwrap(),
+            root.join("src/main.rs")
+        );
+        // No relative path opens the worktree itself.
+        assert_eq!(resolve_target(directory.path(), None).unwrap(), root);
+
+        for traversal in ["../escape", "src/../../escape", "./src/main.rs"] {
+            assert_eq!(
+                resolve_target(directory.path(), Some(traversal))
+                    .unwrap_err()
+                    .reason,
+                REASON_PATH_INVALID,
+                "{traversal} should be refused"
+            );
+        }
+        assert_eq!(
+            resolve_target(directory.path(), Some("/etc/passwd"))
+                .unwrap_err()
+                .reason,
+            REASON_PATH_INVALID
+        );
+        assert_eq!(
+            resolve_target(directory.path(), Some(""))
+                .unwrap_err()
+                .reason,
+            REASON_PATH_INVALID
+        );
+        assert_eq!(
+            resolve_target(Path::new("relative/worktree"), Some("src/main.rs"))
+                .unwrap_err()
+                .reason,
+            REASON_PATH_INVALID
+        );
+        assert_eq!(
+            resolve_target(directory.path(), Some("src/missing.rs"))
+                .unwrap_err()
+                .reason,
+            REASON_PATH_NOT_FOUND
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_that_leaves_the_worktree_is_refused() {
+        let directory = worktree();
+        let outside = tempfile::TempDir::new().unwrap();
+        let secret = outside.path().join("secret");
+        std::fs::write(&secret, "not in the worktree").unwrap();
+        std::os::unix::fs::symlink(&secret, directory.path().join("src/link.rs")).unwrap();
+
+        assert_eq!(
+            resolve_target(directory.path(), Some("src/link.rs"))
+                .unwrap_err()
+                .reason,
+            REASON_PATH_OUTSIDE_WORKTREE
+        );
+    }
+
+    #[test]
+    fn each_editor_spells_the_line_its_own_way() {
+        let program = Path::new("/usr/local/bin/editor");
+        let target = Path::new("/work tree/src/main.rs");
+
+        let vscode = launcher_plan(ExternalEditorKind::Vscode, program, target, Some(42));
+        assert_eq!(vscode.program, program);
+        assert_eq!(
+            vscode.args,
+            vec![
+                OsString::from("--goto"),
+                OsString::from("/work tree/src/main.rs:42")
+            ]
+        );
+        assert_eq!(
+            launcher_plan(ExternalEditorKind::Cursor, program, target, Some(42)).args,
+            vscode.args
+        );
+        assert_eq!(
+            launcher_plan(ExternalEditorKind::Zed, program, target, Some(7)).args,
+            vec![OsString::from("/work tree/src/main.rs:7")]
+        );
+        assert_eq!(
+            launcher_plan(ExternalEditorKind::Jetbrains, program, target, Some(7)).args,
+            vec![
+                OsString::from("--line"),
+                OsString::from("7"),
+                target.as_os_str().to_owned()
+            ]
+        );
+        // A custom program gets the path alone: nothing here knows its flags.
+        assert_eq!(
+            launcher_plan(ExternalEditorKind::Custom, program, target, Some(7)).args,
+            vec![target.as_os_str().to_owned()]
+        );
+    }
+
+    #[test]
+    fn no_line_and_a_zero_line_both_open_the_file_plainly() {
+        let program = Path::new("/usr/local/bin/code");
+        let target = Path::new("/work/src/main.rs");
+        for line in [None, Some(0)] {
+            assert_eq!(
+                launcher_plan(ExternalEditorKind::Vscode, program, target, line).args,
+                vec![target.as_os_str().to_owned()],
+                "line {line:?} should not produce a --goto"
+            );
+        }
+    }
+
+    #[test]
+    fn a_custom_editor_must_be_an_absolute_program_that_exists() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let program = directory.path().join("my-editor");
+        std::fs::write(&program, "#!/bin/sh\n").unwrap();
+
+        assert_eq!(
+            custom_program(Some(&program.display().to_string())).unwrap(),
+            program
+        );
+        assert_eq!(
+            custom_program(None).unwrap_err().reason,
+            REASON_EDITOR_UNKNOWN
+        );
+        assert_eq!(
+            custom_program(Some("   ")).unwrap_err().reason,
+            REASON_EDITOR_UNKNOWN
+        );
+        // A bare name would be a `PATH` lookup, which is a shell's job.
+        assert_eq!(
+            custom_program(Some("vim")).unwrap_err().reason,
+            REASON_EDITOR_UNKNOWN
+        );
+        assert_eq!(
+            custom_program(Some(
+                &directory.path().join("missing").display().to_string()
+            ))
+            .unwrap_err()
+            .reason,
+            REASON_EDITOR_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn detection_searches_the_given_path_and_reports_a_missing_editor() {
+        let directory = tempfile::TempDir::new().unwrap();
+        std::fs::write(directory.path().join("code"), "#!/bin/sh\n").unwrap();
+        let search_path = std::env::join_paths([directory.path()]).unwrap();
+
+        assert_eq!(
+            resolve_program(ExternalEditorKind::Vscode, Some(&search_path)),
+            Some(directory.path().join("code"))
+        );
+        assert_eq!(
+            resolve_program(ExternalEditorKind::Custom, Some(&search_path)),
+            None
+        );
+    }
+
+    #[test]
+    fn failures_serialize_as_stable_reason_and_private_detail() {
+        let value = serde_json::to_value(CodeEditorOpenError::detailed(
+            REASON_OPEN_FAILED,
+            "native detail",
+        ))
+        .unwrap();
+        assert_eq!(value["reason"], REASON_OPEN_FAILED);
+        assert_eq!(value["detail"], "native detail");
+    }
+
+    #[test]
+    fn the_renderer_names_an_editor_from_the_closed_set() {
+        assert_eq!(
+            serde_json::from_str::<ExternalEditorKind>("\"vscode\"").unwrap(),
+            ExternalEditorKind::Vscode
+        );
+        assert_eq!(
+            serde_json::from_str::<ExternalEditorKind>("\"jetbrains\"").unwrap(),
+            ExternalEditorKind::Jetbrains
+        );
+        assert!(serde_json::from_str::<ExternalEditorKind>("\"emacs\"").is_err());
+    }
+}

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -34,6 +34,7 @@ mod channel;
 mod chat_debug;
 mod client_execution;
 mod code_browser;
+mod code_editor;
 mod code_worktree;
 #[cfg(test)]
 mod command_parity;
@@ -854,6 +855,8 @@ pub fn run() {
             present_native_notification,
             code_browser::code_browser_command,
             code_worktree::open_code_worktree,
+            code_editor::open_in_editor,
+            code_editor::detect_external_editors,
             attachments::attach_chat_files,
             attachments::attach_dropped_chat_files,
             image_attachments::publish_chat_image,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -166,8 +166,10 @@ import { useCodeContentRevision } from "./useLiveContent";
 import { SessionLifecycleIndicator } from "./SessionLifecycleIndicator";
 import { SessionPermissionIndicator } from "./SessionPermissionIndicator";
 import { WorkspaceHeader } from "./WorkspaceHeader";
+import { canOpenInExternalEditor } from "./codeWorktreeHost";
 import {
   WorkspaceOverflowMenu,
+  openWorkspaceFileInEditor,
   useWorkspaceCardCommands,
   workspaceHeaderCommands,
 } from "./workspaceActions";
@@ -1160,6 +1162,16 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                 fileReveal?.path === panel.path ? fileReveal.line : undefined
               }
               revealRevision={fileReveal?.revision}
+              onOpenInEditor={
+                canOpenInExternalEditor()
+                  ? (path, line) =>
+                      openWorkspaceFileInEditor({
+                        workspaceId,
+                        relativePath: path,
+                        line,
+                      })
+                  : undefined
+              }
             />
           </Suspense>
         ) : panel.type === "diff" ? (
@@ -1170,6 +1182,15 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             file={panel.path}
             contentRevision={contentRevision}
             onOpenFile={(path) => openFile(path, undefined, region)}
+            onOpenInEditor={
+              canOpenInExternalEditor()
+                ? (path) =>
+                    openWorkspaceFileInEditor({
+                      workspaceId,
+                      relativePath: path,
+                    })
+                : undefined
+            }
           />
         ) : panel.type === "browser" ? (
           <Suspense fallback={<Skeleton className="h-full w-full" />}>

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { MiddleTruncate } from "./MiddleTruncate";
+import { OpenInEditorButton } from "./OpenInEditorButton";
 import { DiffstatBadge } from "./TurnReviewCard";
 import { useLiveResource } from "./useLiveContent";
 
@@ -42,6 +43,7 @@ export function DiffPanel({
   file,
   contentRevision = 0,
   onOpenFile,
+  onOpenInEditor,
 }: {
   client: Pick<ApiClient, "getCodeWorkspaceDiff">;
   workspaceId: string;
@@ -51,6 +53,8 @@ export function DiffPanel({
   file?: string;
   contentRevision?: number;
   onOpenFile?: (path: string) => void;
+  /** Hand the scoped file to the reader's own editor. */
+  onOpenInEditor?: (path: string) => void;
 }) {
   const load = useCallback(
     () => client.getCodeWorkspaceDiff(workspaceId, { turn: turnId, file }),
@@ -109,6 +113,9 @@ export function DiffPanel({
               <FileCode2 className="size-3" aria-hidden />
               Open file
             </button>
+          )}
+          {file && onOpenInEditor && (
+            <OpenInEditorButton onClick={() => onOpenInEditor(file)} />
           )}
         </div>
       </header>

--- a/crates/tidebreak-desktop/ui/src/code/FileViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FileViewer.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useTheme } from "@/theme";
 import { configureMonaco, monacoLanguage, monacoTheme } from "./monacoEnv";
 import { MiddleTruncate } from "./MiddleTruncate";
+import { OpenInEditorButton } from "./OpenInEditorButton";
 import { useLiveResource } from "./useLiveContent";
 
 /**
@@ -20,6 +21,7 @@ export function FileViewer({
   contentRevision = 0,
   revealLine,
   revealRevision = 0,
+  onOpenInEditor,
 }: {
   client: Pick<ApiClient, "getCodeWorkspaceBlob">;
   workspaceId: string;
@@ -27,6 +29,8 @@ export function FileViewer({
   contentRevision?: number;
   revealLine?: number;
   revealRevision?: number;
+  /** Hand this file, at the line on screen, to the reader's own editor. */
+  onOpenInEditor?: (path: string, line?: number) => void;
 }) {
   const { resolved: resolvedTheme } = useTheme();
   const load = useCallback(
@@ -60,11 +64,18 @@ export function FileViewer({
             className="text-muted-foreground font-mono text-xs"
           />
         </div>
-        <span className="grid size-3.5 shrink-0 place-items-center">
-          {refreshing && (
-            <Spinner className="size-3.5" aria-label="Refreshing" />
+        <div className="flex items-center gap-2">
+          <span className="grid size-3.5 shrink-0 place-items-center">
+            {refreshing && (
+              <Spinner className="size-3.5" aria-label="Refreshing" />
+            )}
+          </span>
+          {onOpenInEditor && (
+            <OpenInEditorButton
+              onClick={() => onOpenInEditor(path, revealLine)}
+            />
           )}
-        </span>
+        </div>
       </header>
       {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
       {!data && !error && (

--- a/crates/tidebreak-desktop/ui/src/code/OpenInEditorButton.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/OpenInEditorButton.tsx
@@ -1,0 +1,32 @@
+import { ExternalLink } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import { openInEditorLabel, useEditorPreference } from "./editorPreference";
+
+/**
+ * The one "hand this file to my editor" control, shared by the file viewer and
+ * the diff panel.
+ *
+ * Both panels sit under the same center tab strip and share one header shape,
+ * so the action has to look and read identically in the two of them. It sits
+ * beside the diff panel's "Open file" and wears the same quiet chip treatment:
+ * a recognition glyph at text size, no container, no colour of its own.
+ */
+export function OpenInEditorButton({ onClick }: { onClick: () => void }) {
+  const label = openInEditorLabel(useEditorPreference().editor);
+  return (
+    <button
+      type="button"
+      className={cn(
+        "text-muted-foreground hover:bg-muted hover:text-foreground flex cursor-pointer items-center gap-1 rounded-md px-1.5 py-1 text-xs",
+        FOCUS_RING_TIGHT,
+        HOVER_TINT,
+      )}
+      onClick={onClick}
+    >
+      <ExternalLink className="size-3" aria-hidden />
+      {label}
+    </button>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/codePaletteRows.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codePaletteRows.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { codeNavigationPaletteRows } from "./codePaletteRows";
+import { codeWorkspace } from "../stories/fixtures";
+import {
+  codeNavigationPaletteRows,
+  workspaceActionPaletteRows,
+} from "./codePaletteRows";
+import { setEditorPreference } from "./editorPreference";
 
 describe("codeNavigationPaletteRows", () => {
   it("puts analytics before delivery and navigates to its route", () => {
@@ -36,5 +41,52 @@ describe("codeNavigationPaletteRows", () => {
       row.onSelect();
     }
     expect(navigate.mock.calls.flat()).not.toContain("/code/notifications");
+  });
+});
+
+describe("workspaceActionPaletteRows", () => {
+  const common = {
+    workspace: codeWorkspace,
+    hasPr: false,
+    hasSession: false,
+    attentionPinned: false,
+    quickActions: [],
+  };
+
+  it("carries Open in editor with an icon, and runs the command it names", () => {
+    setEditorPreference({ editor: "cursor", customProgram: "" });
+    const onCommand = vi.fn();
+    const rows = workspaceActionPaletteRows({
+      ...common,
+      canOpenInEditor: true,
+      onCommand,
+    });
+
+    const row = rows.find((item) => item.id === "action:open-in-editor");
+    expect(row?.label).toBe("Open in Cursor");
+    // Every neighbouring action row wears a glyph; a bare row reads as a
+    // second class of command.
+    expect(row?.icon).toBeDefined();
+    row?.onSelect();
+    expect(onCommand).toHaveBeenCalledWith({
+      id: "open-in-editor",
+      label: "Open in Cursor",
+    });
+  });
+
+  it("leaves the row out where no editor here can open the file", () => {
+    for (const input of [
+      { ...common, canOpenInEditor: false },
+      {
+        ...common,
+        workspace: { ...codeWorkspace, status: "archived" as const },
+        canOpenInEditor: true,
+      },
+    ]) {
+      const rows = workspaceActionPaletteRows({ ...input, onCommand: vi.fn() });
+      expect(rows.some((row) => row.id === "action:open-in-editor")).toBe(
+        false,
+      );
+    }
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
@@ -3,6 +3,7 @@ import {
   BarChart3,
   FileText,
   GitPullRequest,
+  ExternalLink,
   MessageSquare,
   Play,
   Plus,
@@ -169,6 +170,8 @@ export function workspaceActionPaletteRows(input: {
   attentionPinned: boolean;
   quickActions: readonly { name: string }[];
   canUneff?: boolean;
+  /** This window can start an editor on the machine holding the worktree. */
+  canOpenInEditor?: boolean;
   onCommand: (command: WorkspaceCommand) => void;
 }): PaletteRow[] {
   const archived = input.workspace.status === "archived";
@@ -178,6 +181,7 @@ export function workspaceActionPaletteRows(input: {
     hasSession: input.hasSession,
     attentionPinned: input.attentionPinned,
     canUneff: input.canUneff,
+    canOpenInEditor: input.canOpenInEditor,
   });
   const quick: WorkspaceCommand[] = archived
     ? []
@@ -204,6 +208,7 @@ export function workspaceActionPaletteRows(input: {
 
 const ACTION_ICONS: Partial<Record<WorkspaceCommandId, PaletteRow["icon"]>> = {
   "new-session": Plus,
+  "open-in-editor": ExternalLink,
   "toggle-terminal": Terminal,
   "open-pr": GitPullRequest,
   "uneff-me": Wrench,

--- a/crates/tidebreak-desktop/ui/src/code/codeWorktreeHost.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeWorktreeHost.test.ts
@@ -4,12 +4,18 @@ const invoke = vi.hoisted(() => vi.fn());
 vi.mock("@tauri-apps/api/core", () => ({ invoke, isTauri: () => true }));
 
 import {
+  CodeEditorOpenError,
   CodeWorktreeOpenError,
+  codeEditorOpenFailureMessage,
   codeWorktreeOpenFailureMessage,
   codeWorktreePlatform,
+  detectExternalEditors,
   openCodeWorktree,
+  openInEditor,
+  parseCodeEditorOpenError,
   parseCodeWorktreeOpenError,
 } from "./codeWorktreeHost";
+import { setEditorPreference } from "./editorPreference";
 
 beforeEach(() => invoke.mockReset());
 
@@ -65,5 +71,99 @@ describe("code worktree host", () => {
       "linux",
     );
     expect(codeWorktreePlatform("Tidebreak mobile")).toBe("unsupported");
+  });
+});
+
+describe("open in editor host", () => {
+  it("sends the workspace, the relative path, and the chosen editor", async () => {
+    setEditorPreference({ editor: "zed", customProgram: "" });
+    invoke.mockResolvedValue({ status: "opened" });
+
+    await openInEditor({
+      workspaceId: "e777ae2f-619c-4ed7-ad1f-8c9dfd179a90",
+      relativePath: "crates/tidebreak-desktop/src/lib.rs",
+      line: 42,
+    });
+
+    expect(invoke).toHaveBeenCalledWith("open_in_editor", {
+      request: {
+        workspaceId: "e777ae2f-619c-4ed7-ad1f-8c9dfd179a90",
+        relativePath: "crates/tidebreak-desktop/src/lib.rs",
+        line: 42,
+        editor: "zed",
+        customProgram: null,
+      },
+    });
+  });
+
+  it("carries the custom program only when the reader chose one", async () => {
+    setEditorPreference({
+      editor: "custom",
+      customProgram: "/opt/homebrew/bin/nvim",
+    });
+    invoke.mockResolvedValue({ status: "opened" });
+
+    await openInEditor({ workspaceId: "ws-1" });
+
+    expect(invoke).toHaveBeenCalledWith("open_in_editor", {
+      request: {
+        workspaceId: "ws-1",
+        relativePath: null,
+        line: null,
+        editor: "custom",
+        customProgram: "/opt/homebrew/bin/nvim",
+      },
+    });
+  });
+
+  it("refuses a result that is not the one opened shape", async () => {
+    setEditorPreference({ editor: "vscode", customProgram: "" });
+    invoke.mockResolvedValue({ status: "maybe" });
+
+    await expect(openInEditor({ workspaceId: "ws-1" })).rejects.toMatchObject({
+      reason: "code_editor_open_failed",
+    });
+  });
+
+  it("keeps native failures typed and their detail out of user copy", () => {
+    const error = parseCodeEditorOpenError({
+      reason: "code_editor_path_outside_worktree",
+      detail: "/etc/passwd",
+    });
+
+    expect(error).toBeInstanceOf(CodeEditorOpenError);
+    expect(error.reason).toBe("code_editor_path_outside_worktree");
+    expect(error.detail).toBe("/etc/passwd");
+    expect(
+      codeEditorOpenFailureMessage({
+        reason: "code_editor_path_outside_worktree",
+      }),
+    ).toBe("That path does not sit inside this workspace's worktree.");
+    expect(parseCodeEditorOpenError("native stack trace")).toMatchObject({
+      reason: "code_editor_open_failed",
+      detail: null,
+    });
+    // A worktree reason is not an editor reason: the two sets stay separate.
+    expect(
+      parseCodeEditorOpenError({ reason: "code_worktree_path_not_found" })
+        .reason,
+    ).toBe("code_editor_open_failed");
+    expect(
+      parseCodeWorktreeOpenError({ reason: "code_editor_open_failed" }).reason,
+    ).toBe("code_worktree_open_failed");
+  });
+
+  it("keeps only well-formed probes from the native detection", async () => {
+    invoke.mockResolvedValue([
+      { id: "vscode", program: "/usr/local/bin/code" },
+      { id: "zed", program: null },
+      { id: "cursor" },
+      "not a probe",
+    ]);
+
+    expect(await detectExternalEditors()).toEqual([
+      { id: "vscode", program: "/usr/local/bin/code" },
+      { id: "zed", program: null },
+    ]);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/codeWorktreeHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeWorktreeHost.ts
@@ -1,6 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 
 import { hasLocalHostAuthority } from "@/host";
+import {
+  currentEditorPreference,
+  type ExternalEditorId,
+} from "./editorPreference";
 
 export type CodeWorktreeOpenReason =
   | "code_worktree_authority_unavailable"
@@ -117,4 +121,142 @@ function isExactOpenedResult(value: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/* -------------------------------------------------------------------------
+ * Open in editor
+ *
+ * The same shape as the folder open above, one step narrower: the renderer
+ * names a workspace and a path relative to it, never a path to run, and the
+ * native side re-reads the worktree root and refuses anything outside it.
+ * ---------------------------------------------------------------------- */
+
+export type CodeEditorOpenReason =
+  | "code_editor_authority_unavailable"
+  | "code_editor_workspace_unavailable"
+  | "code_editor_workspace_inactive"
+  | "code_editor_path_invalid"
+  | "code_editor_path_outside_worktree"
+  | "code_editor_path_not_found"
+  | "code_editor_editor_unknown"
+  | "code_editor_editor_unavailable"
+  | "code_editor_open_failed";
+
+const EDITOR_REASONS = new Set<CodeEditorOpenReason>([
+  "code_editor_authority_unavailable",
+  "code_editor_workspace_unavailable",
+  "code_editor_workspace_inactive",
+  "code_editor_path_invalid",
+  "code_editor_path_outside_worktree",
+  "code_editor_path_not_found",
+  "code_editor_editor_unknown",
+  "code_editor_editor_unavailable",
+  "code_editor_open_failed",
+]);
+
+export class CodeEditorOpenError extends Error {
+  readonly reason: CodeEditorOpenReason;
+  readonly detail: string | null;
+
+  constructor(reason: CodeEditorOpenReason, detail: string | null = null) {
+    super(reason);
+    this.name = "CodeEditorOpenError";
+    this.reason = reason;
+    this.detail = detail;
+  }
+}
+
+/** One editor's availability on this computer, as the native probe found it. */
+export type ExternalEditorProbe = {
+  id: ExternalEditorId;
+  /** The launcher the probe found, or `null` when the editor is not installed. */
+  program: string | null;
+};
+
+/**
+ * Whether this window can start an editor on the machine holding the worktree.
+ *
+ * The same test the folder action uses: a window attached to another machine is
+ * looking at files it cannot reach, and the editor here would open nothing.
+ */
+export function canOpenInExternalEditor(
+  userAgent = globalThis.navigator?.userAgent ?? "",
+): boolean {
+  return canOpenLocalCodeWorktree(userAgent);
+}
+
+/** Ask the native shell to open one worktree file in the reader's editor. */
+export async function openInEditor(input: {
+  workspaceId: string;
+  /** Relative to the worktree root. Omitted opens the worktree itself. */
+  relativePath?: string;
+  line?: number;
+}): Promise<void> {
+  const preference = currentEditorPreference();
+  try {
+    const result: unknown = await invoke("open_in_editor", {
+      request: {
+        workspaceId: input.workspaceId,
+        relativePath: input.relativePath ?? null,
+        line: input.line ?? null,
+        editor: preference.editor,
+        customProgram:
+          preference.editor === "custom" ? preference.customProgram : null,
+      },
+    });
+    if (!isExactOpenedResult(result)) {
+      throw new CodeEditorOpenError("code_editor_open_failed");
+    }
+  } catch (error) {
+    if (error instanceof CodeEditorOpenError) throw error;
+    throw parseCodeEditorOpenError(error);
+  }
+}
+
+/** What this computer has installed, for the settings panel to report. */
+export async function detectExternalEditors(): Promise<ExternalEditorProbe[]> {
+  const result: unknown = await invoke("detect_external_editors");
+  if (!Array.isArray(result)) return [];
+  return result.filter(
+    (probe): probe is ExternalEditorProbe =>
+      isRecord(probe) &&
+      typeof probe.id === "string" &&
+      (probe.program === null || typeof probe.program === "string"),
+  );
+}
+
+export function codeEditorOpenFailureMessage(error: unknown): string {
+  switch (parseCodeEditorOpenError(error).reason) {
+    case "code_editor_authority_unavailable":
+      return "This file is on the attached machine. Open it in an editor there.";
+    case "code_editor_workspace_unavailable":
+      return "Tidebreak could not verify this local workspace. Refresh it, then try again.";
+    case "code_editor_workspace_inactive":
+      return "This workspace no longer has a local worktree. Restore it, then try again.";
+    case "code_editor_path_invalid":
+    case "code_editor_path_outside_worktree":
+      return "That path does not sit inside this workspace's worktree.";
+    case "code_editor_path_not_found":
+      return "That file is no longer in the worktree. Refresh the file tree, then try again.";
+    case "code_editor_editor_unknown":
+      return "Your custom editor needs the full path to its program. Set it in Settings, Coding harnesses.";
+    case "code_editor_editor_unavailable":
+      return "Tidebreak could not find that editor on this computer. Pick another one in Settings, Coding harnesses.";
+    case "code_editor_open_failed":
+      return "The editor did not start. Try opening the worktree folder instead.";
+  }
+}
+
+export function parseCodeEditorOpenError(error: unknown): CodeEditorOpenError {
+  if (error instanceof CodeEditorOpenError) return error;
+  if (
+    isRecord(error) &&
+    EDITOR_REASONS.has(error.reason as CodeEditorOpenReason)
+  ) {
+    return new CodeEditorOpenError(
+      error.reason as CodeEditorOpenReason,
+      typeof error.detail === "string" ? error.detail : null,
+    );
+  }
+  return new CodeEditorOpenError("code_editor_open_failed");
 }

--- a/crates/tidebreak-desktop/ui/src/code/editorPreference.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/editorPreference.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  currentEditorPreference,
+  openInEditorLabel,
+  readStoredEditorPreference,
+  resetEditorPreferenceStore,
+  setEditorPreference,
+} from "./editorPreference";
+
+const STORAGE_KEY = "tidebreak.externalEditor";
+
+beforeEach(() => {
+  localStorage.clear();
+  resetEditorPreferenceStore();
+});
+
+describe("external editor preference", () => {
+  it("stores the choice under the shared key and reads it back", () => {
+    setEditorPreference({
+      editor: "custom",
+      customProgram: "  /opt/homebrew/bin/nvim  ",
+    });
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
+      editor: "custom",
+      customProgram: "/opt/homebrew/bin/nvim",
+    });
+    resetEditorPreferenceStore();
+    expect(readStoredEditorPreference()).toEqual({
+      editor: "custom",
+      customProgram: "/opt/homebrew/bin/nvim",
+    });
+  });
+
+  it("falls back to the default rather than throwing on a bad value", () => {
+    const fallback = { editor: "vscode", customProgram: "" };
+    for (const stored of [
+      "not json",
+      "null",
+      "[]",
+      '{"editor":"emacs"}',
+      '{"editor":"zed","customProgram":7}',
+    ]) {
+      localStorage.setItem(STORAGE_KEY, stored);
+      expect(readStoredEditorPreference()).toEqual(
+        stored === '{"editor":"zed","customProgram":7}'
+          ? { editor: "zed", customProgram: "" }
+          : fallback,
+      );
+    }
+  });
+
+  it("names the editor in the action label, except a custom command", () => {
+    expect(openInEditorLabel("jetbrains")).toBe("Open in JetBrains IDE");
+    expect(openInEditorLabel("custom")).toBe("Open in editor");
+  });
+
+  it("serves the live choice, not the one storage still holds", () => {
+    setEditorPreference({ editor: "zed", customProgram: "" });
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ editor: "vscode", customProgram: "" }),
+    );
+
+    expect(currentEditorPreference().editor).toBe("zed");
+    expect(openInEditorLabel()).toBe("Open in Zed");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/editorPreference.ts
+++ b/crates/tidebreak-desktop/ui/src/code/editorPreference.ts
@@ -1,0 +1,163 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Which editor "Open in editor" starts, and where its program lives.
+ *
+ * The choice is this desktop's, not the workspace's or the server's: the same
+ * workspace opened from two computers should open in whatever editor each
+ * reader installed. So it lives in local storage next to the theme, in the same
+ * module-store shape — the settings panel and every menu that reads it mount
+ * and unmount independently, and each one holding its own boot-time snapshot is
+ * exactly the bug that shape exists to prevent.
+ */
+
+export type ExternalEditorId =
+  | "vscode"
+  | "cursor"
+  | "zed"
+  | "jetbrains"
+  | "custom";
+
+export type EditorPreference = {
+  editor: ExternalEditorId;
+  /** Absolute program path, used only when `editor` is `custom`. */
+  customProgram: string;
+};
+
+/** The editors the settings panel offers, in the order it lists them. */
+export const EXTERNAL_EDITORS: readonly {
+  id: ExternalEditorId;
+  label: string;
+}[] = [
+  { id: "vscode", label: "Visual Studio Code" },
+  { id: "cursor", label: "Cursor" },
+  { id: "zed", label: "Zed" },
+  { id: "jetbrains", label: "JetBrains IDE" },
+  { id: "custom", label: "Custom command…" },
+];
+
+/** The editors the native probe reports on. `custom` is the reader's own. */
+export const DETECTABLE_EDITORS: readonly ExternalEditorId[] = [
+  "vscode",
+  "cursor",
+  "zed",
+  "jetbrains",
+];
+
+const STORAGE_KEY = "tidebreak.externalEditor";
+
+const DEFAULT_PREFERENCE: EditorPreference = {
+  editor: "vscode",
+  customProgram: "",
+};
+
+export function isExternalEditorId(value: unknown): value is ExternalEditorId {
+  return EXTERNAL_EDITORS.some((editor) => editor.id === value);
+}
+
+export function externalEditorLabel(id: ExternalEditorId): string {
+  return EXTERNAL_EDITORS.find((editor) => editor.id === id)?.label ?? id;
+}
+
+/**
+ * What every surface calls the action.
+ *
+ * "Open in Zed", not "Open in editor": the reader picked one, and naming it is
+ * the difference between a menu item they trust and one they have to try. A
+ * custom command has no name worth showing, so that one stays generic.
+ */
+export function openInEditorLabel(
+  editor: ExternalEditorId = currentEditorPreference().editor,
+): string {
+  return editor === "custom"
+    ? "Open in editor"
+    : `Open in ${externalEditorLabel(editor)}`;
+}
+
+/**
+ * The stored preference, or the default when nothing is stored.
+ *
+ * Anything unreadable — a value from an older shape, a hand-edited key — falls
+ * back rather than throwing: a corrupt preference should cost the reader one
+ * trip to settings, not the menu that reads it.
+ */
+export function readStoredEditorPreference(): EditorPreference {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    // Ignore storage access failures (private mode, disabled storage).
+  }
+  if (raw === null) return DEFAULT_PREFERENCE;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object") {
+      return DEFAULT_PREFERENCE;
+    }
+    const value = parsed as Partial<EditorPreference>;
+    if (!isExternalEditorId(value.editor)) return DEFAULT_PREFERENCE;
+    return {
+      editor: value.editor,
+      customProgram:
+        typeof value.customProgram === "string" ? value.customProgram : "",
+    };
+  } catch {
+    return DEFAULT_PREFERENCE;
+  }
+}
+
+let state: EditorPreference = readStoredEditorPreference();
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): EditorPreference {
+  return state;
+}
+
+/**
+ * The preference in force right now.
+ *
+ * Not `readStoredEditorPreference`: storage is where the value survives a
+ * restart, but the store is where a change made this session already is. The
+ * callers outside React — the command list, the native open — have to see the
+ * same value the settings panel just set.
+ */
+export function currentEditorPreference(): EditorPreference {
+  return state;
+}
+
+export function setEditorPreference(next: EditorPreference): void {
+  const value: EditorPreference = {
+    editor: next.editor,
+    customProgram: next.customProgram.trim(),
+  };
+  if (
+    value.editor === state.editor &&
+    value.customProgram === state.customProgram
+  ) {
+    return;
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // Ignore storage access failures; the session still gets the new choice.
+  }
+  state = value;
+  for (const listener of [...listeners]) listener();
+}
+
+/** Test seam: drop back to the boot state without touching storage. */
+export function resetEditorPreferenceStore(): void {
+  state = readStoredEditorPreference();
+  for (const listener of [...listeners]) listener();
+}
+
+export function useEditorPreference(): EditorPreference {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { setEditorPreference } from "./editorPreference";
 import {
+  externalEditorOpenFailureNotice,
   workspaceCommands,
   workspaceHeaderCommands,
   worktreeOpenFailureNotice,
@@ -103,6 +105,95 @@ describe("workspace worktree actions", () => {
     expect(header[headerCopy + 1]).toEqual({
       id: "uneff-me",
       label: "Uneff me",
+    });
+  });
+
+  it("names the chosen editor in both menus, and offers it only locally", () => {
+    setEditorPreference({ editor: "zed", customProgram: "" });
+    const card = workspaceCommands({
+      hasPr: false,
+      archived: false,
+      canOpenWorktree: true,
+      canOpenInEditor: true,
+    });
+    const worktree = card.findIndex(
+      (command) => command.id === "open-worktree",
+    );
+    expect(card[worktree + 1]).toEqual({
+      id: "open-in-editor",
+      label: "Open in Zed",
+    });
+
+    // A custom command has no name worth advertising.
+    setEditorPreference({
+      editor: "custom",
+      customProgram: "/opt/homebrew/bin/nvim",
+    });
+    expect(
+      workspaceCommands({
+        hasPr: false,
+        archived: false,
+        canOpenInEditor: true,
+      }).find((command) => command.id === "open-in-editor"),
+    ).toEqual({ id: "open-in-editor", label: "Open in editor" });
+
+    // A window attached to another machine, and an archived workspace, have
+    // no local file for an editor here to open.
+    for (const commands of [
+      workspaceCommands({
+        hasPr: false,
+        archived: false,
+        canOpenInEditor: false,
+      }),
+      workspaceCommands({
+        hasPr: false,
+        archived: true,
+        canOpenInEditor: true,
+      }),
+    ]) {
+      expect(commands.some((command) => command.id === "open-in-editor")).toBe(
+        false,
+      );
+    }
+  });
+
+  it("puts the editor next to the worktree action in the header overflow", () => {
+    setEditorPreference({ editor: "vscode", customProgram: "" });
+    const common = {
+      archived: false,
+      hasSession: false,
+      attentionPinned: false,
+      quickActions: [],
+    };
+    expect(
+      workspaceHeaderCommands({
+        ...common,
+        canOpenWorktree: true,
+        canOpenInEditor: true,
+      }).slice(0, 2),
+    ).toEqual([
+      { id: "open-worktree", label: "Open worktree folder" },
+      { id: "open-in-editor", label: "Open in Visual Studio Code" },
+    ]);
+    expect(
+      workspaceHeaderCommands({
+        ...common,
+        archived: true,
+        canOpenInEditor: true,
+      }).some((command) => command.id === "open-in-editor"),
+    ).toBe(false);
+  });
+
+  it("says what to do when the editor does not start", () => {
+    expect(
+      externalEditorOpenFailureNotice({
+        reason: "code_editor_editor_unavailable",
+        detail: "/private/native/detail",
+      }),
+    ).toEqual({
+      title: "Could not open that file in your editor",
+      description:
+        "Tidebreak could not find that editor on this computer. Pick another one in Settings, Coding harnesses.",
     });
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -33,10 +33,14 @@ import { ToolOutputPreview } from "@/ToolOutputPreview";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { openInBrowser } from "@/openInBrowser";
 import {
+  canOpenInExternalEditor,
   canOpenLocalCodeWorktree,
+  codeEditorOpenFailureMessage,
   codeWorktreeOpenFailureMessage,
   openCodeWorktree,
+  openInEditor,
 } from "./codeWorktreeHost";
+import { openInEditorLabel } from "./editorPreference";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 import { nextWorkspaceAfterLeaving, railWorkspaceIds } from "./railNavigation";
@@ -53,6 +57,7 @@ export type WorkspaceCommandId =
   | "rename"
   | "copy-branch"
   | "open-worktree"
+  | "open-in-editor"
   | "copy-worktree"
   | "copy-debug-json"
   | "uneff-me"
@@ -99,6 +104,8 @@ export function workspaceCommands(input: {
   hasSession?: boolean;
   attentionPinned?: boolean;
   canOpenWorktree?: boolean;
+  /** This window can start an editor on the machine holding the worktree. */
+  canOpenInEditor?: boolean;
   /** Tidebreak's own checkout is connected, so a debug dump can become a fix. */
   canUneff?: boolean;
 }): WorkspaceCommand[] {
@@ -120,6 +127,8 @@ export function workspaceCommands(input: {
     { id: "copy-branch", label: "Copy branch name" },
     worktreePathCommand(input.canOpenWorktree ?? canOpenLocalCodeWorktree()),
   ];
+  const editor = editorCommand(input.canOpenInEditor);
+  if (editor) items.push(editor);
   if (input.hasPr) {
     items.push({ id: "open-pr", label: "Open pull request" });
   }
@@ -159,6 +168,7 @@ export function workspaceHeaderCommands(input: {
   attentionPinned: boolean;
   quickActions: readonly { name: string }[];
   canOpenWorktree?: boolean;
+  canOpenInEditor?: boolean;
   /** The shown agent has a transcript worth handing to a sibling. */
   canFork?: boolean;
   canUneff?: boolean;
@@ -169,6 +179,10 @@ export function workspaceHeaderCommands(input: {
     ),
     { id: "rename", label: "Rename…" },
   ];
+  const editor = input.archived
+    ? undefined
+    : editorCommand(input.canOpenInEditor);
+  if (editor) items.splice(1, 0, editor);
   if (input.hasSession) {
     items.push(
       input.attentionPinned
@@ -212,6 +226,36 @@ function worktreePathCommand(canOpenWorktree: boolean): WorkspaceCommand {
   return canOpenWorktree
     ? { id: "open-worktree", label: "Open worktree folder" }
     : { id: "copy-worktree", label: "Copy worktree path" };
+}
+
+/**
+ * "Open in Zed", not "Open in editor": the reader picked one, and naming it is
+ * the difference between a menu item they trust and one they have to try. A
+ * custom command has no name worth showing, so that one stays generic. A window
+ * attached to another machine gets no row at all — its editor would open
+ * nothing.
+ */
+function editorCommand(
+  canOpenInEditor?: boolean,
+): WorkspaceCommand | undefined {
+  if (!(canOpenInEditor ?? canOpenInExternalEditor())) return undefined;
+  return { id: "open-in-editor", label: openInEditorLabel() };
+}
+
+/**
+ * Start the reader's editor on one worktree file, and say so plainly when it
+ * does not start. Shared by the workspace command and by the file and diff
+ * panels, which pass the path and line they are already showing.
+ */
+export function openWorkspaceFileInEditor(input: {
+  workspaceId: string;
+  relativePath?: string;
+  line?: number;
+}): void {
+  void openInEditor(input).catch((error) => {
+    const notice = externalEditorOpenFailureNotice(error);
+    toast.error(notice.title, { description: notice.description });
+  });
 }
 
 export function WorkspaceOverflowMenu({
@@ -575,6 +619,9 @@ export function useWorkspaceCardCommands(): {
           });
         });
         return;
+      case "open-in-editor":
+        openWorkspaceFileInEditor({ workspaceId: context.workspace.id });
+        return;
       case "copy-worktree":
         void copyPlainText(context.workspace.worktree_path)
           .then(() => toast.success("Worktree path copied"))
@@ -777,6 +824,16 @@ export function worktreeOpenFailureNotice(error: unknown): {
     title: "Could not open worktree folder",
     description: codeWorktreeOpenFailureMessage(error),
     actionLabel: "Copy path",
+  };
+}
+
+export function externalEditorOpenFailureNotice(error: unknown): {
+  title: string;
+  description: string;
+} {
+  return {
+    title: "Could not open that file in your editor",
+    description: codeEditorOpenFailureMessage(error),
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
@@ -13,6 +13,7 @@ import { hasLocalHostAuthority, pickCodeDirectory } from "@/host";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { hostMachineLabel } from "@/remoteMachine";
 import { SettingsError, SettingsPanel } from "./primitives";
+import { ExternalEditorSection } from "./ExternalEditorSection";
 import { WorktreeRootSection } from "./WorktreeRootSection";
 
 /**
@@ -25,7 +26,9 @@ import { WorktreeRootSection } from "./WorktreeRootSection";
  * progress in both places.
  *
  * The workspace folder sits below the engines: a reader who came here came for
- * an engine, and the folder only matters once one runs.
+ * an engine, and the folder only matters once one runs. The external editor
+ * follows it for the same reason — it is where the files a workspace produces
+ * go next.
  */
 
 export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
@@ -169,6 +172,7 @@ export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
           onReset={() => void saveRoot(null)}
         />
       )}
+      <ExternalEditorSection canDetect={hasLocalHostAuthority()} />
     </SettingsPanel>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/settings/ExternalEditorSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ExternalEditorSection.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  detectExternalEditors,
+  type ExternalEditorProbe,
+} from "@/code/codeWorktreeHost";
+import {
+  EXTERNAL_EDITORS,
+  setEditorPreference,
+  useEditorPreference,
+  type ExternalEditorId,
+} from "@/code/editorPreference";
+import { SettingsField, SettingsSection } from "./primitives";
+
+/**
+ * Which editor "Open in editor" starts.
+ *
+ * The list is the same closed set the native side knows how to launch, and the
+ * rows under it answer the doctor's question about editors: is this one on this
+ * computer, and where. A reader whose editor is not on the list gives a program
+ * path instead, which Tidebreak starts directly rather than through a shell.
+ */
+export function ExternalEditorSection({
+  detect = detectExternalEditors,
+  canDetect,
+}: {
+  /** Story and test seam for the native probe. */
+  detect?: () => Promise<ExternalEditorProbe[]>;
+  /** False on a window attached to another machine: no editors here to probe. */
+  canDetect: boolean;
+}) {
+  const preference = useEditorPreference();
+  const [probes, setProbes] = useState<ExternalEditorProbe[] | null>(null);
+
+  useEffect(() => {
+    if (!canDetect) return;
+    let cancelled = false;
+    void detect()
+      .then((found) => {
+        if (!cancelled) setProbes(found);
+      })
+      .catch(() => {
+        if (!cancelled) setProbes([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [canDetect, detect]);
+
+  const programs = new Map(
+    (probes ?? []).map((probe) => [probe.id, probe.program]),
+  );
+
+  return (
+    <SettingsSection
+      title="External editor"
+      description="Open a workspace file in the editor you already use, from the file viewer, the diff, or the workspace menu."
+    >
+      <SettingsField
+        label="Editor"
+        hint={editorHint(preference.editor, canDetect, probes, programs)}
+      >
+        <Select
+          value={preference.editor}
+          onValueChange={(next) =>
+            setEditorPreference({
+              ...preference,
+              editor: next as ExternalEditorId,
+            })
+          }
+        >
+          <SelectTrigger aria-label="External editor">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {EXTERNAL_EDITORS.map((editor) => (
+              <SelectItem key={editor.id} value={editor.id}>
+                {editor.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingsField>
+      {preference.editor === "custom" && (
+        <SettingsField
+          label="Program"
+          hint="The full path to the program, such as /opt/homebrew/bin/nvim. Tidebreak starts it with the file path and no shell, so flags are not read."
+        >
+          <Input
+            value={preference.customProgram}
+            onChange={(event) =>
+              setEditorPreference({
+                ...preference,
+                customProgram: event.target.value,
+              })
+            }
+            placeholder="/opt/homebrew/bin/nvim"
+            spellCheck={false}
+          />
+        </SettingsField>
+      )}
+      {canDetect && probes !== null && (
+        <div className="divide-subtle overflow-hidden rounded-lg border divide-y">
+          {EXTERNAL_EDITORS.filter((editor) => editor.id !== "custom").map(
+            (editor) => {
+              const program = programs.get(editor.id) ?? null;
+              return (
+                <div
+                  key={editor.id}
+                  className="bg-background flex items-center gap-3 px-3 py-2"
+                >
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <span className="truncate text-sm">{editor.label}</span>
+                    {program ? (
+                      <span
+                        className="text-muted-foreground truncate font-mono text-2xs"
+                        title={program}
+                      >
+                        {program}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">
+                        No launcher on this computer.
+                      </span>
+                    )}
+                  </div>
+                  <Badge
+                    className="ml-auto shrink-0"
+                    variant={program ? "success" : "outline"}
+                  >
+                    {program ? "Installed" : "Not found"}
+                  </Badge>
+                </div>
+              );
+            },
+          )}
+        </div>
+      )}
+    </SettingsSection>
+  );
+}
+
+function editorHint(
+  editor: ExternalEditorId,
+  canDetect: boolean,
+  probes: ExternalEditorProbe[] | null,
+  programs: Map<string, string | null>,
+): string {
+  if (editor === "custom") return "Give the program below.";
+  if (!canDetect) {
+    return "This window works on another machine, so Tidebreak cannot check what is installed here.";
+  }
+  if (probes === null) return "Checking what is installed…";
+  return programs.get(editor)
+    ? "Installed and ready."
+    : "Not found on this computer. Install its command-line launcher, or pick another editor.";
+}

--- a/crates/tidebreak-desktop/ui/src/stories/ExternalEditor.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ExternalEditor.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+
+import { setEditorPreference } from "@/code/editorPreference";
+import type { ExternalEditorId } from "@/code/editorPreference";
+import type { ExternalEditorProbe } from "@/code/codeWorktreeHost";
+import { ExternalEditorSection } from "@/settings/ExternalEditorSection";
+import { SettingsPanel } from "@/settings/primitives";
+
+/**
+ * Settings → Coding harnesses → External editor.
+ *
+ * The reader picks one editor and every "Open in …" in the product starts
+ * naming it. The rows below the picker answer the doctor's question about
+ * editors — is this one on this computer, and where — so a choice that would
+ * fail says so before it is made rather than after.
+ */
+
+function EditorShowcase({
+  probes,
+  canDetect = true,
+}: {
+  probes?: ExternalEditorProbe[];
+  canDetect?: boolean;
+  /** Read by `beforeEach` to seed the store, not by the component. */
+  editor?: ExternalEditorId;
+  customProgram?: string;
+}) {
+  return (
+    <SettingsPanel
+      title="Coding harnesses"
+      description="Coding engines on this computer, and the editor Tidebreak hands files to."
+    >
+      <ExternalEditorSection
+        canDetect={canDetect}
+        detect={async () => probes ?? []}
+      />
+    </SettingsPanel>
+  );
+}
+
+const INSTALLED: ExternalEditorProbe[] = [
+  { id: "vscode", program: "/usr/local/bin/code" },
+  { id: "cursor", program: "/opt/homebrew/bin/cursor" },
+  { id: "zed", program: "/Applications/Zed.app/Contents/MacOS/cli" },
+  { id: "jetbrains", program: null },
+];
+
+const meta = {
+  title: "Settings/External editor",
+  component: EditorShowcase,
+  parameters: { layout: "fullscreen" },
+  beforeEach: ({ args }) => {
+    setEditorPreference({
+      editor: args.editor ?? "vscode",
+      customProgram: args.customProgram ?? "",
+    });
+    return () => setEditorPreference({ editor: "vscode", customProgram: "" });
+  },
+} satisfies Meta<typeof EditorShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Three editors found, one missing, and the chosen one confirmed ready. */
+export const Detected: Story = {
+  args: { probes: INSTALLED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("/usr/local/bin/code")).toBeVisible();
+    await expect(
+      canvas.getByText("No launcher on this computer."),
+    ).toBeVisible();
+  },
+};
+
+/** The chosen editor is not installed, so the field says what closes the gap. */
+export const ChosenEditorMissing: Story = {
+  args: { probes: INSTALLED, editor: "jetbrains" },
+};
+
+/** A custom command takes a program path and no flags. */
+export const CustomCommand: Story = {
+  args: {
+    probes: INSTALLED,
+    editor: "custom",
+    customProgram: "/opt/homebrew/bin/nvim",
+  },
+};
+
+/** Nothing installed: every row says so rather than the list disappearing. */
+export const NothingInstalled: Story = {
+  args: {
+    probes: [
+      { id: "vscode", program: null },
+      { id: "cursor", program: null },
+      { id: "zed", program: null },
+      { id: "jetbrains", program: null },
+    ],
+  },
+};
+
+/** Attached to another machine: no probe to run, and the field says why. */
+export const AttachedRemotely: Story = {
+  args: { canDetect: false },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { toast } from "sonner";
 
+import { setEditorPreference } from "@/code/editorPreference";
 import {
   workspaceCommands,
   worktreeOpenFailureNotice,
@@ -708,6 +709,76 @@ export const RemoteWorktreeFallback: Story = {
       canOpenWorktree: false,
     }),
     detailDefaultOpen: true,
+  },
+};
+
+/**
+ * The card's own menu, held open: the editor action sits under the worktree
+ * folder and names the editor the reader picked, so the row says what it will
+ * do before it is chosen.
+ */
+export const OpenInEditorMenu: Story = {
+  beforeEach: () => {
+    setEditorPreference({ editor: "zed", customProgram: "" });
+    return () => setEditorPreference({ editor: "vscode", customProgram: "" });
+  },
+  render: (args) => (
+    <WorkspaceCard
+      {...args}
+      commands={workspaceCommands({
+        hasPr: false,
+        archived: false,
+        hasSession: true,
+        canOpenWorktree: true,
+        canOpenInEditor: true,
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.pointer({
+      keys: "[MouseRight]",
+      target: await body.findByText(codeWorkspace.title),
+    });
+    await waitFor(() =>
+      expect(
+        body.getByRole("menuitem", { name: "Open worktree folder" }),
+      ).toBeVisible(),
+    );
+    await expect(
+      body.getByRole("menuitem", { name: "Open in Zed" }),
+    ).toBeVisible();
+  },
+};
+
+/** A window attached to another machine gets no editor row to be let down by. */
+export const RemoteHasNoEditorAction: Story = {
+  render: (args) => (
+    <WorkspaceCard
+      {...args}
+      commands={workspaceCommands({
+        hasPr: false,
+        archived: false,
+        hasSession: true,
+        canOpenWorktree: false,
+        canOpenInEditor: false,
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.pointer({
+      keys: "[MouseRight]",
+      target: await body.findByText(codeWorkspace.title),
+    });
+    await waitFor(() =>
+      expect(
+        body.getByRole("menuitem", { name: "Copy worktree path" }),
+      ).toBeVisible(),
+    );
+    await expect(
+      body.queryByRole("menuitem", { name: /^Open in / }),
+    ).toBeNull();
   },
 };
 

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import type {
   Attention,
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { AttentionBadge } from "@/code/AttentionBadge";
 import { SessionLifecycleIndicator } from "@/code/SessionLifecycleIndicator";
 import { SessionPermissionIndicator } from "@/code/SessionPermissionIndicator";
+import { setEditorPreference } from "@/code/editorPreference";
 import {
   WorkspaceOverflowMenu,
   workspaceHeaderCommands,
@@ -62,6 +63,8 @@ function HeaderState({
   pendingApprovals = 0,
   unrecognizedEventCount = 0,
   permissionMode = "allow",
+  canOpenWorktree = false,
+  canOpenInEditor = false,
 }: {
   snapshot: CodeWorkspacePrSnapshot | null;
   loading?: boolean;
@@ -72,6 +75,10 @@ function HeaderState({
   pendingApprovals?: number;
   unrecognizedEventCount?: number;
   permissionMode?: PermissionMode;
+  /** This window hosts the worktree, so the folder action is truthful. */
+  canOpenWorktree?: boolean;
+  /** An editor on this machine can open the worktree's files. */
+  canOpenInEditor?: boolean;
 }) {
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [reviewOpen, setReviewOpen] = useState(initialReviewOpen);
@@ -144,6 +151,8 @@ function HeaderState({
             attentionPinned: false,
             canFork: true,
             canUneff: true,
+            canOpenWorktree,
+            canOpenInEditor,
             quickActions: [],
           })}
           context={{
@@ -286,4 +295,34 @@ export const OverflowActions: Story = {
 
 export const ReviewClosed: Story = {
   args: { snapshot: openPrGit, initialReviewOpen: false },
+};
+
+/**
+ * Local overflow: the folder action, then the editor by name. The two sit
+ * together because they answer the same question — get me out of this window
+ * and into these files.
+ */
+export const OpenInEditorOverflow: Story = {
+  args: { canOpenWorktree: true, canOpenInEditor: true },
+  beforeEach: () => {
+    setEditorPreference({ editor: "cursor", customProgram: "" });
+    return () => setEditorPreference({ editor: "vscode", customProgram: "" });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Workspace actions" }),
+    );
+    const menu = within(document.body);
+    await waitFor(async () =>
+      expect(
+        await menu.findByRole("menuitem", { name: "Open worktree folder" }),
+      ).toBeVisible(),
+    );
+    await waitFor(async () =>
+      expect(
+        await menu.findByRole("menuitem", { name: "Open in Cursor" }),
+      ).toBeVisible(),
+    );
+  },
 };


### PR DESCRIPTION
Every neighbouring tool can hand a file to the editor you already use. Tidebreak could only reveal the worktree in Finder.

Closes #2796

## What lands

A new native command, `open_in_editor`, follows the `open_code_worktree` pattern. The renderer names a workspace id and a path relative to that workspace — never a path to run. The command re-reads the worktree root from the embedded server, canonicalizes both sides before comparing them, and refuses traversal, absolute paths, and symlinks that leave the worktree. It also refuses outright while this window is attached to another machine.

The editor comes from a closed set of launcher plans, so no renderer input reaches a shell:

| Editor | Arguments |
| --- | --- |
| VS Code, Cursor | `--goto <path>:<line>` |
| Zed | `<path>:<line>` |
| JetBrains | `--line <n> <path>` |
| Custom | `<path>` |

A custom editor is held to the same shape as the built-ins: one absolute program path, spawned directly with the file as its only argument. A bare name is refused, because resolving one is a shell's job. `plugins.shell.open` keeps its https-only scope and nothing grants `shell:allow-execute`.

`detect_external_editors` reports which editors this computer has, searching `PATH` and then the known install locations — a desktop app started from Finder inherits a minimal `PATH`, so the probe cannot rely on it alone.

## Where it shows up

The choice is a local-storage module store in the `theme.ts` shape, keyed `tidebreak.externalEditor`, with a picker in Settings → Coding harnesses that says whether each editor is installed and where. Every surface then names the editor rather than saying "editor": the sidebar card menu, the workspace header overflow, the command palette, and a button in the file viewer and diff headers, which pass the path and the line already on screen.

## Decision record 7

This adds two lines to `native-only-commands.txt`, as an amendment to [ADR 0007](docs/decisions/0007-cli-headless-feature-parity.md) rather than a formality. Both commands act on the machine the reader is sitting at, which is not necessarily the machine the server runs on: `open_in_editor` raises a desktop editor here, and `detect_external_editors` looks at this computer's `PATH` and application folders. A headless server has neither, so neither belongs behind a server route.

## Checks

- `cargo check -p tidebreak-desktop`, `cargo test -p tidebreak-desktop` — 280 passed, including `command_parity` and the eight new `code_editor` tests covering path resolution, the symlink escape, per-editor line formatting, and custom-program validation.
- `pnpm exec biome format --write src`, `pnpm exec biome lint src`, `pnpm exec tsc --noEmit`, `pnpm exec vitest run src/code src/settings` — 1056 passed.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`, plus a screenshot pass over the new stories in light and dark.
