### PR TITLE
fix(server): commit ingest side effects with the cursor

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -1279,6 +1279,8 @@ pub struct CodeSessionIncarnation {
     pub events_cursor: i64,
     /// The supervisor's terminal deliverable, when the run reported one.
     pub task_output: Option<String>,
+    /// The last WIP checkpoint ref this incarnation pushed, for resume.
+    pub last_wip_ref: Option<String>,
     /// Intent time.
     pub created_at: chrono::DateTime<chrono::Utc>,
     /// Activation time, when the spawn returned.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1925,6 +1925,7 @@ pub mod code_session_incarnation {
         pub terminal_events_journaled: bool,
         pub events_cursor: i64,
         pub task_output: Option<String>,
+        pub last_wip_ref: Option<String>,
         pub created_at: DateTimeUtc,
         pub activated_at: Option<DateTimeUtc>,
         pub stopped_at: Option<DateTimeUtc>,

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -2789,6 +2789,21 @@ impl MigrationTrait for IncarnationIngest {
                 )
                 .await?;
         }
+        if !manager
+            .has_column("code_session_incarnation", "last_wip_ref")
+            .await?
+        {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(idens::CodeSessionIncarnation::Table)
+                        .add_column(
+                            ColumnDef::new(idens::CodeSessionIncarnation::LastWipRef).text(),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+        }
         Ok(())
     }
 

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -973,6 +973,7 @@ pub(crate) enum CodeSessionIncarnation {
     TerminalEventsJournaled,
     EventsCursor,
     TaskOutput,
+    LastWipRef,
     CreatedAt,
     ActivatedAt,
     StoppedAt,

--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -49,6 +49,7 @@ fn incarnation_from_model(
         terminal_events_journaled: model.terminal_events_journaled,
         events_cursor: model.events_cursor,
         task_output: model.task_output,
+        last_wip_ref: model.last_wip_ref,
         created_at: model.created_at,
         activated_at: model.activated_at,
         stopped_at: model.stopped_at,
@@ -133,6 +134,7 @@ pub async fn create_incarnation_intent(
         terminal_events_journaled: Set(false),
         events_cursor: Set(0),
         task_output: Set(None),
+        last_wip_ref: Set(None),
         created_at: Set(now),
         activated_at: Set(None),
         stopped_at: Set(None),
@@ -281,14 +283,33 @@ pub async fn record_incarnation_spend(
     Ok(())
 }
 
-/// Journals one sandbox event's projection and advances the ingest cursor,
-/// in one transaction.
+/// What one sandbox event writes besides its journal rows.
+///
+/// Everything here commits in the same transaction as the cursor advance,
+/// so a replayed sequence — which the cursor guard skips wholesale — can
+/// never have half of its side effects.
+#[derive(Debug, Default)]
+pub struct IncarnationSideEffects<'a> {
+    /// Journal rows to append, in order.
+    pub journal: &'a [crate::CodeEvent],
+    /// The supervisor's terminal deliverable to retain.
+    pub task_output: Option<&'a str>,
+    /// The WIP checkpoint ref to retain, for resume.
+    pub wip_ref: Option<&'a str>,
+    /// Whether this event is the supervisor's goodbye, raising the gate
+    /// reincarnation waits on.
+    pub terminal_events_journaled: bool,
+}
+
+/// Journals one sandbox event's projection, applies its incarnation-row
+/// side effects, and advances the ingest cursor — all in one transaction.
 ///
 /// Exactly-once per sandbox event: the write is guarded on
 /// `events_cursor < seq`, so a restart that replays an already-ingested
-/// event returns `None` and writes nothing. `spawn_epoch` fences the write
-/// the way every journal append is fenced: a superseded worker cannot
-/// journal into a session that moved on.
+/// event returns `None` and writes nothing — and loses nothing, because
+/// the first ingest committed every side effect with the cursor.
+/// `spawn_epoch` fences the write the way every journal append is fenced:
+/// a superseded worker cannot journal into a session that moved on.
 ///
 /// Returns the journal sequence numbers assigned, in `events` order.
 pub async fn ingest_incarnation_event(
@@ -298,7 +319,7 @@ pub async fn ingest_incarnation_event(
     spawn_epoch: i64,
     id: CodeIncarnationId,
     seq: i64,
-    events: &[crate::CodeEvent],
+    side_effects: IncarnationSideEffects<'_>,
 ) -> Result<Option<Vec<i64>>> {
     let txn = store.conn.begin().await.map_err(store_err)?;
     if !super::acquire_code_session_write_lock(&txn, session_id).await? {
@@ -333,12 +354,12 @@ pub async fn ingest_incarnation_event(
         txn.rollback().await.map_err(store_err)?;
         return Ok(None);
     }
-    let mut seqs = Vec::with_capacity(events.len());
-    for event in events {
+    let mut seqs = Vec::with_capacity(side_effects.journal.len());
+    for event in side_effects.journal {
         seqs.push(super::journal::append_event_on_locked(&txn, owner, session_id, event).await?);
     }
     let now = database_now(&txn).await?;
-    entities::code_session_incarnation::Entity::update_many()
+    let mut update = entities::code_session_incarnation::Entity::update_many()
         .col_expr(
             entities::code_session_incarnation::Column::EventsCursor,
             sea_orm::sea_query::Expr::value(seq),
@@ -346,39 +367,32 @@ pub async fn ingest_incarnation_event(
         .col_expr(
             entities::code_session_incarnation::Column::UpdatedAt,
             sea_orm::sea_query::Expr::value(now),
-        )
+        );
+    if let Some(body) = side_effects.task_output {
+        update = update.col_expr(
+            entities::code_session_incarnation::Column::TaskOutput,
+            sea_orm::sea_query::Expr::value(body),
+        );
+    }
+    if let Some(reference) = side_effects.wip_ref {
+        update = update.col_expr(
+            entities::code_session_incarnation::Column::LastWipRef,
+            sea_orm::sea_query::Expr::value(reference),
+        );
+    }
+    if side_effects.terminal_events_journaled {
+        update = update.col_expr(
+            entities::code_session_incarnation::Column::TerminalEventsJournaled,
+            sea_orm::sea_query::Expr::value(true),
+        );
+    }
+    update
         .filter(entities::code_session_incarnation::Column::Id.eq(id.0))
         .exec(&txn)
         .await
         .map_err(store_err)?;
     txn.commit().await.map_err(store_err)?;
     Ok(Some(seqs))
-}
-
-/// Retains the supervisor's terminal deliverable on the incarnation that
-/// produced it.
-pub async fn record_incarnation_task_output(
-    store: &DbStore,
-    owner: &OwnerId,
-    id: CodeIncarnationId,
-    body: &str,
-) -> Result<()> {
-    let now = database_now(&store.conn).await?;
-    entities::code_session_incarnation::Entity::update_many()
-        .col_expr(
-            entities::code_session_incarnation::Column::TaskOutput,
-            sea_orm::sea_query::Expr::value(body),
-        )
-        .col_expr(
-            entities::code_session_incarnation::Column::UpdatedAt,
-            sea_orm::sea_query::Expr::value(now),
-        )
-        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
-        .filter(entities::code_session_incarnation::Column::Id.eq(id.0))
-        .exec(&store.conn)
-        .await
-        .map_err(store_err)?;
-    Ok(())
 }
 
 /// The session's newest incarnation, in any state.

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4681,7 +4681,11 @@ async fn ingest_journals_once_per_sandbox_event_and_resumes_from_the_cursor() {
         epoch,
         intent.id,
         7,
-        std::slice::from_ref(&first),
+        crate::db::code::IncarnationSideEffects {
+            journal: std::slice::from_ref(&first),
+            wip_ref: Some("mg-wip/sb-1-i1"),
+            ..Default::default()
+        },
     )
     .await
     .unwrap()
@@ -4698,7 +4702,10 @@ async fn ingest_journals_once_per_sandbox_event_and_resumes_from_the_cursor() {
             epoch,
             intent.id,
             replayed,
-            std::slice::from_ref(&first),
+            crate::db::code::IncarnationSideEffects {
+                journal: std::slice::from_ref(&first),
+                ..Default::default()
+            },
         )
         .await
         .unwrap()
@@ -4713,7 +4720,12 @@ async fn ingest_journals_once_per_sandbox_event_and_resumes_from_the_cursor() {
         epoch,
         intent.id,
         8,
-        std::slice::from_ref(&second),
+        crate::db::code::IncarnationSideEffects {
+            journal: std::slice::from_ref(&second),
+            task_output: Some("the findings"),
+            terminal_events_journaled: true,
+            ..Default::default()
+        },
     )
     .await
     .unwrap()
@@ -4721,12 +4733,15 @@ async fn ingest_journals_once_per_sandbox_event_and_resumes_from_the_cursor() {
 
     let page = list_events(&store, &owner, session, 0, 10).await.unwrap();
     assert_eq!(page.events.len(), 2);
-    let cursor = crate::db::code::latest_incarnation(&store, &owner, session)
+    let row = crate::db::code::latest_incarnation(&store, &owner, session)
         .await
         .unwrap()
-        .unwrap()
-        .events_cursor;
-    assert_eq!(cursor, 8);
+        .unwrap();
+    assert_eq!(row.events_cursor, 8);
+    // Side effects committed with their event's cursor advance.
+    assert_eq!(row.last_wip_ref.as_deref(), Some("mg-wip/sb-1-i1"));
+    assert_eq!(row.task_output.as_deref(), Some("the findings"));
+    assert!(row.terminal_events_journaled);
 
     // A superseded worker's epoch cannot journal into the session.
     assert!(crate::db::code::ingest_incarnation_event(
@@ -4736,26 +4751,11 @@ async fn ingest_journals_once_per_sandbox_event_and_resumes_from_the_cursor() {
         epoch + 1,
         intent.id,
         9,
-        std::slice::from_ref(&second),
+        crate::db::code::IncarnationSideEffects {
+            journal: std::slice::from_ref(&second),
+            ..Default::default()
+        },
     )
     .await
     .is_err());
-}
-
-/// The supervisor's terminal deliverable is retained on the incarnation
-/// that produced it.
-#[tokio::test]
-async fn the_task_output_is_retained_on_the_incarnation() {
-    let (_dir, store) = temp_store().await;
-    let owner = OwnerId::local();
-    let (session, _) = seed_owner(&store, &owner, "deliverable").await;
-    let intent = admitted(admit(&store, &owner, session, 1, 4).await);
-    crate::db::code::record_incarnation_task_output(&store, &owner, intent.id, "the findings")
-        .await
-        .unwrap();
-    let row = crate::db::code::latest_incarnation(&store, &owner, session)
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(row.task_output.as_deref(), Some("the findings"));
 }

--- a/crates/tidebreak-server/src/code/remote/ingest.rs
+++ b/crates/tidebreak-server/src/code/remote/ingest.rs
@@ -11,8 +11,9 @@
 //!
 //! The projection itself is pure ([`project_event`]); [`ingest_events`]
 //! applies one cursor read. Attention and the bus publish ride after the
-//! journal commit: a crash between the two leaves attention one event stale,
-//! which the next batch corrects, never a journal gap.
+//! journal commit: a crash between the two leaves attention stale until the
+//! next read replays the sequence, and attention — unlike the journal — is
+//! re-applied on replay, so the replay is what corrects it.
 
 use std::sync::Arc;
 
@@ -20,8 +21,7 @@ use serde_json::Value;
 use tracing::warn;
 
 use tidebreak_core::db::code::{
-    ingest_incarnation_event, latest_incarnation, mark_incarnation_terminal_events_journaled,
-    record_incarnation_task_output,
+    ingest_incarnation_event, latest_incarnation, IncarnationSideEffects,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, BoundedError, CodeEvent, CodeIncarnationId,
@@ -58,6 +58,8 @@ pub(crate) struct Projection {
     pub attention: Option<Attention>,
     /// The terminal deliverable to retain on the incarnation.
     pub task_output: Option<String>,
+    /// The WIP checkpoint ref to retain on the incarnation, for resume.
+    pub wip_ref: Option<String>,
     /// Whether this event closes the incarnation's stream: the supervisor
     /// said goodbye, so its terminal events are now journaled.
     pub terminal_flush: bool,
@@ -70,8 +72,9 @@ pub(crate) struct Projection {
 pub(crate) struct IngestOutcome {
     /// Sandbox event sequences whose projection committed in this call.
     pub ingested: u64,
-    /// Whether the supervisor's own stop marker has been journaled, in this
-    /// batch or an earlier one.
+    /// Whether the supervisor's own stop marker has been journaled — read
+    /// from the durable incarnation row after the batch, never inferred
+    /// from a replayed projection.
     pub terminal_flush_journaled: bool,
     /// The fence this read demands, when the environment reports the sandbox
     /// gone without the supervisor having said goodbye.
@@ -169,11 +172,15 @@ pub(crate) fn project_event(binding: &IngestBinding, kind: &str, payload: &Value
             ));
         }
         "wip_pushed" => {
-            let reference = payload_str(payload, "reference").unwrap_or("a WIP ref");
+            let reference = payload_str(payload, "ref");
             out.journal.push(notice(
                 HarnessNoticeLevel::Info,
-                format!("Work in progress was checkpointed to {reference}."),
+                format!(
+                    "Work in progress was checkpointed to {}.",
+                    reference.unwrap_or("a WIP ref")
+                ),
             ));
+            out.wip_ref = reference.map(str::to_owned);
         }
         "wip_push_failed" | "wip_push_unavailable" => {
             let reason = payload_str(payload, "reason").unwrap_or(kind);
@@ -239,18 +246,18 @@ pub(crate) async fn ingest_events(
     for event in &read.events {
         outcome.ingested += u64::from(apply_one(db, bus, binding, event, &mut outcome).await?);
     }
+    // The durable row is the truth about the goodbye — the batch that
+    // carried it may have committed before a restart, and a replayed
+    // sequence's projection must not claim a gate the row does not show.
+    outcome.terminal_flush_journaled = latest_incarnation(db, &binding.owner, binding.session_id)
+        .await?
+        .is_some_and(|row| row.id == binding.incarnation && row.terminal_events_journaled);
     let drained = read
         .events
         .last()
         .is_none_or(|event| event.seq >= read.latest_event_seq);
     if read.state.is_terminal() && drained && !outcome.terminal_flush_journaled {
-        // The goodbye may have been journaled by an earlier batch; the
-        // incarnation row remembers across restarts.
-        let already = latest_incarnation(db, &binding.owner, binding.session_id)
-            .await?
-            .is_some_and(|row| row.id == binding.incarnation && row.terminal_events_journaled);
-        outcome.terminal_flush_journaled = already;
-        if !already {
+        {
             outcome.fence = Some(if read.state == SandboxState::Completed {
                 // The run ended the way the environment expected, but its last
                 // events never reached this journal: a resume would run without
@@ -300,39 +307,36 @@ async fn apply_one(
             "a sandbox event kind this server does not recognize was skipped"
         );
     }
-    if projection.terminal_flush {
-        outcome.terminal_flush_journaled = true;
-    }
-    let Some(seqs) = ingest_incarnation_event(
+    let ingested = ingest_incarnation_event(
         db,
         &binding.owner,
         binding.session_id,
         binding.spawn_epoch,
         binding.incarnation,
         event.seq,
-        &projection.journal,
+        IncarnationSideEffects {
+            journal: &projection.journal,
+            task_output: projection.task_output.as_deref(),
+            wip_ref: projection.wip_ref.as_deref(),
+            terminal_events_journaled: projection.terminal_flush,
+        },
     )
-    .await?
-    else {
-        // The cursor already covers this sequence: a replay after a restart.
-        // Its side effects committed with it the first time.
-        return Ok(false);
-    };
-    for (seq, journal_event) in seqs.into_iter().zip(projection.journal) {
-        bus.publish(
-            binding.session_id,
-            SequencedCodeEvent {
-                seq,
-                event: journal_event,
-            },
-        );
+    .await?;
+    if let Some(seqs) = &ingested {
+        for (seq, journal_event) in seqs.iter().zip(&projection.journal) {
+            bus.publish(
+                binding.session_id,
+                SequencedCodeEvent {
+                    seq: *seq,
+                    event: journal_event.clone(),
+                },
+            );
+        }
     }
-    if let Some(body) = &projection.task_output {
-        record_incarnation_task_output(db, &binding.owner, binding.incarnation, body).await?;
-    }
-    if projection.terminal_flush {
-        mark_incarnation_terminal_events_journaled(db, &binding.owner, binding.incarnation).await?;
-    }
+    // Attention is applied even for a replayed sequence: the journal write
+    // and the attention write are separate transactions, so a crash between
+    // them leaves attention stale, and the replay is what corrects it.
+    // Re-applying an attention the session already holds is a no-op.
     if let Some(next) = projection.attention {
         let _ = super::super::attention::apply_attention(
             db,
@@ -344,7 +348,7 @@ async fn apply_one(
         )
         .await?;
     }
-    Ok(true)
+    Ok(ingested.is_some())
 }
 
 #[cfg(test)]
@@ -355,7 +359,7 @@ mod tests {
 
     use tidebreak_core::db::code::{
         activate_incarnation, create_incarnation_intent, get_session, insert_repo, insert_session,
-        insert_workspace, latest_incarnation, list_events,
+        insert_workspace, latest_incarnation, list_events, replace_session_attention,
     };
     use tidebreak_core::{
         CodeRepo, CodeSession, CodeSessionKind, CodeSessionLifecycle, CodeWorkspace,
@@ -439,6 +443,9 @@ mod tests {
         let stopped = project_event(&b, "supervisor_stopped", &json!({ "reason": "stopped" }));
         assert!(stopped.terminal_flush);
 
+        let wip = project_event(&b, "wip_pushed", &json!({ "ref": "mg-wip/sb-1-i1" }));
+        assert_eq!(wip.wip_ref.as_deref(), Some("mg-wip/sb-1-i1"));
+
         // Environment lifecycle events are recognized, not vocabulary drift.
         assert!(!project_event(&b, "running", &json!({})).unrecognized);
         assert!(project_event(&b, "brand_new_kind", &json!({})).unrecognized);
@@ -472,23 +479,24 @@ mod tests {
         assert_eq!(live.attention.state, AttentionState::Working);
 
         // The server restarts and re-reads from an older cursor: sequences
-        // 1..3 replay and write nothing; 4 and 5 land once.
+        // 1..3 replay and write nothing; 4 through 6 land once.
         let second = read(
             SandboxState::Completed,
-            5,
+            6,
             vec![
                 event(2, "turn_started", json!({ "turn": 1 })),
                 event(3, "assistant_record", json!({ "body": "hello" })),
-                event(4, "turn_completed", json!({ "turn": 1, "exit_code": 0 })),
+                event(4, "wip_pushed", json!({ "ref": "mg-wip/sb-1-i1" })),
+                event(5, "turn_completed", json!({ "turn": 1, "exit_code": 0 })),
                 event(
-                    5,
+                    6,
                     "supervisor_stopped",
                     json!({ "reason": "task_complete" }),
                 ),
             ],
         );
         let outcome = ingest_events(&db, &bus, &b, &second).await.unwrap();
-        assert_eq!(outcome.ingested, 2);
+        assert_eq!(outcome.ingested, 3);
         assert!(outcome.terminal_flush_journaled);
         assert!(outcome.fence.is_none());
 
@@ -513,6 +521,7 @@ mod tests {
                 "session_started",
                 "turn_started",
                 "assistant_message",
+                "notice",
                 "turn_completed",
                 "notice",
             ],
@@ -528,7 +537,35 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(row.terminal_events_journaled);
-        assert_eq!(row.events_cursor, 5);
+        assert_eq!(row.events_cursor, 6);
+        assert_eq!(row.last_wip_ref.as_deref(), Some("mg-wip/sb-1-i1"));
+
+        // A crash can land between the journal commit and the attention
+        // write. Simulate the stale half: force the session back to Working,
+        // then replay the whole batch — the journal takes nothing twice, and
+        // the replayed attention corrects the session.
+        replace_session_attention(
+            &db,
+            &b.owner,
+            b.session_id,
+            &Attention::working(AttentionSource::Lifecycle),
+            false,
+        )
+        .await
+        .unwrap();
+        let outcome = ingest_events(&db, &bus, &b, &second).await.unwrap();
+        assert_eq!(outcome.ingested, 0);
+        assert!(outcome.terminal_flush_journaled);
+        assert!(outcome.fence.is_none());
+        let page = list_events(&db, &b.owner, b.session_id, 0, 50)
+            .await
+            .unwrap();
+        assert_eq!(page.events.len(), 6);
+        let live = get_session(&db, &b.owner, b.session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(live.attention.state, AttentionState::DoneUnreviewed);
     }
 
     /// A terminal environment state without the supervisor's goodbye demands


### PR DESCRIPTION
## Summary

PR #2879 auto-merged while its review findings were still being fixed; this PR carries those fixes (review verdict on #2879 at 4a361fb3b, both findings).

- Finding 1 (P1): the retained task output, the WIP resume ref, and the terminal-events-journaled gate now commit in the same transaction as the journal rows and the cursor advance (`IncarnationSideEffects` on `ingest_incarnation_event`), so a replayed sequence loses nothing; the outcome's terminal-flush answer reads the durable incarnation row after the batch instead of a replayed projection, so the fence decision cannot contradict the journal.
- Finding 2 (P2): attention is re-applied on replay — it is written in a separate transaction from the journal, and the replay is what corrects a crash between the two. A session can no longer sit at Working after its last `turn_completed`.
- Also from the amendment #2879 merged without: the `wip_pushed` payload key is `ref` (not `reference`), and the pushed ref is retained on `code_session_incarnation.last_wip_ref` (migration `m20260827_000023`) so reincarnation can resume from it.

## Testing

- `cargo test -p tidebreak-server --lib code::remote` (17 pass) — the driven-stream test now forces attention back to Working and replays the full final batch: zero re-ingested, journal unchanged at 6 rows, attention corrected to DoneUnreviewed, gate read from the row.
- `cargo test -p tidebreak-core --lib db::` (392 pass) — the exactly-once test asserts the WIP ref, task output, and gate all commit with their event's cursor advance.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --all -- --check`.

Part of #2871.