### PR TITLE
feat(desktop): register a repo from the new-workspace dialog

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/AddRepoInline.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoInline.tsx
@@ -1,0 +1,136 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import { ParentDirField } from "./AddRepoPalette";
+import type { AddRepoInlineState } from "./useAddRepoInline";
+
+/**
+ * What one submit is about to do with what has been typed.
+ *
+ * Nothing typed reads nothing: the placeholder already names the three
+ * shapes, and repeating it under the field would say it twice.
+ */
+function readsAs(state: AddRepoInlineState): string | null {
+  if (state.kind === "url") return "Clones this remote, then creates.";
+  if (state.kind === "github") return "Clones it from GitHub, then creates.";
+  if (state.kind === "path") return "Registers the checkout at this path.";
+  return null;
+}
+
+/**
+ * Register or clone a repository without leaving the new-workspace composer.
+ *
+ * A registered repository does nothing on its own, so the palette already
+ * hands one straight to this dialog. This field closes the last seam the
+ * other way: the first message is already typed, and adding the repository is
+ * the same submit that creates the workspace.
+ *
+ * One field reads all three sources rather than asking which one first. The
+ * palette still owns the full flow — browsing GitHub, retrying a clone, a
+ * clone resumed from a notification — and this is the short path through it.
+ */
+export function AddRepoInline({
+  state,
+  submitLabel,
+}: {
+  state: AddRepoInlineState;
+  /** What this submit finishes with, which the dialog decides. */
+  submitLabel: string;
+}) {
+  const cloning = state.phase !== null;
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        // The dialog's own form is this popover's React parent. Without this
+        // the same keystroke would also try to create.
+        event.stopPropagation();
+        state.submit();
+      }}
+    >
+      {/* `text-sm` because this form embeds the palette's destination field,
+          and one form must not carry two label sizes. */}
+      <span className="text-sm font-medium">Repository</span>
+      <div className="flex gap-2">
+        <Input
+          value={state.value}
+          onChange={(event) => state.setValue(event.target.value)}
+          placeholder="Path, Git URL, or owner/repo"
+          aria-label="Repository path or URL"
+          disabled={state.busy}
+          autoFocus
+        />
+        {state.canBrowse && (
+          <Button
+            type="button"
+            variant="outline"
+            className="shrink-0"
+            onClick={state.browse}
+            disabled={state.busy}
+          >
+            Browse
+          </Button>
+        )}
+      </div>
+      {/* The reading of the value sits under the value, not under the
+          destination the value happens to also need. */}
+      {state.blocked ? (
+        <p className="text-critical text-xs" data-testid="add-repo-blocked">
+          {state.blocked}
+        </p>
+      ) : (
+        readsAs(state) && (
+          <p className="text-muted-foreground text-xs">{readsAs(state)}</p>
+        )
+      )}
+      {state.needsDestination && !state.blocked && (
+        <ParentDirField
+          value={state.parentDir}
+          busy={state.busy}
+          canBrowse={state.canBrowse}
+          blocked={false}
+          defaultsProbeFailed={state.defaultsProbeFailed}
+          defaultsBusy={state.defaultsBusy}
+          onChange={state.setParentDir}
+          onBrowse={state.browseDestination}
+          onRetryDefaults={state.retryDefaults}
+        />
+      )}
+      {cloning && (
+        // A hairline separates what was asked for from what is happening;
+        // without it the phase reads as a note on the destination field.
+        <div className="flex flex-col gap-1.5 border-t border-border-subtle pt-2">
+          <div className="flex items-center justify-between gap-2">
+            <span
+              className="text-muted-foreground truncate text-xs"
+              data-testid="add-repo-clone-phase"
+            >
+              {state.phase}
+            </span>
+            {state.percent !== null && (
+              <span className="text-muted-foreground shrink-0 font-mono text-xs">
+                {Math.round(state.percent)}%
+              </span>
+            )}
+          </div>
+          <Progress
+            value={state.percent ?? 0}
+            style={{ forcedColorAdjust: "none" }}
+          />
+          <p className="text-muted-foreground text-xs">
+            This clone keeps running if you close this window.
+          </p>
+        </div>
+      )}
+      {state.error && (
+        <p className="text-critical text-xs" data-testid="add-repo-error">
+          {state.error}
+        </p>
+      )}
+      <Button type="submit" className="self-start" disabled={!state.canSubmit}>
+        {state.busy ? (cloning ? "Cloning…" : "Adding…") : submitLabel}
+      </Button>
+    </form>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -1531,7 +1531,12 @@ function FormSubmit({
   );
 }
 
