### PR TITLE
fix(desktop): preserve stacked pull request actions

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -1315,4 +1315,40 @@ describe("stack lanes", () => {
     // above never do.
     expect(screen.getAllByText("Unregistered stack")).toHaveLength(3);
   });
+
+  it("keeps stack lanes after opening detail without stack enrichment", async () => {
+    const user = userEvent.setup();
+    const detail = deliveryPullRequestDetails[2302]!;
+    renderList({
+      ...storyClient(),
+      queryCodeDeliveryPullRequests: async () => ({
+        capability: deliveryRepositoriesSnapshot.capability,
+        items: stackedDeliveryPullRequests,
+        errors: [],
+        fetched_at: "2026-08-21T15:00:00.000Z",
+      }),
+      getCodeDeliveryPullRequestDetail: async () => ({
+        ...detail,
+        summary: {
+          ...detail.summary,
+          stack_parent_number: undefined,
+          stack_number: undefined,
+          stack_size: undefined,
+        },
+        stack: undefined,
+      }),
+    } as unknown as ApiClient);
+
+    await user.click(await screen.findByText("Stack middle: reconcile sweep"));
+    await screen.findByTestId("pull-request-detail-pane");
+    await waitFor(() => {
+      const list = screen.getByRole("list", { name: "Pull requests" });
+      expect(
+        [...list.querySelectorAll("[data-depth]")].map((row) =>
+          row.getAttribute("data-depth"),
+        ),
+      ).toEqual(["0", "1", "2", "0"]);
+    });
+    expect(screen.getByText("Stacked on #2288")).toBeInTheDocument();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -112,7 +112,12 @@ import {
   prStatus,
   type PullRequestListGroup,
 } from "./prState";
-import { arrangeStackLanes, type StackedRow } from "./pullRequestStacks";
+import {
+  arrangeStackLanes,
+  isStackedPullRequest,
+  preservePullRequestStackMetadata,
+  type StackedRow,
+} from "./pullRequestStacks";
 import {
   deliveryPullRequestDigest,
   deliveryRepositoryHasMergeQueue,
@@ -909,6 +914,7 @@ function PullRequestsSurface({
   const runListMerge = async (item: CodeDeliveryPullRequestSummary) => {
     const action = prDirectMergeAction(deliveryPullRequestDigest(item), {
       hasMergeQueue: deliveryRepositoryHasMergeQueue(items, item.repository),
+      suppressAutoMerge: isStackedPullRequest(item),
     });
     if (!action || !item.head_sha || busyId) return;
     if (action.kind === "merge") {
@@ -988,14 +994,24 @@ function PullRequestsSurface({
   };
 
   const applyAdopted = (rows: CodeDeliveryPullRequestSummary[]) =>
-    rows.map((item) => adoptedSummaries.current.get(item.id) ?? item);
+    rows.map((item) => {
+      const adopted = adoptedSummaries.current.get(item.id);
+      if (!adopted) return item;
+      const merged = preservePullRequestStackMetadata(item, adopted);
+      adoptedSummaries.current.set(item.id, merged);
+      return merged;
+    });
 
   const adoptSummary = (summary: CodeDeliveryPullRequestSummary) => {
-    adoptedSummaries.current.set(summary.id, summary);
+    const previous = items.find((item) => item.id === summary.id);
+    const adopted = previous
+      ? preservePullRequestStackMetadata(previous, summary)
+      : summary;
+    adoptedSummaries.current.set(adopted.id, adopted);
     setItems((current) =>
       current.map((item) =>
-        item.id === summary.id
-          ? summary
+        item.id === adopted.id
+          ? adopted
           : (adoptedSummaries.current.get(item.id) ?? item),
       ),
     );
@@ -1007,8 +1023,8 @@ function PullRequestsSurface({
       useCodeDeliveryStore.getState().rememberPullRequestPage({
         ...cached,
         items: cached.items.map((item) =>
-          item.id === summary.id
-            ? summary
+          item.id === adopted.id
+            ? adopted
             : (adoptedSummaries.current.get(item.id) ?? item),
         ),
       });
@@ -1048,18 +1064,26 @@ function PullRequestsSurface({
           .getCodeDeliveryPullRequestDetail(target)
           .then((detail) => {
             if (token === generation.current) {
-              rememberDetail(detail);
+              const previous = items.find(
+                (item) => item.id === detail.summary.id,
+              );
+              const summary = previous
+                ? preservePullRequestStackMetadata(previous, detail.summary)
+                : detail.summary;
+              const adoptedDetail =
+                summary === detail.summary ? detail : { ...detail, summary };
+              rememberDetail(adoptedDetail);
               setTargetDetailState({
                 key: requestKey,
                 pending: false,
-                detail,
+                detail: adoptedDetail,
               });
-              adoptedSummaries.current.set(detail.summary.id, detail.summary);
+              adoptedSummaries.current.set(summary.id, summary);
               setItems((current) =>
-                applyAdopted(dedupeRows([detail.summary, ...current])),
+                applyAdopted(dedupeRows([summary, ...current])),
               );
               if (!routeSelectionFenced.current) {
-                setSelectedId(detail.summary.id);
+                setSelectedId(summary.id);
               }
             }
             return { detail };
@@ -2146,7 +2170,10 @@ function PullRequestRow({
   const checks = checkSummary(checkCounts(item));
   const comments = item.comment_count;
   const mergeAction = item.head_sha
-    ? prDirectMergeAction(deliveryPullRequestDigest(item), { hasMergeQueue })
+    ? prDirectMergeAction(deliveryPullRequestDigest(item), {
+        hasMergeQueue,
+        suppressAutoMerge: isStackedPullRequest(item),
+      })
     : null;
   return (
     <div

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
@@ -532,6 +532,35 @@ describe("merge stack", () => {
     expect(screen.getByRole("button", { name: "Merge" })).toBeInTheDocument();
   });
 
+  it("does not offer auto-merge for a stacked pull request", async () => {
+    const stackedPending = {
+      ...stackedDeliveryPullRequests[1]!,
+      checks: [{ name: "ci", bucket: "pending" as const }],
+      mergeable: "unknown",
+      merge_state_status: "blocked",
+    };
+    await render(
+      <PullRequestDetailSheet
+        client={client({
+          getCodeDeliveryPullRequestDetail: async () => ({
+            ...deliveryPullRequestDetails[2302]!,
+            summary: stackedPending,
+            stack: undefined,
+          }),
+        })}
+        summary={stackedPending}
+        hasMergeQueue={false}
+        onClose={vi.fn()}
+        onChanged={vi.fn()}
+        onOpenWorkspace={vi.fn()}
+      />,
+    );
+    await screen.findByRole("tab", { name: /Conversation/ });
+    expect(
+      screen.queryByRole("button", { name: "Enable auto-merge" }),
+    ).toBeNull();
+  });
+
   it("stops at a layer the merge gate refuses, merging nothing", async () => {
     vi.mocked(toast.warning).mockClear();
     const runAction = vi.fn(

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -85,6 +85,10 @@ import {
   type PullRequestCommentOrder,
 } from "./pullRequestPresentation";
 import {
+  isStackedPullRequest,
+  preservePullRequestStackMetadata,
+} from "./pullRequestStacks";
+import {
   PULL_REQUEST_LIFECYCLE_LABEL,
   PULL_REQUEST_LIFECYCLE_TONE,
   STATUS_TONE_BADGE_VARIANT,
@@ -293,9 +297,17 @@ export function PullRequestDetailPane({
     mounted.current && activeTarget.current === targetId;
 
   const adoptDetail = (next: CodeDeliveryPullRequestDetail) => {
-    setDetail(next);
-    onDetailRef.current?.(next);
-    onSummaryRef.current?.(next.summary);
+    const adoptedSummary = preservePullRequestStackMetadata(
+      summary,
+      next.summary,
+    );
+    const adopted =
+      adoptedSummary === next.summary
+        ? next
+        : { ...next, summary: adoptedSummary };
+    setDetail(adopted);
+    onDetailRef.current?.(adopted);
+    onSummaryRef.current?.(adopted.summary);
   };
 
   const load = async () => {
@@ -421,7 +433,12 @@ export function PullRequestDetailPane({
         // the layer must actually be mergeable now, not just open.
         const action = prDirectMergeAction(
           deliveryPullRequestDigest(fresh.summary),
-          { hasMergeQueue },
+          {
+            hasMergeQueue,
+            suppressAutoMerge:
+              isStackedPullRequest(fresh.summary) ||
+              (fresh.stack?.length ?? 0) > 1,
+          },
         );
         if (!action) {
           toast.warning(
@@ -1123,6 +1140,8 @@ function PrMergeBox({
     detail.can_merge && summary.head_sha
       ? prDirectMergeAction(deliveryPullRequestDigest(summary), {
           hasMergeQueue,
+          suppressAutoMerge:
+            isStackedPullRequest(summary) || (detail.stack?.length ?? 0) > 1,
         })
       : null;
   const canRerun = detail.can_rerun_failed && workflowRunIds.length > 0;

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -305,6 +305,37 @@ describe("prDirectMergeAction", () => {
     });
   });
 
+  it("hides automatic merge actions for stacked pull requests", () => {
+    const blocked = pr({
+      head_sha: "abc",
+      checks: [{ name: "ci", bucket: "pending" }],
+    });
+    expect(
+      prDirectMergeAction(blocked, { suppressAutoMerge: true }),
+    ).toBeNull();
+    expect(
+      prDirectMergeAction(
+        {
+          ...blocked,
+          mergeable: "mergeable",
+          merge_state_status: "clean",
+          checks: [{ name: "ci", bucket: "pass" }],
+        },
+        { suppressAutoMerge: true },
+      ),
+    ).toEqual({ kind: "merge", label: "Merge", auto: false });
+    expect(
+      prDirectMergeAction(blocked, {
+        hasMergeQueue: true,
+        suppressAutoMerge: true,
+      }),
+    ).toEqual({
+      kind: "merge_when_ready",
+      label: "Merge when ready",
+      auto: true,
+    });
+  });
+
   it("offers merge when ready on a merge-queue repository", () => {
     expect(
       prDirectMergeAction(

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -74,7 +74,7 @@ export type PrDirectMergeAction = {
  */
 export function prDirectMergeAction(
   pr: PullRequestDigest,
-  options?: { hasMergeQueue?: boolean },
+  options?: { hasMergeQueue?: boolean; suppressAutoMerge?: boolean },
 ): PrDirectMergeAction | null {
   const { state } = prWorkflowStatus(pr);
   const controls = prMergeControls(state);
@@ -98,6 +98,7 @@ export function prDirectMergeAction(
     return { kind: "merge", label: "Merge", auto: false };
   }
   if (controls.canEnableAutoMerge && !pr.auto_merge_enabled) {
+    if (options?.suppressAutoMerge) return null;
     return {
       kind: "enable_auto_merge",
       label: "Enable auto-merge",

--- a/crates/tidebreak-desktop/ui/src/code/pullRequestStacks.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/pullRequestStacks.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { CodeDeliveryPullRequestSummary } from "../api/types";
-import { arrangeStackLanes } from "./pullRequestStacks";
+import {
+  arrangeStackLanes,
+  isStackedPullRequest,
+  preservePullRequestStackMetadata,
+} from "./pullRequestStacks";
 
 function summary(
   number: number,
@@ -91,5 +95,53 @@ describe("arrangeStackLanes", () => {
     const rows = arrangeStackLanes(items);
     expect(rows).toHaveLength(15);
     expect(Math.max(...rows.map((row) => row.depth))).toBe(10);
+  });
+});
+
+describe("stack metadata", () => {
+  it("keeps list stack metadata when detail omits optional enrichment", () => {
+    const previous = summary(2, {
+      stack_parent_number: 1,
+      unregistered_stack_numbers: [1, 2, 3],
+    });
+    const next = summary(2, { title: "Fresh detail title" });
+
+    expect(preservePullRequestStackMetadata(previous, next)).toMatchObject({
+      title: "Fresh detail title",
+      stack_parent_number: 1,
+      unregistered_stack_numbers: [1, 2, 3],
+    });
+  });
+
+  it("keeps registered stack identity when detail only reaffirms the parent", () => {
+    const previous = summary(2, {
+      stack_parent_number: 1,
+      stack_number: 7,
+      stack_size: 3,
+    });
+    const next = summary(2, { stack_parent_number: 1 });
+
+    expect(preservePullRequestStackMetadata(previous, next)).toMatchObject({
+      stack_parent_number: 1,
+      stack_number: 7,
+      stack_size: 3,
+    });
+  });
+
+  it("trusts detail stack metadata when the host reports a bottom layer", () => {
+    const previous = summary(1, { stack_parent_number: 99 });
+    const next = summary(1, { stack_number: 7, stack_size: 2 });
+
+    expect(preservePullRequestStackMetadata(previous, next)).toEqual(next);
+  });
+
+  it("recognizes registered and inferred stack members", () => {
+    expect(isStackedPullRequest(summary(1))).toBe(false);
+    expect(isStackedPullRequest(summary(2, { stack_parent_number: 1 }))).toBe(
+      true,
+    );
+    expect(
+      isStackedPullRequest(summary(3, { stack_number: 7, stack_size: 2 })),
+    ).toBe(true);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/pullRequestStacks.ts
+++ b/crates/tidebreak-desktop/ui/src/code/pullRequestStacks.ts
@@ -1,5 +1,62 @@
 import type { CodeDeliveryPullRequestSummary } from "../api/types";
 
+/** Preserve list-known stack facts when a detail read omits enrichment. */
+export function preservePullRequestStackMetadata(
+  previous: CodeDeliveryPullRequestSummary,
+  next: CodeDeliveryPullRequestSummary,
+): CodeDeliveryPullRequestSummary {
+  const nextHasRegisteredStack =
+    next.stack_number !== undefined || next.stack_size !== undefined;
+  if (nextHasRegisteredStack) return next;
+
+  const previousHasRegisteredStack =
+    previous.stack_number !== undefined || previous.stack_size !== undefined;
+  if (previousHasRegisteredStack) {
+    return {
+      ...next,
+      ...(previous.stack_number !== undefined
+        ? { stack_number: previous.stack_number }
+        : {}),
+      ...(previous.stack_size !== undefined
+        ? { stack_size: previous.stack_size }
+        : {}),
+      ...(next.stack_parent_number !== undefined
+        ? { stack_parent_number: next.stack_parent_number }
+        : previous.stack_parent_number !== undefined
+          ? { stack_parent_number: previous.stack_parent_number }
+          : {}),
+    };
+  }
+
+  const previousHasInferredStack =
+    previous.stack_parent_number !== undefined ||
+    previous.unregistered_stack_numbers !== undefined;
+  if (!previousHasInferredStack) return next;
+
+  return {
+    ...next,
+    ...(next.stack_parent_number === undefined &&
+    previous.stack_parent_number !== undefined
+      ? { stack_parent_number: previous.stack_parent_number }
+      : {}),
+    ...(next.unregistered_stack_numbers === undefined &&
+    previous.unregistered_stack_numbers !== undefined
+      ? { unregistered_stack_numbers: previous.unregistered_stack_numbers }
+      : {}),
+  };
+}
+
+/** True when the pull request belongs to a registered or inferred stack. */
+export function isStackedPullRequest(
+  item: CodeDeliveryPullRequestSummary,
+): boolean {
+  return (
+    item.stack_parent_number !== undefined ||
+    item.unregistered_stack_numbers !== undefined ||
+    (item.stack_number !== undefined && (item.stack_size ?? 0) > 1)
+  );
+}
+
 /** One delivery row placed in its stack lane. */
 export type StackedRow = {
   /** The summary's own id, so a virtualized list can key on the row. */

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -49,6 +49,7 @@ type DeliveryScenario =
   | "pull-requests-loading"
   | "pull-requests-empty"
   | "pull-requests-stacked"
+  | "pull-requests-stacked-auto-merge-unavailable"
   | "pull-requests-unregistered"
   | "pull-requests-state-changed"
   | "pull-requests-partial"
@@ -80,7 +81,7 @@ async function openListRow(
   list: string,
   title: string,
 ) {
-  const rows = within(canvasElement).getByRole("list", { name: list });
+  const rows = await within(canvasElement).findByRole("list", { name: list });
   await userEvent.click(await within(rows).findByText(title));
 }
 
@@ -159,6 +160,17 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
     merged_at: "2026-08-27T19:45:00.000Z",
     updated_at: "2026-08-27T19:45:00.000Z",
   };
+  const stackedAutoMergeUnavailable = stackedDeliveryPullRequests.map((item) =>
+    item.number === 2302
+      ? {
+          ...item,
+          checks: [{ name: "desktop UI", bucket: "pending" as const }],
+          ready_to_merge: false,
+          mergeable: "unknown",
+          merge_state_status: "blocked",
+        }
+      : item,
+  );
 
   return {
     openCodeUpdates: () => idleSocket(),
@@ -215,11 +227,13 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
             ? []
             : scenario === "pull-requests-stacked"
               ? stackedDeliveryPullRequests
-              : scenario === "pull-requests-unregistered"
-                ? unregisteredDeliveryPullRequests
-                : scenario === "pull-requests-state-changed"
-                  ? [deliveryPullRequests[0]!]
-                  : deliveryPullRequests,
+              : scenario === "pull-requests-stacked-auto-merge-unavailable"
+                ? stackedAutoMergeUnavailable
+                : scenario === "pull-requests-unregistered"
+                  ? unregisteredDeliveryPullRequests
+                  : scenario === "pull-requests-state-changed"
+                    ? [deliveryPullRequests[0]!]
+                    : deliveryPullRequests,
         errors:
           scenario === "pull-requests-partial"
             ? [
@@ -246,8 +260,22 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
             ...deliveryPullRequestDetails[2251]!,
             summary: refreshedMergedPullRequest,
           }
-        : (deliveryPullRequestDetails[number] ??
-          deliveryPullRequestDetails[2251]!),
+        : scenario === "pull-requests-stacked-auto-merge-unavailable" &&
+            number === 2302
+          ? {
+              ...deliveryPullRequestDetails[2302]!,
+              summary: {
+                ...stackedAutoMergeUnavailable.find(
+                  (item) => item.number === 2302,
+                )!,
+                stack_parent_number: undefined,
+                stack_number: undefined,
+                stack_size: undefined,
+              },
+              stack: undefined,
+            }
+          : (deliveryPullRequestDetails[number] ??
+            deliveryPullRequestDetails[2251]!),
     runCodeDeliveryPullRequestAction: async ({
       action,
     }: CodeDeliveryPullRequestActionBody) => ({
@@ -642,6 +670,31 @@ export const PullRequestStackDetail: Story = {
     await expect(
       await body.findByRole("button", { name: /Merge stack \(2 layers\)/ }),
     ).toBeVisible();
+  },
+};
+
+/**
+ * Detail hydration may omit optional stack enrichment. The list keeps its
+ * lane, and a stacked pull request with pending checks offers no unsupported
+ * GitHub auto-merge action.
+ */
+export const PullRequestStackDetailWithoutAutoMerge: Story = {
+  args: { scenario: "pull-requests-stacked-auto-merge-unavailable" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await openPullRequest(canvasElement, "Stack middle: reconcile sweep");
+    await expect(
+      await body.findByRole("heading", {
+        name: "Stack middle: reconcile sweep",
+      }),
+    ).toBeVisible();
+    const depths = [...canvasElement.querySelectorAll("[data-depth]")].map(
+      (row) => row.getAttribute("data-depth"),
+    );
+    await expect(depths).toEqual(["0", "1", "2", "0"]);
+    await expect(
+      body.queryByRole("button", { name: "Enable auto-merge" }),
+    ).toBeNull();
   },
 };
 


### PR DESCRIPTION
## Summary

- preserve list-known stack metadata when pull request detail hydration omits optional stack fields
- keep stacked rows nested after opening a pull request
- hide unsupported `Enable auto-merge` actions for stacked pull requests while preserving direct merge, whole-stack merge, and merge-queue actions
- add regression coverage and a Storybook state for a pending stacked pull request

## Compatibility

This change only affects the desktop pull request list and detail actions. Non-stacked pull requests keep their existing merge behavior. Merge-queue repositories still offer `Merge when ready` for stacked pull requests.

## Validation

- 102 focused Vitest tests across the pull request list, detail pane, stack metadata, and action selection
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- Biome checks on all changed UI files
- `git diff --check`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- Storybook interaction run for the changed state
- inspected light, dark, high-contrast light, and high-contrast dark screenshots at 2× resolution

## Risk

Low. The stack metadata merge only fills fields that a detail response omits. Explicit detail metadata still wins. The auto-merge suppression is limited to pull requests with registered or inferred stack membership.