### PR TITLE
feat(code): make external message intake idempotent and ordered

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -1368,6 +1368,25 @@ pub enum ExternalSessionResolution {
     GrantMismatch,
 }
 
+/// What recording one external message delivery committed
+/// (`docs/slack-sessions.md`, stage 2).
+///
+/// The event id and the queue row it caused commit in one transaction, so a
+/// replayed delivery never writes a second row: it answers `Replay` with the
+/// id the first delivery minted, and the caller derives the outcome from
+/// that row's current state.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExternalMessageRecord {
+    /// First delivery: the queue row and event row committed together.
+    Recorded(Box<CodeQueuedTurn>),
+    /// The event was already recorded. `turn_id` names the row the first
+    /// delivery caused — still queued, promoted into a turn, or retracted.
+    Replay {
+        /// The id shared by the queue row and the turn it promotes into.
+        turn_id: CodeTurnId,
+    },
+}
+
 /// The outcome of asking for a new incarnation under the owner's cap.
 #[derive(Debug, Clone, PartialEq)]
 pub enum IncarnationAdmission {

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1960,6 +1960,28 @@ pub mod code_external_binding {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod code_external_event {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "code_external_event")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub owner: String,
+        pub session_id: Uuid,
+        pub event_id: String,
+        pub channel_ts: String,
+        pub turn_id: Uuid,
+        pub created_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod code_session_image {
     use sea_orm::entity::prelude::*;
 

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -62,6 +62,7 @@ impl MigratorTrait for Migrator {
             Box::new(CodeSessionIncarnations),
             Box::new(IncarnationIngest),
             Box::new(CodeExternalBindings),
+            Box::new(CodeExternalEvents),
         ]
     }
 }
@@ -2923,6 +2924,104 @@ impl MigrationTrait for CodeExternalBindings {
     }
 }
 
