### PR TITLE
feat(server): wire remote sessions into the runtime

### DIFF
--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -127,6 +127,16 @@ pub struct Config {
     /// [`Config::bind_addr`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub listen_addr: Option<SocketAddr>,
+    /// The confined-sandbox runtime endpoint slug remote sessions are
+    /// provisioned through (`docs/slack-sessions.md`). Meaningful only on a
+    /// gateway-authenticated hosted machine, where the sandbox calls ride the
+    /// same gateway as authentication; absent, remote sessions are off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_endpoint: Option<String>,
+    /// The administrator-defined sandbox profile named on every remote spawn.
+    /// Required together with [`Config::runtime_endpoint`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_profile: Option<String>,
     /// Where new code-mode worktrees land when no `code_worktree_root` setting
     /// is stored.
     ///
@@ -223,6 +233,8 @@ impl Config {
             auth_gateway_verifier_url: None,
             public_url: None,
             listen_addr: None,
+            runtime_endpoint: None,
+            runtime_profile: None,
             code_worktree_root_default: None,
         }
     }
@@ -250,6 +262,8 @@ impl Config {
             std::env::var("TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL").ok(),
             std::env::var("TIDEBREAK_PUBLIC_URL").ok(),
             std::env::var("TIDEBREAK_LISTEN_ADDR").ok(),
+            std::env::var("TIDEBREAK_RUNTIME_ENDPOINT").ok(),
+            std::env::var("TIDEBREAK_RUNTIME_PROFILE").ok(),
         )
     }
 
@@ -271,6 +285,8 @@ impl Config {
         auth_gateway_verifier_url: Option<String>,
         public_url: Option<String>,
         listen_addr: Option<String>,
+        runtime_endpoint: Option<String>,
+        runtime_profile: Option<String>,
     ) -> Result<Self> {
         let profile = match profile.filter(|value| !value.is_empty()).as_deref() {
             None | Some("desktop") => Profile::Desktop,
@@ -309,6 +325,13 @@ impl Config {
                 ))
             })?),
         };
+        let runtime_endpoint = runtime_endpoint.filter(|value| !value.trim().is_empty());
+        let runtime_profile = runtime_profile.filter(|value| !value.trim().is_empty());
+        if runtime_endpoint.is_some() != runtime_profile.is_some() {
+            return Err(AgentError::config(
+                "TIDEBREAK_RUNTIME_ENDPOINT and TIDEBREAK_RUNTIME_PROFILE are required together",
+            ));
+        }
         Ok(Self {
             profile,
             data_dir,
@@ -325,6 +348,8 @@ impl Config {
             auth_gateway_verifier_url,
             public_url,
             listen_addr,
+            runtime_endpoint,
+            runtime_profile,
             code_worktree_root_default: None,
         })
     }
@@ -422,6 +447,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .unwrap();
         let expected = std::env::current_dir().unwrap().join(".tidebreak");
@@ -441,9 +468,47 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .unwrap();
         assert_eq!(config.profile, Profile::Desktop);
+    }
+
+    #[test]
+    fn a_runtime_endpoint_requires_its_profile() {
+        // Half-configured remote execution refuses at boot rather than at the
+        // first spawn.
+        let refused = Config::from_vars(
+            None,
+            Some(OsString::from("/data")),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("primary".into()),
+            None,
+        );
+        assert!(refused.is_err());
+        let config = Config::from_vars(
+            None,
+            Some(OsString::from("/data")),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("primary".into()),
+            Some("tidebreak-remote".into()),
+        )
+        .unwrap();
+        assert_eq!(config.runtime_endpoint.as_deref(), Some("primary"));
+        assert_eq!(config.runtime_profile.as_deref(), Some("tidebreak-remote"));
     }
 
     #[test]
@@ -454,6 +519,8 @@ mod tests {
             None,
             None,
             Some(OsString::from("/etc/tidebreak/tokens")),
+            None,
+            None,
             None,
             None,
             None,
@@ -479,7 +546,9 @@ mod tests {
             None,
             None,
             None,
-            None
+            None,
+            None,
+            None,
         )
         .is_err());
     }
@@ -512,6 +581,8 @@ mod tests {
             None,
             None,
             Some("0.0.0.0:8080".into()),
+            None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -530,7 +601,9 @@ mod tests {
             None,
             None,
             None,
-            Some("0.0.0.0".into())
+            Some("0.0.0.0".into()),
+            None,
+            None,
         )
         .is_err());
     }
@@ -576,6 +649,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
         )
         .unwrap();
         assert!(config.container_execution_enabled);
