### PR TITLE
fix(desktop): screenshot-review permission and repo-settings stories

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
@@ -5,7 +5,6 @@ import type { ApiClient } from "@/api/client";
 import type { CodeRepoSnapshot, QuickAction } from "@/api/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { friendlyErrorMessage } from "@/lib/utils";
@@ -223,18 +222,21 @@ export function RepositorySettings({
             checkout in place and marks the workspace Setup failed.
           </p>
         </div>
-        {(loading || busy) && <LoaderCircle className="size-4 animate-spin" />}
+        {(loading || busy) && (
+          <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
+        )}
       </div>
       {error && (
-        <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-critical-border bg-critical-background px-3 py-2 text-xs text-critical-foreground-muted">
-          <span className="flex items-start gap-2">
+        <div className="mb-4 flex flex-col items-stretch gap-2 rounded-md border border-critical-border bg-critical-background px-3 py-2 text-xs text-critical-foreground-muted min-[480px]:flex-row min-[480px]:items-center min-[480px]:justify-between">
+          <span className="flex min-w-0 items-start gap-2">
             <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
-            {error}
+            <span className="min-w-0">{error}</span>
           </span>
           <Button
             type="button"
             size="xs"
             variant="outline"
+            className="shrink-0 self-end min-[480px]:self-auto"
             disabled={loading}
             onClick={() => void load()}
           >
@@ -244,16 +246,10 @@ export function RepositorySettings({
       )}
       {!loading && draft && (
         <div className="flex flex-col gap-4">
-          <div className="grid grid-cols-2 gap-3">
-            <div className="flex flex-col gap-1.5">
-              <Label
-                htmlFor="repo-settings-base-ref"
-                className="text-xs text-muted-foreground"
-              >
-                Base ref
-              </Label>
+          <div className="grid grid-cols-1 gap-3 min-[520px]:grid-cols-2">
+            <label className="flex min-w-0 flex-col gap-1.5">
+              <span className="text-xs text-muted-foreground">Base ref</span>
               <Input
-                id="repo-settings-base-ref"
                 className="font-mono"
                 value={draft.default_base_ref}
                 placeholder="main"
@@ -262,16 +258,12 @@ export function RepositorySettings({
                 }
                 onBlur={() => void commit(draft)}
               />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label
-                htmlFor="repo-settings-branch-prefix"
-                className="text-xs text-muted-foreground"
-              >
+            </label>
+            <label className="flex min-w-0 flex-col gap-1.5">
+              <span className="text-xs text-muted-foreground">
                 Branch prefix
-              </Label>
+              </span>
               <Input
-                id="repo-settings-branch-prefix"
                 className="font-mono"
                 value={draft.branch_prefix}
                 placeholder="tidebreak/"
@@ -280,48 +272,44 @@ export function RepositorySettings({
                 }
                 onBlur={() => void commit(draft)}
               />
-            </div>
+            </label>
           </div>
-          <div className="flex flex-col gap-1.5">
-            <Label
-              htmlFor="repo-settings-setup-script"
-              className="text-xs text-muted-foreground"
-            >
-              Setup script
-            </Label>
-            <Textarea
-              id="repo-settings-setup-script"
-              className="min-h-16 font-mono"
-              rows={3}
-              value={draft.setup_script}
-              placeholder="pnpm install"
-              onChange={(event) =>
-                setDraft({ ...draft, setup_script: event.target.value })
-              }
-              onBlur={() => void commit(draft)}
-            />
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <label className="flex min-w-0 flex-col gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                Setup script
+              </span>
+              <Textarea
+                className="min-h-16 font-mono"
+                rows={3}
+                value={draft.setup_script}
+                placeholder="pnpm install"
+                onChange={(event) =>
+                  setDraft({ ...draft, setup_script: event.target.value })
+                }
+                onBlur={() => void commit(draft)}
+              />
+            </label>
             <p className="text-xs text-muted-foreground">
               Runs after a worktree is created or restored.
             </p>
           </div>
-          <div className="flex flex-col gap-1.5">
-            <Label
-              htmlFor="repo-settings-archive-script"
-              className="text-xs text-muted-foreground"
-            >
-              Archive script
-            </Label>
-            <Textarea
-              id="repo-settings-archive-script"
-              className="min-h-16 font-mono"
-              rows={3}
-              value={draft.archive_script}
-              placeholder="./scripts/back-up.sh"
-              onChange={(event) =>
-                setDraft({ ...draft, archive_script: event.target.value })
-              }
-              onBlur={() => void commit(draft)}
-            />
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <label className="flex min-w-0 flex-col gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                Archive script
+              </span>
+              <Textarea
+                className="min-h-16 font-mono"
+                rows={3}
+                value={draft.archive_script}
+                placeholder="./scripts/back-up.sh"
+                onChange={(event) =>
+                  setDraft({ ...draft, archive_script: event.target.value })
+                }
+                onBlur={() => void commit(draft)}
+              />
+            </label>
             <p className="text-xs text-muted-foreground">
               Runs before the worktree is removed. A failure stops the archive.
             </p>
@@ -368,10 +356,10 @@ export function RepositorySettings({
                     // is the only stable identity it has.
                     // eslint-disable-next-line react/no-array-index-key
                     key={index}
-                    className="flex items-center gap-2"
+                    className="flex min-w-0 flex-wrap items-center gap-2"
                   >
                     <Input
-                      className="w-36"
+                      className="min-w-24 flex-1 basis-28"
                       value={action.name}
                       placeholder="Test"
                       aria-label={`Quick action ${index + 1} name`}
@@ -389,7 +377,7 @@ export function RepositorySettings({
                       onBlur={() => draft && void commit(draft)}
                     />
                     <Input
-                      className="flex-1 font-mono"
+                      className="min-w-0 flex-[2] basis-40 font-mono"
                       value={action.command}
                       placeholder="cargo test"
                       aria-label={`Quick action ${index + 1} command`}
@@ -408,8 +396,6 @@ export function RepositorySettings({
                     />
                     <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
                       <Switch
-                        className="h-4 w-7"
-                        thumbClassName="size-3 data-[state=checked]:translate-x-3"
                         checked={action.auto_run_on_create}
                         aria-label={`Run quick action ${index + 1} on create`}
                         onCheckedChange={(checked) =>

--- a/crates/tidebreak-desktop/ui/src/code/SessionPermissionIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionPermissionIndicator.tsx
@@ -32,11 +32,11 @@ export function SessionPermissionIndicator({ mode }: { mode: PermissionMode }) {
         data-testid="session-permission-indicator"
         tabIndex={0}
         className={cn(
-          "inline-flex items-center gap-1 rounded-sm text-xs text-muted-foreground",
+          "inline-flex min-w-0 max-w-full items-center gap-1 rounded-sm text-xs text-muted-foreground",
           FOCUS_RING,
         )}
       >
-        <Icon className="size-3 shrink-0" aria-hidden="true" />
+        <Icon className="size-3.5 shrink-0" aria-hidden="true" />
         <span className="truncate">{PERMISSION_MODE_LABELS[mode]}</span>
       </span>
     </WithTooltip>

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceHeader.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceHeader.tsx
@@ -167,7 +167,7 @@ export function WorkspaceHeader({
           {sessionStatus && (
             <div
               className={cn(
-                "flex min-w-0 shrink-0 items-center gap-1",
+                "flex min-w-0 items-center gap-1 overflow-hidden",
                 workflow && "ml-auto min-[1100px]:ml-0",
               )}
             >

--- a/crates/tidebreak-desktop/ui/src/stories/PermissionModePicker.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/PermissionModePicker.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { PermissionModePicker } from "@/code/CodeComposer";
-import { CREATE_PERMISSION_MODE_FIXED } from "@/code/labels";
+import {
+  ALLOW_ALL_NOTE,
+  CREATE_PERMISSION_MODE_FIXED,
+  UNSUPERVISED_AUTO_NOTE,
+} from "@/code/labels";
 
 /**
  * Permission mode in the composer footer.
@@ -56,6 +60,42 @@ export const FixedAtCreate: Story = {
       <PermissionModePicker {...args} />
       <p className="text-muted-foreground px-2 text-xs">
         {CREATE_PERMISSION_MODE_FIXED}
+      </p>
+    </div>
+  ),
+};
+
+/**
+ * Create states Allow under the picker (decision 0039). A live session
+ * carries the header chip instead of this line.
+ */
+export const AllowAllNote: Story = {
+  args: {
+    value: "allow",
+    onChange: () => {},
+  },
+  render: (args) => (
+    <div className="flex min-w-0 max-w-sm flex-col">
+      <PermissionModePicker {...args} />
+      <p className="text-muted-foreground px-2 text-xs">{ALLOW_ALL_NOTE}</p>
+    </div>
+  ),
+};
+
+/**
+ * Auto on an engine with no approval channel (decision 0038). Same placement
+ * as Allow: under the control, not inside the menu row.
+ */
+export const UnsupervisedAutoNote: Story = {
+  args: {
+    value: "auto",
+    onChange: () => {},
+  },
+  render: (args) => (
+    <div className="flex min-w-0 max-w-sm flex-col">
+      <PermissionModePicker {...args} />
+      <p className="text-muted-foreground px-2 text-xs">
+        {UNSUPERVISED_AUTO_NOTE}
       </p>
     </div>
   ),

--- a/crates/tidebreak-desktop/ui/src/stories/RepositorySettings.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/RepositorySettings.stories.tsx
@@ -89,3 +89,17 @@ export const NotRegistered: Story = {
 export const LoadFailed: Story = {
   args: { client: client(null) as never },
 };
+
+/**
+ * The tracked-repos dialog is a dense column. Refs stack, quick-action rows
+ * wrap, and the error retry stays reachable instead of clipping the copy.
+ */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-[320px] px-3 py-4">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -816,6 +816,23 @@ export const GroupedByStatus: Story = {
           })}
         />
       </StatusGroup>
+      <StatusGroup rank="setup_failed" count={1}>
+        <WorkspaceCard
+          {...args}
+          workspace={{
+            ...codeWorkspace,
+            id: "ws-setup-failed",
+            title: "Rework the credential exchange",
+            status: "setup_failed",
+          }}
+          visibleMeta={{ repoChip: true, branch: true }}
+          commands={workspaceCommands({
+            hasPr: false,
+            archived: false,
+            setupFailed: true,
+          })}
+        />
+      </StatusGroup>
       <StatusGroup rank="idle" count={1}>
         <WorkspaceCard
           {...args}

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -272,6 +272,22 @@ export const PlansOnly: Story = {
   },
 };
 
+/**
+ * The permission chip sits in the same muted row as lifecycle. At this width
+ * the title and status wrap; the chip truncates instead of overflowing.
+ */
+export const NarrowAskChip: Story = {
+  args: { snapshot: openPrGit, permissionMode: "ask" },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-[360px] overflow-hidden rounded-xl border border-border-subtle bg-background">
+        <Story />
+        <div className="h-24 bg-background" />
+      </div>
+    ),
+  ],
+};
+
 export const Loading: Story = {
   args: { snapshot: null, loading: true },
 };


### PR DESCRIPTION
Closes #2843

## What changed

The Storybook stories from #2807 and #2818 never got a screenshot pass. This pass reviews them against DESIGN.md and the styles contract, then tightens the layout so the new surfaces stay on the type scale at header and dialog widths.

**Permission chip.** `SessionPermissionIndicator` now uses `size-3.5` so the icon matches the primary text line, and it truncates instead of overflowing. The workspace header no longer `shrink-0`s that status cluster, so the chip can give way at narrow widths.

**Repository settings.** Base ref and branch prefix stack below 520px. Quick-action rows wrap instead of clipping a fixed `w-36` name field. The on-create switch uses the shared Switch size. Load errors wrap so Try again stays reachable.

**Stories.** Add `NarrowAskChip`, `Repository settings / Narrow`, create-time Allow and unsupervised Auto notes (those statements were not on a story before), and a `setup_failed` group in `GroupedByStatus`.

## What you could not visually verify

This environment has no controllable browser and no Playwright/MCP screenshot path. Storybook production build succeeded locally (`pnpm --dir crates/tidebreak-desktop/ui storybook:build`) after a stub `xlsx` because cdn.sheetjs.com returned 403 here. Screenshots were not captured. Review the new stories in Storybook before merging if you need pixel confirmation.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome format` and `biome lint` on the touched files
- `vitest run src/code/RepositorySettings.dom.test.tsx src/stylesContract.test.ts` — 6 passed
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — succeeded

## Screenshots

None. No browser in this sandbox.