### PR TITLE
fix(code): block engines with no policy-compatible mode

### DIFF
--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -86,6 +86,10 @@ it("clamps a requested mode down to a managed ceiling", () => {
   expect(clampPermissionMode("plan", "ask")).toBe("plan");
   expect(clampPermissionMode("allow", null)).toBe("allow");
   expect(clampPermissionMode("allow", undefined)).toBe("allow");
+  expect(clampPermissionMode("allow", "ask", ["plan", "auto", "allow"])).toBe(
+    "plan",
+  );
+  expect(clampPermissionMode("allow", "ask", ["auto", "allow"])).toBeNull();
 });
 
 /**

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -60,17 +60,34 @@ function autonomyRank(mode: PermissionMode): number {
 }
 
 /**
- * The mode a create or start should post under a managed ceiling: the
- * requested posture when it is at or below the ceiling, otherwise the
- * ceiling itself. Chat create already seeds this way server-side; code
- * posts an explicit mode, so the client has to clamp before the request.
+ * The mode a create or start should post under a managed ceiling. Keep the
+ * requested posture when the engine supports it and policy permits it.
+ * Otherwise, choose the most autonomous supported posture at or below the
+ * ceiling. Return `null` when the engine has no policy-compatible posture.
+ * Chat create already clamps server-side; code posts an explicit mode, so the
+ * client resolves the supported posture before the request.
  */
 export function clampPermissionMode(
   mode: PermissionMode,
   ceiling: PermissionMode | null | undefined,
-): PermissionMode {
-  if (ceiling == null) return mode;
-  return autonomyRank(mode) > autonomyRank(ceiling) ? ceiling : mode;
+  availableModes: readonly PermissionMode[] = PERMISSION_MODE_SCALE.map(
+    (option) => option.value,
+  ),
+): PermissionMode | null {
+  const ceilingRank =
+    ceiling == null ? Number.POSITIVE_INFINITY : autonomyRank(ceiling);
+  if (availableModes.includes(mode) && autonomyRank(mode) <= ceilingRank) {
+    return mode;
+  }
+
+  let fallback: PermissionMode | null = null;
+  for (const candidate of availableModes) {
+    if (autonomyRank(candidate) > ceilingRank) continue;
+    if (fallback === null || autonomyRank(candidate) > autonomyRank(fallback)) {
+      fallback = candidate;
+    }
+  }
+  return fallback;
 }
 
 export function permissionModeOption(mode: PermissionMode | null) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -108,6 +108,7 @@ function appendRecoveredDraft(current: string, recovered: string): string {
 export function PermissionModePicker({
   value,
   availableModes = MODES,
+  unavailableReason,
   disabled,
   pending,
   onChange,
@@ -127,7 +128,7 @@ export function PermissionModePicker({
       scopeKey={scopeKey}
       value={value}
       clampDisplay={false}
-      disabled={locked || disabled || pending}
+      disabled={locked || Boolean(unavailableReason) || disabled || pending}
       availableModes={availableModes}
       onChange={async (mode: PermissionMode) => {
         if (!availableModes.includes(mode)) {
@@ -143,6 +144,13 @@ export function PermissionModePicker({
         <span className="inline-flex" aria-busy="true">
           {menu}
         </span>
+      </WithTooltip>
+    );
+  }
+  if (unavailableReason) {
+    return (
+      <WithTooltip label={unavailableReason}>
+        <span className="inline-flex">{menu}</span>
       </WithTooltip>
     );
   }
@@ -659,6 +667,7 @@ export function CodeComposer({
   running,
   permissionMode,
   availableModes = MODES,
+  unavailableReason,
   harness,
   model,
   modelOptions,
@@ -690,6 +699,7 @@ export function CodeComposer({
   running: boolean;
   permissionMode: PermissionMode;
   availableModes?: readonly PermissionMode[];
+  /** Why no permission mode can start this session. */
   unavailableReason?: string;
   harness?: HarnessKind;
   model?: string;
@@ -1086,10 +1096,12 @@ export function CodeComposer({
   // carries it in the workspace header instead of under every draft.
   const unsupervisedNote = sessionId
     ? null
-    : unsupervisedModeStatement(
-        permissionMode,
-        availableModes.includes("auto") && !availableModes.includes("ask"),
-      );
+    : unavailableReason
+      ? null
+      : unsupervisedModeStatement(
+          permissionMode,
+          availableModes.includes("auto") && !availableModes.includes("ask"),
+        );
 
   return (
     <div className="relative shrink-0 px-[clamp(0.5rem,4%,5rem)] pb-2">
@@ -1150,6 +1162,7 @@ export function CodeComposer({
           <PermissionModePicker
             value={permissionMode}
             availableModes={availableModes}
+            unavailableReason={unavailableReason}
             pending={settingsPending}
             onChange={onModeChange}
             scopeKey={sessionId ?? "code-create"}
@@ -1218,6 +1231,11 @@ export function CodeComposer({
             {unsupervisedNote && (
               <p className="text-muted-foreground text-xs">
                 {unsupervisedNote}
+              </p>
+            )}
+            {unavailableReason && (
+              <p className="text-muted-foreground text-xs">
+                {unavailableReason}
               </p>
             )}
             {footerNote}

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -25,7 +25,7 @@ import {
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
-import { ALLOW_ALL_NOTE } from "./labels";
+import { ALLOW_ALL_NOTE, PERMISSION_MODE_POLICY_BLOCKED } from "./labels";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import type { ReasoningEffort } from "../api/types";
 import type { CodeTurnSubmission, ParsedHarnessModel } from "./parsers";
@@ -653,6 +653,67 @@ describe("NewWorkspaceDialog", () => {
         model: "sonnet",
       }),
     );
+  });
+
+  it("blocks create when policy leaves the engine no supported mode", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    const grok = harness("grok");
+    grok.caps = {
+      ...grok.caps,
+      plan_mode: "unsupported",
+      structured_approvals: "unsupported",
+    };
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: { harnesses: [grok], notices: [] } as never,
+    });
+    useCodeUiStore.setState({
+      lastCreate: {
+        harness: "grok",
+        modelsByHarness: {},
+        permissionMode: "allow",
+      },
+    });
+    const createCodeWorkspace = vi.fn();
+    const capped: ManagedPolicy = {
+      managed: false,
+      source: "unmanaged",
+      misconfigured: false,
+      allow_local_mcp_servers: false,
+      permission_mode_ceiling: "ask",
+    };
+    await renderWithRouter(
+      <ManagedPolicyContext.Provider value={capped}>
+        <AppContextProvider
+          value={app({
+            createCodeWorkspace,
+            listCodeHarnessModels: vi.fn(async () => ({
+              kind: "grok" as const,
+              models: [],
+              reasoning_efforts: [],
+              fast_mode: false,
+            })),
+          })}
+        >
+          <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+        </AppContextProvider>
+      </ManagedPolicyContext.Provider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(
+      await screen.findByText(PERMISSION_MODE_POLICY_BLOCKED),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Permissions: Allow all" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Create/ })).toBeDisabled();
+
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+    expect(createCodeWorkspace).not.toHaveBeenCalled();
   });
 
   it("creates on Enter in the message; Shift+Enter stays a newline", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -62,6 +62,7 @@ import {
   gatewayCodeModels,
   harnessCanStartNow,
   harnessUnusableReason,
+  PERMISSION_MODE_POLICY_BLOCKED,
   preferredCodeModels,
   requiresHarnessModelIds,
   unsupervisedModeStatement,
@@ -316,28 +317,38 @@ export function NewWorkspaceDialog({
   const honors = (mode: PermissionMode | null | undefined) =>
     mode && availableModes.includes(mode) ? mode : undefined;
   const ceiling = useManagedPolicy().permission_mode_ceiling;
-  const postedMode = clampPermissionMode(
+  const requestedMode =
     honors(permissionMode) ??
-      honors(lastCreate?.permissionMode) ??
-      (selectedHarness
-        ? defaultCreatePermissionMode(selectedHarness.caps)
-        : "plan"),
+    honors(lastCreate?.permissionMode) ??
+    (selectedHarness
+      ? defaultCreatePermissionMode(selectedHarness.caps)
+      : "plan");
+  const permittedMode = clampPermissionMode(
+    requestedMode,
     ceiling,
+    availableModes,
   );
+  const postedMode = permittedMode ?? requestedMode;
+  const policyBlocksCreate = Boolean(selectedHarness && permittedMode === null);
   // The posture create is about to post is never silent: a mode that runs
   // with nobody to ask says so next to the control (decisions 0038, 0039).
-  const unsupervisedNote = selectedHarness
-    ? unsupervisedModeStatement(
-        postedMode,
-        autoIsUnsupervised(selectedHarness.caps),
-      )
-    : null;
+  const unsupervisedNote =
+    selectedHarness && !policyBlocksCreate
+      ? unsupervisedModeStatement(
+          postedMode,
+          autoIsUnsupervised(selectedHarness.caps),
+        )
+      : null;
   // An engine still downloading is a legal pick, not a legal start: create
   // would sit on the same npm install with nothing but a spinner. The install
   // note under the pills says what the wait is, and any engine already on
   // disk is one pick away.
   const canCreate = Boolean(
-    repoId && selectedRepo && selectedHarness && installed,
+    repoId &&
+      selectedRepo &&
+      selectedHarness &&
+      installed &&
+      !policyBlocksCreate,
   );
   const installNote = install && (!install.done || install.error);
 
@@ -961,7 +972,9 @@ export function NewWorkspaceDialog({
                       scopeKey="code-create"
                       value={postedMode}
                       clampDisplay={false}
-                      disabled={availableModes.length === 0}
+                      disabled={
+                        availableModes.length === 0 || policyBlocksCreate
+                      }
                       availableModes={availableModes}
                       onChange={(mode) => setPermissionMode(mode)}
                       {...pickerProps("mode")}
@@ -977,6 +990,11 @@ export function NewWorkspaceDialog({
                 {unsupervisedNote && (
                   <p className="text-muted-foreground px-2 text-xs">
                     {unsupervisedNote}
+                  </p>
+                )}
+                {policyBlocksCreate && (
+                  <p className="text-muted-foreground px-2 text-xs">
+                    {PERMISSION_MODE_POLICY_BLOCKED}
                   </p>
                 )}
               </div>

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -17,7 +17,11 @@ import { ManagedPolicyContext } from "../managedPolicy";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
-import { ALLOW_ALL_NOTE, UNSUPERVISED_AUTO_NOTE } from "./labels";
+import {
+  ALLOW_ALL_NOTE,
+  PERMISSION_MODE_POLICY_BLOCKED,
+  UNSUPERVISED_AUTO_NOTE,
+} from "./labels";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 import type { ReasoningEffort } from "../api/types";
 import type { ParsedHarnessModel } from "./parsers";
@@ -222,6 +226,47 @@ describe("StartSessionPrompt", () => {
       null,
       false,
     );
+  });
+
+  it("blocks start when policy leaves the engine no supported mode", async () => {
+    const onStart = vi.fn();
+    const capped: ManagedPolicy = {
+      managed: false,
+      source: "unmanaged",
+      misconfigured: false,
+      allow_local_mcp_servers: false,
+      permission_mode_ceiling: "ask",
+    };
+    await renderWithRouter(
+      wrap(
+        <ManagedPolicyContext.Provider value={capped}>
+          <StartSessionPrompt
+            workspaceId="workspace-1"
+            harnesses={[
+              entry("grok", {
+                plan_mode: "unsupported",
+                structured_approvals: "unsupported",
+              }),
+            ]}
+            starting={false}
+            selectedMode={null}
+            onSelectMode={vi.fn()}
+            onStart={onStart}
+          />
+        </ManagedPolicyContext.Provider>,
+      ),
+    );
+
+    expect(
+      screen.getByText(PERMISSION_MODE_POLICY_BLOCKED),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(ALLOW_ALL_NOTE)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Permissions: Allow all" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+    expect(onStart).not.toHaveBeenCalled();
   });
 
   it("says opencode's mode is fixed once the session starts", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -29,6 +29,7 @@ import {
   harnessCanStartNow,
   harnessUnusableReason,
   preferredCodeModels,
+  PERMISSION_MODE_POLICY_BLOCKED,
   type CodeModelOption,
 } from "./labels";
 
@@ -115,14 +116,19 @@ export function StartSessionPrompt({
     selectable[0];
   const availableModes = selected ? createPermissionModes(selected.caps) : [];
   const ceiling = useManagedPolicy().permission_mode_ceiling;
-  const mode: PermissionMode = clampPermissionMode(
+  const requestedMode: PermissionMode =
     selectedMode && availableModes.includes(selectedMode)
       ? selectedMode
       : selected
         ? defaultCreatePermissionMode(selected.caps)
-        : "plan",
+        : "plan";
+  const permittedMode = clampPermissionMode(
+    requestedMode,
     ceiling,
+    availableModes,
   );
+  const mode = permittedMode ?? requestedMode;
+  const policyBlocksStart = Boolean(selected && permittedMode === null);
 
   const selectedKind = selected?.kind;
   const model = selectedKind ? modelsByHarness[selectedKind] : undefined;
@@ -231,10 +237,13 @@ export function StartSessionPrompt({
       </div>
       <div className="mt-auto">
         <CodeComposer
-          disabled={starting || !selected || !installed}
+          disabled={starting || !selected || !installed || policyBlocksStart}
           running={starting}
           permissionMode={mode}
           availableModes={availableModes}
+          unavailableReason={
+            policyBlocksStart ? PERMISSION_MODE_POLICY_BLOCKED : undefined
+          }
           harness={selected?.kind}
           model={model}
           modelOptions={modelOptions}

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -93,6 +93,10 @@ export const PERMISSION_MODE_LABELS: Record<PermissionMode, string> = {
 export const PERMISSION_MODE_UNAVAILABLE_REASON =
   "this harness cannot honor that mode";
 
+/** Shown when managed policy leaves an engine with no mode it can honor. */
+export const PERMISSION_MODE_POLICY_BLOCKED =
+  "This engine has no permission mode allowed by your organization's policy.";
+
 /**
  * Shown where the mode is fixed for the life of the surface — a create form
  * that has already posted, a read-only view of someone else's session, or a

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -13,12 +13,15 @@ import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type {
   CodeRepoSnapshot,
   HarnessKind,
+  ManagedPolicy,
+  PermissionMode,
   ReasoningEffort,
 } from "@/api/types";
 import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "@/code/CodeUiStore";
 import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
 import { NewWorkspaceDialog } from "@/code/NewWorkspaceDialog";
+import { ManagedPolicyContext } from "@/managedPolicy";
 import {
   harnessDoctor,
   harnessDoctorCold,
@@ -232,9 +235,13 @@ function withRouter(children: ReactNode) {
 function NewWorkspace({
   doctor = harnessDoctor,
   installs,
+  initialHarness,
+  permissionModeCeiling,
 }: {
   doctor?: typeof harnessDoctor;
   installs?: typeof harnessInstallsInFlight;
+  initialHarness?: HarnessKind;
+  permissionModeCeiling?: PermissionMode;
 }) {
   // Seed the catalog before the dialog mounts: its defaults read the store.
   const [seeded, setSeeded] = useState(false);
@@ -246,14 +253,28 @@ function NewWorkspace({
       workspaces: [],
     });
     useCodeUpdatesStore.setState({ harnessInstalls: installs ?? {} });
-    useCodeUiStore.setState({ newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT });
+    useCodeUiStore.setState({
+      lastCreate: initialHarness
+        ? { harness: initialHarness, modelsByHarness: {} }
+        : null,
+      newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT,
+    });
     setSeeded(true);
-  }, [doctor, installs]);
+  }, [doctor, initialHarness, installs]);
   if (!seeded) return null;
+  const policy: ManagedPolicy = {
+    managed: Boolean(permissionModeCeiling),
+    source: permissionModeCeiling ? "os" : "unmanaged",
+    misconfigured: false,
+    allow_local_mcp_servers: false,
+    permission_mode_ceiling: permissionModeCeiling,
+  };
   return (
-    <AppContextProvider value={appContext()}>
-      <NewWorkspaceDialog open onOpenChange={fn()} repos={repos} />
-    </AppContextProvider>
+    <ManagedPolicyContext.Provider value={policy}>
+      <AppContextProvider value={appContext()}>
+        <NewWorkspaceDialog open onOpenChange={fn()} repos={repos} />
+      </AppContextProvider>
+    </ManagedPolicyContext.Provider>
   );
 }
 
@@ -386,5 +407,28 @@ export const EngineDownloading: Story = {
         done: false,
       },
     },
+  },
+};
+
+/** The selected engine has no mode at or below the managed ceiling. */
+export const BlockedByManagedCeiling: Story = {
+  args: {
+    doctor: {
+      ...harnessDoctor,
+      harnesses: harnessDoctor.harnesses
+        .filter((entry) => entry.kind === "grok")
+        .map((entry) => ({ ...entry, authenticated: true, remediation: "" })),
+    },
+    initialHarness: "grok",
+    permissionModeCeiling: "ask",
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(
+      page.findByText(
+        "This engine has no permission mode allowed by your organization's policy.",
+      ),
+    ).resolves.toBeVisible();
+    await expect(page.getByRole("button", { name: /Create/ })).toBeDisabled();
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
@@ -9,11 +9,17 @@ import {
 } from "@tanstack/react-router";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
-import type { CodeForkTranscript, HarnessKind } from "@/api/types";
+import type {
+  CodeForkTranscript,
+  HarnessKind,
+  ManagedPolicy,
+  PermissionMode,
+} from "@/api/types";
 import { useCodeUiStore } from "@/code/CodeUiStore";
 import { forkFraming, forkTranscriptFile } from "@/code/fork";
 import type { ParsedHarnessModel } from "@/code/parsers";
 import { StartSessionPrompt } from "@/code/StartSessionPrompt";
+import { ManagedPolicyContext } from "@/managedPolicy";
 import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
 
 /**
@@ -128,10 +134,12 @@ function StartSession({
   harnesses,
   starting = false,
   fork,
+  permissionModeCeiling,
 }: {
   harnesses: typeof harnessDoctor.harnesses;
   starting?: boolean;
   fork?: CodeForkTranscript;
+  permissionModeCeiling?: PermissionMode;
 }) {
   // A fork seeds the framing lines the same way the workspace page does, so
   // the story shows the state the reader actually lands in.
@@ -139,25 +147,34 @@ function StartSession({
     if (!fork) return;
     useCodeUiStore.getState().offerComposerPrompt("ws-1", forkFraming(fork));
   }, [fork]);
+  const policy: ManagedPolicy = {
+    managed: Boolean(permissionModeCeiling),
+    source: permissionModeCeiling ? "os" : "unmanaged",
+    misconfigured: false,
+    allow_local_mcp_servers: false,
+    permission_mode_ceiling: permissionModeCeiling,
+  };
   return (
-    <AppContextProvider value={appContext()}>
-      <div className="flex h-full flex-col">
-        <StartSessionPrompt
-          workspaceId="ws-1"
-          harnesses={harnesses}
-          starting={starting}
-          selectedMode={null}
-          onSelectMode={fn()}
-          onStart={fn()}
-          client={client}
-          workspaceFiles={
-            fork
-              ? { items: [forkTranscriptFile(fork)], onRemove: fn() }
-              : undefined
-          }
-        />
-      </div>
-    </AppContextProvider>
+    <ManagedPolicyContext.Provider value={policy}>
+      <AppContextProvider value={appContext()}>
+        <div className="flex h-full flex-col">
+          <StartSessionPrompt
+            workspaceId="ws-1"
+            harnesses={harnesses}
+            starting={starting}
+            selectedMode={null}
+            onSelectMode={fn()}
+            onStart={fn()}
+            client={client}
+            workspaceFiles={
+              fork
+                ? { items: [forkTranscriptFile(fork)], onRemove: fn() }
+                : undefined
+            }
+          />
+        </div>
+      </AppContextProvider>
+    </ManagedPolicyContext.Provider>
   );
 }
 
@@ -184,6 +201,16 @@ export const Starting: Story = {
 /** Engines that need install or sign-in before a session can start. */
 export const NeedsSetup: Story = {
   args: { harnesses: harnessDoctorDegraded.harnesses },
+};
+
+/** Managed policy blocks engines that cannot honor any mode under its ceiling. */
+export const BlockedByManagedCeiling: Story = {
+  args: {
+    harnesses: harnessDoctor.harnesses
+      .filter((entry) => entry.kind === "grok")
+      .map((entry) => ({ ...entry, authenticated: true, remediation: "" })),
+    permissionModeCeiling: "ask",
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

- choose the most autonomous engine-supported permission mode that stays at or below the managed policy ceiling
- block workspace or session creation when an engine has no policy-compatible mode
- explain the block beside the disabled permission and create controls
- cover both creation surfaces and the selection helper with regressions
- add Storybook states for the blocked new-workspace and start-session surfaces

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui format`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui lint`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/PermissionModeMenu.dom.test.tsx src/code/NewWorkspaceDialog.dom.test.tsx src/code/StartSessionPrompt.dom.test.tsx` — 51 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- `git diff --check main...HEAD`

Sixteen Storybook screenshots cover both states at 720 px and 1280 px in light, dark, high-contrast light, and high-contrast dark themes.