### PR TITLE
fix(code): explain a managed ceiling that permits no engine mode

### DIFF
--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -64,6 +64,7 @@ use super::worktree::{
     run_archive_script, run_setup_script, slugify, validate_repo_path, worktree_dir, WorktreeError,
 };
 use crate::error::ServerError;
+use crate::managed_policy::ManagedPolicy;
 use crate::routes::code::types::{CodeDeliveryPullRequestTarget, CodeGitHubRepositoryTarget};
 
 const MANAGED_NODE_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
@@ -368,6 +369,11 @@ pub(crate) struct NewSessionSettings {
     pub reasoning_effort: Option<ReasoningEffort>,
     /// Whether the session starts armed for the engine's fast mode.
     pub fast_mode: bool,
+    /// The managed permission-mode ceiling in force at create, when one is
+    /// asserted. Copied from resolved policy so this path can refuse a
+    /// ceiling that permits no mode the engine offers, after probe, on the
+    /// same ceiling the route already clamps against.
+    pub permission_mode_ceiling: Option<PermissionMode>,
 }
 
 struct SelectedModelCapabilities {
@@ -3115,6 +3121,7 @@ impl CodeRuntime {
             model,
             reasoning_effort,
             fast_mode,
+            permission_mode_ceiling,
         }: NewSessionSettings,
     ) -> Result<CodeSession, ServerError> {
         let lifecycle = self.workspace_lifecycle_lock(workspace_id);
@@ -3188,6 +3195,19 @@ impl CodeRuntime {
             ));
         }
         let caps = adapter.capabilities(&probe);
