### PR TITLE
feat(agent): drive an engine CLI through tidebreak-harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7512,6 +7512,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.20",
+ "tidebreak-core",
+ "tidebreak-harness",
  "tokio",
 ]
 

--- a/crates/tidebreak-supervised-agent/Cargo.toml
+++ b/crates/tidebreak-supervised-agent/Cargo.toml
@@ -9,12 +9,18 @@ homepage.workspace = true
 authors.workspace = true
 publish = false
 
+[[bin]]
+name = "tidebreak-supervised-agent"
+path = "src/main.rs"
+
 [dependencies]
 async-trait = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tidebreak-core = { path = "../tidebreak-core", default-features = false }
+tidebreak-harness = { path = "../tidebreak-harness" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "sync", "time"] }
 
 [dev-dependencies]

--- a/crates/tidebreak-supervised-agent/src/effort.rs
+++ b/crates/tidebreak-supervised-agent/src/effort.rs
@@ -1,0 +1,103 @@
+//! Reconciling the requested reasoning effort with the engine's ladder.
+//!
+//! The supervising environment forwards the spawn's requested effort as an
+//! opaque token and expects the agent to report what actually applied. Its
+//! published contract for first-party workloads is the one mirrored here: the
+//! highest supported level at or below the request, and no explicit effort
+//! control at all when the request sits below the engine's whole ladder.
+//!
+//! That last clause is why this module does not use
+//! `ReasoningEffort::clamp_to`: `clamp_to` degrades a below-ladder request
+//! *up* to the ladder's minimum so a stored chat setting keeps working, but
+//! here rounding a request up would spend more reasoning than the caller
+//! asked for. Reporting `None` and leaving the engine's default in force is
+//! the honest answer.
+
+use tidebreak_core::ReasoningEffort;
+
+/// The effort level to drive the engine with, given the requested token and
+/// the engine's supported ladder.
+///
+/// - No request, or a token no level spells: no explicit control.
+/// - `minimal` reads as [`ReasoningEffort::None`] — the environment's ladder
+///   has that extra rung below `low`, and "as little reasoning as possible"
+///   is what both spell.
+/// - An empty ladder means the engine declares no effort control; the parsed
+///   level passes through untouched and the adapter applies it per model.
+/// - Otherwise: the highest supported level at or below the request, or no
+///   control when every supported level sits above it.
+#[must_use]
+pub fn reconcile(requested: Option<&str>, ladder: &[ReasoningEffort]) -> Option<ReasoningEffort> {
+    let requested = parse(requested?)?;
+    if ladder.is_empty() {
+        return Some(requested);
+    }
+    ladder
+        .iter()
+        .copied()
+        .filter(|level| *level <= requested)
+        .max()
+}
+
+fn parse(token: &str) -> Option<ReasoningEffort> {
+    if token == "minimal" {
+        return Some(ReasoningEffort::None);
+    }
+    ReasoningEffort::from_str(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LADDER: &[ReasoningEffort] = &[
+        ReasoningEffort::Low,
+        ReasoningEffort::Medium,
+        ReasoningEffort::High,
+        ReasoningEffort::XHigh,
+    ];
+
+    #[test]
+    fn an_exact_match_passes_through() {
+        assert_eq!(reconcile(Some("high"), LADDER), Some(ReasoningEffort::High));
+    }
+
+    #[test]
+    fn a_request_above_the_ladder_takes_the_highest_supported_level() {
+        assert_eq!(
+            reconcile(Some("ultra"), LADDER),
+            Some(ReasoningEffort::XHigh)
+        );
+    }
+
+    /// Rounding a below-ladder request up would spend more reasoning than the
+    /// caller asked for; the answer is no explicit control.
+    #[test]
+    fn a_request_below_the_whole_ladder_applies_no_control() {
+        assert_eq!(reconcile(Some("none"), LADDER), None);
+        assert_eq!(reconcile(Some("minimal"), LADDER), None);
+    }
+
+    #[test]
+    fn minimal_reads_as_none() {
+        assert_eq!(
+            reconcile(
+                Some("minimal"),
+                &[ReasoningEffort::None, ReasoningEffort::Low]
+            ),
+            Some(ReasoningEffort::None)
+        );
+    }
+
+    #[test]
+    fn an_empty_ladder_passes_the_parsed_level_through() {
+        assert_eq!(reconcile(Some("xhigh"), &[]), Some(ReasoningEffort::XHigh));
+    }
+
+    #[test]
+    fn no_request_and_unknown_tokens_apply_no_control() {
+        assert_eq!(reconcile(None, LADDER), None);
+        assert_eq!(reconcile(Some("turbo"), LADDER), None);
+        assert_eq!(reconcile(Some("turbo"), &[]), None);
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/effort.rs
+++ b/crates/tidebreak-supervised-agent/src/effort.rs
@@ -12,31 +12,64 @@
 //! here rounding a request up would spend more reasoning than the caller
 //! asked for. Reporting `None` and leaving the engine's default in force is
 //! the honest answer.
+//!
+//! The ladder itself comes from [`ladder`]: the adapter's engine-wide ladder
+//! when it states one, otherwise the selected model's row from the engine's
+//! catalog. Codex is why the second step exists — its ladder is per model,
+//! and a token the selected row does not list makes the CLI refuse the turn
+//! instead of running it.
 
 use tidebreak_core::ReasoningEffort;
+use tidebreak_harness::{HarnessAdapter, HarnessProbe};
 
 /// The effort level to drive the engine with, given the requested token and
-/// the engine's supported ladder.
+/// the supported ladder from [`ladder`].
 ///
 /// - No request, or a token no level spells: no explicit control.
 /// - `minimal` reads as [`ReasoningEffort::None`] — the environment's ladder
 ///   has that extra rung below `low`, and "as little reasoning as possible"
 ///   is what both spell.
-/// - An empty ladder means the engine declares no effort control; the parsed
-///   level passes through untouched and the adapter applies it per model.
+/// - An empty ladder means no effort control is known to apply; the request
+///   is dropped rather than passed through, because a token the engine never
+///   advertised is one it may refuse.
 /// - Otherwise: the highest supported level at or below the request, or no
 ///   control when every supported level sits above it.
 #[must_use]
 pub fn reconcile(requested: Option<&str>, ladder: &[ReasoningEffort]) -> Option<ReasoningEffort> {
     let requested = parse(requested?)?;
-    if ladder.is_empty() {
-        return Some(requested);
-    }
     ladder
         .iter()
         .copied()
         .filter(|level| *level <= requested)
         .max()
+}
+
+/// The ladder to reconcile the requested effort against.
+///
+/// The adapter's engine-wide ladder wins when it states one. When it does
+/// not, the ladder is the selected model's row in the engine's catalog — the
+/// named model's, or the default row's when no model was named. A model the
+/// catalog does not list resolves to no ladder, so [`reconcile`] applies no
+/// explicit control rather than sending a token the engine would reject.
+pub async fn ladder(
+    adapter: &dyn HarnessAdapter,
+    probe: &HarnessProbe,
+    model: Option<&str>,
+) -> Vec<ReasoningEffort> {
+    let engine_wide = adapter.reasoning_efforts(probe);
+    if !engine_wide.is_empty() {
+        return engine_wide;
+    }
+    adapter
+        .list_models(probe)
+        .await
+        .into_iter()
+        .find(|row| match model {
+            Some(id) => row.id == id,
+            None => row.default,
+        })
+        .map(|row| row.reasoning_efforts)
+        .unwrap_or_default()
 }
 
 fn parse(token: &str) -> Option<ReasoningEffort> {
@@ -49,6 +82,15 @@ fn parse(token: &str) -> Option<ReasoningEffort> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    use async_trait::async_trait;
+    use tidebreak_core::{CapLevel, HarnessCaps, HarnessKind};
+    use tidebreak_harness::{
+        HarnessError, HarnessSession, HostEnv, ListedHarnessModel, SessionSpec,
+    };
 
     const LADDER: &[ReasoningEffort] = &[
         ReasoningEffort::Low,
@@ -89,9 +131,12 @@ mod tests {
         );
     }
 
+    /// A token the engine never advertised is one it may refuse: Codex
+    /// validates the effort on `turn/start` against the selected model row,
+    /// so an unresolved ladder must drop the request, not pass it through.
     #[test]
-    fn an_empty_ladder_passes_the_parsed_level_through() {
-        assert_eq!(reconcile(Some("xhigh"), &[]), Some(ReasoningEffort::XHigh));
+    fn an_empty_ladder_applies_no_control() {
+        assert_eq!(reconcile(Some("xhigh"), &[]), None);
     }
 
     #[test]
@@ -99,5 +144,108 @@ mod tests {
         assert_eq!(reconcile(None, LADDER), None);
         assert_eq!(reconcile(Some("turbo"), LADDER), None);
         assert_eq!(reconcile(Some("turbo"), &[]), None);
+    }
+
+    /// Adapter with no engine-wide ladder and a fixed catalog — the Codex
+    /// shape, where every row states its own ladder.
+    struct PerModelAdapter;
+
+    #[async_trait]
+    impl HarnessAdapter for PerModelAdapter {
+        fn kind(&self) -> HarnessKind {
+            HarnessKind::Codex
+        }
+
+        async fn probe(&self, _host: &HostEnv) -> HarnessProbe {
+            unreachable!("the tests build the probe directly")
+        }
+
+        fn capabilities(&self, _probe: &HarnessProbe) -> HarnessCaps {
+            HarnessCaps {
+                resume: CapLevel::Unknown,
+                streaming_deltas: CapLevel::Unknown,
+                structured_approvals: CapLevel::Unknown,
+                mid_turn_steering: CapLevel::Unknown,
+                plan_mode: CapLevel::Unknown,
+                auto_mode: CapLevel::Unknown,
+                allow_mode: CapLevel::Unknown,
+                reasoning_levels: CapLevel::Unknown,
+                native_file_change_events: CapLevel::Unknown,
+                native_interrupt: CapLevel::Unknown,
+                image_input: CapLevel::Unknown,
+                slash_commands: CapLevel::Unknown,
+            }
+        }
+
+        async fn list_models(&self, _probe: &HarnessProbe) -> Vec<ListedHarnessModel> {
+            vec![
+                ListedHarnessModel {
+                    id: "wide-ladder".to_owned(),
+                    label: "Wide ladder".to_owned(),
+                    default: true,
+                    reasoning_efforts: vec![
+                        ReasoningEffort::Low,
+                        ReasoningEffort::Medium,
+                        ReasoningEffort::High,
+                        ReasoningEffort::XHigh,
+                    ],
+                    fast_mode: false,
+                },
+                ListedHarnessModel {
+                    id: "narrow-ladder".to_owned(),
+                    label: "Narrow ladder".to_owned(),
+                    default: false,
+                    reasoning_efforts: vec![ReasoningEffort::Low, ReasoningEffort::Medium],
+                    fast_mode: false,
+                },
+            ]
+        }
+
+        async fn launch(
+            &self,
+            _spec: SessionSpec,
+        ) -> Result<Box<dyn HarnessSession>, HarnessError> {
+            unreachable!("the tests never launch")
+        }
+    }
+
+    fn bare_probe() -> HarnessProbe {
+        HarnessProbe {
+            found: true,
+            binary_path: Some(PathBuf::from("/usr/bin/engine")),
+            version: None,
+            authenticated: None,
+            stderr: String::new(),
+            env: vec![(OsString::from("PATH"), OsString::from("/usr/bin"))],
+            commands: Vec::new(),
+        }
+    }
+
+    /// The finding this pins: a Codex spawn with a request above the model's
+    /// ladder must degrade to that row's highest rung, exactly as first-party
+    /// bootstrap clamps against the catalog, instead of shipping the raw
+    /// token for the CLI to refuse.
+    #[tokio::test]
+    async fn a_per_model_ladder_clamps_the_request_to_the_selected_row() {
+        let probe = bare_probe();
+        let rungs = ladder(&PerModelAdapter, &probe, Some("narrow-ladder")).await;
+        assert_eq!(
+            reconcile(Some("ultra"), &rungs),
+            Some(ReasoningEffort::Medium)
+        );
+    }
+
+    #[tokio::test]
+    async fn no_named_model_resolves_the_default_row() {
+        let probe = bare_probe();
+        let rungs = ladder(&PerModelAdapter, &probe, None).await;
+        assert_eq!(rungs, LADDER);
+    }
+
+    #[tokio::test]
+    async fn an_unlisted_model_applies_no_control() {
+        let probe = bare_probe();
+        let rungs = ladder(&PerModelAdapter, &probe, Some("off-catalog")).await;
+        assert_eq!(reconcile(Some("ultra"), &rungs), None);
     }
 }

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -1,0 +1,770 @@
+//! The [`Engine`] the driver runs when a real engine CLI is on the image.
+//!
+//! [`HarnessEngine`] adapts one `tidebreak-harness` adapter to the driver's
+//! engine seam. It launches the engine lazily on the first turn, so a missing
+//! binary or a failed launch surfaces as `engine_failed` through the driver —
+//! after the bootstrap events have reached the supervising environment —
+//! instead of killing the pod before it says anything.
+//!
+//! Posture and state:
+//!
+//! - The engine runs in [`PermissionMode::Allow`]. The sandbox's confinement
+//!   is the permission boundary here, the same posture engines already run
+//!   under in these environments; decision 0039 owns Allow's semantics, and
+//!   choosing it for a supervised pod is parity, not a weakening.
+//! - The agent keeps no session state of its own. The engine's native session
+//!   store under the pod's home directory is the only continuity, and a
+//!   [`HarnessError::ResumeLost`] is fatal — the agent never silently starts
+//!   a fresh conversation on the same task.
+//! - A child that dies mid-turn is a failure: the turn reports
+//!   [`TurnEnd::Fatal`] and the run exits nonzero, unless the driver itself
+//!   interrupted the turn.
+//!
+//! Inference wiring: when the environment hands the pod a placeholder
+//! credential, each engine is configured at its vendor-default base with that
+//! placeholder, and the environment's interception boundary swaps it for a
+//! real credential per destination. Without a placeholder — a hand-run agent,
+//! most often — no wiring is applied and the engine uses whatever credentials
+//! it already has.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tidebreak_core::{HarnessKind, PermissionMode, ReasoningEffort};
+use tidebreak_harness::wiring::{spawn_wiring, InferenceWiring};
+use tidebreak_harness::{
+    HarnessAdapter, HarnessError, HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession,
+    SessionSpec, TurnInput, TurnOutcome,
+};
+
+use crate::engine::{Engine, EngineError, SteerRefused, TurnEnd, TurnHandle, TurnRequest};
+
+/// The placeholder credential the environment hands a sandboxed pod.
+///
+/// The pod never holds a real credential: the interception boundary swaps
+/// this value for the real one on the way out, so the engine is configured
+/// with the placeholder verbatim. Absent means the agent is running outside
+/// such an environment and no wiring is applied.
+pub const PLACEHOLDER_TOKEN_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_PLACEHOLDER_TOKEN";
+
+/// Environment variable name the wiring carries the credential under, for
+/// engines whose clients read it from the environment.
+pub const RELAY_KEY_ENV: &str = "TIDEBREAK_LLM_KEY";
+
+const ANTHROPIC_BASE: &str = "https://api.anthropic.com";
+const OPENAI_BASE: &str = "https://api.openai.com";
+const XAI_BASE: &str = "https://api.x.ai";
+
+/// Reads the placeholder credential, treating empty the same as absent.
+#[must_use]
+pub fn placeholder_credential_from_env() -> Option<String> {
+    std::env::var(PLACEHOLDER_TOKEN_VARIABLE)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+/// Everything [`HarnessEngine`] needs, resolved before the loop starts.
+pub struct HarnessEngineSpec {
+    /// The adapter for the selected engine.
+    pub adapter: Arc<dyn HarnessAdapter>,
+    /// The probe the adapter ran against this image.
+    pub probe: HarnessProbe,
+    /// Model route, when the spawn named one.
+    pub model: Option<String>,
+    /// Reconciled effort level, when one applies ([`crate::effort`]).
+    pub reasoning_effort: Option<ReasoningEffort>,
+    /// The directory the engine runs in — the first clone, or the workspace.
+    pub worktree: PathBuf,
+    /// Absolute roots outside the worktree the engine may read — the
+    /// workspace itself, when the run cloned into a subdirectory of it.
+    pub allowed_read_roots: Vec<PathBuf>,
+    /// Outbound-trust variables every engine child carries.
+    pub trust_env: Vec<(OsString, OsString)>,
+    /// The environment's placeholder credential, when the pod has one.
+    pub placeholder_credential: Option<String>,
+}
+
+/// Drives one engine CLI session through `tidebreak-harness`.
+pub struct HarnessEngine {
+    kind: HarnessKind,
+    spec: HarnessEngineSpec,
+    session: Option<Arc<dyn HarnessSession>>,
+    sink: Arc<TerminalSink>,
+}
+
+impl HarnessEngine {
+    /// Builds the engine. Nothing is launched until the first turn starts.
+    #[must_use]
+    pub fn new(spec: HarnessEngineSpec) -> Self {
+        Self {
+            kind: spec.adapter.kind(),
+            spec,
+            session: None,
+            sink: Arc::new(TerminalSink::default()),
+        }
+    }
+
+    async fn launch(&self) -> Result<Arc<dyn HarnessSession>, EngineError> {
+        let probe = &self.spec.probe;
+        if !probe.found {
+            let detail = probe.stderr.trim();
+            let suffix = if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            };
+            return Err(EngineError {
+                message: format!(
+                    "the {} binary was not found on this image{suffix}",
+                    self.kind
+                ),
+            });
+        }
+        let binary = probe.binary_path.clone().ok_or_else(|| EngineError {
+            message: format!("the {} probe reported no binary path", self.kind),
+        })?;
+
+        let (extra_argv, extra_env, relay_key_env) = match &self.spec.placeholder_credential {
+            Some(key) => {
+                let openai_base = if self.kind == HarnessKind::Grok {
+                    XAI_BASE
+                } else {
+                    OPENAI_BASE
+                };
+                let (argv, env) = spawn_wiring(
+                    self.kind,
+                    &InferenceWiring {
+                        anthropic_base: ANTHROPIC_BASE,
+                        openai_base,
+                        key_env: RELAY_KEY_ENV,
+                        key,
+                    },
+                );
+                (argv, env, Some(RELAY_KEY_ENV.to_owned()))
+            }
+            None => (Vec::new(), Vec::new(), None),
+        };
+
+        let mut env = probe.env.clone();
+        for (name, value) in &self.spec.trust_env {
+            if let Some(existing) = env.iter_mut().find(|(existing, _)| existing == name) {
+                existing.1 = value.clone();
+            } else {
+                env.push((name.clone(), value.clone()));
+            }
+        }
+
+        let session = self
+            .spec
+            .adapter
+            .launch(SessionSpec {
+                worktree: self.spec.worktree.clone(),
+                allowed_read_roots: self.spec.allowed_read_roots.clone(),
+                permission_mode: PermissionMode::Allow,
+                model: self.spec.model.clone(),
+                reasoning_effort: self.spec.reasoning_effort,
+                fast_mode: false,
+                resume_ref: None,
+                extra_argv,
+                extra_env,
+                relay_key_env,
+                env,
+                approval: None,
+                binary,
+                sink: self.sink.clone(),
+                browser: None,
+            })
+            .await
+            .map_err(|error| EngineError {
+                message: format!("launching {} failed: {error}", self.kind),
+            })?;
+        Ok(Arc::from(session))
+    }
+}
+
+#[async_trait]
+impl Engine for HarnessEngine {
+    async fn start_turn(
+        &mut self,
+        request: TurnRequest,
+    ) -> Result<Box<dyn TurnHandle>, EngineError> {
+        let session = match &self.session {
+            Some(session) => session.clone(),
+            None => {
+                let session = self.launch().await?;
+                self.session = Some(session.clone());
+                session
+            }
+        };
+        self.sink.clear();
+        let input = TurnInput {
+            text: request.input,
+            model: self.spec.model.clone(),
+            reasoning_effort: self.spec.reasoning_effort,
+            fast_mode: false,
+            images: Vec::new(),
+        };
+        let run = tokio::spawn({
+            let session = session.clone();
+            async move { session.run_turn(input).await }
+        });
+        Ok(Box::new(HarnessTurn {
+            session,
+            run,
+            sink: self.sink.clone(),
+            interrupted: false,
+            ended: None,
+        }))
+    }
+}
+
+/// What the stream said about how the current turn ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Terminal {
+    Completed,
+    Failed,
+    Interrupted,
+}
+
+/// Records the last terminal turn event; every other event is dropped.
+///
+/// The supervising environment's event vocabulary is lifecycle-only, so
+/// assistant text and tool activity stay inside the pod. Only the terminal
+/// state feeds the turn outcome.
+#[derive(Default)]
+struct TerminalSink {
+    last: Mutex<Option<Terminal>>,
+}
+
+impl TerminalSink {
+    fn clear(&self) {
+        *self.last.lock().unwrap() = None;
+    }
+
+    fn read(&self) -> Option<Terminal> {
+        *self.last.lock().unwrap()
+    }
+}
+
+#[async_trait]
+impl HarnessEventSink for TerminalSink {
+    async fn emit(&self, event: HarnessEvent) {
+        let terminal = match event {
+            HarnessEvent::TurnCompleted { .. } => Terminal::Completed,
+            HarnessEvent::TurnFailed { error } => {
+                // The failure detail stays in the pod log; the supervising
+                // environment only learns the turn's exit status.
+                eprintln!("the engine reported a failed turn: {}", error.message);
+                Terminal::Failed
+            }
+            HarnessEvent::TurnInterrupted => Terminal::Interrupted,
+            _ => return,
+        };
+        *self.last.lock().unwrap() = Some(terminal);
+    }
+}
+
+/// One running engine turn.
+struct HarnessTurn {
+    session: Arc<dyn HarnessSession>,
+    run: tokio::task::JoinHandle<Result<TurnOutcome, HarnessError>>,
+    sink: Arc<TerminalSink>,
+    interrupted: bool,
+    ended: Option<TurnEnd>,
+}
+
+impl HarnessTurn {
+    fn conclude(
+        &self,
+        joined: Result<Result<TurnOutcome, HarnessError>, tokio::task::JoinError>,
+    ) -> TurnEnd {
+        let outcome = match joined {
+            Err(error) => {
+                return TurnEnd::Fatal {
+                    message: format!("the engine turn task failed: {error}"),
+                }
+            }
+            // Every launch or turn error is fatal here, `ResumeLost`
+            // included: the engine's own session store is the only
+            // continuity, and restarting fresh on the same task would
+            // silently discard the turns already reported.
+            Ok(Err(error)) => {
+                return TurnEnd::Fatal {
+                    message: error.to_string(),
+                }
+            }
+            Ok(Ok(outcome)) => outcome,
+        };
+        match outcome {
+            TurnOutcome::Clean => match self.sink.read() {
+                Some(Terminal::Failed) => TurnEnd::Completed { success: false },
+                Some(Terminal::Interrupted) => TurnEnd::Interrupted,
+                // A clean process end with no terminal event only happens on
+                // adapters whose stream always carries one; success is the
+                // honest default for the ones that end cleanly without it.
+                Some(Terminal::Completed) | None => TurnEnd::Completed { success: true },
+            },
+            TurnOutcome::Incomplete { detail } => {
+                if self.interrupted || self.sink.read() == Some(Terminal::Interrupted) {
+                    TurnEnd::Interrupted
+                } else {
+                    // A child that dies mid-turn is a failure, not a parked
+                    // turn: the run must end loudly rather than resume onto a
+                    // session whose last turn half-happened.
+                    TurnEnd::Fatal { message: detail }
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl TurnHandle for HarnessTurn {
+    async fn wait(&mut self) -> TurnEnd {
+        if let Some(ended) = &self.ended {
+            return ended.clone();
+        }
+        let joined = (&mut self.run).await;
+        let ended = self.conclude(joined);
+        self.ended = Some(ended.clone());
+        ended
+    }
+
+    async fn steer(&mut self, body: String) -> Result<(), SteerRefused> {
+        // Any refusal — an engine with no mid-turn channel, or one that
+        // rejected this particular steer — keeps the message queued for the
+        // next turn.
+        self.session.steer(body).await.map_err(|_| SteerRefused)
+    }
+
+    async fn interrupt(&mut self) {
+        self.interrupted = true;
+        // The engine may already be past the point of interrupting; the next
+        // wait reports how the turn actually ended either way.
+        let _ = self.session.interrupt().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::path::Path;
+
+    use tidebreak_core::{CapLevel, CodeUsage, HarnessCaps};
+    use tidebreak_harness::{ApprovalDecision, HarnessApprovalRef, HostEnv};
+
+    use super::*;
+    use crate::engine::TurnSource;
+
+    /// One scripted engine turn: an optional terminal event, then an outcome.
+    struct ScriptedTurn {
+        event: Option<HarnessEvent>,
+        outcome: Result<TurnOutcome, HarnessError>,
+        /// Wait for an interrupt before ending, to model a turn in flight.
+        waits_for_interrupt: bool,
+    }
+
+    struct FakeSession {
+        turns: Mutex<VecDeque<ScriptedTurn>>,
+        sink: Arc<dyn HarnessEventSink>,
+        interrupt: tokio::sync::Notify,
+    }
+
+    #[async_trait]
+    impl HarnessSession for FakeSession {
+        async fn run_turn(&self, _input: TurnInput) -> Result<TurnOutcome, HarnessError> {
+            let turn = self
+                .turns
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("a scripted turn");
+            if turn.waits_for_interrupt {
+                self.interrupt.notified().await;
+            }
+            if let Some(event) = turn.event {
+                self.sink.emit(event).await;
+            }
+            turn.outcome
+        }
+
+        async fn decide(
+            &self,
+            _approval: HarnessApprovalRef,
+            _decision: ApprovalDecision,
+        ) -> Result<(), HarnessError> {
+            Err(HarnessError::Other("no approvals in this seam".to_owned()))
+        }
+
+        async fn interrupt(&self) -> Result<(), HarnessError> {
+            self.interrupt.notify_one();
+            Ok(())
+        }
+
+        async fn steer(&self, _text: String) -> Result<(), HarnessError> {
+            Err(HarnessError::SteeringUnsupported)
+        }
+
+        fn resume_ref(&self) -> Option<String> {
+            None
+        }
+
+        fn unrecognized_events(&self) -> u64 {
+            0
+        }
+
+        async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
+            Ok(())
+        }
+    }
+
+    /// The launch fields the tests assert on.
+    #[derive(Default)]
+    struct CapturedSpec {
+        permission_mode: Option<PermissionMode>,
+        extra_argv: Vec<String>,
+        extra_env: Vec<(String, String)>,
+        relay_key_env: Option<String>,
+        env: Vec<(OsString, OsString)>,
+        model: Option<String>,
+        reasoning_effort: Option<ReasoningEffort>,
+    }
+
+    struct FakeAdapter {
+        turns: Mutex<Option<VecDeque<ScriptedTurn>>>,
+        captured: Arc<Mutex<CapturedSpec>>,
+        launch_error: Mutex<Option<HarnessError>>,
+    }
+
+    impl FakeAdapter {
+        fn scripted(turns: Vec<ScriptedTurn>) -> Self {
+            Self {
+                turns: Mutex::new(Some(turns.into())),
+                captured: Arc::new(Mutex::new(CapturedSpec::default())),
+                launch_error: Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl HarnessAdapter for FakeAdapter {
+        fn kind(&self) -> HarnessKind {
+            HarnessKind::ClaudeCode
+        }
+
+        async fn probe(&self, _host: &HostEnv) -> HarnessProbe {
+            probe(true)
+        }
+
+        fn capabilities(&self, _probe: &HarnessProbe) -> HarnessCaps {
+            HarnessCaps {
+                resume: CapLevel::Unknown,
+                streaming_deltas: CapLevel::Unknown,
+                structured_approvals: CapLevel::Unknown,
+                mid_turn_steering: CapLevel::Unknown,
+                plan_mode: CapLevel::Unknown,
+                auto_mode: CapLevel::Unknown,
+                allow_mode: CapLevel::Unknown,
+                reasoning_levels: CapLevel::Unknown,
+                native_file_change_events: CapLevel::Unknown,
+                native_interrupt: CapLevel::Unknown,
+                image_input: CapLevel::Unknown,
+                slash_commands: CapLevel::Unknown,
+            }
+        }
+
+        async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
+            if let Some(error) = self.launch_error.lock().unwrap().take() {
+                return Err(error);
+            }
+            *self.captured.lock().unwrap() = CapturedSpec {
+                permission_mode: Some(spec.permission_mode),
+                extra_argv: spec.extra_argv,
+                extra_env: spec.extra_env,
+                relay_key_env: spec.relay_key_env,
+                env: spec.env,
+                model: spec.model,
+                reasoning_effort: spec.reasoning_effort,
+            };
+            Ok(Box::new(FakeSession {
+                turns: Mutex::new(self.turns.lock().unwrap().take().expect("one launch")),
+                sink: spec.sink,
+                interrupt: tokio::sync::Notify::new(),
+            }))
+        }
+    }
+
+    fn probe(found: bool) -> HarnessProbe {
+        HarnessProbe {
+            found,
+            binary_path: found.then(|| PathBuf::from("/usr/bin/engine")),
+            version: None,
+            authenticated: None,
+            stderr: if found {
+                String::new()
+            } else {
+                "engine: command not found".to_owned()
+            },
+            env: vec![(OsString::from("PATH"), OsString::from("/usr/bin"))],
+            commands: Vec::new(),
+        }
+    }
+
+    fn engine_over(adapter: Arc<FakeAdapter>, spec_probe: HarnessProbe) -> HarnessEngine {
+        HarnessEngine::new(HarnessEngineSpec {
+            adapter,
+            probe: spec_probe,
+            model: Some("fable-5".to_owned()),
+            reasoning_effort: Some(ReasoningEffort::High),
+            worktree: PathBuf::from("/workspace/repo"),
+            allowed_read_roots: vec![PathBuf::from("/workspace")],
+            trust_env: vec![(
+                OsString::from("SSL_CERT_FILE"),
+                OsString::from("/tmp/bundle.pem"),
+            )],
+            placeholder_credential: None,
+        })
+    }
+
+    fn request(input: &str) -> TurnRequest {
+        TurnRequest {
+            turn: 1,
+            source: TurnSource::SpawnTask,
+            input: input.to_owned(),
+        }
+    }
+
+    fn completed_event() -> HarnessEvent {
+        HarnessEvent::TurnCompleted {
+            usage: CodeUsage::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_clean_turn_with_a_completed_event_succeeds() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: Some(completed_event()),
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        assert_eq!(turn.wait().await, TurnEnd::Completed { success: true });
+        // The driver re-calls wait after every poll tick; the outcome must
+        // hold.
+        assert_eq!(turn.wait().await, TurnEnd::Completed { success: true });
+    }
+
+    #[tokio::test]
+    async fn a_failed_turn_completes_unsuccessfully() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: Some(HarnessEvent::TurnFailed {
+                error: tidebreak_core::BoundedError {
+                    message: "model refused".to_owned(),
+                },
+            }),
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        assert_eq!(turn.wait().await, TurnEnd::Completed { success: false });
+    }
+
+    /// A child that dies mid-turn is a failure, not a parked turn.
+    #[tokio::test]
+    async fn a_child_that_dies_mid_turn_is_fatal() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: None,
+            outcome: Ok(TurnOutcome::Incomplete {
+                detail: "exited with signal 9".to_owned(),
+            }),
+            waits_for_interrupt: false,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        assert_eq!(
+            turn.wait().await,
+            TurnEnd::Fatal {
+                message: "exited with signal 9".to_owned()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn an_interrupted_turn_reports_interrupted_not_fatal() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: None,
+            outcome: Ok(TurnOutcome::Incomplete {
+                detail: "exited with signal 2".to_owned(),
+            }),
+            waits_for_interrupt: true,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        turn.interrupt().await;
+        assert_eq!(turn.wait().await, TurnEnd::Interrupted);
+    }
+
+    /// Some engines acknowledge an interrupt in their own stream and still
+    /// end the process cleanly.
+    #[tokio::test]
+    async fn an_engine_reported_interrupt_reports_interrupted() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: Some(HarnessEvent::TurnInterrupted),
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        assert_eq!(turn.wait().await, TurnEnd::Interrupted);
+    }
+
+    #[tokio::test]
+    async fn a_lost_resume_is_fatal_never_a_fresh_start() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: None,
+            outcome: Err(HarnessError::ResumeLost("session gone".to_owned())),
+            waits_for_interrupt: false,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        let TurnEnd::Fatal { message } = turn.wait().await else {
+            panic!("expected fatal");
+        };
+        assert!(message.contains("session gone"));
+    }
+
+    #[tokio::test]
+    async fn the_terminal_state_clears_between_turns() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![
+            ScriptedTurn {
+                event: Some(HarnessEvent::TurnFailed {
+                    error: tidebreak_core::BoundedError {
+                        message: "first turn failed".to_owned(),
+                    },
+                }),
+                outcome: Ok(TurnOutcome::Clean),
+                waits_for_interrupt: false,
+            },
+            // No terminal event at all: a stale `Failed` from turn one would
+            // wrongly fail this turn too.
+            ScriptedTurn {
+                event: None,
+                outcome: Ok(TurnOutcome::Clean),
+                waits_for_interrupt: false,
+            },
+        ]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut first = engine.start_turn(request("one")).await.unwrap();
+        assert_eq!(first.wait().await, TurnEnd::Completed { success: false });
+        let mut second = engine.start_turn(request("two")).await.unwrap();
+        assert_eq!(second.wait().await, TurnEnd::Completed { success: true });
+    }
+
+    #[tokio::test]
+    async fn a_missing_binary_fails_the_first_turn_naming_the_engine() {
+        let adapter = Arc::new(FakeAdapter::scripted(Vec::new()));
+        let mut engine = engine_over(adapter, probe(false));
+        let Err(error) = engine.start_turn(request("go")).await else {
+            panic!("expected the missing binary to fail the turn");
+        };
+        assert!(error.message.contains("claude_code"));
+        assert!(error.message.contains("command not found"));
+    }
+
+    #[tokio::test]
+    async fn a_launch_failure_fails_the_first_turn() {
+        let adapter = Arc::new(FakeAdapter::scripted(Vec::new()));
+        *adapter.launch_error.lock().unwrap() =
+            Some(HarnessError::Other("no pty available".to_owned()));
+        let mut engine = engine_over(adapter, probe(true));
+        let Err(error) = engine.start_turn(request("go")).await else {
+            panic!("expected the launch failure to fail the turn");
+        };
+        assert!(error.message.contains("no pty available"));
+    }
+
+    #[tokio::test]
+    async fn an_engine_without_a_steering_channel_keeps_the_message_queued() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: Some(completed_event()),
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        assert!(turn.steer("also do this".to_owned()).await.is_err());
+        assert_eq!(turn.wait().await, TurnEnd::Completed { success: true });
+    }
+
+    #[tokio::test]
+    async fn the_launch_runs_allow_with_the_trust_environment() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: Some(completed_event()),
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let captured = adapter.captured.clone();
+        let mut engine = engine_over(adapter, probe(true));
+        engine.start_turn(request("go")).await.unwrap();
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.permission_mode, Some(PermissionMode::Allow));
+        assert_eq!(captured.model.as_deref(), Some("fable-5"));
+        assert_eq!(captured.reasoning_effort, Some(ReasoningEffort::High));
+        // No placeholder credential: no wiring at all, ambient credentials.
+        assert_eq!(captured.relay_key_env, None);
+        assert!(captured.extra_argv.is_empty());
+        assert!(captured.extra_env.is_empty());
+        // The trust pair joined the probe's environment snapshot.
+        assert!(captured
+            .env
+            .iter()
+            .any(|(name, value)| name == "SSL_CERT_FILE" && value == "/tmp/bundle.pem"));
+        assert!(captured.env.iter().any(|(name, _)| name == "PATH"));
+    }
+
+    #[tokio::test]
+    async fn a_placeholder_credential_wires_the_engine_at_its_vendor_base() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: Some(completed_event()),
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let captured = adapter.captured.clone();
+        let mut engine = engine_over(adapter, probe(true));
+        engine.spec.placeholder_credential = Some("placeholder".to_owned());
+        engine.start_turn(request("go")).await.unwrap();
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.relay_key_env.as_deref(), Some(RELAY_KEY_ENV));
+        assert!(captured
+            .extra_env
+            .iter()
+            .any(|(name, value)| name == "ANTHROPIC_BASE_URL" && value == ANTHROPIC_BASE));
+        assert!(captured
+            .extra_env
+            .iter()
+            .any(|(name, value)| name == "ANTHROPIC_AUTH_TOKEN" && value == "placeholder"));
+    }
+
+    #[tokio::test]
+    async fn the_worktree_and_read_roots_reach_the_launch() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: Some(completed_event()),
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        // Assert through the session spec by capturing paths too.
+        let mut engine = engine_over(adapter.clone(), probe(true));
+        engine.start_turn(request("go")).await.unwrap();
+        // Paths are fixed in `engine_over`; a wrong worktree would have been
+        // caught by the adapter refusing a relative read root at launch.
+        assert!(Path::new("/workspace").is_absolute());
+        let _ = adapter;
+    }
+}

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -20,12 +20,14 @@
 //!   [`TurnEnd::Fatal`] and the run exits nonzero, unless the driver itself
 //!   interrupted the turn.
 //!
-//! Inference wiring: when the environment hands the pod a placeholder
-//! credential, each engine is configured at its vendor-default base with that
-//! placeholder, and the environment's interception boundary swaps it for a
-//! real credential per destination. Without a placeholder — a hand-run agent,
-//! most often — no wiring is applied and the engine uses whatever credentials
-//! it already has.
+//! Inference wiring: a sandboxed pod carries a placeholder credential and
+//! the gateway URL its confinement boundary serves inference through. Every
+//! engine is pointed at that gateway's protocol roots — the boundary
+//! recognizes gateway traffic by authority, so an engine configured at a
+//! vendor-default base would be talking to an unlisted destination, not
+//! getting a credential swap. Without a placeholder — a hand-run agent,
+//! most often — no wiring is applied and the engine uses whatever
+//! credentials it already has.
 
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -39,7 +41,7 @@ use tidebreak_harness::{
     SessionSpec, TurnInput, TurnOutcome,
 };
 
-use crate::engine::{Engine, EngineError, SteerRefused, TurnEnd, TurnHandle, TurnRequest};
+use crate::engine::{Engine, EngineError, SteerOutcome, TurnEnd, TurnHandle, TurnRequest};
 
 /// The placeholder credential the environment hands a sandboxed pod.
 ///
@@ -49,18 +51,66 @@ use crate::engine::{Engine, EngineError, SteerRefused, TurnEnd, TurnHandle, Turn
 /// such an environment and no wiring is applied.
 pub const PLACEHOLDER_TOKEN_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_PLACEHOLDER_TOKEN";
 
+/// The gateway base URL the environment writes on every sandboxed pod.
+///
+/// The confinement boundary recognizes gateway traffic by authority:
+/// inference must go to this host, and `/compat/anthropic` and
+/// `/compat/openai` are the protocol roots hanging off it.
+pub const GATEWAY_URL_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_GATEWAY_URL";
+
 /// Environment variable name the wiring carries the credential under, for
 /// engines whose clients read it from the environment.
 pub const RELAY_KEY_ENV: &str = "TIDEBREAK_LLM_KEY";
 
-const ANTHROPIC_BASE: &str = "https://api.anthropic.com";
-const OPENAI_BASE: &str = "https://api.openai.com";
-const XAI_BASE: &str = "https://api.x.ai";
+/// The environment's inference contract, resolved from the pod's variables.
+#[derive(Debug)]
+pub struct GatewayInference {
+    /// The placeholder credential the boundary swaps for a real one.
+    pub placeholder_credential: String,
+    /// The gateway root every engine's protocol base derives from.
+    pub gateway_url: String,
+}
 
-/// Reads the placeholder credential, treating empty the same as absent.
-#[must_use]
-pub fn placeholder_credential_from_env() -> Option<String> {
-    std::env::var(PLACEHOLDER_TOKEN_VARIABLE)
+/// Resolves the inference contract from the environment.
+///
+/// No placeholder means a hand-run agent on ambient credentials: no wiring.
+/// A placeholder without a usable gateway URL is a broken pod contract and
+/// fails loudly — configuring the engine at a vendor default would aim its
+/// first turn at a destination the confinement boundary refuses.
+pub fn gateway_inference_from_env() -> Result<Option<GatewayInference>, String> {
+    resolve_gateway_inference(
+        read_trimmed(PLACEHOLDER_TOKEN_VARIABLE),
+        read_trimmed(GATEWAY_URL_VARIABLE),
+    )
+}
+
+fn resolve_gateway_inference(
+    placeholder: Option<String>,
+    gateway_url: Option<String>,
+) -> Result<Option<GatewayInference>, String> {
+    let Some(placeholder_credential) = placeholder else {
+        return Ok(None);
+    };
+    let Some(gateway_url) = gateway_url else {
+        return Err(format!(
+            "{PLACEHOLDER_TOKEN_VARIABLE} is set but {GATEWAY_URL_VARIABLE} is missing or empty; \
+             a sandboxed pod always carries both"
+        ));
+    };
+    if !gateway_url.starts_with("https://") && !gateway_url.starts_with("http://") {
+        return Err(format!(
+            "{GATEWAY_URL_VARIABLE} is not an http(s) URL: {gateway_url}"
+        ));
+    }
+    Ok(Some(GatewayInference {
+        placeholder_credential,
+        gateway_url,
+    }))
+}
+
+/// Reads one variable, treating empty and whitespace the same as absent.
+fn read_trimmed(name: &str) -> Option<String> {
+    std::env::var(name)
         .ok()
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
@@ -83,8 +133,8 @@ pub struct HarnessEngineSpec {
     pub allowed_read_roots: Vec<PathBuf>,
     /// Outbound-trust variables every engine child carries.
     pub trust_env: Vec<(OsString, OsString)>,
-    /// The environment's placeholder credential, when the pod has one.
-    pub placeholder_credential: Option<String>,
+    /// The environment's inference contract, when the pod has one.
+    pub gateway_inference: Option<GatewayInference>,
 }
 
 /// Drives one engine CLI session through `tidebreak-harness`.
@@ -127,20 +177,18 @@ impl HarnessEngine {
             message: format!("the {} probe reported no binary path", self.kind),
         })?;
 
-        let (extra_argv, extra_env, relay_key_env) = match &self.spec.placeholder_credential {
-            Some(key) => {
-                let openai_base = if self.kind == HarnessKind::Grok {
-                    XAI_BASE
-                } else {
-                    OPENAI_BASE
-                };
+        let (extra_argv, extra_env, relay_key_env) = match &self.spec.gateway_inference {
+            Some(inference) => {
+                let root = inference.gateway_url.trim_end_matches('/');
+                let anthropic_base = format!("{root}/compat/anthropic");
+                let openai_base = format!("{root}/compat/openai");
                 let (argv, env) = spawn_wiring(
                     self.kind,
                     &InferenceWiring {
-                        anthropic_base: ANTHROPIC_BASE,
-                        openai_base,
+                        anthropic_base: &anthropic_base,
+                        openai_base: &openai_base,
                         key_env: RELAY_KEY_ENV,
-                        key,
+                        key: &inference.placeholder_credential,
                     },
                 );
                 (argv, env, Some(RELAY_KEY_ENV.to_owned()))
@@ -333,11 +381,28 @@ impl TurnHandle for HarnessTurn {
         ended
     }
 
-    async fn steer(&mut self, body: String) -> Result<(), SteerRefused> {
-        // Any refusal — an engine with no mid-turn channel, or one that
-        // rejected this particular steer — keeps the message queued for the
-        // next turn.
-        self.session.steer(body).await.map_err(|_| SteerRefused)
+    async fn steer(&mut self, body: String) -> SteerOutcome {
+        if let Some(ended) = &self.ended {
+            return SteerOutcome::Ended(ended.clone());
+        }
+        let session = Arc::clone(&self.session);
+        let joined = tokio::select! {
+            biased;
+            joined = &mut self.run => joined,
+            result = session.steer(body) => {
+                // Any refusal — an engine with no mid-turn channel, or one
+                // that rejected this steer — keeps the message queued for the
+                // next turn.
+                return if result.is_ok() {
+                    SteerOutcome::Delivered
+                } else {
+                    SteerOutcome::Refused
+                };
+            }
+        };
+        let ended = self.conclude(joined);
+        self.ended = Some(ended.clone());
+        SteerOutcome::Ended(ended)
     }
 
     async fn interrupt(&mut self) {
@@ -352,6 +417,7 @@ impl TurnHandle for HarnessTurn {
 mod tests {
     use std::collections::VecDeque;
     use std::path::Path;
+    use std::time::Duration;
 
     use tidebreak_core::{CapLevel, CodeUsage, HarnessCaps};
     use tidebreak_harness::{ApprovalDecision, HarnessApprovalRef, HostEnv};
@@ -425,6 +491,8 @@ mod tests {
     #[derive(Default)]
     struct CapturedSpec {
         permission_mode: Option<PermissionMode>,
+        worktree: Option<PathBuf>,
+        allowed_read_roots: Vec<PathBuf>,
         extra_argv: Vec<String>,
         extra_env: Vec<(String, String)>,
         relay_key_env: Option<String>,
@@ -482,6 +550,8 @@ mod tests {
             }
             *self.captured.lock().unwrap() = CapturedSpec {
                 permission_mode: Some(spec.permission_mode),
+                worktree: Some(spec.worktree),
+                allowed_read_roots: spec.allowed_read_roots,
                 extra_argv: spec.extra_argv,
                 extra_env: spec.extra_env,
                 relay_key_env: spec.relay_key_env,
@@ -525,7 +595,7 @@ mod tests {
                 OsString::from("SSL_CERT_FILE"),
                 OsString::from("/tmp/bundle.pem"),
             )],
-            placeholder_credential: None,
+            gateway_inference: None,
         })
     }
 
@@ -697,7 +767,27 @@ mod tests {
         }]));
         let mut engine = engine_over(adapter, probe(true));
         let mut turn = engine.start_turn(request("go")).await.unwrap();
-        assert!(turn.steer("also do this".to_owned()).await.is_err());
+        assert_eq!(
+            turn.steer("also do this".to_owned()).await,
+            SteerOutcome::Refused
+        );
+        assert_eq!(turn.wait().await, TurnEnd::Completed { success: true });
+    }
+
+    #[tokio::test]
+    async fn a_completed_turn_wins_over_a_late_steer() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            event: Some(completed_event()),
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(
+            turn.steer("too late".to_owned()).await,
+            SteerOutcome::Ended(TurnEnd::Completed { success: true })
+        );
         assert_eq!(turn.wait().await, TurnEnd::Completed { success: true });
     }
 
@@ -729,7 +819,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_placeholder_credential_wires_the_engine_at_its_vendor_base() {
+    async fn a_placeholder_credential_wires_the_engine_at_the_gateway() {
         let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
             event: Some(completed_event()),
             outcome: Ok(TurnOutcome::Clean),
@@ -737,19 +827,40 @@ mod tests {
         }]));
         let captured = adapter.captured.clone();
         let mut engine = engine_over(adapter, probe(true));
-        engine.spec.placeholder_credential = Some("placeholder".to_owned());
+        // The trailing slash must not double up in the derived roots.
+        engine.spec.gateway_inference = Some(GatewayInference {
+            placeholder_credential: "placeholder".to_owned(),
+            gateway_url: "https://gateway.internal:8443/".to_owned(),
+        });
         engine.start_turn(request("go")).await.unwrap();
 
         let captured = captured.lock().unwrap();
         assert_eq!(captured.relay_key_env.as_deref(), Some(RELAY_KEY_ENV));
-        assert!(captured
-            .extra_env
-            .iter()
-            .any(|(name, value)| name == "ANTHROPIC_BASE_URL" && value == ANTHROPIC_BASE));
+        assert!(captured.extra_env.iter().any(|(name, value)| {
+            name == "ANTHROPIC_BASE_URL"
+                && value == "https://gateway.internal:8443/compat/anthropic"
+        }));
         assert!(captured
             .extra_env
             .iter()
             .any(|(name, value)| name == "ANTHROPIC_AUTH_TOKEN" && value == "placeholder"));
+    }
+
+    /// The placeholder never stands alone: without a gateway URL the pod
+    /// contract is broken, and wiring an engine anywhere else would aim it
+    /// at a destination the confinement boundary refuses.
+    #[test]
+    fn a_placeholder_without_a_gateway_url_is_refused() {
+        let error = resolve_gateway_inference(Some("placeholder".to_owned()), None).unwrap_err();
+        assert!(error.contains(GATEWAY_URL_VARIABLE));
+        let error = resolve_gateway_inference(
+            Some("placeholder".to_owned()),
+            Some("gateway.internal:8443".to_owned()),
+        )
+        .unwrap_err();
+        assert!(error.contains("http"));
+        // No placeholder: a hand-run agent, no wiring, no complaint.
+        assert!(resolve_gateway_inference(None, None).unwrap().is_none());
     }
 
     #[tokio::test]
@@ -759,12 +870,18 @@ mod tests {
             outcome: Ok(TurnOutcome::Clean),
             waits_for_interrupt: false,
         }]));
-        // Assert through the session spec by capturing paths too.
-        let mut engine = engine_over(adapter.clone(), probe(true));
+        let captured = adapter.captured.clone();
+        let mut engine = engine_over(adapter, probe(true));
         engine.start_turn(request("go")).await.unwrap();
-        // Paths are fixed in `engine_over`; a wrong worktree would have been
-        // caught by the adapter refusing a relative read root at launch.
-        assert!(Path::new("/workspace").is_absolute());
-        let _ = adapter;
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(
+            captured.worktree.as_deref(),
+            Some(Path::new("/workspace/repo"))
+        );
+        assert_eq!(
+            captured.allowed_read_roots,
+            vec![PathBuf::from("/workspace")]
+        );
     }
 }

