### PR TITLE
fix(desktop): remove permission mode subtitles

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -62,7 +62,6 @@ import {
   codeModelVendor,
   effortLadder,
   groupCodeModelOptions,
-  unsupervisedModeStatement,
   type CodeModelOption,
   PERMISSION_MODE_UNAVAILABLE_REASON,
   SESSION_PERMISSION_MODE_LOCKED,
@@ -1089,20 +1088,6 @@ export function CodeComposer({
     }
   }
 
-  // The posture is never silent: a mode that runs with nobody to ask says so
-  // under the control that picked it (decisions 0038, 0039). An engine that
-  // offers Auto but not Ask has no approval channel, so its Auto escalates
-  // nothing. Start states it once, where the choice is made; a live session
-  // carries it in the workspace header instead of under every draft.
-  const unsupervisedNote = sessionId
-    ? null
-    : unavailableReason
-      ? null
-      : unsupervisedModeStatement(
-          permissionMode,
-          availableModes.includes("auto") && !availableModes.includes("ask"),
-        );
-
   return (
     <div className="relative shrink-0 px-[clamp(0.5rem,4%,5rem)] pb-2">
       <Composer
@@ -1228,11 +1213,6 @@ export function CodeComposer({
         steerStatus={steerStatus}
         footerNote={
           <>
-            {unsupervisedNote && (
-              <p className="text-muted-foreground text-xs">
-                {unsupervisedNote}
-              </p>
-            )}
             {unavailableReason && (
               <p className="text-muted-foreground text-xs">
                 {unavailableReason}

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -27,7 +27,7 @@ import {
 } from "./CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
-import { ALLOW_ALL_NOTE, PERMISSION_MODE_POLICY_BLOCKED } from "./labels";
+import { PERMISSION_MODE_POLICY_BLOCKED } from "./labels";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import type { ReasoningEffort } from "../api/types";
 import type { CodeTurnSubmission, ParsedHarnessModel } from "./parsers";
@@ -614,11 +614,10 @@ describe("NewWorkspaceDialog", () => {
         screen.getByRole("button", { name: "Model: GPT 5.6 Sol" }),
       ).toBeEnabled(),
     );
-    // Allow is the default where the engine honors it, and it says so.
+    // Allow is the default where the engine honors it.
     expect(
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeEnabled();
-    expect(screen.getByText(ALLOW_ALL_NOTE)).toBeInTheDocument();
 
     fireEvent.keyDown(screen.getByRole("dialog"), {
       key: "Enter",
@@ -697,8 +696,6 @@ describe("NewWorkspaceDialog", () => {
     expect(
       screen.getByRole("button", { name: "Permissions: Ask" }),
     ).toBeEnabled();
-    expect(screen.queryByText(ALLOW_ALL_NOTE)).not.toBeInTheDocument();
-
     fireEvent.keyDown(screen.getByRole("dialog"), {
       key: "Enter",
       metaKey: true,

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -60,7 +60,6 @@ import { HarnessInstallNote } from "./HarnessInstallNote";
 import { useWarmHarnessInstall } from "./useHarnessInstall";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import {
-  autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   effortLadder,
@@ -70,7 +69,6 @@ import {
   PERMISSION_MODE_POLICY_BLOCKED,
   preferredCodeModels,
   requiresHarnessModelIds,
-  unsupervisedModeStatement,
   CREATE_PERMISSION_MODE_FIXED,
   HARNESS_LABELS,
   type CodeModelOption,
@@ -369,15 +367,6 @@ export function NewWorkspaceDialog({
   );
   const postedMode = permittedMode ?? requestedMode;
   const policyBlocksCreate = Boolean(selectedHarness && permittedMode === null);
-  // The posture create is about to post is never silent: a mode that runs
-  // with nobody to ask says so next to the control (decisions 0038, 0039).
-  const unsupervisedNote =
-    selectedHarness && !policyBlocksCreate
-      ? unsupervisedModeStatement(
-          postedMode,
-          autoIsUnsupervised(selectedHarness.caps),
-        )
-      : null;
   // An engine still downloading is a legal pick, not a legal start: create
   // would sit on the same npm install with nothing but a spinner. The install
   // note under the pills says what the wait is, and any engine already on
@@ -1153,11 +1142,6 @@ export function NewWorkspaceDialog({
                   false && (
                   <p className="text-muted-foreground px-2 text-xs">
                     {CREATE_PERMISSION_MODE_FIXED}
-                  </p>
-                )}
-                {unsupervisedNote && (
-                  <p className="text-muted-foreground px-2 text-xs">
-                    {unsupervisedNote}
                   </p>
                 )}
                 {policyBlocksCreate && (

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -17,11 +17,7 @@ import { ManagedPolicyContext } from "../managedPolicy";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
-import {
-  ALLOW_ALL_NOTE,
-  PERMISSION_MODE_POLICY_BLOCKED,
-  UNSUPERVISED_AUTO_NOTE,
-} from "./labels";
+import { PERMISSION_MODE_POLICY_BLOCKED } from "./labels";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 import type { ReasoningEffort } from "../api/types";
 import type { ParsedHarnessModel } from "./parsers";
@@ -162,8 +158,6 @@ describe("StartSessionPrompt", () => {
     expect(
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeInTheDocument();
-    // The default posture is never silent: it says what it will do.
-    expect(screen.getByText(ALLOW_ALL_NOTE)).toBeInTheDocument();
     expect(
       screen.getByRole("combobox", { name: "Harness" }).closest("form"),
     ).toHaveClass("chat-composer");
@@ -211,7 +205,6 @@ describe("StartSessionPrompt", () => {
     expect(
       screen.getByRole("button", { name: "Permissions: Ask" }),
     ).toBeInTheDocument();
-    expect(screen.queryByText(ALLOW_ALL_NOTE)).not.toBeInTheDocument();
     await user.type(
       screen.getByRole("textbox", { name: "Message" }),
       "list the files",
@@ -260,7 +253,6 @@ describe("StartSessionPrompt", () => {
     expect(
       screen.getByText(PERMISSION_MODE_POLICY_BLOCKED),
     ).toBeInTheDocument();
-    expect(screen.queryByText(ALLOW_ALL_NOTE)).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeDisabled();
@@ -359,8 +351,6 @@ describe("StartSessionPrompt", () => {
     expect(
       screen.getByRole("button", { name: "Permissions: Auto" }),
     ).toBeInTheDocument();
-    // Grok's Auto has no approval channel behind it, and the composer says so.
-    expect(screen.getByText(UNSUPERVISED_AUTO_NOTE)).toBeInTheDocument();
     await user.type(
       screen.getByRole("textbox", { name: "Message" }),
       "list the files",

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -3,10 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { ReasoningEffort } from "../api/types";
 import type { ModeCaps } from "./labels";
 import {
-  ALLOW_ALL_NOTE,
   PERMISSION_MODE_POSTURES,
-  UNSUPERVISED_AUTO_NOTE,
-  autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   effortLadder,
@@ -19,7 +16,6 @@ import {
   preferredCodeModels,
   sessionLifecycleTooltip,
   sessionPermissionModeTooltip,
-  unsupervisedModeStatement,
 } from "./labels";
 
 function caps(
@@ -99,32 +95,10 @@ describe("create-time permission mode", () => {
     const grok = caps("unsupported", "unsupported", "supported", "supported");
     expect(createPermissionModes(grok)).toEqual(["auto", "allow"]);
     expect(defaultCreatePermissionMode(grok)).toBe("allow");
-    expect(autoIsUnsupervised(grok)).toBe(true);
     // An engine with an auto posture and no allow-all still lands on Auto.
     const autoOnly = caps("unsupported", "unsupported", "supported");
     expect(createPermissionModes(autoOnly)).toEqual(["auto"]);
     expect(defaultCreatePermissionMode(autoOnly)).toBe("auto");
-    expect(autoIsUnsupervised(autoOnly)).toBe(true);
-    // Supervised Auto rides the approval channel and needs no statement.
-    expect(
-      autoIsUnsupervised(caps("supported", "supported", "supported")),
-    ).toBe(false);
-  });
-});
-
-describe("unsupervisedModeStatement", () => {
-  it("states a posture that runs with nobody to ask", () => {
-    // Allow all never asks, whatever the engine can do.
-    expect(unsupervisedModeStatement("allow", false)).toBe(ALLOW_ALL_NOTE);
-    expect(unsupervisedModeStatement("allow", true)).toBe(ALLOW_ALL_NOTE);
-    // Auto only when the engine has no approval channel to escalate through.
-    expect(unsupervisedModeStatement("auto", true)).toBe(
-      UNSUPERVISED_AUTO_NOTE,
-    );
-    expect(unsupervisedModeStatement("auto", false)).toBeNull();
-    // A posture that escalates needs no statement.
-    expect(unsupervisedModeStatement("ask", true)).toBeNull();
-    expect(unsupervisedModeStatement("plan", true)).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -113,36 +113,9 @@ export const CREATE_PERMISSION_MODE_FIXED =
 export const PERMISSION_MODE_POSTURES: Record<PermissionMode, string> = {
   plan: "Plans the work and writes nothing",
   ask: "Asks before every tool that changes something",
-  // No claim about escalation: whether Auto has anywhere to ask is the
-  // engine's capability, not the mode's (see [`autoIsUnsupervised`]).
   auto: "Decides for itself as it works",
   allow: "Runs every tool without asking",
 };
-
-/** Stated wherever unsupervised Auto is offered (decision 0038). */
-export const UNSUPERVISED_AUTO_NOTE =
-  "This engine has no approval channel: in Auto, every action runs without asking.";
-
-/** Stated wherever Allow is offered (decision 0039). */
-export const ALLOW_ALL_NOTE =
-  "This engine's permission system is off: every action runs without asking.";
-
-/**
- * The statement a surface shows next to the permission control when the
- * posture on offer runs with nobody to ask (decisions 0038, 0039).
- *
- * `null` for a posture that escalates, so the statement appears only where it
- * changes what the reader should expect: Allow all anywhere, and Auto on an
- * engine whose Auto is unsupervised.
- */
-export function unsupervisedModeStatement(
-  mode: PermissionMode,
-  autoUnsupervised: boolean,
-): string | null {
-  if (mode === "allow") return ALLOW_ALL_NOTE;
-  if (mode === "auto" && autoUnsupervised) return UNSUPERVISED_AUTO_NOTE;
-  return null;
-}
 
 /** The header chip's tooltip: the posture, named and spelled out. */
 export function sessionPermissionModeTooltip(mode: PermissionMode): string {
@@ -251,21 +224,10 @@ export function harnessCanStartNow(entry: {
 }
 
 /**
- * True when this engine's Auto runs with nobody to ask (decision 0038):
- * it has an auto posture but no approval channel to escalate through.
- */
-export function autoIsUnsupervised(caps: ModeCaps): boolean {
-  return (
-    caps.auto_mode === "supported" && caps.structured_approvals !== "supported"
-  );
-}
-
-/**
  * Create default: the most autonomous posture the engine honors, walking
  * Allow → Auto → Ask → Plan (decision 0039, amended 2026-08-18). Approving
  * every step of a fresh session cost more than it caught, so create starts
- * where the work runs. The mode is never silent: whichever surface offers it
- * states the posture next to the control (decisions 0033, 0038).
+ * where the work runs.
  */
 export function defaultCreatePermissionMode(caps: ModeCaps): PermissionMode {
   if (caps.allow_mode === "supported") return "allow";

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -333,6 +333,12 @@ export const Default: Story = {
     expect(prompt.getBoundingClientRect().height).toBeGreaterThanOrEqual(
       13 * unit,
     );
+    const engine = page.getByRole("button", { name: /^Harness:/ });
+    const permissions = page.getByRole("button", { name: /^Permissions:/ });
+    expect(permissions.getBoundingClientRect().top).toBeCloseTo(
+      engine.getBoundingClientRect().top,
+      0,
+    );
   },
 };
 

--- a/crates/tidebreak-desktop/ui/src/stories/PermissionModePicker.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/PermissionModePicker.stories.tsx
@@ -1,11 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { PermissionModePicker } from "@/code/CodeComposer";
-import {
-  ALLOW_ALL_NOTE,
-  CREATE_PERMISSION_MODE_FIXED,
-  UNSUPERVISED_AUTO_NOTE,
-} from "@/code/labels";
+import { CREATE_PERMISSION_MODE_FIXED } from "@/code/labels";
 
 /**
  * Permission mode in the composer footer.
@@ -13,7 +9,7 @@ import {
  * Most engines take a new mode on the next turn. opencode fixes its posture
  * when the session is created, so after the first turn the trigger stays
  * visible, disabled, with the locked-mode tooltip. Create surfaces keep the
- * picker live and add a short hint so Plan vs Allow is an informed choice.
+ * picker live and state when the selected engine fixes the mode at creation.
  */
 const meta = {
   title: "Composer/Permission mode",
@@ -60,42 +56,6 @@ export const FixedAtCreate: Story = {
       <PermissionModePicker {...args} />
       <p className="text-muted-foreground px-2 text-xs">
         {CREATE_PERMISSION_MODE_FIXED}
-      </p>
-    </div>
-  ),
-};
-
-/**
- * Create states Allow under the picker (decision 0039). A live session
- * carries the header chip instead of this line.
- */
-export const AllowAllNote: Story = {
-  args: {
-    value: "allow",
-    onChange: () => {},
-  },
-  render: (args) => (
-    <div className="flex min-w-0 max-w-sm flex-col">
-      <PermissionModePicker {...args} />
-      <p className="text-muted-foreground px-2 text-xs">{ALLOW_ALL_NOTE}</p>
-    </div>
-  ),
-};
-
-/**
- * Auto on an engine with no approval channel (decision 0038). Same placement
- * as Allow: under the control, not inside the menu row.
- */
-export const UnsupervisedAutoNote: Story = {
-  args: {
-    value: "auto",
-    onChange: () => {},
-  },
-  render: (args) => (
-    <div className="flex min-w-0 max-w-sm flex-col">
-      <PermissionModePicker {...args} />
-      <p className="text-muted-foreground px-2 text-xs">
-        {UNSUPERVISED_AUTO_NOTE}
       </p>
     </div>
   ),


### PR DESCRIPTION
## Summary

Remove permission-mode subtitle copy from workspace creation and session-start composers. Keep policy-blocked and fixed-session messages because they describe active constraints.

Add a Storybook assertion that the new-workspace permission control stays on the same row as the engine control at the default width. Remove obsolete subtitle stories and helper code.

## Compatibility

This changes presentation only. Permission values, defaults, menu labels, tooltips, policy enforcement, and submitted API payloads remain unchanged.

## Safety and risk

Risk is limited to compact composer layout and removal of redundant explanatory copy. Detailed mode behavior remains available in the permission tooltip. Managed-policy and fixed-mode notices still render.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui test -- src/code/labels.test.ts src/code/StartSessionPrompt.dom.test.tsx src/code/NewWorkspaceDialog.dom.test.tsx` — 253 files and 2,217 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui lint` — 791 files checked
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — passed
- Storybook visual checks across light, dark, high-contrast light, and high-contrast dark themes