### PR TITLE
feat(browser): add managed profile reset

### DIFF
--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -408,6 +408,7 @@ pub(crate) struct BrowserRegistry {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BrowserProfileResetSession {
     pub(crate) browser_id: String,
+    pub(crate) workspace_id: String,
     instance_id: u64,
     previous_halt: bool,
 }
@@ -557,6 +558,7 @@ impl BrowserRegistry {
                 })
                 .map(|(browser_id, record)| BrowserProfileResetSession {
                     browser_id: browser_id.clone(),
+                    workspace_id: record.workspace_id.clone(),
                     instance_id: record.instance_id,
                     previous_halt: *record.dispatch.halt.borrow(),
                 })
@@ -2391,9 +2393,9 @@ mod tests {
             reset
                 .sessions()
                 .iter()
-                .map(|session| session.browser_id.as_str())
+                .map(|session| (session.browser_id.as_str(), session.workspace_id.as_str()))
                 .collect::<Vec<_>>(),
-            ["browser-1", "browser-2"]
+            [("browser-1", "workspace-1"), ("browser-2", "workspace-2")]
         );
         assert_eq!(reset.profile_id(), profile_id);
         assert_eq!(

--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -18,26 +18,18 @@ pub(crate) use tidebreak_core::{
     BrowserEngineDescriptor, BrowserLoadState, BrowserSessionSummary,
 };
 use tidebreak_core::{
-    BrowserEngineName, BrowserGrantCapability, BrowserOrigin, BrowserOriginScope,
+    BrowserEngineName, BrowserGrantCapability, BrowserOrigin, BrowserOriginScope, OwnerId,
 };
+#[cfg(any(target_os = "macos", test))]
+use tokio::sync::OwnedMutexGuard;
 use tokio::sync::{watch, Mutex as AsyncMutex};
 use uuid::Uuid;
 
-pub(crate) const BROWSER_PROFILE_ID: &str = "tidebreak-browser-v1";
 const BROWSER_AUDIT_FILE: &str = "browser-audit.jsonl";
 const AGENT_CAPABILITY_TTL: Duration = Duration::from_secs(90);
 const AGENT_CONFIRMATION_TTL: Duration = Duration::from_secs(30);
 const MAX_AUDIT_ACTION_CHARS: usize = 64;
 const MAX_AUDIT_TARGET_CHARS: usize = 160;
-
-/// Stable UUID bytes for Tidebreak's browser-only WKWebsiteDataStore.
-///
-/// Wry uses this named store on macOS 14+ and falls back to Tidebreak's
-/// app-private default store on older supported macOS versions.
-#[cfg(target_os = "macos")]
-pub(crate) const BROWSER_DATA_STORE_IDENTIFIER: [u8; 16] = [
-    0x74, 0x69, 0x64, 0x65, 0x62, 0x72, 0x65, 0x61, 0x6b, 0x2d, 0x62, 0x72, 0x6f, 0x77, 0x73, 0x65,
-];
 
 fn platform_default_engine() -> BrowserEngineDescriptor {
     #[cfg(target_os = "macos")]
@@ -66,7 +58,7 @@ fn platform_default_engine() -> BrowserEngineDescriptor {
             // Tidebreak can prove that their rendered content is safe.
             screenshot: false,
             cross_origin_frames: false,
-            profile_reset: false,
+            profile_reset: cfg!(target_os = "macos"),
         },
     }
 }
