### PR TITLE
feat(server): drive remote sessions across sandbox incarnations

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -1312,6 +1312,13 @@ pub enum IncarnationAdmission {
     /// The intent row committed; provision against it. Boxed because the
     /// row dwarfs the refusal variant.
     Admitted(Box<CodeSessionIncarnation>),
+    /// The session already holds a live incarnation — another submit won
+    /// the race between observing a stopped predecessor and reserving.
+    /// Retry after it settles.
+    AlreadyLive {
+        /// The live incarnation's 1-based counter.
+        incarnation: i32,
+    },
     /// The owner is at their concurrent-sandbox cap.
     CapExhausted {
         /// Sessions holding the live incarnations, so the refusal can name

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -674,6 +674,19 @@ pub struct CodeWorkspace {
     pub bundle_bytes: Option<i64>,
 }
 
+impl CodeWorkspace {
+    /// Whether this workspace's engine runs in a remote sandbox.
+    ///
+    /// A remote workspace has no host worktree: the clone lives inside the
+    /// sandbox, and the branch state travels as WIP refs on the origin. An
+    /// empty `worktree_path` is the marker — nothing on this machine ever
+    /// creates, reads, or reclaims a checkout for it.
+    #[must_use]
+    pub fn is_remote(&self) -> bool {
+        self.worktree_path.is_empty()
+    }
+}
+
 /// Coarse lifecycle of an observed pull request (decision 77).
 ///
 /// Deliberately narrower than the digest's free-form `state` string: the fact
@@ -1253,6 +1266,8 @@ impl IncarnationState {
 pub struct CodeSessionIncarnation {
     /// Stable id.
     pub id: CodeIncarnationId,
+    /// Owner, carried so machine-wide sweeps can act on what they find.
+    pub owner: crate::OwnerId,
     /// Owning session.
     pub session_id: CodeSessionId,
     /// 1-based counter within the session; the agent names WIP refs with it.
@@ -1294,8 +1309,9 @@ pub struct CodeSessionIncarnation {
 /// The outcome of asking for a new incarnation under the owner's cap.
 #[derive(Debug, Clone, PartialEq)]
 pub enum IncarnationAdmission {
-    /// The intent row committed; provision against it.
-    Admitted(CodeSessionIncarnation),
+    /// The intent row committed; provision against it. Boxed because the
+    /// row dwarfs the refusal variant.
+    Admitted(Box<CodeSessionIncarnation>),
     /// The owner is at their concurrent-sandbox cap.
     CapExhausted {
         /// Sessions holding the live incarnations, so the refusal can name

--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -418,6 +418,37 @@ pub async fn latest_pushed_wip_ref(
         .and_then(|row| row.last_wip_ref))
 }
 
+/// Forget a WIP checkpoint ref the origin no longer advertises.
+///
+/// The remote analog of dropping a rejected resume ref: a spawn already
+/// refused this ref, so every retry through it refuses identically. Clearing
+/// it lets the resume walk-back fall through to an earlier checkpoint, or to
+/// the base ref when none is left.
+pub async fn forget_session_wip_ref(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    reference: &str,
+) -> Result<()> {
+    let now = database_now(&store.conn).await?;
+    entities::code_session_incarnation::Entity::update_many()
+        .col_expr(
+            entities::code_session_incarnation::Column::LastWipRef,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::code_session_incarnation::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_session_incarnation::Column::LastWipRef.eq(reference))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
 /// The session's newest incarnation, in any state.
 pub async fn latest_incarnation(
     store: &DbStore,

--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -110,13 +110,14 @@ pub async fn create_incarnation_intent(
     if let Some(last) = &last {
         // One live incarnation per session: the serialize-stop-then-resume
         // rule. A successor minted beside a live predecessor would race it
-        // for the same engine session.
+        // for the same engine session. Two submits can both observe a
+        // stopped predecessor and race to here, so the loser gets an
+        // admission answer to relay, not an error.
         if IncarnationState::from_str(&last.state) != Some(IncarnationState::Stopped) {
             txn.rollback().await.map_err(store_err)?;
-            return Err(AgentError::Store(format!(
-                "session {} already has a live incarnation {}",
-                session_id.0, last.incarnation
-            )));
+            return Ok(IncarnationAdmission::AlreadyLive {
+                incarnation: last.incarnation,
+            });
         }
     }
     let incarnation = last.as_ref().map_or(1, |row| row.incarnation + 1);

--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -34,6 +34,7 @@ fn incarnation_from_model(
 ) -> Result<CodeSessionIncarnation> {
     Ok(CodeSessionIncarnation {
         id: CodeIncarnationId(model.id),
+        owner: OwnerId::new(&model.owner)?,
         session_id: CodeSessionId(model.session_id),
         incarnation: model.incarnation,
         state: IncarnationState::from_str(&model.state).ok_or_else(|| {
@@ -142,9 +143,9 @@ pub async fn create_incarnation_intent(
     };
     let inserted = model.insert(&txn).await.map_err(store_err)?;
     txn.commit().await.map_err(store_err)?;
-    Ok(IncarnationAdmission::Admitted(incarnation_from_model(
-        inserted,
-    )?))
+    Ok(IncarnationAdmission::Admitted(Box::new(
+        incarnation_from_model(inserted)?,
+    )))
 }
 
 /// Records the spawned sandbox on an intent row and marks it active.

--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -396,6 +396,27 @@ pub async fn ingest_incarnation_event(
     Ok(Some(seqs))
 }
 
+/// The newest WIP checkpoint ref any incarnation of this session pushed.
+///
+/// Resume state walks back past reservations that never ran — a failed
+/// spawn or a swept intent writes a newer row with no ref, and resuming
+/// from the base ref because of it would drop the predecessor's work.
+pub async fn latest_pushed_wip_ref(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<Option<String>> {
+    Ok(entities::code_session_incarnation::Entity::find()
+        .filter(entities::code_session_incarnation::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session_incarnation::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_session_incarnation::Column::LastWipRef.is_not_null())
+        .order_by_desc(entities::code_session_incarnation::Column::Incarnation)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .and_then(|row| row.last_wip_ref))
+}
+
 /// The session's newest incarnation, in any state.
 pub async fn latest_incarnation(
     store: &DbStore,

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4496,9 +4496,7 @@ async fn admit(
 fn admitted(admission: crate::code::IncarnationAdmission) -> crate::code::CodeSessionIncarnation {
     match admission {
         crate::code::IncarnationAdmission::Admitted(row) => *row,
-        crate::code::IncarnationAdmission::CapExhausted { running } => {
-            panic!("expected admission, cap named {running:?}")
-        }
+        other => panic!("expected admission, got {other:?}"),
     }
 }
 
@@ -4570,8 +4568,13 @@ async fn a_second_live_incarnation_for_one_session_is_refused() {
     let (session, _) = seed_owner(&store, &owner, "double").await;
 
     admitted(admit(&store, &owner, session, 1, 4).await);
-    let second = crate::db::code::create_incarnation_intent(&store, &owner, session, 2, 4).await;
-    assert!(second.is_err());
+    let second = crate::db::code::create_incarnation_intent(&store, &owner, session, 2, 4)
+        .await
+        .unwrap();
+    assert_eq!(
+        second,
+        crate::code::IncarnationAdmission::AlreadyLive { incarnation: 1 }
+    );
 }
 
 /// Reincarnation counts up, keeps the starting turn, and the session ledger

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4495,7 +4495,7 @@ async fn admit(
 
 fn admitted(admission: crate::code::IncarnationAdmission) -> crate::code::CodeSessionIncarnation {
     match admission {
-        crate::code::IncarnationAdmission::Admitted(row) => row,
+        crate::code::IncarnationAdmission::Admitted(row) => *row,
         crate::code::IncarnationAdmission::CapExhausted { running } => {
             panic!("expected admission, cap named {running:?}")
         }

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -294,7 +294,11 @@ async fn recover_one(
     }
 }
 
-async fn recover_dead_worker(
+/// Settle a session whose worker died with a turn still open: interrupt the
+/// turn, journal it, set needs-you, and go Idle, all in one fenced
+/// transaction. Remote sessions reuse this when the sandbox ends beneath an
+/// unsettled turn.
+pub(crate) async fn recover_dead_worker(
     store: &DbStore,
     bus: &CodeEventBus,
     session: &CodeSession,

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -52,6 +52,18 @@ pub(crate) async fn recover_running_sessions_with(
         list_sessions_by_lifecycle_all_owners(store, CodeSessionLifecycle::Running).await?;
     let mut actions = Vec::new();
     for session in running {
+        // A remote session's engine lives in a sandbox, not a local child:
+        // Running with no pid is its normal shape, and interrupting it here
+        // would abandon a lease that is still spending. Its own lifecycle
+        // (the pump, the stale-intent sweep, reap) settles it.
+        if let Some(workspace) =
+            tidebreak_core::db::code::get_workspace(store, &session.owner, session.workspace_id)
+                .await?
+        {
+            if workspace.is_remote() {
+                continue;
+            }
+        }
         if let Some(action) = recover_one(store, bus, session, &probe).await? {
             actions.push(action);
         }
@@ -643,6 +655,39 @@ mod tests {
         .await
         .unwrap();
         (directory, store, session_id)
+    }
+
+    /// A remote session runs with no local pid on purpose: boot recovery
+    /// must leave it alone rather than interrupt a turn whose sandbox is
+    /// still working.
+    #[tokio::test]
+    async fn boot_recovery_leaves_remote_sessions_running() {
+        let (_directory, store, session_id, _turn) = seeded_running(None).await;
+        let owner = tidebreak_core::OwnerId::local();
+        let session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut workspace =
+            tidebreak_core::db::code::get_workspace(&store, &owner, session.workspace_id)
+                .await
+                .unwrap()
+                .unwrap();
+        workspace.worktree_path = String::new();
+        tidebreak_core::db::code::save_workspace(&store, &workspace)
+            .await
+            .unwrap();
+
+        let bus = CodeEventBus::default();
+        let actions = recover_running_sessions_with(&store, &bus, |_, _| PidLiveness::Dead)
+            .await
+            .unwrap();
+        assert!(actions.is_empty());
+        let untouched = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(untouched.lifecycle, CodeSessionLifecycle::Running);
     }
 
     async fn seeded_fenced_orphan(

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -310,6 +310,12 @@ impl RemoteDriver<'_> {
             IncarnationAdmission::CapExhausted { running } => {
                 return Ok(RemoteTurnOutcome::CapExhausted { running });
             }
+            IncarnationAdmission::AlreadyLive { .. } => {
+                // Another submit won the race between observing the stopped
+                // predecessor and reserving. Same answer as observing its
+                // intent directly.
+                return Ok(RemoteTurnOutcome::ReincarnationInFlight);
+            }
         };
 
         // Walk back to the last incarnation that actually pushed: the row

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -17,9 +17,9 @@ use std::sync::Arc;
 use tracing::warn;
 
 use tidebreak_core::db::code::{
-    activate_incarnation, create_incarnation_intent, insert_turn, latest_incarnation, latest_turn,
-    mark_incarnation_terminal_events_journaled, save_turn, stale_incarnation_intents_all_owners,
-    stop_incarnation,
+    activate_incarnation, create_incarnation_intent, insert_turn, latest_incarnation,
+    latest_pushed_wip_ref, latest_turn, mark_incarnation_terminal_events_journaled, save_turn,
+    stale_incarnation_intents_all_owners, stop_incarnation,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeRepo, CodeSession, CodeSessionId, CodeSessionIncarnation,
@@ -274,13 +274,13 @@ impl RemoteDriver<'_> {
             }
         };
 
-        let resume_ref = current
-            .as_ref()
-            .and_then(|row| row.last_wip_ref.clone())
-            .unwrap_or_else(|| workspace.base_ref.clone());
-        let resumed_from_wip = current
-            .as_ref()
-            .is_some_and(|row| row.last_wip_ref.is_some());
+        // Walk back to the last incarnation that actually pushed: the row
+        // between it and now may be a reservation that never ran (a failed
+        // spawn, a swept intent), and resuming from the base ref because of
+        // it would drop the predecessor's checkpoint.
+        let pushed = latest_pushed_wip_ref(db, &owner, session.id).await?;
+        let resumed_from_wip = pushed.is_some();
+        let resume_ref = pushed.unwrap_or_else(|| workspace.base_ref.clone());
         let arguments = SpawnArguments {
             profile: settings.profile.clone(),
             harness: "custom".to_owned(),
@@ -403,7 +403,22 @@ impl RemoteDriver<'_> {
                 return Ok(report);
             }
             Err(error) => {
-                return Err(tidebreak_core::AgentError::Store(error.to_string()));
+                // A non-retryable read means the environment will never hand
+                // this stream over — the sandbox is unknown, refused, or the
+                // credential is dead. A drain cannot happen, so parking the
+                // session on one would hold it at FlushPending forever.
+                // Close the row and fence; reap waives the gate and the next
+                // turn reincarnates.
+                if row.state == IncarnationState::Active {
+                    stop_incarnation(db, &owner, row.id, Some("events_refused")).await?;
+                    report.incarnation_stopped = true;
+                }
+                let reason = FenceReason::SandboxLost {
+                    detail: format!("the environment no longer serves this sandbox: {error}"),
+                };
+                report.fenced = Some(reason.clone());
+                recovery::fence_session(db, bus, session, reason).await?;
+                return Ok(report);
             }
         };
 
@@ -1192,6 +1207,153 @@ mod tests {
             fake.cancels.lock().unwrap().as_slice(),
             &["sb-next".to_owned()]
         );
+    }
+
+    /// A reservation that never ran must not cost the predecessor's
+    /// checkpoint: the retry after a failed spawn still resumes from the
+    /// last incarnation that actually pushed.
+    #[tokio::test]
+    async fn a_failed_spawn_between_incarnations_keeps_the_wip_resume_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        // Incarnation 1 runs, pushes WIP, and the environment retires it.
+        driver
+            .submit_turn(&mut session, &workspace, &repo, "start")
+            .await
+            .unwrap();
+        fake.event_reads.lock().unwrap().push_back(read(
+            SandboxState::Completed,
+            3,
+            vec![
+                event(1, "wip_pushed", json!({ "ref": "mg-wip/sb-next-i1" })),
+                event(2, "turn_completed", json!({ "turn": 1, "exit_code": 0 })),
+                event(3, "supervisor_stopped", json!({ "reason": "turn_mode" })),
+            ],
+        ));
+        driver.pump(&mut session, 0).await.unwrap();
+
+        // The next reservation fails to spawn — a stopped row with no ref
+        // now sits newer than the one that pushed.
+        fake.spawn_results
+            .lock()
+            .unwrap()
+            .push_back(Err(RemoteSandboxError::Unavailable {
+                operation: "spawn",
+                detail: "gateway restarting".to_owned(),
+            }));
+        assert!(driver
+            .submit_turn(&mut session, &workspace, &repo, "continue")
+            .await
+            .is_err());
+
+        // The retry still resumes from the pushed checkpoint, not the base.
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "continue")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
+        let spawns = fake.spawns.lock().unwrap();
+        assert_eq!(
+            spawns.last().unwrap().repository_ref.as_deref(),
+            Some("mg-wip/sb-next-i1")
+        );
+    }
+
+    /// An event stream the environment will never serve again cannot park
+    /// the session on a drain that cannot happen: the pump closes the row
+    /// and fences, and a reap then unblocks reincarnation.
+    #[tokio::test]
+    async fn a_dead_event_stream_fences_instead_of_parking_the_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        // The scripted queue is empty, but make the failure explicit and
+        // non-retryable rather than relying on the fake's default.
+        fake.event_reads.lock().unwrap().clear();
+        // FakeProvisioner returns Unavailable when unscripted; that is the
+        // retryable case, so assert it holds nothing first.
+        let report = driver.pump(&mut session, 0).await.unwrap();
+        assert!(report.fenced.is_none());
+
+        // Now the environment refuses the stream outright.
+        struct RefusingReads<'a>(&'a FakeProvisioner);
+        #[async_trait]
+        impl SandboxProvisioner for RefusingReads<'_> {
+            async fn spawn(
+                &self,
+                owner: &OwnerId,
+                arguments: &SpawnArguments,
+            ) -> Result<SandboxLease, RemoteSandboxError> {
+                self.0.spawn(owner, arguments).await
+            }
+            async fn status(
+                &self,
+                owner: &OwnerId,
+                sandbox_id: &str,
+            ) -> Result<SandboxStatus, RemoteSandboxError> {
+                self.0.status(owner, sandbox_id).await
+            }
+            async fn events(
+                &self,
+                _owner: &OwnerId,
+                _sandbox_id: &str,
+                _cursor: EventCursor,
+            ) -> Result<SandboxEvents, RemoteSandboxError> {
+                Err(RemoteSandboxError::Refused {
+                    operation: "events",
+                    code: "sandbox_not_found".to_owned(),
+                    message: "no such sandbox".to_owned(),
+                })
+            }
+            async fn send(
+                &self,
+                owner: &OwnerId,
+                sandbox_id: &str,
+                message: &SandboxMessage,
+            ) -> Result<MessageReceipt, RemoteSandboxError> {
+                self.0.send(owner, sandbox_id, message).await
+            }
+            async fn cancel(
+                &self,
+                owner: &OwnerId,
+                sandbox_id: &str,
+            ) -> Result<(), RemoteSandboxError> {
+                self.0.cancel(owner, sandbox_id).await
+            }
+        }
+        let refusing = RefusingReads(&fake);
+        let driver = driver!(&db, &bus, &refusing, &settings);
+        let report = driver.pump(&mut session, 0).await.unwrap();
+        assert!(report.incarnation_stopped);
+        assert!(matches!(
+            report.fenced,
+            Some(FenceReason::SandboxLost { .. })
+        ));
+        let row = latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.state, IncarnationState::Stopped);
+
+        // Reap waives the never-raised gate; the next turn reincarnates.
+        let reloaded = tidebreak_core::db::code::get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut recovered = driver.reap(reloaded).await.unwrap();
+        let outcome = driver
+            .submit_turn(&mut recovered, &workspace, &repo, "again")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
     }
 
     /// The sweep closes intents that never activated and fences their

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -524,6 +524,23 @@ impl RemoteDriver<'_> {
             .await?;
             report.incarnation_stopped = true;
         }
+        if read.state.is_terminal() {
+            // A turn the dying incarnation never settled — one delivered in
+            // the stop window, after its last turn event — would otherwise
+            // stay Running and refuse every later submit as TurnInFlight.
+            // Interrupt it when the incarnation closes, the way a dead local
+            // worker interrupts its open turn. Re-query rather than reuse
+            // the pre-ingest snapshot: the open turn may have been inserted
+            // while this read was in flight.
+            if let Some(mut open) = latest_turn(db, &owner, session.id)
+                .await?
+                .filter(|turn| turn.status == CodeTurnStatus::Running)
+            {
+                open.status = CodeTurnStatus::Interrupted;
+                open.ended_at = Some(chrono::Utc::now());
+                save_turn(db, &owner, &open).await?;
+            }
+        }
         // A settled turn ends the Running lifecycle whether or not the
         // sandbox itself ended: an inbox-delivered turn completes while the
         // sandbox stays live, and leaving the session Running would let the
@@ -931,6 +948,57 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(row.state, IncarnationState::Active);
+    }
+
+    /// A turn delivered in the stop window — after the incarnation's last
+    /// turn event, before its goodbye — is interrupted when the incarnation
+    /// closes. Leaving it Running would refuse every later submit as
+    /// TurnInFlight with no fence to reap.
+    #[tokio::test]
+    async fn closing_the_incarnation_interrupts_an_unsettled_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        // The send succeeds against the still-Active row, but the sandbox
+        // stops before running the turn: its goodbye carries no turn events.
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "too late")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::Delivered { .. }));
+        fake.event_reads.lock().unwrap().push_back(read(
+            SandboxState::Completed,
+            1,
+            vec![event(
+                1,
+                "supervisor_stopped",
+                json!({ "reason": "turn_mode" }),
+            )],
+        ));
+        driver.pump(&mut session, 0).await.unwrap();
+
+        let turn = latest_turn(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.status, CodeTurnStatus::Interrupted);
+        let live = get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(live.lifecycle, CodeSessionLifecycle::Idle);
+
+        // The session can continue: the next turn reincarnates instead of
+        // refusing as TurnInFlight.
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "again")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
     }
 
     /// The session survives a sandbox stop: the pump closes the incarnation

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -110,9 +110,11 @@ async fn sign_in_needed(
         bus,
         &session.owner,
         session.id,
+        // Structured, so the stall sweep's heuristic cannot replace the
+        // prompt while the user is away signing in.
         Attention::needs_you(
             "sign in to the sandbox environment",
-            AttentionSource::Lifecycle,
+            AttentionSource::Structured,
         ),
         false,
     )
@@ -528,17 +530,18 @@ impl RemoteDriver<'_> {
             // A turn the dying incarnation never settled — one delivered in
             // the stop window, after its last turn event — would otherwise
             // stay Running and refuse every later submit as TurnInFlight.
-            // Interrupt it when the incarnation closes, the way a dead local
-            // worker interrupts its open turn. Re-query rather than reuse
+            // Run dead-worker recovery when the incarnation closes: it
+            // interrupts the turn, journals it, sets needs-you, and goes
+            // Idle in one fenced transaction. Re-query rather than reuse
             // the pre-ingest snapshot: the open turn may have been inserted
             // while this read was in flight.
-            if let Some(mut open) = latest_turn(db, &owner, session.id)
+            let open = latest_turn(db, &owner, session.id)
                 .await?
-                .filter(|turn| turn.status == CodeTurnStatus::Running)
-            {
-                open.status = CodeTurnStatus::Interrupted;
-                open.ended_at = Some(chrono::Utc::now());
-                save_turn(db, &owner, &open).await?;
+                .filter(|turn| turn.status == CodeTurnStatus::Running);
+            if open.is_some() {
+                if let Some(recovered) = recovery::recover_dead_worker(db, bus, session).await? {
+                    *session = recovered;
+                }
             }
         }
         // A settled turn ends the Running lifecycle whether or not the
@@ -991,6 +994,12 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(live.lifecycle, CodeSessionLifecycle::Idle);
+        // The interrupt surfaces: the session must not keep showing work in
+        // progress for a message the dead incarnation never ran.
+        assert!(matches!(
+            live.attention.state,
+            tidebreak_core::AttentionState::NeedsYou { .. }
+        ));
 
         // The session can continue: the next turn reincarnates instead of
         // refusing as TurnInFlight.

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -172,9 +172,9 @@ async fn settle_turn_rows(
     starting_turn: i32,
     running_turn: Option<CodeTurn>,
     events: &[super::wire::SandboxEvent],
-) -> Result<(), tidebreak_core::AgentError> {
+) -> Result<bool, tidebreak_core::AgentError> {
     let Some(mut turn) = running_turn else {
-        return Ok(());
+        return Ok(false);
     };
     for event in events {
         let status = match event.kind.as_str() {
@@ -204,9 +204,9 @@ async fn settle_turn_rows(
         turn.status = status;
         turn.ended_at = Some(chrono::Utc::now());
         save_turn(db, owner, &turn).await?;
-        break;
+        return Ok(true);
     }
-    Ok(())
+    Ok(false)
 }
 
 impl RemoteDriver<'_> {
@@ -511,7 +511,8 @@ impl RemoteDriver<'_> {
         let outcome: IngestOutcome = ingest_events(db, bus, &binding, &read).await?;
         report.ingested = outcome.ingested;
 
-        settle_turn_rows(db, &owner, row.starting_turn, running_turn, &read.events).await?;
+        let turn_settled =
+            settle_turn_rows(db, &owner, row.starting_turn, running_turn, &read.events).await?;
 
         if read.state.is_terminal() && row.state == IncarnationState::Active {
             stop_incarnation(
@@ -522,19 +523,25 @@ impl RemoteDriver<'_> {
             )
             .await?;
             report.incarnation_stopped = true;
-            if session.lifecycle == CodeSessionLifecycle::Running {
-                // The ingest just wrote this turn's verdict (DoneUnreviewed,
-                // needs-you) onto the stored row. Refresh this snapshot
-                // before persisting, or the stale Working it still carries
-                // from turn start would overwrite the verdict.
-                if let Some(stored) =
-                    tidebreak_core::db::code::get_session(db, &owner, session.id).await?
-                {
-                    *session = stored;
-                }
-                session.lifecycle = CodeSessionLifecycle::Idle;
-                let _ = persist_session(db, bus, session).await?;
+        }
+        // A settled turn ends the Running lifecycle whether or not the
+        // sandbox itself ended: an inbox-delivered turn completes while the
+        // sandbox stays live, and leaving the session Running would let the
+        // stall sweep overwrite the turn's done verdict with a stall.
+        if (turn_settled || read.state.is_terminal())
+            && session.lifecycle == CodeSessionLifecycle::Running
+        {
+            // The ingest just wrote this turn's verdict (DoneUnreviewed,
+            // needs-you) onto the stored row. Refresh this snapshot
+            // before persisting, or the stale Working it still carries
+            // from turn start would overwrite the verdict.
+            if let Some(stored) =
+                tidebreak_core::db::code::get_session(db, &owner, session.id).await?
+            {
+                *session = stored;
             }
+            session.lifecycle = CodeSessionLifecycle::Idle;
+            let _ = persist_session(db, bus, session).await?;
         }
         if let Some(reason) = outcome.fence {
             report.fenced = Some(reason.clone());
@@ -889,11 +896,41 @@ mod tests {
         };
         assert_eq!(turn.ordinal, 1);
         assert!(fake.spawns.lock().unwrap().is_empty());
-        let sends = fake.sends.lock().unwrap();
+        {
+            let sends = fake.sends.lock().unwrap();
+            assert_eq!(
+                sends.as_slice(),
+                &[("sb-1".to_owned(), "and then this".to_owned())]
+            );
+        }
+
+        // The turn settles while the sandbox stays live: the session goes
+        // Idle with the turn's verdict, so the stall sweep cannot mistake a
+        // finished turn for a stall.
+        fake.event_reads.lock().unwrap().push_back(read(
+            SandboxState::Running,
+            2,
+            vec![
+                event(1, "turn_started", json!({ "turn": 1 })),
+                event(2, "turn_completed", json!({ "turn": 1, "exit_code": 0 })),
+            ],
+        ));
+        driver.pump(&mut session, 0).await.unwrap();
+        let live = get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(live.lifecycle, CodeSessionLifecycle::Idle);
         assert_eq!(
-            sends.as_slice(),
-            &[("sb-1".to_owned(), "and then this".to_owned())]
+            live.attention.state,
+            tidebreak_core::AttentionState::DoneUnreviewed
         );
+        // The sandbox itself is still live for the next turn.
+        let row = latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.state, IncarnationState::Active);
     }
 
     /// The session survives a sandbox stop: the pump closes the incarnation
@@ -982,6 +1019,13 @@ mod tests {
             .unwrap();
         assert_eq!(settled.ordinal, 2);
         assert_eq!(settled.status, CodeTurnStatus::Completed);
+        // The settlement ends the Running lifecycle even though the
+        // successor sandbox stays live.
+        let after = get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.lifecycle, CodeSessionLifecycle::Idle);
     }
 
     /// A stopped predecessor whose terminal events are not journaled yet

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -1,0 +1,975 @@
+//! Drive a remote session's sandbox: turns, reincarnation, reap, and the
+//! stale-intent sweep.
+//!
+//! A remote session's engine lives in a sandbox the environment provisions;
+//! this module owns the lifecycle decisions the transport-only provisioner
+//! deliberately does not. A turn reaches a live sandbox as an inbox message.
+//! When the sandbox is gone, the next turn reincarnates: reserve the
+//! incarnation (the durable equivalent of the per-workspace turn lock),
+//! spawn against the predecessor's last WIP checkpoint ref, and record the
+//! sandbox on the row before the first event is read. Stop and reincarnate
+//! serialize through the incarnation record — a turn that lands while the
+//! predecessor's terminal events are still in flight waits rather than
+//! resuming without them.
+
+use std::sync::Arc;
+
+use tracing::warn;
+
+use tidebreak_core::db::code::{
+    activate_incarnation, create_incarnation_intent, insert_turn, latest_incarnation, latest_turn,
+    save_turn, stale_incarnation_intents_all_owners, stop_incarnation,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, CodeRepo, CodeSession, CodeSessionId, CodeSessionIncarnation,
+    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, DbStore,
+    FenceReason, IncarnationAdmission, IncarnationState, OwnerId,
+};
+
+use super::super::attention::persist_session;
+use super::super::bus::CodeEventBus;
+use super::super::recovery;
+use super::ingest::{ingest_events, IngestBinding, IngestOutcome};
+use super::wire::{EventCursor, SandboxMessage, SpawnArguments};
+use super::{RemoteSandboxError, SandboxProvisioner};
+
+/// How long an unactivated intent may sit before the sweep closes it: long
+/// enough for a slow spawn round trip, short enough that a crashed server
+/// does not hold a concurrency slot for an afternoon.
+pub(crate) const STALE_INTENT_AGE: chrono::Duration = chrono::Duration::minutes(10);
+
+/// Spawn-time settings for one remote session's sandboxes.
+#[derive(Clone, Debug)]
+pub(crate) struct RemoteSpawnSettings {
+    /// Administrator-defined profile on the runtime endpoint.
+    pub profile: String,
+    /// Concurrent live incarnations one owner may hold.
+    pub incarnation_cap: usize,
+    /// Per-spawn spend ceiling in micro-USD, when one is set.
+    pub spend_ceiling_microusd: Option<i64>,
+}
+
+/// What one submitted turn became.
+#[derive(Debug)]
+pub(crate) enum RemoteTurnOutcome {
+    /// The turn reached the live sandbox's inbox.
+    Delivered {
+        /// The turn row, running. Boxed: the rows dwarf the refusals.
+        turn: Box<CodeTurn>,
+    },
+    /// No sandbox was live; one was provisioned to carry this turn.
+    Reincarnated {
+        /// The turn row, running.
+        turn: Box<CodeTurn>,
+        /// The incarnation now active.
+        incarnation: Box<CodeSessionIncarnation>,
+    },
+    /// The owner's concurrency cap refused, naming what runs.
+    CapExhausted {
+        /// Sessions holding the live incarnations.
+        running: Vec<CodeSessionId>,
+    },
+    /// The predecessor stopped but its terminal events are not journaled
+    /// yet. Retry after a pump; resuming now would miss its last output.
+    FlushPending,
+    /// A reincarnation is already in flight for this session.
+    ReincarnationInFlight,
+}
+
+/// The driver one remote session's lifecycle calls go through: the store,
+/// the live bus, the transport, and the spawn settings, borrowed together
+/// so every operation reads the same world.
+pub(crate) struct RemoteDriver<'a> {
+    /// The store every row lives in.
+    pub db: &'a Arc<DbStore>,
+    /// Live-update bus the journal publishes to.
+    pub bus: &'a CodeEventBus,
+    /// The environment transport.
+    pub provisioner: &'a dyn SandboxProvisioner,
+    /// Spawn-time settings.
+    pub settings: &'a RemoteSpawnSettings,
+}
+
+/// Whether a refusal's own description names this ref.
+fn refusal_names(error: &RemoteSandboxError, reference: &str) -> bool {
+    match error {
+        RemoteSandboxError::Refused { message, .. } => message.contains(reference),
+        _ => false,
+    }
+}
+
+/// One pump of a remote session: read events after the durable cursor,
+/// project them, settle turn rows, and close the incarnation when the
+/// environment says the sandbox ended.
+#[derive(Debug, Default)]
+pub(crate) struct PumpReport {
+    /// Sandbox event sequences ingested this pump.
+    pub ingested: u64,
+    /// Whether the incarnation was closed this pump.
+    pub incarnation_stopped: bool,
+    /// The fence applied, when the read demanded one.
+    pub fenced: Option<FenceReason>,
+}
+
+/// The stop reason recorded when the environment ends a sandbox.
+fn state_token<'a>(
+    _events: &[super::wire::SandboxEvent],
+    state: super::wire::SandboxState,
+) -> &'a str {
+    match state {
+        super::wire::SandboxState::Completed => "completed",
+        super::wire::SandboxState::Failed => "failed",
+        super::wire::SandboxState::Cancelled => "cancelled",
+        super::wire::SandboxState::Expired => "expired",
+        super::wire::SandboxState::CeilingExceeded => "ceiling_exceeded",
+        _ => "ended",
+    }
+}
+
+/// Settle the running turn row from the batch's terminal turn events.
+async fn settle_turn_rows(
+    db: &Arc<DbStore>,
+    owner: &OwnerId,
+    running_turn: Option<CodeTurn>,
+    events: &[super::wire::SandboxEvent],
+) -> Result<(), tidebreak_core::AgentError> {
+    let Some(mut turn) = running_turn else {
+        return Ok(());
+    };
+    for event in events {
+        let status = match event.kind.as_str() {
+            "turn_completed" => {
+                let success = event
+                    .payload
+                    .get("exit_code")
+                    .and_then(serde_json::Value::as_i64)
+                    == Some(0);
+                if success {
+                    CodeTurnStatus::Completed
+                } else {
+                    CodeTurnStatus::Failed
+                }
+            }
+            "turn_interrupted" => CodeTurnStatus::Interrupted,
+            _ => continue,
+        };
+        turn.status = status;
+        turn.ended_at = Some(chrono::Utc::now());
+        save_turn(db, owner, &turn).await?;
+        break;
+    }
+    Ok(())
+}
+
+impl RemoteDriver<'_> {
+    /// Submit one user turn to a remote session.
+    ///
+    /// The session row is updated (lifecycle, attention) on success; the caller
+    /// persists nothing else. `session`, `workspace`, and `repo` are the current
+    /// rows — the caller owns loading and authorization.
+    pub(crate) async fn submit_turn(
+        &self,
+        session: &mut CodeSession,
+        workspace: &CodeWorkspace,
+        repo: &CodeRepo,
+        text: &str,
+    ) -> Result<RemoteTurnOutcome, tidebreak_core::AgentError> {
+        let (db, bus, provisioner, settings) = (self.db, self.bus, self.provisioner, self.settings);
+        let owner = session.owner.clone();
+        let ordinal = latest_turn(db, &owner, session.id)
+            .await?
+            .map_or(1, |turn| turn.ordinal + 1);
+
+        let current = latest_incarnation(db, &owner, session.id).await?;
+        match current.as_ref().map(|row| row.state) {
+            Some(IncarnationState::Intent) => return Ok(RemoteTurnOutcome::ReincarnationInFlight),
+            Some(IncarnationState::Active) => {
+                let row = current.as_ref().expect("state was just observed");
+                let Some(sandbox_id) = row.sandbox_id.as_deref() else {
+                    return Err(tidebreak_core::AgentError::Store(format!(
+                        "active incarnation {} has no sandbox id",
+                        row.id
+                    )));
+                };
+                let message = SandboxMessage {
+                    body: text.to_owned(),
+                    interrupt: false,
+                };
+                message
+                    .validate()
+                    .map_err(tidebreak_core::AgentError::Store)?;
+                match provisioner.send(&owner, sandbox_id, &message).await {
+                    Ok(_) => {
+                        let turn = start_turn_row(db, bus, session, ordinal, text).await?;
+                        return Ok(RemoteTurnOutcome::Delivered {
+                            turn: Box::new(turn),
+                        });
+                    }
+                    Err(RemoteSandboxError::Refused { code, message, .. }) => {
+                        // The environment no longer takes messages for this
+                        // sandbox: it ended without this server having drained
+                        // the news yet. Close the record and fall through to
+                        // reincarnation only once its terminal events are in.
+                        warn!(
+                            session = %session.id,
+                            %code,
+                            "a live sandbox refused a message; closing the incarnation ({message})"
+                        );
+                        stop_incarnation(db, &owner, row.id, Some(&code)).await?;
+                        return Ok(RemoteTurnOutcome::FlushPending);
+                    }
+                    Err(error) => {
+                        return Err(tidebreak_core::AgentError::Store(error.to_string()));
+                    }
+                }
+            }
+            Some(IncarnationState::Stopped) | None => {}
+        }
+        if let Some(predecessor) = &current {
+            if !predecessor.terminal_events_journaled {
+                return Ok(RemoteTurnOutcome::FlushPending);
+            }
+        }
+
+        // Reserve before provisioning: the intent row is the durable equivalent
+        // of the per-workspace turn lock, and it is also the owner's cap slot.
+        let admission = create_incarnation_intent(
+            db,
+            &owner,
+            session.id,
+            i32::try_from(ordinal).unwrap_or(1),
+            settings.incarnation_cap,
+        )
+        .await?;
+        let intent = match admission {
+            IncarnationAdmission::Admitted(row) => *row,
+            IncarnationAdmission::CapExhausted { running } => {
+                return Ok(RemoteTurnOutcome::CapExhausted { running });
+            }
+        };
+
+        let resume_ref = current
+            .as_ref()
+            .and_then(|row| row.last_wip_ref.clone())
+            .unwrap_or_else(|| workspace.base_ref.clone());
+        let resumed_from_wip = current
+            .as_ref()
+            .is_some_and(|row| row.last_wip_ref.is_some());
+        let arguments = SpawnArguments {
+            profile: settings.profile.clone(),
+            harness: "custom".to_owned(),
+            mode: Some("turn".to_owned()),
+            task: text.to_owned(),
+            repository: Some(repository_url(repo)?),
+            repository_ref: Some(resume_ref.clone()),
+            repositories: Vec::new(),
+            apps: Vec::new(),
+            model: session.model.clone(),
+            reasoning_effort: session
+                .reasoning_effort
+                .map(|effort| effort.as_str().to_owned()),
+            subscription: None,
+            idle_timeout_seconds: None,
+            wall_clock_timeout_seconds: None,
+            spend_ceiling_microusd: settings.spend_ceiling_microusd,
+            max_turns: None,
+        };
+        match provisioner.spawn(&owner, &arguments).await {
+            Ok(lease) => {
+                activate_incarnation(db, &owner, intent.id, &lease.sandbox_id).await?;
+                let incarnation = latest_incarnation(db, &owner, session.id)
+                    .await?
+                    .ok_or_else(|| {
+                        tidebreak_core::AgentError::Store(
+                            "the activated incarnation vanished".to_owned(),
+                        )
+                    })?;
+                let turn = start_turn_row(db, bus, session, ordinal, text).await?;
+                Ok(RemoteTurnOutcome::Reincarnated {
+                    turn: Box::new(turn),
+                    incarnation: Box::new(incarnation),
+                })
+            }
+            Err(error) => {
+                // The reservation must not outlive the spawn it reserved for.
+                stop_incarnation(db, &owner, intent.id, Some("spawn_failed")).await?;
+                if resumed_from_wip && refusal_names(&error, &resume_ref) {
+                    // The WIP ref the predecessor pushed is gone from the
+                    // origin: the resume state no longer exists, and retrying
+                    // would refuse identically. Fence so a reap starts fresh.
+                    recovery::fence_session(
+                        db,
+                        bus,
+                        session,
+                        FenceReason::ResumeLost {
+                            detail: format!("the WIP checkpoint ref {resume_ref} is gone"),
+                        },
+                    )
+                    .await?;
+                }
+                Err(tidebreak_core::AgentError::Store(error.to_string()))
+            }
+        }
+    }
+
+    /// Read and apply everything new from the session's live sandbox.
+    ///
+    /// Idle when no incarnation is active. The caller schedules pumps; this
+    /// function is safe to call on any cadence because the cursor is durable
+    /// and replays are no-ops.
+    pub(crate) async fn pump(
+        &self,
+        session: &mut CodeSession,
+        wait_seconds: u16,
+    ) -> Result<PumpReport, tidebreak_core::AgentError> {
+        let (db, bus, provisioner) = (self.db, self.bus, self.provisioner);
+        let owner = session.owner.clone();
+        let mut report = PumpReport::default();
+        let Some(row) = latest_incarnation(db, &owner, session.id).await? else {
+            return Ok(report);
+        };
+        if row.state != IncarnationState::Active {
+            return Ok(report);
+        }
+        let Some(sandbox_id) = row.sandbox_id.clone() else {
+            return Ok(report);
+        };
+
+        let read = match provisioner
+            .events(
+                &owner,
+                &sandbox_id,
+                EventCursor {
+                    after_seq: Some(row.events_cursor),
+                    limit: None,
+                    wait_seconds: Some(u32::from(wait_seconds)),
+                },
+            )
+            .await
+        {
+            Ok(read) => read,
+            Err(error) if error.is_retryable() => {
+                // A transport fault is the next pump's problem, not a lifecycle
+                // signal.
+                return Ok(report);
+            }
+            Err(error) => {
+                return Err(tidebreak_core::AgentError::Store(error.to_string()));
+            }
+        };
+
+        let running_turn = latest_turn(db, &owner, session.id)
+            .await?
+            .filter(|turn| turn.status == CodeTurnStatus::Running);
+        let binding = IngestBinding {
+            owner: owner.clone(),
+            session_id: session.id,
+            spawn_epoch: session.spawn_epoch,
+            incarnation: row.id,
+            harness_kind: session.harness_kind,
+            turn_id: running_turn.as_ref().map(|turn| turn.id),
+        };
+        let outcome: IngestOutcome = ingest_events(db, bus, &binding, &read).await?;
+        report.ingested = outcome.ingested;
+
+        settle_turn_rows(db, &owner, running_turn, &read.events).await?;
+
+        if read.state.is_terminal() {
+            stop_incarnation(
+                db,
+                &owner,
+                row.id,
+                Some(state_token(&read.events, read.state)),
+            )
+            .await?;
+            report.incarnation_stopped = true;
+            if session.lifecycle == CodeSessionLifecycle::Running {
+                session.lifecycle = CodeSessionLifecycle::Idle;
+                let _ = persist_session(db, bus, session).await?;
+            }
+        }
+        if let Some(reason) = outcome.fence {
+            report.fenced = Some(reason.clone());
+            recovery::fence_session(db, bus, session, reason).await?;
+        }
+        Ok(report)
+    }
+
+    /// Reap a fenced remote session: cancel whatever the environment still
+    /// holds, close the incarnation record, and resolve the fence.
+    ///
+    /// Unlike a local reap, nothing is relaunched — the next turn reincarnates
+    /// on demand.
+    pub(crate) async fn reap(
+        &self,
+        session: CodeSession,
+    ) -> Result<CodeSession, recovery::ReapSessionError> {
+        let (db, bus, provisioner) = (self.db, self.bus, self.provisioner);
+        let owner = session.owner.clone();
+        if let Ok(Some(row)) = latest_incarnation(db, &owner, session.id).await {
+            if row.state != IncarnationState::Stopped {
+                if let Some(sandbox_id) = row.sandbox_id.as_deref() {
+                    // Best effort: the reap must not hang on an environment
+                    // that is already gone.
+                    if let Err(error) = provisioner.cancel(&owner, sandbox_id).await {
+                        warn!(
+                            session = %session.id,
+                            %error,
+                            "a reap could not cancel the remote sandbox; its own ceilings bound it"
+                        );
+                    }
+                }
+                let _ = stop_incarnation(db, &owner, row.id, Some("reaped")).await;
+            }
+        }
+        recovery::reap_session(db, bus, session).await
+    }
+}
+
+/// Close intent rows whose spawn outcome nothing recorded, and fence their
+/// sessions so the person sees why nothing is running.
+///
+/// An intent that never activated is a crash between provision and store.
+/// The sandbox it may have spawned is unknown to this server, so it cannot
+/// be cancelled from here; the ceilings requested at spawn bound it.
+pub(crate) async fn sweep_stale_intents(
+    db: &Arc<DbStore>,
+    bus: &CodeEventBus,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<u64, tidebreak_core::AgentError> {
+    let cutoff = now - STALE_INTENT_AGE;
+    let stale = stale_incarnation_intents_all_owners(db, cutoff).await?;
+    let mut closed = 0;
+    for row in stale {
+        stop_incarnation(db, &row.owner, row.id, Some("intent_expired")).await?;
+        closed += 1;
+        let Some(mut session) =
+            tidebreak_core::db::code::get_session(db, &row.owner, row.session_id).await?
+        else {
+            continue;
+        };
+        recovery::fence_session(
+            db,
+            bus,
+            &mut session,
+            FenceReason::IncarnationUnresolved {
+                detail: format!(
+                    "a sandbox reservation from {} never recorded its spawn",
+                    row.created_at.format("%Y-%m-%d %H:%M UTC")
+                ),
+            },
+        )
+        .await?;
+    }
+    Ok(closed)
+}
+
+/// The HTTPS clone URL spawn declares, from the repo's recorded origin.
+fn repository_url(repo: &CodeRepo) -> Result<String, tidebreak_core::AgentError> {
+    match (&repo.origin_host, &repo.origin_owner, &repo.origin_name) {
+        (Some(host), Some(owner), Some(name)) => Ok(format!("https://{host}/{owner}/{name}")),
+        _ => Err(tidebreak_core::AgentError::Store(format!(
+            "repo {} has no recorded origin; a remote session needs one to clone",
+            repo.id
+        ))),
+    }
+}
+
+/// Insert the running turn row and mark the session working.
+async fn start_turn_row(
+    db: &Arc<DbStore>,
+    bus: &CodeEventBus,
+    session: &mut CodeSession,
+    ordinal: i64,
+    text: &str,
+) -> Result<CodeTurn, tidebreak_core::AgentError> {
+    let turn = CodeTurn {
+        id: CodeTurnId::new(),
+        session_id: session.id,
+        ordinal,
+        status: CodeTurnStatus::Running,
+        model: session.model.clone(),
+        fast_mode: session.fast_mode,
+        user_input: text.to_owned(),
+        user_input_blob_id: None,
+        attachments: Vec::new(),
+        checkpoint_ref: None,
+        diffstat: None,
+        usage: None,
+        narrative: None,
+        started_at: chrono::Utc::now(),
+        ended_at: None,
+    };
+    insert_turn(db, &session.owner, &turn).await?;
+    session.lifecycle = CodeSessionLifecycle::Running;
+    super::super::attention::replace_attention(
+        session,
+        Attention::working(AttentionSource::Lifecycle),
+        false,
+    );
+    let _ = persist_session(db, bus, session).await?;
+    Ok(turn)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    use tidebreak_core::db::code::get_session;
+    use tidebreak_core::AttentionState;
+
+    use super::super::fixtures::seed;
+    use super::super::wire::{
+        MessageReceipt, SandboxEvent, SandboxEvents, SandboxLease, SandboxState, SandboxStatus,
+    };
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeProvisioner {
+        spawns: Mutex<Vec<SpawnArguments>>,
+        spawn_results: Mutex<VecDeque<Result<SandboxLease, RemoteSandboxError>>>,
+        sends: Mutex<Vec<(String, String)>>,
+        send_results: Mutex<VecDeque<Result<MessageReceipt, RemoteSandboxError>>>,
+        event_reads: Mutex<VecDeque<SandboxEvents>>,
+        cancels: Mutex<Vec<String>>,
+    }
+
+    fn lease(sandbox_id: &str) -> SandboxLease {
+        SandboxLease {
+            sandbox_id: sandbox_id.to_owned(),
+            state: SandboxState::Pending,
+            latest_event_seq: 0,
+            expires_in_seconds: 7200,
+        }
+    }
+
+    fn receipt() -> MessageReceipt {
+        MessageReceipt {
+            seq: 1,
+            interrupt: false,
+            pending_messages: 0,
+        }
+    }
+
+    fn event(seq: i64, kind: &str, payload: serde_json::Value) -> SandboxEvent {
+        SandboxEvent {
+            seq,
+            kind: kind.to_owned(),
+            payload,
+            created_at: String::new(),
+        }
+    }
+
+    fn read(state: SandboxState, latest: i64, events: Vec<SandboxEvent>) -> SandboxEvents {
+        SandboxEvents {
+            sandbox_id: "sb-1".to_owned(),
+            state,
+            latest_event_seq: latest,
+            events,
+        }
+    }
+
+    #[async_trait]
+    impl SandboxProvisioner for FakeProvisioner {
+        async fn spawn(
+            &self,
+            _owner: &OwnerId,
+            arguments: &SpawnArguments,
+        ) -> Result<SandboxLease, RemoteSandboxError> {
+            self.spawns.lock().unwrap().push(arguments.clone());
+            self.spawn_results
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Ok(lease("sb-next")))
+        }
+
+        async fn status(
+            &self,
+            _owner: &OwnerId,
+            sandbox_id: &str,
+        ) -> Result<SandboxStatus, RemoteSandboxError> {
+            Ok(SandboxStatus {
+                sandbox_id: sandbox_id.to_owned(),
+                state: SandboxState::Running,
+                failure_reason: None,
+                termination_reason: None,
+                latest_event_seq: 0,
+                pending_messages: 0,
+                spend_microusd: None,
+                spend_ceiling_microusd: None,
+                possibly_stalled: false,
+                repository_url: None,
+                completed_at: None,
+            })
+        }
+
+        async fn events(
+            &self,
+            _owner: &OwnerId,
+            _sandbox_id: &str,
+            _cursor: EventCursor,
+        ) -> Result<SandboxEvents, RemoteSandboxError> {
+            self.event_reads
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or(RemoteSandboxError::Unavailable {
+                    operation: "events",
+                    detail: "no scripted read".to_owned(),
+                })
+        }
+
+        async fn send(
+            &self,
+            _owner: &OwnerId,
+            sandbox_id: &str,
+            message: &SandboxMessage,
+        ) -> Result<MessageReceipt, RemoteSandboxError> {
+            self.sends
+                .lock()
+                .unwrap()
+                .push((sandbox_id.to_owned(), message.body.clone()));
+            self.send_results
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Ok(receipt()))
+        }
+
+        async fn cancel(
+            &self,
+            _owner: &OwnerId,
+            sandbox_id: &str,
+        ) -> Result<(), RemoteSandboxError> {
+            self.cancels.lock().unwrap().push(sandbox_id.to_owned());
+            Ok(())
+        }
+    }
+
+    fn settings() -> RemoteSpawnSettings {
+        RemoteSpawnSettings {
+            profile: "tidebreak-remote".to_owned(),
+            incarnation_cap: 2,
+            spend_ceiling_microusd: Some(5_000_000),
+        }
+    }
+
+    macro_rules! driver {
+        ($db:expr, $bus:expr, $fake:expr, $settings:expr) => {
+            RemoteDriver {
+                db: $db,
+                bus: $bus,
+                provisioner: $fake,
+                settings: $settings,
+            }
+        };
+    }
+
+    /// A first turn on a fresh remote session reserves, spawns from the
+    /// workspace base ref, activates, and records the running turn.
+    #[tokio::test]
+    async fn the_first_turn_provisions_a_sandbox_from_the_base_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "build it")
+            .await
+            .unwrap();
+        let RemoteTurnOutcome::Reincarnated { turn, incarnation } = outcome else {
+            panic!("expected a reincarnation");
+        };
+        assert_eq!(turn.ordinal, 1);
+        assert_eq!(turn.status, CodeTurnStatus::Running);
+        assert_eq!(incarnation.incarnation, 1);
+        assert_eq!(incarnation.state, IncarnationState::Active);
+        assert_eq!(incarnation.sandbox_id.as_deref(), Some("sb-next"));
+
+        let spawns = fake.spawns.lock().unwrap();
+        assert_eq!(spawns.len(), 1);
+        assert_eq!(
+            spawns[0].repository.as_deref(),
+            Some("https://github.com/acme/tools")
+        );
+        assert_eq!(spawns[0].repository_ref.as_deref(), Some("main"));
+        assert_eq!(spawns[0].task, "build it");
+        assert_eq!(spawns[0].mode.as_deref(), Some("turn"));
+        assert_eq!(spawns[0].spend_ceiling_microusd, Some(5_000_000));
+        assert_eq!(session.lifecycle, CodeSessionLifecycle::Running);
+    }
+
+    /// A turn while the sandbox lives is an inbox message, not a spawn.
+    #[tokio::test]
+    async fn a_turn_on_a_live_sandbox_is_an_inbox_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "and then this")
+            .await
+            .unwrap();
+        let RemoteTurnOutcome::Delivered { turn } = outcome else {
+            panic!("expected delivery");
+        };
+        assert_eq!(turn.ordinal, 1);
+        assert!(fake.spawns.lock().unwrap().is_empty());
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(
+            sends.as_slice(),
+            &[("sb-1".to_owned(), "and then this".to_owned())]
+        );
+    }
+
+    /// The session survives a sandbox stop: the pump closes the incarnation
+    /// once terminal events land, and the next turn resumes from the WIP ref
+    /// the predecessor pushed, one turn later.
+    #[tokio::test]
+    async fn the_next_turn_resumes_from_the_predecessors_wip_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        // Turn 1 provisions.
+        driver
+            .submit_turn(&mut session, &workspace, &repo, "start")
+            .await
+            .unwrap();
+        // The sandbox works the turn, pushes WIP, says goodbye, and the
+        // environment retires it.
+        fake.event_reads.lock().unwrap().push_back(read(
+            SandboxState::Completed,
+            4,
+            vec![
+                event(1, "turn_started", json!({ "turn": 1 })),
+                event(2, "wip_pushed", json!({ "ref": "mg-wip/sb-next-i1" })),
+                event(3, "turn_completed", json!({ "turn": 1, "exit_code": 0 })),
+                event(4, "supervisor_stopped", json!({ "reason": "turn_mode" })),
+            ],
+        ));
+        let report = driver.pump(&mut session, 0).await.unwrap();
+        assert_eq!(report.ingested, 4);
+        assert!(report.incarnation_stopped);
+        assert!(report.fenced.is_none());
+        let turn = latest_turn(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.status, CodeTurnStatus::Completed);
+
+        // Turn 2 reincarnates from the pushed ref, starting at turn 2.
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "continue")
+            .await
+            .unwrap();
+        let RemoteTurnOutcome::Reincarnated { turn, incarnation } = outcome else {
+            panic!("expected a reincarnation");
+        };
+        assert_eq!(turn.ordinal, 2);
+        assert_eq!(incarnation.incarnation, 2);
+        assert_eq!(incarnation.starting_turn, 2);
+        let spawns = fake.spawns.lock().unwrap();
+        assert_eq!(spawns.len(), 2);
+        assert_eq!(
+            spawns[1].repository_ref.as_deref(),
+            Some("mg-wip/sb-next-i1")
+        );
+    }
+
+    /// A stopped predecessor whose terminal events are not journaled yet
+    /// holds the next turn instead of resuming without its last output.
+    #[tokio::test]
+    async fn a_turn_waits_for_the_predecessors_terminal_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let incarnation = super::super::fixtures::seeded_incarnation(&db, &session).await;
+        stop_incarnation(&db, &session.owner, incarnation, Some("expired"))
+            .await
+            .unwrap();
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "resume")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::FlushPending));
+        assert!(fake.spawns.lock().unwrap().is_empty());
+    }
+
+    /// A spawn refusal naming the WIP ref fences `ResumeLost`: the resume
+    /// state is gone from the origin and retrying would refuse identically.
+    #[tokio::test]
+    async fn a_refusal_naming_the_wip_ref_fences_resume_lost() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+        driver
+            .submit_turn(&mut session, &workspace, &repo, "start")
+            .await
+            .unwrap();
+        fake.event_reads.lock().unwrap().push_back(read(
+            SandboxState::Completed,
+            3,
+            vec![
+                event(1, "wip_pushed", json!({ "ref": "mg-wip/sb-next-i1" })),
+                event(2, "turn_completed", json!({ "turn": 1, "exit_code": 0 })),
+                event(3, "supervisor_stopped", json!({ "reason": "turn_mode" })),
+            ],
+        ));
+        driver.pump(&mut session, 0).await.unwrap();
+
+        fake.spawn_results
+            .lock()
+            .unwrap()
+            .push_back(Err(RemoteSandboxError::Refused {
+                operation: "spawn",
+                code: "invalid_repository_ref".to_owned(),
+                message: "the remote does not advertise mg-wip/sb-next-i1".to_owned(),
+            }));
+        let error = driver
+            .submit_turn(&mut session, &workspace, &repo, "continue")
+            .await;
+        assert!(error.is_err());
+        let live = get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(live.lifecycle, CodeSessionLifecycle::Fenced);
+        assert!(matches!(
+            live.fence_reason,
+            Some(FenceReason::ResumeLost { .. })
+        ));
+        // The failed reservation was released.
+        let row = latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.state, IncarnationState::Stopped);
+    }
+
+    /// Reap cancels the sandbox, closes the record, and resolves the fence
+    /// without relaunching anything.
+    #[tokio::test]
+    async fn reap_cancels_and_recovers_without_a_relaunch() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, _workspace, _repo) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        recovery::fence_session(
+            &db,
+            &bus,
+            &mut session,
+            FenceReason::SandboxLost {
+                detail: "the environment reports the sandbox failed".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        let recovered = driver.reap(session.clone()).await.unwrap();
+        assert_eq!(recovered.lifecycle, CodeSessionLifecycle::Idle);
+        assert!(recovered.fence_reason.is_none());
+        assert_eq!(
+            fake.cancels.lock().unwrap().as_slice(),
+            &["sb-1".to_owned()]
+        );
+        let row = latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.state, IncarnationState::Stopped);
+        assert_eq!(row.stop_reason.as_deref(), Some("reaped"));
+    }
+
+    /// At the owner's cap the refusal names the sessions holding the live
+    /// incarnations, so the surface can say what to stop.
+    #[tokio::test]
+    async fn the_cap_refusal_names_the_running_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, session_a, workspace, repo) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session_a).await;
+        let mut session_b = super::super::fixtures::session_value();
+        session_b.workspace_id = workspace.id;
+        tidebreak_core::db::code::insert_session(&db, &session_b)
+            .await
+            .unwrap();
+        let fake = FakeProvisioner::default();
+        let settings = RemoteSpawnSettings {
+            incarnation_cap: 1,
+            ..settings()
+        };
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        let outcome = driver
+            .submit_turn(&mut session_b, &workspace, &repo, "queue-jump")
+            .await
+            .unwrap();
+        let RemoteTurnOutcome::CapExhausted { running } = outcome else {
+            panic!("expected the cap to refuse");
+        };
+        assert_eq!(running, vec![session_a.id]);
+        assert!(fake.spawns.lock().unwrap().is_empty());
+    }
+
+    /// The sweep closes intents that never activated and fences their
+    /// sessions so the person sees why nothing runs.
+    #[tokio::test]
+    async fn the_sweep_closes_stale_intents_and_fences_the_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, session, _workspace, _repo) = seed(dir.path()).await;
+        let admission = create_incarnation_intent(&db, &session.owner, session.id, 1, 4)
+            .await
+            .unwrap();
+        let IncarnationAdmission::Admitted(_intent) = admission else {
+            panic!("expected admission");
+        };
+
+        // Young intents are left alone.
+        let closed = sweep_stale_intents(&db, &bus, chrono::Utc::now())
+            .await
+            .unwrap();
+        assert_eq!(closed, 0);
+
+        let closed = sweep_stale_intents(&db, &bus, chrono::Utc::now() + STALE_INTENT_AGE * 2)
+            .await
+            .unwrap();
+        assert_eq!(closed, 1);
+        let row = latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.state, IncarnationState::Stopped);
+        assert_eq!(row.stop_reason.as_deref(), Some("intent_expired"));
+        let live = get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            live.attention.state,
+            AttentionState::Fenced { .. }
+        ));
+        assert!(matches!(
+            live.fence_reason,
+            Some(FenceReason::IncarnationUnresolved { .. })
+        ));
+    }
+}

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -114,6 +114,9 @@ pub(crate) struct PumpReport {
     pub incarnation_stopped: bool,
     /// The fence applied, when the read demanded one.
     pub fenced: Option<FenceReason>,
+    /// The environment rejected the credential; the row is held open and
+    /// the next pump after a sign-in resumes the drain.
+    pub sign_in_required: bool,
 }
 
 /// The stop reason recorded when the environment ends a sandbox.
