### PR TITLE
fix(desktop): support image paste in workspace composer

### DIFF
--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -1063,20 +1063,12 @@ export function Composer({
                 denseContext && "border-t border-border/60",
               )}
             >
-              {images && images.items.length > 0 && (
-                <ul
-                  className="m-0 flex list-none flex-wrap gap-2 p-0"
-                  aria-label="Attached images"
-                >
-                  {images.items.map((item) => (
-                    <ImageAttachmentChip
-                      key={item.id}
-                      attachment={item}
-                      onRemove={() => images.onRemove(item.id)}
-                      onRetry={() => images.onRetry(item.id)}
-                    />
-                  ))}
-                </ul>
+              {images && (
+                <ImageAttachmentList
+                  items={images.items}
+                  onRemove={images.onRemove}
+                  onRetry={images.onRetry}
+                />
               )}
               {files && files.items.length > 0 && (
                 <ul
@@ -1694,6 +1686,34 @@ function contextCountLabel(count: number, label: string): string | null {
   return `${count} ${label}${count === 1 ? "" : "s"}`;
 }
 
+/** The canonical image strip shared by every composer surface. */
+export function ImageAttachmentList({
+  items,
+  onRemove,
+  onRetry,
+}: {
+  items: readonly ImageAttachment[];
+  onRemove: (id: string) => void;
+  onRetry?: (id: string) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <ul
+      className="m-0 flex list-none flex-wrap gap-2 p-0"
+      aria-label="Attached images"
+    >
+      {items.map((item) => (
+        <ImageAttachmentChip
+          key={item.id}
+          attachment={item}
+          onRemove={() => onRemove(item.id)}
+          onRetry={onRetry ? () => onRetry(item.id) : undefined}
+        />
+      ))}
+    </ul>
+  );
+}
+
 /**
  * One attached image, from the moment it is attached to the moment it is sent.
  *
@@ -1708,7 +1728,7 @@ function ImageAttachmentChip({
 }: {
   attachment: ImageAttachment;
   onRemove: () => void;
-  onRetry: () => void;
+  onRetry?: () => void;
 }) {
   const uploading =
     attachment.status === "queued" || attachment.status === "uploading";
@@ -1759,7 +1779,7 @@ function ImageAttachmentChip({
           />
         )}
       </span>
-      {failed && (
+      {failed && onRetry && (
         <button
           type="button"
           className="shrink-0 rounded-full border border-border bg-background px-2 py-px text-2xs text-foreground"

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -71,6 +71,7 @@ afterEach(() => {
   useUiStore.setState({ activeTurnSendMode: "queue" });
   useCodeUiStore.setState({
     pendingComposerPrompt: null,
+    pendingComposerImages: null,
     composerActionScope: null,
   });
   useComposerDrafts.setState({ attachments: {} });
@@ -163,6 +164,34 @@ describe("CodeComposer", () => {
     expect(await screen.findByLabelText("Attached images")).toBeInTheDocument();
     expect(screen.getByText("shot.png")).toBeInTheDocument();
     expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+    expect(useCodeUiStore.getState().pendingComposerImages).toBeNull();
+  });
+
+  it("holds offered files until a session exists", async () => {
+    const image = new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
+      type: "image/png",
+    });
+    useCodeUiStore
+      .getState()
+      .offerComposerPrompt("code", "Review this screenshot", [image]);
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("textbox", { name: "Message" })).toHaveValue(
+      "Review this screenshot",
+    );
+    expect(screen.queryByLabelText("Attached images")).toBeNull();
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+    expect(useCodeUiStore.getState().pendingComposerImages).toEqual({
+      scope: "code",
+      files: [image],
+    });
   });
 
   it("submits a one-click workspace action without replacing the draft", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -140,6 +140,31 @@ describe("CodeComposer", () => {
     expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
   });
 
+  it("attaches files offered with a pending prompt", async () => {
+    const image = new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
+      type: "image/png",
+    });
+    useCodeUiStore
+      .getState()
+      .offerComposerPrompt("sess-1", "Review this screenshot", [image]);
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("textbox", { name: "Message" })).toHaveValue(
+      "Review this screenshot",
+    );
+    expect(await screen.findByLabelText("Attached images")).toBeInTheDocument();
+    expect(screen.getByText("shot.png")).toBeInTheDocument();
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+  });
+
   it("submits a one-click workspace action without replacing the draft", async () => {
     const onSend = vi.fn();
     renderComposer(

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -906,7 +906,8 @@ export function CodeComposer({
       return;
     }
     setDraft((current) => appendComposerPrompt(current, request.text));
-    if (request.images && request.images.length > 0) {
+    if (sessionId && request.images && request.images.length > 0) {
+      useCodeUiStore.getState().takeComposerImages(composerPromptScope);
       images.attachFiles(request.images);
     }
     window.requestAnimationFrame(() => {
@@ -914,7 +915,15 @@ export function CodeComposer({
         .querySelector<HTMLTextAreaElement>("[data-composer-input]")
         ?.focus();
     });
-  }, [composerPromptScope, pendingPrompt]);
+  }, [composerPromptScope, pendingPrompt, sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    const files = useCodeUiStore
+      .getState()
+      .takeComposerImages(composerPromptScope);
+    if (files && files.length > 0) images.attachFiles(files);
+  }, [composerPromptScope, sessionId]);
 
   useEffect(() => {
     if (model) setSelectedModel(model);

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -906,6 +906,9 @@ export function CodeComposer({
       return;
     }
     setDraft((current) => appendComposerPrompt(current, request.text));
+    if (request.images && request.images.length > 0) {
+      images.attachFiles(request.images);
+    }
     window.requestAnimationFrame(() => {
       document
         .querySelector<HTMLTextAreaElement>("[data-composer-input]")

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -105,6 +105,8 @@ export type PendingComposerPrompt = {
   scope: string;
   text: string;
   submit: boolean;
+  /** Files to attach when the workspace composer takes this prompt. */
+  images?: readonly File[];
 };
 
 function readStoredCreateDefaults(): CodeCreateDefaults | null {
@@ -330,7 +332,11 @@ export type CodeUiStore = {
    */
   pendingComposerPrompt: PendingComposerPrompt | null;
   composerActionScope: string | null;
-  offerComposerPrompt: (scope: string, prompt: string) => void;
+  offerComposerPrompt: (
+    scope: string,
+    prompt: string,
+    images?: readonly File[],
+  ) => void;
   runComposerPrompt: (scope: string, prompt: string) => boolean;
   takeComposerPrompt: (scope: string) => PendingComposerPrompt | null;
   finishComposerAction: (scope: string) => void;
@@ -500,8 +506,15 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
     set({ openFilePending: null });
     return pending;
   },
-  offerComposerPrompt: (scope, prompt) =>
-    set({ pendingComposerPrompt: { scope, text: prompt, submit: false } }),
+  offerComposerPrompt: (scope, prompt, images) =>
+    set({
+      pendingComposerPrompt: {
+        scope,
+        text: prompt,
+        submit: false,
+        ...(images && images.length > 0 ? { images } : {}),
+      },
+    }),
   runComposerPrompt: (scope, prompt) => {
     if (get().composerActionScope !== null) return false;
     set({

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -105,8 +105,13 @@ export type PendingComposerPrompt = {
   scope: string;
   text: string;
   submit: boolean;
-  /** Files to attach when the workspace composer takes this prompt. */
+  /** Files to attach once a session exists to publish them. */
   images?: readonly File[];
+};
+
+export type PendingComposerImages = {
+  scope: string;
+  files: readonly File[];
 };
 
 function readStoredCreateDefaults(): CodeCreateDefaults | null {
@@ -331,6 +336,7 @@ export type CodeUiStore = {
    * the action.
    */
   pendingComposerPrompt: PendingComposerPrompt | null;
+  pendingComposerImages: PendingComposerImages | null;
   composerActionScope: string | null;
   offerComposerPrompt: (
     scope: string,
@@ -339,6 +345,7 @@ export type CodeUiStore = {
   ) => void;
   runComposerPrompt: (scope: string, prompt: string) => boolean;
   takeComposerPrompt: (scope: string) => PendingComposerPrompt | null;
+  takeComposerImages: (scope: string) => readonly File[] | null;
   finishComposerAction: (scope: string) => void;
   /**
    * Asks raised by the shell keymap that only a workspace surface can carry
@@ -443,6 +450,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   lastCreate: readStoredCreateDefaults(),
   terminalPending: false,
   pendingComposerPrompt: null,
+  pendingComposerImages: null,
   composerActionScope: null,
   quickOpenPending: false,
   newTabMenuPending: false,
@@ -514,6 +522,12 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
         submit: false,
         ...(images && images.length > 0 ? { images } : {}),
       },
+      pendingComposerImages:
+        images && images.length > 0
+          ? { scope, files: images }
+          : get().pendingComposerImages?.scope === scope
+            ? null
+            : get().pendingComposerImages,
     }),
   runComposerPrompt: (scope, prompt) => {
     if (get().composerActionScope !== null) return false;
@@ -528,6 +542,12 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
     if (!prompt || prompt.scope !== scope) return null;
     set({ pendingComposerPrompt: null });
     return prompt;
+  },
+  takeComposerImages: (scope): readonly File[] | null => {
+    const held = get().pendingComposerImages;
+    if (!held || held.scope !== scope) return null;
+    set({ pendingComposerImages: null });
+    return held.files;
   },
   finishComposerAction: (scope) =>
     set((state) => {
@@ -625,6 +645,7 @@ export function resetCodeUiHostState(): void {
     inspectorScope: null,
     terminalPending: false,
     pendingComposerPrompt: null,
+    pendingComposerImages: null,
     composerActionScope: null,
     quickOpenPending: false,
     newTabMenuPending: false,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -694,6 +694,7 @@ afterEach(() => {
   useCodeUiStore.setState({ reviewSidebarOpen: true, inspectorScope: null });
   useCodeUiStore.setState({
     pendingComposerPrompt: null,
+    pendingComposerImages: null,
     composerActionScope: null,
     workflowShortcutPending: null,
     archivePending: false,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -843,7 +843,10 @@ describe("CodeWorkspacePage", () => {
       ),
     );
     expect(publishCodeImage).toHaveBeenCalledWith(CREATED_SESSION.id, image);
-    expect(publishCodeImage).not.toHaveBeenCalledWith("ws-1", expect.anything());
+    expect(publishCodeImage).not.toHaveBeenCalledWith(
+      "ws-1",
+      expect.anything(),
+    );
   });
 
   it("keeps the created session and restores the exact first prompt after the start composer unmounts", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -118,6 +118,17 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), message: vi.fn() },
 }));
 
+const hasLocalHostAuthority = vi.hoisted(() => vi.fn(() => false));
+const publishCodeImage = vi.hoisted(() => vi.fn());
+vi.mock("../host", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../host")>()),
+  hasLocalHostAuthority,
+}));
+vi.mock("../attachments", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../attachments")>()),
+  publishCodeImage,
+}));
+
 // The resize library lays out from real element measurements, which jsdom does
 // not provide; left alone it registers no regions and renders nothing.
 vi.mock("react-resizable-panels", () => ({
@@ -787,6 +798,52 @@ describe("CodeWorkspacePage", () => {
       screen.getByText("Start a session on this workspace."),
     ).toBeInTheDocument();
     expect(toast.error).toHaveBeenCalledWith("Claude Code sign-in expired");
+  });
+
+  it("includes held images on the next start after session create failed", async () => {
+    const image = new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
+      type: "image/png",
+    });
+    hasLocalHostAuthority.mockReturnValue(true);
+    publishCodeImage.mockResolvedValue({
+      attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+      mediaType: "image/png",
+      width: 800,
+      height: 600,
+      byteLen: 4,
+    });
+    const client = makeClient();
+    enableStartHarness(client);
+    useCodeUiStore
+      .getState()
+      .offerComposerPrompt("ws-1", "Review this screenshot", [image]);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    const message = await screen.findByRole("textbox", { name: "Message" });
+    expect(message).toHaveValue("Review this screenshot");
+    expect(screen.queryByLabelText("Attached images")).toBeNull();
+    expect(publishCodeImage).not.toHaveBeenCalled();
+
+    const send = screen.getByRole("button", { name: "Send message" });
+    await waitFor(() => expect(send).toBeEnabled());
+    await user.click(send);
+
+    await waitFor(() =>
+      expect(client.submitCodeTurn).toHaveBeenCalledWith(
+        CREATED_SESSION.id,
+        "Review this screenshot",
+        undefined,
+        [
+          {
+            blob_id: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+            media_type: "image/png",
+          },
+        ],
+      ),
+    );
+    expect(publishCodeImage).toHaveBeenCalledWith(CREATED_SESSION.id, image);
+    expect(publishCodeImage).not.toHaveBeenCalledWith("ws-1", expect.anything());
   });
 
   it("keeps the created session and restores the exact first prompt after the start composer unmounts", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -814,6 +814,9 @@ describe("CodeWorkspacePage", () => {
     });
     const client = makeClient();
     enableStartHarness(client);
+    client.createCodeSession
+      .mockRejectedValueOnce(new Error("Claude Code sign-in expired"))
+      .mockResolvedValueOnce(CREATED_SESSION);
     useCodeUiStore
       .getState()
       .offerComposerPrompt("ws-1", "Review this screenshot", [image]);
@@ -829,6 +832,20 @@ describe("CodeWorkspacePage", () => {
     await waitFor(() => expect(send).toBeEnabled());
     await user.click(send);
 
+    await waitFor(() =>
+      expect(client.createCodeSession).toHaveBeenCalledOnce(),
+    );
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+    expect(publishCodeImage).not.toHaveBeenCalled();
+    expect(message).toHaveValue("Review this screenshot");
+
+    const retry = screen.getByRole("button", { name: "Send message" });
+    await waitFor(() => expect(retry).toBeEnabled());
+    await user.click(retry);
+
+    await waitFor(() =>
+      expect(client.createCodeSession).toHaveBeenCalledTimes(2),
+    );
     await waitFor(() =>
       expect(client.submitCodeTurn).toHaveBeenCalledWith(
         CREATED_SESSION.id,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -132,6 +132,9 @@ import {
 import { CodeInspector, WorkspaceDeliveryPrTab } from "./CodeInspector";
 import { DiffOverview } from "./DiffOverview";
 import { useCodeUiStore } from "./CodeUiStore";
+import { publishCodeImage } from "../attachments";
+import { hasLocalHostAuthority } from "../host";
+import { uploadImageAttachment } from "../ImageAttachments";
 import { forkFraming, forkTranscriptFile } from "./fork";
 import {
   useCodeUpdatesStore,
@@ -710,6 +713,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         throw err;
       }
 
+      const heldImages = useCodeUiStore
+        .getState()
+        .takeComposerImages(workspaceId);
+
       const recovery: FirstTurnRecovery = {
         id: `${created.id}:${request}`,
         sessionId: created.id,
@@ -719,6 +726,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         status: "sending",
       };
       if (!isCurrent()) {
+        if (heldImages && heldImages.length > 0) {
+          useCodeUiStore
+            .getState()
+            .offerComposerPrompt(workspaceId, draft, heldImages);
+        }
         const message =
           "The Code connection changed after the session was created. Send the message again.";
         writeFirstTurnRecovery(startedWithClient, {
@@ -748,9 +760,46 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       }
 
       try {
-        await startedWithClient.submitCodeTurn(created.id, message);
+        const attachments = heldImages?.length
+          ? await Promise.all(
+              heldImages.map(async (file) => {
+                const published = hasLocalHostAuthority()
+                  ? await publishCodeImage(created.id, file)
+                  : await uploadImageAttachment(
+                      startedWithClient,
+                      created.id,
+                      file,
+                      {
+                        onProgress: () => undefined,
+                        signal: new AbortController().signal,
+                        path: (id) =>
+                          `/code/sessions/${encodeURIComponent(id)}/attachments/images`,
+                      },
+                    );
+                return {
+                  blob_id: published.attachmentId,
+                  media_type: published.mediaType,
+                };
+              }),
+            )
+          : [];
+        if (attachments.length > 0) {
+          await startedWithClient.submitCodeTurn(
+            created.id,
+            message,
+            undefined,
+            attachments,
+          );
+        } else {
+          await startedWithClient.submitCodeTurn(created.id, message);
+        }
         clearFirstTurnRecovery(startedWithClient, created.id, recovery.id);
       } catch (err) {
+        if (heldImages && heldImages.length > 0) {
+          useCodeUiStore
+            .getState()
+            .offerComposerPrompt(workspaceId, draft, heldImages);
+        }
         const detail = friendlyErrorMessage(err, "Try sending it again.");
         writeFirstTurnRecovery(startedWithClient, {
           ...recovery,

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -2,12 +2,13 @@
 import {
   act,
   cleanup,
+  createEvent,
   fireEvent,
   screen,
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import { HttpError } from "../api/client";
@@ -34,12 +35,42 @@ import type { CodeTurnSubmission, ParsedHarnessModel } from "./parsers";
 
 const toastError = vi.hoisted(() => vi.fn());
 const toastSuccess = vi.hoisted(() => vi.fn());
+const hasLocalHostAuthority = vi.hoisted(() => vi.fn(() => true));
+const publishCodeImage = vi.hoisted(() => vi.fn());
 vi.mock("sonner", () => ({
   toast: {
     error: toastError,
     success: toastSuccess,
   },
 }));
+vi.mock("../host", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../host")>()),
+  hasLocalHostAuthority,
+}));
+vi.mock("../attachments", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../attachments")>()),
+  publishCodeImage,
+}));
+
+beforeEach(() => {
+  hasLocalHostAuthority.mockReturnValue(true);
+  publishCodeImage.mockReset();
+  publishCodeImage.mockResolvedValue({
+    attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+    mediaType: "image/png",
+    width: 800,
+    height: 600,
+    byteLen: 4,
+  });
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: vi.fn(() => "blob:new-workspace-preview"),
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
 
 afterEach(() => {
   cleanup();
@@ -893,6 +924,106 @@ describe("NewWorkspaceDialog", () => {
     expect(useCodeUiStore.getState().newWorkspaceDraft).toEqual(
       EMPTY_NEW_WORKSPACE_DRAFT,
     );
+  });
+
+  it("attaches a pasted image instead of inserting its clipboard path", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({ listCodeHarnessModels: claudeModels() })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const message = screen.getByRole("textbox", { name: "First message" });
+    const image = new File([new Uint8Array([1, 2, 3, 4])], "image.png", {
+      type: "image/png",
+    });
+    const paste = createEvent.paste(message, {
+      clipboardData: {
+        files: [image],
+        getData: () => "/Users/thet/Desktop/captures/shot.png",
+      },
+    });
+    fireEvent(message, paste);
+
+    expect(paste.defaultPrevented).toBe(true);
+    expect(message).toHaveValue("");
+    expect(screen.getByLabelText("Attached images")).toBeInTheDocument();
+    expect(screen.getByText(/pasted-image-/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+    expect(
+      screen.getByText("Add a message to send the image with the first turn."),
+    ).toBeInTheDocument();
+  });
+
+  it("publishes pasted images into the new session before the first turn", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const submitCodeTurn = vi.fn(
+      async () => ({ kind: "turn" }) as unknown as CodeTurnSubmission,
+    );
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace: vi.fn(async () =>
+            workspace("ws-image", "repo-new", "2026-08-20T00:00:00.000Z"),
+          ),
+          createCodeSession: vi.fn(async () =>
+            session("ws-image", "claude_code", "2026-08-20T00:00:00.000Z"),
+          ),
+          submitCodeTurn,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const message = screen.getByRole("textbox", { name: "First message" });
+    fireEvent.change(message, { target: { value: "Review this screenshot" } });
+    const image = new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
+      type: "image/png",
+    });
+    const paste = createEvent.paste(message, {
+      clipboardData: { files: [image] },
+    });
+    fireEvent(message, paste);
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(submitCodeTurn).toHaveBeenCalledWith(
+        "sess-ws-image",
+        "Review this screenshot",
+        undefined,
+        [
+          {
+            blob_id: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+            media_type: "image/png",
+          },
+        ],
+      ),
+    );
+    expect(publishCodeImage).toHaveBeenCalledWith("sess-ws-image", image);
   });
 
   it("hands the message to the workspace composer when the turn cannot be sent", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -1026,6 +1026,119 @@ describe("NewWorkspaceDialog", () => {
     expect(publishCodeImage).toHaveBeenCalledWith("sess-ws-image", image);
   });
 
+  it("hands pasted images to the workspace composer when the turn cannot be sent", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const image = new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
+      type: "image/png",
+    });
+    const submitCodeTurn = vi.fn(async () => {
+      throw new Error("engine crashed on spawn");
+    });
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace: vi.fn(async () =>
+            workspace("ws-held-image", "repo-new", "2026-08-20T00:00:00.000Z"),
+          ),
+          createCodeSession: vi.fn(async () =>
+            session("ws-held-image", "claude_code", "2026-08-20T00:00:00.000Z"),
+          ),
+          submitCodeTurn,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const message = screen.getByRole("textbox", { name: "First message" });
+    fireEvent.change(message, { target: { value: "Review this screenshot" } });
+    fireEvent(
+      message,
+      createEvent.paste(message, {
+        clipboardData: { files: [image] },
+      }),
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-held-image"),
+    );
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toEqual({
+      scope: "ws-held-image",
+      text: "Review this screenshot",
+      submit: false,
+      images: [image],
+    });
+  });
+
+  it("hands pasted images to the workspace composer when the session cannot start", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const image = new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
+      type: "image/png",
+    });
+    const created = workspace(
+      "ws-recover-image",
+      "repo-new",
+      "2026-08-19T00:00:00.000Z",
+    );
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace: vi.fn(async () => created),
+          createCodeSession: vi.fn(async () => {
+            throw new Error("Codex sign-in expired");
+          }),
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const message = screen.getByRole("textbox", { name: "First message" });
+    fireEvent.change(message, { target: { value: "Review this screenshot" } });
+    fireEvent(
+      message,
+      createEvent.paste(message, {
+        clipboardData: { files: [image] },
+      }),
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-recover-image"),
+    );
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toEqual({
+      scope: "ws-recover-image",
+      text: "Review this screenshot",
+      submit: false,
+      images: [image],
+    });
+  });
+
   it("hands the message to the workspace composer when the turn cannot be sent", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -79,6 +79,7 @@ afterEach(() => {
   useCodeUiStore.setState({
     lastCreate: null,
     pendingComposerPrompt: null,
+    pendingComposerImages: null,
     newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT,
   });
   toastError.mockReset();

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -823,18 +823,23 @@ export function NewWorkspaceDialog({
             await client.submitCodeTurn(session.id, prompt);
           }
         } catch (error) {
-          // Never drop typed words: the workspace composer holds them.
-          useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
+          // Never drop typed words or pasted images: the workspace composer
+          // holds them.
+          useCodeUiStore
+            .getState()
+            .offerComposerPrompt(workspace.id, prompt, attempt.images);
           toast.error(
             `Session started, but the first message could not be sent. ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
           );
         }
       }
     } catch (error) {
-      // No session to send to; the workspace composer holds the text and
-      // start-session on the workspace page picks it up.
+      // No session to send to; the workspace composer holds the text, images,
+      // and start-session on the workspace page picks them up.
       if (prompt) {
-        useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
+        useCodeUiStore
+          .getState()
+          .offerComposerPrompt(workspace.id, prompt, attempt.images);
       }
       toast.error(
         `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type FormEvent,
+} from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { toast } from "sonner";
 import {
@@ -21,6 +28,17 @@ import type {
 } from "../api/types";
 import { HttpError } from "../api/client";
 import { useApp } from "@/AppContext";
+import { ImageAttachmentList, shouldSubmitComposerKey } from "../Composer";
+import { publishCodeImage } from "../attachments";
+import {
+  imageAttachmentName,
+  imageAttachmentRejection,
+  imageFilesFrom,
+  queuedImageAttachment,
+  uploadImageAttachment,
+  type ImageAttachment,
+} from "../ImageAttachments";
+import { hasLocalHostAuthority } from "../host";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
@@ -40,7 +58,6 @@ import {
 } from "@/components/ui/popover";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
-import { shouldSubmitComposerKey } from "../Composer";
 import { clampPermissionMode, PermissionModeMenu } from "../PermissionModeMenu";
 import { useManagedPolicy } from "../managedPolicy";
 import { usesCommandModifier } from "@/ShellShortcuts";
@@ -173,6 +190,12 @@ type CreateAttempt = {
   fastMode: boolean;
   fastModeByHarness: Partial<Record<HarnessKind, boolean>>;
   createMore: boolean;
+  images: readonly File[];
+};
+
+type HeldWorkspaceImage = {
+  attachment: ImageAttachment;
+  file: File;
 };
 
 export function NewWorkspaceDialog({
@@ -216,6 +239,9 @@ export function NewWorkspaceDialog({
     null,
   );
   const [createMore, setCreateMore] = useState(false);
+  const [heldImages, setHeldImages] = useState<HeldWorkspaceImage[]>([]);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const heldImagesRef = useRef<HeldWorkspaceImage[]>([]);
   const [modelsByHarness, setModelsByHarness] = useState<
     Partial<Record<HarnessKind, string>>
   >({});
@@ -305,6 +331,7 @@ export function NewWorkspaceDialog({
         startingPrompt: retry.startingPrompt,
         title: retry.title,
       });
+      replaceHeldImages(retry.images);
     }
     setBaseRef(
       retry?.baseRef ??
@@ -377,8 +404,23 @@ export function NewWorkspaceDialog({
   const engineReady = Boolean(
     selectedHarness && installed && !policyBlocksCreate,
   );
-  const canCreate = Boolean(repoId && selectedRepo && engineReady);
+  const imageNeedsMessage =
+    heldImages.length > 0 && startingPrompt.trim().length === 0;
+  const canCreate = Boolean(
+    repoId && selectedRepo && engineReady && !imageNeedsMessage,
+  );
   const installNote = install && (!install.done || install.error);
+
+  useEffect(
+    () => () => {
+      for (const image of heldImagesRef.current) {
+        if (image.attachment.previewUrl) {
+          URL.revokeObjectURL(image.attachment.previewUrl);
+        }
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!open || !harness) return;
@@ -457,6 +499,84 @@ export function NewWorkspaceDialog({
     });
   }
 
+  function heldImagesFrom(files: readonly File[]): HeldWorkspaceImage[] {
+    const now = new Date();
+    return files.map((file) => {
+      const previewUrl =
+        typeof URL.createObjectURL === "function"
+          ? URL.createObjectURL(file)
+          : null;
+      return {
+        file,
+        attachment: queuedImageAttachment(crypto.randomUUID(), {
+          name: imageAttachmentName(file, now),
+          byteLen: file.size,
+          previewUrl,
+        }),
+      };
+    });
+  }
+
+  function replaceHeldImages(files: readonly File[]) {
+    for (const image of heldImagesRef.current) {
+      if (image.attachment.previewUrl) {
+        URL.revokeObjectURL(image.attachment.previewUrl);
+      }
+    }
+    const next = heldImagesFrom(files);
+    heldImagesRef.current = next;
+    setHeldImages(next);
+    setImageError(null);
+  }
+
+  function attachImages(files: readonly File[]) {
+    const rejection = imageAttachmentRejection(
+      heldImagesRef.current.map((image) => image.attachment),
+      files,
+    );
+    if (rejection) {
+      setImageError(rejection);
+      return;
+    }
+    const next = [...heldImagesRef.current, ...heldImagesFrom(files)];
+    heldImagesRef.current = next;
+    setHeldImages(next);
+    setImageError(null);
+  }
+
+  function removeImage(id: string) {
+    const removed = heldImagesRef.current.find(
+      (image) => image.attachment.id === id,
+    );
+    if (removed?.attachment.previewUrl) {
+      URL.revokeObjectURL(removed.attachment.previewUrl);
+    }
+    const next = heldImagesRef.current.filter(
+      (image) => image.attachment.id !== id,
+    );
+    heldImagesRef.current = next;
+    setHeldImages(next);
+    setImageError(null);
+  }
+
+  function clearImages() {
+    for (const image of heldImagesRef.current) {
+      if (image.attachment.previewUrl) {
+        URL.revokeObjectURL(image.attachment.previewUrl);
+      }
+    }
+    heldImagesRef.current = [];
+    setHeldImages([]);
+    setImageError(null);
+  }
+
+  function onPromptPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    const files = imageFilesFrom(event.clipboardData);
+    if (files.length === 0) return;
+    event.preventDefault();
+    attachImages(files);
+  }
+
   /** One picker open at a time; closing by chord puts focus back on the message. */
   function pickerProps(id: PickerId) {
     return {
@@ -483,7 +603,13 @@ export function NewWorkspaceDialog({
     // A repo handed in came from the add-repo field this submit started in,
     // and carries its own base ref: `baseRef` still holds the old repo's.
     const repo = added ?? selectedRepo;
-    if (!engineReady || !repo || createLocked.current) return;
+    if (
+      !engineReady ||
+      !repo ||
+      createLocked.current ||
+      (heldImagesRef.current.length > 0 && !startingPrompt.trim())
+    )
+      return;
     createLocked.current = true;
     const attempt: CreateAttempt = {
       repoId: repo.id,
@@ -499,8 +625,10 @@ export function NewWorkspaceDialog({
       fastMode: postedFastMode,
       fastModeByHarness: { ...fastByHarness },
       createMore,
+      images: heldImagesRef.current.map((image) => image.file),
     };
     useCodeUiStore.getState().setNewWorkspaceDraft(EMPTY_NEW_WORKSPACE_DRAFT);
+    clearImages();
     if (createMore) {
       focusPrompt();
       queueMicrotask(() => {
@@ -680,7 +808,20 @@ export function NewWorkspaceDialog({
       });
       if (prompt) {
         try {
-          await client.submitCodeTurn(session.id, prompt);
+          const attachments = await publishFirstTurnImages(
+            session.id,
+            attempt.images,
+          );
+          if (attachments.length > 0) {
+            await client.submitCodeTurn(
+              session.id,
+              prompt,
+              undefined,
+              attachments,
+            );
+          } else {
+            await client.submitCodeTurn(session.id, prompt);
+          }
         } catch (error) {
           // Never drop typed words: the workspace composer holds them.
           useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
@@ -699,6 +840,29 @@ export function NewWorkspaceDialog({
         `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
       );
     }
+  }
+
+  async function publishFirstTurnImages(
+    sessionId: string,
+    files: readonly File[],
+  ): Promise<readonly { blob_id: string; media_type: string }[]> {
+    const published = await Promise.all(
+      files.map(async (file) => {
+        if (hasLocalHostAuthority()) {
+          return publishCodeImage(sessionId, file);
+        }
+        return uploadImageAttachment(client, sessionId, file, {
+          onProgress: () => undefined,
+          signal: new AbortController().signal,
+          path: (id) =>
+            `/code/sessions/${encodeURIComponent(id)}/attachments/images`,
+        });
+      }),
+    );
+    return published.map((image) => ({
+      blob_id: image.attachmentId,
+      media_type: image.mediaType,
+    }));
   }
 
   async function revealCreatedWorkspace(
@@ -1001,12 +1165,31 @@ export function NewWorkspaceDialog({
             aria-label="First message"
             placeholder="Describe the first task (optional)"
             className="placeholder:text-muted-foreground max-h-[50vh] min-h-48 w-full resize-none bg-transparent px-4 py-3 text-base outline-none sm:min-h-52"
+            onPaste={onPromptPaste}
             onKeyDown={(event) => {
               if (!shouldSubmitComposerKey(event.nativeEvent)) return;
               event.preventDefault();
               void create();
             }}
           />
+          {(heldImages.length > 0 || imageError) && (
+            <div className="grid gap-1.5 px-4 pb-2">
+              <ImageAttachmentList
+                items={heldImages.map((image) => image.attachment)}
+                onRemove={removeImage}
+              />
+              {imageError && (
+                <p className="text-destructive text-xs" role="alert">
+                  {imageError}
+                </p>
+              )}
+              {imageNeedsMessage && (
+                <p className="text-muted-foreground text-xs">
+                  Add a message to send the image with the first turn.
+                </p>
+              )}
+            </div>
+          )}
           {installNote && (
             <div className="flex flex-col gap-1 px-4 pb-1.5">
               <HarnessInstallNote install={install} />

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -342,6 +342,31 @@ export const Default: Story = {
   },
 };
 
+/** A clipboard image stays attached instead of inserting its local path. */
+export const PastedImage: Story = {
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const prompt = page.getByRole("textbox", { name: "First message" });
+    await userEvent.type(prompt, "Review this screenshot");
+
+    const image = new File(
+      [new Uint8Array([1, 2, 3, 4])],
+      "workspace-composer.png",
+      {
+        type: "image/png",
+      },
+    );
+    const paste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, "clipboardData", {
+      value: { files: [image] },
+    });
+    prompt.dispatchEvent(paste);
+
+    await expect(page.getByLabelText("Attached images")).toBeVisible();
+    await expect(page.getByText("workspace-composer.png")).toBeVisible();
+  },
+};
+
 /** The minimum supported window wraps settings without clipping the actions. */
 export const MinimumWindow: Story = {
   globals: { viewport: { value: "minimumWindow", isRotated: false } },


### PR DESCRIPTION
## What changed

- Treat pasted clipboard images in the new-workspace composer as attachments instead of inserting their local path.
- Keep the image bytes locally until the workspace session exists, then publish them and include their references in the first turn.
- Reuse the existing composer image strip and cover the pasted-image state in Storybook.

## Validation

- `pnpm exec vitest run src/code/NewWorkspaceDialog.dom.test.tsx src/code/CodeComposer.dom.test.tsx src/ComposerPastedText.dom.test.tsx` — 70 tests passed.
- `pnpm exec biome check src/Composer.tsx src/code/NewWorkspaceDialog.tsx src/code/NewWorkspaceDialog.dom.test.tsx src/stories/NewWorkspace.stories.tsx` — passed.
- `pnpm exec tsc --noEmit` — passed.
- `pnpm run storybook:build` — passed.
- Inspected `Code/New workspace / Pasted Image` in light, dark, high-contrast light, and high-contrast dark themes.

## Compatibility and risk

The regular workspace composer keeps its existing upload path. The new-workspace dialog only claims clipboard pastes that contain image files; text-only paste behavior stays unchanged. Image upload still uses the existing native-host and remote/browser transports after the session is created.
