### PR TITLE
feat(agent): add the supervised-agent poll client and turn loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7502,6 +7502,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tidebreak-supervised-agent"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+]
+
+[[package]]
 name = "tidebreak-whisper"
 version = "0.1.0"
 dependencies = [

--- a/crates/tidebreak-server/src/logging.rs
+++ b/crates/tidebreak-server/src/logging.rs
@@ -61,7 +61,8 @@ const DEFAULT_DIRECTIVES: &str = "warn,tidebreak_cli=info,tidebreak_code_executi
     tidebreak_harness=info,tidebreak_host_broker=info,tidebreak_managed_node=info,\
     tidebreak_mcp=info,\
     tidebreak_router=info,tidebreak_sandbox_agent=info,tidebreak_sandbox_protocol=info,\
-    tidebreak_server=info,tidebreak_shell_policy=info,tidebreak_whisper=info";
+    tidebreak_server=info,tidebreak_shell_policy=info,\
+    tidebreak_supervised_agent=info,tidebreak_whisper=info";
 
 /// Keep the structured file focused on purpose-built, payload-free events.
 const DEFAULT_DIAGNOSTIC_DIRECTIVES: &str = "off,tidebreak_diagnostics=info";

--- a/crates/tidebreak-supervised-agent/Cargo.toml
+++ b/crates/tidebreak-supervised-agent/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tidebreak-supervised-agent"
+description = "UNSTABLE: the externally supervised Tidebreak agent — polls a sandbox control endpoint, drives an engine CLI through tidebreak-harness, and reports lifecycle events outward. Decision 0077 names the shape."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+publish = false
+
+[dependencies]
+async-trait = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
+
+[dev-dependencies]
+axum = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "time", "test-util"] }
+
+[lints]
+workspace = true

