### PR TITLE
fix(code): explain remote trigger and attachment refusals

### DIFF
--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1017,6 +1017,82 @@ mod tests {
         assert!(fake.spawns.lock().unwrap().is_empty());
     }
 
+    /// Remote trigger and attachment delivery stay refused until the runtime
+    /// can preserve their delivery contracts. Neither refusal may reach the
+    /// sandbox or create a turn row.
+    #[tokio::test]
+    async fn remote_inputs_without_transport_contracts_are_refused_before_delivery() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
+        let workspace = runtime
+            .create_remote_workspace(&owner, repo.id, Some("remote".into()))
+            .await
+            .unwrap();
+        let session = runtime
+            .create_remote_session(
+                &owner,
+                workspace.id,
+                HarnessKind::ClaudeCode,
+                session_settings(),
+            )
+            .await
+            .unwrap();
+
+        let trigger_error = match runtime
+            .submit_trigger_turn(
+                &owner,
+                session.id,
+                "review changed".into(),
+                tidebreak_core::CodeTriggerDeliveryId::new(),
+                uuid::Uuid::new_v4(),
+            )
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("remote trigger delivery must refuse"),
+        };
+        assert_eq!(trigger_error.kind(), "remote_triggers_unsupported");
+        assert!(
+            trigger_error.message().contains("idempotency key"),
+            "{}",
+            trigger_error.message()
+        );
+
+        let attachment_error = match runtime
+            .submit_turn(
+                &owner,
+                session.id,
+                "inspect this".into(),
+                None,
+                None,
+                vec![tidebreak_core::ImageRef {
+                    blob_id: uuid::Uuid::new_v4(),
+                    media_type: tidebreak_core::ImageMediaType::Png,
+                    width: 1,
+                    height: 1,
+                    byte_len: 1,
+                }],
+            )
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("remote attachment delivery must refuse"),
+        };
+        assert_eq!(attachment_error.kind(), "remote_attachments_unsupported");
+        assert!(
+            attachment_error.message().contains("carries text only"),
+            "{}",
+            attachment_error.message()
+        );
+
+        assert!(fake.spawns.lock().unwrap().is_empty());
+        assert!(fake.sends.lock().unwrap().is_empty());
+        assert!(latest_turn(&runtime.db, &owner, session.id)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
     /// Host worktree reads refuse a remote workspace with the remote marker
     /// instead of treating the empty path as a missing checkout.
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -4065,15 +4065,21 @@ impl CodeRuntime {
             ));
         };
         if trigger_delivery.is_some() {
+            // Trigger delivery is at-most-once. The runtime's spawn and inbox
+            // calls accept no idempotency key and expose no replay result, so
+            // retrying an ambiguous response could run one trigger twice.
             return Err(ServerError::conflict_kind(
                 "remote_triggers_unsupported",
-                "trigger turns do not reach remote sessions yet",
+                "remote trigger turns are disabled because sandbox spawn and inbox calls have no idempotency key; submit the turn manually",
             ));
         }
         if !attachments.is_empty() {
+            // Remote messages carry text only. Until the runtime provides a
+            // bounded, owner-scoped file transfer, attachment bytes have no
+            // safe path into the sandbox.
             return Err(ServerError::conflict_kind(
                 "remote_attachments_unsupported",
-                "remote sessions do not take attachments yet",
+                "remote sessions cannot stage attachment bytes because the sandbox message contract carries text only; send the turn without attachments",
             ));
         }
         // Settings stick without local capability validation: the sandbox

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -58,11 +58,11 @@ criteria" and "Stage: scratch workspaces").
   ([`0063`](decisions/0063-hosted-machines-borrow-forge-credentials.md),
   [`0065`](decisions/0065-hosted-git-acts-as-the-person.md)). Every trust
   statement in this design is made with that unscoped token in mind.
-- Remote session execution is parked in [`deferred.md`](deferred.md).
-  Decision [`0079`](decisions/0079-supervised-agent-declines-the-sandbox-protocol.md)
-  built the agent side only. Everything Tidebreak-side — provisioning,
-  incarnation tracking, event ingestion, resume — is unbuilt and is the
-  heaviest work in this design.
+- Remote session execution now provisions sandboxes, tracks incarnations,
+  ingests events, resumes from pushed WIP refs, and reaps fenced sessions.
+  Trigger turns and image attachments remain typed refusals because the
+  runtime contract cannot preserve their delivery rules; Execution records
+  those product boundaries.
 - The environment that provisions and confines the sandbox is external to
   this repository. Tidebreak calls its spawn, steer, and event APIs and
   requests ceilings at spawn; it does not own enforcement of them. Naming
@@ -442,6 +442,21 @@ micro-USD per session. `TIDEBREAK_RUNTIME_CONCURRENCY_CAP` changes the first.
 `none` leaves that Tidebreak ceiling unset. The runtime profile may still
 impose a lower ceiling. A refusal names the setting that the operator can
 raise before restarting Tidebreak.
+
+Two remote inputs stay refused until the runtime contract can preserve their
+existing safety properties:
+
+- Code trigger turns are at-most-once. Sandbox spawn and inbox calls accept no
+  idempotency key and expose no replay result. If Tidebreak retried an
+  ambiguous response, one pull-request event could run twice. Tidebreak keeps
+  returning `remote_triggers_unsupported` until the runtime accepts a stable
+  operation key and returns the prior outcome on replay.
+- Image attachments never enter transcript text. The sandbox message contract
+  carries text only, and spawn can clone repositories but cannot stage a
+  bounded owner-scoped blob. Tidebreak keeps returning
+  `remote_attachments_unsupported` until the runtime provides that file
+  transfer. Base64 in the prompt and temporary repository commits are not
+  acceptable substitutes.
 
 Remote sessions get their own fence causes — incarnation intent
 unresolved, sandbox lost mid-turn, terminal flush missing — because the


### PR DESCRIPTION
## What changed

- Record why remote code-trigger turns remain refused: trigger delivery is at-most-once, while sandbox spawn and inbox calls have no idempotency key or replay result.
- Record why remote image attachments remain refused: the sandbox message contract carries text and has no bounded owner-scoped file transfer.
- Make both typed conflict messages explain the boundary and the immediate fallback.
- Add a regression test proving that neither refusal spawns a sandbox, sends a message, or creates a turn.
- Update the Slack sessions design page so these refusals are explicit product decisions, as #2889 allows.

This completes the refusal-decision slice of #2889. The refusals can lift when the runtime contract gains the missing delivery primitives.

## Validation

- `cargo test -p tidebreak-server remote_inputs_without_transport_contracts_are_refused_before_delivery`
- `cargo test -p tidebreak-server code::remote::` (49 passed)
- `cargo clippy -p tidebreak-server --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
