### PR TITLE
feat(code): expose remote session create routes

### DIFF
--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -273,8 +273,8 @@ mod tests {
 
     use tidebreak_core::db::code::{insert_repo, latest_turn};
     use tidebreak_core::{
-        CodeRepo, CodeSessionLifecycle, CodeTurnStatus, FenceReason, HarnessKind, OwnerId,
-        PermissionMode, RepoId,
+        CodeRepo, CodeSessionLifecycle, CodeTurnStatus, CodeWorkspaceStatus, FenceReason,
+        HarnessKind, OwnerId, PermissionMode, RepoId,
     };
 
     use super::super::super::runtime::{NewSessionSettings, SubmitTurnOutcome};
@@ -538,6 +538,60 @@ mod tests {
             fake.sends.lock().unwrap().as_slice(),
             &["and then".to_owned()]
         );
+    }
+
+    /// Remote session creation must serialize with workspace lifecycle
+    /// changes so archive cannot leave a new idle session on an archived row.
+    #[tokio::test]
+    async fn remote_session_creation_rechecks_status_under_the_lifecycle_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _fake, owner, repo) = runtime_with_remote(dir.path()).await;
+        let workspace = runtime
+            .create_remote_workspace(&owner, repo.id, Some("remote".into()))
+            .await
+            .unwrap();
+        let lifecycle = runtime.workspace_write_lock(workspace.id);
+        let lifecycle_guard = lifecycle.lock().await;
+        let creating_runtime = runtime.clone();
+        let creating_owner = owner.clone();
+        let mut creating = tokio::spawn(async move {
+            creating_runtime
+                .create_remote_session(
+                    &creating_owner,
+                    workspace.id,
+                    HarnessKind::ClaudeCode,
+                    session_settings(),
+                )
+                .await
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), &mut creating)
+                .await
+                .is_err(),
+            "session creation must wait for the workspace lifecycle lock"
+        );
+        assert!(tidebreak_core::db::code::compare_and_set_workspace_status(
+            &runtime.db,
+            &owner,
+            workspace.id,
+            CodeWorkspaceStatus::Active,
+            CodeWorkspaceStatus::Archiving,
+        )
+        .await
+        .unwrap());
+        drop(lifecycle_guard);
+
+        let error = tokio::time::timeout(std::time::Duration::from_secs(2), creating)
+            .await
+            .expect("session create finished after lifecycle release")
+            .expect("session create task joined")
+            .unwrap_err();
+        assert_eq!(error.kind(), "workspace_not_ready");
+        assert!(runtime
+            .list_workspace_sessions(&owner, workspace.id)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     /// A queued row edited after the sweep's snapshot does not collide with

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1253,12 +1253,12 @@ impl CodeRuntime {
     }
 
     /// Create a workspace whose checkout lives in a sandbox, not on this
-    /// machine. The empty worktree path is the durable remote marker
-    /// ([`CodeWorkspace::is_remote`]); nothing here touches the filesystem.
+    /// machine. A per-workspace `remote:<id>` worktree marker records that
+    /// state ([`CodeWorkspace::is_remote`]); nothing here touches the
+    /// filesystem.
     ///
-    /// No route speaks this yet: the Slack adapter slice is its first caller,
-    /// and until then the runtime tests are.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// The authenticated remote-workspace route exposes this owner-scoped
+    /// runtime path.
     pub(crate) async fn create_remote_workspace(
         &self,
         owner: &OwnerId,
@@ -1439,9 +1439,8 @@ impl CodeRuntime {
     /// local harness is probed or spawned — the sandbox carries the engine,
     /// and the first turn provisions it.
     ///
-    /// No route speaks this yet: the Slack adapter slice is its first caller,
-    /// and until then the runtime tests are.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// The authenticated remote-session route exposes this owner-scoped
+    /// runtime path.
     pub(crate) async fn create_remote_session(
         &self,
         owner: &OwnerId,
@@ -1455,6 +1454,8 @@ impl CodeRuntime {
                 "this deployment has no sandbox runtime configured",
             ));
         }
+        let lifecycle = self.workspace_lifecycle_lock(workspace_id);
+        let _lifecycle_guard = lifecycle.lock().await;
         let workspace = self.get_workspace(owner, workspace_id).await?;
         if !workspace.is_remote() {
             return Err(ServerError::conflict_kind(

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -291,6 +291,16 @@ impl ScopedCode {
             .await
     }
 
+    pub(crate) async fn create_remote_workspace(
+        &self,
+        repo_id: RepoId,
+        title: Option<String>,
+    ) -> Result<CodeWorkspace, ServerError> {
+        self.runtime
+            .create_remote_workspace(&self.owner, repo_id, title)
+            .await
+    }
+
     pub(crate) async fn list_workspaces(
         &self,
         repo_id: Option<RepoId>,
@@ -600,6 +610,17 @@ impl ScopedCode {
     ) -> Result<CodeSession, ServerError> {
         self.runtime
             .create_session(&self.owner, workspace_id, harness, settings)
+            .await
+    }
+
+    pub(crate) async fn create_remote_session(
+        &self,
+        workspace_id: WorkspaceId,
+        harness: HarnessKind,
+        settings: NewSessionSettings,
+    ) -> Result<CodeSession, ServerError> {
+        self.runtime
+            .create_remote_session(&self.owner, workspace_id, harness, settings)
             .await
     }
 

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -892,6 +892,14 @@ pub fn app(state: AppState) -> Router {
             "/code/workspaces",
             post(routes::code::create_workspace).get(routes::code::list_workspaces),
         )
+        .route(
+            "/code/remote/workspaces",
+            post(routes::code::create_remote_workspace),
+        )
+        .route(
+            "/code/remote/workspaces/{id}/sessions",
+            post(routes::code::create_remote_session),
+        )
         .route("/code/storage", get(routes::code::list_storage))
         .route(
             "/code/workspaces/{id}",

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -61,11 +61,11 @@ pub(crate) use repos::{
 };
 pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
-    create_session, delete_queued_turn, fork_session, get_session_debug, get_session_image,
-    interrupt_session, list_queued_turns, list_session_turns, list_workspace_sessions,
-    patch_queued_turn, post_queue_send_now, publish_session_image, put_queue_paused, reap_session,
-    set_attention, set_session_fast_mode, set_session_permission_mode,
-    set_session_reasoning_effort, steer_session, submit_turn,
+    create_remote_session, create_session, delete_queued_turn, fork_session, get_session_debug,
+    get_session_image, interrupt_session, list_queued_turns, list_session_turns,
+    list_workspace_sessions, patch_queued_turn, post_queue_send_now, publish_session_image,
+    put_queue_paused, reap_session, set_attention, set_session_fast_mode,
+    set_session_permission_mode, set_session_reasoning_effort, steer_session, submit_turn,
 };
 pub(crate) use terminals::{
     close_terminal, close_workspace_terminals, create_terminal, list_terminals, read_terminal,
@@ -101,10 +101,10 @@ pub(crate) use types::{
 pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
-    archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
-    get_worktree_root, list_storage, list_workspace_files, list_workspace_tree, list_workspaces,
-    patch_workspace, release_workspace, restore_workspace, retry_workspace_setup, search_workspace,
-    set_worktree_root,
+    archive_workspace, create_remote_workspace, create_workspace, get_workspace,
+    get_workspace_blob, get_workspace_diff, get_worktree_root, list_storage, list_workspace_files,
+    list_workspace_tree, list_workspaces, patch_workspace, release_workspace, restore_workspace,
+    retry_workspace_setup, search_workspace, set_worktree_root,
 };
 
 // Nothing here reaches `AppState.code` directly. Every handler in this module

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -4,22 +4,48 @@ use crate::extract::{Json, Path, RawBytes};
 use crate::routes::image_attachment::{
     inspect_image_bytes, require_declared_type_matches, PublishedImageAttachment,
 };
-use crate::routes::providers_models::refuse_permission_mode_over_ceiling;
+use crate::routes::providers_models::{
+    refuse_permission_mode_over_ceiling, refuse_permission_mode_over_ceiling_value,
+};
 use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
 use axum::body::Body;
-use axum::extract::State;
-use axum::http::{header, HeaderMap, StatusCode};
+use axum::extract::{FromRequestParts, State};
+use axum::http::{header, request::Parts, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 
 use super::types::{
-    CodeForkTranscript, CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuePausedBody,
-    QueuedCodeTurn, QueuedCodeTurnUpdate, QueuedCodeTurnsSnapshot, SequencedCodeEventFrame,
-    SetAttentionBody, SetFastModeBody, SetPermissionModeBody, SetReasoningEffortBody, SteerBody,
-    SubmitTurnBody,
+    CodeForkTranscript, CodeSessionSnapshot, CodeTurnSnapshot, CreateRemoteSessionBody,
+    CreateSessionBody, QueuePausedBody, QueuedCodeTurn, QueuedCodeTurnUpdate,
+    QueuedCodeTurnsSnapshot, SequencedCodeEventFrame, SetAttentionBody, SetFastModeBody,
+    SetPermissionModeBody, SetReasoningEffortBody, SteerBody, SubmitTurnBody,
 };
 use crate::code::runtime::{NewSessionSettings, SubmitTurnOutcome};
-use tidebreak_core::{CodeSessionId, TurnSteer, WorkspaceId};
+use tidebreak_core::{CodeSessionId, PermissionMode, TurnSteer, WorkspaceId};
+
+/// The managed ceiling remote session creation needs, resolved before the
+/// handler receives request fields.
+pub(crate) struct RemoteSessionPolicy {
+    permission_mode_ceiling: Option<PermissionMode>,
+}
+
+impl FromRequestParts<AppState> for RemoteSessionPolicy {
+    type Rejection = ServerError;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let permission_mode_ceiling = state.managed_policy()?.permission_mode_ceiling;
+        refuse_permission_mode_over_ceiling_value(
+            permission_mode_ceiling,
+            Some(PermissionMode::Allow),
+        )?;
+        Ok(Self {
+            permission_mode_ceiling,
+        })
+    }
+}
 
 pub async fn create_session(
     State(state): State<AppState>,
@@ -40,6 +66,35 @@ pub async fn create_session(
                 model: body.model,
                 reasoning_effort: body.reasoning_effort,
                 fast_mode: body.fast_mode,
+                permission_mode_ceiling,
+            },
+        )
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CodeSessionSnapshot::from(session)),
+    ))
+}
+
+/// `POST /code/remote/workspaces/{id}/sessions` — create a session whose
+/// engine runs inside the configured sandbox runtime.
+pub async fn create_remote_session(
+    code: ScopedCode,
+    RemoteSessionPolicy {
+        permission_mode_ceiling,
+    }: RemoteSessionPolicy,
+    Path(workspace_id): Path<WorkspaceId>,
+    Json(body): Json<CreateRemoteSessionBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let session = code
+        .create_remote_session(
+            workspace_id,
+            body.harness,
+            NewSessionSettings {
+                permission_mode: PermissionMode::Allow,
+                model: body.model,
+                reasoning_effort: body.reasoning_effort,
+                fast_mode: false,
                 permission_mode_ceiling,
             },
         )

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -730,6 +730,15 @@ pub struct CreateWorkspaceBody {
     pub base_ref: Option<String>,
 }
 
+/// Body of `POST /code/remote/workspaces`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateRemoteWorkspaceBody {
+    pub repo_id: RepoId,
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
 /// Body of `PATCH /code/workspaces/{id}`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1620,6 +1629,20 @@ pub struct CreateSessionBody {
     pub reasoning_effort: Option<ReasoningEffort>,
     #[serde(default)]
     pub fast_mode: bool,
+}
+
+/// Body of `POST /code/remote/workspaces/{id}/sessions`.
+///
+/// Remote sessions always run in `Allow` mode inside the configured sandbox
+/// and do not expose local-engine fast mode.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateRemoteSessionBody {
+    pub harness: HarnessKind,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<ReasoningEffort>,
 }
 
 /// Body of `POST /code/sessions/{id}/mode`.

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -11,9 +11,10 @@ use super::types::{
     ArchiveWorkspaceBody, CodeFileChange, CodeStorageSnapshot, CodeWorkspaceBlob,
     CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspaceHistorySearchMatch,
     CodeWorkspaceHistorySearchSource, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
-    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, CreateWorkspaceBody,
-    ListWorkspacesQuery, PatchWorkspaceBody, SetCodeWorktreeRootBody, WorkspaceBlobQuery,
-    WorkspaceDiffQuery, WorkspaceFilesQuery, WorkspaceSearchQuery, WorkspaceTreeQuery,
+    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, CreateRemoteWorkspaceBody,
+    CreateWorkspaceBody, ListWorkspacesQuery, PatchWorkspaceBody, SetCodeWorktreeRootBody,
+    WorkspaceBlobQuery, WorkspaceDiffQuery, WorkspaceFilesQuery, WorkspaceSearchQuery,
+    WorkspaceTreeQuery,
 };
 use tidebreak_core::WorkspaceId;
 
@@ -40,6 +41,21 @@ pub async fn create_workspace(
 ) -> Result<impl IntoResponse, ServerError> {
     let workspace = code
         .create_workspace(body.repo_id, body.title, body.base_ref)
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CodeWorkspaceSnapshot::from(workspace)),
+    ))
+}
+
+/// `POST /code/remote/workspaces` — create a workspace whose checkout lives
+/// only in the configured sandbox runtime.
+pub async fn create_remote_workspace(
+    code: ScopedCode,
+    Json(body): Json<CreateRemoteWorkspaceBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let workspace = code
+        .create_remote_workspace(body.repo_id, body.title)
         .await?;
     Ok((
         StatusCode::CREATED,

--- a/crates/tidebreak-server/src/routes/providers_models.rs
+++ b/crates/tidebreak-server/src/routes/providers_models.rs
@@ -256,19 +256,41 @@ pub(super) async fn refuse_permission_mode_over_ceiling(
     };
     let policy = state.managed_policy()?;
     if !policy.permits_permission_mode(mode) {
-        return Err(ServerError::conflict_kind(
-            "permission_mode_locked",
-            format!(
-                "permission mode `{}` exceeds the maximum this managed profile allows (`{}`)",
-                mode.as_str(),
-                policy
-                    .permission_mode_ceiling
-                    .unwrap_or(PermissionMode::Allow)
-                    .as_str()
-            ),
+        return Err(permission_mode_locked_error(
+            mode,
+            policy.permission_mode_ceiling,
         ));
     }
     Ok(())
+}
+
+pub(super) fn refuse_permission_mode_over_ceiling_value(
+    permission_mode_ceiling: Option<PermissionMode>,
+    requested: Option<PermissionMode>,
+) -> Result<(), ServerError> {
+    let Some(mode) = requested else {
+        return Ok(());
+    };
+    if permission_mode_ceiling.is_some_and(|ceiling| mode > ceiling) {
+        return Err(permission_mode_locked_error(mode, permission_mode_ceiling));
+    }
+    Ok(())
+}
+
+fn permission_mode_locked_error(
+    mode: PermissionMode,
+    permission_mode_ceiling: Option<PermissionMode>,
+) -> ServerError {
+    ServerError::conflict_kind(
+        "permission_mode_locked",
+        format!(
+            "permission mode `{}` exceeds the maximum this managed profile allows (`{}`)",
+            mode.as_str(),
+            permission_mode_ceiling
+                .unwrap_or(PermissionMode::Allow)
+                .as_str()
+        ),
+    )
 }
 
 /// Refuse a BYOK credential write on a managed profile.

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -16,6 +16,13 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 use crate::code::browser_runtime::{BrowserRuntime, BrowserRuntimeError, BrowserRuntimeScope};
+use crate::code::remote::driver::RemoteSpawnSettings;
+use crate::code::remote::service::RemoteSessions;
+use crate::code::remote::wire::{
+    EventCursor, MessageReceipt, SandboxEvents, SandboxLease, SandboxMessage, SandboxStatus,
+    SpawnArguments,
+};
+use crate::code::remote::{RemoteSandboxError, SandboxProvisioner};
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
@@ -110,6 +117,53 @@ impl BrowserRuntime for RecordingBrowserRuntime {
     }
 }
 
+struct UnusedRemoteProvisioner;
+
+#[async_trait]
+impl SandboxProvisioner for UnusedRemoteProvisioner {
+    async fn spawn(
+        &self,
+        _owner: &tidebreak_core::OwnerId,
+        _arguments: &SpawnArguments,
+    ) -> Result<SandboxLease, RemoteSandboxError> {
+        panic!("remote create-route tests must not provision a sandbox")
+    }
+
+    async fn status(
+        &self,
+        _owner: &tidebreak_core::OwnerId,
+        _sandbox_id: &str,
+    ) -> Result<SandboxStatus, RemoteSandboxError> {
+        panic!("remote create-route tests must not read sandbox status")
+    }
+
+    async fn events(
+        &self,
+        _owner: &tidebreak_core::OwnerId,
+        _sandbox_id: &str,
+        _cursor: EventCursor,
+    ) -> Result<SandboxEvents, RemoteSandboxError> {
+        panic!("remote create-route tests must not read sandbox events")
+    }
+
+    async fn send(
+        &self,
+        _owner: &tidebreak_core::OwnerId,
+        _sandbox_id: &str,
+        _message: &SandboxMessage,
+    ) -> Result<MessageReceipt, RemoteSandboxError> {
+        panic!("remote create-route tests must not send sandbox messages")
+    }
+
+    async fn cancel(
+        &self,
+        _owner: &tidebreak_core::OwnerId,
+        _sandbox_id: &str,
+    ) -> Result<(), RemoteSandboxError> {
+        panic!("remote create-route tests must not cancel a sandbox")
+    }
+}
+
 async fn code_app(
     events: Vec<HarnessEvent>,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
@@ -146,14 +200,14 @@ async fn code_app_with_optional_browser(
     adapter: ScriptedAdapter,
     browser_runtime: Option<Arc<RecordingBrowserRuntime>>,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
-    code_app_with_options(adapter, browser_runtime, None, None).await
+    code_app_with_options(adapter, browser_runtime, None, None, false).await
 }
 
 async fn code_app_with_put_gate(
     adapter: ScriptedAdapter,
     gate: Arc<PutGate>,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
-    code_app_with_options(adapter, None, Some(gate), None).await
+    code_app_with_options(adapter, None, Some(gate), None, false).await
 }
 
 /// A code app whose OS policy asserts a permission-mode ceiling.
@@ -161,7 +215,14 @@ async fn code_app_with_ceiling(
     adapter: ScriptedAdapter,
     ceiling: PermissionMode,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
-    code_app_with_options(adapter, None, None, Some(ceiling)).await
+    code_app_with_options(adapter, None, None, Some(ceiling), false).await
+}
+
+async fn code_app_with_remote(
+    adapter: ScriptedAdapter,
+    permission_mode_ceiling: Option<PermissionMode>,
+) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    code_app_with_options(adapter, None, None, permission_mode_ceiling, true).await
 }
 
 async fn code_app_with_options(
@@ -169,6 +230,7 @@ async fn code_app_with_options(
     browser_runtime: Option<Arc<RecordingBrowserRuntime>>,
     put_gate: Option<Arc<PutGate>>,
     permission_mode_ceiling: Option<PermissionMode>,
+    remote: bool,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
     let (dir, store) = temp_db_store("code.db").await;
     let db = Arc::new(store);
@@ -180,13 +242,27 @@ async fn code_app_with_options(
     let browser_bridge_command = installed_browser_runtime
         .as_ref()
         .map(|_| crate::code::browser_channel::test_bridge_command());
-    let runtime = Arc::new(CodeRuntime::with_registry_and_browser_runtime(
+    let runtime = CodeRuntime::with_registry_and_browser_runtime(
         db,
         dir.path().to_path_buf(),
         registry,
         installed_browser_runtime,
         browser_bridge_command,
-    ));
+    );
+    let runtime = if remote {
+        runtime.with_remote_sessions(RemoteSessions::new(
+            Arc::new(UnusedRemoteProvisioner),
+            RemoteSpawnSettings {
+                profile: "test-remote".to_owned(),
+                incarnation_cap: 2,
+                spend_ceiling_microusd: None,
+                session_spend_ceiling_microusd: None,
+            },
+        ))
+    } else {
+        runtime
+    };
+    let runtime = Arc::new(runtime);
     let mut state = AppState::new(
         Config::desktop(dir.path()),
         store_trait,
@@ -474,6 +550,35 @@ fn init_git_repo_named(dir: &std::path::Path, name: &str) -> std::path::PathBuf 
 
 fn init_git_repo(dir: &std::path::Path) -> std::path::PathBuf {
     init_git_repo_named(dir, "origin")
+}
+
+fn add_github_remote(repo: &std::path::Path, name: &str) {
+    assert!(std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            &format!("https://github.com/acme/{name}.git"),
+        ])
+        .current_dir(repo)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .status()
+        .unwrap()
+        .success());
+}
+
+async fn record_github_origin(runtime: &CodeRuntime, repo: &serde_json::Value, name: &str) {
+    let repo_id: RepoId = json_id(repo).parse().unwrap();
+    assert!(tidebreak_core::db::code::set_repo_origin(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        repo_id,
+        "github.com",
+        "acme",
+        name,
+    )
+    .await
+    .unwrap());
 }
 
 async fn register_and_workspace(
@@ -1070,6 +1175,189 @@ async fn listing_session_turns_returns_user_input_and_usage() {
     assert_eq!(listed[1]["id"], second["id"]);
     assert_eq!(listed[1]["ordinal"], 2);
     assert_eq!(listed[1]["user_input"], "again");
+}
+
+#[tokio::test]
+async fn remote_create_routes_write_remote_rows_without_a_host_checkout() {
+    let (router, token, runtime, dir) =
+        code_app_with_remote(ScriptedAdapter::new(plain_text_script()), None).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo_named(dir.path(), "remote-create");
+    add_github_remote(&repo, "remote-create");
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let registered: serde_json::Value = registered.json().await.unwrap();
+    record_github_origin(&runtime, &registered, "remote-create").await;
+
+    let workspace_url = format!("http://{addr}/code/remote/workspaces");
+    let unauthenticated = client
+        .post(&workspace_url)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&registered),
+            "title": "remote route",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauthenticated.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let created = client
+        .post(&workspace_url)
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&registered),
+            "title": "remote route",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let workspace_id: WorkspaceId = json_id(&workspace).parse().unwrap();
+    assert_eq!(workspace["title"], "remote route");
+    assert_eq!(workspace["worktree_path"], format!("remote:{workspace_id}"));
+    assert_eq!(workspace["base_ref"], "main");
+
+    let stored = runtime
+        .get_workspace(&tidebreak_core::OwnerId::local(), workspace_id)
+        .await
+        .unwrap();
+    assert!(stored.is_remote());
+
+    let session_url = format!("http://{addr}/code/remote/workspaces/{workspace_id}/sessions");
+    let unauthenticated = client
+        .post(&session_url)
+        .json(&serde_json::json!({ "harness": "claude_code" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauthenticated.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let created = client
+        .post(&session_url)
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "model": "openai::gpt-5.6-sol",
+            "reasoning_effort": "high",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(session["workspace_id"], workspace_id.to_string());
+    assert_eq!(session["permission_mode"], "allow");
+    assert_eq!(session["fast_mode"], false);
+    assert_eq!(session["model"], "openai::gpt-5.6-sol");
+    assert_eq!(session["reasoning_effort"], "high");
+    assert_eq!(session["lifecycle"], "idle");
+
+    let unsupported_mode = client
+        .post(&session_url)
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unsupported_mode.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = unsupported_mode.json().await.unwrap();
+    assert_eq!(body["kind"], "bad_request", "{body}");
+    assert!(body["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("unknown field `permission_mode`")));
+}
+
+#[tokio::test]
+async fn remote_create_routes_keep_configuration_and_workspace_refusals_typed() {
+    let (router, token, _runtime, _dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let disabled = client
+        .post(format!("http://{addr}/code/remote/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "repo_id": RepoId::new() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(disabled.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = disabled.json().await.unwrap();
+    assert_eq!(body["kind"], "remote_disabled", "{body}");
+
+    let (router, token, _runtime, dir) =
+        code_app_with_remote(ScriptedAdapter::new(plain_text_script()), None).await;
+    let addr = serve(router).await;
+    let repo = init_git_repo_named(dir.path(), "local-create");
+    add_github_remote(&repo, "local-create");
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/remote/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "harness": "claude_code" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "workspace_not_remote", "{body}");
+}
+
+#[tokio::test]
+async fn a_managed_ceiling_can_refuse_remote_allow_sessions() {
+    let (router, token, runtime, dir) = code_app_with_remote(
+        ScriptedAdapter::new(plain_text_script()),
+        Some(PermissionMode::Ask),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo_named(dir.path(), "remote-ceiling");
+    add_github_remote(&repo, "remote-ceiling");
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let registered = registered.json::<serde_json::Value>().await.unwrap();
+    record_github_origin(&runtime, &registered, "remote-ceiling").await;
+    let workspace = client
+        .post(format!("http://{addr}/code/remote/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "repo_id": json_id(&registered) }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(workspace.status(), reqwest::StatusCode::CREATED);
+    let workspace = workspace.json::<serde_json::Value>().await.unwrap();
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/remote/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "harness": "claude_code" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "permission_mode_locked", "{body}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
This adds the first bounded slice of #2889.

It exposes authenticated HTTP routes to create remote workspaces and remote sessions through the existing owner-scoped runtime paths. Remote sessions always start in `Allow` mode with fast mode off, and managed permission ceilings can refuse that posture.

The route tests cover authentication, remote-disabled deployments, local-workspace refusal, remote row creation, fixed session posture, unsupported request fields, and managed-policy refusal.

Checks:

- `cargo fmt --all -- --check`
- `cargo test -p tidebreak-server remote_create_routes --lib`
- `cargo test -p tidebreak-server a_managed_ceiling_can_refuse_remote_allow_sessions --lib`
- `cargo test -p tidebreak-server code::remote::service --lib`
- `cargo check -p tidebreak-server`
- `git diff --check origin/main...HEAD`