### PR TITLE
feat(code): show reclaimable disk and pass hook env

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -107,6 +107,7 @@ import {
   type CodePrCommentsSnapshot,
   type CodePrMergeMethod,
   type CodeWorkspaceSnapshot,
+  type CodeStorageSnapshot,
   type CodeCloneDefaults,
   type CodeGithubRepositories,
   type CodeRepoSources,
@@ -175,6 +176,7 @@ import {
   parseCodeTerminalList,
   parseCodeTerminalRead,
   parseCodeWorkspace,
+  parseCodeStorage,
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
   parseCodeWorkspaceSearch,
@@ -2408,6 +2410,34 @@ export class ApiClient {
         ),
       ),
       "code workspace",
+    );
+  }
+
+  async releaseCodeWorkspace(
+    workspaceId: string,
+    force = false,
+  ): Promise<CodeWorkspaceSnapshot> {
+    return requireParsed(
+      parseCodeWorkspace(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/release`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({ force }),
+          },
+        ),
+      ),
+      "code workspace",
+    );
+  }
+
+  async listCodeStorage(): Promise<CodeStorageSnapshot> {
+    return requireParsed(
+      parseCodeStorage(
+        await this.json("/code/storage", { headers: this.headers() }),
+      ),
+      "code storage",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -205,6 +205,10 @@ import {
   type CodeTerminalRead as WireCodeTerminalRead,
   type CodeTerminalSnapshot as WireCodeTerminalSnapshot,
   type CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
+  type CodeStorageSnapshot as WireCodeStorageSnapshot,
+  type CodeRepoStorageSnapshot as WireCodeRepoStorageSnapshot,
+  type CodeWorkspaceStorageSnapshot as WireCodeWorkspaceStorageSnapshot,
+  type CodeStorageAction as WireCodeStorageAction,
   type Diffstat as WireDiffstat,
   type FileChangeKind as WireFileChangeKind,
   type CodeWorkspaceStatus as WireCodeWorkspaceStatus,
@@ -1201,6 +1205,10 @@ export type CodeDeliveryActionResult = WireCodeDeliveryActionResult;
 export type CodeWorkspaceSnapshot = WireCodeWorkspaceSnapshot;
 export type WorkspaceId = WireWorkspaceId;
 export type CodeWorkspaceStatus = WireCodeWorkspaceStatus;
+export type CodeStorageSnapshot = WireCodeStorageSnapshot;
+export type CodeRepoStorageSnapshot = WireCodeRepoStorageSnapshot;
+export type CodeWorkspaceStorageSnapshot = WireCodeWorkspaceStorageSnapshot;
+export type CodeStorageAction = WireCodeStorageAction;
 
 /** One durable conversation with an external coding engine. */
 export type CodeSessionSnapshot = WireCodeSessionSnapshot;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -213,7 +213,13 @@ describe("CodeSidebar", () => {
       destinations.map(
         (button) => button.getAttribute("aria-label") ?? button.textContent,
       ),
-    ).toEqual(["Pull requests", "Notifications", "Analytics", "Archive"]);
+    ).toEqual([
+      "Pull requests",
+      "Notifications",
+      "Analytics",
+      "Archive",
+      "Storage",
+    ]);
     expect(
       screen.getByRole("button", { name: "Settings" }),
     ).toBeInTheDocument();

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -5,6 +5,7 @@ import {
   BarChart3,
   FolderPlus,
   GitPullRequest,
+  HardDrive,
   Plus,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -505,7 +506,11 @@ function CodeDestinations({
 }: {
   pathname: string;
   onNavigate: (
-    to: "/code/delivery/pull-requests" | "/code/analytics" | "/code/archive",
+    to:
+      | "/code/delivery/pull-requests"
+      | "/code/analytics"
+      | "/code/archive"
+      | "/code/storage",
   ) => void;
 }) {
   const destinations = [
@@ -530,6 +535,13 @@ function CodeDestinations({
       to: "/code/archive" as const,
       active: pathname === "/code/archive",
       icon: Archive,
+    },
+    {
+      type: "route" as const,
+      label: "Storage",
+      to: "/code/storage" as const,
+      active: pathname === "/code/storage",
+      icon: HardDrive,
     },
   ];
   return (

--- a/crates/tidebreak-desktop/ui/src/code/CodeStoragePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeStoragePage.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { HardDrive, LoaderCircle, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+
+import { useApp } from "@/AppContext";
+import { archiveForceKind, HttpError } from "@/api/client";
+import type {
+  CodeRepoStorageSnapshot,
+  CodeStorageSnapshot,
+  CodeWorkspaceStorageSnapshot,
+} from "@/api/types";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatBytes } from "@/lib/formatBytes";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { useConfirm } from "@/components/ConfirmDialog";
+import { RouteFrame } from "@/RouteFrame";
+import { CodeSidebar } from "./CodeSidebar";
+import { WORKSPACE_STATUS_LABELS } from "./labels";
+
+export function CodeStoragePage() {
+  return (
+    <RouteFrame sidebar={<CodeSidebar />}>
+      <div className="content-container min-h-0 w-full min-w-0 flex-1 overflow-hidden">
+        <CodeStorageBody />
+      </div>
+    </RouteFrame>
+  );
+}
+
+function CodeStorageBody() {
+  const { client } = useApp();
+  const navigate = useNavigate();
+  const { confirm, dialog } = useConfirm();
+  const [report, setReport] = useState<CodeStorageSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      const next = await client.listCodeStorage();
+      setReport(next);
+      setError(null);
+    } catch (caught) {
+      setError(friendlyErrorMessage(caught, "Could not load storage."));
+    } finally {
+      setLoaded(true);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, [client]);
+
+  const act = async (row: CodeWorkspaceStorageSnapshot) => {
+    if (busy || !row.next_action) return;
+    setBusy(row.id);
+    try {
+      if (row.next_action === "archive") {
+        const archived = await archiveWorkspace(client, confirm, row.id);
+        if (!archived) return;
+        toast.success("Workspace archived");
+      } else {
+        const released = await releaseWorkspace(client, confirm, row.id);
+        if (!released) return;
+        toast.success("Workspace released");
+      }
+      await refresh();
+    } catch (caught) {
+      toast.error(
+        friendlyErrorMessage(
+          caught,
+          row.next_action === "archive"
+            ? "Could not archive"
+            : "Could not release",
+        ),
+      );
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const repos = report?.repos ?? [];
+  const workspaceCount = repos.reduce(
+    (sum, repo) => sum + repo.workspaces.length,
+    0,
+  );
+
+  return (
+    <div className="flex size-full min-h-0 flex-col bg-background">
+      {dialog}
+      <header className="shrink-0 border-b border-border-subtle px-5 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-xl font-semibold tracking-tight">Storage</h1>
+              {loaded && (
+                <span className="text-xs text-muted-foreground">
+                  {workspaceCount} workspace
+                  {workspaceCount === 1 ? "" : "s"}
+                </span>
+              )}
+            </div>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              See what each reclaim tier would free, then archive or release.
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => void refresh()}
+          >
+            <RefreshCw />
+            Refresh
+          </Button>
+        </div>
+      </header>
+      <div className="min-h-0 flex-1 overflow-auto">
+        {!loaded ? (
+          <StorageSkeleton />
+        ) : error ? (
+          <div className="m-5 rounded-lg border border-critical-border bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted">
+            {error}
+          </div>
+        ) : repos.length === 0 ? (
+          <Empty className="min-h-80">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <HardDrive />
+              </EmptyMedia>
+              <EmptyTitle>No repositories yet</EmptyTitle>
+              <EmptyDescription>
+                Register a repository to see how much disk its workspaces use.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <div className="flex flex-col gap-6 px-5 py-4">
+            {repos.map((repo) => (
+              <RepoStorage
+                key={repo.id}
+                repo={repo}
+                busy={busy}
+                onOpen={(id) =>
+                  void navigate({
+                    to: "/code/w/$workspaceId",
+                    params: { workspaceId: id },
+                  })
+                }
+                onAct={(row) => void act(row)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RepoStorage({
+  repo,
+  busy,
+  onOpen,
+  onAct,
+}: {
+  repo: CodeRepoStorageSnapshot;
+  busy: string | null;
+  onOpen: (id: string) => void;
+  onAct: (row: CodeWorkspaceStorageSnapshot) => void;
+}) {
+  return (
+    <section>
+      <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-sm font-medium">{repo.display_name}</h2>
+        <p className="text-xs text-muted-foreground">
+          Clone {formatBytes(repo.clone_bytes)}
+          {repo.clone_reclaimable ? " · checkout can be removed" : ""}
+        </p>
+      </div>
+      {repo.workspaces.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No workspaces.</p>
+      ) : (
+        <div
+          role="list"
+          aria-label={`${repo.display_name} workspaces`}
+          className="min-w-[720px]"
+        >
+          <div className="grid grid-cols-[minmax(220px,1fr)_110px_110px_180px] gap-4 border-b border-border-subtle py-2 text-xs font-medium text-muted-foreground">
+            <span>Workspace</span>
+            <span>Tier</span>
+            <span>On disk</span>
+            <span className="text-right">Next reclaim</span>
+          </div>
+          {repo.workspaces.map((workspace) => (
+            <div
+              key={workspace.id}
+              role="listitem"
+              className="grid grid-cols-[minmax(220px,1fr)_110px_110px_180px] gap-4 border-b border-border-subtle py-3"
+            >
+              <button
+                type="button"
+                className="min-w-0 cursor-pointer truncate text-left text-sm font-medium hover:text-primary"
+                onClick={() => onOpen(workspace.id)}
+              >
+                {workspace.title}
+              </button>
+              <span className="flex items-center text-xs text-muted-foreground">
+                {WORKSPACE_STATUS_LABELS[workspace.status]}
+              </span>
+              <span className="flex items-center font-mono text-xs tabular-nums text-muted-foreground">
+                {formatBytes(workspace.on_disk_bytes)}
+              </span>
+              <span className="flex items-center justify-end gap-2">
+                {workspace.next_action ? (
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant={
+                      workspace.next_action === "release"
+                        ? "outline"
+                        : "default"
+                    }
+                    disabled={Boolean(busy)}
+                    onClick={() => onAct(workspace)}
+                  >
+                    {busy === workspace.id ? (
+                      <LoaderCircle className="animate-spin" />
+                    ) : null}
+                    {workspace.next_action === "archive"
+                      ? "Archive"
+                      : "Release"}{" "}
+                    {formatBytes(workspace.next_reclaim_bytes)}
+                  </Button>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    Bundle {formatBytes(workspace.on_disk_bytes)}
+                  </span>
+                )}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StorageSkeleton() {
+  return (
+    <div className="p-5" role="status">
+      <span className="sr-only">Loading storage</span>
+      {Array.from({ length: 4 }, (_, index) => (
+        <Skeleton key={index} className="mb-2 h-10 w-full" />
+      ))}
+    </div>
+  );
+}
+
+async function archiveWorkspace(
+  client: {
+    archiveCodeWorkspace: (id: string, force?: boolean) => Promise<unknown>;
+  },
+  confirm: (options: {
+    title: string;
+    description: string;
+    confirmLabel: string;
+    destructive?: boolean;
+  }) => Promise<boolean>,
+  workspaceId: string,
+): Promise<boolean> {
+  try {
+    await client.archiveCodeWorkspace(workspaceId, false);
+    return true;
+  } catch (error) {
+    if (!archiveForceKind(error)) throw error;
+    const forced = await confirm({
+      title: "Discard leftover work?",
+      description: `${error instanceof Error ? error.message : String(error)} Commit and push from the review sidebar, or discard.`,
+      confirmLabel: "Discard and archive",
+      destructive: true,
+    });
+    if (!forced) return false;
+    await client.archiveCodeWorkspace(workspaceId, true);
+    return true;
+  }
+}
+
+async function releaseWorkspace(
+  client: {
+    releaseCodeWorkspace: (id: string, force?: boolean) => Promise<unknown>;
+  },
+  confirm: (options: {
+    title: string;
+    description: string;
+    confirmLabel: string;
+    destructive?: boolean;
+  }) => Promise<boolean>,
+  workspaceId: string,
+): Promise<boolean> {
+  const proceed = await confirm({
+    title: "Drop this branch?",
+    description:
+      "Tidebreak keeps a bundle so you can restore the workspace. The branch itself leaves the clone.",
+    confirmLabel: "Release",
+  });
+  if (!proceed) return false;
+  try {
+    await client.releaseCodeWorkspace(workspaceId, false);
+    return true;
+  } catch (error) {
+    if (!(error instanceof HttpError) || error.kind !== "branch_unmerged") {
+      throw error;
+    }
+    const forced = await confirm({
+      title: "Release an unmerged branch?",
+      description: error.message,
+      confirmLabel: "Bundle and drop",
+      destructive: true,
+    });
+    if (!forced) return false;
+    await client.releaseCodeWorkspace(workspaceId, true);
+    return true;
+  }
+}

--- a/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
@@ -291,7 +291,8 @@ export function RepositorySettings({
               />
             </label>
             <p className="text-xs text-muted-foreground">
-              Runs after a worktree is created or restored.
+              Runs after a worktree is created or restored. Tidebreak sets
+              TIDEBREAK_REPO_ROOT and TIDEBREAK_WORKSPACE_NAME.
             </p>
           </div>
           <div className="flex min-w-0 flex-col gap-1.5">
@@ -312,6 +313,7 @@ export function RepositorySettings({
             </label>
             <p className="text-xs text-muted-foreground">
               Runs before the worktree is removed. A failure stops the archive.
+              Tidebreak sets TIDEBREAK_REPO_ROOT and TIDEBREAK_WORKSPACE_NAME.
             </p>
           </div>
           <div className="flex flex-col gap-2">

--- a/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
@@ -4,6 +4,7 @@ import {
   FileText,
   GitPullRequest,
   ExternalLink,
+  HardDrive,
   MessageSquare,
   Play,
   Plus,
@@ -275,6 +276,14 @@ export function codeNavigationPaletteRows(input: {
       label: "Archived workspaces",
       icon: Archive,
       onSelect: () => input.navigate("/code/archive"),
+    },
+    {
+      id: "navigate:storage",
+      section: "navigate",
+      label: "Storage",
+      keywords: "disk reclaim archive release bytes",
+      icon: HardDrive,
+      onSelect: () => input.navigate("/code/storage"),
     },
     {
       id: "navigate:chat",

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -34,6 +34,7 @@ import {
   parseCodeWorkspacePr,
   parseCodeWorkspaceSearch,
   parseCodeWorkspaceTree,
+  parseCodeStorage,
   parseCodeWorktreeRoot,
   parseFenceReason,
   parseHarnessModelList,
@@ -1502,6 +1503,68 @@ describe("parseCodeCheckLogsSnapshot", () => {
     ).toBeNull();
     expect(
       parseCodeCheckLogsSnapshot({ logs: [], errors: [], extra: true }),
+    ).toBeNull();
+  });
+});
+
+describe("parseCodeStorage", () => {
+  const report = {
+    repos: [
+      {
+        id: "repo-1",
+        display_name: "app",
+        clone_bytes: 4096,
+        clone_reclaimable: false,
+        workspaces: [
+          {
+            id: "ws-1",
+            title: "ember-grove",
+            status: "active",
+            on_disk_bytes: 2048,
+            next_action: "archive",
+            next_reclaim_bytes: 2048,
+          },
+        ],
+      },
+    ],
+  };
+
+  it("accepts GET /code/storage", () => {
+    expect(parseCodeStorage(report)).toEqual(report);
+  });
+
+  it("accepts a released workspace with no next action", () => {
+    const released = {
+      repos: [
+        {
+          ...report.repos[0],
+          workspaces: [
+            {
+              id: "ws-2",
+              title: "released",
+              status: "released",
+              on_disk_bytes: 512,
+              next_reclaim_bytes: 0,
+            },
+          ],
+        },
+      ],
+    };
+    expect(parseCodeStorage(released)).toEqual(released);
+  });
+
+  it("rejects an unknown next action", () => {
+    expect(
+      parseCodeStorage({
+        repos: [
+          {
+            ...report.repos[0],
+            workspaces: [
+              { ...report.repos[0].workspaces[0], next_action: "delete" },
+            ],
+          },
+        ],
+      }),
     ).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -30,6 +30,9 @@ import type {
   CodeWorkspacePrSnapshot,
   CodeWatchSnapshot,
   CodeWorkspaceSnapshot,
+  CodeStorageSnapshot,
+  CodeRepoStorageSnapshot,
+  CodeWorkspaceStorageSnapshot,
   CodeActionSnapshot,
   CodeCommitSnapshot,
   CodePushSnapshot,
@@ -1999,6 +2002,9 @@ export function parseCodeWorkspace(
       "pr",
       "created_at",
       "archived_at",
+      "released_at",
+      "released_tip",
+      "bundle_bytes",
     ]) ||
     !nonEmpty(value.id) ||
     !nonEmpty(value.repo_id) ||
@@ -2008,7 +2014,10 @@ export function parseCodeWorkspace(
     !nonEmpty(value.base_ref) ||
     !isMember(value.status, WORKSPACE_STATUSES) ||
     !nonEmpty(value.created_at) ||
-    !optionalString(value.archived_at)
+    !optionalString(value.archived_at) ||
+    !optionalString(value.released_at) ||
+    !optionalString(value.released_tip) ||
+    (value.bundle_bytes !== undefined && !isFiniteNumber(value.bundle_bytes))
   ) {
     return null;
   }
@@ -2024,6 +2033,15 @@ export function parseCodeWorkspace(
     ...(value.archived_at !== undefined
       ? { archived_at: value.archived_at }
       : {}),
+    ...(value.released_at !== undefined
+      ? { released_at: value.released_at }
+      : {}),
+    ...(value.released_tip !== undefined
+      ? { released_tip: value.released_tip }
+      : {}),
+    ...(value.bundle_bytes !== undefined
+      ? { bundle_bytes: value.bundle_bytes }
+      : {}),
   };
   if (value.pr !== undefined) {
     const pr = parsePullRequestDigest(value.pr);
@@ -2031,6 +2049,93 @@ export function parseCodeWorkspace(
     parsed.pr = pr;
   }
   return parsed;
+}
+
+const STORAGE_ACTIONS = new Set(["archive", "release"]);
+
+export function parseCodeStorage(value: unknown): CodeStorageSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<CodeStorageSnapshot>(value, ["repos"]) ||
+    !Array.isArray(value.repos)
+  ) {
+    return null;
+  }
+  const repos = [];
+  for (const repo of value.repos) {
+    const parsed = parseCodeRepoStorage(repo);
+    if (!parsed) return null;
+    repos.push(parsed);
+  }
+  return { repos };
+}
+
+function parseCodeRepoStorage(value: unknown): CodeRepoStorageSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<CodeRepoStorageSnapshot>(value, [
+      "id",
+      "display_name",
+      "clone_bytes",
+      "clone_reclaimable",
+      "workspaces",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.display_name) ||
+    !isFiniteNumber(value.clone_bytes) ||
+    typeof value.clone_reclaimable !== "boolean" ||
+    !Array.isArray(value.workspaces)
+  ) {
+    return null;
+  }
+  const workspaces = [];
+  for (const workspace of value.workspaces) {
+    const parsed = parseCodeWorkspaceStorage(workspace);
+    if (!parsed) return null;
+    workspaces.push(parsed);
+  }
+  return {
+    id: value.id,
+    display_name: value.display_name,
+    clone_bytes: value.clone_bytes,
+    clone_reclaimable: value.clone_reclaimable,
+    workspaces,
+  };
+}
+
+function parseCodeWorkspaceStorage(
+  value: unknown,
+): CodeWorkspaceStorageSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<CodeWorkspaceStorageSnapshot>(value, [
+      "id",
+      "title",
+      "status",
+      "on_disk_bytes",
+      "next_action",
+      "next_reclaim_bytes",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.title) ||
+    !isMember(value.status, WORKSPACE_STATUSES) ||
+    !isFiniteNumber(value.on_disk_bytes) ||
+    !isFiniteNumber(value.next_reclaim_bytes) ||
+    (value.next_action !== undefined &&
+      !isMember(value.next_action, STORAGE_ACTIONS))
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    title: value.title,
+    status: value.status,
+    on_disk_bytes: value.on_disk_bytes,
+    next_reclaim_bytes: value.next_reclaim_bytes,
+    ...(value.next_action !== undefined
+      ? { next_action: value.next_action }
+      : {}),
+  };
 }
 
 export function parsePullRequestDigest(

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -33,6 +33,7 @@ import type {
   CodeStorageSnapshot,
   CodeRepoStorageSnapshot,
   CodeWorkspaceStorageSnapshot,
+  CodeStorageAction,
   CodeActionSnapshot,
   CodeCommitSnapshot,
   CodePushSnapshot,
@@ -2051,7 +2052,7 @@ export function parseCodeWorkspace(
   return parsed;
 }
 
-const STORAGE_ACTIONS = new Set(["archive", "release"]);
+const STORAGE_ACTIONS = new Set<CodeStorageAction>(["archive", "release"]);
 
 export function parseCodeStorage(value: unknown): CodeStorageSnapshot | null {
   if (

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1475,6 +1475,11 @@ export type CodeRepoSource = { kind: string, available: boolean, remediation?: s
 export type CodeRepoSources = { sources: Array<CodeRepoSource>, chooses_destination: boolean, };
 
 /**
+ * One repository on the reclaim surface.
+ */
+export type CodeRepoStorageSnapshot = { id: RepoId, display_name: string, clone_bytes: number, clone_reclaimable: boolean, workspaces: Array<CodeWorkspaceStorageSnapshot>, };
+
+/**
  * What a running interactive session is actually occupied with. This is
  * intentionally coarser than a transcript tool name: list surfaces need to
  * distinguish agent generation, a shell, a passive monitor, and delegated
@@ -1544,6 +1549,16 @@ reasoning_effort?: ReasoningEffort,
  * Whether this session runs its turns in the engine's fast mode.
  */
 fast_mode: boolean, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, };
+
+/**
+ * The next reclaim tier a workspace can take.
+ */
+export type CodeStorageAction = "archive" | "release";
+
+/**
+ * Reclaimable disk for every repo and workspace the principal owns.
+ */
+export type CodeStorageSnapshot = { repos: Array<CodeRepoStorageSnapshot>, };
 
 /**
  * Status of a harness subagent, derived from its spanning `Task` call
@@ -1854,6 +1869,11 @@ bundle_bytes?: number, };
  * Status of a persisted workspace.
  */
 export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archiving" | "archived" | "released";
+
+/**
+ * One workspace's current footprint and the next reclaim step.
+ */
+export type CodeWorkspaceStorageSnapshot = { id: WorkspaceId, title: string, status: CodeWorkspaceStatus, on_disk_bytes: number, next_action?: CodeStorageAction, next_reclaim_bytes: number, };
 
 /**
  * Bounded path listing for `GET /code/workspaces/{id}/tree`.

--- a/crates/tidebreak-desktop/ui/src/lib/formatBytes.ts
+++ b/crates/tidebreak-desktop/ui/src/lib/formatBytes.ts
@@ -9,7 +9,8 @@ export function formatBytes(value: number | null): string {
   if (value === null) return "—";
   if (value < 1_024) return `${value} B`;
   if (value < 1_048_576) return `${round(value / 1_024)} KB`;
-  return `${round(value / 1_048_576)} MB`;
+  if (value < 1_073_741_824) return `${round(value / 1_048_576)} MB`;
+  return `${round(value / 1_073_741_824)} GB`;
 }
 
 function round(value: number): string {

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -24,6 +24,7 @@ import { AppSidebar } from "./sidebar/AppSidebar";
 import { CodeHome } from "./code/CodeHome";
 import { CodeAnalyticsPage } from "./code/CodeAnalyticsPage";
 import { CodeArchivePage } from "./code/CodeArchivePage";
+import { CodeStoragePage } from "./code/CodeStoragePage";
 import {
   CodeDeliveryPage,
   codeDeliverySearchFrom,
@@ -249,6 +250,12 @@ const codeArchiveRoute = createRoute({
   component: CodeArchivePage,
 });
 
+const codeStorageRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/code/storage",
+  component: CodeStoragePage,
+});
+
 function CodeWorkspaceRouteComponent() {
   const { workspaceId } = codeWorkspaceRoute.useParams();
   return <CodeWorkspacePage workspaceId={workspaceId} />;
@@ -353,6 +360,7 @@ export const routeTree = rootRoute.addChildren([
   codeDeliveryPullRequestsRoute,
   codeDeliveryRunsRoute,
   codeArchiveRoute,
+  codeStorageRoute,
   settingsRoute.addChildren([
     settingsIndexRoute,
     settingsMcpRedirectRoute,

--- a/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
@@ -284,7 +284,13 @@ export const DenseSidebar: Story = {
       destinationButtons.map(
         (button) => button.getAttribute("aria-label") ?? button.textContent,
       ),
-    ).toEqual(["Pull requests", "Notifications", "Analytics", "Archive"]);
+    ).toEqual([
+      "Pull requests",
+      "Notifications",
+      "Analytics",
+      "Archive",
+      "Storage",
+    ]);
     await expect(
       await canvas.findByText("Audit Storybook coverage"),
     ).toBeVisible();

--- a/crates/tidebreak-desktop/ui/src/stories/CodeStorage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeStorage.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
   createMemoryHistory,
@@ -19,9 +20,13 @@ import {
 } from "@/code/CodeUpdatesStore";
 import { SidebarExpandStrip } from "@/sidebar/SidebarExpandStrip";
 import { useUiStore } from "@/UiStore";
-import { deliveryCodeRepo, deliveryWorkspaces } from "./fixtures";
+import {
+  deliveryCodeRepo,
+  deliveryWorkspaces,
+  harnessDoctor,
+} from "./fixtures";
 
-const REPORT: CodeStorageSnapshot = {
+const POPULATED: CodeStorageSnapshot = {
   repos: [
     {
       id: deliveryCodeRepo.id,
@@ -70,74 +75,151 @@ function idleSocket(): WebSocket {
   return socket;
 }
 
-function app(report: CodeStorageSnapshot): AppContextValue {
+function storyClient(report: CodeStorageSnapshot): ApiClient {
   return {
-    client: {
-      listCodeStorage: async () => report,
-      listCodeRepos: async () => [deliveryCodeRepo],
-      listCodeWorkspaces: async () => deliveryWorkspaces,
-      getHarnessDoctor: async () => ({ harnesses: [] }),
-      getCodeCloneDefaults: async () => ({
-        parent_dir: "/tmp/src",
-        gh_found: false,
-        gh_remediation: "gh is not installed.",
-      }),
-      openCodeUpdates: () => idleSocket(),
-    } as unknown as ApiClient,
+    openCodeUpdates: () => idleSocket(),
+    listCodeStorage: async () => report,
+    listCodeRepos: async () => [deliveryCodeRepo],
+    listCodeWorkspaces: async () => deliveryWorkspaces,
+    getHarnessDoctor: async () => harnessDoctor,
+    listCodeHarnessModels: async (kind) => ({ kind, models: [] }),
+    getCodeCloneDefaults: async () => ({
+      gh_found: true,
+      gh_authenticated: true,
+      gh_remediation: "",
+    }),
+    startCodeWatch: async () => ({}) as never,
+  } as unknown as ApiClient;
+}
+
+function appContext(client: ApiClient): AppContextValue {
+  return {
+    client,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
     attachment: "local",
-    serverInfo: null,
-    setServerInfo: () => {},
-    connectedFolderPaths: [],
-    refreshConnectedFolderPaths: async () => {},
+    restartForUpdate: async () => {},
   };
 }
 
-function StorageHarness({ report }: { report: CodeStorageSnapshot }) {
-  useCodeCatalogStore.setState({
-    repos: [deliveryCodeRepo],
-    workspaces: deliveryWorkspaces,
-    loaded: true,
-    error: null,
-  });
-  useCodeUiStore.setState({ railPrefs: DEFAULT_RAIL_PREFS });
-  useUiStore.setState({ sidebarCollapsed: false });
-  useCodeUpdatesStore.setState({ connected: true });
-  const root = createRootRoute();
-  const storage = createRoute({
-    getParentRoute: () => root,
+function storyRouter() {
+  const rootRoute = createRootRoute();
+  const storageRoute = createRoute({
+    getParentRoute: () => rootRoute,
     path: "/code/storage",
     component: CodeStoragePage,
   });
-  const router = createRouter({
-    history: createMemoryHistory({ initialEntries: ["/code/storage"] }),
-    routeTree: root.addChildren([storage]),
+  const placeholders = [
+    "/",
+    "/code",
+    "/code/delivery/pull-requests",
+    "/code/archive",
+    "/code/analytics",
+    "/settings",
+  ].map((path) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path,
+      component: () => <p className="p-6">{path}</p>,
+    }),
+  );
+  const workspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code/w/$workspaceId",
+    component: () => <p className="p-6">Workspace</p>,
   });
+  return createRouter({
+    routeTree: rootRoute.addChildren([
+      ...placeholders,
+      workspaceRoute,
+      storageRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/code/storage"] }),
+  });
+}
+
+function resetStoryState() {
+  disconnectCodeUpdates();
+  useCodeCatalogStore.getState().reset();
+  useCodeUpdatesStore.getState().reset();
+  useCodeUiStore.setState({
+    railPrefs: DEFAULT_RAIL_PREFS,
+    reviewSidebarOpen: false,
+    newWorkspaceOpen: false,
+    addRepoOpen: false,
+    pendingComposerPrompt: null,
+    composerActionScope: null,
+  });
+  useUiStore.setState({ sidebarCollapsed: false, sidebarWidth: 280 });
+}
+
+function CodeStorageStory({ report }: { report: CodeStorageSnapshot }) {
+  const [state] = useState(() => {
+    resetStoryState();
+    useCodeCatalogStore.setState({
+      repos: [deliveryCodeRepo],
+      workspaces: deliveryWorkspaces,
+      loaded: true,
+      error: null,
+    });
+    return { client: storyClient(report), router: storyRouter() };
+  });
+  useEffect(
+    () => () => {
+      disconnectCodeUpdates();
+      useCodeCatalogStore.getState().reset();
+      useCodeUpdatesStore.getState().reset();
+    },
+    [],
+  );
   return (
-    <AppContextProvider value={app(report)}>
-      <SidebarExpandStrip />
-      <RouterProvider router={router} />
+    <AppContextProvider value={appContext(state.client)}>
+      <div className="app-shell h-full min-h-0 w-full overflow-hidden">
+        <SidebarExpandStrip macOverlay />
+        <div className="app-body">
+          <RouterProvider router={state.router as never} />
+        </div>
+      </div>
     </AppContextProvider>
   );
 }
 
 const meta = {
   title: "Code/Storage",
-  component: StorageHarness,
+  component: CodeStorageStory,
+  args: { report: POPULATED },
   parameters: { layout: "fullscreen" },
-  decorators: [
-    (Story) => {
-      disconnectCodeUpdates();
-      return <Story />;
-    },
-  ],
-} satisfies Meta<typeof StorageHarness>;
+} satisfies Meta<typeof CodeStorageStory>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Populated: Story = {
-  args: { report: REPORT },
-};
+export const Populated: Story = {};
 
 export const Empty: Story = {
   args: { report: { repos: [] } },

--- a/crates/tidebreak-desktop/ui/src/stories/CodeStorage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeStorage.stories.tsx
@@ -10,7 +10,7 @@ import {
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { ApiClient } from "@/api/client";
-import type { CodeStorageSnapshot } from "@/api/types";
+import type { CodeStorageSnapshot, HarnessKind } from "@/api/types";
 import { CodeStoragePage } from "@/code/CodeStoragePage";
 import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
 import { DEFAULT_RAIL_PREFS, useCodeUiStore } from "@/code/CodeUiStore";
@@ -82,7 +82,7 @@ function storyClient(report: CodeStorageSnapshot): ApiClient {
     listCodeRepos: async () => [deliveryCodeRepo],
     listCodeWorkspaces: async () => deliveryWorkspaces,
     getHarnessDoctor: async () => harnessDoctor,
-    listCodeHarnessModels: async (kind) => ({ kind, models: [] }),
+    listCodeHarnessModels: async (kind: HarnessKind) => ({ kind, models: [] }),
     getCodeCloneDefaults: async () => ({
       gh_found: true,
       gh_authenticated: true,

--- a/crates/tidebreak-desktop/ui/src/stories/CodeStorage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeStorage.stories.tsx
@@ -1,0 +1,144 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import type { ApiClient } from "@/api/client";
+import type { CodeStorageSnapshot } from "@/api/types";
+import { CodeStoragePage } from "@/code/CodeStoragePage";
+import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
+import { DEFAULT_RAIL_PREFS, useCodeUiStore } from "@/code/CodeUiStore";
+import {
+  disconnectCodeUpdates,
+  useCodeUpdatesStore,
+} from "@/code/CodeUpdatesStore";
+import { SidebarExpandStrip } from "@/sidebar/SidebarExpandStrip";
+import { useUiStore } from "@/UiStore";
+import { deliveryCodeRepo, deliveryWorkspaces } from "./fixtures";
+
+const REPORT: CodeStorageSnapshot = {
+  repos: [
+    {
+      id: deliveryCodeRepo.id,
+      display_name: deliveryCodeRepo.display_name,
+      clone_bytes: 1_200_000_000,
+      clone_reclaimable: false,
+      workspaces: [
+        {
+          id: deliveryWorkspaces[0]?.id ?? "ws-1",
+          title: deliveryWorkspaces[0]?.title ?? "Active workspace",
+          status: "active",
+          on_disk_bytes: 850_000_000,
+          next_action: "archive",
+          next_reclaim_bytes: 850_000_000,
+        },
+        {
+          id: "ws-archived",
+          title: "Archived experiment",
+          status: "archived",
+          on_disk_bytes: 12_288,
+          next_action: "release",
+          next_reclaim_bytes: 12_288,
+        },
+        {
+          id: "ws-released",
+          title: "Released cleanup",
+          status: "released",
+          on_disk_bytes: 4096,
+          next_reclaim_bytes: 0,
+        },
+      ],
+    },
+  ],
+};
+
+function idleSocket(): WebSocket {
+  const socket = {
+    onopen: null as WebSocket["onopen"],
+    onclose: null as WebSocket["onclose"],
+    onerror: null as WebSocket["onerror"],
+    close() {},
+    addEventListener() {},
+    removeEventListener() {},
+  } as unknown as WebSocket;
+  queueMicrotask(() => socket.onopen?.(new Event("open")));
+  return socket;
+}
+
+function app(report: CodeStorageSnapshot): AppContextValue {
+  return {
+    client: {
+      listCodeStorage: async () => report,
+      listCodeRepos: async () => [deliveryCodeRepo],
+      listCodeWorkspaces: async () => deliveryWorkspaces,
+      getHarnessDoctor: async () => ({ harnesses: [] }),
+      getCodeCloneDefaults: async () => ({
+        parent_dir: "/tmp/src",
+        gh_found: false,
+        gh_remediation: "gh is not installed.",
+      }),
+      openCodeUpdates: () => idleSocket(),
+    } as unknown as ApiClient,
+    attachment: "local",
+    serverInfo: null,
+    setServerInfo: () => {},
+    connectedFolderPaths: [],
+    refreshConnectedFolderPaths: async () => {},
+  };
+}
+
+function StorageHarness({ report }: { report: CodeStorageSnapshot }) {
+  useCodeCatalogStore.setState({
+    repos: [deliveryCodeRepo],
+    workspaces: deliveryWorkspaces,
+    loaded: true,
+    error: null,
+  });
+  useCodeUiStore.setState({ railPrefs: DEFAULT_RAIL_PREFS });
+  useUiStore.setState({ sidebarCollapsed: false });
+  useCodeUpdatesStore.setState({ connected: true });
+  const root = createRootRoute();
+  const storage = createRoute({
+    getParentRoute: () => root,
+    path: "/code/storage",
+    component: CodeStoragePage,
+  });
+  const router = createRouter({
+    history: createMemoryHistory({ initialEntries: ["/code/storage"] }),
+    routeTree: root.addChildren([storage]),
+  });
+  return (
+    <AppContextProvider value={app(report)}>
+      <SidebarExpandStrip />
+      <RouterProvider router={router} />
+    </AppContextProvider>
+  );
+}
+
+const meta = {
+  title: "Code/Storage",
+  component: StorageHarness,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => {
+      disconnectCodeUpdates();
+      return <Story />;
+    },
+  ],
+} satisfies Meta<typeof StorageHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {
+  args: { report: REPORT },
+};
+
+export const Empty: Story = {
+  args: { report: { repos: [] } },
+};

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -60,12 +60,16 @@ use super::session_worker::{
 #[cfg(windows)]
 use super::worktree::repo_paths_equivalent;
 use super::worktree::{
-    self, archive_blockers, branch_name, create_worktree, prune_worktrees, remove_worktree,
-    run_archive_script, run_setup_script, slugify, validate_repo_path, worktree_dir, WorktreeError,
+    self, archive_blockers, branch_name, create_worktree, directory_bytes, prune_worktrees,
+    remove_worktree, run_archive_script, run_setup_script, slugify, unique_branch_bytes,
+    validate_repo_path, worktree_dir, WorktreeError,
 };
 use crate::error::ServerError;
 use crate::managed_policy::ManagedPolicy;
-use crate::routes::code::types::{CodeDeliveryPullRequestTarget, CodeGitHubRepositoryTarget};
+use crate::routes::code::types::{
+    CodeDeliveryPullRequestTarget, CodeGitHubRepositoryTarget, CodeRepoStorageSnapshot,
+    CodeStorageAction, CodeStorageSnapshot, CodeWorkspaceStorageSnapshot,
+};
 
 const MANAGED_NODE_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
 const MANAGED_NODE_STARTUP_GRACE: Duration = Duration::from_secs(2);
@@ -1288,7 +1292,14 @@ impl CodeRuntime {
         // anything this workspace commits should already carry the right
         // name.
         self.name_workspace_author(owner, &path).await;
-        match run_setup_script(&path, repo.setup_script.as_deref()).await {
+        match run_setup_script(
+            &path,
+            std::path::Path::new(&repo.root_path),
+            &workspace.title,
+            repo.setup_script.as_deref(),
+        )
+        .await
+        {
             Ok(()) => {
                 workspace.status = CodeWorkspaceStatus::Active;
                 match self.save_workspace_final(&workspace).await {
@@ -1351,6 +1362,89 @@ impl CodeRuntime {
         repo_id: Option<RepoId>,
     ) -> Result<Vec<CodeWorkspace>, ServerError> {
         Ok(list_workspaces(&self.db, owner, repo_id).await?)
+    }
+
+    /// Bytes each repo and workspace currently occupy, and what the next
+    /// reclaim tier would free.
+    pub(crate) async fn storage_snapshot(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<CodeStorageSnapshot, ServerError> {
+        let repos = list_repos(&self.db, owner).await?;
+        let workspaces = list_workspaces(&self.db, owner, None).await?;
+        let mut out = Vec::with_capacity(repos.len());
+        for repo in repos {
+            let members: Vec<&CodeWorkspace> = workspaces
+                .iter()
+                .filter(|workspace| workspace.repo_id == repo.id)
+                .collect();
+            let live = members.iter().any(|workspace| {
+                !matches!(
+                    workspace.status,
+                    CodeWorkspaceStatus::Archived | CodeWorkspaceStatus::Released
+                )
+            });
+            let clone_path = std::path::Path::new(&repo.root_path);
+            let clone_bytes = if clone_path.exists() {
+                i64::try_from(directory_bytes(clone_path).await).unwrap_or(i64::MAX)
+            } else {
+                0
+            };
+            let mut rows = Vec::with_capacity(members.len());
+            for workspace in members {
+                rows.push(self.workspace_storage(&repo, workspace).await);
+            }
+            out.push(CodeRepoStorageSnapshot {
+                id: repo.id,
+                display_name: repo.display_name,
+                clone_bytes,
+                clone_reclaimable: repo.cloned_from.is_some() && !live,
+                workspaces: rows,
+            });
+        }
+        Ok(CodeStorageSnapshot { repos: out })
+    }
+
+    async fn workspace_storage(
+        &self,
+        repo: &CodeRepo,
+        workspace: &CodeWorkspace,
+    ) -> CodeWorkspaceStorageSnapshot {
+        let worktree = std::path::Path::new(&workspace.worktree_path);
+        let worktree_bytes = if worktree.exists() {
+            i64::try_from(directory_bytes(worktree).await).unwrap_or(i64::MAX)
+        } else {
+            0
+        };
+        let repo_root = std::path::Path::new(&repo.root_path);
+        let branch_bytes = if workspace.status == CodeWorkspaceStatus::Archived {
+            i64::try_from(
+                unique_branch_bytes(repo_root, &workspace.base_ref, &workspace.branch_name).await,
+            )
+            .unwrap_or(i64::MAX)
+        } else {
+            0
+        };
+        let bundle_bytes = workspace.bundle_bytes.unwrap_or(0);
+        let (on_disk_bytes, next_action, next_reclaim_bytes) = match workspace.status {
+            CodeWorkspaceStatus::Released => (bundle_bytes, None, 0),
+            CodeWorkspaceStatus::Archived => {
+                (branch_bytes, Some(CodeStorageAction::Release), branch_bytes)
+            }
+            _ => (
+                worktree_bytes,
+                Some(CodeStorageAction::Archive),
+                worktree_bytes,
+            ),
+        };
+        CodeWorkspaceStorageSnapshot {
+            id: workspace.id,
+            title: workspace.title.clone(),
+            status: workspace.status,
+            on_disk_bytes,
+            next_action,
+            next_reclaim_bytes,
+        }
     }
 
     pub(crate) async fn get_workspace(
@@ -1542,7 +1636,14 @@ impl CodeRuntime {
             // Decision 0032: the archive script obeys the same
             // failure-preserves rule as setup. Lifecycle exclusion starts
             // before the hook so no in-process writer can overlap it.
-            if let Err(err) = run_archive_script(path, repo.archive_script.as_deref()).await {
+            if let Err(err) = run_archive_script(
+                path,
+                std::path::Path::new(&repo.root_path),
+                &workspace.title,
+                repo.archive_script.as_deref(),
+            )
+            .await
+            {
                 return Err(ServerError::unprocessable_kind(
                     "archive_script_failed",
                     err.to_string(),
@@ -1797,7 +1898,13 @@ impl CodeRuntime {
         // (Decision 0032's failure-preserves rule). One vocabulary for both
         // paths — a reader debugging "setup_failed" should not need to know
         // whether the workspace was created or restored.
-        let setup = run_setup_script(path, repo.setup_script.as_deref()).await;
+        let setup = run_setup_script(
+            path,
+            std::path::Path::new(&repo.root_path),
+            &workspace.title,
+            repo.setup_script.as_deref(),
+        )
+        .await;
         workspace.status = if setup.is_ok() {
             CodeWorkspaceStatus::Active
         } else {
@@ -1869,7 +1976,14 @@ impl CodeRuntime {
         }
         let repo = self.get_repo(owner, workspace.repo_id).await?;
         Self::refuse_removed_repo(&repo)?;
-        match run_setup_script(&path, repo.setup_script.as_deref()).await {
+        match run_setup_script(
+            &path,
+            std::path::Path::new(&repo.root_path),
+            &workspace.title,
+            repo.setup_script.as_deref(),
+        )
+        .await
+        {
             Ok(()) => {
                 workspace.status = CodeWorkspaceStatus::Active;
                 if !self.save_workspace_final(&workspace).await? {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1431,11 +1431,14 @@ impl CodeRuntime {
             CodeWorkspaceStatus::Archived => {
                 (branch_bytes, Some(CodeStorageAction::Release), branch_bytes)
             }
-            _ => (
+            CodeWorkspaceStatus::Active => (
                 worktree_bytes,
                 Some(CodeStorageAction::Archive),
                 worktree_bytes,
             ),
+            CodeWorkspaceStatus::Creating
+            | CodeWorkspaceStatus::SetupFailed
+            | CodeWorkspaceStatus::Archiving => (worktree_bytes, None, 0),
         };
         CodeWorkspaceStorageSnapshot {
             id: workspace.id,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -42,7 +42,7 @@ use crate::routes::code::types::{
     CodeDeliveryPullRequestActionBody, CodeDeliveryPullRequestDetail, CodeDeliveryPullRequestQuery,
     CodeDeliveryPullRequestTarget, CodeDeliveryPullRequestsPage, CodeDeliveryRepositoriesSnapshot,
     CodeDeliveryRunActionBody, CodeDeliveryRunDetail, CodeDeliveryRunQuery, CodeDeliveryRunTarget,
-    CodeDeliveryRunsPage, CodeHarnessInstallSnapshot, CodeRepoSources,
+    CodeDeliveryRunsPage, CodeHarnessInstallSnapshot, CodeRepoSources, CodeStorageSnapshot,
     ResolveCodeDeliveryRepositoriesBody,
 };
 use crate::state::AppState;
@@ -296,6 +296,10 @@ impl ScopedCode {
         repo_id: Option<RepoId>,
     ) -> Result<Vec<CodeWorkspace>, ServerError> {
         self.runtime.list_workspaces(&self.owner, repo_id).await
+    }
+
+    pub(crate) async fn storage_snapshot(&self) -> Result<CodeStorageSnapshot, ServerError> {
+        self.runtime.storage_snapshot(&self.owner).await
     }
 
     pub(crate) async fn get_workspace(

--- a/crates/tidebreak-server/src/code/setup_script.rs
+++ b/crates/tidebreak-server/src/code/setup_script.rs
@@ -40,17 +40,27 @@ pub(crate) fn spawn_workspace_script(
     worktree: &Path,
     script: &str,
 ) -> io::Result<ProcessTreeChild> {
-    let mut command = workspace_script_command(worktree, script)?;
+    spawn_workspace_script_with_env(worktree, script, &[])
+}
+
+fn spawn_workspace_script_with_env(
+    worktree: &Path,
+    script: &str,
+    extra_env: &[(&str, OsString)],
+) -> io::Result<ProcessTreeChild> {
+    let mut command = workspace_script_command(worktree, script, extra_env)?;
     tidebreak_harness::spawn_process_tree(&mut command)
 }
 
 /// Run `script` inside `worktree` via the user's login shell.
 ///
 /// The script is a user-authored command string, so it goes through a shell.
-/// Git operations in this crate never do.
-pub(crate) async fn run_workspace_script(
+/// Git operations in this crate never do. Setup and archive hooks pass the
+/// repo root and workspace name so a script can tell what it is touching.
+pub(crate) async fn run_workspace_script_with_env(
     worktree: &Path,
     script: &str,
+    extra_env: &[(&str, OsString)],
 ) -> Result<ScriptRun, String> {
     let script = script.trim();
     if script.is_empty() {
@@ -62,7 +72,7 @@ pub(crate) async fn run_workspace_script(
             output_truncated: false,
         });
     }
-    let child = spawn_workspace_script(worktree, script)
+    let child = spawn_workspace_script_with_env(worktree, script, extra_env)
         .map_err(|err| format!("failed to spawn workspace script: {err}"))?;
     let output = timeout(
         SCRIPT_TIMEOUT,
@@ -85,7 +95,11 @@ pub(crate) async fn run_workspace_script(
     })
 }
 
-fn workspace_script_command(worktree: &Path, script: &str) -> io::Result<Command> {
+fn workspace_script_command(
+    worktree: &Path,
+    script: &str,
+    extra_env: &[(&str, OsString)],
+) -> io::Result<Command> {
     let (program, args) = workspace_script_launcher(script, std::env::var_os("SHELL"))?;
     let mut command = Command::new(program);
     command
@@ -95,6 +109,9 @@ fn workspace_script_command(worktree: &Path, script: &str) -> io::Result<Command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .env("GIT_TERMINAL_PROMPT", "0");
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
     Ok(command)
 }
 
@@ -173,10 +190,29 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn workspace_scripts_receive_repo_and_workspace_env() {
+        let directory = tempfile::tempdir().expect("worktree");
+        let repo = directory.path().join("repo");
+        let run = run_workspace_script_with_env(
+            directory.path(),
+            r#"printf '%s' "$TIDEBREAK_REPO_ROOT|$TIDEBREAK_WORKSPACE_NAME""#,
+            &[
+                ("TIDEBREAK_REPO_ROOT", repo.clone().into_os_string()),
+                ("TIDEBREAK_WORKSPACE_NAME", OsString::from("ember-grove")),
+            ],
+        )
+        .await
+        .expect("run env script");
+        assert!(run.success, "{}", run.stderr);
+        assert_eq!(run.stdout.trim(), format!("{}|ember-grove", repo.display()));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn workspace_scripts_mark_output_truncated_at_the_read_limit() {
         let directory = tempfile::tempdir().expect("worktree");
         let script = format!("printf '%{}s' '' | tr ' ' x", SCRIPT_OUTPUT_BYTES + 128);
-        let run = run_workspace_script(directory.path(), &script)
+        let run = run_workspace_script_with_env(directory.path(), &script, &[])
             .await
             .expect("run noisy script");
 
@@ -217,7 +253,7 @@ mod tests {
         )
         .expect("write decoy executable");
 
-        let run = run_workspace_script(directory.path(), "Write-Output trusted")
+        let run = run_workspace_script_with_env(directory.path(), "Write-Output trusted", &[])
             .await
             .expect("run trusted PowerShell");
         assert!(run.success, "{}", run.stderr);
@@ -228,7 +264,7 @@ mod tests {
     #[tokio::test]
     async fn windows_powershell_runs_in_the_requested_worktree() {
         let directory = tempfile::tempdir().expect("worktree");
-        let run = run_workspace_script(directory.path(), "(Get-Location).Path")
+        let run = run_workspace_script_with_env(directory.path(), "(Get-Location).Path", &[])
             .await
             .expect("run PowerShell");
         assert!(run.success, "{}", run.stderr);
@@ -237,7 +273,7 @@ mod tests {
             .expect("reported worktree");
         assert_eq!(reported, directory.path().canonicalize().unwrap());
 
-        let failed = run_workspace_script(directory.path(), "cmd.exe /c exit 7")
+        let failed = run_workspace_script_with_env(directory.path(), "cmd.exe /c exit 7", &[])
             .await
             .expect("run failing native command");
         assert!(!failed.success);

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -2056,20 +2056,52 @@ async fn git_stdin(cwd: &Path, args: &[&str], stdin: &[u8]) -> Result<String, St
     let mut child = command
         .spawn()
         .map_err(|err| format!("failed to spawn git: {err}"))?;
-    if let Some(mut pipe) = child.stdin.take() {
-        pipe.write_all(stdin)
+    let stdin_pipe = child.stdin.take();
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdin_bytes = stdin.to_vec();
+    let write = async move {
+        if let Some(mut pipe) = stdin_pipe {
+            pipe.write_all(&stdin_bytes)
+                .await
+                .map_err(|err| format!("failed to write git stdin: {err}"))?;
+        }
+        Ok::<(), String>(())
+    };
+    let read_out = async move {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stdout_pipe {
+            pipe.read_to_end(&mut buf)
+                .await
+                .map_err(|err| format!("failed to read git stdout: {err}"))?;
+        }
+        Ok::<Vec<u8>, String>(buf)
+    };
+    let read_err = async move {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stderr_pipe {
+            pipe.read_to_end(&mut buf)
+                .await
+                .map_err(|err| format!("failed to read git stderr: {err}"))?;
+        }
+        Ok::<Vec<u8>, String>(buf)
+    };
+    let output = timeout(GIT_TIMEOUT, async {
+        let ((), stdout, stderr) = tokio::try_join!(write, read_out, read_err)?;
+        let status = child
+            .wait()
             .await
-            .map_err(|err| format!("failed to write git stdin: {err}"))?;
-    }
-    let output = timeout(GIT_TIMEOUT, child.wait_with_output())
-        .await
-        .map_err(|_| format!("git {} timed out", args.join(" ")))?
-        .map_err(|err| format!("git {} failed: {err}", args.join(" ")))?;
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    if output.status.success() {
+            .map_err(|err| format!("git {} failed: {err}", args.join(" ")))?;
+        Ok::<_, String>((status, stdout, stderr))
+    })
+    .await
+    .map_err(|_| format!("git {} timed out", args.join(" ")))??;
+    let (status, stdout, stderr) = output;
+    let stdout = String::from_utf8_lossy(&stdout).into_owned();
+    if status.success() {
         Ok(stdout)
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        let stderr = String::from_utf8_lossy(&stderr).trim().to_owned();
         Err(if stderr.is_empty() {
             stdout.trim().to_owned()
         } else {

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -13,7 +13,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use super::setup_script::run_workspace_script;
+use super::setup_script::run_workspace_script_with_env;
 
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const GIT_WORKTREE_TIMEOUT: Duration = Duration::from_secs(120);
@@ -31,6 +31,7 @@ const MAX_SEARCH_PREVIEW_CHARS: usize = 500;
 const ARCHIVE_SCAN_MAX_ENTRIES: usize = 10_000;
 const ARCHIVE_SCAN_MAX_PATH_BYTES: usize = 1024 * 1024;
 const ARCHIVE_DISPOSABLE_PATH_KEY: &str = "tidebreak.archiveDisposablePath";
+const DIRECTORY_WALK_MAX_ENTRIES: usize = 100_000;
 const WORKTREE_OPERATION_SUFFIX: &str = ".tidebreak-operation";
 const WORKTREE_REGISTRATION_MARKER: &str = "tidebreak-operation.json";
 
@@ -1173,31 +1174,41 @@ async fn branch_is_registered(repo_root: &Path, branch: &str) -> Result<bool, Wo
 /// Run the setup script, if any. Failure preserves the checkout.
 pub(crate) async fn run_setup_script(
     worktree_path: &Path,
+    repo_root: &Path,
+    workspace_name: &str,
     script: Option<&str>,
 ) -> Result<(), WorktreeError> {
-    run_hook_script(worktree_path, script, "setup").await
+    run_hook_script(worktree_path, repo_root, workspace_name, script, "setup").await
 }
 
 /// Run the archive script, if any. Failure preserves the checkout, so the
 /// caller must not remove the worktree when this returns an error.
 pub(crate) async fn run_archive_script(
     worktree_path: &Path,
+    repo_root: &Path,
+    workspace_name: &str,
     script: Option<&str>,
 ) -> Result<(), WorktreeError> {
-    run_hook_script(worktree_path, script, "archive").await
+    run_hook_script(worktree_path, repo_root, workspace_name, script, "archive").await
 }
 
 /// A non-zero exit is a failure, not a completed run: `run_workspace_script`
 /// only reports `Err` when the script could not be spawned or timed out.
 async fn run_hook_script(
     worktree_path: &Path,
+    repo_root: &Path,
+    workspace_name: &str,
     script: Option<&str>,
     label: &str,
 ) -> Result<(), WorktreeError> {
     let Some(script) = script.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(());
     };
-    let run = run_workspace_script(worktree_path, script)
+    let env = [
+        ("TIDEBREAK_REPO_ROOT", OsString::from(repo_root.as_os_str())),
+        ("TIDEBREAK_WORKSPACE_NAME", OsString::from(workspace_name)),
+    ];
+    let run = run_workspace_script_with_env(worktree_path, script, &env)
         .await
         .map_err(WorktreeError::user)?;
     if run.success {
@@ -1950,6 +1961,123 @@ async fn git_stdout(cwd: Option<&Path>, args: &[&str], limit: Duration) -> Resul
     Ok(git(cwd, args, limit).await?.stdout)
 }
 
+/// Bytes a path occupies on disk. Symlinks are skipped so a walk cannot
+/// escape the tree. Caps the number of entries so a huge worktree still
+/// answers.
+pub(crate) async fn directory_bytes(path: &Path) -> u64 {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || directory_bytes_sync(&path))
+        .await
+        .unwrap_or(0)
+}
+
+fn directory_bytes_sync(path: &Path) -> u64 {
+    let mut total = 0u64;
+    let mut seen = 0usize;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            seen += 1;
+            if seen > DIRECTORY_WALK_MAX_ENTRIES {
+                return total;
+            }
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                stack.push(entry.path());
+                continue;
+            }
+            if file_type.is_file() {
+                if let Ok(metadata) = entry.metadata() {
+                    total = total.saturating_add(metadata.len());
+                }
+            }
+        }
+    }
+    total
+}
+
+/// Unpacked size of objects reachable from `branch` but not from `base`.
+///
+/// That is what a release would drop from the clone (minus the tiny bundle
+/// that remains). A missing branch or range is zero, not an error: the
+/// reclaim surface still has to render.
+pub(crate) async fn unique_branch_bytes(repo_root: &Path, base_ref: &str, branch: &str) -> u64 {
+    if !branch_exists(repo_root, branch).await.unwrap_or(false) {
+        return 0;
+    }
+    let range = format!("{base_ref}..{branch}");
+    let listed = git_stdout(
+        Some(repo_root),
+        &["rev-list", "--objects", "--no-object-names", &range],
+        GIT_TIMEOUT,
+    )
+    .await
+    .unwrap_or_default();
+    let objects: String = listed
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .flat_map(|line| [line, "\n"])
+        .collect();
+    if objects.is_empty() {
+        return 0;
+    }
+    let sizes = git_stdin(
+        repo_root,
+        &["cat-file", "--batch-check=%(objectsize)"],
+        objects.as_bytes(),
+    )
+    .await
+    .unwrap_or_default();
+    sizes
+        .lines()
+        .filter_map(|line| line.trim().parse::<u64>().ok())
+        .fold(0u64, u64::saturating_add)
+}
+
+async fn git_stdin(cwd: &Path, args: &[&str], stdin: &[u8]) -> Result<String, String> {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GIT_TERMINAL_PROMPT", "0");
+    let mut child = command
+        .spawn()
+        .map_err(|err| format!("failed to spawn git: {err}"))?;
+    if let Some(mut pipe) = child.stdin.take() {
+        pipe.write_all(stdin)
+            .await
+            .map_err(|err| format!("failed to write git stdin: {err}"))?;
+    }
+    let output = timeout(GIT_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| format!("git {} timed out", args.join(" ")))?
+        .map_err(|err| format!("git {} failed: {err}", args.join(" ")))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    if output.status.success() {
+        Ok(stdout)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        Err(if stderr.is_empty() {
+            stdout.trim().to_owned()
+        } else {
+            stderr
+        })
+    }
+}
+
 async fn git_nul_stdout(
     cwd: Option<&Path>,
     args: &[&str],
@@ -2060,7 +2188,9 @@ mod tests {
         create_ready(&repo, &path, "tidebreak/first", "main").await;
         verify_inside_worktree(&path).await.unwrap();
 
-        let err = run_setup_script(&path, Some("exit 7")).await.unwrap_err();
+        let err = run_setup_script(&path, &repo, "first", Some("exit 7"))
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("setup script failed"), "{err}");
         assert!(path.join("README.md").is_file());
         verify_inside_worktree(&path).await.unwrap();
@@ -2082,7 +2212,7 @@ mod tests {
         } else {
             "while :; do printf '0123456789abcdef'; done"
         };
-        let error = run_setup_script(&path, Some(noisy_script))
+        let error = run_setup_script(&path, &repo, "noisy-setup", Some(noisy_script))
             .await
             .unwrap_err();
 
@@ -2653,5 +2783,30 @@ mod tests {
         assert!(!branch_exists(&repo, "tidebreak/released").await.unwrap());
         assert!(bundle.exists());
         assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn directory_bytes_counts_files_and_skips_symlinks() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"hello").unwrap();
+        std::fs::create_dir(dir.path().join("nested")).unwrap();
+        std::fs::write(dir.path().join("nested/b.txt"), b"world!").unwrap();
+        assert_eq!(directory_bytes(dir.path()).await, 11);
+    }
+
+    #[tokio::test]
+    async fn unique_branch_bytes_are_zero_on_the_base_and_positive_with_a_commit() {
+        let (_dir, repo) = init_repo();
+        assert_eq!(unique_branch_bytes(&repo, "main", "main").await, 0);
+
+        run(&repo, &["git", "checkout", "-b", "tidebreak/bytes"]);
+        std::fs::write(repo.join("payload.bin"), vec![7u8; 4096]).unwrap();
+        run(&repo, &["git", "add", "payload.bin"]);
+        run(&repo, &["git", "commit", "-m", "payload"]);
+        let unique = unique_branch_bytes(&repo, "main", "tidebreak/bytes").await;
+        assert!(
+            unique >= 4096,
+            "unique objects should include the 4 KiB blob, got {unique}"
+        );
     }
 }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -891,6 +891,7 @@ pub fn app(state: AppState) -> Router {
             "/code/workspaces",
             post(routes::code::create_workspace).get(routes::code::list_workspaces),
         )
+        .route("/code/storage", get(routes::code::list_storage))
         .route(
             "/code/workspaces/{id}",
             get(routes::code::get_workspace).patch(routes::code::patch_workspace),

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -87,13 +87,14 @@ pub(crate) use types::{
     CodeDeliveryRunQuery, CodeDeliveryRunTarget, CodeDeliveryRunsPage, CodeFileChange,
     CodeForkBody, CodeForkTranscript, CodeGithubRepositories, CodeGithubRepository,
     CodeHarnessInstallSnapshot, CodePrCommentsSnapshot, CodePushSnapshot, CodeRepoSnapshot,
-    CodeRepoSource, CodeRepoSources, CodeSessionDebug, CodeSessionDigest, CodeSessionSnapshot,
-    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTriggerSnapshot,
-    CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
+    CodeRepoSource, CodeRepoSources, CodeRepoStorageSnapshot, CodeSessionDebug, CodeSessionDigest,
+    CodeSessionSnapshot, CodeStorageAction, CodeStorageSnapshot, CodeTerminalActivityNotice,
+    CodeTerminalRead, CodeTerminalSnapshot, CodeTriggerSnapshot, CodeTurnSnapshot,
+    CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
     CodeWorkspaceHistorySearchMatch, CodeWorkspaceHistorySearchSource, CodeWorkspacePrSnapshot,
     CodeWorkspacePullRequests, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
-    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, CreateCodeTriggerBody,
-    HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
+    CodeWorkspaceSnapshot, CodeWorkspaceStorageSnapshot, CodeWorkspaceTree, CodeWorktreeRoot,
+    CreateCodeTriggerBody, HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
     ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame, SetCodeWorktreeRootBody,
     UpdateCodeTriggerBody,
 };
@@ -101,8 +102,8 @@ pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
-    get_worktree_root, list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace,
-    release_workspace, restore_workspace, retry_workspace_setup, search_workspace,
+    get_worktree_root, list_storage, list_workspace_files, list_workspace_tree, list_workspaces,
+    patch_workspace, release_workspace, restore_workspace, retry_workspace_setup, search_workspace,
     set_worktree_root,
 };
 

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -98,6 +98,43 @@ impl From<CodeWorkspace> for CodeWorkspaceSnapshot {
     }
 }
 
+/// Reclaimable disk for every repo and workspace the principal owns.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeStorageSnapshot {
+    pub repos: Vec<CodeRepoStorageSnapshot>,
+}
+
+/// One repository on the reclaim surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeRepoStorageSnapshot {
+    pub id: RepoId,
+    pub display_name: String,
+    pub clone_bytes: i64,
+    pub clone_reclaimable: bool,
+    pub workspaces: Vec<CodeWorkspaceStorageSnapshot>,
+}
+
+/// One workspace's current footprint and the next reclaim step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWorkspaceStorageSnapshot {
+    pub id: WorkspaceId,
+    pub title: String,
+    pub status: CodeWorkspaceStatus,
+    pub on_disk_bytes: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub next_action: Option<CodeStorageAction>,
+    pub next_reclaim_bytes: i64,
+}
+
+/// The next reclaim tier a workspace can take.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeStorageAction {
+    Archive,
+    Release,
+}
+
 /// One durable conversation with an external agent engine.
 #[derive(Debug, Clone, PartialEq, Serialize, TS)]
 pub struct CodeSessionSnapshot {

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -8,12 +8,12 @@ use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
 
 use super::types::{
-    ArchiveWorkspaceBody, CodeFileChange, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
-    CodeWorkspaceHistorySearchMatch, CodeWorkspaceHistorySearchSource, CodeWorkspaceSearch,
-    CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot,
-    CreateWorkspaceBody, ListWorkspacesQuery, PatchWorkspaceBody, SetCodeWorktreeRootBody,
-    WorkspaceBlobQuery, WorkspaceDiffQuery, WorkspaceFilesQuery, WorkspaceSearchQuery,
-    WorkspaceTreeQuery,
+    ArchiveWorkspaceBody, CodeFileChange, CodeStorageSnapshot, CodeWorkspaceBlob,
+    CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspaceHistorySearchMatch,
+    CodeWorkspaceHistorySearchSource, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
+    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, CreateWorkspaceBody,
+    ListWorkspacesQuery, PatchWorkspaceBody, SetCodeWorktreeRootBody, WorkspaceBlobQuery,
+    WorkspaceDiffQuery, WorkspaceFilesQuery, WorkspaceSearchQuery, WorkspaceTreeQuery,
 };
 use tidebreak_core::WorkspaceId;
 
@@ -58,6 +58,11 @@ pub async fn list_workspaces(
             .map(CodeWorkspaceSnapshot::from)
             .collect(),
     ))
+}
+
+/// `GET /code/storage` — reclaimable bytes per repo and workspace.
+pub async fn list_storage(code: ScopedCode) -> Result<Json<CodeStorageSnapshot>, ServerError> {
+    Ok(Json(code.storage_snapshot().await?))
 }
 
 pub async fn get_workspace(

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -10138,6 +10138,35 @@ async fn release_frees_the_branch_and_restore_rebuilds_it_from_the_bundle() {
     );
 }
 
+#[tokio::test]
+async fn storage_report_names_archive_as_the_next_reclaim_for_an_active_workspace() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    std::fs::write(path.join("payload.bin"), vec![3u8; 2048]).unwrap();
+
+    let report = client
+        .get(format!("http://{addr}/code/storage"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(report.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = report.json().await.unwrap();
+    let row = &body["repos"][0]["workspaces"][0];
+    assert_eq!(row["title"], workspace["title"]);
+    assert_eq!(row["status"], "active");
+    assert_eq!(row["next_action"], "archive");
+    assert!(
+        row["on_disk_bytes"].as_i64().unwrap() >= 2048,
+        "worktree should include the 2 KiB payload: {row}"
+    );
+    assert_eq!(row["next_reclaim_bytes"], row["on_disk_bytes"]);
+}
+
 /// A released restore keeps its only durable recovery material until the
 /// Active row commits. If that write fails after checkout creation, the exact
 /// attempt is removed and the Released row can retry from the same bundle.

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -413,6 +413,7 @@ mod tests {
         generate::collect_from::<crate::routes::AgentRunProgressPage>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeRepoSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeWorkspaceSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeStorageSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeSessionSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeTurnSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeAnalyticsSnapshot>(&cfg, &mut out);


### PR DESCRIPTION
## What changed

- Setup and archive scripts receive `TIDEBREAK_REPO_ROOT` and `TIDEBREAK_WORKSPACE_NAME`.
- `GET /code/storage` reports clone size and the next reclaim tier per workspace (archive a worktree, release a branch).
- Storage is an Index page next to Archive, with Archive/Release actions that name the bytes they would free.

## Validation

- `cargo test -p tidebreak-server --lib directory_bytes_counts`
- `cargo test -p tidebreak-server --lib unique_branch_bytes_are_zero`
- `cargo test -p tidebreak-server --lib workspace_scripts_receive`
- `cargo test -p tidebreak-server --lib storage_report_names_archive`
- `cargo clippy -p tidebreak-server --lib -- -D warnings`
- `pnpm exec vitest run src/code/parsers.test.ts src/code/codePaletteRows.test.ts`

## Tracking

Closes #2441
