### PR TITLE
feat(code): restore a workspace to a turn checkpoint

### DIFF
--- a/crates/tidebreak-core/fixtures/code-journal-events.json
+++ b/crates/tidebreak-core/fixtures/code-journal-events.json
@@ -107,6 +107,16 @@
     }
   },
   {
+    "type": "checkpoint_restored",
+    "turn_id": "00000000-0000-0000-0000-000000000001",
+    "diffstat": {
+      "files": 3,
+      "insertions": 1,
+      "deletions": 12,
+      "truncated": false
+    }
+  },
+  {
     "type": "harness_notice",
     "level": "warning",
     "message": "unrecognized event type counted"

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -370,6 +370,17 @@ pub enum CodeEvent {
         /// Bounded diffstat.
         diffstat: Diffstat,
     },
+    /// The worktree was put back to a per-turn checkpoint.
+    ///
+    /// Files only. The branch and `HEAD` do not move, and ignored files are
+    /// untouched, so the journal records what the reader actually asked for
+    /// rather than implying a history rewrite.
+    CheckpointRestored {
+        /// The turn whose checkpoint the worktree now holds.
+        turn_id: CodeTurnId,
+        /// Bounded diffstat of what the restore changed.
+        diffstat: Diffstat,
+    },
     /// Visible degradation or an engine-native notice.
     HarnessNotice {
         /// Severity.
@@ -431,8 +442,9 @@ mod tests {
             CodeEvent::TurnFailed { .. } => 12,
             CodeEvent::TurnInterrupted => 13,
             CodeEvent::CheckpointRecorded { .. } => 14,
-            CodeEvent::HarnessNotice { .. } => 15,
-            CodeEvent::AttentionChanged { .. } => 16,
+            CodeEvent::CheckpointRestored { .. } => 15,
+            CodeEvent::HarnessNotice { .. } => 16,
+            CodeEvent::AttentionChanged { .. } => 17,
         }
     }
 
@@ -527,6 +539,15 @@ mod tests {
                     insertions: 10,
                     deletions: 1,
                     truncated: true,
+                },
+            },
+            CodeEvent::CheckpointRestored {
+                turn_id: CodeTurnId(id(1)),
+                diffstat: Diffstat {
+                    files: 3,
+                    insertions: 1,
+                    deletions: 12,
+                    truncated: false,
                 },
             },
             CodeEvent::HarnessNotice {

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -88,6 +88,7 @@ import {
   type CodeSessionSnapshot,
   type CodeTurnSnapshot,
   type CodeActionSnapshot,
+  type CodeCheckpointRestore,
   type CodeCommitSnapshot,
   type CodePushSnapshot,
   type CodeTerminalRead,
@@ -169,6 +170,7 @@ import {
   type CodeTurnSubmission,
   parseQueuedCodeTurn,
   parseCodeAction,
+  parseCodeCheckpointRestore,
   parseCodeCommit,
   parseCodePush,
   parseCodeTerminal,
@@ -3111,6 +3113,33 @@ export class ApiClient {
         ),
       ),
       "code quick action",
+    );
+  }
+
+  /**
+   * Put the workspace's files back to what a turn's checkpoint holds.
+   *
+   * Not `restoreCodeWorkspace`, which reactivates an archived workspace. This
+   * one moves files only: the branch and `HEAD` stay where they are, and
+   * ignored files are left alone. A 409 `workspace_busy` means a turn holds
+   * the checkout; retry once it ends.
+   */
+  async restoreCodeWorkspaceCheckpoint(
+    workspaceId: string,
+    turnId: string,
+  ): Promise<CodeCheckpointRestore> {
+    return requireParsed(
+      parseCodeCheckpointRestore(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/restore-checkpoint`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({ turn_id: turnId }),
+          },
+        ),
+      ),
+      "checkpoint restore",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -174,6 +174,7 @@ import {
   type CodeWatchSnapshot as WireCodeWatchSnapshot,
   type CodeWatchState as WireCodeWatchState,
   type CodeActionSnapshot as WireCodeActionSnapshot,
+  type CodeCheckpointRestore as WireCodeCheckpointRestore,
   type CodeCommitSnapshot as WireCodeCommitSnapshot,
   type CodePushSnapshot as WireCodePushSnapshot,
   type CodeFileChange as WireCodeFileChange,
@@ -1240,6 +1241,8 @@ export type CodeSubagentStatus = WireCodeSubagentStatus;
 export type CodeCommitSnapshot = WireCodeCommitSnapshot;
 export type CodePushSnapshot = WireCodePushSnapshot;
 export type CodeActionSnapshot = WireCodeActionSnapshot;
+/** What restoring a workspace to a turn's checkpoint changed. */
+export type CodeCheckpointRestore = WireCodeCheckpointRestore;
 export type PullRequestDigest = WirePullRequestDigest;
 export type PullRequestCheck = WirePullRequestCheck;
 export type PullRequestCheckBucket = WirePullRequestCheckBucket;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -2088,6 +2088,51 @@ describe("file_changed", () => {
     });
     expect(state.contentRevision).toBe(3);
   });
+
+  /**
+   * A restore rewrites the worktree, so git status, the file list, and the
+   * diff are all stale the moment it lands. `contentRevision` is the only
+   * signal those views watch: without this the frame falls through the
+   * reducer's default branch and every one of them keeps the pre-restore
+   * tree until some later checkpoint happens to bump it.
+   */
+  it("bumps contentRevision when a checkpoint is restored", () => {
+    const before = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "turn_completed", usage: NO_USAGE },
+      {
+        type: "checkpoint_recorded",
+        turn_id: "t1",
+        diffstat: { files: 4, insertions: 40, deletions: 2, truncated: false },
+      },
+    ]);
+
+    const after = play(
+      [
+        {
+          type: "checkpoint_restored",
+          turn_id: "t1",
+          diffstat: {
+            files: 4,
+            insertions: 2,
+            deletions: 40,
+            truncated: false,
+          },
+        },
+      ],
+      before.state,
+    );
+
+    expect(after.state.contentRevision).toBe(before.state.contentRevision + 1);
+    // The seam says what the turn changed, not what undoing it changed.
+    expect(
+      after.state.items.find((item) => item.kind === "turn_boundary"),
+    ).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      diffstat: { files: 4, insertions: 40, deletions: 2, truncated: false },
+    });
+  });
 });
 
 describe("unattributed terminals", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -745,6 +745,21 @@ export function hydrateCodeTurns(
   return reconcilePendingCodeTurns(state, turns);
 }
 
+/**
+ * Something outside the journal rewrote the worktree.
+ *
+ * A restore answers over HTTP and journals separately, and the journal row is
+ * allowed to fail without failing the restore. The views that watch
+ * `contentRevision` must not depend on a row that may never arrive, so the
+ * caller bumps it from the success itself. Applying both is harmless: the
+ * refresh is debounced and idempotent.
+ */
+export function noteCodeWorktreeChanged(
+  state: CodeSessionState,
+): CodeSessionState {
+  return { ...state, contentRevision: state.contentRevision + 1 };
+}
+
 export function reduceCodeSessionEvent(
   state: CodeSessionState,
   framed: SequencedCodeEventFrame,
@@ -1028,6 +1043,20 @@ export function reduceCodeSessionEvent(
           items: applyDiffstat(state.items, event.turn_id, event.diffstat),
           contentRevision: state.contentRevision + 1,
         },
+        effects,
+      };
+    }
+
+    /**
+     * A restore rewrote the worktree, so every worktree-derived view is stale.
+     *
+     * The seam's diffstat is left alone on purpose: it says what that turn
+     * changed, which the restore did not alter. Only the revision moves, and
+     * that is what git status, the file list, and the diff watch.
+     */
+    case "checkpoint_restored": {
+      return {
+        state: { ...state, contentRevision: state.contentRevision + 1 },
         effects,
       };
     }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -4,6 +4,7 @@ import {
   acquireCodeSession,
   acquireCodeSessionFromClient,
   MAX_RETAINED_CODE_SESSIONS,
+  noteCodeSessionWorktreeChanged,
   peekCodeSession,
   releaseCodeSession,
   resetCodeSessionRegistry,
@@ -1075,5 +1076,26 @@ describe("CodeSessionRegistry", () => {
     expect(store.getState().assistantBuffer).toBe("oldlive");
     expect(listener).toHaveBeenCalledTimes(1);
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  /**
+   * A checkpoint restore answers over HTTP and journals separately, and the
+   * journal row is allowed to fail without failing the restore. The
+   * worktree-derived views must not wait on a row that may never arrive.
+   */
+  it("bumps a mounted session's content revision from outside the journal", () => {
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => new FakeSocket(after, onFrame) as unknown as WebSocket;
+    const store = acquireCodeSession("s1", openSocket);
+    const before = store.getState().contentRevision;
+
+    noteCodeSessionWorktreeChanged("s1");
+
+    expect(store.getState().contentRevision).toBe(before + 1);
+    // A session nobody holds refreshes on its next mount, so this is a no-op
+    // rather than a throw.
+    expect(() => noteCodeSessionWorktreeChanged("not-mounted")).not.toThrow();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -9,6 +9,7 @@ import {
 import {
   applyCodeTurnSnapshot,
   hydrateCodeTurns,
+  noteCodeWorktreeChanged,
   reconcilePendingCodeTurns,
   type CodeSessionDeps,
 } from "./CodeSessionReducer";
@@ -231,6 +232,18 @@ export function peekCodeSession(
   sessionId: string,
 ): CodeSessionEntry | undefined {
   return registry.get(sessionId);
+}
+
+/**
+ * Tell a mounted session that the worktree moved under it.
+ *
+ * For a change that arrives over HTTP rather than through the journal — a
+ * checkpoint restore — so the worktree-derived views refresh even when the
+ * journal row does not land. A session nobody is holding refreshes on its
+ * next mount, so an absent entry is not an error.
+ */
+export function noteCodeSessionWorktreeChanged(sessionId: string): void {
+  registry.get(sessionId)?.store.getState().update(noteCodeWorktreeChanged);
 }
 
 /** Test-only: drop every live entry without waiting for unmounts. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -413,6 +413,43 @@ describe("CodeTranscript", () => {
     ).not.toBeInTheDocument();
   });
 
+  /**
+   * Restore overwrites files, so it confirms first, and the copy has to say
+   * how far it reaches: ignored files stay, and the branch does not move.
+   * Nothing may reach the host before the reader says yes.
+   */
+  it("confirms before restoring the files to a turn", async () => {
+    const user = userEvent.setup();
+    const onRestoreToTurn = vi.fn();
+    render(<CodeTranscript items={items} onRestoreToTurn={onRestoreToTurn} />);
+
+    await user.click(screen.getByRole("button", { name: "Turn actions" }));
+    await user.click(
+      screen.getByRole("menuitem", { name: /Restore to this point/ }),
+    );
+
+    const description = await screen.findByText(/Ignored files/);
+    expect(description).toHaveTextContent("HEAD stays where it is");
+    expect(onRestoreToTurn).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Restore files" }));
+    expect(onRestoreToTurn).toHaveBeenCalledWith("t1");
+  });
+
+  it("restores nothing when the reader cancels", async () => {
+    const user = userEvent.setup();
+    const onRestoreToTurn = vi.fn();
+    render(<CodeTranscript items={items} onRestoreToTurn={onRestoreToTurn} />);
+
+    await user.click(screen.getByRole("button", { name: "Turn actions" }));
+    await user.click(
+      screen.getByRole("menuitem", { name: /Restore to this point/ }),
+    );
+    await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    expect(onRestoreToTurn).not.toHaveBeenCalled();
+  });
+
   it("says why a failed turn failed", () => {
     render(
       <CodeTranscript

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -430,6 +430,9 @@ describe("CodeTranscript", () => {
 
     const description = await screen.findByText(/Ignored files/);
     expect(description).toHaveTextContent("HEAD stays where it is");
+    // The server snapshots first, so the copy must not tell the reader their
+    // work is gone.
+    expect(description).toHaveTextContent("stays recoverable from git");
     expect(onRestoreToTurn).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Restore files" }));

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -70,6 +70,7 @@ export function CodeTranscript({
   animateStreaming = true,
   onOpenTurnDiff,
   onForkFromTurn,
+  onRestoreToTurn,
   emptyState,
   sessionId,
   onReveal,
@@ -99,6 +100,8 @@ export function CodeTranscript({
   onOpenTurnDiff?: (turnId: string) => void;
   /** Fork the conversation at the end of one turn, from its seam row. */
   onForkFromTurn?: (turnId: string) => void;
+  /** Put the workspace's files back to what one turn left, from its seam row. */
+  onRestoreToTurn?: (turnId: string) => void;
   /** Copy for a filtered/read-only transcript with no captured rows. */
   emptyState?: { title: string; description: string };
   sessionId?: string;
@@ -216,6 +219,7 @@ export function CodeTranscript({
                   onDecide={onDecide}
                   onOpenTurnDiff={onOpenTurnDiff}
                   onForkFromTurn={onForkFromTurn}
+                  onRestoreToTurn={onRestoreToTurn}
                   sessionId={sessionId}
                   onReveal={onReveal}
                   recap={row.item.id === newestBoundaryId ? recap : undefined}
@@ -538,6 +542,7 @@ const TranscriptItem = memo(function TranscriptItem({
   onDecide,
   onOpenTurnDiff,
   onForkFromTurn,
+  onRestoreToTurn,
   sessionId,
   onReveal,
   recap,
@@ -558,6 +563,7 @@ const TranscriptItem = memo(function TranscriptItem({
   ) => void;
   onOpenTurnDiff?: (turnId: string) => void;
   onForkFromTurn?: (turnId: string) => void;
+  onRestoreToTurn?: (turnId: string) => void;
   sessionId?: string;
   onReveal?: () => void;
   /**
@@ -678,6 +684,7 @@ const TranscriptItem = memo(function TranscriptItem({
           turn={item}
           onOpenTurnDiff={onOpenTurnDiff}
           onForkFromTurn={onForkFromTurn}
+          onRestoreToTurn={onRestoreToTurn}
           narrative={
             recap ? (
               <span className="text-muted-foreground">{recap}</span>

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -141,6 +141,7 @@ import { CodeQuickOpen } from "./CodeQuickOpen";
 import { WorkspaceWorkflowControl } from "./WorkspaceWorkflowControl";
 import {
   acquireCodeSessionFromClient,
+  noteCodeSessionWorktreeChanged,
   releaseCodeSession,
 } from "./CodeSessionRegistry";
 import { submitAcceptedTurn } from "./CodeSessionSend";
@@ -1043,18 +1044,28 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
    *
    * The seam already confirmed with the reader; this is the call. Files only:
    * the branch and `HEAD` stay where they are, and the server snapshots the
-   * worktree into a hidden ref first, so the work this discards is still in
-   * the object database.
+   * worktree into a hidden ref first, so the work this replaces is still in
+   * the object database — the toast names the ref so the reader can reach it.
+   *
+   * The refresh does not wait for the journal. A restore answers over HTTP
+   * and journals separately, and a journal row that fails to land is
+   * deliberately not fatal, so the worktree-derived views are told here too.
+   * The `checkpoint_restored` frame bumps the same revision when it arrives;
+   * the refresh is debounced, so both together cost one reload.
    */
-  async function restoreToTurn(turnId: string) {
+  async function restoreToTurn(sessionId: string, turnId: string) {
     try {
       const restored = await client.restoreCodeWorkspaceCheckpoint(
         workspaceId,
         turnId,
       );
+      noteCodeSessionWorktreeChanged(sessionId);
       const files = restored.stat.files;
       toast.success(
         `Restored ${files} file${files === 1 ? "" : "s"} to this turn`,
+        {
+          description: `What the worktree held is saved at ${restored.safety_ref}`,
+        },
       );
     } catch (err) {
       toast.error(friendlyErrorMessage(err, "Could not restore the files"));
@@ -1444,7 +1455,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                       ? (turnId) => void forkConversation(session.id, turnId)
                       : undefined
                   }
-                  onRestoreToTurn={(turnId) => void restoreToTurn(turnId)}
+                  onRestoreToTurn={(turnId) =>
+                    void restoreToTurn(session.id, turnId)
+                  }
                   subagentCallId={subagentParam}
                   subagentSummary={digest?.subagents?.find(
                     (entry) => entry.call_id === subagentParam,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -188,6 +188,7 @@ import {
 } from "./inspectorLayout";
 import {
   createPermissionModes,
+  fenceBlocksWorkspace,
   fenceReasonText,
   gatewayCodeModels,
   harnessCodeModels,
@@ -781,6 +782,18 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
 
   const fenced =
     session?.lifecycle === "fenced" || session?.fence_reason !== undefined;
+  // A fenced engine may still be writing the checkout. Restore is a write,
+  // so it stays hidden until a reap settles that process — this session, or
+  // a sibling fenced for an unaccounted engine.
+  const restoreClosed =
+    fenced ||
+    workspace?.status !== "active" ||
+    sessions.some(
+      (entry) =>
+        entry.id !== session?.id &&
+        entry.lifecycle === "fenced" &&
+        fenceBlocksWorkspace(entry.fence_reason),
+    );
   const doctorHarnesses = catalog.doctor?.harnesses ?? [];
   const title = digest?.title ?? workspace?.title;
   const repoName = repo?.display_name;
@@ -1455,8 +1468,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                       ? (turnId) => void forkConversation(session.id, turnId)
                       : undefined
                   }
-                  onRestoreToTurn={(turnId) =>
-                    void restoreToTurn(session.id, turnId)
+                  onRestoreToTurn={
+                    restoreClosed
+                      ? undefined
+                      : (turnId) => void restoreToTurn(session.id, turnId)
                   }
                   subagentCallId={subagentParam}
                   subagentSummary={digest?.subagents?.find(

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1039,6 +1039,29 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   }
 
   /**
+   * Put the workspace's files back to what one turn left.
+   *
+   * The seam already confirmed with the reader; this is the call. Files only:
+   * the branch and `HEAD` stay where they are, and the server snapshots the
+   * worktree into a hidden ref first, so the work this discards is still in
+   * the object database.
+   */
+  async function restoreToTurn(turnId: string) {
+    try {
+      const restored = await client.restoreCodeWorkspaceCheckpoint(
+        workspaceId,
+        turnId,
+      );
+      const files = restored.stat.files;
+      toast.success(
+        `Restored ${files} file${files === 1 ? "" : "s"} to this turn`,
+      );
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not restore the files"));
+    }
+  }
+
+  /**
    * Close a conversation tab.
    *
    * Only the draft closes here. A started agent holds a worktree and a running
@@ -1421,6 +1444,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                       ? (turnId) => void forkConversation(session.id, turnId)
                       : undefined
                   }
+                  onRestoreToTurn={(turnId) => void restoreToTurn(turnId)}
                   subagentCallId={subagentParam}
                   subagentSummary={digest?.subagents?.find(
                     (entry) => entry.call_id === subagentParam,
@@ -2016,6 +2040,7 @@ function CodeSessionPane({
   disabled,
   onOpenTurnDiff,
   onForkFromTurn,
+  onRestoreToTurn,
   subagentCallId,
   subagentSummary,
   onBackFromSubagent,
@@ -2031,6 +2056,8 @@ function CodeSessionPane({
   onOpenTurnDiff?: (turnId: string) => void;
   /** Fork this conversation at the end of one turn, from its seam row. */
   onForkFromTurn?: (turnId: string) => void;
+  /** Put the workspace's files back to what one turn left, from its seam row. */
+  onRestoreToTurn?: (turnId: string) => void;
   /** The spanning Task call to inspect inside this still-mounted session. */
   subagentCallId?: string;
   /** Current bounded rail summary, when the Task is still in the digest. */
@@ -2475,6 +2502,7 @@ function CodeSessionPane({
           approvalError={approvalError}
           onOpenTurnDiff={onOpenTurnDiff}
           onForkFromTurn={subagentCallId ? undefined : onForkFromTurn}
+          onRestoreToTurn={subagentCallId ? undefined : onRestoreToTurn}
           onReveal={follow.pauseFollow}
           scrollRef={follow.scrollRef}
           contentRef={follow.contentRef}

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -228,7 +228,7 @@ function TurnActionsMenu({
     const ok = await confirm({
       title: "Restore the files to this point?",
       description:
-        "Every file goes back to how this turn left it, and anything written since is lost. Ignored files — build output, .env — are untouched, and nothing moves the branch: this changes files only, and HEAD stays where it is.",
+        "Every file goes back to how this turn left it. Anything written since is snapshotted first, so it stays recoverable from git — the restore names the snapshot when it finishes. Ignored files — build output, .env — are untouched, and nothing moves the branch: this changes files only, and HEAD stays where it is.",
       confirmLabel: "Restore files",
       destructive: true,
     });

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -3,12 +3,14 @@ import {
   Check,
   CircleSlash,
   GitFork,
+  History,
   MoreHorizontal,
   TriangleAlert,
 } from "lucide-react";
 
 import type { Diffstat } from "../api/types";
 import { Badge } from "@/components/ui/badge";
+import { useConfirm } from "@/components/ConfirmDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -57,6 +59,7 @@ export function TurnReviewCard({
   narrative,
   onOpenTurnDiff,
   onForkFromTurn,
+  onRestoreToTurn,
 }: {
   turn: TurnBoundary;
   /**
@@ -73,6 +76,8 @@ export function TurnReviewCard({
   onOpenTurnDiff?: (turnId: string) => void;
   /** Hand everything up to this turn to a fresh agent, in a new tab. */
   onForkFromTurn?: (turnId: string) => void;
+  /** Put the workspace's files back to what this turn left. */
+  onRestoreToTurn?: (turnId: string) => void;
 }) {
   const duration = formatTurnDuration(turn.durationMs);
   const diffstat = turn.diffstat && hasFileChanges(turn.diffstat) && (
@@ -82,8 +87,12 @@ export function TurnReviewCard({
       onOpenTurnDiff={onOpenTurnDiff}
     />
   );
-  const actions = turn.turnId && onForkFromTurn && (
-    <TurnActionsMenu turnId={turn.turnId} onForkFromTurn={onForkFromTurn} />
+  const actions = turn.turnId && (onForkFromTurn || onRestoreToTurn) && (
+    <TurnActionsMenu
+      turnId={turn.turnId}
+      onForkFromTurn={onForkFromTurn}
+      onRestoreToTurn={onRestoreToTurn}
+    />
   );
 
   if (turn.status === "failed") {
@@ -197,38 +206,69 @@ function SeamRow({
 /**
  * What the reader can do with a finished turn, behind one quiet trigger.
  *
- * Forking is the only entry today, but the seam is where per-turn actions
- * belong, so the affordance is a menu rather than a bare fork button.
+ * The seam is where per-turn actions belong, so the affordance is a menu
+ * rather than a row of buttons. Restore is destructive and confirms first: it
+ * overwrites files the reader may still want, and the copy has to say exactly
+ * how far it reaches, because "restore" reads like a history rewrite and this
+ * is not one.
  */
 function TurnActionsMenu({
   turnId,
   onForkFromTurn,
+  onRestoreToTurn,
 }: {
   turnId: string;
-  onForkFromTurn: (turnId: string) => void;
+  onForkFromTurn?: (turnId: string) => void;
+  onRestoreToTurn?: (turnId: string) => void;
 }) {
+  const { confirm, dialog } = useConfirm();
+
+  async function askThenRestore() {
+    if (!onRestoreToTurn) return;
+    const ok = await confirm({
+      title: "Restore the files to this point?",
+      description:
+        "Every file goes back to how this turn left it, and anything written since is lost. Ignored files — build output, .env — are untouched, and nothing moves the branch: this changes files only, and HEAD stays where it is.",
+      confirmLabel: "Restore files",
+      destructive: true,
+    });
+    if (!ok) return;
+    onRestoreToTurn(turnId);
+  }
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            "text-muted-foreground hover:bg-muted hover:text-foreground grid size-5 shrink-0 cursor-pointer place-items-center rounded-md",
-            FOCUS_RING_TIGHT,
-            HOVER_TINT,
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "text-muted-foreground hover:bg-muted hover:text-foreground grid size-5 shrink-0 cursor-pointer place-items-center rounded-md",
+              FOCUS_RING_TIGHT,
+              HOVER_TINT,
+            )}
+            aria-label="Turn actions"
+          >
+            <MoreHorizontal className="size-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-52">
+          {onForkFromTurn && (
+            <DropdownMenuItem onSelect={() => onForkFromTurn(turnId)}>
+              <GitFork />
+              Fork from here
+            </DropdownMenuItem>
           )}
-          aria-label="Turn actions"
-        >
-          <MoreHorizontal className="size-3.5" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-52">
-        <DropdownMenuItem onSelect={() => onForkFromTurn(turnId)}>
-          <GitFork />
-          Fork from here
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          {onRestoreToTurn && (
+            <DropdownMenuItem onSelect={() => void askThenRestore()}>
+              <History />
+              Restore to this point
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {dialog}
+    </>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -10,6 +10,7 @@ import {
   createPermissionModes,
   defaultCreatePermissionMode,
   effortLadder,
+  fenceBlocksWorkspace,
   gatewayCodeModels,
   groupCodeModelOptions,
   harnessCanStartNow,
@@ -30,6 +31,26 @@ function caps(
 ): ModeCaps {
   return { plan_mode, structured_approvals, auto_mode, allow_mode };
 }
+
+describe("fenceBlocksWorkspace", () => {
+  it("stops the workspace for an unaccounted engine, not for failed turns", () => {
+    expect(fenceBlocksWorkspace(undefined)).toBe(true);
+    expect(fenceBlocksWorkspace({ type: "orphan_alive" })).toBe(true);
+    expect(
+      fenceBlocksWorkspace({ type: "probe_ambiguous", detail: "pid reuse" }),
+    ).toBe(true);
+    expect(fenceBlocksWorkspace({ type: "resume_lost", detail: "gone" })).toBe(
+      true,
+    );
+    expect(
+      fenceBlocksWorkspace({
+        type: "repeated_turn_failures",
+        count: 3,
+        detail: "auth expired",
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("sessionLifecycleTooltip", () => {
   it("joins the harness version and recorded unrecognized engine events", () => {

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -155,6 +155,18 @@ export type ModeCaps = Pick<
   "plan_mode" | "structured_approvals" | "auto_mode" | "allow_mode"
 >;
 
+/**
+ * True when this fence also stops every other session in the workspace.
+ *
+ * Matches the server: a missing reason still blocks, because an unaccounted
+ * engine may be writing the checkout. Repeated turn failures do not — that
+ * engine answered, so a sibling can keep working.
+ */
+export function fenceBlocksWorkspace(reason: FenceReason | undefined): boolean {
+  if (!reason) return true;
+  return reason.type !== "repeated_turn_failures";
+}
+
 export function fenceReasonText(reason: FenceReason): string {
   if (reason.type === "orphan_alive") {
     return "An engine process is still running from a previous session. Reap it before starting another turn.";

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -31,6 +31,7 @@ import type {
   CodeWatchSnapshot,
   CodeWorkspaceSnapshot,
   CodeActionSnapshot,
+  CodeCheckpointRestore,
   CodeCommitSnapshot,
   CodePushSnapshot,
   Diffstat,
@@ -121,6 +122,7 @@ import type {
   CodeTriggerSnapshot as WireCodeTriggerSnapshot,
   CodeWatchSnapshot as WireCodeWatchSnapshot,
   CodeActionSnapshot as WireCodeActionSnapshot,
+  CodeCheckpointRestore as WireCodeCheckpointRestore,
   CodeCommitSnapshot as WireCodeCommitSnapshot,
   CodePushSnapshot as WireCodePushSnapshot,
   CodeFileChange as WireCodeFileChange,
@@ -2384,6 +2386,21 @@ export function parseCodeCommit(value: unknown): CodeCommitSnapshot | null {
   const stat = parseDiffstat(value.stat);
   if (!stat) return null;
   return { sha: value.sha, message: value.message, stat };
+}
+
+export function parseCodeCheckpointRestore(
+  value: unknown,
+): CodeCheckpointRestore | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeCheckpointRestore>(value, ["turn_id", "stat"]) ||
+    !nonEmpty(value.turn_id)
+  ) {
+    return null;
+  }
+  const stat = parseDiffstat(value.stat);
+  if (!stat) return null;
+  return { turn_id: value.turn_id, stat };
 }
 
 export function parseCodePush(value: unknown): CodePushSnapshot | null {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2393,14 +2393,19 @@ export function parseCodeCheckpointRestore(
 ): CodeCheckpointRestore | null {
   if (
     !isRecord(value) ||
-    !onlyKeys<WireCodeCheckpointRestore>(value, ["turn_id", "stat"]) ||
-    !nonEmpty(value.turn_id)
+    !onlyKeys<WireCodeCheckpointRestore>(value, [
+      "turn_id",
+      "safety_ref",
+      "stat",
+    ]) ||
+    !nonEmpty(value.turn_id) ||
+    !nonEmpty(value.safety_ref)
   ) {
     return null;
   }
   const stat = parseDiffstat(value.stat);
   if (!stat) return null;
-  return { turn_id: value.turn_id, stat };
+  return { turn_id: value.turn_id, safety_ref: value.safety_ref, stat };
 }
 
 export function parseCodePush(value: unknown): CodePushSnapshot | null {
@@ -3409,6 +3414,24 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
       if (!diffstat) return null;
       return {
         type: "checkpoint_recorded",
+        turn_id: value.turn_id,
+        diffstat,
+      };
+    }
+    case "checkpoint_restored": {
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "checkpoint_restored" }>>(
+          value,
+          ["type", "turn_id", "diffstat"],
+        ) ||
+        !nonEmpty(value.turn_id)
+      ) {
+        return null;
+      }
+      const diffstat = parseDiffstat(value.diffstat);
+      if (!diffstat) return null;
+      return {
+        type: "checkpoint_restored",
         turn_id: value.turn_id,
         diffstat,
       };

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -944,6 +944,22 @@ export type CodeCheckLogsSnapshot = {
 head_sha?: string, logs: Array<CodeCheckLog>, errors: Array<CodeCheckLogError>, };
 
 /**
+ * What restoring a workspace to a turn's checkpoint changed.
+ *
+ * Files only: the branch and `HEAD` stayed where they were, and ignored
+ * files were not touched.
+ */
+export type CodeCheckpointRestore = { 
+/**
+ * The turn the worktree now matches.
+ */
+turn_id: CodeTurnId, 
+/**
+ * Bounded diffstat of what the restore changed.
+ */
+stat: Diffstat, };
+
+/**
  * Remembered clone destination plus observed `gh` status.
  */
 export type CodeCloneDefaults = { parent_dir?: string, gh_found: boolean, gh_authenticated?: boolean, gh_remediation: string, };
@@ -1298,6 +1314,14 @@ error: BoundedError, } | { "type": "turn_interrupted" } | { "type": "checkpoint_
 turn_id: CodeTurnId, 
 /**
  * Bounded diffstat.
+ */
+diffstat: Diffstat, } | { "type": "checkpoint_restored", 
+/**
+ * The turn whose checkpoint the worktree now holds.
+ */
+turn_id: CodeTurnId, 
+/**
+ * Bounded diffstat of what the restore changed.
  */
 diffstat: Diffstat, } | { "type": "harness_notice", 
 /**
@@ -3908,6 +3932,15 @@ export type ResolveCodeDeliveryRepositoriesBody = { repositories: Array<string>,
  * Whether a `rest_api` record's referenced credential currently resolves.
  */
 export type RestCredentialStatus = "none" | "configured" | "missing";
+
+/**
+ * Body of `POST /code/workspaces/{id}/restore-checkpoint`.
+ */
+export type RestoreCheckpointBody = { 
+/**
+ * The turn whose checkpoint the worktree goes back to.
+ */
+turn_id: CodeTurnId, };
 
 /**
  * One thing a call surfaced.

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -955,6 +955,14 @@ export type CodeCheckpointRestore = {
  */
 turn_id: CodeTurnId, 
 /**
+ * Hidden ref holding the worktree the restore replaced.
+ *
+ * Nothing is lost by a restore: this ref is a full snapshot of what the
+ * worktree held a moment before, so the desktop can name it and the
+ * reader can recover from it with git.
+ */
+safety_ref: string, 
+/**
  * Bounded diffstat of what the restore changed.
  */
 stat: Diffstat, };

--- a/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { CodeTranscript } from "@/code/CodeTranscript";
 import type { CodeTranscriptItem } from "@/code/CodeSessionReducer";
@@ -59,6 +59,28 @@ export const Completed: Story = {};
  */
 export const CompletedWithTurnActions: Story = {
   args: { onForkFromTurn: fn() },
+};
+
+/**
+ * The full per-turn menu. "Restore to this point" puts the workspace's files
+ * back to what the turn left; it confirms first, and the confirmation says how
+ * far it reaches — ignored files stay, and the branch does not move.
+ */
+export const CompletedWithRestore: Story = {
+  args: { onForkFromTurn: fn(), onRestoreToTurn: fn() },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    await userEvent.click(canvas.getByRole("button", { name: "Turn actions" }));
+    await userEvent.click(
+      await body.findByRole("menuitem", { name: /Restore to this point/ }),
+    );
+    await expect(
+      await body.findByRole("heading", {
+        name: "Restore the files to this point?",
+      }),
+    ).toBeInTheDocument();
+  },
 };
 
 /**

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -437,9 +437,10 @@ pub(crate) async fn record_checkpoint(
 /// moves. Ignored files are untouched: a checkpoint tree is built by `add -A`,
 /// which never sees them, so they are in neither side of the transition.
 ///
-/// The worktree as it stands is snapshotted into a hidden safety ref before
-/// anything is written, so a restore the reader did not mean is recoverable
-/// from the object database rather than gone.
+/// Nothing is destroyed on a failure. The worktree as it stands is snapshotted
+/// into a hidden safety ref before anything is written, the checkpoint's tree
+/// is applied before any file is deleted, and the returned ref names the
+/// snapshot so the reader can be told where their work went.
 pub(crate) async fn restore_checkpoint(
     worktree: &Path,
     workspace_id: WorkspaceId,
@@ -462,14 +463,21 @@ pub(crate) async fn restore_checkpoint(
     )
     .await?;
 
-    // `read-tree -u` writes every path the checkpoint holds but knows nothing
-    // about the ones it does not, because the private index it transitions
-    // from starts empty. Files created since the checkpoint are therefore this
-    // function's own work.
-    for path in removed_by_restore(worktree, &before, &target).await? {
+    // The removal set is read off the two trees before either is touched, so
+    // it describes the worktree the reader asked about rather than a
+    // half-applied one.
+    let removed = removed_by_restore(worktree, &before, &target).await?;
+
+    // Apply first, delete second. `read-tree -u` writes every path the
+    // checkpoint holds but knows nothing about the ones it does not, because
+    // the private index it transitions from starts empty — so files created
+    // since the checkpoint are this function's own work. Doing that work
+    // after the apply means a failed apply has destroyed nothing: everything
+    // the reader had is still on disk, and the safety ref covers the rest.
+    apply_tree(worktree, &target).await?;
+    for path in removed {
         remove_restored_path(worktree, &path).await?;
     }
-    apply_tree(worktree, &target).await?;
 
     let changed = collect_changes(worktree, &before, &target, DiffBounds::default()).await?;
     Ok(RestoredCheckpoint {
@@ -3329,6 +3337,105 @@ mod tests {
                 .contains(&restored.safety_ref),
             "the safety ref must be reapable with the workspace's other refs"
         );
+    }
+
+    /// A restore that cannot finish must not have destroyed anything.
+    ///
+    /// The apply runs before any delete, so a checkpoint tree Git refuses to
+    /// check out leaves the worktree exactly as the reader left it. The tree
+    /// here is built by hand because `add -A` cannot produce one: a top-level
+    /// entry named `.git` is the one shape `read-tree -u` refuses outright,
+    /// on every platform and for every user, which is what makes this
+    /// deterministic rather than a permissions race.
+    #[tokio::test]
+    async fn an_apply_that_fails_deletes_nothing() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "apply-fails");
+        let workspace_id = ws();
+        let session_id = sess();
+        std::fs::write(tree.join("scratch.txt"), "at the checkpoint\n").unwrap();
+
+        let blob = git_text(&tree, &["hash-object", "-w", "--stdin"], GIT_TIMEOUT)
+            .await
+            .unwrap_or_default();
+        // `hash-object --stdin` with no stdin hashes the empty blob, which is
+        // all this needs: the entry's name is what Git rejects.
+        let entry = format!("100644 blob {blob}\t.git\n");
+        let hostile_tree = write_tree_from_entries(&tree, &entry).await;
+        let commit = git_text(
+            &tree,
+            &["commit-tree", &hostile_tree, "-m", "hostile checkpoint"],
+            GIT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        let r#ref = checkpoint_ref(workspace_id, session_id, 1);
+        git_text(
+            &tree,
+            &["update-ref", "--no-deref", &r#ref, &commit],
+            GIT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+
+        // What the reader has right now, none of which may disappear.
+        std::fs::remove_file(tree.join("scratch.txt")).unwrap();
+        std::fs::write(tree.join("README.md"), "after the checkpoint\n").unwrap();
+        std::fs::create_dir_all(tree.join("later")).unwrap();
+        std::fs::write(tree.join("later/new.txt"), "postdates it\n").unwrap();
+
+        let err = restore_checkpoint(&tree, workspace_id, &turn_at(1, Some(r#ref)))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("invalid path"), "{err}");
+
+        assert_eq!(
+            std::fs::read_to_string(tree.join("later/new.txt")).unwrap(),
+            "postdates it\n",
+            "a failed apply must not have deleted anything"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("README.md")).unwrap(),
+            "after the checkpoint\n"
+        );
+
+        // And the safety ref was written before the attempt, so even a partial
+        // apply is recoverable.
+        let refs = list_checkpoint_refs(&tree).await.unwrap();
+        let safety = refs
+            .iter()
+            .find(|name| name.contains(PRE_RESTORE_SEGMENT))
+            .expect("the safety ref is written before anything is applied");
+        let listed = git_text(
+            &tree,
+            &["ls-tree", "-r", "--name-only", safety],
+            GIT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert!(listed.contains("later/new.txt"), "{listed}");
+    }
+
+    /// Build a tree from raw index entries, bypassing the path checks `add`
+    /// applies. Only a test needs this.
+    async fn write_tree_from_entries(worktree: &Path, entries: &str) -> String {
+        use std::io::Write as _;
+        let mut child = StdCommand::new("git")
+            .args(["mktree", "--missing"])
+            .current_dir(worktree)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(entries.as_bytes())
+            .unwrap();
+        let out = child.wait_with_output().unwrap();
+        assert!(out.status.success(), "mktree failed");
+        String::from_utf8_lossy(&out.stdout).trim().to_owned()
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -463,20 +463,8 @@ pub(crate) async fn restore_checkpoint(
     )
     .await?;
 
-    // The removal set is read off the two trees before either is touched, so
-    // it describes the worktree the reader asked about rather than a
-    // half-applied one.
-    let removed = removed_by_restore(worktree, &before, &target).await?;
-
-    // Apply first, delete second. `read-tree -u` writes every path the
-    // checkpoint holds but knows nothing about the ones it does not, because
-    // the private index it transitions from starts empty — so files created
-    // since the checkpoint are this function's own work. Doing that work
-    // after the apply means a failed apply has destroyed nothing: everything
-    // the reader had is still on disk, and the safety ref covers the rest.
-    apply_tree(worktree, &target).await?;
-    for path in removed {
-        remove_restored_path(worktree, &path).await?;
+    if let Err(err) = apply_checkpoint_to_worktree(worktree, &before, &target).await {
+        return Err(rollback_restore(worktree, &target, &before, &safety_ref, err).await);
     }
 
     let changed = collect_changes(worktree, &before, &target, DiffBounds::default()).await?;
@@ -484,6 +472,146 @@ pub(crate) async fn restore_checkpoint(
         safety_ref,
         diffstat: changed.stat,
     })
+}
+
+/// Apply the checkpoint tree, then drop paths it does not hold.
+///
+/// Ignored files that exist on disk are copied aside first and written back
+/// after `read-tree`. A later gitignore rule would otherwise omit them from
+/// the safety snapshot while `--reset -u` still overwrote the live copy.
+async fn apply_checkpoint_to_worktree(
+    worktree: &Path,
+    before: &str,
+    target: &str,
+) -> Result<(), CheckpointError> {
+    let removed = removed_by_restore(worktree, before, target).await?;
+    let ignored_live = live_ignored_files_in_tree(worktree, target).await?;
+    apply_tree(worktree, target).await?;
+    restore_file_backups(worktree, &ignored_live).await?;
+    for path in removed {
+        remove_restored_path(worktree, &path).await?;
+    }
+    Ok(())
+}
+
+/// Put the worktree back to the pre-restore snapshot. The original error
+/// stays in front; every failure after the snapshot names the safety ref.
+async fn rollback_restore(
+    worktree: &Path,
+    attempted: &str,
+    previous: &str,
+    safety_ref: &str,
+    failed: CheckpointError,
+) -> CheckpointError {
+    if let Err(err) = apply_tree(worktree, previous).await {
+        return CheckpointError::internal(format!(
+            "{failed}; rolling back from {safety_ref} also failed: {err}"
+        ));
+    }
+    match removed_by_restore(worktree, attempted, previous).await {
+        Ok(paths) => {
+            for path in paths {
+                if let Err(err) = remove_restored_path(worktree, &path).await {
+                    return CheckpointError::internal(format!(
+                        "{failed}; rolling back from {safety_ref} also failed: {err}"
+                    ));
+                }
+            }
+        }
+        Err(err) => {
+            return CheckpointError::internal(format!(
+                "{failed}; rolling back from {safety_ref} also failed: {err}"
+            ));
+        }
+    }
+    CheckpointError::internal(format!("{failed}; previous files are at {safety_ref}"))
+}
+
+/// Files the checkpoint holds that exist on disk and are ignored now.
+///
+/// `add -A` never sees them, so the safety snapshot omits them. `read-tree
+/// --reset -u` still overwrites them, which is why restore writes these bytes
+/// back after apply.
+async fn live_ignored_files_in_tree(
+    worktree: &Path,
+    tree: &str,
+) -> Result<Vec<(GitPath, Vec<u8>)>, CheckpointError> {
+    let raw = git_bytes(
+        worktree,
+        &["ls-tree", "-r", "--name-only", "-z", tree],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    let mut backups = Vec::new();
+    for part in raw.split(|byte| *byte == 0).filter(|part| !part.is_empty()) {
+        if part == b".git" || part.starts_with(b".git/") {
+            continue;
+        }
+        let path = GitPath::from_bytes(part);
+        let relative = PathBuf::from(path.to_os_string().map_err(CheckpointError::internal)?);
+        if !relative
+            .components()
+            .all(|part| matches!(part, std::path::Component::Normal(_)))
+        {
+            continue;
+        }
+        let full = worktree.join(&relative);
+        if !full.is_file() {
+            continue;
+        }
+        if !path_is_ignored(worktree, &path).await? {
+            continue;
+        }
+        let bytes = tokio::fs::read(&full).await.map_err(|err| {
+            CheckpointError::internal(format!("could not read {}: {err}", path.to_wire()))
+        })?;
+        backups.push((path, bytes));
+    }
+    Ok(backups)
+}
+
+async fn path_is_ignored(worktree: &Path, path: &GitPath) -> Result<bool, CheckpointError> {
+    // `check-ignore` rejects `--literal-pathspecs`. `-q` is silent: exit 0
+    // means ignored, exit 1 means not, and both print nothing.
+    match git_text(
+        worktree,
+        &["check-ignore", "-q", "--", &path.to_wire()],
+        GIT_TIMEOUT,
+    )
+    .await
+    {
+        Ok(_) => Ok(true),
+        Err(err) if err.is_empty() => Ok(false),
+        Err(err) => Err(CheckpointError::internal(err)),
+    }
+}
+
+async fn restore_file_backups(
+    worktree: &Path,
+    backups: &[(GitPath, Vec<u8>)],
+) -> Result<(), CheckpointError> {
+    for (path, bytes) in backups {
+        let relative = PathBuf::from(path.to_os_string().map_err(CheckpointError::internal)?);
+        let full = worktree.join(&relative);
+        if full.is_dir() {
+            tokio::fs::remove_dir_all(&full).await.map_err(|err| {
+                CheckpointError::internal(format!(
+                    "could not replace {} with the ignored file: {err}",
+                    path.to_wire()
+                ))
+            })?;
+        }
+        if let Some(parent) = full.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|err| {
+                CheckpointError::internal(format!("could not restore {}: {err}", path.to_wire()))
+            })?;
+        }
+        tokio::fs::write(&full, bytes).await.map_err(|err| {
+            CheckpointError::internal(format!("could not restore {}: {err}", path.to_wire()))
+        })?;
+    }
+    Ok(())
 }
 
 /// Hidden ref for the worktree as it stood just before a restore.
@@ -540,6 +668,7 @@ async fn remove_restored_path(worktree: &Path, path: &GitPath) -> Result<(), Che
     if !relative
         .components()
         .all(|part| matches!(part, std::path::Component::Normal(_)))
+        || relative.components().any(|part| part.as_os_str() == ".git")
     {
         return Err(CheckpointError::internal(format!(
             "git reported a path outside the worktree: {}",
@@ -3414,6 +3543,129 @@ mod tests {
         .await
         .unwrap();
         assert!(listed.contains("later/new.txt"), "{listed}");
+    }
+
+    /// A path the checkpoint holds can later match a new ignore rule. The
+    /// safety snapshot then omits it, so restore must not let `read-tree`
+    /// overwrite the live ignored file.
+    #[tokio::test]
+    async fn a_restore_does_not_overwrite_a_file_that_became_ignored() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "ignore-drift");
+        let workspace_id = ws();
+        std::fs::write(tree.join("secret.txt"), "at the checkpoint\n").unwrap();
+        std::fs::write(tree.join("README.md"), "at the checkpoint\n").unwrap();
+        let recorded = record_checkpoint(
+            &tree,
+            workspace_id,
+            sess(),
+            1,
+            CodeTurnStatus::Completed,
+            None,
+            "main",
+        )
+        .await
+        .unwrap();
+
+        std::fs::write(tree.join(".gitignore"), "secret.txt\n").unwrap();
+        std::fs::write(tree.join("secret.txt"), "live ignored\n").unwrap();
+        std::fs::write(tree.join("README.md"), "after the checkpoint\n").unwrap();
+        // A cold index is the case the safety snapshot actually omits: the
+        // reusable checkpoint index still lists `secret.txt` from the earlier
+        // record, and `add -A` will not untrack it just because it is ignored
+        // now. Dropping that index matches a restore after a process restart.
+        if let Ok(index) = git_text(
+            &tree,
+            &["rev-parse", "--git-path", "tidebreak-checkpoint-index"],
+            GIT_TIMEOUT,
+        )
+        .await
+        {
+            let _ = std::fs::remove_file(tree.join(index));
+        }
+
+        let restored = restore_checkpoint(
+            &tree,
+            workspace_id,
+            &turn_at(1, Some(recorded.checkpoint_ref.clone())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(tree.join("secret.txt")).unwrap(),
+            "live ignored\n",
+            "an ignored file must survive restore even when the checkpoint held it"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("README.md")).unwrap(),
+            "at the checkpoint\n"
+        );
+        let listed = git_text(
+            &tree,
+            &["ls-tree", "-r", "--name-only", &restored.safety_ref],
+            GIT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert!(
+            !listed.contains("secret.txt"),
+            "the safety snapshot still respects gitignore: {listed}"
+        );
+    }
+
+    /// After apply, extras are deleted. If that delete fails, the worktree
+    /// must go back to the pre-restore snapshot and the error must name it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_delete_that_fails_rolls_back_and_names_the_safety_ref() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "delete-fails");
+        let workspace_id = ws();
+        std::fs::write(tree.join("README.md"), "at the checkpoint\n").unwrap();
+        let recorded = record_checkpoint(
+            &tree,
+            workspace_id,
+            sess(),
+            1,
+            CodeTurnStatus::Completed,
+            None,
+            "main",
+        )
+        .await
+        .unwrap();
+
+        std::fs::write(tree.join("README.md"), "after the checkpoint\n").unwrap();
+        std::fs::create_dir_all(tree.join("later")).unwrap();
+        std::fs::write(tree.join("later/new.txt"), "postdates it\n").unwrap();
+        std::fs::set_permissions(tree.join("later"), std::fs::Permissions::from_mode(0o555))
+            .unwrap();
+
+        let err = restore_checkpoint(
+            &tree,
+            workspace_id,
+            &turn_at(1, Some(recorded.checkpoint_ref.clone())),
+        )
+        .await
+        .unwrap_err();
+        let _ =
+            std::fs::set_permissions(tree.join("later"), std::fs::Permissions::from_mode(0o755));
+        let message = err.to_string();
+        assert!(
+            message.contains("/pre-restore/"),
+            "a post-apply failure must name the safety ref: {message}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("later/new.txt")).unwrap(),
+            "postdates it\n",
+            "a failed delete must roll the extras back"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("README.md")).unwrap(),
+            "after the checkpoint\n",
+            "a failed delete must roll applied files back"
+        );
     }
 
     /// Build a tree from raw index entries, bypassing the path checks `add`

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -434,8 +434,10 @@ pub(crate) async fn record_checkpoint(
 ///
 /// Files only. `HEAD`, the branch, the reflog, and the user's index are not
 /// written, so this is not a history rewrite and nothing the reader pushed
-/// moves. Ignored files are untouched: a checkpoint tree is built by `add -A`,
-/// which never sees them, so they are in neither side of the transition.
+/// moves. An ignored file keeps the content it holds now, even when the
+/// checkpoint names that path: `add -A` captured it before the ignore rule
+/// existed, so the tree carries the older bytes and the restore puts the live
+/// ones back.
 ///
 /// Nothing is destroyed on a failure. The worktree as it stands is snapshotted
 /// into a hidden safety ref before anything is written, the checkpoint's tree
@@ -557,10 +559,36 @@ async fn rollback_restore(
 /// `add -A` never sees them, so the safety snapshot omits them. `read-tree
 /// --reset -u` still overwrites them, which is why restore writes these bytes
 /// back after apply.
+///
+/// Gitignore governs untracked paths only, so one `ls-files --others
+/// --ignored` names every candidate and the tree listing says which of them
+/// the checkpoint holds. That is two processes rather than one per file in
+/// the tree.
 async fn live_ignored_files_in_tree(
     worktree: &Path,
     tree: &str,
 ) -> Result<Vec<(GitPath, Vec<u8>)>, CheckpointError> {
+    let listed = git_bytes(
+        worktree,
+        &[
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+        ],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    let ignored: std::collections::HashSet<&[u8]> = listed
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .collect();
+    if ignored.is_empty() {
+        return Ok(Vec::new());
+    }
+
     let raw = git_bytes(
         worktree,
         &["ls-tree", "-r", "--name-only", "-z", tree],
@@ -570,7 +598,7 @@ async fn live_ignored_files_in_tree(
     .map_err(CheckpointError::internal)?;
     let mut backups = Vec::new();
     for part in raw.split(|byte| *byte == 0).filter(|part| !part.is_empty()) {
-        if part == b".git" || part.starts_with(b".git/") {
+        if !ignored.contains(part) {
             continue;
         }
         let path = GitPath::from_bytes(part);
@@ -585,31 +613,12 @@ async fn live_ignored_files_in_tree(
         if !full.is_file() {
             continue;
         }
-        if !path_is_ignored(worktree, &path).await? {
-            continue;
-        }
         let bytes = tokio::fs::read(&full).await.map_err(|err| {
             CheckpointError::internal(format!("could not read {}: {err}", path.to_wire()))
         })?;
         backups.push((path, bytes));
     }
     Ok(backups)
-}
-
-async fn path_is_ignored(worktree: &Path, path: &GitPath) -> Result<bool, CheckpointError> {
-    // `check-ignore` rejects `--literal-pathspecs`. `-q` is silent: exit 0
-    // means ignored, exit 1 means not, and both print nothing.
-    match git_text(
-        worktree,
-        &["check-ignore", "-q", "--", &path.to_wire()],
-        GIT_TIMEOUT,
-    )
-    .await
-    {
-        Ok(_) => Ok(true),
-        Err(err) if err.is_empty() => Ok(false),
-        Err(err) => Err(CheckpointError::internal(err)),
-    }
 }
 
 async fn restore_file_backups(
@@ -3595,19 +3604,8 @@ mod tests {
         std::fs::write(tree.join(".gitignore"), "secret.txt\n").unwrap();
         std::fs::write(tree.join("secret.txt"), "live ignored\n").unwrap();
         std::fs::write(tree.join("README.md"), "after the checkpoint\n").unwrap();
-        // A cold index is the case the safety snapshot actually omits: the
-        // reusable checkpoint index still lists `secret.txt` from the earlier
-        // record, and `add -A` will not untrack it just because it is ignored
-        // now. Dropping that index matches a restore after a process restart.
-        if let Ok(index) = git_text(
-            &tree,
-            &["rev-parse", "--git-path", "tidebreak-checkpoint-index"],
-            GIT_TIMEOUT,
-        )
-        .await
-        {
-            let _ = std::fs::remove_file(tree.join(index));
-        }
+        // A cold index is the case the safety snapshot actually omits.
+        drop_reusable_index(&tree).await;
 
         let restored = restore_checkpoint(
             &tree,
@@ -3693,9 +3691,32 @@ mod tests {
         );
     }
 
+    /// Drop the reusable checkpoint index so the next snapshot is built cold.
+    ///
+    /// A warm index still lists a path from an earlier record, and `add -A`
+    /// does not untrack it just because it is ignored now, so the snapshot
+    /// holds it and the drift case cannot be reached. A restore after a
+    /// process restart is the cold case.
+    async fn drop_reusable_index(tree: &Path) {
+        if let Ok(index) = git_text(
+            tree,
+            &["rev-parse", "--git-path", "tidebreak-checkpoint-index"],
+            GIT_TIMEOUT,
+        )
+        .await
+        {
+            let _ = std::fs::remove_file(tree.join(index));
+        }
+    }
+
     /// A post-apply delete failure must not drop a live ignored file the
     /// checkpoint still names. That path is absent from the safety snapshot,
     /// so rollback's extra-delete would otherwise remove it.
+    ///
+    /// The rollback runs directly. Failing the delete from outside means
+    /// making a directory read-only, and `read-tree` cannot rewrite that
+    /// directory either, so the rollback stops at its own apply and never
+    /// reaches the delete pass this pins.
     #[tokio::test]
     async fn a_failed_restore_keeps_a_live_ignored_checkpoint_path() {
         let (_dir, repo) = init_repo();
@@ -3718,19 +3739,82 @@ mod tests {
         std::fs::write(tree.join(".gitignore"), "secret.txt\n").unwrap();
         std::fs::write(tree.join("secret.txt"), "live ignored\n").unwrap();
         std::fs::write(tree.join("README.md"), "after the checkpoint\n").unwrap();
-        std::fs::create_dir_all(tree.join("later")).unwrap();
-        std::fs::write(tree.join("later/new.txt"), "postdates it\n").unwrap();
-        std::fs::set_permissions(tree.join("later"), std::fs::Permissions::from_mode(0o555))
+        drop_reusable_index(&tree).await;
+
+        let safety_ref = pre_restore_ref(workspace_id);
+        let before = write_snapshot_ref(&tree, &safety_ref, None, "pre-restore snapshot")
+            .await
             .unwrap();
-        if let Ok(index) = git_text(
+        let target = resolve_checkpoint_oid(&tree, &recorded.checkpoint_ref)
+            .await
+            .unwrap();
+        let ignored_live = live_ignored_files_in_tree(&tree, &target).await.unwrap();
+        apply_tree(&tree, &target).await.unwrap();
+        restore_file_backups(&tree, &ignored_live).await.unwrap();
+
+        let err = rollback_restore(
             &tree,
-            &["rev-parse", "--git-path", "tidebreak-checkpoint-index"],
-            GIT_TIMEOUT,
+            &target,
+            &before,
+            &safety_ref,
+            &ignored_live,
+            CheckpointError::internal("the delete failed"),
+        )
+        .await;
+
+        assert_eq!(
+            std::fs::read_to_string(tree.join("secret.txt")).unwrap(),
+            "live ignored\n",
+            "rollback must not delete a live ignored file the checkpoint held"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("README.md")).unwrap(),
+            "after the checkpoint\n",
+            "rollback must put the snapshot's files back"
+        );
+        assert!(
+            err.to_string().contains(&safety_ref),
+            "a rollback must name the safety ref: {err}"
+        );
+    }
+
+    /// The plan is read before the first write. A failure reading it has
+    /// changed nothing, so restore returns as it stands: a rollback there
+    /// would delete the checkpoint's paths from a worktree that still holds
+    /// the reader's own files.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_failure_before_the_first_write_leaves_the_worktree_alone() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "plan-fails");
+        let workspace_id = ws();
+        std::fs::write(tree.join("secret.txt"), "at the checkpoint\n").unwrap();
+        std::fs::write(tree.join("README.md"), "at the checkpoint\n").unwrap();
+        let recorded = record_checkpoint(
+            &tree,
+            workspace_id,
+            sess(),
+            1,
+            CodeTurnStatus::Completed,
+            None,
+            "main",
         )
         .await
-        {
-            let _ = std::fs::remove_file(tree.join(index));
-        }
+        .unwrap();
+
+        std::fs::write(tree.join(".gitignore"), "secret.txt\n").unwrap();
+        std::fs::write(tree.join("secret.txt"), "live ignored\n").unwrap();
+        std::fs::write(tree.join("README.md"), "after the checkpoint\n").unwrap();
+        drop_reusable_index(&tree).await;
+        // Reading the ignored bytes fails, and that read happens before the
+        // first write.
+        std::fs::set_permissions(
+            tree.join("secret.txt"),
+            std::fs::Permissions::from_mode(0o000),
+        )
+        .unwrap();
 
         let err = restore_checkpoint(
             &tree,
@@ -3739,25 +3823,19 @@ mod tests {
         )
         .await
         .unwrap_err();
-        let _ =
-            std::fs::set_permissions(tree.join("later"), std::fs::Permissions::from_mode(0o755));
-        let message = err.to_string();
+        let _ = std::fs::set_permissions(
+            tree.join("secret.txt"),
+            std::fs::Permissions::from_mode(0o644),
+        );
+
         assert!(
-            message.contains("/pre-restore/"),
-            "a post-apply failure must name the safety ref: {message}"
-        );
-        assert_eq!(
-            std::fs::read_to_string(tree.join("secret.txt")).unwrap(),
-            "live ignored\n",
-            "rollback must not delete a live ignored file the checkpoint held"
-        );
-        assert_eq!(
-            std::fs::read_to_string(tree.join("later/new.txt")).unwrap(),
-            "postdates it\n"
+            tree.join("secret.txt").is_file(),
+            "a failure before the first write must not delete the reader's ignored file: {err}"
         );
         assert_eq!(
             std::fs::read_to_string(tree.join("README.md")).unwrap(),
-            "after the checkpoint\n"
+            "after the checkpoint\n",
+            "a failure before the first write must leave the worktree as it stands"
         );
     }
 

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -463,9 +463,7 @@ pub(crate) async fn restore_checkpoint(
     )
     .await?;
 
-    if let Err(err) = apply_checkpoint_to_worktree(worktree, &before, &target).await {
-        return Err(rollback_restore(worktree, &target, &before, &safety_ref, err).await);
-    }
+    apply_checkpoint_to_worktree(worktree, &before, &target, &safety_ref).await?;
 
     let changed = collect_changes(worktree, &before, &target, DiffBounds::default()).await?;
     Ok(RestoredCheckpoint {
@@ -479,28 +477,48 @@ pub(crate) async fn restore_checkpoint(
 /// Ignored files that exist on disk are copied aside first and written back
 /// after `read-tree`. A later gitignore rule would otherwise omit them from
 /// the safety snapshot while `--reset -u` still overwrote the live copy.
+/// Rollback runs only after that apply; a failure before `read-tree` leaves
+/// the worktree alone. After a rollback the copied bytes are written back,
+/// because the snapshot never held them.
 async fn apply_checkpoint_to_worktree(
     worktree: &Path,
     before: &str,
     target: &str,
+    safety_ref: &str,
 ) -> Result<(), CheckpointError> {
     let removed = removed_by_restore(worktree, before, target).await?;
     let ignored_live = live_ignored_files_in_tree(worktree, target).await?;
     apply_tree(worktree, target).await?;
-    restore_file_backups(worktree, &ignored_live).await?;
+    if let Err(err) = finish_checkpoint_apply(worktree, &removed, &ignored_live).await {
+        return Err(
+            rollback_restore(worktree, target, before, safety_ref, &ignored_live, err).await,
+        );
+    }
+    Ok(())
+}
+
+async fn finish_checkpoint_apply(
+    worktree: &Path,
+    removed: &[GitPath],
+    ignored_live: &[(GitPath, Vec<u8>)],
+) -> Result<(), CheckpointError> {
+    restore_file_backups(worktree, ignored_live).await?;
     for path in removed {
-        remove_restored_path(worktree, &path).await?;
+        remove_restored_path(worktree, path).await?;
     }
     Ok(())
 }
 
 /// Put the worktree back to the pre-restore snapshot. The original error
 /// stays in front; every failure after the snapshot names the safety ref.
+/// Ignored live copies are written last: they are not in the snapshot, so
+/// the extra-delete set includes them.
 async fn rollback_restore(
     worktree: &Path,
     attempted: &str,
     previous: &str,
     safety_ref: &str,
+    ignored_live: &[(GitPath, Vec<u8>)],
     failed: CheckpointError,
 ) -> CheckpointError {
     if let Err(err) = apply_tree(worktree, previous).await {
@@ -508,21 +526,28 @@ async fn rollback_restore(
             "{failed}; rolling back from {safety_ref} also failed: {err}"
         ));
     }
-    match removed_by_restore(worktree, attempted, previous).await {
+    let extras_err = match removed_by_restore(worktree, attempted, previous).await {
         Ok(paths) => {
+            let mut extras_err = None;
             for path in paths {
                 if let Err(err) = remove_restored_path(worktree, &path).await {
-                    return CheckpointError::internal(format!(
-                        "{failed}; rolling back from {safety_ref} also failed: {err}"
-                    ));
+                    extras_err = Some(err);
+                    break;
                 }
             }
+            extras_err
         }
-        Err(err) => {
-            return CheckpointError::internal(format!(
-                "{failed}; rolling back from {safety_ref} also failed: {err}"
-            ));
-        }
+        Err(err) => Some(err),
+    };
+    if let Err(err) = restore_file_backups(worktree, ignored_live).await {
+        return CheckpointError::internal(format!(
+            "{failed}; rolling back from {safety_ref} also failed: {err}"
+        ));
+    }
+    if let Some(err) = extras_err {
+        return CheckpointError::internal(format!(
+            "{failed}; rolling back from {safety_ref} also failed: {err}"
+        ));
     }
     CheckpointError::internal(format!("{failed}; previous files are at {safety_ref}"))
 }
@@ -3665,6 +3690,74 @@ mod tests {
             std::fs::read_to_string(tree.join("README.md")).unwrap(),
             "after the checkpoint\n",
             "a failed delete must roll applied files back"
+        );
+    }
+
+    /// A post-apply delete failure must not drop a live ignored file the
+    /// checkpoint still names. That path is absent from the safety snapshot,
+    /// so rollback's extra-delete would otherwise remove it.
+    #[tokio::test]
+    async fn a_failed_restore_keeps_a_live_ignored_checkpoint_path() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "ignore-drift-rollback");
+        let workspace_id = ws();
+        std::fs::write(tree.join("secret.txt"), "at the checkpoint\n").unwrap();
+        std::fs::write(tree.join("README.md"), "at the checkpoint\n").unwrap();
+        let recorded = record_checkpoint(
+            &tree,
+            workspace_id,
+            sess(),
+            1,
+            CodeTurnStatus::Completed,
+            None,
+            "main",
+        )
+        .await
+        .unwrap();
+
+        std::fs::write(tree.join(".gitignore"), "secret.txt\n").unwrap();
+        std::fs::write(tree.join("secret.txt"), "live ignored\n").unwrap();
+        std::fs::write(tree.join("README.md"), "after the checkpoint\n").unwrap();
+        std::fs::create_dir_all(tree.join("later")).unwrap();
+        std::fs::write(tree.join("later/new.txt"), "postdates it\n").unwrap();
+        std::fs::set_permissions(tree.join("later"), std::fs::Permissions::from_mode(0o555))
+            .unwrap();
+        if let Ok(index) = git_text(
+            &tree,
+            &["rev-parse", "--git-path", "tidebreak-checkpoint-index"],
+            GIT_TIMEOUT,
+        )
+        .await
+        {
+            let _ = std::fs::remove_file(tree.join(index));
+        }
+
+        let err = restore_checkpoint(
+            &tree,
+            workspace_id,
+            &turn_at(1, Some(recorded.checkpoint_ref.clone())),
+        )
+        .await
+        .unwrap_err();
+        let _ =
+            std::fs::set_permissions(tree.join("later"), std::fs::Permissions::from_mode(0o755));
+        let message = err.to_string();
+        assert!(
+            message.contains("/pre-restore/"),
+            "a post-apply failure must name the safety ref: {message}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("secret.txt")).unwrap(),
+            "live ignored\n",
+            "rollback must not delete a live ignored file the checkpoint held"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("later/new.txt")).unwrap(),
+            "postdates it\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("README.md")).unwrap(),
+            "after the checkpoint\n"
         );
     }
 

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -35,6 +35,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
+use chrono::Utc;
 use tidebreak_harness::{spawn_process_tree, BoundedProcessOutput, OutputBudget};
 use tokio::process::Command;
 use tokio::time::{timeout, timeout_at, Instant};
@@ -64,6 +65,9 @@ pub(crate) const MAX_DIFF_BYTES: usize = 256 * 1024;
 pub(crate) const MAX_DIFF_FILES: usize = 64;
 
 const REF_PREFIX: &str = "refs/tidebreak/checkpoints";
+/// Segment that separates a workspace's pre-restore safety snapshots from its
+/// per-session checkpoint chains. Never a session id, so the two cannot clash.
+const PRE_RESTORE_SEGMENT: &str = "pre-restore";
 const GIT_PATH_WIRE_PREFIX: &str = "tidebreak-path:v1:";
 
 /// Ordinal of a session's start baseline, one below its first turn.
@@ -171,6 +175,14 @@ pub(crate) struct BoundedDiff {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RecordedCheckpoint {
     pub checkpoint_ref: String,
+    pub diffstat: Diffstat,
+}
+
+/// A completed restore: where the pre-restore worktree is kept, and what
+/// putting the checkpoint back changed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RestoredCheckpoint {
+    pub safety_ref: String,
     pub diffstat: Diffstat,
 }
 
@@ -416,6 +428,165 @@ pub(crate) async fn record_checkpoint(
         checkpoint_ref: r#ref,
         diffstat: files.stat,
     })
+}
+
+/// Put the worktree back to what a turn's checkpoint holds.
+///
+/// Files only. `HEAD`, the branch, the reflog, and the user's index are not
+/// written, so this is not a history rewrite and nothing the reader pushed
+/// moves. Ignored files are untouched: a checkpoint tree is built by `add -A`,
+/// which never sees them, so they are in neither side of the transition.
+///
+/// The worktree as it stands is snapshotted into a hidden safety ref before
+/// anything is written, so a restore the reader did not mean is recoverable
+/// from the object database rather than gone.
+pub(crate) async fn restore_checkpoint(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    turn: &CodeTurn,
+) -> Result<RestoredCheckpoint, CheckpointError> {
+    let target_ref = turn
+        .checkpoint_ref
+        .as_deref()
+        .ok_or_else(|| CheckpointError::user("this turn has no checkpoint"))?;
+    let target = resolve_checkpoint_oid(worktree, target_ref)
+        .await
+        .ok_or_else(|| CheckpointError::user("this turn's checkpoint is gone"))?;
+
+    let safety_ref = pre_restore_ref(workspace_id);
+    let before = write_snapshot_ref(
+        worktree,
+        &safety_ref,
+        None,
+        &format!("pre-restore snapshot for turn {}", turn.ordinal),
+    )
+    .await?;
+
+    // `read-tree -u` writes every path the checkpoint holds but knows nothing
+    // about the ones it does not, because the private index it transitions
+    // from starts empty. Files created since the checkpoint are therefore this
+    // function's own work.
+    for path in removed_by_restore(worktree, &before, &target).await? {
+        remove_restored_path(worktree, &path).await?;
+    }
+    apply_tree(worktree, &target).await?;
+
+    let changed = collect_changes(worktree, &before, &target, DiffBounds::default()).await?;
+    Ok(RestoredCheckpoint {
+        safety_ref,
+        diffstat: changed.stat,
+    })
+}
+
+/// Hidden ref for the worktree as it stood just before a restore.
+///
+/// It sits under the workspace's own prefix, so [`delete_workspace_refs`]
+/// reaps it with everything else the workspace holds. The segment is not a
+/// session id, and a restore holds the workspace's turn lock for far longer
+/// than a millisecond, so two of these cannot collide.
+fn pre_restore_ref(workspace_id: WorkspaceId) -> String {
+    let stamp = Utc::now().format("%Y%m%dT%H%M%S%3fZ");
+    format!("{REF_PREFIX}/{workspace_id}/{PRE_RESTORE_SEGMENT}/{stamp}")
+}
+
+/// Paths a restore has to delete: in the worktree now, absent at the
+/// checkpoint.
+///
+/// Rename detection is off on purpose. `--find-renames` folds "old is gone,
+/// new appeared" into one `R` record, and the path that has to disappear is
+/// then named only as a rename's source — the restore would write the
+/// checkpoint's copy and leave the newer one beside it.
+async fn removed_by_restore(
+    worktree: &Path,
+    from: &str,
+    to: &str,
+) -> Result<Vec<GitPath>, CheckpointError> {
+    let raw = git_bytes(
+        worktree,
+        &[
+            "diff",
+            "--no-renames",
+            "--diff-filter=D",
+            "--name-only",
+            "-z",
+            from,
+            to,
+            "--",
+        ],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(CheckpointError::internal)?;
+    Ok(raw
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .map(GitPath::from_bytes)
+        .collect())
+}
+
+/// Delete one path the checkpoint predates, and any scaffolding it leaves.
+async fn remove_restored_path(worktree: &Path, path: &GitPath) -> Result<(), CheckpointError> {
+    let relative = PathBuf::from(path.to_os_string().map_err(CheckpointError::internal)?);
+    // Git reports repository-relative paths, so anything else is a bug or a
+    // hostile tree. Refuse rather than delete outside the worktree.
+    if !relative
+        .components()
+        .all(|part| matches!(part, std::path::Component::Normal(_)))
+    {
+        return Err(CheckpointError::internal(format!(
+            "git reported a path outside the worktree: {}",
+            path.to_wire()
+        )));
+    }
+    let full = worktree.join(&relative);
+    match tokio::fs::remove_file(&full).await {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(CheckpointError::internal(format!(
+                "could not remove {}: {err}",
+                path.to_wire()
+            )))
+        }
+    }
+    // A directory that held only files the checkpoint predates is scaffolding
+    // the restore should not leave behind. `remove_dir` refuses a non-empty
+    // one, which is the stopping condition.
+    let mut parent = full.parent();
+    while let Some(dir) = parent {
+        if dir == worktree || tokio::fs::remove_dir(dir).await.is_err() {
+            break;
+        }
+        parent = dir.parent();
+    }
+    Ok(())
+}
+
+/// Write `tree` into the worktree through a private index.
+///
+/// `read-tree` needs an index and it must not be the user's, so this uses a
+/// temporary one and deletes it before returning. `--reset -u` overwrites
+/// whatever sits at those paths, untracked files included, and touches nothing
+/// the tree does not name.
+async fn apply_tree(worktree: &Path, tree: &str) -> Result<(), CheckpointError> {
+    let temp = tempfile::NamedTempFile::new().map_err(|err| {
+        CheckpointError::internal(format!("could not create temporary index: {err}"))
+    })?;
+    let index_path = temp.path().to_path_buf();
+    // `git read-tree` wants to create the index; an empty file can confuse it.
+    drop(temp);
+    let _ = tokio::fs::remove_file(&index_path).await;
+
+    let index = index_path.to_string_lossy().into_owned();
+    let result = git_text_env(
+        worktree,
+        &["read-tree", "--reset", "-u", tree],
+        &[("GIT_INDEX_FILE", index.as_str())],
+        GIT_SNAPSHOT_TIMEOUT,
+    )
+    .await;
+    let _ = tokio::fs::remove_file(&index_path).await;
+    result.map(|_| ()).map_err(CheckpointError::internal)
 }
 
 /// Snapshot the worktree, commit it, and move `r#ref` onto the commit.
@@ -3025,5 +3196,154 @@ mod tests {
         .await
         .unwrap_err();
         assert!(!err.to_string().is_empty());
+    }
+
+    /// A turn row that only carries what a restore reads.
+    fn turn_at(ordinal: i64, checkpoint_ref: Option<String>) -> CodeTurn {
+        CodeTurn {
+            id: CodeTurnId::new(),
+            session_id: sess(),
+            ordinal,
+            status: CodeTurnStatus::Completed,
+            model: None,
+            fast_mode: false,
+            user_input: "edit the tree".into(),
+            user_input_blob_id: None,
+            attachments: Vec::new(),
+            checkpoint_ref,
+            diffstat: None,
+            usage: None,
+            narrative: None,
+            started_at: chrono::Utc::now(),
+            ended_at: None,
+        }
+    }
+
+    /// The round trip the whole feature rests on.
+    ///
+    /// An untracked file is the case a naive `git checkout` gets wrong twice
+    /// over: one that existed at the checkpoint has to come back, and one
+    /// created since has to go. An ignored file is in neither checkpoint tree,
+    /// so it has to survive both directions, and `HEAD` must not move.
+    #[tokio::test]
+    async fn a_restore_puts_untracked_files_back_and_keeps_a_safety_ref() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "restore");
+        let workspace_id = ws();
+        std::fs::write(tree.join(".gitignore"), "build/\n").unwrap();
+        std::fs::write(tree.join("scratch.txt"), "at the checkpoint\n").unwrap();
+        std::fs::write(tree.join("README.md"), "at the checkpoint\n").unwrap();
+        std::fs::create_dir_all(tree.join("build")).unwrap();
+        std::fs::write(tree.join("build/out.bin"), "ignored output\n").unwrap();
+
+        let recorded = record_checkpoint(
+            &tree,
+            workspace_id,
+            sess(),
+            1,
+            CodeTurnStatus::Completed,
+            None,
+            "main",
+        )
+        .await
+        .unwrap();
+        let head_before = git_text(&tree, &["rev-parse", "HEAD"], GIT_TIMEOUT)
+            .await
+            .unwrap();
+
+        // Everything the engine did after the turn ended.
+        std::fs::remove_file(tree.join("scratch.txt")).unwrap();
+        std::fs::write(tree.join("README.md"), "after the checkpoint\n").unwrap();
+        std::fs::create_dir_all(tree.join("later/nested")).unwrap();
+        std::fs::write(tree.join("later/nested/new.txt"), "postdates it\n").unwrap();
+        std::fs::write(tree.join("build/out.bin"), "rebuilt\n").unwrap();
+
+        let turn = turn_at(1, Some(recorded.checkpoint_ref.clone()));
+        let restored = restore_checkpoint(&tree, workspace_id, &turn)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(tree.join("scratch.txt")).unwrap(),
+            "at the checkpoint\n",
+            "an untracked file the checkpoint held must come back"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("README.md")).unwrap(),
+            "at the checkpoint\n"
+        );
+        assert!(
+            !tree.join("later/nested/new.txt").exists(),
+            "a file created after the checkpoint must be gone"
+        );
+        assert!(
+            !tree.join("later").exists(),
+            "the directory it created must go with it"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tree.join("build/out.bin")).unwrap(),
+            "rebuilt\n",
+            "an ignored file is in neither tree, so a restore must not touch it"
+        );
+        assert_eq!(
+            git_text(&tree, &["rev-parse", "HEAD"], GIT_TIMEOUT)
+                .await
+                .unwrap(),
+            head_before,
+            "a restore moves files, never HEAD"
+        );
+        assert_eq!(
+            git_text(&tree, &["rev-parse", "--abbrev-ref", "HEAD"], GIT_TIMEOUT)
+                .await
+                .unwrap(),
+            "tidebreak/restore"
+        );
+        assert!(restored.diffstat.files >= 3, "{:?}", restored.diffstat);
+
+        // The safety ref holds the worktree the restore replaced, so the work
+        // it discarded is still in the object database.
+        assert!(
+            restored.safety_ref.starts_with(&format!(
+                "{REF_PREFIX}/{workspace_id}/{PRE_RESTORE_SEGMENT}/"
+            )),
+            "{}",
+            restored.safety_ref
+        );
+        let listed = git_text(
+            &tree,
+            &["ls-tree", "-r", "--name-only", &restored.safety_ref],
+            GIT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert!(listed.contains("later/nested/new.txt"), "{listed}");
+        assert!(!listed.contains("scratch.txt"), "{listed}");
+        assert!(
+            !listed.contains("build/out.bin"),
+            "the safety snapshot respects .gitignore: {listed}"
+        );
+        assert!(
+            list_checkpoint_refs(&tree)
+                .await
+                .unwrap()
+                .contains(&restored.safety_ref),
+            "the safety ref must be reapable with the workspace's other refs"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_turn_without_a_checkpoint_cannot_be_restored() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "no-checkpoint");
+        let err = restore_checkpoint(&tree, ws(), &turn_at(1, None))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("no checkpoint"), "{err}");
+
+        let missing = checkpoint_ref(ws(), sess(), 7);
+        let err = restore_checkpoint(&tree, ws(), &turn_at(7, Some(missing)))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("gone"), "{err}");
     }
 }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -3103,6 +3103,18 @@ impl CodeRuntime {
                 "this turn has not finished, so it has no checkpoint yet",
             ));
         }
+        // The turn lock cannot see a fenced engine. That process may still
+        // be writing this checkout from outside this process, so a restore
+        // would rewrite files underneath it the same way a turn would.
+        if session.lifecycle == CodeSessionLifecycle::Fenced {
+            return Err(ServerError::conflict_kind(
+                "session_fenced",
+                "session is fenced until it is reaped",
+            ));
+        }
+        if let Some(reason) = self.workspace_fence_reason(owner, &session).await? {
+            return Err(ServerError::conflict_kind("workspace_fenced", reason));
+        }
 
         let restored = restore_checkpoint(
             std::path::Path::new(&workspace.worktree_path),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -282,6 +282,8 @@ pub(crate) struct WorkspaceMergeOutcome {
 /// What a restore put back, for the reader who asked for it.
 pub(crate) struct RestoredWorkspaceCheckpoint {
     pub turn_id: CodeTurnId,
+    /// Hidden ref holding the worktree the restore replaced.
+    pub safety_ref: String,
     pub diffstat: Diffstat,
 }
 
@@ -3130,6 +3132,7 @@ impl CodeRuntime {
         }
         Ok(RestoredWorkspaceCheckpoint {
             turn_id,
+            safety_ref: restored.safety_ref,
             diffstat: restored.diffstat,
         })
     }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -11,12 +11,12 @@ use tokio::sync::oneshot;
 use tokio::time::Instant as TokioInstant;
 
 use tidebreak_core::db::code::{
-    abandon_pending_approval, arm_trigger, begin_permission_mode_change,
+    abandon_pending_approval, append_event, arm_trigger, begin_permission_mode_change,
     cancel_permission_mode_change, claim_approval, compare_and_set_workspace_status,
     complete_workspace_archive, confirm_permission_mode_change, delete_trigger, delete_workspace,
     discard_permission_mode_change, fence_permission_mode_change, get_approval, get_open_turn,
-    get_repo, get_repo_by_root_path, get_session, get_workspace, insert_repo, insert_session,
-    insert_workspace, list_approvals, list_events, list_fork_events,
+    get_repo, get_repo_by_root_path, get_session, get_turn, get_workspace, insert_repo,
+    insert_session, insert_workspace, list_approvals, list_events, list_fork_events,
     list_pending_permission_mode_changes, list_repos, list_sessions, list_sessions_all_owners,
     list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
     list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head,
@@ -29,9 +29,9 @@ use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
     CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeRepo, CodeSession, CodeSessionId,
     CodeSessionKind, CodeSessionLifecycle, CodeTrigger, CodeTriggerAction, CodeTriggerCondition,
-    CodeTriggerId, CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore, Diffstat,
-    FenceReason, HarnessKind, OwnerId, PermissionMode, PullRequestDigest, QuickAction,
-    ReasoningEffort, RepoId, WorkspaceId,
+    CodeTriggerId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
+    DbStore, Diffstat, FenceReason, HarnessKind, OwnerId, PermissionMode, PullRequestDigest,
+    QuickAction, ReasoningEffort, RepoId, SequencedCodeEvent, WorkspaceId,
 };
 use tidebreak_harness::{
     builtin_registry, AdapterRegistry, ApprovalChannelSpec, ApprovalDecision, HarnessAdapter,
@@ -44,7 +44,7 @@ use super::browser_channel::{BrowserSubject, BrowserTokenRegistry};
 use super::bus::CodeEventBus;
 use super::checkpoint::{
     delete_workspace_refs, list_changed_files, produce_diff, record_session_baseline,
-    resolve_diff_range, ChangedFile, CheckpointError, DiffBounds,
+    resolve_diff_range, restore_checkpoint, ChangedFile, CheckpointError, DiffBounds,
 };
 use super::ci_logs;
 use super::clone::CloneJobs;
@@ -277,6 +277,12 @@ pub(crate) struct WorkspaceMergeOutcome {
     pub target: CodeDeliveryPullRequestTarget,
     pub accepted_head_sha: String,
     pub status: WorkspaceGitStatus,
+}
+
+/// What a restore put back, for the reader who asked for it.
+pub(crate) struct RestoredWorkspaceCheckpoint {
+    pub turn_id: CodeTurnId,
+    pub diffstat: Diffstat,
 }
 
 struct DeliveryNudgeState {
@@ -3052,6 +3058,80 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)
+    }
+
+    /// Put the workspace's files back to what a turn's checkpoint holds.
+    ///
+    /// The workspace's turn lock is the reservation, exactly as it is for a
+    /// turn (record 55): a database read of "is anything running" cannot be,
+    /// because two callers both pass it before either takes the tree. This
+    /// path never waits on that lock — a restore landing mid-turn would pull
+    /// files out from under a running engine — so contention answers
+    /// `workspace_busy` and the reader retries when the turn ends.
+    ///
+    /// Files only. `HEAD` and the branch do not move, and ignored files are
+    /// untouched.
+    pub(crate) async fn restore_workspace_to_turn(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+        turn_id: CodeTurnId,
+    ) -> Result<RestoredWorkspaceCheckpoint, ServerError> {
+        let lock = self.worktree_turn_lock(id);
+        let Ok(_turn_guard) = lock.try_lock() else {
+            return Err(ServerError::conflict_kind(
+                "workspace_busy",
+                "a turn is running in this workspace; restore once it ends",
+            ));
+        };
+        let workspace = self.require_live_workspace(owner, id).await?;
+        let turn = get_turn(&self.db, owner, turn_id)
+            .await?
+            .ok_or_else(|| ServerError::not_found("turn not found"))?;
+        let session = get_session(&self.db, owner, turn.session_id)
+            .await?
+            .ok_or_else(|| ServerError::not_found("session not found"))?;
+        // Another workspace's turn is indistinguishable from a missing one.
+        if session.workspace_id != workspace.id {
+            return Err(ServerError::not_found("turn not found"));
+        }
+        if turn.status == CodeTurnStatus::Running {
+            return Err(ServerError::conflict_kind(
+                "turn_running",
+                "this turn has not finished, so it has no checkpoint yet",
+            ));
+        }
+
+        let restored = restore_checkpoint(
+            std::path::Path::new(&workspace.worktree_path),
+            workspace.id,
+            &turn,
+        )
+        .await
+        .map_err(map_checkpoint)?;
+
+        let event = CodeEvent::CheckpointRestored {
+            turn_id,
+            diffstat: restored.diffstat.clone(),
+        };
+        match append_event(&self.db, owner, session.id, session.spawn_epoch, &event).await {
+            Ok(seq) => self
+                .bus
+                .publish(session.id, SequencedCodeEvent { seq, event }),
+            // The worktree already holds the checkpoint. A journal row that
+            // could not land is worth a log line, not a failure the reader
+            // would read as "nothing happened".
+            Err(err) => tracing::warn!(
+                session = %session.id,
+                turn = %turn_id,
+                error = %err,
+                "restore succeeded but its journal row did not land"
+            ),
+        }
+        Ok(RestoredWorkspaceCheckpoint {
+            turn_id,
+            diffstat: restored.diffstat,
+        })
     }
 
     async fn require_live_workspace(

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -33,7 +33,10 @@ use super::checkpoint::ChangedFile;
 use super::clone::CloneRequest;
 use super::delivery;
 use super::gh::{self, ActionOutcome, CommitOutcome, PushOutcome, WorkspaceGitStatus};
-use super::runtime::{CodeRuntime, NewSessionSettings, RepoRegistration, SubmitTurnOutcome};
+use super::runtime::{
+    CodeRuntime, NewSessionSettings, RepoRegistration, RestoredWorkspaceCheckpoint,
+    SubmitTurnOutcome,
+};
 use super::worktree;
 use crate::error::ServerError;
 use crate::principal::AuthContext;
@@ -558,6 +561,16 @@ impl ScopedCode {
     ) -> Result<ActionOutcome, ServerError> {
         self.runtime
             .run_workspace_action(&self.owner, id, name)
+            .await
+    }
+
+    pub(crate) async fn restore_workspace_to_turn(
+        &self,
+        id: WorkspaceId,
+        turn_id: CodeTurnId,
+    ) -> Result<RestoredWorkspaceCheckpoint, ServerError> {
+        self.runtime
+            .restore_workspace_to_turn(&self.owner, id, turn_id)
             .await
     }
 

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -908,6 +908,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::restore_workspace),
         )
         .route(
+            "/code/workspaces/{id}/restore-checkpoint",
+            post(routes::code::restore_workspace_checkpoint),
+        )
+        .route(
             "/code/workspaces/{id}/retry-setup",
             post(routes::code::retry_workspace_setup),
         )

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -79,8 +79,8 @@ pub(crate) use types::{
     CodeActionSnapshot, CodeAnalyticsDay, CodeAnalyticsHarness, CodeAnalyticsModel,
     CodeAnalyticsPricingCoverage, CodeAnalyticsRange, CodeAnalyticsRepository,
     CodeAnalyticsSnapshot, CodeAnalyticsTotals, CodeApprovalDecisionBody, CodeApprovalSnapshot,
-    CodeCheckLog, CodeCheckLogError, CodeCheckLogsSnapshot, CodeCloneDefaults,
-    CodeCloneJobSnapshot, CodeCommitSnapshot, CodeDeliveryActionResult,
+    CodeCheckLog, CodeCheckLogError, CodeCheckLogsSnapshot, CodeCheckpointRestore,
+    CodeCloneDefaults, CodeCloneJobSnapshot, CodeCommitSnapshot, CodeDeliveryActionResult,
     CodeDeliveryPullRequestActionBody, CodeDeliveryPullRequestDetail, CodeDeliveryPullRequestFile,
     CodeDeliveryPullRequestQuery, CodeDeliveryPullRequestTarget, CodeDeliveryPullRequestsPage,
     CodeDeliveryRepositoriesSnapshot, CodeDeliveryRunActionBody, CodeDeliveryRunDetail,
@@ -93,16 +93,16 @@ pub(crate) use types::{
     CodeWorkspacePrSnapshot, CodeWorkspacePullRequests, CodeWorkspaceSearch,
     CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot,
     CreateCodeTriggerBody, HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
-    ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame, SetCodeWorktreeRootBody,
-    UpdateCodeTriggerBody,
+    ResolveCodeDeliveryRepositoriesBody, RestoreCheckpointBody, SequencedCodeEventFrame,
+    SetCodeWorktreeRootBody, UpdateCodeTriggerBody,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
     get_worktree_root, list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace,
-    release_workspace, restore_workspace, retry_workspace_setup, search_workspace,
-    set_worktree_root,
+    release_workspace, restore_workspace, restore_workspace_checkpoint, retry_workspace_setup,
+    search_workspace, set_worktree_root,
 };
 
 // Nothing here reaches `AppState.code` directly. Every handler in this module

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -849,6 +849,26 @@ impl From<CodeWatch> for CodeWatchSnapshot {
     }
 }
 
+/// Body of `POST /code/workspaces/{id}/restore-checkpoint`.
+#[derive(Debug, Deserialize, Serialize, TS)]
+#[serde(deny_unknown_fields)]
+pub struct RestoreCheckpointBody {
+    /// The turn whose checkpoint the worktree goes back to.
+    pub turn_id: CodeTurnId,
+}
+
+/// What restoring a workspace to a turn's checkpoint changed.
+///
+/// Files only: the branch and `HEAD` stayed where they were, and ignored
+/// files were not touched.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeCheckpointRestore {
+    /// The turn the worktree now matches.
+    pub turn_id: CodeTurnId,
+    /// Bounded diffstat of what the restore changed.
+    pub stat: Diffstat,
+}
+
 /// Body of `POST /code/workspaces/{id}/pr/merge`.
 #[derive(Debug, Deserialize, Serialize, TS)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -865,6 +865,12 @@ pub struct RestoreCheckpointBody {
 pub struct CodeCheckpointRestore {
     /// The turn the worktree now matches.
     pub turn_id: CodeTurnId,
+    /// Hidden ref holding the worktree the restore replaced.
+    ///
+    /// Nothing is lost by a restore: this ref is a full snapshot of what the
+    /// worktree held a moment before, so the desktop can name it and the
+    /// reader can recover from it with git.
+    pub safety_ref: String,
     /// Bounded diffstat of what the restore changed.
     pub stat: Diffstat,
 }

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -8,11 +8,12 @@ use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
 
 use super::types::{
-    ArchiveWorkspaceBody, CodeFileChange, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
-    CodeWorkspaceSearch, CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot, CodeWorkspaceTree,
-    CodeWorktreeRoot, CreateWorkspaceBody, ListWorkspacesQuery, PatchWorkspaceBody,
-    SetCodeWorktreeRootBody, WorkspaceBlobQuery, WorkspaceDiffQuery, WorkspaceFilesQuery,
-    WorkspaceSearchQuery, WorkspaceTreeQuery,
+    ArchiveWorkspaceBody, CodeCheckpointRestore, CodeFileChange, CodeWorkspaceBlob,
+    CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
+    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, CreateWorkspaceBody,
+    ListWorkspacesQuery, PatchWorkspaceBody, RestoreCheckpointBody, SetCodeWorktreeRootBody,
+    WorkspaceBlobQuery, WorkspaceDiffQuery, WorkspaceFilesQuery, WorkspaceSearchQuery,
+    WorkspaceTreeQuery,
 };
 use tidebreak_core::WorkspaceId;
 