--- a/crates/tidebreak-supervised-agent/src/control.rs
+++ b/crates/tidebreak-supervised-agent/src/control.rs
@@ -1,0 +1,221 @@
+//! The poll client and the bounded event outbox.
+//!
+//! One rule separates this client from a naive HTTP loop: it never retries
+//! silently past a refusal that retrying cannot fix. The endpoint names its
+//! refusals — an unsupported poll schema, an event the stream will not
+//! accept — and an agent that swallows those and keeps polling turns a
+//! five-second bug into an invisible dead sandbox. Named refusals are fatal
+//! and loud; everything else (network faults, server errors, a sidecar still
+//! starting) is retryable, and the driver bounds how long retrying may last.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use crate::wire::{PollRejection, SupervisorEvent, SupervisorInstructions, SupervisorPoll};
+
+/// Serialized ceiling for one poll's event batch.
+///
+/// The endpoint bounds each event payload at 256 KiB and the sidecar bounds
+/// the request body; staying well under both keeps a full batch plus the poll
+/// envelope inside every ceiling at once.
+pub const MAX_BATCH_BYTES: usize = 192 * 1024;
+
+/// Refusal codes that retrying cannot fix.
+///
+/// Each one means this agent built a request the endpoint will never accept:
+/// a schema it does not speak, an event kind the stream refuses, a payload
+/// over the ceiling, or more deliverables than one poll may carry.
+const FATAL_REJECTIONS: [&str; 4] = [
+    "supervisor_poll_schema_unsupported",
+    "sandbox_event_invalid",
+    "sandbox_event_too_large",
+    "sandbox_event_flood",
+];
+
+/// One poll's outcome, when it is not instructions.
+#[derive(Debug, thiserror::Error)]
+pub enum PollFailure {
+    /// A transient fault: retry on the poll cadence.
+    #[error("supervisor poll failed: {0}")]
+    Retryable(String),
+    /// A named refusal that retrying cannot fix: exit loudly.
+    #[error("the control endpoint refused this agent ({code}): {description}")]
+    Fatal {
+        /// Machine-readable refusal code.
+        code: String,
+        /// The endpoint's own description.
+        description: String,
+    },
+}
+
+/// Events waiting for a poll, drained oldest-first under the byte ceiling.
+///
+/// Nothing is dropped: what one poll cannot carry rides the next, and a
+/// batch whose poll failed retryably goes back to the front in order.
+#[derive(Debug, Default)]
+pub struct Outbox {
+    events: VecDeque<SupervisorEvent>,
+}
+
+impl Outbox {
+    /// Queues one event.
+    pub fn push(&mut self, kind: &str, payload: serde_json::Value) {
+        self.events.push_back(SupervisorEvent::new(kind, payload));
+    }
+
+    /// Whether anything is waiting.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Takes the next batch, keeping its serialized size under the ceiling.
+    ///
+    /// Always takes at least one event when any is queued: an event whose
+    /// payload alone exceeds the ceiling goes out alone, so the endpoint's
+    /// refusal is loud rather than the event silently wedging the queue.
+    pub fn take_batch(&mut self) -> Vec<SupervisorEvent> {
+        let mut batch = Vec::new();
+        let mut bytes = 0_usize;
+        while let Some(event) = self.events.front() {
+            let event_bytes = serde_json::to_vec(event).map_or(0, |body| body.len());
+            if !batch.is_empty() && bytes + event_bytes > MAX_BATCH_BYTES {
+                break;
+            }
+            bytes += event_bytes;
+            batch.push(self.events.pop_front().expect("front was just observed"));
+        }
+        batch
+    }
+
+    /// Returns a failed batch to the front, preserving order.
+    pub fn requeue(&mut self, batch: Vec<SupervisorEvent>) {
+        for event in batch.into_iter().rev() {
+            self.events.push_front(event);
+        }
+    }
+}
+
+/// The poll client for one control endpoint.
+#[derive(Debug)]
+pub struct Control {
+    client: reqwest::Client,
+    poll_url: String,
+}
+
+impl Control {
+    /// Builds a client for the endpoint at `control_url`.
+    #[must_use]
+    pub fn new(control_url: &str) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        Self {
+            client,
+            poll_url: format!("{}/supervisor/poll", control_url.trim_end_matches('/')),
+        }
+    }
+
+    /// Posts one poll and classifies the reply.
+    pub async fn poll(&self, poll: &SupervisorPoll) -> Result<SupervisorInstructions, PollFailure> {
+        let response = self
+            .client
+            .post(&self.poll_url)
+            .json(poll)
+            .send()
+            .await
+            .map_err(|error| PollFailure::Retryable(error.to_string()))?;
+        let status = response.status();
+        if status.is_success() {
+            return response
+                .json::<SupervisorInstructions>()
+                .await
+                .map_err(|error| {
+                    PollFailure::Retryable(format!("instructions were unreadable: {error}"))
+                });
+        }
+        let body = response.bytes().await.unwrap_or_default();
+        // 413 is the transport's own "too large": the request can never
+        // shrink by retrying, so it is as final as the named refusals.
+        if status == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
+            return Err(PollFailure::Fatal {
+                code: "payload_too_large".to_owned(),
+                description: "the poll request body exceeds the endpoint's ceiling".to_owned(),
+            });
+        }
+        if let Ok(rejection) = serde_json::from_slice::<PollRejection>(&body) {
+            if FATAL_REJECTIONS.contains(&rejection.error.as_str()) {
+                return Err(PollFailure::Fatal {
+                    code: rejection.error,
+                    description: rejection.error_description,
+                });
+            }
+            return Err(PollFailure::Retryable(format!(
+                "{status}: {} ({})",
+                rejection.error, rejection.error_description
+            )));
+        }
+        Err(PollFailure::Retryable(format!(
+            "{status}: {}",
+            String::from_utf8_lossy(&body)
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batches_stay_under_the_byte_ceiling() {
+        let mut outbox = Outbox::default();
+        // Each event serializes to roughly 64 KiB; four queued means the
+        // first batch carries under the ceiling and the rest wait.
+        let payload = serde_json::json!({"body": "x".repeat(64 * 1024)});
+        for _ in 0..4 {
+            outbox.push("turn_started", payload.clone());
+        }
+        let batch = outbox.take_batch();
+        let bytes: usize = batch
+            .iter()
+            .map(|event| serde_json::to_vec(event).unwrap().len())
+            .sum();
+        assert!(bytes <= MAX_BATCH_BYTES);
+        assert!(batch.len() < 4);
+        assert!(!outbox.is_empty());
+    }
+
+    /// An oversized event must go out alone and fail loudly there, not wedge
+    /// the queue forever.
+    #[test]
+    fn an_oversized_event_still_leaves_the_queue() {
+        let mut outbox = Outbox::default();
+        outbox.push(
+            "task_output",
+            serde_json::json!({"body": "x".repeat(MAX_BATCH_BYTES + 1)}),
+        );
+        outbox.push("supervisor_stopped", serde_json::json!({}));
+        let batch = outbox.take_batch();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].kind, "task_output");
+        assert_eq!(outbox.take_batch().len(), 1);
+    }
+
+    #[test]
+    fn a_requeued_batch_keeps_its_order() {
+        let mut outbox = Outbox::default();
+        outbox.push("supervisor_started", serde_json::json!({}));
+        outbox.push("turn_started", serde_json::json!({}));
+        outbox.push("turn_completed", serde_json::json!({}));
+        let batch = outbox.take_batch();
+        assert_eq!(batch.len(), 3);
+        outbox.requeue(batch);
+        let batch = outbox.take_batch();
+        let kinds: Vec<&str> = batch.iter().map(|event| event.kind.as_str()).collect();
+        assert_eq!(
+            kinds,
+            ["supervisor_started", "turn_started", "turn_completed"]
+        );
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/drive.rs
+++ b/crates/tidebreak-supervised-agent/src/drive.rs
@@ -1,0 +1,947 @@
+//! The turn state machine.
+//!
+//! One driver owns the whole conversation with the control endpoint: it
+//! decides what the next turn is, runs it through the [`Engine`] seam, polls
+//! on a fixed cadence while the turn runs, and reports every lifecycle
+//! transition as an event. The ordering rules that matter live here:
+//!
+//! - The delivery cursor is acknowledged only *after* a message reached the
+//!   engine — steered into a running turn, or carried by a turn that
+//!   launched. A crash before the acknowledgement redelivers; acknowledging
+//!   first would silently skip.
+//! - A named refusal from the endpoint ends the process loudly. A transient
+//!   fault retries on the poll cadence, but only up to a ceiling: an agent
+//!   that cannot reach its supervisor for ten minutes is not supervised and
+//!   must not pretend to be.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use crate::control::{Control, Outbox, PollFailure};
+use crate::engine::{Engine, SteerOutcome, TurnEnd, TurnHandle, TurnRequest, TurnSource};
+use crate::inputs::{Inputs, RunMode, POLL_INTERVAL};
+use crate::wire::{SupervisorMessage, SupervisorPoll};
+use crate::{EXIT_CONTROL_FATAL, EXIT_ENGINE_FAILED};
+
+/// Consecutive retryable poll failures before the agent gives up.
+///
+/// At the five-second cadence this is roughly ten minutes of unreachable
+/// endpoint — long past any sidecar restart, and short enough that a wedged
+/// network shows up as a failed pod instead of a silent one.
+pub const MAX_CONSECUTIVE_POLL_FAILURES: u32 = 120;
+
+/// Why the driver exited nonzero.
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct DriveError {
+    /// Process exit code.
+    pub code: i32,
+    /// What went wrong.
+    pub message: String,
+}
+
+/// What the driver decided to do next.
+enum NextAction {
+    /// Run a turn.
+    Run(TurnRequest),
+    /// Nothing to run: poll idle and wait.
+    Wait,
+}
+
+/// One iteration of the mid-turn select loop.
+enum TurnStep {
+    /// The turn ended.
+    End(TurnEnd),
+    /// The poll cadence ticked.
+    Tick,
+}
+
+/// The supervised turn loop over one engine.
+pub struct Driver<E> {
+    control: Control,
+    engine: E,
+    outbox: Outbox,
+    inbox: VecDeque<SupervisorMessage>,
+    /// Highest sequence delivered to the engine; the poll cursor.
+    delivered_through: Option<i64>,
+    /// Highest sequence enqueued, so unacknowledged redeliveries dedupe.
+    seen_through: i64,
+    consecutive_failures: u32,
+    stop_reason: Option<String>,
+    acceptance_met: bool,
+    mode: RunMode,
+    task: String,
+    turn: u32,
+    max_turns: Option<u32>,
+    ran_spawn_task: bool,
+    last_turn_succeeded: bool,
+    poll_interval: Duration,
+}
+
+impl<E: Engine> Driver<E> {
+    /// Builds a driver from resolved inputs.
+    pub fn new(control: Control, engine: E, inputs: &Inputs) -> Self {
+        // A later incarnation already ran the spawn task; goal mode resumes
+        // the goal, turn mode waits for steering.
+        let resumed = inputs.starting_turn > 1;
+        Self {
+            control,
+            engine,
+            outbox: Outbox::default(),
+            inbox: VecDeque::new(),
+            delivered_through: None,
+            seen_through: 0,
+            consecutive_failures: 0,
+            stop_reason: None,
+            acceptance_met: false,
+            mode: inputs.mode,
+            task: inputs.task.clone(),
+            turn: inputs.starting_turn,
+            max_turns: inputs.max_turns,
+            ran_spawn_task: resumed,
+            last_turn_succeeded: resumed,
+            poll_interval: POLL_INTERVAL,
+        }
+    }
+
+    /// Overrides the poll cadence. Tests shrink it; production keeps the
+    /// default.
+    #[must_use]
+    pub fn with_poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    /// Runs the loop until the endpoint stops the agent or something fails.
+    pub async fn run(mut self) -> Result<(), DriveError> {
+        self.outbox.push(
+            "supervisor_started",
+            serde_json::json!({
+                "harness": "custom",
+                "agent": "tidebreak-supervised-agent",
+            }),
+        );
+        if self.mode == RunMode::Goal && self.turn > 1 {
+            // A resumed goal may already be complete or stopped. Read that
+            // state before another engine turn can begin.
+            self.poll(true).await?;
+        }
+        loop {
+            if let Some(reason) = self.stop_reason.take() {
+                return self.stopped(&reason).await;
+            }
+            match self.decide() {
+                NextAction::Wait => {
+                    self.poll(true).await?;
+                    if self.stop_reason.is_some()
+                        || (self.budget_allows(self.turn) && !self.inbox.is_empty())
+                    {
+                        continue;
+                    }
+                    tokio::time::sleep(self.poll_interval).await;
+                }
+                NextAction::Run(request) => self.run_turn(request).await?,
+            }
+        }
+    }
+
+    /// Whether the turn budget still allows `turn`.
+    fn budget_allows(&self, turn: u32) -> bool {
+        self.max_turns.is_none_or(|max| turn <= max)
+    }
+
+    /// Picks the next turn, or nothing.
+    fn decide(&self) -> NextAction {
+        if !self.budget_allows(self.turn) {
+            // The budget is spent: park idle and keep polling, matching the
+            // spawn contract. The endpoint decides what happens next.
+            return NextAction::Wait;
+        }
+        if !self.ran_spawn_task {
+            return NextAction::Run(TurnRequest {
+                turn: self.turn,
+                source: TurnSource::SpawnTask,
+                input: self.task.clone(),
+            });
+        }
+        if !self.inbox.is_empty() {
+            let input = self
+                .inbox
+                .iter()
+                .map(|message| message.body.as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            return NextAction::Run(TurnRequest {
+                turn: self.turn,
+                source: TurnSource::Inbox,
+                input,
+            });
+        }
+        if self.mode == RunMode::Goal && self.last_turn_succeeded && !self.acceptance_met {
+            // The engine resumes its own session; there is no new input.
+            return NextAction::Run(TurnRequest {
+                turn: self.turn,
+                source: TurnSource::GoalResume,
+                input: String::new(),
+            });
+        }
+        NextAction::Wait
+    }
+
+    /// Runs one turn to its end and reports how it went.
+    async fn run_turn(&mut self, request: TurnRequest) -> Result<(), DriveError> {
+        let turn = request.turn;
+        let source = request.source;
+        self.outbox
+            .push("turn_started", serde_json::json!({ "turn": turn }));
+        let mut handle = match self.engine.start_turn(request).await {
+            Ok(handle) => handle,
+            Err(error) => {
+                // The inbox stays unacknowledged, so whatever this turn was
+                // going to carry redelivers to the next incarnation.
+                return self.engine_failed(&error.to_string()).await;
+            }
+        };
+        if source == TurnSource::SpawnTask {
+            self.ran_spawn_task = true;
+        }
+        if source == TurnSource::Inbox {
+            // The turn launched carrying these bodies: now they count as
+            // delivered.
+            while let Some(message) = self.inbox.pop_front() {
+                self.delivered_through = Some(message.seq);
+            }
+        }
+
+        let end = loop {
+            let step = tokio::select! {
+                end = handle.wait() => TurnStep::End(end),
+                () = tokio::time::sleep(self.poll_interval) => TurnStep::Tick,
+            };
+            match step {
+                TurnStep::End(end) => break end,
+                TurnStep::Tick => {
+                    self.poll(false).await?;
+                    if self.stop_reason.is_some() {
+                        handle.interrupt().await;
+                        continue;
+                    }
+                    if let Some(end) = self.steer_pending(handle.as_mut()).await {
+                        break end;
+                    }
+                }
+            }
+        };
+
+        match end {
+            TurnEnd::Interrupted => {
+                self.outbox
+                    .push("turn_interrupted", serde_json::json!({ "turn": turn }));
+                self.last_turn_succeeded = false;
+            }
+            TurnEnd::Completed { success } => {
+                let may_resume = self.mode == RunMode::Goal
+                    && success
+                    && self.budget_allows(turn + 1)
+                    && !self.acceptance_met;
+                let mut payload = serde_json::json!({
+                    "turn": turn,
+                    "exit_code": if success { 0 } else { 1 },
+                    "may_resume": may_resume,
+                });
+                if self.mode == RunMode::Turn {
+                    payload["gate"] = serde_json::json!("turn_mode");
+                }
+                self.outbox.push("turn_completed", payload);
+                self.last_turn_succeeded = success;
+            }
+            TurnEnd::Fatal { message } => {
+                self.outbox.push(
+                    "turn_completed",
+                    serde_json::json!({
+                        "turn": turn,
+                        "exit_code": 1,
+                        "may_resume": false,
+                    }),
+                );
+                return self.engine_failed(&message).await;
+            }
+        }
+        self.turn += 1;
+        // Between turns the engine is momentarily idle; this poll flushes the
+        // completion events and picks up anything the endpoint queued.
+        self.poll(true).await
+    }
+
+    /// Delivers pending inbox messages into a running turn, in order.
+    async fn steer_pending(&mut self, handle: &mut dyn TurnHandle) -> Option<TurnEnd> {
+        while let Some(message) = self.inbox.front() {
+            if message.interrupt {
+                // The body is not delivered into this turn; it stays queued
+                // and opens the next one.
+                handle.interrupt().await;
+                return None;
+            }
+            let body = message.body.clone();
+            match handle.steer(body).await {
+                SteerOutcome::Delivered => {
+                    let message = self.inbox.pop_front().expect("front was just observed");
+                    self.delivered_through = Some(message.seq);
+                }
+                // This engine takes input only between turns; the message
+                // waits there.
+                SteerOutcome::Refused => return None,
+                // The poll completed after the turn did. Keep the message
+                // queued so the next turn carries it.
+                SteerOutcome::Ended(end) => return Some(end),
+            }
+        }
+        None
+    }
+
+    /// Posts one poll, classifies the outcome, and absorbs instructions.
+    async fn poll(&mut self, idle: bool) -> Result<(), DriveError> {
+        let batch = self.outbox.take_batch();
+        let mut poll = SupervisorPoll::new(idle, self.delivered_through);
+        poll.events.clone_from(&batch);
+        match self.control.poll(&poll).await {
+            Ok(instructions) => {
+                self.consecutive_failures = 0;
+                for message in instructions.messages {
+                    if message.seq > self.seen_through {
+                        self.seen_through = message.seq;
+                        self.inbox.push_back(message);
+                    }
+                }
+                if instructions.stop && self.stop_reason.is_none() {
+                    self.stop_reason = Some(
+                        instructions
+                            .stop_reason
+                            .unwrap_or_else(|| "stop_requested".to_owned()),
+                    );
+                }
+                self.acceptance_met = instructions.acceptance_met;
+                Ok(())
+            }
+            Err(PollFailure::Retryable(message)) => {
+                self.outbox.requeue(batch);
+                self.consecutive_failures += 1;
+                if self.consecutive_failures >= MAX_CONSECUTIVE_POLL_FAILURES {
+                    return Err(DriveError {
+                        code: EXIT_CONTROL_FATAL,
+                        message: format!(
+                            "the control endpoint failed {} consecutive polls; last: {message}",
+                            self.consecutive_failures
+                        ),
+                    });
+                }
+                Ok(())
+            }
+            Err(fatal @ PollFailure::Fatal { .. }) => Err(DriveError {
+                code: EXIT_CONTROL_FATAL,
+                message: fatal.to_string(),
+            }),
+        }
+    }
+
+    /// Reports a clean stop and exits zero.
+    async fn stopped(mut self, reason: &str) -> Result<(), DriveError> {
+        self.outbox.push(
+            "supervisor_stopped",
+            serde_json::json!({ "reason": reason }),
+        );
+        self.flush().await;
+        Ok(())
+    }
+
+    /// Reports an engine failure and exits with [`EXIT_ENGINE_FAILED`].
+    async fn engine_failed(&mut self, message: &str) -> Result<(), DriveError> {
+        self.outbox.push(
+            "supervisor_stopped",
+            serde_json::json!({ "reason": "engine_failed" }),
+        );
+        self.flush().await;
+        Err(DriveError {
+            code: EXIT_ENGINE_FAILED,
+            message: format!("the engine failed: {message}"),
+        })
+    }
+
+    /// Best-effort final delivery of whatever the outbox still holds.
+    async fn flush(&mut self) {
+        for _ in 0..3 {
+            if self.outbox.is_empty() {
+                return;
+            }
+            if self.poll(true).await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+    use axum::Json;
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::*;
+    use crate::engine::EngineError;
+    use crate::inputs::{resolve, RawInputs};
+
+    /// One scripted delay for the next supervisor poll.
+    struct PollBlock {
+        started: oneshot::Sender<()>,
+        release: oneshot::Receiver<()>,
+    }
+
+    /// Everything the mock supervisor records and serves.
+    #[derive(Default)]
+    struct MockSupervisor {
+        events: Vec<(String, serde_json::Value)>,
+        polls: Vec<serde_json::Value>,
+        messages: Vec<(i64, String, bool)>,
+        message_batches: usize,
+        stop: Option<String>,
+        reject: Option<(u16, String)>,
+        block_next_poll: Option<PollBlock>,
+    }
+
+    type SharedSupervisor = Arc<Mutex<MockSupervisor>>;
+
+    async fn poll_route(
+        State(state): State<SharedSupervisor>,
+        Json(body): Json<serde_json::Value>,
+    ) -> axum::response::Response {
+        let (reject, block) = {
+            let mut supervisor = state.lock().unwrap();
+            (supervisor.reject.clone(), supervisor.block_next_poll.take())
+        };
+        if let Some((status, code)) = reject {
+            return (
+                axum::http::StatusCode::from_u16(status).unwrap(),
+                Json(serde_json::json!({
+                    "error": code,
+                    "error_description": "scripted refusal",
+                })),
+            )
+                .into_response();
+        }
+        if let Some(PollBlock { started, release }) = block {
+            let _ = started.send(());
+            let _ = release.await;
+        }
+        let mut supervisor = state.lock().unwrap();
+        supervisor.polls.push(body.clone());
+        if let Some(events) = body.get("events").and_then(serde_json::Value::as_array) {
+            for event in events {
+                supervisor.events.push((
+                    event["kind"].as_str().unwrap_or_default().to_owned(),
+                    event["payload"].clone(),
+                ));
+            }
+        }
+        let delivered = body
+            .get("delivered_through_seq")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+        let messages: Vec<serde_json::Value> = supervisor
+            .messages
+            .iter()
+            .filter(|(seq, _, _)| *seq > delivered)
+            .map(|(seq, message_body, interrupt)| {
+                serde_json::json!({
+                    "seq": seq,
+                    "body": message_body,
+                    "interrupt": interrupt,
+                    "created_at": "2026-08-27T00:00:00Z",
+                })
+            })
+            .collect();
+        if !messages.is_empty() {
+            supervisor.message_batches += 1;
+        }
+        Json(serde_json::json!({
+            "sandbox_id": "018f0000-0000-7000-8000-000000000000",
+            "state": if supervisor.stop.is_some() { "completing" } else { "running" },
+            "stop": supervisor.stop.is_some(),
+            "stop_reason": supervisor.stop,
+            "cursor": delivered,
+            "messages": messages,
+        }))
+        .into_response()
+    }
+
+    async fn start_supervisor() -> (SharedSupervisor, String) {
+        let state: SharedSupervisor = Arc::default();
+        let app = axum::Router::new()
+            .route("/supervisor/poll", axum::routing::post(poll_route))
+            .with_state(Arc::clone(&state));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (state, format!("http://{address}"))
+    }
+
+    /// A scripted engine: the test feeds turn ends through a channel.
+    struct EngineState {
+        turns: Mutex<Vec<TurnRequest>>,
+        steers: Mutex<Vec<String>>,
+        refuse_steer: AtomicBool,
+        ends: tokio::sync::Mutex<mpsc::UnboundedReceiver<TurnEnd>>,
+        end_sender: mpsc::UnboundedSender<TurnEnd>,
+    }
+
+    #[derive(Clone)]
+    struct MockEngine {
+        state: Arc<EngineState>,
+    }
+
+    impl MockEngine {
+        fn new() -> Self {
+            let (end_sender, ends) = mpsc::unbounded_channel();
+            Self {
+                state: Arc::new(EngineState {
+                    turns: Mutex::new(Vec::new()),
+                    steers: Mutex::new(Vec::new()),
+                    refuse_steer: AtomicBool::new(false),
+                    ends: tokio::sync::Mutex::new(ends),
+                    end_sender,
+                }),
+            }
+        }
+
+        fn finish(&self, end: TurnEnd) {
+            self.state.end_sender.send(end).unwrap();
+        }
+
+        fn turns(&self) -> Vec<TurnRequest> {
+            self.state.turns.lock().unwrap().clone()
+        }
+    }
+
+    struct MockTurnHandle {
+        state: Arc<EngineState>,
+    }
+
+    #[async_trait]
+    impl TurnHandle for MockTurnHandle {
+        async fn wait(&mut self) -> TurnEnd {
+            let mut ends = self.state.ends.lock().await;
+            ends.recv().await.unwrap_or(TurnEnd::Fatal {
+                message: "the scripted engine hung up".to_owned(),
+            })
+        }
+
+        async fn steer(&mut self, body: String) -> SteerOutcome {
+            let mut ends = self.state.ends.lock().await;
+            match ends.try_recv() {
+                Ok(end) => return SteerOutcome::Ended(end),
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    return SteerOutcome::Ended(TurnEnd::Fatal {
+                        message: "the scripted engine hung up".to_owned(),
+                    });
+                }
+                Err(mpsc::error::TryRecvError::Empty) => {}
+            }
+            drop(ends);
+            if self.state.refuse_steer.load(Ordering::SeqCst) {
+                return SteerOutcome::Refused;
+            }
+            self.state.steers.lock().unwrap().push(body);
+            SteerOutcome::Delivered
+        }
+
+        async fn interrupt(&mut self) {
+            self.state.end_sender.send(TurnEnd::Interrupted).unwrap();
+        }
+    }
+
+    #[async_trait]
+    impl Engine for MockEngine {
+        async fn start_turn(
+            &mut self,
+            request: TurnRequest,
+        ) -> Result<Box<dyn TurnHandle>, EngineError> {
+            self.state.turns.lock().unwrap().push(request);
+            Ok(Box::new(MockTurnHandle {
+                state: Arc::clone(&self.state),
+            }))
+        }
+    }
+
+    fn inputs(mode: &str, max_turns: Option<&str>) -> Inputs {
+        resolve(RawInputs {
+            task: Some("do the thing".to_owned()),
+            workspace: Some("/workspace".to_owned()),
+            mode: Some(mode.to_owned()),
+            max_turns: max_turns.map(str::to_owned),
+            ..RawInputs::default()
+        })
+        .unwrap()
+    }
+
+    fn driver(engine: MockEngine, url: &str, inputs: &Inputs) -> Driver<MockEngine> {
+        Driver::new(Control::new(url), engine, inputs).with_poll_interval(Duration::from_millis(10))
+    }
+
+    /// Polls a condition on the supervisor until it holds.
+    async fn wait_for(state: &SharedSupervisor, check: impl Fn(&MockSupervisor) -> bool) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if check(&state.lock().unwrap()) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the supervisor never observed the expected state");
+    }
+
+    fn event_kinds(state: &SharedSupervisor) -> Vec<String> {
+        state
+            .lock()
+            .unwrap()
+            .events
+            .iter()
+            .map(|(kind, _)| kind.clone())
+            .collect()
+    }
+
+    fn event_payload(state: &SharedSupervisor, kind: &str, index: usize) -> serde_json::Value {
+        state
+            .lock()
+            .unwrap()
+            .events
+            .iter()
+            .filter(|(event_kind, _)| event_kind == kind)
+            .nth(index)
+            .map(|(_, payload)| payload.clone())
+            .unwrap_or_else(|| panic!("no {kind} event at index {index}"))
+    }
+
+    #[tokio::test]
+    async fn turn_mode_runs_the_task_then_waits_for_steering() {
+        let (state, url) = start_supervisor().await;
+        let engine = MockEngine::new();
+        engine.finish(TurnEnd::Completed { success: true });
+        let run = tokio::spawn(driver(engine.clone(), &url, &inputs("turn", None)).run());
+
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "turn_completed")
+        })
+        .await;
+        assert_eq!(engine.turns()[0].source, TurnSource::SpawnTask);
+        assert_eq!(engine.turns()[0].input, "do the thing");
+        let completed = event_payload(&state, "turn_completed", 0);
+        assert_eq!(completed["gate"], "turn_mode");
+        assert_eq!(completed["may_resume"], false);
+
+        state
+            .lock()
+            .unwrap()
+            .messages
+            .push((1, "now do the next thing".to_owned(), false));
+        wait_for(&state, |supervisor| {
+            supervisor.polls.iter().any(|poll| {
+                poll.get("delivered_through_seq")
+                    .and_then(serde_json::Value::as_i64)
+                    == Some(1)
+            })
+        })
+        .await;
+        assert_eq!(engine.turns().len(), 2);
+        assert_eq!(engine.turns()[1].source, TurnSource::Inbox);
+        assert_eq!(engine.turns()[1].input, "now do the next thing");
+
+        engine.finish(TurnEnd::Completed { success: true });
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .filter(|(kind, _)| kind == "turn_completed")
+                .count()
+                == 2
+        })
+        .await;
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+        let kinds = event_kinds(&state);
+        assert_eq!(kinds[0], "supervisor_started");
+        assert_eq!(kinds.last().map(String::as_str), Some("supervisor_stopped"));
+        assert_eq!(
+            event_payload(&state, "supervisor_stopped", 0)["reason"],
+            "cancelled"
+        );
+    }
+
+    #[tokio::test]
+    async fn goal_mode_resumes_takes_steering_and_honors_stop() {
+        let (state, url) = start_supervisor().await;
+        let engine = MockEngine::new();
+        engine.finish(TurnEnd::Completed { success: true });
+        let run = tokio::spawn(driver(engine.clone(), &url, &inputs("goal", None)).run());
+
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "turn_completed")
+        })
+        .await;
+        let completed = event_payload(&state, "turn_completed", 0);
+        assert_eq!(completed["may_resume"], true);
+        assert!(
+            completed.get("gate").is_none(),
+            "a goal continuation names no gate"
+        );
+
+        // The second turn is a goal resume; a mid-turn message steers into it.
+        wait_for(&state, |_| engine.turns().len() == 2).await;
+        assert_eq!(engine.turns()[1].source, TurnSource::GoalResume);
+        state
+            .lock()
+            .unwrap()
+            .messages
+            .push((1, "focus on the tests".to_owned(), false));
+        wait_for(&state, |supervisor| {
+            supervisor.polls.iter().any(|poll| {
+                poll.get("delivered_through_seq")
+                    .and_then(serde_json::Value::as_i64)
+                    == Some(1)
+            })
+        })
+        .await;
+        assert_eq!(
+            engine.state.steers.lock().unwrap().as_slice(),
+            ["focus on the tests"]
+        );
+
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+        let kinds = event_kinds(&state);
+        assert!(kinds.iter().any(|kind| kind == "turn_interrupted"));
+        assert_eq!(kinds.last().map(String::as_str), Some("supervisor_stopped"));
+    }
+
+    #[tokio::test]
+    async fn a_turn_that_ends_during_poll_keeps_the_message_for_the_next_turn() {
+        let (state, url) = start_supervisor().await;
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        {
+            let mut supervisor = state.lock().unwrap();
+            supervisor.block_next_poll = Some(PollBlock {
+                started: started_tx,
+                release: release_rx,
+            });
+            supervisor
+                .messages
+                .push((1, "after the turn".to_owned(), false));
+        }
+        let engine = MockEngine::new();
+        let run = tokio::spawn(driver(engine.clone(), &url, &inputs("turn", None)).run());
+
+        tokio::time::timeout(Duration::from_secs(10), started_rx)
+            .await
+            .expect("the driver never started its poll")
+            .expect("the poll dropped its start signal");
+        engine.finish(TurnEnd::Completed { success: true });
+        release_tx.send(()).expect("release the blocked poll");
+
+        wait_for(&state, |_| engine.turns().len() == 2).await;
+        assert!(engine.state.steers.lock().unwrap().is_empty());
+        assert_eq!(engine.turns()[1].source, TurnSource::Inbox);
+        assert_eq!(engine.turns()[1].input, "after the turn");
+
+        engine.finish(TurnEnd::Completed { success: true });
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .filter(|(kind, _)| kind == "turn_completed")
+                .count()
+                == 2
+        })
+        .await;
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn an_interrupt_message_preempts_the_turn_and_opens_the_next() {
+        let (state, url) = start_supervisor().await;
+        let engine = MockEngine::new();
+        let run = tokio::spawn(driver(engine.clone(), &url, &inputs("turn", None)).run());
+
+        // The spawn turn is running with no scripted end; an interrupt
+        // message must preempt it.
+        wait_for(&state, |_| engine.turns().len() == 1).await;
+        state
+            .lock()
+            .unwrap()
+            .messages
+            .push((1, "change course".to_owned(), true));
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "turn_interrupted")
+        })
+        .await;
+
+        // The interrupt body was not delivered into the dead turn; it opens
+        // the next one, and only then is the cursor acknowledged.
+        wait_for(&state, |_| engine.turns().len() == 2).await;
+        assert_eq!(engine.turns()[1].source, TurnSource::Inbox);
+        assert_eq!(engine.turns()[1].input, "change course");
+        wait_for(&state, |supervisor| {
+            supervisor.polls.iter().any(|poll| {
+                poll.get("delivered_through_seq")
+                    .and_then(serde_json::Value::as_i64)
+                    == Some(1)
+            })
+        })
+        .await;
+
+        engine.finish(TurnEnd::Completed { success: true });
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn an_exhausted_turn_budget_parks_the_agent_idle() {
+        let (state, url) = start_supervisor().await;
+        let engine = MockEngine::new();
+        engine.finish(TurnEnd::Completed { success: true });
+        let run = tokio::spawn(
+            driver(engine.clone(), &url, &inputs("goal", Some("1")))
+                .with_poll_interval(Duration::from_millis(100))
+                .run(),
+        );
+
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "turn_completed")
+        })
+        .await;
+        assert_eq!(
+            event_payload(&state, "turn_completed", 0)["may_resume"],
+            false
+        );
+
+        state
+            .lock()
+            .unwrap()
+            .messages
+            .push((1, "wait for another budget".to_owned(), false));
+        wait_for(&state, |supervisor| supervisor.message_batches == 1).await;
+        let polls_after_message = state.lock().unwrap().polls.len();
+
+        // The queued message cannot consume another turn. It must not remove
+        // the idle cadence while the agent waits for a stop.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert_eq!(state.lock().unwrap().polls.len(), polls_after_message);
+        assert_eq!(engine.turns().len(), 1);
+
+        state.lock().unwrap().stop = Some("expired".to_owned());
+        run.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_resumed_goal_polls_before_starting_another_turn() {
+        let (state, url) = start_supervisor().await;
+        state.lock().unwrap().stop = Some("acceptance_met".to_owned());
+        let engine = MockEngine::new();
+        let mut resumed = inputs("goal", None);
+        resumed.starting_turn = 2;
+
+        driver(engine.clone(), &url, &resumed).run().await.unwrap();
+
+        assert!(engine.turns().is_empty());
+        assert_eq!(
+            event_payload(&state, "supervisor_stopped", 0)["reason"],
+            "acceptance_met"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_named_refusal_ends_the_run_loudly() {
+        let (state, url) = start_supervisor().await;
+        state.lock().unwrap().reject = Some((400, "sandbox_event_invalid".to_owned()));
+        let engine = MockEngine::new();
+        engine.finish(TurnEnd::Completed { success: true });
+        let error = driver(engine, &url, &inputs("goal", None))
+            .run()
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, EXIT_CONTROL_FATAL);
+        assert!(error.message.contains("sandbox_event_invalid"));
+    }
+
+    #[tokio::test]
+    async fn an_engine_failure_reports_before_exiting_nonzero() {
+        let (state, url) = start_supervisor().await;
+        let engine = MockEngine::new();
+        engine.finish(TurnEnd::Fatal {
+            message: "the engine binary is gone".to_owned(),
+        });
+        let error = driver(engine, &url, &inputs("goal", None))
+            .run()
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, EXIT_ENGINE_FAILED);
+        assert!(error.message.contains("the engine binary is gone"));
+        let kinds = event_kinds(&state);
+        assert!(kinds.iter().any(|kind| kind == "turn_completed"));
+        assert_eq!(kinds.last().map(String::as_str), Some("supervisor_stopped"));
+        assert_eq!(
+            event_payload(&state, "supervisor_stopped", 0)["reason"],
+            "engine_failed"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_steer_keeps_the_message_for_the_next_turn() {
+        let (state, url) = start_supervisor().await;
+        let engine = MockEngine::new();
+        engine.state.refuse_steer.store(true, Ordering::SeqCst);
+        let run = tokio::spawn(driver(engine.clone(), &url, &inputs("turn", None)).run());
+
+        wait_for(&state, |_| engine.turns().len() == 1).await;
+        state
+            .lock()
+            .unwrap()
+            .messages
+            .push((1, "for the next turn".to_owned(), false));
+        // Let several cadences pass: the refused steer must not acknowledge.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(engine.state.steers.lock().unwrap().is_empty());
+        assert!(!state.lock().unwrap().polls.iter().any(|poll| {
+            poll.get("delivered_through_seq")
+                .and_then(serde_json::Value::as_i64)
+                == Some(1)
+        }));
+
+        engine.finish(TurnEnd::Completed { success: true });
+        wait_for(&state, |_| engine.turns().len() == 2).await;
+        assert_eq!(engine.turns()[1].input, "for the next turn");
+        engine.finish(TurnEnd::Completed { success: true });
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/engine.rs
+++ b/crates/tidebreak-supervised-agent/src/engine.rs
@@ -1,0 +1,108 @@
+//! The engine seam the turn loop drives.
+//!
+//! The driver never sees a process. It sees an [`Engine`] that starts turns
+//! and a [`TurnHandle`] it can wait on, steer, or interrupt. The engine-drive
+//! slice implements this over `tidebreak-harness`; the tests here implement
+//! it over channels. The seam exists so the turn state machine — the part
+//! with the ordering bugs — is testable without an engine CLI on the path.
+
+use async_trait::async_trait;
+
+/// Where a turn's input came from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TurnSource {
+    /// The spawn task, on the first turn of the first incarnation.
+    SpawnTask,
+    /// Steering messages drained from the inbox.
+    Inbox,
+    /// A goal-mode continuation with no new input.
+    GoalResume,
+}
+
+/// One turn the driver asks the engine to run.
+#[derive(Clone, Debug)]
+pub struct TurnRequest {
+    /// Turn number, counted across incarnations.
+    pub turn: u32,
+    /// Where the input came from.
+    pub source: TurnSource,
+    /// The input text.
+    pub input: String,
+}
+
+/// How a turn ended.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TurnEnd {
+    /// The engine ran the turn to its own end.
+    Completed {
+        /// Whether the engine reported success.
+        success: bool,
+    },
+    /// The driver interrupted the turn.
+    Interrupted,
+    /// The engine died in a way the loop cannot recover from.
+    Fatal {
+        /// What went wrong.
+        message: String,
+    },
+}
+
+/// The engine could not start a turn.
+#[derive(Debug, thiserror::Error)]
+#[error("the engine could not start a turn: {message}")]
+pub struct EngineError {
+    /// What went wrong.
+    pub message: String,
+}
+
+/// The running turn cannot take a mid-turn message.
+///
+/// Not an error: some engines only accept input between turns. The driver
+/// keeps the message queued for the next turn.
+#[derive(Debug, thiserror::Error)]
+#[error("the engine cannot be steered mid-turn")]
+pub struct SteerRefused;
+
+/// What happened when the driver tried to steer a running turn.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SteerOutcome {
+    /// The message reached the running engine.
+    Delivered,
+    /// The engine accepts input only between turns.
+    Refused,
+    /// The turn ended before the message reached it.
+    Ended(TurnEnd),
+}
+
+/// A running turn.
+#[async_trait]
+pub trait TurnHandle: Send {
+    /// Waits for the turn to end.
+    ///
+    /// Must be cancel-safe: the driver races this against its poll tick in a
+    /// `select` loop and re-calls it after every tick, so a cancelled call
+    /// must neither lose the outcome nor corrupt the handle.
+    async fn wait(&mut self) -> TurnEnd;
+
+    /// Delivers a message into the running turn.
+    ///
+    /// Completion must win when it races delivery. Returning
+    /// [`SteerOutcome::Ended`] keeps the message unacknowledged so the next
+    /// turn receives it.
+    async fn steer(&mut self, body: String) -> SteerOutcome;
+
+    /// Stops the turn. The next [`TurnHandle::wait`] reports how it ended —
+    /// usually [`TurnEnd::Interrupted`], but a turn that finished first keeps
+    /// its own outcome.
+    async fn interrupt(&mut self);
+}
+
+/// An engine CLI the driver runs turns against.
+#[async_trait]
+pub trait Engine: Send {
+    /// Starts one turn.
+    async fn start_turn(
+        &mut self,
+        request: TurnRequest,
+    ) -> Result<Box<dyn TurnHandle>, EngineError>;
+}