-function ParentDirField({
+/**
+ * The clone destination, with the retry the administrator-only defaults read
+ * needs. Shared with the new-workspace composer's inline add-repo field, so
+ * both surfaces ask for a destination the same way.
+ */
+export function ParentDirField({
   value,
   busy,
   canBrowse,

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -26,6 +26,7 @@ import {
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { ALLOW_ALL_NOTE, PERMISSION_MODE_POLICY_BLOCKED } from "./labels";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import type { ReasoningEffort } from "../api/types";
@@ -43,6 +44,7 @@ vi.mock("sonner", () => ({
 afterEach(() => {
   cleanup();
   useCodeCatalogStore.getState().reset();
+  useCodeUpdatesStore.getState().reset();
   useCodeUiStore.setState({
     lastCreate: null,
     pendingComposerPrompt: null,
@@ -1846,5 +1848,216 @@ describe("NewWorkspaceDialog", () => {
     expect(
       screen.queryByRole("switch", { name: /Fast mode/ }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("NewWorkspaceDialog add-repo field", () => {
+  function machineOffersEverything(
+    overrides: Partial<AppContextValue["client"]> = {},
+  ) {
+    return {
+      getCodeRepoSources: vi.fn(async () => ({
+        sources: [
+          { kind: "local", available: true },
+          { kind: "git_url", available: true },
+          { kind: "github", available: true },
+        ],
+        chooses_destination: false,
+      })),
+      getCodeCloneDefaults: vi.fn(async () => ({
+        parent_dir: "/tmp/src",
+        gh_found: true,
+        gh_authenticated: true,
+        gh_remediation: "",
+      })),
+      listCodeHarnessModels: claudeModels(),
+      ...overrides,
+    } as Partial<AppContextValue["client"]>;
+  }
+
+  function firstRun() {
+    useCodeCatalogStore.setState({
+      repos: [],
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+  }
+
+  it("registers a repo and creates on the same submit", async () => {
+    firstRun();
+    const added = repo("repo-added", "tidebreak");
+    const created = workspace(
+      "ws-first",
+      "repo-added",
+      "2026-08-27T12:00:00.000Z",
+    );
+    const createCodeRepo = vi.fn(async () => added);
+    const createCodeWorkspace = vi.fn(async () => created);
+    const createCodeSession = vi.fn(async () =>
+      session("ws-first", "claude_code", "2026-08-27T12:00:00.000Z"),
+    );
+    const submitCodeTurn = vi.fn(async () => ({}) as CodeTurnSubmission);
+    await renderWithRouter(
+      <AppContextProvider
+        value={app(
+          machineOffersEverything({
+            createCodeRepo,
+            createCodeWorkspace,
+            createCodeSession,
+            submitCodeTurn,
+          }),
+        )}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={[]} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    // With nothing registered, the repo pill is the add-repo field.
+    const pill = screen.getByRole("button", { name: "Repo" });
+    expect(pill).toHaveTextContent("Add a repo");
+    expect(pill).toBeEnabled();
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByRole("textbox", { name: "First message" }),
+      "ship the thing",
+    );
+    await user.click(pill);
+    await user.type(
+      await screen.findByRole("textbox", { name: "Repository path or URL" }),
+      "/tmp/src/tidebreak",
+    );
+    await user.click(screen.getByRole("button", { name: /Add and create/ }));
+
+    await waitFor(() => expect(createCodeWorkspace).toHaveBeenCalled());
+    expect(createCodeRepo).toHaveBeenCalledWith({ path: "/tmp/src/tidebreak" });
+    expect(createCodeWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ repo_id: "repo-added" }),
+    );
+    // The whole point: the message typed before the repo existed is the first
+    // turn of the session that same submit started.
+    await waitFor(() =>
+      expect(submitCodeTurn).toHaveBeenCalledWith(
+        "sess-ws-first",
+        "ship the thing",
+      ),
+    );
+  });
+
+  it("keeps the message and says why when registering fails", async () => {
+    firstRun();
+    const createCodeRepo = vi.fn(async () => {
+      throw new Error("not a git repository");
+    });
+    const createCodeWorkspace = vi.fn();
+    await renderWithRouter(
+      <AppContextProvider
+        value={app(
+          machineOffersEverything({ createCodeRepo, createCodeWorkspace }),
+        )}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={[]} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByRole("textbox", { name: "First message" }),
+      "ship the thing",
+    );
+    await user.click(screen.getByRole("button", { name: "Repo" }));
+    await user.type(
+      await screen.findByRole("textbox", { name: "Repository path or URL" }),
+      "/tmp/src/not-a-repo",
+    );
+    await user.click(screen.getByRole("button", { name: /Add and create/ }));
+
+    expect(await screen.findByTestId("add-repo-error")).toHaveTextContent(
+      "not a git repository",
+    );
+    expect(createCodeWorkspace).not.toHaveBeenCalled();
+    // Nothing typed is dropped: the message, and the path that needs an edit.
+    expect(screen.getByRole("textbox", { name: "First message" })).toHaveValue(
+      "ship the thing",
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Repository path or URL" }),
+    ).toHaveValue("/tmp/src/not-a-repo");
+    expect(useCodeUiStore.getState().newWorkspaceDraft.startingPrompt).toBe(
+      "ship the thing",
+    );
+  });
+
+  it("clones a remote and creates on the repository it registers", async () => {
+    firstRun();
+    const cloned = repo("repo-cloned", "app");
+    const created = workspace(
+      "ws-cloned",
+      "repo-cloned",
+      "2026-08-27T12:00:00.000Z",
+    );
+    const startCodeClone = vi.fn(async () => ({
+      id: "job-1",
+      phase: "Counting objects",
+      percent: 10,
+      done: false,
+    }));
+    const getCodeCloneJob = vi.fn(async () => ({
+      id: "job-1",
+      phase: "Done",
+      percent: 100,
+      done: true,
+      repo_id: "repo-cloned",
+    }));
+    const getCodeRepo = vi.fn(async () => cloned);
+    const createCodeWorkspace = vi.fn(async () => created);
+    await renderWithRouter(
+      <AppContextProvider
+        value={app(
+          machineOffersEverything({
+            startCodeClone,
+            getCodeCloneJob,
+            getCodeRepo,
+            createCodeWorkspace,
+            createCodeSession: vi.fn(async () =>
+              session("ws-cloned", "claude_code", "2026-08-27T12:00:00.000Z"),
+            ),
+          }),
+        )}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={[]} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Repo" }));
+    await user.type(
+      await screen.findByRole("textbox", { name: "Repository path or URL" }),
+      "acme/app",
+    );
+    // The destination comes from the machine's remembered default.
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: /Destination/i })).toHaveValue(
+        "/tmp/src",
+      ),
+    );
+    await user.click(screen.getByRole("button", { name: /Add and create/ }));
+
+    await waitFor(() =>
+      expect(startCodeClone).toHaveBeenCalledWith({
+        github: "acme/app",
+        parent_dir: "/tmp/src",
+      }),
+    );
+    await waitFor(() =>
+      expect(createCodeWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({ repo_id: "repo-cloned" }),
+      ),
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -7,6 +7,7 @@ import {
   Ellipsis,
   FolderGit2,
   GitBranch,
+  Plus,
 } from "lucide-react";
 
 import type {
@@ -33,6 +34,7 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
@@ -47,6 +49,8 @@ import {
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
+import { AddRepoInline } from "./AddRepoInline";
+import { useAddRepoInline } from "./useAddRepoInline";
 import {
   FastModeToggle,
   HarnessModelMenu,
@@ -102,6 +106,11 @@ const NO_ENGINE_EFFORTS: ReasoningEffort[] = [];
  * engine honors (decision 0039, amended). The engine menu lists every doctor
  * entry — ready rows are selectable; unusable ones stay visible, dimmed, with
  * the reason.
+ *
+ * The repo pill registers one too. With nothing in the catalog it opens the
+ * add-repo field directly, and that field's submit is this dialog's submit:
+ * the repo is registered or cloned, and the create chain continues on it. A
+ * first run is one message and one submit, not a palette round trip.
  */
 
 /** The repo this reader worked on last: newest workspace, then storage. */
@@ -143,7 +152,14 @@ function recentHarness(
 }
 
 /** Pickers a chord can open; one open at a time, chords toggle. */
-type PickerId = "repo" | "engine" | "model" | "mode" | "base" | "name";
+type PickerId =
+  | "repo"
+  | "addRepo"
+  | "engine"
+  | "model"
+  | "mode"
+  | "base"
+  | "name";
 
 type CreateAttempt = {
   repoId: string;
@@ -220,6 +236,21 @@ export function NewWorkspaceDialog({
   const createLocked = useRef(false);
   const retryAttempt = useRef<CreateAttempt | null>(null);
   const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
+  // A repo registered from this dialog reaches the catalog before the prop
+  // carrying it comes back around, and the create that follows must not wait
+  // a render for it.
+  const [addedRepo, setAddedRepo] = useState<CodeRepoSnapshot | null>(null);
+  // The repo this reader chose during this opening. A catalog that grows
+  // mid-opening — which is exactly what adding a repo does — must not reseed
+  // the form they are already filling in.
+  const pickedRepo = useRef<string | null>(null);
+  const knownRepos = useMemo(
+    () =>
+      addedRepo && !repos.some((repo) => repo.id === addedRepo.id)
+        ? [...repos, addedRepo]
+        : repos,
+    [addedRepo, repos],
+  );
 
   const allHarnesses = doctor?.harnesses ?? [];
   const selectableHarnesses = allHarnesses.filter(
@@ -254,7 +285,14 @@ export function NewWorkspaceDialog({
     : false;
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      pickedRepo.current = null;
+      setAddedRepo(null);
+      return;
+    }
+    // A repo picked or added in this opening is the reader's answer. Catalog
+    // churn after that — including the repo they just added — reseeds nothing.
+    if (pickedRepo.current) return;
     createLocked.current = false;
     const retry = retryAttempt.current;
     retryAttempt.current = null;
@@ -262,7 +300,7 @@ export function NewWorkspaceDialog({
     const nextRepo =
       retry?.repoId ??
       defaultRepoId ??
-      recentRepoId(repos, known, lastCreate?.repoId);
+      recentRepoId(knownRepos, known, lastCreate?.repoId);
     setRepoId(nextRepo);
     if (retry) {
       useCodeUiStore.getState().setNewWorkspaceDraft({
@@ -272,7 +310,7 @@ export function NewWorkspaceDialog({
     }
     setBaseRef(
       retry?.baseRef ??
-        repos.find((repo) => repo.id === nextRepo)?.default_base_ref ??
+        knownRepos.find((repo) => repo.id === nextRepo)?.default_base_ref ??
         "",
     );
     setPickedHarness(retry?.harness ?? null);
@@ -295,7 +333,7 @@ export function NewWorkspaceDialog({
     // Reset against the dialog opening, not against catalog refreshes
     // mid-open — a workspace created elsewhere must not move this form.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, defaultRepoId, repos]);
+  }, [open, defaultRepoId, knownRepos]);
 
   // A pin this machine has never installed is minutes of npm. Warming it
   // when the dialog opens — and again when the engine changes — moves that
@@ -308,7 +346,7 @@ export function NewWorkspaceDialog({
   const needsDownload = Boolean(doctorEntry && !doctorEntry.found);
   const install = useWarmHarnessInstall(client, harness, open, needsDownload);
 
-  const selectedRepo = repos.find((repo) => repo.id === repoId);
+  const selectedRepo = knownRepos.find((repo) => repo.id === repoId);
   const selectedHarness = selectableHarnesses.find(
     (entry) => entry.kind === harness,
   );
@@ -344,13 +382,13 @@ export function NewWorkspaceDialog({
   // would sit on the same npm install with nothing but a spinner. The install
   // note under the pills says what the wait is, and any engine already on
   // disk is one pick away.
-  const canCreate = Boolean(
-    repoId &&
-      selectedRepo &&
-      selectedHarness &&
-      installed &&
-      !policyBlocksCreate,
+  //
+  // Split from the repo so a repo added inline can create in the same submit,
+  // before the catalog prop carrying it has come back around.
+  const engineReady = Boolean(
+    selectedHarness && installed && !policyBlocksCreate,
   );
+  const canCreate = Boolean(repoId && selectedRepo && engineReady);
   const installNote = install && (!install.done || install.error);
 
   useEffect(() => {
@@ -452,13 +490,16 @@ export function NewWorkspaceDialog({
     setOpenPicker(id);
   }
 
-  function create() {
-    if (!canCreate || !selectedRepo || createLocked.current) return;
+  function create(added?: CodeRepoSnapshot) {
+    // A repo handed in came from the add-repo field this submit started in,
+    // and carries its own base ref: `baseRef` still holds the old repo's.
+    const repo = added ?? selectedRepo;
+    if (!engineReady || !repo || createLocked.current) return;
     createLocked.current = true;
     const attempt: CreateAttempt = {
-      repoId,
+      repoId: repo.id,
       title,
-      baseRef,
+      baseRef: added ? added.default_base_ref : baseRef,
       startingPrompt,
       harness,
       permissionMode: postedMode,
@@ -479,7 +520,28 @@ export function NewWorkspaceDialog({
     } else {
       onOpenChange(false);
     }
-    startCreateAttempt(attempt, selectedRepo);
+    startCreateAttempt(attempt, repo);
+  }
+
+  /**
+   * Take the repo the add-repo field just registered, then keep going.
+   *
+   * The whole point of the field is that adding a repo is not its own errand:
+   * the first message is already typed, so this submit continues into the
+   * same create chain. An engine that cannot start yet is the one case that
+   * stops here, and it leaves the repo picked and the message intact.
+   */
+  function repoAdded(repo: CodeRepoSnapshot) {
+    pickedRepo.current = repo.id;
+    setAddedRepo(repo);
+    setRepoId(repo.id);
+    setBaseRef(repo.default_base_ref);
+    setOpenPicker(null);
+    if (engineReady) {
+      create(repo);
+      return;
+    }
+    focusPrompt();
   }
 
   function startCreateAttempt(
@@ -488,7 +550,7 @@ export function NewWorkspaceDialog({
   ) {
     const repo =
       selectedRepo ??
-      repos.find((candidate) => candidate.id === attempt.repoId);
+      knownRepos.find((candidate) => candidate.id === attempt.repoId);
     if (!repo) {
       toast.error("Could not create the workspace because its repo is gone");
       return;
@@ -680,6 +742,14 @@ export function NewWorkspaceDialog({
     void create();
   }
 
+  const addRepo = useAddRepoInline({
+    open,
+    active: openPicker === "addRepo",
+    onAdded: repoAdded,
+  });
+  /** With no repo yet, the pill is the add-repo field rather than a menu. */
+  const firstRepo = knownRepos.length === 0;
+
   const HarnessIcon = HARNESS_ICONS[harness];
   const anyUnusable = allHarnesses.some((entry) =>
     harnessUnusableReason(entry),
@@ -714,7 +784,11 @@ export function NewWorkspaceDialog({
             // with a dropdown up as well.
             if (mod && !event.altKey && !event.shiftKey) {
               event.preventDefault();
-              void create();
+              // The chord belongs to whatever this submit is finishing. With
+              // the add-repo field open, that is registering the repo — which
+              // then continues into the create anyway.
+              if (openPicker === "addRepo") addRepo.submit();
+              else void create();
             }
             return;
           }
@@ -728,7 +802,7 @@ export function NewWorkspaceDialog({
             event.code === "KeyN"
           ) {
             event.preventDefault();
-            togglePicker("repo");
+            togglePicker(firstRepo ? "addRepo" : "repo");
             return;
           }
           if (!event.altKey || mod || event.shiftKey) return;
@@ -755,45 +829,91 @@ export function NewWorkspaceDialog({
           onSubmit={submit}
         >
           <div className="flex min-w-0 flex-wrap items-center gap-x-1 gap-y-1 px-3 pt-3">
-            <DropdownMenu {...pickerProps("repo")}>
-              <WithTooltip label={`Repo · ${command ? "⌘N" : "Ctrl+N"}`}>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    className="h-8 max-w-64 gap-2 px-2.5"
-                    disabled={repos.length === 0}
-                    aria-label="Repo"
-                  >
-                    <FolderGit2 className="size-4 shrink-0 opacity-70" />
-                    <span className="truncate">
-                      {selectedRepo?.display_name ?? "No repos"}
-                    </span>
-                    <ChevronDown className="size-4 shrink-0 opacity-50" />
-                  </Button>
-                </DropdownMenuTrigger>
-              </WithTooltip>
-              <DropdownMenuContent align="start" className="z-[60] w-64">
-                {repos.map((repo) => (
-                  <DropdownMenuItem
-                    key={repo.id}
-                    onSelect={() => {
-                      setRepoId(repo.id);
-                      setBaseRef(repo.default_base_ref);
-                    }}
-                    className="flex items-center gap-2"
-                  >
-                    <FolderGit2 className="text-muted-foreground size-4 shrink-0" />
-                    <span className="min-w-0 flex-1 truncate">
-                      {repo.display_name}
-                    </span>
-                    {repo.id === repoId && (
-                      <Check className="size-4 shrink-0" />
-                    )}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <Popover {...pickerProps("addRepo")}>
+              {firstRepo ? (
+                <WithTooltip
+                  label={`Add a repo · ${command ? "⌘N" : "Ctrl+N"}`}
+                >
+                  <PopoverTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="h-8 max-w-64 gap-2 px-2.5"
+                      aria-label="Repo"
+                    >
+                      <FolderGit2 className="size-4 shrink-0 opacity-70" />
+                      <span className="truncate">Add a repo</span>
+                      <ChevronDown className="size-4 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                </WithTooltip>
+              ) : (
+                <PopoverAnchor asChild>
+                  <span className="inline-flex min-w-0">
+                    <DropdownMenu {...pickerProps("repo")}>
+                      <WithTooltip
+                        label={`Repo · ${command ? "⌘N" : "Ctrl+N"}`}
+                      >
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            className="h-8 max-w-64 gap-2 px-2.5"
+                            aria-label="Repo"
+                          >
+                            <FolderGit2 className="size-4 shrink-0 opacity-70" />
+                            <span className="truncate">
+                              {selectedRepo?.display_name ?? "No repo"}
+                            </span>
+                            <ChevronDown className="size-4 shrink-0 opacity-50" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                      </WithTooltip>
+                      <DropdownMenuContent
+                        align="start"
+                        className="z-[60] w-64"
+                      >
+                        {knownRepos.map((repo) => (
+                          <DropdownMenuItem
+                            key={repo.id}
+                            onSelect={() => {
+                              pickedRepo.current = repo.id;
+                              setRepoId(repo.id);
+                              setBaseRef(repo.default_base_ref);
+                            }}
+                            className="flex items-center gap-2"
+                          >
+                            <FolderGit2 className="text-muted-foreground size-4 shrink-0" />
+                            <span className="min-w-0 flex-1 truncate">
+                              {repo.display_name}
+                            </span>
+                            {repo.id === repoId && (
+                              <Check className="size-4 shrink-0" />
+                            )}
+                          </DropdownMenuItem>
+                        ))}
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onSelect={() => setOpenPicker("addRepo")}
+                          className="flex items-center gap-2"
+                        >
+                          <Plus className="text-muted-foreground size-4 shrink-0" />
+                          <span className="min-w-0 flex-1 truncate">
+                            Add a repo…
+                          </span>
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </span>
+                </PopoverAnchor>
+              )}
+              <PopoverContent align="start" className="z-[60] w-80 p-3">
+                <AddRepoInline
+                  state={addRepo}
+                  submitLabel={engineReady ? "Add and create" : "Add repo"}
+                />
+              </PopoverContent>
+            </Popover>
             <Popover {...pickerProps("name")}>
               <WithTooltip label={`Name · ${alt("N")}`}>
                 <PopoverTrigger asChild>

--- a/crates/tidebreak-desktop/ui/src/code/addRepoInput.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/addRepoInput.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addRepoCloneRequest,
+  addRepoInputClones,
+  classifyAddRepoInput,
+} from "./addRepoInput";
+
+describe("classifyAddRepoInput", () => {
+  it("reads a path, a remote, and a GitHub slug out of one field", () => {
+    expect(classifyAddRepoInput("")).toBe("empty");
+    expect(classifyAddRepoInput("   ")).toBe("empty");
+    expect(classifyAddRepoInput("/Users/sam/src/app")).toBe("path");
+    expect(classifyAddRepoInput("~/src/app")).toBe("path");
+    expect(classifyAddRepoInput("./app")).toBe("path");
+    expect(classifyAddRepoInput("../app")).toBe("path");
+    expect(classifyAddRepoInput("https://example.com/acme/app.git")).toBe(
+      "url",
+    );
+    expect(classifyAddRepoInput("ssh://git@example.com/acme/app")).toBe("url");
+    expect(classifyAddRepoInput("git@github.com:acme/app.git")).toBe("url");
+    expect(classifyAddRepoInput("acme/app")).toBe("github");
+  });
+
+  it("keeps a Windows path off the scp-remote branch", () => {
+    // `C:\src\app` matches Git's `user@host:path` shape closely enough that a
+    // looser rule would try to clone a drive letter.
+    expect(classifyAddRepoInput("C:\\Users\\sam\\app")).toBe("path");
+    expect(classifyAddRepoInput("C:/Users/sam/app")).toBe("path");
+  });
+
+  it("sends anything it cannot place to the machine as a path", () => {
+    // `createCodeRepo` answers with the reason that path is not a repository,
+    // which beats any guess this function could make.
+    expect(classifyAddRepoInput("app")).toBe("path");
+    expect(classifyAddRepoInput("acme/app/extra")).toBe("path");
+  });
+
+  it("knows which kinds need somewhere to clone into", () => {
+    expect(addRepoInputClones("url")).toBe(true);
+    expect(addRepoInputClones("github")).toBe(true);
+    expect(addRepoInputClones("path")).toBe(false);
+    expect(addRepoInputClones("empty")).toBe(false);
+  });
+});
+
+describe("addRepoCloneRequest", () => {
+  it("sends a URL under `url` and a slug under `github`", () => {
+    expect(
+      addRepoCloneRequest({
+        value: " https://example.com/acme/app.git ",
+        parentDir: "/tmp/src",
+        machineChoosesDestination: false,
+      }),
+    ).toEqual({
+      url: "https://example.com/acme/app.git",
+      parent_dir: "/tmp/src",
+    });
+    expect(
+      addRepoCloneRequest({
+        value: "acme/app",
+        parentDir: "/tmp/src",
+        machineChoosesDestination: false,
+      }),
+    ).toEqual({ github: "acme/app", parent_dir: "/tmp/src" });
+  });
+
+  it("omits a destination the machine chooses for itself", () => {
+    // The field was never shown, so whatever a defaults read left behind must
+    // not decide where the checkout lands.
+    expect(
+      addRepoCloneRequest({
+        value: "acme/app",
+        parentDir: "/tmp/stale",
+        machineChoosesDestination: true,
+      }),
+    ).toEqual({ github: "acme/app", parent_dir: undefined });
+  });
+
+  it("refuses a clone with nowhere to go, and a path that never clones", () => {
+    expect(
+      addRepoCloneRequest({
+        value: "acme/app",
+        parentDir: "  ",
+        machineChoosesDestination: false,
+      }),
+    ).toBeNull();
+    expect(
+      addRepoCloneRequest({
+        value: "/Users/sam/app",
+        parentDir: "/tmp/src",
+        machineChoosesDestination: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/addRepoInput.ts
+++ b/crates/tidebreak-desktop/ui/src/code/addRepoInput.ts
@@ -1,0 +1,70 @@
+import type { CodeCloneRequest } from "./CodeUpdatesStore";
+
+/**
+ * What one typed line in the inline add-repo field asks for.
+ *
+ * The add-repo palette asks the source first and then shows the matching
+ * form. The new-workspace composer has room for one field, so the field
+ * reads the answer out of the value instead: a path registers a checkout, a
+ * URL or an `owner/repo` clones one.
+ */
+export type AddRepoInputKind = "empty" | "path" | "url" | "github";
+
+/** A scheme-qualified remote: `https://`, `ssh://`, `git://`, `file://`. */
+const SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+/** Git's scp-like remote, `git@github.com:acme/app.git`. */
+const SCP_REMOTE = /^[^\s/@]+@[^\s/:]+:/;
+/** A path this machine would resolve: absolute, home-relative, or explicit. */
+const PATH_PREFIX = /^(?:[/~]|\.{1,2}\/)/;
+/** A Windows path, so a drive letter never reads as an scp remote. */
+const WINDOWS_PATH = /^[A-Za-z]:[\\/]/;
+/** `owner/repo`, the shorthand `gh` takes. */
+const GITHUB_SLUG = /^[\w.-]+\/[\w.-]+$/;
+
+/**
+ * Read what a value asks for, without asking the machine.
+ *
+ * A value that matches nothing is treated as a path: `createCodeRepo` answers
+ * with the reason that path is not a repository, which is a better error than
+ * anything this function could guess.
+ */
+export function classifyAddRepoInput(value: string): AddRepoInputKind {
+  const trimmed = value.trim();
+  if (!trimmed) return "empty";
+  if (WINDOWS_PATH.test(trimmed) || PATH_PREFIX.test(trimmed)) return "path";
+  if (SCHEME.test(trimmed) || SCP_REMOTE.test(trimmed)) return "url";
+  if (GITHUB_SLUG.test(trimmed)) return "github";
+  return "path";
+}
+
+/** Whether adding this value clones, and so needs somewhere to clone into. */
+export function addRepoInputClones(kind: AddRepoInputKind): boolean {
+  return kind === "url" || kind === "github";
+}
+
+/**
+ * The clone body for a value, or null when the destination is still missing.
+ *
+ * A field nobody was shown must not be sent, so `parent_dir` is omitted
+ * whenever the machine places clones itself — the same rule the palette
+ * follows.
+ */
+export function addRepoCloneRequest({
+  value,
+  parentDir,
+  machineChoosesDestination,
+}: {
+  value: string;
+  parentDir: string;
+  machineChoosesDestination: boolean;
+}): CodeCloneRequest | null {
+  const kind = classifyAddRepoInput(value);
+  if (!addRepoInputClones(kind)) return null;
+  const trimmed = value.trim();
+  const parent = machineChoosesDestination ? undefined : parentDir.trim();
+  if (!machineChoosesDestination && !parent) return null;
+  return {
+    ...(kind === "github" ? { github: trimmed } : { url: trimmed }),
+    parent_dir: parent || undefined,
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/useAddRepoInline.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useAddRepoInline.ts
@@ -1,0 +1,380 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { CodeRepoSnapshot, CodeRepoSources } from "../api/types";
+import { useApp } from "@/AppContext";
+import {
+  attachedRemotely,
+  hasLocalHostAuthority,
+  pickCodeDirectory,
+} from "@/host";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import {
+  activateCodeCloneClient,
+  forgetCodeClone,
+  reconcileCodeClone,
+  setCodeCloneBackground,
+  trackCodeClone,
+  useCodeUpdatesStore,
+} from "./CodeUpdatesStore";
+import {
+  addRepoCloneRequest,
+  addRepoInputClones,
+  classifyAddRepoInput,
+  type AddRepoInputKind,
+} from "./addRepoInput";
+
+const CLONE_POLL_INTERVAL_MS = 1_500;
+
+/** What the inline add-repo field is doing, and what it needs to finish. */
+export type AddRepoInlineState = {
+  value: string;
+  setValue: (next: string) => void;
+  parentDir: string;
+  setParentDir: (next: string) => void;
+  kind: AddRepoInputKind;
+  /** Whether this value clones, and so needs somewhere to clone into. */
+  needsDestination: boolean;
+  machineChoosesDestination: boolean;
+  canBrowse: boolean;
+  attached: boolean;
+  /** Why this value cannot be added from this window, when it cannot. */
+  blocked: string | null;
+  busy: boolean;
+  error: string | null;
+  /** The clone's own phase while one is running. */
+  phase: string | null;
+  percent: number | null;
+  defaultsProbeFailed: boolean;
+  defaultsBusy: boolean;
+  canSubmit: boolean;
+  submit: () => void;
+  browse: () => void;
+  browseDestination: () => void;
+  retryDefaults: () => void;
+};
+
+/**
+ * Register or clone a repository from inside the new-workspace composer.
+ *
+ * The state lives in the dialog rather than in the popover, because a clone
+ * takes minutes and the field it started from is one click from closing. A
+ * clone still running when the dialog closes is handed to the background, the
+ * same way the add-repo palette hands one over, so the resume path already in
+ * `CodeUpdatesStore` picks it up.
+ */
+export function useAddRepoInline({
+  open,
+  active,
+  onAdded,
+}: {
+  /** The dialog is open. Closing it clears what was typed. */
+  open: boolean;
+  /** The field is on screen. The machine is probed once it is. */
+  active: boolean;
+  onAdded: (repo: CodeRepoSnapshot) => void;
+}): AddRepoInlineState {
+  const { client } = useApp();
+  const upsertRepo = useCodeCatalogStore((state) => state.upsertRepo);
+  const [value, setValue] = useState("");
+  const [parentDir, setParentDir] = useState("");
+  const [sources, setSources] = useState<CodeRepoSources | null>(null);
+  const [seededDestination, setSeededDestination] = useState(false);
+  const [defaultsProbeFailed, setDefaultsProbeFailed] = useState(false);
+  const [defaultsBusy, setDefaultsBusy] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const live = useRef(true);
+  const probed = useRef(false);
+  const jobIdRef = useRef<string | null>(null);
+  const handedOff = useRef<string | null>(null);
+  const addedRef = useRef(onAdded);
+  addedRef.current = onAdded;
+  // A destination the reader typed is never overwritten by a probe that
+  // answers later.
+  const destinationEdited = useRef(false);
+
+  const job = useCodeUpdatesStore((state) =>
+    jobId ? state.cloneJobs[jobId] : undefined,
+  );
+
+  const canBrowse = hasLocalHostAuthority();
+  const attached = attachedRemotely();
+  const machineChoosesDestination = sources?.chooses_destination === true;
+  const kind = classifyAddRepoInput(value);
+  const needsDestination =
+    addRepoInputClones(kind) && !machineChoosesDestination;
+
+  const sourceState = useCallback(
+    (wanted: string) =>
+      sources?.sources.find((source) => source.kind === wanted),
+    [sources],
+  );
+
+  // Why the machine would refuse this value before it is sent. A window
+  // attached to another machine cannot name a path that machine resolves,
+  // which is why the palette hides its local source outright.
+  const blocked = useMemo(() => {
+    if (kind === "path") {
+      if (attached) {
+        return "This window is attached to another machine. Clone from a URL instead.";
+      }
+      const local = sourceState("local");
+      if (local && !local.available) {
+        return (
+          local.remediation || "This machine cannot register a local folder."
+        );
+      }
+      return null;
+    }
+    if (kind === "url" || kind === "github") {
+      const source = sourceState(kind === "github" ? "github" : "git_url");
+      if (source && !source.available) {
+        return source.remediation || "This machine cannot clone that source.";
+      }
+      if (attached && !machineChoosesDestination) {
+        return "This machine has no clone destination configured. An administrator sets one on the machine.";
+      }
+    }
+    return null;
+  }, [attached, kind, machineChoosesDestination, sourceState]);
+
+  const loadDefaults = useCallback(
+    async (signal: AbortSignal, replaceDestination: boolean) => {
+      if (replaceDestination) setDefaultsBusy(true);
+      try {
+        const next = await client.getCodeCloneDefaults(signal);
+        if (!live.current || signal.aborted) return;
+        setDefaultsProbeFailed(false);
+        if (replaceDestination || !destinationEdited.current) {
+          setParentDir(next.parent_dir ?? "");
+          setSeededDestination(true);
+        }
+      } catch {
+        if (!live.current || signal.aborted) return;
+        // Administrator-only. A member on a shared machine is refused here,
+        // and the machine fills the destination in for itself.
+        setDefaultsProbeFailed(replaceDestination);
+      } finally {
+        if (live.current && !signal.aborted) setDefaultsBusy(false);
+      }
+    },
+    [client],
+  );
+
+  useEffect(() => {
+    live.current = true;
+    return () => {
+      live.current = false;
+    };
+  }, []);
+
+  // Clearing on close, not on the field closing: a failed register keeps what
+  // was typed so the fix is an edit rather than a retype.
+  useEffect(() => {
+    if (open) return;
+    probed.current = false;
+    destinationEdited.current = false;
+    setValue("");
+    setParentDir("");
+    setSources(null);
+    setSeededDestination(false);
+    setDefaultsProbeFailed(false);
+    setDefaultsBusy(false);
+    setBusy(false);
+    setError(null);
+    setJobId(null);
+    jobIdRef.current = null;
+  }, [open]);
+
+  // Probe once the field is actually on screen. Every Cmd+N would otherwise
+  // spend two requests on a picker most creates never open.
+  useEffect(() => {
+    if (!open || !active || probed.current) return;
+    probed.current = true;
+    activateCodeCloneClient(client);
+    const controller = new AbortController();
+    void client
+      .getCodeRepoSources(controller.signal)
+      .then((next) => {
+        if (live.current && !controller.signal.aborted) setSources(next);
+      })
+      .catch(() => {});
+    void loadDefaults(controller.signal, false);
+    return () => controller.abort();
+  }, [active, client, loadDefaults, open]);
+
+  // The clone's durable state is the server's. Poll it the way the palette
+  // does, so a dropped update stream still finishes the handoff.
+  useEffect(() => {
+    if (!jobId || job?.done) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const poll = async () => {
+      const next = await reconcileCodeClone(client, jobId);
+      if (cancelled || !next || next.done) return;
+      timer = setTimeout(() => void poll(), CLONE_POLL_INTERVAL_MS);
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [client, job?.done, jobId]);
+
+  // A clone still running when the dialog closes keeps running. Backgrounding
+  // it is what makes it resumable from the palette.
+  useEffect(() => {
+    return () => {
+      const running = jobIdRef.current;
+      if (running) setCodeCloneBackground(client, running, true);
+    };
+  }, [client]);
+
+  useEffect(() => {
+    if (!jobId || !job?.done || handedOff.current === jobId) return;
+    handedOff.current = jobId;
+    if (job.error || !job.repo_id) {
+      forgetCodeClone(client, jobId);
+      jobIdRef.current = null;
+      setJobId(null);
+      setBusy(false);
+      setError(job.error || "The clone finished without a repository.");
+      return;
+    }
+    const repoId = job.repo_id;
+    const finishedJobId = jobId;
+    void client
+      .getCodeRepo(repoId)
+      .then((repo) => {
+        if (!live.current) return;
+        upsertRepo(repo);
+        forgetCodeClone(client, finishedJobId);
+        jobIdRef.current = null;
+        setJobId(null);
+        setBusy(false);
+        addedRef.current(repo);
+      })
+      .catch((caught: unknown) => {
+        if (!live.current) return;
+        jobIdRef.current = null;
+        setJobId(null);
+        setBusy(false);
+        setError(
+          friendlyErrorMessage(
+            caught,
+            "Cloned, but could not read the repository",
+          ),
+        );
+      });
+  }, [client, job, jobId, upsertRepo]);
+
+  const canSubmit =
+    !busy &&
+    kind !== "empty" &&
+    !blocked &&
+    (!needsDestination || parentDir.trim().length > 0);
+
+  const submit = useCallback(() => {
+    if (busy || blocked) return;
+    const inputKind = classifyAddRepoInput(value);
+    if (inputKind === "empty") return;
+    setError(null);
+    if (inputKind === "path") {
+      setBusy(true);
+      void client
+        .createCodeRepo({ path: value.trim() })
+        .then((repo) => {
+          if (!live.current) return;
+          upsertRepo(repo);
+          setBusy(false);
+          addedRef.current(repo);
+        })
+        .catch((caught: unknown) => {
+          if (!live.current) return;
+          setBusy(false);
+          setError(
+            friendlyErrorMessage(caught, "Could not register that repository"),
+          );
+        });
+      return;
+    }
+    const request = addRepoCloneRequest({
+      value,
+      parentDir,
+      machineChoosesDestination,
+    });
+    if (!request) return;
+    setBusy(true);
+    void client
+      .startCodeClone(request)
+      .then((started) => {
+        if (!live.current) return;
+        if (!trackCodeClone(client, started, request)) {
+          setBusy(false);
+          return;
+        }
+        handedOff.current = null;
+        jobIdRef.current = started.id;
+        setJobId(started.id);
+      })
+      .catch((caught: unknown) => {
+        if (!live.current) return;
+        setBusy(false);
+        setError(friendlyErrorMessage(caught, "Could not start the clone"));
+      });
+  }, [
+    blocked,
+    busy,
+    client,
+    machineChoosesDestination,
+    parentDir,
+    upsertRepo,
+    value,
+  ]);
+
+  const editParentDir = useCallback((next: string) => {
+    destinationEdited.current = true;
+    setParentDir(next);
+  }, []);
+
+  const browseInto = useCallback(
+    async (into: "value" | "destination") => {
+      const picked = await pickCodeDirectory();
+      if (!picked || !live.current) return;
+      if (into === "value") setValue(picked);
+      else editParentDir(picked);
+    },
+    [editParentDir],
+  );
+
+  const retryDefaults = useCallback(() => {
+    const controller = new AbortController();
+    void loadDefaults(controller.signal, true);
+  }, [loadDefaults]);
+
+  return {
+    value,
+    setValue,
+    parentDir,
+    setParentDir: editParentDir,
+    kind,
+    needsDestination,
+    machineChoosesDestination,
+    canBrowse,
+    attached,
+    blocked,
+    busy,
+    error,
+    phase: jobId ? (job?.phase ?? "Starting") : null,
+    percent: jobId ? (job?.percent ?? null) : null,
+    defaultsProbeFailed: defaultsProbeFailed && !seededDestination,
+    defaultsBusy,
+    canSubmit,
+    submit,
+    browse: () => void browseInto("value"),
+    browseDestination: () => void browseInto("destination"),
+    retryDefaults,
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -140,7 +140,7 @@ const MODELS: Partial<
   ],
 };
 
-function appContext(): AppContextValue {
+function appContext(overrides: Record<string, unknown> = {}): AppContextValue {
   const client = {
     listCodeHarnessModels: async (kind: HarnessKind) => ({
       kind,
@@ -162,6 +162,21 @@ function appContext(): AppContextValue {
       done: false,
     }),
     getHarnessDoctor: async () => harnessDoctor,
+    // What the add-repo field reads before it can offer a source.
+    getCodeRepoSources: async () => ({
+      sources: [
+        { kind: "local", available: true },
+        { kind: "git_url", available: true },
+        { kind: "github", available: true },
+      ],
+      chooses_destination: false,
+    }),
+    getCodeCloneDefaults: async () => ({
+      parent_dir: "/Users/sam/src",
+      gh_found: true,
+      gh_authenticated: true,
+      gh_remediation: "",
+    }),
     // The story has no server: create reports itself as stubbed rather than
     // handing the dialog an empty snapshot.
     createCodeWorkspace: async () => {
@@ -169,6 +184,7 @@ function appContext(): AppContextValue {
     },
     createCodeSession: fn(),
     submitCodeTurn: fn(),
+    ...overrides,
   };
   return {
     client: client as never,
@@ -237,17 +253,22 @@ function NewWorkspace({
   installs,
   initialHarness,
   permissionModeCeiling,
+  catalog = repos,
+  client,
 }: {
   doctor?: typeof harnessDoctor;
   installs?: typeof harnessInstallsInFlight;
   initialHarness?: HarnessKind;
   permissionModeCeiling?: PermissionMode;
+  /** The registered repos. Empty is a first run, which the dialog now serves. */
+  catalog?: CodeRepoSnapshot[];
+  client?: Record<string, unknown>;
 }) {
   // Seed the catalog before the dialog mounts: its defaults read the store.
   const [seeded, setSeeded] = useState(false);
   useEffect(() => {
     useCodeCatalogStore.setState({
-      repos,
+      repos: catalog,
       doctor,
       sessionsByWorkspace: {},
       workspaces: [],
@@ -260,7 +281,7 @@ function NewWorkspace({
       newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT,
     });
     setSeeded(true);
-  }, [doctor, initialHarness, installs]);
+  }, [catalog, doctor, initialHarness, installs]);
   if (!seeded) return null;
   const policy: ManagedPolicy = {
     managed: Boolean(permissionModeCeiling),
@@ -271,8 +292,8 @@ function NewWorkspace({
   };
   return (
     <ManagedPolicyContext.Provider value={policy}>
-      <AppContextProvider value={appContext()}>
-        <NewWorkspaceDialog open onOpenChange={fn()} repos={repos} />
+      <AppContextProvider value={appContext(client)}>
+        <NewWorkspaceDialog open onOpenChange={fn()} repos={catalog} />
       </AppContextProvider>
     </ManagedPolicyContext.Provider>
   );
@@ -430,5 +451,148 @@ export const BlockedByManagedCeiling: Story = {
       ),
     ).resolves.toBeVisible();
     await expect(page.getByRole("button", { name: /Create/ })).toBeDisabled();
+  },
+};
+
+/**
+ * A first run, with nothing registered. The repo pill is the add-repo field
+ * rather than a dead menu, and one field takes a path, a Git URL, or
+ * `owner/repo` — so the message stays typed and the next submit creates.
+ */
+export const FirstRepo: Story = {
+  args: { catalog: [] },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.type(
+      await page.findByRole("textbox", { name: "First message" }),
+      "Add a health endpoint",
+    );
+    const pill = page.getByRole("button", { name: "Repo" });
+    await expect(pill).toHaveTextContent("Add a repo");
+    await userEvent.click(pill);
+    await expect(
+      await page.findByRole("textbox", { name: "Repository path or URL" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Add and create/ }),
+    ).toBeDisabled();
+  },
+};
+
+/**
+ * A remote takes a destination, seeded from what the machine remembers, and
+ * the submit says what it finishes with rather than what it starts.
+ */
+export const FirstRepoFromRemote: Story = {
+  args: { catalog: [] },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await page.findByRole("button", { name: "Repo" }));
+    await userEvent.type(
+      await page.findByRole("textbox", { name: "Repository path or URL" }),
+      "acme/app",
+    );
+    await expect(
+      await page.findByRole("textbox", { name: "Destination folder" }),
+    ).toHaveValue("/Users/sam/src");
+    await expect(
+      page.getByRole("button", { name: /Add and create/ }),
+    ).toBeEnabled();
+  },
+};
+
+/** A clone is minutes of work, so the field reports it and keeps running. */
+export const FirstRepoCloning: Story = {
+  args: {
+    catalog: [],
+    client: {
+      startCodeClone: async () => ({
+        id: "job-story",
+        phase: "Receiving objects",
+        percent: 42,
+        done: false,
+      }),
+      getCodeCloneJob: async () => ({
+        id: "job-story",
+        phase: "Receiving objects",
+        percent: 42,
+        done: false,
+      }),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await page.findByRole("button", { name: "Repo" }));
+    await userEvent.type(
+      await page.findByRole("textbox", { name: "Repository path or URL" }),
+      "https://example.com/acme/app.git",
+    );
+    await userEvent.click(page.getByRole("button", { name: /Add and create/ }));
+    await expect(
+      await page.findByTestId("add-repo-clone-phase"),
+    ).toHaveTextContent("Receiving objects");
+  },
+};
+
+/**
+ * A refused registration is answered where it was typed. The message and the
+ * path both survive, because the fix is an edit rather than a retype.
+ */
+export const FirstRepoRefused: Story = {
+  args: {
+    catalog: [],
+    client: {
+      createCodeRepo: async () => {
+        throw new Error("/Users/sam/notes is not a git repository");
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.type(
+      await page.findByRole("textbox", { name: "First message" }),
+      "Add a health endpoint",
+    );
+    await userEvent.click(page.getByRole("button", { name: "Repo" }));
+    await userEvent.type(
+      await page.findByRole("textbox", { name: "Repository path or URL" }),
+      "/Users/sam/notes",
+    );
+    await userEvent.click(page.getByRole("button", { name: /Add and create/ }));
+    await expect(await page.findByTestId("add-repo-error")).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "First message" }),
+    ).toHaveValue("Add a health endpoint");
+  },
+};
+
+/**
+ * With the engine still downloading there is nothing to create on yet, so the
+ * submit only adds the repo and says so. The dialog stays put with the new
+ * repo picked and the message intact.
+ */
+export const FirstRepoWhileEngineDownloads: Story = {
+  args: {
+    catalog: [],
+    doctor: harnessDoctorCold,
+    installs: {
+      claude_code: {
+        kind: "claude_code",
+        version: "2.1.234",
+        phase: "installing",
+        done: false,
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await page.findByRole("button", { name: "Repo" }));
+    await userEvent.type(
+      await page.findByRole("textbox", { name: "Repository path or URL" }),
+      "/Users/sam/src/app",
+    );
+    await expect(
+      page.getByRole("button", { name: /Add repo/ }),
+    ).toBeInTheDocument();
   },
 };


### PR DESCRIPTION
## What changed

A first run had to leave the new-workspace composer to register a repository, then come back to it. The repo pill now registers one in place.

- With nothing in the catalog, the pill reads "Add a repo" and opens the add-repo field directly instead of a dead, disabled menu.
- With repos registered, the menu gains an "Add a repo…" row under a separator, the same shape the engine menu uses for "Coding harnesses…".
- One field reads all three sources: a path registers a checkout, a Git URL or `owner/repo` clones one. The destination folder appears only for a clone, and only when the machine does not place clones itself; it seeds from `getCodeCloneDefaults`.
- The field's submit is the dialog's submit. Registration or clone completion continues straight into the existing `createCodeWorkspace` → navigate → `createCodeSession` → `submitCodeTurn` chain, on the repo it just added. The message typed before the repo existed becomes that session's first turn.

## Why

Issue #2802. The rest of the flow was already collapsed — the add-repo palette hands off into this dialog with the repo preselected, and one dialog submit already chained workspace, session, and first turn. Repo registration was the last seam, and it cost a palette round trip.

No server change. Workspace create is synchronous, session create requires an active workspace, and every body is `deny_unknown_fields`, so this stays a client-side chain.

## Degradation

Unchanged from today, and covered by tests:

- Registration fails → the error is answered in the field, and both the message and the typed path survive for an edit rather than a retype. `createCodeWorkspace` is never called.
- The workspace, session, or turn fails after registration → the existing `setup_failed` recovery, "Try again" toast, and `offerComposerPrompt` paths run exactly as before.
- A clone is still running when the dialog closes → it is backgrounded through `setCodeCloneBackground`, so the palette's existing resume path picks it up.
- The engine is still downloading → the submit reads "Add repo" rather than "Add and create", and it leaves the repo picked and the message intact.

## Reuse

The palette's `ParentDirField` is now exported and shared, so both surfaces ask for a clone destination the same way. Clone tracking goes through the existing `trackCodeClone` / `reconcileCodeClone` / `forgetCodeClone` / `setCodeCloneBackground` helpers rather than a second implementation. The palette still owns the full flow — browsing GitHub suggestions, retrying a failed clone, resuming one from a notification — and this is the short path through it.

## Files

- `src/code/addRepoInput.ts` — reads a path, a remote, or an `owner/repo` slug out of one field, and shapes the clone body.
- `src/code/useAddRepoInline.ts` — the state, held by the dialog so an in-flight clone survives the picker closing.
- `src/code/AddRepoInline.tsx` — the field itself.
- `src/code/NewWorkspaceDialog.tsx` — the pill, the chords, and `create(added?)` taking the new repo directly.

One incidental fix: the open-reset effect no longer reseeds the form when the catalog changes mid-opening. Adding a repo grows the catalog by definition, and without this the reader's own pick would be overwritten a render later.

## What I ran

- `tsc --noEmit` — clean.
- `biome lint src` — `Checked 788 files. No fixes applied.` `biome format --write src` applied (never prettier).
- `vitest run src/code` — **72 files, 976 tests passed**, including the three new dialog tests and the seven new `addRepoInput` unit tests.
- `vitest run src/stylesContract.test.ts` — passed.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — `Storybook build completed successfully`.

New tests that fail without the change:

- `registers a repo and creates on the same submit` — asserts `createCodeRepo`, then `createCodeWorkspace` with the new `repo_id`, then `submitCodeTurn` with the message typed before the repo existed.
- `keeps the message and says why when registering fails` — asserts the error, that `createCodeWorkspace` is never called, and that both the message and the path survive.
- `clones a remote and creates on the repository it registers` — asserts the `startCodeClone` body and the create on the cloned repo.

## Visual review

Stories added under `Code/New workspace`: `FirstRepo`, `FirstRepoFromRemote`, `FirstRepoCloning`, `FirstRepoRefused`, `FirstRepoWhileEngineDownloads`. I captured all of them from the static build at 2x in dark and light and looked at the images. Three things the screenshots caught and I fixed:

- the popover heading repeated the pill's "Add a repo" — it now reads "Repository";
- the hint under the field repeated the placeholder when nothing was typed, and sat below the destination field rather than under the value it described;
- the heading was `text-xs` while the embedded destination field's label is `text-sm`, so one form carried two label sizes.

Also dropped a decorative icon from the submit button, and added a hairline above the clone progress block so the phase does not read as a note on the destination field.

Closes #2802