+/// Make external message delivery idempotent (docs/slack-sessions.md,
+/// stage 2).
+///
+/// One row per channel event that caused a queue row or turn. The event id
+/// commits in the same transaction as that row, and `turn_id` names it —
+/// the queue row's id becomes the turn's id at promotion, so one column
+/// follows the message through its whole life. A replayed delivery derives
+/// its response from that row's current state; there is no separate outcome
+/// snapshot to go stale.
+struct CodeExternalEvents;
+
+impl MigrationName for CodeExternalEvents {
+    fn name(&self) -> &str {
+        "m20260828_000025_code_external_events"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CodeExternalEvents {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(idens::CodeExternalEvent::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(idens::CodeExternalEvent::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeExternalEvent::Owner)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeExternalEvent::SessionId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeExternalEvent::EventId)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeExternalEvent::ChannelTs)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeExternalEvent::TurnId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::CodeExternalEvent::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_code_external_event_session")
+                            .from(
+                                idens::CodeExternalEvent::Table,
+                                idens::CodeExternalEvent::SessionId,
+                            )
+                            .to(idens::CodeSession::Table, idens::CodeSession::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        // The replay gate: one channel event causes at most one row.
+        manager
+            .create_index(
+                Index::create()
+                    .name("ix_code_external_event_key")
+                    .table(idens::CodeExternalEvent::Table)
+                    .col(idens::CodeExternalEvent::Owner)
+                    .col(idens::CodeExternalEvent::SessionId)
+                    .col(idens::CodeExternalEvent::EventId)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Dropping the table would forget which deliveries already ran, and
+        // the channel's retries would double-submit turns.
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
@@ -2996,6 +3095,7 @@ mod tests {
                 "m20260827_000022_code_session_incarnations",
                 "m20260827_000023_incarnation_ingest",
                 "m20260828_000024_code_external_bindings",
+                "m20260828_000025_code_external_events",
             ]
         );
         assert!(db

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -1150,3 +1150,15 @@ pub(crate) enum CodeExternalBinding {
     SessionId,
     CreatedAt,
 }
+
+#[derive(DeriveIden)]
+pub(crate) enum CodeExternalEvent {
+    Table,
+    Id,
+    Owner,
+    SessionId,
+    EventId,
+    ChannelTs,
+    TurnId,
+    CreatedAt,
+}

--- a/crates/tidebreak-core/src/db/ops/code/external_event.rs
+++ b/crates/tidebreak-core/src/db/ops/code/external_event.rs
@@ -1,0 +1,207 @@
+//! Idempotent external message intake (docs/slack-sessions.md, stage 2).
+//!
+//! A channel delivers at-least-once, so every message carries an event id.
+//! The first delivery commits the event row and the queue row it causes in
+//! one transaction; a replay finds the event row and answers with the id the
+//! first delivery minted, writing nothing. The caller derives the replayed
+//! outcome from that row's current state — still queued, promoted into a
+//! turn, or retracted — so there is no outcome snapshot to go stale.
+//!
+//! Ordering: a channel can also deliver out of order. Each event carries the
+//! channel's own ordering token (`channel_ts`, compared lexicographically —
+//! Slack's fixed-width epoch format sorts correctly this way). While a
+//! message is still queued it can move, so the insert reorders the session's
+//! still-queued external rows by that token. A row already promoted into a
+//! turn is outside the window and never moves, so "A then B" cannot become
+//! "B steered by A".
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
+};
+
+use crate::code::{CodeQueuedTurn, CodeSessionId, CodeTurnId, ExternalMessageRecord};
+use crate::error::{AgentError, Result};
+use crate::OwnerId;
+
+use super::super::super::{entities, store_err, DbStore};
+use super::super::agent_run::database_now;
+use super::acquire_code_session_write_lock;
+use super::queued::queued_turn_from_model;
+
+async fn find_event_on<C>(
+    conn: &C,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    event_id: &str,
+) -> Result<Option<entities::code_external_event::Model>>
+where
+    C: ConnectionTrait,
+{
+    entities::code_external_event::Entity::find()
+        .filter(entities::code_external_event::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_event::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_external_event::Column::EventId.eq(event_id))
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+/// Reorder the session's still-queued external rows by their channel
+/// ordering token. Rows without an event row (desktop follow-ups) keep
+/// their positions; external rows permute within their own position slots,
+/// so the two populations never leapfrog each other as a group.
+async fn order_queued_by_channel_ts<C>(
+    conn: &C,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let rows = entities::code_queued_turn::Entity::find()
+        .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+        .order_by_asc(entities::code_queued_turn::Column::Position)
+        .order_by_asc(entities::code_queued_turn::Column::CreatedAt)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    let events = entities::code_external_event::Entity::find()
+        .filter(entities::code_external_event::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_event::Column::SessionId.eq(session_id.0))
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    let ts_of = |row_id: uuid::Uuid| {
+        events
+            .iter()
+            .find(|event| event.turn_id == row_id)
+            .map(|event| event.channel_ts.clone())
+    };
+    let mut external: Vec<(usize, String)> = rows
+        .iter()
+        .enumerate()
+        .filter_map(|(index, row)| ts_of(row.id).map(|ts| (index, ts)))
+        .collect();
+    let slots: Vec<i32> = external
+        .iter()
+        .map(|(index, _)| rows[*index].position)
+        .collect();
+    external.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+    for ((index, _), slot) in external.into_iter().zip(slots) {
+        let row = &rows[index];
+        if row.position == slot {
+            continue;
+        }
+        entities::code_queued_turn::ActiveModel {
+            id: Set(row.id),
+            position: Set(slot),
+            ..Default::default()
+        }
+        .update(conn)
+        .await
+        .map_err(store_err)?;
+    }
+    Ok(())
+}
+
+/// Record one external message delivery.
+///
+/// First delivery: parks the message as a queue row, records the event
+/// against the row's id, and reorders still-queued external rows by
+/// `channel_ts`, all in one transaction. Replay: answers with the recorded
+/// id and writes nothing. The queue row's id becomes the promoted turn's
+/// id (decision 69), so one id follows the message through its whole life.
+pub async fn record_external_message(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    event_id: &str,
+    channel_ts: &str,
+    message: &str,
+) -> Result<ExternalMessageRecord> {
+    if event_id.trim().is_empty() || channel_ts.trim().is_empty() {
+        return Err(AgentError::Store(
+            "an external message needs an event id and an ordering token".into(),
+        ));
+    }
+    if message.trim().is_empty() || message.contains('\0') {
+        return Err(AgentError::Store("invalid external message".into()));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_code_session_write_lock(&transaction, session_id).await? {
+        return Err(AgentError::Store(format!(
+            "code session {session_id} not found"
+        )));
+    }
+    if let Some(event) = find_event_on(&transaction, owner, session_id, event_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ExternalMessageRecord::Replay {
+            turn_id: CodeTurnId(event.turn_id),
+        });
+    }
+    let existing = entities::code_queued_turn::Entity::find()
+        .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+        .order_by_asc(entities::code_queued_turn::Column::Position)
+        .order_by_asc(entities::code_queued_turn::Column::CreatedAt)
+        .all(&transaction)
+        .await
+        .map_err(store_err)?;
+    if existing.len() >= CodeQueuedTurn::MAX_PER_SESSION {
+        transaction.commit().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "a session may queue at most {} messages",
+            CodeQueuedTurn::MAX_PER_SESSION
+        )));
+    }
+    let position = existing.last().map_or(0, |last| last.position + 1);
+    let now = database_now(&transaction).await?;
+    let queued_id = CodeTurnId::new();
+    entities::code_queued_turn::ActiveModel {
+        id: Set(queued_id.0),
+        owner: Set(owner.as_str().to_owned()),
+        session_id: Set(session_id.0),
+        message: Set(message.to_owned()),
+        attachments_json: Set("[]".to_owned()),
+        position: Set(position),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let inserted = entities::code_external_event::ActiveModel {
+        id: Set(uuid::Uuid::new_v4()),
+        owner: Set(owner.as_str().to_owned()),
+        session_id: Set(session_id.0),
+        event_id: Set(event_id.to_owned()),
+        channel_ts: Set(channel_ts.to_owned()),
+        turn_id: Set(queued_id.0),
+        created_at: Set(now),
+    }
+    .insert(&transaction)
+    .await;
+    if let Err(error) = inserted {
+        // The unique event key refused: a concurrent delivery of the same
+        // event committed between our read and this insert. Drop our rows
+        // and answer with the winner's id.
+        transaction.rollback().await.map_err(store_err)?;
+        let Some(event) = find_event_on(&store.conn, owner, session_id, event_id).await? else {
+            return Err(store_err(error));
+        };
+        return Ok(ExternalMessageRecord::Replay {
+            turn_id: CodeTurnId(event.turn_id),
+        });
+    }
+    order_queued_by_channel_ts(&transaction, owner, session_id).await?;
+    let row = entities::code_queued_turn::Entity::find_by_id(queued_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store("code queued turn disappeared".into()))?;
+    let row = queued_turn_from_model(row)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(ExternalMessageRecord::Recorded(Box::new(row)))
+}

--- a/crates/tidebreak-core/src/db/ops/code/mod.rs
+++ b/crates/tidebreak-core/src/db/ops/code/mod.rs
@@ -13,6 +13,7 @@ use super::super::{entities, store_err};
 
 pub mod approval;
 pub mod binding;
+pub mod external_event;
 pub mod incarnation;
 pub mod journal;
 pub mod pull_request;
@@ -30,6 +31,7 @@ pub mod workspace;
 
 pub use approval::*;
 pub use binding::*;
+pub use external_event::*;
 pub use incarnation::*;
 pub use journal::*;
 pub use pull_request::*;

--- a/crates/tidebreak-core/src/db/ops/code/queued.rs
+++ b/crates/tidebreak-core/src/db/ops/code/queued.rs
@@ -171,6 +171,44 @@ pub async fn promote_queued_turn(
     Ok(true)
 }
 
+/// Claim a snapshot whose row only moved since it was taken.
+///
+/// Like [`promote_queued_turn`], but the delete does not match on
+/// `position`. Content edits bump `updated_at`, so a successful claim here
+/// proves the delivered text is still exactly the row's text — the row was
+/// only reordered, which cannot change what already ran. The remote driver
+/// uses this after the strict claim fails: its message has already reached
+/// the sandbox by then, so a moved row must be consumed under its own id
+/// rather than left behind to run the same text twice. Returns `false` —
+/// with nothing written — when the row was edited or retracted.
+pub async fn promote_moved_queued_turn(
+    store: &DbStore,
+    owner: &OwnerId,
+    expected: &CodeQueuedTurn,
+    turn: &CodeTurn,
+) -> Result<bool> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_code_session_write_lock(&transaction, expected.session_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(false);
+    }
+    let deleted = entities::code_queued_turn::Entity::delete_many()
+        .filter(entities::code_queued_turn::Column::Id.eq(expected.id.0))
+        .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_queued_turn::Column::SessionId.eq(expected.session_id.0))
+        .filter(entities::code_queued_turn::Column::UpdatedAt.eq(expected.updated_at))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if deleted.rows_affected != 1 {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(false);
+    }
+    super::turn::insert_turn_on(&transaction, owner, turn).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(true)
+}
+
 /// Drop one queued message that can no longer run (a dead attachment, a
 /// failed start). Deletes by id alone, so it also cleans up after a promotion
 /// that already removed the row. Returns whether a row was deleted.

