### PR TITLE
fix(desktop): cache pull request detail state

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -163,6 +163,23 @@ async function rowFor(title: string): Promise<HTMLElement> {
 }
 
 describe("delivery pull request list", () => {
+  it("fills the available width before a pull request is open", async () => {
+    renderList();
+
+    const list = await screen.findByRole("list", { name: "Pull requests" });
+    expect(list.parentElement).toHaveClass("min-w-0", "flex-1");
+  });
+
+  it("fills the available width while pull requests load", async () => {
+    renderList({
+      ...storyClient(),
+      queryCodeDeliveryPullRequests: async () => deferred().promise,
+    } as unknown as ApiClient);
+
+    const skeleton = await screen.findByRole("status", { name: "Loading" });
+    expect(skeleton).toHaveClass("w-full", "min-w-0", "flex-1");
+  });
+
   it("re-reads when the server nudges the delivery channel", async () => {
     // The server says when the pull-request store moved (decision 66). The
     // list is a projection of that nudge, not a clock of its own: without
@@ -397,6 +414,59 @@ describe("delivery pull request list", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
+  it("moves a pull request when its opened detail reports a new state", async () => {
+    const user = userEvent.setup();
+    const listed = deliveryPullRequests[0]!;
+    const merged = {
+      ...listed,
+      state: "merged" as const,
+      merged_at: "2026-08-27T19:45:00.000Z",
+      updated_at: "2026-08-27T19:45:00.000Z",
+    };
+    const client = deliveryClient({
+      queryCodeDeliveryPullRequests: async () => ({
+        capability: deliveryRepositoriesSnapshot.capability,
+        items: [listed],
+        errors: [],
+        fetched_at: "2026-08-27T19:44:00.000Z",
+      }),
+      getCodeDeliveryPullRequestDetail: async () => ({
+        ...deliveryPullRequestDetails[2251]!,
+        summary: merged,
+      }),
+    });
+    await renderDeliveryRoute(
+      "pull_requests",
+      client,
+      "/code/delivery/pull-requests?view=all",
+    );
+
+    expect(await rowFor(listed.title)).toHaveAttribute(
+      "data-status-group",
+      "attention",
+    );
+    await user.click(await rowFor(listed.title));
+    const detail = await screen.findByTestId("pull-request-detail-pane");
+    expect(
+      within(detail).getByLabelText("Pull request summary"),
+    ).toHaveTextContent("Merged");
+    await waitFor(async () => {
+      expect(await rowFor(listed.title)).toHaveAttribute(
+        "data-status-group",
+        "done",
+      );
+    });
+    expect(
+      useCodeDeliveryStore
+        .getState()
+        .lastPullRequestPages.flatMap((page) => page.items)
+        .find((item) => item.id === listed.id),
+    ).toMatchObject({ state: "merged" });
+    expect(
+      screen.getByText("Done").closest('[data-pull-request-group="Done"]'),
+    ).not.toBeNull();
+  });
+
   it("moves the open pane with ArrowDown and ArrowUp", async () => {
     const user = userEvent.setup();
     await renderDeliveryRoute(
@@ -418,6 +488,61 @@ describe("delivery pull request list", () => {
         "Build the delivery center",
       ),
     );
+  });
+
+  it("reuses cached detail when arrow navigation returns to a pull request", async () => {
+    const user = userEvent.setup();
+    const getDetail = vi.fn(async ({ number }: { number: number }) =>
+      Promise.resolve(deliveryPullRequestDetails[number]!),
+    );
+    await renderDeliveryRoute(
+      "pull_requests",
+      deliveryClient({ getCodeDeliveryPullRequestDetail: getDetail as never }),
+      "/code/delivery/pull-requests?view=all",
+    );
+
+    await user.click(await rowFor("Build the delivery center"));
+    await screen.findByRole("tab", { name: /Conversation/ });
+    await user.keyboard("{ArrowDown}");
+    await waitFor(() =>
+      expect(
+        getDetail.mock.calls.some(([request]) => request.number === 2229),
+      ).toBe(true),
+    );
+    await screen.findByRole("tab", { name: /Conversation/ });
+    await user.keyboard("{ArrowUp}");
+    await new Promise((resolve) => window.setTimeout(resolve, 180));
+
+    expect(
+      getDetail.mock.calls.filter(([request]) => request.number === 2251),
+    ).toHaveLength(1);
+    expect(screen.getByTestId("pull-request-detail-pane")).toHaveTextContent(
+      "Build the delivery center",
+    );
+  });
+
+  it("debounces uncached detail reads during rapid arrow navigation", async () => {
+    const user = userEvent.setup();
+    const getDetail = vi.fn(async ({ number }: { number: number }) =>
+      Promise.resolve(deliveryPullRequestDetails[number]!),
+    );
+    await renderDeliveryRoute(
+      "pull_requests",
+      deliveryClient({ getCodeDeliveryPullRequestDetail: getDetail as never }),
+      "/code/delivery/pull-requests?view=all",
+    );
+
+    await user.click(await rowFor("Build the delivery center"));
+    await screen.findByRole("tab", { name: /Conversation/ });
+    await user.keyboard("{ArrowDown}{ArrowUp}");
+    await new Promise((resolve) => window.setTimeout(resolve, 180));
+
+    expect(
+      getDetail.mock.calls.filter(([request]) => request.number === 2229),
+    ).toHaveLength(0);
+    expect(
+      getDetail.mock.calls.filter(([request]) => request.number === 2251),
+    ).toHaveLength(1);
   });
 
   it("leaves the open pane alone while typing a comment", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -802,6 +802,9 @@ type TargetDetailState<T> = {
   detail: T | null;
 };
 
+const PULL_REQUEST_DETAIL_SELECTION_DEBOUNCE_MS = 140;
+const MAX_PULL_REQUEST_DETAIL_CACHE = 24;
+
 function PullRequestsSurface({
   repositories,
   capability,
@@ -835,6 +838,7 @@ function PullRequestsSurface({
   const [error, setError] = useState<string | null>(null);
   const [fetchedAt, setFetchedAt] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detailLoadDelayMs, setDetailLoadDelayMs] = useState(0);
   const [targetDetailState, setTargetDetailState] =
     useState<TargetDetailState<CodeDeliveryPullRequestDetail> | null>(null);
   const [revision, setRevision] = useState(0);
@@ -856,6 +860,7 @@ function PullRequestsSurface({
   const adoptedSummaries = useRef(
     new Map<string, CodeDeliveryPullRequestSummary>(),
   );
+  const detailCache = useRef(new Map<string, CodeDeliveryPullRequestDetail>());
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const selected = useMemo(
@@ -953,19 +958,33 @@ function PullRequestsSurface({
   useEffect(() => {
     routeSelectionFenced.current = false;
     setSelectedId(null);
+    setDetailLoadDelayMs(0);
     setTargetDetailState(
       targetKey ? { key: targetKey, pending: true, detail: null } : null,
     );
   }, [targetKey]);
 
-  const selectItem = (id: string) => {
+  const selectItem = (id: string, debounceDetail = false) => {
     routeSelectionFenced.current = true;
+    setDetailLoadDelayMs(
+      debounceDetail ? PULL_REQUEST_DETAIL_SELECTION_DEBOUNCE_MS : 0,
+    );
     setSelectedId(id);
   };
 
   const closeDetail = () => {
     routeSelectionFenced.current = true;
+    setDetailLoadDelayMs(0);
     setSelectedId(null);
+  };
+
+  const rememberDetail = (detail: CodeDeliveryPullRequestDetail) => {
+    detailCache.current.delete(detail.summary.id);
+    detailCache.current.set(detail.summary.id, detail);
+    if (detailCache.current.size > MAX_PULL_REQUEST_DETAIL_CACHE) {
+      const oldest = detailCache.current.keys().next().value;
+      if (oldest) detailCache.current.delete(oldest);
+    }
   };
 
   const applyAdopted = (rows: CodeDeliveryPullRequestSummary[]) =>
@@ -973,7 +992,27 @@ function PullRequestsSurface({
 
   const adoptSummary = (summary: CodeDeliveryPullRequestSummary) => {
     adoptedSummaries.current.set(summary.id, summary);
-    setItems((current) => applyAdopted(current));
+    setItems((current) =>
+      current.map((item) =>
+        item.id === summary.id
+          ? summary
+          : (adoptedSummaries.current.get(item.id) ?? item),
+      ),
+    );
+
+    const cached = useCodeDeliveryStore
+      .getState()
+      .lastPullRequestPages.find((page) => page.key === pageKey);
+    if (cached) {
+      useCodeDeliveryStore.getState().rememberPullRequestPage({
+        ...cached,
+        items: cached.items.map((item) =>
+          item.id === summary.id
+            ? summary
+            : (adoptedSummaries.current.get(item.id) ?? item),
+        ),
+      });
+    }
   };
 
   const query = async (cursor?: string, append = false) => {
@@ -1009,6 +1048,7 @@ function PullRequestsSurface({
           .getCodeDeliveryPullRequestDetail(target)
           .then((detail) => {
             if (token === generation.current) {
+              rememberDetail(detail);
               setTargetDetailState({
                 key: requestKey,
                 pending: false,
@@ -1151,7 +1191,7 @@ function PullRequestsSurface({
         return;
       }
       const nextId = displayIds[nextIndex];
-      if (nextId) selectItem(nextId);
+      if (nextId) selectItem(nextId, true);
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
@@ -1178,9 +1218,23 @@ function PullRequestsSurface({
     targetDetailState.pending &&
     !targetDetailState.detail &&
     pullRequestMatchesTarget(selected, target);
+  const cachedDetail = selected
+    ? detailCache.current.get(selected.id)
+    : undefined;
+  const initialDetail =
+    selected && targetDetailState?.detail?.summary.id === selected.id
+      ? targetDetailState.detail
+      : cachedDetail &&
+          selected &&
+          cachedDetail.summary.updated_at >= selected.updated_at
+        ? cachedDetail
+        : undefined;
 
   const list = (
-    <div ref={scrollRef} className="min-h-0 h-full overflow-auto">
+    <div
+      ref={scrollRef}
+      className="min-h-0 h-full min-w-0 flex-1 overflow-auto"
+    >
       {error && (
         <InlineLoadError message={error} onRetry={() => void query()} />
       )}
@@ -1248,17 +1302,15 @@ function PullRequestsSurface({
       key={selected.id}
       client={client}
       summary={selected}
+      loadDelayMs={detailLoadDelayMs}
       hasMergeQueue={deliveryRepositoryHasMergeQueue(
         items,
         selected.repository,
       )}
-      initialDetail={
-        targetDetailState?.detail?.summary.id === selected.id
-          ? targetDetailState.detail
-          : undefined
-      }
+      initialDetail={initialDetail}
       onClose={closeDetail}
       onChanged={refreshList}
+      onDetail={rememberDetail}
       onSummary={adoptSummary}
       onOpenWorkspace={(workspaceId) =>
         void navigate({
@@ -3682,7 +3734,11 @@ function InlineLoadError({
 
 function DeliveryListSkeleton() {
   return (
-    <div className="flex min-h-0 flex-1 flex-col p-5" role="status">
+    <div
+      className="flex min-h-0 w-full min-w-0 flex-1 flex-col p-5"
+      role="status"
+      aria-label="Loading"
+    >
       <span className="sr-only">Loading</span>
       {Array.from({ length: 7 }, (_, index) => (
         <div

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -171,9 +171,11 @@ export function PullRequestDetailSheet({
   client,
   summary,
   initialDetail,
+  loadDelayMs = 0,
   hasMergeQueue = false,
   onClose,
   onChanged,
+  onDetail,
   onSummary,
   onOpenWorkspace,
 }: {
@@ -187,8 +189,10 @@ export function PullRequestDetailSheet({
   summary: CodeDeliveryPullRequestSummary;
   hasMergeQueue?: boolean;
   initialDetail?: CodeDeliveryPullRequestDetail;
+  loadDelayMs?: number;
   onClose: () => void;
   onChanged: () => void;
+  onDetail?: (detail: CodeDeliveryPullRequestDetail) => void;
   onSummary?: (summary: CodeDeliveryPullRequestSummary) => void;
   onOpenWorkspace: (workspaceId: string) => void;
 }) {
@@ -201,9 +205,11 @@ export function PullRequestDetailSheet({
         client={client}
         summary={summary}
         initialDetail={initialDetail}
+        loadDelayMs={loadDelayMs}
         hasMergeQueue={hasMergeQueue}
         onClose={onClose}
         onChanged={onChanged}
+        onDetail={onDetail}
         onSummary={onSummary}
         onOpenWorkspace={onOpenWorkspace}
       />
@@ -222,9 +228,11 @@ export function PullRequestDetailPane({
   client,
   summary,
   initialDetail,
+  loadDelayMs = 0,
   hasMergeQueue = false,
   onClose,
   onChanged,
+  onDetail,
   onSummary,
   onOpenWorkspace,
 }: {
@@ -239,8 +247,12 @@ export function PullRequestDetailPane({
   /** True when this repository already uses a merge queue. */
   hasMergeQueue?: boolean;
   initialDetail?: CodeDeliveryPullRequestDetail;
+  /** Delay an uncached read while keyboard selection is still moving. */
+  loadDelayMs?: number;
   onClose?: () => void;
   onChanged: () => void;
+  /** Keep loaded detail available when the reader returns to this row. */
+  onDetail?: (detail: CodeDeliveryPullRequestDetail) => void;
   /** The list row should follow this summary so its action matches the pane. */
   onSummary?: (summary: CodeDeliveryPullRequestSummary) => void;
   onOpenWorkspace: (workspaceId: string) => void;
@@ -264,7 +276,9 @@ export function PullRequestDetailPane({
   const generation = useRef(0);
   const activeTarget = useRef(summary.id);
   const mounted = useRef(true);
+  const onDetailRef = useRef(onDetail);
   const onSummaryRef = useRef(onSummary);
+  onDetailRef.current = onDetail;
   onSummaryRef.current = onSummary;
   activeTarget.current = summary.id;
 
@@ -280,6 +294,7 @@ export function PullRequestDetailPane({
 
   const adoptDetail = (next: CodeDeliveryPullRequestDetail) => {
     setDetail(next);
+    onDetailRef.current?.(next);
     onSummaryRef.current?.(next.summary);
   };
 
@@ -319,13 +334,17 @@ export function PullRequestDetailPane({
       setLoading(false);
     } else {
       setDetail(null);
-      void load();
+      const timer = window.setTimeout(() => void load(), loadDelayMs);
+      return () => {
+        window.clearTimeout(timer);
+        generation.current += 1;
+      };
     }
     return () => {
       generation.current += 1;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, initialDetail, summary.id]);
+  }, [client, initialDetail, loadDelayMs, summary.id]);
 
   const runAction = async (
     name: string,

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -50,6 +50,7 @@ type DeliveryScenario =
   | "pull-requests-empty"
   | "pull-requests-stacked"
   | "pull-requests-unregistered"
+  | "pull-requests-state-changed"
   | "pull-requests-partial"
   | "pull-requests-no-viewer"
   | "github-unavailable"
@@ -152,6 +153,12 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
           (workspace) => workspace.status !== "archived",
         )
       : deliveryWorkspaces;
+  const refreshedMergedPullRequest = {
+    ...deliveryPullRequests[0]!,
+    state: "merged" as const,
+    merged_at: "2026-08-27T19:45:00.000Z",
+    updated_at: "2026-08-27T19:45:00.000Z",
+  };
 
   return {
     openCodeUpdates: () => idleSocket(),
@@ -210,7 +217,9 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
               ? stackedDeliveryPullRequests
               : scenario === "pull-requests-unregistered"
                 ? unregisteredDeliveryPullRequests
-                : deliveryPullRequests,
+                : scenario === "pull-requests-state-changed"
+                  ? [deliveryPullRequests[0]!]
+                  : deliveryPullRequests,
         errors:
           scenario === "pull-requests-partial"
             ? [
@@ -232,7 +241,13 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
     getCodeDeliveryPullRequestDetail: async ({
       number,
     }: CodeDeliveryPullRequestTarget) =>
-      deliveryPullRequestDetails[number] ?? deliveryPullRequestDetails[2251]!,
+      scenario === "pull-requests-state-changed" && number === 2251
+        ? {
+            ...deliveryPullRequestDetails[2251]!,
+            summary: refreshedMergedPullRequest,
+          }
+        : (deliveryPullRequestDetails[number] ??
+          deliveryPullRequestDetails[2251]!),
     runCodeDeliveryPullRequestAction: async ({
       action,
     }: CodeDeliveryPullRequestActionBody) => ({
@@ -642,6 +657,21 @@ export const PullRequestDetail: Story = {
   },
 };
 
+/** Opening stale list data adopts the merged state and moves the row to Done. */
+export const PullRequestStateChangedOnOpen: Story = {
+  args: { scenario: "pull-requests-state-changed" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await openPullRequest(canvasElement, "Build the delivery center");
+    await expect(
+      await canvas.findByLabelText("Pull request summary"),
+    ).toHaveTextContent("Merged");
+    const row = await canvas.findByRole("listitem");
+    await expect(row).toHaveAttribute("data-status-group", "done");
+    await expect(await canvas.findByText("Done")).toBeVisible();
+  },
+};
+
 /**
  * A stack-shaped chain the host has no stack for: every row carries the
  * unregistered marker, and the detail sheet offers to register the chain
@@ -936,6 +966,12 @@ export const PullRequestsWithoutViewerLogin: Story = {
 
 export const PullRequestsLoading: Story = {
   args: { scenario: "pull-requests-loading" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("status", { name: "Loading" }),
+    ).toHaveClass("w-full", "min-w-0", "flex-1");
+  },
 };
 
 export const PullRequestsEmpty: Story = {


### PR DESCRIPTION
## Summary

- Make the pull-request list and loading skeleton fill the available width until a detail pane opens.
- Adopt the summary returned by the opened PR detail so changed lifecycle state moves the row to the correct group.
- Cache up to 24 loaded PR details for the page session.
- Debounce uncached detail reads during rapid ArrowUp and ArrowDown navigation.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeDeliveryPage.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/code/CodeDeliveryPage.tsx src/code/PullRequestDetail.tsx src/code/CodeDeliveryPage.dom.test.tsx src/stories/DeliveryCenter.stories.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- `git diff --check`

## Backwards compatibility and risk

The change stays within the existing delivery page and detail-pane flow. Cached details are session-local and bounded, and the freshness timestamp prevents an older cached detail from replacing a newer list summary. The debounce only applies to keyboard selection and does not change direct row clicks or explicit refreshes.