--- a/crates/tidebreak-supervised-agent/src/inputs.rs
+++ b/crates/tidebreak-supervised-agent/src/inputs.rs
@@ -1,0 +1,436 @@
+//! The environment contract the supervising sandbox injects.
+//!
+//! Every input arrives as a `MODEL_GATEWAY_SANDBOX_*` variable on the pod
+//! specification. The names are mirrored here rather than shared: the
+//! environment publishes them as its integration contract for bring-your-own
+//! workloads, and the coupling that matters is the pod specification, not a
+//! crate boundary.
+//!
+//! The surface is treated as unversioned. Every variable the agent can
+//! default is defaulted, and an empty value means the same as an absent one,
+//! because the environment writes empty strings for fields the spawn did not
+//! declare. Only the task is genuinely required — an agent with no task has
+//! nothing to do and fails loudly, naming the variable, so the operator
+//! reading a terminated pod learns which field of the pod specification is
+//! wrong.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::EXIT_MISSING_INPUT;
+
+/// The task handed to the agent. Required.
+pub const TASK_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_TASK";
+/// Control endpoint as `host:port`; `http://` is assumed when no scheme.
+pub const SUPERVISOR_ENDPOINT_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_SUPERVISOR_ENDPOINT";
+/// Workspace directory the engine runs in. Defaults to the working directory.
+pub const WORKSPACE_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_WORKSPACE";
+/// Continuation policy: `goal` (default) or `turn`.
+pub const MODE_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_MODE";
+/// Turn budget including the spawn-task turn. Empty means uncapped.
+pub const MAX_TURNS_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_MAX_TURNS";
+/// Turn number this incarnation starts at. Defaults to 1.
+pub const STARTING_TURN_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_STARTING_TURN";
+/// Model route the engine should be driven with. Empty means engine default.
+pub const MODEL_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_MODEL";
+/// Requested reasoning effort. Empty means the engine and model default.
+pub const REASONING_EFFORT_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_REASONING_EFFORT";
+/// Primary repository HTTPS URL. Empty means a research sandbox: no clone.
+pub const REPOSITORY_URL_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_REPOSITORY_URL";
+/// Branch or commit to check out. Empty means the remote's default branch.
+pub const REPOSITORY_REF_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_REPOSITORY_REF";
+/// JSON array of `{url, repository_ref}` for every declared repository.
+pub const REPOSITORIES_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_REPOSITORIES";
+/// Forge push posture: `denied`, `allowed`, or absent for research.
+pub const FORGE_PUSH_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_FORGE_PUSH";
+/// Sandbox identifier, when the environment names one.
+pub const SANDBOX_ID_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_ID";
+/// Incarnation counter for reincarnation-aware naming.
+pub const INCARNATION_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_INCARNATION";
+
+const DEFAULT_SUPERVISOR_ENDPOINT: &str = "127.0.0.1:15003";
+/// Poll cadence, matching the endpoint's expected liveness rhythm.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Continuation policy after a successful turn.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunMode {
+    /// Keep resuming until the goal ships or a bound stops the run.
+    Goal,
+    /// Park after each turn and wait for steering.
+    Turn,
+}
+
+/// One declared repository.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Repository {
+    /// HTTPS URL as declared.
+    pub url: String,
+    /// Branch or commit, when one was declared.
+    pub repository_ref: Option<String>,
+}
+
+/// Every input the agent reads, resolved and defaulted.
+#[derive(Clone, Debug)]
+pub struct Inputs {
+    /// Task text for the first turn.
+    pub task: String,
+    /// Absolute URL of the control endpoint's poll route base.
+    pub control_url: String,
+    /// Directory the engine runs in.
+    pub workspace: PathBuf,
+    /// Continuation policy.
+    pub mode: RunMode,
+    /// Turn budget, when one was declared.
+    pub max_turns: Option<u32>,
+    /// Turn number this incarnation starts at.
+    pub starting_turn: u32,
+    /// Declared model route, when one was named.
+    pub model: Option<String>,
+    /// Requested reasoning effort, when one was named.
+    pub reasoning_effort: Option<String>,
+    /// Every declared repository, in declared order. Empty means research.
+    pub repositories: Vec<Repository>,
+    /// Whether pushes to the forge are denied.
+    pub forge_push_denied: bool,
+    /// Sandbox identifier, when the environment names one.
+    pub sandbox_id: Option<String>,
+    /// Incarnation counter, defaulting to 1.
+    pub incarnation: u32,
+}
+
+/// A missing or unusable input, carrying the exit code and the variable name.
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct InputError {
+    /// Process exit code for a loud failure.
+    pub code: i32,
+    /// What is wrong, naming the variable.
+    pub message: String,
+}
+
+impl InputError {
+    fn missing(variable: &str) -> Self {
+        Self {
+            code: EXIT_MISSING_INPUT,
+            message: format!("{variable} is required and was not set"),
+        }
+    }
+
+    fn unusable(variable: &str, detail: &str) -> Self {
+        Self {
+            code: EXIT_MISSING_INPUT,
+            message: format!("{variable} is unusable: {detail}"),
+        }
+    }
+}
+
+/// Raw environment values, separated from `std::env` so tests inject them.
+#[derive(Clone, Debug, Default)]
+pub struct RawInputs {
+    pub task: Option<String>,
+    pub supervisor_endpoint: Option<String>,
+    pub workspace: Option<String>,
+    pub mode: Option<String>,
+    pub max_turns: Option<String>,
+    pub starting_turn: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub repository_url: Option<String>,
+    pub repository_ref: Option<String>,
+    pub repositories: Option<String>,
+    pub forge_push: Option<String>,
+    pub sandbox_id: Option<String>,
+    pub incarnation: Option<String>,
+}
+
+impl RawInputs {
+    /// Reads every variable from the process environment.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let var = |name: &str| std::env::var(name).ok();
+        Self {
+            task: var(TASK_VARIABLE),
+            supervisor_endpoint: var(SUPERVISOR_ENDPOINT_VARIABLE),
+            workspace: var(WORKSPACE_VARIABLE),
+            mode: var(MODE_VARIABLE),
+            max_turns: var(MAX_TURNS_VARIABLE),
+            starting_turn: var(STARTING_TURN_VARIABLE),
+            model: var(MODEL_VARIABLE),
+            reasoning_effort: var(REASONING_EFFORT_VARIABLE),
+            repository_url: var(REPOSITORY_URL_VARIABLE),
+            repository_ref: var(REPOSITORY_REF_VARIABLE),
+            repositories: var(REPOSITORIES_VARIABLE),
+            forge_push: var(FORGE_PUSH_VARIABLE),
+            sandbox_id: var(SANDBOX_ID_VARIABLE),
+            incarnation: var(INCARNATION_VARIABLE),
+        }
+    }
+}
+
+/// Trims a value and treats empty the same as absent.
+fn optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+/// Resolves every input, naming the first one that is absent or unusable.
+pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
+    let task = optional(raw.task).ok_or_else(|| InputError::missing(TASK_VARIABLE))?;
+
+    let endpoint =
+        optional(raw.supervisor_endpoint).unwrap_or_else(|| DEFAULT_SUPERVISOR_ENDPOINT.to_owned());
+    let control_url = if endpoint.contains("://") {
+        endpoint
+    } else {
+        format!("http://{endpoint}")
+    };
+
+    let workspace = optional(raw.workspace).map_or_else(
+        || {
+            std::env::current_dir().map_err(|error| {
+                InputError::unusable(
+                    WORKSPACE_VARIABLE,
+                    &format!(
+                        "no workspace was set and the working directory is unreadable: {error}"
+                    ),
+                )
+            })
+        },
+        |value| Ok(PathBuf::from(value)),
+    )?;
+
+    let mode = match optional(raw.mode).as_deref() {
+        None | Some("goal") => RunMode::Goal,
+        Some("turn") => RunMode::Turn,
+        Some(other) => {
+            return Err(InputError::unusable(
+                MODE_VARIABLE,
+                &format!("expected \"goal\" or \"turn\", got {other:?}"),
+            ))
+        }
+    };
+
+    let max_turns = optional(raw.max_turns)
+        .map(|value| {
+            value.parse::<u32>().map_err(|error| {
+                InputError::unusable(MAX_TURNS_VARIABLE, &format!("{value:?}: {error}"))
+            })
+        })
+        .transpose()?;
+
+    let starting_turn = optional(raw.starting_turn)
+        .map(|value| {
+            value.parse::<u32>().map_err(|error| {
+                InputError::unusable(STARTING_TURN_VARIABLE, &format!("{value:?}: {error}"))
+            })
+        })
+        .transpose()?
+        .unwrap_or(1)
+        .max(1);
+
+    let repository_url = optional(raw.repository_url);
+    // A ref without a repository is ignored — there is nothing to check out.
+    let repository_ref = repository_url
+        .as_ref()
+        .and_then(|_| optional(raw.repository_ref));
+    let repositories =
+        parse_repositories(optional(raw.repositories).as_deref()).unwrap_or_else(|| {
+            match repository_url {
+                Some(url) => vec![Repository {
+                    url,
+                    repository_ref,
+                }],
+                None => Vec::new(),
+            }
+        });
+
+    let forge_push_denied = optional(raw.forge_push).as_deref() == Some("denied");
+
+    let incarnation = optional(raw.incarnation)
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(1);
+
+    Ok(Inputs {
+        task,
+        control_url,
+        workspace,
+        mode,
+        max_turns,
+        starting_turn,
+        model: optional(raw.model),
+        reasoning_effort: optional(raw.reasoning_effort),
+        repositories,
+        forge_push_denied,
+        sandbox_id: optional(raw.sandbox_id),
+        incarnation,
+    })
+}
+
+/// Parses the JSON repository list, keeping only usable entries.
+///
+/// Matches the environment's own parser: a malformed document or an empty
+/// list yields `None` so the singular variables stay authoritative.
+fn parse_repositories(raw: Option<&str>) -> Option<Vec<Repository>> {
+    let raw = raw?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(raw).ok()?;
+    let repositories = parsed
+        .into_iter()
+        .filter_map(|entry| {
+            let url = entry.get("url")?.as_str()?.trim().to_owned();
+            if url.is_empty() {
+                return None;
+            }
+            let repository_ref = entry
+                .get("repository_ref")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned);
+            Some(Repository {
+                url,
+                repository_ref,
+            })
+        })
+        .collect::<Vec<_>>();
+    (!repositories.is_empty()).then_some(repositories)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal() -> RawInputs {
+        RawInputs {
+            task: Some("do the thing".to_owned()),
+            workspace: Some("/workspace".to_owned()),
+            ..RawInputs::default()
+        }
+    }
+
+    #[test]
+    fn defaults_cover_every_optional_variable() {
+        let inputs = resolve(minimal()).unwrap();
+        assert_eq!(inputs.control_url, "http://127.0.0.1:15003");
+        assert_eq!(inputs.mode, RunMode::Goal);
+        assert_eq!(inputs.max_turns, None);
+        assert_eq!(inputs.starting_turn, 1);
+        assert_eq!(inputs.model, None);
+        assert_eq!(inputs.reasoning_effort, None);
+        assert!(inputs.repositories.is_empty());
+        assert!(!inputs.forge_push_denied);
+        assert_eq!(inputs.incarnation, 1);
+    }
+
+    /// The environment writes empty strings for undeclared fields; they must
+    /// read the same as absent ones.
+    #[test]
+    fn empty_values_read_as_absent() {
+        let raw = RawInputs {
+            mode: Some(String::new()),
+            model: Some("  ".to_owned()),
+            repository_url: Some(String::new()),
+            max_turns: Some(String::new()),
+            ..minimal()
+        };
+        let inputs = resolve(raw).unwrap();
+        assert_eq!(inputs.mode, RunMode::Goal);
+        assert_eq!(inputs.model, None);
+        assert!(inputs.repositories.is_empty());
+        assert_eq!(inputs.max_turns, None);
+    }
+
+    #[test]
+    fn missing_task_names_the_variable() {
+        let error = resolve(RawInputs::default()).unwrap_err();
+        assert_eq!(error.code, EXIT_MISSING_INPUT);
+        assert!(error.message.contains(TASK_VARIABLE));
+    }
+
+    #[test]
+    fn unknown_mode_fails_loudly_instead_of_becoming_goal() {
+        let raw = RawInputs {
+            mode: Some("gaol".to_owned()),
+            ..minimal()
+        };
+        let error = resolve(raw).unwrap_err();
+        assert!(error.message.contains(MODE_VARIABLE));
+    }
+
+    #[test]
+    fn starting_turn_is_honored() {
+        let raw = RawInputs {
+            starting_turn: Some("4".to_owned()),
+            ..minimal()
+        };
+        assert_eq!(resolve(raw).unwrap().starting_turn, 4);
+    }
+
+    #[test]
+    fn endpoint_gains_a_scheme_only_when_missing() {
+        let raw = RawInputs {
+            supervisor_endpoint: Some("10.0.0.2:9000".to_owned()),
+            ..minimal()
+        };
+        assert_eq!(resolve(raw).unwrap().control_url, "http://10.0.0.2:9000");
+        let raw = RawInputs {
+            supervisor_endpoint: Some("https://sidecar.local:9000".to_owned()),
+            ..minimal()
+        };
+        assert_eq!(
+            resolve(raw).unwrap().control_url,
+            "https://sidecar.local:9000"
+        );
+    }
+
+    #[test]
+    fn repository_list_wins_over_the_singular_variables() {
+        let raw = RawInputs {
+            repository_url: Some("https://example.com/org/single.git".to_owned()),
+            repository_ref: Some("main".to_owned()),
+            repositories: Some(
+                r#"[{"url": "https://example.com/org/a.git", "repository_ref": "dev"},
+                    {"url": "https://example.com/org/b.git"}]"#
+                    .to_owned(),
+            ),
+            ..minimal()
+        };
+        let inputs = resolve(raw).unwrap();
+        assert_eq!(inputs.repositories.len(), 2);
+        assert_eq!(inputs.repositories[0].url, "https://example.com/org/a.git");
+        assert_eq!(
+            inputs.repositories[0].repository_ref.as_deref(),
+            Some("dev")
+        );
+        assert_eq!(inputs.repositories[1].repository_ref, None);
+    }
+
+    #[test]
+    fn singular_repository_fills_in_when_the_list_is_malformed() {
+        let raw = RawInputs {
+            repository_url: Some("https://example.com/org/single.git".to_owned()),
+            repository_ref: Some("main".to_owned()),
+            repositories: Some("not json".to_owned()),
+            ..minimal()
+        };
+        let inputs = resolve(raw).unwrap();
+        assert_eq!(inputs.repositories.len(), 1);
+        assert_eq!(
+            inputs.repositories[0].repository_ref.as_deref(),
+            Some("main")
+        );
+    }
+
+    #[test]
+    fn a_ref_without_a_repository_is_ignored() {
+        let raw = RawInputs {
+            repository_ref: Some("main".to_owned()),
+            ..minimal()
+        };
+        assert!(resolve(raw).unwrap().repositories.is_empty());
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/lib.rs
+++ b/crates/tidebreak-supervised-agent/src/lib.rs
@@ -1,0 +1,26 @@
+//! The externally supervised Tidebreak agent (decision 0077).
+//!
+//! An externally supervised sandbox — a controlled execution environment that
+//! Tidebreak does not provision — starts this agent, owns the durable event
+//! stream, and exposes a control endpoint. The agent initiates outbound polls
+//! to that endpoint, drives an engine CLI through `tidebreak-harness`, and
+//! reports lifecycle events outward. It runs no listener, accepts no attach,
+//! and keeps no durable state of its own: the endpoint's cursor is the truth.
+//!
+//! This crate is a library for now. The binary arrives with the engine-drive
+//! slice; until then the modules here are the poll client, the environment
+//! contract, and the turn state machine, each testable against an in-process
+//! mock endpoint.
+
+pub mod control;
+pub mod drive;
+pub mod engine;
+pub mod inputs;
+pub mod wire;
+
+/// A required environment variable is absent or unusable.
+pub const EXIT_MISSING_INPUT: i32 = 64;
+/// The control endpoint refused this agent in a way retrying cannot fix.
+pub const EXIT_CONTROL_FATAL: i32 = 69;
+/// The engine failed in a way the turn loop cannot recover from.
+pub const EXIT_ENGINE_FAILED: i32 = 70;

--- a/crates/tidebreak-supervised-agent/src/wire.rs
+++ b/crates/tidebreak-supervised-agent/src/wire.rs
@@ -1,0 +1,185 @@
+//! The supervisor poll wire contract, as this agent speaks it.
+//!
+//! These types mirror the control endpoint's published shapes; they are owned
+//! here rather than imported so the agent tracks the endpoint's API directly
+//! (decision 0077 — no protocol crate sits between). Two asymmetries are
+//! deliberate:
+//!
+//! - The request types serialize exactly the fields the endpoint documents
+//!   and nothing else, because the endpoint rejects unknown request fields.
+//! - The response types default every field the agent can live without, so an
+//!   endpoint that grows a field — or an older one that lacks one — keeps
+//!   working. The endpoint owns the schema; this side stays lenient.
+
+use serde::{Deserialize, Serialize};
+
+/// Poll schema version this agent speaks. The endpoint accepts its current
+/// release and the one before it, so this pins the agent to a known dialect
+/// rather than silently drifting.
+pub const SUPERVISOR_POLL_SCHEMA_VERSION: u32 = 1;
+
+/// One turn of the poll loop, as the agent reports it.
+#[derive(Clone, Debug, Serialize)]
+pub struct SupervisorPoll {
+    /// Always [`SUPERVISOR_POLL_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Whether the engine is idle rather than mid-turn. Process state, not
+    /// judgement: no engine turn is running.
+    pub idle: bool,
+    /// Highest inbox sequence this agent has delivered to the engine.
+    ///
+    /// Sent *after* delivery. An agent that dies before sending it redelivers
+    /// on restart, which is the at-least-once guarantee; one that sent it
+    /// first would silently skip.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivered_through_seq: Option<i64>,
+    /// Lifecycle and progress events to append to the sandbox's stream.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<SupervisorEvent>,
+}
+
+impl SupervisorPoll {
+    /// A poll carrying the current delivery cursor and nothing else.
+    #[must_use]
+    pub fn new(idle: bool, delivered_through_seq: Option<i64>) -> Self {
+        Self {
+            schema_version: SUPERVISOR_POLL_SCHEMA_VERSION,
+            idle,
+            delivered_through_seq,
+            events: Vec::new(),
+        }
+    }
+}
+
+/// One event the agent reports about itself.
+///
+/// The endpoint constrains `kind` to a lowercase slug of at most 63
+/// characters and bounds the payload; [`crate::control::Outbox`] keeps each
+/// poll's batch under that bound.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SupervisorEvent {
+    /// Slug-shaped event kind.
+    pub kind: String,
+    /// Event payload.
+    pub payload: serde_json::Value,
+}
+
+impl SupervisorEvent {
+    /// Builds one event.
+    #[must_use]
+    pub fn new(kind: &str, payload: serde_json::Value) -> Self {
+        Self {
+            kind: kind.to_owned(),
+            payload,
+        }
+    }
+}
+
+/// What the endpoint tells the agent in reply.
+///
+/// Every field beyond the message stream is advisory here: the environment
+/// ends the sandbox regardless of whether the agent honors `stop`, so acting
+/// on these promptly is tidiness, not correctness.
+#[derive(Clone, Debug, Deserialize)]
+pub struct SupervisorInstructions {
+    /// Whether the agent should stop the engine and exit.
+    #[serde(default)]
+    pub stop: bool,
+    /// Why it was asked to stop, when something asked.
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    /// Highest inbox sequence the endpoint has recorded as delivered.
+    #[serde(default)]
+    pub cursor: i64,
+    /// Undelivered messages after the cursor, oldest first and gap-free.
+    #[serde(default)]
+    pub messages: Vec<SupervisorMessage>,
+    /// Whether this sandbox has shipped a pull request this run.
+    ///
+    /// Computed by the environment from traffic it observed directly; the
+    /// agent never infers this itself.
+    #[serde(default)]
+    pub acceptance_met: bool,
+}
+
+/// One steering message on its way to the engine.
+#[derive(Clone, Debug, Deserialize)]
+pub struct SupervisorMessage {
+    /// Per-sandbox monotonic, gap-free sequence number.
+    pub seq: i64,
+    /// Ordinary input for the engine.
+    pub body: String,
+    /// Whether the turn in flight should be preempted to deliver it.
+    #[serde(default)]
+    pub interrupt: bool,
+}
+
+/// The error body the endpoint returns on a refused poll.
+#[derive(Clone, Debug, Deserialize)]
+pub struct PollRejection {
+    /// Machine-readable refusal code.
+    pub error: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub error_description: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The endpoint rejects unknown request fields, so the serialized poll
+    /// must carry exactly the documented ones — and omit the optional ones
+    /// rather than send nulls an older endpoint may refuse.
+    #[test]
+    fn poll_serializes_only_documented_fields() {
+        let poll = SupervisorPoll::new(true, None);
+        let value = serde_json::to_value(&poll).unwrap();
+        let object = value.as_object().unwrap();
+        assert_eq!(
+            object.keys().collect::<Vec<_>>(),
+            ["idle", "schema_version"],
+            "empty optionals must be omitted, not nulled"
+        );
+
+        let mut poll = SupervisorPoll::new(false, Some(7));
+        poll.events
+            .push(SupervisorEvent::new("turn_started", serde_json::json!({})));
+        let value = serde_json::to_value(&poll).unwrap();
+        let object = value.as_object().unwrap();
+        let mut keys = object.keys().cloned().collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(
+            keys,
+            ["delivered_through_seq", "events", "idle", "schema_version"]
+        );
+    }
+
+    /// The agent must keep working against an endpoint that adds response
+    /// fields, and against one that omits fields this release knows about.
+    #[test]
+    fn instructions_tolerate_unknown_and_missing_fields() {
+        let full: SupervisorInstructions = serde_json::from_value(serde_json::json!({
+            "sandbox_id": "018f0000-0000-7000-8000-000000000000",
+            "state": "running",
+            "stop": false,
+            "cursor": 3,
+            "messages": [{"seq": 4, "body": "go", "interrupt": false, "created_at": "2026-08-27T00:00:00Z"}],
+            "acceptance_met": true,
+            "wrap_up_due": [{"ceiling": "spend"}],
+            "spend_microusd": 12,
+            "write_class_requests": 1,
+            "cost_limit_exhausted": false,
+            "retry_after_seconds": 5
+        }))
+        .unwrap();
+        assert!(full.acceptance_met);
+        assert_eq!(full.messages.len(), 1);
+        assert_eq!(full.messages[0].seq, 4);
+
+        let sparse: SupervisorInstructions =
+            serde_json::from_value(serde_json::json!({"cursor": 0})).unwrap();
+        assert!(!sparse.stop);
+        assert!(sparse.messages.is_empty());
+    }
+}


### PR DESCRIPTION
## What changed

- Add the `tidebreak-supervised-agent` crate with typed inputs, the control-poll client, a bounded event outbox, wire types, an engine seam, and the turn state machine.
- Acknowledge inbox sequences only after a message reaches a running engine or launches the next turn.
- Make turn completion win when it races a slow supervisor poll, so a late message stays queued instead of being acknowledged into a dead turn.
- Keep named endpoint refusals fatal, bound transient poll failures, and ignore response fields that this slice does not implement.

## Validation

- `cargo test -p tidebreak-supervised-agent` — 22 passed on this slice.
- `cargo test -p tidebreak-supervised-agent` — 75 passed on the complete stack.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Compatibility and risk

This adds a new crate and control-loop consumer. No existing desktop, server, persisted-data, or wire behavior changes on this layer.