--- a/crates/tidebreak-core/src/db/ops/code/queued.rs
+++ b/crates/tidebreak-core/src/db/ops/code/queued.rs
@@ -23,7 +23,9 @@ use super::super::super::{entities, store_err, DbStore};
 use super::super::agent_run::database_now;
 use super::acquire_code_session_write_lock;
 
-fn queued_turn_from_model(model: entities::code_queued_turn::Model) -> Result<CodeQueuedTurn> {
+pub(super) fn queued_turn_from_model(
+    model: entities::code_queued_turn::Model,
+) -> Result<CodeQueuedTurn> {
     Ok(CodeQueuedTurn {
         id: CodeTurnId(model.id),
         session_id: CodeSessionId(model.session_id),

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -5047,3 +5047,143 @@ async fn ingest_journals_once_per_sandbox_event_and_resumes_from_the_cursor() {
     .await
     .is_err());
 }
+
+/// A session bound to a fresh conversation, for the external message tests.
+async fn seed_external_session(
+    store: &crate::db::DbStore,
+    owner: &OwnerId,
+    label: &str,
+) -> CodeSessionId {
+    let (session, _) = seed_owner(store, owner, label).await;
+    let stored = crate::db::code::get_session(store, owner, session)
+        .await
+        .unwrap()
+        .unwrap();
+    let workspace = crate::db::code::get_workspace(store, owner, stored.workspace_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let (external_workspace, external_session) = external_pair(owner, workspace.repo_id, label);
+    match crate::db::code::resolve_external_session(
+        store,
+        owner,
+        crate::code::CodeGrantId::new(),
+        "slack",
+        label,
+        &external_workspace,
+        &external_session,
+    )
+    .await
+    .unwrap()
+    {
+        crate::code::ExternalSessionResolution::Created(binding) => binding.session_id,
+        other => panic!("expected a fresh binding, got {other:?}"),
+    }
+}
+
+/// A replayed event id answers with the first delivery's row id and writes
+/// nothing; a distinct event id parks a second row.
+#[tokio::test]
+async fn a_replayed_external_message_records_once() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session_id = seed_external_session(&store, &owner, "replay-once").await;
+
+    let first = crate::db::code::record_external_message(
+        &store,
+        &owner,
+        session_id,
+        "Ev001",
+        "1700000001.000100",
+        "hello",
+    )
+    .await
+    .unwrap();
+    let crate::code::ExternalMessageRecord::Recorded(row) = first else {
+        panic!("first delivery must record");
+    };
+
+    let replay = crate::db::code::record_external_message(
+        &store,
+        &owner,
+        session_id,
+        "Ev001",
+        "1700000001.000100",
+        "hello",
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        replay,
+        crate::code::ExternalMessageRecord::Replay { turn_id: row.id }
+    );
+    let queued = crate::db::code::list_queued_turns(&store, &owner, session_id)
+        .await
+        .unwrap();
+    assert_eq!(queued.len(), 1, "a replay must not park a second row");
+
+    let second = crate::db::code::record_external_message(
+        &store,
+        &owner,
+        session_id,
+        "Ev002",
+        "1700000002.000100",
+        "again",
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        second,
+        crate::code::ExternalMessageRecord::Recorded(_)
+    ));
+}
+
+/// Out-of-order deliveries apply in channel order while still queued, and
+/// external rows permute within their own slots so a desktop follow-up
+/// keeps its place in line.
+#[tokio::test]
+async fn out_of_order_external_messages_apply_in_channel_order() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session_id = seed_external_session(&store, &owner, "ts-order").await;
+
+    let desktop = enqueue_queued_turn(&store, &owner, &queued_message(session_id, "desktop"))
+        .await
+        .unwrap();
+    let later = crate::db::code::record_external_message(
+        &store,
+        &owner,
+        session_id,
+        "EvB",
+        "1700000002.000100",
+        "message B",
+    )
+    .await
+    .unwrap();
+    let crate::code::ExternalMessageRecord::Recorded(later) = later else {
+        panic!("B must record");
+    };
+    let earlier = crate::db::code::record_external_message(
+        &store,
+        &owner,
+        session_id,
+        "EvA",
+        "1700000001.000100",
+        "message A",
+    )
+    .await
+    .unwrap();
+    let crate::code::ExternalMessageRecord::Recorded(earlier) = earlier else {
+        panic!("A must record");
+    };
+
+    let queued = crate::db::code::list_queued_turns(&store, &owner, session_id)
+        .await
+        .unwrap();
+    let order: Vec<_> = queued.iter().map(|row| row.id).collect();
+    assert_eq!(
+        order,
+        vec![desktop.id, earlier.id, later.id],
+        "the earlier channel token must run before the later one"
+    );
+}

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -184,12 +184,12 @@ pub use code::{
     CodeTriggerDeliverySink, CodeTriggerFire, CodeTriggerFireIdentity, CodeTriggerFirePayload,
     CodeTriggerFireState, CodeTriggerId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeUsage,
     CodeWatch, CodeWatchId, CodeWatchState, CodeWorkflowRunFact, CodeWorkflowRunId, CodeWorkspace,
-    CodeWorkspaceStatus, Diffstat, ExternalSessionResolution, FileChangeKind, HarnessCaps,
-    HarnessCommand, HarnessKind, HarnessNoticeLevel, HarnessTier, IncarnationAdmission,
-    IncarnationState, PullRequestCheck, PullRequestCheckBucket, PullRequestComment,
-    PullRequestCommentKind, PullRequestDigest, QuickAction, RepoId, SequencedCodeEvent, ToolDetail,
-    ToolOutcome, WorkspaceId, MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS,
-    MAX_SESSION_SUBAGENTS, MAX_TOOL_SUMMARY_CHARS,
+    CodeWorkspaceStatus, Diffstat, ExternalMessageRecord, ExternalSessionResolution,
+    FileChangeKind, HarnessCaps, HarnessCommand, HarnessKind, HarnessNoticeLevel, HarnessTier,
+    IncarnationAdmission, IncarnationState, PullRequestCheck, PullRequestCheckBucket,
+    PullRequestComment, PullRequestCommentKind, PullRequestDigest, QuickAction, RepoId,
+    SequencedCodeEvent, ToolDetail, ToolOutcome, WorkspaceId, MAX_EVENT_TEXT_CHARS,
+    MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS, MAX_SESSION_SUBAGENTS, MAX_TOOL_SUMMARY_CHARS,
 };
 pub use compaction::{
     CompactionPolicy, CompactionSelection, CompactionSourceBoundary, CompactionTokenBounds,

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -852,14 +852,24 @@ async fn start_turn_row(
     };
     match promoted {
         // Claim the queue row and insert its turn in one transaction, the
-        // way a local worker promotes. A stale claim — the row was edited,
-        // reordered, or retracted after the sweep's snapshot — writes the
-        // turn under a fresh id instead: the snapshot's text already reached
-        // the sandbox, so the transcript must show it, and the surviving
-        // queue row keeps its own id so its later promotion cannot collide
-        // with this turn.
+        // way a local worker promotes. The strict claim can fail on a
+        // position-only move — an out-of-order external message reorders
+        // still-queued rows — and that must not count as stale: the text
+        // already reached the sandbox, so the moved row is consumed under
+        // its own id, or the same message would promote and run again.
+        // Only an edit or retraction writes the turn under a fresh id
+        // instead: the delivered text differs from what the row now says,
+        // so the transcript must show what ran, and the surviving row
+        // keeps its own id so its later promotion cannot collide.
         Some(row) => {
             if !tidebreak_core::db::code::promote_queued_turn(db, &session.owner, row, &turn)
+                .await?
+                && !tidebreak_core::db::code::promote_moved_queued_turn(
+                    db,
+                    &session.owner,
+                    row,
+                    &turn,
+                )
                 .await?
             {
                 warn!(

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -277,7 +277,9 @@ mod tests {
         PermissionMode, RepoId,
     };
 
-    use super::super::super::runtime::{NewSessionSettings, SubmitTurnOutcome};
+    use super::super::super::runtime::{
+        ExternalMessageOutcome, NewSessionSettings, SubmitTurnOutcome,
+    };
     use super::super::driver::RemoteSpawnSettings;
     use super::super::wire::{
         EventCursor, MessageReceipt, SandboxEvent, SandboxEvents, SandboxLease, SandboxMessage,
@@ -1092,6 +1094,132 @@ mod tests {
                 session_id: binding.session_id
             }
         );
+    }
+
+    /// External messages are idempotent on the event id: an idle session
+    /// runs the message as a turn, a replay answers with that same turn,
+    /// a busy session queues durably, and another grant cannot submit.
+    #[tokio::test]
+    async fn an_external_message_is_idempotent_and_queues_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
+        let grant = tidebreak_core::CodeGrantId::new();
+        let resolved = runtime
+            .external_get_or_create(
+                &owner,
+                grant,
+                "slack",
+                "T1/C9/77.1",
+                repo.id,
+                None,
+                HarnessKind::ClaudeCode,
+                session_settings(),
+            )
+            .await
+            .unwrap();
+        let tidebreak_core::ExternalSessionResolution::Created(binding) = resolved else {
+            panic!("expected a create");
+        };
+        let session_id = binding.session_id;
+
+        let first = runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "start".into(),
+                "Ev1",
+                "1700000001.000100",
+            )
+            .await
+            .unwrap();
+        let ExternalMessageOutcome::NewTurn(turn) = first else {
+            panic!("an idle session must run the message, got {first:?}");
+        };
+        assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+
+        // The channel redelivers Ev1: same turn, no second spawn or row.
+        let replay = runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "start".into(),
+                "Ev1",
+                "1700000001.000100",
+            )
+            .await
+            .unwrap();
+        let ExternalMessageOutcome::NewTurn(replayed) = replay else {
+            panic!("a replay must answer with the promoted turn, got {replay:?}");
+        };
+        assert_eq!(replayed.id, turn.id);
+        assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+
+        // The session is busy: the next event parks durably, and its replay
+        // answers with the same row.
+        let busy = runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "and then".into(),
+                "Ev2",
+                "1700000002.000100",
+            )
+            .await
+            .unwrap();
+        let ExternalMessageOutcome::Queued(row) = busy else {
+            panic!("a busy session must queue, got {busy:?}");
+        };
+        let busy_replay = runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "and then".into(),
+                "Ev2",
+                "1700000002.000100",
+            )
+            .await
+            .unwrap();
+        let ExternalMessageOutcome::Queued(replayed_row) = busy_replay else {
+            panic!("a replayed queued event must answer queued, got {busy_replay:?}");
+        };
+        assert_eq!(replayed_row.id, row.id);
+        let (queued_rows, _) = runtime.list_queued_turns(&owner, session_id).await.unwrap();
+        assert_eq!(queued_rows.len(), 1);
+
+        // Another grant holds no binding to this session and cannot submit.
+        let foreign = runtime
+            .external_submit_message(
+                &owner,
+                tidebreak_core::CodeGrantId::new(),
+                session_id,
+                "hijack".into(),
+                "Ev3",
+                "1700000003.000100",
+            )
+            .await;
+        assert!(foreign.is_err(), "a foreign grant must refuse");
+
+        // An ended session refuses instead of queueing into the void.
+        let mut stored = runtime.get_session(&owner, session_id).await.unwrap();
+        stored.lifecycle = CodeSessionLifecycle::Ended;
+        assert!(tidebreak_core::db::code::save_session(&runtime.db, &stored)
+            .await
+            .unwrap());
+        let ended = runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "still there?".into(),
+                "Ev4",
+                "1700000004.000100",
+            )
+            .await;
+        assert!(ended.is_err(), "an ended session must refuse");
     }
 
     /// A repository with no recorded origin cannot back a remote workspace:

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1222,6 +1222,157 @@ mod tests {
         assert!(ended.is_err(), "an ended session must refuse");
     }
 
