### PR TITLE
feat(browser): migrate renderer state to native authority

### DIFF
--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -27,6 +27,7 @@ server_info: hands the renderer the embedded server's address and per-launch tok
 request_user_attention: native window attention hint when a parked question needs the user.
 is_window_focused: reports main-window focus; document.hidden is the tab, not the window.
 present_native_notification: posts an OS banner and asks for notification permission on first unfocused present.
+code_browser_import_legacy_state: moves one renderer browser record into private native storage and acknowledges disposal before the renderer deletes its old copy.
 code_browser_command: creates and controls sandboxed native child webviews whose bounds and lifecycle exist only in the desktop shell.
 open_code_worktree: opens a local Code worktree through this operating system's folder handler; a headless server cannot open desktop UI.
 open_in_editor: starts the editor installed on the machine the reader is sitting at, on one file inside a local worktree; the server may be that machine or another, and neither can raise a desktop editor here.

--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -25,7 +25,9 @@ use tokio::sync::OwnedMutexGuard;
 use tokio::sync::{watch, Mutex as AsyncMutex};
 use uuid::Uuid;
 
-use crate::browser_recovery::{BrowserSessionStore, RecoveredBrowserSession};
+use crate::browser_recovery::{
+    BrowserSessionStore, LegacyBrowserImportResult, LegacyBrowserSession, RecoveredBrowserSession,
+};
 
 const BROWSER_AUDIT_FILE: &str = "browser-audit.jsonl";
 const AGENT_CAPABILITY_TTL: Duration = Duration::from_secs(90);