--- a/crates/tidebreak-supervised-agent/src/inputs.rs
+++ b/crates/tidebreak-supervised-agent/src/inputs.rs
@@ -17,6 +17,8 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use tidebreak_core::HarnessKind;
+
 use crate::EXIT_MISSING_INPUT;
 
 /// The task handed to the agent. Required.
@@ -47,6 +49,16 @@ pub const FORGE_PUSH_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_FORGE_PUSH";
 pub const SANDBOX_ID_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_ID";
 /// Incarnation counter for reincarnation-aware naming.
 pub const INCARNATION_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_INCARNATION";
+/// Engine CLI the agent drives, as a `HarnessKind` token. Defaults to
+/// `claude_code`.
+///
+/// This one is Tidebreak's own, not part of the environment's contract: the
+/// environment declares no engine selector for a custom workload, so the pod
+/// specification that installs the agent also picks its engine. An
+/// unrecognized token fails loudly rather than silently running the default,
+/// because a typo here would otherwise drive the wrong engine for the whole
+/// run.
+pub const ENGINE_VARIABLE: &str = "TIDEBREAK_AGENT_ENGINE";
 
 const DEFAULT_SUPERVISOR_ENDPOINT: &str = "127.0.0.1:15003";
 /// Poll cadence, matching the endpoint's expected liveness rhythm.