+    /// The race the channel's out-of-order delivery creates: the sweep
+    /// snapshots head B, message A arrives with an earlier `channel_ts` and
+    /// moves B, and the claim then runs with a stale position. B's text has
+    /// already reached the sandbox, so B's row must be consumed under its
+    /// own id — a surviving row would promote later and run the same
+    /// message twice — while A stays queued for the next idle.
+    #[tokio::test]
+    async fn a_moved_head_is_consumed_by_its_promotion_not_run_twice() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
+        let grant = tidebreak_core::CodeGrantId::new();
+        let resolved = runtime
+            .external_get_or_create(
+                &owner,
+                grant,
+                "slack",
+                "T1/C4/5.5",
+                repo.id,
+                None,
+                HarnessKind::ClaudeCode,
+                session_settings(),
+            )
+            .await
+            .unwrap();
+        let tidebreak_core::ExternalSessionResolution::Created(binding) = resolved else {
+            panic!("expected a create");
+        };
+        let session_id = binding.session_id;
+
+        // Turn 1 runs; B parks behind it.
+        runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "start".into(),
+                "Ev0",
+                "1700000000.000100",
+            )
+            .await
+            .unwrap();
+        let queued_b = runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "message B".into(),
+                "EvB",
+                "1700000002.000100",
+            )
+            .await
+            .unwrap();
+        let ExternalMessageOutcome::Queued(row_b) = queued_b else {
+            panic!("B must queue behind the running turn");
+        };
+
+        // The sweep's snapshot of head B, taken before A arrives.
+        let stale = tidebreak_core::db::code::queued_turn_head(&runtime.db, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stale.id, row_b.id);
+
+        // A lands with an earlier channel token and moves B.
+        runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "message A".into(),
+                "EvA",
+                "1700000001.000100",
+            )
+            .await
+            .unwrap();
+
+        // Turn 1 settles; the session is idle for the promotion.
+        fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+            sandbox_id: "sb-1".to_owned(),
+            state: SandboxState::Running,
+            latest_event_seq: 2,
+            events: vec![
+                event(1, "turn_started", serde_json::json!({ "turn": 1 })),
+                event(
+                    2,
+                    "turn_completed",
+                    serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                ),
+            ],
+        });
+        let mut live = runtime.get_session(&owner, session_id).await.unwrap();
+        let remote = runtime.remote_sessions().unwrap();
+        let driver = remote.driver(&runtime.db, runtime.bus.as_ref());
+        driver.pump(&mut live, 0).await.unwrap();
+
+        // The promotion runs with the stale snapshot: B's text goes to the
+        // sandbox, and the claim must consume B's row under its own id.
+        let workspace = runtime
+            .get_workspace(&owner, live.workspace_id)
+            .await
+            .unwrap();
+        let stored_repo = runtime.get_repo(&owner, workspace.repo_id).await.unwrap();
+        let mut promoting = runtime.get_session(&owner, session_id).await.unwrap();
+        let outcome = driver
+            .submit_turn_from(
+                &mut promoting,
+                &workspace,
+                &stored_repo,
+                &stale.message,
+                Some(&stale),
+            )
+            .await
+            .unwrap();
+        let super::super::driver::RemoteTurnOutcome::Delivered { turn } = outcome else {
+            panic!("the promotion must deliver, got {outcome:?}");
+        };
+        assert_eq!(
+            turn.id, row_b.id,
+            "a moved row promotes under its own id, keeping the event linkage"
+        );
+        let remaining =
+            tidebreak_core::db::code::list_queued_turns(&runtime.db, &owner, session_id)
+                .await
+                .unwrap();
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|row| row.message.as_str())
+                .collect::<Vec<_>>(),
+            vec!["message A"],
+            "B's row must be consumed; only A stays queued"
+        );
+
+        // The channel's replay of EvB now answers the promoted turn.
+        let replay = runtime
+            .external_submit_message(
+                &owner,
+                grant,
+                session_id,
+                "message B".into(),
+                "EvB",
+                "1700000002.000100",
+            )
+            .await
+            .unwrap();
+        let ExternalMessageOutcome::NewTurn(replayed) = replay else {
+            panic!("EvB's replay must answer the promoted turn, got {replay:?}");
+        };
+        assert_eq!(replayed.id, row_b.id);
+    }
+
     /// A repository with no recorded origin cannot back a remote workspace:
     /// the sandbox would have nothing to clone.
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -149,6 +149,21 @@ pub(crate) enum SubmitTurnOutcome {
     AlreadyDelivered,
 }
 