@@ -133,13 +136,15 @@ fn state_token<'a>(
 
 /// Settle the running turn row from the batch's terminal turn events.
 ///
-/// The agent numbers its turns from `starting_turn`, so its `turn` payload
-/// is the session ordinal. Only the event carrying the running turn's own
-/// ordinal settles it: a batch that still holds an earlier turn's ending
-/// must not close a turn that started after it.
+/// The agent numbers turns within its own incarnation starting at 1 — the
+/// spawn carries no session ordinal — so an event's `turn` payload maps to
+/// session ordinal `starting_turn + turn - 1`. Only the event mapping to
+/// the running turn's own ordinal settles it: a batch that still holds an
+/// earlier turn's ending must not close a turn that started after it.
 async fn settle_turn_rows(
     db: &Arc<DbStore>,
     owner: &OwnerId,
+    starting_turn: i32,
     running_turn: Option<CodeTurn>,
     events: &[super::wire::SandboxEvent],
 ) -> Result<(), tidebreak_core::AgentError> {
@@ -163,11 +168,12 @@ async fn settle_turn_rows(
             "turn_interrupted" => CodeTurnStatus::Interrupted,
             _ => continue,
         };
-        let event_ordinal = event
+        let mapped_ordinal = event
             .payload
             .get("turn")
-            .and_then(serde_json::Value::as_i64);
-        if event_ordinal != Some(turn.ordinal) {
+            .and_then(serde_json::Value::as_i64)
+            .map(|agent_turn| i64::from(starting_turn) + agent_turn - 1);
+        if mapped_ordinal != Some(turn.ordinal) {
             continue;
         }
         turn.status = status;
@@ -402,13 +408,41 @@ impl RemoteDriver<'_> {
                 // signal.
                 return Ok(report);
             }
+            Err(RemoteSandboxError::SignInRequired(detail)) => {
+                // Token expiry is not a lost sandbox: the lease keeps
+                // running and the next read after a sign-in drains it. Hold
+                // the row — closing it here would release the cap slot
+                // beside a live sandbox — and surface the sign-in.
+                report.sign_in_required = true;
+                let _ = super::super::attention::apply_attention(
+                    db,
+                    bus,
+                    &owner,
+                    session.id,
+                    Attention::needs_you(
+                        "sign in to the sandbox environment",
+                        AttentionSource::Lifecycle,
+                    ),
+                    false,
+                )
+                .await?;
+                warn!(session = %session.id, %detail, "the sandbox stream needs a sign-in");
+                return Ok(report);
+            }
             Err(error) => {
-                // A non-retryable read means the environment will never hand
-                // this stream over — the sandbox is unknown, refused, or the
-                // credential is dead. A drain cannot happen, so parking the
-                // session on one would hold it at FlushPending forever.
-                // Close the row and fence; reap waives the gate and the next
-                // turn reincarnates.
+                // The environment refuses this stream and will never hand it
+                // over. A drain cannot happen, so parking the session on one
+                // would hold it at FlushPending forever. Cancel best effort —
+                // a refusal does not prove the workload is gone — then close
+                // the row and fence; reap waives the gate and the next turn
+                // reincarnates.
+                if let Err(cancel_error) = provisioner.cancel(&owner, &sandbox_id).await {
+                    warn!(
+                        session = %session.id,
+                        %cancel_error,
+                        "could not cancel a sandbox whose stream is refused; its ceilings bound it"
+                    );
+                }
                 if row.state == IncarnationState::Active {
                     stop_incarnation(db, &owner, row.id, Some("events_refused")).await?;
                     report.incarnation_stopped = true;
@@ -436,7 +470,7 @@ impl RemoteDriver<'_> {
         let outcome: IngestOutcome = ingest_events(db, bus, &binding, &read).await?;
         report.ingested = outcome.ingested;
 
-        settle_turn_rows(db, &owner, running_turn, &read.events).await?;
+        settle_turn_rows(db, &owner, row.starting_turn, running_turn, &read.events).await?;
 
         if read.state.is_terminal() && row.state == IncarnationState::Active {
             stop_incarnation(
@@ -861,12 +895,32 @@ mod tests {
         assert_eq!(turn.ordinal, 2);
         assert_eq!(incarnation.incarnation, 2);
         assert_eq!(incarnation.starting_turn, 2);
-        let spawns = fake.spawns.lock().unwrap();
-        assert_eq!(spawns.len(), 2);
-        assert_eq!(
-            spawns[1].repository_ref.as_deref(),
-            Some("mg-wip/sb-next-i1")
-        );
+        {
+            let spawns = fake.spawns.lock().unwrap();
+            assert_eq!(spawns.len(), 2);
+            assert_eq!(
+                spawns[1].repository_ref.as_deref(),
+                Some("mg-wip/sb-next-i1")
+            );
+        }
+
+        // The successor numbers its own turns from 1: its first completion
+        // settles session turn 2 through the incarnation's starting turn.
+        fake.event_reads.lock().unwrap().push_back(read(
+            SandboxState::Running,
+            2,
+            vec![
+                event(1, "turn_started", json!({ "turn": 1 })),
+                event(2, "turn_completed", json!({ "turn": 1, "exit_code": 0 })),
+            ],
+        ));
+        driver.pump(&mut session, 0).await.unwrap();
+        let settled = latest_turn(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(settled.ordinal, 2);
+        assert_eq!(settled.status, CodeTurnStatus::Completed);
     }
 
     /// A stopped predecessor whose terminal events are not journaled yet
@@ -1151,7 +1205,7 @@ mod tests {
             "turn_completed",
             json!({ "turn": 1, "exit_code": 0 }),
         )];
-        settle_turn_rows(&db, &session.owner, Some(running.clone()), &stale)
+        settle_turn_rows(&db, &session.owner, 1, Some(running.clone()), &stale)
             .await
             .unwrap();
         let row = latest_turn(&db, &session.owner, session.id)
@@ -1165,7 +1219,7 @@ mod tests {
             "turn_completed",
             json!({ "turn": 2, "exit_code": 0 }),
         )];
-        settle_turn_rows(&db, &session.owner, Some(running), &own)
+        settle_turn_rows(&db, &session.owner, 1, Some(running), &own)
             .await
             .unwrap();
         let row = latest_turn(&db, &session.owner, session.id)
@@ -1337,6 +1391,12 @@ mod tests {
             report.fenced,
             Some(FenceReason::SandboxLost { .. })
         ));
+        // The workload may still exist behind the refusal: it was cancelled
+        // before the cap slot was released.
+        assert_eq!(
+            fake.cancels.lock().unwrap().as_slice(),
+            &["sb-1".to_owned()]
+        );
         let row = latest_incarnation(&db, &session.owner, session.id)
             .await
             .unwrap()
@@ -1354,6 +1414,83 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
+    }
+
+    /// An expired credential is not a lost sandbox: the row is held open
+    /// beside the live lease, nothing is cancelled or fenced, and the
+    /// sign-in need is surfaced.
+    #[tokio::test]
+    async fn a_rejected_credential_holds_the_row_and_asks_for_sign_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, _workspace, _repo) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+
+        struct ExpiredToken<'a>(&'a FakeProvisioner);
+        #[async_trait]
+        impl SandboxProvisioner for ExpiredToken<'_> {
+            async fn spawn(
+                &self,
+                owner: &OwnerId,
+                arguments: &SpawnArguments,
+            ) -> Result<SandboxLease, RemoteSandboxError> {
+                self.0.spawn(owner, arguments).await
+            }
+            async fn status(
+                &self,
+                owner: &OwnerId,
+                sandbox_id: &str,
+            ) -> Result<SandboxStatus, RemoteSandboxError> {
+                self.0.status(owner, sandbox_id).await
+            }
+            async fn events(
+                &self,
+                _owner: &OwnerId,
+                _sandbox_id: &str,
+                _cursor: EventCursor,
+            ) -> Result<SandboxEvents, RemoteSandboxError> {
+                Err(RemoteSandboxError::SignInRequired(
+                    "token expired".to_owned(),
+                ))
+            }
+            async fn send(
+                &self,
+                owner: &OwnerId,
+                sandbox_id: &str,
+                message: &SandboxMessage,
+            ) -> Result<MessageReceipt, RemoteSandboxError> {
+                self.0.send(owner, sandbox_id, message).await
+            }
+            async fn cancel(
+                &self,
+                owner: &OwnerId,
+                sandbox_id: &str,
+            ) -> Result<(), RemoteSandboxError> {
+                self.0.cancel(owner, sandbox_id).await
+            }
+        }
+        let expired = ExpiredToken(&fake);
+        let driver = driver!(&db, &bus, &expired, &settings);
+
+        let report = driver.pump(&mut session, 0).await.unwrap();
+        assert!(report.sign_in_required);
+        assert!(report.fenced.is_none());
+        assert!(!report.incarnation_stopped);
+        assert!(fake.cancels.lock().unwrap().is_empty());
+        let row = latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.state, IncarnationState::Active);
+        let live = tidebreak_core::db::code::get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            live.attention.state,
+            tidebreak_core::AttentionState::NeedsYou { .. }
+        ));
     }
 
     /// The sweep closes intents that never activated and fences their

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -18,7 +18,8 @@ use tracing::warn;
 
 use tidebreak_core::db::code::{
     activate_incarnation, create_incarnation_intent, insert_turn, latest_incarnation, latest_turn,
-    save_turn, stale_incarnation_intents_all_owners, stop_incarnation,
+    mark_incarnation_terminal_events_journaled, save_turn, stale_incarnation_intents_all_owners,
+    stop_incarnation,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeRepo, CodeSession, CodeSessionId, CodeSessionIncarnation,
@@ -74,6 +75,10 @@ pub(crate) enum RemoteTurnOutcome {
     FlushPending,
     /// A reincarnation is already in flight for this session.
     ReincarnationInFlight,
+    /// A turn is already running. The caller queues at the turn boundary,
+    /// the way every other submit path does; the driver never interleaves
+    /// two running turn rows on one session.
+    TurnInFlight,
 }
 
 /// The driver one remote session's lifecycle calls go through: the store,
@@ -127,6 +132,11 @@ fn state_token<'a>(
 }
 
 /// Settle the running turn row from the batch's terminal turn events.