@@ -141,6 +142,28 @@ pub async fn retry_workspace_setup(
 ) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
     let workspace = code.retry_workspace_setup(id).await?;
     Ok(Json(CodeWorkspaceSnapshot::from(workspace)))
+}
+
+/// `POST /code/workspaces/{id}/restore-checkpoint` — put the files back to a
+/// turn.
+///
+/// Not `/restore`, which reactivates an archived workspace. This one touches
+/// files: the worktree goes back to what the turn's checkpoint holds, the
+/// branch and `HEAD` stay where they are, and ignored files are left alone.
+/// The worktree as it stands is snapshotted into a hidden ref first. 409
+/// kinds: `workspace_busy` (a turn holds the workspace's checkout),
+/// `workspace_not_ready`, `turn_running`, and `no_checkpoint` (the turn ended
+/// before checkpoints, or its ref was reaped).
+pub async fn restore_workspace_checkpoint(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+    Json(body): Json<RestoreCheckpointBody>,
+) -> Result<Json<CodeCheckpointRestore>, ServerError> {
+    let restored = code.restore_workspace_to_turn(id, body.turn_id).await?;
+    Ok(Json(CodeCheckpointRestore {
+        turn_id: restored.turn_id,
+        stat: restored.diffstat,
+    }))
 }
 
 pub async fn list_workspace_tree(

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -152,8 +152,9 @@ pub async fn retry_workspace_setup(
 /// branch and `HEAD` stay where they are, and ignored files are left alone.
 /// The worktree as it stands is snapshotted into a hidden ref first. 409
 /// kinds: `workspace_busy` (a turn holds the workspace's checkout),
-/// `workspace_not_ready`, `turn_running`, and `no_checkpoint` (the turn ended
-/// before checkpoints, or its ref was reaped).
+/// `workspace_not_ready`, `turn_running`, `session_fenced`,
+/// `workspace_fenced` (a sibling is fenced until it is reaped), and
+/// `no_checkpoint` (the turn ended before checkpoints, or its ref was reaped).
 pub async fn restore_workspace_checkpoint(
     code: ScopedCode,
     Path(id): Path<WorkspaceId>,

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -162,6 +162,7 @@ pub async fn restore_workspace_checkpoint(
     let restored = code.restore_workspace_to_turn(id, body.turn_id).await?;
     Ok(Json(CodeCheckpointRestore {
         turn_id: restored.turn_id,
+        safety_ref: restored.safety_ref,
         stat: restored.diffstat,
     }))
 }

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -6446,6 +6446,237 @@ async fn a_completed_turn_records_a_checkpoint_and_serves_bounded_review() {
     );
 }
 
+/// The whole point of the hidden refs: a reader can put the files back.
+///
+/// The route restores an untracked file the checkpoint held, drops one
+/// created since, leaves an ignored build artifact alone, and leaves `HEAD`
+/// exactly where it was.
+#[tokio::test]
+async fn restoring_a_turn_checkpoint_rewinds_the_files_and_journals_it() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let worktree = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    std::fs::write(worktree.join(".gitignore"), "build/\n").unwrap();
+    std::fs::write(worktree.join("scratch.txt"), "at the checkpoint\n").unwrap();
+    std::fs::write(worktree.join("README.md"), "at the checkpoint\n").unwrap();
+    std::fs::create_dir_all(worktree.join("build")).unwrap();
+    std::fs::write(worktree.join("build/out.bin"), "ignored output\n").unwrap();
+
+    let turn = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "edit the tree" }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(turn["status"], "completed");
+    let head_before = git_head(&worktree);
+
+    std::fs::remove_file(worktree.join("scratch.txt")).unwrap();
+    std::fs::write(worktree.join("README.md"), "after the checkpoint\n").unwrap();
+    std::fs::create_dir_all(worktree.join("later")).unwrap();
+    std::fs::write(worktree.join("later/new.txt"), "postdates it\n").unwrap();
+    std::fs::write(worktree.join("build/out.bin"), "rebuilt\n").unwrap();
+
+    let restored = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/restore-checkpoint",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "turn_id": json_id(&turn) }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(restored.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = restored.json().await.unwrap();
+    assert_eq!(body["turn_id"], turn["id"]);
+    assert!(body["stat"]["files"].as_u64().unwrap() >= 3, "{body}");
+
+    assert_eq!(
+        std::fs::read_to_string(worktree.join("scratch.txt")).unwrap(),
+        "at the checkpoint\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree.join("README.md")).unwrap(),
+        "at the checkpoint\n"
+    );
+    assert!(!worktree.join("later").exists());
+    assert_eq!(
+        std::fs::read_to_string(worktree.join("build/out.bin")).unwrap(),
+        "rebuilt\n",
+        "a restore must not touch ignored files"
+    );
+    assert_eq!(
+        git_head(&worktree),
+        head_before,
+        "a restore never moves HEAD"
+    );
+
+    let refs = for_each_checkpoint_ref(&repo);
+    assert!(
+        refs.iter().any(|name| name.contains("/pre-restore/")),
+        "the pre-restore safety snapshot must survive the restore: {refs:?}"
+    );
+
+    let events = journaled_events(&runtime.db, json_id(&session).parse().unwrap()).await;
+    assert!(
+        events.iter().any(|framed| {
+            matches!(
+                framed.event,
+                tidebreak_core::CodeEvent::CheckpointRestored { .. }
+            )
+        }),
+        "expected CheckpointRestored in {events:?}"
+    );
+}
+
+/// The worktree takes one writer at a time (record 55). A restore that landed
+/// mid-turn would pull files out from under a running engine, so it answers
+/// the busy conflict instead of waiting for the lock.
+#[tokio::test]
+async fn a_running_turn_refuses_a_checkpoint_restore() {
+    let (router, token, runtime, dir) =
+        code_app_with(ScriptedAdapter::new(approval_script()).with_approvals(CapLevel::Supported))
+            .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let (mut events, _) = runtime.bus.attach(parsed);
+
+    // Parking on an approval keeps the turn — and its hold on the worktree —
+    // open on an event the test can wait for, rather than a wall-clock race.
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "edit the tree" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let running_turn_id = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let CodeEvent::TurnStarted { turn_id } = events.recv().await.unwrap().event {
+                break turn_id;
+            }
+        }
+    })
+    .await
+    .expect("turn never started");
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/restore-checkpoint",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "turn_id": running_turn_id.to_string() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "workspace_busy");
+
+    let _ = client
+        .post(format!(
+            "http://{addr}/code/sessions/{session_id}/interrupt"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await;
+    let _ = turn.await;
+}
+
+fn git_head(worktree: &std::path::Path) -> String {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(worktree)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_owned()
+}
+
+fn for_each_checkpoint_ref(repo: &std::path::Path) -> Vec<String> {
+    let out = std::process::Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/tidebreak/checkpoints/",
+        ])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 #[tokio::test]
 async fn a_failed_checkpoint_does_not_fail_the_turn() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -6643,6 +6643,119 @@ async fn a_running_turn_refuses_a_checkpoint_restore() {
     let _ = turn.await;
 }
 
