### PR TITLE
feat(browser): recover native sessions after restart

### DIFF
--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -25,6 +25,8 @@ use tokio::sync::OwnedMutexGuard;
 use tokio::sync::{watch, Mutex as AsyncMutex};
 use uuid::Uuid;
 
+use crate::browser_recovery::{BrowserSessionStore, RecoveredBrowserSession};
+
 const BROWSER_AUDIT_FILE: &str = "browser-audit.jsonl";
 const AGENT_CAPABILITY_TTL: Duration = Duration::from_secs(90);
 const AGENT_CONFIRMATION_TTL: Duration = Duration::from_secs(30);
@@ -258,6 +260,14 @@ struct BrowserRecord {
     resetting: bool,
 }
 
+pub(crate) struct ManagedBrowserRegistration {
+    pub(crate) owner_id: OwnerId,
+    pub(crate) profile_id: String,
+    pub(crate) url: String,
+    pub(crate) title: Option<String>,
+    pub(crate) visible: bool,
+}
+
 #[derive(Clone)]
 struct BrowserDispatchState {
     halt: watch::Sender<bool>,
@@ -402,6 +412,7 @@ struct BrowserRegistryState {
 pub(crate) struct BrowserRegistry {
     state: Arc<Mutex<BrowserRegistryState>>,
     audit: BrowserAuditLog,
+    sessions: BrowserSessionStore,
 }
 
 #[cfg(any(target_os = "macos", test))]
@@ -461,13 +472,43 @@ impl Default for BrowserRegistry {
         Self {
             state: Arc::new(Mutex::new(BrowserRegistryState::default())),
             audit: BrowserAuditLog::default(),
+            sessions: BrowserSessionStore::default(),
         }
     }
 }
 
 impl BrowserRegistry {
     pub(crate) fn initialize_private_state(&self, data_dir: &Path) -> Result<(), String> {
-        self.audit.initialize(data_dir)
+        self.audit.initialize(data_dir)?;
+        self.sessions.initialize(data_dir)
+    }
+
+    pub(crate) fn recover_session(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+    ) -> Result<Option<RecoveredBrowserSession>, String> {
+        self.sessions.recover(owner_id, browser_id, workspace_id)
+    }
+
+    pub(crate) fn ensure_recovery_binding(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+    ) -> Result<(), String> {
+        self.sessions
+            .ensure_binding(owner_id, browser_id, workspace_id)
+    }
+
+    pub(crate) fn forget_recovery(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+    ) -> Result<(), String> {
+        self.sessions.forget(owner_id, browser_id, workspace_id)
     }
 
     pub(crate) fn register_managed(
@@ -479,6 +520,32 @@ impl BrowserRegistry {
         url: String,
         visible: bool,
     ) -> Result<u64, String> {
+        self.register_managed_with_title(
+            browser_id,
+            workspace_id,
+            ManagedBrowserRegistration {
+                owner_id,
+                profile_id,
+                url,
+                title: None,
+                visible,
+            },
+        )
+    }
+
+    pub(crate) fn register_managed_with_title(
+        &self,
+        browser_id: &str,
+        workspace_id: &str,
+        registration: ManagedBrowserRegistration,
+    ) -> Result<u64, String> {
+        let ManagedBrowserRegistration {
+            owner_id,
+            profile_id,
+            url,
+            title,
+            visible,
+        } = registration;
         let mut state = self.lock();
         if let Some(record) = state.records.get(browser_id) {
             ensure_workspace(browser_id, workspace_id, record)?;
@@ -495,7 +562,7 @@ impl BrowserRegistry {
                 workspace_id: workspace_id.to_owned(),
                 profile_id,
                 url: Some(url),
-                title: None,
+                title,
                 load_state: BrowserLoadState::Loading,
                 document_epoch: 0,
                 visible,
@@ -1539,10 +1606,33 @@ impl BrowserRegistry {
         instance_id: u64,
         url: String,
     ) -> Option<BrowserSnapshot> {
-        self.update_instance(browser_id, workspace_id, instance_id, |record| {
-            record.url = Some(url);
-            record.load_state = BrowserLoadState::Ready;
-        })
+        let (snapshot, owner_id, title) = {
+            let mut state = self.lock();
+            {
+                let record = state.records.get_mut(browser_id)?;
+                if record.workspace_id != workspace_id
+                    || record.instance_id != instance_id
+                    || record.resetting
+                {
+                    return None;
+                }
+                record.url = Some(url.clone());
+                record.load_state = BrowserLoadState::Ready;
+            }
+            let record = state.records.get(browser_id)?;
+            (
+                record.snapshot(browser_id, agent_access_for_record(&state, record)),
+                record.owner_id.clone(),
+                record.title.clone(),
+            )
+        };
+        if let Err(error) =
+            self.sessions
+                .commit(&owner_id, browser_id, workspace_id, &url, title.as_deref())
+        {
+            log_recovery_persistence_error(error);
+        }
+        Some(snapshot)
     }
 
     /// Record a validated same-document URL change without advancing the
@@ -1556,22 +1646,35 @@ impl BrowserRegistry {
         document_epoch: u64,
         url: String,
     ) -> Option<BrowserSnapshot> {
-        let mut state = self.lock();
-        {
-            let record = state.records.get_mut(browser_id)?;
-            if record.workspace_id != workspace_id
-                || record.instance_id != instance_id
-                || record.document_epoch != document_epoch
-                || record.resetting
-                || record.url.as_deref() == Some(url.as_str())
+        let (snapshot, owner_id, title) = {
+            let mut state = self.lock();
             {
-                return None;
+                let record = state.records.get_mut(browser_id)?;
+                if record.workspace_id != workspace_id
+                    || record.instance_id != instance_id
+                    || record.document_epoch != document_epoch
+                    || record.resetting
+                    || record.url.as_deref() == Some(url.as_str())
+                {
+                    return None;
+                }
+                record.url = Some(url.clone());
+                record.load_state = BrowserLoadState::Ready;
             }
-            record.url = Some(url);
-            record.load_state = BrowserLoadState::Ready;
+            let record = state.records.get(browser_id)?;
+            (
+                record.snapshot(browser_id, agent_access_for_record(&state, record)),
+                record.owner_id.clone(),
+                record.title.clone(),
+            )
+        };
+        if let Err(error) =
+            self.sessions
+                .commit(&owner_id, browser_id, workspace_id, &url, title.as_deref())
+        {
+            log_recovery_persistence_error(error);
         }
-        let record = state.records.get(browser_id)?;
-        Some(record.snapshot(browser_id, agent_access_for_record(&state, record)))
+        Some(snapshot)
     }
 
     pub(crate) fn title_changed(
@@ -1582,22 +1685,40 @@ impl BrowserRegistry {
         url: Option<String>,
         title: String,
     ) -> Option<BrowserSnapshot> {
-        let mut state = self.lock();
-        {
-            let record = state.records.get_mut(browser_id)?;
-            if record.workspace_id != workspace_id
-                || record.instance_id != instance_id
-                || record.resetting
-                || url
-                    .as_ref()
-                    .is_some_and(|url| record.url.as_ref() != Some(url))
+        let (snapshot, owner_id, title) = {
+            let mut state = self.lock();
             {
-                return None;
+                let record = state.records.get_mut(browser_id)?;
+                if record.workspace_id != workspace_id
+                    || record.instance_id != instance_id
+                    || record.resetting
+                    || url
+                        .as_ref()
+                        .is_some_and(|url| record.url.as_ref() != Some(url))
+                {
+                    return None;
+                }
+                record.title = Some(title);
             }
-            record.title = Some(title);
+            let record = state.records.get(browser_id)?;
+            (
+                record.snapshot(browser_id, agent_access_for_record(&state, record)),
+                record.owner_id.clone(),
+                record.title.clone(),
+            )
+        };
+        if let Some(url) = url {
+            if let Err(error) = self.sessions.update_title(
+                &owner_id,
+                browser_id,
+                workspace_id,
+                &url,
+                title.as_deref(),
+            ) {
+                log_recovery_persistence_error(error);
+            }
         }
-        let record = state.records.get(browser_id)?;
-        Some(record.snapshot(browser_id, agent_access_for_record(&state, record)))
+        Some(snapshot)
     }
 
     pub(crate) fn remove(&self, browser_id: &str, workspace_id: &str) -> Result<bool, String> {
@@ -2162,6 +2283,10 @@ fn clean_audit_text(value: &str, max_chars: usize, fallback: &str) -> String {
     clean_controller_text(value, max_chars, fallback)
 }
 
+fn log_recovery_persistence_error(error: String) {
+    eprintln!("tidebreak-desktop: browser recovery state was not persisted: {error}");
+}
+
 fn ensure_workspace(
     browser_id: &str,
     workspace_id: &str,
@@ -2323,6 +2448,230 @@ mod tests {
                 true,
             )
             .is_err());
+    }
+
+    #[test]
+    fn restart_recovers_only_the_last_completed_navigation_without_authority() {
+        let private = tempfile::tempdir().unwrap();
+        let owner = OwnerId::local();
+        let registry = BrowserRegistry::default();
+        registry.initialize_private_state(private.path()).unwrap();
+        let instance = registry
+            .register_managed(
+                "browser-1",
+                "workspace-1",
+                owner.clone(),
+                Uuid::new_v4().to_string(),
+                "https://example.com/committed".to_owned(),
+                true,
+            )
+            .unwrap();
+        let ready = registry
+            .page_started(
+                "browser-1",
+                "workspace-1",
+                instance,
+                "https://example.com/committed".to_owned(),
+            )
+            .and_then(|_| {
+                registry.page_finished(
+                    "browser-1",
+                    "workspace-1",
+                    instance,
+                    "https://example.com/committed".to_owned(),
+                )
+            })
+            .unwrap();
+        registry
+            .title_changed(
+                "browser-1",
+                "workspace-1",
+                instance,
+                Some("https://example.com/committed".to_owned()),
+                "Committed page".to_owned(),
+            )
+            .unwrap();
+        let origin = BrowserOrigin::from_url("https://example.com/committed").unwrap();
+        registry
+            .grant_browser_access(
+                "browser-1",
+                "workspace-1",
+                &origin,
+                BrowserOriginScope::Origin {
+                    origin: origin.clone(),
+                },
+                &[BrowserGrantCapability::BrowserControlOrigin],
+            )
+            .unwrap();
+        let capability = registry.issue_agent_capability("workspace-1", "Code agent");
+        force_agent_controller(&registry, "browser-1", capability);
+        registry
+            .record_semantic_snapshot(
+                "browser-1",
+                "workspace-1",
+                ready.document_epoch.unwrap(),
+                "snapshot-1".to_owned(),
+                HashMap::from([("@e1".to_owned(), target("Continue"))]),
+            )
+            .unwrap();
+
+        registry
+            .page_started(
+                "browser-1",
+                "workspace-1",
+                instance,
+                "https://example.com/in-flight".to_owned(),
+            )
+            .unwrap();
+        registry
+            .title_changed(
+                "browser-1",
+                "workspace-1",
+                instance,
+                Some("https://example.com/in-flight".to_owned()),
+                "In-flight page".to_owned(),
+            )
+            .unwrap();
+        drop(registry);
+
+        let reopened = BrowserRegistry::default();
+        reopened.initialize_private_state(private.path()).unwrap();
+        let recovered = reopened
+            .recover_session(&owner, "browser-1", "workspace-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(recovered.url, "https://example.com/committed");
+        assert_eq!(recovered.title.as_deref(), Some("Committed page"));
+
+        reopened
+            .register_managed_with_title(
+                "browser-1",
+                "workspace-1",
+                ManagedBrowserRegistration {
+                    owner_id: owner,
+                    profile_id: Uuid::new_v4().to_string(),
+                    url: recovered.url,
+                    title: recovered.title,
+                    visible: true,
+                },
+            )
+            .unwrap();
+        let snapshot = reopened.snapshot("browser-1", "workspace-1").unwrap();
+        assert_eq!(snapshot.document_epoch, Some(0));
+        assert_eq!(
+            snapshot.controller.unwrap().kind,
+            BrowserControllerKind::Human
+        );
+        let access = snapshot.agent_access.unwrap();
+        assert!(!access.shared);
+        assert!(!access.can_observe);
+        assert!(!access.can_control);
+        let state = reopened.lock();
+        let record = state.records.get("browser-1").unwrap();
+        assert!(record.controller_capability_id.is_none());
+        assert!(record.semantic_snapshot.is_none());
+        assert!(state.capabilities.is_empty());
+        assert!(state.grants.is_empty());
+    }
+
+    #[test]
+    fn same_document_navigation_becomes_the_recovery_url() {
+        let private = tempfile::tempdir().unwrap();
+        let owner = OwnerId::local();
+        let registry = BrowserRegistry::default();
+        registry.initialize_private_state(private.path()).unwrap();
+        let instance = registry
+            .register_managed(
+                "browser-1",
+                "workspace-1",
+                owner.clone(),
+                Uuid::new_v4().to_string(),
+                "https://example.com/start".to_owned(),
+                true,
+            )
+            .unwrap();
+        let ready = registry
+            .page_started(
+                "browser-1",
+                "workspace-1",
+                instance,
+                "https://example.com/start".to_owned(),
+            )
+            .and_then(|_| {
+                registry.page_finished(
+                    "browser-1",
+                    "workspace-1",
+                    instance,
+                    "https://example.com/start".to_owned(),
+                )
+            })
+            .unwrap();
+        registry
+            .same_document_navigation(
+                "browser-1",
+                "workspace-1",
+                instance,
+                ready.document_epoch.unwrap(),
+                "https://example.com/start#details".to_owned(),
+            )
+            .unwrap();
+        drop(registry);
+
+        let reopened = BrowserRegistry::default();
+        reopened.initialize_private_state(private.path()).unwrap();
+        assert_eq!(
+            reopened
+                .recover_session(&owner, "browser-1", "workspace-1")
+                .unwrap()
+                .unwrap()
+                .url,
+            "https://example.com/start#details"
+        );
+    }
+
+    #[test]
+    fn explicit_close_forgets_only_the_exact_recovery_binding() {
+        let private = tempfile::tempdir().unwrap();
+        let owner = OwnerId::local();
+        let registry = BrowserRegistry::default();
+        registry.initialize_private_state(private.path()).unwrap();
+        let instance = registry
+            .register_managed(
+                "browser-1",
+                "workspace-1",
+                owner.clone(),
+                Uuid::new_v4().to_string(),
+                "https://example.com/".to_owned(),
+                true,
+            )
+            .unwrap();
+        registry
+            .page_finished(
+                "browser-1",
+                "workspace-1",
+                instance,
+                "https://example.com/".to_owned(),
+            )
+            .unwrap();
+
+        assert!(registry
+            .recover_session(&owner, "browser-1", "workspace-2")
+            .is_err());
+        assert!(registry
+            .forget_recovery(&owner, "browser-1", "workspace-2")
+            .is_err());
+        registry.remove("browser-1", "workspace-1").unwrap();
+        registry
+            .forget_recovery(&owner, "browser-1", "workspace-1")
+            .unwrap();
+        drop(registry);
+
+        let reopened = BrowserRegistry::default();
+        reopened.initialize_private_state(private.path()).unwrap();
+        assert!(reopened
+            .recover_session(&owner, "browser-1", "workspace-1")
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]

--- a/crates/tidebreak-desktop/src/browser_recovery.rs
+++ b/crates/tidebreak-desktop/src/browser_recovery.rs
@@ -1,0 +1,489 @@
+//! Durable, native-owned browser restart metadata.
+//!
+//! The store records only completed navigation state. Live engine handles,
+//! document epochs, controller capabilities, grants, and in-flight work stay
+//! in memory so a restart cannot replay authority or an unfinished action.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs::{self, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tidebreak_core::OwnerId;
+use url::Url;
+use uuid::Uuid;
+
+const FILE_NAME: &str = "browser-sessions.json";
+const VERSION: u8 = 1;
+const MAX_FILE_BYTES: u64 = 1024 * 1024;
+const MAX_SESSIONS: usize = 256;
+const MAX_BROWSER_ID_CHARS: usize = 80;
+const MAX_WORKSPACE_ID_CHARS: usize = 200;
+const MAX_URL_CHARS: usize = 8_192;
+const MAX_TITLE_CHARS: usize = 160;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RecoveredBrowserSession {
+    pub(crate) url: String,
+    pub(crate) title: Option<String>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct BrowserSessionStore {
+    inner: Arc<Mutex<BrowserSessionState>>,
+}
+
+#[derive(Default)]
+struct BrowserSessionState {
+    directory: Option<PathBuf>,
+    path: Option<PathBuf>,
+    sessions: HashMap<String, StoredBrowserSession>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredBrowserSessions {
+    version: u8,
+    sessions: Vec<StoredBrowserSession>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredBrowserSession {
+    browser_id: String,
+    owner_id: OwnerId,
+    workspace_id: String,
+    committed_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    updated_at: DateTime<Utc>,
+}
+
+impl BrowserSessionStore {
+    pub(crate) fn initialize(&self, data_dir: &Path) -> Result<(), String> {
+        fs::create_dir_all(data_dir)
+            .map_err(|_| "could not create private browser state".to_owned())?;
+        let path = data_dir.join(FILE_NAME);
+        let sessions = load_sessions(&path)?;
+        let mut state = self.lock();
+        if let Some(existing) = &state.path {
+            return if existing == &path {
+                Ok(())
+            } else {
+                Err("browser session storage was initialized more than once".to_owned())
+            };
+        }
+        state.directory = Some(data_dir.to_path_buf());
+        state.path = Some(path);
+        state.sessions = sessions
+            .into_iter()
+            .map(|session| (session.browser_id.clone(), session))
+            .collect();
+        Ok(())
+    }
+
+    pub(crate) fn recover(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+    ) -> Result<Option<RecoveredBrowserSession>, String> {
+        validate_identity(browser_id, workspace_id)?;
+        let state = self.lock();
+        let Some(session) = state.sessions.get(browser_id) else {
+            return Ok(None);
+        };
+        ensure_binding(session, owner_id, workspace_id)?;
+        Ok(Some(RecoveredBrowserSession {
+            url: session.committed_url.clone(),
+            title: session.title.clone(),
+        }))
+    }
+
+    pub(crate) fn ensure_binding(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+    ) -> Result<(), String> {
+        validate_identity(browser_id, workspace_id)?;
+        if let Some(session) = self.lock().sessions.get(browser_id) {
+            ensure_binding(session, owner_id, workspace_id)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn commit(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+        url: &str,
+        title: Option<&str>,
+    ) -> Result<(), String> {
+        validate_identity(browser_id, workspace_id)?;
+        let committed_url = validated_url(url)?;
+        let title = clean_title(title);
+        let mut state = self.lock();
+        if let Some(existing) = state.sessions.get(browser_id) {
+            ensure_binding(existing, owner_id, workspace_id)?;
+        } else if state.sessions.len() >= MAX_SESSIONS {
+            return Err("browser session storage is full".to_owned());
+        }
+        let mut next = state.sessions.clone();
+        next.insert(
+            browser_id.to_owned(),
+            StoredBrowserSession {
+                browser_id: browser_id.to_owned(),
+                owner_id: owner_id.clone(),
+                workspace_id: workspace_id.to_owned(),
+                committed_url,
+                title,
+                updated_at: Utc::now(),
+            },
+        );
+        persist_if_initialized(&state, &next)?;
+        state.sessions = next;
+        Ok(())
+    }
+
+    pub(crate) fn update_title(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+        url: &str,
+        title: Option<&str>,
+    ) -> Result<bool, String> {
+        validate_identity(browser_id, workspace_id)?;
+        let committed_url = validated_url(url)?;
+        let title = clean_title(title);
+        let mut state = self.lock();
+        let Some(existing) = state.sessions.get(browser_id) else {
+            return Ok(false);
+        };
+        ensure_binding(existing, owner_id, workspace_id)?;
+        if existing.committed_url != committed_url {
+            return Ok(false);
+        }
+        if existing.title == title {
+            return Ok(true);
+        }
+        let mut next = state.sessions.clone();
+        let session = next
+            .get_mut(browser_id)
+            .expect("browser session was checked above");
+        session.title = title;
+        session.updated_at = Utc::now();
+        persist_if_initialized(&state, &next)?;
+        state.sessions = next;
+        Ok(true)
+    }
+
+    pub(crate) fn forget(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+    ) -> Result<(), String> {
+        validate_identity(browser_id, workspace_id)?;
+        let mut state = self.lock();
+        let Some(existing) = state.sessions.get(browser_id) else {
+            return Ok(());
+        };
+        ensure_binding(existing, owner_id, workspace_id)?;
+        let mut next = state.sessions.clone();
+        next.remove(browser_id);
+        persist_if_initialized(&state, &next)?;
+        state.sessions = next;
+        Ok(())
+    }
+
+    fn lock(&self) -> MutexGuard<'_, BrowserSessionState> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+fn ensure_binding(
+    session: &StoredBrowserSession,
+    owner_id: &OwnerId,
+    workspace_id: &str,
+) -> Result<(), String> {
+    if session.owner_id != *owner_id || session.workspace_id != workspace_id {
+        Err("browser session belongs to a different workspace".to_owned())
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_identity(browser_id: &str, workspace_id: &str) -> Result<(), String> {
+    if browser_id.is_empty()
+        || browser_id.chars().count() > MAX_BROWSER_ID_CHARS
+        || !browser_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        return Err("browser session id is not valid".to_owned());
+    }
+    if workspace_id.is_empty()
+        || workspace_id.chars().count() > MAX_WORKSPACE_ID_CHARS
+        || workspace_id.chars().any(char::is_control)
+    {
+        return Err("browser workspace id is not valid".to_owned());
+    }
+    Ok(())
+}
+
+fn validated_url(value: &str) -> Result<String, String> {
+    if value.chars().count() > MAX_URL_CHARS || value.chars().any(char::is_control) {
+        return Err("browser session URL is not valid".to_owned());
+    }
+    let url = Url::parse(value).map_err(|_| "browser session URL is not valid".to_owned())?;
+    if !matches!(url.scheme(), "http" | "https")
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return Err("browser session URL is not valid".to_owned());
+    }
+    Ok(url.to_string())
+}
+
+fn clean_title(value: Option<&str>) -> Option<String> {
+    let title: String = value?
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(MAX_TITLE_CHARS)
+        .collect();
+    (!title.is_empty()).then_some(title)
+}
+
+fn load_sessions(path: &Path) -> Result<Vec<StoredBrowserSession>, String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(_) => return Err("browser session storage is unavailable".to_owned()),
+    };
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err("browser session storage is invalid".to_owned());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if metadata.permissions().mode() & 0o077 != 0 {
+            return Err("browser session storage has broad permissions".to_owned());
+        }
+    }
+    if metadata.len() > MAX_FILE_BYTES {
+        return Ok(Vec::new());
+    }
+    let bytes = fs::read(path).map_err(|_| "browser session storage is unavailable".to_owned())?;
+    let Ok(stored) = serde_json::from_slice::<StoredBrowserSessions>(&bytes) else {
+        return Ok(Vec::new());
+    };
+    if validate_sessions(&stored).is_err() {
+        return Ok(Vec::new());
+    }
+    Ok(stored.sessions)
+}
+
+fn validate_sessions(stored: &StoredBrowserSessions) -> Result<(), String> {
+    if stored.version != VERSION || stored.sessions.len() > MAX_SESSIONS {
+        return Err("browser session storage uses an unsupported shape".to_owned());
+    }
+    let mut browser_ids = HashSet::new();
+    for session in &stored.sessions {
+        validate_identity(&session.browser_id, &session.workspace_id)?;
+        if !browser_ids.insert(session.browser_id.as_str())
+            || validated_url(&session.committed_url)? != session.committed_url
+            || clean_title(session.title.as_deref()) != session.title
+        {
+            return Err("browser session storage is invalid".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn persist_if_initialized(
+    state: &BrowserSessionState,
+    sessions: &HashMap<String, StoredBrowserSession>,
+) -> Result<(), String> {
+    let (Some(directory), Some(path)) = (&state.directory, &state.path) else {
+        return Ok(());
+    };
+    let mut sessions = sessions.values().cloned().collect::<Vec<_>>();
+    sessions.sort_by(|left, right| left.browser_id.cmp(&right.browser_id));
+    let bytes = serde_json::to_vec_pretty(&StoredBrowserSessions {
+        version: VERSION,
+        sessions,
+    })
+    .map_err(|_| "browser session storage could not be encoded".to_owned())?;
+    if bytes.len() as u64 > MAX_FILE_BYTES {
+        return Err("browser session storage is too large".to_owned());
+    }
+    write_atomically(directory, path, &bytes)
+        .map_err(|_| "browser session storage is unavailable".to_owned())
+}
+
+fn write_atomically(directory: &Path, destination: &Path, bytes: &[u8]) -> io::Result<()> {
+    let temporary = directory.join(format!(".browser-sessions-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_file(&temporary, destination)?;
+        sync_directory(directory)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(temporary, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let temporary = temporary
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let succeeded = unsafe {
+        MoveFileExW(
+            temporary.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if succeeded == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(directory: &Path) -> io::Result<()> {
+    fs::File::open(directory)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_directory(_directory: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_private(path: &Path, bytes: &[u8]) {
+        fs::write(path, bytes).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
+    #[test]
+    fn completed_session_reopens_for_the_exact_owner_and_workspace() {
+        let private = tempfile::tempdir().unwrap();
+        let owner = OwnerId::local();
+        let store = BrowserSessionStore::default();
+        store.initialize(private.path()).unwrap();
+        store
+            .commit(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                "https://example.com/docs",
+                Some("  Documentation   home  "),
+            )
+            .unwrap();
+
+        let reopened = BrowserSessionStore::default();
+        reopened.initialize(private.path()).unwrap();
+
+        assert_eq!(
+            reopened
+                .recover(&owner, "browser-1", "workspace-1")
+                .unwrap(),
+            Some(RecoveredBrowserSession {
+                url: "https://example.com/docs".to_owned(),
+                title: Some("Documentation home".to_owned()),
+            })
+        );
+    }
+
+    #[test]
+    fn guessed_workspace_cannot_recover_or_delete_another_session() {
+        let store = BrowserSessionStore::default();
+        let owner = OwnerId::local();
+        store
+            .commit(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                "https://example.com/",
+                None,
+            )
+            .unwrap();
+
+        assert!(store.recover(&owner, "browser-1", "workspace-2").is_err());
+        assert!(store.forget(&owner, "browser-1", "workspace-2").is_err());
+        assert!(store
+            .recover(&owner, "browser-1", "workspace-1")
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn invalid_or_oversized_content_is_discarded() {
+        let private = tempfile::tempdir().unwrap();
+        let path = private.path().join(FILE_NAME);
+        write_private(&path, b"not json");
+        let store = BrowserSessionStore::default();
+        store.initialize(private.path()).unwrap();
+        assert!(store
+            .recover(&OwnerId::local(), "browser-1", "workspace-1")
+            .unwrap()
+            .is_none());
+
+        write_private(&path, &vec![b'x'; (MAX_FILE_BYTES + 1) as usize]);
+        let reopened = BrowserSessionStore::default();
+        reopened.initialize(private.path()).unwrap();
+        assert!(reopened
+            .recover(&OwnerId::local(), "browser-1", "workspace-1")
+            .unwrap()
+            .is_none());
+    }
+}

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 use crate::browser_control::{
     BrowserAgentAccess, BrowserController, BrowserDispatchEffect, BrowserLoadState,
-    BrowserNavigationDecision, BrowserRegistry, BrowserSnapshot,
+    BrowserNavigationDecision, BrowserRegistry, BrowserSnapshot, ManagedBrowserRegistration,
 };
 #[cfg(any(target_os = "macos", test))]
 use crate::browser_profile::normalize_website_host;
@@ -166,13 +166,18 @@ pub(crate) async fn code_browser_command(
                 registry.set_visible(&request.browser_id, &request.workspace_id, visible)?;
                 return registry.snapshot(&request.browser_id, &request.workspace_id);
             }
+            let owner_id = OwnerId::local();
+            let recovered =
+                registry.recover_session(&owner_id, &request.browser_id, &request.workspace_id)?;
             // A platform webview can disappear independently after a native
             // failure. Remove that same-workspace stale record before
             // allocating a fresh native instance; a cross-workspace record is
             // deliberately rejected rather than rebound.
             registry.remove(&request.browser_id, &request.workspace_id)?;
-            let owner_id = OwnerId::local();
             let profile = profiles.get_or_create(&owner_id)?;
+            let (url, title) = recovered
+                .map(|session| (session.url, session.title))
+                .unwrap_or((url, None));
             create_browser(
                 &app,
                 &registry,
@@ -182,6 +187,7 @@ pub(crate) async fn code_browser_command(
                 &request.browser_id,
                 &label,
                 &url,
+                title,
                 bounds,
                 visible,
             )
@@ -255,11 +261,18 @@ pub(crate) async fn code_browser_command(
             registry.snapshot(&request.browser_id, &request.workspace_id)
         }
         CodeBrowserAction::Close => {
+            let owner_id = OwnerId::local();
+            registry.ensure_recovery_binding(
+                &owner_id,
+                &request.browser_id,
+                &request.workspace_id,
+            )?;
             if let Some(webview) = existing {
                 registry.ensure_workspace(&request.browser_id, &request.workspace_id)?;
                 webview.close().map_err(browser_error)?;
             }
             registry.remove(&request.browser_id, &request.workspace_id)?;
+            registry.forget_recovery(&owner_id, &request.browser_id, &request.workspace_id)?;
             Ok(BrowserSnapshot::missing(
                 &request.browser_id,
                 &request.workspace_id,
@@ -449,6 +462,7 @@ fn create_browser(
     browser_id: &str,
     label: &str,
     url: &str,
+    title: Option<String>,
     bounds: CodeBrowserBounds,
     visible: bool,
 ) -> Result<BrowserSnapshot, String> {
@@ -465,13 +479,16 @@ fn create_browser(
     let profile_id = profile.profile_id();
     profiles.record_url(&owner_id, &profile_id, &target)?;
 
-    let instance_id = registry.register_managed(
+    let instance_id = registry.register_managed_with_title(
         browser_id,
         workspace_id,
-        owner_id.clone(),
-        profile_id.clone(),
-        target.to_string(),
-        visible,
+        ManagedBrowserRegistration {
+            owner_id: owner_id.clone(),
+            profile_id: profile_id.clone(),
+            url: target.to_string(),
+            title,
+            visible,
+        },
     )?;
 
     let navigation_main = main.clone();

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -25,6 +25,7 @@ mod broker;
 )]
 mod browser_control;
 mod browser_profile;
+mod browser_recovery;
 mod browser_runtime_adapter;
 #[allow(
     dead_code,


### PR DESCRIPTION
## What changed

- Persist the last completed native browser URL and title in private app state.
- Restore only sessions with the exact owner and workspace binding after restart.
- Drop in-flight navigation, controller state, grants, capabilities, semantic state, and document epochs during recovery.
- Remove recovery metadata on explicit tab close while keeping committed URLs through profile reset reconstruction.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tidebreak-desktop browser_ -- --nocapture` (86 passed)
- `cargo check -p tidebreak-desktop`
- `git diff --check`

## Compatibility and risk

This adds `browser-sessions.json` version 1 under private app data. The store uses atomic replacement, bounded input, and owner/workspace checks. Unix files use mode `0600`. Invalid content is discarded, while broadly readable storage fails closed.

## Tracking

Closes #2783