@@ -587,6 +662,8 @@ mod tests {
             None,
             None,
             Some("yes".into()),
+            None,
+            None,
             None,
             None,
             None,
@@ -608,6 +685,8 @@ mod tests {
             Some("https://gateway.example.test".into()),
             Some("https://gateway.model-gateway.svc.cluster.local".into()),
             Some("https://tidebreak.example.test".into()),
+            None,
+            None,
             None,
         )
         .unwrap();

--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -487,6 +487,39 @@ pub async fn session_spend_microusd(
 /// request path: the sweep runs machine-wide, and each row it finds is a
 /// spawn whose outcome nothing recorded. The sweep stops the row and, when the environment knows a
 /// matching sandbox, cancels it.
+/// Incarnations a pump still owes work, every owner: the active ones, and
+/// the stopped ones whose terminal events are not journaled yet.
+pub async fn pumpable_incarnations_all_owners(
+    store: &DbStore,
+) -> Result<Vec<CodeSessionIncarnation>> {
+    entities::code_session_incarnation::Entity::find()
+        .filter(
+            sea_orm::Condition::any()
+                .add(
+                    entities::code_session_incarnation::Column::State
+                        .eq(IncarnationState::Active.as_str()),
+                )
+                .add(
+                    sea_orm::Condition::all()
+                        .add(
+                            entities::code_session_incarnation::Column::State
+                                .eq(IncarnationState::Stopped.as_str()),
+                        )
+                        .add(
+                            entities::code_session_incarnation::Column::TerminalEventsJournaled
+                                .eq(false),
+                        ),
+                ),
+        )
+        .order_by_asc(entities::code_session_incarnation::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(incarnation_from_model)
+        .collect()
+}
+
 pub async fn stale_incarnation_intents_all_owners(
     store: &DbStore,
     cutoff: chrono::DateTime<chrono::Utc>,

--- a/crates/tidebreak-core/src/db/ops/code/queued.rs
+++ b/crates/tidebreak-core/src/db/ops/code/queued.rs
@@ -85,6 +85,25 @@ pub async fn queued_turn_head(
         .transpose()
 }
 
+/// Every (owner, session) pair holding at least one queued message. The
+/// remote sweep uses this to find heads to promote; local sessions drain
+/// their own queues through their workers and ignore it.
+pub async fn sessions_with_queued_turns_all_owners(
+    store: &DbStore,
+) -> Result<Vec<(OwnerId, CodeSessionId)>> {
+    let rows = entities::code_queued_turn::Entity::find()
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    let mut pairs: Vec<(OwnerId, CodeSessionId)> = rows
+        .into_iter()
+        .map(|row| Ok((OwnerId::new(&row.owner)?, CodeSessionId(row.session_id))))
+        .collect::<Result<_>>()?;
+    pairs.sort_by(|a, b| (a.0.as_str(), a.1 .0).cmp(&(b.0.as_str(), b.1 .0)));
+    pairs.dedup();
+    Ok(pairs)
+}
+
 /// Park one message at the queue tail. The caller supplies the row id, which
 /// is the turn id promotion later inserts under.
 pub async fn enqueue_queued_turn(

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -67,6 +67,7 @@ pub(crate) enum RemoteTurnOutcome {
         /// The turn row, running.
         turn: Box<CodeTurn>,
         /// The incarnation now active.
+        #[cfg_attr(not(test), allow(dead_code))]
         incarnation: Box<CodeSessionIncarnation>,
     },
     /// The owner's concurrency cap refused, naming what runs.
@@ -301,6 +302,19 @@ impl RemoteDriver<'_> {
         repo: &CodeRepo,
         text: &str,
     ) -> Result<RemoteTurnOutcome, tidebreak_core::AgentError> {
+        self.submit_turn_from(session, workspace, repo, text, None)
+            .await
+    }
+
+    /// Submit one turn, optionally as the atomic promotion of a queued row.
+    pub(crate) async fn submit_turn_from(
+        &self,
+        session: &mut CodeSession,
+        workspace: &CodeWorkspace,
+        repo: &CodeRepo,
+        text: &str,
+        promoted: Option<&tidebreak_core::CodeQueuedTurn>,
+    ) -> Result<RemoteTurnOutcome, tidebreak_core::AgentError> {
         let (db, bus, provisioner, settings) = (self.db, self.bus, self.provisioner, self.settings);
         let owner = session.owner.clone();
         let last = latest_turn(db, &owner, session.id).await?;
@@ -380,7 +394,8 @@ impl RemoteDriver<'_> {
                     .map_err(tidebreak_core::AgentError::Store)?;
                 match provisioner.send(&owner, sandbox_id, &message).await {
                     Ok(_) => {
-                        let turn = start_turn_row(db, bus, session, ordinal, text).await?;
+                        let turn =
+                            start_turn_row(db, bus, session, ordinal, text, promoted).await?;
                         return Ok(RemoteTurnOutcome::Delivered {
                             turn: Box::new(turn),
                         });
@@ -509,7 +524,7 @@ impl RemoteDriver<'_> {
                             "the activated incarnation vanished".to_owned(),
                         )
                     })?;
-                let turn = start_turn_row(db, bus, session, ordinal, text).await?;
+                let turn = start_turn_row(db, bus, session, ordinal, text, promoted).await?;
                 Ok(RemoteTurnOutcome::Reincarnated {
                     turn: Box::new(turn),
                     incarnation: Box::new(incarnation),
@@ -810,9 +825,10 @@ async fn start_turn_row(
     session: &mut CodeSession,
     ordinal: i64,
     text: &str,
+    promoted: Option<&tidebreak_core::CodeQueuedTurn>,
 ) -> Result<CodeTurn, tidebreak_core::AgentError> {
     let turn = CodeTurn {
-        id: CodeTurnId::new(),
+        id: promoted.map_or_else(CodeTurnId::new, |row| row.id),
         session_id: session.id,
         ordinal,
         status: CodeTurnStatus::Running,
@@ -828,7 +844,25 @@ async fn start_turn_row(
         started_at: chrono::Utc::now(),
         ended_at: None,
     };
-    insert_turn(db, &session.owner, &turn).await?;
+    match promoted {
+        // Delete the queue row and insert its turn in one transaction, the
+        // way a local worker promotes. A row that changed or vanished under
+        // the promotion still gets its turn row — the message already
+        // reached the sandbox by the time this runs, so the transcript must
+        // show it either way.
+        Some(row) => {
+            if !tidebreak_core::db::code::promote_queued_turn(db, &session.owner, row, &turn)
+                .await?
+            {
+                warn!(
+                    session = %session.id,
+                    "a queued message changed under its promotion; recording the turn without it"
+                );
+                insert_turn(db, &session.owner, &turn).await?;
+            }
+        }
+        None => insert_turn(db, &session.owner, &turn).await?,
+    }
     session.lifecycle = CodeSessionLifecycle::Running;
     super::super::attention::replace_attention(
         session,

--- a/crates/tidebreak-server/src/code/remote/mod.rs
+++ b/crates/tidebreak-server/src/code/remote/mod.rs
@@ -31,15 +31,12 @@
 //!
 //! [`0079`]: ../../../../../docs/decisions/0079-supervised-agent-declines-the-sandbox-protocol.md
 
-// The session runtime consumes this module in a later slice (#2873); until
-// then only the tests construct it. Same stance as `scripted_harness`.
-#![cfg_attr(not(test), allow(dead_code))]
-
 pub(crate) mod driver;
 #[cfg(test)]
 pub(crate) mod fixtures;
 pub(crate) mod gateway;
 pub(crate) mod ingest;
+pub(crate) mod service;
 pub(crate) mod wire;
 
 use async_trait::async_trait;

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1,0 +1,553 @@
+//! Wire remote sessions into the running server: the configured transport,
+//! the per-session pump tasks, and the periodic sweep that reconciles both.
+//!
+//! The sweep is the only scheduler. Every tick it closes stale intents,
+//! makes sure each incarnation that still owes events has a pump task, and
+//! promotes the queue head of any idle remote session. Pump tasks hold the
+//! long event wait; everything else is a cheap store read, so a crashed or
+//! finished task is simply respawned on the next tick from durable state.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, Weak};
+
+use tracing::warn;
+
+use tidebreak_core::db::code::{get_session, pumpable_incarnations_all_owners};
+use tidebreak_core::{CodeSessionId, CodeSessionLifecycle, DbStore, OwnerId};
+
+use super::super::runtime::CodeRuntime;
+use super::driver::{sweep_stale_intents, RemoteDriver, RemoteSpawnSettings};
+use super::SandboxProvisioner;
+
+/// How often the sweep reconciles pump tasks and promotes queue heads.
+const REMOTE_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// The held wait a pump task asks the events read to hold.
+const PUMP_HELD_WAIT_SECONDS: u16 = 20;
+
+/// How long a pump task sleeps after a transport fault before retrying.
+const PUMP_FAULT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Spawn settings a deployment starts with until they are operator-tunable:
+/// three concurrent sandboxes per owner, $5 per spawn, $20 per session. The
+/// per-spawn ceiling bounds one runaway incarnation; the per-session ledger
+/// bounds their sum, since reincarnation multiplies the former.
+pub(crate) fn default_settings(profile: String) -> RemoteSpawnSettings {
+    RemoteSpawnSettings {
+        profile,
+        incarnation_cap: 3,
+        spend_ceiling_microusd: Some(5_000_000),
+        session_spend_ceiling_microusd: Some(20_000_000),
+    }
+}
+
+/// The remote-session context one deployment configures: the transport and
+/// the spawn settings, plus the live pump tasks the sweep reconciles.
+pub(crate) struct RemoteSessions {
+    /// The environment transport.
+    pub(crate) provisioner: Arc<dyn SandboxProvisioner>,
+    /// Spawn-time settings.
+    pub(crate) settings: RemoteSpawnSettings,
+    /// Live pump tasks by session. The sweep prunes finished entries and
+    /// spawns missing ones; nothing else writes here.
+    pumps: Mutex<HashMap<CodeSessionId, tokio::task::JoinHandle<()>>>,
+}
+
+impl RemoteSessions {
+    pub(crate) fn new(
+        provisioner: Arc<dyn SandboxProvisioner>,
+        settings: RemoteSpawnSettings,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            provisioner,
+            settings,
+            pumps: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// The driver view over this context for one call.
+    pub(crate) fn driver<'a>(
+        &'a self,
+        db: &'a Arc<DbStore>,
+        bus: &'a super::super::bus::CodeEventBus,
+    ) -> RemoteDriver<'a> {
+        RemoteDriver {
+            db,
+            bus,
+            provisioner: self.provisioner.as_ref(),
+            settings: &self.settings,
+        }
+    }
+
+    /// Make sure `session` has a pump task, spawning one when it has none.
+    fn ensure_pump(
+        self: &Arc<Self>,
+        runtime: &Arc<CodeRuntime>,
+        owner: OwnerId,
+        session: CodeSessionId,
+    ) {
+        let mut pumps = self.pumps.lock().expect("remote pumps");
+        pumps.retain(|_, handle| !handle.is_finished());
+        if pumps.contains_key(&session) {
+            return;
+        }
+        let runtime = Arc::downgrade(runtime);
+        let remote = Arc::clone(self);
+        pumps.insert(
+            session,
+            tokio::spawn(async move {
+                pump_session(runtime, remote, owner, session).await;
+            }),
+        );
+    }
+}
+
+impl Drop for RemoteSessions {
+    fn drop(&mut self) {
+        for (_, handle) in self.pumps.lock().expect("remote pumps").drain() {
+            handle.abort();
+        }
+    }
+}
+
+/// One session's pump loop: drain events on the held wait until the session
+/// stops being pumpable. Exits on any fault or terminal condition — the
+/// sweep respawns from durable state, so an exit is never a leak.
+async fn pump_session(
+    runtime: Weak<CodeRuntime>,
+    remote: Arc<RemoteSessions>,
+    owner: OwnerId,
+    session_id: CodeSessionId,
+) {
+    loop {
+        let Some(runtime) = runtime.upgrade() else {
+            return;
+        };
+        let Ok(Some(mut session)) = get_session(runtime.db(), &owner, session_id).await else {
+            return;
+        };
+        if matches!(
+            session.lifecycle,
+            CodeSessionLifecycle::Fenced | CodeSessionLifecycle::Ended
+        ) {
+            return;
+        }
+        let driver = remote.driver(runtime.db(), runtime.bus());
+        match driver.pump(&mut session, PUMP_HELD_WAIT_SECONDS).await {
+            Ok(report) => {
+                if report.sign_in_required {
+                    // Nothing drains until the owner signs in; the sweep
+                    // brings the task back to try again.
+                    return;
+                }
+                if report.incarnation_stopped || report.fenced.is_some() {
+                    return;
+                }
+            }
+            Err(error) => {
+                warn!(session = %session_id, %error, "a remote pump failed; backing off");
+                // Drop the runtime handle across the sleep so shutdown is
+                // not held open by a backoff.
+                drop(runtime);
+                tokio::time::sleep(PUMP_FAULT_BACKOFF).await;
+            }
+        }
+    }
+}
+
+/// Holds the remote sweep alive; aborts it on drop.
+pub(crate) struct RemoteSweepGuard(Option<tokio::task::JoinHandle<()>>);
+
+impl RemoteSweepGuard {
+    pub(crate) fn spawn(runtime: Weak<CodeRuntime>) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(REMOTE_SWEEP_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let Some(runtime) = runtime.upgrade() else {
+                    return;
+                };
+                sweep_remote(&runtime).await;
+            }
+        });
+        Self(Some(handle))
+    }
+}
+
+impl Drop for RemoteSweepGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// One sweep tick: expire stale intents, reconcile pump tasks against the
+/// incarnations that owe events, and promote idle remote queue heads.
+pub(crate) async fn sweep_remote(runtime: &Arc<CodeRuntime>) {
+    let Some(remote) = runtime.remote_sessions() else {
+        return;
+    };
+    if let Err(error) = sweep_stale_intents(runtime.db(), runtime.bus(), chrono::Utc::now()).await {
+        warn!(%error, "the stale-intent sweep failed");
+    }
+    match pumpable_incarnations_all_owners(runtime.db()).await {
+        Ok(rows) => {
+            for row in rows {
+                if row.sandbox_id.is_some() {
+                    remote.ensure_pump(runtime, row.owner.clone(), row.session_id);
+                }
+            }
+        }
+        Err(error) => warn!(%error, "could not list pumpable incarnations"),
+    }
+    if let Err(error) = runtime.promote_remote_queue_heads().await {
+        warn!(error = ?error, "remote queue promotion failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex as StdMutex;
+
+    use async_trait::async_trait;
+
+    use tidebreak_core::db::code::{insert_repo, latest_turn};
+    use tidebreak_core::{
+        CodeRepo, CodeSessionLifecycle, CodeTurnStatus, FenceReason, HarnessKind, OwnerId,
+        PermissionMode, RepoId,
+    };
+
+    use super::super::super::runtime::{NewSessionSettings, SubmitTurnOutcome};
+    use super::super::driver::RemoteSpawnSettings;
+    use super::super::wire::{
+        EventCursor, MessageReceipt, SandboxEvent, SandboxEvents, SandboxLease, SandboxMessage,
+        SandboxState, SandboxStatus, SpawnArguments,
+    };
+    use super::super::{RemoteSandboxError, SandboxProvisioner};
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeProvisioner {
+        spawns: StdMutex<Vec<SpawnArguments>>,
+        sends: StdMutex<Vec<String>>,
+        event_reads: StdMutex<VecDeque<SandboxEvents>>,
+        cancels: StdMutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl SandboxProvisioner for FakeProvisioner {
+        async fn spawn(
+            &self,
+            _owner: &OwnerId,
+            arguments: &SpawnArguments,
+        ) -> Result<SandboxLease, RemoteSandboxError> {
+            self.spawns.lock().unwrap().push(arguments.clone());
+            Ok(SandboxLease {
+                sandbox_id: "sb-1".to_owned(),
+                state: SandboxState::Pending,
+                latest_event_seq: 0,
+                expires_in_seconds: 7200,
+            })
+        }
+
+        async fn status(
+            &self,
+            _owner: &OwnerId,
+            sandbox_id: &str,
+        ) -> Result<SandboxStatus, RemoteSandboxError> {
+            Ok(SandboxStatus {
+                sandbox_id: sandbox_id.to_owned(),
+                state: SandboxState::Running,
+                failure_reason: None,
+                termination_reason: None,
+                latest_event_seq: 0,
+                pending_messages: 0,
+                spend_microusd: None,
+                spend_ceiling_microusd: None,
+                possibly_stalled: false,
+                repository_url: None,
+                completed_at: None,
+            })
+        }
+
+        async fn events(
+            &self,
+            _owner: &OwnerId,
+            _sandbox_id: &str,
+            _cursor: EventCursor,
+        ) -> Result<SandboxEvents, RemoteSandboxError> {
+            self.event_reads
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or(RemoteSandboxError::Unavailable {
+                    operation: "events",
+                    detail: "no scripted read".to_owned(),
+                })
+        }
+
+        async fn send(
+            &self,
+            _owner: &OwnerId,
+            _sandbox_id: &str,
+            message: &SandboxMessage,
+        ) -> Result<MessageReceipt, RemoteSandboxError> {
+            self.sends.lock().unwrap().push(message.body.clone());
+            Ok(MessageReceipt {
+                seq: 1,
+                interrupt: false,
+                pending_messages: 0,
+            })
+        }
+
+        async fn cancel(
+            &self,
+            _owner: &OwnerId,
+            sandbox_id: &str,
+        ) -> Result<(), RemoteSandboxError> {
+            self.cancels.lock().unwrap().push(sandbox_id.to_owned());
+            Ok(())
+        }
+    }
+
+    fn settings() -> RemoteSpawnSettings {
+        RemoteSpawnSettings {
+            profile: "tidebreak-remote".to_owned(),
+            incarnation_cap: 2,
+            spend_ceiling_microusd: None,
+            session_spend_ceiling_microusd: None,
+        }
+    }
+
+    async fn runtime_with_remote(
+        root: &std::path::Path,
+    ) -> (Arc<CodeRuntime>, Arc<FakeProvisioner>, OwnerId, CodeRepo) {
+        let db = tidebreak_core::DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            root.join("code.db").display()
+        ))
+        .await
+        .unwrap();
+        let fake = Arc::new(FakeProvisioner::default());
+        let runtime = CodeRuntime::new(
+            Arc::new(db),
+            root.to_path_buf(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .with_remote_sessions(RemoteSessions::new(fake.clone(), settings()));
+        let runtime = Arc::new(runtime);
+        let owner = OwnerId::local();
+        let repo = CodeRepo {
+            id: RepoId::new(),
+            owner: owner.clone(),
+            root_path: root.join("repo").display().to_string(),
+            display_name: "tools".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: Vec::new(),
+            created_at: chrono::Utc::now(),
+            removed_at: None,
+            cloned_from: None,
+            origin_host: Some("github.com".into()),
+            origin_owner: Some("acme".into()),
+            origin_name: Some("tools".into()),
+        };
+        insert_repo(runtime.db(), &repo).await.unwrap();
+        (runtime, fake, owner, repo)
+    }
+
+    fn session_settings() -> NewSessionSettings {
+        NewSessionSettings {
+            permission_mode: PermissionMode::Allow,
+            model: None,
+            reasoning_effort: None,
+            fast_mode: false,
+            permission_mode_ceiling: None,
+        }
+    }
+
+    fn event(seq: i64, kind: &str, payload: serde_json::Value) -> SandboxEvent {
+        SandboxEvent {
+            seq,
+            kind: kind.to_owned(),
+            payload,
+            created_at: String::new(),
+        }
+    }
+
+    /// The runtime carries a turn to a sandbox and back with no local
+    /// harness: create, submit (spawn), pump (settle), promote the queued
+    /// follow-up at idle.
+    #[tokio::test]
+    async fn a_remote_session_carries_a_turn_without_a_local_harness() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
+        let remote = runtime.remote_sessions().unwrap();
+
+        let workspace = runtime
+            .create_remote_workspace(&owner, repo.id, Some("remote".into()))
+            .await
+            .unwrap();
+        assert!(workspace.is_remote());
+        let session = runtime
+            .create_remote_session(
+                &owner,
+                workspace.id,
+                HarnessKind::ClaudeCode,
+                session_settings(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(session.lifecycle, CodeSessionLifecycle::Idle);
+
+        let outcome = runtime
+            .submit_turn(&owner, session.id, "start".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, SubmitTurnOutcome::Ran(_)));
+        {
+            let spawns = fake.spawns.lock().unwrap();
+            assert_eq!(spawns.len(), 1);
+            assert_eq!(spawns[0].repository_ref.as_deref(), Some("main"));
+            assert_eq!(
+                spawns[0].repository.as_deref(),
+                Some("https://github.com/acme/tools")
+            );
+        }
+
+        // A send while the turn runs parks as a durable queue row.
+        let queued = runtime
+            .submit_turn(
+                &owner,
+                session.id,
+                "and then".into(),
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(queued, SubmitTurnOutcome::Queued(_)));
+
+        // The pump settles turn 1; promotion then delivers the head to the
+        // still-live sandbox as an inbox message.
+        fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+            sandbox_id: "sb-1".to_owned(),
+            state: SandboxState::Running,
+            latest_event_seq: 2,
+            events: vec![
+                event(1, "turn_started", serde_json::json!({ "turn": 1 })),
+                event(
+                    2,
+                    "turn_completed",
+                    serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                ),
+            ],
+        });
+        let mut live = runtime.get_session(&owner, session.id).await.unwrap();
+        remote
+            .driver(runtime.db(), runtime.bus())
+            .pump(&mut live, 0)
+            .await
+            .unwrap();
+        runtime.promote_remote_queue_heads().await.unwrap();
+
+        let (queued_rows, _) = runtime.list_queued_turns(&owner, session.id).await.unwrap();
+        assert!(queued_rows.is_empty());
+        let turn = latest_turn(runtime.db(), &owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.ordinal, 2);
+        assert_eq!(turn.status, CodeTurnStatus::Running);
+        assert_eq!(
+            fake.sends.lock().unwrap().as_slice(),
+            &["and then".to_owned()]
+        );
+    }
+
+    /// A fenced remote session reaps through the driver: the sandbox is
+    /// cancelled and no local worker is spawned.
+    #[tokio::test]
+    async fn a_remote_reap_cancels_the_sandbox_and_spawns_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
+        let workspace = runtime
+            .create_remote_workspace(&owner, repo.id, Some("remote".into()))
+            .await
+            .unwrap();
+        let session = runtime
+            .create_remote_session(
+                &owner,
+                workspace.id,
+                HarnessKind::ClaudeCode,
+                session_settings(),
+            )
+            .await
+            .unwrap();
+        runtime
+            .submit_turn(&owner, session.id, "start".into(), None, None, Vec::new())
+            .await
+            .unwrap();
+        let mut live = runtime.get_session(&owner, session.id).await.unwrap();
+        super::super::super::recovery::fence_session(
+            runtime.db(),
+            runtime.bus(),
+            &mut live,
+            FenceReason::SandboxLost {
+                detail: "the environment reports the sandbox failed".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let reaped = runtime.reap(&owner, session.id).await.unwrap();
+        assert_eq!(reaped.lifecycle, CodeSessionLifecycle::Idle);
+        assert!(reaped.fence_reason.is_none());
+        assert_eq!(
+            fake.cancels.lock().unwrap().as_slice(),
+            &["sb-1".to_owned()]
+        );
+    }
+
+    /// A repository with no recorded origin cannot back a remote workspace:
+    /// the sandbox would have nothing to clone.
+    #[tokio::test]
+    async fn a_remote_workspace_requires_a_recorded_origin() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _fake, owner, _repo) = runtime_with_remote(dir.path()).await;
+        let mut local_only = CodeRepo {
+            id: RepoId::new(),
+            owner: owner.clone(),
+            root_path: dir.path().join("local").display().to_string(),
+            display_name: "local".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: Vec::new(),
+            created_at: chrono::Utc::now(),
+            removed_at: None,
+            cloned_from: None,
+            origin_host: None,
+            origin_owner: None,
+            origin_name: None,
+        };
+        local_only.origin_host = None;
+        insert_repo(runtime.db(), &local_only).await.unwrap();
+        let refused = runtime
+            .create_remote_workspace(&owner, local_only.id, None)
+            .await;
+        assert!(refused.is_err());
+    }
+}

--- a/crates/tidebreak-server/src/code/remote/wire.rs
+++ b/crates/tidebreak-server/src/code/remote/wire.rs
@@ -13,6 +13,10 @@
 //!   environment that grows a field — or an older one that lacks one —
 //!   keeps working.
 
+// Wire structs mirror the pinned contract in full; fields the runtime does
+// not read yet still document and deserialize it.
+#![cfg_attr(not(test), allow(dead_code))]
+
 use serde::{Deserialize, Serialize};
 
 /// Longest `events` wait the environment honors, in seconds. A larger

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -193,6 +193,10 @@ pub(crate) struct CodeRuntime {
     /// machine (decision 71). `None` everywhere else: a machine whose engines
     /// carry their own provider credentials keeps using them.
     harness_llm: Option<Arc<super::harness_llm::HarnessLlmRelay>>,
+    /// The configured remote-session context, on a deployment with a sandbox
+    /// runtime endpoint (docs/slack-sessions.md). `None` everywhere else;
+    /// remote workspaces then refuse turns rather than half-running.
+    remote: Option<Arc<super::remote::service::RemoteSessions>>,
     loopback_base: Mutex<Option<String>>,
     /// Memoized harness probes, one per kind. See [`CodeRuntime::probe`].
     probes: Mutex<HashMap<HarnessKind, HarnessProbe>>,
@@ -241,6 +245,8 @@ pub(crate) struct CodeRuntime {
     reconcile_started: AtomicBool,
     pr_refresh_sweep: Mutex<Option<super::pr_refresh::PrRefreshGuard>>,
     pr_refresh_started: AtomicBool,
+    remote_sweep: Mutex<Option<super::remote::service::RemoteSweepGuard>>,
+    remote_started: AtomicBool,
     /// Workspaces with a background naming call in flight.
     ///
     /// One call per workspace at a time; a second trigger is dropped rather
@@ -441,6 +447,7 @@ impl CodeRuntime {
             host_tool_broker,
             git_credentials,
             harness_llm,
+            remote: None,
             loopback_base: Mutex::new(None),
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
@@ -468,6 +475,8 @@ impl CodeRuntime {
             reconcile_started: AtomicBool::new(false),
             pr_refresh_sweep: Mutex::new(None),
             pr_refresh_started: AtomicBool::new(false),
+            remote_sweep: Mutex::new(None),
+            remote_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
             recap: Mutex::new(None),
             #[cfg(test)]
@@ -529,6 +538,7 @@ impl CodeRuntime {
             runtime.ensure_trigger_sweep();
             runtime.ensure_reconcile_sweep();
             runtime.ensure_pr_refresh_sweep();
+            runtime.ensure_remote_sweep();
             actions
         })
     }
@@ -574,6 +584,7 @@ impl CodeRuntime {
             host_tool_broker: None,
             git_credentials: None,
             harness_llm: None,
+            remote: None,
             loopback_base: Mutex::new(None),
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
@@ -601,6 +612,8 @@ impl CodeRuntime {
             reconcile_started: AtomicBool::new(false),
             pr_refresh_sweep: Mutex::new(None),
             pr_refresh_started: AtomicBool::new(false),
+            remote_sweep: Mutex::new(None),
+            remote_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
             recap: Mutex::new(None),
             #[cfg(test)]
@@ -635,6 +648,30 @@ impl CodeRuntime {
     pub(crate) fn with_clone_parent_default(mut self, parent: PathBuf) -> Self {
         self.clone_parent_default = Some(parent);
         self
+    }
+
+    /// Enable remote sessions with a configured transport and settings.
+    pub(crate) fn with_remote_sessions(
+        mut self,
+        remote: Arc<super::remote::service::RemoteSessions>,
+    ) -> Self {
+        self.remote = Some(remote);
+        self
+    }
+
+    /// The remote-session context, when this deployment configured one.
+    pub(crate) fn remote_sessions(&self) -> Option<Arc<super::remote::service::RemoteSessions>> {
+        self.remote.clone()
+    }
+
+    /// The store, for the remote service's driver calls.
+    pub(crate) fn db(&self) -> &Arc<DbStore> {
+        &self.db
+    }
+
+    /// The live bus, for the remote service's driver calls.
+    pub(crate) fn bus(&self) -> &CodeEventBus {
+        &self.bus
     }
 
     #[cfg(test)]
@@ -1219,6 +1256,128 @@ impl CodeRuntime {
         }
         self.delivery_cache.invalidate_owner(owner);
         Ok(())
+    }
+
+    /// Create a workspace whose checkout lives in a sandbox, not on this
+    /// machine. The empty worktree path is the durable remote marker
+    /// ([`CodeWorkspace::is_remote`]); nothing here touches the filesystem.
+    ///
+    /// No route speaks this yet: the Slack adapter slice is its first caller,
+    /// and until then the runtime tests are.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) async fn create_remote_workspace(
+        &self,
+        owner: &OwnerId,
+        repo_id: RepoId,
+        title: Option<String>,
+    ) -> Result<CodeWorkspace, ServerError> {
+        if self.remote.is_none() {
+            return Err(ServerError::conflict_kind(
+                "remote_disabled",
+                "this deployment has no sandbox runtime configured",
+            ));
+        }
+        let repo = self.get_repo(owner, repo_id).await?;
+        Self::refuse_removed_repo(&repo)?;
+        if repo.origin_host.is_none() || repo.origin_owner.is_none() || repo.origin_name.is_none() {
+            return Err(ServerError::conflict_kind(
+                "repo_origin_unknown",
+                "the repository records no origin, so a sandbox cannot clone it",
+            ));
+        }
+        let title = title
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_default();
+        let id = WorkspaceId::new();
+        let branch = branch_name(&repo.branch_prefix, &title, id.0.as_u128());
+        let existing = list_workspaces(&self.db, owner, Some(repo_id)).await?;
+        if existing
+            .iter()
+            .any(|workspace| workspace.branch_name == branch)
+        {
+            return Err(ServerError::conflict_kind(
+                "branch_collision",
+                format!("branch {branch} already exists on this repository"),
+            ));
+        }
+        let workspace = CodeWorkspace {
+            id,
+            owner: owner.clone(),
+            repo_id,
+            title,
+            worktree_path: String::new(),
+            branch_name: branch,
+            base_ref: repo.default_base_ref.clone(),
+            status: CodeWorkspaceStatus::Active,
+            pr: None,
+            created_at: Utc::now(),
+            archived_at: None,
+            released_at: None,
+            released_tip: None,
+            bundle_bytes: None,
+        };
+        insert_workspace(&self.db, &workspace).await?;
+        Ok(workspace)
+    }
+
+    /// Create a session on a remote workspace: a row and nothing else. No
+    /// local harness is probed or spawned — the sandbox carries the engine,
+    /// and the first turn provisions it.
+    ///
+    /// No route speaks this yet: the Slack adapter slice is its first caller,
+    /// and until then the runtime tests are.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) async fn create_remote_session(
+        &self,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+        harness: HarnessKind,
+        settings: NewSessionSettings,
+    ) -> Result<CodeSession, ServerError> {
+        if self.remote.is_none() {
+            return Err(ServerError::conflict_kind(
+                "remote_disabled",
+                "this deployment has no sandbox runtime configured",
+            ));
+        }
+        let workspace = self.get_workspace(owner, workspace_id).await?;
+        if !workspace.is_remote() {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_remote",
+                "this workspace has a local checkout; create a local session on it",
+            ));
+        }
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
+        let session = CodeSession {
+            id: CodeSessionId::new(),
+            owner: owner.clone(),
+            workspace_id,
+            kind: CodeSessionKind::Interactive,
+            harness_kind: harness,
+            harness_version: None,
+            harness_resume_ref: None,
+            permission_mode: settings.permission_mode,
+            model: normalize_model(settings.model),
+            reasoning_effort: settings.reasoning_effort,
+            fast_mode: false,
+            lifecycle: CodeSessionLifecycle::Idle,
+            fence_reason: None,
+            child_pid: None,
+            child_process_identity: None,
+            spawn_epoch: 1,
+            attention: Attention::working(AttentionSource::Lifecycle),
+            unrecognized_event_count: 0,
+            subagents: Vec::new(),
+            created_at: Utc::now(),
+        };
+        insert_session(&self.db, &session).await?;
+        Ok(session)
     }
 
     pub(crate) async fn create_workspace(
@@ -3453,6 +3612,24 @@ impl CodeRuntime {
                 "session has ended",
             ));
         }
+        if workspace.is_remote() {
+            // The sandbox path: no local worker, no worktree lock, no
+            // harness probe. Everything below this branch assumes a checkout
+            // on this machine.
+            return self
+                .submit_remote_turn(
+                    owner,
+                    session,
+                    &workspace,
+                    message,
+                    model,
+                    reasoning_effort,
+                    attachments,
+                    trigger_delivery,
+                    queue_if_busy,
+                )
+                .await;
+        }
         // No capability gate on attachments. An engine that states image input
         // is handed the bytes on its own protocol; every other one is handed a
         // private file and an absolute path in the prompt. The worker picks
@@ -3646,6 +3823,217 @@ impl CodeRuntime {
         .map_err(ServerError::from)?;
         wake_queue(handle);
         Ok(SubmitTurnOutcome::Queued(Box::new(row)))
+    }
+
+    /// Submit one turn to a remote session's sandbox (docs/slack-sessions.md).
+    #[allow(clippy::too_many_arguments)]
+    async fn submit_remote_turn(
+        &self,
+        owner: &OwnerId,
+        mut session: CodeSession,
+        workspace: &CodeWorkspace,
+        message: String,
+        model: Option<String>,
+        reasoning_effort: Option<Option<ReasoningEffort>>,
+        attachments: Vec<tidebreak_core::ImageRef>,
+        trigger_delivery: Option<TriggerDeliveryClaim>,
+        queue_if_busy: bool,
+    ) -> Result<SubmitTurnOutcome, ServerError> {
+        let Some(remote) = self.remote_sessions() else {
+            return Err(ServerError::conflict_kind(
+                "remote_disabled",
+                "this deployment has no sandbox runtime configured",
+            ));
+        };
+        if trigger_delivery.is_some() {
+            return Err(ServerError::conflict_kind(
+                "remote_triggers_unsupported",
+                "trigger turns do not reach remote sessions yet",
+            ));
+        }
+        if !attachments.is_empty() {
+            return Err(ServerError::conflict_kind(
+                "remote_attachments_unsupported",
+                "remote sessions do not take attachments yet",
+            ));
+        }
+        // Settings stick without local capability validation: the sandbox
+        // engine reads them off the spawn, and no local harness answers for
+        // a remote one.
+        let mut next = CodeSessionExecutionSettings::from(&session);
+        if let Some(model) = normalize_model(model) {
+            next.model = Some(model);
+        }
+        if let Some(effort) = reasoning_effort {
+            next.reasoning_effort = effort;
+        }
+        if next != CodeSessionExecutionSettings::from(&session) {
+            session = replace_session_execution_settings(&self.db, owner, &session, &next)
+                .await?
+                .ok_or_else(|| {
+                    ServerError::conflict_kind(
+                        "session_settings_changed",
+                        "the session settings changed before the turn could reserve them",
+                    )
+                })?;
+        }
+        // Queue-default, exactly as the local path: a busy session parks the
+        // send as a durable row the remote sweep promotes at the next idle.
+        let in_flight = session.lifecycle == CodeSessionLifecycle::Running
+            || get_open_turn(&self.db, owner, session.id).await?.is_some();
+        let backlog = !tidebreak_core::db::code::list_queued_turns(&self.db, owner, session.id)
+            .await?
+            .is_empty();
+        if in_flight || backlog {
+            if !queue_if_busy {
+                return Err(ServerError::conflict_kind(
+                    "trigger_turn_busy",
+                    "the turn was not accepted because the session is busy",
+                ));
+            }
+            return self.park_remote_follow_up(owner, &session, message).await;
+        }
+        let repo = self.get_repo(owner, workspace.repo_id).await?;
+        let driver = remote.driver(&self.db, &self.bus);
+        let outcome = driver
+            .submit_turn(&mut session, workspace, &repo, &message)
+            .await?;
+        self.relay_remote_outcome(owner, &session, outcome, message, queue_if_busy)
+            .await
+    }
+
+    /// Translate a driver outcome into the submit answer the routes speak.
+    async fn relay_remote_outcome(
+        &self,
+        owner: &OwnerId,
+        session: &CodeSession,
+        outcome: super::remote::driver::RemoteTurnOutcome,
+        message: String,
+        queue_if_busy: bool,
+    ) -> Result<SubmitTurnOutcome, ServerError> {
+        use super::remote::driver::RemoteTurnOutcome as Outcome;
+        match outcome {
+            Outcome::Delivered { turn } | Outcome::Reincarnated { turn, .. } => {
+                Ok(SubmitTurnOutcome::Ran(turn))
+            }
+            Outcome::TurnInFlight | Outcome::ReincarnationInFlight | Outcome::FlushPending => {
+                if !queue_if_busy {
+                    return Err(ServerError::conflict_kind(
+                        "trigger_turn_busy",
+                        "the turn was not accepted because the session is busy",
+                    ));
+                }
+                self.park_remote_follow_up(owner, session, message).await
+            }
+            Outcome::CapExhausted { running } => Err(ServerError::conflict_kind(
+                "sandbox_cap_exhausted",
+                format!(
+                    "the sandbox cap is full: {} session(s) hold the slots",
+                    running.len()
+                ),
+            )),
+            Outcome::SpendExhausted {
+                spent_microusd,
+                ceiling_microusd,
+            } => Err(ServerError::conflict_kind(
+                "session_spend_exhausted",
+                format!(
+                    "this session has spent {spent_microusd} of its {ceiling_microusd} micro-USD ceiling"
+                ),
+            )),
+            Outcome::SignInRequired => Err(ServerError::conflict_kind(
+                "sign_in_required",
+                "sign in to the sandbox environment, then retry",
+            )),
+        }
+    }
+
+    /// Park a message for a remote session. The remote sweep promotes the
+    /// head at the next idle; there is no worker to nudge.
+    async fn park_remote_follow_up(
+        &self,
+        owner: &OwnerId,
+        session: &CodeSession,
+        message: String,
+    ) -> Result<SubmitTurnOutcome, ServerError> {
+        let queued = tidebreak_core::db::code::list_queued_turns(&self.db, owner, session.id)
+            .await
+            .map_err(ServerError::from)?;
+        if queued.len() >= CodeQueuedTurn::MAX_PER_SESSION {
+            return Err(ServerError::conflict_kind(
+                "queue_full",
+                format!(
+                    "this session may queue at most {} messages",
+                    CodeQueuedTurn::MAX_PER_SESSION
+                ),
+            ));
+        }
+        let now = chrono::Utc::now();
+        let row = tidebreak_core::db::code::enqueue_queued_turn(
+            &self.db,
+            owner,
+            &CodeQueuedTurn {
+                id: CodeTurnId::new(),
+                session_id: session.id,
+                message,
+                attachments: Vec::new(),
+                position: 0,
+                created_at: now,
+                updated_at: now,
+            },
+        )
+        .await
+        .map_err(ServerError::from)?;
+        Ok(SubmitTurnOutcome::Queued(Box::new(row)))
+    }
+
+    /// Promote the queue head of every idle remote session. Called from the
+    /// remote sweep; local sessions drain their own queues through their
+    /// workers and are skipped here.
+    pub(crate) async fn promote_remote_queue_heads(&self) -> Result<(), ServerError> {
+        let Some(remote) = self.remote_sessions() else {
+            return Ok(());
+        };
+        let pairs =
+            tidebreak_core::db::code::sessions_with_queued_turns_all_owners(&self.db).await?;
+        for (owner, session_id) in pairs {
+            let Ok(mut session) = self.get_session(&owner, session_id).await else {
+                continue;
+            };
+            if session.lifecycle != CodeSessionLifecycle::Idle {
+                continue;
+            }
+            let Ok(workspace) = self.get_workspace(&owner, session.workspace_id).await else {
+                continue;
+            };
+            if !workspace.is_remote() {
+                continue;
+            }
+            if tidebreak_core::db::code::queue_paused(&self.db, &owner, session_id).await? {
+                continue;
+            }
+            let Some(head) =
+                tidebreak_core::db::code::queued_turn_head(&self.db, &owner, session_id).await?
+            else {
+                continue;
+            };
+            let Ok(repo) = self.get_repo(&owner, workspace.repo_id).await else {
+                continue;
+            };
+            let driver = remote.driver(&self.db, &self.bus);
+            let message = head.message.clone();
+            if let Err(error) = driver
+                .submit_turn_from(&mut session, &workspace, &repo, &message, Some(&head))
+                .await
+            {
+                tracing::warn!(
+                    session = %session_id,
+                    %error,
+                    "promoting a queued remote message failed; the row stays queued"
+                );
+            }
+        }
+        Ok(())
     }
 
     /// The session's queued messages plus whether promotion is paused.
@@ -3930,6 +4318,24 @@ impl CodeRuntime {
                 "not_fenced",
                 "only a fenced session can be reaped",
             ));
+        }
+        let workspace = self.get_workspace(owner, session.workspace_id).await?;
+        if workspace.is_remote() {
+            // No worker to shut down and nothing to relaunch: the driver
+            // cancels whatever the environment still holds, closes the
+            // incarnation, and resolves the fence. The next turn
+            // reincarnates on demand.
+            let Some(remote) = self.remote_sessions() else {
+                return Err(ServerError::conflict_kind(
+                    "remote_disabled",
+                    "this deployment has no sandbox runtime configured",
+                ));
+            };
+            let driver = remote.driver(&self.db, &self.bus);
+            return driver.reap(session).await.map_err(|error| match error {
+                recovery::ReapSessionError::Store(error) => ServerError::from(error),
+                other => ServerError::conflict_kind("session_not_reaped", other.to_string()),
+            });
         }
         let handle = self.workers.lock().expect("code workers").remove(&id);
         let decision_gate = handle
@@ -4714,6 +5120,16 @@ impl CodeRuntime {
         }
         let guard = super::reconcile::ReconcileSweepGuard::spawn(Arc::downgrade(self));
         *self.reconcile_sweep.lock().expect("reconcile sweep") = Some(guard);
+    }
+
+    /// Start the remote-session sweep once, on deployments that configured
+    /// remote execution. A no-op everywhere else.
+    pub(super) fn ensure_remote_sweep(self: &Arc<Self>) {
+        if self.remote.is_none() || self.remote_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let guard = super::remote::service::RemoteSweepGuard::spawn(Arc::downgrade(self));
+        *self.remote_sweep.lock().expect("remote sweep") = Some(guard);
     }
 
     /// End one session: mark the row ended, stop its worker, and re-assert.

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1923,6 +1923,32 @@ async fn bind_inner(
     };
     #[cfg(feature = "scripted-harness")]
     scripted_harness::install_from_env(&mut runtime.adapters)?;
+    // Remote sessions need both halves: the configured runtime endpoint and
+    // a gateway to mint owner-scoped tokens through. Half a configuration is
+    // a boot error, not a silently local deployment.
+    let runtime = match (
+        state.config.runtime_endpoint.clone(),
+        state.config.runtime_profile.clone(),
+    ) {
+        (Some(endpoint), Some(profile)) => {
+            let Some(gateway) = state.on_behalf_of_gateway.clone() else {
+                return Err(AgentError::config(
+                    "TIDEBREAK_RUNTIME_ENDPOINT requires gateway authentication (TIDEBREAK_AUTH_GATEWAY_URL): sandboxes are provisioned as their owner",
+                ));
+            };
+            let provisioner = code::remote::gateway::GatewayProvisioner::new(
+                gateway.gateway_base_url(),
+                &endpoint,
+                gateway.runtime_tokens(&endpoint),
+            )
+            .map_err(|error| AgentError::config(format!("sandbox runtime client: {error}")))?;
+            runtime.with_remote_sessions(code::remote::service::RemoteSessions::new(
+                Arc::new(provisioner),
+                code::remote::service::default_settings(profile),
+            ))
+        }
+        _ => runtime,
+    };
     let code = Arc::new(runtime);
     // Recovery runs after the bind, below: the workers it re-attaches need the
     // bound loopback address to reach their approval endpoint.

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -439,6 +439,27 @@ impl OboGateway {
         })
     }
 