+/// A fenced engine may still be writing the checkout. The turn lock cannot
+/// see it, so a restore is the same write a turn is and answers the same
+/// conflict until a reap settles the process.
+#[tokio::test]
+async fn a_fenced_session_refuses_a_checkpoint_restore() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let turn = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "edit the tree" }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(turn["status"], "completed");
+
+    let owner = tidebreak_core::OwnerId::local();
+    let session_id: CodeSessionId = json_id(&session).parse().unwrap();
+    let mut row = tidebreak_core::db::code::get_session(&runtime.db, &owner, session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    mark_as_exited_orphan(&mut row);
+    tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/restore-checkpoint",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "turn_id": json_id(&turn) }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "session_fenced");
+}
+
+#[tokio::test]
+async fn a_fenced_sibling_closes_the_workspace_to_a_checkpoint_restore() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let ids = create_sibling_sessions(&client, addr, &token, &workspace, 2).await;
+    let turn = client
+        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "edit the tree" }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(turn["status"], "completed");
+
+    let owner = tidebreak_core::OwnerId::local();
+    let fenced_id: CodeSessionId = ids[0].parse().unwrap();
+    let mut row = tidebreak_core::db::code::get_session(&runtime.db, &owner, fenced_id)
+        .await
+        .unwrap()
+        .unwrap();
+    mark_as_exited_orphan(&mut row);
+    tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/restore-checkpoint",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "turn_id": json_id(&turn) }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "workspace_fenced");
+}
+
 fn git_head(worktree: &std::path::Path) -> String {
     let out = std::process::Command::new("git")
         .args(["rev-parse", "HEAD"])

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -6586,8 +6586,7 @@ async fn a_running_turn_refuses_a_checkpoint_restore() {
         .json::<serde_json::Value>()
         .await
         .unwrap();
-    let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
     let (mut events, _) = runtime.bus.attach(parsed);
 
     // Parking on an approval keeps the turn — and its hold on the worktree —
@@ -6595,10 +6594,13 @@ async fn a_running_turn_refuses_a_checkpoint_restore() {
     let turn = tokio::spawn({
         let client = client.clone();
         let token = token.clone();
-        let session_id = session_id.clone();
+        let session = session.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!(
+                    "http://{addr}/code/sessions/{}/turns",
+                    json_id(&session)
+                ))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "edit the tree" }))
                 .send()
@@ -6632,7 +6634,8 @@ async fn a_running_turn_refuses_a_checkpoint_restore() {
 
     let _ = client
         .post(format!(
-            "http://{addr}/code/sessions/{session_id}/interrupt"
+            "http://{addr}/code/sessions/{}/interrupt",
+            json_id(&session)
         ))
         .bearer_auth(&token)
         .send()

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -441,6 +441,10 @@ mod tests {
         // The merge request body, so the renderer sends exactly the accepted
         // method vocabulary.
         generate::collect_from::<crate::routes::code::MergeCodePrBody>(&cfg, &mut out);
+        // The restore request and its result: the renderer sends a turn id and
+        // reads back what putting that checkpoint back changed.
+        generate::collect_from::<crate::routes::code::RestoreCheckpointBody>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeCheckpointRestore>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeDeliveryRepositoriesSnapshot>(
             &cfg, &mut out,
         );

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -225,9 +225,6 @@ purpose:
   modelctl-managed gateway auth, and the hosted relay all work without
   pointing spawn at a different executable. Revisit when a machine has a
   real need to run a newer or custom binary than the pin.
-- **Checkpoint restore.** Per-turn checkpoints land with v1 as hidden refs
-  and power turn-scoped diffs; the surface that restores a workspace to an
-  earlier checkpoint waits until review flows have settled.
 - **Parallel turns in one worktree.** Several agents may share a workspace
   ([record 55](decisions/0055-multiple-sessions-per-workspace.md)), but their
   turns are serialized on the checkout: two harnesses editing one tree is

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -944,6 +944,22 @@ export type CodeCheckLogsSnapshot = {
 head_sha?: string, logs: Array<CodeCheckLog>, errors: Array<CodeCheckLogError>, };
 
 /**
+ * What restoring a workspace to a turn's checkpoint changed.
+ *
+ * Files only: the branch and `HEAD` stayed where they were, and ignored
+ * files were not touched.
+ */
+export type CodeCheckpointRestore = { 
+/**
+ * The turn the worktree now matches.
+ */
+turn_id: CodeTurnId, 
+/**
+ * Bounded diffstat of what the restore changed.
+ */
+stat: Diffstat, };
+
+/**
  * Remembered clone destination plus observed `gh` status.
  */
 export type CodeCloneDefaults = { parent_dir?: string, gh_found: boolean, gh_authenticated?: boolean, gh_remediation: string, };
@@ -1298,6 +1314,14 @@ error: BoundedError, } | { "type": "turn_interrupted" } | { "type": "checkpoint_
 turn_id: CodeTurnId, 
 /**
  * Bounded diffstat.
+ */
+diffstat: Diffstat, } | { "type": "checkpoint_restored", 
+/**
+ * The turn whose checkpoint the worktree now holds.
+ */
+turn_id: CodeTurnId, 
+/**
+ * Bounded diffstat of what the restore changed.
  */
 diffstat: Diffstat, } | { "type": "harness_notice", 
 /**
@@ -3908,6 +3932,15 @@ export type ResolveCodeDeliveryRepositoriesBody = { repositories: Array<string>,
  * Whether a `rest_api` record's referenced credential currently resolves.
  */
 export type RestCredentialStatus = "none" | "configured" | "missing";
+
+/**
+ * Body of `POST /code/workspaces/{id}/restore-checkpoint`.
+ */
+export type RestoreCheckpointBody = { 
+/**
+ * The turn whose checkpoint the worktree goes back to.
+ */
+turn_id: CodeTurnId, };
 
 /**
  * One thing a call surfaced.

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -955,6 +955,14 @@ export type CodeCheckpointRestore = {
  */
 turn_id: CodeTurnId, 
 /**
+ * Hidden ref holding the worktree the restore replaced.
+ *
+ * Nothing is lost by a restore: this ref is a full snapshot of what the
+ * worktree held a moment before, so the desktop can name it and the
+ * reader can recover from it with git.
+ */
+safety_ref: string, 
+/**
  * Bounded diffstat of what the restore changed.
  */
 stat: Diffstat, };


### PR DESCRIPTION
Per-turn checkpoints have existed as hidden refs since [record 32](https://github.com/brightwave-inc/tidebreak/blob/main/docs/decisions/0032-code-workspaces-worktrees-checkpoints.md), but nothing could read one back. This adds the restore path end to end.

## What it does

`restore_checkpoint` snapshots the worktree into a pre-restore safety ref, deletes the files that postdate the checkpoint, then writes the checkpoint's tree through a private index. Files only: `HEAD`, the branch, the reflog, and the user's index are untouched, and ignored files sit in neither tree so they survive.

Rename detection is off when computing what to delete. `--find-renames` folds a disappearing path into an `R` record, so the old copy would be left beside the restored one.

The runtime path takes the workspace's turn lock without waiting — a restore landing mid-turn would pull files out from under a running engine — so contention answers `409 workspace_busy`. It journals `CheckpointRestored` next to `CheckpointRecorded`.

The route is `POST /code/workspaces/{id}/restore-checkpoint`. `/restore` already reactivates an archived workspace.

In the transcript, the per-turn seam menu gains "Restore to this point" behind a confirmation that says how far the restore reaches: ignored files stay, and nothing moves the branch.

## Tests

- `a_restore_puts_untracked_files_back_and_keeps_a_safety_ref` — the round trip an untracked file gets wrong twice over: one that existed at the checkpoint comes back, one created since goes, an ignored build artifact survives, and `HEAD` does not move.
- `restoring_a_turn_checkpoint_rewinds_the_files_and_journals_it` — the same through the route, including the safety ref and the journal row.
- `a_running_turn_refuses_a_checkpoint_restore` — a turn parked on an approval holds the checkout, so the restore answers the busy conflict.
- `a_turn_without_a_checkpoint_cannot_be_restored` — no ref, and a reaped ref.
- Two renderer tests for the seam menu: the confirmation states the limits and nothing reaches the host until the reader accepts; cancelling calls nothing.
- A `Code/Turn review card` story showing the full per-turn menu and its confirmation.

## Checks

`cargo check -p tidebreak-server`, `cargo fmt --all --check`, the new server tests plus the rest of `code::checkpoint::tests` (32 passed), `UPDATE_WIRE_TYPES=1` and `UPDATE_CODE_JOURNAL_FIXTURE=1` regeneration, biome format and lint, the full renderer vitest suite (2152 passed), `tsc --noEmit`, and `storybook:build`. The mobile copy of `wire.ts` is byte-identical to the generated one.

Closes #2797