+///
+/// The agent numbers its turns from `starting_turn`, so its `turn` payload
+/// is the session ordinal. Only the event carrying the running turn's own
+/// ordinal settles it: a batch that still holds an earlier turn's ending
+/// must not close a turn that started after it.
 async fn settle_turn_rows(
     db: &Arc<DbStore>,
     owner: &OwnerId,
@@ -153,6 +163,13 @@ async fn settle_turn_rows(
             "turn_interrupted" => CodeTurnStatus::Interrupted,
             _ => continue,
         };
+        let event_ordinal = event
+            .payload
+            .get("turn")
+            .and_then(serde_json::Value::as_i64);
+        if event_ordinal != Some(turn.ordinal) {
+            continue;
+        }
         turn.status = status;
         turn.ended_at = Some(chrono::Utc::now());
         save_turn(db, owner, &turn).await?;
@@ -176,9 +193,14 @@ impl RemoteDriver<'_> {
     ) -> Result<RemoteTurnOutcome, tidebreak_core::AgentError> {
         let (db, bus, provisioner, settings) = (self.db, self.bus, self.provisioner, self.settings);
         let owner = session.owner.clone();
-        let ordinal = latest_turn(db, &owner, session.id)
-            .await?
-            .map_or(1, |turn| turn.ordinal + 1);
+        let last = latest_turn(db, &owner, session.id).await?;
+        if last
+            .as_ref()
+            .is_some_and(|turn| turn.status == CodeTurnStatus::Running)
+        {
+            return Ok(RemoteTurnOutcome::TurnInFlight);
+        }
+        let ordinal = last.map_or(1, |turn| turn.ordinal + 1);
 
         let current = latest_incarnation(db, &owner, session.id).await?;
         match current.as_ref().map(|row| row.state) {
@@ -208,14 +230,15 @@ impl RemoteDriver<'_> {
                     Err(RemoteSandboxError::Refused { code, message, .. }) => {
                         // The environment no longer takes messages for this
                         // sandbox: it ended without this server having drained
-                        // the news yet. Close the record and fall through to
-                        // reincarnation only once its terminal events are in.
+                        // the news yet. The row stays active so the pump can
+                        // drain the remaining events — including the goodbye
+                        // that raises the reincarnation gate — and close it
+                        // against the terminal state it reads.
                         warn!(
                             session = %session.id,
                             %code,
-                            "a live sandbox refused a message; closing the incarnation ({message})"
+                            "a live sandbox refused a message; the pump will drain and close it ({message})"
                         );
-                        stop_incarnation(db, &owner, row.id, Some(&code)).await?;
                         return Ok(RemoteTurnOutcome::FlushPending);
                     }
                     Err(error) => {
@@ -226,7 +249,10 @@ impl RemoteDriver<'_> {
             Some(IncarnationState::Stopped) | None => {}
         }
         if let Some(predecessor) = &current {
-            if !predecessor.terminal_events_journaled {
+            // The gate holds only for a predecessor that actually ran: an
+            // intent that never activated, or a spawn that failed, has no
+            // output a resume could miss.
+            if predecessor.sandbox_id.is_some() && !predecessor.terminal_events_journaled {
                 return Ok(RemoteTurnOutcome::FlushPending);
             }
         }
@@ -276,7 +302,22 @@ impl RemoteDriver<'_> {
         };
         match provisioner.spawn(&owner, &arguments).await {
             Ok(lease) => {
-                activate_incarnation(db, &owner, intent.id, &lease.sandbox_id).await?;
+                if let Err(error) =
+                    activate_incarnation(db, &owner, intent.id, &lease.sandbox_id).await
+                {
+                    // The protocol closed the row under us (the sweep, say).
+                    // The sandbox this call holds is orphaned: cancel it, or
+                    // a later turn provisions a second one for this session.
+                    if let Err(cancel_error) = provisioner.cancel(&owner, &lease.sandbox_id).await {
+                        warn!(
+                            session = %session.id,
+                            sandbox = %lease.sandbox_id,
+                            %cancel_error,
+                            "an orphaned sandbox could not be cancelled; its ceilings bound it"
+                        );
+                    }
+                    return Err(error);
+                }
                 let incarnation = latest_incarnation(db, &owner, session.id)
                     .await?
                     .ok_or_else(|| {
@@ -328,7 +369,15 @@ impl RemoteDriver<'_> {
         let Some(row) = latest_incarnation(db, &owner, session.id).await? else {
             return Ok(report);
         };
-        if row.state != IncarnationState::Active {
+        // Active rows are pumped for progress. A stopped row that still has
+        // events to drain — its goodbye has not raised the gate — is pumped
+        // too, so a stop can never strand the terminal flush undelivered.
+        let drains = match row.state {
+            IncarnationState::Active => true,
+            IncarnationState::Stopped => !row.terminal_events_journaled,
+            IncarnationState::Intent => false,
+        };
+        if !drains {
             return Ok(report);
         }
         let Some(sandbox_id) = row.sandbox_id.clone() else {
@@ -374,7 +423,7 @@ impl RemoteDriver<'_> {
 
         settle_turn_rows(db, &owner, running_turn, &read.events).await?;
 
-        if read.state.is_terminal() {
+        if read.state.is_terminal() && row.state == IncarnationState::Active {
             stop_incarnation(
                 db,
                 &owner,
@@ -420,6 +469,13 @@ impl RemoteDriver<'_> {
                     }
                 }
                 let _ = stop_incarnation(db, &owner, row.id, Some("reaped")).await;
+            }
+            if !row.terminal_events_journaled {
+                // Reap is the person accepting whatever the sandbox never
+                // delivered — the fence said so. Waive the gate, or the next
+                // turn after a successful reap waits forever instead of
+                // reincarnating on demand.
+                let _ = mark_incarnation_terminal_events_journaled(db, &owner, row.id).await;
             }
         }
         recovery::reap_session(db, bus, session).await
@@ -528,8 +584,13 @@ mod tests {
     };
     use super::*;
 
+    type SpawnHook = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
+
     #[derive(Default)]
     struct FakeProvisioner {
+        /// Awaited inside the next spawn, after the intent row exists —
+        /// the window an activation race lives in.
+        on_spawn: Mutex<Option<SpawnHook>>,
         spawns: Mutex<Vec<SpawnArguments>>,
         spawn_results: Mutex<VecDeque<Result<SandboxLease, RemoteSandboxError>>>,
         sends: Mutex<Vec<(String, String)>>,
@@ -580,6 +641,10 @@ mod tests {
             _owner: &OwnerId,
             arguments: &SpawnArguments,
         ) -> Result<SandboxLease, RemoteSandboxError> {
+            let hook = self.on_spawn.lock().unwrap().take();
+            if let Some(hook) = hook {
+                hook.await;
+            }
             self.spawns.lock().unwrap().push(arguments.clone());
             self.spawn_results
                 .lock()
@@ -898,6 +963,15 @@ mod tests {
             .unwrap();
         assert_eq!(row.state, IncarnationState::Stopped);
         assert_eq!(row.stop_reason.as_deref(), Some("reaped"));
+        // The reap waived the terminal-flush gate the sandbox never raised,
+        // so the next turn reincarnates on demand instead of waiting forever.
+        assert!(row.terminal_events_journaled);
+        let mut recovered = recovered;
+        let outcome = driver
+            .submit_turn(&mut recovered, &_workspace, &_repo, "again")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
     }
 
     /// At the owner's cap the refusal names the sessions holding the live
@@ -928,6 +1002,196 @@ mod tests {
         };
         assert_eq!(running, vec![session_a.id]);
         assert!(fake.spawns.lock().unwrap().is_empty());
+    }
+
+    /// A live sandbox that refuses a message stays open for the pump: the
+    /// drain delivers the goodbye, closes the row, and the next turn then
+    /// reincarnates instead of waiting forever.
+    #[tokio::test]
+    async fn a_refused_message_leaves_the_row_for_the_pump_to_drain() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        fake.send_results
+            .lock()
+            .unwrap()
+            .push_back(Err(RemoteSandboxError::Refused {
+                operation: "send",
+                code: "sandbox_not_running".to_owned(),
+                message: "the sandbox has ended".to_owned(),
+            }));
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "late")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::FlushPending));
+        let row = latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.state, IncarnationState::Active);
+
+        // The pump drains the terminal events and closes the row.
+        fake.event_reads.lock().unwrap().push_back(read(
+            SandboxState::Expired,
+            2,
+            vec![
+                event(1, "turn_completed", json!({ "turn": 1, "exit_code": 0 })),
+                event(2, "supervisor_stopped", json!({ "reason": "expired" })),
+            ],
+        ));
+        let report = driver.pump(&mut session, 0).await.unwrap();
+        assert!(report.incarnation_stopped);
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "late")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
+    }
+
+    /// A spawn that fails releases a reservation with nothing to drain: the
+    /// next turn reincarnates instead of waiting on a gate no sandbox can
+    /// ever raise.
+    #[tokio::test]
+    async fn a_failed_spawn_does_not_gate_the_next_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        fake.spawn_results
+            .lock()
+            .unwrap()
+            .push_back(Err(RemoteSandboxError::Refused {
+                operation: "spawn",
+                code: "profile_not_found".to_owned(),
+                message: "no such profile".to_owned(),
+            }));
+        assert!(driver
+            .submit_turn(&mut session, &workspace, &repo, "start")
+            .await
+            .is_err());
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "retry")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
+    }
+
+    /// One running turn at a time: a second submit is refused for the
+    /// caller's queue, never interleaved as a second running row.
+    #[tokio::test]
+    async fn a_second_submit_while_a_turn_runs_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        driver
+            .submit_turn(&mut session, &workspace, &repo, "first")
+            .await
+            .unwrap();
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "second")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::TurnInFlight));
+        assert!(fake.sends.lock().unwrap().is_empty());
+        assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+    }
+
+    /// A batch still carrying an earlier turn's ending must not settle a
+    /// turn that started after it.
+    #[tokio::test]
+    async fn an_earlier_turns_ending_does_not_settle_the_running_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, _bus, session, _workspace, _repo) = seed(dir.path()).await;
+        let running = CodeTurn {
+            id: CodeTurnId::new(),
+            session_id: session.id,
+            ordinal: 2,
+            status: CodeTurnStatus::Running,
+            model: None,
+            fast_mode: false,
+            user_input: "second".to_owned(),
+            user_input_blob_id: None,
+            attachments: Vec::new(),
+            checkpoint_ref: None,
+            diffstat: None,
+            usage: None,
+            narrative: None,
+            started_at: chrono::Utc::now(),
+            ended_at: None,
+        };
+        insert_turn(&db, &session.owner, &running).await.unwrap();
+
+        let stale = [event(
+            9,
+            "turn_completed",
+            json!({ "turn": 1, "exit_code": 0 }),
+        )];
+        settle_turn_rows(&db, &session.owner, Some(running.clone()), &stale)
+            .await
+            .unwrap();
+        let row = latest_turn(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, CodeTurnStatus::Running);
+
+        let own = [event(
+            10,
+            "turn_completed",
+            json!({ "turn": 2, "exit_code": 0 }),
+        )];
+        settle_turn_rows(&db, &session.owner, Some(running), &own)
+            .await
+            .unwrap();
+        let row = latest_turn(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, CodeTurnStatus::Completed);
+    }
+
+    /// A lease whose activation loses to the protocol is cancelled, not
+    /// leaked beside a released cap slot.
+    #[tokio::test]
+    async fn an_activation_race_cancels_the_orphaned_lease() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        // While the spawn is in flight, the sweep closes the intent.
+        let hook_db = db.clone();
+        let hook_owner = session.owner.clone();
+        let hook_session = session.id;
+        *fake.on_spawn.lock().unwrap() = Some(Box::pin(async move {
+            let row = latest_incarnation(&hook_db, &hook_owner, hook_session)
+                .await
+                .unwrap()
+                .unwrap();
+            stop_incarnation(&hook_db, &hook_owner, row.id, Some("intent_expired"))
+                .await
+                .unwrap();
+        }));
+
+        assert!(driver
+            .submit_turn(&mut session, &workspace, &repo, "start")
+            .await
+            .is_err());
+        assert_eq!(
+            fake.cancels.lock().unwrap().as_slice(),
+            &["sb-next".to_owned()]
+        );
     }
 
     /// The sweep closes intents that never activated and fences their

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -17,9 +17,10 @@ use std::sync::Arc;
 use tracing::warn;
 
 use tidebreak_core::db::code::{
-    activate_incarnation, create_incarnation_intent, insert_turn, latest_incarnation,
-    latest_pushed_wip_ref, latest_turn, mark_incarnation_terminal_events_journaled, save_turn,
-    stale_incarnation_intents_all_owners, stop_incarnation,
+    activate_incarnation, create_incarnation_intent, forget_session_wip_ref, insert_turn,
+    latest_incarnation, latest_pushed_wip_ref, latest_turn,
+    mark_incarnation_terminal_events_journaled, save_turn, stale_incarnation_intents_all_owners,
+    stop_incarnation,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeRepo, CodeSession, CodeSessionId, CodeSessionIncarnation,
@@ -389,7 +390,12 @@ impl RemoteDriver<'_> {
                 if resumed_from_wip && refusal_names(&error, &resume_ref) {
                     // The WIP ref the predecessor pushed is gone from the
                     // origin: the resume state no longer exists, and retrying
-                    // would refuse identically. Fence so a reap starts fresh.
+                    // would refuse identically. Forget the ref — the local
+                    // resume-lost path drops its rejected ref for the same
+                    // reason — so the turn after a reap resumes from an
+                    // earlier checkpoint or the base instead of looping on
+                    // this refusal. Then fence so a reap starts fresh.
+                    forget_session_wip_ref(db, &owner, session.id, &resume_ref).await?;
                     recovery::fence_session(
                         db,
                         bus,
@@ -1051,6 +1057,20 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(row.state, IncarnationState::Stopped);
+
+        // The gone checkpoint is forgotten: after a reap, the next turn
+        // resumes from the base ref instead of looping on the same refusal.
+        let mut recovered = driver.reap(live).await.unwrap();
+        let outcome = driver
+            .submit_turn(&mut recovered, &workspace, &repo, "continue")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
+        let spawns = fake.spawns.lock().unwrap();
+        assert_eq!(
+            spawns.last().unwrap().repository_ref.as_deref(),
+            Some("main")
+        );
     }
 
     /// Reap cancels the sandbox, closes the record, and resolves the fence

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -79,6 +79,9 @@ pub(crate) enum RemoteTurnOutcome {
     /// the way every other submit path does; the driver never interleaves
     /// two running turn rows on one session.
     TurnInFlight,
+    /// The environment rejected the owner's credential. Nothing was sent or
+    /// provisioned; sign in and retry.
+    SignInRequired,
 }
 
 /// The driver one remote session's lifecycle calls go through: the store,
@@ -93,6 +96,27 @@ pub(crate) struct RemoteDriver<'a> {
     pub provisioner: &'a dyn SandboxProvisioner,
     /// Spawn-time settings.
     pub settings: &'a RemoteSpawnSettings,
+}
+
+/// Surface the sign-in need on the session's attention.
+async fn sign_in_needed(
+    db: &Arc<DbStore>,
+    bus: &CodeEventBus,
+    session: &CodeSession,
+) -> Result<(), tidebreak_core::AgentError> {
+    let _ = super::super::attention::apply_attention(
+        db,
+        bus,
+        &session.owner,
+        session.id,
+        Attention::needs_you(
+            "sign in to the sandbox environment",
+            AttentionSource::Lifecycle,
+        ),
+        false,
+    )
+    .await?;
+    Ok(())
 }
 
 /// Whether a refusal's own description names this ref.
@@ -233,6 +257,14 @@ impl RemoteDriver<'_> {
                             turn: Box::new(turn),
                         });
                     }
