### PR TITLE
feat(agent): bootstrap the pod, preserve WIP, and honor the completion latch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7510,6 +7510,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
 ]

--- a/crates/tidebreak-supervised-agent/Cargo.toml
+++ b/crates/tidebreak-supervised-agent/Cargo.toml
@@ -15,11 +15,12 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "sync", "time"] }
 
 [dev-dependencies]
 axum = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "time", "test-util"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "process", "sync", "time", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/tidebreak-supervised-agent/src/bootstrap.rs
+++ b/crates/tidebreak-supervised-agent/src/bootstrap.rs
@@ -1,0 +1,469 @@
+//! Everything the pod does before the first poll.
+//!
+//! The agent is the pod's only command, so the setup a hosted runtime would
+//! do around it falls to the agent itself: prepare outbound trust, clone the
+//! declared repositories or prepare a bare workspace, and pre-create the
+//! completion latch directory. Each step emits the lifecycle event the
+//! supervising environment expects, collected here and delivered ahead of
+//! `supervisor_started` so the stream reads in the order the work happened.
+//!
+//! Bootstrap is blocking and runs before the async loop: nothing here is
+//! worth overlapping, and a failure must reach the pod log before anything
+//! else runs.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::completion::completion_latch_path;
+use crate::inputs::{Inputs, Repository};
+use crate::trust::{self, Trust, TrustOptions};
+
+/// One collected lifecycle event: kind and payload.
+pub type Event = (String, serde_json::Value);
+
+/// A cloned repository's place in the workspace.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClonedRepository {
+    /// Clone directory, under the workspace.
+    pub directory: PathBuf,
+    /// Position in the declared order, zero-based.
+    pub position: usize,
+}
+
+/// The prepared pod: trust, working directory, clones, and the events that
+/// describe how it got there.
+#[derive(Debug)]
+pub struct Bootstrap {
+    /// Outbound trust every spawned child carries.
+    pub trust: Trust,
+    /// Where the engine runs: the first clone, or the workspace itself.
+    pub workdir: PathBuf,
+    /// Every clone, in declared order.
+    pub clones: Vec<ClonedRepository>,
+    /// Lifecycle events, in the order the work happened.
+    pub events: Vec<Event>,
+}
+
+/// Bootstrap failed; the stage names which step.
+#[derive(Debug, thiserror::Error)]
+#[error("{stage}: {message}")]
+pub struct BootstrapError {
+    /// Which step failed: `trust_prepare_failed`, `repository_clone_failed`,
+    /// or `workspace_prepare_failed`.
+    pub stage: &'static str,
+    /// What went wrong, with enough context to act on from the pod log.
+    pub message: String,
+}
+
+/// Prepares the pod and collects the lifecycle events describing it.
+pub fn run(
+    inputs: &Inputs,
+    trust_options: &TrustOptions,
+    effective_reasoning_effort: Option<&str>,
+) -> Result<Bootstrap, BootstrapError> {
+    let mut events: Vec<Event> = Vec::new();
+    let mut push = |kind: &str, payload: serde_json::Value| {
+        events.push((kind.to_owned(), payload));
+    };
+
+    push(
+        "bootstrap_started",
+        serde_json::json!({
+            "harness": "custom",
+            "repository": inputs.repositories.first().map(|repository| &repository.url),
+            "workspace": inputs.workspace.display().to_string(),
+        }),
+    );
+
+    let trust = trust::prepare(trust_options).map_err(|error| BootstrapError {
+        stage: "trust_prepare_failed",
+        message: error.message,
+    })?;
+    push(
+        "trust_prepared",
+        serde_json::json!({
+            "bundle": trust.bundle.display().to_string(),
+            "merged_system_roots": trust.merged_system_roots,
+        }),
+    );
+
+    push(
+        "harness_configured",
+        serde_json::json!({
+            "harness": "custom",
+            "model": inputs.model,
+            "requested_reasoning_effort": inputs.reasoning_effort,
+            "effective_reasoning_effort": effective_reasoning_effort,
+            "scope": "user",
+        }),
+    );
+
+    let mut clones = Vec::new();
+    let workdir = if inputs.repositories.is_empty() {
+        std::fs::create_dir_all(&inputs.workspace).map_err(|error| BootstrapError {
+            stage: "workspace_prepare_failed",
+            message: format!(
+                "the workspace {} could not be created: {error}",
+                inputs.workspace.display()
+            ),
+        })?;
+        push(
+            "workspace_prepared",
+            serde_json::json!({ "directory": inputs.workspace.display().to_string() }),
+        );
+        inputs.workspace.clone()
+    } else {
+        let directories = assign_repository_directories(&inputs.repositories);
+        for (position, (repository, directory)) in
+            inputs.repositories.iter().zip(&directories).enumerate()
+        {
+            let target = clone_repository(&inputs.workspace, repository, directory, &trust)
+                .map_err(|message| BootstrapError {
+                    stage: "repository_clone_failed",
+                    message,
+                })?;
+            push(
+                "repository_cloned",
+                serde_json::json!({
+                    "repository": repository.url,
+                    "ref": repository.repository_ref,
+                    "directory": target.display().to_string(),
+                    "position": position,
+                }),
+            );
+            clones.push(ClonedRepository {
+                directory: target,
+                position,
+            });
+        }
+        clones[0].directory.clone()
+    };
+
+    // The latch directory is best-effort: a task that cannot write its latch
+    // still runs, but the operator should know the channel is missing.
+    let latch = completion_latch_path(&inputs.workspace);
+    if let Some(parent) = latch.parent() {
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            push(
+                "completion_latch_unavailable",
+                serde_json::json!({
+                    "path": crate::completion::COMPLETION_LATCH_PATH,
+                    "error": error.to_string(),
+                }),
+            );
+        }
+    }
+
+    Ok(Bootstrap {
+        trust,
+        workdir,
+        clones,
+        events,
+    })
+}
+
+/// Derives a clone directory name from a repository URL.
+///
+/// The last path segment, without any `.git` suffix, filtered to filename-safe
+/// characters. An empty result falls back to `repository`.
+#[must_use]
+pub fn repository_directory(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    let path = match trimmed.split_once("://") {
+        Some((_, rest)) => rest.split_once('/').map_or("", |(_, path)| path),
+        None => trimmed.split_once(':').map_or(trimmed, |(_, path)| path),
+    };
+    let segment = path
+        .rsplit('/')
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches(".git");
+    let directory: String = segment
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+        .collect();
+    let directory = directory.trim_matches('.').to_owned();
+    if directory.is_empty() {
+        "repository".to_owned()
+    } else {
+        directory
+    }
+}
+
+/// Assigns each declared repository a distinct directory name.
+///
+/// Two repositories with the same basename get numbered suffixes in declared
+/// order: the first keeps the base, later ones take the first free
+/// `<base>-2`, `<base>-3`, and so on.
+#[must_use]
+pub fn assign_repository_directories(repositories: &[Repository]) -> Vec<String> {
+    let mut taken: Vec<String> = Vec::new();
+    for repository in repositories {
+        let base = repository_directory(&repository.url);
+        let mut candidate = base.clone();
+        let mut counter = 2;
+        while taken.contains(&candidate) {
+            candidate = format!("{base}-{counter}");
+            counter += 1;
+        }
+        taken.push(candidate);
+    }
+    taken
+}
+
+/// Clones one repository into the workspace and checks out its declared ref.
+fn clone_repository(
+    workspace: &Path,
+    repository: &Repository,
+    directory: &str,
+    trust: &Trust,
+) -> Result<PathBuf, String> {
+    std::fs::create_dir_all(workspace).map_err(|error| {
+        format!(
+            "the workspace {} could not be created: {error}",
+            workspace.display()
+        )
+    })?;
+    let target = workspace.join(directory);
+    run_git(
+        workspace,
+        trust,
+        &[
+            "-c",
+            "credential.helper=",
+            "clone",
+            "--",
+            &repository.url,
+            &target.display().to_string(),
+        ],
+    )
+    .map_err(|error| format!("cloning {} failed: {error}", repository.url))?;
+    if let Some(reference) = &repository.repository_ref {
+        if run_git(&target, trust, &["checkout", reference]).is_err() {
+            // A commit that is not on the cloned branches — a PR head, most
+            // often — needs an explicit fetch before it can be checked out.
+            run_git(
+                &target,
+                trust,
+                &[
+                    "-c",
+                    "credential.helper=",
+                    "fetch",
+                    "origin",
+                    "--",
+                    reference,
+                ],
+            )
+            .map_err(|error| {
+                format!(
+                    "fetching {} from {} failed: {error}",
+                    reference, repository.url
+                )
+            })?;
+            run_git(&target, trust, &["checkout", reference]).map_err(|error| {
+                format!(
+                    "checking out {} in {} failed: {error}",
+                    reference,
+                    target.display()
+                )
+            })?;
+        }
+    }
+    Ok(target)
+}
+
+/// Runs one git command with the trust environment, output inherited so it
+/// lands in the pod log.
+fn run_git(directory: &Path, trust: &Trust, arguments: &[&str]) -> Result<(), String> {
+    let mut command = Command::new("git");
+    command
+        .args(arguments)
+        .current_dir(directory)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .stdin(Stdio::null());
+    for (name, value) in trust.environment() {
+        command.env(name, value);
+    }
+    let status = command
+        .status()
+        .map_err(|error| format!("git could not be started: {error}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("git exited with {status}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inputs::{resolve, RawInputs};
+    use std::time::Duration;
+
+    #[test]
+    fn directory_names_come_from_the_last_path_segment() {
+        assert_eq!(
+            repository_directory("https://example.com/org/tidebreak.git"),
+            "tidebreak"
+        );
+        assert_eq!(
+            repository_directory("https://example.com/org/tidebreak/"),
+            "tidebreak"
+        );
+        assert_eq!(
+            repository_directory("git@example.com:org/tidebreak.git"),
+            "tidebreak"
+        );
+        assert_eq!(repository_directory("https://example.com/"), "repository");
+        assert_eq!(
+            repository_directory("https://example.com/org/.."),
+            "repository"
+        );
+    }
+
+    #[test]
+    fn colliding_names_take_numbered_suffixes_in_declared_order() {
+        let repositories = vec![
+            Repository {
+                url: "https://example.com/a/app.git".to_owned(),
+                repository_ref: None,
+            },
+            Repository {
+                url: "https://example.com/b/app.git".to_owned(),
+                repository_ref: None,
+            },
+            Repository {
+                url: "https://example.com/c/app.git".to_owned(),
+                repository_ref: None,
+            },
+        ];
+        assert_eq!(
+            assign_repository_directories(&repositories),
+            ["app", "app-2", "app-3"]
+        );
+    }
+
+    fn trust_options(root: &Path) -> TrustOptions {
+        let certificate = root.join("ca.crt");
+        std::fs::write(&certificate, "CA\n").unwrap();
+        TrustOptions {
+            certificate,
+            timeout: Duration::ZERO,
+            baseline: None,
+            bundle: root.join("bundle.pem"),
+        }
+    }
+
+    fn inputs(workspace: &Path) -> Inputs {
+        resolve(RawInputs {
+            task: Some("do the thing".to_owned()),
+            workspace: Some(workspace.display().to_string()),
+            ..RawInputs::default()
+        })
+        .unwrap()
+    }
+
+    /// Builds a local git remote with one commit on `main` and a second
+    /// commit on a `feature` branch.
+    fn fixture_remote(root: &Path) -> PathBuf {
+        let remote = root.join("remote");
+        std::fs::create_dir_all(&remote).unwrap();
+        let git = |arguments: &[&str]| {
+            let status = Command::new("git")
+                .args(arguments)
+                .current_dir(&remote)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .unwrap();
+            assert!(status.success(), "git {arguments:?} failed");
+        };
+        git(&["init", "--initial-branch=main"]);
+        std::fs::write(remote.join("README.md"), "hello\n").unwrap();
+        git(&["add", "-A"]);
+        git(&[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@example.invalid",
+            "commit",
+            "-m",
+            "first",
+        ]);
+        git(&["branch", "feature"]);
+        remote
+    }
+
+    #[test]
+    fn a_research_run_prepares_a_bare_workspace() {
+        let root = tempfile::tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        let bootstrap = run(&inputs(&workspace), &trust_options(root.path()), None).unwrap();
+        assert!(workspace.is_dir());
+        assert_eq!(bootstrap.workdir, workspace);
+        assert!(bootstrap.clones.is_empty());
+        // The latch directory is pre-created so the task can just write the
+        // file.
+        assert!(workspace.join(".model-gateway").is_dir());
+        let kinds: Vec<&str> = bootstrap
+            .events
+            .iter()
+            .map(|(kind, _)| kind.as_str())
+            .collect();
+        assert_eq!(
+            kinds,
+            [
+                "bootstrap_started",
+                "trust_prepared",
+                "harness_configured",
+                "workspace_prepared",
+            ]
+        );
+        let started = &bootstrap.events[0].1;
+        assert_eq!(started["repository"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn a_declared_repository_is_cloned_and_its_ref_checked_out() {
+        let root = tempfile::tempdir().unwrap();
+        let remote = fixture_remote(root.path());
+        let workspace = root.path().join("workspace");
+        let mut inputs = inputs(&workspace);
+        inputs.repositories = vec![Repository {
+            url: remote.display().to_string(),
+            repository_ref: Some("feature".to_owned()),
+        }];
+        let bootstrap = run(&inputs, &trust_options(root.path()), None).unwrap();
+        assert_eq!(bootstrap.workdir, workspace.join("remote"));
+        assert!(bootstrap.workdir.join("README.md").is_file());
+        let head = Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .current_dir(&bootstrap.workdir)
+            .output()
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&head.stdout).trim(), "feature");
+        let cloned = bootstrap
+            .events
+            .iter()
+            .find(|(kind, _)| kind == "repository_cloned")
+            .unwrap();
+        assert_eq!(cloned.1["position"], 0);
+        assert_eq!(cloned.1["ref"], "feature");
+    }
+
+    #[test]
+    fn a_failed_clone_names_its_stage() {
+        let root = tempfile::tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        let mut inputs = inputs(&workspace);
+        inputs.repositories = vec![Repository {
+            url: root.path().join("missing").display().to_string(),
+            repository_ref: None,
+        }];
+        let error = run(&inputs, &trust_options(root.path()), None).unwrap_err();
+        assert_eq!(error.stage, "repository_clone_failed");
+        assert!(error.message.contains("missing"));
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/completion.rs
+++ b/crates/tidebreak-supervised-agent/src/completion.rs
@@ -1,0 +1,249 @@
+//! The two files a sandboxed run communicates through.
+//!
+//! A supervised run has no return channel except its event stream, so two
+//! well-known files carry the agent's own signals outward. The completion
+//! latch at `.model-gateway/task-complete` under the workspace lets a bounded
+//! task declare itself done mid-run; `TASK_OUTPUT.md` carries the deliverable
+//! for a run whose work cannot leave as pushed branches. Both readers match
+//! the supervising environment's first-party ones byte for byte, because the
+//! environment's tooling consumes the resulting events.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+/// Latch path relative to the workspace.
+pub const COMPLETION_LATCH_PATH: &str = ".model-gateway/task-complete";
+/// Ceiling for the note carried inside the latch file.
+pub const COMPLETION_NOTE_MAX_BYTES: u64 = 4096;
+/// Deliverable filename, probed in the working directory then the workspace.
+pub const TASK_OUTPUT_NAME: &str = "TASK_OUTPUT.md";
+/// Ceiling for the deliverable body one event may carry.
+pub const TASK_OUTPUT_MAX_BODY_BYTES: u64 = 224 * 1024;
+
+/// A written latch: the task declared itself complete.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompletionLatch {
+    /// The note inside the file, when it held usable text.
+    pub note: Option<String>,
+    /// Why the note was dropped, when the file held something unusable.
+    pub note_skipped: Option<&'static str>,
+}
+
+/// Where the latch lives for a given workspace.
+#[must_use]
+pub fn completion_latch_path(workspace: &Path) -> PathBuf {
+    workspace.join(COMPLETION_LATCH_PATH)
+}
+
+/// Reads the completion latch, when one was written.
+///
+/// The file's existence is the signal; its content is only a best-effort
+/// note. A note that is too large, not text, or unreadable is dropped with a
+/// named reason rather than blocking completion — the task already finished,
+/// and refusing to notice would strand a done run.
+#[must_use]
+pub fn read_completion_latch(workspace: &Path) -> Option<CompletionLatch> {
+    let path = completion_latch_path(workspace);
+    // A directory at the latch path is not a latch.
+    if !path.is_file() {
+        return None;
+    }
+    let skipped = |reason| {
+        Some(CompletionLatch {
+            note: None,
+            note_skipped: Some(reason),
+        })
+    };
+    let Ok(metadata) = std::fs::metadata(&path) else {
+        return skipped("unreadable");
+    };
+    if metadata.len() > COMPLETION_NOTE_MAX_BYTES {
+        return skipped("too_large");
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(note) if note.contains('\0') => skipped("not_text"),
+        Ok(note) => {
+            let note = note.trim();
+            Some(CompletionLatch {
+                note: (!note.is_empty()).then(|| note.to_owned()),
+                note_skipped: None,
+            })
+        }
+        Err(_) => skipped("unreadable"),
+    }
+}
+
+/// Builds the `task_complete` event payload for a read latch.
+#[must_use]
+pub fn task_complete_payload(latch: &CompletionLatch) -> serde_json::Value {
+    let mut payload = serde_json::json!({ "path": COMPLETION_LATCH_PATH });
+    if let Some(note) = &latch.note {
+        payload["bytes"] = serde_json::json!(note.len());
+        payload["note"] = serde_json::json!(note);
+    }
+    if let Some(reason) = latch.note_skipped {
+        payload["note_skipped"] = serde_json::json!(reason);
+    }
+    payload
+}
+
+/// A read deliverable, bounded to what one event may carry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskOutput {
+    /// The body, cut back to the ceiling when the file exceeds it.
+    pub body: String,
+    /// Whether the file was larger than the body carried.
+    pub truncated: bool,
+    /// The file's full size on disk.
+    pub file_bytes: u64,
+}
+
+/// Reads the deliverable from `directory`, when one was written.
+///
+/// `Ok(None)` means no file; `Err` names why an existing file could not be
+/// delivered. An oversized file is truncated at the ceiling and marked, never
+/// dropped — and when the cut lands mid-character, the body is trimmed back
+/// to the last complete one rather than refused.
+pub fn read_task_output(directory: &Path) -> Result<Option<TaskOutput>, &'static str> {
+    let path = directory.join(TASK_OUTPUT_NAME);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let metadata = std::fs::metadata(&path).map_err(|_| "unreadable")?;
+    let file_bytes = metadata.len();
+    let truncated = file_bytes > TASK_OUTPUT_MAX_BODY_BYTES;
+    let file = std::fs::File::open(&path).map_err(|_| "unreadable")?;
+    let mut body = Vec::new();
+    file.take(TASK_OUTPUT_MAX_BODY_BYTES)
+        .read_to_end(&mut body)
+        .map_err(|_| "unreadable")?;
+    let body = match String::from_utf8(body) {
+        Ok(body) => body,
+        Err(error) if truncated && error.utf8_error().error_len().is_none() => {
+            // The ceiling cut a multi-byte character; keep what is whole.
+            let valid = error.utf8_error().valid_up_to();
+            let mut bytes = error.into_bytes();
+            bytes.truncate(valid);
+            String::from_utf8(bytes).map_err(|_| "not_text")?
+        }
+        Err(_) => return Err("not_text"),
+    };
+    if body.contains('\0') {
+        return Err("not_text");
+    }
+    Ok(Some(TaskOutput {
+        body,
+        truncated,
+        file_bytes,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_absent_latch_reads_as_none() {
+        let root = tempfile::tempdir().unwrap();
+        assert_eq!(read_completion_latch(root.path()), None);
+    }
+
+    #[test]
+    fn a_directory_at_the_latch_path_is_not_a_latch() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(completion_latch_path(root.path())).unwrap();
+        assert_eq!(read_completion_latch(root.path()), None);
+    }
+
+    #[test]
+    fn a_blank_latch_completes_without_a_note() {
+        let root = tempfile::tempdir().unwrap();
+        let path = completion_latch_path(root.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "  \n").unwrap();
+        let latch = read_completion_latch(root.path()).unwrap();
+        assert_eq!(latch.note, None);
+        assert_eq!(latch.note_skipped, None);
+        assert_eq!(
+            task_complete_payload(&latch),
+            serde_json::json!({ "path": COMPLETION_LATCH_PATH })
+        );
+    }
+
+    #[test]
+    fn a_note_rides_the_completion_payload() {
+        let root = tempfile::tempdir().unwrap();
+        let path = completion_latch_path(root.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "shipped as PR 7\n").unwrap();
+        let latch = read_completion_latch(root.path()).unwrap();
+        assert_eq!(latch.note.as_deref(), Some("shipped as PR 7"));
+        let payload = task_complete_payload(&latch);
+        assert_eq!(payload["note"], "shipped as PR 7");
+        assert_eq!(payload["bytes"], 15);
+    }
+
+    /// An unusable note must not block completion: the latch still fires,
+    /// with the reason named.
+    #[test]
+    fn an_oversized_note_is_dropped_but_still_completes() {
+        let root = tempfile::tempdir().unwrap();
+        let path = completion_latch_path(root.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "x".repeat(COMPLETION_NOTE_MAX_BYTES as usize + 1)).unwrap();
+        let latch = read_completion_latch(root.path()).unwrap();
+        assert_eq!(latch.note, None);
+        assert_eq!(latch.note_skipped, Some("too_large"));
+        assert_eq!(task_complete_payload(&latch)["note_skipped"], "too_large");
+    }
+
+    #[test]
+    fn a_binary_note_is_dropped_as_not_text() {
+        let root = tempfile::tempdir().unwrap();
+        let path = completion_latch_path(root.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"done\0").unwrap();
+        let latch = read_completion_latch(root.path()).unwrap();
+        assert_eq!(latch.note_skipped, Some("not_text"));
+    }
+
+    #[test]
+    fn an_absent_deliverable_reads_as_none() {
+        let root = tempfile::tempdir().unwrap();
+        assert_eq!(read_task_output(root.path()), Ok(None));
+    }
+
+    #[test]
+    fn a_small_deliverable_arrives_whole() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join(TASK_OUTPUT_NAME), "# Findings\n").unwrap();
+        let output = read_task_output(root.path()).unwrap().unwrap();
+        assert_eq!(output.body, "# Findings\n");
+        assert!(!output.truncated);
+        assert_eq!(output.file_bytes, 11);
+    }
+
+    /// The ceiling can land mid-character; the body must be cut back to the
+    /// last complete one instead of refusing the whole deliverable.
+    #[test]
+    fn truncation_cuts_back_to_a_character_boundary() {
+        let root = tempfile::tempdir().unwrap();
+        let cap = TASK_OUTPUT_MAX_BODY_BYTES as usize;
+        // Fill to one byte short of the ceiling, then a 3-byte character
+        // that straddles it.
+        let mut body = "x".repeat(cap - 1);
+        body.push('€');
+        std::fs::write(root.path().join(TASK_OUTPUT_NAME), &body).unwrap();
+        let output = read_task_output(root.path()).unwrap().unwrap();
+        assert_eq!(output.body.len(), cap - 1);
+        assert!(output.truncated);
+        assert_eq!(output.file_bytes, body.len() as u64);
+    }
+
+    #[test]
+    fn a_binary_deliverable_is_refused_as_not_text() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join(TASK_OUTPUT_NAME), b"report\0body").unwrap();
+        assert_eq!(read_task_output(root.path()), Err("not_text"));
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/drive.rs
+++ b/crates/tidebreak-supervised-agent/src/drive.rs
@@ -502,13 +502,52 @@ impl<E: Engine> Driver<E> {
     }
 
     /// Runs one checkpoint and queues whatever it reports.
+    ///
+    /// The git work runs on its own task while the driver keeps polling at
+    /// its normal cadence: a checkpoint may legitimately take minutes
+    /// (`CHECKPOINT_BUDGET`), and going silent that long would read as a
+    /// stall to a supervising environment that treats the poll interval as
+    /// the liveness heartbeat. Poll errors are swallowed here deliberately —
+    /// the terminal checkpoint must complete even when the endpoint is
+    /// already gone — and the failure counter is not reset, so a dead
+    /// endpoint still ends the run at the next regular poll.
     async fn checkpoint(&mut self, point: &CheckpointPoint) {
         if self.push_denied {
             return;
         }
-        if let Some(wip) = self.wip.as_mut() {
-            for (kind, payload) in wip.checkpoint(point).await {
-                self.outbox.push(&kind, payload);
+        let Some(mut wip) = self.wip.take() else {
+            return;
+        };
+        let point = point.clone();
+        let mut job = tokio::spawn(async move {
+            let events = wip.checkpoint(&point).await;
+            (wip, events)
+        });
+        let joined = loop {
+            tokio::select! {
+                joined = &mut job => break joined,
+                () = tokio::time::sleep(self.poll_interval) => {
+                    let _ = self.poll(true).await;
+                }
+            }
+        };
+        match joined {
+            Ok((wip, events)) => {
+                self.wip = Some(wip);
+                for (kind, payload) in events {
+                    self.outbox.push(&kind, payload);
+                }
+            }
+            // A panicked checkpoint task loses the WIP context; later
+            // checkpoints are skipped rather than crashing the run.
+            Err(error) => {
+                self.outbox.push(
+                    "wip_push_failed",
+                    serde_json::json!({
+                        "reason": "checkpoint_task_failed",
+                        "error": error.to_string(),
+                    }),
+                );
             }
         }
     }
@@ -1250,6 +1289,83 @@ mod tests {
         let pushed_at = kinds.iter().position(|kind| kind == "wip_pushed");
         assert!(completed_at < pushed_at);
 
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn checkpoint_heartbeats_report_idle_after_the_turn_ends() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let (state, url) = start_supervisor().await;
+        let root = tempfile::tempdir().unwrap();
+        let clone = git_fixture(root.path());
+        let hook = root.path().join("origin/.git/hooks/pre-receive");
+        std::fs::write(&hook, "#!/bin/sh\nsleep 1\n").unwrap();
+        let mut permissions = std::fs::metadata(&hook).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&hook, permissions).unwrap();
+        let wip = WipContext::capture(
+            "sb-drive".to_owned(),
+            1,
+            &[crate::bootstrap::ClonedRepository {
+                directory: clone.clone(),
+                position: 0,
+            }],
+            crate::trust::Trust {
+                bundle: root.path().join("bundle.pem"),
+                certificate: root.path().join("ca.crt"),
+                merged_system_roots: false,
+            },
+        )
+        .await;
+        let engine = MockEngine::new();
+        let run = tokio::spawn(
+            driver(engine.clone(), &url, &inputs_at(root.path(), "turn"))
+                .with_poll_interval(Duration::from_millis(5))
+                .with_wip(wip)
+                .run(),
+        );
+
+        wait_for(&state, |_| engine.turns().len() == 1).await;
+        std::fs::write(clone.join("draft.txt"), "unfinished\n").unwrap();
+        engine.finish(TurnEnd::Completed { success: true });
+
+        wait_for(&state, |supervisor| {
+            supervisor.polls.iter().any(|poll| {
+                poll.get("events")
+                    .and_then(serde_json::Value::as_array)
+                    .is_some_and(|events| {
+                        events.iter().any(|event| event["kind"] == "turn_completed")
+                    })
+            })
+        })
+        .await;
+        let completed_idle = {
+            let supervisor = state.lock().unwrap();
+            supervisor
+                .polls
+                .iter()
+                .find(|poll| {
+                    poll.get("events")
+                        .and_then(serde_json::Value::as_array)
+                        .is_some_and(|events| {
+                            events.iter().any(|event| event["kind"] == "turn_completed")
+                        })
+                })
+                .expect("a poll carrying turn_completed")["idle"]
+                .clone()
+        };
+        assert_eq!(completed_idle, true);
+
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "wip_pushed")
+        })
+        .await;
         state.lock().unwrap().stop = Some("cancelled".to_owned());
         run.await.unwrap().unwrap();
     }

