### PR TITLE
feat(core): record sandbox incarnations with an intent protocol

### DIFF
--- a/crates/tidebreak-core/src/attention.rs
+++ b/crates/tidebreak-core/src/attention.rs
@@ -96,6 +96,27 @@ pub enum FenceReason {
         /// Bounded detail from the last failure, as the engine reported it.
         detail: String,
     },
+    /// A remote session's incarnation record cannot say whether a sandbox
+    /// runs: an intent that never activated, or an environment answer the
+    /// protocol could not reconcile. Reap closes the record; the reconcile
+    /// sweep cancels whatever the environment still holds.
+    IncarnationUnresolved {
+        /// Bounded human-readable detail.
+        detail: String,
+    },
+    /// The environment reports a remote session's sandbox gone mid-turn —
+    /// node loss, a substrate refusal, a kill the session did not ask for.
+    SandboxLost {
+        /// Bounded detail, as the environment classified it.
+        detail: String,
+    },
+    /// A remote incarnation stopped but its terminal events never reached
+    /// the journal, so a resume would run without its predecessor's last
+    /// output. Reap acknowledges the gap and unblocks a fresh incarnation.
+    TerminalFlushMissing {
+        /// Bounded human-readable detail.
+        detail: String,
+    },
 }
 
 impl FenceReason {
@@ -111,11 +132,20 @@ impl FenceReason {
     /// answered and the turns failed — an expired credential, a refused
     /// prompt, a provider outage. The process is accounted for and the
     /// worktree is not at risk, so a healthy sibling session keeps working.
+    ///
+    /// Also false for the remote causes ([`Self::IncarnationUnresolved`],
+    /// [`Self::SandboxLost`], [`Self::TerminalFlushMissing`]): a remote
+    /// session's engine writes inside its sandbox, never to a host worktree,
+    /// so there is nothing on this machine its fence must protect. The
+    /// session itself still waits for an explicit reap.
     #[must_use]
     pub const fn blocks_workspace(&self) -> bool {
         match self {
             Self::OrphanAlive | Self::ProbeAmbiguous { .. } | Self::ResumeLost { .. } => true,
-            Self::RepeatedTurnFailures { .. } => false,
+            Self::RepeatedTurnFailures { .. }
+            | Self::IncarnationUnresolved { .. }
+            | Self::SandboxLost { .. }
+            | Self::TerminalFlushMissing { .. } => false,
         }
     }
 }

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -103,6 +103,10 @@ code_id_type!(
     CodeWatchId
 );
 code_id_type!(
+    /// Identifies one sandbox lifetime within a remote session.
+    CodeIncarnationId
+);
+code_id_type!(
     /// Identifies one durable trigger rule bound to a repository.
     CodeTriggerId
 );
@@ -1201,6 +1205,94 @@ pub struct CodeQueuedTurn {
 impl CodeQueuedTurn {
     /// Queue depth cap per session, matching the chat queue's per-chat cap.
     pub const MAX_PER_SESSION: usize = 32;
+}
+
+/// Lifecycle of one sandbox lifetime within a remote session.
+///
+/// Written in the order the protocol runs: the intent row commits before the
+/// environment is asked to provision, activation records what the spawn
+/// returned, and stopped is terminal. A row that never leaves intent marks a
+/// spawn whose outcome nothing recorded — the reconcile sweep's quarry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IncarnationState {
+    /// Committed before provisioning; no sandbox is known yet.
+    Intent,
+    /// The environment accepted the spawn; `sandbox_id` names the sandbox.
+    Active,
+    /// Terminal. `stop_reason` says why, when known.
+    Stopped,
+}
+
+impl IncarnationState {
+    /// The stored token, matching the table's CHECK constraint.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Intent => "intent",
+            Self::Active => "active",
+            Self::Stopped => "stopped",
+        }
+    }
+
+    /// Parses a stored token.
+    #[must_use]
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "intent" => Some(Self::Intent),
+            "active" => Some(Self::Active),
+            "stopped" => Some(Self::Stopped),
+            _ => None,
+        }
+    }
+}
+
+/// One sandbox lifetime of a remote session, as stored.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeSessionIncarnation {
+    /// Stable id.
+    pub id: CodeIncarnationId,
+    /// Owning session.
+    pub session_id: CodeSessionId,
+    /// 1-based counter within the session; the agent names WIP refs with it.
+    pub incarnation: i32,
+    /// Where in the protocol this row is.
+    pub state: IncarnationState,
+    /// The environment's sandbox identifier, recorded at activation.
+    pub sandbox_id: Option<String>,
+    /// The turn number this incarnation starts at, for resume.
+    pub starting_turn: i32,
+    /// Terminal classification, when the environment named one.
+    pub stop_reason: Option<String>,
+    /// Last observed inference spend in micro-USD, for the session ledger.
+    pub spend_microusd: Option<i64>,
+    /// Whether this incarnation's terminal events reached the journal.
+    ///
+    /// Reincarnation waits on this: a successor built before the
+    /// predecessor's terminal events land would resume without them.
+    pub terminal_events_journaled: bool,
+    /// Intent time.
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Activation time, when the spawn returned.
+    pub activated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Stop time.
+    pub stopped_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Last write time.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// The outcome of asking for a new incarnation under the owner's cap.
+#[derive(Debug, Clone, PartialEq)]
+pub enum IncarnationAdmission {
+    /// The intent row committed; provision against it.
+    Admitted(CodeSessionIncarnation),
+    /// The owner is at their concurrent-sandbox cap.
+    CapExhausted {
+        /// Sessions holding the live incarnations, so the refusal can name
+        /// what is running instead of only a number.
+        running: Vec<CodeSessionId>,
+    },
 }
 
 /// Bounded image reference recorded on a code-mode user turn.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1906,6 +1906,35 @@ pub mod code_queued_turn {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod code_session_incarnation {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "code_session_incarnation")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub owner: String,
