### PR TITLE
fix(mobile): restore Expo web export

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -60,7 +60,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "expo-router",
     "expo-secure-store",
     "expo-web-browser",
-    "expo-linking",
   ],
   extra: {
     appVariant: VARIANT,

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -30,6 +30,7 @@
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.23.0",
+    "react-native-web": "0.21.2",
     "zustand": "5.0.8"
   },
   "devDependencies": {

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-native-screens:
         specifier: 4.23.0
         version: 4.23.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native-web:
+        specifier: 0.21.2
+        version: 0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       zustand:
         specifier: 5.0.8
         version: 5.0.8(@types/react@19.2.7)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
@@ -1380,6 +1383,9 @@ packages:
     resolution: {integrity: sha512-Pg0DmsJ/DbLP8JuxnRSDmrIaQjKhpzd2uYAZRyB2A8fJQzJWpAFLr7TUAXhiGD5025F6+PVPAnJL3HXaeMfZqQ==}
     engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
 
+  '@react-native/normalize-colors@0.74.89':
+    resolution: {integrity: sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg==}
+
   '@react-native/normalize-colors@0.83.1':
     resolution: {integrity: sha512-84feABbmeWo1kg81726UOlMKAhcQyFXYz2SjRKYkS78QmfhVDhJ2o/ps1VjhFfBz0i/scDwT1XNv9GwmRIghkg==}
 
@@ -2125,9 +2131,15 @@ packages:
     resolution: {integrity: sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==}
     engines: {node: '>=6.4.0'}
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-in-js-utils@3.1.0:
+    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -2510,6 +2522,12 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
+  fbjs-css-vars@1.0.2:
+    resolution: {integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==}
+
+  fbjs@3.0.5:
+    resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2674,6 +2692,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  hyphenate-style-name@1.1.0:
+    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2701,6 +2722,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inline-style-prefixer@7.0.1:
+    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -3055,6 +3079,9 @@ packages:
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -3264,6 +3291,15 @@ packages:
   negotiator@1.1.0:
     resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
     engines: {node: '>=18'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
@@ -3476,6 +3512,9 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  promise@7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
 
@@ -3579,6 +3618,12 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-web@0.21.2:
+    resolution: {integrity: sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-native-worklets@0.8.3:
     resolution: {integrity: sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==}
@@ -3750,6 +3795,9 @@ packages:
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -3877,6 +3925,9 @@ packages:
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
 
+  styleq@0.1.3:
+    resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3966,6 +4017,9 @@ packages:
   toqr@0.1.1:
     resolution: {integrity: sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -4004,6 +4058,10 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ua-parser-js@1.0.41:
+    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
 
   undici-types@8.3.0:
@@ -4179,11 +4237,17 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-url-minimum@0.1.2:
     resolution: {integrity: sha512-XPEm0XFQWNVG292lII1PrRRJl3sItrs7CettZ4ncYxuDVpLyy+NwlGyut2hXI0JswcJUxeCH+CyOJK0ZzAXD6A==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5941,6 +6005,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@react-native/normalize-colors@0.74.89': {}
+
   '@react-native/normalize-colors@0.83.1': {}
 
   '@react-native/normalize-colors@0.83.10': {}
@@ -6747,11 +6813,21 @@ snapshots:
     dependencies:
       browserslist: 4.28.8
 
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-in-js-utils@3.1.0:
+    dependencies:
+      hyphenate-style-name: 1.1.0
 
   cssesc@3.0.0: {}
 
@@ -7164,6 +7240,20 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
+  fbjs-css-vars@1.0.2: {}
+
+  fbjs@3.0.5:
+    dependencies:
+      cross-fetch: 3.2.0
+      fbjs-css-vars: 1.0.2
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      promise: 7.3.1
+      setimmediate: 1.0.5
+      ua-parser-js: 1.0.41
+    transitivePeerDependencies:
+      - encoding
+
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
@@ -7318,6 +7408,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hyphenate-style-name@1.1.0: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -7339,6 +7431,10 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  inline-style-prefixer@7.0.1:
+    dependencies:
+      css-in-js-utils: 3.1.0
 
   invariant@2.2.4:
     dependencies:
@@ -7650,6 +7746,8 @@ snapshots:
   marky@1.3.0: {}
 
   memoize-one@5.2.1: {}
+
+  memoize-one@6.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -8076,6 +8174,10 @@ snapshots:
     dependencies:
       content-type: 2.1.0
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-forge@1.4.0: {}
 
   node-int64@0.4.0: {}
@@ -8262,6 +8364,10 @@ snapshots:
 
   progress@2.0.3: {}
 
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
+
   promise@8.3.0:
     dependencies:
       asap: 2.0.6
@@ -8367,6 +8473,21 @@ snapshots:
       react-freeze: 1.0.4(react@19.2.8)
       react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
       warn-once: 0.1.1
+
+  react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@react-native/normalize-colors': 0.74.89
+      fbjs: 3.0.5
+      inline-style-prefixer: 7.0.1
+      memoize-one: 6.0.0
+      nullthrows: 1.1.1
+      postcss-value-parser: 4.2.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      styleq: 0.1.3
+    transitivePeerDependencies:
+      - encoding
 
   react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1):
     dependencies:
@@ -8603,6 +8724,8 @@ snapshots:
 
   server-only@0.0.1: {}
 
+  setimmediate@1.0.5: {}
+
   setprototypeof@1.2.0: {}
 
   sf-symbols-typescript@2.2.0: {}
@@ -8699,6 +8822,8 @@ snapshots:
       js-tokens: 9.0.1
 
   structured-headers@0.4.1: {}
+
+  styleq@0.1.3: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -8809,6 +8934,8 @@ snapshots:
 
   toqr@0.1.1: {}
 
+  tr46@0.0.3: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -8839,6 +8966,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  ua-parser-js@1.0.41: {}
 
   undici-types@8.3.0: {}
 
@@ -8997,9 +9126,16 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@3.0.1: {}
+
   whatwg-fetch@3.6.20: {}
 
   whatwg-url-minimum@0.1.2: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/mobile/src/expoConfig.test.ts
+++ b/mobile/src/expoConfig.test.ts
@@ -1,0 +1,66 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const mobileRoot = join(here, "..");
+const expoCli = join(mobileRoot, "node_modules/expo/bin/cli");
+
+type PublicExpoConfig = {
+  scheme?: string;
+  android?: {
+    intentFilters?: Array<{
+      action?: string;
+      data?: Array<{ scheme?: string; host?: string }>;
+      category?: string[];
+    }>;
+  };
+  extra?: {
+    oauthRedirectUri?: string;
+  };
+};
+
+function resolvePublicConfig(appVariant: string): PublicExpoConfig {
+  const result = spawnSync(
+    process.execPath,
+    [expoCli, "config", "--type", "public", "--json"],
+    {
+      cwd: mobileRoot,
+      encoding: "utf8",
+      env: { ...process.env, APP_VARIANT: appVariant },
+    },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      ["Expo config resolution failed.", result.stdout, result.stderr]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+
+  return JSON.parse(result.stdout) as PublicExpoConfig;
+}
+
+describe("Expo config", () => {
+  it.each([
+    ["production", "tidebreak"],
+    ["staging", "tidebreak-staging"],
+    ["development", "tidebreak-dev"],
+  ])(
+    "resolves the %s config with its deep-link contract",
+    (appVariant, scheme) => {
+      const config = resolvePublicConfig(appVariant);
+
+      expect(config.scheme).toBe(scheme);
+      expect(config.extra?.oauthRedirectUri).toBe(`${scheme}://callback`);
+      expect(config.android?.intentFilters).toContainEqual({
+        action: "VIEW",
+        autoVerify: false,
+        data: [{ scheme, host: "callback" }],
+        category: ["BROWSABLE", "DEFAULT"],
+      });
+    },
+  );
+});

--- a/mobile/src/lib/storage.test.ts
+++ b/mobile/src/lib/storage.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SESSION_STORAGE_KEY,
+  storageForOs,
+  type SecureStorage,
+} from "./storage";
+import { TokenStore, type TokenHttp } from "./tokenStore";
+
+function throwingNative(): SecureStorage {
+  const boom = async () => {
+    throw new Error("expo-secure-store web stub");
+  };
+  return {
+    getItem: vi.fn(boom),
+    setItem: vi.fn(boom),
+    deleteItem: vi.fn(boom),
+  };
+}
+
+describe("storageForOs", () => {
+  it("hydrates on web without calling the native stub", async () => {
+    const native = throwingNative();
+    const store = new TokenStore(storageForOs("web", native), {
+      postForm: vi.fn(),
+    } as TokenHttp);
+    await expect(store.hydrate()).resolves.toBeNull();
+    expect(native.getItem).not.toHaveBeenCalled();
+  });
+
+  it("persists a session in memory on web", async () => {
+    const native = throwingNative();
+    const store = new TokenStore(storageForOs("web", native), {
+      postForm: vi.fn(),
+    } as TokenHttp);
+    await store.replace({
+      gatewayUrl: "https://gateway.example.test",
+      refreshToken: "mg_rt_0",
+      accessTokens: [],
+    });
+    expect(store.snapshot()?.refreshToken).toBe("mg_rt_0");
+    expect(native.setItem).not.toHaveBeenCalled();
+  });
+
+  it("uses native storage off web", async () => {
+    const native = throwingNative();
+    native.getItem = vi.fn(async () => null);
+    await expect(
+      storageForOs("ios", native).getItem(SESSION_STORAGE_KEY),
+    ).resolves.toBeNull();
+    expect(native.getItem).toHaveBeenCalledWith(SESSION_STORAGE_KEY);
+  });
+});

--- a/mobile/src/lib/storage.ts
+++ b/mobile/src/lib/storage.ts
@@ -20,3 +20,8 @@ export function memoryStorage(): SecureStorage {
     },
   };
 }
+
+/** expo-secure-store's web module is an empty stub, so persist in memory there. */
+export function storageForOs(os: string, native: SecureStorage): SecureStorage {
+  return os === "web" ? memoryStorage() : native;
+}

--- a/mobile/src/session/runtime.ts
+++ b/mobile/src/session/runtime.ts
@@ -1,7 +1,8 @@
+import { Platform } from "react-native";
 import * as SecureStore from "expo-secure-store";
 import { TokenStore } from "../lib/tokenStore";
 import { fetchTokenHttp } from "../lib/gateway";
-import type { SecureStorage } from "../lib/storage";
+import { storageForOs, type SecureStorage } from "../lib/storage";
 
 const expoStorage: SecureStorage = {
   getItem: (key) => SecureStore.getItemAsync(key),
@@ -9,4 +10,7 @@ const expoStorage: SecureStorage = {
   deleteItem: (key) => SecureStore.deleteItemAsync(key),
 };
 
-export const tokenStore = new TokenStore(expoStorage, fetchTokenHttp());
+export const tokenStore = new TokenStore(
+  storageForOs(Platform.OS, expoStorage),
+  fetchTokenHttp(),
+);


### PR DESCRIPTION
Fixes #2792

## What changed

- Removed the invalid `expo-linking` config-plugin entry while retaining `expo-linking` as the runtime deep-link dependency.
- Preserved production, staging, and development schemes, OAuth callback URIs, and Android callback intent filters.
- Added the exact `react-native-web` dependency required by Expo web export.
- Added a focused regression that resolves the real public Expo configuration for all three app variants.

## Validation

```text
pnpm@10.18.3 install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
Done in 2.6s using pnpm v10.18.3
```

```text
vitest run src/expoConfig.test.ts
Test Files  1 passed (1)
Tests       3 passed (3)
```

```text
pnpm typecheck: exit 0
pnpm lint: exit 0

Test Files  16 passed (16)
Tests       58 passed (58)
```

Resolved public Expo configuration:

```text
{"name":"Tidebreak","scheme":"tidebreak","oauthRedirectUri":"tidebreak://callback","plugins":["expo-router","expo-secure-store","expo-web-browser"],"androidCallback":"tidebreak://callback"}
{"name":"Tidebreak Staging","scheme":"tidebreak-staging","oauthRedirectUri":"tidebreak-staging://callback","plugins":["expo-router","expo-secure-store","expo-web-browser"],"androidCallback":"tidebreak-staging://callback"}
{"name":"Tidebreak Dev","scheme":"tidebreak-dev","oauthRedirectUri":"tidebreak-dev://callback","plugins":["expo-router","expo-secure-store","expo-web-browser"],"androidCallback":"tidebreak-dev://callback"}
```

```text
EXPO_OFFLINE=1 EXPO_NO_TELEMETRY=1 CI=1 expo export --platform web
Web Bundled 2765ms node_modules/expo-router/entry.js (1303 modules)

› web bundles (3):
_expo/static/css/web-ff16f6ebeb327f6e3bf6bcf012c8e0c2.css (12KB)
_expo/static/js/web/entry-7b0f00adcafaafb8240917362cc156da.js (2.3MB)
_expo/static/js/web/fetch-ffccacea105760e197fc3fb68b010d17.js (770B)

› Files (2):
index.html (1.4KB)
metadata.json (49B)

Exported: /tmp/tidebreak-2792-web-export-restacked.XLGOLl
```

Artifact inspection:

```text
index.html                         1362 bytes
metadata.json                        49 bytes
CSS bundle                        11975 bytes
entry JavaScript bundle         2253868 bytes
fetch JavaScript bundle              770 bytes
title=Tidebreak
rootElement=true
bundler=metro
bundleMarker=tidebreak://callback present=true
```

## Review

Three incremental review rounds completed. No P1 or P2 findings remain; no P3 nits were found.