--- a/crates/tidebreak-supervised-agent/src/drive.rs
+++ b/crates/tidebreak-supervised-agent/src/drive.rs
@@ -15,11 +15,15 @@
 //!   must not pretend to be.
 
 use std::collections::VecDeque;
+use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::bootstrap::Event;
+use crate::completion;
 use crate::control::{Control, Outbox, PollFailure};
 use crate::engine::{Engine, SteerOutcome, TurnEnd, TurnHandle, TurnRequest, TurnSource};
 use crate::inputs::{Inputs, RunMode, POLL_INTERVAL};
+use crate::wip::{self, CheckpointPoint, WipContext};
 use crate::wire::{SupervisorMessage, SupervisorPoll};
 use crate::{EXIT_CONTROL_FATAL, EXIT_ENGINE_FAILED};
 
@@ -76,6 +80,16 @@ pub struct Driver<E> {
     ran_spawn_task: bool,
     last_turn_succeeded: bool,
     poll_interval: Duration,
+    /// Workspace root: where the completion latch lives.
+    workspace: PathBuf,
+    /// Where the engine runs; the deliverable file is looked for here first.
+    workdir: PathBuf,
+    /// No repositories were declared: results leave as the deliverable file.
+    research: bool,
+    /// Pushes are denied by policy: no checkpoints, deliverable compensates.
+    push_denied: bool,
+    /// Checkpoint state, when the run has clones worth preserving.
+    wip: Option<WipContext>,
 }
 
 impl<E: Engine> Driver<E> {
@@ -101,6 +115,11 @@ impl<E: Engine> Driver<E> {
             ran_spawn_task: resumed,
             last_turn_succeeded: resumed,
             poll_interval: POLL_INTERVAL,
+            workspace: inputs.workspace.clone(),
+            workdir: inputs.workspace.clone(),
+            research: inputs.repositories.is_empty(),
+            push_denied: inputs.forge_push_denied,
+            wip: None,
         }
     }
 