@@ -246,6 +238,7 @@ impl BrowserAuditLog {
 #[derive(Clone)]
 struct BrowserRecord {
     instance_id: u64,
+    owner_id: OwnerId,
     workspace_id: String,
     profile_id: String,
     url: Option<String>,
@@ -262,6 +255,7 @@ struct BrowserRecord {
     semantic_snapshot: Option<StoredSemanticSnapshot>,
     screenshot_epoch: Option<u64>,
     inspect_enabled: bool,
+    resetting: bool,
 }
 
 #[derive(Clone)]
@@ -410,6 +404,57 @@ pub(crate) struct BrowserRegistry {
     audit: BrowserAuditLog,
 }
 
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BrowserProfileResetSession {
+    pub(crate) browser_id: String,
+    instance_id: u64,
+    previous_halt: bool,
+}
+
+/// Exclusive native reset lease for every live session using one managed
+/// profile. The dispatch guards keep agent work drained until the profile is
+/// either deleted or the reset aborts. Dropping an unfinished lease releases
+/// the temporary halt latch on any session that is still the same instance.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) struct BrowserProfileResetLease {
+    registry: BrowserRegistry,
+    owner_id: OwnerId,
+    profile_id: String,
+    sessions: Vec<BrowserProfileResetSession>,
+    _dispatch_guards: Vec<OwnedMutexGuard<()>>,
+    finished: bool,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl BrowserProfileResetLease {
+    pub(crate) fn owner_id(&self) -> &OwnerId {
+        &self.owner_id
+    }
+
+    pub(crate) fn profile_id(&self) -> &str {
+        &self.profile_id
+    }
+
+    pub(crate) fn sessions(&self) -> &[BrowserProfileResetSession] {
+        &self.sessions
+    }
+
+    pub(crate) fn finish(mut self) {
+        self.registry.finish_profile_reset(&self);
+        self.finished = true;
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl Drop for BrowserProfileResetLease {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.registry.cancel_profile_reset(self);
+        }
+    }
+}
+
 impl Default for BrowserRegistry {
     fn default() -> Self {
         Self {
@@ -424,10 +469,12 @@ impl BrowserRegistry {
         self.audit.initialize(data_dir)
     }
 
-    pub(crate) fn register(
+    pub(crate) fn register_managed(
         &self,
         browser_id: &str,
         workspace_id: &str,
+        owner_id: OwnerId,
+        profile_id: String,
         url: String,
         visible: bool,
     ) -> Result<u64, String> {
@@ -443,8 +490,9 @@ impl BrowserRegistry {
             browser_id.to_owned(),
             BrowserRecord {
                 instance_id,
+                owner_id,
                 workspace_id: workspace_id.to_owned(),
-                profile_id: BROWSER_PROFILE_ID.to_owned(),
+                profile_id,
                 url: Some(url),
                 title: None,
                 load_state: BrowserLoadState::Loading,
@@ -459,9 +507,123 @@ impl BrowserRegistry {
                 semantic_snapshot: None,
                 screenshot_epoch: None,
                 inspect_enabled: false,
+                resetting: false,
             },
         );
         Ok(instance_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn register(
+        &self,
+        browser_id: &str,
+        workspace_id: &str,
+        url: String,
+        visible: bool,
+    ) -> Result<u64, String> {
+        self.register_managed(
+            browser_id,
+            workspace_id,
+            OwnerId::local(),
+            "00000000-0000-4000-8000-000000000001".to_owned(),
+            url,
+            visible,
+        )
+    }
+
+    /// Halt and drain every live session on the exact profile selected by the
+    /// trusted triggering browser. No owner or profile selector is accepted
+    /// from renderer IPC.
+    #[cfg(any(target_os = "macos", test))]
+    pub(crate) async fn begin_profile_reset(
+        &self,
+        browser_id: &str,
+        workspace_id: &str,
+    ) -> Result<BrowserProfileResetLease, String> {
+        let (owner_id, profile_id, sessions, gates) = {
+            let mut state = self.lock();
+            let trigger = state
+                .records
+                .get(browser_id)
+                .ok_or_else(|| "browser session is not registered".to_owned())?;
+            ensure_workspace(browser_id, workspace_id, trigger)?;
+            let owner_id = trigger.owner_id.clone();
+            let profile_id = trigger.profile_id.clone();
+            let mut sessions = state
+                .records
+                .iter()
+                .filter(|(_, record)| {
+                    record.owner_id == owner_id && record.profile_id == profile_id
+                })
+                .map(|(browser_id, record)| BrowserProfileResetSession {
+                    browser_id: browser_id.clone(),
+                    instance_id: record.instance_id,
+                    previous_halt: *record.dispatch.halt.borrow(),
+                })
+                .collect::<Vec<_>>();
+            sessions.sort_by(|left, right| left.browser_id.cmp(&right.browser_id));
+            let gates = sessions
+                .iter()
+                .map(|session| {
+                    let record = state
+                        .records
+                        .get_mut(&session.browser_id)
+                        .expect("reset session was collected from the same registry lock");
+                    record.dispatch.halt.send_replace(true);
+                    record.resetting = true;
+                    Arc::clone(&record.dispatch.gate)
+                })
+                .collect::<Vec<_>>();
+            (owner_id, profile_id, sessions, gates)
+        };
+
+        let mut lease = BrowserProfileResetLease {
+            registry: self.clone(),
+            owner_id,
+            profile_id,
+            sessions,
+            _dispatch_guards: Vec::with_capacity(gates.len()),
+            finished: false,
+        };
+        for gate in gates {
+            lease._dispatch_guards.push(gate.lock_owned().await);
+        }
+        Ok(lease)
+    }
+
+    #[cfg(any(target_os = "macos", test))]
+    fn cancel_profile_reset(&self, reset: &BrowserProfileResetLease) {
+        let mut state = self.lock();
+        for session in &reset.sessions {
+            let Some(record) = state.records.get_mut(&session.browser_id) else {
+                continue;
+            };
+            if record.instance_id == session.instance_id
+                && record.owner_id == reset.owner_id
+                && record.profile_id == reset.profile_id
+            {
+                record.dispatch.halt.send_replace(session.previous_halt);
+                record.resetting = false;
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "macos", test))]
+    fn finish_profile_reset(&self, reset: &BrowserProfileResetLease) {
+        let reset_instances = reset
+            .sessions
+            .iter()
+            .map(|session| (session.browser_id.as_str(), session.instance_id))
+            .collect::<HashMap<_, _>>();
+        let mut state = self.lock();
+        state.records.retain(|browser_id, record| {
+            !(record.owner_id == reset.owner_id
+                && record.profile_id == reset.profile_id
+                && reset_instances.get(browser_id.as_str()) == Some(&record.instance_id))
+        });
+        state.confirmations.retain(|_, confirmation| {
+            !reset_instances.contains_key(confirmation.browser_id.as_str())
+        });
     }
 
     pub(crate) fn ensure_workspace(
@@ -499,7 +661,7 @@ impl BrowserRegistry {
         let mut sessions: Vec<_> = state
             .records
             .iter()
-            .filter(|(_, record)| record.workspace_id == workspace_id)
+            .filter(|(_, record)| record.workspace_id == workspace_id && !record.resetting)
             .map(|(browser_id, record)| record.summary(browser_id))
             .collect();
         sessions.sort_by(|left, right| left.browser_id.cmp(&right.browser_id));
@@ -822,7 +984,11 @@ impl BrowserRegistry {
         let mut sessions: Vec<_> = state
             .records
             .iter()
-            .filter(|(_, record)| record.workspace_id == capability.workspace_id && record.visible)
+            .filter(|(_, record)| {
+                record.workspace_id == capability.workspace_id
+                    && record.visible
+                    && !record.resetting
+            })
             .filter(|(_, record)| {
                 current_origin(record).is_some_and(|origin| {
                     grants_cover(
@@ -1291,6 +1457,9 @@ impl BrowserRegistry {
         if record.workspace_id != workspace_id || record.instance_id != instance_id {
             return BrowserNavigationDecision::Deny;
         }
+        if record.resetting {
+            return BrowserNavigationDecision::Deny;
+        }
         if record.controller.kind != BrowserControllerKind::Agent {
             return BrowserNavigationDecision::Allow;
         }
@@ -1391,6 +1560,7 @@ impl BrowserRegistry {
             if record.workspace_id != workspace_id
                 || record.instance_id != instance_id
                 || record.document_epoch != document_epoch
+                || record.resetting
                 || record.url.as_deref() == Some(url.as_str())
             {
                 return None;
@@ -1415,6 +1585,7 @@ impl BrowserRegistry {
             let record = state.records.get_mut(browser_id)?;
             if record.workspace_id != workspace_id
                 || record.instance_id != instance_id
+                || record.resetting
                 || url
                     .as_ref()
                     .is_some_and(|url| record.url.as_ref() != Some(url))
@@ -1466,7 +1637,10 @@ impl BrowserRegistry {
         let Some(record) = state.records.get_mut(browser_id) else {
             return Err(BrowserTargetError::StaleTarget);
         };
-        if record.workspace_id != workspace_id || record.document_epoch != document_epoch {
+        if record.workspace_id != workspace_id
+            || record.document_epoch != document_epoch
+            || record.resetting
+        {
             return Err(BrowserTargetError::StaleTarget);
         }
         record.semantic_snapshot = Some(StoredSemanticSnapshot {
@@ -1744,6 +1918,7 @@ impl BrowserRegistry {
         };
         if record.workspace_id != workspace_id
             || record.document_epoch != document_epoch
+            || record.resetting
             || record.load_state != BrowserLoadState::Ready
         {
             return Err(BrowserTargetError::StaleTarget);
@@ -1775,6 +1950,7 @@ impl BrowserRegistry {
             return;
         };
         if record.workspace_id == workspace_id
+            && !record.resetting
             && record
                 .semantic_snapshot
                 .as_ref()
@@ -1795,7 +1971,10 @@ impl BrowserRegistry {
         let mut state = self.lock();
         {
             let record = state.records.get_mut(browser_id)?;
-            if record.workspace_id != workspace_id || record.instance_id != instance_id {
+            if record.workspace_id != workspace_id
+                || record.instance_id != instance_id
+                || record.resetting
+            {
                 return None;
             }
             update(record);
@@ -1986,12 +2165,14 @@ fn ensure_workspace(
     workspace_id: &str,
     record: &BrowserRecord,
 ) -> Result<(), String> {
-    if record.workspace_id == workspace_id {
-        Ok(())
-    } else {
+    if record.workspace_id != workspace_id {
         Err(format!(
             "browser session {browser_id} belongs to a different workspace"
         ))
+    } else if record.resetting {
+        Err("browser profile is being reset".to_owned())
+    } else {
+        Ok(())
     }
 }
 
@@ -2142,6 +2323,132 @@ mod tests {
             .is_err());
     }
 
+    #[tokio::test]
+    async fn profile_reset_drains_and_removes_only_matching_native_sessions() {
+        let registry = BrowserRegistry::default();
+        let owner = OwnerId::local();
+        let other_owner = OwnerId::new("other-owner").unwrap();
+        let profile_id = Uuid::new_v4().to_string();
+        registry
+            .register_managed(
+                "browser-1",
+                "workspace-1",
+                owner.clone(),
+                profile_id.clone(),
+                "https://example.com/one".to_owned(),
+                true,
+            )
+            .unwrap();
+        registry
+            .register_managed(
+                "browser-2",
+                "workspace-2",
+                owner.clone(),
+                profile_id.clone(),
+                "https://example.org/two".to_owned(),
+                true,
+            )
+            .unwrap();
+        registry
+            .register_managed(
+                "other-owner",
+                "workspace-3",
+                other_owner,
+                profile_id.clone(),
+                "https://owner.example/".to_owned(),
+                true,
+            )
+            .unwrap();
+        registry
+            .register_managed(
+                "other-profile",
+                "workspace-1",
+                owner.clone(),
+                Uuid::new_v4().to_string(),
+                "https://unrelated.example/".to_owned(),
+                true,
+            )
+            .unwrap();
+        let origin = BrowserOrigin::from_url("https://example.com/one").unwrap();
+        registry
+            .grant_browser_access(
+                "browser-1",
+                "workspace-1",
+                &origin,
+                BrowserOriginScope::Origin {
+                    origin: origin.clone(),
+                },
+                &[BrowserGrantCapability::BrowserObserveOrigin],
+            )
+            .unwrap();
+
+        let reset = registry
+            .begin_profile_reset("browser-1", "workspace-1")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            reset
+                .sessions()
+                .iter()
+                .map(|session| session.browser_id.as_str())
+                .collect::<Vec<_>>(),
+            ["browser-1", "browser-2"]
+        );
+        assert_eq!(reset.profile_id(), profile_id);
+        assert_eq!(
+            registry.snapshot("browser-1", "workspace-1").unwrap_err(),
+            "browser profile is being reset"
+        );
+
+        reset.finish();
+
+        assert!(registry.snapshot("browser-1", "workspace-1").is_err());
+        assert!(registry.snapshot("browser-2", "workspace-2").is_err());
+        assert!(registry.snapshot("other-owner", "workspace-3").is_ok());
+        assert!(registry.snapshot("other-profile", "workspace-1").is_ok());
+
+        registry
+            .register_managed(
+                "fresh-browser",
+                "workspace-1",
+                owner,
+                Uuid::new_v4().to_string(),
+                "https://example.com/fresh".to_owned(),
+                true,
+            )
+            .unwrap();
+        assert!(
+            registry
+                .snapshot("fresh-browser", "workspace-1")
+                .unwrap()
+                .agent_access
+                .unwrap()
+                .can_observe
+        );
+    }
+
+    #[tokio::test]
+    async fn aborted_profile_reset_restores_the_previous_dispatch_latch() {
+        let (registry, _) = ready_registry(true);
+        {
+            let reset = registry
+                .begin_profile_reset("browser-1", "workspace-1")
+                .await
+                .unwrap();
+            assert_eq!(reset.sessions().len(), 1);
+        }
+
+        assert!(registry.snapshot("browser-1", "workspace-1").is_ok());
+        assert!(!*registry
+            .lock()
+            .records
+            .get("browser-1")
+            .unwrap()
+            .dispatch
+            .halt
+            .borrow());
+    }
     #[test]
     fn model_facing_lists_are_workspace_scoped_and_stably_ordered() {
         let registry = BrowserRegistry::default();
@@ -2721,6 +3028,10 @@ mod tests {
         let descriptor = platform_default_engine();
         assert!(!descriptor.capabilities.semantic_actions);
         assert!(!descriptor.capabilities.screenshot);
+        assert_eq!(
+            descriptor.capabilities.profile_reset,
+            cfg!(target_os = "macos")
+        );
     }
 
     #[tokio::test]

--- a/crates/tidebreak-desktop/src/browser_profile.rs
+++ b/crates/tidebreak-desktop/src/browser_profile.rs
@@ -1,0 +1,726 @@
+//! Native-only lifecycle for Tidebreak's managed development-browser profile.
+//!
+//! The renderer receives an opaque profile id only as session metadata. The
+//! engine data-store identifier, website records needed by older WebKit, and
+//! every byte written by the engine remain in this native app profile.
+
+use std::{
+    collections::{BTreeSet, HashSet},
+    fs::{self, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use serde::{Deserialize, Serialize};
+use tidebreak_core::OwnerId;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use url::Url;
+use uuid::Uuid;
+
+const DIRECTORY: &str = "browser";
+const MANIFEST_FILE: &str = "managed-profiles.json";
+const VERSION: u8 = 1;
+const MAX_MANIFEST_BYTES: u64 = 512 * 1024;
+const MAX_PROFILES: usize = 32;
+const MAX_WEBSITE_HOSTS: usize = 4_096;
+const MAX_WEBSITE_HOST_CHARS: usize = 253;
+
+/// The browser-only named store already shipped on main before profile
+/// manifests existed. The first local-owner allocation adopts this exact
+/// Tidebreak store so an application update does not discard its cookies.
+/// Once adopted, the manifest permanently retires this bootstrap identity and
+/// reset allocates a fresh UUID instead of selecting it again.
+const INITIAL_LOCAL_DATA_STORE_IDENTIFIER: [u8; 16] = [
+    0x74, 0x69, 0x64, 0x65, 0x62, 0x72, 0x65, 0x61, 0x6b, 0x2d, 0x62, 0x72, 0x6f, 0x77, 0x73, 0x65,
+];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedBrowserProfile {
+    owner_id: OwnerId,
+    profile_id: Uuid,
+    #[cfg(any(target_os = "macos", test))]
+    data_store_identifier: Uuid,
+    #[cfg(any(target_os = "macos", test))]
+    website_hosts: BTreeSet<String>,
+}
+
+impl ManagedBrowserProfile {
+    pub(crate) fn owner_id(&self) -> &OwnerId {
+        &self.owner_id
+    }
+
+    pub(crate) fn profile_id(&self) -> String {
+        self.profile_id.to_string()
+    }
+
+    /// Stable native engine identity. This value never crosses Tauri IPC.
+    #[cfg(any(target_os = "macos", test))]
+    pub(crate) fn data_store_identifier(&self) -> [u8; 16] {
+        *self.data_store_identifier.as_bytes()
+    }
+
+    /// Website-record selectors used only by the targeted pre-macOS 14 reset.
+    #[cfg(any(target_os = "macos", test))]
+    pub(crate) fn website_hosts(&self) -> &BTreeSet<String> {
+        &self.website_hosts
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct BrowserProfileStore {
+    inner: Arc<Mutex<BrowserProfileState>>,
+    lifecycle: Arc<AsyncMutex<()>>,
+}
+
+struct BrowserProfileState {
+    directory: PathBuf,
+    path: PathBuf,
+    initial_local_store_available: bool,
+    profiles: Vec<StoredBrowserProfile>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredBrowserProfiles {
+    version: u8,
+    #[serde(default = "default_initial_local_store_available")]
+    initial_local_store_available: bool,
+    profiles: Vec<StoredBrowserProfile>,
+}
+
+fn default_initial_local_store_available() -> bool {
+    true
+}
+
+struct LoadedBrowserProfiles {
+    initial_local_store_available: bool,
+    profiles: Vec<StoredBrowserProfile>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredBrowserProfile {
+    owner_id: OwnerId,
+    profile_id: Uuid,
+    data_store_identifier: Uuid,
+    website_hosts: BTreeSet<String>,
+}
+
+impl StoredBrowserProfile {
+    fn managed(&self) -> ManagedBrowserProfile {
+        ManagedBrowserProfile {
+            owner_id: self.owner_id.clone(),
+            profile_id: self.profile_id,
+            #[cfg(any(target_os = "macos", test))]
+            data_store_identifier: self.data_store_identifier,
+            #[cfg(any(target_os = "macos", test))]
+            website_hosts: self.website_hosts.clone(),
+        }
+    }
+}
+
+impl BrowserProfileStore {
+    pub(crate) fn open(data_dir: &Path) -> Result<Self, String> {
+        let directory = data_dir.join(DIRECTORY);
+        fs::create_dir_all(&directory).map_err(profile_storage_error)?;
+        let metadata = fs::symlink_metadata(&directory).map_err(profile_storage_error)?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Err("browser profile storage is invalid".to_owned());
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))
+                .map_err(profile_storage_error)?;
+        }
+        let path = directory.join(MANIFEST_FILE);
+        let loaded = load_profiles(&path)?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(BrowserProfileState {
+                directory,
+                path,
+                initial_local_store_available: loaded.initial_local_store_available,
+                profiles: loaded.profiles,
+            })),
+            lifecycle: Arc::new(AsyncMutex::new(())),
+        })
+    }
+
+    /// Serialize native profile allocation and reset. A reset therefore
+    /// cannot delete a store while another command is creating a view on it.
+    pub(crate) async fn lock_lifecycle(&self) -> OwnedMutexGuard<()> {
+        Arc::clone(&self.lifecycle).lock_owned().await
+    }
+
+    pub(crate) fn get_or_create(
+        &self,
+        owner_id: &OwnerId,
+    ) -> Result<ManagedBrowserProfile, String> {
+        let mut state = self.lock();
+        if let Some(profile) = state
+            .profiles
+            .iter()
+            .find(|profile| profile.owner_id == *owner_id)
+        {
+            return Ok(profile.managed());
+        }
+        if state.profiles.len() >= MAX_PROFILES {
+            return Err("browser profile storage is full".to_owned());
+        }
+
+        let initial_store = Uuid::from_bytes(INITIAL_LOCAL_DATA_STORE_IDENTIFIER);
+        let profile_id = fresh_uuid(
+            state
+                .profiles
+                .iter()
+                .flat_map(|profile| [profile.profile_id, profile.data_store_identifier])
+                .chain(std::iter::once(initial_store)),
+        );
+        let adopts_initial_store = owner_id.is_local() && state.initial_local_store_available;
+        let data_store_identifier = if adopts_initial_store {
+            initial_store
+        } else {
+            fresh_uuid(
+                state
+                    .profiles
+                    .iter()
+                    .flat_map(|profile| [profile.profile_id, profile.data_store_identifier])
+                    .chain([profile_id, initial_store]),
+            )
+        };
+        let profile = StoredBrowserProfile {
+            owner_id: owner_id.clone(),
+            profile_id,
+            data_store_identifier,
+            website_hosts: BTreeSet::new(),
+        };
+        let mut next = state.profiles.clone();
+        next.push(profile.clone());
+        next.sort_by(|left, right| left.owner_id.as_str().cmp(right.owner_id.as_str()));
+        let initial_local_store_available =
+            state.initial_local_store_available && !adopts_initial_store;
+        persist_profiles(
+            &state.directory,
+            &state.path,
+            initial_local_store_available,
+            &next,
+        )?;
+        state.initial_local_store_available = initial_local_store_available;
+        state.profiles = next;
+        Ok(profile.managed())
+    }
+
+    /// Resolve the exact owner/profile pair derived by the native session
+    /// registry. A guessed id and another owner's real id are indistinguishable.
+    #[cfg(any(target_os = "macos", test))]
+    pub(crate) fn resolve(
+        &self,
+        owner_id: &OwnerId,
+        profile_id: &str,
+    ) -> Result<ManagedBrowserProfile, String> {
+        let profile_id =
+            Uuid::parse_str(profile_id).map_err(|_| "browser profile is unavailable".to_owned())?;
+        self.lock()
+            .profiles
+            .iter()
+            .find(|profile| profile.owner_id == *owner_id && profile.profile_id == profile_id)
+            .map(StoredBrowserProfile::managed)
+            .ok_or_else(|| "browser profile is unavailable".to_owned())
+    }
+
+    /// Record only the normalized website host, never a URL, path, query, or
+    /// page content. Older WebKit groups removable records by site/domain.
+    pub(crate) fn record_url(
+        &self,
+        owner_id: &OwnerId,
+        profile_id: &str,
+        url: &Url,
+    ) -> Result<(), String> {
+        let host = website_host(url)?;
+        let profile_id =
+            Uuid::parse_str(profile_id).map_err(|_| "browser profile is unavailable".to_owned())?;
+        let mut state = self.lock();
+        let Some(index) = state
+            .profiles
+            .iter()
+            .position(|profile| profile.owner_id == *owner_id && profile.profile_id == profile_id)
+        else {
+            return Err("browser profile is unavailable".to_owned());
+        };
+        if state.profiles[index].website_hosts.contains(&host) {
+            return Ok(());
+        }
+        if state.profiles[index].website_hosts.len() >= MAX_WEBSITE_HOSTS {
+            return Err("browser profile has too many website records".to_owned());
+        }
+
+        let mut next = state.profiles.clone();
+        next[index].website_hosts.insert(host);
+        persist_profiles(
+            &state.directory,
+            &state.path,
+            state.initial_local_store_available,
+            &next,
+        )?;
+        state.profiles = next;
+        Ok(())
+    }
+
+    /// Forget only the exact native-managed profile after its engine data has
+    /// been deleted. No path or engine identifier is accepted from the caller.
+    #[cfg(any(target_os = "macos", test))]
+    pub(crate) fn forget(&self, owner_id: &OwnerId, profile_id: &str) -> Result<(), String> {
+        let profile_id =
+            Uuid::parse_str(profile_id).map_err(|_| "browser profile is unavailable".to_owned())?;
+        let mut state = self.lock();
+        let Some(index) = state
+            .profiles
+            .iter()
+            .position(|profile| profile.owner_id == *owner_id && profile.profile_id == profile_id)
+        else {
+            return Err("browser profile is unavailable".to_owned());
+        };
+        let mut next = state.profiles.clone();
+        next.remove(index);
+        persist_profiles(
+            &state.directory,
+            &state.path,
+            state.initial_local_store_available,
+            &next,
+        )?;
+        state.profiles = next;
+        Ok(())
+    }
+
+    fn lock(&self) -> MutexGuard<'_, BrowserProfileState> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+fn fresh_uuid(existing: impl IntoIterator<Item = Uuid>) -> Uuid {
+    let existing = existing.into_iter().collect::<HashSet<_>>();
+    loop {
+        let candidate = Uuid::new_v4();
+        if !candidate.is_nil() && !existing.contains(&candidate) {
+            return candidate;
+        }
+    }
+}
+
+fn website_host(url: &Url) -> Result<String, String> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err("browser profile accepts only HTTP and HTTPS websites".to_owned());
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| "browser website has no host".to_owned())?;
+    normalize_website_host(host).ok_or_else(|| "browser website host is not valid".to_owned())
+}
+
+pub(crate) fn normalize_website_host(host: &str) -> Option<String> {
+    let host = host
+        .trim()
+        .trim_end_matches('.')
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_ascii_lowercase();
+    valid_website_host(&host).then_some(host)
+}
+
+fn valid_website_host(host: &str) -> bool {
+    !host.is_empty()
+        && host.chars().count() <= MAX_WEBSITE_HOST_CHARS
+        && host
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b':' | b'_'))
+}
+
+fn load_profiles(path: &Path) -> Result<LoadedBrowserProfiles, String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(LoadedBrowserProfiles {
+                initial_local_store_available: true,
+                profiles: Vec::new(),
+            });
+        }
+        Err(error) => return Err(profile_storage_error(error)),
+    };
+    if !metadata.is_file()
+        || metadata.file_type().is_symlink()
+        || metadata.len() > MAX_MANIFEST_BYTES
+    {
+        return Err("browser profile storage is invalid".to_owned());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if metadata.permissions().mode() & 0o077 != 0 {
+            return Err("browser profile storage has broad permissions".to_owned());
+        }
+    }
+    let bytes = fs::read(path).map_err(profile_storage_error)?;
+    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        return Err("browser profile storage is invalid".to_owned());
+    }
+    let stored: StoredBrowserProfiles = serde_json::from_slice(&bytes)
+        .map_err(|_| "browser profile storage is invalid".to_owned())?;
+    validate_profiles(&stored)?;
+    let initial_store = Uuid::from_bytes(INITIAL_LOCAL_DATA_STORE_IDENTIFIER);
+    let initial_local_store_available = stored.initial_local_store_available
+        && !stored.profiles.iter().any(|profile| {
+            profile.owner_id.is_local() || profile.data_store_identifier == initial_store
+        });
+    Ok(LoadedBrowserProfiles {
+        initial_local_store_available,
+        profiles: stored.profiles,
+    })
+}
+
+fn validate_profiles(stored: &StoredBrowserProfiles) -> Result<(), String> {
+    if stored.version != VERSION || stored.profiles.len() > MAX_PROFILES {
+        return Err("browser profile storage uses an unsupported shape".to_owned());
+    }
+    let initial_store = Uuid::from_bytes(INITIAL_LOCAL_DATA_STORE_IDENTIFIER);
+    let mut owners = HashSet::new();
+    let mut identifiers = HashSet::new();
+    for profile in &stored.profiles {
+        if !owners.insert(profile.owner_id.as_str())
+            || profile.profile_id.is_nil()
+            || profile.data_store_identifier.is_nil()
+            || profile.profile_id == initial_store
+            || (profile.data_store_identifier == initial_store && !profile.owner_id.is_local())
+            || !identifiers.insert(profile.profile_id)
+            || !identifiers.insert(profile.data_store_identifier)
+            || profile.website_hosts.len() > MAX_WEBSITE_HOSTS
+            || profile
+                .website_hosts
+                .iter()
+                .any(|host| normalize_website_host(host).as_deref() != Some(host.as_str()))
+        {
+            return Err("browser profile storage is invalid".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn persist_profiles(
+    directory: &Path,
+    destination: &Path,
+    initial_local_store_available: bool,
+    profiles: &[StoredBrowserProfile],
+) -> Result<(), String> {
+    let bytes = serde_json::to_vec_pretty(&StoredBrowserProfiles {
+        version: VERSION,
+        initial_local_store_available,
+        profiles: profiles.to_vec(),
+    })
+    .map_err(|_| "browser profile storage could not be encoded".to_owned())?;
+    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        return Err("browser profile storage is too large".to_owned());
+    }
+    write_atomically(directory, destination, &bytes).map_err(profile_storage_error)
+}
+
+fn write_atomically(directory: &Path, destination: &Path, bytes: &[u8]) -> io::Result<()> {
+    let temporary = directory.join(format!(".managed-profiles-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_file(&temporary, destination)?;
+        sync_directory(directory)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(temporary, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let temporary = temporary
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let succeeded = unsafe {
+        MoveFileExW(
+            temporary.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if succeeded == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(directory: &Path) -> io::Result<()> {
+    fs::File::open(directory)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_directory(_directory: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+fn profile_storage_error(_error: impl std::fmt::Display) -> String {
+    "browser profile storage is unavailable".to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_owner_reopens_the_same_persistent_profile() {
+        let private = tempfile::tempdir().unwrap();
+        let owner = OwnerId::local();
+        let first = BrowserProfileStore::open(private.path())
+            .unwrap()
+            .get_or_create(&owner)
+            .unwrap();
+
+        let reopened = BrowserProfileStore::open(private.path())
+            .unwrap()
+            .get_or_create(&owner)
+            .unwrap();
+
+        assert_eq!(reopened.profile_id(), first.profile_id());
+        assert_eq!(
+            reopened.data_store_identifier(),
+            first.data_store_identifier()
+        );
+        assert_eq!(
+            first.data_store_identifier(),
+            INITIAL_LOCAL_DATA_STORE_IDENTIFIER
+        );
+    }
+
+    #[test]
+    fn owners_are_isolated_and_cannot_redeem_each_others_profile_ids() {
+        let private = tempfile::tempdir().unwrap();
+        let store = BrowserProfileStore::open(private.path()).unwrap();
+        let alice = OwnerId::new("alice").unwrap();
+        let bob = OwnerId::new("bob").unwrap();
+        let alice_profile = store.get_or_create(&alice).unwrap();
+        let bob_profile = store.get_or_create(&bob).unwrap();
+
+        assert_ne!(alice_profile.profile_id(), bob_profile.profile_id());
+        assert_ne!(
+            alice_profile.data_store_identifier(),
+            bob_profile.data_store_identifier()
+        );
+        assert!(store.resolve(&bob, &alice_profile.profile_id()).is_err());
+        assert!(store.forget(&bob, &alice_profile.profile_id()).is_err());
+        assert_eq!(
+            store
+                .resolve(&alice, &alice_profile.profile_id())
+                .unwrap()
+                .profile_id(),
+            alice_profile.profile_id()
+        );
+    }
+
+    #[test]
+    fn guessed_profile_ids_are_refused_without_changing_the_real_profile() {
+        let private = tempfile::tempdir().unwrap();
+        let store = BrowserProfileStore::open(private.path()).unwrap();
+        let owner = OwnerId::local();
+        let profile = store.get_or_create(&owner).unwrap();
+
+        assert!(store.forget(&owner, &Uuid::new_v4().to_string()).is_err());
+        assert_eq!(
+            store
+                .resolve(&owner, &profile.profile_id())
+                .unwrap()
+                .profile_id(),
+            profile.profile_id()
+        );
+    }
+
+    #[test]
+    fn successful_reset_allocates_a_fresh_profile_next_time() {
+        let private = tempfile::tempdir().unwrap();
+        let store = BrowserProfileStore::open(private.path()).unwrap();
+        let owner = OwnerId::local();
+        let first = store.get_or_create(&owner).unwrap();
+        store.forget(&owner, &first.profile_id()).unwrap();
+
+        let fresh = store.get_or_create(&owner).unwrap();
+
+        assert_ne!(fresh.profile_id(), first.profile_id());
+        assert_ne!(fresh.data_store_identifier(), first.data_store_identifier());
+        assert_ne!(
+            fresh.data_store_identifier(),
+            INITIAL_LOCAL_DATA_STORE_IDENTIFIER
+        );
+        drop(store);
+
+        let reopened = BrowserProfileStore::open(private.path())
+            .unwrap()
+            .get_or_create(&owner)
+            .unwrap();
+        assert_eq!(reopened.profile_id(), fresh.profile_id());
+        assert_eq!(
+            reopened.data_store_identifier(),
+            fresh.data_store_identifier()
+        );
+    }
+
+    #[test]
+    fn only_normalized_website_hosts_enter_native_reset_metadata() {
+        let private = tempfile::tempdir().unwrap();
+        let store = BrowserProfileStore::open(private.path()).unwrap();
+        let owner = OwnerId::local();
+        let profile = store.get_or_create(&owner).unwrap();
+        store
+            .record_url(
+                &owner,
+                &profile.profile_id(),
+                &Url::parse("https://Docs.Example.COM/private?token=secret").unwrap(),
+            )
+            .unwrap();
+
+        let reopened = BrowserProfileStore::open(private.path())
+            .unwrap()
+            .resolve(&owner, &profile.profile_id())
+            .unwrap();
+        assert_eq!(
+            reopened.website_hosts(),
+            &BTreeSet::from(["docs.example.com".to_owned()])
+        );
+        let manifest =
+            fs::read_to_string(private.path().join(DIRECTORY).join(MANIFEST_FILE)).unwrap();
+        assert!(manifest.contains("docs.example.com"));
+        assert!(!manifest.contains("/private"));
+        assert!(!manifest.contains("token"));
+        assert!(!manifest.contains("secret"));
+    }
+
+    #[test]
+    fn another_owner_cannot_consume_the_local_bootstrap_store() {
+        let private = tempfile::tempdir().unwrap();
+        let alice = OwnerId::new("alice").unwrap();
+        let first = BrowserProfileStore::open(private.path()).unwrap();
+        let alice_profile = first.get_or_create(&alice).unwrap();
+        assert_ne!(
+            alice_profile.data_store_identifier(),
+            INITIAL_LOCAL_DATA_STORE_IDENTIFIER
+        );
+        drop(first);
+
+        let local = BrowserProfileStore::open(private.path())
+            .unwrap()
+            .get_or_create(&OwnerId::local())
+            .unwrap();
+        assert_eq!(
+            local.data_store_identifier(),
+            INITIAL_LOCAL_DATA_STORE_IDENTIFIER
+        );
+    }
+
+    #[test]
+    fn manifest_rejects_identifier_collisions_across_profile_and_store_kinds() {
+        let shared = Uuid::new_v4();
+        let stored = StoredBrowserProfiles {
+            version: VERSION,
+            initial_local_store_available: true,
+            profiles: vec![
+                StoredBrowserProfile {
+                    owner_id: OwnerId::new("alice").unwrap(),
+                    profile_id: Uuid::new_v4(),
+                    data_store_identifier: shared,
+                    website_hosts: BTreeSet::new(),
+                },
+                StoredBrowserProfile {
+                    owner_id: OwnerId::new("bob").unwrap(),
+                    profile_id: shared,
+                    data_store_identifier: Uuid::new_v4(),
+                    website_hosts: BTreeSet::new(),
+                },
+            ],
+        };
+
+        assert!(validate_profiles(&stored).is_err());
+    }
+
+    #[test]
+    fn legacy_manifest_without_bootstrap_flag_remains_readable_and_retires_it() {
+        let private = tempfile::tempdir().unwrap();
+        let directory = private.path().join(DIRECTORY);
+        fs::create_dir_all(&directory).unwrap();
+        let path = directory.join(MANIFEST_FILE);
+        let profile_id = Uuid::new_v4();
+        let data_store_identifier = Uuid::new_v4();
+        let bytes = serde_json::to_vec_pretty(&serde_json::json!({
+            "version": VERSION,
+            "profiles": [{
+                "owner_id": OwnerId::LOCAL,
+                "profile_id": profile_id,
+                "data_store_identifier": data_store_identifier,
+                "website_hosts": [],
+            }],
+        }))
+        .unwrap();
+        write_atomically(&directory, &path, &bytes).unwrap();
+
+        let store = BrowserProfileStore::open(private.path()).unwrap();
+        let legacy = store.get_or_create(&OwnerId::local()).unwrap();
+        assert_eq!(legacy.profile_id(), profile_id.to_string());
+        assert_eq!(
+            legacy.data_store_identifier(),
+            *data_store_identifier.as_bytes()
+        );
+
+        store
+            .forget(&OwnerId::local(), &legacy.profile_id())
+            .unwrap();
+        let fresh = store.get_or_create(&OwnerId::local()).unwrap();
+        assert_ne!(
+            fresh.data_store_identifier(),
+            INITIAL_LOCAL_DATA_STORE_IDENTIFIER
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_profile_directory_is_refused() {
+        use std::os::unix::fs::symlink;
+
+        let private = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), private.path().join(DIRECTORY)).unwrap();
+
+        assert!(BrowserProfileStore::open(private.path()).is_err());
+    }
+}

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -37,6 +37,7 @@ const CODE_BROWSER_EVENT: &str = "code-browser:event";
 const MAX_BROWSER_ID_CHARS: usize = 80;
 const MAX_WORKSPACE_ID_CHARS: usize = 200;
 const MAX_BROWSER_URL_CHARS: usize = 8_192;
+const MAX_JS_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const AGENT_NAVIGATION_START_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const AGENT_NAVIGATION_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 const SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL: std::time::Duration =
@@ -84,7 +85,12 @@ enum CodeBrowserAction {
         enabled: bool,
     },
     RemoveInspect,
-    ResetProfile,
+    ResetProfile {
+        /// Correlates renderer recovery with native phase events. It never
+        /// selects an owner, profile, engine store, or filesystem path.
+        #[serde(rename = "resetId")]
+        reset_id: u64,
+    },
     Close,
 }
 
@@ -119,6 +125,17 @@ struct CodeBrowserEvent {
     agent_access: Option<BrowserAgentAccess>,
     #[serde(skip_serializing_if = "Option::is_none")]
     origin: Option<String>,
+}
+
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodeBrowserProfileResetEvent {
+    workspace_id: String,
+    browser_id: String,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    reset_id: u64,
 }
 
 #[tauri::command]
@@ -169,7 +186,8 @@ pub(crate) async fn code_browser_command(
                 visible,
             )
         }
-        CodeBrowserAction::ResetProfile => {
+        CodeBrowserAction::ResetProfile { reset_id } => {
+            validated_profile_reset_id(reset_id)?;
             let _lifecycle = profiles.lock_lifecycle().await;
             reset_browser_profile(
                 &app,
@@ -177,6 +195,7 @@ pub(crate) async fn code_browser_command(
                 &profiles,
                 &request.browser_id,
                 &request.workspace_id,
+                reset_id,
             )
             .await?;
             Ok(BrowserSnapshot::missing(
@@ -920,21 +939,44 @@ async fn reset_browser_profile(
     profiles: &BrowserProfileStore,
     browser_id: &str,
     workspace_id: &str,
+    reset_id: u64,
 ) -> Result<(), String> {
     let reset = registry
         .begin_profile_reset(browser_id, workspace_id)
         .await?;
-    let profile = profiles.resolve(reset.owner_id(), reset.profile_id())?;
+    let sessions = reset.sessions().to_vec();
+    let profile = match profiles.resolve(reset.owner_id(), reset.profile_id()) {
+        Ok(profile) => profile,
+        Err(error) => {
+            return recover_failed_profile_reset(reset, error, || {
+                emit_profile_reset_event(app, &sessions, reset_id, "profile_reset_reconstruct");
+            });
+        }
+    };
     let owner_id = reset.owner_id().clone();
     let profile_id = reset.profile_id().to_owned();
-    close_before_delete(
+    let result = close_before_delete(
+        || emit_profile_reset_event(app, &sessions, reset_id, "profile_reset_closing"),
         || close_profile_sessions(app, reset.sessions()),
+        || emit_profile_reset_event(app, &sessions, reset_id, "profile_reset_deleting_data"),
         || delete_managed_profile(app, &profile),
     )
-    .await?;
-    reset.finish();
-    profiles.forget(&owner_id, &profile_id)?;
-    Ok(())
+    .await;
+    match result {
+        Ok(()) => match profiles.forget(&owner_id, &profile_id) {
+            Ok(()) => {
+                reset.finish();
+                emit_profile_reset_event(app, &sessions, reset_id, "profile_reset_reconstruct");
+                Ok(())
+            }
+            Err(error) => recover_failed_profile_reset(reset, error, || {
+                emit_profile_reset_event(app, &sessions, reset_id, "profile_reset_reconstruct");
+            }),
+        },
+        Err(error) => recover_failed_profile_reset(reset, error, || {
+            emit_profile_reset_event(app, &sessions, reset_id, "profile_reset_reconstruct");
+        }),
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -944,23 +986,67 @@ async fn reset_browser_profile(
     _profiles: &BrowserProfileStore,
     _browser_id: &str,
     _workspace_id: &str,
+    _reset_id: u64,
 ) -> Result<(), String> {
     Err("browser profile reset is not available on this platform".to_owned())
 }
 
 #[cfg(any(target_os = "macos", test))]
-async fn close_before_delete<C, CloseFuture, D, DeleteFuture>(
+async fn close_before_delete<S, C, CloseFuture, P, D, DeleteFuture>(
+    started: S,
     close: C,
+    closed: P,
     delete: D,
 ) -> Result<(), String>
 where
+    S: FnOnce(),
     C: FnOnce() -> CloseFuture,
     CloseFuture: std::future::Future<Output = Result<(), String>>,
+    P: FnOnce(),
     D: FnOnce() -> DeleteFuture,
     DeleteFuture: std::future::Future<Output = Result<(), String>>,
 {
+    started();
     close().await?;
+    closed();
     delete().await
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn recover_failed_profile_reset<R>(
+    reset: crate::browser_control::BrowserProfileResetLease,
+    error: String,
+    reconstruct: R,
+) -> Result<(), String>
+where
+    R: FnOnce(),
+{
+    drop(reset);
+    reconstruct();
+    Err(error)
+}
+
+#[cfg(target_os = "macos")]
+fn emit_profile_reset_event(
+    app: &AppHandle,
+    sessions: &[crate::browser_control::BrowserProfileResetSession],
+    reset_id: u64,
+    kind: &'static str,
+) {
+    let Some(main) = app.get_webview("main") else {
+        return;
+    };
+    for session in sessions {
+        let _ = main.emit(
+            CODE_BROWSER_EVENT,
+            CodeBrowserProfileResetEvent {
+                workspace_id: session.workspace_id.clone(),
+                browser_id: session.browser_id.clone(),
+                kind,
+                reset_id,
+            },
+        );
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -1160,7 +1246,7 @@ fn run_action(
         | CodeBrowserAction::TakeHumanControl
         | CodeBrowserAction::SetInspect { .. }
         | CodeBrowserAction::RemoveInspect
-        | CodeBrowserAction::ResetProfile
+        | CodeBrowserAction::ResetProfile { .. }
         | CodeBrowserAction::Close => Err(format!(
             "browser action is not valid for the open session {browser_id}"
         )),
@@ -1277,6 +1363,13 @@ pub(crate) fn validated_workspace_id(workspace_id: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn validated_profile_reset_id(reset_id: u64) -> Result<(), String> {
+    if reset_id == 0 || reset_id > MAX_JS_SAFE_INTEGER {
+        return Err("browser profile reset id is not valid".to_owned());
+    }
+    Ok(())
+}
+
 fn emit_event(main: &Webview, event: CodeBrowserEvent) {
     let _ = main.emit(CODE_BROWSER_EVENT, event);
 }
@@ -1382,6 +1475,33 @@ mod tests {
     }
 
     #[test]
+    fn profile_reset_ids_stay_exact_across_renderer_events() {
+        assert!(validated_profile_reset_id(1).is_ok());
+        assert!(validated_profile_reset_id(MAX_JS_SAFE_INTEGER).is_ok());
+        assert!(validated_profile_reset_id(0).is_err());
+        assert!(validated_profile_reset_id(MAX_JS_SAFE_INTEGER + 1).is_err());
+    }
+
+    #[test]
+    fn profile_reset_events_carry_the_target_session_and_cycle() {
+        assert_eq!(
+            serde_json::to_value(CodeBrowserProfileResetEvent {
+                workspace_id: "workspace-1".to_owned(),
+                browser_id: "browser-1".to_owned(),
+                kind: "profile_reset_reconstruct",
+                reset_id: 17,
+            })
+            .unwrap(),
+            serde_json::json!({
+                "workspaceId": "workspace-1",
+                "browserId": "browser-1",
+                "type": "profile_reset_reconstruct",
+                "resetId": 17,
+            })
+        );
+    }
+
+    #[test]
     fn browser_urls_are_http_only_and_cannot_reenter_the_app_origin() {
         let renderer = Url::parse("http://localhost:1420/code/w/one").unwrap();
         assert!(validated_url("https://example.com/docs", Some(&renderer)).is_ok());
@@ -1429,9 +1549,17 @@ mod tests {
         let delete_events = std::sync::Arc::clone(&events);
 
         close_before_delete(
+            {
+                let events = std::sync::Arc::clone(&events);
+                move || events.lock().unwrap().push("closing")
+            },
             move || async move {
                 close_events.lock().unwrap().push("close");
                 Ok(())
+            },
+            {
+                let events = std::sync::Arc::clone(&events);
+                move || events.lock().unwrap().push("deleting")
             },
             move || async move {
                 delete_events.lock().unwrap().push("delete");
@@ -1441,7 +1569,10 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(*events.lock().unwrap(), ["close", "delete"]);
+        assert_eq!(
+            *events.lock().unwrap(),
+            ["closing", "close", "deleting", "delete"]
+        );
     }
 
     #[tokio::test]
@@ -1450,7 +1581,9 @@ mod tests {
         let delete_probe = std::sync::Arc::clone(&deleted);
 
         assert!(close_before_delete(
+            || {},
             || async { Err("close failed".to_owned()) },
+            || panic!("deletion phase must wait for every session to close"),
             move || async move {
                 delete_probe.store(true, std::sync::atomic::Ordering::SeqCst);
                 Ok(())
@@ -1460,6 +1593,57 @@ mod tests {
         .is_err());
 
         assert!(!deleted.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn profile_reset_preserves_the_deletion_error_after_the_phase_signal() {
+        let phases = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let closing = std::sync::Arc::clone(&phases);
+        let deleting = std::sync::Arc::clone(&phases);
+
+        let error = close_before_delete(
+            move || closing.lock().unwrap().push("closing"),
+            || async { Ok(()) },
+            move || deleting.lock().unwrap().push("deleting"),
+            || async { Err("WebKit could not remove profile data".to_owned()) },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(*phases.lock().unwrap(), ["closing", "deleting"]);
+        assert_eq!(error, "WebKit could not remove profile data");
+    }
+
+    #[tokio::test]
+    async fn failed_profile_reset_restores_registry_before_reconstruction() {
+        let registry = BrowserRegistry::default();
+        registry
+            .register(
+                "browser-1",
+                "workspace-1",
+                "https://example.com/app".to_owned(),
+                true,
+            )
+            .unwrap();
+        let reset = registry
+            .begin_profile_reset("browser-1", "workspace-1")
+            .await
+            .unwrap();
+        let recovered_registry = registry.clone();
+
+        let error = recover_failed_profile_reset(
+            reset,
+            "WebKit could not remove profile data".to_owned(),
+            move || {
+                assert!(recovered_registry
+                    .snapshot("browser-1", "workspace-1")
+                    .is_ok());
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error, "WebKit could not remove profile data");
+        assert!(registry.snapshot("browser-1", "workspace-1").is_ok());
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -14,18 +14,19 @@ use tauri_plugin_dialog::{
 };
 use tidebreak_core::{
     BrowserGrantCapability, BrowserNavigateArgs, BrowserNavigateResult, BrowserOrigin,
-    BrowserOriginScope,
+    BrowserOriginScope, OwnerId,
 };
 use tokio::sync::oneshot;
 use url::Url;
 use uuid::Uuid;
 
-#[cfg(target_os = "macos")]
-use crate::browser_control::BROWSER_DATA_STORE_IDENTIFIER;
 use crate::browser_control::{
     BrowserAgentAccess, BrowserController, BrowserDispatchEffect, BrowserLoadState,
     BrowserNavigationDecision, BrowserRegistry, BrowserSnapshot,
 };
+#[cfg(any(target_os = "macos", test))]
+use crate::browser_profile::normalize_website_host;
+use crate::browser_profile::{BrowserProfileStore, ManagedBrowserProfile};
 use crate::browser_semantics::{
     browser_inject_inspect_overlay, browser_install_same_document_navigation_observer,
     browser_read_same_document_navigation_observer, browser_remove_inspect_overlay,
@@ -40,6 +41,10 @@ const AGENT_NAVIGATION_START_TIMEOUT: std::time::Duration = std::time::Duration:
 const AGENT_NAVIGATION_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 const SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL: std::time::Duration =
     std::time::Duration::from_millis(100);
+#[cfg(target_os = "macos")]
+const PROFILE_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(target_os = "macos")]
+const PROFILE_CLOSE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -79,6 +84,7 @@ enum CodeBrowserAction {
         enabled: bool,
     },
     RemoveInspect,
+    ResetProfile,
     Close,
 }
 
@@ -119,12 +125,14 @@ struct CodeBrowserEvent {
 pub(crate) async fn code_browser_command(
     app: AppHandle,
     registry: tauri::State<'_, BrowserRegistry>,
+    profiles: tauri::State<'_, BrowserProfileStore>,
     request: CodeBrowserCommandRequest,
 ) -> Result<BrowserSnapshot, String> {
     validated_workspace_id(&request.workspace_id)?;
     let label = browser_label(&request.browser_id)?;
     let existing = app.get_webview(&label);
     let registry = registry.inner().clone();
+    let profiles = profiles.inner().clone();
 
     match request.action {
         CodeBrowserAction::Create {
@@ -132,6 +140,8 @@ pub(crate) async fn code_browser_command(
             bounds,
             visible,
         } => {
+            let _lifecycle = profiles.lock_lifecycle().await;
+            let existing = app.get_webview(&label);
             if let Some(webview) = existing {
                 registry.ensure_workspace(&request.browser_id, &request.workspace_id)?;
                 set_bounds(&webview, bounds)?;
@@ -144,9 +154,13 @@ pub(crate) async fn code_browser_command(
             // allocating a fresh native instance; a cross-workspace record is
             // deliberately rejected rather than rebound.
             registry.remove(&request.browser_id, &request.workspace_id)?;
+            let owner_id = OwnerId::local();
+            let profile = profiles.get_or_create(&owner_id)?;
             create_browser(
                 &app,
                 &registry,
+                &profiles,
+                profile,
                 &request.workspace_id,
                 &request.browser_id,
                 &label,
@@ -154,6 +168,21 @@ pub(crate) async fn code_browser_command(
                 bounds,
                 visible,
             )
+        }
+        CodeBrowserAction::ResetProfile => {
+            let _lifecycle = profiles.lock_lifecycle().await;
+            reset_browser_profile(
+                &app,
+                &registry,
+                &profiles,
+                &request.browser_id,
+                &request.workspace_id,
+            )
+            .await?;
+            Ok(BrowserSnapshot::missing(
+                &request.browser_id,
+                &request.workspace_id,
+            ))
         }
         CodeBrowserAction::Snapshot => match existing {
             Some(_) => registry.snapshot(&request.browser_id, &request.workspace_id),
@@ -395,6 +424,8 @@ pub(crate) async fn navigate_browser_for_agent(
 fn create_browser(
     app: &AppHandle,
     registry: &BrowserRegistry,
+    profiles: &BrowserProfileStore,
+    profile: ManagedBrowserProfile,
     workspace_id: &str,
     browser_id: &str,
     label: &str,
@@ -411,14 +442,27 @@ fn create_browser(
     let renderer_url = main.url().ok();
     let target = validated_url(url, renderer_url.as_ref())?;
     let safe_bounds = validated_bounds(bounds)?;
+    let owner_id = profile.owner_id().clone();
+    let profile_id = profile.profile_id();
+    profiles.record_url(&owner_id, &profile_id, &target)?;
 
-    let instance_id = registry.register(browser_id, workspace_id, target.to_string(), visible)?;
+    let instance_id = registry.register_managed(
+        browser_id,
+        workspace_id,
+        owner_id.clone(),
+        profile_id.clone(),
+        target.to_string(),
+        visible,
+    )?;
 
     let navigation_main = main.clone();
     let navigation_browser = browser_id.to_owned();
     let navigation_workspace = workspace_id.to_owned();
     let navigation_renderer_url = renderer_url.clone();
     let navigation_registry = registry.clone();
+    let navigation_profiles = profiles.clone();
+    let navigation_owner = owner_id;
+    let navigation_profile = profile_id;
     let popup_main = main.clone();
     let popup_browser = browser_id.to_owned();
     let popup_workspace = workspace_id.to_owned();
@@ -436,7 +480,7 @@ fn create_browser(
 
     let builder = WebviewBuilder::new(label, WebviewUrl::External(target));
     #[cfg(target_os = "macos")]
-    let builder = builder.data_store_identifier(BROWSER_DATA_STORE_IDENTIFIER);
+    let builder = builder.data_store_identifier(profile.data_store_identifier());
     let builder = builder
         .on_navigation(move |url| {
             let Ok(safe_url) = validated_url(url.as_str(), navigation_renderer_url.as_ref()) else {
@@ -470,7 +514,35 @@ fn create_browser(
                 safe_url.as_str(),
                 &origin,
             ) {
-                BrowserNavigationDecision::Allow => true,
+                BrowserNavigationDecision::Allow => {
+                    if navigation_profiles
+                        .record_url(&navigation_owner, &navigation_profile, &safe_url)
+                        .is_err()
+                    {
+                        emit_event(
+                            &navigation_main,
+                            CodeBrowserEvent {
+                                workspace_id: navigation_workspace.clone(),
+                                browser_id: navigation_browser.clone(),
+                                kind: "navigation_blocked",
+                                url: Some(url.to_string()),
+                                title: None,
+                                message: Some(
+                                    "This site could not be added to the managed browser profile"
+                                        .to_owned(),
+                                ),
+                                load_state: None,
+                                document_epoch: None,
+                                controller: None,
+                                agent_access: None,
+                                origin: None,
+                            },
+                        );
+                        false
+                    } else {
+                        true
+                    }
+                }
                 BrowserNavigationDecision::Pause { origin, snapshot } => {
                     emit_event(
                         &navigation_main,
@@ -841,6 +913,224 @@ async fn native_loopback_share_choice(
     }
 }
 
+#[cfg(target_os = "macos")]
+async fn reset_browser_profile(
+    app: &AppHandle,
+    registry: &BrowserRegistry,
+    profiles: &BrowserProfileStore,
+    browser_id: &str,
+    workspace_id: &str,
+) -> Result<(), String> {
+    let reset = registry
+        .begin_profile_reset(browser_id, workspace_id)
+        .await?;
+    let profile = profiles.resolve(reset.owner_id(), reset.profile_id())?;
+    let owner_id = reset.owner_id().clone();
+    let profile_id = reset.profile_id().to_owned();
+    close_before_delete(
+        || close_profile_sessions(app, reset.sessions()),
+        || delete_managed_profile(app, &profile),
+    )
+    .await?;
+    reset.finish();
+    profiles.forget(&owner_id, &profile_id)?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn reset_browser_profile(
+    _app: &AppHandle,
+    _registry: &BrowserRegistry,
+    _profiles: &BrowserProfileStore,
+    _browser_id: &str,
+    _workspace_id: &str,
+) -> Result<(), String> {
+    Err("browser profile reset is not available on this platform".to_owned())
+}
+
+#[cfg(any(target_os = "macos", test))]
+async fn close_before_delete<C, CloseFuture, D, DeleteFuture>(
+    close: C,
+    delete: D,
+) -> Result<(), String>
+where
+    C: FnOnce() -> CloseFuture,
+    CloseFuture: std::future::Future<Output = Result<(), String>>,
+    D: FnOnce() -> DeleteFuture,
+    DeleteFuture: std::future::Future<Output = Result<(), String>>,
+{
+    close().await?;
+    delete().await
+}
+
+#[cfg(target_os = "macos")]
+async fn close_profile_sessions(
+    app: &AppHandle,
+    sessions: &[crate::browser_control::BrowserProfileResetSession],
+) -> Result<(), String> {
+    let labels = sessions
+        .iter()
+        .map(|session| browser_label(&session.browser_id))
+        .collect::<Result<Vec<_>, _>>()?;
+    for label in &labels {
+        if let Some(webview) = app.get_webview(label) {
+            webview.close().map_err(browser_error)?;
+        }
+    }
+
+    let deadline = tokio::time::Instant::now() + PROFILE_CLOSE_TIMEOUT;
+    loop {
+        if labels.iter().all(|label| app.get_webview(label).is_none()) {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err("browser sessions did not close before profile reset".to_owned());
+        }
+        tokio::time::sleep(PROFILE_CLOSE_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(target_os = "macos")]
+async fn delete_managed_profile(
+    app: &AppHandle,
+    profile: &ManagedBrowserProfile,
+) -> Result<(), String> {
+    if macos_major_version() >= 14 {
+        let identifier = profile.data_store_identifier();
+        let identifiers = app
+            .fetch_data_store_identifiers()
+            .await
+            .map_err(browser_error)?;
+        if identifiers.contains(&identifier) {
+            app.remove_data_store(identifier)
+                .await
+                .map_err(browser_error)?;
+        }
+        Ok(())
+    } else {
+        remove_legacy_website_data(app, profile.website_hosts()).await
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_major_version() -> isize {
+    objc2_foundation::NSProcessInfo::processInfo()
+        .operatingSystemVersion()
+        .majorVersion
+}
+
+#[cfg(target_os = "macos")]
+async fn remove_legacy_website_data(
+    app: &AppHandle,
+    website_hosts: &std::collections::BTreeSet<String>,
+) -> Result<(), String> {
+    use std::{
+        ptr::NonNull,
+        sync::{Arc, Mutex},
+    };
+
+    use block2::RcBlock;
+    use objc2::{msg_send, rc::Retained, runtime::AnyObject, MainThreadMarker};
+    use objc2_foundation::{NSArray, NSString};
+    use objc2_web_kit::WKWebsiteDataStore;
+
+    if website_hosts.is_empty() {
+        return Ok(());
+    }
+
+    let website_hosts = Arc::new(website_hosts.clone());
+    let (sender, receiver) = oneshot::channel();
+    let sender = Arc::new(Mutex::new(Some(sender)));
+    let callback_sender = Arc::clone(&sender);
+    app.run_on_main_thread(move || {
+        let Some(mtm) = MainThreadMarker::new() else {
+            if let Some(sender) = sender.lock().ok().and_then(|mut sender| sender.take()) {
+                let _ = sender.send(Err(
+                    "browser profile reset requires the main thread".to_owned()
+                ));
+            }
+            return;
+        };
+        unsafe {
+            let store = WKWebsiteDataStore::defaultDataStore(mtm);
+            let data_types = WKWebsiteDataStore::allWebsiteDataTypes(mtm);
+            let removal_store = store.clone();
+            let removal_types = data_types.clone();
+            let fetch_sender = Arc::clone(&callback_sender);
+            let fetch_hosts = Arc::clone(&website_hosts);
+            let fetch = RcBlock::new(move |records: NonNull<NSArray<AnyObject>>| {
+                let matching = records
+                    .as_ref()
+                    .to_vec()
+                    .into_iter()
+                    .filter(|record| {
+                        let display_name: Retained<NSString> = msg_send![&**record, displayName];
+                        website_record_matches(&display_name.to_string(), &fetch_hosts)
+                    })
+                    .collect::<Vec<_>>();
+                if matching.is_empty() {
+                    if let Some(sender) = fetch_sender
+                        .lock()
+                        .ok()
+                        .and_then(|mut sender| sender.take())
+                    {
+                        let _ = sender.send(Ok(()));
+                    }
+                    return;
+                }
+
+                let records = NSArray::from_retained_slice(&matching);
+                let retained_records = records.clone();
+                let removal_sender = Arc::clone(&fetch_sender);
+                let removed = RcBlock::new(move || {
+                    let _keep_records_alive = &retained_records;
+                    if let Some(sender) = removal_sender
+                        .lock()
+                        .ok()
+                        .and_then(|mut sender| sender.take())
+                    {
+                        let _ = sender.send(Ok(()));
+                    }
+                });
+                let _: () = msg_send![
+                    &*removal_store,
+                    removeDataOfTypes: &*removal_types,
+                    forDataRecords: &*records,
+                    completionHandler: &*removed
+                ];
+            });
+            let _: () = msg_send![
+                &*store,
+                fetchDataRecordsOfTypes: &*data_types,
+                completionHandler: &*fetch
+            ];
+        }
+    })
+    .map_err(browser_error)?;
+
+    tokio::time::timeout(PROFILE_CLOSE_TIMEOUT, receiver)
+        .await
+        .map_err(|_| "browser website data reset timed out".to_owned())?
+        .map_err(|_| "browser website data reset was interrupted".to_owned())?
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn website_record_matches(
+    record_display_name: &str,
+    website_hosts: &std::collections::BTreeSet<String>,
+) -> bool {
+    let Some(record) = normalize_website_host(record_display_name) else {
+        return false;
+    };
+    website_hosts.iter().any(|host| {
+        host == &record
+            || ((record == "localhost" || record.contains('.'))
+                && host
+                    .strip_suffix(&record)
+                    .is_some_and(|prefix| prefix.ends_with('.')))
+    })
+}
+
 fn run_action(
     app: &AppHandle,
     browser_id: &str,
@@ -870,6 +1160,7 @@ fn run_action(
         | CodeBrowserAction::TakeHumanControl
         | CodeBrowserAction::SetInspect { .. }
         | CodeBrowserAction::RemoveInspect
+        | CodeBrowserAction::ResetProfile
         | CodeBrowserAction::Close => Err(format!(
             "browser action is not valid for the open session {browser_id}"
         )),
@@ -1130,5 +1421,60 @@ mod tests {
             height: 500.0,
         })
         .is_err());
+    }
+    #[tokio::test]
+    async fn profile_reset_closes_sessions_before_deleting_profile_data() {
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let close_events = std::sync::Arc::clone(&events);
+        let delete_events = std::sync::Arc::clone(&events);
+
+        close_before_delete(
+            move || async move {
+                close_events.lock().unwrap().push("close");
+                Ok(())
+            },
+            move || async move {
+                delete_events.lock().unwrap().push("delete");
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(*events.lock().unwrap(), ["close", "delete"]);
+    }
+
+    #[tokio::test]
+    async fn profile_reset_never_deletes_when_a_session_does_not_close() {
+        let deleted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let delete_probe = std::sync::Arc::clone(&deleted);
+
+        assert!(close_before_delete(
+            || async { Err("close failed".to_owned()) },
+            move || async move {
+                delete_probe.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .is_err());
+
+        assert!(!deleted.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn legacy_webkit_reset_selects_only_records_for_managed_browser_hosts() {
+        let hosts = std::collections::BTreeSet::from([
+            "docs.example.com".to_owned(),
+            "localhost".to_owned(),
+        ]);
+
+        assert!(website_record_matches("example.com", &hosts));
+        assert!(website_record_matches("docs.example.com", &hosts));
+        assert!(website_record_matches("localhost", &hosts));
+        assert!(!website_record_matches("ample.com", &hosts));
+        assert!(!website_record_matches("evil-example.com", &hosts));
+        assert!(!website_record_matches("com", &hosts));
+        assert!(!website_record_matches("tidebreak.invalid", &hosts));
     }
 }

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -24,6 +24,7 @@ mod broker;
     reason = "the staged browser bridge is test-covered and will be wired in #2339 and #2340"
 )]
 mod browser_control;
+mod browser_profile;
 mod browser_runtime_adapter;
 #[allow(
     dead_code,
@@ -912,6 +913,7 @@ pub fn run() {
             let browser_registry = browser_control::BrowserRegistry::default();
             browser_registry.initialize_private_state(&data)?;
             app.manage(browser_registry);
+            app.manage(browser_profile::BrowserProfileStore::open(&data)?);
             let home = home_dir(&handle)?;
             // Built before anything that reaches the host: `server_info`
             // consults the attachment first, because a remote client must not

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.dom.test.tsx
@@ -95,9 +95,7 @@ describe("BrowserToolbar managed profile reset", () => {
     expect(
       screen.queryByRole("button", { name: "Browser options" }),
     ).toBeNull();
-    await user.click(
-      screen.getByRole("button", { name: "Open externally" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Open externally" }));
     expect(onOpenExternal).toHaveBeenCalledOnce();
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.dom.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BrowserHostSnapshot } from "./browserHost";
+import type { BrowserSession } from "./browserSession";
+import { BrowserToolbar } from "./BrowserToolbar";
+
+const baseEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
+  name: "wk_webview",
+  capabilities: {
+    lifecycle: true,
+    persistentProfile: true,
+    semanticSnapshot: false,
+    semanticActions: false,
+    screenshot: false,
+    crossOriginFrames: false,
+    profileReset: false,
+  },
+};
+
+const resetEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
+  ...baseEngine,
+  capabilities: {
+    ...baseEngine.capabilities,
+    profileReset: true,
+  },
+};
+
+const session: BrowserSession = {
+  version: 1,
+  id: "browser-1",
+  workspaceId: "workspace-1",
+  url: "https://example.com/app",
+  address: "example.com/app",
+  title: "Example app",
+  loadState: "ready",
+  error: null,
+  notice: null,
+  inspectEnabled: false,
+  history: [{ url: "https://example.com/app", title: "Example app" }],
+  historyIndex: 0,
+  updatedAt: Date.parse("2026-08-27T12:00:00.000Z"),
+};
+
+function toolbarProps(
+  engine: BrowserHostSnapshot["engine"],
+  options: {
+    onOpenExternal?: () => void;
+    onResetProfile?: () => Promise<void>;
+    onOverlayOpenChange?: (open: boolean) => void;
+  } = {},
+) {
+  return {
+    session,
+    address: session.address,
+    addressError: null,
+    canGoBack: false,
+    canGoForward: false,
+    engine,
+    onAddressChange: vi.fn(),
+    onNavigate: vi.fn(),
+    onBack: vi.fn(),
+    onForward: vi.fn(),
+    onReload: vi.fn(),
+    onStop: vi.fn(),
+    onSelectHistory: vi.fn(),
+    onOpenExternal: options.onOpenExternal ?? vi.fn(),
+    onResetProfile: options.onResetProfile,
+    onOverlayOpenChange: options.onOverlayOpenChange ?? vi.fn(),
+  };
+}
+
+async function openResetConfirmation(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Browser options" }));
+  await user.click(
+    await screen.findByRole("menuitem", {
+      name: "Reset development profile",
+    }),
+  );
+  await screen.findByRole("alertdialog");
+}
+
+afterEach(cleanup);
+
+describe("BrowserToolbar managed profile reset", () => {
+  it("keeps direct external-open and hides reset when native support is absent", async () => {
+    const user = userEvent.setup();
+    const onOpenExternal = vi.fn();
+    render(
+      <BrowserToolbar {...toolbarProps(baseEngine, { onOpenExternal })} />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Browser options" }),
+    ).toBeNull();
+    await user.click(
+      screen.getByRole("button", { name: "Open externally" }),
+    );
+    expect(onOpenExternal).toHaveBeenCalledOnce();
+  });
+
+  it("explains the exact Tidebreak-only reset boundary before approval", async () => {
+    const user = userEvent.setup();
+    render(<BrowserToolbar {...toolbarProps(resetEngine)} />);
+
+    await openResetConfirmation(user);
+
+    expect(
+      screen.getByRole("heading", { name: "Reset development profile?" }),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        /closes every Tidebreak browser tab and deletes the managed development-profile cookies, site data, and cache/i,
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        /Safari, Chrome, and your personal browser profiles are never read or changed/i,
+      ),
+    ).toBeVisible();
+  });
+
+  it("does not reset when the destructive confirmation is canceled", async () => {
+    const user = userEvent.setup();
+    const onResetProfile = vi.fn(async () => undefined);
+    const onOverlayOpenChange = vi.fn();
+    render(
+      <BrowserToolbar
+        {...toolbarProps(resetEngine, {
+          onResetProfile,
+          onOverlayOpenChange,
+        })}
+      />,
+    );
+
+    await openResetConfirmation(user);
+    await user.click(screen.getByRole("button", { name: "Keep profile" }));
+
+    expect(onResetProfile).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(onOverlayOpenChange).toHaveBeenLastCalledWith(false),
+    );
+  });
+
+  it("shows progress and keeps the native browser obscured until reset settles", async () => {
+    const user = userEvent.setup();
+    let resolveReset: (() => void) | undefined;
+    const onResetProfile = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReset = resolve;
+        }),
+    );
+    const onOverlayOpenChange = vi.fn();
+    render(
+      <BrowserToolbar
+        {...toolbarProps(resetEngine, {
+          onResetProfile,
+          onOverlayOpenChange,
+        })}
+      />,
+    );
+
+    await openResetConfirmation(user);
+    await user.click(
+      screen.getByRole("button", { name: "Reset development profile" }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Resetting the Tidebreak development profile… closing browser tabs.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Resetting development profile" }),
+    ).toBeDisabled();
+    expect(onOverlayOpenChange).toHaveBeenLastCalledWith(true);
+
+    await act(async () => resolveReset?.());
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          "Resetting the Tidebreak development profile… closing browser tabs.",
+        ),
+      ).toBeNull(),
+    );
+    expect(onOverlayOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("presents a native failure with retry and dismissal", async () => {
+    const user = userEvent.setup();
+    const onResetProfile = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("WebKit could not remove profile data"))
+      .mockResolvedValueOnce(undefined);
+    render(
+      <BrowserToolbar {...toolbarProps(resetEngine, { onResetProfile })} />,
+    );
+
+    await openResetConfirmation(user);
+    await user.click(
+      screen.getByRole("button", { name: "Reset development profile" }),
+    );
+
+    expect(
+      await screen.findByText("WebKit could not remove profile data"),
+    ).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Reset development profile",
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Browser options" }),
+      ).toBeEnabled(),
+    );
+    expect(onResetProfile).toHaveBeenCalledTimes(2);
+    expect(
+      screen.queryByText("WebKit could not remove profile data"),
+    ).toBeNull();
+
+    onResetProfile.mockRejectedValueOnce(new Error("Profile is still busy"));
+    await openResetConfirmation(user);
+    await user.click(
+      screen.getByRole("button", { name: "Reset development profile" }),
+    );
+    expect(await screen.findByText("Profile is still busy")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByText("Profile is still busy")).toBeNull();
+  });
+
+  it("releases obscuration if reset support disappears with the menu open", async () => {
+    const user = userEvent.setup();
+    const onOverlayOpenChange = vi.fn();
+    const props = toolbarProps(resetEngine, { onOverlayOpenChange });
+    const view = render(<BrowserToolbar {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Browser options" }));
+    expect(onOverlayOpenChange).toHaveBeenLastCalledWith(true);
+
+    view.rerender(<BrowserToolbar {...props} engine={baseEngine} />);
+
+    await waitFor(() =>
+      expect(onOverlayOpenChange).toHaveBeenLastCalledWith(false),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Browser options" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Open externally" }),
+    ).toBeVisible();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.dom.test.tsx
@@ -3,7 +3,10 @@ import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { BrowserHostSnapshot } from "./browserHost";
+import type {
+  BrowserHostSnapshot,
+  BrowserProfileResetPhase,
+} from "./browserHost";
 import type { BrowserSession } from "./browserSession";
 import { BrowserToolbar } from "./BrowserToolbar";
 
@@ -50,6 +53,7 @@ function toolbarProps(
     onOpenExternal?: () => void;
     onResetProfile?: () => Promise<void>;
     onOverlayOpenChange?: (open: boolean) => void;
+    profileResetPhase?: BrowserProfileResetPhase;
   } = {},
 ) {
   return {
@@ -67,8 +71,13 @@ function toolbarProps(
     onStop: vi.fn(),
     onSelectHistory: vi.fn(),
     onOpenExternal: options.onOpenExternal ?? vi.fn(),
-    onResetProfile: options.onResetProfile,
+    onResetProfile:
+      options.onResetProfile ??
+      (engine?.capabilities.profileReset
+        ? vi.fn(async () => undefined)
+        : undefined),
     onOverlayOpenChange: options.onOverlayOpenChange ?? vi.fn(),
+    profileResetPhase: options.profileResetPhase,
   };
 }
 
@@ -99,6 +108,22 @@ describe("BrowserToolbar managed profile reset", () => {
     expect(onOpenExternal).toHaveBeenCalledOnce();
   });
 
+  it("does not offer reset without the production owner callback", () => {
+    render(
+      <BrowserToolbar
+        {...toolbarProps(resetEngine)}
+        onResetProfile={undefined}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Browser options" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Open externally" }),
+    ).toBeVisible();
+  });
+
   it("explains the exact Tidebreak-only reset boundary before approval", async () => {
     const user = userEvent.setup();
     render(<BrowserToolbar {...toolbarProps(resetEngine)} />);
@@ -110,13 +135,16 @@ describe("BrowserToolbar managed profile reset", () => {
     ).toBeVisible();
     expect(
       screen.getByText(
-        /closes every Tidebreak browser tab and deletes the managed development-profile cookies, site data, and cache/i,
+        /same stored Tidebreak browser pages will return signed out in a fresh Tidebreak development profile/i,
       ),
     ).toBeVisible();
     expect(
       screen.getByText(
-        /Safari, Chrome, and your personal browser profiles are never read or changed/i,
+        /Managed cookies, site data, and cache are deleted; Safari and Chrome are untouched/i,
       ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/existing agent origin grants remain/i),
     ).toBeVisible();
   });
 
@@ -142,7 +170,7 @@ describe("BrowserToolbar managed profile reset", () => {
     );
   });
 
-  it("shows progress and keeps the native browser obscured until reset settles", async () => {
+  it("shows each native phase and keeps the browser obscured until reset settles", async () => {
     const user = userEvent.setup();
     let resolveReset: (() => void) | undefined;
     const onResetProfile = vi.fn(
@@ -152,14 +180,11 @@ describe("BrowserToolbar managed profile reset", () => {
         }),
     );
     const onOverlayOpenChange = vi.fn();
-    render(
-      <BrowserToolbar
-        {...toolbarProps(resetEngine, {
-          onResetProfile,
-          onOverlayOpenChange,
-        })}
-      />,
-    );
+    const props = toolbarProps(resetEngine, {
+      onResetProfile,
+      onOverlayOpenChange,
+    });
+    const view = render(<BrowserToolbar {...props} />);
 
     await openResetConfirmation(user);
     await user.click(
@@ -176,16 +201,55 @@ describe("BrowserToolbar managed profile reset", () => {
     ).toBeDisabled();
     expect(onOverlayOpenChange).toHaveBeenLastCalledWith(true);
 
+    view.rerender(<BrowserToolbar {...props} profileResetPhase="deleting" />);
+    expect(
+      await screen.findByText(
+        "Resetting the Tidebreak development profile… deleting managed cookies, site data, and cache.",
+      ),
+    ).toBeVisible();
+
+    view.rerender(
+      <BrowserToolbar {...props} profileResetPhase="reconstructing" />,
+    );
+    expect(
+      await screen.findByText(
+        "Resetting the Tidebreak development profile… reopening stored browser pages.",
+      ),
+    ).toBeVisible();
+
+    view.rerender(<BrowserToolbar {...props} profileResetPhase={null} />);
+    expect(
+      screen.getByText(
+        "Resetting the Tidebreak development profile… reopening stored browser pages.",
+      ),
+    ).toBeVisible();
+
     await act(async () => resolveReset?.());
 
     await waitFor(() =>
       expect(
-        screen.queryByText(
-          "Resetting the Tidebreak development profile… closing browser tabs.",
-        ),
+        screen.queryByRole("button", { name: "Resetting development profile" }),
       ).toBeNull(),
     );
     expect(onOverlayOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("shows a sibling reset phase and prevents a competing reset", () => {
+    render(
+      <BrowserToolbar
+        {...toolbarProps(resetEngine)}
+        profileResetPhase="deleting"
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Resetting the Tidebreak development profile… deleting managed cookies, site data, and cache.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Resetting development profile" }),
+    ).toBeDisabled();
   });
 
   it("presents a native failure with retry and dismissal", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -166,8 +166,8 @@ export function BrowserToolbar({
       description: (
         <>
           This closes every Tidebreak browser tab and deletes the managed
-          development-profile cookies, site data, and cache. Safari, Chrome,
-          and your personal browser profiles are never read or changed.
+          development-profile cookies, site data, and cache. Safari, Chrome, and
+          your personal browser profiles are never read or changed.
         </>
       ),
       confirmLabel: "Reset development profile",

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -23,14 +23,17 @@ import {
   Laptop,
   LoaderCircle,
   LockKeyhole,
+  MoreHorizontal,
   Pause,
   RefreshCw,
   Search,
   ShieldCheck,
   ShieldAlert,
+  Trash2,
   X,
 } from "lucide-react";
 
+import { useConfirm } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -40,12 +43,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "../interactive";
-import type {
-  BrowserAgentAccess,
-  BrowserController,
-  BrowserHostSnapshot,
+import {
+  resetCodeBrowserProfile,
+  type BrowserAgentAccess,
+  type BrowserController,
+  type BrowserHostSnapshot,
 } from "./browserHost";
 import { browserSecurity, MAX_BROWSER_URL_CHARS } from "./browserNavigation";
 import type { BrowserSession } from "./browserSession";
@@ -99,6 +103,7 @@ export function BrowserToolbar({
   onRevokeAgent,
   onSelectHistory,
   onOpenExternal,
+  onResetProfile,
   onOverlayOpenChange,
   onAgentAccessOpenChange,
   agentAccessOpen = false,
@@ -126,6 +131,7 @@ export function BrowserToolbar({
   onRevokeAgent?: () => void;
   onSelectHistory: (index: number) => void;
   onOpenExternal: () => void;
+  onResetProfile?: () => Promise<void>;
   onOverlayOpenChange: (open: boolean) => void;
   onAgentAccessOpenChange?: (open: boolean) => void;
   agentAccessOpen?: boolean;
@@ -139,10 +145,70 @@ export function BrowserToolbar({
   const securityId = useId();
   const compactToolbar = useCompactToolbar(toolbarRef, COMPACT_TOOLBAR_WIDTH);
   const security = session.url ? browserSecurity(session.url) : null;
+  const { confirm, dialog: resetDialog } = useConfirm();
+  const [optionsOpen, setOptionsOpen] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [resetError, setResetError] = useState<string | null>(null);
+  const resetFlowRef = useRef(false);
+  const canResetProfile = Boolean(engine?.capabilities.profileReset);
+
+  function handleOptionsOpenChange(open: boolean) {
+    setOptionsOpen(open);
+    if (!resetFlowRef.current) onOverlayOpenChange(open);
+  }
+
+  async function handleResetProfile() {
+    resetFlowRef.current = true;
+    setOptionsOpen(false);
+    onOverlayOpenChange(true);
+    const approved = await confirm({
+      title: "Reset development profile?",
+      description: (
+        <>
+          This closes every Tidebreak browser tab and deletes the managed
+          development-profile cookies, site data, and cache. Safari, Chrome,
+          and your personal browser profiles are never read or changed.
+        </>
+      ),
+      confirmLabel: "Reset development profile",
+      cancelLabel: "Keep profile",
+      destructive: true,
+    });
+    if (!approved) {
+      resetFlowRef.current = false;
+      onOverlayOpenChange(false);
+      return;
+    }
+
+    setResetting(true);
+    setResetError(null);
+    try {
+      if (onResetProfile) {
+        await onResetProfile();
+      } else {
+        await resetCodeBrowserProfile(session.workspaceId, session.id);
+        window.location.reload();
+      }
+    } catch (error) {
+      setResetError(
+        friendlyErrorMessage(error, "Could not reset the development profile"),
+      );
+    } finally {
+      setResetting(false);
+      resetFlowRef.current = false;
+      onOverlayOpenChange(false);
+    }
+  }
 
   useEffect(() => {
     if (!session.url) inputRef.current?.focus();
   }, [session.url]);
+
+  useEffect(() => {
+    if (canResetProfile || !optionsOpen || resetFlowRef.current) return;
+    setOptionsOpen(false);
+    onOverlayOpenChange(false);
+  }, [canResetProfile, onOverlayOpenChange, optionsOpen]);
 
   function submit(event: FormEvent) {
     event.preventDefault();
@@ -360,18 +426,65 @@ export function BrowserToolbar({
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <WithTooltip label="Open externally">
-          <Button
-            type="button"
-            variant="ghost"
-            size={compactToolbar ? "icon-xs" : "icon-sm"}
-            disabled={!session.url}
-            onClick={onOpenExternal}
+        {canResetProfile ? (
+          <DropdownMenu
+            open={optionsOpen}
+            onOpenChange={handleOptionsOpenChange}
           >
-            <ExternalLink />
-            <span className="sr-only">Open externally</span>
-          </Button>
-        </WithTooltip>
+            <WithTooltip label="Browser options">
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size={compactToolbar ? "icon-xs" : "icon-sm"}
+                  disabled={resetting}
+                  aria-label={
+                    resetting
+                      ? "Resetting development profile"
+                      : "Browser options"
+                  }
+                >
+                  {resetting ? (
+                    <LoaderCircle className="animate-spin motion-reduce:animate-none" />
+                  ) : (
+                    <MoreHorizontal />
+                  )}
+                </Button>
+              </DropdownMenuTrigger>
+            </WithTooltip>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuItem
+                disabled={!session.url || resetting}
+                onSelect={onOpenExternal}
+              >
+                <ExternalLink />
+                Open externally
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                disabled={resetting}
+                onSelect={() => void handleResetProfile()}
+              >
+                <Trash2 />
+                Reset development profile
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <WithTooltip label="Open externally">
+            <Button
+              type="button"
+              variant="ghost"
+              size={compactToolbar ? "icon-xs" : "icon-sm"}
+              disabled={!session.url}
+              onClick={onOpenExternal}
+            >
+              <ExternalLink />
+              <span className="sr-only">Open externally</span>
+            </Button>
+          </WithTooltip>
+        )}
       </div>
 
       {addressError && (
@@ -391,6 +504,25 @@ export function BrowserToolbar({
           onTakeOver={onTakeOver}
         />
       )}
+      {resetting && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="border-t border-info-border bg-info-background px-3 py-1.5 text-xs text-info-foreground"
+        >
+          Resetting the Tidebreak development profile… closing browser tabs.
+        </div>
+      )}
+      {resetError && (
+        <BrowserNoticeRow
+          tone="critical"
+          message={resetError}
+          actionLabel="Try again"
+          onAction={() => void handleResetProfile()}
+          onDismiss={() => setResetError(null)}
+        />
+      )}
+      {resetDialog}
     </header>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -46,10 +46,10 @@ import { WithTooltip } from "@/components/ui/tooltip";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "../interactive";
 import {
-  resetCodeBrowserProfile,
   type BrowserAgentAccess,
   type BrowserController,
   type BrowserHostSnapshot,
+  type BrowserProfileResetPhase,
 } from "./browserHost";
 import { browserSecurity, MAX_BROWSER_URL_CHARS } from "./browserNavigation";
 import type { BrowserSession } from "./browserSession";
@@ -103,6 +103,7 @@ export function BrowserToolbar({
   onRevokeAgent,
   onSelectHistory,
   onOpenExternal,
+  profileResetPhase,
   onResetProfile,
   onOverlayOpenChange,
   onAgentAccessOpenChange,
@@ -130,6 +131,7 @@ export function BrowserToolbar({
   onShareAgent?: () => void;
   onRevokeAgent?: () => void;
   onSelectHistory: (index: number) => void;
+  profileResetPhase?: BrowserProfileResetPhase | null;
   onOpenExternal: () => void;
   onResetProfile?: () => Promise<void>;
   onOverlayOpenChange: (open: boolean) => void;
@@ -150,7 +152,16 @@ export function BrowserToolbar({
   const [resetting, setResetting] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
   const resetFlowRef = useRef(false);
-  const canResetProfile = Boolean(engine?.capabilities.profileReset);
+  const lastResetPhaseRef = useRef<BrowserProfileResetPhase>("closing");
+  const canResetProfile = Boolean(
+    engine?.capabilities.profileReset && onResetProfile,
+  );
+  const resetInProgress = resetting || Boolean(profileResetPhase);
+  if (profileResetPhase) {
+    lastResetPhaseRef.current = profileResetPhase;
+  } else if (!resetInProgress) {
+    lastResetPhaseRef.current = "closing";
+  }
 
   function handleOptionsOpenChange(open: boolean) {
     setOptionsOpen(open);
@@ -158,6 +169,7 @@ export function BrowserToolbar({
   }
 
   async function handleResetProfile() {
+    if (!onResetProfile) return;
     resetFlowRef.current = true;
     setOptionsOpen(false);
     onOverlayOpenChange(true);
@@ -165,9 +177,10 @@ export function BrowserToolbar({
       title: "Reset development profile?",
       description: (
         <>
-          This closes every Tidebreak browser tab and deletes the managed
-          development-profile cookies, site data, and cache. Safari, Chrome, and
-          your personal browser profiles are never read or changed.
+          The same stored Tidebreak browser pages will return signed out in a
+          fresh Tidebreak development profile. Managed cookies, site data, and
+          cache are deleted; Safari and Chrome are untouched, and existing agent
+          origin grants remain.
         </>
       ),
       confirmLabel: "Reset development profile",
@@ -183,12 +196,7 @@ export function BrowserToolbar({
     setResetting(true);
     setResetError(null);
     try {
-      if (onResetProfile) {
-        await onResetProfile();
-      } else {
-        await resetCodeBrowserProfile(session.workspaceId, session.id);
-        window.location.reload();
-      }
+      await onResetProfile();
     } catch (error) {
       setResetError(
         friendlyErrorMessage(error, "Could not reset the development profile"),
@@ -437,14 +445,14 @@ export function BrowserToolbar({
                   type="button"
                   variant="ghost"
                   size={compactToolbar ? "icon-xs" : "icon-sm"}
-                  disabled={resetting}
+                  disabled={resetInProgress}
                   aria-label={
-                    resetting
+                    resetInProgress
                       ? "Resetting development profile"
                       : "Browser options"
                   }
                 >
-                  {resetting ? (
+                  {resetInProgress ? (
                     <LoaderCircle className="animate-spin motion-reduce:animate-none" />
                   ) : (
                     <MoreHorizontal />
@@ -463,7 +471,7 @@ export function BrowserToolbar({
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 variant="destructive"
-                disabled={resetting}
+                disabled={resetInProgress}
                 onSelect={() => void handleResetProfile()}
               >
                 <Trash2 />
@@ -504,13 +512,15 @@ export function BrowserToolbar({
           onTakeOver={onTakeOver}
         />
       )}
-      {resetting && (
+      {resetInProgress && (
         <div
           role="status"
           aria-live="polite"
           className="border-t border-info-border bg-info-background px-3 py-1.5 text-xs text-info-foreground"
         >
-          Resetting the Tidebreak development profile… closing browser tabs.
+          <span className="live-label-shimmer">
+            {profileResetStatusMessage(lastResetPhaseRef.current)}
+          </span>
         </div>
       )}
       {resetError && (
@@ -525,6 +535,17 @@ export function BrowserToolbar({
       {resetDialog}
     </header>
   );
+}
+
+function profileResetStatusMessage(phase: BrowserProfileResetPhase): string {
+  switch (phase) {
+    case "deleting":
+      return "Resetting the Tidebreak development profile… deleting managed cookies, site data, and cache.";
+    case "reconstructing":
+      return "Resetting the Tidebreak development profile… reopening stored browser pages.";
+    case "closing":
+      return "Resetting the Tidebreak development profile… closing browser tabs.";
+  }
 }
 
 function BrowserAgentAccessControl({

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -1446,6 +1446,19 @@ describe("CodeBrowserTab", () => {
         runtime.calls.filter(({ action }) => action.type === "create"),
       ).toHaveLength(2),
     );
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_closing",
+        resetId,
+      });
+    });
+    expect(
+      screen.getByText(
+        "Resetting the Tidebreak development profile… reopening stored browser pages.",
+      ),
+    ).toBeVisible();
     expect(
       screen.getByText(
         "Resetting the Tidebreak development profile… reopening stored browser pages.",

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -31,6 +31,14 @@ type CommandCall = {
   action: BrowserHostAction;
 };
 
+function resetIdFrom(calls: CommandCall[]): number {
+  const reset = calls.find(({ action }) => action.type === "reset_profile");
+  if (!reset || reset.action.type !== "reset_profile") {
+    throw new Error("profile reset command was not sent");
+  }
+  return reset.action.resetId;
+}
+
 const inspectEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
   name: "wk_webview",
   capabilities: {
@@ -41,6 +49,14 @@ const inspectEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
     screenshot: false,
     crossOriginFrames: false,
     profileReset: false,
+  },
+};
+
+const resetEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
+  ...inspectEngine,
+  capabilities: {
+    ...inspectEngine.capabilities,
+    profileReset: true,
   },
 };
 
@@ -61,12 +77,15 @@ function agentAccess(
 
 function browserHost(options?: {
   createGate?: Promise<void>;
+  createGates?: Array<Promise<void> | undefined>;
   createError?: string;
   createErrors?: Array<string | null>;
   existing?: boolean;
   snapshotGate?: Promise<void>;
   actionErrors?: Partial<Record<BrowserHostAction["type"], string>>;
   runtime?: Partial<BrowserHostSnapshot>;
+  resetGate?: Promise<void>;
+  resetError?: string;
 }): {
   host: CodeBrowserHost;
   calls: CommandCall[];
@@ -109,14 +128,18 @@ function browserHost(options?: {
         }
         const actionError = options?.actionErrors?.[action.type];
         if (actionError) throw new Error(actionError);
+        if (action.type === "reset_profile") {
+          if (options?.resetGate) await options.resetGate;
+          if (options?.resetError) throw new Error(options.resetError);
+        }
         if (action.type === "create") {
+          const createGate =
+            options?.createGates?.[createAttempt] ?? options?.createGate;
           const createError =
             options?.createErrors?.[createAttempt] ?? options?.createError;
           createAttempt += 1;
           if (createError) throw new Error(createError);
-        }
-        if (action.type === "create" && options?.createGate) {
-          await options.createGate;
+          if (createGate) await createGate;
         }
         if (action.type === "set_inspect") inspectEnabled = action.enabled;
         if (action.type === "remove_inspect") inspectEnabled = false;
@@ -1332,6 +1355,352 @@ describe("CodeBrowserTab", () => {
       });
     });
     expect(screen.getByRole("button", { name: "Reload" })).toBeEnabled();
+  });
+
+  it("reopens the stored page after a successful production profile reset", async () => {
+    const user = userEvent.setup();
+    let releaseReset: (() => void) | undefined;
+    let releaseRecovery: (() => void) | undefined;
+    const resetGate = new Promise<void>((resolve) => {
+      releaseReset = resolve;
+    });
+    const recoveryGate = new Promise<void>((resolve) => {
+      releaseRecovery = resolve;
+    });
+    const runtime = browserHost({
+      createGates: [undefined, recoveryGate],
+      resetGate,
+      runtime: { engine: resetEngine },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/app"
+        host={runtime.host}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Browser options" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: "Reset development profile",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Reset development profile",
+      }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Resetting the Tidebreak development profile… closing browser tabs.",
+      ),
+    ).toBeVisible();
+    await waitFor(() =>
+      expect(
+        runtime.calls.some(({ action }) => action.type === "reset_profile"),
+      ).toBe(true),
+    );
+    const resetId = resetIdFrom(runtime.calls);
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_closing",
+        resetId,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_deleting_data",
+        resetId,
+      });
+    });
+    expect(
+      await screen.findByText(
+        "Resetting the Tidebreak development profile… deleting managed cookies, site data, and cache.",
+      ),
+    ).toBeVisible();
+
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_reconstruct",
+        resetId,
+      });
+      releaseReset?.();
+    });
+    expect(
+      await screen.findByText(
+        "Resetting the Tidebreak development profile… reopening stored browser pages.",
+      ),
+    ).toBeVisible();
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(2),
+    );
+    expect(
+      screen.getByText(
+        "Resetting the Tidebreak development profile… reopening stored browser pages.",
+      ),
+    ).toBeVisible();
+    await act(async () => releaseRecovery?.());
+    expect(
+      await screen.findByRole("button", { name: "Browser options" }),
+    ).toBeEnabled();
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "reset_profile"),
+    ).toHaveLength(1);
+
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_reconstruct",
+        resetId,
+      });
+    });
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "create"),
+    ).toHaveLength(2);
+  });
+
+  it("reconstructs the native view before showing a deletion failure", async () => {
+    const user = userEvent.setup();
+    let releaseReset: (() => void) | undefined;
+    let releaseRecovery: (() => void) | undefined;
+    const resetGate = new Promise<void>((resolve) => {
+      releaseReset = resolve;
+    });
+    const recoveryGate = new Promise<void>((resolve) => {
+      releaseRecovery = resolve;
+    });
+    const runtime = browserHost({
+      createGates: [undefined, recoveryGate],
+      resetGate,
+      resetError: "WebKit could not remove the managed profile data",
+      runtime: { engine: resetEngine },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/app"
+        host={runtime.host}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Browser options" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: "Reset development profile",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Reset development profile",
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        runtime.calls.some(({ action }) => action.type === "reset_profile"),
+      ).toBe(true),
+    );
+    const resetId = resetIdFrom(runtime.calls);
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_deleting_data",
+        resetId,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_reconstruct",
+        resetId,
+      });
+      releaseReset?.();
+    });
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(2),
+    );
+    expect(
+      screen.queryByText("WebKit could not remove the managed profile data"),
+    ).toBeNull();
+    expect(
+      screen.getByText(
+        "Resetting the Tidebreak development profile… reopening stored browser pages.",
+      ),
+    ).toBeVisible();
+
+    await act(async () => releaseRecovery?.());
+    expect(
+      await screen.findByText(
+        "WebKit could not remove the managed profile data",
+      ),
+    ).toBeVisible();
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "create"),
+    ).toHaveLength(2);
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/app",
+      });
+    });
+    await user.click(screen.getByRole("button", { name: "Reload" }));
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "reload" },
+      }),
+    );
+  });
+
+  it("reconstructs a sibling stored tab from the native reset cycle", async () => {
+    const runtime = browserHost({ runtime: { engine: resetEngine } });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/app"
+        host={runtime.host}
+      />,
+    );
+
+    await screen.findByRole("button", { name: "Browser options" });
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_closing",
+        resetId: 9001,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_deleting_data",
+        resetId: 9001,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_reconstruct",
+        resetId: 9001,
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(2),
+    );
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/app",
+      });
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "reload" },
+      }),
+    );
+  });
+
+  it("does not accept a pre-reset create response as the reconstructed view", async () => {
+    let releaseInitialCreate: (() => void) | undefined;
+    const initialCreateGate = new Promise<void>((resolve) => {
+      releaseInitialCreate = resolve;
+    });
+    const runtime = browserHost({
+      createGates: [initialCreateGate, undefined],
+      runtime: { engine: resetEngine },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/app"
+        host={runtime.host}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(1),
+    );
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_closing",
+        resetId: 9002,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_deleting_data",
+        resetId: 9002,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_reconstruct",
+        resetId: 9002,
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(2),
+    );
+    await act(async () => releaseInitialCreate?.());
+    expect(
+      runtime.calls.filter(({ action }) => action.type === "create"),
+    ).toHaveLength(2);
+
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/app",
+      });
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "reload" },
+      }),
+    );
   });
 
   it("uses native Reload when the browser view already exists", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -1472,6 +1472,94 @@ describe("CodeBrowserTab", () => {
     ).toHaveLength(2);
   });
 
+  it("rejects pre-reset document epochs after native closing is acknowledged", async () => {
+    const user = userEvent.setup();
+    let releaseReset: (() => void) | undefined;
+    const resetGate = new Promise<void>((resolve) => {
+      releaseReset = resolve;
+    });
+    const runtime = browserHost({
+      resetGate,
+      runtime: { engine: resetEngine },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/app"
+        host={runtime.host}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Browser options" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: "Reset development profile",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Reset development profile",
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        runtime.calls.some(({ action }) => action.type === "reset_profile"),
+      ).toBe(true),
+    );
+    const resetId = resetIdFrom(runtime.calls);
+
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/app",
+        documentEpoch: 9,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_closing",
+        resetId,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_deleting_data",
+        resetId,
+      });
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "profile_reset_reconstruct",
+        resetId,
+      });
+      releaseReset?.();
+    });
+
+    await waitFor(() =>
+      expect(
+        runtime.calls.filter(({ action }) => action.type === "create"),
+      ).toHaveLength(2),
+    );
+    await act(async () => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/fresh",
+        documentEpoch: 1,
+      });
+    });
+
+    expect(
+      screen.getByRole("textbox", { name: "Address or search" }),
+    ).toHaveValue("example.com/fresh");
+  });
+
   it("reconstructs the native view before showing a deletion failure", async () => {
     const user = userEvent.setup();
     let releaseReset: (() => void) | undefined;

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -135,6 +135,7 @@ function CodeBrowserTabSession({
   const nativeCreateRequestedUrl = useRef<string | null>(null);
   const activeProfileResetId = useRef<number | null>(null);
   const locallyInitiatedProfileResetId = useRef<number | null>(null);
+  const nativeClosingConfirmedProfileResetId = useRef<number | null>(null);
   const completedProfileResetIds = useRef(new Set<number>());
   const profileResetRecovery = useRef<{
     resetId: number;
@@ -244,6 +245,7 @@ function CodeBrowserTabSession({
       if (completedProfileResetIds.current.has(resetId)) return false;
       if (activeProfileResetId.current !== resetId) {
         activeProfileResetId.current = resetId;
+        nativeClosingConfirmedProfileResetId.current = null;
         profileResetRecovery.current = null;
         markNativeClosedForProfileReset();
       }
@@ -251,6 +253,23 @@ function CodeBrowserTabSession({
       return true;
     },
     [markNativeClosedForProfileReset],
+  );
+
+  const confirmNativeProfileResetClosing = useCallback(
+    (resetId: number) => {
+      const resetWasAlreadyActive = activeProfileResetId.current === resetId;
+      if (!beginProfileResetCycle(resetId, "closing")) return;
+      if (nativeClosingConfirmedProfileResetId.current === resetId) return;
+      nativeClosingConfirmedProfileResetId.current = resetId;
+      if (resetWasAlreadyActive) {
+        // A locally initiated reset hides the surface before native acquires
+        // the reset lease. Fence again once native has marked the records as
+        // resetting, so no response or document epoch from that short window
+        // can be mistaken for the reconstructed view.
+        markNativeClosedForProfileReset();
+      }
+    },
+    [beginProfileResetCycle, markNativeClosedForProfileReset],
   );
 
   const finishProfileResetCycle = useCallback((resetId: number) => {
@@ -262,6 +281,9 @@ function CodeBrowserTabSession({
     }
     if (activeProfileResetId.current !== resetId) return;
     activeProfileResetId.current = null;
+    if (nativeClosingConfirmedProfileResetId.current === resetId) {
+      nativeClosingConfirmedProfileResetId.current = null;
+    }
     if (profileResetRecovery.current?.resetId === resetId) {
       profileResetRecovery.current = null;
     }
@@ -659,7 +681,7 @@ function CodeBrowserTabSession({
     function handleHostEvent(event: BrowserHostEvent) {
       if (event.type === "profile_reset_closing") {
         if (event.resetId !== undefined) {
-          beginProfileResetCycle(event.resetId, "closing");
+          confirmNativeProfileResetClosing(event.resetId);
         }
         return;
       }
@@ -795,6 +817,7 @@ function CodeBrowserTabSession({
   }, [
     beginProfileResetCycle,
     browserId,
+    confirmNativeProfileResetClosing,
     createAndReconcileNative,
     finishProfileResetCycle,
     host,

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -23,9 +23,11 @@ import { BrowserNoticeRow, BrowserToolbar } from "./BrowserToolbar";
 import { BrowserViewportControl } from "./BrowserViewportControl";
 import {
   browserUnavailableMessage,
+  resetCodeBrowserProfile,
   type BrowserBounds,
   type BrowserHostAction,
   type BrowserHostEvent,
+  type BrowserProfileResetPhase,
   type BrowserHostSnapshot,
   type CodeBrowserHost,
   nativeCodeBrowserHost,
@@ -61,6 +63,13 @@ import {
 
 const SLOW_LOAD_MS = 15_000;
 const PERSIST_DELAY_MS = 150;
+let nextProfileResetId = 0;
+
+function createProfileResetId(): number {
+  nextProfileResetId =
+    nextProfileResetId >= Number.MAX_SAFE_INTEGER ? 1 : nextProfileResetId + 1;
+  return nextProfileResetId;
+}
 
 type BrowserAgentHostAction = Extract<
   BrowserHostAction,
@@ -108,14 +117,29 @@ function CodeBrowserTabSession({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [agentAccessOpen, setAgentAccessOpen] = useState(false);
   const [viewportOpen, setViewportOpen] = useState(false);
+  const [profileResetPhase, setProfileResetPhase] =
+    useState<BrowserProfileResetPhase | null>(null);
+  const [profileResetReconstructing, setProfileResetReconstructing] =
+    useState(false);
   const [slow, setSlow] = useState(false);
   const [runtime, setRuntime] = useState<BrowserHostSnapshot | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const mountedRef = useRef(true);
   const nativeReady = useRef(false);
   const nativePresence = useRef<"unknown" | "missing" | "present">("unknown");
-  const nativeCreateInFlight = useRef<Promise<void> | null>(null);
+  const nativeSurfaceGeneration = useRef(0);
+  const nativeCreateInFlight = useRef<{
+    generation: number;
+    operation: Promise<void>;
+  } | null>(null);
   const nativeCreateRequestedUrl = useRef<string | null>(null);
+  const activeProfileResetId = useRef<number | null>(null);
+  const locallyInitiatedProfileResetId = useRef<number | null>(null);
+  const completedProfileResetIds = useRef(new Set<number>());
+  const profileResetRecovery = useRef<{
+    resetId: number;
+    operation: Promise<void>;
+  } | null>(null);
   const nativeExpectedNavigationUrl = useRef<string | null>(null);
   const nativeDocumentEpoch = useRef(0);
   const resizeCreateAttempted = useRef(false);
@@ -134,6 +158,7 @@ function CodeBrowserTabSession({
     !historyOpen &&
     !agentAccessOpen &&
     !viewportOpen &&
+    !profileResetReconstructing &&
     session.loadState !== "failed";
   const visibleRef = useRef(visible);
 
@@ -196,91 +221,173 @@ function CodeBrowserTabSession({
     window.cancelAnimationFrame(frame);
   }, []);
 
-  const scheduleNativeReveal = useCallback(() => {
+  const markNativeClosedForProfileReset = useCallback(() => {
     cancelNativeReveal();
-    if (
-      !mountedRef.current ||
-      !nativeReady.current ||
-      !visibleRef.current ||
-      !host.available()
-    ) {
-      return;
-    }
+    nativeSurfaceGeneration.current =
+      nativeSurfaceGeneration.current >= Number.MAX_SAFE_INTEGER
+        ? 1
+        : nativeSurfaceGeneration.current + 1;
+    nativeReady.current = false;
+    nativePresence.current = "missing";
+    nativeCreateRequestedUrl.current = null;
+    nativeExpectedNavigationUrl.current = null;
+    nativeDocumentEpoch.current = 0;
+    resizeCreateAttempted.current = false;
+    nativeHistoryAvailable.current = false;
+    lastNativeBounds.current = null;
+    visibleRef.current = false;
+    setProfileResetReconstructing(true);
+  }, [cancelNativeReveal]);
 
-    const frame = window.requestAnimationFrame(() => {
-      if (nativeRevealFrame.current !== frame) return;
-      nativeRevealFrame.current = null;
+  const beginProfileResetCycle = useCallback(
+    (resetId: number, phase: BrowserProfileResetPhase): boolean => {
+      if (completedProfileResetIds.current.has(resetId)) return false;
+      if (activeProfileResetId.current !== resetId) {
+        activeProfileResetId.current = resetId;
+        profileResetRecovery.current = null;
+        markNativeClosedForProfileReset();
+      }
+      setProfileResetPhase(phase);
+      return true;
+    },
+    [markNativeClosedForProfileReset],
+  );
+
+  const finishProfileResetCycle = useCallback((resetId: number) => {
+    completedProfileResetIds.current.add(resetId);
+    while (completedProfileResetIds.current.size > 8) {
+      const oldest = completedProfileResetIds.current.values().next().value;
+      if (oldest === undefined) break;
+      completedProfileResetIds.current.delete(oldest);
+    }
+    if (activeProfileResetId.current !== resetId) return;
+    activeProfileResetId.current = null;
+    if (profileResetRecovery.current?.resetId === resetId) {
+      profileResetRecovery.current = null;
+    }
+    setProfileResetPhase(null);
+    setProfileResetReconstructing(false);
+  }, []);
+
+  const scheduleNativeReveal = useCallback(
+    (expectedGeneration = nativeSurfaceGeneration.current) => {
+      cancelNativeReveal();
       if (
         !mountedRef.current ||
         !nativeReady.current ||
         !visibleRef.current ||
-        !host.available()
+        !host.available() ||
+        nativeSurfaceGeneration.current !== expectedGeneration
       ) {
         return;
       }
-      void host
-        .command(workspaceId, browserId, { type: "set_visible", visible: true })
-        .catch(() => undefined);
-    });
-    nativeRevealFrame.current = frame;
-  }, [browserId, cancelNativeReveal, host, workspaceId]);
+
+      const frame = window.requestAnimationFrame(() => {
+        if (nativeRevealFrame.current !== frame) return;
+        nativeRevealFrame.current = null;
+        if (
+          !mountedRef.current ||
+          !nativeReady.current ||
+          !visibleRef.current ||
+          !host.available() ||
+          nativeSurfaceGeneration.current !== expectedGeneration
+        ) {
+          return;
+        }
+        void host
+          .command(workspaceId, browserId, {
+            type: "set_visible",
+            visible: true,
+          })
+          .catch(() => undefined);
+      });
+      nativeRevealFrame.current = frame;
+    },
+    [browserId, cancelNativeReveal, host, workspaceId],
+  );
 
   /** Reconcile live bounds and visibility after a native view becomes ready. */
-  const reconcileAfterNativeReady = useCallback(async () => {
-    if (!mountedRef.current) {
-      nativeReady.current = false;
-      cancelNativeReveal();
-      await host.command(workspaceId, browserId, {
-        type: "set_visible",
-        visible: false,
-      });
-      return;
-    }
-    nativeReady.current = true;
-    const bounds = readBrowserBounds(viewportSurfaceRef.current);
-    if (bounds && !sameBrowserBounds(lastNativeBounds.current, bounds)) {
-      lastNativeBounds.current = bounds;
-      recordRuntime(
-        await host.command(workspaceId, browserId, {
-          type: "set_bounds",
-          bounds,
-        }),
-      );
-    }
-    if (!mountedRef.current || !visibleRef.current) {
-      if (!mountedRef.current) nativeReady.current = false;
-      cancelNativeReveal();
-      recordRuntime(
+  const reconcileAfterNativeReady = useCallback(
+    async (
+      expectedGeneration = nativeSurfaceGeneration.current,
+    ): Promise<boolean> => {
+      if (nativeSurfaceGeneration.current !== expectedGeneration) return false;
+      if (!mountedRef.current) {
+        nativeReady.current = false;
+        cancelNativeReveal();
+        if (nativeSurfaceGeneration.current !== expectedGeneration) {
+          return false;
+        }
         await host.command(workspaceId, browserId, {
           type: "set_visible",
           visible: false,
-        }),
-      );
-      return;
-    }
-    scheduleNativeReveal();
-  }, [
-    browserId,
-    cancelNativeReveal,
-    host,
-    recordRuntime,
-    scheduleNativeReveal,
-    workspaceId,
-  ]);
+        });
+        return false;
+      }
+      nativeReady.current = true;
+      const bounds = readBrowserBounds(viewportSurfaceRef.current);
+      if (bounds && !sameBrowserBounds(lastNativeBounds.current, bounds)) {
+        if (nativeSurfaceGeneration.current !== expectedGeneration) {
+          return false;
+        }
+        lastNativeBounds.current = bounds;
+        const snapshot = await host.command(workspaceId, browserId, {
+          type: "set_bounds",
+          bounds,
+        });
+        if (nativeSurfaceGeneration.current !== expectedGeneration) {
+          return false;
+        }
+        recordRuntime(snapshot);
+      }
+      if (nativeSurfaceGeneration.current !== expectedGeneration) return false;
+      if (!mountedRef.current || !visibleRef.current) {
+        if (!mountedRef.current) nativeReady.current = false;
+        cancelNativeReveal();
+        if (nativeSurfaceGeneration.current !== expectedGeneration) {
+          return false;
+        }
+        const snapshot = await host.command(workspaceId, browserId, {
+          type: "set_visible",
+          visible: false,
+        });
+        if (nativeSurfaceGeneration.current !== expectedGeneration) {
+          return false;
+        }
+        recordRuntime(snapshot);
+        return true;
+      }
+      scheduleNativeReveal(expectedGeneration);
+      return true;
+    },
+    [
+      browserId,
+      cancelNativeReveal,
+      host,
+      recordRuntime,
+      scheduleNativeReveal,
+      workspaceId,
+    ],
+  );
 
   const createAndReconcileNative = useCallback(
     async (url: string): Promise<boolean> => {
       if (!host.available()) return false;
+      const generation = nativeSurfaceGeneration.current;
       if (nativeReady.current) {
-        await reconcileAfterNativeReady();
-        return true;
+        await reconcileAfterNativeReady(generation);
+        return (
+          nativeSurfaceGeneration.current === generation && nativeReady.current
+        );
       }
       nativeCreateRequestedUrl.current = url;
       const pending = nativeCreateInFlight.current;
-      if (pending) {
+      if (pending?.generation === generation) {
         nativeExpectedNavigationUrl.current = url;
-        await pending;
-        return nativeReady.current;
+        await pending.operation;
+        return (
+          nativeSurfaceGeneration.current === generation && nativeReady.current
+        );
       }
       const bounds = readBrowserBounds(viewportSurfaceRef.current);
       if (!bounds) return false;
@@ -288,20 +395,22 @@ function CodeBrowserTabSession({
       resizeCreateAttempted.current = true;
       const operation = (async () => {
         try {
-          recordRuntime(
-            await host.command(workspaceId, browserId, {
-              type: "create",
-              url,
-              bounds,
-              visible: false,
-            }),
-          );
+          const snapshot = await host.command(workspaceId, browserId, {
+            type: "create",
+            url,
+            bounds,
+            visible: false,
+          });
+          if (nativeSurfaceGeneration.current !== generation) return;
+          recordRuntime(snapshot);
           nativePresence.current = "present";
           lastNativeBounds.current = bounds;
-          await reconcileAfterNativeReady();
+          await reconcileAfterNativeReady(generation);
+          if (nativeSurfaceGeneration.current !== generation) return;
           nativeHistoryAvailable.current =
             sessionRef.current.history.length <= 1;
         } catch (error) {
+          if (nativeSurfaceGeneration.current !== generation) return;
           nativeReady.current = false;
           nativePresence.current = "missing";
           if (nativeExpectedNavigationUrl.current === url) {
@@ -311,7 +420,11 @@ function CodeBrowserTabSession({
         }
 
         let deliveredUrl = url;
-        while (mountedRef.current && nativeReady.current) {
+        while (
+          mountedRef.current &&
+          nativeReady.current &&
+          nativeSurfaceGeneration.current === generation
+        ) {
           const requestedUrl = nativeCreateRequestedUrl.current;
           if (!requestedUrl || requestedUrl === deliveredUrl) break;
           recordRuntime(
@@ -324,18 +437,60 @@ function CodeBrowserTabSession({
           nativeHistoryAvailable.current = false;
         }
       })();
-      nativeCreateInFlight.current = operation;
+      const inFlight = { generation, operation };
+      nativeCreateInFlight.current = inFlight;
       try {
         await operation;
-        return true;
+        return (
+          nativeSurfaceGeneration.current === generation && nativeReady.current
+        );
       } finally {
-        if (nativeCreateInFlight.current === operation) {
+        if (nativeCreateInFlight.current === inFlight) {
           nativeCreateInFlight.current = null;
           nativeCreateRequestedUrl.current = null;
         }
       }
     },
     [browserId, host, reconcileAfterNativeReady, recordRuntime, workspaceId],
+  );
+
+  const reconstructAfterProfileReset = useCallback(
+    (resetId: number): Promise<void> => {
+      if (completedProfileResetIds.current.has(resetId)) {
+        return Promise.resolve();
+      }
+      const pending = profileResetRecovery.current;
+      if (pending?.resetId === resetId) return pending.operation;
+      if (!beginProfileResetCycle(resetId, "reconstructing")) {
+        return Promise.resolve();
+      }
+
+      const operation = (async () => {
+        const url = sessionRef.current.url;
+        if (!url) return;
+        try {
+          if (!host.available()) throw new Error(browserUnavailableMessage());
+          const created = await createAndReconcileNative(url);
+          if (!created) throw new Error("The browser surface is not ready");
+        } catch (error) {
+          if (mountedRef.current) {
+            updateSession((current) =>
+              failBrowserSession(
+                current,
+                friendlyErrorMessage(
+                  error,
+                  "Could not restore the in-app browser",
+                ),
+              ),
+            );
+          }
+          throw error;
+        }
+      })();
+      profileResetRecovery.current = { resetId, operation };
+      return operation;
+    },
+    [beginProfileResetCycle, createAndReconcileNative, host, updateSession],
   );
 
   useEffect(() => {
@@ -446,11 +601,17 @@ function CodeBrowserTabSession({
 
       if (!current.url) return;
 
+      const snapshotGeneration = nativeSurfaceGeneration.current;
       try {
         const snapshot = await host.command(workspaceId, browserId, {
           type: "snapshot",
         });
-        if (cancelled) return;
+        if (
+          cancelled ||
+          nativeSurfaceGeneration.current !== snapshotGeneration
+        ) {
+          return;
+        }
         if (
           snapshot.browserId !== browserId ||
           snapshot.workspaceId !== workspaceId
@@ -475,13 +636,16 @@ function CodeBrowserTabSession({
             });
             setAddress(browserDisplayAddress(snapshot.url));
           }
-          await reconcileAfterNativeReady();
+          await reconcileAfterNativeReady(snapshotGeneration);
         } else {
           nativePresence.current = "missing";
           await createAndReconcileNative(current.url);
         }
       } catch (error) {
-        if (!cancelled) {
+        if (
+          !cancelled &&
+          nativeSurfaceGeneration.current === snapshotGeneration
+        ) {
           updateSession((value) =>
             failBrowserSession(
               value,
@@ -493,6 +657,38 @@ function CodeBrowserTabSession({
     }
 
     function handleHostEvent(event: BrowserHostEvent) {
+      if (event.type === "profile_reset_closing") {
+        if (event.resetId !== undefined) {
+          beginProfileResetCycle(event.resetId, "closing");
+        }
+        return;
+      }
+      if (event.type === "profile_reset_deleting_data") {
+        if (event.resetId !== undefined) {
+          beginProfileResetCycle(event.resetId, "deleting");
+        }
+        return;
+      }
+      if (event.type === "profile_reset_reconstruct") {
+        if (event.resetId === undefined) return;
+        const resetId = event.resetId;
+        if (completedProfileResetIds.current.has(resetId)) return;
+        const recovery = reconstructAfterProfileReset(resetId);
+        void recovery.then(
+          () => {
+            if (locallyInitiatedProfileResetId.current !== resetId) {
+              finishProfileResetCycle(resetId);
+            }
+          },
+          () => {
+            if (locallyInitiatedProfileResetId.current !== resetId) {
+              finishProfileResetCycle(resetId);
+            }
+          },
+        );
+        return;
+      }
+
       if (
         event.documentEpoch !== undefined &&
         event.documentEpoch < nativeDocumentEpoch.current
@@ -597,10 +793,13 @@ function CodeBrowserTabSession({
       unsubscribe?.();
     };
   }, [
+    beginProfileResetCycle,
     browserId,
     createAndReconcileNative,
+    finishProfileResetCycle,
     host,
     recordRuntime,
+    reconstructAfterProfileReset,
     reconcileAfterNativeReady,
     updateSession,
     workspaceId,
@@ -618,6 +817,7 @@ function CodeBrowserTabSession({
         const bounds = readBrowserBounds(surface);
         if (!bounds) return;
         if (!nativeReady.current) {
+          if (profileResetReconstructing) return;
           const url = sessionRef.current.url;
           if (
             nativePresence.current === "missing" &&
@@ -670,7 +870,14 @@ function CodeBrowserTabSession({
       window.removeEventListener("resize", sync);
       if (frame !== null) window.cancelAnimationFrame(frame);
     };
-  }, [browserId, createAndReconcileNative, host, updateSession, workspaceId]);
+  }, [
+    browserId,
+    createAndReconcileNative,
+    host,
+    profileResetReconstructing,
+    updateSession,
+    workspaceId,
+  ]);
 
   useEffect(() => {
     if (!nativeReady.current || !host.available()) return;
@@ -868,6 +1075,29 @@ function CodeBrowserTabSession({
     await host.openExternal(url).catch(() => undefined);
   }
 
+  async function resetProfile() {
+    const resetId = createProfileResetId();
+    locallyInitiatedProfileResetId.current = resetId;
+    beginProfileResetCycle(resetId, "closing");
+    let resetError: unknown;
+    try {
+      await resetCodeBrowserProfile(workspaceId, browserId, resetId, host);
+    } catch (error) {
+      resetError = error;
+    }
+
+    let reconstructionError: unknown;
+    try {
+      await reconstructAfterProfileReset(resetId);
+    } catch (error) {
+      reconstructionError = error;
+    } finally {
+      locallyInitiatedProfileResetId.current = null;
+      finishProfileResetCycle(resetId);
+    }
+    if (resetError) throw resetError;
+    if (reconstructionError) throw reconstructionError;
+  }
   const notice = session.notice;
   const noticeTarget = notice?.url ? validateBrowserUrl(notice.url) : null;
   const actionableNoticeUrl = noticeTarget?.ok ? noticeTarget.url : null;
@@ -932,6 +1162,8 @@ function CodeBrowserTabSession({
         }
         onSelectHistory={(index) => void selectHistory(index)}
         onOpenExternal={() => void openExternal()}
+        profileResetPhase={profileResetPhase}
+        onResetProfile={resetProfile}
         onOverlayOpenChange={setHistoryOpen}
         onAgentAccessOpenChange={setAgentAccessOpen}
         agentAccessOpen={agentAccessOpen}

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -71,6 +71,17 @@ function createProfileResetId(): number {
   return nextProfileResetId;
 }
 
+function profileResetPhaseRank(phase: BrowserProfileResetPhase): number {
+  switch (phase) {
+    case "closing":
+      return 0;
+    case "deleting":
+      return 1;
+    case "reconstructing":
+      return 2;
+  }
+}
+
 type BrowserAgentHostAction = Extract<
   BrowserHostAction,
   {
@@ -136,6 +147,7 @@ function CodeBrowserTabSession({
   const activeProfileResetId = useRef<number | null>(null);
   const locallyInitiatedProfileResetId = useRef<number | null>(null);
   const nativeClosingConfirmedProfileResetId = useRef<number | null>(null);
+  const profileResetPhaseRef = useRef<BrowserProfileResetPhase | null>(null);
   const completedProfileResetIds = useRef(new Set<number>());
   const profileResetRecovery = useRef<{
     resetId: number;
@@ -248,7 +260,14 @@ function CodeBrowserTabSession({
         nativeClosingConfirmedProfileResetId.current = null;
         profileResetRecovery.current = null;
         markNativeClosedForProfileReset();
+      } else if (
+        profileResetPhaseRef.current !== null &&
+        profileResetPhaseRank(phase) <
+          profileResetPhaseRank(profileResetPhaseRef.current)
+      ) {
+        return false;
       }
+      profileResetPhaseRef.current = phase;
       setProfileResetPhase(phase);
       return true;
     },
@@ -258,10 +277,11 @@ function CodeBrowserTabSession({
   const confirmNativeProfileResetClosing = useCallback(
     (resetId: number) => {
       const resetWasAlreadyActive = activeProfileResetId.current === resetId;
+      const phaseBeforeNativeClosing = profileResetPhaseRef.current;
       if (!beginProfileResetCycle(resetId, "closing")) return;
       if (nativeClosingConfirmedProfileResetId.current === resetId) return;
       nativeClosingConfirmedProfileResetId.current = resetId;
-      if (resetWasAlreadyActive) {
+      if (resetWasAlreadyActive && phaseBeforeNativeClosing === "closing") {
         // A locally initiated reset hides the surface before native acquires
         // the reset lease. Fence again once native has marked the records as
         // resetting, so no response or document epoch from that short window
@@ -284,6 +304,7 @@ function CodeBrowserTabSession({
     if (nativeClosingConfirmedProfileResetId.current === resetId) {
       nativeClosingConfirmedProfileResetId.current = null;
     }
+    profileResetPhaseRef.current = null;
     if (profileResetRecovery.current?.resetId === resetId) {
       profileResetRecovery.current = null;
     }

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
@@ -6,6 +6,7 @@ import {
   browserUnavailableMessage,
   closeCodeBrowser,
   nativeCodeBrowserHost,
+  resetCodeBrowserProfile,
   type CodeBrowserHost,
 } from "./browserHost";
 import {
@@ -65,6 +66,45 @@ describe("browser host lifecycle", () => {
     await closeCodeBrowser("workspace-1", "browser-1", host);
 
     expect(readStoredBrowserSession("browser-1")).toBeNull();
+    expect(command).not.toHaveBeenCalled();
+  });
+});
+
+describe("managed browser profile reset", () => {
+  it("sends only the trusted session identity and reset command", async () => {
+    const command = vi.fn().mockResolvedValue({
+      exists: false,
+      workspaceId: "workspace-1",
+      browserId: "browser-1",
+    });
+    const host: CodeBrowserHost = {
+      available: () => true,
+      command,
+      subscribe: vi.fn(async () => () => undefined),
+      openExternal: vi.fn(async () => undefined),
+    };
+
+    await resetCodeBrowserProfile("workspace-1", "browser-1", host);
+
+    expect(command).toHaveBeenCalledWith("workspace-1", "browser-1", {
+      type: "reset_profile",
+    });
+  });
+
+  it("refuses reset when this renderer has no local host authority", async () => {
+    const command = vi.fn();
+    const host: CodeBrowserHost = {
+      available: () => false,
+      command,
+      subscribe: vi.fn(async () => () => undefined),
+      openExternal: vi.fn(async () => undefined),
+    };
+
+    await expect(
+      resetCodeBrowserProfile("workspace-1", "browser-1", host),
+    ).rejects.toThrow(
+      "The managed browser profile is available only on this computer",
+    );
     expect(command).not.toHaveBeenCalled();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
@@ -71,7 +71,7 @@ describe("browser host lifecycle", () => {
 });
 
 describe("managed browser profile reset", () => {
-  it("sends only the trusted session identity and reset command", async () => {
+  it("sends only session identity and a non-authoritative reset correlation id", async () => {
     const command = vi.fn().mockResolvedValue({
       exists: false,
       workspaceId: "workspace-1",
@@ -84,10 +84,11 @@ describe("managed browser profile reset", () => {
       openExternal: vi.fn(async () => undefined),
     };
 
-    await resetCodeBrowserProfile("workspace-1", "browser-1", host);
+    await resetCodeBrowserProfile("workspace-1", "browser-1", 17, host);
 
     expect(command).toHaveBeenCalledWith("workspace-1", "browser-1", {
       type: "reset_profile",
+      resetId: 17,
     });
   });
 
@@ -101,7 +102,7 @@ describe("managed browser profile reset", () => {
     };
 
     await expect(
-      resetCodeBrowserProfile("workspace-1", "browser-1", host),
+      resetCodeBrowserProfile("workspace-1", "browser-1", 18, host),
     ).rejects.toThrow(
       "The managed browser profile is available only on this computer",
     );

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
@@ -61,8 +61,13 @@ export type BrowserHostAction =
   | { type: "take_human_control" }
   | { type: "set_inspect"; enabled: boolean }
   | { type: "remove_inspect" }
-  | { type: "reset_profile" }
+  | { type: "reset_profile"; resetId: number }
   | { type: "close" };
+
+export type BrowserProfileResetPhase =
+  | "closing"
+  | "deleting"
+  | "reconstructing";
 
 export type BrowserHostSnapshot = {
   exists: boolean;
@@ -104,7 +109,11 @@ export type BrowserHostEvent = {
     | "navigation_blocked"
     | "controller_changed"
     | "agent_navigation_paused"
-    | "agent_access_changed";
+    | "agent_access_changed"
+    | "profile_reset_closing"
+    | "profile_reset_deleting_data"
+    | "profile_reset_reconstruct";
+  resetId?: number;
   url?: string;
   title?: string;
   message?: string;
@@ -208,11 +217,13 @@ export function browserUnavailableMessage(): string {
 
 /**
  * Reset the one managed profile selected by this trusted native session.
- * Renderer code never supplies a profile id, engine handle, or filesystem path.
+ * `resetId` only correlates native phase events. Renderer code never supplies a
+ * profile id, engine handle, or filesystem path.
  */
 export async function resetCodeBrowserProfile(
   workspaceId: string,
   browserId: string,
+  resetId: number,
   host: CodeBrowserHost = nativeCodeBrowserHost,
 ): Promise<void> {
   if (!host.available()) {
@@ -220,7 +231,10 @@ export async function resetCodeBrowserProfile(
       "The managed browser profile is available only on this computer",
     );
   }
-  await host.command(workspaceId, browserId, { type: "reset_profile" });
+  await host.command(workspaceId, browserId, {
+    type: "reset_profile",
+    resetId,
+  });
 }
 /** Explicit tab close. Tab switches only hide the native child webview. */
 export async function closeCodeBrowser(

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
@@ -61,6 +61,7 @@ export type BrowserHostAction =
   | { type: "take_human_control" }
   | { type: "set_inspect"; enabled: boolean }
   | { type: "remove_inspect" }
+  | { type: "reset_profile" }
   | { type: "close" };
 
 export type BrowserHostSnapshot = {
@@ -205,6 +206,22 @@ export function browserUnavailableMessage(): string {
     : "The in-app browser is available in the Tidebreak desktop app";
 }
 
+/**
+ * Reset the one managed profile selected by this trusted native session.
+ * Renderer code never supplies a profile id, engine handle, or filesystem path.
+ */
+export async function resetCodeBrowserProfile(
+  workspaceId: string,
+  browserId: string,
+  host: CodeBrowserHost = nativeCodeBrowserHost,
+): Promise<void> {
+  if (!host.available()) {
+    throw new Error(
+      "The managed browser profile is available only on this computer",
+    );
+  }
+  await host.command(workspaceId, browserId, { type: "reset_profile" });
+}
 /** Explicit tab close. Tab switches only hide the native child webview. */
 export async function closeCodeBrowser(
   workspaceId: string,

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import {
   BrowserAgentControlRow,
@@ -39,7 +39,10 @@ type BrowserScenario =
   | "inspect-enable-failure"
   | "inspect-remove-failure"
   | "inspect-off"
-  | "inspect-on";
+  | "inspect-on"
+  | "profile-reset-confirmation"
+  | "profile-resetting"
+  | "profile-reset-failure";
 
 const inspectEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
   name: "wk_webview",
@@ -51,6 +54,13 @@ const inspectEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
     screenshot: false,
     crossOriginFrames: false,
     profileReset: false,
+  },
+};
+const resetEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
+  ...inspectEngine,
+  capabilities: {
+    ...inspectEngine.capabilities,
+    profileReset: true,
   },
 };
 
@@ -197,6 +207,21 @@ function BrowserStory({
         : scenario === "paused"
           ? pausedAccess
           : unsharedAccess;
+  const profileResetScenario =
+    scenario === "profile-reset-confirmation" ||
+    scenario === "profile-resetting" ||
+    scenario === "profile-reset-failure";
+  const onResetProfile =
+    scenario === "profile-resetting"
+      ? () => new Promise<void>(() => {})
+      : scenario === "profile-reset-failure"
+        ? () =>
+            Promise.reject(
+              new Error("WebKit could not remove the managed profile data"),
+            )
+        : profileResetScenario
+          ? () => Promise.resolve()
+          : undefined;
 
   return (
     <div className="grid min-h-dvh place-items-center bg-muted/45 p-4 sm:p-8">
@@ -214,7 +239,7 @@ function BrowserStory({
           canGoForward={false}
           controller={controller}
           agentAccess={agentAccess}
-          engine={inspectEngine}
+          engine={profileResetScenario ? resetEngine : inspectEngine}
           onAddressChange={setAddress}
           onNavigate={fn()}
           onBack={fn()}
@@ -227,6 +252,7 @@ function BrowserStory({
           onRevokeAgent={fn()}
           onSelectHistory={fn()}
           onOpenExternal={fn()}
+          onResetProfile={onResetProfile}
           onOverlayOpenChange={fn()}
           onAgentAccessOpenChange={fn()}
           onToggleInspect={fn()}
@@ -335,9 +361,11 @@ function BrowserStory({
 function NarrowToolbarStory({
   width,
   access,
+  resetProfile = false,
 }: {
   width: 320 | 390;
   access: BrowserAgentAccess;
+  resetProfile?: boolean;
 }) {
   const session = browserSession("ready");
   const [address, setAddress] = useState(session.address);
@@ -360,7 +388,7 @@ function NarrowToolbarStory({
           canGoForward={false}
           controller={undefined}
           agentAccess={access}
-          engine={inspectEngine}
+          engine={resetProfile ? resetEngine : inspectEngine}
           onAddressChange={setAddress}
           onNavigate={fn()}
           onBack={fn()}
@@ -372,6 +400,7 @@ function NarrowToolbarStory({
           onShareAgent={fn()}
           onRevokeAgent={fn()}
           onSelectHistory={fn()}
+          onResetProfile={resetProfile ? () => Promise.resolve() : undefined}
           onOpenExternal={fn()}
           onOverlayOpenChange={fn()}
           onAgentAccessOpenChange={fn()}
@@ -584,6 +613,73 @@ export const AgentControlled: Story = {
   },
 };
 
+export const ManagedProfileResetConfirmation: Story = {
+  args: { scenario: "profile-reset-confirmation" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Browser options" }),
+    );
+    await userEvent.click(
+      await body.findByRole("menuitem", {
+        name: "Reset development profile",
+      }),
+    );
+    await expect(await body.findByRole("alertdialog")).toBeVisible();
+  },
+};
+
+export const ManagedProfileResetting: Story = {
+  args: { scenario: "profile-resetting" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Browser options" }),
+    );
+    await userEvent.click(
+      await body.findByRole("menuitem", {
+        name: "Reset development profile",
+      }),
+    );
+    await userEvent.click(
+      await body.findByRole("button", {
+        name: "Reset development profile",
+      }),
+    );
+    await expect(
+      canvas.getByText(
+        "Resetting the Tidebreak development profile… closing browser tabs.",
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const ManagedProfileResetFailure: Story = {
+  args: { scenario: "profile-reset-failure" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Browser options" }),
+    );
+    await userEvent.click(
+      await body.findByRole("menuitem", {
+        name: "Reset development profile",
+      }),
+    );
+    await userEvent.click(
+      await body.findByRole("button", {
+        name: "Reset development profile",
+      }),
+    );
+    await expect(
+      canvas.getByText("WebKit could not remove the managed profile data"),
+    ).toBeVisible();
+  },
+};
+
 export const HumanTakeoverRequired: Story = { args: { scenario: "takeover" } };
 
 export const SlowPage: Story = { args: { scenario: "slow" } };
@@ -686,6 +782,30 @@ export const ToolbarNarrow390Paused: Story = {
       access={{ ...pausedAccess, shared: true, scope: "origin" }}
     />
   ),
+};
+
+export const ToolbarNarrow320ManagedProfileReset: Story = {
+  args: { scenario: "profile-reset-confirmation" },
+  render: () => (
+    <NarrowToolbarStory
+      width={320}
+      access={unsharedAccess}
+      resetProfile
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Browser options" }),
+    );
+    await userEvent.click(
+      await body.findByRole("menuitem", {
+        name: "Reset development profile",
+      }),
+    );
+    await expect(await body.findByRole("alertdialog")).toBeVisible();
+  },
 };
 
 export const InspectOff: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -42,6 +42,7 @@ type BrowserScenario =
   | "inspect-on"
   | "profile-reset-confirmation"
   | "profile-resetting"
+  | "profile-reset-reconstructing"
   | "profile-reset-failure";
 
 const inspectEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
@@ -185,6 +186,7 @@ function BrowserStory({
   const [viewportState, setViewportState] = useState<BrowserViewport>(
     viewport ?? { preset: "fit", customWidth: 1024 },
   );
+  const [profileResetStarted, setProfileResetStarted] = useState(false);
   const inspectEnabled =
     scenario === "inspect-on" || scenario === "inspect-remove-failure";
   const inspectFailure =
@@ -210,10 +212,22 @@ function BrowserStory({
   const profileResetScenario =
     scenario === "profile-reset-confirmation" ||
     scenario === "profile-resetting" ||
+    scenario === "profile-reset-reconstructing" ||
     scenario === "profile-reset-failure";
+  const profileResetPhase = profileResetStarted
+    ? scenario === "profile-resetting"
+      ? "deleting"
+      : scenario === "profile-reset-reconstructing"
+        ? "reconstructing"
+        : null
+    : null;
   const onResetProfile =
-    scenario === "profile-resetting"
-      ? () => new Promise<void>(() => {})
+    scenario === "profile-resetting" ||
+    scenario === "profile-reset-reconstructing"
+      ? () => {
+          setProfileResetStarted(true);
+          return new Promise<void>(() => {});
+        }
       : scenario === "profile-reset-failure"
         ? () =>
             Promise.reject(
@@ -253,6 +267,7 @@ function BrowserStory({
           onSelectHistory={fn()}
           onOpenExternal={fn()}
           onResetProfile={onResetProfile}
+          profileResetPhase={profileResetPhase}
           onOverlayOpenChange={fn()}
           onAgentAccessOpenChange={fn()}
           onToggleInspect={fn()}
@@ -651,7 +666,33 @@ export const ManagedProfileResetting: Story = {
     );
     await expect(
       canvas.getByText(
-        "Resetting the Tidebreak development profile… closing browser tabs.",
+        "Resetting the Tidebreak development profile… deleting managed cookies, site data, and cache.",
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const ManagedProfileReconstructing: Story = {
+  args: { scenario: "profile-reset-reconstructing" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Browser options" }),
+    );
+    await userEvent.click(
+      await body.findByRole("menuitem", {
+        name: "Reset development profile",
+      }),
+    );
+    await userEvent.click(
+      await body.findByRole("button", {
+        name: "Reset development profile",
+      }),
+    );
+    await expect(
+      canvas.getByText(
+        "Resetting the Tidebreak development profile… reopening stored browser pages.",
       ),
     ).toBeVisible();
   },

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -787,11 +787,7 @@ export const ToolbarNarrow390Paused: Story = {
 export const ToolbarNarrow320ManagedProfileReset: Story = {
   args: { scenario: "profile-reset-confirmation" },
   render: () => (
-    <NarrowToolbarStory
-      width={320}
-      access={unsharedAccess}
-      resetProfile
-    />
+    <NarrowToolbarStory width={320} access={unsharedAccess} resetProfile />
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import {
   BrowserAgentControlRow,
@@ -626,7 +626,8 @@ export const ManagedProfileResetConfirmation: Story = {
         name: "Reset development profile",
       }),
     );
-    await expect(await body.findByRole("alertdialog")).toBeVisible();
+    const dialog = await body.findByRole("alertdialog");
+    await waitFor(() => expect(dialog).toBeVisible());
   },
 };
 
@@ -800,7 +801,8 @@ export const ToolbarNarrow320ManagedProfileReset: Story = {
         name: "Reset development profile",
       }),
     );
-    await expect(await body.findByRole("alertdialog")).toBeVisible();
+    const dialog = await body.findByRole("alertdialog");
+    await waitFor(() => expect(dialog).toBeVisible());
   },
 };
 


### PR DESCRIPTION
## Summary

- persist one opaque Tidebreak-managed development-browser profile per native owner, adopting the existing Tidebreak-only WebKit store for local-owner continuity
- serialize profile creation and reset, derive reset identity from the trusted native browser record, drain and close all matching live sessions before deleting only the managed data store, and preserve origin grants
- expose a capability-gated reset flow with Tidebreak-only confirmation copy, progress, failure/retry handling, and desktop/narrow Storybook states

## Platform behavior

- macOS 14+: use and remove the exact named `WKWebsiteDataStore` identifier
- macOS 10.15-13: use Tidebreak’s app-private default store and remove only website records matching hosts recorded for the managed browser profile
- renderer IPC never accepts or receives an owner selector, native data-store identifier, filesystem path, or engine handle

## Validation

Passed locally:

- `cargo fmt --all --check`
- `git diff --check`
- isolated compilation/tests of the exact `browser_profile.rs` source: 9 passed
- isolated compilation/tests of the exact `browser_control.rs` source: 44 passed

Unavailable in this sandbox:

- repository-level Rust tests/checks: Cargo cannot fetch pinned Symphonia revision `619c6806e5122b3206b8938773a801dd4a8a5950`; the Git dependency fetch returns HTTP 403
- UI typecheck, Biome lint, focused Vitest tests, and Storybook build: pnpm 10.18.3 is not installed, `node_modules` is absent, and Corepack cannot download pnpm from the npm registry
- visual screenshot review: there is no built/exposed Storybook preview and no Chromium/Playwright browser binary. The missing prerequisite is an installed lockfile dependency tree plus a capture-capable browser (or an externally exposed Storybook preview). Visual review is not claimed as passed.

Closes #2782
Part of #2336