+        pub session_id: Uuid,
+        pub incarnation: i32,
+        pub state: String,
+        pub sandbox_id: Option<String>,
+        pub starting_turn: i32,
+        pub stop_reason: Option<String>,
+        pub spend_microusd: Option<i64>,
+        pub terminal_events_journaled: bool,
+        pub created_at: DateTimeUtc,
+        pub activated_at: Option<DateTimeUtc>,
+        pub stopped_at: Option<DateTimeUtc>,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod code_session_image {
     use sea_orm::entity::prelude::*;
 

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -59,6 +59,7 @@ impl MigratorTrait for Migrator {
             Box::new(CodePermissionModeIntent),
             Box::new(AgentNotification),
             Box::new(CodeWorkflowRuns),
+            Box::new(CodeSessionIncarnations),
         ]
     }
 }
@@ -2591,6 +2592,151 @@ impl MigrationTrait for CodeQueuedTurns {
     }
 }
 
+/// Record every sandbox lifetime of a remote session as a durable row.
+///
+/// The intent → active → stopped protocol for remote execution (issue
+/// 2870): the row is written *before* the environment is asked to
+/// provision, so a crash between the spawn returning and the activation
+/// update leaves an intent row a reconcile sweep can find, instead of a
+/// spending sandbox nothing remembers. The `sandbox_incarnation` advisory
+/// row serializes the per-owner concurrency reservation the same way the
+/// claim paths serialize theirs.
+struct CodeSessionIncarnations;
+
+impl MigrationName for CodeSessionIncarnations {
+    fn name(&self) -> &str {
+        "m20260827_000022_code_session_incarnations"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CodeSessionIncarnations {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(idens::CodeSessionIncarnation::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::Owner)
+                            .text()
+                            .not_null()
+                            .default("local"),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::SessionId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::Incarnation)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::State)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(idens::CodeSessionIncarnation::SandboxId).text())
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::StartingTurn)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(idens::CodeSessionIncarnation::StopReason).text())
+                    .col(ColumnDef::new(idens::CodeSessionIncarnation::SpendMicrousd).big_integer())
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::TerminalEventsJournaled)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::ActivatedAt)
+                            .timestamp_with_time_zone(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::StoppedAt)
+                            .timestamp_with_time_zone(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeSessionIncarnation::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_code_session_incarnation_session")
+                            .from(
+                                idens::CodeSessionIncarnation::Table,
+                                idens::CodeSessionIncarnation::SessionId,
+                            )
+                            .to(idens::CodeSession::Table, idens::CodeSession::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(
+                        Expr::col(idens::CodeSessionIncarnation::State)
+                            .is_in(["intent", "active", "stopped"]),
+                    )
+                    .check(Expr::col(idens::CodeSessionIncarnation::Incarnation).gte(1))
+                    .check(Expr::col(idens::CodeSessionIncarnation::StartingTurn).gte(1))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("ix_code_session_incarnation_session")
+                    .table(idens::CodeSessionIncarnation::Table)
+                    .col(idens::CodeSessionIncarnation::SessionId)
+                    .col(idens::CodeSessionIncarnation::Incarnation)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("ix_code_session_incarnation_owner_state")
+                    .table(idens::CodeSessionIncarnation::Table)
+                    .col(idens::CodeSessionIncarnation::Owner)
+                    .col(idens::CodeSessionIncarnation::State)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        // The reservation lock, seeded the way the baseline seeds the claim
+        // paths: a missing row reads as a hard error at acquire time.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "INSERT INTO advisory_lock (name) VALUES ('sandbox_incarnation') \
+                 ON CONFLICT DO NOTHING",
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Dropping the table would forget sandboxes that may still be
+        // running; the reconcile sweep needs these rows to cancel them.
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
@@ -2661,6 +2807,7 @@ mod tests {
                 "m20260826_000019_code_permission_mode_intent",
                 "m20260826_000020_agent_notification",
                 "m20260827_000021_code_workflow_runs",
+                "m20260827_000022_code_session_incarnations",
             ]
         );
         assert!(db

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -959,6 +959,25 @@ pub(crate) enum CodeQueuedTurn {
 }
 
 #[derive(DeriveIden)]
+pub(crate) enum CodeSessionIncarnation {
+    Table,
+    Id,
+    Owner,
+    SessionId,
+    Incarnation,
+    State,
+    SandboxId,
+    StartingTurn,
+    StopReason,
+    SpendMicrousd,
+    TerminalEventsJournaled,
+    CreatedAt,
+    ActivatedAt,
+    StoppedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
 pub(crate) enum CodeEvent {
     Table,
     SessionId,

--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -1,0 +1,334 @@
+//! Durable sandbox lifetimes for remote sessions (the incarnation intent
+//! protocol).
+//!
+//! The order is the contract: [`create_incarnation_intent`] commits a row
+//! *before* the environment is asked to provision, [`activate_incarnation`]
+//! records what the spawn returned, and [`stop_incarnation`] is terminal. A
+//! crash between spawn and activation leaves an intent row the reconcile
+//! sweep can find and cancel, instead of a spending sandbox nothing
+//! remembers.
+//!
+//! The intent insert is also the owner's concurrency reservation. It counts
+//! live rows and inserts in one transaction under the `sandbox_incarnation`
+//! advisory lock, so two sessions reincarnating at once cannot both read
+//! `cap - 1` and both spawn — the check-then-act shape the cap exists to
+//! prevent.
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+
+use crate::code::{
+    CodeIncarnationId, CodeSessionId, CodeSessionIncarnation, IncarnationAdmission,
+    IncarnationState,
+};
+use crate::error::{AgentError, Result};
+use crate::OwnerId;
+
+use super::super::super::{entities, store_err, DbStore};
+use super::super::agent_run::database_now;
+use super::super::{acquire_advisory_lock, AdvisoryLockName};
+
+fn incarnation_from_model(
+    model: entities::code_session_incarnation::Model,
+) -> Result<CodeSessionIncarnation> {
+    Ok(CodeSessionIncarnation {
+        id: CodeIncarnationId(model.id),
+        session_id: CodeSessionId(model.session_id),
+        incarnation: model.incarnation,
+        state: IncarnationState::from_str(&model.state).ok_or_else(|| {
+            AgentError::Store(format!(
+                "invalid stored incarnation state {:?}",
+                model.state
+            ))
+        })?,
+        sandbox_id: model.sandbox_id,
+        starting_turn: model.starting_turn,
+        stop_reason: model.stop_reason,
+        spend_microusd: model.spend_microusd,
+        terminal_events_journaled: model.terminal_events_journaled,
+        created_at: model.created_at,
+        activated_at: model.activated_at,
+        stopped_at: model.stopped_at,
+        updated_at: model.updated_at,
+    })
+}
+
+/// Rows that hold a slot against the owner's cap: everything not stopped.
+fn live_states() -> [&'static str; 2] {
+    [
+        IncarnationState::Intent.as_str(),
+        IncarnationState::Active.as_str(),
+    ]
+}
+
+/// Reserves the owner's next incarnation for `session_id`, or refuses at
+/// the cap.
+///
+/// On admission the returned row is in [`IncarnationState::Intent`] with the
+/// next per-session incarnation number; the caller provisions against it and
+/// then activates or stops it. On refusal the sessions holding live
+/// incarnations come back so the refusal can name what is running.
+pub async fn create_incarnation_intent(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    starting_turn: i32,
+    cap: usize,
+) -> Result<IncarnationAdmission> {
+    let txn = store.conn.begin().await.map_err(store_err)?;
+    acquire_advisory_lock(&txn, AdvisoryLockName::SandboxIncarnation).await?;
+
+    let live = entities::code_session_incarnation::Entity::find()
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::State.is_in(live_states()))
+        .all(&txn)
+        .await
+        .map_err(store_err)?;
+    if live.len() >= cap {
+        let mut running: Vec<CodeSessionId> = live
+            .iter()
+            .map(|row| CodeSessionId(row.session_id))
+            .collect();
+        running.sort_by_key(|id| id.0);
+        running.dedup();
+        txn.rollback().await.map_err(store_err)?;
+        return Ok(IncarnationAdmission::CapExhausted { running });
+    }
+
+    let last = entities::code_session_incarnation::Entity::find()
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::SessionId.eq(session_id.0))
+        .order_by_desc(entities::code_session_incarnation::Column::Incarnation)
+        .one(&txn)
+        .await
+        .map_err(store_err)?;
+    if let Some(last) = &last {
+        // One live incarnation per session: the serialize-stop-then-resume
+        // rule. A successor minted beside a live predecessor would race it
+        // for the same engine session.
+        if IncarnationState::from_str(&last.state) != Some(IncarnationState::Stopped) {
+            txn.rollback().await.map_err(store_err)?;
+            return Err(AgentError::Store(format!(
+                "session {} already has a live incarnation {}",
+                session_id.0, last.incarnation
+            )));
+        }
+    }
+    let incarnation = last.as_ref().map_or(1, |row| row.incarnation + 1);
+
+    let now = database_now(&txn).await?;
+    let model = entities::code_session_incarnation::ActiveModel {
+        id: Set(uuid::Uuid::new_v4()),
+        owner: Set(owner.as_str().to_owned()),
+        session_id: Set(session_id.0),
+        incarnation: Set(incarnation),
+        state: Set(IncarnationState::Intent.as_str().to_owned()),
+        sandbox_id: Set(None),
+        starting_turn: Set(starting_turn),
+        stop_reason: Set(None),
+        spend_microusd: Set(None),
+        terminal_events_journaled: Set(false),
+        created_at: Set(now),
+        activated_at: Set(None),
+        stopped_at: Set(None),
+        updated_at: Set(now),
+    };
+    let inserted = model.insert(&txn).await.map_err(store_err)?;
+    txn.commit().await.map_err(store_err)?;
+    Ok(IncarnationAdmission::Admitted(incarnation_from_model(
+        inserted,
+    )?))
+}
+
+/// Records the spawned sandbox on an intent row and marks it active.
+///
+/// Guarded on the current state: activating a row that is not an intent —
+/// stopped by the sweep while the spawn was in flight, say — is reported,
+/// and the caller must treat the sandbox it spawned as orphaned and cancel
+/// it rather than run against a row the protocol already closed.
+pub async fn activate_incarnation(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeIncarnationId,
+    sandbox_id: &str,
+) -> Result<()> {
+    let now = database_now(&store.conn).await?;
+    let updated = entities::code_session_incarnation::Entity::update_many()
+        .col_expr(
+            entities::code_session_incarnation::Column::State,
+            sea_orm::sea_query::Expr::value(IncarnationState::Active.as_str()),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::SandboxId,
+            sea_orm::sea_query::Expr::value(sandbox_id),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::ActivatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::Id.eq(id.0))
+        .filter(
+            entities::code_session_incarnation::Column::State.eq(IncarnationState::Intent.as_str()),
+        )
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "incarnation {} is not an open intent",
+            id.0
+        )));
+    }
+    Ok(())
+}
+
+/// Marks an incarnation stopped, from intent or active. Idempotent: a row
+/// already stopped keeps its first reason.
+pub async fn stop_incarnation(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeIncarnationId,
+    reason: Option<&str>,
+) -> Result<()> {
+    let now = database_now(&store.conn).await?;
+    entities::code_session_incarnation::Entity::update_many()
+        .col_expr(
+            entities::code_session_incarnation::Column::State,
+            sea_orm::sea_query::Expr::value(IncarnationState::Stopped.as_str()),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::StopReason,
+            sea_orm::sea_query::Expr::value(reason),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::StoppedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::Id.eq(id.0))
+        .filter(entities::code_session_incarnation::Column::State.is_in(live_states()))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+/// Records that the incarnation's terminal events reached the journal.
+///
+/// The gate reincarnation waits on: a successor built before this is set
+/// would resume without its predecessor's last output.
+pub async fn mark_incarnation_terminal_events_journaled(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeIncarnationId,
+) -> Result<()> {
+    let now = database_now(&store.conn).await?;
+    entities::code_session_incarnation::Entity::update_many()
+        .col_expr(
+            entities::code_session_incarnation::Column::TerminalEventsJournaled,
+            sea_orm::sea_query::Expr::value(true),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::Id.eq(id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+/// Updates the last observed spend on an incarnation, for the session
+/// ledger. Per-spawn ceilings multiply by reincarnation; the ledger is what
+/// a cumulative per-session ceiling reads.
+pub async fn record_incarnation_spend(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeIncarnationId,
+    spend_microusd: i64,
+) -> Result<()> {
+    let now = database_now(&store.conn).await?;
+    entities::code_session_incarnation::Entity::update_many()
+        .col_expr(
+            entities::code_session_incarnation::Column::SpendMicrousd,
+            sea_orm::sea_query::Expr::value(spend_microusd),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::Id.eq(id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+/// The session's newest incarnation, in any state.
+pub async fn latest_incarnation(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<Option<CodeSessionIncarnation>> {
+    entities::code_session_incarnation::Entity::find()
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::SessionId.eq(session_id.0))
+        .order_by_desc(entities::code_session_incarnation::Column::Incarnation)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(incarnation_from_model)
+        .transpose()
+}
+
+/// The session's cumulative spend across every incarnation, in micro-USD.
+pub async fn session_spend_microusd(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<i64> {
+    let rows = entities::code_session_incarnation::Entity::find()
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::SessionId.eq(session_id.0))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(rows.iter().filter_map(|row| row.spend_microusd).sum())
+}
+
+/// Intent rows older than `cutoff` that never activated, every owner.
+///
+/// `_all_owners` because this is the reconcile sweep's system path, not a
+/// request path: the sweep runs machine-wide, and each row it finds is a
+/// spawn whose outcome nothing recorded. The sweep stops the row and, when the environment knows a
+/// matching sandbox, cancels it.
+pub async fn stale_incarnation_intents_all_owners(
+    store: &DbStore,
+    cutoff: chrono::DateTime<chrono::Utc>,
+) -> Result<Vec<CodeSessionIncarnation>> {
+    entities::code_session_incarnation::Entity::find()
+        .filter(
+            entities::code_session_incarnation::Column::State.eq(IncarnationState::Intent.as_str()),
+        )
+        .filter(entities::code_session_incarnation::Column::CreatedAt.lt(cutoff))
+        .order_by_asc(entities::code_session_incarnation::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(incarnation_from_model)
+        .collect()
+}

--- a/crates/tidebreak-core/src/db/ops/code/mod.rs
+++ b/crates/tidebreak-core/src/db/ops/code/mod.rs
@@ -12,6 +12,7 @@ use crate::OwnerId;
 use super::super::{entities, store_err};
 
 pub mod approval;
+pub mod incarnation;
 pub mod journal;
 pub mod pull_request;
 pub mod queued;
@@ -27,6 +28,7 @@ pub mod workflow_run;
 pub mod workspace;
 
 pub use approval::*;
+pub use incarnation::*;
 pub use journal::*;
 pub use pull_request::*;
 pub use queued::*;

--- a/crates/tidebreak-core/src/db/ops/mod.rs
+++ b/crates/tidebreak-core/src/db/ops/mod.rs
@@ -49,6 +49,8 @@ pub(in crate::db) enum AdvisoryLockName {
     AgentRunClaim,
     /// Serializes parking and resuming turns that wait on agent runs.
     TurnAgentRunWait,
+    /// Serializes per-owner sandbox incarnation reservations.
+    SandboxIncarnation,
 }
 
 impl AdvisoryLockName {
@@ -60,6 +62,7 @@ impl AdvisoryLockName {
             Self::TurnClaim => "turn_claim",
             Self::AgentRunClaim => "agent_run_claim",
             Self::TurnAgentRunWait => "turn_agent_run_wait",
+            Self::SandboxIncarnation => "sandbox_incarnation",
         }
     }
 }

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4478,3 +4478,176 @@ async fn workflow_run_facts_drop_rows_that_left_the_host_page() {
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].github_id, 77);
 }
+
+// --- Sandbox incarnations (the intent -> active -> stopped protocol) ---
+
+async fn admit(
+    store: &crate::db::DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    starting_turn: i32,
+    cap: usize,
+) -> crate::code::IncarnationAdmission {
+    crate::db::code::create_incarnation_intent(store, owner, session_id, starting_turn, cap)
+        .await
+        .unwrap()
+}
+
+fn admitted(admission: crate::code::IncarnationAdmission) -> crate::code::CodeSessionIncarnation {
+    match admission {
+        crate::code::IncarnationAdmission::Admitted(row) => row,
+        crate::code::IncarnationAdmission::CapExhausted { running } => {
+            panic!("expected admission, cap named {running:?}")
+        }
+    }
+}
+
+/// The reservation is the cap: a second owner-wide live incarnation past the
+/// cap is refused naming what runs, and a stop frees the slot.
+#[tokio::test]
+async fn the_incarnation_cap_refuses_and_names_the_running_sessions() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let (session_a, _) = seed_owner(&store, &owner, "cap-a").await;
+    let (session_b, _) = seed_owner(&store, &owner, "cap-b").await;
+
+    let first = admitted(admit(&store, &owner, session_a, 1, 1).await);
+    assert_eq!(first.incarnation, 1);
+    assert_eq!(first.state, crate::code::IncarnationState::Intent);
+
+    let refused = admit(&store, &owner, session_b, 1, 1).await;
+    match refused {
+        crate::code::IncarnationAdmission::CapExhausted { running } => {
+            assert_eq!(running, vec![session_a]);
+        }
+        other => panic!("expected the cap to refuse, got {other:?}"),
+    }
+
+    crate::db::code::stop_incarnation(&store, &owner, first.id, Some("cancelled"))
+        .await
+        .unwrap();
+    admitted(admit(&store, &owner, session_b, 1, 1).await);
+}
+
+/// Activation is guarded on the intent state: a row the protocol already
+/// closed refuses, so the caller cancels the sandbox it spawned instead of
+/// running against a closed row.
+#[tokio::test]
+async fn activation_records_the_sandbox_and_only_from_an_open_intent() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let (session, _) = seed_owner(&store, &owner, "activate").await;
+
+    let intent = admitted(admit(&store, &owner, session, 1, 4).await);
+    crate::db::code::activate_incarnation(&store, &owner, intent.id, "sandbox-1")
+        .await
+        .unwrap();
+    let live = crate::db::code::latest_incarnation(&store, &owner, session)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live.state, crate::code::IncarnationState::Active);
+    assert_eq!(live.sandbox_id.as_deref(), Some("sandbox-1"));
+    assert!(live.activated_at.is_some());
+
+    let again = crate::db::code::activate_incarnation(&store, &owner, intent.id, "sandbox-2").await;
+    assert!(again.is_err());
+
+    crate::db::code::stop_incarnation(&store, &owner, intent.id, Some("expired"))
+        .await
+        .unwrap();
+    let stopped =
+        crate::db::code::activate_incarnation(&store, &owner, intent.id, "sandbox-3").await;
+    assert!(stopped.is_err());
+}
+
+/// One live incarnation per session: a successor minted beside a live
+/// predecessor would race it for the same engine session.
+#[tokio::test]
+async fn a_second_live_incarnation_for_one_session_is_refused() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let (session, _) = seed_owner(&store, &owner, "double").await;
+
+    admitted(admit(&store, &owner, session, 1, 4).await);
+    let second = crate::db::code::create_incarnation_intent(&store, &owner, session, 2, 4).await;
+    assert!(second.is_err());
+}
+
+/// Reincarnation counts up, keeps the starting turn, and the session ledger
+/// sums spend across every incarnation.
+#[tokio::test]
+async fn reincarnation_counts_up_and_the_ledger_sums_across_incarnations() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let (session, _) = seed_owner(&store, &owner, "ledger").await;
+
+    let first = admitted(admit(&store, &owner, session, 1, 4).await);
+    crate::db::code::activate_incarnation(&store, &owner, first.id, "sandbox-1")
+        .await
+        .unwrap();
+    crate::db::code::record_incarnation_spend(&store, &owner, first.id, 1_500_000)
+        .await
+        .unwrap();
+    crate::db::code::stop_incarnation(&store, &owner, first.id, Some("completed"))
+        .await
+        .unwrap();
+    crate::db::code::mark_incarnation_terminal_events_journaled(&store, &owner, first.id)
+        .await
+        .unwrap();
+
+    let second = admitted(admit(&store, &owner, session, 5, 4).await);
+    assert_eq!(second.incarnation, 2);
+    assert_eq!(second.starting_turn, 5);
+    crate::db::code::activate_incarnation(&store, &owner, second.id, "sandbox-2")
+        .await
+        .unwrap();
+    crate::db::code::record_incarnation_spend(&store, &owner, second.id, 700_000)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        crate::db::code::session_spend_microusd(&store, &owner, session)
+            .await
+            .unwrap(),
+        2_200_000
+    );
+    let latest = crate::db::code::latest_incarnation(&store, &owner, session)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(latest.incarnation, 2);
+    // The predecessor's journaled gate is on its own row, not the latest.
+    assert!(!latest.terminal_events_journaled);
+}
+
+/// The sweep reads exactly the intents whose spawn outcome nothing recorded:
+/// old enough, never activated.
+#[tokio::test]
+async fn stale_intents_list_only_old_unactivated_rows() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let (session_a, _) = seed_owner(&store, &owner, "stale-a").await;
+    let (session_b, _) = seed_owner(&store, &owner, "stale-b").await;
+
+    let orphan = admitted(admit(&store, &owner, session_a, 1, 4).await);
+    let activated = admitted(admit(&store, &owner, session_b, 1, 4).await);
+    crate::db::code::activate_incarnation(&store, &owner, activated.id, "sandbox-ok")
+        .await
+        .unwrap();
+
+    let past = Utc::now() - chrono::Duration::minutes(5);
+    assert!(
+        crate::db::code::stale_incarnation_intents_all_owners(&store, past)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    let future = Utc::now() + chrono::Duration::minutes(5);
+    let stale = crate::db::code::stale_incarnation_intents_all_owners(&store, future)
+        .await
+        .unwrap();
+    assert_eq!(stale.len(), 1);
+    assert_eq!(stale[0].id, orphan.id);
+}

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -135,6 +135,13 @@ export function fenceReasonText(reason: FenceReason): string {
   if (reason.type === "resume_lost") {
     return `The engine no longer has this session, so it cannot continue (${reason.detail}). Reap it to start a fresh engine session in this workspace; the transcript above is kept.`;
   }
+  if (
+    reason.type === "incarnation_unresolved" ||
+    reason.type === "sandbox_lost" ||
+    reason.type === "terminal_flush_missing"
+  ) {
+    return `${reason.detail} Reap the session to close out the remote sandbox and start fresh; the journal above is kept.`;
+  }
   return reason.detail;
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -1311,6 +1311,26 @@ describe("parseFenceReason", () => {
         detail: "401",
       }),
     ).toEqual({ type: "repeated_turn_failures", count: 3, detail: "401" });