@@ -97,6 +109,8 @@ pub struct Inputs {
     pub sandbox_id: Option<String>,
     /// Incarnation counter, defaulting to 1.
     pub incarnation: u32,
+    /// Engine CLI the agent drives.
+    pub engine: HarnessKind,
 }
 
 /// A missing or unusable input, carrying the exit code and the variable name.
@@ -142,6 +156,7 @@ pub struct RawInputs {
     pub forge_push: Option<String>,
     pub sandbox_id: Option<String>,
     pub incarnation: Option<String>,
+    pub engine: Option<String>,
 }
 
 impl RawInputs {
@@ -164,6 +179,7 @@ impl RawInputs {
             forge_push: var(FORGE_PUSH_VARIABLE),
             sandbox_id: var(SANDBOX_ID_VARIABLE),
             incarnation: var(INCARNATION_VARIABLE),
+            engine: var(ENGINE_VARIABLE),
         }
     }
 }
@@ -252,6 +268,21 @@ pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
         .and_then(|value| value.parse::<u32>().ok())
         .unwrap_or(1);
 
+    let engine = match optional(raw.engine) {
+        None => HarnessKind::ClaudeCode,
+        Some(token) => HarnessKind::from_str(&token).ok_or_else(|| {
+            let known = HarnessKind::ALL
+                .iter()
+                .map(|kind| kind.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            InputError::unusable(
+                ENGINE_VARIABLE,
+                &format!("unknown engine {token:?}; expected one of {known}"),
+            )
+        })?,
+    };
+
     Ok(Inputs {
         task,
         control_url,
@@ -265,6 +296,7 @@ pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
         forge_push_denied,
         sandbox_id: optional(raw.sandbox_id),
         incarnation,
+        engine,
     })
 }
 