+    /// The live subject bearer for `owner`, when this process has seen one.
+    fn subject_for(&self, owner: &OwnerId) -> Option<Arc<str>> {
+        let users = self.users.lock().ok()?;
+        let slot = users.get(owner)?;
+        let subject = slot.subject.lock().ok()?;
+        Some(subject.clone())
+    }
+
+    /// Owner-scoped runtime bearers for one confined-sandbox endpoint.
+    ///
+    /// Each token is exchanged for the `runtime:{endpoint_slug}` audience so
+    /// a sandbox is provisioned as its owner, never as a shared machine
+    /// identity (docs/slack-sessions.md).
+    pub(crate) fn runtime_tokens(self: &Arc<Self>, endpoint_slug: &str) -> Arc<RuntimeTokens> {
+        Arc::new(RuntimeTokens {
+            gateway: self.clone(),
+            audience: format!("runtime:{endpoint_slug}"),
+            cache: tokio::sync::Mutex::new(HashMap::new()),
+        })
+    }
+
     /// The current inference token for `owner`, exchanging one if the cached
     /// token is missing or near expiry.
     ///
@@ -1171,6 +1192,59 @@ fn git_refusal(status: reqwest::StatusCode, body: &[u8]) -> GitForgeError {
     GitForgeError::Unavailable(format!(
         "the Model Gateway git-credential request failed with status {status}"
     ))
+}
+
+/// [`OboGateway`]-backed source of runtime bearers for one endpoint.
+///
+/// Tokens are cached per owner and re-exchanged near expiry, single-flight
+/// per source instance. A caller this process holds no live session for
+/// fails as sign-in-required rather than borrowing another identity.
+pub(crate) struct RuntimeTokens {
+    gateway: Arc<OboGateway>,
+    audience: String,
+    cache: tokio::sync::Mutex<HashMap<OwnerId, CachedToken>>,
+}
+
+#[async_trait::async_trait]
+impl crate::code::remote::RuntimeTokenSource for RuntimeTokens {
+    async fn runtime_token(
+        &self,
+        owner: &OwnerId,
+    ) -> std::result::Result<
+        crate::code::remote::RuntimeToken,
+        crate::code::remote::RemoteSandboxError,
+    > {
+        use crate::code::remote::{RemoteSandboxError, RuntimeToken};
+        // Holding the cache across the exchange is the single-flight gate: a
+        // second call for the same owner waits and then finds a fresh token.
+        let mut cache = self.cache.lock().await;
+        if let Some(current) = cache.get(owner) {
+            if current.is_fresh() {
+                return Ok(RuntimeToken {
+                    secret: current.token.to_string(),
+                });
+            }
+        }
+        let Some(subject) = self.gateway.subject_for(owner) else {
+            return Err(RemoteSandboxError::SignInRequired(
+                "this machine holds no live Model Gateway session for you; sign in again".into(),
+            ));
+        };
+        let minted = self
+            .gateway
+            .exchange(&subject, &self.audience)
+            .await
+            .map_err(|error| match error {
+                AgentError::SignInRequired(detail) => RemoteSandboxError::SignInRequired(detail),
+                other => RemoteSandboxError::Unavailable {
+                    operation: "token",
+                    detail: other.to_string(),
+                },
+            })?;
+        let secret = minted.token.to_string();
+        cache.insert(owner.clone(), minted);
+        Ok(RuntimeToken { secret })
+    }
 }
 
 /// Per-caller git-forge lending, as code mode consumes it (decision 63).