@@ -109,6 +128,31 @@ impl<E: Engine> Driver<E> {
     #[must_use]
     pub fn with_poll_interval(mut self, interval: Duration) -> Self {
         self.poll_interval = interval;
+        self
+    }
+
+    /// Names the directory the engine runs in — the first clone, when the
+    /// run has one.
+    #[must_use]
+    pub fn with_workdir(mut self, workdir: PathBuf) -> Self {
+        self.workdir = workdir;
+        self
+    }
+
+    /// Attaches checkpoint state for the run's clones.
+    #[must_use]
+    pub fn with_wip(mut self, wip: WipContext) -> Self {
+        self.wip = Some(wip);
+        self
+    }
+
+    /// Queues events to deliver ahead of `supervisor_started` — the
+    /// bootstrap events, in the order the work happened.
+    #[must_use]
+    pub fn preload_events(mut self, events: Vec<Event>) -> Self {
+        for (kind, payload) in events {
+            self.outbox.push(&kind, payload);
+        }
         self
     }
 
@@ -121,6 +165,12 @@ impl<E: Engine> Driver<E> {
                 "agent": "tidebreak-supervised-agent",
             }),
         );
+        if self.push_denied && !self.research {
+            // Announce once why no checkpoints will follow; the deliverable
+            // file is the compensating channel.
+            self.outbox
+                .push("wip_push_unavailable", wip::unavailable_payload());
+        }
         if self.mode == RunMode::Goal && self.turn > 1 {
             // A resumed goal may already be complete or stopped. Read that
             // state before another engine turn can begin.
@@ -240,20 +290,53 @@ impl<E: Engine> Driver<E> {
                 self.last_turn_succeeded = false;
             }
             TurnEnd::Completed { success } => {
-                let may_resume = self.mode == RunMode::Goal
-                    && success
-                    && self.budget_allows(turn + 1)
-                    && !self.acceptance_met;
-                let mut payload = serde_json::json!({
-                    "turn": turn,
-                    "exit_code": if success { 0 } else { 1 },
-                    "may_resume": may_resume,
-                });
-                if self.mode == RunMode::Turn {
-                    payload["gate"] = serde_json::json!("turn_mode");
+                // The completion latch is read once per finished turn, at the
+                // boundary, and only a successful turn can latch: a failing
+                // turn's claim of completion is not trusted.
+                let latch = if success {
+                    completion::read_completion_latch(&self.workspace)
+                } else {
+                    None
+                };
+                if let Some(latch) = latch {
+                    self.outbox.push(
+                        "turn_completed",
+                        serde_json::json!({
+                            "turn": turn,
+                            "exit_code": 0,
+                            "may_resume": false,
+                            "gate": "task_complete",
+                        }),
+                    );
+                    self.checkpoint(&CheckpointPoint::SuccessfulTurn { turn })
+                        .await;
+                    self.outbox
+                        .push("task_complete", completion::task_complete_payload(&latch));
+                    self.last_turn_succeeded = true;
+                    // An endpoint-requested stop that raced in keeps its own
+                    // reason.
+                    self.stop_reason
+                        .get_or_insert_with(|| "task_complete".to_owned());
+                } else {
+                    let may_resume = self.mode == RunMode::Goal
+                        && success
+                        && self.budget_allows(turn + 1)
+                        && !self.acceptance_met;
+                    let mut payload = serde_json::json!({
+                        "turn": turn,
+                        "exit_code": if success { 0 } else { 1 },
+                        "may_resume": may_resume,
+                    });
+                    if self.mode == RunMode::Turn {
+                        payload["gate"] = serde_json::json!("turn_mode");
+                    }
+                    self.outbox.push("turn_completed", payload);
+                    self.last_turn_succeeded = success;
+                    if success {
+                        self.checkpoint(&CheckpointPoint::SuccessfulTurn { turn })
+                            .await;
+                    }
                 }
-                self.outbox.push("turn_completed", payload);
-                self.last_turn_succeeded = success;
             }
             TurnEnd::Fatal { message } => {
                 self.outbox.push(
@@ -346,6 +429,7 @@ impl<E: Engine> Driver<E> {
 
     /// Reports a clean stop and exits zero.
     async fn stopped(mut self, reason: &str) -> Result<(), DriveError> {
+        self.terminal_events(reason).await;
         self.outbox.push(
             "supervisor_stopped",
             serde_json::json!({ "reason": reason }),
@@ -356,6 +440,7 @@ impl<E: Engine> Driver<E> {
 
     /// Reports an engine failure and exits with [`EXIT_ENGINE_FAILED`].
     async fn engine_failed(&mut self, message: &str) -> Result<(), DriveError> {
+        self.terminal_events("engine_failed").await;
         self.outbox.push(
             "supervisor_stopped",
             serde_json::json!({ "reason": "engine_failed" }),
@@ -365,6 +450,67 @@ impl<E: Engine> Driver<E> {
             code: EXIT_ENGINE_FAILED,
             message: format!("the engine failed: {message}"),
         })
+    }
+
+    /// The last chance to preserve work: a terminal checkpoint, and the
+    /// deliverable file when the run's results leave no other way.
+    async fn terminal_events(&mut self, reason: &str) {
+        self.checkpoint(&CheckpointPoint::Terminal {
+            reason: reason.to_owned(),
+        })
+        .await;
+        if self.research || self.push_denied {
+            self.push_task_output();
+        }
+    }
+
+    /// Reads the deliverable file — the working directory first, then the
+    /// workspace — and reports it, or why it could not be carried.
+    fn push_task_output(&mut self) {
+        let mut directories = vec![self.workdir.clone()];
+        if self.workspace != self.workdir {
+            directories.push(self.workspace.clone());
+        }
+        for directory in directories {
+            let path = directory.join(completion::TASK_OUTPUT_NAME);
+            match completion::read_task_output(&directory) {
+                Ok(Some(output)) => {
+                    self.outbox.push(
+                        "task_output",
+                        serde_json::json!({
+                            "path": path.display().to_string(),
+                            "bytes": output.file_bytes,
+                            "truncated": output.truncated,
+                            "body": output.body,
+                        }),
+                    );
+                    return;
+                }
+                Ok(None) => {}
+                Err(reason) => {
+                    self.outbox.push(
+                        "task_output_skipped",
+                        serde_json::json!({
+                            "path": path.display().to_string(),
+                            "reason": reason,
+                        }),
+                    );
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Runs one checkpoint and queues whatever it reports.
+    async fn checkpoint(&mut self, point: &CheckpointPoint) {
+        if self.push_denied {
+            return;
+        }
+        if let Some(wip) = self.wip.as_mut() {
+            for (kind, payload) in wip.checkpoint(point).await {
+                self.outbox.push(&kind, payload);
+            }
+        }
     }
 
     /// Best-effort final delivery of whatever the outbox still holds.
@@ -943,5 +1089,207 @@ mod tests {
         engine.finish(TurnEnd::Completed { success: true });
         state.lock().unwrap().stop = Some("cancelled".to_owned());
         run.await.unwrap().unwrap();
+    }
+
+    fn inputs_at(workspace: &std::path::Path, mode: &str) -> Inputs {
+        resolve(RawInputs {
+            task: Some("do the thing".to_owned()),
+            workspace: Some(workspace.display().to_string()),
+            mode: Some(mode.to_owned()),
+            ..RawInputs::default()
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_completion_latch_ends_the_run_as_task_complete() {
+        let (state, url) = start_supervisor().await;
+        let root = tempfile::tempdir().unwrap();
+        let engine = MockEngine::new();
+        let run = tokio::spawn(driver(engine.clone(), &url, &inputs_at(root.path(), "goal")).run());
+
+        // The turn is running; the task writes its latch, then the turn ends.
+        wait_for(&state, |_| engine.turns().len() == 1).await;
+        let latch_directory = root.path().join(".model-gateway");
+        std::fs::create_dir_all(&latch_directory).unwrap();
+        std::fs::write(latch_directory.join("task-complete"), "shipped the fix\n").unwrap();
+        engine.finish(TurnEnd::Completed { success: true });
+
+        run.await.unwrap().unwrap();
+        let completed = event_payload(&state, "turn_completed", 0);
+        assert_eq!(completed["gate"], "task_complete");
+        assert_eq!(completed["may_resume"], false);
+        let complete = event_payload(&state, "task_complete", 0);
+        assert_eq!(complete["path"], ".model-gateway/task-complete");
+        assert_eq!(complete["note"], "shipped the fix");
+        assert_eq!(
+            event_payload(&state, "supervisor_stopped", 0)["reason"],
+            "task_complete"
+        );
+        let kinds = event_kinds(&state);
+        let completed_at = kinds.iter().position(|kind| kind == "turn_completed");
+        let complete_at = kinds.iter().position(|kind| kind == "task_complete");
+        assert!(completed_at < complete_at);
+    }
+
+    #[tokio::test]
+    async fn the_deliverable_file_rides_the_final_poll() {
+        let (state, url) = start_supervisor().await;
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("TASK_OUTPUT.md"), "# Findings\n").unwrap();
+        let engine = MockEngine::new();
+        engine.finish(TurnEnd::Completed { success: true });
+        let run = tokio::spawn(driver(engine.clone(), &url, &inputs_at(root.path(), "turn")).run());
+
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "turn_completed")
+        })
+        .await;
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+        let output = event_payload(&state, "task_output", 0);
+        assert_eq!(output["body"], "# Findings\n");
+        assert_eq!(output["truncated"], false);
+        let kinds = event_kinds(&state);
+        let output_at = kinds.iter().position(|kind| kind == "task_output");
+        let stopped_at = kinds.iter().position(|kind| kind == "supervisor_stopped");
+        assert!(output_at < stopped_at);
+    }
+
+    /// Builds a source repository and a clone whose origin accepts
+    /// checkpoint refs.
+    fn git_fixture(root: &std::path::Path) -> std::path::PathBuf {
+        let git = |directory: &std::path::Path, arguments: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(arguments)
+                .current_dir(directory)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {arguments:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        let origin = root.join("origin");
+        std::fs::create_dir_all(&origin).unwrap();
+        git(&origin, &["init", "--initial-branch=main"]);
+        std::fs::write(origin.join("README.md"), "hello\n").unwrap();
+        git(&origin, &["add", "-A"]);
+        git(
+            &origin,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.invalid",
+                "commit",
+                "-m",
+                "first",
+            ],
+        );
+        let clone = root.join("clone");
+        git(
+            root,
+            &[
+                "clone",
+                &origin.display().to_string(),
+                &clone.display().to_string(),
+            ],
+        );
+        clone
+    }
+
+    #[tokio::test]
+    async fn a_successful_turn_checkpoints_the_clone() {
+        let (state, url) = start_supervisor().await;
+        let root = tempfile::tempdir().unwrap();
+        let clone = git_fixture(root.path());
+        let wip = WipContext::capture(
+            "sb-drive".to_owned(),
+            1,
+            &[crate::bootstrap::ClonedRepository {
+                directory: clone.clone(),
+                position: 0,
+            }],
+            crate::trust::Trust {
+                bundle: root.path().join("bundle.pem"),
+                certificate: root.path().join("ca.crt"),
+                merged_system_roots: false,
+            },
+        )
+        .await;
+        let engine = MockEngine::new();
+        let run = tokio::spawn(
+            driver(engine.clone(), &url, &inputs_at(root.path(), "turn"))
+                .with_wip(wip)
+                .run(),
+        );
+
+        // The turn leaves an uncommitted file behind; the boundary
+        // checkpoint must preserve it.
+        wait_for(&state, |_| engine.turns().len() == 1).await;
+        std::fs::write(clone.join("draft.txt"), "unfinished\n").unwrap();
+        engine.finish(TurnEnd::Completed { success: true });
+
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "wip_pushed")
+        })
+        .await;
+        let pushed = event_payload(&state, "wip_pushed", 0);
+        assert_eq!(pushed["checkpoint"], "successful_turn");
+        assert_eq!(pushed["ref"], "mg-wip/sb-drive-i1");
+        let kinds = event_kinds(&state);
+        let completed_at = kinds.iter().position(|kind| kind == "turn_completed");
+        let pushed_at = kinds.iter().position(|kind| kind == "wip_pushed");
+        assert!(completed_at < pushed_at);
+
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn denied_pushes_are_announced_once() {
+        let (state, url) = start_supervisor().await;
+        let root = tempfile::tempdir().unwrap();
+        let mut inputs = inputs_at(root.path(), "turn");
+        inputs.repositories = vec![crate::inputs::Repository {
+            url: "https://example.com/org/app.git".to_owned(),
+            repository_ref: None,
+        }];
+        inputs.forge_push_denied = true;
+        let engine = MockEngine::new();
+        engine.finish(TurnEnd::Completed { success: true });
+        let run = tokio::spawn(driver(engine.clone(), &url, &inputs).run());
+
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "turn_completed")
+        })
+        .await;
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+        let kinds = event_kinds(&state);
+        assert_eq!(kinds[0], "supervisor_started");
+        assert_eq!(kinds[1], "wip_push_unavailable");
+        assert_eq!(
+            kinds
+                .iter()
+                .filter(|kind| *kind == "wip_push_unavailable")
+                .count(),
+            1
+        );
+        assert_eq!(
+            event_payload(&state, "wip_push_unavailable", 0)["deliverable"],
+            "TASK_OUTPUT.md"
+        );
     }
 }

--- a/crates/tidebreak-supervised-agent/src/lib.rs
+++ b/crates/tidebreak-supervised-agent/src/lib.rs
@@ -12,10 +12,14 @@
 //! contract, and the turn state machine, each testable against an in-process
 //! mock endpoint.
 
+pub mod bootstrap;
+pub mod completion;
 pub mod control;
 pub mod drive;
 pub mod engine;
 pub mod inputs;
+pub mod trust;
+pub mod wip;
 pub mod wire;
 
 /// A required environment variable is absent or unusable.

--- a/crates/tidebreak-supervised-agent/src/trust.rs
+++ b/crates/tidebreak-supervised-agent/src/trust.rs
@@ -1,0 +1,252 @@
+//! Outbound trust for the sandbox's intercepting proxy.
+//!
+//! The supervising environment routes every outbound TLS connection through
+//! an intercepting sidecar and mounts the sidecar's CA certificate into the
+//! pod. A child process that does not trust that CA fails certificate
+//! verification on its first request, so before anything leaves the pod the
+//! agent waits for the certificate, merges it with the image's system roots,
+//! and hands every spawned child the resulting bundle through the standard
+//! trust variables.
+//!
+//! The agent never mutates its own process environment. The crate forbids
+//! `unsafe`, and a global mutation would race every thread; instead
+//! [`Trust::environment`] returns the pairs and each spawned child carries
+//! them explicitly.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// Path of the sidecar's CA certificate, when the environment overrides it.
+pub const CA_CERTIFICATE_VARIABLE: &str = "SANDBOX_CA_CERTIFICATE";
+/// Seconds to wait for the certificate, when the environment overrides it.
+pub const CA_TIMEOUT_VARIABLE: &str = "SANDBOX_CA_TIMEOUT";
+
+const DEFAULT_CA_CERTIFICATE: &str = "/var/run/model-gateway/sandbox-ca/ca.crt";
+const DEFAULT_CA_TIMEOUT: Duration = Duration::from_secs(60);
+/// Where a Linux image keeps its trusted roots.
+const SYSTEM_CA_BUNDLE: &str = "/etc/ssl/certs/ca-certificates.crt";
+
+/// Where the trust inputs live for one run.
+#[derive(Clone, Debug)]
+pub struct TrustOptions {
+    /// The sidecar CA certificate the agent waits for.
+    pub certificate: PathBuf,
+    /// How long to wait for the certificate to appear.
+    pub timeout: Duration,
+    /// The image's own root bundle, when one exists to merge.
+    pub baseline: Option<PathBuf>,
+    /// Where the merged bundle is written.
+    pub bundle: PathBuf,
+}
+
+impl TrustOptions {
+    /// Resolves the paths the environment declares, with defaults for the
+    /// rest.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let certificate = std::env::var(CA_CERTIFICATE_VARIABLE)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .map_or_else(|| PathBuf::from(DEFAULT_CA_CERTIFICATE), PathBuf::from);
+        let timeout = std::env::var(CA_TIMEOUT_VARIABLE)
+            .ok()
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .map_or(DEFAULT_CA_TIMEOUT, Duration::from_secs);
+        Self {
+            certificate,
+            timeout,
+            baseline: system_roots(),
+            bundle: std::env::temp_dir().join("sandbox-ca-bundle.pem"),
+        }
+    }
+}
+
+/// Finds the image's root bundle: the standard path, or the same path
+/// relative to the agent's own install prefix for a relocated toolchain.
+fn system_roots() -> Option<PathBuf> {
+    let system = PathBuf::from(SYSTEM_CA_BUNDLE);
+    if system.is_file() {
+        return Some(system);
+    }
+    let executable = std::env::current_exe().ok()?;
+    let relative = executable
+        .parent()?
+        .parent()?
+        .join("etc/ssl/certs/ca-certificates.crt");
+    relative.is_file().then_some(relative)
+}
+
+/// The prepared trust material every spawned child carries.
+#[derive(Clone, Debug)]
+pub struct Trust {
+    /// The merged bundle: system roots plus the sidecar CA.
+    pub bundle: PathBuf,
+    /// The sidecar CA alone, for the variables that are additive.
+    pub certificate: PathBuf,
+    /// Whether system roots were found and merged in.
+    pub merged_system_roots: bool,
+}
+
+impl Trust {
+    /// The trust variables each spawned child carries.
+    ///
+    /// The first four replace their tool's default root store, so they name
+    /// the merged bundle; `NODE_EXTRA_CA_CERTS` is additive on top of Node's
+    /// own roots, so it names the sidecar CA alone.
+    #[must_use]
+    pub fn environment(&self) -> [(&'static str, &Path); 5] {
+        [
+            ("SSL_CERT_FILE", self.bundle.as_path()),
+            ("REQUESTS_CA_BUNDLE", self.bundle.as_path()),
+            ("CURL_CA_BUNDLE", self.bundle.as_path()),
+            ("GIT_SSL_CAINFO", self.bundle.as_path()),
+            ("NODE_EXTRA_CA_CERTS", self.certificate.as_path()),
+        ]
+    }
+}
+
+/// Trust could not be prepared; the pod cannot reach anything without it.
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct TrustError {
+    /// What went wrong, naming the path involved.
+    pub message: String,
+}
+
+impl TrustError {
+    fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+/// Waits for the sidecar CA and writes the merged bundle.
+///
+/// Blocking: call it before the async loop starts. The wait polls once a
+/// second until the certificate file exists and is non-empty, because the
+/// sidecar and the workload container start concurrently and the certificate
+/// is written when the sidecar is ready.
+pub fn prepare(options: &TrustOptions) -> Result<Trust, TrustError> {
+    wait_for_certificate(&options.certificate, options.timeout)?;
+    let certificate = std::fs::read(&options.certificate).map_err(|error| {
+        TrustError::new(format!(
+            "{} could not be read: {error}",
+            options.certificate.display()
+        ))
+    })?;
+    let mut bundle = Vec::new();
+    let mut merged_system_roots = false;
+    if let Some(baseline) = &options.baseline {
+        let mut roots = std::fs::read(baseline).map_err(|error| {
+            TrustError::new(format!(
+                "the system root bundle {} could not be read: {error}",
+                baseline.display()
+            ))
+        })?;
+        if !roots.ends_with(b"\n") {
+            roots.push(b'\n');
+        }
+        bundle = roots;
+        merged_system_roots = true;
+    }
+    bundle.extend_from_slice(&certificate);
+    std::fs::write(&options.bundle, &bundle).map_err(|error| {
+        TrustError::new(format!(
+            "the trust bundle {} could not be written: {error}",
+            options.bundle.display()
+        ))
+    })?;
+    Ok(Trust {
+        bundle: options.bundle.clone(),
+        certificate: options.certificate.clone(),
+        merged_system_roots,
+    })
+}
+
+fn wait_for_certificate(path: &Path, timeout: Duration) -> Result<(), TrustError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if std::fs::metadata(path).is_ok_and(|metadata| metadata.len() > 0) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(TrustError::new(format!(
+                "{} never appeared; the trust sidecar did not become ready within {} seconds",
+                path.display(),
+                timeout.as_secs()
+            )));
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(root: &Path) -> TrustOptions {
+        TrustOptions {
+            certificate: root.join("ca.crt"),
+            timeout: Duration::ZERO,
+            baseline: None,
+            bundle: root.join("bundle.pem"),
+        }
+    }
+
+    #[test]
+    fn the_bundle_merges_roots_ahead_of_the_sidecar_ca() {
+        let root = tempfile::tempdir().unwrap();
+        let mut options = options(root.path());
+        std::fs::write(&options.certificate, "SIDECAR\n").unwrap();
+        let baseline = root.path().join("roots.crt");
+        // No trailing newline: the merge must add one so the PEM blocks
+        // stay separated.
+        std::fs::write(&baseline, "ROOTS").unwrap();
+        options.baseline = Some(baseline);
+
+        let trust = prepare(&options).unwrap();
+        assert!(trust.merged_system_roots);
+        assert_eq!(
+            std::fs::read_to_string(&trust.bundle).unwrap(),
+            "ROOTS\nSIDECAR\n"
+        );
+        // The additive variable names the sidecar CA alone; the replacing
+        // ones name the merged bundle.
+        let environment = trust.environment();
+        assert!(environment
+            .iter()
+            .take(4)
+            .all(|(_, path)| *path == trust.bundle));
+        assert_eq!(environment[4].0, "NODE_EXTRA_CA_CERTS");
+        assert_eq!(environment[4].1, trust.certificate);
+    }
+
+    #[test]
+    fn no_baseline_means_the_bundle_is_the_sidecar_ca() {
+        let root = tempfile::tempdir().unwrap();
+        let options = options(root.path());
+        std::fs::write(&options.certificate, "SIDECAR\n").unwrap();
+        let trust = prepare(&options).unwrap();
+        assert!(!trust.merged_system_roots);
+        assert_eq!(std::fs::read_to_string(&trust.bundle).unwrap(), "SIDECAR\n");
+    }
+
+    #[test]
+    fn a_certificate_that_never_appears_fails_naming_the_path() {
+        let root = tempfile::tempdir().unwrap();
+        let error = prepare(&options(root.path())).unwrap_err();
+        assert!(error.message.contains("ca.crt"));
+        assert!(error.message.contains("never appeared"));
+    }
+
+    /// The sidecar creates the file before writing it; an empty file must
+    /// read as "not ready yet", not as an empty trust bundle.
+    #[test]
+    fn an_empty_certificate_is_not_ready() {
+        let root = tempfile::tempdir().unwrap();
+        let options = options(root.path());
+        std::fs::write(&options.certificate, "").unwrap();
+        let error = prepare(&options).unwrap_err();
+        assert!(error.message.contains("never appeared"));
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/wip.rs
+++ b/crates/tidebreak-supervised-agent/src/wip.rs
@@ -347,6 +347,12 @@ async fn checkpoint_dirty_tree(
             ))
         }
     };
+    let index = match IndexSnapshot::capture(job, directory).await {
+        Ok(index) => index,
+        Err(error) => {
+            return Some(failure_after_head_push(tree, job, "index_unavailable", &error).await)
+        }
+    };
     if let Err(error) = git(
         job.trust,
         directory,
@@ -356,6 +362,7 @@ async fn checkpoint_dirty_tree(
     )
     .await
     {
+        let _ = index.restore();
         return Some(failure_after_head_push(tree, job, "stage_failed", &error).await);
     }
     // The tree id is both the snapshot's content and the dedup fingerprint:
@@ -371,12 +378,12 @@ async fn checkpoint_dirty_tree(
     {
         Ok(id) => id.trim().to_owned(),
         Err(error) => {
-            let _ = restore_index(job, directory).await;
+            let _ = index.restore();
             return Some(failure_after_head_push(tree, job, "snapshot_failed", &error).await);
         }
     };
     if tree.last_pushed_dirty.as_ref() == Some(&(tree_id.clone(), base_head.clone())) {
-        let _ = restore_index(job, directory).await;
+        let _ = index.restore();
         return None;
     }
     let snapshot = match git(
@@ -403,11 +410,11 @@ async fn checkpoint_dirty_tree(
     {
         Ok(sha) => sha.trim().to_owned(),
         Err(error) => {
-            let _ = restore_index(job, directory).await;
+            let _ = index.restore();
             return Some(failure_after_head_push(tree, job, "commit_failed", &error).await);
         }
     };
-    let restored = restore_index(job, directory).await.is_ok();
+    let restored = index.restore().is_ok();
     match git(
         job.trust,
         directory,
@@ -444,27 +451,77 @@ async fn checkpoint_dirty_tree(
     }
 }
 
-/// Unstages the snapshot staging so the engine's next turn sees the index it
-/// left behind. HEAD never moved, so this is an index-only reset.
-async fn restore_index(job: &TreeJob<'_>, directory: &Path) -> Result<String, String> {
-    git(
-        job.trust,
-        directory,
-        MUTATION_BOUND,
-        job.share,
-        &["reset", "--mixed", "--quiet"],
-    )
-    .await
+/// The engine's index exactly as it stood before the snapshot staged
+/// anything, restored by writing the bytes back. A `git reset` is not an
+/// index-only restore: it aborts an in-progress merge, rebase, or
+/// cherry-pick and flattens unmerged entries, so the engine's next turn
+/// would resume in a repository state it never created.
+struct IndexSnapshot {
+    path: PathBuf,
+    contents: Option<Vec<u8>>,
+}
+
+impl IndexSnapshot {
+    async fn capture(job: &TreeJob<'_>, directory: &Path) -> Result<Self, String> {
+        let raw = git(
+            job.trust,
+            directory,
+            PLUMBING_BOUND,
+            job.share,
+            &["rev-parse", "--git-path", "index"],
+        )
+        .await?;
+        let mut path = PathBuf::from(raw.trim());
+        if path.is_relative() {
+            path = directory.join(path);
+        }
+        let contents = match std::fs::read(&path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(format!(
+                    "the index at {} could not be read: {error}",
+                    path.display()
+                ))
+            }
+        };
+        Ok(Self { path, contents })
+    }
+
+    fn restore(&self) -> Result<(), String> {
+        match &self.contents {
+            Some(bytes) => std::fs::write(&self.path, bytes).map_err(|error| {
+                format!(
+                    "the index at {} could not be restored: {error}",
+                    self.path.display()
+                )
+            }),
+            None => match std::fs::remove_file(&self.path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(format!(
+                    "the staged index at {} could not be removed: {error}",
+                    self.path.display()
+                )),
+            },
+        }
+    }
 }
 
 /// A step failed mid-checkpoint; the last committed head may still be worth
-/// preserving, so try to push it before reporting.
+/// preserving, so try to push it before reporting — unless the checkpoint
+/// ref holds a dirty snapshot, whose work HEAD does not contain.
 async fn failure_after_head_push(
     tree: &TreeState,
     job: &TreeJob<'_>,
     reason: &str,
     error: &str,
 ) -> Event {
+    if tree.last_pushed_dirty.is_some() {
+        let mut event = failure_event(tree, job, reason, error, None, Some(false), None);
+        event.1["head_push_skipped"] = serde_json::json!("would_replace_dirty_snapshot");
+        return event;
+    }
     let head = match git(
         job.trust,
         &tree.directory,
@@ -816,6 +873,105 @@ mod tests {
         assert_eq!(events[0].1["commit"], head);
         // The engine's own commit stays on the branch.
         assert_eq!(run(&clone, &["rev-parse", "HEAD"]), head);
+    }
+
+    /// A mid-checkpoint failure must not push HEAD over a dirty snapshot the
+    /// ref already preserves: HEAD does not contain that work.
+    #[tokio::test]
+    async fn a_failure_never_pushes_head_over_a_dirty_snapshot() {
+        let root = tempfile::tempdir().unwrap();
+        let clone = fixture(root.path());
+        let mut context = context(root.path(), &clone).await;
+        std::fs::write(clone.join("draft.txt"), "unfinished\n").unwrap();
+        let events = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 1 })
+            .await;
+        let snapshot = events[0].1["commit"].as_str().unwrap().to_owned();
+        let origin = root.path().join("origin");
+        assert_eq!(
+            run(&origin, &["rev-parse", "refs/heads/mg-wip/sb-1-i1"]),
+            snapshot
+        );
+
+        let trust = trust(root.path());
+        let job = TreeJob {
+            trust: &trust,
+            reference: checkpoint_ref("sb-1", 1, 0),
+            message: "m".to_owned(),
+            point: serde_json::json!({}),
+            share: Instant::now() + CHECKPOINT_BUDGET,
+        };
+        let (kind, payload) =
+            failure_after_head_push(&context.trees[0], &job, "status_failed", "boom").await;
+        assert_eq!(kind, "wip_push_failed");
+        assert_eq!(payload["reason"], "status_failed");
+        assert_eq!(payload["head_pushed"], false);
+        assert_eq!(payload["head_push_skipped"], "would_replace_dirty_snapshot");
+        // The snapshot still owns the ref.
+        assert_eq!(
+            run(&origin, &["rev-parse", "refs/heads/mg-wip/sb-1-i1"]),
+            snapshot
+        );
+    }
+
+    /// A checkpoint during a conflicted merge must hand the merge back
+    /// exactly as the engine left it: MERGE_HEAD intact, entries still
+    /// unmerged. A reset-based restore aborts the merge instead.
+    #[tokio::test]
+    async fn a_conflicted_merge_survives_the_checkpoint() {
+        let root = tempfile::tempdir().unwrap();
+        let clone = fixture(root.path());
+        run(&clone, &["checkout", "-b", "side"]);
+        std::fs::write(clone.join("README.md"), "side\n").unwrap();
+        run(&clone, &["add", "-A"]);
+        run(
+            &clone,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.invalid",
+                "commit",
+                "-m",
+                "side",
+            ],
+        );
+        run(&clone, &["checkout", "main"]);
+        std::fs::write(clone.join("README.md"), "main\n").unwrap();
+        run(&clone, &["add", "-A"]);
+        run(
+            &clone,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.invalid",
+                "commit",
+                "-m",
+                "main",
+            ],
+        );
+        let merge = Command::new("git")
+            .args(["merge", "side"])
+            .current_dir(&clone)
+            .output()
+            .unwrap();
+        assert!(!merge.status.success(), "the merge must conflict");
+        let head = run(&clone, &["rev-parse", "HEAD"]);
+        let mut context = context(root.path(), &clone).await;
+
+        let events = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 1 })
+            .await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "wip_pushed");
+        assert_eq!(events[0].1["created_commit"], true);
+        assert_eq!(events[0].1["task_branch_restored"], true);
+
+        // The merge is still in progress, entries still unmerged.
+        assert_eq!(run(&clone, &["rev-parse", "HEAD"]), head);
+        assert!(clone.join(".git").join("MERGE_HEAD").is_file());
+        assert!(run(&clone, &["status", "--porcelain"]).contains("UU README.md"));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-supervised-agent/src/wip.rs
+++ b/crates/tidebreak-supervised-agent/src/wip.rs
@@ -1,0 +1,767 @@
+//! Work-in-progress preservation for supervised runs.
+//!
+//! A sandbox can be stopped at any moment — a spend ceiling, a wall-clock
+//! bound, a cancel — and whatever sits uncommitted in its clones would die
+//! with the pod. So after every successful turn and once more at stop, the
+//! agent snapshots each cloned tree to a per-sandbox ref on the origin
+//! remote, then restores the task branch so the engine never sees the
+//! snapshot commit.
+//!
+//! The ref names follow the supervising environment's published convention —
+//! `mg-wip/<sandbox-id>-i<incarnation>` for the first repository, with an
+//! `-r<position>` suffix for later ones — because its recovery tooling and a
+//! successor sandbox resume from those refs.
+//!
+//! Everything here is deadline-bounded. A checkpoint shares one budget
+//! across all trees, each git command gets the lesser of its class bound and
+//! the tree's share, and a command that cannot start before the deadline
+//! fails loudly instead of hanging the stop path.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::bootstrap::{ClonedRepository, Event};
+use crate::trust::Trust;
+
+/// Whole-checkpoint budget across every tree.
+pub const CHECKPOINT_BUDGET: Duration = Duration::from_secs(600);
+/// Bound for commands that walk the working tree (status, add).
+const TREE_WALK_BOUND: Duration = Duration::from_secs(120);
+/// Bound for commands that mutate refs or the index (commit, reset).
+const MUTATION_BOUND: Duration = Duration::from_secs(30);
+/// Bound for plumbing reads (rev-parse, rev-list, write-tree).
+const PLUMBING_BOUND: Duration = Duration::from_secs(10);
+/// Bound for the push itself.
+const PUSH_BOUND: Duration = Duration::from_secs(180);
+/// Ceiling for a diagnostic carried inside an event.
+const DIAGNOSTIC_MAX_CHARS: usize = 4096;
+
+/// Why this checkpoint ran; the payload carries it.
+#[derive(Clone, Debug)]
+pub enum CheckpointPoint {
+    /// A turn just completed successfully.
+    SuccessfulTurn {
+        /// The turn that completed.
+        turn: u32,
+    },
+    /// The run is stopping.
+    Terminal {
+        /// The stop reason.
+        reason: String,
+    },
+}
+
+impl CheckpointPoint {
+    fn fields(&self) -> serde_json::Value {
+        match self {
+            Self::SuccessfulTurn { turn } => {
+                serde_json::json!({ "checkpoint": "successful_turn", "turn": turn })
+            }
+            Self::Terminal { reason } => {
+                serde_json::json!({ "checkpoint": "terminal", "terminal_reason": reason })
+            }
+        }
+    }
+}
+
+/// One tree's checkpoint state across the run.
+#[derive(Debug)]
+struct TreeState {
+    directory: PathBuf,
+    position: usize,
+    /// HEAD at capture, so a later detached or rebased head still pushes.
+    initial_head: Option<String>,
+    /// Last commit that reached the checkpoint ref.
+    last_pushed_head: Option<String>,
+    /// Fingerprint of the last pushed dirty state: (tree id, base head).
+    last_pushed_dirty: Option<(String, String)>,
+}
+
+/// The checkpoint state for one sandbox incarnation.
+#[derive(Debug)]
+pub struct WipContext {
+    sandbox_id: String,
+    incarnation: u32,
+    trust: Trust,
+    trees: Vec<TreeState>,
+}
+
+/// The payload for `wip_push_unavailable`, announced once when policy denies
+/// pushes: the deliverable file is the compensating channel.
+#[must_use]
+pub fn unavailable_payload() -> serde_json::Value {
+    serde_json::json!({
+        "reason": "push_denied_by_policy",
+        "deliverable": crate::completion::TASK_OUTPUT_NAME,
+    })
+}
+
+impl WipContext {
+    /// Captures each clone's starting head and builds the context.
+    pub async fn capture(
+        sandbox_id: String,
+        incarnation: u32,
+        clones: &[ClonedRepository],
+        trust: Trust,
+    ) -> Self {
+        let mut trees = Vec::new();
+        for clone in clones {
+            // Best-effort: a tree whose head cannot be read still gets
+            // checkpointed, it just loses the moved-head shortcut.
+            let initial_head = git(
+                &trust,
+                &clone.directory,
+                PLUMBING_BOUND,
+                Instant::now() + PLUMBING_BOUND,
+                &["rev-parse", "HEAD"],
+            )
+            .await
+            .ok()
+            .map(|head| head.trim().to_owned());
+            trees.push(TreeState {
+                directory: clone.directory.clone(),
+                position: clone.position,
+                initial_head,
+                last_pushed_head: None,
+                last_pushed_dirty: None,
+            });
+        }
+        Self {
+            sandbox_id,
+            incarnation,
+            trust,
+            trees,
+        }
+    }
+
+    /// Checkpoints every tree, returning the events to report.
+    ///
+    /// A tree with nothing new to preserve produces no event. A tree that
+    /// fails produces a `wip_push_failed` naming what went wrong, and the
+    /// remaining trees still run — one broken clone must not cost the
+    /// others their snapshot.
+    pub async fn checkpoint(&mut self, point: &CheckpointPoint) -> Vec<Event> {
+        let deadline = Instant::now() + CHECKPOINT_BUDGET;
+        let total = self.trees.len();
+        let mut events = Vec::new();
+        for index in 0..total {
+            // Re-divide what is left before every tree, so one slow tree
+            // cannot starve the rest of the whole budget.
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let share =
+                Instant::now() + remaining / u32::try_from(total - index).unwrap_or(1).max(1);
+            let job = TreeJob {
+                trust: &self.trust,
+                reference: checkpoint_ref(
+                    &self.sandbox_id,
+                    self.incarnation,
+                    self.trees[index].position,
+                ),
+                message: format!(
+                    "tidebreak: preserve sandbox WIP {} i{}",
+                    self.sandbox_id, self.incarnation
+                ),
+                point: point.fields(),
+                share,
+            };
+            if let Some(event) = checkpoint_tree(&mut self.trees[index], &job).await {
+                events.push(event);
+            }
+        }
+        events
+    }
+}
+
+/// The checkpoint ref for one repository position.
+#[must_use]
+pub fn checkpoint_ref(sandbox_id: &str, incarnation: u32, position: usize) -> String {
+    let base = format!("mg-wip/{sandbox_id}-i{incarnation}");
+    if position == 0 {
+        base
+    } else {
+        format!("{base}-r{position}")
+    }
+}
+
+/// Everything one tree's checkpoint needs besides its own state.
+struct TreeJob<'a> {
+    trust: &'a Trust,
+    reference: String,
+    message: String,
+    point: serde_json::Value,
+    share: Instant,
+}
+
+async fn checkpoint_tree(tree: &mut TreeState, job: &TreeJob<'_>) -> Option<Event> {
+    let directory = tree.directory.clone();
+    let status = match git(
+        job.trust,
+        &directory,
+        TREE_WALK_BOUND,
+        job.share,
+        &["status", "--porcelain=v1", "--untracked-files=all"],
+    )
+    .await
+    {
+        Ok(status) => status,
+        Err(error) => {
+            return Some(failure_after_head_push(tree, job, "status_failed", &error).await)
+        }
+    };
+    let dirty = !status.trim().is_empty();
+
+    let mut base = None;
+    let mut fingerprint = None;
+    if dirty {
+        // The base head is what the task branch is restored to after the
+        // snapshot commit; without it there is nothing safe to restore, so
+        // this failure has no fallback push.
+        let base_head = match git(
+            job.trust,
+            &directory,
+            PLUMBING_BOUND,
+            job.share,
+            &["rev-parse", "HEAD"],
+        )
+        .await
+        {
+            Ok(head) => head.trim().to_owned(),
+            Err(error) => {
+                return Some(failure_event(
+                    tree,
+                    job,
+                    "head_unavailable",
+                    &error,
+                    None,
+                    None,
+                    None,
+                ))
+            }
+        };
+        if let Err(error) = git(
+            job.trust,
+            &directory,
+            TREE_WALK_BOUND,
+            job.share,
+            &["add", "-A", "--"],
+        )
+        .await
+        {
+            return Some(failure_after_head_push(tree, job, "stage_failed", &error).await);
+        }
+        // Best-effort fingerprint: the same dirty state pushed once need
+        // not be pushed again every turn.
+        fingerprint = git(
+            job.trust,
+            &directory,
+            PLUMBING_BOUND,
+            job.share,
+            &["write-tree"],
+        )
+        .await
+        .ok()
+        .map(|id| id.trim().to_owned());
+        if let Some(tree_id) = &fingerprint {
+            if tree.last_pushed_dirty.as_ref() == Some(&(tree_id.clone(), base_head.clone())) {
+                let _ = restore_task_branch(job, &directory, &base_head).await;
+                return None;
+            }
+        }
+        if let Err(error) = git(
+            job.trust,
+            &directory,
+            MUTATION_BOUND,
+            job.share,
+            &[
+                "-c",
+                "user.name=Tidebreak WIP",
+                "-c",
+                "user.email=tidebreak-wip@invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--no-verify",
+                "--message",
+                &job.message,
+            ],
+        )
+        .await
+        {
+            return Some(failure_after_head_push(tree, job, "commit_failed", &error).await);
+        }
+        base = Some(base_head);
+    }
+
+    let head = match git(
+        job.trust,
+        &directory,
+        PLUMBING_BOUND,
+        job.share,
+        &["rev-parse", "HEAD"],
+    )
+    .await
+    {
+        Ok(head) => head.trim().to_owned(),
+        Err(error) => {
+            return Some(failure_event(
+                tree,
+                job,
+                "head_unavailable",
+                &error,
+                None,
+                None,
+                None,
+            ))
+        }
+    };
+
+    let mut inspection_warning = None;
+    let should_push = if dirty {
+        true
+    } else if tree.last_pushed_head.as_deref() == Some(head.as_str()) {
+        false
+    } else if tree
+        .initial_head
+        .as_deref()
+        .is_some_and(|initial| initial != head)
+    {
+        true
+    } else {
+        // A clean tree still at its starting head may hold commits the turn
+        // authored and then reset onto; only unpushed local commits count.
+        match git(
+            job.trust,
+            &directory,
+            PLUMBING_BOUND,
+            job.share,
+            &["rev-list", "--count", "HEAD", "--not", "--remotes"],
+        )
+        .await
+        {
+            Ok(count) => count.trim().parse::<u64>().map_or(true, |count| count > 0),
+            Err(error) => {
+                // When the question cannot be answered, push and say why the
+                // snapshot may be redundant.
+                inspection_warning = Some(compact_diagnostic(&error));
+                true
+            }
+        }
+    };
+    if !should_push {
+        return None;
+    }
+
+    match git(
+        job.trust,
+        &directory,
+        PUSH_BOUND,
+        job.share,
+        &[
+            "push",
+            "--force",
+            "--no-verify",
+            "origin",
+            &format!("HEAD:refs/heads/{}", job.reference),
+        ],
+    )
+    .await
+    {
+        Ok(_) => {
+            let mut payload = base_payload(tree, job);
+            payload["commit"] = serde_json::json!(head);
+            payload["created_commit"] = serde_json::json!(dirty);
+            if let Some(warning) = inspection_warning {
+                payload["inspection_warning"] = serde_json::json!(warning);
+            }
+            if let Some(base_head) = base {
+                let restored = restore_task_branch(job, &directory, &base_head)
+                    .await
+                    .is_ok();
+                payload["task_branch_restored"] = serde_json::json!(restored);
+                if restored {
+                    tree.last_pushed_dirty = fingerprint.map(|tree_id| (tree_id, base_head));
+                }
+            }
+            tree.last_pushed_head = Some(head);
+            Some(("wip_pushed".to_owned(), payload))
+        }
+        Err(error) => Some(failure_event(
+            tree,
+            job,
+            "push_failed",
+            &error,
+            Some(&head),
+            Some(false),
+            None,
+        )),
+    }
+}
+
+/// Unstages the snapshot so the engine's next turn sees its own state.
+async fn restore_task_branch(
+    job: &TreeJob<'_>,
+    directory: &Path,
+    base_head: &str,
+) -> Result<String, String> {
+    git(
+        job.trust,
+        directory,
+        MUTATION_BOUND,
+        job.share,
+        &["reset", "--mixed", "--quiet", base_head],
+    )
+    .await
+}
+
+/// A step failed mid-checkpoint; the last committed head may still be worth
+/// preserving, so try to push it before reporting.
+async fn failure_after_head_push(
+    tree: &TreeState,
+    job: &TreeJob<'_>,
+    reason: &str,
+    error: &str,
+) -> Event {
+    let head = match git(
+        job.trust,
+        &tree.directory,
+        PLUMBING_BOUND,
+        job.share,
+        &["rev-parse", "HEAD"],
+    )
+    .await
+    {
+        Ok(head) => head.trim().to_owned(),
+        Err(_) => return failure_event(tree, job, reason, error, None, None, None),
+    };
+    match git(
+        job.trust,
+        &tree.directory,
+        PUSH_BOUND,
+        job.share,
+        &[
+            "push",
+            "--force",
+            "--no-verify",
+            "origin",
+            &format!("{head}:refs/heads/{}", job.reference),
+        ],
+    )
+    .await
+    {
+        Ok(_) => failure_event(tree, job, reason, error, Some(&head), Some(true), None),
+        Err(push_error) => failure_event(
+            tree,
+            job,
+            "push_failed",
+            &push_error,
+            Some(&head),
+            Some(false),
+            Some((reason, error)),
+        ),
+    }
+}
+
+fn base_payload(tree: &TreeState, job: &TreeJob<'_>) -> serde_json::Value {
+    let mut payload = serde_json::json!({
+        "ref": job.reference,
+        "directory": tree.directory.display().to_string(),
+    });
+    if let Some(object) = payload.as_object_mut() {
+        if let Some(fields) = job.point.as_object() {
+            for (key, value) in fields {
+                object.insert(key.clone(), value.clone());
+            }
+        }
+    }
+    payload
+}
+
+fn failure_event(
+    tree: &TreeState,
+    job: &TreeJob<'_>,
+    reason: &str,
+    error: &str,
+    commit: Option<&str>,
+    head_pushed: Option<bool>,
+    preceded_by: Option<(&str, &str)>,
+) -> Event {
+    let mut payload = base_payload(tree, job);
+    payload["reason"] = serde_json::json!(reason);
+    payload["error"] = serde_json::json!(compact_diagnostic(error));
+    if let Some(commit) = commit {
+        payload["commit"] = serde_json::json!(commit);
+    }
+    if let Some(head_pushed) = head_pushed {
+        payload["head_pushed"] = serde_json::json!(head_pushed);
+    }
+    if let Some((preceding_reason, preceding_error)) = preceded_by {
+        payload["preceded_by"] = serde_json::json!(preceding_reason);
+        payload["preceding_error"] = serde_json::json!(compact_diagnostic(preceding_error));
+    }
+    ("wip_push_failed".to_owned(), payload)
+}
+
+/// Cuts a diagnostic to what an event may reasonably carry.
+fn compact_diagnostic(diagnostic: &str) -> String {
+    if diagnostic.chars().count() <= DIAGNOSTIC_MAX_CHARS {
+        return diagnostic.to_owned();
+    }
+    let mut compacted: String = diagnostic.chars().take(DIAGNOSTIC_MAX_CHARS).collect();
+    compacted.push('…');
+    compacted
+}
+
+/// Runs one git command under the lesser of its class bound and the tree's
+/// share of the checkpoint budget.
+async fn git(
+    trust: &Trust,
+    directory: &Path,
+    class_bound: Duration,
+    share_deadline: Instant,
+    arguments: &[&str],
+) -> Result<String, String> {
+    let remaining = share_deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return Err(format!(
+            "git {} was not started: the checkpoint deadline is exhausted",
+            arguments.join(" ")
+        ));
+    }
+    let bound = class_bound.min(remaining);
+    let mut command = tokio::process::Command::new("git");
+    command
+        .args(arguments)
+        .current_dir(directory)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .stdin(std::process::Stdio::null())
+        .kill_on_drop(true);
+    for (name, value) in trust.environment() {
+        command.env(name, value);
+    }
+    let output = tokio::time::timeout(bound, command.output())
+        .await
+        .map_err(|_| {
+            format!(
+                "git {} timed out after {} seconds",
+                arguments.join(" "),
+                bound.as_secs()
+            )
+        })?
+        .map_err(|error| format!("git could not be started: {error}"))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let diagnostic = if stderr.trim().is_empty() {
+        String::from_utf8_lossy(&output.stdout).trim().to_owned()
+    } else {
+        stderr.trim().to_owned()
+    };
+    Err(format!("git exited with {}: {diagnostic}", output.status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn refs_follow_the_published_convention() {
+        assert_eq!(checkpoint_ref("sb-1", 1, 0), "mg-wip/sb-1-i1");
+        assert_eq!(checkpoint_ref("sb-1", 3, 2), "mg-wip/sb-1-i3-r2");
+    }
+
+    fn run(directory: &Path, arguments: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(arguments)
+            .current_dir(directory)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {arguments:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_owned()
+    }
+
+    /// A source repository with one commit, and a clone of it whose origin
+    /// accepts pushes to checkpoint refs.
+    fn fixture(root: &Path) -> PathBuf {
+        let origin = root.join("origin");
+        std::fs::create_dir_all(&origin).unwrap();
+        run(&origin, &["init", "--initial-branch=main"]);
+        std::fs::write(origin.join("README.md"), "hello\n").unwrap();
+        run(&origin, &["add", "-A"]);
+        run(
+            &origin,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.invalid",
+                "commit",
+                "-m",
+                "first",
+            ],
+        );
+        let clone = root.join("clone");
+        run(
+            root,
+            &[
+                "clone",
+                &origin.display().to_string(),
+                &clone.display().to_string(),
+            ],
+        );
+        clone
+    }
+
+    fn trust(root: &Path) -> Trust {
+        Trust {
+            bundle: root.join("bundle.pem"),
+            certificate: root.join("ca.crt"),
+            merged_system_roots: false,
+        }
+    }
+
+    async fn context(root: &Path, clone: &Path) -> WipContext {
+        WipContext::capture(
+            "sb-1".to_owned(),
+            1,
+            &[ClonedRepository {
+                directory: clone.to_path_buf(),
+                position: 0,
+            }],
+            trust(root),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn a_dirty_tree_is_committed_pushed_and_restored() {
+        let root = tempfile::tempdir().unwrap();
+        let clone = fixture(root.path());
+        let mut context = context(root.path(), &clone).await;
+        let base = run(&clone, &["rev-parse", "HEAD"]);
+        std::fs::write(clone.join("draft.txt"), "unfinished\n").unwrap();
+
+        let events = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 2 })
+            .await;
+        assert_eq!(events.len(), 1);
+        let (kind, payload) = &events[0];
+        assert_eq!(kind, "wip_pushed");
+        assert_eq!(payload["ref"], "mg-wip/sb-1-i1");
+        assert_eq!(payload["checkpoint"], "successful_turn");
+        assert_eq!(payload["turn"], 2);
+        assert_eq!(payload["created_commit"], true);
+        assert_eq!(payload["task_branch_restored"], true);
+
+        // The snapshot reached origin and carries the dirty file.
+        let origin = root.path().join("origin");
+        let pushed = run(&origin, &["rev-parse", "refs/heads/mg-wip/sb-1-i1"]);
+        assert_eq!(payload["commit"], pushed);
+        let listing = run(&origin, &["ls-tree", "--name-only", &pushed]);
+        assert!(listing.contains("draft.txt"));
+
+        // The task branch is back where the engine left it, file intact.
+        assert_eq!(run(&clone, &["rev-parse", "HEAD"]), base);
+        assert!(clone.join("draft.txt").is_file());
+    }
+
+    #[tokio::test]
+    async fn an_unchanged_tree_pushes_nothing() {
+        let root = tempfile::tempdir().unwrap();
+        let clone = fixture(root.path());
+        let mut context = context(root.path(), &clone).await;
+        let events = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 1 })
+            .await;
+        assert!(events.is_empty());
+    }
+
+    /// The second checkpoint of the same dirty state must be silent: the
+    /// snapshot already exists and re-pushing it every turn is churn.
+    #[tokio::test]
+    async fn the_same_dirty_state_is_not_pushed_twice() {
+        let root = tempfile::tempdir().unwrap();
+        let clone = fixture(root.path());
+        let mut context = context(root.path(), &clone).await;
+        std::fs::write(clone.join("draft.txt"), "unfinished\n").unwrap();
+        let first = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 1 })
+            .await;
+        assert_eq!(first.len(), 1);
+        let second = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 2 })
+            .await;
+        assert!(second.is_empty());
+
+        // New work resumes pushing.
+        std::fs::write(clone.join("draft.txt"), "more\n").unwrap();
+        let third = context
+            .checkpoint(&CheckpointPoint::Terminal {
+                reason: "expired".to_owned(),
+            })
+            .await;
+        assert_eq!(third.len(), 1);
+        assert_eq!(third[0].1["terminal_reason"], "expired");
+    }
+
+    /// A clean tree whose head moved — the engine committed — still pushes,
+    /// without creating a snapshot commit.
+    #[tokio::test]
+    async fn an_authored_commit_is_pushed_without_a_snapshot() {
+        let root = tempfile::tempdir().unwrap();
+        let clone = fixture(root.path());
+        let mut context = context(root.path(), &clone).await;
+        std::fs::write(clone.join("work.txt"), "done\n").unwrap();
+        run(&clone, &["add", "-A"]);
+        run(
+            &clone,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.invalid",
+                "commit",
+                "-m",
+                "real work",
+            ],
+        );
+        let head = run(&clone, &["rev-parse", "HEAD"]);
+        let events = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 1 })
+            .await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].1["created_commit"], false);
+        assert_eq!(events[0].1["commit"], head);
+        // The engine's own commit stays on the branch.
+        assert_eq!(run(&clone, &["rev-parse", "HEAD"]), head);
+    }
+
+    #[tokio::test]
+    async fn a_failed_push_reports_instead_of_hiding() {
+        let root = tempfile::tempdir().unwrap();
+        let clone = fixture(root.path());
+        // Break the remote so the push must fail.
+        run(
+            &clone,
+            &["remote", "set-url", "origin", "/nonexistent/origin"],
+        );
+        let mut context = context(root.path(), &clone).await;
+        std::fs::write(clone.join("draft.txt"), "unfinished\n").unwrap();
+        let events = context
+            .checkpoint(&CheckpointPoint::Terminal {
+                reason: "cancelled".to_owned(),
+            })
+            .await;
+        assert_eq!(events.len(), 1);
+        let (kind, payload) = &events[0];
+        assert_eq!(kind, "wip_push_failed");
+        assert_eq!(payload["reason"], "push_failed");
+        assert_eq!(payload["head_pushed"], false);
+        assert!(payload["error"].as_str().unwrap().contains("git exited"));
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/wip.rs
+++ b/crates/tidebreak-supervised-agent/src/wip.rs
@@ -4,8 +4,9 @@
 //! bound, a cancel — and whatever sits uncommitted in its clones would die
 //! with the pod. So after every successful turn and once more at stop, the
 //! agent snapshots each cloned tree to a per-sandbox ref on the origin
-//! remote, then restores the task branch so the engine never sees the
-//! snapshot commit.
+//! remote. Dirty state is snapshotted with plumbing (`write-tree` +
+//! `commit-tree`) that never moves HEAD, so the engine cannot observe the
+//! snapshot commit on its branch no matter where the checkpoint fails.
 //!
 //! The ref names follow the supervising environment's published convention —
 //! `mg-wip/<sandbox-id>-i<incarnation>` for the first repository, with an
@@ -208,88 +209,8 @@ async fn checkpoint_tree(tree: &mut TreeState, job: &TreeJob<'_>) -> Option<Even
             return Some(failure_after_head_push(tree, job, "status_failed", &error).await)
         }
     };