@@ -432,5 +464,32 @@ mod tests {
             ..minimal()
         };
         assert!(resolve(raw).unwrap().repositories.is_empty());
+    }
+
+    #[test]
+    fn the_engine_defaults_to_claude_code() {
+        assert_eq!(resolve(minimal()).unwrap().engine, HarnessKind::ClaudeCode);
+    }
+
+    #[test]
+    fn a_declared_engine_is_honored() {
+        let raw = RawInputs {
+            engine: Some("codex".to_owned()),
+            ..minimal()
+        };
+        assert_eq!(resolve(raw).unwrap().engine, HarnessKind::Codex);
+    }
+
+    /// A typo must not silently drive the default engine for the whole run.
+    #[test]
+    fn an_unknown_engine_fails_naming_the_variable_and_the_tokens() {
+        let raw = RawInputs {
+            engine: Some("claude".to_owned()),
+            ..minimal()
+        };
+        let error = resolve(raw).unwrap_err();
+        assert_eq!(error.code, EXIT_MISSING_INPUT);
+        assert!(error.message.contains(ENGINE_VARIABLE));
+        assert!(error.message.contains("claude_code"));
     }
 }

--- a/crates/tidebreak-supervised-agent/src/lib.rs
+++ b/crates/tidebreak-supervised-agent/src/lib.rs
@@ -7,16 +7,21 @@
 //! reports lifecycle events outward. It runs no listener, accepts no attach,
 //! and keeps no durable state of its own: the endpoint's cursor is the truth.
 //!
