### PR TITLE
feat(server): pin the sandbox provisioning contract

### DIFF
--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod pr_refresh;
 pub(crate) mod recap;
 pub(crate) mod reconcile;
 pub(crate) mod recovery;
+pub(crate) mod remote;
 pub(crate) mod runtime;
 pub(crate) mod scoped;
 pub(crate) mod scratch;

--- a/crates/tidebreak-server/src/code/remote/gateway.rs
+++ b/crates/tidebreak-server/src/code/remote/gateway.rs
@@ -1,0 +1,637 @@
+//! The gateway-backed [`SandboxProvisioner`].
+//!
+//! Transport only, against the routes pinned in the module docs. The URL
+//! join keeps a gateway deployed under a subpath working, the same way
+//! `connectors::gateway` joins. Per-request timeouts differ by call: spawn
+//! runs the environment's whole preflight (repository `ls-remote` included),
+//! and an events read may deliberately hold up to 25 seconds.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tidebreak_core::OwnerId;
+
+use super::wire::{
+    EventCursor, MessageReceipt, RuntimeErrorBody, SandboxEvents, SandboxLease, SandboxMessage,
+    SandboxStatus, SpawnArguments, EVENTS_MAX_WAIT_SECONDS,
+};
+use super::{RemoteSandboxError, RuntimeTokenSource, SandboxProvisioner};
+
+/// Ceiling on a spawn request: preflight resolves every declared
+/// repository against its remote before anything commits.
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(120);
+/// Ceiling on status, send, and cancel.
+const CALL_TIMEOUT: Duration = Duration::from_secs(30);
+/// Slack an events read gets beyond its own held wait.
+const EVENTS_TIMEOUT_SLACK: Duration = Duration::from_secs(15);
+
+/// The provisioning client for a gateway-confined sandbox.
+pub(crate) struct GatewayProvisioner {
+    base_url: reqwest::Url,
+    endpoint_slug: String,
+    tokens: Arc<dyn RuntimeTokenSource>,
+    http: reqwest::Client,
+}
+
+impl GatewayProvisioner {
+    /// Builds a client against one gateway deployment and runtime endpoint.
+    pub(crate) fn new(
+        base_url: &str,
+        endpoint_slug: &str,
+        tokens: Arc<dyn RuntimeTokenSource>,
+    ) -> Result<Self, RemoteSandboxError> {
+        let mut base = base_url.to_owned();
+        if !base.ends_with('/') {
+            base.push('/');
+        }
+        let base_url = reqwest::Url::parse(&base).map_err(|error| {
+            RemoteSandboxError::InvalidRequest(format!("gateway base URL is unusable: {error}"))
+        })?;
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| RemoteSandboxError::Unavailable {
+                operation: "client",
+                detail: error.to_string(),
+            })?;
+        Ok(Self {
+            base_url,
+            endpoint_slug: endpoint_slug.to_owned(),
+            tokens,
+            http,
+        })
+    }
+
+    /// Joins below the configured base so a subpath deployment keeps its
+    /// prefix.
+    fn endpoint(&self, path: &str) -> Result<reqwest::Url, RemoteSandboxError> {
+        self.base_url
+            .join(path.trim_start_matches('/'))
+            .map_err(|error| {
+                RemoteSandboxError::InvalidRequest(format!("could not build endpoint URL: {error}"))
+            })
+    }
+
+    /// Sends one prepared request and maps the outcome.
+    async fn dispatch(
+        &self,
+        operation: &'static str,
+        request: reqwest::RequestBuilder,
+        owner: &OwnerId,
+    ) -> Result<reqwest::Response, RemoteSandboxError> {
+        let token = self.tokens.runtime_token(owner).await?;
+        let response = request
+            .bearer_auth(&token.secret)
+            .send()
+            .await
+            .map_err(|error| RemoteSandboxError::Unavailable {
+                operation,
+                detail: error.without_url().to_string(),
+            })?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(response);
+        }
+        let body: RuntimeErrorBody = response.json().await.unwrap_or_default();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(RemoteSandboxError::SignInRequired(
+                if body.error_description.is_empty() {
+                    format!("HTTP status {}", status.as_u16())
+                } else {
+                    body.error_description
+                },
+            ));
+        }
+        if status.is_client_error() {
+            return Err(RemoteSandboxError::Refused {
+                operation,
+                code: if body.error.is_empty() {
+                    format!("http_{}", status.as_u16())
+                } else {
+                    body.error
+                },
+                message: body.error_description,
+            });
+        }
+        Err(RemoteSandboxError::Unavailable {
+            operation,
+            detail: format!("HTTP status {}", status.as_u16()),
+        })
+    }
+
+    /// Decodes a JSON body, naming the operation on failure.
+    async fn decode<T: for<'de> serde::Deserialize<'de>>(
+        operation: &'static str,
+        response: reqwest::Response,
+    ) -> Result<T, RemoteSandboxError> {
+        response
+            .json()
+            .await
+            .map_err(|_| RemoteSandboxError::Unavailable {
+                operation,
+                detail: "invalid response body".to_owned(),
+            })
+    }
+}
+
+#[async_trait]
+impl SandboxProvisioner for GatewayProvisioner {
+    async fn spawn(
+        &self,
+        owner: &OwnerId,
+        arguments: &SpawnArguments,
+    ) -> Result<SandboxLease, RemoteSandboxError> {
+        let url = self.endpoint(&format!(
+            "api/v1/runtime/endpoints/{}/sandboxes",
+            self.endpoint_slug
+        ))?;
+        let request = self
+            .http
+            .post(url)
+            .timeout(SPAWN_TIMEOUT)
+            .json(&serde_json::json!({ "arguments": arguments }));
+        let response = self.dispatch("spawn", request, owner).await?;
+        Self::decode("spawn", response).await
+    }
+
+    async fn status(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+    ) -> Result<SandboxStatus, RemoteSandboxError> {
+        let url = self.endpoint(&format!("api/v1/runtime/sandboxes/{sandbox_id}"))?;
+        let request = self.http.get(url).timeout(CALL_TIMEOUT);
+        let response = self.dispatch("status", request, owner).await?;
+        Self::decode("status", response).await
+    }
+
+    async fn events(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+        cursor: EventCursor,
+    ) -> Result<SandboxEvents, RemoteSandboxError> {
+        let wait = cursor
+            .wait_seconds
+            .unwrap_or(0)
+            .min(EVENTS_MAX_WAIT_SECONDS);
+        let url = self.endpoint(&format!("api/v1/runtime/sandboxes/{sandbox_id}/events"))?;
+        let request = self
+            .http
+            .get(url)
+            .timeout(Duration::from_secs(u64::from(wait)) + EVENTS_TIMEOUT_SLACK)
+            .query(&EventCursor {
+                wait_seconds: (wait > 0).then_some(wait),
+                ..cursor
+            });
+        let response = self.dispatch("events", request, owner).await?;
+        Self::decode("events", response).await
+    }
+
+    async fn send(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+        message: &SandboxMessage,
+    ) -> Result<MessageReceipt, RemoteSandboxError> {
+        message
+            .validate()
+            .map_err(RemoteSandboxError::InvalidRequest)?;
+        let url = self.endpoint(&format!("api/v1/runtime/sandboxes/{sandbox_id}/messages"))?;
+        let request = self.http.post(url).timeout(CALL_TIMEOUT).json(message);
+        let response = self.dispatch("send", request, owner).await?;
+        Self::decode("send", response).await
+    }
+
+    async fn cancel(&self, owner: &OwnerId, sandbox_id: &str) -> Result<(), RemoteSandboxError> {
+        let url = self.endpoint(&format!("api/v1/runtime/sandboxes/{sandbox_id}/cancel"))?;
+        let request = self.http.post(url).timeout(CALL_TIMEOUT);
+        self.dispatch("cancel", request, owner).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    use axum::extract::{Path, Query, State};
+    use axum::http::{HeaderMap, StatusCode};
+    use axum::routing::{get, post};
+    use axum::{Json, Router};
+    use serde_json::{json, Value};
+
+    use super::super::wire::SandboxState;
+    use super::super::RuntimeToken;
+    use super::*;
+
+    /// One captured request: the bearer presented and the JSON body, if any.
+    #[derive(Clone, Debug)]
+    struct Captured {
+        bearer: Option<String>,
+        body: Value,
+        query: HashMap<String, String>,
+    }
+
+    /// A fake runtime surface that records what it was asked and answers
+    /// from a canned script.
+    #[derive(Default)]
+    struct FakeRuntime {
+        captured: Mutex<Vec<Captured>>,
+        requests: AtomicUsize,
+        /// Status code and body the next requests answer with; empty means
+        /// the happy path.
+        refusal: Option<(StatusCode, Value)>,
+    }
+
+    impl FakeRuntime {
+        fn capture(&self, headers: &HeaderMap, body: Value, query: HashMap<String, String>) {
+            self.requests.fetch_add(1, Ordering::SeqCst);
+            self.captured.lock().unwrap().push(Captured {
+                bearer: headers
+                    .get(axum::http::header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| value.strip_prefix("Bearer "))
+                    .map(str::to_owned),
+                body,
+                query,
+            });
+        }
+
+        fn scripted(&self) -> Option<(StatusCode, Json<Value>)> {
+            self.refusal
+                .as_ref()
+                .map(|(status, body)| (*status, Json(body.clone())))
+        }
+    }
+
+    async fn spawn_route(
+        State(runtime): State<Arc<FakeRuntime>>,
+        Path(slug): Path<String>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, Json<Value>) {
+        runtime.capture(
+            &headers,
+            json!({ "slug": slug, "body": body }),
+            HashMap::new(),
+        );
+        if let Some(scripted) = runtime.scripted() {
+            return scripted;
+        }
+        (
+            StatusCode::OK,
+            Json(json!({
+                "sandbox_id": "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f",
+                "execution_id": "ignored",
+                "execution_mode": "buffered",
+                "state": "pending",
+                "latest_event_seq": 0,
+                "expires_in_seconds": 3600,
+            })),
+        )
+    }
+
+    async fn status_route(
+        State(runtime): State<Arc<FakeRuntime>>,
+        Path(sandbox_id): Path<String>,
+        headers: HeaderMap,
+    ) -> (StatusCode, Json<Value>) {
+        runtime.capture(
+            &headers,
+            json!({ "sandbox_id": sandbox_id }),
+            HashMap::new(),
+        );
+        if let Some(scripted) = runtime.scripted() {
+            return scripted;
+        }
+        (
+            StatusCode::OK,
+            Json(json!({
+                "sandbox_id": sandbox_id,
+                "state": "running",
+                "latest_event_seq": 12,
+                "pending_messages": 1,
+                "possibly_stalled": false,
+            })),
+        )
+    }
+
+    async fn events_route(
+        State(runtime): State<Arc<FakeRuntime>>,
+        Path(sandbox_id): Path<String>,
+        Query(query): Query<HashMap<String, String>>,
+        headers: HeaderMap,
+    ) -> Json<Value> {
+        runtime.capture(&headers, json!({ "sandbox_id": sandbox_id }), query);
+        Json(json!({
+            "sandbox_id": sandbox_id,
+            "state": "running",
+            "latest_event_seq": 4,
+            "events": [
+                { "seq": 3, "kind": "turn_started", "payload": { "turn": 2 }, "created_at": "2026-08-27T00:00:00Z" },
+                { "seq": 4, "kind": "kind_from_the_future", "payload": {}, "created_at": "2026-08-27T00:00:01Z" },
+            ],
+        }))
+    }
+
+    async fn messages_route(
+        State(runtime): State<Arc<FakeRuntime>>,
+        Path(sandbox_id): Path<String>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, Json<Value>) {
+        runtime.capture(&headers, body, HashMap::new());
+        if let Some(scripted) = runtime.scripted() {
+            return scripted;
+        }
+        (
+            StatusCode::OK,
+            Json(json!({
+                "sandbox_id": sandbox_id,
+                "seq": 7,
+                "interrupt": false,
+                "pending_messages": 0,
+            })),
+        )
+    }
+
+    async fn cancel_route(
+        State(runtime): State<Arc<FakeRuntime>>,
+        Path(sandbox_id): Path<String>,
+        headers: HeaderMap,
+    ) -> StatusCode {
+        runtime.capture(
+            &headers,
+            json!({ "sandbox_id": sandbox_id }),
+            HashMap::new(),
+        );
+        StatusCode::NO_CONTENT
+    }
+
+    async fn serve(runtime: Arc<FakeRuntime>) -> String {
+        let app = Router::new()
+            .route(
+                "/api/v1/runtime/endpoints/{slug}/sandboxes",
+                post(spawn_route),
+            )
+            .route("/api/v1/runtime/sandboxes/{sandbox_id}", get(status_route))
+            .route(
+                "/api/v1/runtime/sandboxes/{sandbox_id}/events",
+                get(events_route),
+            )
+            .route(
+                "/api/v1/runtime/sandboxes/{sandbox_id}/messages",
+                post(messages_route),
+            )
+            .route(
+                "/api/v1/runtime/sandboxes/{sandbox_id}/cancel",
+                post(cancel_route),
+            )
+            .with_state(runtime);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{address}")
+    }
+
+    /// Hands out one static token, the way tests inject credentials.
+    struct StaticTokens;
+
+    #[async_trait]
+    impl RuntimeTokenSource for StaticTokens {
+        async fn runtime_token(&self, _: &OwnerId) -> Result<RuntimeToken, RemoteSandboxError> {
+            Ok(RuntimeToken {
+                secret: "mg_at_test".to_owned(),
+            })
+        }
+    }
+
+    fn owner() -> OwnerId {
+        OwnerId::new("person-1").unwrap()
+    }
+
+    async fn client(runtime: Arc<FakeRuntime>) -> GatewayProvisioner {
+        let base = serve(runtime).await;
+        GatewayProvisioner::new(&base, "primary", Arc::new(StaticTokens)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn spawn_presents_the_bearer_on_the_endpoint_path_and_reads_the_lease() {
+        let runtime = Arc::new(FakeRuntime::default());
+        let provisioner = client(runtime.clone()).await;
+        let lease = provisioner
+            .spawn(
+                &owner(),
+                &SpawnArguments {
+                    profile: "default".to_owned(),
+                    harness: "claude_code".to_owned(),
+                    task: "fix the flaky test".to_owned(),
+                    repository: Some("https://github.com/org/repo".to_owned()),
+                    ..SpawnArguments::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(lease.sandbox_id, "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f");
+        assert_eq!(lease.state, SandboxState::Pending);
+        assert_eq!(lease.expires_in_seconds, 3600);
+
+        let captured = runtime.captured.lock().unwrap();
+        assert_eq!(captured[0].bearer.as_deref(), Some("mg_at_test"));
+        assert_eq!(captured[0].body["slug"], json!("primary"));
+        let arguments = &captured[0].body["body"]["arguments"];
+        assert_eq!(arguments["harness"], json!("claude_code"));
+        // Absent options must be omitted, not null: the spawn body rejects
+        // unknown or malformed fields.
+        assert!(arguments.get("model").is_none());
+        assert!(arguments.get("repositories").is_none());
+    }
+
+    #[tokio::test]
+    async fn status_reads_the_fields_the_session_acts_on() {
+        let runtime = Arc::new(FakeRuntime::default());
+        let provisioner = client(runtime).await;
+        let status = provisioner
+            .status(&owner(), "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f")
+            .await
+            .unwrap();
+        assert_eq!(status.sandbox_id, "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f");
+        assert_eq!(status.state, SandboxState::Running);
+        assert!(!status.state.is_terminal());
+        assert_eq!(status.latest_event_seq, 12);
+        assert_eq!(status.pending_messages, 1);
+        assert!(!status.possibly_stalled);
+        // Lenient decode: everything the fake omitted reads as absent.
+        assert_eq!(status.failure_reason, None);
+        assert_eq!(status.termination_reason, None);
+        assert_eq!(status.repository_url, None);
+        assert_eq!(status.spend_microusd, None);
+        assert_eq!(status.spend_ceiling_microusd, None);
+        assert_eq!(status.completed_at, None);
+    }
+
+    #[tokio::test]
+    async fn a_named_refusal_carries_the_environments_code_and_is_not_retryable() {
+        let runtime = Arc::new(FakeRuntime {
+            refusal: Some((
+                StatusCode::BAD_REQUEST,
+                json!({
+                    "error": "repository_not_operable",
+                    "error_description": "The GitHub App installation does not cover org/private.",
+                }),
+            )),
+            ..FakeRuntime::default()
+        });
+        let provisioner = client(runtime).await;
+        let error = provisioner
+            .spawn(
+                &owner(),
+                &SpawnArguments {
+                    profile: "default".to_owned(),
+                    harness: "claude_code".to_owned(),
+                    task: "task".to_owned(),
+                    ..SpawnArguments::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(!error.is_retryable());
+        match error {
+            RemoteSandboxError::Refused { code, message, .. } => {
+                assert_eq!(code, "repository_not_operable");
+                assert!(message.contains("org/private"));
+            }
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_invalid_token_asks_for_sign_in() {
+        let runtime = Arc::new(FakeRuntime {
+            refusal: Some((
+                StatusCode::UNAUTHORIZED,
+                json!({
+                    "error": "invalid_runtime_token",
+                    "error_description": "A valid runtime access token is required.",
+                }),
+            )),
+            ..FakeRuntime::default()
+        });
+        let provisioner = client(runtime).await;
+        let error = provisioner
+            .status(&owner(), "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f")
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RemoteSandboxError::SignInRequired(_)));
+    }
+
+    #[tokio::test]
+    async fn a_server_fault_is_retryable() {
+        let runtime = Arc::new(FakeRuntime {
+            refusal: Some((StatusCode::BAD_GATEWAY, json!({}))),
+            ..FakeRuntime::default()
+        });
+        let provisioner = client(runtime).await;
+        let error = provisioner
+            .status(&owner(), "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f")
+            .await
+            .unwrap_err();
+        assert!(error.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn events_round_trip_the_cursor_and_clamp_the_wait() {
+        let runtime = Arc::new(FakeRuntime::default());
+        let provisioner = client(runtime.clone()).await;
+        let events = provisioner
+            .events(
+                &owner(),
+                "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f",
+                EventCursor {
+                    after_seq: Some(2),
+                    limit: Some(100),
+                    wait_seconds: Some(600),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(events.latest_event_seq, 4);
+        assert_eq!(events.sandbox_id, "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f");
+        // State rides the events page so a poll loop need not also poll status.
+        assert_eq!(events.state, SandboxState::Running);
+        assert_eq!(events.events[0].seq, 3);
+        assert_eq!(events.events[0].payload["turn"], json!(2));
+        assert_eq!(events.events[0].created_at, "2026-08-27T00:00:00Z");
+        assert_eq!(events.events.len(), 2);
+        // Unknown kinds pass through untouched; interpretation is the
+        // session runtime's job, not the transport's.
+        assert_eq!(events.events[1].kind, "kind_from_the_future");
+
+        let captured = runtime.captured.lock().unwrap();
+        assert_eq!(captured[0].query.get("after_seq").unwrap(), "2");
+        assert_eq!(captured[0].query.get("limit").unwrap(), "100");
+        // 600 exceeds the environment's held-wait ceiling; the client clamps
+        // rather than letting the server clamp with a shorter HTTP timeout
+        // than the wait it asked for.
+        assert_eq!(captured[0].query.get("wait_seconds").unwrap(), "25");
+    }
+
+    #[tokio::test]
+    async fn an_empty_message_never_reaches_the_environment() {
+        let runtime = Arc::new(FakeRuntime::default());
+        let provisioner = client(runtime.clone()).await;
+        let error = provisioner
+            .send(
+                &owner(),
+                "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f",
+                &SandboxMessage {
+                    body: "  ".to_owned(),
+                    interrupt: false,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RemoteSandboxError::InvalidRequest(_)));
+        assert_eq!(runtime.requests.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn send_reads_the_receipt_and_cancel_accepts_no_content() {
+        let runtime = Arc::new(FakeRuntime::default());
+        let provisioner = client(runtime.clone()).await;
+        let sandbox = "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f";
+        let receipt = provisioner
+            .send(
+                &owner(),
+                sandbox,
+                &SandboxMessage {
+                    body: "also check the retry path".to_owned(),
+                    interrupt: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(receipt.seq, 7);
+        assert!(!receipt.interrupt);
+        assert_eq!(receipt.pending_messages, 0);
+        provisioner.cancel(&owner(), sandbox).await.unwrap();
+        let captured = runtime.captured.lock().unwrap();
+        assert_eq!(captured.len(), 2);
+        assert!(captured[0].body.get("interrupt").is_none());
+    }
+
+    #[tokio::test]
+    async fn the_token_never_appears_in_debug_output() {
+        let token = RuntimeToken {
+            secret: "mg_at_secret".to_owned(),
+        };
+        assert!(!format!("{token:?}").contains("mg_at_secret"));
+    }
+}

--- a/crates/tidebreak-server/src/code/remote/mod.rs
+++ b/crates/tidebreak-server/src/code/remote/mod.rs
@@ -1,0 +1,168 @@
+//! Remote session execution: the client side of the confining environment's
+//! sandbox runtime API.
+//!
+//! Decision [`0079`] split remote execution in two: the workload half is
+//! `tidebreak-supervised-agent`, polling outward to a control endpoint the
+//! environment owns; this module is the other half — the Tidebreak machine
+//! asking that environment to provision, watch, steer, and stop the sandbox
+//! a remote session's engine runs in. Tidebreak never dials into the pod.
+//!
+//! The pinned contract (`/api/v1/runtime/...` on the gateway):
+//!
+//! - `POST /api/v1/runtime/endpoints/{endpoint_slug}/sandboxes` — spawn.
+//!   Preflight refuses loudly (unknown profile, unreachable repository, a
+//!   ref the remote does not advertise, an unresolvable credential) before
+//!   anything is provisioned.
+//! - `GET /api/v1/runtime/sandboxes/{id}` — status. Cheap to poll.
+//! - `GET /api/v1/runtime/sandboxes/{id}/events` — the durable, sequenced,
+//!   gap-free event stream; `after_seq` resumes without loss, `wait_seconds`
+//!   (at most 25) holds until an event lands.
+//! - `POST /api/v1/runtime/sandboxes/{id}/messages` — append to the inbox
+//!   the agent drains. At-least-once and asynchronous: a receipt means
+//!   durable, not read.
+//! - `POST /api/v1/runtime/sandboxes/{id}/cancel` — stop, with a short
+//!   grace so the terminal WIP checkpoint can land.
+//!
+//! Every call authenticates with a short-lived `mg_at_` bearer minted for
+//! the resource `runtime:{endpoint_slug}` carrying the `runtime:execute`
+//! scope. Minting is behind [`RuntimeTokenSource`] because whose credential
+//! backs it is an owner-scoped policy question (the caller's machine-bound
+//! session, decisions 0049/0051), not a transport one.
+//!
+//! [`0079`]: ../../../../../docs/decisions/0079-supervised-agent-declines-the-sandbox-protocol.md
+
+// The session runtime consumes this module in a later slice (#2873); until
+// then only the tests construct it. Same stance as `scripted_harness`.
+#![cfg_attr(not(test), allow(dead_code))]
+
+pub(crate) mod gateway;
+pub(crate) mod wire;
+
+use async_trait::async_trait;
+use tidebreak_core::OwnerId;
+
+use wire::{
+    EventCursor, MessageReceipt, SandboxEvents, SandboxLease, SandboxMessage, SandboxStatus,
+    SpawnArguments,
+};
+
+/// Why one runtime call did not produce its result.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RemoteSandboxError {
+    /// The environment named a refusal; retrying the same request cannot
+    /// fix it. Carries the environment's own code and description so the
+    /// session surfaces the real reason, not a paraphrase.
+    #[error("the sandbox environment refused {operation} ({code}): {message}")]
+    Refused {
+        /// Which call was refused.
+        operation: &'static str,
+        /// Machine-readable refusal code.
+        code: String,
+        /// The environment's own description.
+        message: String,
+    },
+    /// The runtime token was rejected or cannot be minted; the owner signs
+    /// in again. Never retried onto another credential.
+    #[error("the sandbox environment rejected the runtime credential: {0}")]
+    SignInRequired(String),
+    /// A transport or server fault; retryable on the caller's cadence.
+    #[error("{operation} did not reach the sandbox environment: {detail}")]
+    Unavailable {
+        /// Which call failed.
+        operation: &'static str,
+        /// What went wrong.
+        detail: String,
+    },
+    /// This side refused the request before sending it.
+    #[error("invalid sandbox request: {0}")]
+    InvalidRequest(String),
+}
+
+impl RemoteSandboxError {
+    /// Whether retrying the same call later can succeed.
+    #[must_use]
+    pub(crate) fn is_retryable(&self) -> bool {
+        matches!(self, Self::Unavailable { .. })
+    }
+}
+
+/// A short-lived bearer for the runtime surface.
+///
+/// The secret is the whole value: no `Clone`, and `Debug` redacts it.
+pub(crate) struct RuntimeToken {
+    /// The `mg_at_` access token presented as the bearer.
+    pub secret: String,
+}
+
+impl std::fmt::Debug for RuntimeToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RuntimeToken")
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Mints the runtime bearer one owner's calls present.
+///
+/// Owner-scoped so spend, repository access, and policy follow the person
+/// (decision 0065's stance, applied to sandboxes): a session's sandbox is
+/// provisioned as its owner, never as a shared machine identity.
+#[async_trait]
+pub(crate) trait RuntimeTokenSource: Send + Sync {
+    /// A live token for `owner`, minted or refreshed as needed.
+    ///
+    /// # Errors
+    ///
+    /// [`RemoteSandboxError::SignInRequired`] when no credential for this
+    /// owner can mint one.
+    async fn runtime_token(&self, owner: &OwnerId) -> Result<RuntimeToken, RemoteSandboxError>;
+}
+
+/// The provisioning client a remote session drives its sandbox through.
+///
+/// One method per pinned route. Implementations are transport only: no
+/// lifecycle decisions, no retries past what a single call needs, no
+/// interpretation of event payloads — the session runtime owns all of that.
+#[async_trait]
+pub(crate) trait SandboxProvisioner: Send + Sync {
+    /// Asks the environment to provision one sandbox.
+    ///
+    /// Preflight refusals surface as [`RemoteSandboxError::Refused`] with
+    /// the environment's code; nothing was provisioned in that case.
+    async fn spawn(
+        &self,
+        owner: &OwnerId,
+        arguments: &SpawnArguments,
+    ) -> Result<SandboxLease, RemoteSandboxError>;
+
+    /// One sandbox's current lifecycle state.
+    async fn status(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+    ) -> Result<SandboxStatus, RemoteSandboxError>;
+
+    /// Reads the durable event stream after a cursor, oldest first.
+    ///
+    /// Holding `wait_seconds` under [`wire::EVENTS_MAX_WAIT_SECONDS`] keeps
+    /// the environment's clamp out of the picture.
+    async fn events(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+        cursor: EventCursor,
+    ) -> Result<SandboxEvents, RemoteSandboxError>;
+
+    /// Appends one message to the sandbox's inbox.
+    async fn send(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+        message: &SandboxMessage,
+    ) -> Result<MessageReceipt, RemoteSandboxError>;
+
+    /// Asks the environment to stop the sandbox. Idempotent server-side; a
+    /// running sandbox keeps a short grace so its terminal checkpoint lands.
+    async fn cancel(&self, owner: &OwnerId, sandbox_id: &str) -> Result<(), RemoteSandboxError>;
+}

--- a/crates/tidebreak-server/src/code/remote/wire.rs
+++ b/crates/tidebreak-server/src/code/remote/wire.rs
@@ -1,0 +1,367 @@
+//! The gateway runtime wire contract, as this server speaks it.
+//!
+//! These types mirror the confining environment's runtime API shapes
+//! (`/api/v1/runtime/...`); they are owned here rather than imported, the
+//! same stance `tidebreak-supervised-agent` takes toward the control
+//! endpoint (decision 0079): the environment owns the schema and this side
+//! tracks it directly. Two asymmetries are deliberate:
+//!
+//! - Request types serialize exactly the fields the environment documents
+//!   and nothing else, because the spawn and message bodies reject unknown
+//!   fields.
+//! - Response types default every field this server can live without, so an
+//!   environment that grows a field — or an older one that lacks one —
+//!   keeps working.
+
+use serde::{Deserialize, Serialize};
+
+/// Longest `events` wait the environment honors, in seconds. A larger
+/// request is clamped server-side; staying at or under it keeps the clamp
+/// out of the picture.
+pub(crate) const EVENTS_MAX_WAIT_SECONDS: u32 = 25;
+
+/// Largest message body the environment accepts, in bytes.
+pub(crate) const MESSAGE_MAX_BODY_BYTES: usize = 32 * 1024;
+
+/// One spawn request's arguments, exactly as the environment defines them.
+///
+/// Idle, wall-clock, and spend ceilings only ever narrow the profile's; the
+/// environment intersects rather than trusting these values. `max_turns` is
+/// a spawn-only opt-in — omission means no supervisor turn cap.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub(crate) struct SpawnArguments {
+    /// Administrator-defined profile name on the runtime endpoint.
+    pub profile: String,
+    /// Harness token the sandbox drives headless (`claude_code`, `codex`,
+    /// `opencode`, `grok_build`, `custom`).
+    pub harness: String,
+    /// Continuation policy: `goal` or `turn`. Omitted lets the environment
+    /// default (`goal` for a first-party harness).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    /// Task handed to the harness.
+    pub task: String,
+    /// Primary repository HTTPS URL. Absent for a research sandbox.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    /// Branch or commit to start from. Preflight verifies the remote
+    /// advertises it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository_ref: Option<String>,
+    /// Additional repositories beyond the primary, each with its own ref.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<SpawnRepository>,
+    /// Optional connected-app subset narrowing what the sandbox may reach.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub apps: Vec<String>,
+    /// Optional gateway model ID the harness is driven with.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Optional provider-neutral reasoning effort token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+    /// Optional subscription account the sandbox's inference is pinned to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription: Option<String>,
+    /// Optional idle ceiling in seconds, at most the profile's.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_seconds: Option<u32>,
+    /// Optional wall-clock ceiling in seconds, at most the profile's.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wall_clock_timeout_seconds: Option<u32>,
+    /// Optional spend ceiling in micro-USD of shadow model cost.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spend_ceiling_microusd: Option<i64>,
+    /// Optional turn budget including the spawn-task turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u32>,
+}
+
+/// One git repository a spawn declares.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct SpawnRepository {
+    /// HTTPS URL of the repository.
+    pub url: String,
+    /// Branch or commit to start from. Absent means the remote's default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository_ref: Option<String>,
+}
+
+/// What one accepted spawn produced. The spawner detaches; what it keeps is
+/// the identifier and the cursor position to resume from.
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct SandboxLease {
+    /// Sandbox identifier every other call takes. Opaque here.
+    pub sandbox_id: String,
+    /// Lifecycle state at the moment the row committed.
+    pub state: SandboxState,
+    /// Highest event sequence already persisted; resume after this.
+    #[serde(default)]
+    pub latest_event_seq: i64,
+    /// Wall-clock ceiling in seconds. A duration whose clock starts at pod
+    /// start, not a deadline.
+    #[serde(default)]
+    pub expires_in_seconds: i64,
+}
+
+/// One sandbox's lifecycle state.
+///
+/// `Unknown` absorbs states a newer environment names; treating them as
+/// non-terminal keeps this server polling rather than declaring an outcome
+/// it cannot read.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SandboxState {
+    /// Recorded and preflighted; no backend object exists yet.
+    Pending,
+    /// A backend object has been requested and is not yet ready.
+    Provisioning,
+    /// The harness is executing its task.
+    Running,
+    /// The task finished and results are still being delivered.
+    Completing,
+    /// The task finished and its results were delivered.
+    Completed,
+    /// The sandbox died: node loss, out-of-memory, a substrate refusal.
+    Failed,
+    /// A user or administrator cancelled the sandbox.
+    Cancelled,
+    /// The wall-clock ceiling elapsed before the task finished.
+    Expired,
+    /// A configured spend bound stopped the run.
+    CeilingExceeded,
+    /// A state this server does not know.
+    #[serde(other)]
+    Unknown,
+}
+
+impl SandboxState {
+    /// Whether the environment will run this sandbox no further.
+    #[must_use]
+    pub(crate) fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed
+                | Self::Failed
+                | Self::Cancelled
+                | Self::Expired
+                | Self::CeilingExceeded
+        )
+    }
+}
+
+/// Current state of one sandbox, reduced to the fields this server acts on.
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct SandboxStatus {
+    /// Sandbox identifier.
+    pub sandbox_id: String,
+    /// Current lifecycle state.
+    pub state: SandboxState,
+    /// Stable classification for a failed or expired sandbox.
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+    /// Why the sandbox was asked to stop, when something asked.
+    #[serde(default)]
+    pub termination_reason: Option<String>,
+    /// Highest event sequence persisted, or zero for a silent sandbox.
+    #[serde(default)]
+    pub latest_event_seq: i64,
+    /// Messages appended but not yet acknowledged as delivered.
+    #[serde(default)]
+    pub pending_messages: i64,
+    /// Primary repository the spawn pinned, absent for a research sandbox.
+    #[serde(default)]
+    pub repository_url: Option<String>,
+    /// Consumed inference spend in micro-USD of shadow model cost.
+    #[serde(default)]
+    pub spend_microusd: Option<i64>,
+    /// Spend ceiling in micro-USD, resolved at spawn.
+    #[serde(default)]
+    pub spend_ceiling_microusd: Option<i64>,
+    /// Advisory derivation that the run is busy and producing nothing.
+    #[serde(default)]
+    pub possibly_stalled: bool,
+    /// UTC completion timestamp, present exactly for terminal states.
+    #[serde(default)]
+    pub completed_at: Option<String>,
+}
+
+/// Cursor into one sandbox's durable, gap-free event stream.
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct EventCursor {
+    /// Highest sequence already seen; omit to read from the beginning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_seq: Option<i64>,
+    /// Maximum events to return.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+    /// Hold until an event lands past `after_seq`, at most
+    /// [`EVENTS_MAX_WAIT_SECONDS`]. Omit or zero for a single read.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wait_seconds: Option<u32>,
+}
+
+/// A page of one sandbox's durable event stream.
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct SandboxEvents {
+    /// Sandbox identifier.
+    pub sandbox_id: String,
+    /// State at read time, so an event poll need not also poll status.
+    pub state: SandboxState,
+    /// Highest sequence persisted, which may exceed the last event returned.
+    #[serde(default)]
+    pub latest_event_seq: i64,
+    /// Events after the requested cursor, oldest first and gap-free.
+    #[serde(default)]
+    pub events: Vec<SandboxEvent>,
+}
+
+/// One durable sandbox progress event.
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct SandboxEvent {
+    /// Per-sandbox monotonic, gap-free sequence number.
+    pub seq: i64,
+    /// Event kind slug.
+    pub kind: String,
+    /// Event payload.
+    #[serde(default)]
+    pub payload: serde_json::Value,
+    /// UTC event timestamp.
+    #[serde(default)]
+    pub created_at: String,
+}
+
+/// One message on its way into a running sandbox's inbox.
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct SandboxMessage {
+    /// Ordinary input for the sandbox's next turn. The environment attaches
+    /// no meaning to it.
+    pub body: String,
+    /// Whether to preempt the turn in flight rather than wait for it.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub interrupt: bool,
+}
+
+impl SandboxMessage {
+    /// Refuses a body the environment would refuse, before the request.
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if self.body.trim().is_empty() {
+            return Err("sandbox message body is empty".to_owned());
+        }
+        if self.body.len() > MESSAGE_MAX_BODY_BYTES {
+            return Err(format!(
+                "sandbox message body is {} bytes; the ceiling is {MESSAGE_MAX_BODY_BYTES}",
+                self.body.len()
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// The receipt for one appended message. Durability, never delivery:
+/// delivery is at-least-once and asynchronous.
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub(crate) struct MessageReceipt {
+    /// Per-sandbox monotonic sequence this message was recorded at.
+    pub seq: i64,
+    /// Whether it will preempt the turn in flight.
+    #[serde(default)]
+    pub interrupt: bool,
+    /// Messages ahead of this one still waiting to be delivered.
+    #[serde(default)]
+    pub pending_messages: i64,
+}
+
+/// The environment's error body: `{"error", "error_description"}`.
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(crate) struct RuntimeErrorBody {
+    /// Machine-readable refusal code.
+    #[serde(default)]
+    pub error: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub error_description: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The spawn body rejects unknown fields server-side, so what this side
+    /// serializes must be exactly the documented shape: declared fields
+    /// present, absent options omitted rather than null.
+    #[test]
+    fn spawn_arguments_omit_absent_fields() {
+        let arguments = SpawnArguments {
+            profile: "default".to_owned(),
+            harness: "claude_code".to_owned(),
+            task: "fix the flaky test".to_owned(),
+            repository: Some("https://github.com/org/repo".to_owned()),
+            ..SpawnArguments::default()
+        };
+        let value = serde_json::to_value(&arguments).unwrap();
+        let object = value.as_object().unwrap();
+        assert_eq!(
+            object.keys().collect::<Vec<_>>(),
+            ["harness", "profile", "repository", "task"]
+                .iter()
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_default_interrupt_is_omitted_from_the_message_body() {
+        let message = SandboxMessage {
+            body: "steer left".to_owned(),
+            interrupt: false,
+        };
+        let value = serde_json::to_value(&message).unwrap();
+        assert!(value.get("interrupt").is_none());
+        let message = SandboxMessage {
+            interrupt: true,
+            ..message
+        };
+        let value = serde_json::to_value(&message).unwrap();
+        assert_eq!(value["interrupt"], serde_json::json!(true));
+    }
+
+    /// A newer environment may name states this build does not know; they
+    /// must decode as `Unknown` and read as non-terminal.
+    #[test]
+    fn an_unknown_state_decodes_and_is_not_terminal() {
+        let state: SandboxState = serde_json::from_str("\"hibernating\"").unwrap();
+        assert_eq!(state, SandboxState::Unknown);
+        assert!(!state.is_terminal());
+        let state: SandboxState = serde_json::from_str("\"ceiling_exceeded\"").unwrap();
+        assert_eq!(state, SandboxState::CeilingExceeded);
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn a_lease_decodes_leniently() {
+        let lease: SandboxLease = serde_json::from_value(serde_json::json!({
+            "sandbox_id": "0d9f5a52-6a5e-4f6e-9d16-1f9a1c2b3d4e",
+            "execution_id": "unused-by-this-side",
+            "execution_mode": "buffered",
+            "state": "pending",
+            "unknown_future_field": 7,
+        }))
+        .unwrap();
+        assert_eq!(lease.state, SandboxState::Pending);
+        assert_eq!(lease.latest_event_seq, 0);
+    }
+
+    #[test]
+    fn message_validation_names_the_fault() {
+        let empty = SandboxMessage {
+            body: "   ".to_owned(),
+            interrupt: false,
+        };
+        assert!(empty.validate().unwrap_err().contains("empty"));
+        let oversized = SandboxMessage {
+            body: "x".repeat(MESSAGE_MAX_BODY_BYTES + 1),
+            interrupt: false,
+        };
+        assert!(oversized.validate().unwrap_err().contains("ceiling"));
+    }
+}

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -376,10 +376,16 @@ thread with `repo:owner/name`."
 The session's engine runs in a per-session confined sandbox driven by
 `tidebreak-supervised-agent`
 ([`0079`](decisions/0079-supervised-agent-declines-the-sandbox-protocol.md)).
-Tidebreak calls the confining environment's provisioning API — that
-external contract (spawn, steer, events, ceilings) is a named stage 1
-dependency, and this section is written against it, not against
-machinery Tidebreak owns. This unparks remote session execution in
+Tidebreak calls the confining environment's runtime API. That contract
+is pinned in `crates/tidebreak-server/src/code/remote/`: spawn on
+`POST /api/v1/runtime/endpoints/{endpoint_slug}/sandboxes` (preflight
+refuses loudly before anything is provisioned), status, a durable
+gap-free events cursor with a held wait of at most 25 seconds, inbox
+messages, and cancel — each call authenticated with a short-lived
+per-owner bearer minted for the `runtime:{endpoint_slug}` resource with
+the `runtime:execute` scope, so a sandbox is provisioned as its owner
+and never as a shared machine identity. This unparks remote session
+execution in
 [`deferred.md`](deferred.md); the parking of "deeper isolation" there
 concerned detached execution under Tidebreak's own container trust root,
 which this path does not use.
@@ -532,8 +538,9 @@ none.
 
 ### Stage 1: remote execution for repository sessions
 
-The heaviest stage, and named as such: provisioning client against the
-confining environment's API, incarnation intent protocol, event
+The heaviest stage, and named as such: the provisioning client against
+the pinned runtime contract (landed in `code/remote/`), incarnation
+intent protocol, event
 ingestion into the journal, WIP-ref resume with the new remote fence
 causes, cap reservation, spend ledger, per-session idle stop. It also
 widens the supervised agent's event vocabulary with a bounded per-turn


### PR DESCRIPTION
Slice 1 of #2875 (Slack sessions stage 1); closes #2869.

Pins the provisioning contract between Tidebreak and the environment that confines a remote session's sandbox, and lands the client:

- `code/remote/wire.rs` — the runtime API shapes, mirrored locally the way `tidebreak-supervised-agent` mirrors the control endpoint (decision 0079): requests serialize exactly the documented fields (the spawn and message bodies reject unknown fields), responses default everything this side can live without, and an unknown lifecycle state decodes as non-terminal `Unknown` so a newer environment never reads as an outcome.
- `code/remote/mod.rs` — the `SandboxProvisioner` trait (spawn, status, events, send, cancel), a typed error split (named refusal / sign-in required / retryable unavailability / local invalid request), and the `RuntimeTokenSource` seam: every call presents a per-owner `mg_at_` bearer minted for `runtime:{endpoint_slug}` with the `runtime:execute` scope, so sandboxes are provisioned as their owner, never as a shared machine identity.
- `code/remote/gateway.rs` — the gateway-backed implementation. Spawn gets a 120s ceiling (preflight resolves every declared repository against its remote); an events read gets its held wait (clamped to the environment's 25s ceiling) plus slack; refusal bodies map to the environment's own code and description.

Nothing consumes the module yet — the session runtime does in #2873 — so the module carries the `scripted_harness`-style `cfg_attr(not(test), allow(dead_code))`.

Ran: `cargo test -p tidebreak-server --lib code::remote` (14 tests, including a fake runtime server asserting the bearer, paths, body shape, cursor round-trip and wait clamp, refusal mapping, and that an empty message never leaves the process), `cargo clippy -p tidebreak-server --all-targets` clean for the module, `cargo fmt --check`.
