### PR TITLE
feat(desktop): select workspace cards and fold rail settings

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -992,7 +992,8 @@ describe("app shell", () => {
     await screen.findByTestId("transcript");
     await waitFor(() => expect(listPendingUserQuestions).toHaveBeenCalled());
 
-    await user.click(screen.getByText("Settings"));
+    await user.click(screen.getByRole("button", { name: "Account menu" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Settings" }));
     expect(await screen.findByTestId("settings")).toBeInTheDocument();
     // A bare /settings redirects to the first section, so that is where the URL
     // lands rather than on /settings itself.
@@ -1046,7 +1047,8 @@ describe("app shell", () => {
     const user = userEvent.setup();
     const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
-    await user.click(screen.getByText("Settings"));
+    await user.click(screen.getByRole("button", { name: "Account menu" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Settings" }));
     await screen.findByTestId("settings");
 
     // Browsing sections must not bury the way out: section hops replace the

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -80,6 +80,22 @@ const client = {
     gh_found: false,
     gh_remediation: "gh is not installed.",
   })),
+  getGatewayStatus: vi.fn(async () => ({
+    signed_in: false,
+    model_count: 0,
+    sign_in: { state: "idle" as const },
+  })),
+  getCodeDeliveryRepositories: vi.fn(async () => ({
+    capability: {
+      found: true,
+      authenticated: true,
+      viewer_login: "mira-chen",
+      remediation: "",
+    },
+    repositories: [],
+    errors: [],
+    fetched_at: "2026-08-15T00:00:00.000Z",
+  })),
   openCodeUpdates: vi.fn((_onNotice: (notice: unknown) => void) => {
     return {
       close() {},
@@ -128,7 +144,11 @@ afterEach(() => {
   useCodeDeliveryStore.getState().reset();
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
-  useCodeUiStore.setState({ railPrefs: DEFAULT_RAIL_PREFS });
+  useCodeUiStore.setState({
+    railPrefs: DEFAULT_RAIL_PREFS,
+    selectedWorkspaceIds: [],
+    selectionAnchorId: null,
+  });
   window.localStorage.clear();
 });
 
@@ -414,5 +434,122 @@ describe("CodeSidebar", () => {
         name: "Broken setup · Setup failed · app · tidebreak/broken",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("cmd-clicks select without navigating, and a pair shows the bulk menu", async () => {
+    client.listCodeWorkspaces.mockResolvedValueOnce([
+      {
+        id: "ws-1",
+        repo_id: "repo-1",
+        title: "Fix login",
+        worktree_path: "/tmp/app/.worktrees/fix-login",
+        branch_name: "tidebreak/fix-login",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-15T00:00:00.000Z",
+      },
+      {
+        id: "ws-2",
+        repo_id: "repo-1",
+        title: "Fix logout",
+        worktree_path: "/tmp/app/.worktrees/fix-logout",
+        branch_name: "tidebreak/fix-logout",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-16T00:00:00.000Z",
+      },
+    ]);
+    const { router } = await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const first = await screen.findByRole("button", { name: /^Fix login/ });
+    const second = await screen.findByRole("button", { name: /^Fix logout/ });
+    fireEvent.click(first, { metaKey: true });
+    fireEvent.click(second, { metaKey: true });
+    expect(router.state.location.pathname).toBe("/code");
+    expect(first).toHaveAttribute("aria-selected", "true");
+    expect(second).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.contextMenu(first);
+    expect(
+      await screen.findByRole("menuitem", { name: "Archive 2 workspaces" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Force archive 2 workspaces" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Rename…" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("cmd-clicks include the open workspace", async () => {
+    client.listCodeWorkspaces.mockResolvedValueOnce([
+      {
+        id: "ws-1",
+        repo_id: "repo-1",
+        title: "Fix login",
+        worktree_path: "/tmp/app/.worktrees/fix-login",
+        branch_name: "tidebreak/fix-login",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-15T00:00:00.000Z",
+      },
+      {
+        id: "ws-2",
+        repo_id: "repo-1",
+        title: "Fix logout",
+        worktree_path: "/tmp/app/.worktrees/fix-logout",
+        branch_name: "tidebreak/fix-logout",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-16T00:00:00.000Z",
+      },
+    ]);
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code/w/ws-1" },
+    );
+    const open = await screen.findByRole("button", { name: /^Fix login/ });
+    const other = await screen.findByRole("button", { name: /^Fix logout/ });
+    fireEvent.click(other, { metaKey: true });
+    expect(open).toHaveAttribute("aria-selected", "true");
+    expect(other).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("clears selection when you click away from the cards", async () => {
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    const card = await screen.findByRole("button", { name: /^Fix login/ });
+    fireEvent.click(card, { metaKey: true });
+    expect(card).toHaveAttribute("aria-selected", "true");
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Workspaces" }));
+    expect(card).not.toHaveAttribute("aria-selected");
+  });
+
+  it("opens and clears selection on an unmodified click", async () => {
+    const { router } = await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    const card = await screen.findByRole("button", { name: /^Fix login/ });
+    fireEvent.click(card, { metaKey: true });
+    expect(card).toHaveAttribute("aria-selected", "true");
+    fireEvent.click(card);
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-1"),
+    );
+    expect(card).not.toHaveAttribute("aria-selected");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -33,15 +33,23 @@ import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import { RailSettingsMenu } from "./RailSettingsMenu";
 import {
   useWorkspaceCardCommands,
+  workspaceBulkCommands,
   workspaceCommands,
 } from "./workspaceActions";
 import { tidebreakProductRepo } from "./uneffMe";
-import { WorkspaceCard } from "./WorkspaceCard";
+import { WorkspaceCard, WorkspaceStatusMark } from "./WorkspaceCard";
 import {
   arrangeWorkspaces,
   isPutAway,
+  isWorkspaceStatusRank,
   workspaceStackParent,
 } from "./workspaceCards";
+import {
+  pointerSelectIntent,
+  rangeWorkspaceSelection,
+  seedOpenWorkspaceSelection,
+  toggleWorkspaceSelection,
+} from "./workspaceSelection";
 import { fetchFixErrorsLogs } from "./checkLogs";
 import { prWorkflowPrompt } from "./prActions";
 import type { WorkspaceWorkflowAction } from "./workspaceWorkflow";
@@ -92,7 +100,7 @@ export function CodeSidebar() {
   const setAddRepoOpen = useCodeUiStore((state) => state.setAddRepoOpen);
   const prefs = useCodeUiStore((state) => state.railPrefs);
   const runComposerPrompt = useCodeUiStore((state) => state.runComposerPrompt);
-  const { run, dialogs } = useWorkspaceCardCommands();
+  const { run, runBulk, dialogs } = useWorkspaceCardCommands();
   const layout = useLayoutState();
   const terminalOpen =
     findCodeTerminalTab(layout) !== null && pathname.startsWith("/code/w/");
@@ -108,6 +116,73 @@ export function CodeSidebar() {
 
   const groups = arrangeWorkspaces(prefs.sortMode, repos, workspaces, digests);
   const canOpenWorktree = canOpenLocalCodeWorktree();
+  const selectedWorkspaceIds = useCodeUiStore(
+    (state) => state.selectedWorkspaceIds,
+  );
+  const replaceWorkspaceSelection = useCodeUiStore(
+    (state) => state.replaceWorkspaceSelection,
+  );
+  const clearWorkspaceSelection = useCodeUiStore(
+    (state) => state.clearWorkspaceSelection,
+  );
+  const selectableIds = groups.flatMap((group) =>
+    group.workspaces
+      .filter((workspace) => workspace.status !== "creating")
+      .map((workspace) => workspace.id),
+  );
+  const selectedWorkspaces = workspaces.filter(
+    (workspace) =>
+      selectedWorkspaceIds.includes(workspace.id) &&
+      workspace.status !== "creating" &&
+      !isPutAway(workspace),
+  );
+
+  function applyPointerSelect(
+    workspaceId: string,
+    event: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean },
+  ) {
+    const intent = pointerSelectIntent(event);
+    const { selectedWorkspaceIds: current, selectionAnchorId } =
+      useCodeUiStore.getState();
+    const seeded = seedOpenWorkspaceSelection(
+      current,
+      viewedWorkspaceId,
+      selectableIds,
+      workspaceId,
+    );
+    if (intent === "range") {
+      const anchor = selectionAnchorId ?? seeded.anchorId;
+      replaceWorkspaceSelection(
+        rangeWorkspaceSelection(selectableIds, anchor, workspaceId),
+        anchor ?? workspaceId,
+      );
+      return;
+    }
+    if (intent === "toggle") {
+      replaceWorkspaceSelection(
+        toggleWorkspaceSelection(seeded.selected, workspaceId),
+        workspaceId,
+      );
+    }
+  }
+
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      if (useCodeUiStore.getState().selectedWorkspaceIds.length === 0) return;
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (
+        target.closest(
+          "[data-workspace-card], [role='menu'], [role='alertdialog']",
+        )
+      ) {
+        return;
+      }
+      clearWorkspaceSelection();
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [clearWorkspaceSelection]);
 
   return (
     <SidebarFrame
@@ -163,23 +238,52 @@ export function CodeSidebar() {
         </button>
       </div>
 
-      <div className="flex min-h-0 flex-col gap-1">
+      <div
+        className="flex min-h-0 flex-col gap-1"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            if (useCodeUiStore.getState().selectedWorkspaceIds.length === 0) {
+              return;
+            }
+            event.preventDefault();
+            clearWorkspaceSelection();
+            return;
+          }
+          if (
+            (event.metaKey || event.ctrlKey) &&
+            event.key.toLowerCase() === "a"
+          ) {
+            event.preventDefault();
+            replaceWorkspaceSelection(selectableIds, selectableIds[0] ?? null);
+          }
+        }}
+      >
         {groups.map((group) => (
           <div key={group.key} className="flex flex-col gap-1">
-            {group.label && (
-              <div
-                className="truncate px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90"
-                title={group.label}
-              >
-                {group.key === "archived"
-                  ? `${group.label} · ${group.workspaces.length}`
-                  : group.label}
-              </div>
-            )}
+            {group.label &&
+              (isWorkspaceStatusRank(group.key) ? (
+                <div className="flex items-center gap-1.5 px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90">
+                  <WorkspaceStatusMark rank={group.key} />
+                  <span className="min-w-0 truncate" title={group.label}>
+                    {group.label} · {group.workspaces.length}
+                  </span>
+                </div>
+              ) : (
+                <div
+                  className="truncate px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90"
+                  title={group.label}
+                >
+                  {group.key === "archived"
+                    ? `${group.label} · ${group.workspaces.length}`
+                    : group.label}
+                </div>
+              ))}
             {group.workspaces.map((workspace) => {
               const digest = digests[workspace.id];
               const pr = digest?.pr_state ?? workspace.pr;
               const creating = workspace.status === "creating";
+              const selected = selectedWorkspaceIds.includes(workspace.id);
+              const bulk = selected && selectedWorkspaces.length > 1;
               return (
                 <WorkspaceCard
                   key={workspace.id}
@@ -191,6 +295,7 @@ export function CodeSidebar() {
                       ?.display_name ?? workspace.repo_id
                   }
                   active={pathname === `/code/w/${workspace.id}`}
+                  selected={selected}
                   terminalOpen={
                     terminalOpen && viewedWorkspaceId === workspace.id
                   }
@@ -202,22 +307,25 @@ export function CodeSidebar() {
                       prefs.showRepoChip && prefs.sortMode !== "by-repo",
                     branch: prefs.showBranch && !creating,
                   }}
+                  contextMenuLabel={bulk ? "Workspace" : undefined}
                   commands={
                     creating
                       ? []
-                      : workspaceCommands({
-                          hasPr: Boolean(pr),
-                          archived: isPutAway(workspace),
-                          hasSession: Boolean(sessions[workspace.id]),
-                          attentionPinned:
-                            (
-                              digest?.attention ??
-                              sessions[workspace.id]?.attention
-                            )?.state.type === "manual",
-                          canOpenWorktree,
-                          canUneff: Boolean(tidebreakProductRepo(repos)),
-                          setupFailed: workspace.status === "setup_failed",
-                        })
+                      : bulk
+                        ? workspaceBulkCommands(selectedWorkspaces.length)
+                        : workspaceCommands({
+                            hasPr: Boolean(pr),
+                            archived: isPutAway(workspace),
+                            hasSession: Boolean(sessions[workspace.id]),
+                            attentionPinned:
+                              (
+                                digest?.attention ??
+                                sessions[workspace.id]?.attention
+                              )?.state.type === "manual",
+                            canOpenWorktree,
+                            canUneff: Boolean(tidebreakProductRepo(repos)),
+                            setupFailed: workspace.status === "setup_failed",
+                          })
                   }
                   childSessions={watchChildren(
                     { childrenByWorkspace },
@@ -232,10 +340,18 @@ export function CodeSidebar() {
                   }
                   onOpen={() => {
                     if (creating) return;
+                    clearWorkspaceSelection();
                     void navigate({
                       to: "/code/w/$workspaceId",
                       params: { workspaceId: workspace.id },
                     });
+                  }}
+                  onSelectPointer={(event) =>
+                    applyPointerSelect(workspace.id, event)
+                  }
+                  onMenuOpen={() => {
+                    if (selectedWorkspaceIds.includes(workspace.id)) return;
+                    replaceWorkspaceSelection([workspace.id], workspace.id);
                   }}
                   onOpenChildSession={(sessionId) =>
                     void navigate({
@@ -345,14 +461,21 @@ export function CodeSidebar() {
                       params: { workspaceId: workspace.id },
                     });
                   }}
-                  onCommand={(command) =>
+                  onCommand={(command) => {
+                    if (
+                      bulk &&
+                      (command === "archive" || command === "force-archive")
+                    ) {
+                      runBulk(command, selectedWorkspaces);
+                      return;
+                    }
                     run(command, {
                       workspace,
                       title: digest?.title ?? workspace.title,
                       pr,
                       session: sessions[workspace.id],
-                    })
-                  }
+                    });
+                  }}
                 />
               );
             })}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -405,6 +405,17 @@ export type CodeUiStore = {
   openFilePending: string | null;
   requestOpenFilePath: (path: string) => void;
   takeOpenFilePath: () => string | null;
+  /**
+   * Ephemeral rail selection. Cmd/Ctrl-click and shift-click write it;
+   * unmodified click, Escape, and a bulk archive clear it. Not persisted.
+   */
+  selectedWorkspaceIds: string[];
+  selectionAnchorId: string | null;
+  replaceWorkspaceSelection: (
+    ids: readonly string[],
+    anchorId: string | null,
+  ) => void;
+  clearWorkspaceSelection: () => void;
 };
 
 /** The header's primary action, as the palette's leading row. */
@@ -473,6 +484,15 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   publishWorkflowSuggestion: (workflowSuggestion) =>
     set({ workflowSuggestion }),
   openFilePending: null,
+  selectedWorkspaceIds: [],
+  selectionAnchorId: null,
+  replaceWorkspaceSelection: (ids, anchorId) =>
+    set({
+      selectedWorkspaceIds: [...ids],
+      selectionAnchorId: anchorId,
+    }),
+  clearWorkspaceSelection: () =>
+    set({ selectedWorkspaceIds: [], selectionAnchorId: null }),
   requestOpenFilePath: (path) => set({ openFilePending: path }),
   takeOpenFilePath: () => {
     const pending = get().openFilePending;
@@ -600,5 +620,7 @@ export function resetCodeUiHostState(): void {
     archivePending: false,
     workflowSuggestion: null,
     openFilePending: null,
+    selectedWorkspaceIds: [],
+    selectionAnchorId: null,
   });
 }

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { workspaceCommands } from "./workspaceActions";
+import { workspaceBulkCommands, workspaceCommands } from "./workspaceActions";
 import { WorkspaceCard } from "./WorkspaceCard";
 import type {
   CodeSessionDigest,
@@ -39,9 +39,13 @@ function renderCard(overrides?: {
   visibleMeta?: { repoChip: boolean; branch: boolean };
   detailDefaultOpen?: boolean;
   canOpenWorktree?: boolean;
+  selected?: boolean;
+  commands?: ReturnType<typeof workspaceCommands>;
+  contextMenuLabel?: string;
 }) {
   const onOpen = vi.fn();
   const onCommand = vi.fn();
+  const onSelectPointer = vi.fn();
   const merged = {
     ...workspace,
     ...overrides?.workspace,
@@ -54,20 +58,26 @@ function renderCard(overrides?: {
       session={undefined}
       repoName="app"
       active={false}
+      selected={overrides?.selected}
       terminalOpen={false}
       density={overrides?.density ?? "detailed"}
       visibleMeta={overrides?.visibleMeta ?? { repoChip: true, branch: false }}
-      commands={workspaceCommands({
-        hasPr: Boolean(overrides?.pr),
-        archived: merged.status === "archived",
-        canOpenWorktree: overrides?.canOpenWorktree,
-      })}
+      commands={
+        overrides?.commands ??
+        workspaceCommands({
+          hasPr: Boolean(overrides?.pr),
+          archived: merged.status === "archived",
+          canOpenWorktree: overrides?.canOpenWorktree,
+        })
+      }
+      contextMenuLabel={overrides?.contextMenuLabel}
       detailDefaultOpen={overrides?.detailDefaultOpen}
       onOpen={onOpen}
+      onSelectPointer={onSelectPointer}
       onCommand={onCommand}
     />,
   );
-  return { onOpen, onCommand };
+  return { onOpen, onCommand, onSelectPointer };
 }
 
 describe("WorkspaceCard", () => {
@@ -263,9 +273,35 @@ describe("WorkspaceCard", () => {
   it("keeps a workspace without a session looking empty", () => {
     renderCard();
 
+    expect(screen.getByLabelText("Idle")).toBeInTheDocument();
     expect(screen.queryByText("Idle")).not.toBeInTheDocument();
     expect(screen.queryByText("Done")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Claude Code")).not.toBeInTheDocument();
+  });
+
+  it("does not open on a modifier click so the rail can select", async () => {
+    const { onOpen, onSelectPointer } = renderCard();
+    const row = screen.getByRole("button", { name: /^Fix login/ });
+    fireEvent.click(row, { metaKey: true });
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onSelectPointer).toHaveBeenCalledTimes(1);
+    fireEvent.click(row);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("names a bulk menu without the single-card commands", async () => {
+    renderCard({
+      selected: true,
+      contextMenuLabel: "Workspace",
+      commands: workspaceBulkCommands(2),
+    });
+    fireEvent.contextMenu(screen.getByRole("button", { name: /^Fix login/ }));
+    const menu = await screen.findByRole("menu");
+    expect(menu).toHaveTextContent("Workspace");
+    expect(menu).toHaveTextContent("Archive 2 workspaces");
+    expect(menu).toHaveTextContent("Force archive 2 workspaces");
+    expect(menu).not.toHaveTextContent("Rename");
+    expect(menu).not.toHaveTextContent("New session");
   });
 
   it("keeps a parked agent visible as a completed turn", () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -39,6 +39,7 @@ function renderCard(overrides?: {
   visibleMeta?: { repoChip: boolean; branch: boolean };
   detailDefaultOpen?: boolean;
   canOpenWorktree?: boolean;
+  active?: boolean;
   selected?: boolean;
   commands?: ReturnType<typeof workspaceCommands>;
   contextMenuLabel?: string;
@@ -57,7 +58,7 @@ function renderCard(overrides?: {
       digest={undefined}
       session={undefined}
       repoName="app"
-      active={false}
+      active={overrides?.active ?? false}
       selected={overrides?.selected}
       terminalOpen={false}
       density={overrides?.density ?? "detailed"}
@@ -287,6 +288,23 @@ describe("WorkspaceCard", () => {
     expect(onSelectPointer).toHaveBeenCalledTimes(1);
     fireEvent.click(row);
     expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the active shadow when the open workspace is also selected", () => {
+    renderCard({ selected: true });
+    const selectedOnly = document.querySelector("[data-workspace-card]");
+    expect(selectedOnly).toHaveAttribute("data-selected");
+    expect(selectedOnly).not.toHaveAttribute("data-active");
+    const selectedOnlyClass = selectedOnly?.className ?? "";
+    cleanup();
+
+    renderCard({ selected: true, active: true });
+    const selectedAndActive = document.querySelector("[data-workspace-card]");
+    expect(selectedAndActive).toHaveAttribute("data-selected");
+    expect(selectedAndActive).toHaveAttribute("data-active");
+    expect(selectedAndActive?.className).not.toBe(selectedOnlyClass);
+    expect(selectedAndActive?.className).toContain("shadow-[");
+    expect(selectedOnlyClass).not.toContain("shadow-[");
   });
 
   it("names a bulk menu without the single-card commands", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -3,6 +3,7 @@ import {
   Archive,
   Bot,
   CheckCircle2,
+  Circle,
   CircleAlert,
   Copy,
   CornerDownRight,
@@ -25,9 +26,11 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuLabel,
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { Spinner } from "@/components/ui/spinner";
 import {
   HoverCard,
   HoverCardContent,
@@ -75,15 +78,70 @@ import {
   sessionActivityLineLabel,
   watchRowLabel,
   workspaceCardLabel,
+  workspaceCardStatus,
   workspacePrChipSummary,
+  WORKSPACE_STATUS_RANK_LABELS,
+  WORKSPACE_STATUS_RANK_TONES,
   type CardDensity,
+  type WorkspaceStatusRank,
 } from "./workspaceCards";
+import { pointerSelectIntent } from "./workspaceSelection";
 import {
   PULL_REQUEST_LIFECYCLE_TONE,
   prCompactStatusLabel,
   prCompactStatusTone,
   pullRequestLifecycle,
 } from "./prState";
+
+/** Compact rank glyph shared by the card and by-status group headers. */
+export function WorkspaceStatusMark({
+  rank,
+  creating = false,
+  prState,
+}: {
+  rank: WorkspaceStatusRank;
+  creating?: boolean;
+  prState?: string;
+}) {
+  if (creating) {
+    return (
+      <span role="img" aria-label="Creating workspace">
+        <LoaderCircle
+          className={cn("size-3 animate-spin", STATUS_MARK.pending)}
+          aria-hidden
+        />
+      </span>
+    );
+  }
+  const label = WORKSPACE_STATUS_RANK_LABELS[rank];
+  const className = cn(
+    "size-3",
+    STATUS_MARK[WORKSPACE_STATUS_RANK_TONES[rank]],
+  );
+  return (
+    <span role="img" aria-label={label} data-workspace-status={rank}>
+      {rank === "needs_you" ? (
+        <CircleAlert className={className} aria-hidden />
+      ) : rank === "running" ? (
+        <Spinner className={className} aria-hidden />
+      ) : rank === "pr_open" ? (
+        <GitPullRequest
+          className={className}
+          aria-hidden
+          data-pr-state={prState ?? "open"}
+        />
+      ) : rank === "done_unreviewed" ? (
+        <CheckCircle2 className={className} aria-hidden />
+      ) : rank === "setup_failed" ? (
+        <CircleAlert className={className} aria-hidden />
+      ) : rank === "archived" ? (
+        <Archive className={className} aria-hidden />
+      ) : (
+        <Circle className={className} aria-hidden />
+      )}
+    </span>
+  );
+}
 
 /**
  * One workspace in the rail.
@@ -98,6 +156,7 @@ export function WorkspaceCard({
   session,
   repoName,
   active,
+  selected = false,
   terminalOpen,
   density,
   visibleMeta,
@@ -105,7 +164,10 @@ export function WorkspaceCard({
   childSessions = [],
   stackParent,
   detailDefaultOpen = false,
+  contextMenuLabel,
   onOpen,
+  onSelectPointer,
+  onMenuOpen,
   onCommand,
   onOpenChildSession,
   onOpenSubagent,
@@ -117,6 +179,7 @@ export function WorkspaceCard({
   session: CodeSessionSnapshot | undefined;
   repoName: string;
   active: boolean;
+  selected?: boolean;
   terminalOpen: boolean;
   density: CardDensity;
   visibleMeta: { repoChip: boolean; branch: boolean };
@@ -126,7 +189,15 @@ export function WorkspaceCard({
   stackParent?: { id: string; title: string } | null;
   /** Open the hover detail at mount time. Stories use this for visual review. */
   detailDefaultOpen?: boolean;
+  /** Section label for a bulk context menu. */
+  contextMenuLabel?: string;
   onOpen: () => void;
+  onSelectPointer?: (event: {
+    shiftKey: boolean;
+    metaKey: boolean;
+    ctrlKey: boolean;
+  }) => void;
+  onMenuOpen?: () => void;
   onCommand: (command: WorkspaceCommand["id"]) => void;
   onOpenChildSession?: (sessionId: string) => void;
   onOpenSubagent?: (callId: string) => void;
@@ -137,6 +208,7 @@ export function WorkspaceCard({
   const pr = digest?.pr_state ?? workspace.pr;
   const archived = isPutAway(workspace);
   const creating = workspace.status === "creating";
+  const cardStatus = workspaceCardStatus(workspace, digest);
   const attentionMark = attentionMarkForDigest(digest);
   const [detailOpen, setDetailOpen] = useState(detailDefaultOpen);
   const compactDetail = useCompactWorkspaceDetail();
@@ -152,16 +224,22 @@ export function WorkspaceCard({
     <article
       className={cn(
         "group/workspace relative rounded-xl border border-transparent transition-[background-color,border-color,box-shadow,opacity] duration-150",
-        active
-          ? "border-border-subtle bg-background shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_6%,transparent)]"
-          : "hover:bg-background/55",
+        selected
+          ? "border-border bg-muted/60"
+          : active
+            ? "border-border-subtle bg-background shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_6%,transparent)]"
+            : "hover:bg-background/55",
         archived && "opacity-65",
       )}
+      data-workspace-card=""
       data-active={active || undefined}
+      data-selected={selected || undefined}
     >
       <ContextMenu
         onOpenChange={(open) => {
-          if (open) setDetailOpen(false);
+          if (!open) return;
+          setDetailOpen(false);
+          onMenuOpen?.();
         }}
       >
         <HoverCard
@@ -185,6 +263,7 @@ export function WorkspaceCard({
                   workspaceStatus: workspace.status,
                 })}
                 aria-current={active ? "page" : undefined}
+                aria-selected={selected || undefined}
                 disabled={creating}
                 className={cn(
                   "flex w-full cursor-pointer flex-col gap-0.5 rounded-xl px-2.5 py-2 text-left",
@@ -192,10 +271,25 @@ export function WorkspaceCard({
                   HOVER_TINT,
                   creating && "cursor-wait",
                 )}
-                onClick={onOpen}
+                onClick={(event) => {
+                  if (creating) return;
+                  if (
+                    onSelectPointer &&
+                    pointerSelectIntent(event) !== "open"
+                  ) {
+                    event.preventDefault();
+                    onSelectPointer(event);
+                    return;
+                  }
+                  onOpen();
+                }}
               >
                 <span className="flex min-w-0 items-center gap-2">
-                  <AttentionBadge attention={attentionMark} compact />
+                  <WorkspaceStatusMark
+                    rank={cardStatus.rank}
+                    creating={creating}
+                    prState={pr ? pullRequestLifecycle(pr) : undefined}
+                  />
                   <span className="min-w-0 flex-1 truncate text-md font-medium leading-5">
                     {title}
                   </span>
@@ -203,17 +297,9 @@ export function WorkspaceCard({
                     className="flex shrink-0 items-center gap-1.5"
                     aria-hidden
                   >
-                    {pr && <PrGlyph pr={pr} />}
+                    {pr && cardStatus.rank !== "pr_open" && <PrGlyph pr={pr} />}
                     {terminalOpen && (
                       <SquareTerminal className="size-3 text-muted-foreground" />
-                    )}
-                    {creating && (
-                      <LoaderCircle
-                        className={cn(
-                          "size-3 animate-spin",
-                          STATUS_MARK.pending,
-                        )}
-                      />
                     )}
                   </span>
                 </span>
@@ -268,6 +354,9 @@ export function WorkspaceCard({
         </HoverCard>
 
         <ContextMenuContent>
+          {contextMenuLabel && (
+            <ContextMenuLabel>{contextMenuLabel}</ContextMenuLabel>
+          )}
           {commands.map((command) => (
             <WorkspaceMenuItem
               key={command.id}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -224,11 +224,11 @@ export function WorkspaceCard({
     <article
       className={cn(
         "group/workspace relative rounded-xl border border-transparent transition-[background-color,border-color,box-shadow,opacity] duration-150",
-        selected
-          ? "border-border bg-muted/60"
-          : active
-            ? "border-border-subtle bg-background shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_6%,transparent)]"
-            : "hover:bg-background/55",
+        selected && "border-border bg-muted/60",
+        active &&
+          "shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_6%,transparent)]",
+        !selected && active && "border-border-subtle bg-background",
+        !selected && !active && "hover:bg-background/55",
         archived && "opacity-65",
       )}
       data-workspace-card=""

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.test.ts
@@ -40,4 +40,15 @@ describe("nextWorkspaceAfterLeaving", () => {
     expect(nextWorkspaceAfterLeaving(["a"], "a")).toBeNull();
     expect(nextWorkspaceAfterLeaving([], "a")).toBeNull();
   });
+
+  it("skips every id that left in the same pass", () => {
+    const left = new Set(["b", "c"]);
+    expect(nextWorkspaceAfterLeaving(["a", "b", "c", "d"], "b", left)).toBe(
+      "d",
+    );
+    expect(nextWorkspaceAfterLeaving(["a", "b", "c"], "c", left)).toBe("a");
+    expect(
+      nextWorkspaceAfterLeaving(["a", "b", "c"], "b", new Set(["a", "b", "c"])),
+    ).toBeNull();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
@@ -51,16 +51,23 @@ export function stepRailWorkspace(
 }
 
 /**
- * The workspace to open after `leftId` leaves the rail, or `null` for `/code`.
+ * The workspace to open after cards leave the rail, or `null` for `/code`.
  *
  * Archiving the open workspace must not leave the reader on a page the rail
  * no longer draws. The next live card is the replacement; an empty rail falls
- * through to the code home.
+ * through to the code home. Pass every id that left in this pass so a bulk
+ * archive does not land on another card the same pass just archived.
  */
 export function nextWorkspaceAfterLeaving(
   ids: readonly string[],
-  leftId: string,
+  fromId: string,
+  leaving: ReadonlySet<string> = new Set([fromId]),
 ): string | null {
-  const next = stepWorkspaceId(ids, leftId, 1);
-  return next && next !== leftId ? next : null;
+  const remaining = ids.filter((id) => !leaving.has(id));
+  if (remaining.length === 0) return null;
+  const fromIndex = ids.indexOf(fromId);
+  if (fromIndex < 0) return remaining[0] ?? null;
+  return (
+    remaining.find((id) => ids.indexOf(id) > fromIndex) ?? remaining[0] ?? null
+  );
 }

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
@@ -3,10 +3,27 @@ import { describe, expect, it } from "vitest";
 import { setEditorPreference } from "./editorPreference";
 import {
   externalEditorOpenFailureNotice,
+  workspaceBulkCommands,
   workspaceCommands,
   workspaceHeaderCommands,
   worktreeOpenFailureNotice,
 } from "./workspaceActions";
+
+describe("workspaceBulkCommands", () => {
+  it("names the count and keeps force-archive destructive", () => {
+    const commands = workspaceBulkCommands(4);
+    expect(commands).toEqual([
+      { id: "archive", label: "Archive 4 workspaces" },
+      {
+        id: "force-archive",
+        label: "Force archive 4 workspaces",
+        destructive: true,
+        separated: true,
+      },
+    ]);
+    expect(workspaceBulkCommands(2)[0]?.label).toBe("Archive 2 workspaces");
+  });
+});
 
 describe("workspace worktree actions", () => {
   it("offers a native folder action only for an active local workspace", () => {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -522,8 +522,7 @@ export function useWorkspaceCardCommands(): {
     if (!ok) return;
     const liveIds = railWorkspaceIds();
     const viewing = codeWorkspaceIdFromPath(pathname);
-    let archivedViewed = false;
-    let archivedCount = 0;
+    const archivedIds = new Set<string>();
     const failed: string[] = [];
 
     for (const workspace of workspaces) {
@@ -531,19 +530,18 @@ export function useWorkspaceCardCommands(): {
         const archived = await client.archiveCodeWorkspace(workspace.id, force);
         upsertWorkspace(archived);
         forgetWorkspaceSession(workspace.id);
-        archivedCount += 1;
-        if (viewing === workspace.id) archivedViewed = true;
+        archivedIds.add(workspace.id);
       } catch {
         failed.push(workspace.title);
       }
     }
 
     useCodeUiStore.getState().clearWorkspaceSelection();
-    if (archivedCount > 0) {
+    if (archivedIds.size > 0) {
       toast.success(
-        archivedCount === 1
+        archivedIds.size === 1
           ? "Workspace archived"
-          : `${archivedCount} workspaces archived`,
+          : `${archivedIds.size} workspaces archived`,
       );
     }
     if (failed.length > 0) {
@@ -553,8 +551,8 @@ export function useWorkspaceCardCommands(): {
           : `Could not archive ${failed.length} workspaces`,
       );
     }
-    if (!archivedViewed || viewing === undefined) return;
-    const nextId = nextWorkspaceAfterLeaving(liveIds, viewing);
+    if (viewing === undefined || !archivedIds.has(viewing)) return;
+    const nextId = nextWorkspaceAfterLeaving(liveIds, viewing, archivedIds);
     if (nextId) {
       await navigate({
         to: "/code/w/$workspaceId",

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -167,6 +167,22 @@ export function workspaceCommands(input: {
   return items;
 }
 
+/** Right-click on a multi-selection. Count is always greater than one. */
+export function workspaceBulkCommands(count: number): WorkspaceCommand[] {
+  return [
+    {
+      id: "archive",
+      label: `Archive ${count} workspaces`,
+    },
+    {
+      id: "force-archive",
+      label: `Force archive ${count} workspaces`,
+      destructive: true,
+      separated: true,
+    },
+  ];
+}
+
 /**
  * Header overflow: worktree access, rename, pin/clear, repo quick actions,
  * then archive. Opening the workspace and its terminal remain card-only.
@@ -391,6 +407,10 @@ export async function archiveWorkspaceWithConfirm(options: {
 
 export function useWorkspaceCardCommands(): {
   run: (command: WorkspaceCommandId, context: WorkspaceCommandContext) => void;
+  runBulk: (
+    command: Extract<WorkspaceCommandId, "archive" | "force-archive">,
+    workspaces: readonly CodeWorkspaceSnapshot[],
+  ) => void;
   dialogs: ReactElement;
 } {
   const { client } = useApp();
@@ -476,6 +496,76 @@ export function useWorkspaceCardCommands(): {
    * reader who already knows and does not want two dialogs about it. One
    * confirmation still stands between the click and the worktree going away.
    */
+  async function runBulkArchive(
+    workspaces: readonly CodeWorkspaceSnapshot[],
+    force: boolean,
+  ) {
+    const count = workspaces.length;
+    if (count === 0) return;
+    const ok = await confirm(
+      force
+        ? {
+            title: `Discard changes and archive ${count} workspaces?`,
+            description:
+              "Uncommitted and unpushed work is lost and a running session is stopped. Branches and their commits are kept.",
+            confirmLabel: "Discard and archive",
+            destructive: true,
+          }
+        : {
+            title: `Archive ${count} workspaces?`,
+            description:
+              "They leave the rail and collect in Archive. Worktrees go away; branches stay.",
+            confirmLabel: "Archive",
+            destructive: true,
+          },
+    );
+    if (!ok) return;
+    const liveIds = railWorkspaceIds();
+    const viewing = codeWorkspaceIdFromPath(pathname);
+    let archivedViewed = false;
+    let archivedCount = 0;
+    const failed: string[] = [];
+
+    for (const workspace of workspaces) {
+      try {
+        const archived = await client.archiveCodeWorkspace(workspace.id, force);
+        upsertWorkspace(archived);
+        forgetWorkspaceSession(workspace.id);
+        archivedCount += 1;
+        if (viewing === workspace.id) archivedViewed = true;
+      } catch {
+        failed.push(workspace.title);
+      }
+    }
+
+    useCodeUiStore.getState().clearWorkspaceSelection();
+    if (archivedCount > 0) {
+      toast.success(
+        archivedCount === 1
+          ? "Workspace archived"
+          : `${archivedCount} workspaces archived`,
+      );
+    }
+    if (failed.length > 0) {
+      toast.error(
+        failed.length === 1
+          ? `Could not archive ${failed[0]}`
+          : `Could not archive ${failed.length} workspaces`,
+      );
+    }
+    if (!archivedViewed || viewing === undefined) return;
+    const nextId = nextWorkspaceAfterLeaving(liveIds, viewing);
+    if (nextId) {
+      await navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId: nextId },
+        replace: true,
+      });
+      return;
+    }
+    await navigate({ to: "/code", replace: true });
+  }
+
   async function runForceArchive(workspace: CodeWorkspaceSnapshot) {
     const liveIds = railWorkspaceIds();
     const ok = await confirm({
@@ -773,6 +863,13 @@ export function useWorkspaceCardCommands(): {
     }
   }
 
+  function runBulk(
+    command: Extract<WorkspaceCommandId, "archive" | "force-archive">,
+    workspaces: readonly CodeWorkspaceSnapshot[],
+  ): void {
+    void runBulkArchive(workspaces, command === "force-archive");
+  }
+
   const renameDialog = (
     <Dialog
       open={rename !== null}
@@ -844,6 +941,7 @@ export function useWorkspaceCardCommands(): {
 
   return {
     run,
+    runBulk,
     dialogs: (
       <>
         {dialog}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -17,6 +17,7 @@ import {
   sessionActivityLineLabel,
   sessionRowLabel,
   workspaceCardLabel,
+  workspaceCardStatus,
   workspacePrChipSummary,
   workspaceStackParent,
   workspaceStatusRank,
@@ -322,6 +323,74 @@ describe("workspaceStatusRank", () => {
         digest("ws-a", { lifecycle: "running" }),
       ),
     ).toBe("running");
+  });
+
+  it("ranks stalled and fenced with needs-you", () => {
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app"),
+        digest("ws-a", {
+          attention: {
+            state: { type: "stalled", idle_secs: 90 },
+            source: "heuristic",
+          },
+        }),
+      ),
+    ).toBe("needs_you");
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app"),
+        digest("ws-a", {
+          attention: {
+            state: { type: "fenced", reason: { type: "orphan_alive" } },
+            source: "structured",
+          },
+        }),
+      ),
+    ).toBe("needs_you");
+  });
+
+  it("ranks an idle session with turns as done, and an empty one as idle", () => {
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app"),
+        digest("ws-a", { lifecycle: "idle", turn_count: 3 }),
+      ),
+    ).toBe("done_unreviewed");
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app"),
+        digest("ws-a", { lifecycle: "idle", turn_count: 0 }),
+      ),
+    ).toBe("idle");
+    expect(workspaceStatusRank(workspace("ws-a", "app"), undefined)).toBe(
+      "idle",
+    );
+  });
+});
+
+describe("workspaceCardStatus", () => {
+  it("pairs each rank with the label and tone the rail paints", () => {
+    expect(
+      workspaceCardStatus(
+        workspace("ws-a", "app"),
+        digest("ws-a", {
+          attention: {
+            state: {
+              type: "needs_you",
+              prompt: "an approval is waiting",
+              source: "structured",
+            },
+            source: "structured",
+          },
+        }),
+      ),
+    ).toEqual({ rank: "needs_you", tone: "critical", label: "Needs you" });
+    expect(workspaceCardStatus(workspace("ws-a", "app"), undefined)).toEqual({
+      rank: "idle",
+      tone: "neutral",
+      label: "Idle",
+    });
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -7,6 +7,7 @@ import type {
 } from "../api/types";
 import { attentionLabel, LIFECYCLE_LABELS } from "./labels";
 import { prCompactStatusLabel, pullRequestLifecycle } from "./prState";
+import type { StatusTone } from "./statusTone";
 
 /**
  * Pure presentation logic for workspace cards: grouping by repo, the state
@@ -126,33 +127,83 @@ export const WORKSPACE_STATUS_RANK_LABELS: Record<WorkspaceStatusRank, string> =
     archived: "Archived",
   };
 
+export const WORKSPACE_STATUS_RANK_TONES: Record<
+  WorkspaceStatusRank,
+  StatusTone
+> = {
+  needs_you: "critical",
+  running: "running",
+  pr_open: "ready",
+  done_unreviewed: "neutral",
+  setup_failed: "warning",
+  idle: "neutral",
+  archived: "neutral",
+};
+
+export function isWorkspaceStatusRank(
+  value: string,
+): value is WorkspaceStatusRank {
+  return (WORKSPACE_STATUS_RANK_ORDER as readonly string[]).includes(value);
+}
+
 /**
  * Rank a workspace for the by-status rail. Needs-you wins, then a running
  * engine, then an open PR, then done-unreviewed, then a workspace whose setup
  * script failed, then idle. Archived is last. A digest may change the rank;
  * viewing or selecting never does.
  *
- * A failed setup ranks below live work because the checkout survives and the
- * engine can still run in it — but above idle, because nothing else on the
- * card says the script never finished.
+ * Stalled and fenced join needs-you so the card mark and the group agree.
+ * Idle or ended sessions with turns join Done, matching
+ * `attentionMarkForDigest`. A failed setup ranks below live work because the
+ * checkout survives — but above idle, because nothing else on the card says
+ * the script never finished.
  */
 export function workspaceStatusRank(
   workspace: CodeWorkspaceSnapshot,
   digest: CodeSessionDigest | undefined,
 ): WorkspaceStatusRank {
   if (isPutAway(workspace)) return "archived";
-  if (digest?.attention.state.type === "needs_you") return "needs_you";
+  const attentionType = digest?.attention.state.type;
+  if (
+    attentionType === "needs_you" ||
+    attentionType === "stalled" ||
+    attentionType === "fenced"
+  ) {
+    return "needs_you";
+  }
   if (digest?.lifecycle === "running") return "running";
   const pr = digest?.pr_state ?? workspace.pr;
   if (pr) {
     const lifecycle = pullRequestLifecycle(pr);
     if (lifecycle === "open" || lifecycle === "draft") return "pr_open";
   }
-  if (digest?.attention.state.type === "done_unreviewed") {
+  if (
+    attentionType === "done_unreviewed" ||
+    (digest !== undefined && digest.turn_count > 0)
+  ) {
     return "done_unreviewed";
   }
   if (workspace.status === "setup_failed") return "setup_failed";
   return "idle";
+}
+
+export type WorkspaceCardStatus = {
+  rank: WorkspaceStatusRank;
+  tone: StatusTone;
+  label: string;
+};
+
+/** The rank, tone, and label the card and by-status headers share. */
+export function workspaceCardStatus(
+  workspace: CodeWorkspaceSnapshot,
+  digest: CodeSessionDigest | undefined,
+): WorkspaceCardStatus {
+  const rank = workspaceStatusRank(workspace, digest);
+  return {
+    rank,
+    tone: WORKSPACE_STATUS_RANK_TONES[rank],
+    label: WORKSPACE_STATUS_RANK_LABELS[rank],
+  };
 }
 
 export type StatusWorkspaceGroup = {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceSelection.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceSelection.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  pointerSelectIntent,
+  rangeWorkspaceSelection,
+  seedOpenWorkspaceSelection,
+  toggleWorkspaceSelection,
+} from "./workspaceSelection";
+
+const visible = ["a", "b", "c", "d"];
+
+describe("pointerSelectIntent", () => {
+  it("opens on a plain click, toggles on cmd/ctrl, and ranges on shift", () => {
+    expect(
+      pointerSelectIntent({ shiftKey: false, metaKey: false, ctrlKey: false }),
+    ).toBe("open");
+    expect(
+      pointerSelectIntent({ shiftKey: false, metaKey: true, ctrlKey: false }),
+    ).toBe("toggle");
+    expect(
+      pointerSelectIntent({ shiftKey: false, metaKey: false, ctrlKey: true }),
+    ).toBe("toggle");
+    expect(
+      pointerSelectIntent({ shiftKey: true, metaKey: false, ctrlKey: false }),
+    ).toBe("range");
+    expect(
+      pointerSelectIntent({ shiftKey: true, metaKey: true, ctrlKey: false }),
+    ).toBe("range");
+  });
+});
+
+describe("toggleWorkspaceSelection", () => {
+  it("adds a missing id and drops one that is already selected", () => {
+    expect(toggleWorkspaceSelection(["a"], "c")).toEqual(["a", "c"]);
+    expect(toggleWorkspaceSelection(["a", "c"], "a")).toEqual(["c"]);
+  });
+});
+
+describe("seedOpenWorkspaceSelection", () => {
+  it("starts a gesture with the open workspace when selection is empty", () => {
+    expect(seedOpenWorkspaceSelection([], "a", visible, "c")).toEqual({
+      selected: ["a"],
+      anchorId: "a",
+    });
+  });
+
+  it("does not seed when you cmd-click the open workspace itself", () => {
+    expect(seedOpenWorkspaceSelection([], "a", visible, "a")).toEqual({
+      selected: [],
+      anchorId: "a",
+    });
+  });
+
+  it("leaves an existing selection alone", () => {
+    expect(seedOpenWorkspaceSelection(["b"], "a", visible, "c")).toEqual({
+      selected: ["b"],
+      anchorId: null,
+    });
+  });
+});
+
+describe("rangeWorkspaceSelection", () => {
+  it("selects the inclusive span from the anchor through the target", () => {
+    expect(rangeWorkspaceSelection(visible, "a", "c")).toEqual(["a", "b", "c"]);
+    expect(rangeWorkspaceSelection(visible, "d", "b")).toEqual(["b", "c", "d"]);
+  });
+
+  it("falls back to the target when the anchor is missing or off the rail", () => {
+    expect(rangeWorkspaceSelection(visible, null, "c")).toEqual(["c"]);
+    expect(rangeWorkspaceSelection(visible, "gone", "c")).toEqual(["c"]);
+  });
+
+  it("crosses a group boundary because visible order is already flattened", () => {
+    expect(rangeWorkspaceSelection(visible, "b", "d")).toEqual(["b", "c", "d"]);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspaceSelection.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceSelection.ts
@@ -1,0 +1,58 @@
+export type PointerSelectIntent = "open" | "toggle" | "range";
+
+/** Cmd/Ctrl toggles. Shift ranges. A plain click still opens. */
+export function pointerSelectIntent(event: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+}): PointerSelectIntent {
+  if (event.shiftKey) return "range";
+  if (event.metaKey || event.ctrlKey) return "toggle";
+  return "open";
+}
+
+export function toggleWorkspaceSelection(
+  selected: readonly string[],
+  id: string,
+): string[] {
+  return selected.includes(id)
+    ? selected.filter((item) => item !== id)
+    : [...selected, id];
+}
+
+/**
+ * The open workspace joins the first modifier-click so a cmd/shift gesture
+ * never leaves behind the card you were already on.
+ */
+export function seedOpenWorkspaceSelection(
+  selected: readonly string[],
+  openId: string | undefined,
+  visibleIds: readonly string[],
+  clickedId: string,
+): { selected: string[]; anchorId: string | null } {
+  if (selected.length > 0) {
+    return { selected: [...selected], anchorId: null };
+  }
+  if (!openId || openId === clickedId || !visibleIds.includes(openId)) {
+    return { selected: [], anchorId: openId ?? null };
+  }
+  return { selected: [openId], anchorId: openId };
+}
+
+/**
+ * Inclusive range from the anchor through the target in visible rail order.
+ * A missing anchor or id falls back to the target alone.
+ */
+export function rangeWorkspaceSelection(
+  visibleIds: readonly string[],
+  anchorId: string | null,
+  targetId: string,
+): string[] {
+  if (anchorId === null) return [targetId];
+  const start = visibleIds.indexOf(anchorId);
+  const end = visibleIds.indexOf(targetId);
+  if (start < 0 || end < 0) return [targetId];
+  const from = Math.min(start, end);
+  const to = Math.max(start, end);
+  return visibleIds.slice(from, to + 1);
+}

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarAccountMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarAccountMenu.dom.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SidebarAccountMenuPanel } from "./SidebarAccountMenu";
+import { railAccountIdentity } from "./railAccountIdentity";
+
+afterEach(cleanup);
+
+describe("SidebarAccountMenuPanel", () => {
+  it("keeps the chip empty until an account exists", () => {
+    render(
+      <SidebarAccountMenuPanel
+        identity={railAccountIdentity({ gateway: null })}
+        themeMode="system"
+        onSettings={vi.fn()}
+        onThemeMode={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Account menu" }),
+    ).toHaveTextContent("Account");
+    expect(screen.queryByText("@")).not.toBeInTheDocument();
+  });
+
+  it("opens settings from the menu", async () => {
+    const user = userEvent.setup();
+    const onSettings = vi.fn();
+    render(
+      <SidebarAccountMenuPanel
+        identity={railAccountIdentity({
+          gateway: {
+            signed_in: true,
+            account_hint: "abaas@example.test",
+          },
+        })}
+        themeMode="dark"
+        onSettings={onSettings}
+        onThemeMode={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Account menu" }));
+    expect(screen.getAllByText("abaas@example.test").length).toBeGreaterThan(0);
+    await user.click(screen.getByRole("menuitem", { name: "Settings" }));
+    expect(onSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarAccountMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarAccountMenu.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Monitor, Moon, Settings, Sun } from "lucide-react";
+
+import type { GatewayStatus } from "@/api/types";
+import { useApp } from "@/AppContext";
+import { useCodeDeliveryStore } from "@/code/CodeDeliveryStore";
+import { GithubAvatar } from "@/code/GithubAvatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { useTheme, type ThemeMode } from "@/theme";
+import {
+  railAccountIdentity,
+  type RailAccountIdentity,
+} from "./railAccountIdentity";
+
+const THEME_OPTIONS: readonly { value: ThemeMode; label: string }[] = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
+];
+
+/**
+ * The rail's account chip. Identity fills in from the model gateway or GitHub
+ * when those exist; settings and theme live in the menu so they do not occupy
+ * footer rows of their own.
+ */
+export function SidebarAccountMenu({
+  defaultOpen = false,
+}: {
+  defaultOpen?: boolean;
+}) {
+  const { client } = useApp();
+  const { mode, setMode } = useTheme();
+  const navigate = useNavigate();
+  const [gateway, setGateway] = useState<GatewayStatus | null>(null);
+  const githubLogin = useCodeDeliveryStore(
+    (state) => state.repositorySnapshot?.capability.viewer_login,
+  );
+  const identity = railAccountIdentity({ gateway, githubLogin });
+
+  useEffect(() => {
+    let cancelled = false;
+    void client
+      .getGatewayStatus()
+      .then((status) => {
+        if (!cancelled) setGateway(status);
+      })
+      .catch(() => {
+        if (!cancelled) setGateway(null);
+      });
+    void useCodeDeliveryStore
+      .getState()
+      .loadRepositories(client)
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  return (
+    <SidebarAccountMenuPanel
+      identity={identity}
+      themeMode={mode}
+      defaultOpen={defaultOpen}
+      onSettings={() => void navigate({ to: "/settings" })}
+      onThemeMode={setMode}
+    />
+  );
+}
+
+export function SidebarAccountMenuPanel({
+  identity,
+  themeMode,
+  defaultOpen = false,
+  onSettings,
+  onThemeMode,
+}: {
+  identity: RailAccountIdentity;
+  themeMode: ThemeMode;
+  defaultOpen?: boolean;
+  onSettings: () => void;
+  onThemeMode: (mode: ThemeMode) => void;
+}) {
+  const ThemeIcon =
+    themeMode === "light" ? Sun : themeMode === "dark" ? Moon : Monitor;
+
+  return (
+    <DropdownMenu defaultOpen={defaultOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="hover:bg-accent inline-flex min-h-8 w-full cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm font-normal outline-none focus-visible:ring-3 focus-visible:ring-ring/25"
+          aria-label="Account menu"
+        >
+          <AccountAvatar identity={identity} />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate leading-4">{identity.title}</span>
+            {identity.detail && (
+              <span className="text-muted-foreground block truncate text-2xs leading-4">
+                {identity.detail}
+              </span>
+            )}
+          </span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="w-64"
+      >
+        <div className="flex items-center gap-2.5 px-2 py-2">
+          <AccountAvatar identity={identity} />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{identity.title}</p>
+            {identity.detail ? (
+              <p className="text-muted-foreground truncate text-xs">
+                {identity.detail}
+              </p>
+            ) : (
+              <p className="text-muted-foreground truncate text-xs">
+                Sign in from Settings
+              </p>
+            )}
+          </div>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="gap-2" onSelect={onSettings}>
+          <Settings />
+          Settings
+        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="gap-2">
+            <ThemeIcon />
+            Theme
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            {THEME_OPTIONS.map((option) => (
+              <DropdownMenuItem
+                key={option.value}
+                className="gap-2"
+                onSelect={() => onThemeMode(option.value)}
+              >
+                <span
+                  className={cn(
+                    "size-1.5 rounded-full",
+                    themeMode === option.value
+                      ? "bg-foreground"
+                      : "bg-transparent",
+                  )}
+                  aria-hidden
+                />
+                {option.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function AccountAvatar({ identity }: { identity: RailAccountIdentity }) {
+  if (identity.githubLogin) {
+    return <GithubAvatar login={identity.githubLogin} className="size-6" />;
+  }
+  if (identity.source === "local") {
+    return (
+      <span
+        className="border-border size-6 shrink-0 rounded-full border"
+        aria-hidden
+      />
+    );
+  }
+  return (
+    <span
+      className="bg-muted text-muted-foreground grid size-6 shrink-0 place-items-center rounded-full text-2xs font-semibold uppercase"
+      aria-hidden
+    >
+      {identity.title.slice(0, 2)}
+    </span>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarAccountMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarAccountMenu.tsx
@@ -50,17 +50,16 @@ export function SidebarAccountMenu({
 
   useEffect(() => {
     let cancelled = false;
-    void client
-      .getGatewayStatus()
+    void Promise.resolve()
+      .then(() => client.getGatewayStatus())
       .then((status) => {
         if (!cancelled) setGateway(status);
       })
       .catch(() => {
         if (!cancelled) setGateway(null);
       });
-    void useCodeDeliveryStore
-      .getState()
-      .loadRepositories(client)
+    void Promise.resolve()
+      .then(() => useCodeDeliveryStore.getState().loadRepositories(client))
       .catch(() => undefined);
     return () => {
       cancelled = true;

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -1,14 +1,7 @@
 import { getName } from "@tauri-apps/api/app";
 import { useEffect, useState, type ReactNode } from "react";
-import { useNavigate, useRouterState } from "@tanstack/react-router";
-import {
-  Monitor,
-  Moon,
-  PanelLeftClose,
-  RotateCw,
-  Settings,
-  Sun,
-} from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import { PanelLeftClose, RotateCw } from "lucide-react";
 
 import { useApp } from "@/AppContext";
 import { WithTooltip } from "@/components/ui/tooltip";
@@ -21,8 +14,8 @@ import {
   SidebarFooter,
   SidebarHeader,
 } from "./primitives";
-import { useTheme } from "@/theme";
 import { useUiStore } from "@/UiStore";
+import { SidebarAccountMenu } from "./SidebarAccountMenu";
 
 /**
  * The parts of the rail that do not depend on where the reader is: the way
@@ -41,11 +34,7 @@ export function SidebarFrame({
 }) {
   const navigate = useNavigate();
   const { updateState, restartForUpdate } = useApp();
-  const { mode: themeMode, cycle: cycleTheme } = useTheme();
   const toggleSidebar = useUiStore((state) => state.toggleSidebar);
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  });
   const [appName, setAppName] = useState("Tidebreak");
 
   // Keep dev and staging windows distinguishable, but put that identity in
@@ -115,28 +104,7 @@ export function SidebarFrame({
             )}
           </SidebarButton>
         )}
-        <SidebarButton
-          aria-label={`Theme: ${themeMode}. Click to change.`}
-          onClick={cycleTheme}
-        >
-          {themeMode === "light" ? (
-            <Sun />
-          ) : themeMode === "dark" ? (
-            <Moon />
-          ) : (
-            <Monitor />
-          )}
-          <span>Theme</span>
-        </SidebarButton>
-        <SidebarButton
-          aria-current={pathname === "/settings" ? "page" : undefined}
-          data-active={pathname === "/settings" || undefined}
-          className="data-[active]:bg-muted"
-          onClick={() => void navigate({ to: "/settings" })}
-        >
-          <Settings />
-          <span>Settings</span>
-        </SidebarButton>
+        <SidebarAccountMenu />
       </SidebarFooter>
     </SidebarRail>
   );

--- a/crates/tidebreak-desktop/ui/src/sidebar/railAccountIdentity.test.ts
+++ b/crates/tidebreak-desktop/ui/src/sidebar/railAccountIdentity.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { railAccountIdentity } from "./railAccountIdentity";
+
+describe("railAccountIdentity", () => {
+  it("stays local when nothing is signed in", () => {
+    expect(
+      railAccountIdentity({
+        gateway: { signed_in: false },
+      }),
+    ).toEqual({
+      title: "Account",
+      detail: null,
+      githubLogin: undefined,
+      source: "local",
+    });
+  });
+
+  it("uses a gateway hint, and a GitHub login as the face when both exist", () => {
+    expect(
+      railAccountIdentity({
+        gateway: { signed_in: true, account_hint: "abaas@example.test" },
+      }),
+    ).toEqual({
+      title: "abaas",
+      detail: "abaas@example.test",
+      githubLogin: undefined,
+      source: "gateway",
+    });
+    expect(
+      railAccountIdentity({
+        gateway: { signed_in: true, account_hint: "abaas@example.test" },
+        githubLogin: "thet",
+      }),
+    ).toEqual({
+      title: "thet",
+      detail: "abaas@example.test",
+      githubLogin: "thet",
+      source: "gateway",
+    });
+  });
+
+  it("names a GitHub login when the gateway is empty", () => {
+    expect(
+      railAccountIdentity({
+        gateway: null,
+        githubLogin: "mira-chen",
+      }),
+    ).toEqual({
+      title: "mira-chen",
+      detail: null,
+      githubLogin: "mira-chen",
+      source: "github",
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/sidebar/railAccountIdentity.ts
+++ b/crates/tidebreak-desktop/ui/src/sidebar/railAccountIdentity.ts
@@ -1,0 +1,56 @@
+export type RailAccountIdentity = {
+  title: string;
+  detail: string | null;
+  githubLogin: string | undefined;
+  source: "gateway" | "github" | "local";
+};
+
+/**
+ * Who the rail account chip names.
+ *
+ * Tidebreak has no first-party profile. A signed-in model gateway supplies an
+ * account hint (usually an email). GitHub's `gh` login, when Delivery already
+ * knows it, supplies a face. Otherwise the chip stays empty.
+ */
+export function railAccountIdentity(input: {
+  gateway: { signed_in: boolean; account_hint?: string } | null;
+  githubLogin?: string;
+}): RailAccountIdentity {
+  const githubLogin = trimToUndefined(input.githubLogin);
+  const hint =
+    input.gateway?.signed_in === true
+      ? trimToUndefined(input.gateway.account_hint)
+      : undefined;
+  if (hint) {
+    return {
+      title: githubLogin ?? localPart(hint),
+      detail: hint === githubLogin ? "Model Gateway" : hint,
+      githubLogin,
+      source: "gateway",
+    };
+  }
+  if (githubLogin) {
+    return {
+      title: githubLogin,
+      detail: null,
+      githubLogin,
+      source: "github",
+    };
+  }
+  return {
+    title: "Account",
+    detail: null,
+    githubLogin: undefined,
+    source: "local",
+  };
+}
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function localPart(hint: string): string {
+  const at = hint.indexOf("@");
+  return at > 0 ? hint.slice(0, at) : hint;
+}

--- a/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
@@ -99,6 +99,22 @@ function storyClient(scenario: HomeScenario): ApiClient {
       chooses_destination: false,
     }),
     openCodeUpdates: storySocket,
+    getGatewayStatus: async () => ({
+      signed_in: false,
+      model_count: 0,
+      sign_in: { state: "idle" as const },
+    }),
+    getCodeDeliveryRepositories: async () => ({
+      capability: {
+        found: true,
+        authenticated: true,
+        viewer_login: "github",
+        remediation: "",
+      },
+      repositories: [],
+      errors: [],
+      fetched_at: "2026-08-15T00:00:00.000Z",
+    }),
   } as unknown as ApiClient;
 }
 

--- a/crates/tidebreak-desktop/ui/src/stories/SidebarAccount.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SidebarAccount.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+
+import { SidebarAccountMenuPanel } from "@/sidebar/SidebarAccountMenu";
+import { railAccountIdentity } from "@/sidebar/railAccountIdentity";
+import { gatewaySignedIn } from "./fixtures";
+
+const meta = {
+  title: "Navigation/Account menu",
+  component: SidebarAccountMenuPanel,
+  args: {
+    identity: railAccountIdentity({ gateway: null }),
+    themeMode: "system",
+    onSettings: fn(),
+    onThemeMode: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-page-background flex h-[28rem] w-[264px] flex-col justify-end rounded-lg border border-border-subtle p-2">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SidebarAccountMenuPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** No gateway or GitHub session: an empty chip, settings still one click away. */
+export const Empty: Story = {};
+
+export const ModelGateway: Story = {
+  args: {
+    identity: railAccountIdentity({ gateway: gatewaySignedIn }),
+  },
+};
+
+export const GitHub: Story = {
+  args: {
+    identity: railAccountIdentity({
+      gateway: null,
+      githubLogin: "github",
+    }),
+  },
+};
+
+export const GatewayAndGitHub: Story = {
+  args: {
+    identity: railAccountIdentity({
+      gateway: gatewaySignedIn,
+      githubLogin: "github",
+    }),
+  },
+};
+
+export const Open: Story = {
+  args: {
+    identity: railAccountIdentity({ gateway: gatewaySignedIn }),
+    defaultOpen: true,
+  },
+};
+
+export const OpenTheme: Story = {
+  args: {
+    identity: railAccountIdentity({ gateway: gatewaySignedIn }),
+    themeMode: "dark",
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await body.findByRole("button", { name: "Account menu" }),
+    );
+    await userEvent.click(await body.findByRole("menuitem", { name: "Theme" }));
+    await waitFor(() =>
+      expect(body.getByRole("menuitem", { name: "Dark" })).toBeVisible(),
+    );
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -1,13 +1,24 @@
+import { useState, type ComponentProps, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import {
+  expect,
+  fireEvent,
+  fn,
+  userEvent,
+  waitFor,
+  within,
+} from "storybook/test";
 import { toast } from "sonner";
 
 import { setEditorPreference } from "@/code/editorPreference";
 import {
+  workspaceBulkCommands,
   workspaceCommands,
   worktreeOpenFailureNotice,
 } from "@/code/workspaceActions";
-import { WorkspaceCard } from "@/code/WorkspaceCard";
+import { WorkspaceCard, WorkspaceStatusMark } from "@/code/WorkspaceCard";
+import type { WorkspaceStatusRank } from "@/code/workspaceCards";
+import { WORKSPACE_STATUS_RANK_LABELS } from "@/code/workspaceCards";
 import { Toaster } from "@/components/ui/sonner";
 import {
   archivedWorkspace,
@@ -67,6 +78,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Idle: Story = {};
+
+export const Selected: Story = {
+  args: { selected: true },
+};
+
+export const SelectedAndActive: Story = {
+  args: { selected: true, active: true },
+};
 
 /** A create appears in the rail while the worktree and first session start. */
 export const Creating: Story = {
@@ -607,9 +626,9 @@ export const PullRequestTones: Story = {
 /**
  * The status ramp on one screen, which is the only way to catch a tone drawn
  * at the wrong strength. Read down the glyph rail: working moves, needs-you is
- * the one red, stalled is amber, done is quiet, parked still shows the agent,
- * and merged is purple rather than a second shade of green. Check this in both
- * themes.
+ * the one red, stalled joins needs-you, done is quiet, an empty workspace
+ * still has an outline circle, and merged is purple rather than a second
+ * shade of green. Check this in both themes.
  */
 export const StatusTones: Story = {
   render: (args) => (
@@ -621,6 +640,7 @@ export const StatusTones: Story = {
           ["Stalled", stalledDigest, codeSession, undefined],
           ["Done, unreviewed", doneDigest, idleSession, undefined],
           ["Parked, complete", idleCompleteDigest, grokIdleSession, undefined],
+          ["PR open", undefined, undefined, openPrDigest],
           ["PR merged", undefined, undefined, mergedPrDigest],
           ["No session", undefined, undefined, undefined],
         ] as const
@@ -708,6 +728,203 @@ export const Rail: Story = {
       />
     </div>
   ),
+};
+
+function StatusGroup({
+  rank,
+  count,
+  children,
+}: {
+  rank: WorkspaceStatusRank;
+  count: number;
+  children: ReactNode;
+}) {
+  const label = WORKSPACE_STATUS_RANK_LABELS[rank];
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1.5 px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90">
+        <WorkspaceStatusMark rank={rank} />
+        <span>
+          {label} · {count}
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** By-status rail: each live rank as a labeled group. */
+export const GroupedByStatus: Story = {
+  render: (args) => (
+    <div className="flex flex-col">
+      <StatusGroup rank="needs_you" count={1}>
+        <WorkspaceCard
+          {...args}
+          workspace={{
+            ...codeWorkspace,
+            id: "ws-a",
+            title: "Needs a decision",
+          }}
+          digest={{ ...needsYouDigest, title: "Needs a decision" }}
+          session={codeSession}
+          commands={workspaceCommands({
+            hasPr: false,
+            archived: false,
+            hasSession: true,
+          })}
+        />
+      </StatusGroup>
+      <StatusGroup rank="running" count={1}>
+        <WorkspaceCard
+          {...args}
+          workspace={{ ...codeWorkspace, id: "ws-b", title: "Turn in flight" }}
+          digest={{ ...runningDigest, title: "Turn in flight" }}
+          session={codeSession}
+          commands={workspaceCommands({
+            hasPr: false,
+            archived: false,
+            hasSession: true,
+          })}
+        />
+      </StatusGroup>
+      <StatusGroup rank="pr_open" count={1}>
+        <WorkspaceCard
+          {...args}
+          workspace={{
+            ...codeWorkspace,
+            id: "ws-c",
+            title: "Shipped, checks green",
+            pr: openPrDigest,
+          }}
+          commands={workspaceCommands({ hasPr: true, archived: false })}
+        />
+      </StatusGroup>
+      <StatusGroup rank="done_unreviewed" count={1}>
+        <WorkspaceCard
+          {...args}
+          workspace={{
+            ...codeWorkspace,
+            id: "ws-d",
+            title: "Parked exploration",
+          }}
+          digest={{ ...idleCompleteDigest, title: "Parked exploration" }}
+          session={grokIdleSession}
+          commands={workspaceCommands({
+            hasPr: false,
+            archived: false,
+            hasSession: true,
+          })}
+        />
+      </StatusGroup>
+      <StatusGroup rank="idle" count={1}>
+        <WorkspaceCard
+          {...args}
+          workspace={{ ...codeWorkspace, id: "ws-e", title: "Empty workspace" }}
+        />
+      </StatusGroup>
+    </div>
+  ),
+};
+
+/** Three selected cards in a Needs you group. */
+export const MultiSelected: Story = {
+  render: (args) => (
+    <StatusGroup rank="needs_you" count={3}>
+      {["Slack integration", "Reasoning effort", "Hosted tidebreak"].map(
+        (title, index) => (
+          <WorkspaceCard
+            {...args}
+            key={title}
+            workspace={{
+              ...codeWorkspace,
+              id: `ws-sel-${index}`,
+              title,
+            }}
+            digest={{ ...needsYouDigest, title }}
+            session={codeSession}
+            selected
+            commands={workspaceBulkCommands(3)}
+            contextMenuLabel="Workspace"
+          />
+        ),
+      )}
+    </StatusGroup>
+  ),
+};
+
+function BulkMenuDemo({
+  args,
+}: {
+  args: ComponentProps<typeof WorkspaceCard>;
+}) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const ids = ["ws-bulk-a", "ws-bulk-b"] as const;
+  const bulk = selected.length > 1;
+  return (
+    <div className="flex flex-col gap-0.5 pt-14">
+      {ids.map((id, index) => (
+        <WorkspaceCard
+          {...args}
+          key={id}
+          workspace={{
+            ...codeWorkspace,
+            id,
+            title: index === 0 ? "First workspace" : "Second workspace",
+          }}
+          selected={selected.includes(id)}
+          contextMenuLabel={
+            bulk && selected.includes(id) ? "Workspace" : undefined
+          }
+          commands={
+            bulk && selected.includes(id)
+              ? workspaceBulkCommands(selected.length)
+              : workspaceCommands({ hasPr: false, archived: false })
+          }
+          onSelectPointer={(event) => {
+            if (event.shiftKey || event.metaKey || event.ctrlKey) {
+              setSelected((current) =>
+                current.includes(id)
+                  ? current.filter((item) => item !== id)
+                  : [...current, id],
+              );
+            }
+          }}
+          onMenuOpen={() => {
+            if (!selected.includes(id)) setSelected([id]);
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Cmd-click two cards, then right-click: archive and force-archive with a count. */
+export const BulkMenu: Story = {
+  render: (args) => <BulkMenuDemo args={args} />,
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    const first = await body.findByRole("button", {
+      name: /^First workspace/,
+    });
+    const second = await body.findByRole("button", {
+      name: /^Second workspace/,
+    });
+    fireEvent.click(first, { metaKey: true });
+    fireEvent.click(second, { metaKey: true });
+    await userEvent.pointer({ keys: "[MouseRight]", target: first });
+    await waitFor(() =>
+      expect(
+        body.getByRole("menuitem", { name: "Archive 2 workspaces" }),
+      ).toBeVisible(),
+    );
+    await expect(
+      body.getByRole("menuitem", { name: "Force archive 2 workspaces" }),
+    ).toBeVisible();
+    await expect(body.queryByRole("menuitem", { name: "Rename…" })).toBeNull();
+    await expect(
+      body.queryByRole("menuitem", { name: "New session" }),
+    ).toBeNull();
+  },
 };
 
 /** A local workspace leads with the file manager action in its hover detail. */


### PR DESCRIPTION
Cmd-click and shift-click select workspace cards on the code rail, including the workspace you already have open. A click away from the cards clears the selection. Right-click on more than one selected card archives them in bulk.

Every card draws a status rank glyph so grouping by status is readable. Theme and Settings move into a footer account chip. That chip stays empty until Model Gateway or GitHub is signed in; GitHub fills the username and avatar from `gh` via Delivery capability.

## Validation

`pnpm --dir crates/tidebreak-desktop/ui test` on the workspace card, selection, sidebar, and account-menu files.

## Compatibility and risk

None. Selection is ephemeral UI state. No wire or persistence change.