-//! This crate is a library for now. The binary arrives with the engine-drive
-//! slice; until then the modules here are the poll client, the environment
-//! contract, and the turn state machine, each testable against an in-process
-//! mock endpoint.
+//! The crate ships one binary, `tidebreak-supervised-agent`, assembled from
+//! modules that stay individually testable against an in-process mock
+//! endpoint: the environment contract ([`inputs`]), trust and clone
+//! preparation ([`trust`], [`bootstrap`]), the poll client ([`control`],
+//! [`wire`]), the turn state machine ([`drive`]), and the engine seam
+//! ([`engine`]) with its `tidebreak-harness` implementation
+//! ([`harness_engine`]).
 
 pub mod bootstrap;
 pub mod completion;
 pub mod control;
 pub mod drive;
+pub mod effort;
 pub mod engine;
+pub mod harness_engine;
 pub mod inputs;
 pub mod trust;
 pub mod wip;

--- a/crates/tidebreak-supervised-agent/src/main.rs
+++ b/crates/tidebreak-supervised-agent/src/main.rs
@@ -63,8 +63,15 @@ async fn run() -> i32 {
 
     let host = HostEnv::from_process();
     let probe = adapter.probe(&host).await;
-    let ladder = adapter.reasoning_efforts(&probe);
-    let effective = effort::reconcile(inputs.reasoning_effort.as_deref(), &ladder);
+    // Resolving the ladder can shell out to the engine's model catalog, so
+    // only do it when there is a request to reconcile.
+    let effective = match inputs.reasoning_effort.as_deref() {
+        Some(requested) => {
+            let ladder = effort::ladder(adapter.as_ref(), &probe, inputs.model.as_deref()).await;
+            effort::reconcile(Some(requested), &ladder)
+        }
+        None => None,
+    };
 
     let trust_options = TrustOptions::from_env();
     // Bootstrap blocks on the trust sidecar and on git; keep the runtime's

--- a/crates/tidebreak-supervised-agent/src/main.rs
+++ b/crates/tidebreak-supervised-agent/src/main.rs
@@ -24,7 +24,7 @@ use tidebreak_harness::HostEnv;
 use tidebreak_supervised_agent::control::Control;
 use tidebreak_supervised_agent::drive::Driver;
 use tidebreak_supervised_agent::harness_engine::{
-    placeholder_credential_from_env, HarnessEngine, HarnessEngineSpec,
+    gateway_inference_from_env, HarnessEngine, HarnessEngineSpec,
 };
 use tidebreak_supervised_agent::inputs::{resolve, RawInputs};
 use tidebreak_supervised_agent::trust::TrustOptions;
@@ -42,6 +42,16 @@ async fn run() -> i32 {
         Err(error) => {
             eprintln!("{error}");
             return error.code;
+        }
+    };
+    // Part of the environment contract: a placeholder credential without a
+    // gateway URL is a broken pod, better refused here than at the first
+    // turn's inference request.
+    let gateway_inference = match gateway_inference_from_env() {
+        Ok(inference) => inference,
+        Err(error) => {
+            eprintln!("{error}");
+            return EXIT_MISSING_INPUT;
         }
     };
 
@@ -108,7 +118,7 @@ async fn run() -> i32 {
         worktree: workdir.clone(),
         allowed_read_roots,
         trust_env,
-        placeholder_credential: placeholder_credential_from_env(),
+        gateway_inference,
     });
 
     let wip = if !inputs.forge_push_denied && !bootstrap.clones.is_empty() {

--- a/crates/tidebreak-supervised-agent/src/main.rs
+++ b/crates/tidebreak-supervised-agent/src/main.rs
@@ -1,0 +1,150 @@
+//! The `tidebreak-supervised-agent` binary.
+//!
+//! Assembly order matters and each failure has a distinct voice:
+//!
+//! 1. Resolve the environment contract; a missing or unusable input exits
+//!    with its own code before anything runs.
+//! 2. Probe the selected engine on this image and reconcile the requested
+//!    reasoning effort against its ladder, so bootstrap can report what
+//!    actually applied.
+//! 3. Bootstrap: wait for outbound trust, clone the declared repositories,
+//!    and collect the lifecycle events describing that work.
+//! 4. Hand everything to the driver, which reports those events on its first
+//!    poll and then runs the turn loop until the endpoint stops the run.
+//!
+//! Failures before the driver starts print to stderr — the pod log is the
+//! only witness that early. Once the driver is polling, failures also reach
+//! the supervising endpoint as lifecycle events.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use tidebreak_harness::builtin_registry;
+use tidebreak_harness::HostEnv;
+use tidebreak_supervised_agent::control::Control;
+use tidebreak_supervised_agent::drive::Driver;
+use tidebreak_supervised_agent::harness_engine::{
+    placeholder_credential_from_env, HarnessEngine, HarnessEngineSpec,
+};
+use tidebreak_supervised_agent::inputs::{resolve, RawInputs};
+use tidebreak_supervised_agent::trust::TrustOptions;
+use tidebreak_supervised_agent::wip::WipContext;
+use tidebreak_supervised_agent::{bootstrap, effort, EXIT_MISSING_INPUT};
+
+#[tokio::main]
+async fn main() {
+    std::process::exit(run().await);
+}
+
+async fn run() -> i32 {
+    let inputs = match resolve(RawInputs::from_env()) {
+        Ok(inputs) => inputs,
+        Err(error) => {
+            eprintln!("{error}");
+            return error.code;
+        }
+    };
+
+    let registry = builtin_registry();
+    let Some(adapter) = registry.get(inputs.engine) else {
+        eprintln!("no adapter is registered for engine {}", inputs.engine);
+        return EXIT_MISSING_INPUT;
+    };
+
+    let host = HostEnv::from_process();
+    let probe = adapter.probe(&host).await;
+    let ladder = adapter.reasoning_efforts(&probe);
+    let effective = effort::reconcile(inputs.reasoning_effort.as_deref(), &ladder);
+
+    let trust_options = TrustOptions::from_env();
+    // Bootstrap blocks on the trust sidecar and on git; keep the runtime's
+    // workers free while it does.
+    let bootstrap = {
+        let inputs = inputs.clone();
+        let trust_options = trust_options.clone();
+        let joined = tokio::task::spawn_blocking(move || {
+            bootstrap::run(
+                &inputs,
+                &trust_options,
+                effective.map(tidebreak_core::ReasoningEffort::as_str),
+            )
+        })
+        .await;
+        match joined {
+            Ok(Ok(bootstrap)) => bootstrap,
+            Ok(Err(error)) => {
+                eprintln!("{error}");
+                return 1;
+            }
+            Err(error) => {
+                eprintln!("the bootstrap task failed: {error}");
+                return 1;
+            }
+        }
+    };
+
+    let workdir = canonical(&bootstrap.workdir);
+    let workspace = canonical(&inputs.workspace);
+    // The engine may read the workspace around its worktree when the run
+    // cloned into a subdirectory of it.
+    let allowed_read_roots = if workspace == workdir {
+        Vec::new()
+    } else {
+        vec![workspace]
+    };
+
+    let trust_env: Vec<(OsString, OsString)> = bootstrap
+        .trust
+        .environment()
+        .iter()
+        .map(|(name, path)| (OsString::from(name), path.as_os_str().to_owned()))
+        .collect();
+
+    let engine = HarnessEngine::new(HarnessEngineSpec {
+        adapter,
+        probe,
+        model: inputs.model.clone(),
+        reasoning_effort: effective,
+        worktree: workdir.clone(),
+        allowed_read_roots,
+        trust_env,
+        placeholder_credential: placeholder_credential_from_env(),
+    });
+
+    let wip = if !inputs.forge_push_denied && !bootstrap.clones.is_empty() {
+        Some(
+            WipContext::capture(
+                inputs
+                    .sandbox_id
+                    .clone()
+                    .unwrap_or_else(|| "local".to_owned()),
+                inputs.incarnation,
+                &bootstrap.clones,
+                bootstrap.trust.clone(),
+            )
+            .await,
+        )
+    } else {
+        None
+    };
+
+    let mut driver = Driver::new(Control::new(&inputs.control_url), engine, &inputs)
+        .preload_events(bootstrap.events)
+        .with_workdir(workdir);
+    if let Some(wip) = wip {
+        driver = driver.with_wip(wip);
+    }
+    match driver.run().await {
+        Ok(()) => 0,
+        Err(error) => {
+            eprintln!("{}", error.message);
+            error.code
+        }
+    }
+}
+
+/// Resolves symlinks so path comparisons and git commands agree; a path that
+/// cannot be canonicalized is used as declared.
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}


### PR DESCRIPTION
## What changed

- Add the supervised-agent binary and drive Claude Code, Codex, OpenCode, or Grok through `tidebreak-harness`.
- Map the requested reasoning effort to each engine capability ladder and pass the declared worktree and read roots into the launch.
- When the sandbox placeholder credential is present, require the gateway URL and point engines at its `/compat/anthropic` and `/compat/openai` protocol roots.
- Make engine steering race completion so a dead turn cannot acknowledge a message, and cover the completion-first path with a harness regression.

## Validation

- `cargo test -p tidebreak-supervised-agent` — 75 passed.
- `cargo test -p tidebreak-harness` — 318 passed.
- `python3 scripts/adr.py check` — 78 decisions verified and the manifest is synchronized.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Compatibility and risk

This introduces a standalone binary and its environment contract. Existing desktop and server engine launches remain unchanged.