### PR TITLE
feat(mobile): browse and message chats

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -46,6 +46,8 @@ export default function RootLayout() {
             name="workspace/[id]/start"
             options={{ title: "Start session" }}
           />
+          <Stack.Screen name="chats" options={{ title: "Chats" }} />
+          <Stack.Screen name="chat/[id]" options={{ title: "Chat" }} />
           <Stack.Screen name="sessions" options={{ title: "Sessions" }} />
           <Stack.Screen name="session/[id]" options={{ title: "Session" }} />
           <Stack.Screen name="approvals" options={{ title: "Approvals" }} />

--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -1,0 +1,320 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import * as Crypto from "expo-crypto";
+import {
+  useIsFocused,
+  useLocalSearchParams,
+  useRouter,
+} from "expo-router";
+import { useEffect, useRef, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  RefreshControl,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Button, LoadingState } from "../../src/components/Controls";
+import { ErrorText } from "../../src/components/Screen";
+import {
+  addOptimisticMobileChatQueuedTurn,
+  chatTurnIdentityForDraft,
+  getMobileChat,
+  getMobileChatTranscript,
+  listMobileChatQueuedTurns,
+  postMobileChatMessage,
+  type MobileChatMessage,
+  type MobileChatQueue,
+  type MobileChatQueuedTurn,
+  type MobileChatTurnIdentity,
+} from "../../src/lib/chatApi";
+import { useSessionStore } from "../../src/session/store";
+import { useMachineClient } from "../../src/session/useMachineClient";
+
+export default function ChatDetailScreen() {
+  const router = useRouter();
+  const isFocused = useIsFocused();
+  const params = useLocalSearchParams<{ id?: string; title?: string }>();
+  const machine = useSessionStore((state) => state.session?.machine);
+  const client = useMachineClient();
+  const queryClient = useQueryClient();
+  const scrollRef = useRef<ScrollView>(null);
+  const sendingRef = useRef(false);
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [receipt, setReceipt] = useState<string | null>(null);
+  const [pendingIdentity, setPendingIdentity] =
+    useState<MobileChatTurnIdentity | null>(null);
+  const chatId = params.id;
+  const machineKey = machine?.baseUrl;
+  const chatQuery = useQuery({
+    queryKey: ["mobile-chat", machineKey, chatId],
+    enabled: !!client && !!chatId && isFocused,
+    queryFn: () => getMobileChat(client!, chatId!),
+  });
+  const transcriptQuery = useQuery({
+    queryKey: ["mobile-chat-transcript", machineKey, chatId],
+    enabled: !!client && !!chatId && isFocused,
+    queryFn: () => getMobileChatTranscript(client!, chatId!),
+    refetchInterval: isFocused ? 3_000 : false,
+  });
+  const queueKey = ["mobile-chat-queue", machineKey, chatId] as const;
+  const queueQuery = useQuery({
+    queryKey: queueKey,
+    enabled: !!client && !!chatId && isFocused,
+    queryFn: () => listMobileChatQueuedTurns(client!, chatId!),
+    refetchInterval: isFocused ? 3_000 : false,
+  });
+  const messages = transcriptQuery.data?.messages ?? [];
+  const queued = queueQuery.data?.queued ?? [];
+
+  useEffect(() => {
+    scrollRef.current?.scrollToEnd({ animated: true });
+  }, [messages.length, queued.length]);
+
+  async function refreshMessages() {
+    await Promise.all([transcriptQuery.refetch(), queueQuery.refetch()]);
+  }
+
+  async function sendMessage() {
+    const content = message.trim();
+    if (!client || !chatId || !content || sendingRef.current) return;
+    const identity = chatTurnIdentityForDraft(
+      pendingIdentity,
+      content,
+      Crypto.randomUUID,
+    );
+    setPendingIdentity(identity);
+    sendingRef.current = true;
+    setSending(true);
+    setSendError(null);
+    setReceipt(null);
+    try {
+      await postMobileChatMessage(
+        client,
+        chatId,
+        identity.turnId,
+        identity.content,
+      );
+      await queryClient.cancelQueries({ queryKey: queueKey });
+      queryClient.setQueryData<MobileChatQueue>(queueKey, (current) =>
+        addOptimisticMobileChatQueuedTurn(
+          current,
+          chatId,
+          identity,
+          new Date().toISOString(),
+        ),
+      );
+      setMessage("");
+      setPendingIdentity(null);
+      setReceipt("Message accepted. Responses refresh automatically.");
+      await queryClient.invalidateQueries({
+        queryKey: ["mobile-chat-transcript", machineKey, chatId],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["mobile-chats", machineKey],
+      });
+    } catch (error) {
+      setSendError(
+        error instanceof Error ? error.message : "The message could not be sent.",
+      );
+    } finally {
+      sendingRef.current = false;
+      setSending(false);
+    }
+  }
+
+  if (!machine || !client || !chatId) {
+    return (
+      <SafeAreaView className="flex-1 bg-page-background px-5 py-6">
+        <ErrorText>Attach a machine before you open this chat.</ErrorText>
+        <View className="mt-4">
+          <Button label="Go back" onPress={() => router.replace("/chats")} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const title = chatQuery.data?.title?.trim() || params.title || "New work";
+
+  return (
+    <SafeAreaView className="flex-1 bg-page-background">
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 74 : 0}
+      >
+        <View className="border-b border-border px-5 py-3">
+          <Text
+            className="text-lg font-semibold text-foreground"
+            numberOfLines={2}
+          >
+            {title}
+          </Text>
+          <Text
+            className="mt-0.5 font-mono text-xs text-muted-foreground"
+            numberOfLines={1}
+          >
+            {chatQuery.data?.model || "Default model"}
+          </Text>
+        </View>
+
+        <ScrollView
+          ref={scrollRef}
+          className="flex-1"
+          contentContainerClassName="gap-3 px-5 py-4"
+          keyboardShouldPersistTaps="handled"
+          refreshControl={
+            <RefreshControl
+              refreshing={
+                transcriptQuery.isRefetching || queueQuery.isRefetching
+              }
+              onRefresh={() => void refreshMessages()}
+            />
+          }
+        >
+          {chatQuery.isError ? (
+            <ErrorText>
+              {chatQuery.error instanceof Error
+                ? chatQuery.error.message
+                : "The chat could not be loaded."}
+            </ErrorText>
+          ) : null}
+          {transcriptQuery.isLoading ? (
+            <LoadingState label="Loading messages…" />
+          ) : null}
+          {transcriptQuery.isError ? (
+            <ErrorText>
+              {transcriptQuery.error instanceof Error
+                ? transcriptQuery.error.message
+                : "The messages could not be loaded."}
+            </ErrorText>
+          ) : null}
+          {queueQuery.isError ? (
+            <ErrorText>
+              {queueQuery.error instanceof Error
+                ? queueQuery.error.message
+                : "The queued messages could not be loaded."}
+            </ErrorText>
+          ) : null}
+          {!transcriptQuery.isLoading &&
+          !transcriptQuery.isError &&
+          !queueQuery.isLoading &&
+          !queueQuery.isError &&
+          messages.length === 0 &&
+          queued.length === 0 ? (
+            <View className="rounded-xl border border-border bg-background p-4">
+              <Text className="text-base font-medium text-foreground">
+                Start the conversation
+              </Text>
+              <Text className="mt-1 text-sm text-muted-foreground">
+                Send the first message from the composer.
+              </Text>
+            </View>
+          ) : null}
+          {messages.map((item) => (
+            <ChatMessage key={item.id} message={item} />
+          ))}
+          {queued.map((turn) => (
+            <QueuedChatMessage
+              key={turn.id}
+              turn={turn}
+              paused={queueQuery.data?.paused ?? false}
+            />
+          ))}
+        </ScrollView>
+
+        <View className="gap-2 border-t border-border bg-background px-4 py-3">
+          {receipt ? (
+            <Text className="text-xs text-success-foreground">{receipt}</Text>
+          ) : null}
+          {sendError ? <ErrorText>{sendError}</ErrorText> : null}
+          <TextInput
+            multiline
+            value={message}
+            editable={!sending}
+            accessibilityLabel="Message"
+            placeholder="Message this chat"
+            placeholderTextColor="#697386"
+            textAlignVertical="top"
+            className="max-h-40 min-h-20 rounded-xl border border-border bg-page-background px-3 py-3 text-base text-foreground"
+            onChangeText={(next) => {
+              setMessage(next);
+              setReceipt(null);
+              setSendError(null);
+            }}
+          />
+          <Button
+            label="Send"
+            busy={sending}
+            disabled={!message.trim() || chatQuery.isError}
+            onPress={() => void sendMessage()}
+          />
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function QueuedChatMessage({
+  turn,
+  paused,
+}: {
+  turn: MobileChatQueuedTurn;
+  paused: boolean;
+}) {
+  return (
+    <View
+      accessible
+      accessibilityLabel={paused ? "Queued message, paused" : "Queued message"}
+      className="ml-8 rounded-xl border border-dashed border-info-border bg-info-background p-3"
+    >
+      <Text className="mb-1 text-xs font-medium uppercase tracking-wide text-info-foreground">
+        {paused ? "Queued · Paused" : "Queued"}
+      </Text>
+      <Text className="text-base text-foreground" selectable>
+        {turn.content}
+      </Text>
+    </View>
+  );
+}
+
+function ChatMessage({ message }: { message: MobileChatMessage }) {
+  if (message.role === "compaction") {
+    return (
+      <Text className="py-2 text-center text-xs text-muted-foreground">
+        Earlier messages were summarized.
+      </Text>
+    );
+  }
+  const user = message.role === "user";
+  const system = message.role === "system";
+  return (
+    <View
+      className={`rounded-xl border p-3 ${
+        user
+          ? "ml-8 border-primary bg-primary"
+          : system
+            ? "border-info-border bg-info-background"
+            : "mr-8 border-border bg-background"
+      }`}
+    >
+      {system ? (
+        <Text className="mb-1 text-xs font-medium uppercase tracking-wide text-info-foreground">
+          System
+        </Text>
+      ) : null}
+      <Text
+        className={`text-base ${
+          user ? "text-primary-foreground" : "text-foreground"
+        }`}
+        selectable
+      >
+        {message.content}
+      </Text>
+    </View>
+  );
+}

--- a/mobile/app/chats.tsx
+++ b/mobile/app/chats.tsx
@@ -1,0 +1,166 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIsFocused, useRouter } from "expo-router";
+import { useRef, useState } from "react";
+import {
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Button, LoadingState } from "../src/components/Controls";
+import { Body, ErrorText } from "../src/components/Screen";
+import {
+  createMobileChat,
+  listMobileChats,
+  type MobileChat,
+} from "../src/lib/chatApi";
+import { useSessionStore } from "../src/session/store";
+import { useMachineClient } from "../src/session/useMachineClient";
+
+export default function ChatsScreen() {
+  const router = useRouter();
+  const isFocused = useIsFocused();
+  const queryClient = useQueryClient();
+  const machine = useSessionStore((state) => state.session?.machine);
+  const client = useMachineClient();
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const creatingRef = useRef(false);
+  const queryKey = ["mobile-chats", machine?.baseUrl] as const;
+  const chatsQuery = useQuery({
+    queryKey,
+    enabled: !!client && isFocused,
+    queryFn: () => listMobileChats(client!),
+  });
+
+  async function createChat() {
+    if (!client || creatingRef.current) return;
+    creatingRef.current = true;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const chat = await createMobileChat(client);
+      queryClient.setQueryData<MobileChat[]>(queryKey, (current) => [
+        chat,
+        ...(current ?? []).filter((item) => item.id !== chat.id),
+      ]);
+      router.push({
+        pathname: "/chat/[id]",
+        params: { id: chat.id, title: chat.title || "New work" },
+      });
+    } catch (error) {
+      setCreateError(
+        error instanceof Error ? error.message : "The chat could not be created.",
+      );
+    } finally {
+      creatingRef.current = false;
+      setCreating(false);
+    }
+  }
+
+  if (!machine || !client) {
+    return (
+      <SafeAreaView className="flex-1 bg-page-background px-5 py-6">
+        <Text className="text-2xl font-semibold text-foreground">Chats</Text>
+        <View className="mt-3">
+          <Body>Attach a Tidebreak machine to use chats.</Body>
+        </View>
+        <View className="mt-4">
+          <Button label="Attach" onPress={() => router.replace("/attach")} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const chats = chatsQuery.data ?? [];
+
+  return (
+    <SafeAreaView className="flex-1 bg-page-background">
+      <ScrollView
+        contentContainerClassName="gap-3 px-5 py-6"
+        refreshControl={
+          <RefreshControl
+            refreshing={chatsQuery.isRefetching}
+            onRefresh={() => void chatsQuery.refetch()}
+          />
+        }
+      >
+        <View className="flex-row items-center justify-between gap-3">
+          <View className="flex-1">
+            <Text className="text-2xl font-semibold text-foreground">Chats</Text>
+            <Text className="mt-1 text-sm text-muted-foreground">
+              Send a message without opening the desktop app.
+            </Text>
+          </View>
+          <Button
+            label="New chat"
+            compact
+            busy={creating}
+            onPress={() => void createChat()}
+          />
+        </View>
+
+        {createError ? <ErrorText>{createError}</ErrorText> : null}
+        {chatsQuery.isLoading ? <LoadingState label="Loading chats…" /> : null}
+        {chatsQuery.isError ? (
+          <ErrorText>
+            {chatsQuery.error instanceof Error
+              ? chatsQuery.error.message
+              : "The chat list could not be loaded."}
+          </ErrorText>
+        ) : null}
+        {!chatsQuery.isLoading && !chatsQuery.isError && chats.length === 0 ? (
+          <View className="rounded-xl border border-border bg-background p-4">
+            <Text className="text-base font-medium text-foreground">
+              No chats yet
+            </Text>
+            <Text className="mt-1 text-sm text-muted-foreground">
+              Start a chat, then send its first message from your phone.
+            </Text>
+          </View>
+        ) : null}
+
+        {chats.map((chat) => (
+          <Pressable
+            key={chat.id}
+            accessibilityRole="button"
+            accessibilityLabel={`Open ${chat.title?.trim() || "new work"}`}
+            className="gap-1 rounded-xl border border-border bg-background p-4"
+            onPress={() =>
+              router.push({
+                pathname: "/chat/[id]",
+                params: { id: chat.id, title: chat.title || "New work" },
+              })
+            }
+          >
+            <Text className="text-base font-medium text-foreground">
+              {chat.title?.trim() || "New work"}
+            </Text>
+            <Text
+              className="font-mono text-xs text-muted-foreground"
+              numberOfLines={1}
+            >
+              {chat.model || "Default model"}
+            </Text>
+            <Text className="text-xs text-muted-foreground">
+              {formatChatDate(chat.created_at)}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function formatChatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/mobile/app/home.tsx
+++ b/mobile/app/home.tsx
@@ -123,6 +123,12 @@ export default function HomeScreen() {
       </View>
       <Pressable
         className="rounded-lg border border-border bg-background px-4 py-3"
+        onPress={() => router.push("/chats")}
+      >
+        <Text className="text-center text-base text-foreground">Chats</Text>
+      </Pressable>
+      <Pressable
+        className="rounded-lg border border-border bg-background px-4 py-3"
         onPress={() => router.push("/approvals")}
       >
         <Text className="text-center text-base text-foreground">Approvals</Text>

--- a/mobile/src/lib/chatApi.test.ts
+++ b/mobile/src/lib/chatApi.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MachineClient } from "./machine";
+import {
+  addOptimisticMobileChatQueuedTurn,
+  chatTurnIdentityForDraft,
+  createMobileChat,
+  getMobileChat,
+  getMobileChatTranscript,
+  listMobileChatQueuedTurns,
+  listMobileChats,
+  parseMobileChat,
+  parseMobileChatQueue,
+  parseMobileChatQueuedTurn,
+  parseMobileChatTranscript,
+  postMobileChatMessage,
+} from "./chatApi";
+
+const chat = {
+  id: "chat-1",
+  project_id: null,
+  title: "Launch review",
+  model: "model-gateway::gpt-5.6-sol",
+  reasoning_effort: "high",
+  permission_mode: "ask",
+  network_policy: { mode: "open" },
+  attachment_revision: 0,
+  root_attachments: [],
+  created_at: "2026-08-27T20:00:00Z",
+};
+
+const transcript = {
+  messages: [
+    {
+      id: "message-1",
+      role: "user",
+      content: "Review the launch flow.",
+      created_at: "2026-08-27T20:00:01Z",
+      citations: [],
+    },
+  ],
+  tool_activity: [],
+  terminal_turns: [],
+  last_event_seq: 3,
+};
+
+const queuedTurn = {
+  id: "00000000-0000-4000-8000-000000000001",
+  chat_id: "chat-1",
+  content: "Continue.",
+  attachments: [],
+  file_attachments: [],
+  invoked_skills: [],
+  voice_input_used: false,
+  position: 0,
+  created_at: "2026-08-27T20:00:02Z",
+  updated_at: "2026-08-27T20:00:02Z",
+};
+
+function fakeClient(response: unknown): {
+  client: Pick<MachineClient, "getJson" | "requestJson">;
+  getJson: ReturnType<typeof vi.fn>;
+  requestJson: ReturnType<typeof vi.fn>;
+} {
+  const getJson = vi.fn(async () => response);
+  const requestJson = vi.fn(async () => response);
+  return { client: { getJson, requestJson }, getJson, requestJson };
+}
+
+describe("mobile chat API contracts", () => {
+  it("validates chat rows and rejects a partial list", async () => {
+    expect(parseMobileChat(chat)).toEqual({
+      id: "chat-1",
+      project_id: null,
+      title: "Launch review",
+      model: "model-gateway::gpt-5.6-sol",
+      created_at: "2026-08-27T20:00:00Z",
+    });
+    expect(parseMobileChat({ id: "chat-1" })).toBeNull();
+    expect(parseMobileChat({ ...chat, model: "" })).toBeNull();
+
+    const listed = fakeClient([chat]);
+    await expect(listMobileChats(listed.client)).resolves.toHaveLength(1);
+    expect(listed.getJson).toHaveBeenCalledWith("/chats");
+
+    const invalid = fakeClient([chat, { ...chat, created_at: null }]);
+    await expect(listMobileChats(invalid.client)).rejects.toThrow(/invalid data/);
+  });
+
+  it("loads one chat and its renderer-safe transcript", async () => {
+    const one = fakeClient(chat);
+    await expect(getMobileChat(one.client, "chat/1")).resolves.toMatchObject({
+      id: "chat-1",
+    });
+    expect(one.getJson).toHaveBeenCalledWith("/chats/chat%2F1");
+
+    expect(parseMobileChatTranscript(transcript)).toEqual({
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          content: "Review the launch flow.",
+          created_at: "2026-08-27T20:00:01Z",
+        },
+      ],
+      last_event_seq: 3,
+    });
+    expect(
+      parseMobileChatTranscript({
+        ...transcript,
+        messages: [{ ...transcript.messages[0], citations: null }],
+      }),
+    ).toBeNull();
+    expect(
+      parseMobileChatTranscript({ ...transcript, last_event_seq: -1 }),
+    ).toBeNull();
+
+    const history = fakeClient(transcript);
+    await expect(
+      getMobileChatTranscript(history.client, "chat/1"),
+    ).resolves.toMatchObject({
+      messages: [expect.objectContaining({ id: "message-1" })],
+      last_event_seq: 3,
+    });
+    expect(history.getJson).toHaveBeenCalledWith("/chats/chat%2F1/messages");
+  });
+
+  it("creates a chat with sticky defaults", async () => {
+    const created = fakeClient(chat);
+    await expect(createMobileChat(created.client)).resolves.toMatchObject({
+      id: "chat-1",
+    });
+    expect(created.requestJson).toHaveBeenCalledWith("/chats", {
+      method: "POST",
+      body: {},
+      expectedStatus: 201,
+    });
+  });
+
+  it("loads and validates a chat queue", async () => {
+    expect(parseMobileChatQueuedTurn(queuedTurn)).toEqual(queuedTurn);
+    expect(
+      parseMobileChatQueuedTurn({ ...queuedTurn, attachments: [null] }),
+    ).toBeNull();
+    expect(
+      parseMobileChatQueuedTurn({ ...queuedTurn, position: -1 }),
+    ).toBeNull();
+    expect(
+      parseMobileChatQueuedTurn({ ...queuedTurn, content: "" }),
+    ).toBeNull();
+
+    const snapshot = { queued: [queuedTurn], paused: true };
+    expect(parseMobileChatQueue(snapshot)).toEqual(snapshot);
+    expect(parseMobileChatQueue({ ...snapshot, paused: "yes" })).toBeNull();
+
+    const listed = fakeClient(snapshot);
+    await expect(
+      listMobileChatQueuedTurns(listed.client, "chat/1"),
+    ).resolves.toEqual(snapshot);
+    expect(listed.getJson).toHaveBeenCalledWith("/chats/chat%2F1/queued");
+
+    const invalid = fakeClient({
+      queued: [queuedTurn, { ...queuedTurn, updated_at: null }],
+      paused: false,
+    });
+    await expect(
+      listMobileChatQueuedTurns(invalid.client, "chat-1"),
+    ).rejects.toThrow(/invalid data/);
+  });
+
+  it("posts a queued, idempotent turn with the caller's identity", async () => {
+    const sent = fakeClient(undefined);
+    await postMobileChatMessage(
+      sent.client,
+      "chat/1",
+      "00000000-0000-4000-8000-000000000001",
+      "  Continue.  ",
+    );
+    expect(sent.requestJson).toHaveBeenCalledWith(
+      "/chats/chat%2F1/messages",
+      {
+        method: "POST",
+        body: {
+          turn_id: "00000000-0000-4000-8000-000000000001",
+          content: "Continue.",
+          attachments: [],
+          file_attachments: [],
+          invoked_skills: [],
+          voice_input_used: false,
+          queue: true,
+        },
+        expectedStatus: 202,
+      },
+    );
+
+    await expect(
+      postMobileChatMessage(sent.client, "chat-1", "turn-2", "   "),
+    ).rejects.toThrow(/must not be empty/);
+  });
+
+  it("reuses a turn id when the same failed draft is retried", () => {
+    const pending = {
+      turnId: "00000000-0000-4000-8000-000000000001",
+      content: "Continue.",
+    };
+    expect(
+      chatTurnIdentityForDraft(pending, "  Continue.  ", () => "new-turn"),
+    ).toBe(pending);
+    expect(
+      chatTurnIdentityForDraft(pending, "Try another way.", () => "new-turn"),
+    ).toEqual({ turnId: "new-turn", content: "Try another way." });
+  });
+
+  it("adds one optimistic queued turn and deduplicates its turn id", () => {
+    const identity = {
+      turnId: "00000000-0000-4000-8000-000000000002",
+      content: "Try another way.",
+    };
+    const snapshot = addOptimisticMobileChatQueuedTurn(
+      { queued: [queuedTurn], paused: true },
+      "chat-1",
+      identity,
+      "2026-08-27T20:00:03Z",
+    );
+    expect(snapshot).toEqual({
+      paused: true,
+      queued: [
+        queuedTurn,
+        {
+          id: identity.turnId,
+          chat_id: "chat-1",
+          content: identity.content,
+          attachments: [],
+          file_attachments: [],
+          invoked_skills: [],
+          voice_input_used: false,
+          position: 1,
+          created_at: "2026-08-27T20:00:03Z",
+          updated_at: "2026-08-27T20:00:03Z",
+        },
+      ],
+    });
+    expect(
+      addOptimisticMobileChatQueuedTurn(
+        snapshot,
+        "chat-1",
+        identity,
+        "2026-08-27T20:00:04Z",
+      ),
+    ).toBe(snapshot);
+  });
+});

--- a/mobile/src/lib/chatApi.ts
+++ b/mobile/src/lib/chatApi.ts
@@ -1,0 +1,336 @@
+import type { TranscriptRole } from "../generated/wire";
+import type { MachineClient } from "./machine";
+
+type MachineJsonClient = Pick<MachineClient, "getJson" | "requestJson">;
+
+export type MobileChat = {
+  id: string;
+  project_id: string | null;
+  title: string | null;
+  model: string | null;
+  created_at: string;
+};
+
+export type MobileChatMessage = {
+  id: string;
+  role: TranscriptRole;
+  content: string;
+  created_at: string;
+};
+
+export type MobileChatTranscript = {
+  messages: MobileChatMessage[];
+  last_event_seq: number;
+};
+
+export type MobileChatQueuedTurn = {
+  id: string;
+  chat_id: string;
+  content: string;
+  attachments: string[];
+  file_attachments: string[];
+  invoked_skills: string[];
+  voice_input_used: boolean;
+  position: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type MobileChatQueue = {
+  queued: MobileChatQueuedTurn[];
+  paused: boolean;
+};
+
+export type MobileChatTurnIdentity = {
+  turnId: string;
+  content: string;
+};
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function nullableNonEmpty(value: unknown): value is string | null {
+  return value === null || nonEmpty(value);
+}
+
+function nonNegativeSafeInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0
+  );
+}
+
+function nonEmptyStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(nonEmpty);
+}
+
+function transcriptRole(value: unknown): value is TranscriptRole {
+  return ["user", "assistant", "system", "compaction"].includes(
+    String(value),
+  );
+}
+
+export function parseMobileChat(value: unknown): MobileChat | null {
+  const chat = record(value);
+  if (
+    !chat ||
+    !nonEmpty(chat.id) ||
+    !(chat.project_id === null || nonEmpty(chat.project_id)) ||
+    !nullableNonEmpty(chat.title) ||
+    !nullableNonEmpty(chat.model) ||
+    !nonEmpty(chat.created_at)
+  ) {
+    return null;
+  }
+  return {
+    id: chat.id,
+    project_id: chat.project_id,
+    title: chat.title,
+    model: chat.model,
+    created_at: chat.created_at,
+  };
+}
+
+export function parseMobileChatMessage(
+  value: unknown,
+): MobileChatMessage | null {
+  const message = record(value);
+  if (
+    !message ||
+    !nonEmpty(message.id) ||
+    !transcriptRole(message.role) ||
+    typeof message.content !== "string" ||
+    !nonEmpty(message.created_at) ||
+    !Array.isArray(message.citations)
+  ) {
+    return null;
+  }
+  return {
+    id: message.id,
+    role: message.role,
+    content: message.content,
+    created_at: message.created_at,
+  };
+}
+
+export function parseMobileChatTranscript(
+  value: unknown,
+): MobileChatTranscript | null {
+  const transcript = record(value);
+  if (
+    !transcript ||
+    !Array.isArray(transcript.messages) ||
+    !Array.isArray(transcript.tool_activity) ||
+    !Array.isArray(transcript.terminal_turns) ||
+    !nonNegativeSafeInteger(transcript.last_event_seq)
+  ) {
+    return null;
+  }
+  const messages = transcript.messages.map(parseMobileChatMessage);
+  if (messages.some((message) => message === null)) return null;
+  return {
+    messages: messages as MobileChatMessage[],
+    last_event_seq: transcript.last_event_seq,
+  };
+}
+
+export function parseMobileChatQueuedTurn(
+  value: unknown,
+): MobileChatQueuedTurn | null {
+  const turn = record(value);
+  if (
+    !turn ||
+    !nonEmpty(turn.id) ||
+    !nonEmpty(turn.chat_id) ||
+    !nonEmpty(turn.content) ||
+    !nonEmptyStringArray(turn.attachments) ||
+    !nonEmptyStringArray(turn.file_attachments) ||
+    !nonEmptyStringArray(turn.invoked_skills) ||
+    typeof turn.voice_input_used !== "boolean" ||
+    !nonNegativeSafeInteger(turn.position) ||
+    !nonEmpty(turn.created_at) ||
+    !nonEmpty(turn.updated_at)
+  ) {
+    return null;
+  }
+  return {
+    id: turn.id,
+    chat_id: turn.chat_id,
+    content: turn.content,
+    attachments: turn.attachments,
+    file_attachments: turn.file_attachments,
+    invoked_skills: turn.invoked_skills,
+    voice_input_used: turn.voice_input_used,
+    position: turn.position,
+    created_at: turn.created_at,
+    updated_at: turn.updated_at,
+  };
+}
+
+export function parseMobileChatQueue(value: unknown): MobileChatQueue | null {
+  const snapshot = record(value);
+  if (
+    !snapshot ||
+    !Array.isArray(snapshot.queued) ||
+    typeof snapshot.paused !== "boolean"
+  ) {
+    return null;
+  }
+  const queued = snapshot.queued.map(parseMobileChatQueuedTurn);
+  if (queued.some((turn) => turn === null)) return null;
+  return {
+    queued: queued as MobileChatQueuedTurn[],
+    paused: snapshot.paused,
+  };
+}
+
+function required<T>(value: T | null, label: string): T {
+  if (!value) throw new Error(`${label} response contains invalid data.`);
+  return value;
+}
+
+function parseChatList(value: unknown): MobileChat[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Chat list response is not an array.");
+  }
+  return value.map((item) => required(parseMobileChat(item), "Chat list"));
+}
+
+export async function listMobileChats(
+  client: MachineJsonClient,
+): Promise<MobileChat[]> {
+  return parseChatList(await client.getJson("/chats"));
+}
+
+export async function getMobileChat(
+  client: MachineJsonClient,
+  chatId: string,
+): Promise<MobileChat> {
+  return required(
+    parseMobileChat(
+      await client.getJson(`/chats/${encodeURIComponent(chatId)}`),
+    ),
+    "Chat",
+  );
+}
+
+export async function createMobileChat(
+  client: MachineJsonClient,
+): Promise<MobileChat> {
+  return required(
+    parseMobileChat(
+      await client.requestJson("/chats", {
+        method: "POST",
+        body: {},
+        expectedStatus: 201,
+      }),
+    ),
+    "Chat",
+  );
+}
+
+export async function getMobileChatTranscript(
+  client: MachineJsonClient,
+  chatId: string,
+): Promise<MobileChatTranscript> {
+  return required(
+    parseMobileChatTranscript(
+      await client.getJson(
+        `/chats/${encodeURIComponent(chatId)}/messages`,
+      ),
+    ),
+    "Chat transcript",
+  );
+}
+
+export async function listMobileChatQueuedTurns(
+  client: MachineJsonClient,
+  chatId: string,
+): Promise<MobileChatQueue> {
+  return required(
+    parseMobileChatQueue(
+      await client.getJson(
+        `/chats/${encodeURIComponent(chatId)}/queued`,
+      ),
+    ),
+    "Chat queue",
+  );
+}
+
+export async function postMobileChatMessage(
+  client: MachineJsonClient,
+  chatId: string,
+  turnId: string,
+  content: string,
+): Promise<void> {
+  const message = content.trim();
+  if (!message) throw new Error("Message must not be empty.");
+  await client.requestJson(
+    `/chats/${encodeURIComponent(chatId)}/messages`,
+    {
+      method: "POST",
+      body: {
+        turn_id: turnId,
+        content: message,
+        attachments: [],
+        file_attachments: [],
+        invoked_skills: [],
+        voice_input_used: false,
+        queue: true,
+      },
+      expectedStatus: 202,
+    },
+  );
+}
+
+export function chatTurnIdentityForDraft(
+  pending: MobileChatTurnIdentity | null,
+  content: string,
+  createTurnId: () => string,
+): MobileChatTurnIdentity {
+  const message = content.trim();
+  if (pending?.content === message) return pending;
+  return { turnId: createTurnId(), content: message };
+}
+
+export function addOptimisticMobileChatQueuedTurn(
+  current: MobileChatQueue | undefined,
+  chatId: string,
+  identity: MobileChatTurnIdentity,
+  createdAt: string,
+): MobileChatQueue {
+  const snapshot = current ?? { queued: [], paused: false };
+  if (snapshot.queued.some((turn) => turn.id === identity.turnId)) {
+    return snapshot;
+  }
+  const position = snapshot.queued.reduce(
+    (largest, turn) => Math.max(largest, turn.position),
+    -1,
+  ) + 1;
+  return {
+    ...snapshot,
+    queued: [
+      ...snapshot.queued,
+      {
+        id: identity.turnId,
+        chat_id: chatId,
+        content: identity.content,
+        attachments: [],
+        file_attachments: [],
+        invoked_skills: [],
+        voice_input_used: false,
+        position,
+        created_at: createdAt,
+        updated_at: createdAt,
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## What changed

Add a mobile chat list and chat detail screen. You can create a chat with the machine's sticky defaults, reopen existing chats, refresh the durable transcript, and send queued messages from your phone.

Use a client-generated turn ID for each draft and reuse that ID after a failed request. An uncertain retry cannot create a duplicate turn. Chat queries stop polling when the screen leaves focus.

## Validation

- `CI=true npx --yes pnpm@10.18.3 --dir mobile typecheck`
- `CI=true npx --yes pnpm@10.18.3 --dir mobile lint`
- `CI=true npx --yes pnpm@10.18.3 --dir mobile test` — 20 files and 76 tests passed.
- Expo web export — 1,316 modules bundled.
- Visual screenshot review is blocked because no browser is connected to this session.

## Compatibility and risk

No persisted or wire-format changes. The mobile client validates the chat and transcript fields it renders before accepting a response.

## Tracking

Part of #2647