### PR TITLE
feat(mobile): start sessions from workspaces

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -42,6 +42,10 @@ export default function RootLayout() {
           <Stack.Screen name="pair" options={{ title: "Gateway" }} />
           <Stack.Screen name="attach" options={{ title: "Machine" }} />
           <Stack.Screen name="home" options={{ title: "Attached" }} />
+          <Stack.Screen
+            name="workspace/[id]/start"
+            options={{ title: "Start session" }}
+          />
           <Stack.Screen name="sessions" options={{ title: "Sessions" }} />
           <Stack.Screen name="session/[id]" options={{ title: "Session" }} />
           <Stack.Screen name="approvals" options={{ title: "Approvals" }} />

--- a/mobile/app/home.tsx
+++ b/mobile/app/home.tsx
@@ -2,17 +2,18 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { Pressable, Text, View } from "react-native";
 import { Screen, Body, ErrorText } from "../src/components/Screen";
-import { parseWorkspaceList, workspaceDisplayName } from "../src/lib/attach";
+import { listActiveCodeWorkspaces } from "../src/lib/api";
 import { fetchIdentity } from "../src/lib/gateway";
-import { fetchRefusingRedirects } from "../src/lib/http";
 import { RESOURCE_CONTROL } from "../src/lib/resource";
 import { tokenStore } from "../src/session/runtime";
 import { useSessionStore } from "../src/session/store";
+import { useMachineClient } from "../src/session/useMachineClient";
 
 export default function HomeScreen() {
   const router = useRouter();
   const session = useSessionStore((state) => state.session);
   const setSession = useSessionStore((state) => state.setSession);
+  const client = useMachineClient();
 
   const identityQuery = useQuery({
     queryKey: ["identity", session?.gatewayUrl],
@@ -27,19 +28,9 @@ export default function HomeScreen() {
   });
 
   const workspacesQuery = useQuery({
-    queryKey: ["workspaces", session?.machine?.baseUrl],
-    enabled: !!session?.machine,
-    queryFn: async () => {
-      const token = await tokenStore.getAccessToken(session!.machine!.resource);
-      const response = await fetchRefusingRedirects(
-        `${session!.machine!.baseUrl}/code/workspaces`,
-        { headers: { Authorization: `Bearer ${token}` } },
-      );
-      if (!response.ok) {
-        throw new Error(`Workspace list failed (HTTP ${response.status})`);
-      }
-      return parseWorkspaceList(await response.json());
-    },
+    queryKey: ["code-workspaces", session?.machine?.baseUrl],
+    enabled: !!client,
+    queryFn: () => listActiveCodeWorkspaces(client!),
   });
 
   if (!session?.machine) {
@@ -95,11 +86,40 @@ export default function HomeScreen() {
               : `${workspaces.length} workspace${workspaces.length === 1 ? "" : "s"}`}
           </Text>
         )}
-        {workspaces.map((workspace) => (
-          <Text key={workspace.id} className="text-sm text-muted-foreground">
-            {workspaceDisplayName(workspace)}
+        {!workspacesQuery.isLoading && !workspacesQuery.isError && workspaces.length === 0 ? (
+          <Text className="text-sm text-muted-foreground">
+            No active workspaces are available on this machine.
           </Text>
+        ) : null}
+        {workspaces.map((workspace) => (
+          <Pressable
+            key={workspace.id}
+            accessibilityRole="button"
+            accessibilityLabel={`Start a session in ${workspace.title || workspace.branch_name}`}
+            className="gap-1 border-t border-border py-3 first:border-t-0"
+            onPress={() =>
+              router.push({
+                pathname: "/workspace/[id]/start",
+                params: { id: workspace.id },
+              })
+            }
+          >
+            <Text className="text-sm font-medium text-foreground">
+              {workspace.title || "Untitled workspace"}
+            </Text>
+            <Text
+              className="font-mono text-xs text-muted-foreground"
+              numberOfLines={1}
+            >
+              {workspace.branch_name}
+            </Text>
+          </Pressable>
         ))}
+        {workspaces.length > 0 ? (
+          <Text className="text-xs text-muted-foreground">
+            Tap a workspace to start a session.
+          </Text>
+        ) : null}
       </View>
       <Pressable
         className="rounded-lg border border-border bg-background px-4 py-3"

--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -35,6 +35,7 @@ import {
   type AmbiguousCodeSubmission,
 } from "../../src/lib/submission";
 import type { TimelineItem } from "../../src/lib/transcript";
+import { useSessionDraftRecoveryStore } from "../../src/session/draftRecovery";
 import { useSessionStore } from "../../src/session/store";
 import { useMachineClient } from "../../src/session/useMachineClient";
 import { useSessionEvents } from "../../src/session/useSessionEvents";
@@ -52,6 +53,12 @@ export default function SessionDetailScreen() {
   const session = useSessionStore((state) => state.session);
   const client = useMachineClient();
   const queryClient = useQueryClient();
+  const recoveredDraft = useSessionDraftRecoveryStore((state) =>
+    params.id ? state.bySession[params.id] : undefined,
+  );
+  const consumeRecoveredDraft = useSessionDraftRecoveryStore(
+    (state) => state.consume,
+  );
   const [refreshVersion, setRefreshVersion] = useState(0);
   const transcript = useSessionEvents(client, params.id, refreshVersion);
   const approvalsQuery = useQuery({
@@ -67,6 +74,7 @@ export default function SessionDetailScreen() {
   const steeringRef = useRef(false);
   const interruptingRef = useRef(false);
   const refreshingRef = useRef(false);
+  const recoveredSessionRef = useRef<string | null>(null);
   const [pinned, setPinned] = useState(true);
   const [showJump, setShowJump] = useState(false);
   const [message, setMessage] = useState("");
@@ -87,6 +95,20 @@ export default function SessionDetailScreen() {
     refreshing,
     deliveryUnknown,
   });
+
+  useEffect(() => {
+    if (
+      !params.id ||
+      !recoveredDraft ||
+      recoveredSessionRef.current === params.id
+    ) {
+      return;
+    }
+    recoveredSessionRef.current = params.id;
+    setMessage(recoveredDraft.draft);
+    setSendError(recoveredDraft.error);
+    consumeRecoveredDraft(params.id);
+  }, [consumeRecoveredDraft, params.id, recoveredDraft]);
 
   useEffect(() => {
     if (pinned) {

--- a/mobile/app/workspace/[id]/start.tsx
+++ b/mobile/app/workspace/[id]/start.tsx
@@ -1,0 +1,449 @@
+import { useQuery } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  Button,
+  Field,
+  LoadingState,
+  SectionLabel,
+} from "../../../src/components/Controls";
+import { ErrorText } from "../../../src/components/Screen";
+import type {
+  HarnessKind,
+  PermissionMode,
+} from "../../../src/generated/wire";
+import {
+  getCodePermissionPolicy,
+  launchCodeSession,
+  listActiveCodeWorkspaces,
+  listCodeHarnessModels,
+  listCodeHarnesses,
+  type CodeHarnessOption,
+} from "../../../src/lib/api";
+import {
+  defaultCreatePermissionMode,
+  HARNESS_LABELS,
+  harnessCanStartNow,
+  harnessUnavailableReason,
+  PERMISSION_MODE_DESCRIPTIONS,
+  PERMISSION_MODE_LABELS,
+  permissionModeWarning,
+  permittedPermissionModes,
+} from "../../../src/lib/codeLaunch";
+import { useSessionDraftRecoveryStore } from "../../../src/session/draftRecovery";
+import { useSessionStore } from "../../../src/session/store";
+import { useMachineClient } from "../../../src/session/useMachineClient";
+
+const NO_HARNESSES: CodeHarnessOption[] = [];
+
+export default function StartWorkspaceSessionScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ id?: string }>();
+  const machine = useSessionStore((state) => state.session?.machine);
+  const client = useMachineClient();
+  const offerDraft = useSessionDraftRecoveryStore((state) => state.offer);
+  const [selectedHarnessKind, setSelectedHarnessKind] =
+    useState<HarnessKind | null>(null);
+  const [modelsByHarness, setModelsByHarness] = useState<
+    Partial<Record<HarnessKind, string>>
+  >({});
+  const [modesByHarness, setModesByHarness] = useState<
+    Partial<Record<HarnessKind, PermissionMode>>
+  >({});
+  const [message, setMessage] = useState("");
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+  const launchRef = useRef(false);
+  const workspaceId = params.id;
+  const machineKey = machine?.baseUrl;
+
+  const workspacesQuery = useQuery({
+    queryKey: ["code-workspaces", machineKey],
+    enabled: !!client,
+    queryFn: () => listActiveCodeWorkspaces(client!),
+  });
+  const harnessesQuery = useQuery({
+    queryKey: ["code-harnesses", machineKey],
+    enabled: !!client,
+    queryFn: () => listCodeHarnesses(client!),
+  });
+  const policyQuery = useQuery({
+    queryKey: ["code-permission-policy", machineKey],
+    enabled: !!client,
+    queryFn: () => getCodePermissionPolicy(client!),
+  });
+
+  const workspace = workspacesQuery.data?.find(
+    (item) => item.id === workspaceId,
+  );
+  const harnesses = harnessesQuery.data ?? NO_HARNESSES;
+  const ceiling = policyQuery.data?.permission_mode_ceiling;
+
+  const launchableHarnesses = useMemo(
+    () =>
+      harnesses.filter(
+        (harness) =>
+          harnessCanStartNow(harness) &&
+          permittedPermissionModes(harness.caps, ceiling).length > 0,
+      ),
+    [ceiling, harnesses],
+  );
+
+  useEffect(() => {
+    const selected = harnesses.find(
+      (harness) => harness.kind === selectedHarnessKind,
+    );
+    if (
+      selected &&
+      harnessCanStartNow(selected) &&
+      permittedPermissionModes(selected.caps, ceiling).length > 0
+    ) {
+      return;
+    }
+    setSelectedHarnessKind(launchableHarnesses[0]?.kind ?? null);
+  }, [ceiling, harnesses, launchableHarnesses, selectedHarnessKind]);
+
+  const selectedHarness = harnesses.find(
+    (harness) => harness.kind === selectedHarnessKind,
+  );
+  const permittedModes = selectedHarness
+    ? permittedPermissionModes(selectedHarness.caps, ceiling)
+    : [];
+  const rememberedMode = selectedHarnessKind
+    ? modesByHarness[selectedHarnessKind]
+    : undefined;
+  const selectedMode =
+    rememberedMode && permittedModes.includes(rememberedMode)
+      ? rememberedMode
+      : defaultCreatePermissionMode(permittedModes);
+
+  const modelsQuery = useQuery({
+    queryKey: ["code-harness-models", machineKey, selectedHarnessKind],
+    enabled: !!client && !!selectedHarnessKind && !!selectedHarness,
+    queryFn: () => listCodeHarnessModels(client!, selectedHarnessKind!),
+  });
+  const models = modelsQuery.data?.models ?? [];
+  const rememberedModel = selectedHarnessKind
+    ? modelsByHarness[selectedHarnessKind]
+    : undefined;
+  const selectedModel =
+    models.find((model) => model.id === rememberedModel)?.id ??
+    models.find((model) => model.default)?.id ??
+    models[0]?.id;
+  const selectedModeWarning =
+    selectedHarness && selectedMode
+      ? permissionModeWarning(selectedMode, selectedHarness.caps)
+      : null;
+
+  async function startSession() {
+    if (
+      launchRef.current ||
+      !client ||
+      !workspace ||
+      !selectedHarness ||
+      !selectedMode
+    ) {
+      return;
+    }
+    launchRef.current = true;
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      const result = await launchCodeSession(
+        client,
+        workspace.id,
+        {
+          harness: selectedHarness.kind,
+          permission_mode: selectedMode,
+          ...(selectedModel ? { model: selectedModel } : {}),
+        },
+        message,
+      );
+      if (result.undeliveredDraft) {
+        offerDraft(result.session.id, {
+          draft: result.undeliveredDraft,
+          error: `The session started, but the first message did not send. ${result.sendError ?? "Send it again from this session."}`,
+        });
+      }
+      router.replace({
+        pathname: "/session/[id]",
+        params: {
+          id: result.session.id,
+          title: workspace.title || "Session",
+          workspace: workspace.title || workspace.branch_name,
+        },
+      });
+    } catch (error) {
+      setLaunchError(
+        error instanceof Error
+          ? error.message
+          : "The session could not be started.",
+      );
+    } finally {
+      launchRef.current = false;
+      setLaunching(false);
+    }
+  }
+
+  if (!machine || !client || !workspaceId) {
+    return (
+      <SafeAreaView className="flex-1 bg-page-background px-5 py-6">
+        <ErrorText>Attach a machine before you start a session.</ErrorText>
+        <View className="mt-4">
+          <Button label="Go back" onPress={() => router.replace("/")} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const optionsLoading =
+    workspacesQuery.isLoading ||
+    harnessesQuery.isLoading ||
+    policyQuery.isLoading;
+  const optionsError =
+    workspacesQuery.error ?? harnessesQuery.error ?? policyQuery.error;
+
+  return (
+    <SafeAreaView className="flex-1 bg-page-background">
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 74 : 0}
+      >
+        <ScrollView
+          contentContainerClassName="gap-5 px-5 py-6"
+          keyboardShouldPersistTaps="handled"
+        >
+          <Text className="text-2xl font-semibold text-foreground">
+            Start session
+          </Text>
+
+          {optionsLoading ? <LoadingState label="Loading launch options…" /> : null}
+          {optionsError ? (
+            <ErrorText>
+              {optionsError instanceof Error
+                ? optionsError.message
+                : "The launch options could not be loaded."}
+            </ErrorText>
+          ) : null}
+          {!optionsLoading && !optionsError && !workspace ? (
+            <ErrorText>This workspace is no longer active.</ErrorText>
+          ) : null}
+
+          {workspace ? (
+            <View className="gap-1 rounded-xl border border-border bg-background p-4">
+              <SectionLabel>Workspace</SectionLabel>
+              <Text className="text-base font-medium text-foreground">
+                {workspace.title || "Untitled workspace"}
+              </Text>
+              <Text
+                className="font-mono text-xs text-muted-foreground"
+                numberOfLines={1}
+              >
+                {workspace.branch_name}
+              </Text>
+            </View>
+          ) : null}
+
+          {!optionsLoading && harnesses.length > 0 ? (
+            <View className="gap-2">
+              <SectionLabel>Harness</SectionLabel>
+              {harnesses.map((harness) => {
+                const unavailable = harnessUnavailableReason(harness);
+                const policyBlocked =
+                  !unavailable &&
+                  permittedPermissionModes(harness.caps, ceiling).length === 0;
+                return (
+                  <ChoiceRow
+                    key={harness.kind}
+                    label={HARNESS_LABELS[harness.kind]}
+                    detail={
+                      unavailable ??
+                      (policyBlocked
+                        ? "Blocked by the machine permission policy."
+                        : harness.version
+                          ? `Version ${harness.version}`
+                          : "Ready")
+                    }
+                    selected={selectedHarnessKind === harness.kind}
+                    disabled={!!unavailable || policyBlocked || launching}
+                    onPress={() => {
+                      setLaunchError(null);
+                      setSelectedHarnessKind(harness.kind);
+                    }}
+                  />
+                );
+              })}
+              {launchableHarnesses.length === 0 ? (
+                <ErrorText>No harness on this machine can start a session.</ErrorText>
+              ) : null}
+            </View>
+          ) : null}
+          {!optionsLoading && !optionsError && harnesses.length === 0 ? (
+            <ErrorText>No harness is configured on this machine.</ErrorText>
+          ) : null}
+
+          {selectedHarness ? (
+            <View className="gap-2">
+              <SectionLabel>Model</SectionLabel>
+              {modelsQuery.isLoading ? (
+                <LoadingState label="Loading models…" />
+              ) : null}
+              {modelsQuery.isError ? (
+                <ErrorText>
+                  {modelsQuery.error instanceof Error
+                    ? modelsQuery.error.message
+                    : "The model list could not be loaded."}
+                </ErrorText>
+              ) : null}
+              {!modelsQuery.isLoading && models.length === 0 ? (
+                <View className="rounded-xl border border-border bg-background p-4">
+                  <Text className="text-sm text-foreground">
+                    Use the harness default model.
+                  </Text>
+                </View>
+              ) : null}
+              {models.map((model) => (
+                <ChoiceRow
+                  key={model.id}
+                  label={model.label}
+                  detail={model.id}
+                  meta={model.default ? "Default" : undefined}
+                  selected={selectedModel === model.id}
+                  disabled={launching}
+                  monoDetail
+                  onPress={() => {
+                    if (!selectedHarnessKind) return;
+                    setModelsByHarness((current) => ({
+                      ...current,
+                      [selectedHarnessKind]: model.id,
+                    }));
+                  }}
+                />
+              ))}
+            </View>
+          ) : null}
+
+          {selectedHarness && permittedModes.length > 0 ? (
+            <View className="gap-2">
+              <SectionLabel>Permissions</SectionLabel>
+              {ceiling ? (
+                <Text className="text-xs text-muted-foreground">
+                  This machine permits {PERMISSION_MODE_LABELS[ceiling]} or less.
+                </Text>
+              ) : null}
+              {permittedModes.map((mode) => (
+                <ChoiceRow
+                  key={mode}
+                  label={PERMISSION_MODE_LABELS[mode]}
+                  detail={PERMISSION_MODE_DESCRIPTIONS[mode]}
+                  selected={selectedMode === mode}
+                  disabled={launching}
+                  onPress={() => {
+                    if (!selectedHarnessKind) return;
+                    setModesByHarness((current) => ({
+                      ...current,
+                      [selectedHarnessKind]: mode,
+                    }));
+                  }}
+                />
+              ))}
+              {selectedModeWarning ? (
+                <View className="rounded-lg border border-warning-border bg-warning-background p-3">
+                  <Text className="text-sm text-warning-foreground">
+                    {selectedModeWarning}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          ) : null}
+
+          {workspace && selectedHarness && selectedMode ? (
+            <Field
+              label="First message"
+              hint="Optional. If sending fails, the created session keeps this draft."
+              multiline
+              value={message}
+              onChangeText={setMessage}
+              placeholder="What should the agent work on?"
+              editable={!launching}
+            />
+          ) : null}
+
+          {launchError ? <ErrorText>{launchError}</ErrorText> : null}
+
+          <Button
+            label="Start session"
+            busy={launching}
+            disabled={
+              optionsLoading ||
+              !!optionsError ||
+              !workspace ||
+              !selectedHarness ||
+              !selectedMode
+            }
+            onPress={() => void startSession()}
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function ChoiceRow({
+  label,
+  detail,
+  meta,
+  selected,
+  disabled,
+  monoDetail = false,
+  onPress,
+}: {
+  label: string;
+  detail: string;
+  meta?: string;
+  selected: boolean;
+  disabled: boolean;
+  monoDetail?: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected, disabled }}
+      disabled={disabled}
+      className={`min-h-16 rounded-xl border p-4 disabled:opacity-50 ${
+        selected
+          ? "border-primary bg-muted"
+          : "border-border bg-background"
+      }`}
+      onPress={onPress}
+    >
+      <View className="flex-row items-start justify-between gap-3">
+        <View className="min-w-0 flex-1 gap-1">
+          <Text className="text-sm font-medium text-foreground">{label}</Text>
+          <Text
+            className={`${monoDetail ? "font-mono " : ""}text-xs text-muted-foreground`}
+            numberOfLines={monoDetail ? 1 : undefined}
+          >
+            {detail}
+          </Text>
+        </View>
+        {selected || meta ? (
+          <Text className="text-xs font-medium text-foreground">
+            {selected ? "Selected" : meta}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}

--- a/mobile/src/lib/api.test.ts
+++ b/mobile/src/lib/api.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MachineClient } from "./machine";
 import {
+  createCodeSession,
   decideCodeApproval,
+  getCodePermissionPolicy,
   interruptCodeSession,
+  launchCodeSession,
+  listActiveCodeWorkspaces,
   listCodeApprovals,
+  listCodeHarnessModels,
+  listCodeHarnesses,
   listCodeQueuedTurns,
   listCodeTurns,
   parseCodeApproval,
+  parseCodeHarness,
+  parseCodeHarnessModels,
+  parseCodeWorkspace,
+  parseCreatedCodeSession,
   parseCodeTurnSubmission,
   steerCodeSession,
   submitCodeTurn,
@@ -42,6 +52,62 @@ const approval = {
   requested_at: "2026-08-27T00:00:02Z",
 };
 
+const caps = {
+  resume: "supported",
+  streaming_deltas: "supported",
+  structured_approvals: "supported",
+  mid_turn_steering: "supported",
+  plan_mode: "supported",
+  auto_mode: "supported",
+  allow_mode: "supported",
+  reasoning_levels: "supported",
+  native_file_change_events: "supported",
+  native_interrupt: "supported",
+  image_input: "unsupported",
+  slash_commands: "supported",
+};
+
+const harness = {
+  kind: "codex",
+  found: true,
+  installable: true,
+  version: "1.0.0",
+  tier: "reference",
+  caps,
+  commands: [],
+  authenticated: true,
+  auth_mode: "local_sign_in",
+  remediation: "",
+  stderr: "",
+  unrecognized_event_count: 0,
+  relaunch_composes_permission_mode: true,
+};
+
+const workspace = {
+  id: "workspace-1",
+  repo_id: "repo-1",
+  title: "Mobile launch",
+  worktree_path: "/workspace/mobile-launch",
+  branch_name: "thet/mobile-launch",
+  base_ref: "main",
+  status: "active",
+  created_at: "2026-08-27T00:00:00Z",
+};
+
+const createdSession = {
+  id: "session-2",
+  workspace_id: "workspace-1",
+  kind: "interactive",
+  harness_kind: "codex",
+  permission_mode: "auto",
+  model: "gpt-5.6-sol",
+  fast_mode: false,
+  lifecycle: "created",
+  attention: { state: { type: "idle" }, source: "lifecycle" },
+  unrecognized_event_count: 0,
+  created_at: "2026-08-27T00:00:03Z",
+};
+
 function fakeClient(response: unknown): {
   client: Pick<MachineClient, "getJson" | "requestJson">;
   getJson: ReturnType<typeof vi.fn>;
@@ -53,6 +119,172 @@ function fakeClient(response: unknown): {
 }
 
 describe("mobile supervision API contracts", () => {
+  it("validates active workspaces instead of silently accepting partial rows", async () => {
+    expect(parseCodeWorkspace(workspace)).toMatchObject({
+      id: "workspace-1",
+      status: "active",
+    });
+    expect(parseCodeWorkspace({ id: "workspace-1" })).toBeNull();
+
+    const listed = fakeClient([
+      workspace,
+      { ...workspace, id: "workspace-2", status: "archived" },
+    ]);
+    await expect(listActiveCodeWorkspaces(listed.client)).resolves.toEqual([
+      expect.objectContaining({ id: "workspace-1" }),
+    ]);
+    expect(listed.getJson).toHaveBeenCalledWith("/code/workspaces");
+
+    const invalid = fakeClient([workspace, { ...workspace, branch_name: 42 }]);
+    await expect(listActiveCodeWorkspaces(invalid.client)).rejects.toThrow(
+      /invalid data/,
+    );
+  });
+
+  it("validates harness capabilities and each listed model", async () => {
+    expect(parseCodeHarness(harness)).toMatchObject({
+      kind: "codex",
+      caps: { structured_approvals: "supported" },
+    });
+    expect(
+      parseCodeHarness({
+        ...harness,
+        caps: { ...caps, allow_mode: "maybe" },
+      }),
+    ).toBeNull();
+
+    const doctor = fakeClient({ harnesses: [harness] });
+    await expect(listCodeHarnesses(doctor.client)).resolves.toHaveLength(1);
+    expect(doctor.getJson).toHaveBeenCalledWith("/code/harnesses");
+
+    const listing = {
+      kind: "codex",
+      models: [
+        {
+          id: "gpt-5.6-sol",
+          label: "GPT-5.6 Sol",
+          default: true,
+          reasoning_efforts: ["high", "ultra"],
+          fast_mode: true,
+        },
+      ],
+      reasoning_efforts: ["high", "ultra"],
+      source: "model_gateway",
+    };
+    expect(parseCodeHarnessModels(listing)).toEqual(listing);
+    expect(
+      parseCodeHarnessModels({
+        ...listing,
+        models: [{ ...listing.models[0], fast_mode: "yes" }],
+      }),
+    ).toBeNull();
+
+    const models = fakeClient(listing);
+    await expect(
+      listCodeHarnessModels(models.client, "codex"),
+    ).resolves.toEqual(listing);
+    expect(models.getJson).toHaveBeenCalledWith(
+      "/code/harnesses/codex/models",
+    );
+  });
+
+  it("reads the managed permission ceiling and rejects unknown modes", async () => {
+    const capped = fakeClient({
+      managed: true,
+      source: "os",
+      permission_mode_ceiling: "ask",
+    });
+    await expect(getCodePermissionPolicy(capped.client)).resolves.toEqual({
+      permission_mode_ceiling: "ask",
+    });
+
+    const invalid = fakeClient({ permission_mode_ceiling: "danger" });
+    await expect(getCodePermissionPolicy(invalid.client)).rejects.toThrow(
+      /invalid data/,
+    );
+  });
+
+  it("creates a session through the workspace route and checks the response identity", async () => {
+    expect(parseCreatedCodeSession(createdSession)).toMatchObject({
+      id: "session-2",
+      workspace_id: "workspace-1",
+    });
+    expect(
+      parseCreatedCodeSession({ ...createdSession, fast_mode: "false" }),
+    ).toBeNull();
+
+    const created = fakeClient({
+      ...createdSession,
+      workspace_id: "workspace/1",
+    });
+    await expect(
+      createCodeSession(created.client, "workspace/1", {
+        harness: "codex",
+        permission_mode: "auto",
+        model: "gpt-5.6-sol",
+      }),
+    ).resolves.toMatchObject({ id: "session-2" });
+    expect(created.requestJson).toHaveBeenCalledWith(
+      "/code/workspaces/workspace%2F1/sessions",
+      {
+        method: "POST",
+        body: {
+          harness: "codex",
+          permission_mode: "auto",
+          model: "gpt-5.6-sol",
+        },
+        expectedStatus: 201,
+      },
+    );
+
+    const mismatched = fakeClient({
+      ...createdSession,
+      workspace_id: "workspace-elsewhere",
+    });
+    await expect(
+      createCodeSession(mismatched.client, "workspace-1", {
+        harness: "codex",
+        permission_mode: "auto",
+      }),
+    ).rejects.toThrow(/did not match/);
+  });
+
+  it("keeps the first-message draft when the session starts but send fails", async () => {
+    const getJson = vi.fn();
+    const requestJson = vi
+      .fn()
+      .mockResolvedValueOnce(createdSession)
+      .mockRejectedValueOnce(new Error("Connection ended"));
+    const client = { getJson, requestJson };
+
+    await expect(
+      launchCodeSession(
+        client,
+        "workspace-1",
+        {
+          harness: "codex",
+          permission_mode: "auto",
+          model: "gpt-5.6-sol",
+        },
+        "  Fix the launch flow.  ",
+      ),
+    ).resolves.toEqual({
+      session: expect.objectContaining({ id: "session-2" }),
+      submitted: null,
+      undeliveredDraft: "  Fix the launch flow.  ",
+      sendError: "Connection ended",
+    });
+    expect(requestJson).toHaveBeenNthCalledWith(
+      2,
+      "/code/sessions/session-2/turns",
+      {
+        method: "POST",
+        body: { message: "Fix the launch flow." },
+        expectedStatus: 202,
+      },
+    );
+  });
+
   it("distinguishes an accepted turn from a queued follow-up", async () => {
     expect(parseCodeTurnSubmission(turn)).toEqual({ kind: "ran", turn });
     expect(parseCodeTurnSubmission(queued)).toEqual({ kind: "queued", queued });

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -1,8 +1,18 @@
 import type {
+  CapLevel,
   CodeApprovalKind,
   CodeApprovalSnapshot,
+  CodeSessionLifecycle,
   CodeTurnSnapshot,
+  CodeWorkspaceStatus,
+  HarnessAuthMode,
+  HarnessCaps,
+  HarnessKind,
+  HarnessModel,
+  HarnessModelSource,
+  PermissionMode,
   QueuedCodeTurn,
+  ReasoningEffort,
 } from "../generated/wire";
 import type { MachineClient } from "./machine";
 
@@ -11,6 +21,65 @@ export type CodeTurnSubmission =
   | { kind: "queued"; queued: QueuedCodeTurn };
 
 type MachineJsonClient = Pick<MachineClient, "getJson" | "requestJson">;
+
+export type ActiveCodeWorkspace = {
+  id: string;
+  repo_id: string;
+  title: string;
+  branch_name: string;
+  base_ref: string;
+  status: CodeWorkspaceStatus;
+  created_at: string;
+};
+
+export type CodeHarnessOption = {
+  kind: HarnessKind;
+  found: boolean;
+  installable: boolean;
+  version?: string;
+  authenticated?: boolean;
+  auth_mode: HarnessAuthMode;
+  remediation: string;
+  caps: HarnessCaps;
+};
+
+export type CodeHarnessModels = {
+  kind: HarnessKind;
+  models: HarnessModel[];
+  reasoning_efforts: ReasoningEffort[];
+  source: HarnessModelSource;
+};
+
+export type CodePermissionPolicy = {
+  permission_mode_ceiling?: PermissionMode;
+};
+
+export type CreateCodeSessionInput = {
+  harness: HarnessKind;
+  permission_mode: PermissionMode;
+  model?: string;
+  reasoning_effort?: ReasoningEffort;
+  fast_mode?: boolean;
+};
+
+export type CreatedCodeSession = {
+  id: string;
+  workspace_id: string;
+  harness_kind: HarnessKind;
+  permission_mode: PermissionMode;
+  model?: string;
+  reasoning_effort?: ReasoningEffort;
+  fast_mode: boolean;
+  lifecycle: CodeSessionLifecycle;
+  created_at: string;
+};
+
+export type CodeSessionLaunchResult = {
+  session: CreatedCodeSession;
+  submitted: CodeTurnSubmission | null;
+  undeliveredDraft: string | null;
+  sendError: string | null;
+};
 
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object"
@@ -26,8 +95,232 @@ function optionalString(value: unknown): value is string | undefined {
   return value === undefined || typeof value === "string";
 }
 
+function optionalBoolean(value: unknown): value is boolean | undefined {
+  return value === undefined || typeof value === "boolean";
+}
+
 function finiteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+function codeWorkspaceStatus(value: unknown): value is CodeWorkspaceStatus {
+  return [
+    "creating",
+    "setup_failed",
+    "active",
+    "archiving",
+    "archived",
+    "released",
+  ].includes(String(value));
+}
+
+function harnessKind(value: unknown): value is HarnessKind {
+  return ["claude_code", "codex", "opencode", "grok"].includes(
+    String(value),
+  );
+}
+
+function harnessAuthMode(value: unknown): value is HarnessAuthMode {
+  return [
+    "local_sign_in",
+    "gateway_managed",
+    "gateway_relay",
+    "hosted_unavailable",
+  ].includes(String(value));
+}
+
+function capLevel(value: unknown): value is CapLevel {
+  return ["supported", "unsupported", "unknown"].includes(String(value));
+}
+
+function permissionMode(value: unknown): value is PermissionMode {
+  return ["plan", "ask", "auto", "allow"].includes(String(value));
+}
+
+function reasoningEffort(value: unknown): value is ReasoningEffort {
+  return ["none", "low", "medium", "high", "xhigh", "max", "ultra"].includes(
+    String(value),
+  );
+}
+
+function codeSessionLifecycle(value: unknown): value is CodeSessionLifecycle {
+  return ["created", "idle", "running", "fenced", "ended"].includes(
+    String(value),
+  );
+}
+
+function parseHarnessCaps(value: unknown): HarnessCaps | null {
+  const caps = record(value);
+  if (
+    !caps ||
+    !capLevel(caps.resume) ||
+    !capLevel(caps.streaming_deltas) ||
+    !capLevel(caps.structured_approvals) ||
+    !capLevel(caps.mid_turn_steering) ||
+    !capLevel(caps.plan_mode) ||
+    !capLevel(caps.auto_mode) ||
+    !capLevel(caps.allow_mode) ||
+    !capLevel(caps.reasoning_levels) ||
+    !capLevel(caps.native_file_change_events) ||
+    !capLevel(caps.native_interrupt) ||
+    !capLevel(caps.image_input) ||
+    !capLevel(caps.slash_commands)
+  ) {
+    return null;
+  }
+  return {
+    resume: caps.resume,
+    streaming_deltas: caps.streaming_deltas,
+    structured_approvals: caps.structured_approvals,
+    mid_turn_steering: caps.mid_turn_steering,
+    plan_mode: caps.plan_mode,
+    auto_mode: caps.auto_mode,
+    allow_mode: caps.allow_mode,
+    reasoning_levels: caps.reasoning_levels,
+    native_file_change_events: caps.native_file_change_events,
+    native_interrupt: caps.native_interrupt,
+    image_input: caps.image_input,
+    slash_commands: caps.slash_commands,
+  };
+}
+
+export function parseCodeWorkspace(
+  value: unknown,
+): ActiveCodeWorkspace | null {
+  const workspace = record(value);
+  if (
+    !workspace ||
+    !nonEmpty(workspace.id) ||
+    !nonEmpty(workspace.repo_id) ||
+    typeof workspace.title !== "string" ||
+    !nonEmpty(workspace.branch_name) ||
+    !nonEmpty(workspace.base_ref) ||
+    !codeWorkspaceStatus(workspace.status) ||
+    !nonEmpty(workspace.created_at)
+  ) {
+    return null;
+  }
+  return {
+    id: workspace.id,
+    repo_id: workspace.repo_id,
+    title: workspace.title,
+    branch_name: workspace.branch_name,
+    base_ref: workspace.base_ref,
+    status: workspace.status,
+    created_at: workspace.created_at,
+  };
+}
+
+export function parseCodeHarness(value: unknown): CodeHarnessOption | null {
+  const harness = record(value);
+  const caps = parseHarnessCaps(harness?.caps);
+  if (
+    !harness ||
+    !harnessKind(harness.kind) ||
+    typeof harness.found !== "boolean" ||
+    typeof harness.installable !== "boolean" ||
+    !optionalString(harness.version) ||
+    !optionalBoolean(harness.authenticated) ||
+    !harnessAuthMode(harness.auth_mode) ||
+    typeof harness.remediation !== "string" ||
+    !caps
+  ) {
+    return null;
+  }
+  return {
+    kind: harness.kind,
+    found: harness.found,
+    installable: harness.installable,
+    ...(harness.version !== undefined ? { version: harness.version } : {}),
+    ...(harness.authenticated !== undefined
+      ? { authenticated: harness.authenticated }
+      : {}),
+    auth_mode: harness.auth_mode,
+    remediation: harness.remediation,
+    caps,
+  };
+}
+
+function parseHarnessModel(value: unknown): HarnessModel | null {
+  const model = record(value);
+  if (
+    !model ||
+    !nonEmpty(model.id) ||
+    !nonEmpty(model.label) ||
+    typeof model.default !== "boolean" ||
+    !Array.isArray(model.reasoning_efforts) ||
+    !model.reasoning_efforts.every(reasoningEffort) ||
+    typeof model.fast_mode !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    id: model.id,
+    label: model.label,
+    default: model.default,
+    reasoning_efforts: model.reasoning_efforts,
+    fast_mode: model.fast_mode,
+  };
+}
+
+export function parseCodeHarnessModels(
+  value: unknown,
+): CodeHarnessModels | null {
+  const listing = record(value);
+  if (
+    !listing ||
+    !harnessKind(listing.kind) ||
+    !Array.isArray(listing.models) ||
+    !Array.isArray(listing.reasoning_efforts) ||
+    !listing.reasoning_efforts.every(reasoningEffort) ||
+    !["harness", "model_gateway"].includes(String(listing.source))
+  ) {
+    return null;
+  }
+  const models = listing.models.map(parseHarnessModel);
+  if (models.some((model) => model === null)) return null;
+  return {
+    kind: listing.kind,
+    models: models as HarnessModel[],
+    reasoning_efforts: listing.reasoning_efforts,
+    source: listing.source as HarnessModelSource,
+  };
+}
+
+export function parseCreatedCodeSession(
+  value: unknown,
+): CreatedCodeSession | null {
+  const session = record(value);
+  if (
+    !session ||
+    !nonEmpty(session.id) ||
+    !nonEmpty(session.workspace_id) ||
+    !harnessKind(session.harness_kind) ||
+    !permissionMode(session.permission_mode) ||
+    !optionalString(session.model) ||
+    !(
+      session.reasoning_effort === undefined ||
+      reasoningEffort(session.reasoning_effort)
+    ) ||
+    typeof session.fast_mode !== "boolean" ||
+    !codeSessionLifecycle(session.lifecycle) ||
+    !nonEmpty(session.created_at)
+  ) {
+    return null;
+  }
+  return {
+    id: session.id,
+    workspace_id: session.workspace_id,
+    harness_kind: session.harness_kind,
+    permission_mode: session.permission_mode,
+    ...(session.model !== undefined ? { model: session.model } : {}),
+    ...(session.reasoning_effort !== undefined
+      ? { reasoning_effort: session.reasoning_effort }
+      : {}),
+    fast_mode: session.fast_mode,
+    lifecycle: session.lifecycle,
+    created_at: session.created_at,
+  };
 }
 
 function parseApprovalKind(value: unknown): CodeApprovalKind | null {
@@ -142,6 +435,131 @@ function parseList<T>(
 function required<T>(value: T | null, label: string): T {
   if (!value) throw new Error(`${label} response contains invalid data.`);
   return value;
+}
+
+export async function listActiveCodeWorkspaces(
+  client: MachineJsonClient,
+): Promise<ActiveCodeWorkspace[]> {
+  return parseList(
+    await client.getJson("/code/workspaces"),
+    parseCodeWorkspace,
+    "Code workspaces",
+  ).filter((workspace) => workspace.status === "active");
+}
+
+export async function listCodeHarnesses(
+  client: MachineJsonClient,
+): Promise<CodeHarnessOption[]> {
+  const report = record(await client.getJson("/code/harnesses"));
+  if (!report || !Array.isArray(report.harnesses)) {
+    throw new Error("Code harnesses response contains invalid data.");
+  }
+  return parseList(report.harnesses, parseCodeHarness, "Code harnesses");
+}
+
+export async function listCodeHarnessModels(
+  client: MachineJsonClient,
+  kind: HarnessKind,
+): Promise<CodeHarnessModels> {
+  const listing = required(
+    parseCodeHarnessModels(
+      await client.getJson(
+        `/code/harnesses/${encodeURIComponent(kind)}/models`,
+      ),
+    ),
+    "Code harness models",
+  );
+  if (listing.kind !== kind) {
+    throw new Error("Code harness models response named a different harness.");
+  }
+  return listing;
+}
+
+export async function getCodePermissionPolicy(
+  client: MachineJsonClient,
+): Promise<CodePermissionPolicy> {
+  const policy = record(await client.getJson("/policy"));
+  if (!policy) {
+    throw new Error("Machine policy response contains invalid data.");
+  }
+  if (
+    policy.permission_mode_ceiling !== undefined &&
+    !permissionMode(policy.permission_mode_ceiling)
+  ) {
+    throw new Error("Machine policy response contains invalid data.");
+  }
+  return policy.permission_mode_ceiling === undefined
+    ? {}
+    : { permission_mode_ceiling: policy.permission_mode_ceiling };
+}
+
+export async function createCodeSession(
+  client: MachineJsonClient,
+  workspaceId: string,
+  input: CreateCodeSessionInput,
+): Promise<CreatedCodeSession> {
+  const body = {
+    harness: input.harness,
+    permission_mode: input.permission_mode,
+    ...(input.model ? { model: input.model } : {}),
+    ...(input.reasoning_effort
+      ? { reasoning_effort: input.reasoning_effort }
+      : {}),
+    ...(input.fast_mode ? { fast_mode: true } : {}),
+  };
+  const session = required(
+    parseCreatedCodeSession(
+      await client.requestJson(
+        `/code/workspaces/${encodeURIComponent(workspaceId)}/sessions`,
+        { method: "POST", body, expectedStatus: 201 },
+      ),
+    ),
+    "Code session",
+  );
+  if (
+    session.workspace_id !== workspaceId ||
+    session.harness_kind !== input.harness ||
+    session.permission_mode !== input.permission_mode
+  ) {
+    throw new Error("Code session response did not match the launch request.");
+  }
+  return session;
+}
+
+export async function launchCodeSession(
+  client: MachineJsonClient,
+  workspaceId: string,
+  input: CreateCodeSessionInput,
+  firstMessage: string,
+): Promise<CodeSessionLaunchResult> {
+  const session = await createCodeSession(client, workspaceId, input);
+  const submittedMessage = firstMessage.trim();
+  if (!submittedMessage) {
+    return {
+      session,
+      submitted: null,
+      undeliveredDraft: null,
+      sendError: null,
+    };
+  }
+  try {
+    return {
+      session,
+      submitted: await submitCodeTurn(client, session.id, submittedMessage),
+      undeliveredDraft: null,
+      sendError: null,
+    };
+  } catch (error) {
+    return {
+      session,
+      submitted: null,
+      undeliveredDraft: firstMessage,
+      sendError:
+        error instanceof Error
+          ? error.message
+          : "The first message could not be sent.",
+    };
+  }
 }
 
 export async function listCodeApprovals(

--- a/mobile/src/lib/codeLaunch.test.ts
+++ b/mobile/src/lib/codeLaunch.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { CodeHarnessOption } from "./api";
+import {
+  createPermissionModes,
+  defaultCreatePermissionMode,
+  harnessUnavailableReason,
+  permissionModeWarning,
+  permittedPermissionModes,
+} from "./codeLaunch";
+
+const harness: CodeHarnessOption = {
+  kind: "codex",
+  found: true,
+  installable: true,
+  authenticated: true,
+  auth_mode: "local_sign_in",
+  remediation: "",
+  caps: {
+    resume: "supported",
+    streaming_deltas: "supported",
+    structured_approvals: "supported",
+    mid_turn_steering: "supported",
+    plan_mode: "supported",
+    auto_mode: "supported",
+    allow_mode: "supported",
+    reasoning_levels: "supported",
+    native_file_change_events: "supported",
+    native_interrupt: "supported",
+    image_input: "unsupported",
+    slash_commands: "supported",
+  },
+};
+
+describe("mobile code launch choices", () => {
+  it("offers only modes the harness supports and policy permits", () => {
+    expect(createPermissionModes(harness.caps)).toEqual([
+      "plan",
+      "ask",
+      "auto",
+      "allow",
+    ]);
+    const capped = permittedPermissionModes(harness.caps, "ask");
+    expect(capped).toEqual(["plan", "ask"]);
+    expect(defaultCreatePermissionMode(capped)).toBe("ask");
+  });
+
+  it("states why a harness cannot start instead of leaving a dead control", () => {
+    expect(harnessUnavailableReason(harness)).toBeNull();
+    expect(
+      harnessUnavailableReason({
+        ...harness,
+        found: false,
+        authenticated: undefined,
+      }),
+    ).toMatch(/desktop first/);
+    expect(
+      harnessUnavailableReason({
+        ...harness,
+        auth_mode: "hosted_unavailable",
+      }),
+    ).toMatch(/hosted machines/);
+    expect(
+      harnessUnavailableReason({
+        ...harness,
+        authenticated: false,
+        remediation: "Run codex login.",
+      }),
+    ).toBe("Run codex login.");
+  });
+
+  it("warns when the selected posture has nobody to ask", () => {
+    expect(permissionModeWarning("allow", harness.caps)).toMatch(
+      /without asking/,
+    );
+    expect(permissionModeWarning("auto", harness.caps)).toBeNull();
+    expect(
+      permissionModeWarning("auto", {
+        ...harness.caps,
+        structured_approvals: "unsupported",
+      }),
+    ).toMatch(/no approval channel/);
+  });
+});
+

--- a/mobile/src/lib/codeLaunch.ts
+++ b/mobile/src/lib/codeLaunch.ts
@@ -1,0 +1,105 @@
+import type {
+  HarnessCaps,
+  HarnessKind,
+  PermissionMode,
+} from "../generated/wire";
+import type { CodeHarnessOption } from "./api";
+
+export const HARNESS_LABELS: Record<HarnessKind, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex CLI",
+  opencode: "opencode",
+  grok: "Grok CLI",
+};
+
+export const PERMISSION_MODE_LABELS: Record<PermissionMode, string> = {
+  plan: "Plan",
+  ask: "Ask",
+  auto: "Auto",
+  allow: "Allow all",
+};
+
+export const PERMISSION_MODE_DESCRIPTIONS: Record<PermissionMode, string> = {
+  plan: "Plans the work and writes nothing.",
+  ask: "Asks before every tool that changes something.",
+  auto: "Decides for itself as it works.",
+  allow: "Runs every tool without asking.",
+};
+
+const PERMISSION_SCALE: PermissionMode[] = ["plan", "ask", "auto", "allow"];
+
+type ModeCaps = Pick<
+  HarnessCaps,
+  "plan_mode" | "structured_approvals" | "auto_mode" | "allow_mode"
+>;
+
+export function createPermissionModes(caps: ModeCaps): PermissionMode[] {
+  const modes: PermissionMode[] = [];
+  if (caps.plan_mode === "supported") modes.push("plan");
+  if (caps.structured_approvals === "supported") modes.push("ask");
+  if (caps.auto_mode === "supported") modes.push("auto");
+  if (caps.allow_mode === "supported") modes.push("allow");
+  return modes;
+}
+
+export function permittedPermissionModes(
+  caps: ModeCaps,
+  ceiling: PermissionMode | undefined,
+): PermissionMode[] {
+  const modes = createPermissionModes(caps);
+  if (!ceiling) return modes;
+  const ceilingRank = PERMISSION_SCALE.indexOf(ceiling);
+  return modes.filter(
+    (mode) => PERMISSION_SCALE.indexOf(mode) <= ceilingRank,
+  );
+}
+
+export function defaultCreatePermissionMode(
+  modes: readonly PermissionMode[],
+): PermissionMode | null {
+  return modes.length > 0 ? modes[modes.length - 1] ?? null : null;
+}
+
+export function harnessUnavailableReason(
+  harness: CodeHarnessOption,
+): string | null {
+  if (harness.auth_mode === "hosted_unavailable") {
+    return "Not available on hosted machines.";
+  }
+  if (!harness.found) {
+    return harness.installable
+      ? "Install this harness from Tidebreak desktop first."
+      : "Not installed on this machine.";
+  }
+  if (
+    harness.auth_mode === "local_sign_in" &&
+    harness.authenticated !== true
+  ) {
+    return harness.remediation || "Sign in on the machine first.";
+  }
+  if (createPermissionModes(harness.caps).length === 0) {
+    return "This harness cannot start a session.";
+  }
+  return null;
+}
+
+export function harnessCanStartNow(harness: CodeHarnessOption): boolean {
+  return harnessUnavailableReason(harness) === null;
+}
+
+export function permissionModeWarning(
+  mode: PermissionMode,
+  caps: ModeCaps,
+): string | null {
+  if (mode === "allow") {
+    return "This harness runs every tool without asking.";
+  }
+  if (
+    mode === "auto" &&
+    caps.structured_approvals !== "supported"
+  ) {
+    return "This harness has no approval channel. Auto runs every action without asking.";
+  }
+  return null;
+}
+

--- a/mobile/src/session/draftRecovery.test.ts
+++ b/mobile/src/session/draftRecovery.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSessionDraftRecoveryStore } from "./draftRecovery";
+
+describe("session draft recovery", () => {
+  beforeEach(() => useSessionDraftRecoveryStore.getState().reset());
+
+  it("keeps an undelivered launch draft until the created session opens", () => {
+    useSessionDraftRecoveryStore.getState().offer("session-1", {
+      draft: "Keep these words",
+      error: "The first message did not send.",
+    });
+    expect(
+      useSessionDraftRecoveryStore.getState().bySession["session-1"],
+    ).toEqual({
+      draft: "Keep these words",
+      error: "The first message did not send.",
+    });
+
+    useSessionDraftRecoveryStore.getState().consume("session-1");
+    expect(
+      useSessionDraftRecoveryStore.getState().bySession["session-1"],
+    ).toBeUndefined();
+  });
+});
+

--- a/mobile/src/session/draftRecovery.ts
+++ b/mobile/src/session/draftRecovery.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+export type SessionDraftRecovery = {
+  draft: string;
+  error: string;
+};
+
+type SessionDraftRecoveryState = {
+  bySession: Record<string, SessionDraftRecovery>;
+  offer: (sessionId: string, recovery: SessionDraftRecovery) => void;
+  consume: (sessionId: string) => void;
+  reset: () => void;
+};
+
+export const useSessionDraftRecoveryStore =
+  create<SessionDraftRecoveryState>((set) => ({
+    bySession: {},
+    offer: (sessionId, recovery) =>
+      set((state) => ({
+        bySession: { ...state.bySession, [sessionId]: recovery },
+      })),
+    consume: (sessionId) =>
+      set((state) => {
+        if (!(sessionId in state.bySession)) return state;
+        const bySession = { ...state.bySession };
+        delete bySession[sessionId];
+        return { bySession };
+      }),
+    reset: () => set({ bySession: {} }),
+  }));
+


### PR DESCRIPTION
## What changed

Add the mobile workspace-to-session launch flow. Active workspace rows now open a form that chooses a usable harness, model, and permission mode while honoring the machine policy.

Validate workspace, harness, model, policy, and created-session responses before using them. If the first message fails after session creation, open the session with the draft and error intact.

## Validation

- `CI=true npx --yes pnpm@10.18.3 --dir mobile typecheck`
- `CI=true npx --yes pnpm@10.18.3 --dir mobile lint`
- `CI=true npx --yes pnpm@10.18.3 --dir mobile test` — 19 files and 71 tests passed.
- Expo web export — 1,306 modules bundled.
- Visual screenshot review is blocked because no browser is connected to this session.

## Compatibility and risk

No persisted or wire-format changes. A machine that omits the current launch capability fields now returns a clear invalid-data error instead of rendering dead controls.

## Tracking

Part of #2647