-    let dirty = !status.trim().is_empty();
-
-    let mut base = None;
-    let mut fingerprint = None;
-    if dirty {
-        // The base head is what the task branch is restored to after the
-        // snapshot commit; without it there is nothing safe to restore, so
-        // this failure has no fallback push.
-        let base_head = match git(
-            job.trust,
-            &directory,
-            PLUMBING_BOUND,
-            job.share,
-            &["rev-parse", "HEAD"],
-        )
-        .await
-        {
-            Ok(head) => head.trim().to_owned(),
-            Err(error) => {
-                return Some(failure_event(
-                    tree,
-                    job,
-                    "head_unavailable",
-                    &error,
-                    None,
-                    None,
-                    None,
-                ))
-            }
-        };
-        if let Err(error) = git(
-            job.trust,
-            &directory,
-            TREE_WALK_BOUND,
-            job.share,
-            &["add", "-A", "--"],
-        )
-        .await
-        {
-            return Some(failure_after_head_push(tree, job, "stage_failed", &error).await);
-        }
-        // Best-effort fingerprint: the same dirty state pushed once need
-        // not be pushed again every turn.
-        fingerprint = git(
-            job.trust,
-            &directory,
-            PLUMBING_BOUND,
-            job.share,
-            &["write-tree"],
-        )
-        .await
-        .ok()
-        .map(|id| id.trim().to_owned());
-        if let Some(tree_id) = &fingerprint {
-            if tree.last_pushed_dirty.as_ref() == Some(&(tree_id.clone(), base_head.clone())) {
-                let _ = restore_task_branch(job, &directory, &base_head).await;
-                return None;
-            }
-        }
-        if let Err(error) = git(
-            job.trust,
-            &directory,
-            MUTATION_BOUND,
-            job.share,
-            &[
-                "-c",
-                "user.name=Tidebreak WIP",
-                "-c",
-                "user.email=tidebreak-wip@invalid",
-                "-c",
-                "commit.gpgsign=false",
-                "commit",
-                "--no-verify",
-                "--message",
-                &job.message,
-            ],
-        )
-        .await
-        {
-            return Some(failure_after_head_push(tree, job, "commit_failed", &error).await);
-        }
-        base = Some(base_head);
+    if !status.trim().is_empty() {
+        return checkpoint_dirty_tree(tree, job, &directory).await;
     }
 
     let head = match git(
@@ -316,7 +237,9 @@ async fn checkpoint_tree(tree: &mut TreeState, job: &TreeJob<'_>) -> Option<Even
     };
 
     let mut inspection_warning = None;
-    let should_push = if dirty {
+    let should_push = if tree.last_pushed_dirty.is_some() {
+        // The remote ref still names a synthetic dirty snapshot. A later
+        // clean tree supersedes that work even when HEAD itself never moved.
         true
     } else if tree.last_pushed_head.as_deref() == Some(head.as_str()) {
         false
@@ -369,19 +292,11 @@ async fn checkpoint_tree(tree: &mut TreeState, job: &TreeJob<'_>) -> Option<Even
         Ok(_) => {
             let mut payload = base_payload(tree, job);
             payload["commit"] = serde_json::json!(head);
-            payload["created_commit"] = serde_json::json!(dirty);
+            payload["created_commit"] = serde_json::json!(false);
             if let Some(warning) = inspection_warning {
                 payload["inspection_warning"] = serde_json::json!(warning);
             }
-            if let Some(base_head) = base {
-                let restored = restore_task_branch(job, &directory, &base_head)
-                    .await
-                    .is_ok();
-                payload["task_branch_restored"] = serde_json::json!(restored);
-                if restored {
-                    tree.last_pushed_dirty = fingerprint.map(|tree_id| (tree_id, base_head));
-                }
-            }
+            tree.last_pushed_dirty = None;
             tree.last_pushed_head = Some(head);
             Some(("wip_pushed".to_owned(), payload))
         }
@@ -397,18 +312,147 @@ async fn checkpoint_tree(tree: &mut TreeState, job: &TreeJob<'_>) -> Option<Even
     }
 }
 
-/// Unstages the snapshot so the engine's next turn sees its own state.
-async fn restore_task_branch(
+/// Snapshots a dirty tree without ever moving HEAD.
+///
+/// The staged state becomes a tree object, `commit-tree` wraps it in a
+/// commit parented on the current head, and the commit's sha is pushed
+/// directly to the checkpoint ref. The task branch is untouched on every
+/// path — success and failure alike — and the index is restored before the
+/// push, so no push outcome can leave the engine's next turn looking at
+/// staged state it did not stage.
+async fn checkpoint_dirty_tree(
+    tree: &mut TreeState,
     job: &TreeJob<'_>,
     directory: &Path,
-    base_head: &str,
-) -> Result<String, String> {
+) -> Option<Event> {
+    let base_head = match git(
+        job.trust,
+        directory,
+        PLUMBING_BOUND,
+        job.share,
+        &["rev-parse", "HEAD"],
+    )
+    .await
+    {
+        Ok(head) => head.trim().to_owned(),
+        Err(error) => {
+            return Some(failure_event(
+                tree,
+                job,
+                "head_unavailable",
+                &error,
+                None,
+                None,
+                None,
+            ))
+        }
+    };
+    if let Err(error) = git(
+        job.trust,
+        directory,
+        TREE_WALK_BOUND,
+        job.share,
+        &["add", "-A", "--"],
+    )
+    .await
+    {
+        return Some(failure_after_head_push(tree, job, "stage_failed", &error).await);
+    }
+    // The tree id is both the snapshot's content and the dedup fingerprint:
+    // the same dirty state pushed once need not be pushed again every turn.
+    let tree_id = match git(
+        job.trust,
+        directory,
+        PLUMBING_BOUND,
+        job.share,
+        &["write-tree"],
+    )
+    .await
+    {
+        Ok(id) => id.trim().to_owned(),
+        Err(error) => {
+            let _ = restore_index(job, directory).await;
+            return Some(failure_after_head_push(tree, job, "snapshot_failed", &error).await);
+        }
+    };
+    if tree.last_pushed_dirty.as_ref() == Some(&(tree_id.clone(), base_head.clone())) {
+        let _ = restore_index(job, directory).await;
+        return None;
+    }
+    let snapshot = match git(
+        job.trust,
+        directory,
+        MUTATION_BOUND,
+        job.share,
+        &[
+            "-c",
+            "user.name=Tidebreak WIP",
+            "-c",
+            "user.email=tidebreak-wip@invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "commit-tree",
+            "-p",
+            &base_head,
+            "-m",
+            &job.message,
+            &tree_id,
+        ],
+    )
+    .await
+    {
+        Ok(sha) => sha.trim().to_owned(),
+        Err(error) => {
+            let _ = restore_index(job, directory).await;
+            return Some(failure_after_head_push(tree, job, "commit_failed", &error).await);
+        }
+    };
+    let restored = restore_index(job, directory).await.is_ok();
+    match git(
+        job.trust,
+        directory,
+        PUSH_BOUND,
+        job.share,
+        &[
+            "push",
+            "--force",
+            "--no-verify",
+            "origin",
+            &format!("{snapshot}:refs/heads/{}", job.reference),
+        ],
+    )
+    .await
+    {
+        Ok(_) => {
+            let mut payload = base_payload(tree, job);
+            payload["commit"] = serde_json::json!(snapshot);
+            payload["created_commit"] = serde_json::json!(true);
+            payload["task_branch_restored"] = serde_json::json!(restored);
+            tree.last_pushed_dirty = Some((tree_id, base_head));
+            tree.last_pushed_head = Some(snapshot);
+            Some(("wip_pushed".to_owned(), payload))
+        }
+        Err(error) => Some(failure_event(
+            tree,
+            job,
+            "push_failed",
+            &error,
+            Some(&snapshot),
+            Some(false),
+            None,
+        )),
+    }
+}
+
+/// Unstages the snapshot staging so the engine's next turn sees the index it
+/// left behind. HEAD never moved, so this is an index-only reset.
+async fn restore_index(job: &TreeJob<'_>, directory: &Path) -> Result<String, String> {
     git(
         job.trust,
         directory,
         MUTATION_BOUND,
         job.share,
-        &["reset", "--mixed", "--quiet", base_head],
+        &["reset", "--mixed", "--quiet"],
     )
     .await
 }
@@ -709,6 +753,39 @@ mod tests {
         assert_eq!(third[0].1["terminal_reason"], "expired");
     }
 
+    #[tokio::test]
+    async fn a_clean_tree_supersedes_the_last_dirty_snapshot() {
+        let root = tempfile::tempdir().unwrap();
+        let clone = fixture(root.path());
+        let mut context = context(root.path(), &clone).await;
+        let head = run(&clone, &["rev-parse", "HEAD"]);
+        std::fs::write(clone.join("draft.txt"), "discard me\n").unwrap();
+
+        let dirty = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 1 })
+            .await;
+        assert_eq!(dirty.len(), 1);
+        assert_eq!(dirty[0].1["created_commit"], true);
+        std::fs::remove_file(clone.join("draft.txt")).unwrap();
+
+        let clean = context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 2 })
+            .await;
+        assert_eq!(clean.len(), 1);
+        assert_eq!(clean[0].1["created_commit"], false);
+        assert_eq!(clean[0].1["commit"], head);
+
+        let origin = root.path().join("origin");
+        assert_eq!(
+            run(&origin, &["rev-parse", "refs/heads/mg-wip/sb-1-i1"]),
+            head
+        );
+        assert!(context
+            .checkpoint(&CheckpointPoint::SuccessfulTurn { turn: 3 })
+            .await
+            .is_empty());
+    }
+
     /// A clean tree whose head moved — the engine committed — still pushes,
     /// without creating a snapshot commit.
     #[tokio::test]
@@ -751,6 +828,7 @@ mod tests {
             &["remote", "set-url", "origin", "/nonexistent/origin"],
         );
         let mut context = context(root.path(), &clone).await;
+        let base = run(&clone, &["rev-parse", "HEAD"]);
         std::fs::write(clone.join("draft.txt"), "unfinished\n").unwrap();
         let events = context
             .checkpoint(&CheckpointPoint::Terminal {
@@ -763,5 +841,11 @@ mod tests {
         assert_eq!(payload["reason"], "push_failed");
         assert_eq!(payload["head_pushed"], false);
         assert!(payload["error"].as_str().unwrap().contains("git exited"));
+
+        // The failed push must not leave the engine on the snapshot commit,
+        // and the staging done for the snapshot must be undone.
+        assert_eq!(run(&clone, &["rev-parse", "HEAD"]), base);
+        assert!(clone.join("draft.txt").is_file());
+        assert!(run(&clone, &["status", "--porcelain"]).contains("?? draft.txt"));
     }
 }

--- a/crates/tidebreak-supervised-agent/src/wip.rs
+++ b/crates/tidebreak-supervised-agent/src/wip.rs
@@ -951,12 +951,26 @@ mod tests {
                 "main",
             ],
         );
+        // The merge needs an identity even to conflict: without one git
+        // dies before touching the tree (CI runners auto-detect none).
         let merge = Command::new("git")
-            .args(["merge", "side"])
+            .args([
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.invalid",
+                "merge",
+                "side",
+            ])
             .current_dir(&clone)
             .output()
             .unwrap();
         assert!(!merge.status.success(), "the merge must conflict");
+        assert!(
+            clone.join(".git").join("MERGE_HEAD").is_file(),
+            "the merge died without conflicting: {}",
+            String::from_utf8_lossy(&merge.stderr)
+        );
         let head = run(&clone, &["rev-parse", "HEAD"]);
         let mut context = context(root.path(), &clone).await;
 


### PR DESCRIPTION
## What changed

- Bootstrap the supervised workspace, clone declared repositories, select requested refs, and prepare the merged certificate bundle.
- Read the completion latch and bounded task output from `/workspace`.
- Preserve dirty work as pushed WIP snapshots without moving the task branch or leaving `HEAD` on a snapshot after a failed push.
- Keep the supervision poll cadence alive while checkpoint work runs, and report checkpoint outcomes through the event stream.

## Validation

- `cargo test -p tidebreak-supervised-agent` — 75 passed on the complete stack.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Compatibility and risk

The behavior is confined to the new supervised-agent crate. Repository writes use the declared clone and push scope; existing Tidebreak workspaces and sessions are unchanged.