### PR TITLE
feat(mobile): add delivery dashboard

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -48,6 +48,7 @@ export default function RootLayout() {
           />
           <Stack.Screen name="chats" options={{ title: "Chats" }} />
           <Stack.Screen name="chat/[id]" options={{ title: "Chat" }} />
+          <Stack.Screen name="delivery" options={{ title: "Delivery" }} />
           <Stack.Screen name="sessions" options={{ title: "Sessions" }} />
           <Stack.Screen name="session/[id]" options={{ title: "Session" }} />
           <Stack.Screen name="approvals" options={{ title: "Approvals" }} />

--- a/mobile/app/delivery.tsx
+++ b/mobile/app/delivery.tsx
@@ -1,0 +1,629 @@
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useIsFocused, useRouter } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  type ListRenderItemInfo,
+  Pressable,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Button, LoadingState, StatusPill } from "../src/components/Controls";
+import { Body, ErrorText } from "../src/components/Screen";
+import {
+  groupMobileDeliveryPullRequests,
+  listMobileDeliveryRepositories,
+  mobileDeliveryCheckProgress,
+  mobileDeliveryLaneCountLabel,
+  mobileDeliveryLaneIsConfirmedEmpty,
+  mobileDeliveryRepositoryTarget,
+  queryMobileDeliveryPullRequests,
+  uniqueMobileDeliveryPullRequests,
+  uniqueMobileDeliverySourceErrors,
+  type MobileDeliveryCapability,
+  type MobileDeliveryLane,
+  type MobileDeliveryPullRequest,
+  type MobileDeliverySourceError,
+} from "../src/lib/deliveryApi";
+import { useSessionStore } from "../src/session/store";
+import { useMachineClient } from "../src/session/useMachineClient";
+
+const LANE_META: Record<
+  MobileDeliveryLane,
+  {
+    title: string;
+    description: string;
+    tone: "critical" | "success" | "info";
+  }
+> = {
+  attention: {
+    title: "Needs attention",
+    description: "Failed checks, requested changes, conflicts, or stale branches.",
+    tone: "critical",
+  },
+  ready: {
+    title: "Ready to merge",
+    description: "Green and waiting for you.",
+    tone: "success",
+  },
+  in_progress: {
+    title: "In progress",
+    description: "Checks or reviews are still moving.",
+    tone: "info",
+  },
+};
+
+const LANE_ORDER: readonly MobileDeliveryLane[] = [
+  "attention",
+  "ready",
+  "in_progress",
+];
+
+type DeliveryListItem =
+  | {
+      id: string;
+      kind: "lane";
+      lane: MobileDeliveryLane;
+      count: number;
+      hasNextPage: boolean;
+    }
+  | { id: string; kind: "empty"; lane: MobileDeliveryLane }
+  | {
+      id: string;
+      kind: "pull_request";
+      pullRequest: MobileDeliveryPullRequest;
+    };
+
+export default function DeliveryScreen() {
+  const router = useRouter();
+  const isFocused = useIsFocused();
+  const queryClient = useQueryClient();
+  const machine = useSessionStore((state) => state.session?.machine);
+  const client = useMachineClient();
+  const repositoryRefreshRef = useRef(false);
+  const pullRequestRefreshRef = useRef(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [linkError, setLinkError] = useState<string | null>(null);
+
+  const repositoriesQuery = useQuery({
+    queryKey: ["mobile-delivery-repositories", machine?.baseUrl],
+    enabled: !!client && isFocused,
+    queryFn: async ({ signal }) => {
+      const refresh = repositoryRefreshRef.current;
+      const snapshot = await listMobileDeliveryRepositories(client!, {
+        refresh,
+        signal,
+      });
+      if (refresh) repositoryRefreshRef.current = false;
+      return snapshot;
+    },
+  });
+  const repositorySnapshot = repositoriesQuery.data;
+  const repositories = repositorySnapshot?.repositories ?? [];
+  const repositoryTargets = useMemo(
+    () => repositories.map(mobileDeliveryRepositoryTarget),
+    [repositories],
+  );
+  const repositoryKey = repositoryTargets
+    .map((repository) =>
+      [repository.host, repository.owner, repository.name].join("/"),
+    )
+    .join("|");
+  const repositoriesAvailable =
+    repositorySnapshot?.capability.found === true &&
+    repositorySnapshot.capability.authenticated !== false &&
+    repositoryTargets.length > 0;
+  const pullRequestsQueryKey = [
+    "mobile-delivery-pull-requests",
+    machine?.baseUrl,
+    repositoryKey,
+  ] as const;
+
+  const pullRequestsQuery = useInfiniteQuery({
+    queryKey: pullRequestsQueryKey,
+    enabled: !!client && isFocused && repositoriesAvailable,
+    initialPageParam: null as string | null,
+    queryFn: async ({ pageParam, signal }) => {
+      const refresh = pullRequestRefreshRef.current && pageParam === null;
+      const page = await queryMobileDeliveryPullRequests(client!, {
+        repositories: repositoryTargets,
+        ...(pageParam ? { cursor: pageParam } : {}),
+        refresh,
+        signal,
+      });
+      if (refresh) pullRequestRefreshRef.current = false;
+      return page;
+    },
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? null,
+  });
+
+  const pages = pullRequestsQuery.data?.pages ?? [];
+  const pullRequests = useMemo(
+    () =>
+      uniqueMobileDeliveryPullRequests(
+        pages.flatMap((page) => page.items),
+      ),
+    [pages],
+  );
+  const lanes = useMemo(
+    () => groupMobileDeliveryPullRequests(pullRequests),
+    [pullRequests],
+  );
+  const listItems = useMemo<DeliveryListItem[]>(() => {
+    if (pullRequests.length === 0) return [];
+    const hasNextPage = pullRequestsQuery.hasNextPage === true;
+    return LANE_ORDER.flatMap((lane) => {
+      const rows: DeliveryListItem[] = [
+        {
+          id: `lane:${lane}`,
+          kind: "lane",
+          lane,
+          count: lanes[lane].length,
+          hasNextPage,
+        },
+      ];
+      if (mobileDeliveryLaneIsConfirmedEmpty(lanes[lane], hasNextPage)) {
+        rows.push({ id: `empty:${lane}`, kind: "empty", lane });
+      } else {
+        rows.push(
+          ...lanes[lane].map((pullRequest) => ({
+            id: `pull-request:${pullRequest.id}`,
+            kind: "pull_request" as const,
+            pullRequest,
+          })),
+        );
+      }
+      return rows;
+    });
+  }, [lanes, pullRequests.length, pullRequestsQuery.hasNextPage]);
+  const sourceErrors = useMemo(
+    () =>
+      uniqueMobileDeliverySourceErrors([
+        ...(repositorySnapshot?.errors ?? []),
+        ...pages.flatMap((page) => page.errors),
+      ]),
+    [pages, repositorySnapshot?.errors],
+  );
+  const latestPage = pages[pages.length - 1];
+  const capability = latestPage?.capability ?? repositorySnapshot?.capability;
+  const fetchedAt = latestPage?.fetched_at ?? repositorySnapshot?.fetched_at;
+
+  useEffect(() => {
+    if (isFocused) return;
+    void queryClient.cancelQueries({
+      queryKey: ["mobile-delivery-repositories", machine?.baseUrl],
+    });
+    void queryClient.cancelQueries({
+      queryKey: ["mobile-delivery-pull-requests", machine?.baseUrl],
+    });
+  }, [isFocused, machine?.baseUrl, queryClient]);
+
+  async function refresh() {
+    if (!client || !isFocused || refreshing) return;
+    setRefreshing(true);
+    setLinkError(null);
+    repositoryRefreshRef.current = true;
+    pullRequestRefreshRef.current = true;
+    try {
+      const result = await repositoriesQuery.refetch();
+      const refreshedRepositories = result.data?.repositories ?? [];
+      const refreshedRepositoryTargets = refreshedRepositories.map(
+        mobileDeliveryRepositoryTarget,
+      );
+      const refreshedRepositoriesAvailable =
+        result.data?.capability.found === true &&
+        result.data.capability.authenticated !== false &&
+        refreshedRepositoryTargets.length > 0;
+      if (refreshedRepositoriesAvailable) {
+        const refreshedRepositoryKey = refreshedRepositoryTargets
+          .map((repository) =>
+            [repository.host, repository.owner, repository.name].join("/"),
+          )
+          .join("|");
+        await queryClient.resetQueries({
+          queryKey: [
+            "mobile-delivery-pull-requests",
+            machine?.baseUrl,
+            refreshedRepositoryKey,
+          ],
+          exact: true,
+        });
+      }
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  function loadNextPage() {
+    if (
+      isFocused &&
+      pullRequestsQuery.hasNextPage &&
+      !pullRequestsQuery.isFetchingNextPage
+    ) {
+      void pullRequestsQuery.fetchNextPage();
+    }
+  }
+
+  function renderItem({
+    item,
+    index,
+  }: ListRenderItemInfo<DeliveryListItem>) {
+    if (item.kind === "lane") {
+      const meta = LANE_META[item.lane];
+      return (
+        <View className={index === 0 ? "gap-1 pb-2.5" : "mt-5 gap-1 pb-2.5"}>
+          <View className="flex-row items-center justify-between gap-3">
+            <Text className="text-lg font-semibold text-foreground">
+              {meta.title}
+            </Text>
+            <StatusPill tone={meta.tone}>
+              {mobileDeliveryLaneCountLabel(
+                item.count,
+                item.hasNextPage,
+              )}
+            </StatusPill>
+          </View>
+          <Text className="text-xs text-muted-foreground">
+            {meta.description}
+          </Text>
+        </View>
+      );
+    }
+    if (item.kind === "empty") {
+      return (
+        <Text className="mb-2.5 py-1 text-sm text-muted-foreground">
+          Nothing in this lane.
+        </Text>
+      );
+    }
+    return (
+      <View className="mb-2.5">
+        <PullRequestRow
+          pullRequest={item.pullRequest}
+          onOpen={openPullRequest}
+        />
+      </View>
+    );
+  }
+
+  async function openPullRequest(pullRequest: MobileDeliveryPullRequest) {
+    setLinkError(null);
+    try {
+      await WebBrowser.openBrowserAsync(pullRequest.url);
+    } catch (error) {
+      setLinkError(
+        error instanceof Error
+          ? error.message
+          : "The pull request could not be opened.",
+      );
+    }
+  }
+
+  if (!machine || !client) {
+    return (
+      <SafeAreaView className="flex-1 bg-page-background px-5 py-6">
+        <Text className="text-2xl font-semibold text-foreground">Delivery</Text>
+        <View className="mt-3">
+          <Body>Attach a Tidebreak machine to review pull requests.</Body>
+        </View>
+        <View className="mt-4">
+          <Button label="Attach" onPress={() => router.replace("/attach")} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-page-background">
+      <FlatList
+        contentContainerClassName="px-5 py-6"
+        data={listItems}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        refreshing={refreshing}
+        onRefresh={() => void refresh()}
+        onEndReached={loadNextPage}
+        onEndReachedThreshold={0.35}
+        ListHeaderComponent={
+          <View className="gap-4">
+            <View className="gap-1">
+              <View className="flex-row items-start justify-between gap-3">
+                <Text className="flex-1 text-2xl font-semibold text-foreground">
+                  Delivery
+                </Text>
+                {repositories.length > 0 ? (
+                  <StatusPill>
+                    {repositories.length} repo
+                    {repositories.length === 1 ? "" : "s"}
+                  </StatusPill>
+                ) : null}
+              </View>
+              <Text className="text-sm text-muted-foreground">
+                Review open pull requests across your tracked repositories.
+              </Text>
+              {fetchedAt ? (
+                <Text className="text-xs text-muted-foreground">
+                  Updated {formatDeliveryDate(fetchedAt)}
+                </Text>
+              ) : null}
+            </View>
+
+            {linkError ? <ErrorText>{linkError}</ErrorText> : null}
+            {repositoriesQuery.isLoading ? (
+              <LoadingState label="Loading repositories…" />
+            ) : null}
+            {repositoriesQuery.isError ? (
+              <ErrorText>
+                {repositoriesQuery.error instanceof Error
+                  ? repositoriesQuery.error.message
+                  : "Delivery repositories could not be loaded."}
+              </ErrorText>
+            ) : null}
+
+            {capability && !deliveryCapabilityAvailable(capability) ? (
+              <CapabilityState capability={capability} />
+            ) : null}
+
+            {repositorySnapshot &&
+            deliveryCapabilityAvailable(repositorySnapshot.capability) &&
+            repositories.length === 0 ? (
+              <View className="rounded-xl border border-border bg-background p-4">
+                <Text className="text-base font-medium text-foreground">
+                  No GitHub repositories
+                </Text>
+                <Text className="mt-1 text-sm text-muted-foreground">
+                  Add a GitHub-backed repository in Tidebreak, then pull to
+                  refresh.
+                </Text>
+              </View>
+            ) : null}
+
+            {sourceErrors.length > 0 ? (
+              <SourceErrors errors={sourceErrors} />
+            ) : null}
+
+            {repositoriesAvailable && pullRequestsQuery.isLoading ? (
+              <LoadingState label="Loading pull requests…" />
+            ) : null}
+            {pullRequestsQuery.isError ? (
+              <ErrorText>
+                {pullRequestsQuery.error instanceof Error
+                  ? pullRequestsQuery.error.message
+                  : "Pull requests could not be loaded."}
+              </ErrorText>
+            ) : null}
+
+            {repositoriesAvailable &&
+            !pullRequestsQuery.isLoading &&
+            !pullRequestsQuery.isError &&
+            pullRequestsQuery.hasNextPage !== true &&
+            pullRequests.length === 0 ? (
+              <View className="rounded-xl border border-border bg-background p-4">
+                <Text className="text-base font-medium text-foreground">
+                  No open pull requests
+                </Text>
+                <Text className="mt-1 text-sm text-muted-foreground">
+                  Open pull requests appear here when a tracked repository has
+                  work in flight.
+                </Text>
+              </View>
+            ) : null}
+
+            {listItems.length > 0 ? <View className="h-1" /> : null}
+          </View>
+        }
+        ListFooterComponent={
+          pullRequestsQuery.isFetchingNextPage ? (
+            <View className="flex-row items-center justify-center gap-2 py-4">
+              <ActivityIndicator size="small" />
+              <Text className="text-sm text-muted-foreground">
+                Loading more…
+              </Text>
+            </View>
+          ) : pullRequestsQuery.hasNextPage ? (
+            <View className="pt-2">
+              <Button
+                label="Load more"
+                variant="secondary"
+                onPress={() => void pullRequestsQuery.fetchNextPage()}
+              />
+            </View>
+          ) : null
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+function PullRequestRow({
+  pullRequest,
+  onOpen,
+}: {
+  pullRequest: MobileDeliveryPullRequest;
+  onOpen: (pullRequest: MobileDeliveryPullRequest) => Promise<void>;
+}) {
+  const status = pullRequestStatus(pullRequest);
+  const checks = pullRequestCheckStatus(pullRequest);
+  return (
+    <Pressable
+      accessibilityRole="link"
+      accessibilityLabel={`${pullRequest.repository.name_with_owner} pull request ${pullRequest.number}, ${pullRequest.title}. ${status.label}. ${checks.label}.`}
+      className="gap-2 rounded-xl border border-border bg-background p-4"
+      onPress={() => void onOpen(pullRequest)}
+    >
+      <View className="flex-row items-start justify-between gap-3">
+        <Text
+          className="flex-1 font-mono text-xs text-muted-foreground"
+          numberOfLines={1}
+        >
+          {pullRequest.repository.name_with_owner} · #{pullRequest.number}
+        </Text>
+        <StatusPill tone={status.tone}>{status.label}</StatusPill>
+      </View>
+      <Text className="text-base font-medium text-foreground">
+        {pullRequest.title}
+      </Text>
+      <Text
+        className="font-mono text-xs text-muted-foreground"
+        numberOfLines={1}
+      >
+        {pullRequest.head_branch} → {pullRequest.base_branch}
+      </Text>
+      <View className="flex-row flex-wrap items-center justify-between gap-2">
+        <Text className={`text-xs font-medium ${checks.className}`}>
+          {checks.label}
+        </Text>
+        <Text className="text-xs text-muted-foreground">
+          {pullRequest.author ? `@${pullRequest.author} · ` : ""}
+          {formatDeliveryDate(pullRequest.updated_at)}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+function CapabilityState({
+  capability,
+}: {
+  capability: MobileDeliveryCapability;
+}) {
+  const title = capability.found
+    ? "GitHub needs sign-in"
+    : "GitHub is unavailable";
+  const fallback = capability.found
+    ? "Sign in to GitHub on the attached machine, then pull to refresh."
+    : "Install or connect GitHub on the attached machine, then pull to refresh.";
+  return (
+    <View className="rounded-xl border border-warning-border bg-warning-background p-4">
+      <Text className="text-base font-medium text-warning-foreground">
+        {title}
+      </Text>
+      <Text className="mt-1 text-sm text-warning-foreground">
+        {capability.remediation || fallback}
+      </Text>
+    </View>
+  );
+}
+
+function SourceErrors({ errors }: { errors: MobileDeliverySourceError[] }) {
+  const visible = errors.slice(0, 3);
+  return (
+    <View className="rounded-xl border border-warning-border bg-warning-background p-4">
+      <Text className="text-base font-medium text-warning-foreground">
+        Some repositories could not be loaded
+      </Text>
+      <View className="mt-2 gap-2">
+        {visible.map((error) => (
+          <Text
+            key={sourceErrorKey(error)}
+            className="text-sm text-warning-foreground"
+          >
+            {sourceErrorRepository(error)}: {error.message}
+          </Text>
+        ))}
+        {errors.length > visible.length ? (
+          <Text className="text-xs text-warning-foreground">
+            {errors.length - visible.length} more source error
+            {errors.length - visible.length === 1 ? "" : "s"}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function deliveryCapabilityAvailable(
+  capability: MobileDeliveryCapability,
+): boolean {
+  return capability.found && capability.authenticated !== false;
+}
+
+function pullRequestStatus(pullRequest: MobileDeliveryPullRequest): {
+  label: string;
+  tone: "neutral" | "info" | "warning" | "success" | "critical";
+} {
+  if (pullRequest.attention_reasons.includes("changes_requested")) {
+    return { label: "Changes requested", tone: "critical" };
+  }
+  if (pullRequest.attention_reasons.includes("checks_failed")) {
+    return { label: "Checks failed", tone: "critical" };
+  }
+  if (pullRequest.attention_reasons.includes("conflicts")) {
+    return { label: "Conflicts", tone: "critical" };
+  }
+  if (pullRequest.attention_reasons.includes("behind")) {
+    return { label: "Update branch", tone: "warning" };
+  }
+  if (pullRequest.attention_reasons.includes("blocked")) {
+    return { label: "Blocked", tone: "warning" };
+  }
+  if (pullRequest.ready_to_merge) {
+    return { label: "Ready to merge", tone: "success" };
+  }
+  if (pullRequest.draft) return { label: "Draft", tone: "neutral" };
+  const reviewDecision = pullRequest.review_decision?.trim().toLowerCase();
+  if (reviewDecision === "approved") {
+    return { label: "Approved", tone: "success" };
+  }
+  if (reviewDecision === "review_required") {
+    return { label: "Needs review", tone: "warning" };
+  }
+  return { label: "In progress", tone: "info" };
+}
+
+function pullRequestCheckStatus(pullRequest: MobileDeliveryPullRequest): {
+  label: string;
+  className: string;
+} {
+  const checks = mobileDeliveryCheckProgress(pullRequest.checks);
+  if (checks.total === 0) {
+    return { label: "No checks", className: "text-muted-foreground" };
+  }
+  const progress = `${checks.terminal}/${checks.total} checks`;
+  if (checks.failing > 0) {
+    return {
+      label: `${progress} · ${checks.failing} failed`,
+      className: "text-critical-foreground",
+    };
+  }
+  if (checks.pending > 0) {
+    return {
+      label: `${progress} · ${checks.pending} running`,
+      className: "text-info-foreground",
+    };
+  }
+  if (checks.skipped === checks.total) {
+    return {
+      label: `${progress} · ${checks.skipped} skipped`,
+      className: "text-muted-foreground",
+    };
+  }
+  return { label: progress, className: "text-success-foreground" };
+}
+
+function sourceErrorRepository(error: MobileDeliverySourceError): string {
+  if (!error.repository) return "GitHub";
+  return `${error.repository.owner}/${error.repository.name}`;
+}
+
+function sourceErrorKey(error: MobileDeliverySourceError): string {
+  return `${sourceErrorRepository(error)}:${error.kind}:${error.message}`;
+}
+
+function formatDeliveryDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/mobile/app/home.tsx
+++ b/mobile/app/home.tsx
@@ -123,6 +123,12 @@ export default function HomeScreen() {
       </View>
       <Pressable
         className="rounded-lg border border-border bg-background px-4 py-3"
+        onPress={() => router.push("/delivery")}
+      >
+        <Text className="text-center text-base text-foreground">Delivery</Text>
+      </Pressable>
+      <Pressable
+        className="rounded-lg border border-border bg-background px-4 py-3"
         onPress={() => router.push("/chats")}
       >
         <Text className="text-center text-base text-foreground">Chats</Text>

--- a/mobile/src/components/Controls.tsx
+++ b/mobile/src/components/Controls.tsx
@@ -86,7 +86,7 @@ export function StatusPill({
   tone = "neutral",
 }: {
   children: ReactNode;
-  tone?: "neutral" | "live" | "warning" | "info";
+  tone?: "neutral" | "live" | "warning" | "info" | "success" | "critical";
 }) {
   const style = {
     neutral: {
@@ -104,6 +104,14 @@ export function StatusPill({
     info: {
       container: "border-info-border bg-info-background",
       text: "text-info-foreground",
+    },
+    success: {
+      container: "border-success-border bg-success-background",
+      text: "text-success-foreground",
+    },
+    critical: {
+      container: "border-critical-border bg-critical-background",
+      text: "text-critical-foreground",
     },
   }[tone];
   return (

--- a/mobile/src/global.css
+++ b/mobile/src/global.css
@@ -18,6 +18,7 @@
   --success: #2f9e62;
   --success-foreground: #166534;
   --success-background: #ecfdf3;
+  --success-border: #a7dfbd;
   --info: #3b82c4;
   --info-foreground: #1d4ed8;
   --info-background: #eff6ff;

--- a/mobile/src/lib/deliveryApi.test.ts
+++ b/mobile/src/lib/deliveryApi.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MachineClient } from "./machine";
+import {
+  groupMobileDeliveryPullRequests,
+  listMobileDeliveryRepositories,
+  mobileDeliveryCheckProgress,
+  mobileDeliveryLaneCountLabel,
+  mobileDeliveryLaneIsConfirmedEmpty,
+  parseMobileDeliveryPullRequestsPage,
+  parseMobileDeliveryRepositoriesSnapshot,
+  queryMobileDeliveryPullRequests,
+} from "./deliveryApi";
+
+const repository = {
+  host: "github.com",
+  owner: "brightwave-inc",
+  name: "tidebreak",
+  name_with_owner: "brightwave-inc/tidebreak",
+  url: "https://github.com/brightwave-inc/tidebreak",
+  default_branch: "main",
+  tidebreak_repo_id: "repo-1",
+};
+
+const capability = {
+  found: true,
+  authenticated: true,
+  viewer_login: "naingthet",
+  remediation: "",
+};
+
+const pullRequest = {
+  id: "github.com/brightwave-inc/tidebreak#2852",
+  repository,
+  number: 2852,
+  url: "https://github.com/brightwave-inc/tidebreak/pull/2852",
+  title: "Browse and message chats",
+  state: "open",
+  draft: false,
+  author: "naingthet",
+  head_branch: "thet/mobile-chat-messaging",
+  base_branch: "thet/mobile-spawn-flow",
+  review_decision: "review_required",
+  auto_merge_enabled: false,
+  checks: [
+    { name: "Mobile", bucket: "pass" },
+    { name: "Release", bucket: "skipped", detail: "Not a release" },
+  ],
+  attention_reasons: [],
+  ready_to_merge: false,
+  workspace_links: [],
+  labels: ["mobile"],
+  created_at: "2026-08-27T20:00:00Z",
+  updated_at: "2026-08-27T21:00:00Z",
+};
+
+const repositoriesSnapshot = {
+  capability,
+  repositories: [repository],
+  errors: [],
+  fetched_at: "2026-08-27T21:00:00Z",
+};
+
+const pullRequestsPage = {
+  capability,
+  items: [pullRequest],
+  next_cursor: "page-2",
+  errors: [
+    {
+      repository: {
+        host: "github.com",
+        owner: "brightwave-inc",
+        name: "model-gateway",
+      },
+      kind: "rate_limited",
+      message: "GitHub asked Tidebreak to retry later.",
+      retry_at: "2026-08-27T21:05:00Z",
+    },
+  ],
+  fetched_at: "2026-08-27T21:00:00Z",
+};
+
+function fakeClient(response: unknown): {
+  client: Pick<MachineClient, "getJson" | "requestJson">;
+  getJson: ReturnType<typeof vi.fn>;
+  requestJson: ReturnType<typeof vi.fn>;
+} {
+  const getJson = vi.fn(async () => response);
+  const requestJson = vi.fn(async () => response);
+  return { client: { getJson, requestJson }, getJson, requestJson };
+}
+
+describe("mobile Delivery API contracts", () => {
+  it("parses renderer-safe repository and capability fields", async () => {
+    expect(parseMobileDeliveryRepositoriesSnapshot(repositoriesSnapshot)).toEqual({
+      capability: { found: true, authenticated: true, remediation: "" },
+      repositories: [
+        {
+          host: "github.com",
+          owner: "brightwave-inc",
+          name: "tidebreak",
+          name_with_owner: "brightwave-inc/tidebreak",
+          url: "https://github.com/brightwave-inc/tidebreak",
+        },
+      ],
+      errors: [],
+      fetched_at: "2026-08-27T21:00:00Z",
+    });
+    expect(
+      parseMobileDeliveryRepositoriesSnapshot({
+        ...repositoriesSnapshot,
+        capability: { ...capability, authenticated: "yes" },
+      }),
+    ).toBeNull();
+    expect(
+      parseMobileDeliveryRepositoriesSnapshot({
+        ...repositoriesSnapshot,
+        repositories: [{ ...repository, url: "javascript:alert(1)" }],
+      }),
+    ).toBeNull();
+
+    const listed = fakeClient(repositoriesSnapshot);
+    await expect(listMobileDeliveryRepositories(listed.client)).resolves.toMatchObject({
+      repositories: [expect.objectContaining({ name: "tidebreak" })],
+    });
+    expect(listed.getJson).toHaveBeenCalledWith(
+      "/code/delivery/repositories",
+    );
+
+    const refreshed = fakeClient(repositoriesSnapshot);
+    const signal = new AbortController().signal;
+    await listMobileDeliveryRepositories(refreshed.client, {
+      refresh: true,
+      signal,
+    });
+    expect(refreshed.getJson).toHaveBeenCalledWith(
+      "/code/delivery/repositories?refresh=true",
+      { signal },
+    );
+  });
+
+  it("sends an open pull-request query with bounded paging", async () => {
+    const queried = fakeClient(pullRequestsPage);
+    await expect(
+      queryMobileDeliveryPullRequests(queried.client, {
+        repositories: [
+          { host: "github.com", owner: "brightwave-inc", name: "tidebreak" },
+        ],
+        cursor: "page-2",
+        refresh: false,
+      }),
+    ).resolves.toMatchObject({ next_cursor: "page-2" });
+    expect(queried.requestJson).toHaveBeenCalledWith(
+      "/code/delivery/pull-requests/query",
+      {
+        method: "POST",
+        body: {
+          repositories: [
+            {
+              host: "github.com",
+              owner: "brightwave-inc",
+              name: "tidebreak",
+            },
+          ],
+          states: ["open"],
+          review_states: [],
+          check_states: [],
+          authors: [],
+          attention_only: false,
+          ready_only: false,
+          cursor: "page-2",
+          limit: 30,
+          refresh: false,
+        },
+        expectedStatus: 200,
+      },
+    );
+
+    await queryMobileDeliveryPullRequests(queried.client, {
+      repositories: [
+        { host: "github.com", owner: "brightwave-inc", name: "tidebreak" },
+      ],
+      refresh: true,
+      signal: new AbortController().signal,
+    });
+    expect(queried.requestJson).toHaveBeenLastCalledWith(
+      "/code/delivery/pull-requests/query",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        body: expect.objectContaining({
+          refresh: true,
+          limit: 30,
+        }),
+      }),
+    );
+    expect(
+      queried.requestJson.mock.calls[1]?.[1]?.body,
+    ).not.toHaveProperty("cursor");
+
+    const invalidRefresh = fakeClient(pullRequestsPage);
+    await expect(
+      queryMobileDeliveryPullRequests(invalidRefresh.client, {
+        repositories: [
+          { host: "github.com", owner: "brightwave-inc", name: "tidebreak" },
+        ],
+        cursor: "page-2",
+        refresh: true,
+      }),
+    ).rejects.toThrow(/cannot continue from an existing cursor/);
+    expect(invalidRefresh.requestJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid pull-request fields without leaking unused fields", () => {
+    expect(parseMobileDeliveryPullRequestsPage(pullRequestsPage)).toEqual({
+      capability: { found: true, authenticated: true, remediation: "" },
+      items: [
+        {
+          id: "github.com/brightwave-inc/tidebreak#2852",
+          repository: {
+            host: "github.com",
+            owner: "brightwave-inc",
+            name: "tidebreak",
+            name_with_owner: "brightwave-inc/tidebreak",
+            url: "https://github.com/brightwave-inc/tidebreak",
+          },
+          number: 2852,
+          url: "https://github.com/brightwave-inc/tidebreak/pull/2852",
+          title: "Browse and message chats",
+          draft: false,
+          author: "naingthet",
+          head_branch: "thet/mobile-chat-messaging",
+          base_branch: "thet/mobile-spawn-flow",
+          review_decision: "review_required",
+          checks: [
+            { name: "Mobile", bucket: "pass" },
+            { name: "Release", bucket: "skipped" },
+          ],
+          attention_reasons: [],
+          ready_to_merge: false,
+          updated_at: "2026-08-27T21:00:00Z",
+        },
+      ],
+      next_cursor: "page-2",
+      errors: [
+        {
+          repository: {
+            host: "github.com",
+            owner: "brightwave-inc",
+            name: "model-gateway",
+          },
+          kind: "rate_limited",
+          message: "GitHub asked Tidebreak to retry later.",
+          retry_at: "2026-08-27T21:05:00Z",
+        },
+      ],
+      fetched_at: "2026-08-27T21:00:00Z",
+    });
+    expect(
+      parseMobileDeliveryPullRequestsPage({
+        ...pullRequestsPage,
+        items: [{ ...pullRequest, checks: [{ name: "Mobile", bucket: "later" }] }],
+      }),
+    ).toBeNull();
+    expect(
+      parseMobileDeliveryPullRequestsPage({
+        ...pullRequestsPage,
+        items: [{ ...pullRequest, number: 0 }],
+      }),
+    ).toBeNull();
+  });
+
+  it("groups lanes and counts skipped checks as terminal", () => {
+    const parsed = parseMobileDeliveryPullRequestsPage({
+      ...pullRequestsPage,
+      next_cursor: undefined,
+      items: [
+        {
+          ...pullRequest,
+          id: "attention",
+          attention_reasons: ["checks_failed"],
+          ready_to_merge: false,
+        },
+        {
+          ...pullRequest,
+          id: "ready",
+          attention_reasons: [],
+          ready_to_merge: true,
+        },
+        {
+          ...pullRequest,
+          id: "progress",
+          attention_reasons: [],
+          ready_to_merge: false,
+        },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(groupMobileDeliveryPullRequests(parsed!.items)).toMatchObject({
+      attention: [{ id: "attention" }],
+      ready: [{ id: "ready" }],
+      in_progress: [{ id: "progress" }],
+    });
+    expect(
+      mobileDeliveryCheckProgress([
+        { name: "Mobile", bucket: "pass" },
+        { name: "Desktop", bucket: "fail" },
+        { name: "Release", bucket: "skipped" },
+      ]),
+    ).toEqual({
+      total: 3,
+      terminal: 3,
+      passing: 1,
+      pending: 0,
+      failing: 1,
+      skipped: 1,
+    });
+    expect(
+      mobileDeliveryCheckProgress([
+        { name: "Mobile", bucket: "pass" },
+        { name: "Desktop", bucket: "pending" },
+        { name: "Release", bucket: "skipped" },
+      ]),
+    ).toMatchObject({ total: 3, terminal: 2, pending: 1, skipped: 1 });
+    expect(mobileDeliveryLaneCountLabel(2, true)).toBe("2 loaded");
+    expect(mobileDeliveryLaneCountLabel(2, false)).toBe("2");
+    expect(mobileDeliveryLaneIsConfirmedEmpty([], true)).toBe(false);
+    expect(mobileDeliveryLaneIsConfirmedEmpty([], false)).toBe(true);
+    expect(
+      mobileDeliveryLaneIsConfirmedEmpty(parsed!.items, false),
+    ).toBe(false);
+  });
+});

--- a/mobile/src/lib/deliveryApi.ts
+++ b/mobile/src/lib/deliveryApi.ts
@@ -1,0 +1,506 @@
+import type {
+  CodeDeliveryPrAttentionReason,
+  PullRequestCheckBucket,
+} from "../generated/wire";
+import type { MachineClient } from "./machine";
+
+type MachineJsonClient = Pick<MachineClient, "getJson" | "requestJson">;
+
+export type MobileDeliveryCapability = {
+  found: boolean;
+  authenticated?: boolean;
+  remediation: string;
+};
+
+export type MobileDeliveryRepositoryTarget = {
+  host: string;
+  owner: string;
+  name: string;
+};
+
+export type MobileDeliveryRepository = MobileDeliveryRepositoryTarget & {
+  name_with_owner: string;
+  url: string;
+};
+
+export type MobileDeliverySourceError = {
+  repository?: MobileDeliveryRepositoryTarget;
+  kind: string;
+  message: string;
+  retry_at?: string;
+};
+
+export type MobileDeliveryCheck = {
+  name: string;
+  bucket: PullRequestCheckBucket;
+};
+
+export type MobileDeliveryPullRequest = {
+  id: string;
+  repository: MobileDeliveryRepository;
+  number: number;
+  url: string;
+  title: string;
+  draft: boolean;
+  author?: string;
+  head_branch: string;
+  base_branch: string;
+  review_decision?: string;
+  checks: MobileDeliveryCheck[];
+  attention_reasons: CodeDeliveryPrAttentionReason[];
+  ready_to_merge: boolean;
+  updated_at: string;
+};
+
+export type MobileDeliveryRepositoriesSnapshot = {
+  capability: MobileDeliveryCapability;
+  repositories: MobileDeliveryRepository[];
+  errors: MobileDeliverySourceError[];
+  fetched_at: string;
+};
+
+export type MobileDeliveryPullRequestsPage = {
+  capability: MobileDeliveryCapability;
+  items: MobileDeliveryPullRequest[];
+  next_cursor?: string;
+  errors: MobileDeliverySourceError[];
+  fetched_at: string;
+};
+
+export type MobileDeliveryLane = "attention" | "ready" | "in_progress";
+
+export type MobileDeliveryLanes = Record<
+  MobileDeliveryLane,
+  MobileDeliveryPullRequest[]
+>;
+
+export type MobileDeliveryCheckProgress = {
+  total: number;
+  terminal: number;
+  passing: number;
+  pending: number;
+  failing: number;
+  skipped: number;
+};
+
+const CHECK_BUCKETS = ["pass", "pending", "fail", "skipped"] as const;
+const ATTENTION_REASONS = [
+  "changes_requested",
+  "checks_failed",
+  "conflicts",
+  "behind",
+  "blocked",
+] as const;
+
+export const MOBILE_DELIVERY_PAGE_SIZE = 30;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function optionalNonEmpty(value: unknown): value is string | undefined {
+  return value === undefined || nonEmpty(value);
+}
+
+function timestamp(value: unknown): value is string {
+  return nonEmpty(value) && !Number.isNaN(Date.parse(value));
+}
+
+function httpUrl(value: unknown): value is string {
+  if (!nonEmpty(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function positiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function member<T extends string>(
+  value: unknown,
+  values: readonly T[],
+): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+function parseCapability(value: unknown): MobileDeliveryCapability | null {
+  const capability = record(value);
+  if (
+    !capability ||
+    typeof capability.found !== "boolean" ||
+    (capability.authenticated !== undefined &&
+      typeof capability.authenticated !== "boolean") ||
+    typeof capability.remediation !== "string"
+  ) {
+    return null;
+  }
+  return {
+    found: capability.found,
+    ...(capability.authenticated !== undefined
+      ? { authenticated: capability.authenticated }
+      : {}),
+    remediation: capability.remediation,
+  };
+}
+
+function parseRepositoryTarget(
+  value: unknown,
+): MobileDeliveryRepositoryTarget | null {
+  const repository = record(value);
+  if (
+    !repository ||
+    !nonEmpty(repository.host) ||
+    !nonEmpty(repository.owner) ||
+    !nonEmpty(repository.name)
+  ) {
+    return null;
+  }
+  return {
+    host: repository.host,
+    owner: repository.owner,
+    name: repository.name,
+  };
+}
+
+function parseRepository(value: unknown): MobileDeliveryRepository | null {
+  const repository = record(value);
+  const target = parseRepositoryTarget(repository);
+  if (
+    !repository ||
+    !target ||
+    !nonEmpty(repository.name_with_owner) ||
+    !httpUrl(repository.url)
+  ) {
+    return null;
+  }
+  return {
+    ...target,
+    name_with_owner: repository.name_with_owner,
+    url: repository.url,
+  };
+}
+
+function parseSourceError(value: unknown): MobileDeliverySourceError | null {
+  const error = record(value);
+  if (
+    !error ||
+    !nonEmpty(error.kind) ||
+    !nonEmpty(error.message) ||
+    (error.retry_at !== undefined && !timestamp(error.retry_at))
+  ) {
+    return null;
+  }
+  const repository =
+    error.repository === undefined
+      ? undefined
+      : parseRepositoryTarget(error.repository);
+  if (error.repository !== undefined && !repository) return null;
+  return {
+    ...(repository ? { repository } : {}),
+    kind: error.kind,
+    message: error.message,
+    ...(error.retry_at !== undefined ? { retry_at: error.retry_at } : {}),
+  };
+}
+
+function parseCheck(value: unknown): MobileDeliveryCheck | null {
+  const check = record(value);
+  if (
+    !check ||
+    !nonEmpty(check.name) ||
+    !member(check.bucket, CHECK_BUCKETS)
+  ) {
+    return null;
+  }
+  return { name: check.name, bucket: check.bucket };
+}
+
+function parsePullRequest(value: unknown): MobileDeliveryPullRequest | null {
+  const pullRequest = record(value);
+  if (
+    !pullRequest ||
+    !nonEmpty(pullRequest.id) ||
+    !positiveSafeInteger(pullRequest.number) ||
+    !httpUrl(pullRequest.url) ||
+    !nonEmpty(pullRequest.title) ||
+    typeof pullRequest.draft !== "boolean" ||
+    !optionalNonEmpty(pullRequest.author) ||
+    !nonEmpty(pullRequest.head_branch) ||
+    !nonEmpty(pullRequest.base_branch) ||
+    !optionalNonEmpty(pullRequest.review_decision) ||
+    !Array.isArray(pullRequest.checks) ||
+    !Array.isArray(pullRequest.attention_reasons) ||
+    !pullRequest.attention_reasons.every((reason) =>
+      member(reason, ATTENTION_REASONS),
+    ) ||
+    typeof pullRequest.ready_to_merge !== "boolean" ||
+    !timestamp(pullRequest.updated_at)
+  ) {
+    return null;
+  }
+  const repository = parseRepository(pullRequest.repository);
+  if (!repository) return null;
+  const checks = pullRequest.checks.map(parseCheck);
+  if (checks.some((check) => check === null)) return null;
+  return {
+    id: pullRequest.id,
+    repository,
+    number: pullRequest.number,
+    url: pullRequest.url,
+    title: pullRequest.title,
+    draft: pullRequest.draft,
+    ...(pullRequest.author !== undefined
+      ? { author: pullRequest.author }
+      : {}),
+    head_branch: pullRequest.head_branch,
+    base_branch: pullRequest.base_branch,
+    ...(pullRequest.review_decision !== undefined
+      ? { review_decision: pullRequest.review_decision }
+      : {}),
+    checks: checks as MobileDeliveryCheck[],
+    attention_reasons:
+      pullRequest.attention_reasons as CodeDeliveryPrAttentionReason[],
+    ready_to_merge: pullRequest.ready_to_merge,
+    updated_at: pullRequest.updated_at,
+  };
+}
+
+function parseSourceErrors(value: unknown): MobileDeliverySourceError[] | null {
+  if (!Array.isArray(value)) return null;
+  const errors = value.map(parseSourceError);
+  return errors.some((error) => error === null)
+    ? null
+    : (errors as MobileDeliverySourceError[]);
+}
+
+export function parseMobileDeliveryRepositoriesSnapshot(
+  value: unknown,
+): MobileDeliveryRepositoriesSnapshot | null {
+  const snapshot = record(value);
+  if (
+    !snapshot ||
+    !Array.isArray(snapshot.repositories) ||
+    !timestamp(snapshot.fetched_at)
+  ) {
+    return null;
+  }
+  const capability = parseCapability(snapshot.capability);
+  const repositories = snapshot.repositories.map(parseRepository);
+  const errors = parseSourceErrors(snapshot.errors);
+  if (
+    !capability ||
+    repositories.some((repository) => repository === null) ||
+    !errors
+  ) {
+    return null;
+  }
+  return {
+    capability,
+    repositories: repositories as MobileDeliveryRepository[],
+    errors,
+    fetched_at: snapshot.fetched_at,
+  };
+}
+
+export function parseMobileDeliveryPullRequestsPage(
+  value: unknown,
+): MobileDeliveryPullRequestsPage | null {
+  const page = record(value);
+  if (
+    !page ||
+    !Array.isArray(page.items) ||
+    !optionalNonEmpty(page.next_cursor) ||
+    !timestamp(page.fetched_at)
+  ) {
+    return null;
+  }
+  const capability = parseCapability(page.capability);
+  const items = page.items.map(parsePullRequest);
+  const errors = parseSourceErrors(page.errors);
+  if (!capability || items.some((item) => item === null) || !errors) {
+    return null;
+  }
+  return {
+    capability,
+    items: items as MobileDeliveryPullRequest[],
+    ...(page.next_cursor !== undefined
+      ? { next_cursor: page.next_cursor }
+      : {}),
+    errors,
+    fetched_at: page.fetched_at,
+  };
+}
+
+function required<T>(value: T | null, label: string): T {
+  if (!value) throw new Error(`${label} response contains invalid data.`);
+  return value;
+}
+
+export async function listMobileDeliveryRepositories(
+  client: MachineJsonClient,
+  options: {
+    refresh?: boolean;
+    signal?: AbortSignal;
+  } = {},
+): Promise<MobileDeliveryRepositoriesSnapshot> {
+  const path = options.refresh
+    ? "/code/delivery/repositories?refresh=true"
+    : "/code/delivery/repositories";
+  return required(
+    parseMobileDeliveryRepositoriesSnapshot(
+      options.signal
+        ? await client.getJson(path, { signal: options.signal })
+        : await client.getJson(path),
+    ),
+    "Delivery repositories",
+  );
+}
+
+export async function queryMobileDeliveryPullRequests(
+  client: MachineJsonClient,
+  options: {
+    repositories: MobileDeliveryRepositoryTarget[];
+    cursor?: string;
+    refresh?: boolean;
+    limit?: number;
+    signal?: AbortSignal;
+  },
+): Promise<MobileDeliveryPullRequestsPage> {
+  if (options.refresh && options.cursor) {
+    throw new Error(
+      "Delivery refresh cannot continue from an existing cursor.",
+    );
+  }
+  return required(
+    parseMobileDeliveryPullRequestsPage(
+      await client.requestJson("/code/delivery/pull-requests/query", {
+        method: "POST",
+        body: {
+          repositories: options.repositories,
+          states: ["open"],
+          review_states: [],
+          check_states: [],
+          authors: [],
+          attention_only: false,
+          ready_only: false,
+          ...(options.cursor ? { cursor: options.cursor } : {}),
+          limit: options.limit ?? MOBILE_DELIVERY_PAGE_SIZE,
+          refresh: options.refresh ?? false,
+        },
+        expectedStatus: 200,
+        ...(options.signal ? { signal: options.signal } : {}),
+      }),
+    ),
+    "Delivery pull requests",
+  );
+}
+
+export function mobileDeliveryRepositoryTarget(
+  repository: MobileDeliveryRepository,
+): MobileDeliveryRepositoryTarget {
+  return {
+    host: repository.host,
+    owner: repository.owner,
+    name: repository.name,
+  };
+}
+
+export function mobileDeliveryLane(
+  pullRequest: MobileDeliveryPullRequest,
+): MobileDeliveryLane {
+  if (pullRequest.attention_reasons.length > 0) return "attention";
+  if (pullRequest.ready_to_merge) return "ready";
+  return "in_progress";
+}
+
+export function groupMobileDeliveryPullRequests(
+  pullRequests: readonly MobileDeliveryPullRequest[],
+): MobileDeliveryLanes {
+  const lanes: MobileDeliveryLanes = {
+    attention: [],
+    ready: [],
+    in_progress: [],
+  };
+  for (const pullRequest of pullRequests) {
+    lanes[mobileDeliveryLane(pullRequest)].push(pullRequest);
+  }
+  return lanes;
+}
+
+export function mobileDeliveryLaneCountLabel(
+  count: number,
+  hasNextPage: boolean,
+): string {
+  return hasNextPage ? `${count} loaded` : String(count);
+}
+
+export function mobileDeliveryLaneIsConfirmedEmpty(
+  pullRequests: readonly MobileDeliveryPullRequest[],
+  hasNextPage: boolean,
+): boolean {
+  return pullRequests.length === 0 && !hasNextPage;
+}
+
+export function mobileDeliveryCheckProgress(
+  checks: readonly MobileDeliveryCheck[],
+): MobileDeliveryCheckProgress {
+  const progress: MobileDeliveryCheckProgress = {
+    total: checks.length,
+    terminal: 0,
+    passing: 0,
+    pending: 0,
+    failing: 0,
+    skipped: 0,
+  };
+  for (const check of checks) {
+    if (check.bucket === "pass") {
+      progress.passing += 1;
+      progress.terminal += 1;
+    } else if (check.bucket === "pending") {
+      progress.pending += 1;
+    } else if (check.bucket === "fail") {
+      progress.failing += 1;
+      progress.terminal += 1;
+    } else {
+      progress.skipped += 1;
+      progress.terminal += 1;
+    }
+  }
+  return progress;
+}
+
+export function uniqueMobileDeliveryPullRequests(
+  pullRequests: readonly MobileDeliveryPullRequest[],
+): MobileDeliveryPullRequest[] {
+  const seen = new Set<string>();
+  return pullRequests.filter((pullRequest) => {
+    if (seen.has(pullRequest.id)) return false;
+    seen.add(pullRequest.id);
+    return true;
+  });
+}
+
+export function uniqueMobileDeliverySourceErrors(
+  errors: readonly MobileDeliverySourceError[],
+): MobileDeliverySourceError[] {
+  const seen = new Set<string>();
+  return errors.filter((error) => {
+    const repository = error.repository
+      ? `${error.repository.host}/${error.repository.owner}/${error.repository.name}`
+      : "global";
+    const key = `${repository}:${error.kind}:${error.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/mobile/src/lib/http.ts
+++ b/mobile/src/lib/http.ts
@@ -20,6 +20,7 @@ export type HttpRequestInit = {
   method?: string;
   headers?: Record<string, string>;
   body?: string;
+  signal?: AbortSignal;
 };
 
 /** The response surface shared by DOM `Response` and expo's `FetchResponse`. */

--- a/mobile/src/lib/machine.test.ts
+++ b/mobile/src/lib/machine.test.ts
@@ -49,6 +49,7 @@ describe("machineWsUrl", () => {
 describe("MachineClient requests", () => {
   it("mints the attached resource and sends JSON without following redirects", async () => {
     const getAccessToken = vi.fn(async () => "machine-token");
+    const abort = new AbortController();
     const fetchImpl = vi.fn(
       async (_url: string, _init?: RequestInit) =>
         new Response(JSON.stringify({ accepted: true }), { status: 202 }),
@@ -65,6 +66,7 @@ describe("MachineClient requests", () => {
         method: "POST",
         body: { message: "continue" },
         expectedStatus: 202,
+        signal: abort.signal,
       }),
     ).resolves.toEqual({ accepted: true });
     expect(getAccessToken).toHaveBeenCalledWith("tidebreak:attached");
@@ -76,6 +78,7 @@ describe("MachineClient requests", () => {
       method: "POST",
       redirect: "manual",
       body: JSON.stringify({ message: "continue" }),
+      signal: abort.signal,
       headers: {
         Authorization: "Bearer machine-token",
         "Content-Type": "application/json",

--- a/mobile/src/lib/machine.ts
+++ b/mobile/src/lib/machine.ts
@@ -43,6 +43,7 @@ export type MachineRequestOptions = {
   method?: string;
   body?: unknown;
   expectedStatus?: number | readonly number[];
+  signal?: AbortSignal;
 };
 
 export class MachineRequestError extends Error {
@@ -99,8 +100,11 @@ function parseErrorBody(text: string): { kind: string | null; message: string } 
 export class MachineClient {
   constructor(private readonly options: MachineClientOptions) {}
 
-  async getJson(path: string): Promise<unknown> {
-    return this.requestJson(path);
+  async getJson(
+    path: string,
+    request: Pick<MachineRequestOptions, "signal"> = {},
+  ): Promise<unknown> {
+    return this.requestJson(path, request);
   }
 
   async requestJson(
@@ -115,6 +119,7 @@ export class MachineClient {
     };
     const init: HttpRequestInit = { headers };
     if (request.method) init.method = request.method;
+    if (request.signal) init.signal = request.signal;
     if (request.body !== undefined) {
       headers["Content-Type"] = "application/json";
       init.body = JSON.stringify(request.body);

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
         success: "var(--success)",
         "success-foreground": "var(--success-foreground)",
         "success-background": "var(--success-background)",
+        "success-border": "var(--success-border)",
         info: "var(--info)",
         "info-foreground": "var(--info-foreground)",
         "info-background": "var(--info-background)",


### PR DESCRIPTION
## What changed

- Add a read-only mobile Delivery dashboard for open pull requests across tracked GitHub repositories.
- Group work into Needs attention, Ready to merge, and In progress lanes with virtualized paging, pull-to-refresh, partial-source warnings, capability remediation, and in-app GitHub links.
- Force pull-to-refresh to re-read GitHub authentication and restart pull-request paging from page one.
- Parse only renderer-used response fields, include skipped checks in terminal progress, and cancel in-flight reads when the screen loses focus.
- Add Delivery navigation and success/critical status pill tones.

## Validation

- `CI=true npx --yes pnpm@10.18.3 --dir mobile typecheck`
- `CI=true npx --yes pnpm@10.18.3 --dir mobile lint`
- `CI=true npx --yes pnpm@10.18.3 --dir mobile test` — 82 tests passed.
- `CI=true npx --yes pnpm@10.18.3 --dir mobile exec expo export --platform web --output-dir <temporary-directory>` — web export completed with 1,314 modules.
- Screenshot review could not run because the mobile package has no Storybook setup and no browser session is connected.

## Compatibility and risk

No persisted-data or wire-format changes. The machine client only adds optional `AbortSignal` forwarding. The dashboard does not mutate pull requests.

## Tracking

Part of #2648.