### PR TITLE
feat(harness): detect capabilities per engine version line

### DIFF
--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -158,7 +158,8 @@ fn claude_settings_models(
                 default: current == Some(id),
                 fast_mode: model_serves_fast_mode(id),
                 id: id.to_owned(),
-                reasoning_efforts: EFFORT_LADDER.to_vec(),
+                // The caller stamps the probed ladder over every row.
+                reasoning_efforts: Vec::new(),
             });
         }
     }
@@ -170,7 +171,7 @@ fn claude_settings_models(
                     label: crate::display_model_label(current),
                     id: current.to_owned(),
                     default: true,
-                    reasoning_efforts: EFFORT_LADDER.to_vec(),
+                    reasoning_efforts: Vec::new(),
                     fast_mode: model_serves_fast_mode(current),
                 },
             );
@@ -245,14 +246,27 @@ impl HarnessAdapter for ClaudeCodeAdapter {
         caps
     }
 
-    fn reasoning_efforts(&self, _probe: &HarnessProbe) -> Vec<ReasoningEffort> {
-        EFFORT_LADDER.to_vec()
+    fn reasoning_efforts(&self, probe: &HarnessProbe) -> Vec<ReasoningEffort> {
+        // The ladder reads off the pinned 2.1.234 `--help`. When
+        // `capabilities` degrades `reasoning_levels` for an engine off that
+        // line, session create refuses every level, so advertising the
+        // pinned ladder would offer a control that only fails. The empty
+        // ladder hides the picker instead.
+        if self.capabilities(probe).reasoning_levels == CapLevel::Supported {
+            EFFORT_LADDER.to_vec()
+        } else {
+            Vec::new()
+        }
     }
 
     async fn list_models(&self, probe: &HarnessProbe) -> Vec<crate::ListedHarnessModel> {
         // `claude models` is not a catalog command — it starts a session
-        // with that prompt. Read the user's Claude settings instead.
-        claude_settings_models(&probe.env)
+        // with that prompt. Read the user's Claude settings instead. Every
+        // row takes the probed ladder so the listing agrees with the picker.
+        crate::with_reasoning_efforts(
+            claude_settings_models(&probe.env),
+            &self.reasoning_efforts(probe),
+        )
     }
 
     async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
@@ -786,6 +800,48 @@ mod tests {
         assert_eq!(caps.plan_mode, CapLevel::Supported);
         assert_eq!(caps.auto_mode, CapLevel::Supported);
         assert_eq!(caps.allow_mode, CapLevel::Supported);
+    }
+
+    /// A degraded `reasoning_levels` empties the advertised ladder with it.
+    /// Session create refuses every level once the flag is not `Supported`,
+    /// so a probe or listing that kept the pinned ladder would offer a
+    /// picker whose every choice fails.
+    #[tokio::test]
+    async fn a_degraded_reasoning_flag_empties_the_advertised_ladder() {
+        let home = tempfile::tempdir().unwrap();
+        let settings_dir = home.path().join(".claude");
+        std::fs::create_dir_all(&settings_dir).unwrap();
+        std::fs::write(
+            settings_dir.join("settings.json"),
+            serde_json::to_vec(&serde_json::json!({"model": "claude-declared-next"})).unwrap(),
+        )
+        .unwrap();
+        let probe = |version: &str| HarnessProbe {
+            found: true,
+            binary_path: None,
+            version: Some(version.to_owned()),
+            authenticated: None,
+            stderr: String::new(),
+            env: vec![("HOME".into(), home.path().as_os_str().to_owned())],
+            commands: Vec::new(),
+        };
+        let adapter = ClaudeCodeAdapter::new();
+
+        let pinned = probe("2.1.234 (Claude Code)");
+        assert_eq!(adapter.reasoning_efforts(&pinned), EFFORT_LADDER);
+        let models = adapter.list_models(&pinned).await;
+        assert!(!models.is_empty());
+        assert!(models
+            .iter()
+            .all(|model| model.reasoning_efforts == EFFORT_LADDER));
+
+        let declared = probe("3.0.1 (Claude Code)");
+        assert!(adapter.reasoning_efforts(&declared).is_empty());
+        let models = adapter.list_models(&declared).await;
+        assert!(!models.is_empty());
+        assert!(models
+            .iter()
+            .all(|model| model.reasoning_efforts.is_empty()));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -215,9 +215,9 @@ impl HarnessAdapter for ClaudeCodeAdapter {
         }
     }
 
-    fn capabilities(&self, _probe: &HarnessProbe) -> HarnessCaps {
+    fn capabilities(&self, probe: &HarnessProbe) -> HarnessCaps {
         // Honest values for v2.1.233, from captured fixtures and `--help`.
-        HarnessCaps {
+        let mut caps = HarnessCaps {
             resume: CapLevel::Supported,
             streaming_deltas: CapLevel::Supported,
             // Permission flags are documented on the 2.1 line. The product
@@ -233,7 +233,16 @@ impl HarnessAdapter for ClaudeCodeAdapter {
             native_interrupt: CapLevel::Supported,
             image_input: CapLevel::Supported,
             slash_commands: CapLevel::Unknown,
+        };
+        // Off the captured 2.1 line — a declared newer engine, say — the
+        // stream contract and permission flags are stable documented
+        // surface, but the flags read off one pin's `--help` and fixtures
+        // drop back to Unknown (decision 31 rule 3).
+        if crate::probe::off_pinned_line(probe.version.as_deref(), (2, 1)) {
+            caps.reasoning_levels = CapLevel::Unknown;
+            caps.image_input = CapLevel::Unknown;
         }
+        caps
     }
 
     fn reasoning_efforts(&self, _probe: &HarnessProbe) -> Vec<ReasoningEffort> {
@@ -754,6 +763,28 @@ mod tests {
             commands: Vec::new(),
         });
         assert_eq!(caps.structured_approvals, CapLevel::Supported);
+        assert_eq!(caps.allow_mode, CapLevel::Supported);
+    }
+
+    #[test]
+    fn pin_specific_observations_degrade_off_the_2_1_line() {
+        let caps = ClaudeCodeAdapter::new().capabilities(&HarnessProbe {
+            found: true,
+            binary_path: None,
+            version: Some("3.0.1 (Claude Code)".into()),
+            authenticated: None,
+            stderr: String::new(),
+            env: Vec::new(),
+            commands: Vec::new(),
+        });
+        assert_eq!(caps.reasoning_levels, CapLevel::Unknown);
+        assert_eq!(caps.image_input, CapLevel::Unknown);
+        // Documented stream and permission surface stays advertised.
+        assert_eq!(caps.resume, CapLevel::Supported);
+        assert_eq!(caps.streaming_deltas, CapLevel::Supported);
+        assert_eq!(caps.structured_approvals, CapLevel::Supported);
+        assert_eq!(caps.plan_mode, CapLevel::Supported);
+        assert_eq!(caps.auto_mode, CapLevel::Supported);
         assert_eq!(caps.allow_mode, CapLevel::Supported);
     }
 

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -83,8 +83,8 @@ impl HarnessAdapter for GrokAdapter {
         }
     }
 
-    fn capabilities(&self, _probe: &HarnessProbe) -> HarnessCaps {
-        HarnessCaps {
+    fn capabilities(&self, probe: &HarnessProbe) -> HarnessCaps {
+        let mut caps = HarnessCaps {
             resume: CapLevel::Supported,
             streaming_deltas: CapLevel::Supported,
             // Print-mode streaming-json has no parked approval request.
@@ -108,7 +108,15 @@ impl HarnessAdapter for GrokAdapter {
             native_interrupt: CapLevel::Supported,
             image_input: CapLevel::Unknown,
             slash_commands: CapLevel::Unknown,
+        };
+        // Off the captured 1.0 line the unprompted-write observation behind
+        // Auto no longer holds; a later default posture is unproven
+        // (decision 31 rule 3). The Unsupported verdicts stay: this adapter
+        // composes no approval channel or plan flags at any version.
+        if crate::probe::off_pinned_line(probe.version.as_deref(), (1, 0)) {
+            caps.auto_mode = CapLevel::Unknown;
         }
+        caps
     }
 
     fn reasoning_efforts(&self, _probe: &HarnessProbe) -> Vec<ReasoningEffort> {
@@ -484,6 +492,26 @@ mod tests {
         assert_eq!(caps.slash_commands, CapLevel::Unknown);
         assert_eq!(caps.mid_turn_steering, CapLevel::Unsupported);
         assert_eq!(caps.native_file_change_events, CapLevel::Unknown);
+    }
+
+    #[test]
+    fn auto_posture_degrades_off_the_1_0_line() {
+        let caps = GrokAdapter::new().capabilities(&HarnessProbe {
+            found: true,
+            binary_path: None,
+            version: Some("grok 1.1.0 (0badc0de) [stable]".into()),
+            authenticated: Some(true),
+            stderr: String::new(),
+            env: Vec::new(),
+            commands: Vec::new(),
+        });
+        assert_eq!(caps.auto_mode, CapLevel::Unknown);
+        // The adapter composes no approval channel or plan flags at any
+        // version, so those verdicts hold.
+        assert_eq!(caps.structured_approvals, CapLevel::Unsupported);
+        assert_eq!(caps.mid_turn_steering, CapLevel::Unsupported);
+        assert_eq!(caps.plan_mode, CapLevel::Unsupported);
+        assert_eq!(caps.allow_mode, CapLevel::Supported);
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -74,8 +74,8 @@ impl HarnessAdapter for OpencodeAdapter {
         }
     }
 
-    fn capabilities(&self, _probe: &HarnessProbe) -> HarnessCaps {
-        HarnessCaps {
+    fn capabilities(&self, probe: &HarnessProbe) -> HarnessCaps {
+        let mut caps = HarnessCaps {
             resume: CapLevel::Supported,
             streaming_deltas: CapLevel::Supported,
             structured_approvals: CapLevel::Supported,
@@ -96,7 +96,14 @@ impl HarnessAdapter for OpencodeAdapter {
             native_interrupt: CapLevel::Supported,
             image_input: CapLevel::Unknown,
             slash_commands: CapLevel::Unknown,
+        };
+        // Off the captured 1.18 line the missing-effort-flag finding no
+        // longer applies: a later minor may have grown the flag, so the
+        // verdict drops back to Unknown (decision 31 rule 3).
+        if crate::probe::off_pinned_line(probe.version.as_deref(), (1, 18)) {
+            caps.reasoning_levels = CapLevel::Unknown;
         }
+        caps
     }
 
     /// The agent and permission ruleset ride `POST /session`, and resuming is
@@ -199,6 +206,7 @@ mod tests {
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         }
         .with_declared_binary(tidebreak_core::HarnessKind::Opencode, &binary, "1.19.2");
         let probe = OpencodeAdapter::new().probe(&host).await;
@@ -386,6 +394,26 @@ mod tests {
         assert_eq!(caps.native_file_change_events, CapLevel::Unknown);
         assert_eq!(caps.image_input, CapLevel::Unknown);
         assert_eq!(caps.slash_commands, CapLevel::Unknown);
+    }
+
+    #[test]
+    fn missing_effort_flag_finding_degrades_off_the_1_18_line() {
+        let caps = OpencodeAdapter::new().capabilities(&HarnessProbe {
+            found: true,
+            binary_path: None,
+            version: Some("1.19.2".into()),
+            authenticated: Some(true),
+            stderr: String::new(),
+            env: Vec::new(),
+            commands: Vec::new(),
+        });
+        assert_eq!(caps.reasoning_levels, CapLevel::Unknown);
+        // The serve API contract the adapter drives stays advertised.
+        assert_eq!(caps.resume, CapLevel::Supported);
+        assert_eq!(caps.structured_approvals, CapLevel::Supported);
+        assert_eq!(caps.plan_mode, CapLevel::Supported);
+        assert_eq!(caps.auto_mode, CapLevel::Supported);
+        assert_eq!(caps.allow_mode, CapLevel::Supported);
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -45,6 +45,10 @@ pub struct HostEnv {
     /// PATH; the declared version is authoritative, so probe never runs
     /// `--version` against it.
     pub declared_binaries: Vec<(tidebreak_core::HarnessKind, DeclaredBinary)>,
+    /// Complete child environment the embedding environment asserts. When
+    /// set, probes never run the login shell: commands resolve against this
+    /// environment's `PATH`, and environment captures return it verbatim.
+    pub declared_env: Option<Vec<(OsString, OsString)>>,
 }
 
 /// A harness binary the embedding environment installed itself.
@@ -83,6 +87,7 @@ impl HostEnv {
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         }
     }
 
@@ -122,6 +127,15 @@ impl HostEnv {
     pub fn declared_version(&self, kind: tidebreak_core::HarnessKind) -> Option<&str> {
         self.declared(kind)
             .map(|declared| declared.version.as_str())
+    }
+
+    /// Assert the complete probe environment. Probes then skip the login
+    /// shell entirely: resolution scans this environment's `PATH`, and the
+    /// captured child environment is this one, verbatim.
+    #[must_use]
+    pub fn with_declared_env(mut self, env: Vec<(OsString, OsString)>) -> Self {
+        self.declared_env = Some(env);
+        self
     }
 }
 
@@ -191,6 +205,20 @@ pub async fn probe_shell(host: &HostEnv, name: &str) -> Result<ProbeCapture, Pro
             // doctor refresh install the pin.
             return Err(ProbeError::NotFound(name.to_owned()));
         }
+    }
+    // A declared environment replaces the login shell: resolve against its
+    // PATH directly, and return it as the capture.
+    if let Some(env) = &host.declared_env {
+        #[cfg(windows)]
+        let resolved = resolve_windows_command(env, name);
+        #[cfg(not(windows))]
+        let resolved = resolve_unix_command(env, name);
+        let binary = resolved.ok_or_else(|| ProbeError::NotFound(name.to_owned()))?;
+        return Ok(ProbeCapture {
+            binary,
+            env: env.clone(),
+            stderr: String::new(),
+        });
     }
     #[cfg(windows)]
     {
@@ -300,6 +328,15 @@ fn kind_for_command(name: &str) -> Option<tidebreak_core::HarnessKind> {
     }
 }
 
+#[cfg(not(windows))]
+fn resolve_unix_command(env: &[(OsString, OsString)], name: &str) -> Option<PathBuf> {
+    let path = env_value(env, std::ffi::OsStr::new("PATH"))?;
+    std::env::split_paths(path)
+        .filter(|dir| dir.is_absolute())
+        .map(|dir| dir.join(name))
+        .find(|candidate| is_absolute_executable(candidate))
+}
+
 /// Capture for a binary the embedding environment declared.
 ///
 /// The path is validated, never resolved: a declaration bypasses both the
@@ -378,6 +415,9 @@ fn process_env_without_tidebreak() -> Vec<(OsString, OsString)> {
 }
 
 async fn capture_shell_env(host: &HostEnv) -> Result<Vec<(OsString, OsString)>, ProbeError> {
+    if let Some(env) = &host.declared_env {
+        return Ok(env.clone());
+    }
     #[cfg(windows)]
     {
         Ok(windows_process_env(host))
@@ -475,6 +515,30 @@ pub(crate) fn env_sets_any(env: &[(OsString, OsString)], names: &[&str]) -> bool
     names.iter().any(|name| {
         env_value(env, std::ffi::OsStr::new(name)).is_some_and(|value| !value.is_empty())
     })
+}
+
+/// The first `major.minor` a version line states. Scans whitespace tokens for
+/// one whose leading `v`-stripped form starts `<digits>.<digits>`, so banner
+/// words and build hashes around the number do not matter.
+pub(crate) fn version_minor_line(version: Option<&str>) -> Option<(u64, u64)> {
+    version
+        .into_iter()
+        .flat_map(str::split_whitespace)
+        .find_map(|candidate| {
+            let candidate = candidate.strip_prefix('v').unwrap_or(candidate);
+            let mut parts = candidate.split('.');
+            let major = parts.next()?.parse::<u64>().ok()?;
+            let minor = parts.next()?.parse::<u64>().ok()?;
+            Some((major, minor))
+        })
+}
+
+/// Whether a probed version states a `major.minor` other than the pinned
+/// line. A missing or unparseable version is not off-line: with nothing to
+/// compare, an adapter keeps the pinned capture's flags rather than degrading
+/// the product it ships today.
+pub(crate) fn off_pinned_line(version: Option<&str>, pinned: (u64, u64)) -> bool {
+    version_minor_line(version).is_some_and(|line| line != pinned)
 }
 
 fn apply_captured_env(command: &mut Command, env: &[(std::ffi::OsString, std::ffi::OsString)]) {
@@ -969,6 +1033,7 @@ eval "$cmd"
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         }
     }
 
@@ -1053,6 +1118,7 @@ printf '\n%s\n' "TIDEBREAK_PROBE_END_${end_tok}"
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         };
         match resolve_binary(&host, "claude").await {
             Err(ProbeError::RelativePath { name, path })
@@ -1078,6 +1144,7 @@ printf '\n%s\n' "TIDEBREAK_PROBE_END_${end_tok}"
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         };
         let resolved = resolve_binary(&host, "claude").await.unwrap();
         assert_eq!(resolved, bin);
@@ -1131,6 +1198,7 @@ eval "$cmd"
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         };
         let capture = probe_shell(&host, "claude").await.unwrap();
         assert_eq!(capture.binary, bin);
@@ -1188,6 +1256,7 @@ eval "$cmd"
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         };
         let capture = pinned_probe_capture(&host, binary.clone()).await;
         assert_eq!(capture.binary, binary);
@@ -1222,6 +1291,7 @@ eval "$cmd"
             data_dir: None,
             managed_node_root: Some(node_root),
             declared_binaries: Vec::new(),
+            declared_env: None,
         };
 
         let capture = pinned_probe_capture(&host, binary.clone()).await;
@@ -1254,6 +1324,7 @@ eval "$cmd"
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         }
         .with_declared_binary(tidebreak_core::HarnessKind::ClaudeCode, &binary, "9.9.9");
         let capture = probe_shell(&host, "claude").await.unwrap();
@@ -1324,10 +1395,87 @@ eval "$cmd"
             data_dir: Some(data_dir.path().to_path_buf()),
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         }
         .with_declared_binary(tidebreak_core::HarnessKind::ClaudeCode, &declared, "9.9.9");
         let capture = probe_shell(&host, "claude").await.unwrap();
         assert_eq!(capture.binary, declared);
+    }
+
+    #[test]
+    fn version_lines_parse_from_banner_tokens() {
+        assert_eq!(
+            version_minor_line(Some("2.1.233 (Claude Code)")),
+            Some((2, 1))
+        );
+        assert_eq!(
+            version_minor_line(Some("grok 1.0.4 (d846eb93d94d) [stable]")),
+            Some((1, 0))
+        );
+        assert_eq!(version_minor_line(Some("v1.18.18")), Some((1, 18)));
+        assert_eq!(version_minor_line(Some("development build")), None);
+        assert_eq!(version_minor_line(None), None);
+        assert!(off_pinned_line(Some("3.0.1 (Claude Code)"), (2, 1)));
+        assert!(!off_pinned_line(Some("2.1.300 (Claude Code)"), (2, 1)));
+        // Nothing to compare: keep the pinned capture's flags.
+        assert!(!off_pinned_line(None, (2, 1)));
+        assert!(!off_pinned_line(Some("development build"), (2, 1)));
+    }
+
+    #[tokio::test]
+    async fn declared_env_resolves_on_its_own_path_without_a_login_shell() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("claude");
+        write_exec(&binary, "#!/bin/sh\nexit 1\n");
+        let declared_env = vec![
+            (
+                OsString::from("PATH"),
+                dir.path().as_os_str().to_os_string(),
+            ),
+            (OsString::from("SANDBOX_MARKER"), OsString::from("1")),
+        ];
+        // A shell that cannot run: only the declared environment can
+        // produce this capture.
+        let host = HostEnv {
+            shell: dir.path().join("missing-shell"),
+            env: Vec::new(),
+            clear_env: true,
+            data_dir: None,
+            managed_node_root: None,
+            declared_binaries: Vec::new(),
+            declared_env: None,
+        }
+        .with_declared_env(declared_env.clone());
+        let capture = probe_shell(&host, "claude").await.unwrap();
+        assert_eq!(capture.binary, binary);
+        assert_eq!(capture.env, declared_env);
+        assert!(matches!(
+            probe_shell(&host, "codex").await,
+            Err(ProbeError::NotFound(name)) if name == "codex"
+        ));
+    }
+
+    #[tokio::test]
+    async fn declared_binary_captures_the_declared_env_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("declared-grok");
+        write_exec(&binary, "#!/bin/sh\nexit 1\n");
+        let declared_env = vec![(OsString::from("PATH"), OsString::from("/usr/bin"))];
+        let host = HostEnv {
+            shell: dir.path().join("missing-shell"),
+            env: Vec::new(),
+            clear_env: true,
+            data_dir: None,
+            managed_node_root: None,
+            declared_binaries: Vec::new(),
+            declared_env: None,
+        }
+        .with_declared_binary(tidebreak_core::HarnessKind::Grok, &binary, "1.0.4")
+        .with_declared_env(declared_env.clone());
+        let capture = probe_shell(&host, "grok").await.unwrap();
+        assert_eq!(capture.binary, binary);
+        assert_eq!(capture.env, declared_env);
+        assert!(capture.stderr.is_empty(), "no shell ran, so no shell error");
     }
 
     #[tokio::test]
@@ -1350,6 +1498,7 @@ eval "$cmd"
             data_dir: Some(data_dir.path().to_path_buf()),
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         };
 
         assert!(matches!(
@@ -1412,6 +1561,7 @@ mod windows_tests {
             data_dir: None,
             managed_node_root: None,
             declared_binaries: Vec::new(),
+            declared_env: None,
         };
 
         let capture = probe_shell(&host, "claude").await.unwrap();


### PR DESCRIPTION
## What changed

- Derive Claude, OpenCode, and Grok capability levels from the declared engine version line instead of advertising one hard-coded set.
- Keep verified pinned-version behavior intact and degrade version-sensitive capabilities to unknown outside the captured line.
- Empty Claude reasoning-effort choices when the effort flag is no longer verified, so doctor output, model listings, and the composer agree.
- Add version parsing and capability regressions for the supported and degraded paths.

## Validation

- `cargo test -p tidebreak-harness` — 318 passed on the restacked stack.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Compatibility and risk

Pinned engine versions keep their existing capabilities. Declared versions outside the verified lines now hide controls that the harness cannot promise instead of offering actions that fail later.

## Tracking

Closes #2813