@@ -500,6 +502,17 @@ impl BrowserRegistry {
     ) -> Result<(), String> {
         self.sessions
             .ensure_binding(owner_id, browser_id, workspace_id)
+    }
+
+    pub(crate) fn import_legacy_session(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+        legacy: Option<LegacyBrowserSession>,
+    ) -> Result<LegacyBrowserImportResult, String> {
+        self.sessions
+            .import_legacy(owner_id, browser_id, workspace_id, legacy)
     }
 
     pub(crate) fn forget_recovery(

--- a/crates/tidebreak-desktop/src/browser_recovery.rs
+++ b/crates/tidebreak-desktop/src/browser_recovery.rs
@@ -19,9 +19,12 @@ use url::Url;
 use uuid::Uuid;
 
 const FILE_NAME: &str = "browser-sessions.json";
-const VERSION: u8 = 1;
+const VERSION: u8 = 2;
+const PREVIOUS_FILE_VERSION: u8 = 1;
+const LEGACY_RENDERER_VERSION: u8 = 1;
 const MAX_FILE_BYTES: u64 = 1024 * 1024;
 const MAX_SESSIONS: usize = 256;
+const MAX_LEGACY_IMPORT_ACKNOWLEDGEMENTS: usize = 1024;
 const MAX_BROWSER_ID_CHARS: usize = 80;
 const MAX_WORKSPACE_ID_CHARS: usize = 200;
 const MAX_URL_CHARS: usize = 8_192;
@@ -30,6 +33,36 @@ const MAX_TITLE_CHARS: usize = 160;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RecoveredBrowserSession {
     pub(crate) url: String,
+    pub(crate) title: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LegacyBrowserSession {
+    pub(crate) version: u8,
+    pub(crate) browser_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) url: Option<String>,
+    pub(crate) title: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum LegacyBrowserImportStatus {
+    Imported,
+    NativeStateKept,
+    AlreadyHandled,
+    Discarded,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LegacyBrowserImportResult {
+    pub(crate) status: LegacyBrowserImportStatus,
+    pub(crate) browser_id: String,
+    pub(crate) workspace_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) title: Option<String>,
 }
 
@@ -43,13 +76,23 @@ struct BrowserSessionState {
     directory: Option<PathBuf>,
     path: Option<PathBuf>,
     sessions: HashMap<String, StoredBrowserSession>,
+    legacy_import_acknowledgements:
+        HashMap<LegacyBrowserImportKey, StoredLegacyBrowserImportAcknowledgement>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-struct StoredBrowserSessions {
+struct StoredBrowserSessionsV1 {
     version: u8,
     sessions: Vec<StoredBrowserSession>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredBrowserSessionsV2 {
+    version: u8,
+    sessions: Vec<StoredBrowserSession>,
+    legacy_import_acknowledgements: Vec<StoredLegacyBrowserImportAcknowledgement>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -64,12 +107,34 @@ struct StoredBrowserSession {
     updated_at: DateTime<Utc>,
 }
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct LegacyBrowserImportKey {
+    owner_id: OwnerId,
+    browser_id: String,
+    workspace_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredLegacyBrowserImportAcknowledgement {
+    owner_id: OwnerId,
+    browser_id: String,
+    workspace_id: String,
+    acknowledged_at: DateTime<Utc>,
+}
+
+#[derive(Default)]
+struct LoadedBrowserSessionState {
+    sessions: Vec<StoredBrowserSession>,
+    legacy_import_acknowledgements: Vec<StoredLegacyBrowserImportAcknowledgement>,
+}
+
 impl BrowserSessionStore {
     pub(crate) fn initialize(&self, data_dir: &Path) -> Result<(), String> {
         fs::create_dir_all(data_dir)
             .map_err(|_| "could not create private browser state".to_owned())?;
         let path = data_dir.join(FILE_NAME);
-        let sessions = load_sessions(&path)?;
+        let loaded = load_state(&path)?;
         let mut state = self.lock();
         if let Some(existing) = &state.path {
             return if existing == &path {
@@ -80,9 +145,15 @@ impl BrowserSessionStore {
         }
         state.directory = Some(data_dir.to_path_buf());
         state.path = Some(path);
-        state.sessions = sessions
+        state.sessions = loaded
+            .sessions
             .into_iter()
             .map(|session| (session.browser_id.clone(), session))
+            .collect();
+        state.legacy_import_acknowledgements = loaded
+            .legacy_import_acknowledgements
+            .into_iter()
+            .map(|acknowledgement| (acknowledgement_key(&acknowledgement), acknowledgement))
             .collect();
         Ok(())
     }
@@ -147,7 +218,7 @@ impl BrowserSessionStore {
                 updated_at: Utc::now(),
             },
         );
-        persist_if_initialized(&state, &next)?;
+        persist_if_initialized(&state, &next, &state.legacy_import_acknowledgements)?;
         state.sessions = next;
         Ok(())
     }
@@ -180,9 +251,87 @@ impl BrowserSessionStore {
             .expect("browser session was checked above");
         session.title = title;
         session.updated_at = Utc::now();
-        persist_if_initialized(&state, &next)?;
+        persist_if_initialized(&state, &next, &state.legacy_import_acknowledgements)?;
         state.sessions = next;
         Ok(true)
+    }
+
+    pub(crate) fn import_legacy(
+        &self,
+        owner_id: &OwnerId,
+        browser_id: &str,
+        workspace_id: &str,
+        legacy: Option<LegacyBrowserSession>,
+    ) -> Result<LegacyBrowserImportResult, String> {
+        validate_identity(browser_id, workspace_id)?;
+        let key = LegacyBrowserImportKey {
+            owner_id: owner_id.clone(),
+            browser_id: browser_id.to_owned(),
+            workspace_id: workspace_id.to_owned(),
+        };
+        let mut state = self.lock();
+        if state.legacy_import_acknowledgements.contains_key(&key) {
+            return Ok(legacy_import_result(
+                LegacyBrowserImportStatus::AlreadyHandled,
+                browser_id,
+                workspace_id,
+                session_for_binding(&state.sessions, owner_id, browser_id, workspace_id),
+            ));
+        }
+        if state.legacy_import_acknowledgements.len() >= MAX_LEGACY_IMPORT_ACKNOWLEDGEMENTS {
+            return Err("browser legacy import storage is full".to_owned());
+        }
+
+        let existing = state.sessions.get(browser_id).cloned();
+        let (status, imported, result_session) = match existing {
+            Some(session)
+                if session.owner_id == *owner_id && session.workspace_id == workspace_id =>
+            {
+                (
+                    LegacyBrowserImportStatus::NativeStateKept,
+                    None,
+                    Some(session),
+                )
+            }
+            Some(_) => (LegacyBrowserImportStatus::Discarded, None, None),
+            None => match legacy.and_then(|legacy| {
+                imported_legacy_session(owner_id, browser_id, workspace_id, legacy)
+            }) {
+                Some(session) => (
+                    LegacyBrowserImportStatus::Imported,
+                    Some(session.clone()),
+                    Some(session),
+                ),
+                None => (LegacyBrowserImportStatus::Discarded, None, None),
+            },
+        };
+
+        if imported.is_some() && state.sessions.len() >= MAX_SESSIONS {
+            return Err("browser session storage is full".to_owned());
+        }
+        let mut next_sessions = state.sessions.clone();
+        if let Some(session) = imported {
+            next_sessions.insert(browser_id.to_owned(), session);
+        }
+        let mut next_acknowledgements = state.legacy_import_acknowledgements.clone();
+        next_acknowledgements.insert(
+            key,
+            StoredLegacyBrowserImportAcknowledgement {
+                owner_id: owner_id.clone(),
+                browser_id: browser_id.to_owned(),
+                workspace_id: workspace_id.to_owned(),
+                acknowledged_at: Utc::now(),
+            },
+        );
+        persist_if_initialized(&state, &next_sessions, &next_acknowledgements)?;
+        state.sessions = next_sessions;
+        state.legacy_import_acknowledgements = next_acknowledgements;
+        Ok(legacy_import_result(
+            status,
+            browser_id,
+            workspace_id,
+            result_session.as_ref(),
+        ))
     }
 
     pub(crate) fn forget(
@@ -193,14 +342,33 @@ impl BrowserSessionStore {
     ) -> Result<(), String> {
         validate_identity(browser_id, workspace_id)?;
         let mut state = self.lock();
-        let Some(existing) = state.sessions.get(browser_id) else {
-            return Ok(());
+        if let Some(existing) = state.sessions.get(browser_id) {
+            ensure_binding(existing, owner_id, workspace_id)?;
+        }
+        let key = LegacyBrowserImportKey {
+            owner_id: owner_id.clone(),
+            browser_id: browser_id.to_owned(),
+            workspace_id: workspace_id.to_owned(),
         };
-        ensure_binding(existing, owner_id, workspace_id)?;
+        if !state.legacy_import_acknowledgements.contains_key(&key)
+            && state.legacy_import_acknowledgements.len() >= MAX_LEGACY_IMPORT_ACKNOWLEDGEMENTS
+        {
+            return Err("browser legacy import storage is full".to_owned());
+        }
         let mut next = state.sessions.clone();
         next.remove(browser_id);
-        persist_if_initialized(&state, &next)?;
+        let mut next_acknowledgements = state.legacy_import_acknowledgements.clone();
+        next_acknowledgements.entry(key).or_insert_with(|| {
+            StoredLegacyBrowserImportAcknowledgement {
+                owner_id: owner_id.clone(),
+                browser_id: browser_id.to_owned(),
+                workspace_id: workspace_id.to_owned(),
+                acknowledged_at: Utc::now(),
+            }
+        });
+        persist_if_initialized(&state, &next, &next_acknowledgements)?;
         state.sessions = next;
+        state.legacy_import_acknowledgements = next_acknowledgements;
         Ok(())
     }
 
@@ -221,6 +389,55 @@ fn ensure_binding(
     } else {
         Ok(())
     }
+}
+
+fn session_for_binding<'a>(
+    sessions: &'a HashMap<String, StoredBrowserSession>,
+    owner_id: &OwnerId,
+    browser_id: &str,
+    workspace_id: &str,
+) -> Option<&'a StoredBrowserSession> {
+    sessions
+        .get(browser_id)
+        .filter(|session| session.owner_id == *owner_id && session.workspace_id == workspace_id)
+}
+
+fn legacy_import_result(
+    status: LegacyBrowserImportStatus,
+    browser_id: &str,
+    workspace_id: &str,
+    session: Option<&StoredBrowserSession>,
+) -> LegacyBrowserImportResult {
+    LegacyBrowserImportResult {
+        status,
+        browser_id: browser_id.to_owned(),
+        workspace_id: workspace_id.to_owned(),
+        url: session.map(|session| session.committed_url.clone()),
+        title: session.and_then(|session| session.title.clone()),
+    }
+}
+
+fn imported_legacy_session(
+    owner_id: &OwnerId,
+    browser_id: &str,
+    workspace_id: &str,
+    legacy: LegacyBrowserSession,
+) -> Option<StoredBrowserSession> {
+    if legacy.version != LEGACY_RENDERER_VERSION
+        || legacy.browser_id != browser_id
+        || legacy.workspace_id != workspace_id
+    {
+        return None;
+    }
+    let committed_url = validated_url(legacy.url.as_deref()?).ok()?;
+    Some(StoredBrowserSession {
+        browser_id: browser_id.to_owned(),
+        owner_id: owner_id.clone(),
+        workspace_id: workspace_id.to_owned(),
+        committed_url,
+        title: clean_title(legacy.title.as_deref()),
+        updated_at: Utc::now(),
+    })
 }
 
 fn validate_identity(browser_id: &str, workspace_id: &str) -> Result<(), String> {
@@ -256,20 +473,37 @@ fn validated_url(value: &str) -> Result<String, String> {
 }
 
 fn clean_title(value: Option<&str>) -> Option<String> {
-    let title: String = value?
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+    let value = value?;
+    if value
         .chars()
-        .take(MAX_TITLE_CHARS)
-        .collect();
+        .any(|character| character.is_control() && !character.is_whitespace())
+    {
+        return None;
+    }
+    let mut title = String::new();
+    let mut title_chars = 0;
+    for word in value.split_whitespace() {
+        if !title.is_empty() && title_chars < MAX_TITLE_CHARS {
+            title.push(' ');
+            title_chars += 1;
+        }
+        for character in word.chars() {
+            if title_chars >= MAX_TITLE_CHARS {
+                return Some(title);
+            }
+            title.push(character);
+            title_chars += 1;
+        }
+    }
     (!title.is_empty()).then_some(title)
 }
 
-fn load_sessions(path: &Path) -> Result<Vec<StoredBrowserSession>, String> {
+fn load_state(path: &Path) -> Result<LoadedBrowserSessionState, String> {
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(LoadedBrowserSessionState::default())
+        }
         Err(_) => return Err("browser session storage is unavailable".to_owned()),
     };
     if !metadata.is_file() || metadata.file_type().is_symlink() {
@@ -283,24 +517,54 @@ fn load_sessions(path: &Path) -> Result<Vec<StoredBrowserSession>, String> {
         }
     }
     if metadata.len() > MAX_FILE_BYTES {
-        return Ok(Vec::new());
+        return Ok(LoadedBrowserSessionState::default());
     }
     let bytes = fs::read(path).map_err(|_| "browser session storage is unavailable".to_owned())?;
-    let Ok(stored) = serde_json::from_slice::<StoredBrowserSessions>(&bytes) else {
-        return Ok(Vec::new());
+    let Ok(header) = serde_json::from_slice::<StoredBrowserSessionsHeader>(&bytes) else {
+        return Ok(LoadedBrowserSessionState::default());
     };
-    if validate_sessions(&stored).is_err() {
-        return Ok(Vec::new());
+    match header.version {
+        PREVIOUS_FILE_VERSION => {
+            let Ok(stored) = serde_json::from_slice::<StoredBrowserSessionsV1>(&bytes) else {
+                return Ok(LoadedBrowserSessionState::default());
+            };
+            if validate_sessions(PREVIOUS_FILE_VERSION, &stored.sessions).is_err() {
+                return Ok(LoadedBrowserSessionState::default());
+            }
+            Ok(LoadedBrowserSessionState {
+                sessions: stored.sessions,
+                legacy_import_acknowledgements: Vec::new(),
+            })
+        }
+        VERSION => {
+            let Ok(stored) = serde_json::from_slice::<StoredBrowserSessionsV2>(&bytes) else {
+                return Ok(LoadedBrowserSessionState::default());
+            };
+            if validate_sessions(VERSION, &stored.sessions).is_err()
+                || validate_acknowledgements(&stored.legacy_import_acknowledgements).is_err()
+            {
+                return Ok(LoadedBrowserSessionState::default());
+            }
+            Ok(LoadedBrowserSessionState {
+                sessions: stored.sessions,
+                legacy_import_acknowledgements: stored.legacy_import_acknowledgements,
+            })
+        }
+        _ => Ok(LoadedBrowserSessionState::default()),
     }
-    Ok(stored.sessions)
 }
 
-fn validate_sessions(stored: &StoredBrowserSessions) -> Result<(), String> {
-    if stored.version != VERSION || stored.sessions.len() > MAX_SESSIONS {
+#[derive(Deserialize)]
+struct StoredBrowserSessionsHeader {
+    version: u8,
+}
+
+fn validate_sessions(version: u8, sessions: &[StoredBrowserSession]) -> Result<(), String> {
+    if !matches!(version, PREVIOUS_FILE_VERSION | VERSION) || sessions.len() > MAX_SESSIONS {
         return Err("browser session storage uses an unsupported shape".to_owned());
     }
     let mut browser_ids = HashSet::new();
-    for session in &stored.sessions {
+    for session in sessions {
         validate_identity(&session.browser_id, &session.workspace_id)?;
         if !browser_ids.insert(session.browser_id.as_str())
             || validated_url(&session.committed_url)? != session.committed_url
@@ -312,18 +576,54 @@ fn validate_sessions(stored: &StoredBrowserSessions) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_acknowledgements(
+    acknowledgements: &[StoredLegacyBrowserImportAcknowledgement],
+) -> Result<(), String> {
+    if acknowledgements.len() > MAX_LEGACY_IMPORT_ACKNOWLEDGEMENTS {
+        return Err("browser legacy import storage is too large".to_owned());
+    }
+    let mut keys = HashSet::new();
+    for acknowledgement in acknowledgements {
+        validate_identity(&acknowledgement.browser_id, &acknowledgement.workspace_id)?;
+        if !keys.insert(acknowledgement_key(acknowledgement)) {
+            return Err("browser legacy import storage is invalid".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn acknowledgement_key(
+    acknowledgement: &StoredLegacyBrowserImportAcknowledgement,
+) -> LegacyBrowserImportKey {
+    LegacyBrowserImportKey {
+        owner_id: acknowledgement.owner_id.clone(),
+        browser_id: acknowledgement.browser_id.clone(),
+        workspace_id: acknowledgement.workspace_id.clone(),
+    }
+}
+
 fn persist_if_initialized(
     state: &BrowserSessionState,
     sessions: &HashMap<String, StoredBrowserSession>,
+    acknowledgements: &HashMap<LegacyBrowserImportKey, StoredLegacyBrowserImportAcknowledgement>,
 ) -> Result<(), String> {
     let (Some(directory), Some(path)) = (&state.directory, &state.path) else {
         return Ok(());
     };
     let mut sessions = sessions.values().cloned().collect::<Vec<_>>();
     sessions.sort_by(|left, right| left.browser_id.cmp(&right.browser_id));
-    let bytes = serde_json::to_vec_pretty(&StoredBrowserSessions {
+    let mut legacy_import_acknowledgements = acknowledgements.values().cloned().collect::<Vec<_>>();
+    legacy_import_acknowledgements.sort_by(|left, right| {
+        left.owner_id
+            .as_str()
+            .cmp(right.owner_id.as_str())
+            .then_with(|| left.browser_id.cmp(&right.browser_id))
+            .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+    });
+    let bytes = serde_json::to_vec_pretty(&StoredBrowserSessionsV2 {
         version: VERSION,
         sessions,
+        legacy_import_acknowledgements,
     })
     .map_err(|_| "browser session storage could not be encoded".to_owned())?;
     if bytes.len() as u64 > MAX_FILE_BYTES {
@@ -405,6 +705,21 @@ fn sync_directory(_directory: &Path) -> io::Result<()> {
 mod tests {
     use super::*;
 
+    fn legacy(
+        browser_id: &str,
+        workspace_id: &str,
+        url: Option<&str>,
+        title: Option<&str>,
+    ) -> LegacyBrowserSession {
+        LegacyBrowserSession {
+            version: LEGACY_RENDERER_VERSION,
+            browser_id: browser_id.to_owned(),
+            workspace_id: workspace_id.to_owned(),
+            url: url.map(str::to_owned),
+            title: title.map(str::to_owned),
+        }
+    }
+
     fn write_private(path: &Path, bytes: &[u8]) {
         fs::write(path, bytes).unwrap();
         #[cfg(unix)]
@@ -464,6 +779,249 @@ mod tests {
             .recover(&owner, "browser-1", "workspace-1")
             .unwrap()
             .is_some());
+    }
+
+    #[test]
+    fn legacy_session_imports_once_and_reopens_from_native_state() {
+        let private = tempfile::tempdir().unwrap();
+        let owner = OwnerId::local();
+        let store = BrowserSessionStore::default();
+        store.initialize(private.path()).unwrap();
+
+        let imported = store
+            .import_legacy(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                Some(legacy(
+                    "browser-1",
+                    "workspace-1",
+                    Some("https://example.com/docs"),
+                    Some("  Legacy   docs  "),
+                )),
+            )
+            .unwrap();
+        assert_eq!(imported.status, LegacyBrowserImportStatus::Imported);
+        assert_eq!(imported.url.as_deref(), Some("https://example.com/docs"));
+        assert_eq!(imported.title.as_deref(), Some("Legacy docs"));
+
+        let reopened = BrowserSessionStore::default();
+        reopened.initialize(private.path()).unwrap();
+        let repeated = reopened
+            .import_legacy(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                Some(legacy(
+                    "browser-1",
+                    "workspace-1",
+                    Some("https://attacker.example/overwrite"),
+                    Some("Overwrite"),
+                )),
+            )
+            .unwrap();
+        assert_eq!(repeated.status, LegacyBrowserImportStatus::AlreadyHandled);
+        assert_eq!(
+            reopened
+                .recover(&owner, "browser-1", "workspace-1")
+                .unwrap()
+                .unwrap()
+                .url,
+            "https://example.com/docs"
+        );
+    }
+
+    #[test]
+    fn native_state_wins_and_cross_workspace_legacy_state_is_discarded() {
+        let owner = OwnerId::local();
+        let store = BrowserSessionStore::default();
+        store
+            .commit(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                "https://native.example/",
+                Some("Native page"),
+            )
+            .unwrap();
+
+        let kept = store
+            .import_legacy(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                Some(legacy(
+                    "browser-1",
+                    "workspace-1",
+                    Some("https://legacy.example/"),
+                    Some("Legacy page"),
+                )),
+            )
+            .unwrap();
+        assert_eq!(kept.status, LegacyBrowserImportStatus::NativeStateKept);
+        assert_eq!(kept.url.as_deref(), Some("https://native.example/"));
+
+        let discarded = store
+            .import_legacy(
+                &owner,
+                "browser-1",
+                "workspace-2",
+                Some(legacy(
+                    "browser-1",
+                    "workspace-2",
+                    Some("https://stale.example/"),
+                    Some("Stale page"),
+                )),
+            )
+            .unwrap();
+        assert_eq!(discarded.status, LegacyBrowserImportStatus::Discarded);
+        assert!(discarded.url.is_none());
+        assert_eq!(
+            store
+                .import_legacy(
+                    &owner,
+                    "browser-1",
+                    "workspace-2",
+                    Some(legacy(
+                        "browser-1",
+                        "workspace-2",
+                        Some("https://retry.example/"),
+                        None,
+                    )),
+                )
+                .unwrap()
+                .status,
+            LegacyBrowserImportStatus::AlreadyHandled
+        );
+        assert_eq!(
+            store
+                .recover(&owner, "browser-1", "workspace-1")
+                .unwrap()
+                .unwrap()
+                .url,
+            "https://native.example/"
+        );
+    }
+
+    #[test]
+    fn malformed_legacy_state_is_acknowledged_without_creating_a_session() {
+        let owner = OwnerId::local();
+        let store = BrowserSessionStore::default();
+
+        let discarded = store
+            .import_legacy(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                Some(legacy(
+                    "browser-1",
+                    "another-workspace",
+                    Some("javascript:alert(1)"),
+                    Some("Bad\0title"),
+                )),
+            )
+            .unwrap();
+        assert_eq!(discarded.status, LegacyBrowserImportStatus::Discarded);
+        assert!(store
+            .recover(&owner, "browser-1", "workspace-1")
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            store
+                .import_legacy(&owner, "browser-1", "workspace-1", None)
+                .unwrap()
+                .status,
+            LegacyBrowserImportStatus::AlreadyHandled
+        );
+    }
+
+    #[test]
+    fn explicit_close_acknowledges_migration_and_prevents_resurrection() {
+        let private = tempfile::tempdir().unwrap();
+        let owner = OwnerId::local();
+        let store = BrowserSessionStore::default();
+        store.initialize(private.path()).unwrap();
+        store
+            .commit(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                "https://example.com/closed",
+                None,
+            )
+            .unwrap();
+        store.forget(&owner, "browser-1", "workspace-1").unwrap();
+
+        let reopened = BrowserSessionStore::default();
+        reopened.initialize(private.path()).unwrap();
+        let repeated = reopened
+            .import_legacy(
+                &owner,
+                "browser-1",
+                "workspace-1",
+                Some(legacy(
+                    "browser-1",
+                    "workspace-1",
+                    Some("https://example.com/closed"),
+                    None,
+                )),
+            )
+            .unwrap();
+        assert_eq!(repeated.status, LegacyBrowserImportStatus::AlreadyHandled);
+        assert!(repeated.url.is_none());
+        assert!(reopened
+            .recover(&owner, "browser-1", "workspace-1")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn version_one_state_loads_and_upgrades_on_the_next_write() {
+        let private = tempfile::tempdir().unwrap();
+        let path = private.path().join(FILE_NAME);
+        let owner = OwnerId::local();
+        let bytes = serde_json::to_vec_pretty(&StoredBrowserSessionsV1 {
+            version: PREVIOUS_FILE_VERSION,
+            sessions: vec![StoredBrowserSession {
+                browser_id: "browser-1".to_owned(),
+                owner_id: owner.clone(),
+                workspace_id: "workspace-1".to_owned(),
+                committed_url: "https://example.com/legacy-native".to_owned(),
+                title: Some("Legacy native".to_owned()),
+                updated_at: Utc::now(),
+            }],
+        })
+        .unwrap();
+        write_private(&path, &bytes);
+
+        let store = BrowserSessionStore::default();
+        store.initialize(private.path()).unwrap();
+        assert_eq!(
+            store
+                .recover(&owner, "browser-1", "workspace-1")
+                .unwrap()
+                .unwrap()
+                .title
+                .as_deref(),
+            Some("Legacy native")
+        );
+        assert_eq!(
+            store
+                .import_legacy(&owner, "browser-2", "workspace-1", None)
+                .unwrap()
+                .status,
+            LegacyBrowserImportStatus::Discarded
+        );
+
+        let stored: serde_json::Value = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(stored["version"], VERSION);
+        assert_eq!(
+            stored["legacy_import_acknowledgements"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -27,6 +27,9 @@ use crate::browser_control::{
 #[cfg(any(target_os = "macos", test))]
 use crate::browser_profile::normalize_website_host;
 use crate::browser_profile::{BrowserProfileStore, ManagedBrowserProfile};
+use crate::browser_recovery::{
+    LegacyBrowserImportResult, LegacyBrowserSession, RecoveredBrowserSession,
+};
 use crate::browser_semantics::{
     browser_inject_inspect_overlay, browser_install_same_document_navigation_observer,
     browser_read_same_document_navigation_observer, browser_remove_inspect_overlay,
@@ -53,6 +56,24 @@ pub(crate) struct CodeBrowserCommandRequest {
     workspace_id: String,
     browser_id: String,
     action: CodeBrowserAction,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CodeBrowserLegacyStateRequest {
+    workspace_id: String,
+    browser_id: String,
+    legacy_state: Option<CodeBrowserLegacyState>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CodeBrowserLegacyState {
+    version: u8,
+    id: String,
+    workspace_id: String,
+    url: Option<String>,
+    title: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -139,6 +160,28 @@ struct CodeBrowserProfileResetEvent {
 }
 
 #[tauri::command]
+pub(crate) fn code_browser_import_legacy_state(
+    registry: tauri::State<'_, BrowserRegistry>,
+    request: CodeBrowserLegacyStateRequest,
+) -> Result<LegacyBrowserImportResult, String> {
+    validated_workspace_id(&request.workspace_id)?;
+    browser_label(&request.browser_id)?;
+    let legacy = request.legacy_state.map(|state| LegacyBrowserSession {
+        version: state.version,
+        browser_id: state.id,
+        workspace_id: state.workspace_id,
+        url: state.url,
+        title: state.title,
+    });
+    registry.import_legacy_session(
+        &OwnerId::local(),
+        &request.browser_id,
+        &request.workspace_id,
+        legacy,
+    )
+}
+
+#[tauri::command]
 pub(crate) async fn code_browser_command(
     app: AppHandle,
     registry: tauri::State<'_, BrowserRegistry>,
@@ -213,9 +256,15 @@ pub(crate) async fn code_browser_command(
             Some(_) => registry.snapshot(&request.browser_id, &request.workspace_id),
             None => {
                 registry.remove(&request.browser_id, &request.workspace_id)?;
-                Ok(BrowserSnapshot::missing(
+                let recovered = registry.recover_session(
+                    &OwnerId::local(),
                     &request.browser_id,
                     &request.workspace_id,
+                )?;
+                Ok(missing_browser_snapshot(
+                    &request.browser_id,
+                    &request.workspace_id,
+                    recovered,
                 ))
             }
         },
@@ -447,6 +496,19 @@ pub(crate) async fn navigate_browser_for_agent(
             },
         )
         .await
+}
+
+fn missing_browser_snapshot(
+    browser_id: &str,
+    workspace_id: &str,
+    recovered: Option<RecoveredBrowserSession>,
+) -> BrowserSnapshot {
+    let mut snapshot = BrowserSnapshot::missing(browser_id, workspace_id);
+    if let Some(recovered) = recovered {
+        snapshot.url = Some(recovered.url);
+        snapshot.title = recovered.title;
+    }
+    snapshot
 }
 
 #[allow(
@@ -1489,6 +1551,29 @@ mod tests {
         assert!(validated_workspace_id("").is_err());
         assert!(validated_workspace_id("workspace\nother").is_err());
         assert!(validated_workspace_id(&"w".repeat(MAX_WORKSPACE_ID_CHARS + 1)).is_err());
+    }
+
+    #[test]
+    fn missing_webview_snapshot_projects_only_durable_navigation_metadata() {
+        let snapshot = missing_browser_snapshot(
+            "browser-1",
+            "workspace-1",
+            Some(RecoveredBrowserSession {
+                url: "https://example.com/restored".to_owned(),
+                title: Some("Restored page".to_owned()),
+            }),
+        );
+
+        assert!(!snapshot.exists);
+        assert_eq!(
+            snapshot.url.as_deref(),
+            Some("https://example.com/restored")
+        );
+        assert_eq!(snapshot.title.as_deref(), Some("Restored page"));
+        assert!(snapshot.profile_id.is_none());
+        assert!(snapshot.document_epoch.is_none());
+        assert!(snapshot.controller.is_none());
+        assert!(snapshot.agent_access.is_none());
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -855,6 +855,7 @@ pub fn run() {
             request_user_attention,
             is_window_focused,
             present_native_notification,
+            code_browser::code_browser_import_legacy_state,
             code_browser::code_browser_command,
             code_worktree::open_code_worktree,
             code_editor::open_in_editor,

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -45,6 +45,7 @@ import { hasLocalHostAuthority, hasNativeHost } from "./host";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePortalOverlayOpen } from "@/lib/usePortalOverlayOpen";
 import { foregroundBrowserScope } from "./code/browser/foregroundBrowserScope";
+import { seedBrowserSession } from "./code/browser/browserPersistence";
 import { MarkdownLinkProvider } from "./MessageMarkdown";
 
 import { friendlyErrorMessage } from "./lib/utils";
@@ -703,6 +704,11 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       }
     }
     const browserId = crypto.randomUUID();
+    seedBrowserSession({
+      browserId,
+      workspaceId: foregroundBrowserScope(chatId),
+      initialUrl: url,
+    });
     if (url) {
       setBrowserInitialUrls((current) => ({
         ...current,

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -45,7 +45,6 @@ import { hasLocalHostAuthority, hasNativeHost } from "./host";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePortalOverlayOpen } from "@/lib/usePortalOverlayOpen";
 import { foregroundBrowserScope } from "./code/browser/foregroundBrowserScope";
-import { seedBrowserSession } from "./code/browser/browserPersistence";
 import { MarkdownLinkProvider } from "./MessageMarkdown";
 
 import { friendlyErrorMessage } from "./lib/utils";
@@ -188,6 +187,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const [browserTitles, setBrowserTitles] = useState<Record<string, string>>(
     {},
   );
+  const [browserInitialUrls, setBrowserInitialUrls] = useState<
+    Record<string, string>
+  >({});
 
   // A chat id that is not in the list — deleted in another window, or a stale
   // deep link — should land somewhere real rather than on an empty frame. The
@@ -701,14 +703,15 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       }
     }
     const browserId = crypto.randomUUID();
-    const session = seedBrowserSession({
-      browserId,
-      workspaceId: foregroundBrowserScope(chatId),
-      initialUrl: url,
-    });
+    if (url) {
+      setBrowserInitialUrls((current) => ({
+        ...current,
+        [browserId]: url,
+      }));
+    }
     setBrowserTitles((current) => ({
       ...current,
-      [browserId]: session.title || "Browser",
+      [browserId]: "Browser",
     }));
     openPanel({ type: "browser", browserId });
   }
@@ -1029,6 +1032,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             <CodeBrowserTab
               workspaceId={foregroundBrowserScope(chatId)}
               browserId={panel.browserId}
+              initialUrl={browserInitialUrls[panel.browserId]}
               obscured={overlayOpen}
               onTitleChange={(title) =>
                 setBrowserTitles((current) =>

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -48,10 +48,29 @@ import { LEGACY_BROWSER_STORAGE_KEY } from "./browser/browserPersistence";
 const browserMocks = vi.hoisted(() => ({
   close: vi.fn(async () => undefined),
 }));
+const persistMocks = vi.hoisted(() => ({
+  seed: vi.fn(),
+}));
 
 vi.mock("./browser/browserHost", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./browser/browserHost")>();
   return { ...actual, closeCodeBrowser: browserMocks.close };
+});
+
+vi.mock("./browser/browserPersistence", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./browser/browserPersistence")>();
+  return {
+    ...actual,
+    seedBrowserSession: (args: {
+      browserId: string;
+      workspaceId: string;
+      initialUrl?: string;
+    }) => {
+      persistMocks.seed(args);
+      return actual.seedBrowserSession(args);
+    },
+  };
 });
 
 vi.mock("./browser/CodeBrowserTab", () => ({
@@ -701,6 +720,7 @@ afterEach(() => {
   });
   resetWorkflowPromptStore();
   browserMocks.close.mockClear();
+  persistMocks.seed.mockClear();
   window.localStorage.clear();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
@@ -2750,6 +2770,11 @@ describe("CodeWorkspacePage", () => {
     expect(
       await screen.findByTestId("browser-panel-browser-1"),
     ).toBeInTheDocument();
+    expect(persistMocks.seed).toHaveBeenCalledWith({
+      browserId: "browser-1",
+      workspaceId: "ws-1",
+      initialUrl: undefined,
+    });
     expect(window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY)).toBeNull();
     await waitFor(() =>
       expect(router.state.location.search).toMatchObject({

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -43,11 +43,7 @@ import {
   forkTranscriptFile,
   messageWithWorkspaceFiles,
 } from "./fork";
-import {
-  readStoredBrowserSession,
-  seedBrowserSession,
-  writeStoredBrowserSession,
-} from "./browser/browserPersistence";
+import { LEGACY_BROWSER_STORAGE_KEY } from "./browser/browserPersistence";
 
 const browserMocks = vi.hoisted(() => ({
   close: vi.fn(async () => undefined),
@@ -61,16 +57,19 @@ vi.mock("./browser/browserHost", async (importOriginal) => {
 vi.mock("./browser/CodeBrowserTab", () => ({
   CodeBrowserTab: ({
     browserId,
+    initialUrl,
     obscured,
     onTitleChange,
   }: {
     browserId: string;
+    initialUrl?: string;
     obscured?: boolean;
     onTitleChange?: (title: string) => void;
   }) => (
     <button
       type="button"
       data-testid={`browser-panel-${browserId}`}
+      data-initial-url={initialUrl ?? ""}
       data-obscured={String(Boolean(obscured))}
       onClick={() => onTitleChange?.("Tidebreak docs")}
     >
@@ -2751,7 +2750,7 @@ describe("CodeWorkspacePage", () => {
     expect(
       await screen.findByTestId("browser-panel-browser-1"),
     ).toBeInTheDocument();
-    expect(readStoredBrowserSession("browser-1")?.workspaceId).toBe("ws-1");
+    expect(window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY)).toBeNull();
     await waitFor(() =>
       expect(router.state.location.search).toMatchObject({
         tabs: "browser.browser-1",
@@ -2764,28 +2763,32 @@ describe("CodeWorkspacePage", () => {
     ).toBeInTheDocument();
   });
 
-  it("restores a persisted browser title without polling storage", async () => {
+  it("starts a restored browser tab from native state instead of legacy storage", async () => {
     const client = makeClient();
-    const session = seedBrowserSession({
-      browserId: "browser-restored",
-      workspaceId: "ws-1",
-      initialUrl: "https://docs.tidebreak.dev",
-    });
-    writeStoredBrowserSession({ ...session, title: "Tidebreak handbook" });
+    window.localStorage.setItem(
+      LEGACY_BROWSER_STORAGE_KEY,
+      JSON.stringify({
+        "browser-restored": {
+          version: 1,
+          id: "browser-restored",
+          workspaceId: "ws-1",
+          url: "https://docs.tidebreak.dev",
+          title: "Tidebreak handbook",
+          updatedAt: 17,
+        },
+      }),
+    );
 
     await mountWorkspace(client, "/code/w/ws-1?tabs=browser.browser-restored");
 
-    expect(
-      await screen.findByRole("tab", { name: "Tidebreak handbook" }),
-    ).toHaveAttribute("aria-selected", "true");
+    expect(await screen.findByRole("tab", { name: "Browser" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   it("hides the native browser behind dialogs and portaled menus", async () => {
     const client = makeClient();
-    seedBrowserSession({
-      browserId: "browser-1",
-      workspaceId: "ws-1",
-    });
     const user = userEvent.setup();
     await mountWorkspace(client, "/code/w/ws-1?tabs=browser.browser-1");
 
@@ -2806,7 +2809,6 @@ describe("CodeWorkspacePage", () => {
 
   it("closes a native browser only when its editor tab is removed", async () => {
     const client = makeClient();
-    seedBrowserSession({ browserId: "browser-1", workspaceId: "ws-1" });
     const user = userEvent.setup();
     await mountWorkspace(
       client,
@@ -2829,7 +2831,6 @@ describe("CodeWorkspacePage", () => {
 
   it("closes surviving native browser sessions when the workspace tears down", async () => {
     const client = makeClient();
-    seedBrowserSession({ browserId: "browser-1", workspaceId: "ws-1" });
     const mounted = await mountWorkspace(
       client,
       "/code/w/ws-1?tabs=browser.browser-1",

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -112,6 +112,7 @@ import {
 } from "./CodeCenterTabs";
 import { DiffPanel } from "./DiffPanel";
 import { closeCodeBrowser } from "./browser/browserHost";
+import { seedBrowserSession } from "./browser/browserPersistence";
 
 const FileViewer = lazy(async () => {
   const module = await import("./FileViewer");
@@ -830,6 +831,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
 
   function openBrowser(url?: string, preferredRegion?: CodeEditorRegion) {
     const browserId = crypto.randomUUID();
+    seedBrowserSession({
+      browserId,
+      workspaceId,
+      initialUrl: url,
+    });
     if (url) {
       setBrowserInitialUrls((current) => ({
         ...current,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -112,10 +112,6 @@ import {
 } from "./CodeCenterTabs";
 import { DiffPanel } from "./DiffPanel";
 import { closeCodeBrowser } from "./browser/browserHost";
-import {
-  seedBrowserSession,
-  storedBrowserTitle,
-} from "./browser/browserPersistence";
 
 const FileViewer = lazy(async () => {
   const module = await import("./FileViewer");
@@ -447,8 +443,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     revision: number;
   } | null>(null);
   const [browserTitles, setBrowserTitles] = useState<Record<string, string>>(
-    () => storedBrowserTitles(layout),
+    () => browserTitlesForLayout(layout),
   );
+  const [browserInitialUrls, setBrowserInitialUrls] = useState<
+    Record<string, string>
+  >({});
   const [terminalLabels, setTerminalLabels] = useState<Record<string, string>>(
     () => nameTerminals({}, codeTerminalIds(layout)),
   );
@@ -548,7 +547,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       let changed = false;
       const next: Record<string, string> = {};
       for (const browserId of ids) {
-        const title = current[browserId] ?? storedBrowserTitle(browserId);
+        const title = current[browserId] ?? "Browser";
         next[browserId] = title;
         if (current[browserId] !== title) changed = true;
       }
@@ -831,14 +830,15 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
 
   function openBrowser(url?: string, preferredRegion?: CodeEditorRegion) {
     const browserId = crypto.randomUUID();
-    const browser = seedBrowserSession({
-      browserId,
-      workspaceId,
-      initialUrl: url,
-    });
+    if (url) {
+      setBrowserInitialUrls((current) => ({
+        ...current,
+        [browserId]: url,
+      }));
+    }
     setBrowserTitles((current) => ({
       ...current,
-      [browserId]: browser.title || "Browser",
+      [browserId]: "Browser",
     }));
     setWorkspaceLayout(
       openCodeEditor(layout, { type: "browser", browserId }, preferredRegion),
@@ -1201,6 +1201,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             <CodeBrowserTab
               workspaceId={workspaceId}
               browserId={panel.browserId}
+              initialUrl={browserInitialUrls[panel.browserId]}
               obscured={workspaceOverlayOpen}
               onTitleChange={(title) =>
                 setBrowserTitles((current) =>
@@ -1856,12 +1857,9 @@ function useCodeShortcutHints(): { terminal: string; review: string } {
   }, []);
 }
 
-function storedBrowserTitles(layout: LayoutState): Record<string, string> {
+function browserTitlesForLayout(layout: LayoutState): Record<string, string> {
   return Object.fromEntries(
-    codeBrowserIds(layout).map((browserId) => [
-      browserId,
-      storedBrowserTitle(browserId),
-    ]),
+    codeBrowserIds(layout).map((browserId) => [browserId, "Browser"]),
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -19,8 +19,10 @@ import type {
   BrowserHostSnapshot,
   CodeBrowserHost,
 } from "./browserHost";
+import { browserUnavailableMessage } from "./browserHost";
 import {
   LEGACY_BROWSER_STORAGE_KEY,
+  seedBrowserSession,
   type LegacyBrowserState,
 } from "./browserPersistence";
 import { CodeBrowserTab } from "./CodeBrowserTab";
@@ -82,6 +84,7 @@ function agentAccess(
 }
 
 function browserHost(options?: {
+  available?: boolean;
   createGate?: Promise<void>;
   createGates?: Array<Promise<void> | undefined>;
   createError?: string;
@@ -108,7 +111,7 @@ function browserHost(options?: {
   let handler: ((event: BrowserHostEvent) => void) | null = null;
   const openExternal = vi.fn().mockResolvedValue(undefined);
   const host: CodeBrowserHost = {
-    available: () => true,
+    available: () => options?.available ?? true,
     importLegacyState: vi.fn(
       async (
         workspaceId,
@@ -841,6 +844,113 @@ describe("CodeBrowserTab", () => {
         action: expect.objectContaining({ url: "https://example.com/one" }),
       }),
     );
+  });
+
+  it("creates from a seeded URL when the panel remounts without initialUrl", async () => {
+    seedBrowserSession({
+      browserId: "browser-1",
+      workspaceId: "workspace-1",
+      initialUrl: "https://docs.example/path",
+    });
+    const runtime = browserHost({
+      runtime: { url: "https://docs.example/path" },
+      legacyImportResult: {
+        status: "imported",
+        url: "https://docs.example/path",
+      },
+    });
+
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() => expect(runtime.imports).toHaveLength(1));
+    expect(runtime.imports[0]?.legacyState?.url).toBe(
+      "https://docs.example/path",
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: expect.objectContaining({
+          type: "create",
+          url: "https://docs.example/path",
+        }),
+      }),
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Address or search" }),
+    ).toHaveValue("docs.example/path");
+  });
+
+  it("migrates leftover state and names why the browser cannot run here", async () => {
+    storeLegacySession("browser-1", {
+      url: "https://legacy.example/docs",
+      title: "Docs",
+    });
+    const runtime = browserHost({
+      available: false,
+      legacyImportResult: {
+        status: "imported",
+        url: "https://legacy.example/docs",
+        title: "Docs",
+      },
+    });
+
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        host={runtime.host}
+      />,
+    );
+
+    await waitFor(() => expect(runtime.imports).toHaveLength(1));
+    expect(runtime.imports[0]).toEqual({
+      workspaceId: "workspace-1",
+      browserId: "browser-1",
+      legacyState: {
+        version: 1,
+        id: "browser-1",
+        workspaceId: "workspace-1",
+        url: "https://legacy.example/docs",
+        title: "Docs",
+      },
+    });
+    expect(runtime.calls).toEqual([]);
+    expect(
+      await screen.findByText(browserUnavailableMessage()),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Bring the live work into the workspace"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "Address or search" }),
+    ).toHaveValue("legacy.example/docs");
+  });
+
+  it("explains the missing host even when no leftover URL exists", async () => {
+    const runtime = browserHost({ available: false });
+
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        host={runtime.host}
+      />,
+    );
+
+    expect(
+      await screen.findByText(browserUnavailableMessage()),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Bring the live work into the workspace"),
+    ).not.toBeInTheDocument();
+    expect(runtime.imports).toEqual([]);
+    expect(runtime.calls).toEqual([]);
   });
 
   it("never writes browser session state after native acknowledgement", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -15,20 +15,26 @@ import type {
   BrowserAgentAccess,
   BrowserHostAction,
   BrowserHostEvent,
+  BrowserLegacyImportResult,
   BrowserHostSnapshot,
   CodeBrowserHost,
 } from "./browserHost";
 import {
-  readStoredBrowserSession,
-  writeStoredBrowserSession,
+  LEGACY_BROWSER_STORAGE_KEY,
+  type LegacyBrowserState,
 } from "./browserPersistence";
-import { beginBrowserNavigation, createBrowserSession } from "./browserSession";
 import { CodeBrowserTab } from "./CodeBrowserTab";
 
 type CommandCall = {
   workspaceId: string;
   browserId: string;
   action: BrowserHostAction;
+};
+
+type LegacyImportCall = {
+  workspaceId: string;
+  browserId: string;
+  legacyState: LegacyBrowserState | null;
 };
 
 function resetIdFrom(calls: CommandCall[]): number {
@@ -86,19 +92,41 @@ function browserHost(options?: {
   runtime?: Partial<BrowserHostSnapshot>;
   resetGate?: Promise<void>;
   resetError?: string;
+  legacyImportError?: string;
+  legacyImportResult?: Partial<BrowserLegacyImportResult>;
 }): {
   host: CodeBrowserHost;
   calls: CommandCall[];
+  imports: LegacyImportCall[];
   emit: (event: BrowserHostEvent) => void;
   openExternal: ReturnType<typeof vi.fn>;
 } {
   const calls: CommandCall[] = [];
+  const imports: LegacyImportCall[] = [];
   let createAttempt = 0;
   let inspectEnabled = options?.runtime?.inspectEnabled ?? false;
   let handler: ((event: BrowserHostEvent) => void) | null = null;
   const openExternal = vi.fn().mockResolvedValue(undefined);
   const host: CodeBrowserHost = {
     available: () => true,
+    importLegacyState: vi.fn(
+      async (
+        workspaceId,
+        browserId,
+        legacyState,
+      ): Promise<BrowserLegacyImportResult> => {
+        imports.push({ workspaceId, browserId, legacyState });
+        if (options?.legacyImportError) {
+          throw new Error(options.legacyImportError);
+        }
+        return {
+          status: "already_handled",
+          browserId,
+          workspaceId,
+          ...options?.legacyImportResult,
+        };
+      },
+    ),
     subscribe: vi.fn(async (next) => {
       handler = next;
       return () => {
@@ -124,7 +152,12 @@ function browserHost(options?: {
                 title: "Restored page",
                 loadState: "ready" as const,
               }
-            : { exists: false, workspaceId, browserId };
+            : {
+                exists: false,
+                ...options?.runtime,
+                workspaceId,
+                browserId,
+              };
         }
         const actionError = options?.actionErrors?.[action.type];
         if (actionError) throw new Error(actionError);
@@ -158,9 +191,35 @@ function browserHost(options?: {
   return {
     host,
     calls,
+    imports,
     emit: (event) => handler?.(event),
     openExternal,
   };
+}
+
+function storeLegacySession(
+  browserId: string,
+  update: Record<string, unknown> = {},
+): void {
+  window.localStorage.setItem(
+    LEGACY_BROWSER_STORAGE_KEY,
+    JSON.stringify({
+      [browserId]: {
+        version: 1,
+        id: browserId,
+        workspaceId: "workspace-1",
+        url: "https://example.com/two",
+        title: "Legacy page",
+        history: [
+          { url: "https://example.com/one" },
+          { url: "https://example.com/two" },
+        ],
+        historyIndex: 1,
+        updatedAt: 17,
+        ...update,
+      },
+    }),
+  );
 }
 
 let mockedClientWidth = 1024;
@@ -255,7 +314,7 @@ describe("CodeBrowserTab", () => {
     );
   });
 
-  it("updates the toolbar and persisted session for same-document navigation", async () => {
+  it("updates the toolbar without recreating renderer browser authority", async () => {
     const runtime = browserHost();
     render(
       <CodeBrowserTab
@@ -292,9 +351,9 @@ describe("CodeBrowserTab", () => {
       expect(
         screen.getByRole("textbox", { name: "Address or search" }),
       ).toHaveValue(url.replace("https://", ""));
-      await waitFor(() =>
-        expect(readStoredBrowserSession("browser-1")?.url).toBe(url),
-      );
+      expect(
+        window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY),
+      ).toBeNull();
     }
   });
 
@@ -726,16 +785,22 @@ describe("CodeBrowserTab", () => {
     ).toHaveValue("example.com/two");
   });
 
-  it("uses persisted history after recreating a missing native webview", async () => {
-    const runtime = browserHost();
-    const first = createBrowserSession({
-      id: "browser-1",
-      workspaceId: "workspace-1",
-      initialUrl: "https://example.com/one",
+  it("migrates legacy metadata once, keeps native state, and discards renderer history", async () => {
+    storeLegacySession("browser-1", {
+      url: "https://legacy.example/two",
+      title: "Legacy title",
     });
-    writeStoredBrowserSession(
-      beginBrowserNavigation(first, "https://example.com/two"),
-    );
+    const runtime = browserHost({
+      runtime: {
+        url: "https://native.example/restored",
+        title: "Native title",
+      },
+      legacyImportResult: {
+        status: "native_state_kept",
+        url: "https://native.example/restored",
+        title: "Native title",
+      },
+    });
 
     render(
       <CodeBrowserTab
@@ -744,31 +809,73 @@ describe("CodeBrowserTab", () => {
         host={runtime.host}
       />,
     );
+    await waitFor(() => expect(runtime.imports).toHaveLength(1));
+    expect(runtime.imports[0]).toEqual({
+      workspaceId: "workspace-1",
+      browserId: "browser-1",
+      legacyState: {
+        version: 1,
+        id: "browser-1",
+        workspaceId: "workspace-1",
+        url: "https://legacy.example/two",
+        title: "Legacy title",
+      },
+    });
+    expect(window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY)).toBeNull();
     await waitFor(() =>
       expect(runtime.calls).toContainEqual({
         workspaceId: "workspace-1",
         browserId: "browser-1",
         action: expect.objectContaining({
           type: "create",
-          url: "https://example.com/two",
+          url: "https://native.example/restored",
         }),
       }),
     );
-
-    await userEvent.click(screen.getByRole("button", { name: "Back" }));
-
-    await waitFor(() =>
-      expect(runtime.calls).toContainEqual({
-        workspaceId: "workspace-1",
-        browserId: "browser-1",
-        action: { type: "navigate", url: "https://example.com/one" },
+    expect(
+      screen.getByRole("textbox", { name: "Address or search" }),
+    ).toHaveValue("native.example/restored");
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    expect(runtime.calls).not.toContainEqual(
+      expect.objectContaining({
+        action: expect.objectContaining({ url: "https://example.com/one" }),
       }),
     );
-    expect(runtime.calls).not.toContainEqual({
-      workspaceId: "workspace-1",
-      browserId: "browser-1",
-      action: { type: "back" },
+  });
+
+  it("never writes browser session state after native acknowledgement", async () => {
+    storeLegacySession("browser-1");
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    const runtime = browserHost({
+      runtime: { url: "https://example.com/two" },
+      legacyImportResult: { status: "imported" },
     });
+    const view = render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        host={runtime.host}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY),
+      ).toBeNull(),
+    );
+    act(() => {
+      runtime.emit({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        type: "navigation_finished",
+        url: "https://example.com/three",
+      });
+    });
+    view.unmount();
+
+    expect(
+      setItem.mock.calls.filter(([key]) => key === LEGACY_BROWSER_STORAGE_KEY),
+    ).toEqual([]);
   });
 
   it("ignores a late title event from the page navigated away from", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -40,6 +40,7 @@ import {
 import {
   clearLegacyBrowserSession,
   readLegacyBrowserSession,
+  type LegacyBrowserStateRead,
 } from "./browserPersistence";
 import {
   type BrowserViewport,
@@ -109,6 +110,22 @@ export function CodeBrowserTab(props: CodeBrowserTabProps) {
       {...props}
     />
   );
+}
+
+function hydrateSessionFromLegacy(
+  session: BrowserSession,
+  legacy: LegacyBrowserStateRead | null,
+): BrowserSession {
+  if (legacy?.kind !== "valid") return session;
+  if (legacy.state.workspaceId !== session.workspaceId) return session;
+  let next = session;
+  if (!next.url && legacy.state.url) {
+    next = finishBrowserNavigation(next, legacy.state.url);
+  }
+  if (legacy.state.title) {
+    next = setBrowserTitle(next, legacy.state.title);
+  }
+  return next;
 }
 
 function CodeBrowserTabSession({
@@ -574,12 +591,40 @@ function CodeBrowserTabSession({
     let unsubscribe: (() => void) | undefined;
 
     async function boot() {
-      const current = sessionRef.current;
-      if (!host.available()) {
-        if (current.url) {
-          updateSession((value) =>
-            failBrowserSession(value, browserUnavailableMessage()),
+      async function importLegacy() {
+        if (!legacyState) return;
+        const imported = await host.importLegacyState(
+          workspaceId,
+          browserId,
+          legacyState.state,
+        );
+        if (
+          imported.browserId !== browserId ||
+          imported.workspaceId !== workspaceId
+        ) {
+          throw new Error(
+            "The browser host acknowledged another workspace's session",
           );
+        }
+        clearLegacyBrowserSession(browserId);
+      }
+
+      if (!host.available()) {
+        try {
+          await importLegacy();
+        } catch {
+          // Leftover renderer state stays until a host can acknowledge it.
+        }
+        if (!cancelled) {
+          updateSession((value) =>
+            failBrowserSession(
+              hydrateSessionFromLegacy(value, legacyState),
+              browserUnavailableMessage(),
+            ),
+          );
+          if (sessionRef.current.url) {
+            setAddress(browserDisplayAddress(sessionRef.current.url));
+          }
         }
         return;
       }
@@ -616,26 +661,10 @@ function CodeBrowserTabSession({
       const snapshotGeneration = nativeSurfaceGeneration.current;
       let legacyImportError: unknown = null;
       try {
-        if (legacyState) {
-          try {
-            const imported = await host.importLegacyState(
-              workspaceId,
-              browserId,
-              legacyState.state,
-            );
-            if (cancelled) return;
-            if (
-              imported.browserId !== browserId ||
-              imported.workspaceId !== workspaceId
-            ) {
-              throw new Error(
-                "The browser host acknowledged another workspace's session",
-              );
-            }
-            clearLegacyBrowserSession(browserId);
-          } catch (error) {
-            legacyImportError = error;
-          }
+        try {
+          await importLegacy();
+        } catch (error) {
+          legacyImportError = error;
         }
 
         const snapshot = await host.command(workspaceId, browserId, {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -38,9 +38,8 @@ import {
   validateBrowserUrl,
 } from "./browserNavigation";
 import {
-  readStoredBrowserSession,
-  restoreOrCreateBrowserSession,
-  writeStoredBrowserSession,
+  clearLegacyBrowserSession,
+  readLegacyBrowserSession,
 } from "./browserPersistence";
 import {
   type BrowserViewport,
@@ -52,6 +51,7 @@ import {
   beginBrowserNavigation,
   canBrowserGoBack,
   canBrowserGoForward,
+  createBrowserSession,
   failBrowserSession,
   finishBrowserNavigation,
   moveBrowserHistory,
@@ -62,7 +62,6 @@ import {
 } from "./browserSession";
 
 const SLOW_LOAD_MS = 15_000;
-const PERSIST_DELAY_MS = 150;
 let nextProfileResetId = 0;
 
 function createProfileResetId(): number {
@@ -121,8 +120,9 @@ function CodeBrowserTabSession({
   onTitleChange,
 }: CodeBrowserTabProps) {
   const [session, setSession] = useState(() =>
-    restoreOrCreateBrowserSession({ browserId, workspaceId, initialUrl }),
+    createBrowserSession({ id: browserId, workspaceId, initialUrl }),
   );
+  const [legacyState] = useState(() => readLegacyBrowserSession(browserId));
   const [address, setAddress] = useState(session.address);
   const [addressError, setAddressError] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -159,7 +159,6 @@ function CodeBrowserTabSession({
   const nativeHistoryAvailable = useRef(false);
   const lastNativeBounds = useRef<BrowserBounds | null>(null);
   const nativeRevealFrame = useRef<number | null>(null);
-  const persistTimer = useRef<number | null>(null);
   const sessionRef = useRef(session);
   const [viewport, setViewport] = useState(() => restoreOrDefaultViewport());
   const viewportSurfaceRef = useRef<HTMLDivElement | null>(null);
@@ -558,34 +557,6 @@ function CodeBrowserTabSession({
   }, [onTitleChange, session.title]);
 
   useEffect(() => {
-    if (persistTimer.current !== null) {
-      window.clearTimeout(persistTimer.current);
-    }
-    persistTimer.current = window.setTimeout(() => {
-      persistTimer.current = null;
-      writeStoredBrowserSession(sessionRef.current);
-    }, PERSIST_DELAY_MS);
-    return () => {
-      if (persistTimer.current !== null) {
-        window.clearTimeout(persistTimer.current);
-        persistTimer.current = null;
-      }
-    };
-  }, [session]);
-
-  useEffect(
-    () => () => {
-      // An explicit tab close removes storage before or after this component's
-      // cleanup depending on React's unmount order. Do not resurrect a session
-      // the workspace owner has already closed.
-      if (readStoredBrowserSession(browserId)) {
-        writeStoredBrowserSession(sessionRef.current);
-      }
-    },
-    [browserId],
-  );
-
-  useEffect(() => {
     writeStoredViewport(viewport);
   }, [viewport]);
 
@@ -642,10 +613,31 @@ function CodeBrowserTabSession({
         return;
       }
 
-      if (!current.url) return;
-
       const snapshotGeneration = nativeSurfaceGeneration.current;
+      let legacyImportError: unknown = null;
       try {
+        if (legacyState) {
+          try {
+            const imported = await host.importLegacyState(
+              workspaceId,
+              browserId,
+              legacyState.state,
+            );
+            if (cancelled) return;
+            if (
+              imported.browserId !== browserId ||
+              imported.workspaceId !== workspaceId
+            ) {
+              throw new Error(
+                "The browser host acknowledged another workspace's session",
+              );
+            }
+            clearLegacyBrowserSession(browserId);
+          } catch (error) {
+            legacyImportError = error;
+          }
+        }
+
         const snapshot = await host.command(workspaceId, browserId, {
           type: "snapshot",
         });
@@ -682,7 +674,20 @@ function CodeBrowserTabSession({
           await reconcileAfterNativeReady(snapshotGeneration);
         } else {
           nativePresence.current = "missing";
-          await createAndReconcileNative(current.url);
+          if (snapshot.url) {
+            updateSession((value) => {
+              let next = finishBrowserNavigation(value, snapshot.url!);
+              if (snapshot.title) next = setBrowserTitle(next, snapshot.title);
+              return next;
+            });
+            setAddress(browserDisplayAddress(snapshot.url));
+          }
+          const url = snapshot.url ?? sessionRef.current.url;
+          if (url) {
+            await createAndReconcileNative(url);
+          } else if (legacyImportError) {
+            throw legacyImportError;
+          }
         }
       } catch (error) {
         if (
@@ -842,6 +847,7 @@ function CodeBrowserTabSession({
     createAndReconcileNative,
     finishProfileResetCycle,
     host,
+    legacyState,
     recordRuntime,
     reconstructAfterProfileReset,
     reconcileAfterNativeReady,

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
@@ -10,27 +10,36 @@ import {
   type CodeBrowserHost,
 } from "./browserHost";
 import {
-  readStoredBrowserSession,
-  writeStoredBrowserSession,
+  LEGACY_BROWSER_STORAGE_KEY,
+  readLegacyBrowserSession,
 } from "./browserPersistence";
-import { createBrowserSession } from "./browserSession";
 
 // The gate is `hasNativeHost() && !attachedRemotely()`, so the native half has
 // to be true for the attachment half to be observable at all.
 const isTauri = vi.hoisted(() => vi.fn(() => true));
 vi.mock("@tauri-apps/api/core", () => ({ isTauri, invoke: vi.fn() }));
 
+function storeLegacySession(browserId: string): void {
+  window.localStorage.setItem(
+    LEGACY_BROWSER_STORAGE_KEY,
+    JSON.stringify({
+      [browserId]: {
+        version: 1,
+        id: browserId,
+        workspaceId: "workspace-1",
+        url: "https://example.com",
+        title: "Example",
+        updatedAt: 17,
+      },
+    }),
+  );
+}
+
 describe("browser host lifecycle", () => {
   beforeEach(() => window.localStorage.clear());
 
   it("removes persisted state and closes the native view on explicit tab close", async () => {
-    writeStoredBrowserSession(
-      createBrowserSession({
-        id: "browser-1",
-        workspaceId: "workspace-1",
-        initialUrl: "https://example.com",
-      }),
-    );
+    storeLegacySession("browser-1");
     const command = vi.fn().mockResolvedValue({
       exists: false,
       workspaceId: "workspace-1",
@@ -38,6 +47,7 @@ describe("browser host lifecycle", () => {
     });
     const host: CodeBrowserHost = {
       available: () => true,
+      importLegacyState: vi.fn(),
       command,
       subscribe: vi.fn(async () => () => undefined),
       openExternal: vi.fn(async () => undefined),
@@ -45,19 +55,18 @@ describe("browser host lifecycle", () => {
 
     await closeCodeBrowser("workspace-1", "browser-1", host);
 
-    expect(readStoredBrowserSession("browser-1")).toBeNull();
+    expect(readLegacyBrowserSession("browser-1")).toBeNull();
     expect(command).toHaveBeenCalledWith("workspace-1", "browser-1", {
       type: "close",
     });
   });
 
   it("still removes persisted state when no native desktop host exists", async () => {
-    writeStoredBrowserSession(
-      createBrowserSession({ id: "browser-1", workspaceId: "workspace-1" }),
-    );
+    storeLegacySession("browser-1");
     const command = vi.fn();
     const host: CodeBrowserHost = {
       available: () => false,
+      importLegacyState: vi.fn(),
       command,
       subscribe: vi.fn(async () => () => undefined),
       openExternal: vi.fn(async () => undefined),
@@ -65,7 +74,7 @@ describe("browser host lifecycle", () => {
 
     await closeCodeBrowser("workspace-1", "browser-1", host);
 
-    expect(readStoredBrowserSession("browser-1")).toBeNull();
+    expect(readLegacyBrowserSession("browser-1")).toBeNull();
     expect(command).not.toHaveBeenCalled();
   });
 });
@@ -79,6 +88,7 @@ describe("managed browser profile reset", () => {
     });
     const host: CodeBrowserHost = {
       available: () => true,
+      importLegacyState: vi.fn(),
       command,
       subscribe: vi.fn(async () => () => undefined),
       openExternal: vi.fn(async () => undefined),
@@ -96,6 +106,7 @@ describe("managed browser profile reset", () => {
     const command = vi.fn();
     const host: CodeBrowserHost = {
       available: () => false,
+      importLegacyState: vi.fn(),
       command,
       subscribe: vi.fn(async () => () => undefined),
       openExternal: vi.fn(async () => undefined),

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
@@ -3,7 +3,10 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { attachedRemotely, hasLocalHostAuthority, openExternal } from "@/host";
-import { removeStoredBrowserSession } from "./browserPersistence";
+import {
+  clearLegacyBrowserSession,
+  type LegacyBrowserState,
+} from "./browserPersistence";
 
 export const CODE_BROWSER_EVENT = "code-browser:event";
 
@@ -124,8 +127,21 @@ export type BrowserHostEvent = {
   origin?: string;
 };
 
+export type BrowserLegacyImportResult = {
+  status: "imported" | "native_state_kept" | "already_handled" | "discarded";
+  browserId: string;
+  workspaceId: string;
+  url?: string;
+  title?: string;
+};
+
 export type CodeBrowserHost = {
   available: () => boolean;
+  importLegacyState: (
+    workspaceId: string,
+    browserId: string,
+    legacyState: LegacyBrowserState | null,
+  ) => Promise<BrowserLegacyImportResult>;
   command: (
     workspaceId: string,
     browserId: string,
@@ -145,6 +161,10 @@ export const nativeCodeBrowserHost: CodeBrowserHost = {
    * screen — so a window attached to a machine has no browser to offer.
    */
   available: hasLocalHostAuthority,
+  importLegacyState: async (workspaceId, browserId, legacyState) =>
+    invoke<BrowserLegacyImportResult>("code_browser_import_legacy_state", {
+      request: { workspaceId, browserId, legacyState },
+    }),
   command: async (workspaceId, browserId, action) => {
     const normalized = await logicalBrowserAction(action);
     return invoke<BrowserHostSnapshot>("code_browser_command", {
@@ -242,7 +262,7 @@ export async function closeCodeBrowser(
   browserId: string,
   host: CodeBrowserHost = nativeCodeBrowserHost,
 ): Promise<void> {
-  removeStoredBrowserSession(browserId);
+  clearLegacyBrowserSession(browserId);
   if (!host.available()) return;
   await host
     .command(workspaceId, browserId, { type: "close" })

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.test.ts
@@ -1,91 +1,97 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  readStoredBrowserSession,
-  removeStoredBrowserSession,
-  seedBrowserSession,
-  storedBrowserTitle,
-  writeStoredBrowserSession,
+  clearLegacyBrowserSession,
+  LEGACY_BROWSER_STORAGE_KEY,
+  readLegacyBrowserSession,
 } from "./browserPersistence";
-import { beginBrowserNavigation, createBrowserSession } from "./browserSession";
 
-describe("browser persistence", () => {
+function storeLegacySession(
+  browserId: string,
+  update: Record<string, unknown> = {},
+): void {
+  window.localStorage.setItem(
+    LEGACY_BROWSER_STORAGE_KEY,
+    JSON.stringify({
+      [browserId]: {
+        version: 1,
+        id: browserId,
+        workspaceId: "workspace-1",
+        url: "https://example.com/docs",
+        title: "Documentation",
+        loadState: "failed",
+        error: "network failed",
+        inspectEnabled: true,
+        history: [
+          { url: "https://example.com/one" },
+          { url: "https://example.com/docs" },
+        ],
+        historyIndex: 1,
+        updatedAt: 17,
+        ...update,
+      },
+    }),
+  );
+}
+
+describe("legacy browser persistence migration", () => {
   beforeEach(() => window.localStorage.clear());
 
-  it("round-trips useful state but clears transient failures", () => {
-    const session = {
-      ...createBrowserSession({
+  it("reads only URL and title from a valid legacy session", () => {
+    storeLegacySession("browser-1");
+
+    expect(readLegacyBrowserSession("browser-1")).toEqual({
+      kind: "valid",
+      state: {
+        version: 1,
         id: "browser-1",
         workspaceId: "workspace-1",
-        initialUrl: "https://example.com/docs",
-      }),
-      loadState: "failed" as const,
-      error: "network failed",
-      notice: {
-        kind: "popup" as const,
-        url: "https://example.com/sign-in",
-        message: "popup",
+        url: "https://example.com/docs",
+        title: "Documentation",
       },
-      inspectEnabled: true,
-    };
-    writeStoredBrowserSession(session);
-    expect(readStoredBrowserSession("browser-1")).toMatchObject({
-      id: "browser-1",
-      workspaceId: "workspace-1",
-      url: "https://example.com/docs",
-      loadState: "ready",
-      error: null,
-      notice: null,
-      inspectEnabled: false,
     });
   });
 
-  it("keeps the selected entry correct when stored history is trimmed", () => {
-    let session = createBrowserSession({
-      id: "browser-1",
-      workspaceId: "workspace-1",
+  it("marks malformed and cross-workspace metadata for native disposal", () => {
+    storeLegacySession("browser-1", { url: "javascript:alert(1)" });
+    expect(readLegacyBrowserSession("browser-1")).toEqual({
+      kind: "invalid",
+      state: null,
     });
-    for (let index = 0; index < 60; index += 1) {
-      session = beginBrowserNavigation(
-        session,
-        `https://example.com/${index}`,
-        index,
-      );
-    }
-    writeStoredBrowserSession(session);
-    const restored = readStoredBrowserSession("browser-1");
-    expect(restored?.history).toHaveLength(50);
-    expect(restored?.history[restored.historyIndex]?.url).toBe(
-      "https://example.com/59",
+
+    storeLegacySession("browser-1", { workspaceId: "workspace-2" });
+    expect(readLegacyBrowserSession("browser-1")).toMatchObject({
+      kind: "valid",
+      state: { workspaceId: "workspace-2" },
+    });
+  });
+
+  it("clears only the acknowledged entry and never writes during reads", () => {
+    storeLegacySession("browser-1");
+    const first = JSON.parse(
+      window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY)!,
     );
-  });
-
-  it("drops malformed sessions and removes closed sessions", () => {
     window.localStorage.setItem(
-      "tidebreak.code-browser-sessions.v1",
-      JSON.stringify({ "browser-1": { version: 9 } }),
+      LEGACY_BROWSER_STORAGE_KEY,
+      JSON.stringify({ ...first, "browser-2": { version: 9 } }),
     );
-    expect(readStoredBrowserSession("browser-1")).toBeNull();
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
 
-    writeStoredBrowserSession(
-      createBrowserSession({ id: "browser-1", workspaceId: "workspace-1" }),
-    );
-    removeStoredBrowserSession("browser-1");
-    expect(readStoredBrowserSession("browser-1")).toBeNull();
+    readLegacyBrowserSession("browser-1");
+    expect(setItem).not.toHaveBeenCalled();
+
+    clearLegacyBrowserSession("browser-1");
+    expect(
+      JSON.parse(window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY)!),
+    ).toEqual({ "browser-2": { version: 9 } });
   });
 
-  it("seeds a new panel before mount and exposes its lightweight tab title", () => {
-    seedBrowserSession({
-      browserId: "browser-1",
-      workspaceId: "workspace-1",
-      initialUrl: "https://example.com/docs",
-    });
+  it("removes an unreadable legacy payload after native acknowledgement", () => {
+    window.localStorage.setItem(LEGACY_BROWSER_STORAGE_KEY, "not json");
+    expect(readLegacyBrowserSession("browser-1")?.kind).toBe("invalid");
 
-    expect(readStoredBrowserSession("browser-1")).toMatchObject({
-      workspaceId: "workspace-1",
-      url: "https://example.com/docs",
-    });
-    expect(storedBrowserTitle("browser-1")).toBe("Browser");
+    clearLegacyBrowserSession("browser-1");
+    expect(window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY)).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.test.ts
@@ -5,6 +5,7 @@ import {
   clearLegacyBrowserSession,
   LEGACY_BROWSER_STORAGE_KEY,
   readLegacyBrowserSession,
+  seedBrowserSession,
 } from "./browserPersistence";
 
 function storeLegacySession(
@@ -93,5 +94,29 @@ describe("legacy browser persistence migration", () => {
 
     clearLegacyBrowserSession("browser-1");
     expect(window.localStorage.getItem(LEGACY_BROWSER_STORAGE_KEY)).toBeNull();
+  });
+
+  it("writes a URL before the panel mounts and skips empty tabs", () => {
+    seedBrowserSession({
+      browserId: "browser-1",
+      workspaceId: "workspace-1",
+    });
+    expect(readLegacyBrowserSession("browser-1")).toBeNull();
+
+    seedBrowserSession({
+      browserId: "browser-1",
+      workspaceId: "workspace-1",
+      initialUrl: "https://docs.example/path",
+    });
+    expect(readLegacyBrowserSession("browser-1")).toEqual({
+      kind: "valid",
+      state: {
+        version: 1,
+        id: "browser-1",
+        workspaceId: "workspace-1",
+        url: "https://docs.example/path",
+        title: null,
+      },
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
@@ -76,6 +76,66 @@ export function clearLegacyBrowserSession(
   }
 }
 
+/**
+ * Persist a URL before the browser panel mounts.
+ *
+ * Native recovery only commits after `page_finished`. Reload the window
+ * before that and the layout still names this tab, so the URL has to land
+ * in leftover renderer storage the boot path already migrates.
+ */
+export function seedBrowserSession({
+  browserId,
+  workspaceId,
+  initialUrl,
+  storage = window.localStorage,
+}: {
+  browserId: string;
+  workspaceId: string;
+  initialUrl?: string;
+  storage?: Pick<Storage, "getItem" | "setItem">;
+}): void {
+  const target = initialUrl ? validateBrowserUrl(initialUrl) : null;
+  const url = target?.ok ? target.url : null;
+  if (!url) return;
+  writeLegacyBrowserSession(
+    {
+      version: 1,
+      id: browserId,
+      workspaceId,
+      url,
+      title: null,
+    },
+    storage,
+  );
+}
+
+function writeLegacyBrowserSession(
+  state: LegacyBrowserState,
+  storage: Pick<Storage, "getItem" | "setItem">,
+): void {
+  try {
+    const raw = storage.getItem(LEGACY_BROWSER_STORAGE_KEY);
+    let sessions: Record<string, unknown> = {};
+    if (raw) {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        sessions = { ...(parsed as Record<string, unknown>) };
+      }
+    }
+    sessions[state.id] = {
+      version: 1,
+      id: state.id,
+      workspaceId: state.workspaceId,
+      url: state.url,
+      title: state.title ?? "",
+      updatedAt: Date.now(),
+    };
+    storage.setItem(LEGACY_BROWSER_STORAGE_KEY, JSON.stringify(sessions));
+  } catch {
+    // Opening a tab must not fail if storage is unavailable.
+  }
+}
+
 function parseLegacyBrowserState(
   value: unknown,
   expectedId: string,

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
@@ -1,144 +1,86 @@
-import {
-  createBrowserSession,
-  type BrowserHistoryEntry,
-  type BrowserSession,
-} from "./browserSession";
-import { browserDisplayAddress, validateBrowserUrl } from "./browserNavigation";
+import { validateBrowserUrl } from "./browserNavigation";
 
-const STORAGE_KEY = "tidebreak.code-browser-sessions.v1";
-const MAX_STORED_SESSIONS = 24;
-const MAX_STORED_HISTORY = 50;
+export const LEGACY_BROWSER_STORAGE_KEY = "tidebreak.code-browser-sessions.v1";
 
-type StoredBrowserSessions = Record<string, BrowserSession>;
+export type LegacyBrowserState = {
+  version: 1;
+  id: string;
+  workspaceId: string;
+  url: string | null;
+  title: string | null;
+};
 
-export function readStoredBrowserSession(
+export type LegacyBrowserStateRead =
+  | { kind: "valid"; state: LegacyBrowserState }
+  | { kind: "invalid"; state: null };
+
+/** Read one renderer-owned session only for the native one-time migration. */
+export function readLegacyBrowserSession(
   browserId: string,
   storage: Pick<Storage, "getItem"> = window.localStorage,
-): BrowserSession | null {
+): LegacyBrowserStateRead | null {
+  let raw: string | null;
   try {
-    const raw = storage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return null;
-    return parseBrowserSession(
-      (parsed as Record<string, unknown>)[browserId],
-      browserId,
-    );
+    raw = storage.getItem(LEGACY_BROWSER_STORAGE_KEY);
   } catch {
     return null;
   }
-}
+  if (!raw) return null;
 
-export function writeStoredBrowserSession(
-  session: BrowserSession,
-  storage: Pick<Storage, "getItem" | "setItem"> = window.localStorage,
-): void {
+  let parsed: unknown;
   try {
-    const raw = storage.getItem(STORAGE_KEY);
-    const parsed: unknown = raw ? JSON.parse(raw) : {};
-    const sessions: StoredBrowserSessions = {};
-    if (parsed && typeof parsed === "object") {
-      for (const [id, candidate] of Object.entries(
-        parsed as Record<string, unknown>,
-      )) {
-        const valid = parseBrowserSession(candidate, id);
-        if (valid) sessions[id] = valid;
-      }
-    }
-    sessions[session.id] = persistableSession(session);
-    const bounded = Object.fromEntries(
-      Object.entries(sessions)
-        .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
-        .slice(0, MAX_STORED_SESSIONS),
-    );
-    storage.setItem(STORAGE_KEY, JSON.stringify(bounded));
+    parsed = JSON.parse(raw);
   } catch {
-    // Browser restoration is useful, but storage must never block navigation.
+    return { kind: "invalid", state: null };
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { kind: "invalid", state: null };
+  }
+  const sessions = parsed as Record<string, unknown>;
+  if (!Object.hasOwn(sessions, browserId)) return null;
+  const state = parseLegacyBrowserState(sessions[browserId], browserId);
+  return state ? { kind: "valid", state } : { kind: "invalid", state: null };
 }
 
-export function removeStoredBrowserSession(
+/** Clear one legacy entry only after native code acknowledges the migration. */
+export function clearLegacyBrowserSession(
   browserId: string,
-  storage: Pick<Storage, "getItem" | "setItem"> = window.localStorage,
+  storage: Pick<
+    Storage,
+    "getItem" | "setItem" | "removeItem"
+  > = window.localStorage,
 ): void {
+  let raw: string | null;
   try {
-    const raw = storage.getItem(STORAGE_KEY);
-    if (!raw) return;
+    raw = storage.getItem(LEGACY_BROWSER_STORAGE_KEY);
+  } catch {
+    return;
+  }
+  if (!raw) return;
+
+  try {
     const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      storage.removeItem(LEGACY_BROWSER_STORAGE_KEY);
+      return;
+    }
     const sessions = { ...(parsed as Record<string, unknown>) };
     delete sessions[browserId];
-    storage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+    if (Object.keys(sessions).length === 0) {
+      storage.removeItem(LEGACY_BROWSER_STORAGE_KEY);
+    } else {
+      storage.setItem(LEGACY_BROWSER_STORAGE_KEY, JSON.stringify(sessions));
+    }
   } catch {
-    // Best-effort cleanup.
+    storage.removeItem(LEGACY_BROWSER_STORAGE_KEY);
   }
 }
 
-export function restoreOrCreateBrowserSession({
-  browserId,
-  workspaceId,
-  initialUrl,
-}: {
-  browserId: string;
-  workspaceId: string;
-  initialUrl?: string;
-}): BrowserSession {
-  const restored = readStoredBrowserSession(browserId);
-  if (restored?.workspaceId === workspaceId) return restored;
-  const created = createBrowserSession({
-    id: browserId,
-    workspaceId,
-    initialUrl,
-  });
-  writeStoredBrowserSession(created);
-  return created;
-}
-
-/** Seed a newly allocated browser tab before the URL-backed panel mounts. */
-export function seedBrowserSession({
-  browserId,
-  workspaceId,
-  initialUrl,
-}: {
-  browserId: string;
-  workspaceId: string;
-  initialUrl?: string;
-}): BrowserSession {
-  const session = createBrowserSession({
-    id: browserId,
-    workspaceId,
-    initialUrl,
-  });
-  writeStoredBrowserSession(session);
-  return session;
-}
-
-/** Lightweight title lookup for center-tab rendering before the panel mounts. */
-export function storedBrowserTitle(browserId: string): string {
-  return readStoredBrowserSession(browserId)?.title || "Browser";
-}
-
-function persistableSession(session: BrowserSession): BrowserSession {
-  const historyStart = Math.max(0, session.history.length - MAX_STORED_HISTORY);
-  const history = session.history.slice(historyStart);
-  const shiftedIndex = session.historyIndex - historyStart;
-  return {
-    ...session,
-    loadState: session.url ? "ready" : "idle",
-    error: null,
-    notice: null,
-    history,
-    historyIndex: history.length
-      ? Math.min(Math.max(shiftedIndex, 0), history.length - 1)
-      : -1,
-  };
-}
-
-function parseBrowserSession(
+function parseLegacyBrowserState(
   value: unknown,
   expectedId: string,
-): BrowserSession | null {
-  if (!value || typeof value !== "object") return null;
+): LegacyBrowserState | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
   if (
     record.version !== 1 ||
@@ -151,53 +93,19 @@ function parseBrowserSession(
     return null;
   }
 
-  const history = parseHistory(record.history);
-  const rawIndex =
-    typeof record.historyIndex === "number" &&
-    Number.isInteger(record.historyIndex)
-      ? record.historyIndex
-      : history.length - 1;
-  const historyIndex = history.length
-    ? Math.min(Math.max(rawIndex, 0), history.length - 1)
-    : -1;
-  const current = history[historyIndex];
-  const rawUrl = typeof record.url === "string" ? record.url : current?.url;
-  const target = rawUrl ? validateBrowserUrl(rawUrl) : null;
-  const url = target?.ok ? target.url : null;
+  let url: string | null = null;
+  if (record.url !== null && record.url !== undefined) {
+    if (typeof record.url !== "string") return null;
+    const target = validateBrowserUrl(record.url);
+    if (!target.ok) return null;
+    url = target.url;
+  }
 
   return {
     version: 1,
     id: expectedId,
     workspaceId: record.workspaceId,
     url,
-    address: url ? browserDisplayAddress(url) : "",
-    title: record.title.slice(0, 160) || "Browser",
-    loadState: url ? "ready" : "idle",
-    error: null,
-    notice: null,
-    inspectEnabled: false,
-    history,
-    historyIndex,
-    updatedAt: record.updatedAt,
+    title: record.title || null,
   };
-}
-
-function parseHistory(value: unknown): BrowserHistoryEntry[] {
-  if (!Array.isArray(value)) return [];
-  const history: BrowserHistoryEntry[] = [];
-  for (const candidate of value.slice(-MAX_STORED_HISTORY)) {
-    if (!candidate || typeof candidate !== "object") continue;
-    const record = candidate as Record<string, unknown>;
-    if (typeof record.url !== "string") continue;
-    const target = validateBrowserUrl(record.url);
-    if (!target.ok) continue;
-    history.push({
-      url: target.url,
-      title:
-        typeof record.title === "string"
-          ? record.title.replace(/\s+/g, " ").trim().slice(0, 160) || undefined
-          : undefined,
-    });
-  }
-  return history;
 }


### PR DESCRIPTION
## What changed

- Add browser session storage version 2 with durable migration acknowledgements scoped to the owner, browser, and workspace.
- Import valid legacy renderer metadata once, then clear it only after native code acknowledges the result.
- Keep native snapshots authoritative for identity, ownership, URL, title, and recovery when no webview exists.
- Remove normal renderer browser-session writes to `localStorage`. Legacy history and controller state are discarded, while viewport preferences remain renderer-local.
- Preserve version 1 native-file compatibility.

## Validation

- Rust browser tests: 91 passed.
- Focused Rust browser-recovery tests: 8 passed.
- UI test suite: 2,219 passed.
- Focused browser-recovery UI tests: 120 passed.
- UI production build.
- TypeScript, UI lint, `cargo check`, Clippy with warnings denied, native command parity, Rust formatting, Biome formatting, and `git diff --check`.

## Compatibility and risk

The native store upgrades to version 2 while continuing to read version 1 files. Migration acknowledgements survive explicit browser close so stale renderer data cannot regain authority. Invalid, stale, cross-workspace, or guessed identifiers are discarded.

## Stack

This PR is stacked on #2860.

## Tracking

Closes #2784