+                    Err(RemoteSandboxError::SignInRequired(detail)) => {
+                        // Token expiry between pumps is not a failed turn:
+                        // hold the row beside the live lease and surface the
+                        // sign-in, the same way the pump path does.
+                        warn!(session = %session.id, %detail, "a send needs a sign-in");
+                        sign_in_needed(db, bus, session).await?;
+                        return Ok(RemoteTurnOutcome::SignInRequired);
+                    }
                     Err(RemoteSandboxError::Refused { code, message, .. }) => {
                         // The environment no longer takes messages for this
                         // sandbox: it ended without this server having drained
@@ -337,6 +369,14 @@ impl RemoteDriver<'_> {
                     incarnation: Box::new(incarnation),
                 })
             }
+            Err(RemoteSandboxError::SignInRequired(detail)) => {
+                // No sandbox exists, so the reservation is safe to release;
+                // the retry after a sign-in reserves again.
+                stop_incarnation(db, &owner, intent.id, Some("sign_in_required")).await?;
+                warn!(session = %session.id, %detail, "a spawn needs a sign-in");
+                sign_in_needed(db, bus, session).await?;
+                Ok(RemoteTurnOutcome::SignInRequired)
+            }
             Err(error) => {
                 // The reservation must not outlive the spawn it reserved for.
                 stop_incarnation(db, &owner, intent.id, Some("spawn_failed")).await?;
@@ -414,18 +454,7 @@ impl RemoteDriver<'_> {
                 // the row — closing it here would release the cap slot
                 // beside a live sandbox — and surface the sign-in.
                 report.sign_in_required = true;
-                let _ = super::super::attention::apply_attention(
-                    db,
-                    bus,
-                    &owner,
-                    session.id,
-                    Attention::needs_you(
-                        "sign in to the sandbox environment",
-                        AttentionSource::Lifecycle,
-                    ),
-                    false,
-                )
-                .await?;
+                sign_in_needed(db, bus, session).await?;
                 warn!(session = %session.id, %detail, "the sandbox stream needs a sign-in");
                 return Ok(report);
             }
