### PR TITLE
feat(code): hosted machines list the gateway catalog as each engine's models

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -187,7 +187,7 @@ import {
   parseCodeWatch,
   parseCodePrComments,
   parseHarnessModelList,
-  type ParsedHarnessModel,
+  type ParsedHarnessModelList,
   parseHarnessDoctorReport,
   parseSequencedCodeEvent,
   parseCodeUpdateNotice,
@@ -2285,11 +2285,9 @@ export class ApiClient {
     );
   }
 
-  async listCodeHarnessModels(kind: HarnessKind): Promise<{
-    kind: HarnessKind;
-    models: ParsedHarnessModel[];
-    reasoning_efforts: ReasoningEffort[];
-  }> {
+  async listCodeHarnessModels(
+    kind: HarnessKind,
+  ): Promise<ParsedHarnessModelList> {
     return requireParsed(
       parseHarnessModelList(
         await this.json(`/code/harnesses/${encodeURIComponent(kind)}/models`, {

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
@@ -196,6 +196,36 @@ describe("CodeCatalogStore.ensureHarnessModels", () => {
     ]);
   });
 
+  it("preserves model-gateway provenance for hosted picker rows", async () => {
+    const client = {
+      listCodeHarnessModels: vi.fn(async () => ({
+        kind: "opencode" as const,
+        source: "model_gateway" as const,
+        models: [
+          {
+            id: "model-gateway/glm-5.3",
+            label: "GLM 5.3",
+            default: true,
+            reasoning_efforts: [],
+            fast_mode: false,
+          },
+        ],
+        reasoning_efforts: [],
+      })),
+    };
+
+    await useCodeCatalogStore
+      .getState()
+      .ensureHarnessModels(client, "opencode");
+
+    expect(useCodeCatalogStore.getState().modelsByHarness.opencode).toEqual([
+      expect.objectContaining({
+        id: "model-gateway/glm-5.3",
+        source: "opencode · model-gateway",
+      }),
+    ]);
+  });
+
   it("shares the initial catalog refresh with an opening picker", async () => {
     let resolveCodex!: (value: { kind: "codex"; models: [] }) => void;
     const codex = new Promise<Parameters<typeof resolveCodex>[0]>((done) => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -13,7 +13,12 @@ import {
   codeClientGeneration,
   isCodeClientGenerationActive,
 } from "./CodeClientGeneration";
-import { harnessCodeModels, type CodeModelOption } from "./labels";
+import {
+  HARNESS_LABELS,
+  harnessCodeModels,
+  type CodeModelOption,
+} from "./labels";
+import type { ParsedHarnessModelList } from "./parsers";
 
 const HARNESS_KINDS: HarnessKind[] = [
   "claude_code",
@@ -106,6 +111,17 @@ export function isOptimisticWorkspace(workspace: CodeWorkspaceSnapshot) {
   return workspace.id.startsWith(OPTIMISTIC_WORKSPACE_ID_PREFIX);
 }
 
+/** Preserve whether the server listed the engine or the hosted gateway. */
+export function codeModelsFromHarnessListing(
+  listed: Pick<ParsedHarnessModelList, "models" | "source">,
+  kind: HarnessKind,
+): CodeModelOption[] {
+  const models = harnessCodeModels(listed.models, kind);
+  if (listed.source !== "model_gateway") return models;
+  const source = `${HARNESS_LABELS[kind]} · model-gateway`;
+  return models.map((model) => ({ ...model, source }));
+}
+
 function loadHarnessModels(
   client: Pick<ApiClient, "listCodeHarnessModels">,
   kind: HarnessKind,
@@ -125,7 +141,7 @@ function loadHarnessModels(
     .listCodeHarnessModels(kind)
     .then((listed) => {
       if (!requestIsCurrent(context)) return [];
-      const models = harnessCodeModels(listed.models, kind);
+      const models = codeModelsFromHarnessListing(listed, kind);
       get().rememberHarnessModels(kind, models, listed.reasoning_efforts);
       return models;
     })

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -125,7 +125,10 @@ const CodeBrowserTab = lazy(async () => {
   const module = await import("./browser/CodeBrowserTab");
   return { default: module.CodeBrowserTab };
 });
-import { useCodeCatalogStore } from "./CodeCatalogStore";
+import {
+  codeModelsFromHarnessListing,
+  useCodeCatalogStore,
+} from "./CodeCatalogStore";
 import { CodeInspector, WorkspaceDeliveryPrTab } from "./CodeInspector";
 import { DiffOverview } from "./DiffOverview";
 import { useCodeUiStore } from "./CodeUiStore";
@@ -2274,7 +2277,7 @@ function CodeSessionPane({
         if (cancelled) return;
         rememberHarnessModels(
           session.harness_kind,
-          harnessCodeModels(listed.models, session.harness_kind),
+          codeModelsFromHarnessListing(listed, session.harness_kind),
           listed.reasoning_efforts,
         );
       },

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -36,6 +36,7 @@ import {
   parseCodeWorkspaceTree,
   parseCodeWorktreeRoot,
   parseFenceReason,
+  parseHarnessModelList,
   parseCodeCheckLogsSnapshot,
 } from "./parsers";
 
@@ -145,6 +146,39 @@ const SESSION = {
   unrecognized_event_count: 0,
   created_at: "2026-08-15T12:00:00.000Z",
 };
+
+describe("parseHarnessModelList", () => {
+  const listing = {
+    kind: "opencode",
+    models: [
+      {
+        id: "model-gateway/glm-5.3",
+        label: "GLM 5.3",
+        default: true,
+        reasoning_efforts: [],
+        fast_mode: false,
+      },
+    ],
+    reasoning_efforts: [],
+  };
+
+  it(
+    "preserves hosted catalog provenance and defaults old servers to native",
+    () => {
+      expect(
+        parseHarnessModelList({ ...listing, source: "model_gateway" }),
+      ).toEqual({ ...listing, source: "model_gateway" });
+      expect(parseHarnessModelList(listing)).toEqual({
+        ...listing,
+        source: "harness",
+      });
+    },
+  );
+
+  it("rejects an unknown catalog source", () => {
+    expect(parseHarnessModelList({ ...listing, source: "shared" })).toBeNull();
+  });
+});
 
 describe("parseCodeSubscriptionUsage", () => {
   it("accepts normalized personal and shared provider windows", () => {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -162,18 +162,15 @@ describe("parseHarnessModelList", () => {
     reasoning_efforts: [],
   };
 
-  it(
-    "preserves hosted catalog provenance and defaults old servers to native",
-    () => {
-      expect(
-        parseHarnessModelList({ ...listing, source: "model_gateway" }),
-      ).toEqual({ ...listing, source: "model_gateway" });
-      expect(parseHarnessModelList(listing)).toEqual({
-        ...listing,
-        source: "harness",
-      });
-    },
-  );
+  it("preserves hosted catalog provenance and defaults old servers to native", () => {
+    expect(
+      parseHarnessModelList({ ...listing, source: "model_gateway" }),
+    ).toEqual({ ...listing, source: "model_gateway" });
+    expect(parseHarnessModelList(listing)).toEqual({
+      ...listing,
+      source: "harness",
+    });
+  });
 
   it("rejects an unknown catalog source", () => {
     expect(parseHarnessModelList({ ...listing, source: "shared" })).toBeNull();

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -131,6 +131,7 @@ import type {
   HarnessCaps as WireHarnessCaps,
   HarnessDoctorEntry as WireHarnessDoctorEntry,
   HarnessDoctorReport as WireHarnessDoctorReport,
+  HarnessModelSource as WireHarnessModelSource,
   QuickAction as WireQuickAction,
   SequencedCodeEventFrame as WireSequencedCodeEventFrame,
   ToolDetail as WireToolDetail,
@@ -202,6 +203,10 @@ const HARNESS_AUTH_MODES = new Set<HarnessAuthMode>([
   "gateway_managed",
   "gateway_relay",
   "hosted_unavailable",
+]);
+const HARNESS_MODEL_SOURCES = new Set<WireHarnessModelSource>([
+  "harness",
+  "model_gateway",
 ]);
 const CAP_LEVELS = new Set<CapLevel>(["supported", "unsupported", "unknown"]);
 const PERMISSION_MODES = new Set<PermissionMode>([
@@ -2980,6 +2985,14 @@ export type ParsedHarnessModel = {
   fast_mode: boolean;
 };
 
+export type ParsedHarnessModelList = {
+  kind: HarnessKind;
+  /** Missing means an older server whose listing was always native. */
+  source?: WireHarnessModelSource;
+  models: ParsedHarnessModel[];
+  reasoning_efforts: ReasoningEffort[];
+};
+
 function parseEfforts(value: unknown): ReasoningEffort[] {
   // A server that predates the field, or a level this build cannot label,
   // narrows the offer rather than failing the whole list.
@@ -2990,11 +3003,9 @@ function parseEfforts(value: unknown): ReasoningEffort[] {
     : [];
 }
 
-export function parseHarnessModelList(value: unknown): {
-  kind: HarnessKind;
-  models: ParsedHarnessModel[];
-  reasoning_efforts: ReasoningEffort[];
-} | null {
+export function parseHarnessModelList(
+  value: unknown,
+): ParsedHarnessModelList | null {
   if (
     !isRecord(value) ||
     !isMember(value.kind, HARNESS_KINDS) ||
@@ -3002,6 +3013,13 @@ export function parseHarnessModelList(value: unknown): {
   ) {
     return null;
   }
+  const source =
+    value.source === undefined
+      ? "harness"
+      : isMember(value.source, HARNESS_MODEL_SOURCES)
+        ? value.source
+        : null;
+  if (source === null) return null;
   const models: ParsedHarnessModel[] = [];
   for (const item of value.models) {
     if (
@@ -3024,6 +3042,7 @@ export function parseHarnessModelList(value: unknown): {
   }
   return {
     kind: value.kind,
+    source,
     models,
     reasoning_efforts: parseEfforts(value.reasoning_efforts),
   };

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2627,11 +2627,6 @@ reasoning_efforts: Array<ReasoningEffort>,
 fast_mode: boolean, };
 
 /**
- * Whose catalog produced a harness model list.
- */
-export type HarnessModelSource = "harness" | "model_gateway";
-
-/**
  * `GET /code/harnesses/{kind}/models`.
  */
 export type HarnessModelList = { kind: HarnessKind, models: Array<HarnessModel>, 
@@ -2645,6 +2640,11 @@ export type HarnessModelList = { kind: HarnessKind, models: Array<HarnessModel>,
  * control at all.
  */
 reasoning_efforts: Array<ReasoningEffort>, source: HarnessModelSource, };
+
+/**
+ * Whose catalog produced a harness model list.
+ */
+export type HarnessModelSource = "harness" | "model_gateway";
 
 /**
  * Severity of a visible-degradation notice.

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2613,7 +2613,7 @@ export type HarnessDoctorReport = { harnesses: Array<HarnessDoctorEntry>, };
 export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok";
 
 /**
- * One model a harness CLI listed.
+ * One model row offered for a harness session.
  */
 export type HarnessModel = { id: string, label: string, default: boolean, 
 /**
@@ -2625,6 +2625,11 @@ reasoning_efforts: Array<ReasoningEffort>,
  * control, the same way an empty effort ladder does.
  */
 fast_mode: boolean, };
+
+/**
+ * Whose catalog produced a harness model list.
+ */
+export type HarnessModelSource = "harness" | "model_gateway";
 
 /**
  * `GET /code/harnesses/{kind}/models`.
@@ -2639,7 +2644,7 @@ export type HarnessModelList = { kind: HarnessKind, models: Array<HarnessModel>,
  * and wins where it exists. Empty means the engine takes no effort
  * control at all.
  */
-reasoning_efforts: Array<ReasoningEffort>, };
+reasoning_efforts: Array<ReasoningEffort>, source: HarnessModelSource, };
 
 /**
  * Severity of a visible-degradation notice.

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -39,7 +39,6 @@ use axum::response::Response;
 use tidebreak_core::{AgentError, CodeSessionId, HarnessKind, OwnerId};
 
 use crate::obo_gateway::{GatewayCompatModel, OboGateway};
-use crate::providers::GatewayModelProtocol;
 
 /// Whose inference a relay key spends.
 #[derive(Clone)]
@@ -119,15 +118,17 @@ impl HarnessLlmRelay {
         }
     }
 
-    /// The caller's models on one protocol this relay carries. Keeping the
-    /// read behind the relay means hosted pickers and the turns they start
-    /// always answer to the same gateway deployment.
-    pub(crate) async fn models(
+    /// Both of the caller's compat listings. Keeping the read behind the
+    /// relay means hosted pickers and the turns they start always answer to
+    /// the same gateway deployment.
+    pub(crate) async fn listings(
         &self,
         owner: &OwnerId,
-        protocol: GatewayModelProtocol,
-    ) -> tidebreak_core::Result<Vec<GatewayCompatModel>> {
-        self.obo.compat_models(owner, protocol).await
+    ) -> tidebreak_core::Result<(
+        tidebreak_core::Result<Vec<GatewayCompatModel>>,
+        tidebreak_core::Result<Vec<GatewayCompatModel>>,
+    )> {
+        self.obo.compat_listings(owner).await
     }
 
     /// Mint the relay key for `subject`, replacing any prior key the same

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -38,7 +38,8 @@ use axum::response::Response;
 
 use tidebreak_core::{AgentError, CodeSessionId, HarnessKind, OwnerId};
 
-use crate::obo_gateway::OboGateway;
+use crate::obo_gateway::{GatewayCompatModel, OboGateway};
+use crate::providers::GatewayModelProtocol;
 
 /// Whose inference a relay key spends.
 #[derive(Clone)]
@@ -116,6 +117,17 @@ impl HarnessLlmRelay {
             client,
             state: Mutex::new(RelayState::default()),
         }
+    }
+
+    /// The caller's models on one protocol this relay carries. Keeping the
+    /// read behind the relay means hosted pickers and the turns they start
+    /// always answer to the same gateway deployment.
+    pub(crate) async fn models(
+        &self,
+        owner: &OwnerId,
+        protocol: GatewayModelProtocol,
+    ) -> tidebreak_core::Result<Vec<GatewayCompatModel>> {
+        self.obo.compat_models(owner, protocol).await
     }
 
     /// Mint the relay key for `subject`, replacing any prior key the same

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -848,6 +848,12 @@ impl ScopedCode {
         self.runtime.harness_llm().is_some()
     }
 
+    /// The engine inference relay, on a machine that has one. The hosted
+    /// model listing reads the caller's gateway catalog through it.
+    pub(crate) fn harness_llm(&self) -> Option<Arc<super::harness_llm::HarnessLlmRelay>> {
+        self.runtime.harness_llm()
+    }
+
     /// Warm the pinned install of one engine. See
     /// [`CodeRuntime::start_harness_install`].
     ///

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -43,8 +43,6 @@ use futures::StreamExt as _;
 use tidebreak_core::{AgentError, OwnerId, Profile, Result};
 use tidebreak_router::BearerTokenSource;
 
-use crate::providers::GatewayModelProtocol;
-
 /// Mint a replacement this close to expiry instead of using the cached token.
 ///
 /// Matches the desktop's refresh leeway, so a turn never opens a request with
@@ -686,95 +684,59 @@ impl OboGateway {
         })
     }
 
-    /// One model listing the engine relay can carry for `owner`, read from
-    /// the matching gateway compat surface with their fresh inference token
-    /// (decision 71, issue 2755).
+    /// Both compat listings the engine relay can carry for `owner`, each
+    /// read with their fresh inference token (decision 71, issue 2755).
     ///
-    /// The listing is exactly the set a turn through that protocol
-    /// authenticates against, so an engine picker served from it offers no
-    /// dead picks and omits nothing entitled. Reading one protocol does not
-    /// depend on the other compat surface being available.
+    /// Both surfaces are always requested so a caller-supplied engine kind
+    /// never chooses the HTTP destination. A one-protocol engine still
+    /// succeeds when the unused listing is down: the picker keeps only the
+    /// result its wiring can honor.
     ///
     /// # Errors
-    /// Fails when this process holds no live subject for `owner`, when the
-    /// exchange or a read is refused, on transport failure, and when a body
-    /// is not a listing shape.
-    pub(crate) async fn compat_models(
+    /// Each side fails on its own when this process holds no live subject
+    /// for `owner`, when the exchange or that read is refused, on transport
+    /// failure, and when that body is not a listing shape.
+    pub(crate) async fn compat_listings(
         &self,
         owner: &OwnerId,
-        protocol: GatewayModelProtocol,
-    ) -> Result<Vec<GatewayCompatModel>> {
+    ) -> Result<(
+        Result<Vec<GatewayCompatModel>>,
+        Result<Vec<GatewayCompatModel>>,
+    )> {
         let token = self.bearer_for(owner).await?;
-        self.compat_models_page(protocol, &token).await
+        Ok(futures::future::join(
+            self.anthropic_compat_listing(&token),
+            self.openai_compat_listing(&token),
+        )
+        .await)
     }
 
-    /// One compat listing. The endpoint is selected from this gateway's
-    /// prevalidated fixed fields, rather than accepting a URL-shaped helper
-    /// argument. This keeps the protocol boundary explicit and prevents a
-    /// caller-controlled destination from reaching the HTTP client.
-    async fn compat_models_page(
-        &self,
-        protocol: GatewayModelProtocol,
-        token: &str,
-    ) -> Result<Vec<GatewayCompatModel>> {
-        let response = match protocol {
-            GatewayModelProtocol::AnthropicMessages => {
-                self.client.get(self.anthropic_models_url.clone())
-            }
-            GatewayModelProtocol::OpenaiResponses => {
-                self.client.get(self.openai_models_url.clone())
-            }
-        }
-        .bearer_auth(token)
-        .send()
+    async fn anthropic_compat_listing(&self, token: &str) -> Result<Vec<GatewayCompatModel>> {
+        parse_compat_listing(
+            self.client
+                .get(self.anthropic_models_url.clone())
+                .bearer_auth(token)
+                .send()
+                .await
+                .map_err(|error| {
+                    AgentError::msg(format!("the Model Gateway model listing failed: {error}"))
+                })?,
+        )
         .await
-        .map_err(|error| {
-            AgentError::msg(format!("the Model Gateway model listing failed: {error}"))
-        })?;
-        let status = response.status();
-        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-            return Err(AgentError::SignInRequired(
-                "the Model Gateway refused the model listing for your session; sign in again"
-                    .into(),
-            ));
-        }
-        let body = read_bounded(response, CATALOG_RESPONSE_LIMIT).await?;
-        if !status.is_success() {
-            return Err(AgentError::msg(format!(
-                "the Model Gateway model listing failed with status {status}"
-            )));
-        }
-        let listing: serde_json::Value = serde_json::from_slice(&body).map_err(|error| {
-            AgentError::msg(format!(
-                "the Model Gateway returned an unreadable model listing: {error}"
-            ))
-        })?;
-        let rows = listing
-            .get("data")
-            .and_then(|data| data.as_array())
-            .ok_or_else(|| AgentError::msg("the Model Gateway model listing has no data array"))?;
-        Ok(rows
-            .iter()
-            .filter_map(|row| {
-                let id = row.get("id")?.as_str()?.trim();
-                if id.is_empty() {
-                    return None;
-                }
-                Some(GatewayCompatModel {
-                    display_name: row
-                        .get("display_name")
-                        .and_then(|value| value.as_str())
-                        .map(str::trim)
-                        .filter(|display_name| !display_name.is_empty())
-                        .map(str::to_owned),
-                    family_default: row
-                        .get("is_family_default")
-                        .and_then(|value| value.as_bool())
-                        == Some(true),
-                    id: id.to_owned(),
-                })
-            })
-            .collect())
+    }
+
+    async fn openai_compat_listing(&self, token: &str) -> Result<Vec<GatewayCompatModel>> {
+        parse_compat_listing(
+            self.client
+                .get(self.openai_models_url.clone())
+                .bearer_auth(token)
+                .send()
+                .await
+                .map_err(|error| {
+                    AgentError::msg(format!("the Model Gateway model listing failed: {error}"))
+                })?,
+        )
+        .await
     }
 
     /// The forge identity this caller's git operations would act as, probed
@@ -1360,6 +1322,55 @@ pub(crate) mod test_support {
             self.listed.lock().expect("listed").clone()
         }
     }
+}
+
+/// Parse one compat listing body. Shared by both surfaces because they
+/// share the `data` array shape; only the Anthropic surface carries
+/// display names and family defaults.
+async fn parse_compat_listing(response: reqwest::Response) -> Result<Vec<GatewayCompatModel>> {
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(AgentError::SignInRequired(
+            "the Model Gateway refused the model listing for your session; sign in again".into(),
+        ));
+    }
+    let body = read_bounded(response, CATALOG_RESPONSE_LIMIT).await?;
+    if !status.is_success() {
+        return Err(AgentError::msg(format!(
+            "the Model Gateway model listing failed with status {status}"
+        )));
+    }
+    let listing: serde_json::Value = serde_json::from_slice(&body).map_err(|error| {
+        AgentError::msg(format!(
+            "the Model Gateway returned an unreadable model listing: {error}"
+        ))
+    })?;
+    let rows = listing
+        .get("data")
+        .and_then(|data| data.as_array())
+        .ok_or_else(|| AgentError::msg("the Model Gateway model listing has no data array"))?;
+    Ok(rows
+        .iter()
+        .filter_map(|row| {
+            let id = row.get("id")?.as_str()?.trim();
+            if id.is_empty() {
+                return None;
+            }
+            Some(GatewayCompatModel {
+                display_name: row
+                    .get("display_name")
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|display_name| !display_name.is_empty())
+                    .map(str::to_owned),
+                family_default: row
+                    .get("is_family_default")
+                    .and_then(|value| value.as_bool())
+                    == Some(true),
+                id: id.to_owned(),
+            })
+        })
+        .collect())
 }
 
 /// Read at most `limit` bytes, refusing anything larger.

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -705,29 +705,32 @@ impl OboGateway {
         protocol: GatewayModelProtocol,
     ) -> Result<Vec<GatewayCompatModel>> {
         let token = self.bearer_for(owner).await?;
-        let url = match protocol {
-            GatewayModelProtocol::AnthropicMessages => &self.anthropic_models_url,
-            GatewayModelProtocol::OpenaiResponses => &self.openai_models_url,
-        };
-        self.compat_models_page(url, &token).await
+        self.compat_models_page(protocol, &token).await
     }
 
-    /// One compat listing. The two surfaces share the `data` array shape;
-    /// only the Anthropic surface carries display names and family defaults.
+    /// One compat listing. The endpoint is selected from this gateway's
+    /// prevalidated fixed fields, rather than accepting a URL-shaped helper
+    /// argument. This keeps the protocol boundary explicit and prevents a
+    /// caller-controlled destination from reaching the HTTP client.
     async fn compat_models_page(
         &self,
-        url: &reqwest::Url,
+        protocol: GatewayModelProtocol,
         token: &str,
     ) -> Result<Vec<GatewayCompatModel>> {
-        let response = self
-            .client
-            .get(url.clone())
-            .bearer_auth(token)
-            .send()
-            .await
-            .map_err(|error| {
-                AgentError::msg(format!("the Model Gateway model listing failed: {error}"))
-            })?;
+        let response = match protocol {
+            GatewayModelProtocol::AnthropicMessages => {
+                self.client.get(self.anthropic_models_url.clone())
+            }
+            GatewayModelProtocol::OpenaiResponses => {
+                self.client.get(self.openai_models_url.clone())
+            }
+        }
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|error| {
+            AgentError::msg(format!("the Model Gateway model listing failed: {error}"))
+        })?;
         let status = response.status();
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
             return Err(AgentError::SignInRequired(

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -43,6 +43,8 @@ use futures::StreamExt as _;
 use tidebreak_core::{AgentError, OwnerId, Profile, Result};
 use tidebreak_router::BearerTokenSource;
 
+use crate::providers::GatewayModelProtocol;
+
 /// Mint a replacement this close to expiry instead of using the cached token.
 ///
 /// Matches the desktop's refresh leeway, so a turn never opens a request with
@@ -263,6 +265,16 @@ pub(crate) enum GitForgeError {
     Unavailable(String),
 }
 
+/// One model row from a gateway compat listing, reduced to what an engine
+/// picker needs: the id a turn presents, the display name when the listing
+/// carries one, and the family default the Anthropic surface annotates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GatewayCompatModel {
+    pub(crate) id: String,
+    pub(crate) display_name: Option<String>,
+    pub(crate) family_default: bool,
+}
+
 /// Per-caller inference credentials for a gateway-authenticated deployment.
 ///
 /// Construct one per process with [`OboGateway::from_config`], record each
@@ -275,6 +287,10 @@ pub(crate) struct OboGateway {
     token_url: reqwest::Url,
     /// The member catalog a caller's exchanged capability reads.
     catalog_url: reqwest::Url,
+    /// The per-protocol compat model listings the engine relay can carry
+    /// (decision 71, issue 2755).
+    anthropic_models_url: reqwest::Url,
+    openai_models_url: reqwest::Url,
     /// The git-credential mint, presented with the machine-bound token
     /// directly (decision 63).
     git_credential_url: reqwest::Url,
@@ -343,6 +359,8 @@ impl OboGateway {
         let base = normalized_gateway_base(base_url)?;
         let token_url = join_below(&base, "oauth/token")?;
         let catalog_url = join_below(&base, "api/v1/me/catalog")?;
+        let anthropic_models_url = join_below(&base, "compat/anthropic/v1/models")?;
+        let openai_models_url = join_below(&base, "compat/openai/v1/models")?;
         let git_credential_url = join_below(&base, "api/v1/tidebreak/git-credential")?;
         let git_forge_url = join_below(&base, "api/v1/tidebreak/git-forge")?;
         let git_repositories_url = join_below(&base, "api/v1/tidebreak/git-repositories")?;
@@ -357,6 +375,8 @@ impl OboGateway {
         Ok(Self {
             token_url,
             catalog_url,
+            anthropic_models_url,
+            openai_models_url,
             git_credential_url,
             git_forge_url,
             git_repositories_url,
@@ -664,6 +684,94 @@ impl OboGateway {
             },
             etag,
         })
+    }
+
+    /// One model listing the engine relay can carry for `owner`, read from
+    /// the matching gateway compat surface with their fresh inference token
+    /// (decision 71, issue 2755).
+    ///
+    /// The listing is exactly the set a turn through that protocol
+    /// authenticates against, so an engine picker served from it offers no
+    /// dead picks and omits nothing entitled. Reading one protocol does not
+    /// depend on the other compat surface being available.
+    ///
+    /// # Errors
+    /// Fails when this process holds no live subject for `owner`, when the
+    /// exchange or a read is refused, on transport failure, and when a body
+    /// is not a listing shape.
+    pub(crate) async fn compat_models(
+        &self,
+        owner: &OwnerId,
+        protocol: GatewayModelProtocol,
+    ) -> Result<Vec<GatewayCompatModel>> {
+        let token = self.bearer_for(owner).await?;
+        let url = match protocol {
+            GatewayModelProtocol::AnthropicMessages => &self.anthropic_models_url,
+            GatewayModelProtocol::OpenaiResponses => &self.openai_models_url,
+        };
+        self.compat_models_page(url, &token).await
+    }
+
+    /// One compat listing. The two surfaces share the `data` array shape;
+    /// only the Anthropic surface carries display names and family defaults.
+    async fn compat_models_page(
+        &self,
+        url: &reqwest::Url,
+        token: &str,
+    ) -> Result<Vec<GatewayCompatModel>> {
+        let response = self
+            .client
+            .get(url.clone())
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|error| {
+                AgentError::msg(format!("the Model Gateway model listing failed: {error}"))
+            })?;
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(AgentError::SignInRequired(
+                "the Model Gateway refused the model listing for your session; sign in again"
+                    .into(),
+            ));
+        }
+        let body = read_bounded(response, CATALOG_RESPONSE_LIMIT).await?;
+        if !status.is_success() {
+            return Err(AgentError::msg(format!(
+                "the Model Gateway model listing failed with status {status}"
+            )));
+        }
+        let listing: serde_json::Value = serde_json::from_slice(&body).map_err(|error| {
+            AgentError::msg(format!(
+                "the Model Gateway returned an unreadable model listing: {error}"
+            ))
+        })?;
+        let rows = listing
+            .get("data")
+            .and_then(|data| data.as_array())
+            .ok_or_else(|| AgentError::msg("the Model Gateway model listing has no data array"))?;
+        Ok(rows
+            .iter()
+            .filter_map(|row| {
+                let id = row.get("id")?.as_str()?.trim();
+                if id.is_empty() {
+                    return None;
+                }
+                Some(GatewayCompatModel {
+                    display_name: row
+                        .get("display_name")
+                        .and_then(|value| value.as_str())
+                        .map(str::trim)
+                        .filter(|display_name| !display_name.is_empty())
+                        .map(str::to_owned),
+                    family_default: row
+                        .get("is_family_default")
+                        .and_then(|value| value.as_bool())
+                        == Some(true),
+                    id: id.to_owned(),
+                })
+            })
+            .collect())
     }
 
     /// The forge identity this caller's git operations would act as, probed

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -11,7 +11,6 @@ use super::types::{
 use crate::code::harness_label;
 use crate::code::harness_llm::relay_covered;
 use crate::obo_gateway::GatewayCompatModel;
-use crate::providers::GatewayModelProtocol;
 use tidebreak_core::HarnessKind;
 
 /// The doctor surface, served from the memoized probes (decision 0034).
@@ -118,16 +117,17 @@ pub async fn list_harness_models(
 /// listings, the same surfaces [`crate::code::harness_llm::spawn_wiring`]
 /// points each engine at.
 ///
-/// Each engine reads only the listing its relay wiring can reach. Claude Code
-/// posts to the Anthropic surface; Codex and Grok to the OpenAI one; opencode
-/// sees both. OpenCode ids are provider-qualified so its request body selects
-/// the provider wired to that listing: `anthropic/{raw}` for Anthropic and
-/// `model-gateway/{raw}` for OpenAI Responses. Duplicate raw ids prefer the
-/// Anthropic surface. Gateway rows carry no per-model effort ladder or
-/// fast-mode promise — the engine's own ladder above is the honest outer
-/// bound — and only the Anthropic surface's `is_family_default` annotation
-/// claims a default. The wiring per engine is
-/// [`crate::code::harness_llm::spawn_wiring`].
+/// Both listings are always fetched; `kind` only chooses which rows to
+/// keep. Claude Code posts to the Anthropic surface; Codex and Grok to the
+/// OpenAI one; opencode sees both. A one-protocol engine still succeeds
+/// when the unused listing is down. OpenCode ids are provider-qualified so
+/// its request body selects the provider wired to that listing:
+/// `anthropic/{raw}` for Anthropic and `model-gateway/{raw}` for OpenAI
+/// Responses. Duplicate raw ids prefer the Anthropic surface. Gateway rows
+/// carry no per-model effort ladder or fast-mode promise — the engine's
+/// own ladder above is the honest outer bound — and only the Anthropic
+/// surface's `is_family_default` annotation claims a default. The wiring
+/// per engine is [`crate::code::harness_llm::spawn_wiring`].
 async fn hosted_models(
     code: &ScopedCode,
     kind: HarnessKind,
@@ -135,25 +135,19 @@ async fn hosted_models(
     let relay = code
         .harness_llm()
         .expect("hosted means the relay is active");
+    let (anthropic, openai) = relay.listings(code.owner()).await?;
     match kind {
-        HarnessKind::ClaudeCode => Ok(relay
-            .models(code.owner(), GatewayModelProtocol::AnthropicMessages)
-            .await?
+        HarnessKind::ClaudeCode => Ok(anthropic?
             .into_iter()
             .map(|row| hosted_model(row, None))
             .collect()),
-        HarnessKind::Codex | HarnessKind::Grok => Ok(relay
-            .models(code.owner(), GatewayModelProtocol::OpenaiResponses)
-            .await?
+        HarnessKind::Codex | HarnessKind::Grok => Ok(openai?
             .into_iter()
             .map(|row| hosted_model(row, None))
             .collect()),
         HarnessKind::Opencode => {
-            let (anthropic, openai) = futures::future::try_join(
-                relay.models(code.owner(), GatewayModelProtocol::AnthropicMessages),
-                relay.models(code.owner(), GatewayModelProtocol::OpenaiResponses),
-            )
-            .await?;
+            let anthropic = anthropic?;
+            let openai = openai?;
             let mut seen = std::collections::HashSet::new();
             let mut models = Vec::with_capacity(anthropic.len() + openai.len());
             for row in anthropic {

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -6,10 +6,12 @@ use crate::extract::Json;
 
 use super::types::{
     CodeHarnessInstallSnapshot, HarnessAuthMode, HarnessDoctorEntry, HarnessDoctorReport,
-    HarnessModel, HarnessModelList, InstallHarnessQuery,
+    HarnessModel, HarnessModelList, HarnessModelSource, InstallHarnessQuery,
 };
 use crate::code::harness_label;
 use crate::code::harness_llm::relay_covered;
+use crate::obo_gateway::GatewayCompatModel;
+use crate::providers::GatewayModelProtocol;
 use tidebreak_core::HarnessKind;
 
 /// The doctor surface, served from the memoized probes (decision 0034).
@@ -51,6 +53,12 @@ pub async fn install_harness(
 }
 
 /// Models this harness currently lists. Not on the doctor path.
+///
+/// On a gateway-hosted machine the relay is the only inference path
+/// (decision 71), so the picker's truth is the gateway catalog, not the
+/// engine's local CLI listing: the CLI cannot see gateway-only models, and
+/// models it lists may not be entitled at the gateway — both dead picks.
+/// See [`hosted_models`].
 pub async fn list_harness_models(
     code: ScopedCode,
     Path(kind): Path<HarnessKind>,
@@ -63,34 +71,116 @@ pub async fn list_harness_models(
             format!("{kind} is not installed"),
         ));
     }
-    let listed = adapter.list_models(&probe).await;
+    let hosted = code.harness_llm_relay_active();
+    let (models, source) = if hosted {
+        (
+            hosted_models(&code, kind).await?,
+            HarnessModelSource::ModelGateway,
+        )
+    } else {
+        (
+            adapter
+                .list_models(&probe)
+                .await
+                .into_iter()
+                .map(|model| HarnessModel {
+                    id: model.id,
+                    label: model.label,
+                    default: model.default,
+                    reasoning_efforts: model.reasoning_efforts,
+                    fast_mode: model.fast_mode,
+                })
+                .collect(),
+            HarnessModelSource::Harness,
+        )
+    };
     // An engine that states one ladder for every model says so directly. One
     // that states a ladder per row — Codex — has no single answer, so the
     // outer bound is the union of what its rows advertise.
     let mut reasoning_efforts = adapter.reasoning_efforts(&probe);
     if reasoning_efforts.is_empty() {
-        reasoning_efforts = listed
+        reasoning_efforts = models
             .iter()
             .flat_map(|model| model.reasoning_efforts.iter().copied())
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
             .collect();
     }
-    let models = listed
-        .into_iter()
-        .map(|model| HarnessModel {
-            id: model.id,
-            label: model.label,
-            default: model.default,
-            reasoning_efforts: model.reasoning_efforts,
-            fast_mode: model.fast_mode,
-        })
-        .collect();
     Ok(Json(HarnessModelList {
         kind,
         models,
         reasoning_efforts,
+        source,
     }))
+}
+
+/// The engine's hosted picker rows: the caller's per-protocol compat
+/// listings, the same surfaces [`crate::code::harness_llm::spawn_wiring`]
+/// points each engine at.
+///
+/// Each engine reads only the listing its relay wiring can reach. Claude Code
+/// posts to the Anthropic surface; Codex and Grok to the OpenAI one; opencode
+/// sees both. OpenCode ids are provider-qualified so its request body selects
+/// the provider wired to that listing: `anthropic/{raw}` for Anthropic and
+/// `model-gateway/{raw}` for OpenAI Responses. Duplicate raw ids prefer the
+/// Anthropic surface. Gateway rows carry no per-model effort ladder or
+/// fast-mode promise — the engine's own ladder above is the honest outer
+/// bound — and only the Anthropic surface's `is_family_default` annotation
+/// claims a default. The wiring per engine is
+/// [`crate::code::harness_llm::spawn_wiring`].
+async fn hosted_models(
+    code: &ScopedCode,
+    kind: HarnessKind,
+) -> Result<Vec<HarnessModel>, ServerError> {
+    let relay = code
+        .harness_llm()
+        .expect("hosted means the relay is active");
+    match kind {
+        HarnessKind::ClaudeCode => Ok(relay
+            .models(code.owner(), GatewayModelProtocol::AnthropicMessages)
+            .await?
+            .into_iter()
+            .map(|row| hosted_model(row, None))
+            .collect()),
+        HarnessKind::Codex | HarnessKind::Grok => Ok(relay
+            .models(code.owner(), GatewayModelProtocol::OpenaiResponses)
+            .await?
+            .into_iter()
+            .map(|row| hosted_model(row, None))
+            .collect()),
+        HarnessKind::Opencode => {
+            let (anthropic, openai) = futures::future::try_join(
+                relay.models(code.owner(), GatewayModelProtocol::AnthropicMessages),
+                relay.models(code.owner(), GatewayModelProtocol::OpenaiResponses),
+            )
+            .await?;
+            let mut seen = std::collections::HashSet::new();
+            let mut models = Vec::with_capacity(anthropic.len() + openai.len());
+            for row in anthropic {
+                if seen.insert(row.id.clone()) {
+                    models.push(hosted_model(row, Some("anthropic")));
+                }
+            }
+            for row in openai {
+                if seen.insert(row.id.clone()) {
+                    models.push(hosted_model(row, Some("model-gateway")));
+                }
+            }
+            Ok(models)
+        }
+    }
+}
+
+fn hosted_model(row: GatewayCompatModel, provider: Option<&str>) -> HarnessModel {
+    let label = row.display_name.unwrap_or_else(|| row.id.clone());
+    let id = provider.map_or(row.id.clone(), |provider| format!("{provider}/{}", row.id));
+    HarnessModel {
+        id,
+        label,
+        default: row.family_default,
+        reasoning_efforts: Vec::new(),
+        fast_mode: false,
+    }
 }
 
 async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -424,7 +424,7 @@ pub struct HarnessDoctorEntry {
     pub relaunch_composes_permission_mode: bool,
 }
 
-/// One model a harness CLI listed.
+/// One model row offered for a harness session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct HarnessModel {
     pub id: String,
@@ -437,6 +437,16 @@ pub struct HarnessModel {
     /// control, the same way an empty effort ladder does.
     #[serde(default)]
     pub fast_mode: bool,
+}
+
+/// Whose catalog produced a harness model list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessModelSource {
+    /// The engine's own native listing command, used on local machines.
+    Harness,
+    /// The caller-usable Model Gateway compat listing, used on hosted machines.
+    ModelGateway,
 }
 
 /// `GET /code/harnesses/{kind}/models`.
@@ -453,6 +463,7 @@ pub struct HarnessModelList {
     /// control at all.
     #[serde(default)]
     pub reasoning_efforts: Vec<ReasoningEffort>,
+    pub source: HarnessModelSource,
 }
 
 /// Body of `POST /code/repos/clone`.

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 use std::net::Ipv4Addr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -8298,6 +8299,425 @@ async fn the_doctor_reports_relay_engines_ready_on_a_hosted_machine() {
     assert_eq!(opencode["kind"], "opencode");
     assert_eq!(opencode["auth_mode"], "gateway_relay");
     assert_eq!(opencode["remediation"], "");
+}
+
+/// A caller-scoped fake for the exact compat surfaces hosted engine pickers
+/// read. Either surface may be absent, which lets tests prove a one-protocol
+/// engine never depends on the other protocol's listing.
+#[derive(Clone)]
+struct FakeModelGateway {
+    anthropic: Option<serde_json::Value>,
+    openai: Option<serde_json::Value>,
+    anthropic_reads: Arc<AtomicUsize>,
+    openai_reads: Arc<AtomicUsize>,
+}
+
+impl FakeModelGateway {
+    fn new(anthropic: Option<serde_json::Value>, openai: Option<serde_json::Value>) -> Self {
+        Self {
+            anthropic,
+            openai,
+            anthropic_reads: Arc::new(AtomicUsize::new(0)),
+            openai_reads: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn full() -> Self {
+        Self::new(
+            Some(serde_json::json!({
+                "data": [
+                    {
+                        "type": "model",
+                        "id": " claude-opus-5 ",
+                        "display_name": " Claude Opus 5 ",
+                        "is_family_default": true,
+                    },
+                    {
+                        "type": "model",
+                        "id": "shared/model",
+                        "display_name": "Shared via Anthropic",
+                    },
+                    { "type": "model", "id": "   ", "display_name": "Dead row" },
+                    { "type": "model", "display_name": "Missing id" },
+                ],
+                "has_more": false,
+            })),
+            Some(serde_json::json!({
+                "object": "list",
+                "data": [
+                    {
+                        "id": "glm-5.3",
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "model-gateway",
+                    },
+                    {
+                        "id": "shared/model",
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "model-gateway",
+                    },
+                    {
+                        "id": " trim-me ",
+                        "display_name": "   ",
+                        "object": "model",
+                    },
+                    { "id": "", "object": "model" },
+                    { "id": 7, "object": "model" },
+                ],
+            })),
+        )
+    }
+
+    async fn start(
+        self,
+    ) -> (
+        Arc<crate::obo_gateway::OboGateway>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let mut app = axum::Router::new().route(
+            "/oauth/token",
+            axum::routing::post(|| async {
+                axum::Json(serde_json::json!({
+                    "access_token": "mg_it_fresh",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                }))
+            }),
+        );
+        if let Some(listing) = self.anthropic {
+            let reads = self.anthropic_reads.clone();
+            app = app.route(
+                "/compat/anthropic/v1/models",
+                axum::routing::get(move |headers: axum::http::HeaderMap| {
+                    let listing = listing.clone();
+                    let reads = reads.clone();
+                    async move {
+                        assert_eq!(
+                            headers
+                                .get(axum::http::header::AUTHORIZATION)
+                                .and_then(|value| value.to_str().ok()),
+                            Some("Bearer mg_it_fresh"),
+                            "the listing must ride the caller's exchanged inference grant"
+                        );
+                        reads.fetch_add(1, Ordering::SeqCst);
+                        axum::Json(listing)
+                    }
+                }),
+            );
+        }
+        if let Some(listing) = self.openai {
+            let reads = self.openai_reads.clone();
+            app = app.route(
+                "/compat/openai/v1/models",
+                axum::routing::get(move |headers: axum::http::HeaderMap| {
+                    let listing = listing.clone();
+                    let reads = reads.clone();
+                    async move {
+                        assert_eq!(
+                            headers
+                                .get(axum::http::header::AUTHORIZATION)
+                                .and_then(|value| value.to_str().ok()),
+                            Some("Bearer mg_it_fresh"),
+                            "the listing must ride the caller's exchanged inference grant"
+                        );
+                        reads.fetch_add(1, Ordering::SeqCst);
+                        axum::Json(listing)
+                    }
+                }),
+            );
+        }
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let gateway = Arc::new(
+            crate::obo_gateway::OboGateway::new(
+                &format!("http://{address}"),
+                "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed"
+                    .to_owned(),
+            )
+            .unwrap(),
+        );
+        (gateway, server)
+    }
+}
+
+async fn hosted_model_app(
+    gateway: Arc<crate::obo_gateway::OboGateway>,
+    record_caller: bool,
+) -> (Router, Arc<str>, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("code.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = AdapterRegistry::new();
+    for &kind in HarnessKind::ALL {
+        let mut adapter = ScriptedAdapter::new(plain_text_script())
+            .with_kind(kind)
+            .with_models(vec![listed_model("local-only-model", true, &[], true)]);
+        if kind == HarnessKind::ClaudeCode {
+            adapter = adapter.with_reasoning_levels(CapLevel::Supported);
+        }
+        registry.register(Arc::new(adapter));
+    }
+    if record_caller {
+        gateway.record_caller(&tidebreak_core::OwnerId::local(), "mg_at_live".into());
+    }
+    let runtime = Arc::new(
+        CodeRuntime::with_registry(db, dir.path().to_path_buf(), registry).with_harness_llm(
+            Arc::new(crate::code::harness_llm::HarnessLlmRelay::new(gateway)),
+        ),
+    );
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime);
+    let token = state.token.clone();
+    (app(state), token, dir)
+}
+
+async fn fetch_harness_models(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    kind: HarnessKind,
+) -> reqwest::Response {
+    client
+        .get(format!("http://{addr}/code/harnesses/{kind}/models"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap()
+}
+
+fn model_ids(listing: &serde_json::Value) -> Vec<&str> {
+    listing["models"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["id"].as_str().unwrap())
+        .collect()
+}
+
+/// Issue 2755: all four hosted engines list the caller-usable gateway rows
+/// their relay wiring can run. OpenCode's ids name the configured provider,
+/// duplicate raw ids prefer the Anthropic surface, malformed rows disappear,
+/// and no engine's local-only row leaks into the hosted picker.
+#[tokio::test]
+async fn a_hosted_machine_lists_the_gateway_catalog_as_an_engines_models() {
+    let fake = FakeModelGateway::full();
+    let observed = fake.clone();
+    let (gateway, gateway_server) = fake.start().await;
+    let (router, token, _dir) = hosted_model_app(gateway, true).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+
+    let claude = fetch_harness_models(&client, addr, token.as_ref(), HarnessKind::ClaudeCode)
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let rows = claude["models"].as_array().unwrap();
+    assert_eq!(
+        model_ids(&claude),
+        ["claude-opus-5", "shared/model"],
+        "the Anthropic surface's rows are the picker truth: {claude}"
+    );
+    assert_eq!(
+        rows[0]["label"], "Claude Opus 5",
+        "display name maps to the label"
+    );
+    assert_eq!(
+        rows[0]["default"], true,
+        "the catalog's family default claims the picker default"
+    );
+    assert_eq!(rows[1]["default"], false);
+    assert_eq!(
+        rows[0]["fast_mode"], false,
+        "a gateway row promises no fast mode the catalog does not state"
+    );
+    assert_eq!(
+        claude["reasoning_efforts"],
+        serde_json::to_value(ReasoningEffort::ALL).unwrap(),
+        "the engine's own ladder stays the outer bound"
+    );
+
+    let codex = fetch_harness_models(&client, addr, token.as_ref(), HarnessKind::Codex)
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        model_ids(&codex),
+        ["glm-5.3", "shared/model", "trim-me"],
+        "Codex sees the OpenAI surface, which the Anthropic-only row stays off: {codex}"
+    );
+    assert_eq!(
+        codex["models"][2]["label"], "trim-me",
+        "a blank display name falls back to the trimmed id"
+    );
+
+    let grok = fetch_harness_models(&client, addr, token.as_ref(), HarnessKind::Grok)
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(model_ids(&grok), model_ids(&codex));
+
+    let opencode = fetch_harness_models(&client, addr, token.as_ref(), HarnessKind::Opencode)
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        model_ids(&opencode),
+        [
+            "anthropic/claude-opus-5",
+            "anthropic/shared/model",
+            "model-gateway/glm-5.3",
+            "model-gateway/trim-me",
+        ],
+        "OpenCode must post every pick through the provider wired to the listing surface: {opencode}"
+    );
+    for listing in [&claude, &codex, &grok, &opencode] {
+        assert_eq!(
+            listing["source"], "model_gateway",
+            "hosted rows must identify the gateway catalog: {listing}"
+        );
+        assert!(
+            !model_ids(listing).contains(&"local-only-model"),
+            "the engine's local listing is never the hosted truth: {listing}"
+        );
+    }
+    assert_eq!(
+        observed.anthropic_reads.load(Ordering::SeqCst),
+        2,
+        "Claude and OpenCode are the only Anthropic listing readers"
+    );
+    assert_eq!(
+        observed.openai_reads.load(Ordering::SeqCst),
+        3,
+        "Codex, Grok, and OpenCode are the only OpenAI listing readers"
+    );
+    gateway_server.abort();
+}
+
+/// A one-protocol engine reads only the listing its turns use. An unrelated
+/// compat surface may be unavailable without turning every picker into an
+/// error; OpenCode still requires both because it offers both providers.
+#[tokio::test]
+async fn a_hosted_engine_does_not_require_an_unrelated_gateway_listing() {
+    let anthropic_only = FakeModelGateway::new(
+        Some(serde_json::json!({
+            "data": [{ "id": "claude-opus-5", "display_name": "Claude Opus 5" }]
+        })),
+        None,
+    );
+    let observed_anthropic = anthropic_only.clone();
+    let (gateway, gateway_server) = anthropic_only.start().await;
+    let (router, token, _dir) = hosted_model_app(gateway, true).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let claude = fetch_harness_models(&client, addr, token.as_ref(), HarnessKind::ClaudeCode).await;
+    assert_eq!(claude.status(), reqwest::StatusCode::OK);
+    assert_eq!(observed_anthropic.anthropic_reads.load(Ordering::SeqCst), 1);
+    assert_eq!(observed_anthropic.openai_reads.load(Ordering::SeqCst), 0);
+    gateway_server.abort();
+
+    let openai_only = FakeModelGateway::new(
+        None,
+        Some(serde_json::json!({
+            "object": "list",
+            "data": [{ "id": "glm-5.3", "object": "model" }]
+        })),
+    );
+    let observed_openai = openai_only.clone();
+    let (gateway, gateway_server) = openai_only.start().await;
+    let (router, token, _dir) = hosted_model_app(gateway, true).await;
+    let addr = serve(router).await;
+    for kind in [HarnessKind::Codex, HarnessKind::Grok] {
+        let response = fetch_harness_models(&client, addr, token.as_ref(), kind).await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK, "{kind}");
+    }
+    assert_eq!(observed_openai.anthropic_reads.load(Ordering::SeqCst), 0);
+    assert_eq!(observed_openai.openai_reads.load(Ordering::SeqCst), 2);
+    gateway_server.abort();
+}
+
+/// The hosted branch is caller-owned and fail-closed. If authentication has
+/// not recorded this request's principal, the route returns an error and
+/// never falls back to a local CLI row or reads a gateway listing unauthenticated.
+#[tokio::test]
+async fn a_hosted_model_listing_without_caller_ownership_fails_closed() {
+    let fake = FakeModelGateway::full();
+    let observed = fake.clone();
+    let (gateway, gateway_server) = fake.start().await;
+    let (router, token, _dir) = hosted_model_app(gateway, false).await;
+    let addr = serve(router).await;
+    let response = fetch_harness_models(
+        &reqwest::Client::new(),
+        addr,
+        token.as_ref(),
+        HarnessKind::ClaudeCode,
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+    );
+    let body = response.json::<serde_json::Value>().await.unwrap();
+    assert_eq!(body["kind"], "authentication", "{body}");
+    assert!(
+        !body.to_string().contains("local-only-model"),
+        "a missing caller grant must never fall back locally: {body}"
+    );
+    assert_eq!(observed.anthropic_reads.load(Ordering::SeqCst), 0);
+    assert_eq!(observed.openai_reads.load(Ordering::SeqCst), 0);
+    gateway_server.abort();
+}
+
+/// Issue 2755's other half: away from a hosted machine the models route is
+/// the engine's own listing, exactly as before.
+#[tokio::test]
+async fn a_local_machine_keeps_the_engine_own_model_listing() {
+    let adapter = ScriptedAdapter::new(plain_text_script())
+        .with_reasoning_levels(CapLevel::Supported)
+        .with_models(vec![
+            listed_model("fast-thinker", true, &[ReasoningEffort::High], true),
+            listed_model("steady", false, &[ReasoningEffort::Low], false),
+        ]);
+    let (router, token, _runtime, _dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let listed = client
+        .get(format!("http://{addr}/code/harnesses/claude_code/models"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(listed["kind"], "claude_code");
+    assert_eq!(listed["source"], "harness");
+    let rows = listed["models"].as_array().unwrap();
+    let ids: Vec<&str> = rows.iter().map(|row| row["id"].as_str().unwrap()).collect();
+    assert_eq!(ids, ["fast-thinker", "steady"]);
+    assert_eq!(rows[0]["default"], true);
+    assert_eq!(rows[0]["reasoning_efforts"], serde_json::json!(["high"]));
+    assert_eq!(rows[0]["fast_mode"], true);
+    assert_eq!(rows[1]["reasoning_efforts"], serde_json::json!(["low"]));
+    assert_eq!(
+        listed["reasoning_efforts"],
+        serde_json::to_value(ReasoningEffort::ALL).unwrap()
+    );
 }
 
 /// A session restored at boot comes back supervised. Recovery re-attaches its

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -8598,20 +8598,19 @@ async fn a_hosted_machine_lists_the_gateway_catalog_as_an_engines_models() {
     }
     assert_eq!(
         observed.anthropic_reads.load(Ordering::SeqCst),
-        2,
-        "Claude and OpenCode are the only Anthropic listing readers"
+        4,
+        "every hosted picker reads both listings; four engines, four Anthropic reads"
     );
     assert_eq!(
         observed.openai_reads.load(Ordering::SeqCst),
-        3,
-        "Codex, Grok, and OpenCode are the only OpenAI listing readers"
+        4,
+        "every hosted picker reads both listings; four engines, four OpenAI reads"
     );
     gateway_server.abort();
 }
 
-/// A one-protocol engine reads only the listing its turns use. An unrelated
-/// compat surface may be unavailable without turning every picker into an
-/// error; OpenCode still requires both because it offers both providers.
+/// A one-protocol engine still succeeds when the unused listing is down.
+/// OpenCode still requires both because it offers both providers.
 #[tokio::test]
 async fn a_hosted_engine_does_not_require_an_unrelated_gateway_listing() {
     let anthropic_only = FakeModelGateway::new(

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2613,7 +2613,7 @@ export type HarnessDoctorReport = { harnesses: Array<HarnessDoctorEntry>, };
 export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok";
 
 /**
- * One model a harness CLI listed.
+ * One model row offered for a harness session.
  */
 export type HarnessModel = { id: string, label: string, default: boolean, 
 /**
@@ -2639,7 +2639,12 @@ export type HarnessModelList = { kind: HarnessKind, models: Array<HarnessModel>,
  * and wins where it exists. Empty means the engine takes no effort
  * control at all.
  */
-reasoning_efforts: Array<ReasoningEffort>, };
+reasoning_efforts: Array<ReasoningEffort>, source: HarnessModelSource, };
+
+/**
+ * Whose catalog produced a harness model list.
+ */
+export type HarnessModelSource = "harness" | "model_gateway";
 
 /**
  * Severity of a visible-degradation notice.


### PR DESCRIPTION
## What

On a gateway-hosted machine, `GET /code/harnesses/{kind}/models` now serves each engine picker from the caller-usable Model Gateway compat listing carried by that engine's relay path. Local machines keep the engine's native model listing unchanged.

- Claude Code reads only `/compat/anthropic/v1/models`.
- Codex and Grok read only `/compat/openai/v1/models`.
- opencode reads both concurrently. Anthropic rows are emitted as `anthropic/{id}` and OpenAI Responses rows as `model-gateway/{id}`, so every pick selects the provider configured for that relay surface. Duplicate raw ids prefer Anthropic.
- Gateway ids and display names are trimmed, malformed/blank ids are dropped, and blank display names fall back to the id.
- Hosted responses identify their provenance as `source: "model_gateway"`; local responses use `source: "harness"`. Older servers without the field still parse as native listings.

The compat listing is fetched through `HarnessLlmRelay` with the caller's on-behalf-of inference grant, the same ownership and deployment boundary used for relayed turns. Missing caller ownership fails closed and never falls back to a local CLI catalog. One-protocol engines do not depend on the unrelated compat surface being available.

## Why

On hosted machines the relay is the only inference path. A native engine catalog can omit gateway-only models or offer models the caller cannot run through the gateway, producing dead picks. Reading the exact compat surface used by the engine's turns makes the picker and execution path agree. The existing `/code/llm/openai/v1/models` forwarding route and its `api_backend: "responses"` tagging remain the precedent for Grok's engine-facing listing.

The desktop preserves the hosted catalog provenance in existing picker rows (`{engine} · model-gateway`) without changing protected permission-policy or browser-owned files.

## Regression coverage

- All four hosted engines receive only the protocol rows their relay wiring can run.
- OpenCode ids are provider-qualified and duplicate raw ids are deduplicated.
- Caller-grant authentication is asserted at the fake gateway.
- Missing ownership fails closed with no local fallback or unauthenticated listing read.
- Claude works when only the Anthropic listing is available; Codex and Grok work when only the OpenAI listing is available.
- Local machines retain native ids, defaults, effort ladders, fast-mode flags, and `source: "harness"`.
- Desktop parsing preserves/defaults/rejects catalog provenance, and the shared catalog store keeps the `model-gateway` source label.

## Validation

Passed locally:

- `cargo fmt --all -- --check`
- `npx --yes @biomejs/biome@2.5.10 format src`
- `npx --yes @biomejs/biome@2.5.10 lint src`
- `git diff --check origin/main...HEAD`
- Protected browser/mobile/permission-policy file scope check

Unavailable in this environment:

- Focused Rust compilation/tests: the pinned Symphonia Git revision cannot be fetched here (GitHub returns HTTP 403); offline mode has no cached checkout.
- Full desktop tests/build: the frozen dependency install reaches the locked graph but the external SheetJS tarball at `cdn.sheetjs.com` returns HTTP 403.

CI is therefore authoritative for Rust compilation, generated-wire equality, desktop tests/build, and the full required lanes. No Storybook story or screenshot was added because this changes provenance text on existing model rows, not a reusable component or meaningful new UI state.

Closes #2755.