+/// Result of one external message delivery (`docs/slack-sessions.md`,
+/// stage 2). A replayed delivery answers with the same shape the first one
+/// earned, derived from the row's current state.
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug)]
+pub(crate) enum ExternalMessageOutcome {
+    /// The message became a running turn.
+    NewTurn(Box<CodeTurn>),
+    /// The session was busy; the message sits as a durable queue row.
+    Queued(Box<CodeQueuedTurn>),
+    /// The row the first delivery caused was retracted before it could
+    /// run; the replay has nothing to point at.
+    Dropped,
+}
+
 enum LivePermissionModeOutcome {
     Unavailable,
     RelaunchRequired,
@@ -4177,79 +4192,172 @@ impl CodeRuntime {
     /// remote sweep; local sessions drain their own queues through their
     /// workers and are skipped here.
     pub(crate) async fn promote_remote_queue_heads(&self) -> Result<(), ServerError> {
+        if self.remote.is_none() {
+            return Ok(());
+        }
+        let sessions = list_sessions_all_owners(&self.db).await?;
+        for session in sessions {
+            self.try_promote_remote_head(session).await?;
+        }
+        Ok(())
+    }
+
+    /// Promote one idle remote session's queue head, when it has one and
+    /// nothing holds promotion. Shared by the sweep and the external
+    /// messages path, which tries the head immediately after enqueueing
+    /// rather than waiting out a sweep tick.
+    async fn try_promote_remote_head(&self, mut session: CodeSession) -> Result<(), ServerError> {
         let Some(remote) = self.remote_sessions() else {
             return Ok(());
         };
-        let sessions = list_sessions_all_owners(&self.db).await?;
-        for mut session in sessions {
-            if session.lifecycle != CodeSessionLifecycle::Idle {
-                continue;
+        if session.lifecycle != CodeSessionLifecycle::Idle {
+            return Ok(());
+        }
+        let Ok(workspace) = self
+            .get_workspace(&session.owner, session.workspace_id)
+            .await
+        else {
+            return Ok(());
+        };
+        if !workspace.is_remote() {
+            return Ok(());
+        }
+        if tidebreak_core::db::code::queue_paused(&self.db, &session.owner, session.id).await? {
+            return Ok(());
+        }
+        if remote.promotion_held(session.id) {
+            return Ok(());
+        }
+        let Some(head) = queued_turn_head(&self.db, &session.owner, session.id).await? else {
+            return Ok(());
+        };
+        let Ok(repo) = self.get_repo(&session.owner, workspace.repo_id).await else {
+            return Ok(());
+        };
+        let driver = remote.driver(&self.db, self.bus.as_ref());
+        let message = head.message.clone();
+        use super::remote::driver::RemoteTurnOutcome as Outcome;
+        match driver
+            .submit_turn_from(&mut session, &workspace, &repo, &message, Some(&head))
+            .await
+        {
+            // The claim was the atomic promotion; nothing to delete.
+            Ok(Outcome::Delivered { .. }) | Ok(Outcome::Reincarnated { .. }) => {
+                remote.clear_promotion_hold(session.id);
             }
-            let Ok(workspace) = self
-                .get_workspace(&session.owner, session.workspace_id)
-                .await
-            else {
-                continue;
-            };
-            if !workspace.is_remote() {
-                continue;
+            // Permanent for this session: nothing exposes a way to raise
+            // the ceiling, and every retry would re-journal the refusal
+            // and re-cancel the sandbox. Pause the queue so the tray
+            // shows why nothing moves; unpausing retries deliberately.
+            Ok(Outcome::SpendExhausted { .. }) => {
+                let _ = tidebreak_core::db::code::set_queue_paused(
+                    &self.db,
+                    &session.owner,
+                    session.id,
+                    true,
+                )
+                .await;
             }
-            if tidebreak_core::db::code::queue_paused(&self.db, &session.owner, session.id).await? {
-                continue;
+            // Transient machine-side refusals: hold retries so the
+            // notice and attention do not repeat every sweep tick. The
+            // hold expiring retries on its own once the slot may be
+            // free or the owner has signed in.
+            Ok(Outcome::CapExhausted { .. }) | Ok(Outcome::SignInRequired) => {
+                remote.hold_promotion(session.id);
             }
-            if remote.promotion_held(session.id) {
-                continue;
-            }
-            let Some(head) = queued_turn_head(&self.db, &session.owner, session.id).await? else {
-                continue;
-            };
-            let Ok(repo) = self.get_repo(&session.owner, workspace.repo_id).await else {
-                continue;
-            };
-            let driver = remote.driver(&self.db, self.bus.as_ref());
-            let message = head.message.clone();
-            use super::remote::driver::RemoteTurnOutcome as Outcome;
-            match driver
-                .submit_turn_from(&mut session, &workspace, &repo, &message, Some(&head))
-                .await
-            {
-                // The claim was the atomic promotion; nothing to delete.
-                Ok(Outcome::Delivered { .. }) | Ok(Outcome::Reincarnated { .. }) => {
-                    remote.clear_promotion_hold(session.id);
-                }
-                // Permanent for this session: nothing exposes a way to raise
-                // the ceiling, and every retry would re-journal the refusal
-                // and re-cancel the sandbox. Pause the queue so the tray
-                // shows why nothing moves; unpausing retries deliberately.
-                Ok(Outcome::SpendExhausted { .. }) => {
-                    let _ = tidebreak_core::db::code::set_queue_paused(
-                        &self.db,
-                        &session.owner,
-                        session.id,
-                        true,
-                    )
-                    .await;
-                }
-                // Transient machine-side refusals: hold retries so the
-                // notice and attention do not repeat every sweep tick. The
-                // hold expiring retries on its own once the slot may be
-                // free or the owner has signed in.
-                Ok(Outcome::CapExhausted { .. }) | Ok(Outcome::SignInRequired) => {
-                    remote.hold_promotion(session.id);
-                }
-                // Busy shapes: the row stays queued for the next idle.
-                Ok(_) => {}
-                Err(error) => {
-                    tracing::warn!(
-                        session = %session.id,
-                        %error,
-                        "promoting a queued remote message failed; the row stays queued"
-                    );
-                    remote.hold_promotion(session.id);
-                }
+            // Busy shapes: the row stays queued for the next idle.
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(
+                    session = %session.id,
+                    %error,
+                    "promoting a queued remote message failed; the row stays queued"
+                );
+                remote.hold_promotion(session.id);
             }
         }
         Ok(())
+    }
+
+    /// Take one external message for a bound session
+    /// (`docs/slack-sessions.md`, stage 2).
+    ///
+    /// Idempotent across the channel's retries: the event id commits with
+    /// the queue row it causes, and a replay derives its answer from that
+    /// row's current state — still queued, promoted into a turn, or
+    /// retracted — without writing a second row. An idle session promotes
+    /// the head immediately; a busy one queues durably.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) async fn external_submit_message(
+        &self,
+        owner: &OwnerId,
+        grant_id: tidebreak_core::CodeGrantId,
+        session_id: CodeSessionId,
+        message: String,
+        event_id: &str,
+        channel_ts: &str,
+    ) -> Result<ExternalMessageOutcome, ServerError> {
+        if self.remote.is_none() {
+            return Err(ServerError::conflict_kind(
+                "remote_disabled",
+                "this deployment has no sandbox runtime configured",
+            ));
+        }
+        if !tidebreak_core::db::code::session_bound_to_grant(&self.db, owner, session_id, grant_id)
+            .await?
+        {
+            return Err(ServerError::conflict_kind(
+                "grant_scope",
+                "this grant holds no binding to that session",
+            ));
+        }
+        let session = self.get_session(owner, session_id).await?;
+        match session.lifecycle {
+            CodeSessionLifecycle::Ended => {
+                return Err(ServerError::conflict_kind(
+                    "session_ended",
+                    "the bound session has ended; the conversation is closed",
+                ));
+            }
+            CodeSessionLifecycle::Fenced => {
+                return Err(ServerError::conflict_kind(
+                    "session_fenced",
+                    "the bound session is fenced pending a reap",
+                ));
+            }
+            _ => {}
+        }
+        let record = tidebreak_core::db::code::record_external_message(
+            &self.db, owner, session_id, event_id, channel_ts, &message,
+        )
+        .await?;
+        let (turn_id, fresh) = match &record {
+            tidebreak_core::ExternalMessageRecord::Recorded(row) => (row.id, true),
+            tidebreak_core::ExternalMessageRecord::Replay { turn_id } => (*turn_id, false),
+        };
+        if fresh {
+            // Best effort: a refusal leaves the row queued for the sweep.
+            let session = self.get_session(owner, session_id).await?;
+            if let Err(error) = self.try_promote_remote_head(session).await {
+                tracing::warn!(
+                    session = %session_id,
+                    ?error,
+                    "promoting an external message failed; the row stays queued"
+                );
+            }
+        }
+        if let Some(row) = tidebreak_core::db::code::list_queued_turns(&self.db, owner, session_id)
+            .await?
+            .into_iter()
+            .find(|row| row.id == turn_id)
+        {
+            return Ok(ExternalMessageOutcome::Queued(Box::new(row)));
+        }
+        if let Some(turn) = tidebreak_core::db::code::get_turn(&self.db, owner, turn_id).await? {
+            return Ok(ExternalMessageOutcome::NewTurn(Box::new(turn)));
+        }
+        // The row the first delivery caused was retracted before it ran.
+        Ok(ExternalMessageOutcome::Dropped)
     }
 
     /// Park a message as a durable queue row (decision 69).


### PR DESCRIPTION
Stage 2 of docs/slack-sessions.md, slice 2 (#2892). Builds on the binding table from #2896.

## What

- New `code_external_event` table: one row per channel event, unique on `(owner, session_id, event_id)`. The event row and the queue row it causes commit in one transaction, and `turn_id` names that row — the queue row's id becomes the promoted turn's id (decision 69), so one id follows the message through its whole life.
- `record_external_message` (core op): first delivery parks the message as a durable queue row and records the event; a replay answers `Replay { turn_id }` and writes nothing. A concurrent duplicate delivery loses on the unique key, rolls back whole, and answers with the winner's id.
- Ordering: each event carries the channel's ordering token (`channel_ts`, compared lexicographically — Slack's fixed-width epoch format sorts correctly this way). The insert reorders the session's still-queued external rows by that token, permuting them within their own position slots so desktop follow-ups keep their place. A row already promoted into a turn is outside the window and never moves, so "A then B" cannot become "B steered by A".
- `CodeRuntime::external_submit_message`: scopes by grant (`session_bound_to_grant`), refuses ended and fenced sessions, records the event, promotes the head immediately when the session is idle, and derives the outcome — `NewTurn`, `Queued`, or `Dropped` (the row was retracted before it ran) — from the row's current state. The remote sweep and the immediate promotion now share one per-session helper.

No route speaks this yet; the grant-authenticated routes are #2894.

## Done-when (from #2892)

- A replayed `event_id` returns the row-derived outcome without a second turn: pinned by `a_replayed_external_message_records_once` (core) and `an_external_message_is_idempotent_and_queues_busy` (runtime — replay of a promoted event answers the same turn with no second spawn).
- Out-of-order `ts` within the window applies in order: `out_of_order_external_messages_apply_in_channel_order`.
- The busy path queues durably, and a replay of a queued event answers the same row: the runtime test covers both.

## Checks run

`cargo fmt --all`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test -p tidebreak-core --lib` (796 passed), `cargo test -p tidebreak-server --lib remote` (68 passed).


Closes #2892.
