### PR TITLE
feat(mobile): show approvals in sessions

### DIFF
--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -1,3 +1,4 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import {
@@ -12,15 +13,19 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { CodeApprovalCard } from "../../src/components/CodeApprovalCard";
 import { Button, LoadingState, StatusPill } from "../../src/components/Controls";
 import { ErrorText } from "../../src/components/Screen";
 import {
+  decideCodeApproval,
   interruptCodeSession,
+  listCodeApprovals,
   listCodeQueuedTurns,
   listCodeTurns,
   steerCodeSession,
   submitCodeTurn,
 } from "../../src/lib/api";
+import { pendingApprovals } from "../../src/lib/approvals";
 import {
   clearDeliveredDraft,
   codeSubmissionWasAccepted,
@@ -46,8 +51,17 @@ export default function SessionDetailScreen() {
   }>();
   const session = useSessionStore((state) => state.session);
   const client = useMachineClient();
+  const queryClient = useQueryClient();
   const [refreshVersion, setRefreshVersion] = useState(0);
   const transcript = useSessionEvents(client, params.id, refreshVersion);
+  const approvalsQuery = useQuery({
+    queryKey: ["code-approvals", client, params.id],
+    enabled: !!client && !!params.id,
+    queryFn: () => listCodeApprovals(client!, params.id!),
+    refetchInterval: 5_000,
+  });
+  const approvals = pendingApprovals(approvalsQuery.data ?? []);
+  const approvalListKey = approvals.map((approval) => approval.id).join(":");
   const scrollRef = useRef<ScrollView>(null);
   const submittingTurnRef = useRef(false);
   const steeringRef = useRef(false);
@@ -80,7 +94,14 @@ export default function SessionDetailScreen() {
     } else {
       setShowJump(true);
     }
-  }, [transcript.items, pinned]);
+  }, [approvalListKey, transcript.items, pinned]);
+
+  useEffect(() => {
+    if (transcript.approvalRevision === 0) return;
+    void queryClient.invalidateQueries({
+      queryKey: ["code-approvals", client, params.id],
+    });
+  }, [client, params.id, queryClient, transcript.approvalRevision]);
 
   useEffect(() => {
     if (!transcript.activeTurnId) setMode("followup");
@@ -209,6 +230,21 @@ export default function SessionDetailScreen() {
     }
   }
 
+  async function decideApproval(
+    approvalId: string,
+    decision: "approve" | "deny",
+    feedback?: string,
+  ) {
+    if (!client) return;
+    try {
+      await decideCodeApproval(client, approvalId, decision, feedback);
+    } finally {
+      // The decision can commit even when its response is lost. Replace every
+      // cached approval list before the reader can submit the decision again.
+      await queryClient.invalidateQueries({ queryKey: ["code-approvals"] });
+    }
+  }
+
   async function refreshAfterAmbiguousAction() {
     if (
       !client ||
@@ -310,6 +346,23 @@ export default function SessionDetailScreen() {
                 <TimelineRow key={item.id} item={item} />
               ))
             )}
+            {approvalsQuery.isError ? (
+              <ErrorText>
+                {approvalsQuery.error instanceof Error
+                  ? approvalsQuery.error.message
+                  : "Could not load approvals for this session."}
+              </ErrorText>
+            ) : null}
+            {approvals.map((approval) => (
+              <CodeApprovalCard
+                key={approval.id}
+                approval={approval}
+                onApprove={() => decideApproval(approval.id, "approve")}
+                onDeny={(feedback) =>
+                  decideApproval(approval.id, "deny", feedback)
+                }
+              />
+            ))}
           </ScrollView>
           {showJump && !pinned ? (
             <Pressable

--- a/mobile/src/lib/transcript.test.ts
+++ b/mobile/src/lib/transcript.test.ts
@@ -75,6 +75,27 @@ describe("reduceTranscript", () => {
     expect(state.activeTurnId).toBeNull();
   });
 
+  it("marks durable approval changes for an authoritative list refresh", () => {
+    let state = reduceTranscript(initialTranscript(), {
+      seq: 7,
+      event: {
+        type: "approval_requested",
+        approval_id: "approval-1",
+      },
+    });
+    expect(state.approvalRevision).toBe(7);
+
+    state = reduceTranscript(state, {
+      seq: 8,
+      event: {
+        type: "approval_resolved",
+        approval_id: "approval-1",
+        decision: { type: "deny", feedback: "Use the focused test." },
+      },
+    });
+    expect(state.approvalRevision).toBe(8);
+  });
+
   it("hydrates user turns once, in ordinal order, and recovers a running id", () => {
     const turns = [
       {

--- a/mobile/src/lib/transcript.ts
+++ b/mobile/src/lib/transcript.ts
@@ -13,6 +13,7 @@ export type TimelineItem =
 
 export type TranscriptState = {
   lastSeq: number;
+  approvalRevision: number;
   items: TimelineItem[];
   assistantBuffer: string;
   tools: Record<string, { name: string; summary: string }>;
@@ -22,6 +23,7 @@ export type TranscriptState = {
 export function initialTranscript(): TranscriptState {
   return {
     lastSeq: 0,
+    approvalRevision: 0,
     items: [],
     assistantBuffer: "",
     tools: {},
@@ -164,13 +166,13 @@ function applyEvent(
       );
     case "approval_requested":
       return appendStatus(
-        state,
+        { ...state, approvalRevision: state.lastSeq },
         `appr:${event.approval_id}`,
         "Approval waiting",
       );
     case "approval_resolved":
       return appendStatus(
-        state,
+        { ...state, approvalRevision: state.lastSeq },
         `appr-done:${event.approval_id}`,
         `Approval ${event.decision.type}`,
       );


### PR DESCRIPTION
Part of #2647.

## What changed

- Shows pending session approvals in the live session timeline, with the full structured summary and harness payload.
- Supports approve and deny-with-feedback without leaving the session.
- Refreshes the authoritative approval list when durable approval events arrive and after every decision, including lost-response cases.
- Keeps the existing steer, interrupt, follow-up, and draft-recovery controls in the same supervision surface.

## Validation

- `CI=true npx --yes pnpm@10.18.3 typecheck`
- `CI=true npx --yes pnpm@10.18.3 lint`
- `CI=true npx --yes pnpm@10.18.3 test` — 17 files and 62 tests passed.
- Expo web bundled the session preview successfully. Visual screenshot review remains unavailable because no browser instance is connected to this session.

## Compatibility and risk

No wire, persistence, or native platform contracts change.

## Tracking

Part of #2647.
