### PR TITLE
feat(mobile): add chat prompt cards

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -48,6 +48,7 @@ export default function RootLayout() {
           />
           <Stack.Screen name="chats" options={{ title: "Chats" }} />
           <Stack.Screen name="chat/[id]" options={{ title: "Chat" }} />
+          <Stack.Screen name="delivery" options={{ title: "Delivery" }} />
           <Stack.Screen name="sessions" options={{ title: "Sessions" }} />
           <Stack.Screen name="session/[id]" options={{ title: "Session" }} />
           <Stack.Screen name="approvals" options={{ title: "Approvals" }} />

--- a/mobile/app/chat/[id].tsx
+++ b/mobile/app/chat/[id].tsx
@@ -16,6 +16,11 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  ChatPlanApprovalCard,
+  ChatToolApprovalCard,
+  ChatUserQuestionsCard,
+} from "../../src/components/ChatPromptCards";
 import { Button, LoadingState } from "../../src/components/Controls";
 import { ErrorText } from "../../src/components/Screen";
 import {
@@ -30,6 +35,16 @@ import {
   type MobileChatQueuedTurn,
   type MobileChatTurnIdentity,
 } from "../../src/lib/chatApi";
+import {
+  answerMobileUserQuestions,
+  decideMobilePlan,
+  decideMobileToolApproval,
+  listMobilePendingPlanApprovals,
+  listMobilePendingToolApprovals,
+  listMobilePendingUserQuestions,
+  type MobilePlanDecision,
+  type MobileUserQuestionAnswer,
+} from "../../src/lib/chatPrompts";
 import { useSessionStore } from "../../src/session/store";
 import { useMachineClient } from "../../src/session/useMachineClient";
 
@@ -42,8 +57,10 @@ export default function ChatDetailScreen() {
   const queryClient = useQueryClient();
   const scrollRef = useRef<ScrollView>(null);
   const sendingRef = useRef(false);
+  const refreshingRef = useRef(false);
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   const [receipt, setReceipt] = useState<string | null>(null);
   const [pendingIdentity, setPendingIdentity] =
@@ -68,15 +85,125 @@ export default function ChatDetailScreen() {
     queryFn: () => listMobileChatQueuedTurns(client!, chatId!),
     refetchInterval: isFocused ? 3_000 : false,
   });
+  const approvalsKey = [
+    "mobile-chat-approvals",
+    machineKey,
+    chatId,
+  ] as const;
+  const approvalsQuery = useQuery({
+    queryKey: approvalsKey,
+    enabled: !!client && !!chatId && isFocused,
+    queryFn: () => listMobilePendingToolApprovals(client!, chatId!),
+    refetchInterval: isFocused ? 3_000 : false,
+  });
+  const questionsKey = [
+    "mobile-chat-questions",
+    machineKey,
+    chatId,
+  ] as const;
+  const questionsQuery = useQuery({
+    queryKey: questionsKey,
+    enabled: !!client && !!chatId && isFocused,
+    queryFn: () => listMobilePendingUserQuestions(client!, chatId!),
+    refetchInterval: isFocused ? 3_000 : false,
+  });
+  const plansKey = ["mobile-chat-plans", machineKey, chatId] as const;
+  const plansQuery = useQuery({
+    queryKey: plansKey,
+    enabled: !!client && !!chatId && isFocused,
+    queryFn: () => listMobilePendingPlanApprovals(client!, chatId!),
+    refetchInterval: isFocused ? 3_000 : false,
+  });
   const messages = transcriptQuery.data?.messages ?? [];
   const queued = queueQuery.data?.queued ?? [];
+  const approvals = approvalsQuery.data ?? [];
+  const questions = questionsQuery.data ?? [];
+  const plans = plansQuery.data ?? [];
+  const pendingPromptCount = questions.length + plans.length;
+  const promptQueriesLoading =
+    questionsQuery.isLoading || plansQuery.isLoading;
+  const promptQueriesFailed = questionsQuery.isError || plansQuery.isError;
 
   useEffect(() => {
     scrollRef.current?.scrollToEnd({ animated: true });
-  }, [messages.length, queued.length]);
+  }, [approvals.length, messages.length, queued.length]);
 
   async function refreshMessages() {
-    await Promise.all([transcriptQuery.refetch(), queueQuery.refetch()]);
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        chatQuery.refetch(),
+        transcriptQuery.refetch(),
+        queueQuery.refetch(),
+        approvalsQuery.refetch(),
+        questionsQuery.refetch(),
+        plansQuery.refetch(),
+      ]);
+    } finally {
+      refreshingRef.current = false;
+      setRefreshing(false);
+    }
+  }
+
+  async function refreshPromptState(
+    queryKey: readonly unknown[],
+  ): Promise<void> {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey }),
+      queryClient.invalidateQueries({
+        queryKey: ["mobile-chat-transcript", machineKey, chatId],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ["mobile-chats", machineKey],
+      }),
+    ]);
+  }
+
+  async function decideApproval(
+    callId: string,
+    decision:
+      | { decision: "approve" }
+      | { decision: "reject"; feedback: string },
+  ): Promise<void> {
+    if (!client || !chatId) return;
+    try {
+      await decideMobileToolApproval(client, chatId, callId, decision);
+    } finally {
+      await refreshPromptState(approvalsKey);
+    }
+  }
+
+  async function answerQuestions(
+    callId: string,
+    answers: MobileUserQuestionAnswer[],
+    additionalUserContext?: string,
+  ): Promise<void> {
+    if (!client || !chatId) return;
+    try {
+      await answerMobileUserQuestions(
+        client,
+        chatId,
+        callId,
+        answers,
+        additionalUserContext,
+      );
+    } finally {
+      await refreshPromptState(questionsKey);
+    }
+  }
+
+  async function decidePlan(
+    callId: string,
+    decision: MobilePlanDecision,
+  ): Promise<void> {
+    if (!client || !chatId) return;
+    try {
+      await decideMobilePlan(client, chatId, callId, decision);
+    } finally {
+      await refreshPromptState(plansKey);
+    }
   }
 
   async function sendMessage() {
@@ -169,9 +296,7 @@ export default function ChatDetailScreen() {
           keyboardShouldPersistTaps="handled"
           refreshControl={
             <RefreshControl
-              refreshing={
-                transcriptQuery.isRefetching || queueQuery.isRefetching
-              }
+              refreshing={refreshing}
               onRefresh={() => void refreshMessages()}
             />
           }
@@ -200,12 +325,35 @@ export default function ChatDetailScreen() {
                 : "The queued messages could not be loaded."}
             </ErrorText>
           ) : null}