+    // The remote-session causes (issue 2870): a null would drop a fenced
+    // remote session from the list rather than just its badge.
+    expect(
+      parseFenceReason({
+        type: "incarnation_unresolved",
+        detail: "no spawn outcome",
+      }),
+    ).toEqual({ type: "incarnation_unresolved", detail: "no spawn outcome" });
+    expect(
+      parseFenceReason({ type: "sandbox_lost", detail: "node loss" }),
+    ).toEqual({
+      type: "sandbox_lost",
+      detail: "node loss",
+    });
+    expect(
+      parseFenceReason({
+        type: "terminal_flush_missing",
+        detail: "events unread",
+      }),
+    ).toEqual({ type: "terminal_flush_missing", detail: "events unread" });
   });
 
   it("rejects a malformed reason", () => {
@@ -1322,6 +1342,7 @@ describe("parseFenceReason", () => {
         detail: "x",
       }),
     ).toBeNull();
+    expect(parseFenceReason({ type: "sandbox_lost" })).toBeNull();
     expect(parseFenceReason({ type: "who_knows" })).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -3695,6 +3695,14 @@ export function parseFenceReason(value: unknown): FenceReason | null {
     return { type: "resume_lost", detail: value.detail };
   }
   if (
+    (value.type === "incarnation_unresolved" ||
+      value.type === "sandbox_lost" ||
+      value.type === "terminal_flush_missing") &&
+    typeof value.detail === "string"
+  ) {
+    return { type: value.type, detail: value.detail };
+  }
+  if (
     value.type === "repeated_turn_failures" &&
     typeof value.count === "number" &&
     typeof value.detail === "string"

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2399,6 +2399,18 @@ count: number,
 /**
  * Bounded detail from the last failure, as the engine reported it.
  */
+detail: string, } | { "type": "incarnation_unresolved", 
+/**
+ * Bounded human-readable detail.
+ */
+detail: string, } | { "type": "sandbox_lost", 
+/**
+ * Bounded detail, as the environment classified it.
+ */
+detail: string, } | { "type": "terminal_flush_missing", 
+/**
+ * Bounded human-readable detail.
+ */
 detail: string, };
 
 /**


### PR DESCRIPTION
## Summary

Store substrate for the incarnation intent protocol (#2870, epic #2875, design: `docs/slack-sessions.md`).

- New `code_session_incarnation` table (migration `m20260827_000022_code_session_incarnations`): uuid pk, owner, FK to `code_session` with cascade delete, `state in ('intent','active','stopped')`, per-session incarnation counter with a unique `(session_id, incarnation)` index, sandbox id, starting turn, stop reason, spend, and a terminal-events-journaled flag.
- Ops in `db/ops/code/incarnation.rs`: `create_incarnation_intent` reserves the owner's next incarnation in one transaction under a new `sandbox_incarnation` advisory lock — at the cap it refuses and names the sessions holding live incarnations; it also refuses a second live incarnation per session. `activate_incarnation` is guarded on an open intent, `stop_incarnation` is idempotent, and `stale_incarnation_intents_all_owners` is the reconcile sweep's system path for intents that never activated.
- Spend ledger: per-incarnation `record_incarnation_spend` plus `session_spend_microusd` summing across incarnations, for a cumulative per-session ceiling.
- Three new `FenceReason` variants — `incarnation_unresolved`, `sandbox_lost`, `terminal_flush_missing` — none of which block the workspace, since a remote engine writes inside its sandbox rather than the host worktree. Wire types regenerated; UI parser and fence copy updated.

## Testing

- `cargo test -p tidebreak-core` (db::tests::code 67 pass, attention 6 pass), including five new tests for the cap refusal, guarded activation, single-live-incarnation rule, ledger sum across reincarnations, and the stale-intent sweep query.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --all -- --check`.
- UI: biome check clean, `tsc --noEmit` clean, `vitest run src/code/parsers.test.ts` (72 pass).

Part of #2870.