@@ -482,6 +511,15 @@ impl RemoteDriver<'_> {
             .await?;
             report.incarnation_stopped = true;
             if session.lifecycle == CodeSessionLifecycle::Running {
+                // The ingest just wrote this turn's verdict (DoneUnreviewed,
+                // needs-you) onto the stored row. Refresh this snapshot
+                // before persisting, or the stale Working it still carries
+                // from turn start would overwrite the verdict.
+                if let Some(stored) =
+                    tidebreak_core::db::code::get_session(db, &owner, session.id).await?
+                {
+                    *session = stored;
+                }
                 session.lifecycle = CodeSessionLifecycle::Idle;
                 let _ = persist_session(db, bus, session).await?;
             }
@@ -883,6 +921,17 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(turn.status, CodeTurnStatus::Completed);
+        // The persist after the sandbox stop must not write the snapshot's
+        // stale Working back over the verdict the ingest just journaled.
+        let live = tidebreak_core::db::code::get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            live.attention.state,
+            tidebreak_core::AttentionState::DoneUnreviewed
+        );
+        assert_eq!(live.lifecycle, CodeSessionLifecycle::Idle);
 
         // Turn 2 reincarnates from the pushed ref, starting at turn 2.
         let outcome = driver
@@ -1478,6 +1527,47 @@ mod tests {
         assert!(report.fenced.is_none());
         assert!(!report.incarnation_stopped);
         assert!(fake.cancels.lock().unwrap().is_empty());
+        let row = latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.state, IncarnationState::Active);
+        let live = tidebreak_core::db::code::get_session(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            live.attention.state,
+            tidebreak_core::AttentionState::NeedsYou { .. }
+        ));
+    }
+
+    /// A send that needs a sign-in fails no turn: the row stays open, no
+    /// turn row is inserted, and the sign-in need is surfaced.
+    #[tokio::test]
+    async fn a_send_that_needs_sign_in_holds_the_turn_and_surfaces_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = driver!(&db, &bus, &fake, &settings);
+
+        fake.send_results
+            .lock()
+            .unwrap()
+            .push_back(Err(RemoteSandboxError::SignInRequired(
+                "token expired".to_owned(),
+            )));
+        let outcome = driver
+            .submit_turn(&mut session, &workspace, &repo, "held")
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RemoteTurnOutcome::SignInRequired));
+        assert!(latest_turn(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .is_none());
         let row = latest_incarnation(&db, &session.owner, session.id)
             .await
             .unwrap()

--- a/crates/tidebreak-server/src/code/remote/fixtures.rs
+++ b/crates/tidebreak-server/src/code/remote/fixtures.rs
@@ -1,0 +1,120 @@
+//! Shared test fixtures for the remote modules: a seeded store with a repo,
+//! workspace, session, and an activated incarnation.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tidebreak_core::db::code::{
+    activate_incarnation, create_incarnation_intent, insert_repo, insert_session, insert_workspace,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, CodeIncarnationId, CodeRepo, CodeSession, CodeSessionId,
+    CodeSessionKind, CodeSessionLifecycle, CodeWorkspace, CodeWorkspaceStatus, DbStore,
+    HarnessKind, IncarnationAdmission, OwnerId, PermissionMode, RepoId, WorkspaceId,
+};
+
+use super::super::bus::CodeEventBus;
+
+/// A session value with sensible remote defaults, unsaved.
+pub(crate) fn session_value() -> CodeSession {
+    CodeSession {
+        id: CodeSessionId::new(),
+        owner: OwnerId::local(),
+        workspace_id: WorkspaceId::new(),
+        kind: CodeSessionKind::Interactive,
+        harness_kind: HarnessKind::ClaudeCode,
+        harness_version: None,
+        harness_resume_ref: None,
+        permission_mode: PermissionMode::Allow,
+        model: None,
+        reasoning_effort: None,
+        fast_mode: false,
+        lifecycle: CodeSessionLifecycle::Running,
+        fence_reason: None,
+        child_pid: None,
+        child_process_identity: None,
+        spawn_epoch: 1,
+        attention: Attention::working(AttentionSource::Lifecycle),
+        unrecognized_event_count: 0,
+        subagents: Vec::new(),
+        created_at: chrono::Utc::now(),
+    }
+}
+
+/// A store with one repo (origin recorded), one remote workspace (no host
+/// path), and one session, all inserted.
+pub(crate) async fn seed(
+    root: &Path,
+) -> (
+    Arc<DbStore>,
+    CodeEventBus,
+    CodeSession,
+    CodeWorkspace,
+    CodeRepo,
+) {
+    let db = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            root.join("code.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let owner = OwnerId::local();
+    let repo = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: root.join("repo").display().to_string(),
+        display_name: "example".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "tidebreak/".into(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: chrono::Utc::now(),
+        removed_at: None,
+        cloned_from: None,
+        origin_host: Some("github.com".into()),
+        origin_owner: Some("acme".into()),
+        origin_name: Some("tools".into()),
+    };
+    insert_repo(&db, &repo).await.unwrap();
+    let workspace = CodeWorkspace {
+        id: WorkspaceId::new(),
+        owner: owner.clone(),
+        repo_id: repo.id,
+        title: "remote".into(),
+        worktree_path: String::new(),
+        branch_name: "tidebreak/remote".into(),
+        base_ref: "main".into(),
+        status: CodeWorkspaceStatus::Active,
+        pr: None,
+        created_at: chrono::Utc::now(),
+        archived_at: None,
+        released_at: None,
+        released_tip: None,
+        bundle_bytes: None,
+    };
+    insert_workspace(&db, &workspace).await.unwrap();
+    let mut session = session_value();
+    session.workspace_id = workspace.id;
+    insert_session(&db, &session).await.unwrap();
+    (db, CodeEventBus::default(), session, workspace, repo)
+}
+
+/// Reserve and activate one incarnation for the session.
+pub(crate) async fn seeded_incarnation(
+    db: &Arc<DbStore>,
+    session: &CodeSession,
+) -> CodeIncarnationId {
+    let admission = create_incarnation_intent(db, &session.owner, session.id, 1, 4)
+        .await
+        .unwrap();
+    let IncarnationAdmission::Admitted(row) = admission else {
+        panic!("expected admission");
+    };
+    activate_incarnation(db, &session.owner, row.id, "sb-1")
+        .await
+        .unwrap();
+    row.id
+}

--- a/crates/tidebreak-server/src/code/remote/ingest.rs
+++ b/crates/tidebreak-server/src/code/remote/ingest.rs
@@ -353,19 +353,15 @@ async fn apply_one(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
 
     use serde_json::json;
 
     use tidebreak_core::db::code::{
-        activate_incarnation, create_incarnation_intent, get_session, insert_repo, insert_session,
-        insert_workspace, latest_incarnation, list_events, replace_session_attention,
+        get_session, latest_incarnation, list_events, replace_session_attention,
     };
-    use tidebreak_core::{
-        CodeRepo, CodeSession, CodeSessionKind, CodeSessionLifecycle, CodeWorkspace,
-        CodeWorkspaceStatus, IncarnationAdmission, PermissionMode, RepoId, WorkspaceId,
-    };
+    use tidebreak_core::CodeSession;
 
+    use super::super::fixtures::{seed, seeded_incarnation, session_value};
     use super::*;
 
     fn binding(session: &CodeSession, incarnation: CodeIncarnationId) -> IngestBinding {
@@ -456,7 +452,7 @@ mod tests {
     #[tokio::test]
     async fn a_driven_stream_survives_a_restart_mid_stream() {
         let dir = tempfile::tempdir().unwrap();
-        let (db, bus, session) = seed(dir.path()).await;
+        let (db, bus, session, _workspace, _repo) = seed(dir.path()).await;
         let incarnation = seeded_incarnation(&db, &session).await;
         let b = binding(&session, incarnation);
 
@@ -573,7 +569,7 @@ mod tests {
     #[tokio::test]
     async fn a_terminal_state_without_a_goodbye_demands_a_fence() {
         let dir = tempfile::tempdir().unwrap();
-        let (db, bus, session) = seed(dir.path()).await;
+        let (db, bus, session, _workspace, _repo) = seed(dir.path()).await;
         let incarnation = seeded_incarnation(&db, &session).await;
         let b = binding(&session, incarnation);
 
@@ -606,104 +602,5 @@ mod tests {
         );
         let outcome = ingest_events(&db, &bus, &b, &undrained).await.unwrap();
         assert!(outcome.fence.is_none());
-    }
-
-    fn session_value() -> CodeSession {
-        CodeSession {
-            id: CodeSessionId::new(),
-            owner: OwnerId::local(),
-            workspace_id: WorkspaceId::new(),
-            kind: CodeSessionKind::Interactive,
-            harness_kind: HarnessKind::ClaudeCode,
-            harness_version: None,
-            harness_resume_ref: None,
-            permission_mode: PermissionMode::Allow,
-            model: None,
-            reasoning_effort: None,
-            fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Running,
-            fence_reason: None,
-            child_pid: None,
-            child_process_identity: None,
-            spawn_epoch: 1,
-            attention: Attention::working(tidebreak_core::AttentionSource::Lifecycle),
-            unrecognized_event_count: 0,
-            subagents: Vec::new(),
-            created_at: chrono::Utc::now(),
-        }
-    }
-
-    async fn seed(root: &Path) -> (Arc<DbStore>, CodeEventBus, CodeSession) {
-        let db = Arc::new(
-            DbStore::connect(&format!(
-                "sqlite://{}?mode=rwc",
-                root.join("code.db").display()
-            ))
-            .await
-            .unwrap(),
-        );
-        let owner = OwnerId::local();
-        let repo_id = RepoId::new();
-        insert_repo(
-            &db,
-            &CodeRepo {
-                id: repo_id,
-                owner: owner.clone(),
-                root_path: root.join("repo").display().to_string(),
-                display_name: "example".into(),
-                default_base_ref: "main".into(),
-                branch_prefix: "tidebreak/".into(),
-                setup_script: None,
-                archive_script: None,
-                quick_actions: Vec::new(),
-                created_at: chrono::Utc::now(),
-                removed_at: None,
-                cloned_from: None,
-                origin_host: None,
-                origin_owner: None,
-                origin_name: None,
-            },
-        )
-        .await
-        .unwrap();
-        let workspace_id = WorkspaceId::new();
-        insert_workspace(
-            &db,
-            &CodeWorkspace {
-                id: workspace_id,
-                owner: owner.clone(),
-                repo_id,
-                title: "remote".into(),
-                worktree_path: root.join("tree").display().to_string(),
-                branch_name: "tidebreak/remote".into(),
-                base_ref: "main".into(),
-                status: CodeWorkspaceStatus::Active,
-                pr: None,
-                created_at: chrono::Utc::now(),
-                archived_at: None,
-                released_at: None,
-                released_tip: None,
-                bundle_bytes: None,
-            },
-        )
-        .await
-        .unwrap();
-        let mut session = session_value();
-        session.workspace_id = workspace_id;
-        insert_session(&db, &session).await.unwrap();
-        (db, CodeEventBus::default(), session)
-    }
-
-    async fn seeded_incarnation(db: &Arc<DbStore>, session: &CodeSession) -> CodeIncarnationId {
-        let admission = create_incarnation_intent(db, &session.owner, session.id, 1, 4)
-            .await
-            .unwrap();
-        let IncarnationAdmission::Admitted(row) = admission else {
-            panic!("expected admission");
-        };
-        activate_incarnation(db, &session.owner, row.id, "sb-1")
-            .await
-            .unwrap();
-        row.id
     }
 }

--- a/crates/tidebreak-server/src/code/remote/mod.rs
+++ b/crates/tidebreak-server/src/code/remote/mod.rs
@@ -35,6 +35,9 @@
 // then only the tests construct it. Same stance as `scripted_harness`.
 #![cfg_attr(not(test), allow(dead_code))]
 
+pub(crate) mod driver;
+#[cfg(test)]
+pub(crate) mod fixtures;
 pub(crate) mod gateway;
 pub(crate) mod ingest;
 pub(crate) mod wire;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -829,17 +829,36 @@ impl CodeRuntime {
         // that is still usable so submit_turn is not stuck after a restart.
         // Concurrently: each attach launches an engine child, so a serial pass
         // charged app launch the sum of every restored session.
+        // Remote sessions have no local worker to re-attach: their engine
+        // lives in a sandbox, and spawning a host harness against the empty
+        // worktree path would fail loudly for a session that is healthy.
+        let mut remote_workspaces = std::collections::HashSet::new();
+        let mut checked_workspaces = std::collections::HashSet::new();
+        for session in &recovered_sessions {
+            if !checked_workspaces.insert(session.workspace_id) {
+                continue;
+            }
+            if let Ok(workspace) = self
+                .get_workspace(&session.owner, session.workspace_id)
+                .await
+            {
+                if workspace.is_remote() {
+                    remote_workspaces.insert(session.workspace_id);
+                }
+            }
+        }
         let resumable: Vec<CodeSession> = recovered_sessions
             .into_iter()
             .filter(|session| {
                 !matches!(
                     session.lifecycle,
                     CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
-                ) && !self
-                    .workers
-                    .lock()
-                    .expect("code workers")
-                    .contains_key(&session.id)
+                ) && !remote_workspaces.contains(&session.workspace_id)
+                    && !self
+                        .workers
+                        .lock()
+                        .expect("code workers")
+                        .contains_key(&session.id)
             })
             .collect();
         futures::future::join_all(resumable.into_iter().map(|session| async move {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -3072,6 +3072,12 @@ impl CodeRuntime {
                 format!("workspace is {}", workspace.status.as_str()),
             ));
         }
+        if workspace.is_remote() {
+            return Err(ServerError::conflict_kind(
+                "workspace_remote",
+                "this workspace's engine runs in a remote sandbox; there is no host worktree",
+            ));
+        }
         if !std::path::Path::new(&workspace.worktree_path).exists() {
             return Err(ServerError::not_found("workspace worktree is gone"));
         }

--- a/crates/tidebreak-server/src/code/worktree_orphans.rs
+++ b/crates/tidebreak-server/src/code/worktree_orphans.rs
@@ -226,3 +226,85 @@ fn write_sidecar(sidecar: &Path, record: &OrphanedWorktrees) -> std::io::Result<
     }
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A remote workspace has no host worktree by design: the scan must not
+    /// record it as an orphan, while a real on-disk tree is recorded.
+    #[tokio::test]
+    async fn the_scan_leaves_remote_workspace_rows_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let database = dir.path().join("code.db");
+        let store =
+            tidebreak_core::DbStore::connect(&format!("sqlite://{}?mode=rwc", database.display()))
+                .await
+                .unwrap();
+        let owner = tidebreak_core::OwnerId::local();
+        let repo = tidebreak_core::CodeRepo {
+            id: tidebreak_core::RepoId::new(),
+            owner: owner.clone(),
+            root_path: dir.path().join("repo").display().to_string(),
+            display_name: "example".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: Vec::new(),
+            created_at: chrono::Utc::now(),
+            removed_at: None,
+            cloned_from: None,
+            origin_host: None,
+            origin_owner: None,
+            origin_name: None,
+        };
+        tidebreak_core::db::code::insert_repo(&store, &repo)
+            .await
+            .unwrap();
+        let workspace = |title: &str, path: String| tidebreak_core::CodeWorkspace {
+            id: tidebreak_core::WorkspaceId::new(),
+            owner: owner.clone(),
+            repo_id: repo.id,
+            title: title.into(),
+            worktree_path: path,
+            branch_name: format!("tidebreak/{title}"),
+            base_ref: "main".into(),
+            status: tidebreak_core::CodeWorkspaceStatus::Active,
+            pr: None,
+            created_at: chrono::Utc::now(),
+            archived_at: None,
+            released_at: None,
+            released_tip: None,
+            bundle_bytes: None,
+        };
+        let on_disk = dir.path().join("tree");
+        std::fs::create_dir_all(&on_disk).unwrap();
+        tidebreak_core::db::code::insert_workspace(
+            &store,
+            &workspace("local", on_disk.display().to_string()),
+        )
+        .await
+        .unwrap();
+        tidebreak_core::db::code::insert_workspace(&store, &workspace("remote", String::new()))
+            .await
+            .unwrap();
+        // The scan opens the file immutable, which cannot see a live WAL;
+        // checkpoint so the rows are in the main file, as they are by the
+        // time a reset scans a closed database.
+        use sea_orm::ConnectionTrait as _;
+        drop(store);
+        let checkpoint = Database::connect(format!("sqlite://{}?mode=rw", database.display()))
+            .await
+            .unwrap();
+        checkpoint
+            .execute_unprepared("PRAGMA wal_checkpoint(TRUNCATE);")
+            .await
+            .unwrap();
+        checkpoint.close().await.unwrap();
+
+        let found = scan(&database).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].worktree_path, on_disk.display().to_string());
+    }
+}


### PR DESCRIPTION
## Summary

The remote session driver (#2873, epic #2875, design: `docs/slack-sessions.md`).

- `crates/tidebreak-server/src/code/remote/driver.rs`: `RemoteDriver` owns the lifecycle decisions the transport-only provisioner does not.
  - Turn submission: a live sandbox gets the turn as an inbox message; a gone sandbox triggers reincarnation — reserve under the owner's cap via the incarnation intent (a cap refusal names the sessions holding live incarnations), spawn from the predecessor's `last_wip_ref` at the next turn number, activate with the returned sandbox id. A stopped predecessor whose terminal events are not journaled yet returns `FlushPending` instead of resuming without its last output; a live intent returns `ReincarnationInFlight`.
  - WIP-ref resume: first incarnation spawns from the workspace base ref; successors from the retained `mg-wip/<sandbox>-i<n>` ref. A spawn refusal whose description names that ref fences `ResumeLost` and releases the reservation.
  - `pump`: reads events after the durable cursor, projects them through ingestion, settles turn rows at terminal turn events, closes the incarnation when the environment retires the sandbox, and applies the fence the read demands (`sandbox_lost` / `terminal_flush_missing`).
  - `reap`: cancels whatever the environment still holds (best effort), closes the record, resolves the fence through the existing recovery path — and relaunches nothing; the next turn reincarnates on demand.
  - `sweep_stale_intents`: closes intent rows older than ten minutes that never activated and fences their sessions `incarnation_unresolved`.
- Remote workspaces store an empty `worktree_path` (`CodeWorkspace::is_remote`): `require_live_workspace` refuses with a distinct `workspace_remote` conflict instead of a spurious not-found, and the orphan scan's existing on-disk filter leaves the rows alone (now pinned by a test).
- `IncarnationAdmission::Admitted` boxes its row, and `CodeSessionIncarnation` carries its owner so the machine-wide sweep can act on what it finds.

Runtime wiring — constructing the gateway provisioner from configuration, remote workspace/session creation routes, registering the sweep, and branching submit/reap in `CodeRuntime` — lands with the cap-and-ledger slice (#2874), which owns the settings these calls take.

## Testing

- `cargo test -p tidebreak-server --lib code::remote` (25 pass): first-turn provisioning from the base ref, inbox delivery on a live sandbox, survival across sandbox stop with resume from the pushed WIP ref at the next turn (the issue's done-when, against a scripted provisioner), `FlushPending` hold, `ResumeLost` fencing on a ref-naming refusal with the reservation released, cap refusal naming the running session, reap without relaunch, and the stale-intent sweep fencing the session.
- `cargo test -p tidebreak-server --lib code::worktree_orphans`: the scan records the on-disk workspace and skips the remote row.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --all -- --check`, `cargo test -p tidebreak-core --lib db::` (392 pass).

Part of #2873.