### PR TITLE
fix(release): add per-crate publish guards

### DIFF
--- a/crates/tidebreak-cli/Cargo.toml
+++ b/crates/tidebreak-cli/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-code-execution/Cargo.toml
+++ b/crates/tidebreak-code-execution/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-core/Cargo.toml
+++ b/crates/tidebreak-core/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-desktop/Cargo.toml
+++ b/crates/tidebreak-desktop/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-egress/Cargo.toml
+++ b/crates/tidebreak-egress/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-harness/Cargo.toml
+++ b/crates/tidebreak-harness/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-host-broker/Cargo.toml
+++ b/crates/tidebreak-host-broker/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
+publish = false
 
 [[bin]]
 name = "tidebreak-host-broker"

--- a/crates/tidebreak-mcp/Cargo.toml
+++ b/crates/tidebreak-mcp/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-router/Cargo.toml
+++ b/crates/tidebreak-router/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-shell-policy/Cargo.toml
+++ b/crates/tidebreak-shell-policy/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Deterministic allow/ask/deny analysis for shell commands against standing rules."
+publish = false
 
 [lints]
 workspace = true

--- a/crates/tidebreak-whisper/Cargo.toml
+++ b/crates/tidebreak-whisper/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/docs/decisions/0071-hosted-engines-ride-the-callers-inference.md
+++ b/docs/decisions/0071-hosted-engines-ride-the-callers-inference.md
@@ -77,10 +77,8 @@ gateway does not answer (the engine's own retry policy applies).
 
 ## Consequences
 
-- Hosted Claude Code and Codex sessions run turns as the caller, with the
-  caller's entitlements and metering, matching chat.
-- Opencode and Grok sessions on hosted machines still launch without
-  credentials and fail their first turn; they need equivalent wiring.
+- Hosted Claude Code, Codex, OpenCode, and Grok sessions run turns as the
+  caller, with the caller's entitlements and metering, matching chat.
 - A Codex thread started before this decision recorded the default
   provider in its rollout; resuming it may still fail. A new session is
   the path.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -924,36 +924,41 @@ test("dependency policy covers advisories, licenses, sources, and the locked gra
   );
 });
 
-test("every workspace crate opts out of crates.io publication in its own manifest", () => {
-  const metadata = JSON.parse(
-    execFileSync(
-      "cargo",
-      ["metadata", "--format-version", "1", "--no-deps"],
-      { cwd: repositoryRoot, encoding: "utf8" },
-    ),
-  );
-  const workspaceMembers = new Set(metadata.workspace_members);
-  const missing = metadata.packages
-    .filter((pkg) => workspaceMembers.has(pkg.id))
-    .filter((pkg) => {
-      const manifest = readFileSync(pkg.manifest_path, "utf8");
-      const packageStart = manifest.indexOf("[package]");
-      if (packageStart === -1) return true;
-      const sectionEnd = manifest.indexOf("\n[", packageStart + 1);
-      const packageSection = manifest.slice(
-        packageStart + "[package]".length,
-        sectionEnd === -1 ? undefined : sectionEnd,
-      );
-      return !/^publish\s*=\s*false\s*$/m.test(packageSection);
-    })
-    .map((pkg) => pkg.manifest_path);
+test(
+  "every workspace crate opts out of crates.io publication in its own manifest",
+  // Mutation fixtures copy policy files, not the Cargo workspace.
+  { skip: !existsSync(repositoryFile("Cargo.toml")) },
+  () => {
+    const metadata = JSON.parse(
+      execFileSync(
+        "cargo",
+        ["metadata", "--format-version", "1", "--no-deps"],
+        { cwd: repositoryRoot, encoding: "utf8" },
+      ),
+    );
+    const workspaceMembers = new Set(metadata.workspace_members);
+    const missing = metadata.packages
+      .filter((pkg) => workspaceMembers.has(pkg.id))
+      .filter((pkg) => {
+        const manifest = readFileSync(pkg.manifest_path, "utf8");
+        const packageStart = manifest.indexOf("[package]");
+        if (packageStart === -1) return true;
+        const sectionEnd = manifest.indexOf("\n[", packageStart + 1);
+        const packageSection = manifest.slice(
+          packageStart + "[package]".length,
+          sectionEnd === -1 ? undefined : sectionEnd,
+        );
+        return !/^publish\s*=\s*false\s*$/m.test(packageSection);
+      })
+      .map((pkg) => pkg.manifest_path);
 
-  assert.deepEqual(
-    missing,
-    [],
-    "every workspace crate must set publish = false in its own [package] section",
-  );
-});
+    assert.deepEqual(
+      missing,
+      [],
+      "every workspace crate must set publish = false in its own [package] section",
+    );
+  },
+);
 
 test("E2B template pin provenance and writes share the validated source revision", () => {
   const pin = workflowJob(workflows["publish-e2b-template.yml"], "pin");

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -924,6 +924,37 @@ test("dependency policy covers advisories, licenses, sources, and the locked gra
   );
 });
 
+test("every workspace crate opts out of crates.io publication in its own manifest", () => {
+  const metadata = JSON.parse(
+    execFileSync(
+      "cargo",
+      ["metadata", "--format-version", "1", "--no-deps"],
+      { cwd: repositoryRoot, encoding: "utf8" },
+    ),
+  );
+  const workspaceMembers = new Set(metadata.workspace_members);
+  const missing = metadata.packages
+    .filter((pkg) => workspaceMembers.has(pkg.id))
+    .filter((pkg) => {
+      const manifest = readFileSync(pkg.manifest_path, "utf8");
+      const packageStart = manifest.indexOf("[package]");
+      if (packageStart === -1) return true;
+      const sectionEnd = manifest.indexOf("\n[", packageStart + 1);
+      const packageSection = manifest.slice(
+        packageStart + "[package]".length,
+        sectionEnd === -1 ? undefined : sectionEnd,
+      );
+      return !/^publish\s*=\s*false\s*$/m.test(packageSection);
+    })
+    .map((pkg) => pkg.manifest_path);
+
+  assert.deepEqual(
+    missing,
+    [],
+    "every workspace crate must set publish = false in its own [package] section",
+  );
+});
+
 test("E2B template pin provenance and writes share the validated source revision", () => {
   const pin = workflowJob(workflows["publish-e2b-template.yml"], "pin");
 


### PR DESCRIPTION
Adds `publish = false` to every workspace crate so an accidental crates.io publish stops at each package boundary.

Updates Decision 71 to reflect relay support across all four hosted engines. Adds a workflow-security contract that enumerates Cargo workspace members and requires the guard in each crate manifest.

Validation:

- `node --test scripts/workflow-security.test.mjs` — 46 passed.
- `cargo metadata --format-version 1 --no-deps` — passed.
- `git diff --check main...HEAD` — passed.

Closes #2814.