### PR DESCRIPTION
Closes #2882. Slice of the Slack sessions stage 1 epic #2875 (`docs/slack-sessions.md`); gives the driver from #2881 its callers.

- Configuration names the sandbox runtime: `TIDEBREAK_RUNTIME_ENDPOINT` and `TIDEBREAK_RUNTIME_PROFILE`, required together and refused at boot without gateway authentication, since sandboxes are provisioned as their owner.
- `OboGateway::runtime_tokens` exchanges each owner's machine-bound bearer for the `runtime:{endpoint_slug}` audience, cached per owner with single-flight refresh; a caller with no live session fails as sign-in-required rather than borrowing another identity.
- `CodeRuntime` branches on the durable remote marker (`workspace.is_remote()`): submit routes through the driver with queue-default parking (no worker, no worktree lock, no harness probe), reap goes through the driver's cancel-and-recover, and `create_remote_workspace` / `create_remote_session` write rows without touching the filesystem. A repository with no recorded origin refuses — the sandbox would have nothing to clone.
- One sweep (`remote/service.rs`, registered beside the existing sweeps) schedules everything: it expires stale intents, keeps a pump task holding the long event wait on every incarnation that owes events, and promotes the queue head of idle remote sessions as an atomic `promote_queued_turn`. Pump tasks respawn from durable state, so a restart neither respawns nor orphans a session (#2881 pinned boot recovery leaving remote sessions on their sandbox).

Deferred, noted in #2882: HTTP routes and desktop surface for the remote create paths land with the Slack adapter slice, their first external caller; trigger turns and attachments refuse with typed conflicts until then.

Validation: `cargo test -p tidebreak-server --lib code::remote` (40 passing, including three runtime-level tests: turn to sandbox and back with queue promotion, reap through the driver, origin validation), `obo_gateway` (25) and `config` (15) suites, workspace clippy with `-D warnings`, `cargo fmt --check`.