+        refuse_ceiling_with_no_offered_mode(permission_mode_ceiling, harness, &caps)?;
+        if let Some(ceiling) = permission_mode_ceiling {
+            if permission_mode > ceiling {
+                return Err(ServerError::conflict_kind(
+                    "permission_mode_locked",
+                    format!(
+                        "permission mode `{}` exceeds the maximum this managed profile allows (`{}`)",
+                        permission_mode.as_str(),
+                        ceiling.as_str()
+                    ),
+                ));
+            }
+        }
         refuse_unhonored_mode(harness, permission_mode, &caps)?;
         if probe.binary_path.is_none() {
             return Err(ServerError::unprocessable_kind(
@@ -5828,21 +5848,55 @@ fn normalize_model(model: Option<String>) -> Option<String> {
     })
 }
 
+fn offered_permission_modes(caps: &tidebreak_core::HarnessCaps) -> Vec<PermissionMode> {
+    PermissionMode::ALL
+        .iter()
+        .copied()
+        .filter(|&mode| honors_permission_mode(mode, caps))
+        .collect()
+}
+
+fn honors_permission_mode(mode: PermissionMode, caps: &tidebreak_core::HarnessCaps) -> bool {
+    // Each mode stands on its own capability flag (decision 0038): Auto is
+    // never derived from the approval channel, so an engine whose only
+    // honest posture is unsupervised Auto can still be driven.
+    match mode {
+        PermissionMode::Plan => caps.plan_mode == CapLevel::Supported,
+        PermissionMode::Ask => caps.structured_approvals == CapLevel::Supported,
+        PermissionMode::Auto => caps.auto_mode == CapLevel::Supported,
+        PermissionMode::Allow => caps.allow_mode == CapLevel::Supported,
+    }
+}
+
+fn refuse_ceiling_with_no_offered_mode(
+    ceiling: Option<PermissionMode>,
+    harness: HarnessKind,
+    caps: &tidebreak_core::HarnessCaps,
+) -> Result<(), ServerError> {
+    let Some(ceiling) = ceiling else {
+        return Ok(());
+    };
+    if !ManagedPolicy::permission_mode_ceiling_excludes_all(
+        Some(ceiling),
+        offered_permission_modes(caps),
+    ) {
+        return Ok(());
+    }
+    Err(ServerError::conflict_kind(
+        "permission_mode_locked",
+        format!(
+            "{harness} offers no permission mode at or below the managed ceiling (`{}`)",
+            ceiling.as_str()
+        ),
+    ))
+}
+
 fn refuse_unhonored_mode(
     harness: HarnessKind,
     mode: PermissionMode,
     caps: &tidebreak_core::HarnessCaps,
 ) -> Result<(), ServerError> {
-    // Each mode stands on its own capability flag (decision 0038): Auto is
-    // never derived from the approval channel, so an engine whose only
-    // honest posture is unsupervised Auto can still be driven.
-    let ok = match mode {
-        PermissionMode::Plan => caps.plan_mode == CapLevel::Supported,
-        PermissionMode::Ask => caps.structured_approvals == CapLevel::Supported,
-        PermissionMode::Auto => caps.auto_mode == CapLevel::Supported,
-        PermissionMode::Allow => caps.allow_mode == CapLevel::Supported,
-    };
-    if ok {
+    if honors_permission_mode(mode, caps) {
         return Ok(());
     }
     let reason = match mode {

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -329,6 +329,7 @@ impl CodeRuntime {
                     // conversation someone is watching, and a watch task runs
                     // unattended where nobody is waiting on the tokens.
                     fast_mode: false,
+                    permission_mode_ceiling: None,
                 },
             )
             .await?;

--- a/crates/tidebreak-server/src/managed_policy.rs
+++ b/crates/tidebreak-server/src/managed_policy.rs
@@ -162,6 +162,17 @@ impl ManagedPolicy {
         self.permission_mode_ceiling
             .is_none_or(|ceiling| mode <= ceiling)
     }
+
+    /// True when an asserted ceiling leaves `offered` empty.
+    pub(crate) fn permission_mode_ceiling_excludes_all(
+        ceiling: Option<PermissionMode>,
+        offered: impl IntoIterator<Item = PermissionMode>,
+    ) -> bool {
+        let Some(ceiling) = ceiling else {
+            return false;
+        };
+        offered.into_iter().all(|mode| mode > ceiling)
+    }
 }
 
 /// An OS-managed policy reader. One per platform — macOS managed preferences,
@@ -1677,6 +1688,25 @@ mod tests {
             plan_capped.clamp_permission_mode(None),
             Some(PermissionMode::Plan)
         );
+
+        // A Plan-only ceiling against Auto/Allow offered modes is empty:
+        // the clamp still has a number, but create has nothing to post.
+        assert!(ManagedPolicy::permission_mode_ceiling_excludes_all(
+            Some(PermissionMode::Plan),
+            [PermissionMode::Auto, PermissionMode::Allow],
+        ));
+        assert!(!ManagedPolicy::permission_mode_ceiling_excludes_all(
+            Some(PermissionMode::Ask),
+            [
+                PermissionMode::Plan,
+                PermissionMode::Ask,
+                PermissionMode::Auto
+            ],
+        ));
+        assert!(!ManagedPolicy::permission_mode_ceiling_excludes_all(
+            None,
+            [PermissionMode::Auto],
+        ));
     }
 
     /// The channel-fallthrough decision, end to end through resolution: a

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -27,7 +27,10 @@ pub async fn create_session(
     Path(workspace_id): Path<WorkspaceId>,
     Json(body): Json<CreateSessionBody>,
 ) -> Result<impl IntoResponse, ServerError> {
-    refuse_permission_mode_over_ceiling(&state, Some(body.permission_mode)).await?;
+    // Ceiling vs. engine intersection is decided after probe, inside create:
+    // an empty intersection must name the conflict instead of looking like a
+    // single over-ceiling pick.
+    let permission_mode_ceiling = state.managed_policy()?.permission_mode_ceiling;
     let session = code
         .create_session(
             workspace_id,
@@ -37,6 +40,7 @@ pub async fn create_session(
                 model: body.model,
                 reasoning_effort: body.reasoning_effort,
                 fast_mode: body.fast_mode,
+                permission_mode_ceiling,
             },
         )
         .await?;

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -105,6 +105,7 @@ pub(crate) struct ScriptedAdapter {
     steering_delay: Duration,
     steering_rejection: Option<String>,
     structured_approvals: CapLevel,
+    plan_mode: CapLevel,
     auto_mode: CapLevel,
     allow_mode: CapLevel,
     image_input: CapLevel,
@@ -163,6 +164,7 @@ impl ScriptedAdapter {
             steering_delay: Duration::ZERO,
             steering_rejection: None,
             structured_approvals: CapLevel::Unsupported,
+            plan_mode: CapLevel::Supported,
             auto_mode: CapLevel::Unsupported,
             allow_mode: CapLevel::Unsupported,
             image_input: CapLevel::Unknown,
@@ -244,6 +246,12 @@ impl ScriptedAdapter {
     /// for exercising the mode gate's per-flag refusals.
     pub(crate) fn with_auto_mode(mut self, level: CapLevel) -> Self {
         self.auto_mode = level;
+        self
+    }
+
+    /// Overrides plan independently of the other postures.
+    pub(crate) fn with_plan_mode(mut self, level: CapLevel) -> Self {
+        self.plan_mode = level;
         self
     }
 
@@ -423,7 +431,7 @@ impl HarnessAdapter for ScriptedAdapter {
             streaming_deltas: CapLevel::Supported,
             structured_approvals: self.structured_approvals,
             mid_turn_steering: self.mid_turn_steering,
-            plan_mode: CapLevel::Supported,
+            plan_mode: self.plan_mode,
             auto_mode: self.auto_mode,
             allow_mode: self.allow_mode,
             reasoning_levels: self.reasoning_levels,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -783,6 +783,54 @@ async fn a_managed_ceiling_refuses_over_ceiling_code_session_modes() {
     assert_eq!(body["permission_mode"], "plan", "{body}");
 }
 
+/// A Plan-only ceiling against an engine that only offers Auto/Allow is not
+/// a missing picker: create must name the ceiling and the engine.
+#[tokio::test]
+async fn a_managed_ceiling_that_permits_no_engine_mode_is_named() {
+    let adapter = ScriptedAdapter::new(plain_text_script())
+        .with_kind(HarnessKind::Grok)
+        .with_plan_mode(CapLevel::Unsupported)
+        .with_auto_mode(CapLevel::Supported)
+        .with_allow_mode(CapLevel::Supported);
+    let (router, token, _runtime, dir) = code_app_with_ceiling(adapter, PermissionMode::Plan).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+
+    let sessions_url = format!(
+        "http://{addr}/code/workspaces/{}/sessions",
+        json_id(&workspace)
+    );
+    // Posting the engine's default (Auto) or a below-ceiling Plan must both
+    // name the empty intersection — not look like a lone over-ceiling pick
+    // or an engine that simply cannot honor Plan.
+    for mode in ["auto", "plan"] {
+        let refused = client
+            .post(&sessions_url)
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "harness": "grok",
+                "permission_mode": mode,
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+        let body: serde_json::Value = refused.json().await.unwrap();
+        assert_eq!(body["kind"], "permission_mode_locked", "{body}");
+        let message = body["message"].as_str().unwrap_or("");
+        assert!(
+            message.contains("grok") && message.contains("plan") && message.contains("ceiling"),
+            "{mode}: {message}"
+        );
+        assert!(
+            !message.contains("exceeds the maximum"),
+            "{mode}: {message}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn plan_is_the_only_session_mode_and_a_turn_journals_end_to_end() {
     let (router, token, _runtime, dir) = code_app(plain_text_script()).await;


### PR DESCRIPTION
Closes #2842.

## Why

If a managed permission ceiling permits no mode the engine offers, you currently hit a dead end: the picker has nothing selectable and create either refuses without naming the policy or looks like a single over-ceiling pick.

## What you get

When session create probes the engine and the ceiling intersects its offered modes to empty, you receive `permission_mode_locked` that names the engine and the ceiling. The check reuses the existing OS-managed ceiling; it does not add a second permission system.

If you post Auto (the engine default) or Plan (at a Plan-only ceiling) against Grok-style Auto/Allow caps, you still get that empty-intersection message rather than a generic over-ceiling or `permission_mode_unavailable` error.

## Test

`a_managed_ceiling_that_permits_no_engine_mode_is_named` fails if the empty intersection stays silent.