### PR TITLE
fix(desktop): keep settled work-mode command cards folded

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -70,7 +71,8 @@ describe("AgentActivityTimeline", () => {
     expect(screen.queryByRole("list")).toBeNull();
   });
 
-  it("gives a failed command an open card with its headline, exit status, and captured output", () => {
+  it("gives a failed command a folded card that reveals headline, exit status, and captured output", async () => {
+    const user = userEvent.setup();
     const { rerender } = render(
       <AgentActivityTimeline state={state} active={false} expanded />,
     );
@@ -81,10 +83,18 @@ describe("AgentActivityTimeline", () => {
     const card = within(commandRow).getByRole("button", {
       name: /pip install matplotlib/,
     });
-    expect(card.getAttribute("aria-expanded")).toBe("true");
+    expect(card.getAttribute("aria-expanded")).toBe("false");
     expect(card.querySelector(".font-mono")?.textContent).toBe(
       "pip install matplotlib",
     );
+    expect(within(commandRow).queryByText("Exit 1")).toBeNull();
+    expect(
+      within(commandRow).queryByText(/ERROR: no matching distribution/),
+    ).toBeNull();
+
+    await user.click(card);
+
+    expect(card.getAttribute("aria-expanded")).toBe("true");
     expect(within(commandRow).getByText("Exit 1")).toBeTruthy();
     expect(
       within(commandRow).getByText(/ERROR: no matching distribution/),
@@ -109,7 +119,7 @@ describe("AgentActivityTimeline", () => {
     expect(screen.getByText("No output captured.")).toBeTruthy();
   });
 
-  it("leads a narrated command with its sentence and keeps the command line in the body", () => {
+  it("leads a narrated command with its sentence and keeps the command line in the body", async () => {
     const narrated: AgentActivityState = {
       ...state,
       items: state.items.map((item, index) =>
@@ -127,6 +137,7 @@ describe("AgentActivityTimeline", () => {
           : item,
       ),
     };
+    const user = userEvent.setup();
     render(<AgentActivityTimeline state={narrated} active={false} expanded />);
 
     const commandRow = within(screen.getByRole("list")).getAllByRole(
@@ -137,6 +148,7 @@ describe("AgentActivityTimeline", () => {
     });
     // The sentence is prose, so it does not wear the command's monospace.
     expect(card.querySelector(".font-mono")).toBeNull();
+    await user.click(card);
     // The literal action is not lost: the open body still carries it.
     expect(within(commandRow).getByText("pip install matplotlib")).toBeTruthy();
   });

--- a/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
@@ -251,7 +251,8 @@ type ExecActivityDetail = Extract<
  * A command step's row: the same boxless expandable chrome a foreground exec
  * call and code mode use. The body holds the outcome, full unelided command
  * line and, once the step has settled, the tail of what the command printed;
- * a failed row starts open so the reader lands on what failed.
+ * a settled row, including a failed one, stays folded until the reader
+ * opens it.
  */
 function ExecActivityCard({
   detail,
@@ -278,7 +279,6 @@ function ExecActivityCard({
       badge={
         <ExecActivityBadge outcome={outcome} exitCode={detail.exit_code} />
       }
-      defaultExpanded={failed}
       className={cn(failed && "text-critical")}
       // The assistive label names the command, not the sentence about it: it
       // stands in for a title the reader can see but a screen reader would

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.dom.test.tsx
@@ -87,4 +87,55 @@ describe("ToolCommandCard expansion", () => {
     expect(screen.getByText("Done")).toBeTruthy();
     expect(screen.getByLabelText("Output")).toHaveTextContent("rendered");
   });
+
+  it("keeps a failed command folded until the reader opens it", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ToolCommandCard
+        name="exec"
+        status="failed"
+        preview={preview}
+        result={{
+          tool: "exec",
+          exitCode: 101,
+          timedOut: false,
+          outputTruncated: false,
+          stdout: "",
+          stderr: "module not found\n",
+          backend: "local",
+        }}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /python3 render.py/ });
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Exit 101")).toBeNull();
+    expect(screen.queryByText(/module not found/)).toBeNull();
+
+    await user.click(row);
+
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Exit 101")).toBeTruthy();
+    expect(screen.getByLabelText("Output")).toHaveTextContent(
+      "module not found",
+    );
+
+    rerender(
+      <ToolCommandCard
+        name="exec"
+        status="failed"
+        preview={preview}
+        result={{
+          tool: "exec",
+          exitCode: null,
+          timedOut: true,
+          outputTruncated: false,
+          stdout: "",
+          stderr: "",
+          backend: "local",
+        }}
+      />,
+    );
+    expect(screen.getByText("Timed out")).toBeTruthy();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.test.tsx
@@ -1,6 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import type { ExecResultPreview } from "./api";
 import { toolPreviewPresentation } from "./ToolPreview";
 import {
   ToolCommandCard,
@@ -153,8 +152,18 @@ describe("ToolCommandCard", () => {
       />,
     );
 
+    const failed = renderToStaticMarkup(
+      <ToolCommandCard
+        name="exec"
+        status="failed"
+        preview={preview}
+        result={null}
+      />,
+    );
+
     expect(running).toContain('aria-expanded="true"');
     expect(done).toContain('aria-expanded="false"');
+    expect(failed).toContain('aria-expanded="false"');
   });
 
   it("keeps settled metadata in the expanded detail", () => {
@@ -192,9 +201,21 @@ describe("ToolCommandCard", () => {
     expect(completed).not.toContain("Done");
     expect(waiting).not.toContain("Waiting for approval");
     expect(cancelled).not.toContain("Not run");
+    expect(
+      visibleText(
+        renderToStaticMarkup(
+          <ToolCommandCard
+            name="exec"
+            status="failed"
+            preview={preview}
+            result={null}
+          />,
+        ),
+      ),
+    ).not.toContain("Failed");
 
-    // Active and failed commands start open, so their status is already part
-    // of the detail the reader needs now.
+    // A live command starts open, so its status is already part of the
+    // detail the reader needs now.
     expect(
       visibleText(
         renderToStaticMarkup(
@@ -207,18 +228,6 @@ describe("ToolCommandCard", () => {
         ),
       ),
     ).toContain("Running…");
-    expect(
-      visibleText(
-        renderToStaticMarkup(
-          <ToolCommandCard
-            name="exec"
-            status="failed"
-            preview={preview}
-            result={null}
-          />,
-        ),
-      ),
-    ).toContain("Failed");
   });
 
   it("says a degraded run is degraded without needing the card opened", () => {
@@ -372,41 +381,5 @@ describe("command output", () => {
 
     expect(markup).toContain('role="tab"');
     expect(visibleText(markup)).toContain("Waiting for output…");
-  });
-});
-
-describe("outcome badges", () => {
-  const ran: ExecResultPreview = {
-    tool: "exec",
-    exitCode: 0,
-    timedOut: false,
-    outputTruncated: false,
-    stdout: "",
-    stderr: "",
-  };
-
-  it("prefers the most specific thing it can say about a failure", () => {
-    const badge = (
-      result: ExecResultPreview | null,
-      status: "completed" | "failed",
-    ) =>
-      visibleText(
-        renderToStaticMarkup(
-          <ToolCommandCard
-            name="exec"
-            status={status}
-            preview={preview}
-            result={result}
-          />,
-        ),
-      );
-
-    expect(badge({ ...ran, exitCode: 101 }, "failed")).toContain("Exit 101");
-    expect(
-      badge({ ...ran, exitCode: null, timedOut: true }, "failed"),
-    ).toContain("Timed out");
-    expect(badge(ran, "completed")).not.toContain("Done");
-    // No result to be specific about yet.
-    expect(badge(null, "failed")).toContain("Failed");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
@@ -268,8 +268,8 @@ const FALLBACK_TOOL: ToolPresentation = {
  * does not read shell. A call that narrated nothing falls back to the command
  * itself, in monospace. Either way the literal command and its output are in
  * the body, one click away. It opens while the command is still running;
- * otherwise it collapses back to one line once the badge carries the
- * outcome.
+ * a settled card, including a failed one, collapses back to one line once
+ * the badge carries the outcome.
  *
  * Only tools that project a preview get a card. Everything else lives in the
  * activity rail, where a line of text is the whole story the renderer has.
@@ -321,7 +321,7 @@ export function ToolCommandCard({
         trailing={
           <ToolStatusIcon tone={presentation.tone} className="size-3.5" />
         }
-        defaultExpanded={running || presentation.tone === "failed"}
+        defaultExpanded={running}
       >
         {tabbed ? (
           <Tabs defaultValue="output">

--- a/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
@@ -138,6 +138,33 @@ $ pnpm test -- TaskPlanCard.dom.test.tsx`}
           </div>
           <div>
             <p className="text-xs font-medium text-muted-foreground">
+              Failed (collapsed)
+            </p>
+            <ToolCardShell
+              icon={<FileText className="size-3.5" aria-hidden="true" />}
+              title="Checking the PowerPoint library"
+              label="Run a command: Tool could not complete"
+              badge={
+                <>
+                  <Badge variant="outline">Local</Badge>
+                  <Badge variant="outline" className="text-destructive">
+                    Exit 1
+                  </Badge>
+                </>
+              }
+              trailing={
+                <CircleAlert className="text-muted-foreground size-3.5" />
+              }
+            >
+              <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+                <pre className="whitespace-pre-wrap">
+                  {`Error: Cannot find module 'pptxgenjs'`}
+                </pre>
+              </div>
+            </ToolCardShell>
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">
               Settled (collapsed)
             </p>
             <ToolCardShell


### PR DESCRIPTION
Failed exec rows in work mode opened themselves and filled the transcript with stderr. Settled command cards, including failed ones, now stay folded. Click a row to inspect the command, exit status, and output.

Running commands still open while they run.

## Test plan
- Open a work chat whose transcript includes failed execs. Confirm those rows start folded and that the CircleAlert glyph remains on the row.
- Expand a failed row. Confirm Local/Exit badges and output appear.
- Confirm a running command still starts expanded.