+          {approvalsQuery.isError ? (
+            <ErrorText>
+              {approvalsQuery.error instanceof Error
+                ? approvalsQuery.error.message
+                : "The pending approvals could not be loaded."}
+            </ErrorText>
+          ) : null}
+          {questionsQuery.isError ? (
+            <ErrorText>
+              {questionsQuery.error instanceof Error
+                ? questionsQuery.error.message
+                : "The pending questions could not be loaded."}
+            </ErrorText>
+          ) : null}
+          {plansQuery.isError ? (
+            <ErrorText>
+              {plansQuery.error instanceof Error
+                ? plansQuery.error.message
+                : "The pending plans could not be loaded."}
+            </ErrorText>
+          ) : null}
           {!transcriptQuery.isLoading &&
           !transcriptQuery.isError &&
           !queueQuery.isLoading &&
           !queueQuery.isError &&
           messages.length === 0 &&
-          queued.length === 0 ? (
+          queued.length === 0 &&
+          approvals.length === 0 &&
+          pendingPromptCount === 0 ? (
             <View className="rounded-xl border border-border bg-background p-4">
               <Text className="text-base font-medium text-foreground">
                 Start the conversation
@@ -218,6 +366,15 @@ export default function ChatDetailScreen() {
           {messages.map((item) => (
             <ChatMessage key={item.id} message={item} />
           ))}
+          {approvals.map((approval) => (
+            <ChatToolApprovalCard
+              key={approval.callId}
+              approval={approval}
+              onDecide={(decision) =>
+                decideApproval(approval.callId, decision)
+              }
+            />
+          ))}
           {queued.map((turn) => (
             <QueuedChatMessage
               key={turn.id}
@@ -227,32 +384,84 @@ export default function ChatDetailScreen() {
           ))}
         </ScrollView>
 
-        <View className="gap-2 border-t border-border bg-background px-4 py-3">
-          {receipt ? (
-            <Text className="text-xs text-success-foreground">{receipt}</Text>
-          ) : null}
-          {sendError ? <ErrorText>{sendError}</ErrorText> : null}
-          <TextInput
-            multiline
-            value={message}
-            editable={!sending}
-            accessibilityLabel="Message"
-            placeholder="Message this chat"
-            placeholderTextColor="#697386"
-            textAlignVertical="top"
-            className="max-h-40 min-h-20 rounded-xl border border-border bg-page-background px-3 py-3 text-base text-foreground"
-            onChangeText={(next) => {
-              setMessage(next);
-              setReceipt(null);
-              setSendError(null);
-            }}
-          />
-          <Button
-            label="Send"
-            busy={sending}
-            disabled={!message.trim() || chatQuery.isError}
-            onPress={() => void sendMessage()}
-          />
+        <View className="border-t border-border bg-background">
+          {promptQueriesLoading ? (
+            <Text className="px-4 py-4 text-sm text-muted-foreground">
+              Checking for questions and plans…
+            </Text>
+          ) : promptQueriesFailed && pendingPromptCount === 0 ? (
+            <View className="gap-2 px-4 py-3">
+              <ErrorText>
+                The app could not verify whether this chat is waiting for a
+                question or plan decision.
+              </ErrorText>
+              <Button
+                label="Retry"
+                variant="secondary"
+                onPress={() => void refreshMessages()}
+              />
+            </View>
+          ) : pendingPromptCount > 0 ? (
+            <ScrollView
+              className="max-h-96"
+              contentContainerClassName="gap-3 px-4 py-3"
+              keyboardShouldPersistTaps="handled"
+              nestedScrollEnabled
+            >
+              {questions.map((request) => (
+                <ChatUserQuestionsCard
+                  key={request.callId}
+                  request={request}
+                  onAnswer={(answers, additionalUserContext) =>
+                    answerQuestions(
+                      request.callId,
+                      answers,
+                      additionalUserContext,
+                    )
+                  }
+                />
+              ))}
+              {plans.map((request) => (
+                <ChatPlanApprovalCard
+                  key={request.callId}
+                  request={request}
+                  onDecide={(decision) =>
+                    decidePlan(request.callId, decision)
+                  }
+                />
+              ))}
+            </ScrollView>
+          ) : (
+            <View className="gap-2 px-4 py-3">
+              {receipt ? (
+                <Text className="text-xs text-success-foreground">
+                  {receipt}
+                </Text>
+              ) : null}
+              {sendError ? <ErrorText>{sendError}</ErrorText> : null}
+              <TextInput
+                multiline
+                value={message}
+                editable={!sending}
+                accessibilityLabel="Message"
+                placeholder="Message this chat"
+                placeholderTextColor="#697386"
+                textAlignVertical="top"
+                className="max-h-40 min-h-20 rounded-xl border border-border bg-page-background px-3 py-3 text-base text-foreground"
+                onChangeText={(next) => {
+                  setMessage(next);
+                  setReceipt(null);
+                  setSendError(null);
+                }}
+              />
+              <Button
+                label="Send"
+                busy={sending}
+                disabled={!message.trim() || chatQuery.isError}
+                onPress={() => void sendMessage()}
+              />
+            </View>
+          )}
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>

--- a/mobile/app/delivery.tsx
+++ b/mobile/app/delivery.tsx
@@ -1,0 +1,629 @@
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useIsFocused, useRouter } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  type ListRenderItemInfo,
+  Pressable,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Button, LoadingState, StatusPill } from "../src/components/Controls";
+import { Body, ErrorText } from "../src/components/Screen";
+import {
+  groupMobileDeliveryPullRequests,
+  listMobileDeliveryRepositories,
+  mobileDeliveryCheckProgress,
+  mobileDeliveryLaneCountLabel,
+  mobileDeliveryLaneIsConfirmedEmpty,
+  mobileDeliveryRepositoryTarget,
+  queryMobileDeliveryPullRequests,
+  uniqueMobileDeliveryPullRequests,
+  uniqueMobileDeliverySourceErrors,
+  type MobileDeliveryCapability,
+  type MobileDeliveryLane,
+  type MobileDeliveryPullRequest,
+  type MobileDeliverySourceError,
+} from "../src/lib/deliveryApi";
+import { useSessionStore } from "../src/session/store";
+import { useMachineClient } from "../src/session/useMachineClient";
+
+const LANE_META: Record<
+  MobileDeliveryLane,
+  {
+    title: string;
+    description: string;
+    tone: "critical" | "success" | "info";
+  }
+> = {
+  attention: {
+    title: "Needs attention",
+    description: "Failed checks, requested changes, conflicts, or stale branches.",
+    tone: "critical",
+  },
+  ready: {
+    title: "Ready to merge",
+    description: "Green and waiting for you.",
+    tone: "success",
+  },
+  in_progress: {
+    title: "In progress",
+    description: "Checks or reviews are still moving.",
+    tone: "info",
+  },
+};
+
+const LANE_ORDER: readonly MobileDeliveryLane[] = [
+  "attention",
+  "ready",
+  "in_progress",
+];
+
+type DeliveryListItem =
+  | {
+      id: string;
+      kind: "lane";
+      lane: MobileDeliveryLane;
+      count: number;
+      hasNextPage: boolean;
+    }
+  | { id: string; kind: "empty"; lane: MobileDeliveryLane }
+  | {
+      id: string;
+      kind: "pull_request";
+      pullRequest: MobileDeliveryPullRequest;
+    };
+
+export default function DeliveryScreen() {
+  const router = useRouter();
+  const isFocused = useIsFocused();
+  const queryClient = useQueryClient();
+  const machine = useSessionStore((state) => state.session?.machine);
+  const client = useMachineClient();
+  const repositoryRefreshRef = useRef(false);
+  const pullRequestRefreshRef = useRef(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [linkError, setLinkError] = useState<string | null>(null);
+
+  const repositoriesQuery = useQuery({
+    queryKey: ["mobile-delivery-repositories", machine?.baseUrl],
+    enabled: !!client && isFocused,
+    queryFn: async ({ signal }) => {
+      const refresh = repositoryRefreshRef.current;
+      const snapshot = await listMobileDeliveryRepositories(client!, {
+        refresh,
+        signal,
+      });
+      if (refresh) repositoryRefreshRef.current = false;
+      return snapshot;
+    },
+  });
+  const repositorySnapshot = repositoriesQuery.data;
+  const repositories = repositorySnapshot?.repositories ?? [];
+  const repositoryTargets = useMemo(
+    () => repositories.map(mobileDeliveryRepositoryTarget),
+    [repositories],
+  );
+  const repositoryKey = repositoryTargets
+    .map((repository) =>
+      [repository.host, repository.owner, repository.name].join("/"),
+    )
+    .join("|");
+  const repositoriesAvailable =
+    repositorySnapshot?.capability.found === true &&
+    repositorySnapshot.capability.authenticated !== false &&
+    repositoryTargets.length > 0;
+  const pullRequestsQueryKey = [
+    "mobile-delivery-pull-requests",
+    machine?.baseUrl,
+    repositoryKey,
+  ] as const;
+
+  const pullRequestsQuery = useInfiniteQuery({
+    queryKey: pullRequestsQueryKey,
+    enabled: !!client && isFocused && repositoriesAvailable,
+    initialPageParam: null as string | null,
+    queryFn: async ({ pageParam, signal }) => {
+      const refresh = pullRequestRefreshRef.current && pageParam === null;
+      const page = await queryMobileDeliveryPullRequests(client!, {
+        repositories: repositoryTargets,
+        ...(pageParam ? { cursor: pageParam } : {}),
+        refresh,
+        signal,
+      });
+      if (refresh) pullRequestRefreshRef.current = false;
+      return page;
+    },
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? null,
+  });
+
+  const pages = pullRequestsQuery.data?.pages ?? [];
+  const pullRequests = useMemo(
+    () =>
+      uniqueMobileDeliveryPullRequests(
+        pages.flatMap((page) => page.items),
+      ),
+    [pages],
+  );
+  const lanes = useMemo(
+    () => groupMobileDeliveryPullRequests(pullRequests),
+    [pullRequests],
+  );
+  const listItems = useMemo<DeliveryListItem[]>(() => {
+    if (pullRequests.length === 0) return [];
+    const hasNextPage = pullRequestsQuery.hasNextPage === true;
+    return LANE_ORDER.flatMap((lane) => {
+      const rows: DeliveryListItem[] = [
+        {
+          id: `lane:${lane}`,
+          kind: "lane",
+          lane,
+          count: lanes[lane].length,
+          hasNextPage,
+        },
+      ];
+      if (mobileDeliveryLaneIsConfirmedEmpty(lanes[lane], hasNextPage)) {
+        rows.push({ id: `empty:${lane}`, kind: "empty", lane });
+      } else {
+        rows.push(
+          ...lanes[lane].map((pullRequest) => ({
+            id: `pull-request:${pullRequest.id}`,
+            kind: "pull_request" as const,
+            pullRequest,
+          })),
+        );
+      }
+      return rows;
+    });
+  }, [lanes, pullRequests.length, pullRequestsQuery.hasNextPage]);
+  const sourceErrors = useMemo(
+    () =>
+      uniqueMobileDeliverySourceErrors([
+        ...(repositorySnapshot?.errors ?? []),
+        ...pages.flatMap((page) => page.errors),
+      ]),
+    [pages, repositorySnapshot?.errors],
+  );
+  const latestPage = pages[pages.length - 1];
+  const capability = latestPage?.capability ?? repositorySnapshot?.capability;
+  const fetchedAt = latestPage?.fetched_at ?? repositorySnapshot?.fetched_at;
+
+  useEffect(() => {
+    if (isFocused) return;
+    void queryClient.cancelQueries({
+      queryKey: ["mobile-delivery-repositories", machine?.baseUrl],
+    });
+    void queryClient.cancelQueries({
+      queryKey: ["mobile-delivery-pull-requests", machine?.baseUrl],
+    });
+  }, [isFocused, machine?.baseUrl, queryClient]);
+
+  async function refresh() {
+    if (!client || !isFocused || refreshing) return;
+    setRefreshing(true);
+    setLinkError(null);
+    repositoryRefreshRef.current = true;
+    pullRequestRefreshRef.current = true;
+    try {
+      const result = await repositoriesQuery.refetch();
+      const refreshedRepositories = result.data?.repositories ?? [];
+      const refreshedRepositoryTargets = refreshedRepositories.map(
+        mobileDeliveryRepositoryTarget,
+      );
+      const refreshedRepositoriesAvailable =
+        result.data?.capability.found === true &&
+        result.data.capability.authenticated !== false &&
+        refreshedRepositoryTargets.length > 0;
+      if (refreshedRepositoriesAvailable) {
+        const refreshedRepositoryKey = refreshedRepositoryTargets
+          .map((repository) =>
+            [repository.host, repository.owner, repository.name].join("/"),
+          )
+          .join("|");
+        await queryClient.resetQueries({
+          queryKey: [
+            "mobile-delivery-pull-requests",
+            machine?.baseUrl,
+            refreshedRepositoryKey,
+          ],
+          exact: true,
+        });
+      }
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  function loadNextPage() {
+    if (
+      isFocused &&
+      pullRequestsQuery.hasNextPage &&
+      !pullRequestsQuery.isFetchingNextPage
+    ) {
+      void pullRequestsQuery.fetchNextPage();
+    }
+  }
+
+  function renderItem({
+    item,
+    index,
+  }: ListRenderItemInfo<DeliveryListItem>) {
+    if (item.kind === "lane") {
+      const meta = LANE_META[item.lane];
+      return (
+        <View className={index === 0 ? "gap-1 pb-2.5" : "mt-5 gap-1 pb-2.5"}>
+          <View className="flex-row items-center justify-between gap-3">
+            <Text className="text-lg font-semibold text-foreground">
+              {meta.title}
+            </Text>
+            <StatusPill tone={meta.tone}>
+              {mobileDeliveryLaneCountLabel(
+                item.count,
+                item.hasNextPage,
+              )}
+            </StatusPill>
+          </View>
+          <Text className="text-xs text-muted-foreground">
+            {meta.description}
+          </Text>
+        </View>
+      );
+    }
+    if (item.kind === "empty") {
+      return (
+        <Text className="mb-2.5 py-1 text-sm text-muted-foreground">
+          Nothing in this lane.
+        </Text>
+      );
+    }
+    return (
+      <View className="mb-2.5">
+        <PullRequestRow
+          pullRequest={item.pullRequest}
+          onOpen={openPullRequest}
+        />
+      </View>
+    );
+  }
+
+  async function openPullRequest(pullRequest: MobileDeliveryPullRequest) {
+    setLinkError(null);
+    try {
+      await WebBrowser.openBrowserAsync(pullRequest.url);
+    } catch (error) {
+      setLinkError(
+        error instanceof Error
+          ? error.message
+          : "The pull request could not be opened.",
+      );
+    }
+  }
+
+  if (!machine || !client) {
+    return (
+      <SafeAreaView className="flex-1 bg-page-background px-5 py-6">
+        <Text className="text-2xl font-semibold text-foreground">Delivery</Text>
+        <View className="mt-3">
+          <Body>Attach a Tidebreak machine to review pull requests.</Body>
+        </View>
+        <View className="mt-4">
+          <Button label="Attach" onPress={() => router.replace("/attach")} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-page-background">
+      <FlatList
+        contentContainerClassName="px-5 py-6"
+        data={listItems}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        refreshing={refreshing}
+        onRefresh={() => void refresh()}
+        onEndReached={loadNextPage}
+        onEndReachedThreshold={0.35}
+        ListHeaderComponent={
+          <View className="gap-4">
+            <View className="gap-1">
+              <View className="flex-row items-start justify-between gap-3">
+                <Text className="flex-1 text-2xl font-semibold text-foreground">
+                  Delivery
+                </Text>
+                {repositories.length > 0 ? (
+                  <StatusPill>
+                    {repositories.length} repo
+                    {repositories.length === 1 ? "" : "s"}
+                  </StatusPill>
+                ) : null}
+              </View>
+              <Text className="text-sm text-muted-foreground">
+                Review open pull requests across your tracked repositories.
+              </Text>
+              {fetchedAt ? (
+                <Text className="text-xs text-muted-foreground">
+                  Updated {formatDeliveryDate(fetchedAt)}
+                </Text>
+              ) : null}
+            </View>
+
+            {linkError ? <ErrorText>{linkError}</ErrorText> : null}
+            {repositoriesQuery.isLoading ? (
+              <LoadingState label="Loading repositories…" />
+            ) : null}
+            {repositoriesQuery.isError ? (
+              <ErrorText>
+                {repositoriesQuery.error instanceof Error
+                  ? repositoriesQuery.error.message
+                  : "Delivery repositories could not be loaded."}
+              </ErrorText>
+            ) : null}
+
+            {capability && !deliveryCapabilityAvailable(capability) ? (
+              <CapabilityState capability={capability} />
+            ) : null}
+
+            {repositorySnapshot &&
+            deliveryCapabilityAvailable(repositorySnapshot.capability) &&
+            repositories.length === 0 ? (
+              <View className="rounded-xl border border-border bg-background p-4">
+                <Text className="text-base font-medium text-foreground">
+                  No GitHub repositories
+                </Text>
+                <Text className="mt-1 text-sm text-muted-foreground">
+                  Add a GitHub-backed repository in Tidebreak, then pull to
+                  refresh.
+                </Text>
+              </View>
+            ) : null}
+
+            {sourceErrors.length > 0 ? (
+              <SourceErrors errors={sourceErrors} />
+            ) : null}
+
+            {repositoriesAvailable && pullRequestsQuery.isLoading ? (
+              <LoadingState label="Loading pull requests…" />
+            ) : null}
+            {pullRequestsQuery.isError ? (
+              <ErrorText>
+                {pullRequestsQuery.error instanceof Error
+                  ? pullRequestsQuery.error.message
+                  : "Pull requests could not be loaded."}
+              </ErrorText>
+            ) : null}
+
+            {repositoriesAvailable &&
+            !pullRequestsQuery.isLoading &&
+            !pullRequestsQuery.isError &&
+            pullRequestsQuery.hasNextPage !== true &&
+            pullRequests.length === 0 ? (
+              <View className="rounded-xl border border-border bg-background p-4">
+                <Text className="text-base font-medium text-foreground">
+                  No open pull requests
+                </Text>
+                <Text className="mt-1 text-sm text-muted-foreground">
+                  Open pull requests appear here when a tracked repository has
+                  work in flight.
+                </Text>
+              </View>
+            ) : null}
+
+            {listItems.length > 0 ? <View className="h-1" /> : null}
+          </View>
+        }
+        ListFooterComponent={
+          pullRequestsQuery.isFetchingNextPage ? (
+            <View className="flex-row items-center justify-center gap-2 py-4">
+              <ActivityIndicator size="small" />
+              <Text className="text-sm text-muted-foreground">
+                Loading more…
+              </Text>
+            </View>
+          ) : pullRequestsQuery.hasNextPage ? (
+            <View className="pt-2">
+              <Button
+                label="Load more"
+                variant="secondary"
+                onPress={() => void pullRequestsQuery.fetchNextPage()}
+              />
+            </View>
+          ) : null
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+function PullRequestRow({
+  pullRequest,
+  onOpen,
+}: {
+  pullRequest: MobileDeliveryPullRequest;
+  onOpen: (pullRequest: MobileDeliveryPullRequest) => Promise<void>;
+}) {
+  const status = pullRequestStatus(pullRequest);
+  const checks = pullRequestCheckStatus(pullRequest);
+  return (
+    <Pressable
+      accessibilityRole="link"
+      accessibilityLabel={`${pullRequest.repository.name_with_owner} pull request ${pullRequest.number}, ${pullRequest.title}. ${status.label}. ${checks.label}.`}
+      className="gap-2 rounded-xl border border-border bg-background p-4"
+      onPress={() => void onOpen(pullRequest)}
+    >
+      <View className="flex-row items-start justify-between gap-3">
+        <Text
+          className="flex-1 font-mono text-xs text-muted-foreground"
+          numberOfLines={1}
+        >
+          {pullRequest.repository.name_with_owner} · #{pullRequest.number}
+        </Text>
+        <StatusPill tone={status.tone}>{status.label}</StatusPill>
+      </View>
+      <Text className="text-base font-medium text-foreground">
+        {pullRequest.title}
+      </Text>
+      <Text
+        className="font-mono text-xs text-muted-foreground"
+        numberOfLines={1}
+      >
+        {pullRequest.head_branch} → {pullRequest.base_branch}
+      </Text>
+      <View className="flex-row flex-wrap items-center justify-between gap-2">
+        <Text className={`text-xs font-medium ${checks.className}`}>
+          {checks.label}
+        </Text>
+        <Text className="text-xs text-muted-foreground">
+          {pullRequest.author ? `@${pullRequest.author} · ` : ""}
+          {formatDeliveryDate(pullRequest.updated_at)}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+function CapabilityState({
+  capability,
+}: {
+  capability: MobileDeliveryCapability;
+}) {
+  const title = capability.found
+    ? "GitHub needs sign-in"
+    : "GitHub is unavailable";
+  const fallback = capability.found
+    ? "Sign in to GitHub on the attached machine, then pull to refresh."
+    : "Install or connect GitHub on the attached machine, then pull to refresh.";
+  return (
+    <View className="rounded-xl border border-warning-border bg-warning-background p-4">
+      <Text className="text-base font-medium text-warning-foreground">
+        {title}
+      </Text>
+      <Text className="mt-1 text-sm text-warning-foreground">
+        {capability.remediation || fallback}
+      </Text>
+    </View>
+  );
+}
+
+function SourceErrors({ errors }: { errors: MobileDeliverySourceError[] }) {
+  const visible = errors.slice(0, 3);
+  return (
+    <View className="rounded-xl border border-warning-border bg-warning-background p-4">
+      <Text className="text-base font-medium text-warning-foreground">
+        Some repositories could not be loaded
+      </Text>
+      <View className="mt-2 gap-2">
+        {visible.map((error) => (
+          <Text
+            key={sourceErrorKey(error)}
+            className="text-sm text-warning-foreground"
+          >
+            {sourceErrorRepository(error)}: {error.message}
+          </Text>
+        ))}
+        {errors.length > visible.length ? (
+          <Text className="text-xs text-warning-foreground">
+            {errors.length - visible.length} more source error
+            {errors.length - visible.length === 1 ? "" : "s"}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function deliveryCapabilityAvailable(
+  capability: MobileDeliveryCapability,
+): boolean {
+  return capability.found && capability.authenticated !== false;
+}
+
+function pullRequestStatus(pullRequest: MobileDeliveryPullRequest): {
+  label: string;
+  tone: "neutral" | "info" | "warning" | "success" | "critical";
+} {
+  if (pullRequest.attention_reasons.includes("changes_requested")) {
+    return { label: "Changes requested", tone: "critical" };
+  }
+  if (pullRequest.attention_reasons.includes("checks_failed")) {
+    return { label: "Checks failed", tone: "critical" };
+  }
+  if (pullRequest.attention_reasons.includes("conflicts")) {
+    return { label: "Conflicts", tone: "critical" };
+  }
+  if (pullRequest.attention_reasons.includes("behind")) {
+    return { label: "Update branch", tone: "warning" };
+  }
+  if (pullRequest.attention_reasons.includes("blocked")) {
+    return { label: "Blocked", tone: "warning" };
+  }
+  if (pullRequest.ready_to_merge) {
+    return { label: "Ready to merge", tone: "success" };
+  }
+  if (pullRequest.draft) return { label: "Draft", tone: "neutral" };
+  const reviewDecision = pullRequest.review_decision?.trim().toLowerCase();
+  if (reviewDecision === "approved") {
+    return { label: "Approved", tone: "success" };
+  }
+  if (reviewDecision === "review_required") {
+    return { label: "Needs review", tone: "warning" };
+  }
+  return { label: "In progress", tone: "info" };
+}
+
+function pullRequestCheckStatus(pullRequest: MobileDeliveryPullRequest): {
+  label: string;
+  className: string;
+} {
+  const checks = mobileDeliveryCheckProgress(pullRequest.checks);
+  if (checks.total === 0) {
+    return { label: "No checks", className: "text-muted-foreground" };
+  }
+  const progress = `${checks.terminal}/${checks.total} checks`;
+  if (checks.failing > 0) {
+    return {
+      label: `${progress} · ${checks.failing} failed`,
+      className: "text-critical-foreground",
+    };
+  }
+  if (checks.pending > 0) {
+    return {
+      label: `${progress} · ${checks.pending} running`,
+      className: "text-info-foreground",
+    };
+  }
+  if (checks.skipped === checks.total) {
+    return {
+      label: `${progress} · ${checks.skipped} skipped`,
+      className: "text-muted-foreground",
+    };
+  }
+  return { label: progress, className: "text-success-foreground" };
+}
+
+function sourceErrorRepository(error: MobileDeliverySourceError): string {
+  if (!error.repository) return "GitHub";
+  return `${error.repository.owner}/${error.repository.name}`;
+}
+
+function sourceErrorKey(error: MobileDeliverySourceError): string {
+  return `${sourceErrorRepository(error)}:${error.kind}:${error.message}`;
+}
+
+function formatDeliveryDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/mobile/app/home.tsx
+++ b/mobile/app/home.tsx
@@ -123,6 +123,12 @@ export default function HomeScreen() {
       </View>
       <Pressable
         className="rounded-lg border border-border bg-background px-4 py-3"
+        onPress={() => router.push("/delivery")}
+      >
+        <Text className="text-center text-base text-foreground">Delivery</Text>
+      </Pressable>
+      <Pressable
+        className="rounded-lg border border-border bg-background px-4 py-3"
         onPress={() => router.push("/chats")}
       >
         <Text className="text-center text-base text-foreground">Chats</Text>

--- a/mobile/src/components/ChatPromptCards.tsx
+++ b/mobile/src/components/ChatPromptCards.tsx
@@ -1,0 +1,489 @@
+import { useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import {
+  mobileApprovalQuestion,
+  mobileApprovalSummary,
+  mobileToolPreviewDetail,
+  type MobilePendingPlanApproval,
+  type MobilePendingToolApproval,
+  type MobilePendingUserQuestions,
+  type MobilePlanDecision,
+  type MobileUserQuestionAnswer,
+} from "../lib/chatPrompts";
+import { Button, Field, SectionLabel } from "./Controls";
+import { ErrorText } from "./Screen";
+
+export function ChatToolApprovalCard({
+  approval,
+  onDecide,
+}: {
+  approval: MobilePendingToolApproval;
+  onDecide: (
+    decision:
+      | { decision: "approve" }
+      | { decision: "reject"; feedback: string },
+  ) => Promise<void>;
+}) {
+  const [rejecting, setRejecting] = useState(false);
+  const [feedback, setFeedback] = useState("");
+  const [busy, setBusy] = useState<"approve" | "reject" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function decide(kind: "approve" | "reject") {
+    const reason = feedback.trim();
+    if (kind === "reject" && !reason) {
+      setError("Tell the agent what to change before rejecting.");
+      return;
+    }
+    setBusy(kind);
+    setError(null);
+    try {
+      await onDecide(
+        kind === "approve"
+          ? { decision: "approve" }
+          : { decision: "reject", feedback: reason },
+      );
+    } catch (reasonCaught) {
+      setError(
+        reasonCaught instanceof Error
+          ? reasonCaught.message
+          : "The approval decision could not be sent.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <View className="gap-3 rounded-xl border border-warning-border bg-background p-4">
+      <View className="gap-1">
+        <SectionLabel>Approval needed</SectionLabel>
+        <Text className="text-base font-semibold text-foreground">
+          {mobileApprovalQuestion(approval)}
+        </Text>
+        <Text className="text-sm text-muted-foreground">
+          {mobileApprovalSummary(approval.approval)}
+        </Text>
+      </View>
+
+      {approval.autoJudgeStatus === "judging" ? (
+        <Text className="text-xs text-info-foreground">
+          Tidebreak is deciding automatically. You can still decide now.
+        </Text>
+      ) : null}
+
+      {approval.preview ? (
+        <ScrollView
+          className="max-h-48 rounded-lg border border-border bg-muted p-3"
+          nestedScrollEnabled
+        >
+          <Text className="font-mono text-xs text-foreground" selectable>
+            {mobileToolPreviewDetail(approval.preview)}
+          </Text>
+        </ScrollView>
+      ) : (
+        <View className="rounded-lg border border-border bg-muted p-3">
+          <Text className="text-sm text-muted-foreground">
+            No action preview is available for this request.
+          </Text>
+        </View>
+      )}
+
+      {rejecting ? (
+        <Field
+          label="Feedback for the agent"
+          hint="The agent receives this with the rejection."
+          value={feedback}
+          onChangeText={(value) => {
+            setFeedback(value);
+            setError(null);
+          }}
+          placeholder="Explain what should change"
+          maxLength={512}
+          editable={busy === null}
+        />
+      ) : null}
+
+      {error ? <ErrorText>{error}</ErrorText> : null}
+
+      {rejecting ? (
+        <View className="gap-2 sm:flex-row">
+          <View className="flex-1">
+            <Button
+              label="Reject with feedback"
+              variant="destructive"
+              busy={busy === "reject"}
+              disabled={busy !== null}
+              onPress={() => void decide("reject")}
+            />
+          </View>
+          <View className="flex-1">
+            <Button
+              label="Cancel"
+              variant="secondary"
+              disabled={busy !== null}
+              onPress={() => {
+                setRejecting(false);
+                setError(null);
+              }}
+            />
+          </View>
+        </View>
+      ) : (
+        <View className="gap-2 sm:flex-row">
+          {approval.canApprove ? (
+            <View className="flex-1">
+              <Button
+                label="Approve once"
+                busy={busy === "approve"}
+                disabled={busy !== null}
+                onPress={() => void decide("approve")}
+              />
+            </View>
+          ) : null}
+          <View className="flex-1">
+            <Button
+              label="Reject…"
+              variant="secondary"
+              disabled={busy !== null}
+              onPress={() => setRejecting(true)}
+            />
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+type DraftAnswer = {
+  selectedOptionIds: string[];
+  customAnswer?: string;
+};
+
+export function ChatUserQuestionsCard({
+  request,
+  onAnswer,
+}: {
+  request: MobilePendingUserQuestions;
+  onAnswer: (
+    answers: MobileUserQuestionAnswer[],
+    additionalUserContext?: string,
+  ) => Promise<void>;
+}) {
+  const [drafts, setDrafts] = useState<Record<string, DraftAnswer>>({});
+  const [page, setPage] = useState(0);
+  const [additionalContext, setAdditionalContext] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const question =
+    request.questions[Math.min(page, request.questions.length - 1)];
+
+  const answers = useMemo(
+    () =>
+      request.questions.flatMap<MobileUserQuestionAnswer>((entry) => {
+        const draft = drafts[entry.id];
+        if (!draft) return [];
+        const customAnswer = draft.customAnswer?.trim();
+        if (draft.selectedOptionIds.length === 0 && !customAnswer) return [];
+        return [
+          {
+            questionId: entry.id,
+            selectedOptionIds: draft.selectedOptionIds,
+            ...(customAnswer ? { customAnswer } : {}),
+          },
+        ];
+      }),
+    [drafts, request.questions],
+  );
+
+  if (!question) return null;
+
+  const questionId = question.id;
+  const draft = drafts[question.id] ?? { selectedOptionIds: [] };
+  const multi = question.questionType === "multi_select";
+  const last = page === request.questions.length - 1;
+
+  function update(next: DraftAnswer) {
+    setDrafts((current) => ({ ...current, [questionId]: next }));
+    setError(null);
+  }
+
+  function chooseOption(optionId: string) {
+    if (busy) return;
+    if (multi) {
+      update({
+        ...draft,
+        selectedOptionIds: draft.selectedOptionIds.includes(optionId)
+          ? draft.selectedOptionIds.filter((id) => id !== optionId)
+          : [...draft.selectedOptionIds, optionId],
+      });
+      return;
+    }
+    update({ selectedOptionIds: [optionId] });
+  }
+
+  function setCustomAnswer(value: string) {
+    update({
+      selectedOptionIds: multi ? draft.selectedOptionIds : [],
+      customAnswer: value,
+    });
+  }
+
+  async function submit(skipAll = false) {
+    setBusy(true);
+    setError(null);
+    try {
+      const context = additionalContext.trim();
+      await onAnswer(
+        skipAll ? [] : answers,
+        skipAll || !context ? undefined : context,
+      );
+    } catch (reason) {
+      setError(
+        reason instanceof Error
+          ? reason.message
+          : "The answers could not be sent.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <View className="gap-3 rounded-xl border border-border bg-background p-4">
+      <View className="gap-1">
+        <View className="flex-row items-center justify-between gap-3">
+          <SectionLabel>{question.header}</SectionLabel>
+          {request.questions.length > 1 ? (
+            <Text className="text-xs text-muted-foreground">
+              {page + 1} of {request.questions.length}
+            </Text>
+          ) : null}
+        </View>
+        <Text className="text-base font-semibold text-foreground">
+          {question.question}
+        </Text>
+        {multi ? (
+          <Text className="text-xs text-muted-foreground">
+            Select all that apply.
+          </Text>
+        ) : null}
+      </View>
+
+      <View className="gap-2">
+        {question.options.map((option) => {
+          const selected = draft.selectedOptionIds.includes(option.id);
+          return (
+            <Pressable
+              key={option.id}
+              accessibilityRole={multi ? "checkbox" : "radio"}
+              accessibilityState={{ checked: selected, disabled: busy }}
+              disabled={busy}
+              className={`min-h-16 flex-row items-start gap-3 rounded-xl border p-3 disabled:opacity-50 ${
+                selected
+                  ? "border-primary bg-muted"
+                  : "border-border bg-page-background"
+              }`}
+              onPress={() => chooseOption(option.id)}
+            >
+              <Text className="w-5 text-base text-foreground">
+                {multi ? (selected ? "■" : "□") : selected ? "●" : "○"}
+              </Text>
+              <View className="min-w-0 flex-1 gap-1">
+                <Text className="text-sm font-medium text-foreground">
+                  {option.label}
+                </Text>
+                <Text className="text-xs text-muted-foreground">
+                  {option.description}
+                </Text>
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {question.allowFreeForm ? (
+        <Field
+          label={multi ? "Other answer (optional)" : "Other answer"}
+          multiline
+          value={draft.customAnswer ?? ""}
+          onChangeText={setCustomAnswer}
+          placeholder="Write your own answer"
+          maxLength={2_000}
+          editable={!busy}
+        />
+      ) : null}
+
+      {last ? (
+        <Field
+          label="Additional context (optional)"
+          multiline
+          value={additionalContext}
+          onChangeText={(value) => {
+            setAdditionalContext(value);
+            setError(null);
+          }}
+          placeholder="Add context that applies to all answers"
+          maxLength={2_000}
+          editable={!busy}
+        />
+      ) : null}
+
+      {error ? <ErrorText>{error}</ErrorText> : null}
+
+      <View className="gap-2">
+        <View className="flex-row gap-2">
+          {page > 0 ? (
+            <View className="flex-1">
+              <Button
+                label="Back"
+                compact
+                variant="secondary"
+                disabled={busy}
+                onPress={() => setPage((current) => current - 1)}
+              />
+            </View>
+          ) : null}
+          <View className="flex-1">
+            <Button
+              label={last ? "Continue" : "Next"}
+              compact
+              busy={last && busy}
+              disabled={busy}
+              onPress={() => {
+                if (last) void submit();
+                else setPage((current) => current + 1);
+              }}
+            />
+          </View>
+        </View>
+        <Button
+          label={request.questions.length === 1 ? "Skip question" : "Skip all"}
+          compact
+          variant="secondary"
+          disabled={busy}
+          onPress={() => void submit(true)}
+        />
+      </View>
+    </View>
+  );
+}
+
+export function ChatPlanApprovalCard({
+  request,
+  onDecide,
+}: {
+  request: MobilePendingPlanApproval;
+  onDecide: (decision: MobilePlanDecision) => Promise<void>;
+}) {
+  const [revising, setRevising] = useState(false);
+  const [feedback, setFeedback] = useState("");
+  const [busy, setBusy] = useState<"accept" | "reject" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function decide(kind: "accept" | "reject") {
+    const reason = feedback.trim();
+    if (kind === "reject" && !reason) {
+      setError("Explain what the agent should change in the plan.");
+      return;
+    }
+    setBusy(kind);
+    setError(null);
+    try {
+      await onDecide(
+        kind === "accept"
+          ? { decision: "accept" }
+          : { decision: "reject", feedback: reason },
+      );
+    } catch (reasonCaught) {
+      setError(
+        reasonCaught instanceof Error
+          ? reasonCaught.message
+          : "The plan decision could not be sent.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <View className="gap-3 rounded-xl border border-border bg-background p-4">
+      <View className="gap-1">
+        <SectionLabel>Plan ready</SectionLabel>
+        <Text className="text-base font-semibold text-foreground">
+          {request.title}
+        </Text>
+      </View>
+
+      <ScrollView
+        className="max-h-72 rounded-lg border border-border bg-page-background p-3"
+        nestedScrollEnabled
+      >
+        <Text className="text-sm leading-6 text-foreground" selectable>
+          {request.plan}
+        </Text>
+      </ScrollView>
+
+      {revising ? (
+        <Field
+          label="Plan feedback"
+          hint="The agent revises the plan before asking again."
+          multiline
+          value={feedback}
+          onChangeText={(value) => {
+            setFeedback(value);
+            setError(null);
+          }}
+          placeholder="Explain what should change"
+          maxLength={4_000}
+          editable={busy === null}
+        />
+      ) : null}
+
+      {error ? <ErrorText>{error}</ErrorText> : null}
+
+      {revising ? (
+        <View className="gap-2 sm:flex-row">
+          <View className="flex-1">
+            <Button
+              label="Send back for changes"
+              busy={busy === "reject"}
+              disabled={busy !== null}
+              onPress={() => void decide("reject")}
+            />
+          </View>
+          <View className="flex-1">
+            <Button
+              label="Cancel"
+              variant="secondary"
+              disabled={busy !== null}
+              onPress={() => {
+                setRevising(false);
+                setError(null);
+              }}
+            />
+          </View>
+        </View>
+      ) : (
+        <View className="gap-2 sm:flex-row">
+          <View className="flex-1">
+            <Button
+              label="Execute plan"
+              busy={busy === "accept"}
+              disabled={busy !== null}
+              onPress={() => void decide("accept")}
+            />
+          </View>
+          <View className="flex-1">
+            <Button
+              label="Request changes…"
+              variant="secondary"
+              disabled={busy !== null}
+              onPress={() => setRevising(true)}
+            />
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/mobile/src/components/Controls.tsx
+++ b/mobile/src/components/Controls.tsx
@@ -86,7 +86,7 @@ export function StatusPill({
   tone = "neutral",
 }: {
   children: ReactNode;
-  tone?: "neutral" | "live" | "warning" | "info";
+  tone?: "neutral" | "live" | "warning" | "info" | "success" | "critical";
 }) {
   const style = {
     neutral: {
@@ -104,6 +104,14 @@ export function StatusPill({
     info: {
       container: "border-info-border bg-info-background",
       text: "text-info-foreground",
+    },
+    success: {
+      container: "border-success-border bg-success-background",
+      text: "text-success-foreground",
+    },
+    critical: {
+      container: "border-critical-border bg-critical-background",
+      text: "text-critical-foreground",
     },
   }[tone];
   return (

--- a/mobile/src/global.css
+++ b/mobile/src/global.css
@@ -18,6 +18,7 @@
   --success: #2f9e62;
   --success-foreground: #166534;
   --success-background: #ecfdf3;
+  --success-border: #a7dfbd;
   --info: #3b82c4;
   --info-foreground: #1d4ed8;
   --info-background: #eff6ff;

--- a/mobile/src/lib/chatPrompts.test.ts
+++ b/mobile/src/lib/chatPrompts.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MachineClient } from "./machine";
+import {
+  answerMobileUserQuestions,
+  decideMobilePlan,
+  decideMobileToolApproval,
+  listMobilePendingPlanApprovals,
+  listMobilePendingToolApprovals,
+  listMobilePendingUserQuestions,
+  mobileApprovalQuestion,
+  mobileToolPreviewDetail,
+  parseMobilePendingPlanApproval,
+  parseMobilePendingToolApproval,
+  parseMobilePendingUserQuestions,
+  parseMobileToolActionPreview,
+} from "./chatPrompts";
+
+const execPreview = {
+  tool: "exec",
+  command: "pnpm",
+  args: ["test", "--", "chat prompts"],
+  cwd: "mobile",
+  files: ["package.json", "src/lib/chatPrompts.ts"],
+  summary: "Run the focused mobile tests.",
+};
+
+const approval = {
+  call_id: "call-approval",
+  turn_id: "turn-1",
+  action: "exec",
+  approval: "exec_may_run_networked_command",
+  class: "sensitive",
+  preview: execPreview,
+  can_approve: true,
+  can_remember: true,
+  grant_rungs: [
+    "exact_action",
+    { command_prefix: { tokens: 1 } },
+    "whole_tool",
+  ],
+  auto_judge_status: "judging",
+};
+
+const questions = {
+  call_id: "call-questions",
+  turn_id: "turn-1",
+  questions: [
+    {
+      id: "target",
+      header: "Target",
+      question: "Where should I deploy?",
+      options: [
+        {
+          id: "staging",
+          label: "Staging",
+          description: "Deploy for internal verification.",
+        },
+        {
+          id: "production",
+          label: "Production",
+          description: "Deploy to customers.",
+        },
+      ],
+      question_type: "single_select",
+      allow_free_form: true,
+    },
+  ],
+  asked_at: "2026-08-27T20:00:00Z",
+};
+
+const plan = {
+  call_id: "call-plan",
+  turn_id: "turn-1",
+  title: "Add mobile prompt cards",
+  plan:
+    "## Steps\n1. Parse each pending prompt strictly.\n2. Show its mobile card.\n3. Submit the exact decision.",
+  proposed_at: "2026-08-27T20:00:01Z",
+};
+
+function fakeClient(response: unknown): {
+  client: Pick<MachineClient, "getJson" | "requestJson">;
+  getJson: ReturnType<typeof vi.fn>;
+  requestJson: ReturnType<typeof vi.fn>;
+} {
+  const getJson = vi.fn(async () => response);
+  const requestJson = vi.fn(async () => response);
+  return { client: { getJson, requestJson }, getJson, requestJson };
+}
+
+describe("mobile chat prompt contracts", () => {
+  it("parses a closed approval and preserves its exact action preview", () => {
+    expect(parseMobilePendingToolApproval(approval)).toEqual({
+      callId: "call-approval",
+      turnId: "turn-1",
+      action: "exec",
+      approval: "exec_may_run_networked_command",
+      class: "sensitive",
+      preview: execPreview,
+      canApprove: true,
+      canRemember: true,
+      grantRungs: approval.grant_rungs,
+      autoJudgeStatus: "judging",
+    });
+    expect(
+      parseMobilePendingToolApproval({ ...approval, can_approve: false }),
+    ).toBeNull();
+    expect(
+      parseMobilePendingToolApproval({ ...approval, hidden_argument: "no" }),
+    ).toBeNull();
+    expect(
+      parseMobilePendingToolApproval({
+        ...approval,
+        grant_rungs: [{ command_prefix: { tokens: 0 } }],
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects an untrusted preview instead of partially rendering it", () => {
+    expect(parseMobileToolActionPreview(execPreview)).toEqual(execPreview);
+    expect(
+      parseMobileToolActionPreview({
+        ...execPreview,
+        command: "pnpm\ntouch hidden",
+      }),
+    ).toBeNull();
+    expect(
+      parseMobileToolActionPreview({
+        ...execPreview,
+        secret: "raw arguments stay behind the server boundary",
+      }),
+    ).toBeNull();
+    expect(
+      parseMobileToolActionPreview({
+        tool: "delegate_agent",
+        task: "Inspect the mobile build.",
+        network: {
+          mode: "allowed_hosts",
+          allowed_hosts: ["registry.npmjs.org"],
+          package_managers: true,
+        },
+      }),
+    ).toMatchObject({ tool: "delegate_agent" });
+  });
+
+  it("loads approvals only when calls are unique and belong to one turn", async () => {
+    const listed = fakeClient([approval]);
+    await expect(
+      listMobilePendingToolApprovals(listed.client, "chat/1"),
+    ).resolves.toHaveLength(1);
+    expect(listed.getJson).toHaveBeenCalledWith("/chats/chat%2F1/approvals");
+
+    const duplicate = fakeClient([approval, approval]);
+    await expect(
+      listMobilePendingToolApprovals(duplicate.client, "chat-1"),
+    ).rejects.toThrow(/duplicate call/i);
+
+    const mixedTurns = fakeClient([
+      approval,
+      { ...approval, call_id: "call-2", turn_id: "turn-2" },
+    ]);
+    await expect(
+      listMobilePendingToolApprovals(mixedTurns.client, "chat-1"),
+    ).rejects.toThrow(/multiple turns/i);
+  });
+
+  it("sends approve-once and bounded rejection feedback", async () => {
+    const sent = fakeClient(undefined);
+    await decideMobileToolApproval(
+      sent.client,
+      "chat/1",
+      "call/1",
+      { decision: "approve" },
+    );
+    expect(sent.requestJson).toHaveBeenLastCalledWith(
+      "/chats/chat%2F1/approvals/call%2F1",
+      {
+        method: "POST",
+        body: { decision: "approve", grant: null },
+        expectedStatus: 204,
+      },
+    );
+
+    await decideMobileToolApproval(
+      sent.client,
+      "chat-1",
+      "call-2",
+      { decision: "reject", feedback: "  Use the cached result.  " },
+    );
+    expect(sent.requestJson).toHaveBeenLastCalledWith(
+      "/chats/chat-1/approvals/call-2",
+      {
+        method: "POST",
+        body: {
+          decision: "reject",
+          reason: "Use the cached result.",
+        },
+        expectedStatus: 204,
+      },
+    );
+    await expect(
+      decideMobileToolApproval(sent.client, "chat-1", "call-3", {
+        decision: "reject",
+        feedback: "   ",
+      }),
+    ).rejects.toThrow(/what to change/i);
+  });
+
+  it("parses question blocks as one closed, unique answer contract", async () => {
+    expect(parseMobilePendingUserQuestions(questions)).toEqual({
+      callId: "call-questions",
+      turnId: "turn-1",
+      questions: [
+        {
+          id: "target",
+          header: "Target",
+          question: "Where should I deploy?",
+          options: questions.questions[0]!.options,
+          questionType: "single_select",
+          allowFreeForm: true,
+        },
+      ],
+      askedAt: "2026-08-27T20:00:00Z",
+    });
+    expect(
+      parseMobilePendingUserQuestions({
+        ...questions,
+        questions: [
+          {
+            ...questions.questions[0],
+            options: [
+              questions.questions[0]!.options[0],
+              questions.questions[0]!.options[0],
+            ],
+          },
+        ],
+      }),
+    ).toBeNull();
+    expect(
+      parseMobilePendingUserQuestions({
+        ...questions,
+        questions: [
+          {
+            ...questions.questions[0],
+            options: [],
+            allow_free_form: false,
+          },
+        ],
+      }),
+    ).toBeNull();
+
+    const listed = fakeClient([questions]);
+    await expect(
+      listMobilePendingUserQuestions(listed.client, "chat/1"),
+    ).resolves.toHaveLength(1);
+    expect(listed.getJson).toHaveBeenCalledWith(
+      "/chats/chat%2F1/questions/pending",
+    );
+  });
+
+  it("submits selected options, free-form text, context, and explicit skips", async () => {
+    const sent = fakeClient(undefined);
+    await answerMobileUserQuestions(
+      sent.client,
+      "chat/1",
+      "call/1",
+      [
+        {
+          questionId: "target",
+          selectedOptionIds: ["staging"],
+          customAnswer: "  Use the blue environment.  ",
+        },
+      ],
+      "  Keep production untouched.  ",
+    );
+    expect(sent.requestJson).toHaveBeenLastCalledWith(
+      "/chats/chat%2F1/questions/call%2F1/answer",
+      {
+        method: "POST",
+        body: {
+          answers: [
+            {
+              question_id: "target",
+              selected_option_ids: ["staging"],
+              custom_answer: "Use the blue environment.",
+            },
+          ],
+          additional_user_context: "Keep production untouched.",
+        },
+      },
+    );
+
+    await answerMobileUserQuestions(
+      sent.client,
+      "chat-1",
+      "call-2",
+      [],
+    );
+    expect(sent.requestJson).toHaveBeenLastCalledWith(
+      "/chats/chat-1/questions/call-2/answer",
+      { method: "POST", body: { answers: [] } },
+    );
+  });
+
+  it("parses plans and submits accept or revision decisions", async () => {
+    expect(parseMobilePendingPlanApproval(plan)).toEqual({
+      callId: "call-plan",
+      turnId: "turn-1",
+      title: "Add mobile prompt cards",
+      plan: plan.plan,
+      proposedAt: "2026-08-27T20:00:01Z",
+    });
+    expect(
+      parseMobilePendingPlanApproval({ ...plan, plan: "bad\u202eplan" }),
+    ).toBeNull();
+
+    const listed = fakeClient([plan]);
+    await expect(
+      listMobilePendingPlanApprovals(listed.client, "chat/1"),
+    ).resolves.toHaveLength(1);
+    expect(listed.getJson).toHaveBeenCalledWith(
+      "/chats/chat%2F1/plans/pending",
+    );
+
+    const sent = fakeClient(undefined);
+    await decideMobilePlan(sent.client, "chat/1", "call/1", {
+      decision: "accept",
+    });
+    expect(sent.requestJson).toHaveBeenLastCalledWith(
+      "/chats/chat%2F1/plans/call%2F1/decision",
+      { method: "POST", body: { decision: "accept" } },
+    );
+    await decideMobilePlan(sent.client, "chat-1", "call-2", {
+      decision: "reject",
+      feedback: "  Split the deployment into another step.  ",
+    });
+    expect(sent.requestJson).toHaveBeenLastCalledWith(
+      "/chats/chat-1/plans/call-2/decision",
+      {
+        method: "POST",
+        body: {
+          decision: "reject",
+          feedback: "Split the deployment into another step.",
+        },
+      },
+    );
+  });
+
+  it("uses literal renderer-safe details instead of model narration", () => {
+    const parsed = parseMobilePendingToolApproval(approval)!;
+    expect(mobileApprovalQuestion(parsed)).toBe(
+      "Run this command with network access?",
+    );
+    expect(mobileToolPreviewDetail(parsed.preview!)).toBe(
+      "pnpm test -- 'chat prompts'\n" +
+        "# working directory: mobile\n" +
+        "# staged files: package.json, src/lib/chatPrompts.ts",
+    );
+    expect(mobileToolPreviewDetail(parsed.preview!)).not.toContain(
+      execPreview.summary,
+    );
+  });
+});

--- a/mobile/src/lib/chatPrompts.ts
+++ b/mobile/src/lib/chatPrompts.ts
@@ -1,0 +1,841 @@
+import {
+  RENDERER_TOOL_NAMES,
+  type ApprovalGrantRung,
+  type NetworkPolicy,
+  type PendingApprovalSnapshot as WirePendingApprovalSnapshot,
+  type PendingPlanApproval as WirePendingPlanApproval,
+  type PendingUserQuestions as WirePendingUserQuestions,
+  type RendererToolName,
+  type ToolActionPreview,
+  type ToolApprovalKind,
+  type UserQuestion as WireUserQuestion,
+  type UserQuestionOption as WireUserQuestionOption,
+  type UserQuestionType,
+} from "../generated/wire";
+import type { MachineClient } from "./machine";
+
+type MachineJsonClient = Pick<MachineClient, "getJson" | "requestJson">;
+
+export type MobilePendingToolApproval = {
+  callId: string;
+  turnId: string;
+  action: RendererToolName;
+  approval: ToolApprovalKind;
+  class: WirePendingApprovalSnapshot["class"];
+  preview: ToolActionPreview | null;
+  canApprove: boolean;
+  canRemember: boolean;
+  grantRungs: ApprovalGrantRung[];
+  autoJudgeStatus: NonNullable<
+    WirePendingApprovalSnapshot["auto_judge_status"]
+  > | null;
+};
+
+export type MobileUserQuestionOption = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+export type MobileUserQuestion = {
+  id: string;
+  header: string;
+  question: string;
+  options: MobileUserQuestionOption[];
+  questionType: UserQuestionType;
+  allowFreeForm: boolean;
+};
+
+export type MobilePendingUserQuestions = {
+  callId: string;
+  turnId: string;
+  questions: MobileUserQuestion[];
+  askedAt: string;
+};
+
+export type MobileUserQuestionAnswer = {
+  questionId: string;
+  selectedOptionIds: string[];
+  customAnswer?: string;
+};
+
+export type MobilePendingPlanApproval = {
+  callId: string;
+  turnId: string;
+  title: string;
+  plan: string;
+  proposedAt: string;
+};
+
+export type MobilePlanDecision =
+  | { decision: "accept" }
+  | { decision: "reject"; feedback?: string };
+
+const APPROVABLE_KINDS = {
+  search_may_share_query_and_excerpts: true,
+  web_search_may_share_query: true,
+  web_extract_may_fetch_url: true,
+  exec_may_run_networked_command: true,
+  external_mcp_may_call_server: true,
+  workspace_may_modify_files: true,
+  delegate_may_run_background_agent: true,
+  computer_may_control_app: true,
+  unsupported: false,
+} as const satisfies Record<ToolApprovalKind, boolean>;
+
+const APPROVAL_KINDS = {
+  search_may_share_query_and_excerpts: true,
+  web_search_may_share_query: true,
+  web_extract_may_fetch_url: true,
+  exec_may_run_networked_command: true,
+  external_mcp_may_call_server: true,
+  workspace_may_modify_files: true,
+  delegate_may_run_background_agent: true,
+  computer_may_control_app: true,
+  unsupported: true,
+} as const satisfies Record<ToolApprovalKind, true>;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function onlyKeys<Wire>(
+  value: Record<string, unknown>,
+  allowed: readonly (keyof Wire & string)[],
+): boolean {
+  const names = new Set<string>(allowed);
+  return Object.keys(value).every((key) => names.has(key));
+}
+
+function forbiddenPreviewCharacter(character: string): boolean {
+  const code = character.codePointAt(0) ?? 0;
+  return (
+    code < 32 ||
+    (code >= 127 && code <= 159) ||
+    code === 0x2028 ||
+    code === 0x2029 ||
+    (code >= 0x202a && code <= 0x202e) ||
+    (code >= 0x2066 && code <= 0x2069)
+  );
+}
+
+function bounded(value: unknown, maxChars: number): value is string {
+  return (
+    typeof value === "string" &&
+    Array.from(value).length <= maxChars &&
+    !Array.from(value).some(forbiddenPreviewCharacter)
+  );
+}
+
+function boundedBlock(value: unknown, maxChars: number): value is string {
+  return (
+    typeof value === "string" &&
+    Array.from(value).length <= maxChars &&
+    !Array.from(value).some(
+      (character) =>
+        forbiddenPreviewCharacter(character) &&
+        character !== "\n" &&
+        character !== "\t",
+    )
+  );
+}
+
+function nonEmptyBounded(value: unknown, maxChars: number): value is string {
+  return bounded(value, maxChars) && value.trim().length > 0;
+}
+
+function optionalBounded(
+  value: unknown,
+  maxChars: number,
+): value is string | null {
+  return value === null || nonEmptyBounded(value, maxChars);
+}
+
+function stringList(
+  value: unknown,
+  maxItems: number,
+  maxChars: number,
+): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length <= maxItems &&
+    value.every((item) => bounded(item, maxChars))
+  );
+}
+
+function narration(value: Record<string, unknown>): { summary?: string } {
+  return nonEmptyBounded(value.summary, 200)
+    ? { summary: value.summary }
+    : {};
+}
+
+function parseNetworkPolicy(value: unknown): NetworkPolicy | null {
+  const policy = record(value);
+  if (!policy) return null;
+  if (
+    (policy.mode === "off" ||
+      policy.mode === "package_managers" ||
+      policy.mode === "open") &&
+    onlyKeys<NetworkPolicy>(policy, ["mode"])
+  ) {
+    return { mode: policy.mode };
+  }
+  if (
+    policy.mode !== "allowed_hosts" ||
+    !onlyKeys<Extract<NetworkPolicy, { mode: "allowed_hosts" }>>(policy, [
+      "mode",
+      "allowed_hosts",
+      "package_managers",
+    ]) ||
+    !stringList(policy.allowed_hosts, 64, 512) ||
+    typeof policy.package_managers !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    mode: "allowed_hosts",
+    allowed_hosts: policy.allowed_hosts,
+    package_managers: policy.package_managers,
+  };
+}
+
+export function parseMobileToolActionPreview(
+  value: unknown,
+): ToolActionPreview | null {
+  const preview = record(value);
+  if (!preview) return null;
+  if (preview.tool === "search") {
+    if (
+      !onlyKeys<Extract<ToolActionPreview, { tool: "search" }>>(preview, [
+        "tool",
+        "query",
+        "summary",
+      ]) ||
+      !nonEmptyBounded(preview.query, 512)
+    ) {
+      return null;
+    }
+    return { tool: "search", query: preview.query, ...narration(preview) };
+  }
+  if (preview.tool === "web_search") {
+    if (
+      !onlyKeys<Extract<ToolActionPreview, { tool: "web_search" }>>(preview, [
+        "tool",
+        "query",
+        "domains",
+        "start_published_at",
+        "end_published_at",
+        "summary",
+      ]) ||
+      !nonEmptyBounded(preview.query, 512) ||
+      !stringList(preview.domains, 32, 512) ||
+      !optionalBounded(preview.start_published_at, 512) ||
+      !optionalBounded(preview.end_published_at, 512)
+    ) {
+      return null;
+    }
+    return {
+      tool: "web_search",
+      query: preview.query,
+      domains: preview.domains,
+      start_published_at: preview.start_published_at,
+      end_published_at: preview.end_published_at,
+      ...narration(preview),
+    };
+  }
+  if (preview.tool === "web_extract") {
+    if (
+      !onlyKeys<Extract<ToolActionPreview, { tool: "web_extract" }>>(
+        preview,
+        ["tool", "url", "summary"],
+      ) ||
+      !nonEmptyBounded(preview.url, 512)
+    ) {
+      return null;
+    }
+    return {
+      tool: "web_extract",
+      url: preview.url,
+      ...narration(preview),
+    };
+  }
+  if (preview.tool === "write_file") {
+    if (
+      !onlyKeys<Extract<ToolActionPreview, { tool: "write_file" }>>(
+        preview,
+        ["tool", "path", "summary"],
+      ) ||
+      !nonEmptyBounded(preview.path, 512)
+    ) {
+      return null;
+    }
+    return {
+      tool: "write_file",
+      path: preview.path,
+      ...narration(preview),
+    };
+  }
+  if (preview.tool === "delegate_agent") {
+    const network = parseNetworkPolicy(preview.network);
+    if (
+      !onlyKeys<Extract<ToolActionPreview, { tool: "delegate_agent" }>>(
+        preview,
+        ["tool", "task", "network"],
+      ) ||
+      !nonEmptyBounded(preview.task, 512) ||
+      !network
+    ) {
+      return null;
+    }
+    return { tool: "delegate_agent", task: preview.task, network };
+  }
+  if (preview.tool !== "exec") return null;
+  const files = preview.files === undefined ? [] : preview.files;
+  if (
+    !onlyKeys<Extract<ToolActionPreview, { tool: "exec" }>>(preview, [
+      "tool",
+      "command",
+      "args",
+      "cwd",
+      "files",
+      "summary",
+    ]) ||
+    !nonEmptyBounded(preview.command, 512) ||
+    !stringList(preview.args, 32, 512) ||
+    !nonEmptyBounded(preview.cwd, 512) ||
+    !stringList(files, 32, 512)
+  ) {
+    return null;
+  }
+  return {
+    tool: "exec",
+    command: preview.command,
+    args: preview.args,
+    cwd: preview.cwd,
+    files,
+    ...narration(preview),
+  };
+}
+
+function isRendererToolName(value: unknown): value is RendererToolName {
+  return (
+    typeof value === "string" &&
+    (RENDERER_TOOL_NAMES as readonly string[]).includes(value)
+  );
+}
+
+function isApprovalKind(value: unknown): value is ToolApprovalKind {
+  return typeof value === "string" && Object.hasOwn(APPROVAL_KINDS, value);
+}
+
+function isRememberableKind(kind: ToolApprovalKind): boolean {
+  return (
+    APPROVABLE_KINDS[kind] &&
+    kind !== "external_mcp_may_call_server" &&
+    kind !== "computer_may_control_app"
+  );
+}
+
+function parseGrantRung(value: unknown): ApprovalGrantRung | null {
+  if (value === "exact_action" || value === "whole_tool") return value;
+  const rung = record(value);
+  if (!rung || Object.keys(rung).length !== 1) return null;
+  const command = record(rung.command_prefix);
+  if (command && Object.keys(command).length === 1) {
+    return Number.isSafeInteger(command.tokens) && Number(command.tokens) > 0
+      ? { command_prefix: { tokens: Number(command.tokens) } }
+      : null;
+  }
+  const path = record(rung.path_prefix);
+  if (path && Object.keys(path).length === 1) {
+    return Number.isSafeInteger(path.segments) && Number(path.segments) > 0
+      ? { path_prefix: { segments: Number(path.segments) } }
+      : null;
+  }
+  return null;
+}
+
+export function parseMobilePendingToolApproval(
+  value: unknown,
+): MobilePendingToolApproval | null {
+  const approval = record(value);
+  if (
+    !approval ||
+    !onlyKeys<WirePendingApprovalSnapshot>(approval, [
+      "call_id",
+      "turn_id",
+      "action",
+      "approval",
+      "class",
+      "preview",
+      "can_approve",
+      "can_remember",
+      "grant_rungs",
+      "auto_judge_status",
+    ]) ||
+    !nonEmptyBounded(approval.call_id, 128) ||
+    !nonEmptyBounded(approval.turn_id, 128) ||
+    !isRendererToolName(approval.action) ||
+    !isApprovalKind(approval.approval) ||
+    (approval.class !== "read_only" &&
+      approval.class !== "workspace" &&
+      approval.class !== "sensitive") ||
+    typeof approval.can_approve !== "boolean" ||
+    approval.can_approve !== APPROVABLE_KINDS[approval.approval] ||
+    typeof approval.can_remember !== "boolean" ||
+    !Array.isArray(approval.grant_rungs) ||
+    approval.grant_rungs.length > 32 ||
+    !(
+      approval.auto_judge_status === undefined ||
+      approval.auto_judge_status === "judging" ||
+      approval.auto_judge_status === "approved" ||
+      approval.auto_judge_status === "declined"
+    )
+  ) {
+    return null;
+  }
+  const grantRungs = approval.grant_rungs.map(parseGrantRung);
+  if (
+    grantRungs.some((rung) => rung === null) ||
+    (grantRungs.length > 0 && !isRememberableKind(approval.approval)) ||
+    approval.can_remember !== (grantRungs.length > 0)
+  ) {
+    return null;
+  }
+  return {
+    callId: approval.call_id,
+    turnId: approval.turn_id,
+    action: approval.action,
+    approval: approval.approval,
+    class: approval.class,
+    preview: parseMobileToolActionPreview(approval.preview),
+    canApprove: approval.can_approve,
+    canRemember: approval.can_remember,
+    grantRungs: grantRungs as ApprovalGrantRung[],
+    autoJudgeStatus: approval.auto_judge_status ?? null,
+  };
+}
+
+function parseQuestionOption(value: unknown): MobileUserQuestionOption | null {
+  const option = record(value);
+  if (
+    !option ||
+    !onlyKeys<WireUserQuestionOption>(option, [
+      "id",
+      "label",
+      "description",
+    ]) ||
+    !nonEmptyBounded(option.id, 64) ||
+    !nonEmptyBounded(option.label, 80) ||
+    !nonEmptyBounded(option.description, 240)
+  ) {
+    return null;
+  }
+  return {
+    id: option.id,
+    label: option.label,
+    description: option.description,
+  };
+}
+
+function parseQuestion(value: unknown): MobileUserQuestion | null {
+  const question = record(value);
+  if (
+    !question ||
+    !onlyKeys<WireUserQuestion>(question, [
+      "id",
+      "header",
+      "question",
+      "options",
+      "question_type",
+      "allow_free_form",
+    ]) ||
+    !nonEmptyBounded(question.id, 64) ||
+    !nonEmptyBounded(question.header, 32) ||
+    !nonEmptyBounded(question.question, 500) ||
+    !Array.isArray(question.options) ||
+    question.options.length > 5 ||
+    (question.question_type !== "single_select" &&
+      question.question_type !== "multi_select") ||
+    typeof question.allow_free_form !== "boolean" ||
+    (question.options.length === 0 && !question.allow_free_form)
+  ) {
+    return null;
+  }
+  const options = question.options.map(parseQuestionOption);
+  if (options.some((option) => option === null)) return null;
+  const optionIds = (options as MobileUserQuestionOption[]).map(
+    (option) => option.id,
+  );
+  if (new Set(optionIds).size !== optionIds.length) return null;
+  return {
+    id: question.id,
+    header: question.header,
+    question: question.question,
+    options: options as MobileUserQuestionOption[],
+    questionType: question.question_type,
+    allowFreeForm: question.allow_free_form,
+  };
+}
+
+export function parseMobilePendingUserQuestions(
+  value: unknown,
+): MobilePendingUserQuestions | null {
+  const request = record(value);
+  if (
+    !request ||
+    !onlyKeys<WirePendingUserQuestions>(request, [
+      "call_id",
+      "turn_id",
+      "questions",
+      "asked_at",
+    ]) ||
+    !nonEmptyBounded(request.call_id, 128) ||
+    !nonEmptyBounded(request.turn_id, 128) ||
+    !Array.isArray(request.questions) ||
+    request.questions.length < 1 ||
+    request.questions.length > 3 ||
+    !nonEmptyBounded(request.asked_at, 64)
+  ) {
+    return null;
+  }
+  const questions = request.questions.map(parseQuestion);
+  if (questions.some((question) => question === null)) return null;
+  const questionIds = (questions as MobileUserQuestion[]).map(
+    (question) => question.id,
+  );
+  if (new Set(questionIds).size !== questionIds.length) return null;
+  return {
+    callId: request.call_id,
+    turnId: request.turn_id,
+    questions: questions as MobileUserQuestion[],
+    askedAt: request.asked_at,
+  };
+}
+
+export function parseMobilePendingPlanApproval(
+  value: unknown,
+): MobilePendingPlanApproval | null {
+  const request = record(value);
+  if (
+    !request ||
+    !onlyKeys<WirePendingPlanApproval>(request, [
+      "call_id",
+      "turn_id",
+      "title",
+      "plan",
+      "proposed_at",
+    ]) ||
+    !nonEmptyBounded(request.call_id, 128) ||
+    !nonEmptyBounded(request.turn_id, 128) ||
+    !nonEmptyBounded(request.title, 120) ||
+    !boundedBlock(request.plan, 40_000) ||
+    !request.plan.trim() ||
+    !nonEmptyBounded(request.proposed_at, 64)
+  ) {
+    return null;
+  }
+  return {
+    callId: request.call_id,
+    turnId: request.turn_id,
+    title: request.title,
+    plan: request.plan,
+    proposedAt: request.proposed_at,
+  };
+}
+
+function parseStrictList<T>(
+  value: unknown,
+  parse: (item: unknown) => T | null,
+  label: string,
+  identity: (item: T) => string,
+): T[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} response is not an array.`);
+  }
+  const parsed = value.map(parse);
+  if (parsed.some((item) => item === null)) {
+    throw new Error(`${label} response contains invalid data.`);
+  }
+  const items = parsed as T[];
+  const identities = items.map(identity);
+  if (new Set(identities).size !== identities.length) {
+    throw new Error(`${label} response contains a duplicate call.`);
+  }
+  return items;
+}
+
+export async function listMobilePendingToolApprovals(
+  client: MachineJsonClient,
+  chatId: string,
+): Promise<MobilePendingToolApproval[]> {
+  const approvals = parseStrictList(
+    await client.getJson(`/chats/${encodeURIComponent(chatId)}/approvals`),
+    parseMobilePendingToolApproval,
+    "Pending approval",
+    (approval) => approval.callId,
+  );
+  const turnIds = new Set(approvals.map((approval) => approval.turnId));
+  if (turnIds.size > 1) {
+    throw new Error("Pending approval response spans multiple turns.");
+  }
+  return approvals;
+}
+
+export async function decideMobileToolApproval(
+  client: MachineJsonClient,
+  chatId: string,
+  callId: string,
+  decision:
+    | { decision: "approve" }
+    | { decision: "reject"; feedback: string },
+): Promise<void> {
+  const body =
+    decision.decision === "approve"
+      ? { decision: "approve", grant: null }
+      : {
+          decision: "reject",
+          reason: validApprovalFeedback(decision.feedback),
+        };
+  await client.requestJson(
+    `/chats/${encodeURIComponent(chatId)}/approvals/${encodeURIComponent(callId)}`,
+    { method: "POST", body, expectedStatus: 204 },
+  );
+}
+
+export async function listMobilePendingUserQuestions(
+  client: MachineJsonClient,
+  chatId: string,
+): Promise<MobilePendingUserQuestions[]> {
+  return parseStrictList(
+    await client.getJson(
+      `/chats/${encodeURIComponent(chatId)}/questions/pending`,
+    ),
+    parseMobilePendingUserQuestions,
+    "Pending question",
+    (request) => request.callId,
+  );
+}
+
+export async function answerMobileUserQuestions(
+  client: MachineJsonClient,
+  chatId: string,
+  callId: string,
+  answers: MobileUserQuestionAnswer[],
+  additionalUserContext?: string,
+): Promise<void> {
+  if (answers.length > 3) {
+    throw new Error("You can answer at most three questions at once.");
+  }
+  const questionIds = new Set<string>();
+  const bodyAnswers = answers.map((answer) => {
+    if (
+      !nonEmptyBounded(answer.questionId, 64) ||
+      questionIds.has(answer.questionId) ||
+      answer.selectedOptionIds.length > 5 ||
+      !answer.selectedOptionIds.every((option) =>
+        nonEmptyBounded(option, 64),
+      ) ||
+      new Set(answer.selectedOptionIds).size !==
+        answer.selectedOptionIds.length
+    ) {
+      throw new Error("Question answers contain invalid data.");
+    }
+    questionIds.add(answer.questionId);
+    const customAnswer = answer.customAnswer?.trim();
+    if (
+      customAnswer !== undefined &&
+      (!boundedBlock(customAnswer, 2_000) || !customAnswer)
+    ) {
+      throw new Error("Custom answers must contain readable text.");
+    }
+    if (answer.selectedOptionIds.length === 0 && !customAnswer) {
+      throw new Error("Each submitted answer must include a choice or text.");
+    }
+    return {
+      question_id: answer.questionId,
+      selected_option_ids: answer.selectedOptionIds,
+      ...(customAnswer ? { custom_answer: customAnswer } : {}),
+    };
+  });
+  const context = additionalUserContext?.trim();
+  if (context !== undefined && (!boundedBlock(context, 2_000) || !context)) {
+    throw new Error("Additional context must contain readable text.");
+  }
+  await client.requestJson(
+    `/chats/${encodeURIComponent(chatId)}/questions/${encodeURIComponent(callId)}/answer`,
+    {
+      method: "POST",
+      body: {
+        answers: bodyAnswers,
+        ...(context ? { additional_user_context: context } : {}),
+      },
+    },
+  );
+}
+
+export async function listMobilePendingPlanApprovals(
+  client: MachineJsonClient,
+  chatId: string,
+): Promise<MobilePendingPlanApproval[]> {
+  return parseStrictList(
+    await client.getJson(`/chats/${encodeURIComponent(chatId)}/plans/pending`),
+    parseMobilePendingPlanApproval,
+    "Pending plan",
+    (request) => request.callId,
+  );
+}
+
+export async function decideMobilePlan(
+  client: MachineJsonClient,
+  chatId: string,
+  callId: string,
+  decision: MobilePlanDecision,
+): Promise<void> {
+  const feedback =
+    decision.decision === "reject" ? decision.feedback?.trim() : undefined;
+  if (
+    feedback !== undefined &&
+    (!boundedBlock(feedback, 4_000) || !feedback)
+  ) {
+    throw new Error("Plan feedback must contain readable text.");
+  }
+  await client.requestJson(
+    `/chats/${encodeURIComponent(chatId)}/plans/${encodeURIComponent(callId)}/decision`,
+    {
+      method: "POST",
+      body:
+        decision.decision === "reject" && feedback
+          ? { decision: "reject", feedback }
+          : { decision: decision.decision },
+    },
+  );
+}
+
+function validApprovalFeedback(value: string): string {
+  const feedback = value.trim();
+  if (!nonEmptyBounded(feedback, 512)) {
+    throw new Error("Tell the agent what to change before rejecting.");
+  }
+  return feedback;
+}
+
+export function mobileApprovalQuestion(
+  approval: MobilePendingToolApproval,
+): string {
+  if (!approval.canApprove) return "Reject this unsupported action?";
+  switch (approval.approval) {
+    case "search_may_share_query_and_excerpts":
+      return "Search this conversation's sources?";
+    case "web_search_may_share_query":
+      return "Send this query to the web search provider?";
+    case "web_extract_may_fetch_url":
+      return "Fetch this public web page?";
+    case "exec_may_run_networked_command":
+      return "Run this command with network access?";
+    case "external_mcp_may_call_server":
+      return "Call this external MCP server?";
+    case "workspace_may_modify_files":
+      return approval.preview?.tool === "write_file"
+        ? "Write this file?"
+        : "Modify this work's files?";
+    case "delegate_may_run_background_agent":
+      return "Start this background agent?";
+    case "computer_may_control_app":
+      return "Control this app?";
+    case "unsupported":
+      return "Reject this unsupported action?";
+  }
+}
+
+export function mobileApprovalSummary(kind: ToolApprovalKind): string {
+  switch (kind) {
+    case "search_may_share_query_and_excerpts":
+      return "The search may use your query and matching excerpts from this conversation.";
+    case "web_search_may_share_query":
+      return "The configured provider receives the full query and filters.";
+    case "web_extract_may_fetch_url":
+      return "Tidebreak sends a request to the exact public URL shown here.";
+    case "exec_may_run_networked_command":
+      return "The command can reach the network under this conversation's policy.";
+    case "external_mcp_may_call_server":
+      return "The external server receives the approved call.";
+    case "workspace_may_modify_files":
+      return "The action can change files in this conversation's private workspace.";
+    case "delegate_may_run_background_agent":
+      return "The background agent runs unattended in its own workspace.";
+    case "computer_may_control_app":
+      return "The action can interact with the selected application.";
+    case "unsupported":
+      return "This action cannot be approved from the mobile app.";
+  }
+}
+
+export function mobileToolPreviewDetail(preview: ToolActionPreview): string {
+  if (preview.tool === "search") {
+    return `${preview.query}\n# searched against this conversation's sources`;
+  }
+  if (preview.tool === "web_search") {
+    const dates =
+      preview.start_published_at && preview.end_published_at
+        ? `# published between ${preview.start_published_at} and ${preview.end_published_at}`
+        : preview.start_published_at
+          ? `# published on or after ${preview.start_published_at}`
+          : preview.end_published_at
+            ? `# published on or before ${preview.end_published_at}`
+            : null;
+    return [
+      preview.query,
+      preview.domains.length > 0
+        ? `# limited to ${preview.domains.join(", ")}`
+        : null,
+      dates,
+      "# sent to the configured web search provider",
+    ]
+      .filter((line): line is string => line !== null)
+      .join("\n");
+  }
+  if (preview.tool === "web_extract") {
+    return `${preview.url}\n# fetched from the public web`;
+  }
+  if (preview.tool === "write_file") {
+    return `${preview.path}\n# written into this work's workspace`;
+  }
+  if (preview.tool === "delegate_agent") {
+    const network =
+      preview.network.mode === "allowed_hosts"
+        ? `Allowed hosts: ${preview.network.allowed_hosts.join(", ") || "none"}${
+            preview.network.package_managers ? "; package managers allowed" : ""
+          }`
+        : preview.network.mode === "package_managers"
+          ? "Package managers only"
+          : preview.network.mode === "open"
+            ? "Open public network access"
+            : "Network off";
+    return [
+      preview.task,
+      `# network: ${network}`,
+      "# runs unattended; its own calls are not asked about",
+    ].join("\n");
+  }
+  const command = [preview.command, ...preview.args]
+    .map(quoteArgument)
+    .join(" ");
+  return [
+    command,
+    preview.cwd !== "." ? `# working directory: ${preview.cwd}` : null,
+    preview.files.length > 0
+      ? `# staged files: ${preview.files.join(", ")}`
+      : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}
+
+function quoteArgument(value: string): string {
+  if (value.length === 0) return "''";
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/mobile/src/lib/deliveryApi.test.ts
+++ b/mobile/src/lib/deliveryApi.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MachineClient } from "./machine";
+import {
+  groupMobileDeliveryPullRequests,
+  listMobileDeliveryRepositories,
+  mobileDeliveryCheckProgress,
+  mobileDeliveryLaneCountLabel,
+  mobileDeliveryLaneIsConfirmedEmpty,
+  parseMobileDeliveryPullRequestsPage,
+  parseMobileDeliveryRepositoriesSnapshot,
+  queryMobileDeliveryPullRequests,
+} from "./deliveryApi";
+
+const repository = {
+  host: "github.com",
+  owner: "brightwave-inc",
+  name: "tidebreak",
+  name_with_owner: "brightwave-inc/tidebreak",
+  url: "https://github.com/brightwave-inc/tidebreak",
+  default_branch: "main",
+  tidebreak_repo_id: "repo-1",
+};
+
+const capability = {
+  found: true,
+  authenticated: true,
+  viewer_login: "naingthet",
+  remediation: "",
+};
+
+const pullRequest = {
+  id: "github.com/brightwave-inc/tidebreak#2852",
+  repository,
+  number: 2852,
+  url: "https://github.com/brightwave-inc/tidebreak/pull/2852",
+  title: "Browse and message chats",
+  state: "open",
+  draft: false,
+  author: "naingthet",
+  head_branch: "thet/mobile-chat-messaging",
+  base_branch: "thet/mobile-spawn-flow",
+  review_decision: "review_required",
+  auto_merge_enabled: false,
+  checks: [
+    { name: "Mobile", bucket: "pass" },
+    { name: "Release", bucket: "skipped", detail: "Not a release" },
+  ],
+  attention_reasons: [],
+  ready_to_merge: false,
+  workspace_links: [],
+  labels: ["mobile"],
+  created_at: "2026-08-27T20:00:00Z",
+  updated_at: "2026-08-27T21:00:00Z",
+};
+
+const repositoriesSnapshot = {
+  capability,
+  repositories: [repository],
+  errors: [],
+  fetched_at: "2026-08-27T21:00:00Z",
+};
+
+const pullRequestsPage = {
+  capability,
+  items: [pullRequest],
+  next_cursor: "page-2",
+  errors: [
+    {
+      repository: {
+        host: "github.com",
+        owner: "brightwave-inc",
+        name: "model-gateway",
+      },
+      kind: "rate_limited",
+      message: "GitHub asked Tidebreak to retry later.",
+      retry_at: "2026-08-27T21:05:00Z",
+    },
+  ],
+  fetched_at: "2026-08-27T21:00:00Z",
+};
+
+function fakeClient(response: unknown): {
+  client: Pick<MachineClient, "getJson" | "requestJson">;
+  getJson: ReturnType<typeof vi.fn>;
+  requestJson: ReturnType<typeof vi.fn>;
+} {
+  const getJson = vi.fn(async () => response);
+  const requestJson = vi.fn(async () => response);
+  return { client: { getJson, requestJson }, getJson, requestJson };
+}
+
+describe("mobile Delivery API contracts", () => {
+  it("parses renderer-safe repository and capability fields", async () => {
+    expect(parseMobileDeliveryRepositoriesSnapshot(repositoriesSnapshot)).toEqual({
+      capability: { found: true, authenticated: true, remediation: "" },
+      repositories: [
+        {
+          host: "github.com",
+          owner: "brightwave-inc",
+          name: "tidebreak",
+          name_with_owner: "brightwave-inc/tidebreak",
+          url: "https://github.com/brightwave-inc/tidebreak",
+        },
+      ],
+      errors: [],
+      fetched_at: "2026-08-27T21:00:00Z",
+    });
+    expect(
+      parseMobileDeliveryRepositoriesSnapshot({
+        ...repositoriesSnapshot,
+        capability: { ...capability, authenticated: "yes" },
+      }),
+    ).toBeNull();
+    expect(
+      parseMobileDeliveryRepositoriesSnapshot({
+        ...repositoriesSnapshot,
+        repositories: [{ ...repository, url: "javascript:alert(1)" }],
+      }),
+    ).toBeNull();
+
+    const listed = fakeClient(repositoriesSnapshot);
+    await expect(listMobileDeliveryRepositories(listed.client)).resolves.toMatchObject({
+      repositories: [expect.objectContaining({ name: "tidebreak" })],
+    });
+    expect(listed.getJson).toHaveBeenCalledWith(
+      "/code/delivery/repositories",
+    );
+
+    const refreshed = fakeClient(repositoriesSnapshot);
+    const signal = new AbortController().signal;
+    await listMobileDeliveryRepositories(refreshed.client, {
+      refresh: true,
+      signal,
+    });
+    expect(refreshed.getJson).toHaveBeenCalledWith(
+      "/code/delivery/repositories?refresh=true",
+      { signal },
+    );
+  });
+
+  it("sends an open pull-request query with bounded paging", async () => {
+    const queried = fakeClient(pullRequestsPage);
+    await expect(
+      queryMobileDeliveryPullRequests(queried.client, {
+        repositories: [
+          { host: "github.com", owner: "brightwave-inc", name: "tidebreak" },
+        ],
+        cursor: "page-2",
+        refresh: false,
+      }),
+    ).resolves.toMatchObject({ next_cursor: "page-2" });
+    expect(queried.requestJson).toHaveBeenCalledWith(
+      "/code/delivery/pull-requests/query",
+      {
+        method: "POST",
+        body: {
+          repositories: [
+            {
+              host: "github.com",
+              owner: "brightwave-inc",
+              name: "tidebreak",
+            },
+          ],
+          states: ["open"],
+          review_states: [],
+          check_states: [],
+          authors: [],
+          attention_only: false,
+          ready_only: false,
+          cursor: "page-2",
+          limit: 30,
+          refresh: false,
+        },
+        expectedStatus: 200,
+      },
+    );
+
+    await queryMobileDeliveryPullRequests(queried.client, {
+      repositories: [
+        { host: "github.com", owner: "brightwave-inc", name: "tidebreak" },
+      ],
+      refresh: true,
+      signal: new AbortController().signal,
+    });
+    expect(queried.requestJson).toHaveBeenLastCalledWith(
+      "/code/delivery/pull-requests/query",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        body: expect.objectContaining({
+          refresh: true,
+          limit: 30,
+        }),
+      }),
+    );
+    expect(
+      queried.requestJson.mock.calls[1]?.[1]?.body,
+    ).not.toHaveProperty("cursor");
+
+    const invalidRefresh = fakeClient(pullRequestsPage);
+    await expect(
+      queryMobileDeliveryPullRequests(invalidRefresh.client, {
+        repositories: [
+          { host: "github.com", owner: "brightwave-inc", name: "tidebreak" },
+        ],
+        cursor: "page-2",
+        refresh: true,
+      }),
+    ).rejects.toThrow(/cannot continue from an existing cursor/);
+    expect(invalidRefresh.requestJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid pull-request fields without leaking unused fields", () => {
+    expect(parseMobileDeliveryPullRequestsPage(pullRequestsPage)).toEqual({
+      capability: { found: true, authenticated: true, remediation: "" },
+      items: [
+        {
+          id: "github.com/brightwave-inc/tidebreak#2852",
+          repository: {
+            host: "github.com",
+            owner: "brightwave-inc",
+            name: "tidebreak",
+            name_with_owner: "brightwave-inc/tidebreak",
+            url: "https://github.com/brightwave-inc/tidebreak",
+          },
+          number: 2852,
+          url: "https://github.com/brightwave-inc/tidebreak/pull/2852",
+          title: "Browse and message chats",
+          draft: false,
+          author: "naingthet",
+          head_branch: "thet/mobile-chat-messaging",
+          base_branch: "thet/mobile-spawn-flow",
+          review_decision: "review_required",
+          checks: [
+            { name: "Mobile", bucket: "pass" },
+            { name: "Release", bucket: "skipped" },
+          ],
+          attention_reasons: [],
+          ready_to_merge: false,
+          updated_at: "2026-08-27T21:00:00Z",
+        },
+      ],
+      next_cursor: "page-2",
+      errors: [
+        {
+          repository: {
+            host: "github.com",
+            owner: "brightwave-inc",
+            name: "model-gateway",
+          },
+          kind: "rate_limited",
+          message: "GitHub asked Tidebreak to retry later.",
+          retry_at: "2026-08-27T21:05:00Z",
+        },
+      ],
+      fetched_at: "2026-08-27T21:00:00Z",
+    });
+    expect(
+      parseMobileDeliveryPullRequestsPage({
+        ...pullRequestsPage,
+        items: [{ ...pullRequest, checks: [{ name: "Mobile", bucket: "later" }] }],
+      }),
+    ).toBeNull();
+    expect(
+      parseMobileDeliveryPullRequestsPage({
+        ...pullRequestsPage,
+        items: [{ ...pullRequest, number: 0 }],
+      }),
+    ).toBeNull();
+  });
+
+  it("groups lanes and counts skipped checks as terminal", () => {
+    const parsed = parseMobileDeliveryPullRequestsPage({
+      ...pullRequestsPage,
+      next_cursor: undefined,
+      items: [
+        {
+          ...pullRequest,
+          id: "attention",
+          attention_reasons: ["checks_failed"],
+          ready_to_merge: false,
+        },
+        {
+          ...pullRequest,
+          id: "ready",
+          attention_reasons: [],
+          ready_to_merge: true,
+        },
+        {
+          ...pullRequest,
+          id: "progress",
+          attention_reasons: [],
+          ready_to_merge: false,
+        },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(groupMobileDeliveryPullRequests(parsed!.items)).toMatchObject({
+      attention: [{ id: "attention" }],
+      ready: [{ id: "ready" }],
+      in_progress: [{ id: "progress" }],
+    });
+    expect(
+      mobileDeliveryCheckProgress([
+        { name: "Mobile", bucket: "pass" },
+        { name: "Desktop", bucket: "fail" },
+        { name: "Release", bucket: "skipped" },
+      ]),
+    ).toEqual({
+      total: 3,
+      terminal: 3,
+      passing: 1,
+      pending: 0,
+      failing: 1,
+      skipped: 1,
+    });
+    expect(
+      mobileDeliveryCheckProgress([
+        { name: "Mobile", bucket: "pass" },
+        { name: "Desktop", bucket: "pending" },
+        { name: "Release", bucket: "skipped" },
+      ]),
+    ).toMatchObject({ total: 3, terminal: 2, pending: 1, skipped: 1 });
+    expect(mobileDeliveryLaneCountLabel(2, true)).toBe("2 loaded");
+    expect(mobileDeliveryLaneCountLabel(2, false)).toBe("2");
+    expect(mobileDeliveryLaneIsConfirmedEmpty([], true)).toBe(false);
+    expect(mobileDeliveryLaneIsConfirmedEmpty([], false)).toBe(true);
+    expect(
+      mobileDeliveryLaneIsConfirmedEmpty(parsed!.items, false),
+    ).toBe(false);
+  });
+});

--- a/mobile/src/lib/deliveryApi.ts
+++ b/mobile/src/lib/deliveryApi.ts
@@ -1,0 +1,506 @@
+import type {
+  CodeDeliveryPrAttentionReason,
+  PullRequestCheckBucket,
+} from "../generated/wire";
+import type { MachineClient } from "./machine";
+
+type MachineJsonClient = Pick<MachineClient, "getJson" | "requestJson">;
+
+export type MobileDeliveryCapability = {
+  found: boolean;
+  authenticated?: boolean;
+  remediation: string;
+};
+
+export type MobileDeliveryRepositoryTarget = {
+  host: string;
+  owner: string;
+  name: string;
+};
+
+export type MobileDeliveryRepository = MobileDeliveryRepositoryTarget & {
+  name_with_owner: string;
+  url: string;
+};
+
+export type MobileDeliverySourceError = {
+  repository?: MobileDeliveryRepositoryTarget;
+  kind: string;
+  message: string;
+  retry_at?: string;
+};
+
+export type MobileDeliveryCheck = {
+  name: string;
+  bucket: PullRequestCheckBucket;
+};
+
+export type MobileDeliveryPullRequest = {
+  id: string;
+  repository: MobileDeliveryRepository;
+  number: number;
+  url: string;
+  title: string;
+  draft: boolean;
+  author?: string;
+  head_branch: string;
+  base_branch: string;
+  review_decision?: string;
+  checks: MobileDeliveryCheck[];
+  attention_reasons: CodeDeliveryPrAttentionReason[];
+  ready_to_merge: boolean;
+  updated_at: string;
+};
+
+export type MobileDeliveryRepositoriesSnapshot = {
+  capability: MobileDeliveryCapability;
+  repositories: MobileDeliveryRepository[];
+  errors: MobileDeliverySourceError[];
+  fetched_at: string;
+};
+
+export type MobileDeliveryPullRequestsPage = {
+  capability: MobileDeliveryCapability;
+  items: MobileDeliveryPullRequest[];
+  next_cursor?: string;
+  errors: MobileDeliverySourceError[];
+  fetched_at: string;
+};
+
+export type MobileDeliveryLane = "attention" | "ready" | "in_progress";
+
+export type MobileDeliveryLanes = Record<
+  MobileDeliveryLane,
+  MobileDeliveryPullRequest[]
+>;
+
+export type MobileDeliveryCheckProgress = {
+  total: number;
+  terminal: number;
+  passing: number;
+  pending: number;
+  failing: number;
+  skipped: number;
+};
+
+const CHECK_BUCKETS = ["pass", "pending", "fail", "skipped"] as const;
+const ATTENTION_REASONS = [
+  "changes_requested",
+  "checks_failed",
+  "conflicts",
+  "behind",
+  "blocked",
+] as const;
+
+export const MOBILE_DELIVERY_PAGE_SIZE = 30;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function optionalNonEmpty(value: unknown): value is string | undefined {
+  return value === undefined || nonEmpty(value);
+}
+
+function timestamp(value: unknown): value is string {
+  return nonEmpty(value) && !Number.isNaN(Date.parse(value));
+}
+
+function httpUrl(value: unknown): value is string {
+  if (!nonEmpty(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function positiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function member<T extends string>(
+  value: unknown,
+  values: readonly T[],
+): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+function parseCapability(value: unknown): MobileDeliveryCapability | null {
+  const capability = record(value);
+  if (
+    !capability ||
+    typeof capability.found !== "boolean" ||
+    (capability.authenticated !== undefined &&
+      typeof capability.authenticated !== "boolean") ||
+    typeof capability.remediation !== "string"
+  ) {
+    return null;
+  }
+  return {
+    found: capability.found,
+    ...(capability.authenticated !== undefined
+      ? { authenticated: capability.authenticated }
+      : {}),
+    remediation: capability.remediation,
+  };
+}
+
+function parseRepositoryTarget(
+  value: unknown,
+): MobileDeliveryRepositoryTarget | null {
+  const repository = record(value);
+  if (
+    !repository ||
+    !nonEmpty(repository.host) ||
+    !nonEmpty(repository.owner) ||
+    !nonEmpty(repository.name)
+  ) {
+    return null;
+  }
+  return {
+    host: repository.host,
+    owner: repository.owner,
+    name: repository.name,
+  };
+}
+
+function parseRepository(value: unknown): MobileDeliveryRepository | null {
+  const repository = record(value);
+  const target = parseRepositoryTarget(repository);
+  if (
+    !repository ||
+    !target ||
+    !nonEmpty(repository.name_with_owner) ||
+    !httpUrl(repository.url)
+  ) {
+    return null;
+  }
+  return {
+    ...target,
+    name_with_owner: repository.name_with_owner,
+    url: repository.url,
+  };
+}
+
+function parseSourceError(value: unknown): MobileDeliverySourceError | null {
+  const error = record(value);
+  if (
+    !error ||
+    !nonEmpty(error.kind) ||
+    !nonEmpty(error.message) ||
+    (error.retry_at !== undefined && !timestamp(error.retry_at))
+  ) {
+    return null;
+  }
+  const repository =
+    error.repository === undefined
+      ? undefined
+      : parseRepositoryTarget(error.repository);
+  if (error.repository !== undefined && !repository) return null;
+  return {
+    ...(repository ? { repository } : {}),
+    kind: error.kind,
+    message: error.message,
+    ...(error.retry_at !== undefined ? { retry_at: error.retry_at } : {}),
+  };
+}
+
+function parseCheck(value: unknown): MobileDeliveryCheck | null {
+  const check = record(value);
+  if (
+    !check ||
+    !nonEmpty(check.name) ||
+    !member(check.bucket, CHECK_BUCKETS)
+  ) {
+    return null;
+  }
+  return { name: check.name, bucket: check.bucket };
+}
+
+function parsePullRequest(value: unknown): MobileDeliveryPullRequest | null {
+  const pullRequest = record(value);
+  if (
+    !pullRequest ||
+    !nonEmpty(pullRequest.id) ||
+    !positiveSafeInteger(pullRequest.number) ||
+    !httpUrl(pullRequest.url) ||
+    !nonEmpty(pullRequest.title) ||
+    typeof pullRequest.draft !== "boolean" ||
+    !optionalNonEmpty(pullRequest.author) ||
+    !nonEmpty(pullRequest.head_branch) ||
+    !nonEmpty(pullRequest.base_branch) ||
+    !optionalNonEmpty(pullRequest.review_decision) ||
+    !Array.isArray(pullRequest.checks) ||
+    !Array.isArray(pullRequest.attention_reasons) ||
+    !pullRequest.attention_reasons.every((reason) =>
+      member(reason, ATTENTION_REASONS),
+    ) ||
+    typeof pullRequest.ready_to_merge !== "boolean" ||
+    !timestamp(pullRequest.updated_at)
+  ) {
+    return null;
+  }
+  const repository = parseRepository(pullRequest.repository);
+  if (!repository) return null;
+  const checks = pullRequest.checks.map(parseCheck);
+  if (checks.some((check) => check === null)) return null;
+  return {
+    id: pullRequest.id,
+    repository,
+    number: pullRequest.number,
+    url: pullRequest.url,
+    title: pullRequest.title,
+    draft: pullRequest.draft,
+    ...(pullRequest.author !== undefined
+      ? { author: pullRequest.author }
+      : {}),
+    head_branch: pullRequest.head_branch,
+    base_branch: pullRequest.base_branch,
+    ...(pullRequest.review_decision !== undefined
+      ? { review_decision: pullRequest.review_decision }
+      : {}),
+    checks: checks as MobileDeliveryCheck[],
+    attention_reasons:
+      pullRequest.attention_reasons as CodeDeliveryPrAttentionReason[],
+    ready_to_merge: pullRequest.ready_to_merge,
+    updated_at: pullRequest.updated_at,
+  };
+}
+
+function parseSourceErrors(value: unknown): MobileDeliverySourceError[] | null {
+  if (!Array.isArray(value)) return null;
+  const errors = value.map(parseSourceError);
+  return errors.some((error) => error === null)
+    ? null
+    : (errors as MobileDeliverySourceError[]);
+}
+
+export function parseMobileDeliveryRepositoriesSnapshot(
+  value: unknown,
+): MobileDeliveryRepositoriesSnapshot | null {
+  const snapshot = record(value);
+  if (
+    !snapshot ||
+    !Array.isArray(snapshot.repositories) ||
+    !timestamp(snapshot.fetched_at)
+  ) {
+    return null;
+  }
+  const capability = parseCapability(snapshot.capability);
+  const repositories = snapshot.repositories.map(parseRepository);
+  const errors = parseSourceErrors(snapshot.errors);
+  if (
+    !capability ||
+    repositories.some((repository) => repository === null) ||
+    !errors
+  ) {
+    return null;
+  }
+  return {
+    capability,
+    repositories: repositories as MobileDeliveryRepository[],
+    errors,
+    fetched_at: snapshot.fetched_at,
+  };
+}
+
+export function parseMobileDeliveryPullRequestsPage(
+  value: unknown,
+): MobileDeliveryPullRequestsPage | null {
+  const page = record(value);
+  if (
+    !page ||
+    !Array.isArray(page.items) ||
+    !optionalNonEmpty(page.next_cursor) ||
+    !timestamp(page.fetched_at)
+  ) {
+    return null;
+  }
+  const capability = parseCapability(page.capability);
+  const items = page.items.map(parsePullRequest);
+  const errors = parseSourceErrors(page.errors);
+  if (!capability || items.some((item) => item === null) || !errors) {
+    return null;
+  }
+  return {
+    capability,
+    items: items as MobileDeliveryPullRequest[],
+    ...(page.next_cursor !== undefined
+      ? { next_cursor: page.next_cursor }
+      : {}),
+    errors,
+    fetched_at: page.fetched_at,
+  };
+}
+
+function required<T>(value: T | null, label: string): T {
+  if (!value) throw new Error(`${label} response contains invalid data.`);
+  return value;
+}
+
+export async function listMobileDeliveryRepositories(
+  client: MachineJsonClient,
+  options: {
+    refresh?: boolean;
+    signal?: AbortSignal;
+  } = {},
+): Promise<MobileDeliveryRepositoriesSnapshot> {
+  const path = options.refresh
+    ? "/code/delivery/repositories?refresh=true"
+    : "/code/delivery/repositories";
+  return required(
+    parseMobileDeliveryRepositoriesSnapshot(
+      options.signal
+        ? await client.getJson(path, { signal: options.signal })
+        : await client.getJson(path),
+    ),
+    "Delivery repositories",
+  );
+}
+
+export async function queryMobileDeliveryPullRequests(
+  client: MachineJsonClient,
+  options: {
+    repositories: MobileDeliveryRepositoryTarget[];
+    cursor?: string;
+    refresh?: boolean;
+    limit?: number;
+    signal?: AbortSignal;
+  },
+): Promise<MobileDeliveryPullRequestsPage> {
+  if (options.refresh && options.cursor) {
+    throw new Error(
+      "Delivery refresh cannot continue from an existing cursor.",
+    );
+  }
+  return required(
+    parseMobileDeliveryPullRequestsPage(
+      await client.requestJson("/code/delivery/pull-requests/query", {
+        method: "POST",
+        body: {
+          repositories: options.repositories,
+          states: ["open"],
+          review_states: [],
+          check_states: [],
+          authors: [],
+          attention_only: false,
+          ready_only: false,
+          ...(options.cursor ? { cursor: options.cursor } : {}),
+          limit: options.limit ?? MOBILE_DELIVERY_PAGE_SIZE,
+          refresh: options.refresh ?? false,
+        },
+        expectedStatus: 200,
+        ...(options.signal ? { signal: options.signal } : {}),
+      }),
+    ),
+    "Delivery pull requests",
+  );
+}
+
+export function mobileDeliveryRepositoryTarget(
+  repository: MobileDeliveryRepository,
+): MobileDeliveryRepositoryTarget {
+  return {
+    host: repository.host,
+    owner: repository.owner,
+    name: repository.name,
+  };
+}
+
+export function mobileDeliveryLane(
+  pullRequest: MobileDeliveryPullRequest,
+): MobileDeliveryLane {
+  if (pullRequest.attention_reasons.length > 0) return "attention";
+  if (pullRequest.ready_to_merge) return "ready";
+  return "in_progress";
+}
+
+export function groupMobileDeliveryPullRequests(
+  pullRequests: readonly MobileDeliveryPullRequest[],
+): MobileDeliveryLanes {
+  const lanes: MobileDeliveryLanes = {
+    attention: [],
+    ready: [],
+    in_progress: [],
+  };
+  for (const pullRequest of pullRequests) {
+    lanes[mobileDeliveryLane(pullRequest)].push(pullRequest);
+  }
+  return lanes;
+}
+
+export function mobileDeliveryLaneCountLabel(
+  count: number,
+  hasNextPage: boolean,
+): string {
+  return hasNextPage ? `${count} loaded` : String(count);
+}
+
+export function mobileDeliveryLaneIsConfirmedEmpty(
+  pullRequests: readonly MobileDeliveryPullRequest[],
+  hasNextPage: boolean,
+): boolean {
+  return pullRequests.length === 0 && !hasNextPage;
+}
+
+export function mobileDeliveryCheckProgress(
+  checks: readonly MobileDeliveryCheck[],
+): MobileDeliveryCheckProgress {
+  const progress: MobileDeliveryCheckProgress = {
+    total: checks.length,
+    terminal: 0,
+    passing: 0,
+    pending: 0,
+    failing: 0,
+    skipped: 0,
+  };
+  for (const check of checks) {
+    if (check.bucket === "pass") {
+      progress.passing += 1;
+      progress.terminal += 1;
+    } else if (check.bucket === "pending") {
+      progress.pending += 1;
+    } else if (check.bucket === "fail") {
+      progress.failing += 1;
+      progress.terminal += 1;
+    } else {
+      progress.skipped += 1;
+      progress.terminal += 1;
+    }
+  }
+  return progress;
+}
+
+export function uniqueMobileDeliveryPullRequests(
+  pullRequests: readonly MobileDeliveryPullRequest[],
+): MobileDeliveryPullRequest[] {
+  const seen = new Set<string>();
+  return pullRequests.filter((pullRequest) => {
+    if (seen.has(pullRequest.id)) return false;
+    seen.add(pullRequest.id);
+    return true;
+  });
+}
+
+export function uniqueMobileDeliverySourceErrors(
+  errors: readonly MobileDeliverySourceError[],
+): MobileDeliverySourceError[] {
+  const seen = new Set<string>();
+  return errors.filter((error) => {
+    const repository = error.repository
+      ? `${error.repository.host}/${error.repository.owner}/${error.repository.name}`
+      : "global";
+    const key = `${repository}:${error.kind}:${error.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/mobile/src/lib/http.ts
+++ b/mobile/src/lib/http.ts
@@ -20,6 +20,7 @@ export type HttpRequestInit = {
   method?: string;
   headers?: Record<string, string>;
   body?: string;
+  signal?: AbortSignal;
 };
 
 /** The response surface shared by DOM `Response` and expo's `FetchResponse`. */

--- a/mobile/src/lib/machine.test.ts
+++ b/mobile/src/lib/machine.test.ts
@@ -49,6 +49,7 @@ describe("machineWsUrl", () => {
 describe("MachineClient requests", () => {
   it("mints the attached resource and sends JSON without following redirects", async () => {
     const getAccessToken = vi.fn(async () => "machine-token");
+    const abort = new AbortController();
     const fetchImpl = vi.fn(
       async (_url: string, _init?: RequestInit) =>
         new Response(JSON.stringify({ accepted: true }), { status: 202 }),
@@ -65,6 +66,7 @@ describe("MachineClient requests", () => {
         method: "POST",
         body: { message: "continue" },
         expectedStatus: 202,
+        signal: abort.signal,
       }),
     ).resolves.toEqual({ accepted: true });
     expect(getAccessToken).toHaveBeenCalledWith("tidebreak:attached");
@@ -76,6 +78,7 @@ describe("MachineClient requests", () => {
       method: "POST",
       redirect: "manual",
       body: JSON.stringify({ message: "continue" }),
+      signal: abort.signal,
       headers: {
         Authorization: "Bearer machine-token",
         "Content-Type": "application/json",

--- a/mobile/src/lib/machine.ts
+++ b/mobile/src/lib/machine.ts
@@ -43,6 +43,7 @@ export type MachineRequestOptions = {
   method?: string;
   body?: unknown;
   expectedStatus?: number | readonly number[];
+  signal?: AbortSignal;
 };
 
 export class MachineRequestError extends Error {
@@ -99,8 +100,11 @@ function parseErrorBody(text: string): { kind: string | null; message: string } 
 export class MachineClient {
   constructor(private readonly options: MachineClientOptions) {}
 
-  async getJson(path: string): Promise<unknown> {
-    return this.requestJson(path);
+  async getJson(
+    path: string,
+    request: Pick<MachineRequestOptions, "signal"> = {},
+  ): Promise<unknown> {
+    return this.requestJson(path, request);
   }
 
   async requestJson(
@@ -115,6 +119,7 @@ export class MachineClient {
     };
     const init: HttpRequestInit = { headers };
     if (request.method) init.method = request.method;
+    if (request.signal) init.signal = request.signal;
     if (request.body !== undefined) {
       headers["Content-Type"] = "application/json";
       init.body = JSON.stringify(request.body);

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
         success: "var(--success)",
         "success-foreground": "var(--success-foreground)",
         "success-background": "var(--success-background)",
+        "success-border": "var(--success-border)",
         info: "var(--info)",
         "info-foreground": "var(--info-foreground)",
         "info-background": "var(--info-background)",


### PR DESCRIPTION
## What changed

- Add strict mobile parsers and API methods for pending tool approvals, questions, and plans.
- Show prompt cards in chat and replace the composer while a prompt needs a response.
- Let you approve once, reject with feedback, answer single-select, multi-select, or free-form questions, skip questions, execute plans, and request plan revisions.
- Show literal renderer-safe action previews for tool approvals.
- Poll while the chat is focused and support pull-to-refresh for prompt state.

## Validation

- `CI=true npx --yes pnpm@10.18.3 --dir mobile typecheck`
- `CI=true npx --yes pnpm@10.18.3 --dir mobile lint`
- `CI=true npx --yes pnpm@10.18.3 --dir mobile test` — 90 tests passed.
- `CI=true npx --yes pnpm@10.18.3 --dir mobile exec expo export --platform web --output-dir <temporary-directory>` — web export completed with 1,245 modules.
- Screenshot review could not run because the mobile package has no Storybook setup and no browser session is connected.

## Compatibility and risk

No persisted-data or wire-format changes. The cards use existing machine prompt endpoints and reject malformed renderer input.

## Tracking

Closes #2648.