### PR TITLE
feat(server): store self-host credentials in Vault KV

### DIFF
--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -15,9 +15,10 @@
 //! `tidebreak mcp <workspace>` serves the built-in read-only filesystem tools over
 //! MCP stdio, confined to the explicit workspace directory.
 //!
-//! `tidebreak rehome-secrets` rewrites the profile's stored credentials so their
-//! keychain items belong to the running binary's code signature, which is what
-//! stops macOS asking for credentials an earlier build created.
+//! `tidebreak rehome-secrets` rewrites the desktop profile's stored credentials
+//! so their keychain items belong to the running binary's code signature, which
+//! stops macOS asking for credentials an earlier build created. Self-host
+//! profiles reject this command because they never use the OS keychain.
 //!
 //! `tidebreak output list|show|revisions|export <chat> …` reads a conversation's
 //! outputs and writes one to a path, and `tidebreak attach <chat> <file>` puts a
@@ -1013,8 +1014,8 @@ async fn serve() -> Result<()> {
     server.serve().await
 }
 
-/// Rewrite this profile's stored credentials so their item belongs to this
-/// binary's code signature.
+/// Rewrite the desktop profile's stored credentials so their item belongs to
+/// this binary's code signature.
 ///
 /// macOS keeps prompting for credentials an earlier, differently signed build
 /// created — see [`tidebreak_server::secret_rehome`] for why an approval given at

--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -5,7 +5,7 @@
 //! - **Boot config** — this module. The immutable, start-of-day settings needed
 //!   *before* the store exists: which [`Profile`] to run and where app data
 //!   lives. The profile selects which backend implementations get wired at boot
-//!   (SQLite vs Postgres, keychain vs KMS, …).
+//!   (SQLite vs Postgres, keychain vs Vault, …).
 //! - **Runtime settings** — the mutable, per-user settings that live in the
 //!   `Store`'s `setting` table (enabled model provider + chosen model, approval
 //!   policy, preferences). Reached with `Store::get_setting` / `set_setting`;
@@ -28,8 +28,96 @@ pub enum Profile {
     /// Single-user desktop: SQLite, OS keychain, local filesystem. The default.
     #[default]
     Desktop,
-    /// Self-hosted server: Postgres, env/KMS secrets, object storage.
+    /// Self-hosted server: Postgres, Vault or environment secrets, object storage.
     SelfHost,
+}
+
+/// HashiCorp Vault KV v2 custody for a self-host profile's stored secrets.
+///
+/// The token is read from `token_file` by the server for every Vault request.
+/// Keeping the credential out of this serializable boot config prevents it
+/// from entering diagnostics or persisted configuration by accident.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VaultSecretConfig {
+    /// Vault server base URL. HTTPS is required outside literal loopback development.
+    pub address: String,
+    /// Mounted file containing the Vault token.
+    pub token_file: PathBuf,
+    /// KV v2 mount path, such as `secret`.
+    pub mount: String,
+    /// Secret path below the mount, such as `tidebreak/production`.
+    pub path: String,
+    /// Optional Vault Enterprise or HCP namespace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+}
+
+impl VaultSecretConfig {
+    const DEFAULT_MOUNT: &'static str = "secret";
+    const DEFAULT_PATH: &'static str = "tidebreak";
+
+    fn from_vars(
+        address: Option<String>,
+        token_file: Option<OsString>,
+        mount: Option<String>,
+        path: Option<String>,
+        namespace: Option<String>,
+    ) -> Result<Option<Self>> {
+        let address = address.filter(|value| !value.trim().is_empty());
+        let token_file = token_file
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from);
+        let mount = mount.filter(|value| !value.trim().is_empty());
+        let path = path.filter(|value| !value.trim().is_empty());
+        let namespace = namespace.filter(|value| !value.trim().is_empty());
+        let configured = address.is_some()
+            || token_file.is_some()
+            || mount.is_some()
+            || path.is_some()
+            || namespace.is_some();
+        if !configured {
+            return Ok(None);
+        }
+        let address = address.ok_or_else(|| {
+            AgentError::config(
+                "TIDEBREAK_VAULT_ADDR is required when Vault secret custody is configured",
+            )
+        })?;
+        let token_file = token_file.ok_or_else(|| {
+            AgentError::config(
+                "TIDEBREAK_VAULT_TOKEN_FILE is required when Vault secret custody is configured",
+            )
+        })?;
+        let mount = normalize_vault_path(
+            "TIDEBREAK_VAULT_MOUNT",
+            mount.as_deref().unwrap_or(Self::DEFAULT_MOUNT),
+        )?;
+        let path = normalize_vault_path(
+            "TIDEBREAK_VAULT_PATH",
+            path.as_deref().unwrap_or(Self::DEFAULT_PATH),
+        )?;
+        Ok(Some(Self {
+            address: address.trim().to_string(),
+            token_file,
+            mount,
+            path,
+            namespace: namespace.map(|value| value.trim().to_string()),
+        }))
+    }
+}
+
+fn normalize_vault_path(name: &str, value: &str) -> Result<String> {
+    let value = value.trim().trim_matches('/');
+    if value.is_empty()
+        || value
+            .split('/')
+            .any(|segment| segment.is_empty() || matches!(segment, "." | ".."))
+    {
+        return Err(AgentError::config(format!(
+            "{name} must contain non-empty path segments and no `.` or `..` segment"
+        )));
+    }
+    Ok(value.to_string())
 }
 
 /// Boot configuration.
@@ -117,6 +205,13 @@ pub struct Config {
     /// path prefix, without a trailing slash).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_url: Option<String>,
+    /// Remote credential custody for the self-host profile.
+    ///
+    /// When absent, provider environment variables remain readable, but
+    /// deployment-plane credential writes fail with an operator-facing setup
+    /// error instead of reaching the desktop OS keychain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vault_secrets: Option<VaultSecretConfig>,
     /// The address the API binds, for deployments that must be reachable from
     /// outside the machine (a container publishing a port, say). `None` — the
     /// default — keeps the loopback, ephemeral-port bind every profile has
@@ -257,6 +352,7 @@ impl Config {
             auth_gateway_url: None,
             auth_gateway_verifier_url: None,
             public_url: None,
+            vault_secrets: None,
             listen_addr: None,
             runtime_endpoint: None,
             runtime_profile: None,
@@ -277,7 +373,10 @@ impl Config {
     /// image), `TIDEBREAK_AUTH_TOKENS_FILE` or `TIDEBREAK_AUTH_GATEWAY_URL`
     /// (self-host only; exactly one is required there), optional
     /// `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` for cluster-internal validation,
-    /// `TIDEBREAK_PUBLIC_URL` for machine-bound Gateway credentials,
+    /// `TIDEBREAK_PUBLIC_URL` for machine-bound Gateway credentials, optional
+    /// `TIDEBREAK_VAULT_ADDR` and `TIDEBREAK_VAULT_TOKEN_FILE` for self-host
+    /// credential custody, plus optional `TIDEBREAK_VAULT_MOUNT`,
+    /// `TIDEBREAK_VAULT_PATH`, and `TIDEBREAK_VAULT_NAMESPACE`,
     /// `TIDEBREAK_LISTEN_ADDR` (self-host only; default loopback on an
     /// ephemeral port), and optional `TIDEBREAK_RUNTIME_ENDPOINT` plus
     /// `TIDEBREAK_RUNTIME_PROFILE` together to enable remote sessions. Remote
@@ -285,6 +384,13 @@ impl Config {
     /// `TIDEBREAK_RUNTIME_SPAWN_SPEND_CEILING_MICROUSD`, and
     /// `TIDEBREAK_RUNTIME_SESSION_SPEND_CEILING_MICROUSD`.
     pub fn from_env() -> Result<Self> {
+        let vault_secrets = VaultSecretConfig::from_vars(
+            std::env::var("TIDEBREAK_VAULT_ADDR").ok(),
+            std::env::var_os("TIDEBREAK_VAULT_TOKEN_FILE"),
+            std::env::var("TIDEBREAK_VAULT_MOUNT").ok(),
+            std::env::var("TIDEBREAK_VAULT_PATH").ok(),
+            std::env::var("TIDEBREAK_VAULT_NAMESPACE").ok(),
+        )?;
         Self::from_vars(
             std::env::var("TIDEBREAK_PROFILE").ok(),
             std::env::var_os("TIDEBREAK_DATA_DIR"),
@@ -297,6 +403,7 @@ impl Config {
             std::env::var("TIDEBREAK_LISTEN_ADDR").ok(),
             std::env::var("TIDEBREAK_RUNTIME_ENDPOINT").ok(),
             std::env::var("TIDEBREAK_RUNTIME_PROFILE").ok(),
+            vault_secrets,
         )?
         .with_runtime_limit_vars(
             std::env::var("TIDEBREAK_RUNTIME_CONCURRENCY_CAP").ok(),
@@ -325,6 +432,7 @@ impl Config {
         listen_addr: Option<String>,
         runtime_endpoint: Option<String>,
         runtime_profile: Option<String>,
+        vault_secrets: Option<VaultSecretConfig>,
     ) -> Result<Self> {
         let profile = match profile.filter(|value| !value.is_empty()).as_deref() {
             None | Some("desktop") => Profile::Desktop,
@@ -354,6 +462,11 @@ impl Config {
         let auth_gateway_verifier_url =
             auth_gateway_verifier_url.filter(|value| !value.trim().is_empty());
         let public_url = public_url.filter(|value| !value.trim().is_empty());
+        if profile != Profile::SelfHost && vault_secrets.is_some() {
+            return Err(AgentError::config(
+                "Vault secret custody is available only with TIDEBREAK_PROFILE=self_host",
+            ));
+        }
         let listen_addr = match listen_addr.filter(|value| !value.is_empty()) {
             None => None,
             Some(value) => Some(value.parse::<SocketAddr>().map_err(|_| {
@@ -385,6 +498,7 @@ impl Config {
             auth_gateway_url,
             auth_gateway_verifier_url,
             public_url,
+            vault_secrets,
             listen_addr,
             runtime_endpoint,
             runtime_profile,
@@ -588,6 +702,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         let expected = std::env::current_dir().unwrap().join(".tidebreak");
@@ -600,6 +715,7 @@ mod tests {
         let config = Config::from_vars(
             Some(String::new()),
             Some(OsString::from("/data")),
+            None,
             None,
             None,
             None,
@@ -630,6 +746,7 @@ mod tests {
             None,
             Some("primary".into()),
             None,
+            None,
         );
         assert!(refused.is_err());
         let config = Config::from_vars(
@@ -644,6 +761,7 @@ mod tests {
             None,
             Some("primary".into()),
             Some("tidebreak-remote".into()),
+            None,
         )
         .unwrap();
         assert_eq!(config.runtime_endpoint.as_deref(), Some("primary"));
@@ -695,6 +813,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(config.profile, Profile::SelfHost);
@@ -709,6 +828,7 @@ mod tests {
     fn unknown_profile_var_is_an_error() {
         assert!(Config::from_vars(
             Some("bogus".into()),
+            None,
             None,
             None,
             None,
@@ -753,6 +873,7 @@ mod tests {
             Some("0.0.0.0:8080".into()),
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -772,6 +893,7 @@ mod tests {
             None,
             None,
             Some("0.0.0.0".into()),
+            None,
             None,
             None
         )
@@ -803,6 +925,7 @@ mod tests {
             config.runtime_session_spend_ceiling_microusd,
             Some(20_000_000)
         );
+        assert_eq!(config.vault_secrets, None);
     }
 
     #[test]
@@ -842,6 +965,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         assert!(config.container_execution_enabled);
@@ -853,6 +977,7 @@ mod tests {
             None,
             None,
             Some("yes".into()),
+            None,
             None,
             None,
             None,
@@ -879,6 +1004,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -893,6 +1019,109 @@ mod tests {
             config.public_url.as_deref(),
             Some("https://tidebreak.example.test")
         );
+    }
+
+    #[test]
+    fn complete_vault_vars_are_normalized() {
+        let vault = VaultSecretConfig::from_vars(
+            Some(" https://vault.example.test ".into()),
+            Some(OsString::from("/run/secrets/vault-token")),
+            Some("/secret/".into()),
+            Some("/tidebreak/production/".into()),
+            Some(" platform/team-a ".into()),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(vault.address, "https://vault.example.test");
+        assert_eq!(vault.token_file, PathBuf::from("/run/secrets/vault-token"));
+        assert_eq!(vault.mount, "secret");
+        assert_eq!(vault.path, "tidebreak/production");
+        assert_eq!(vault.namespace.as_deref(), Some("platform/team-a"));
+
+        let config = Config::from_vars(
+            Some("self_host".into()),
+            Some(OsString::from("/data")),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(vault.clone()),
+        )
+        .unwrap();
+        assert_eq!(config.vault_secrets, Some(vault));
+    }
+
+    #[test]
+    fn incomplete_vault_vars_are_rejected() {
+        let missing_address = VaultSecretConfig::from_vars(
+            None,
+            Some(OsString::from("/run/secrets/vault-token")),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(missing_address.contains("TIDEBREAK_VAULT_ADDR"));
+
+        let missing_token_file = VaultSecretConfig::from_vars(
+            Some("https://vault.example.test".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(missing_token_file.contains("TIDEBREAK_VAULT_TOKEN_FILE"));
+    }
+
+    #[test]
+    fn invalid_vault_paths_are_rejected() {
+        for (mount, path) in [
+            ("/", "tidebreak"),
+            ("secret", "tidebreak//production"),
+            ("secret/../other", "tidebreak"),
+            ("secret", "./tidebreak"),
+        ] {
+            let error = VaultSecretConfig::from_vars(
+                Some("https://vault.example.test".into()),
+                Some(OsString::from("/run/secrets/vault-token")),
+                Some(mount.into()),
+                Some(path.into()),
+                None,
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(
+                error.contains("TIDEBREAK_VAULT_MOUNT") || error.contains("TIDEBREAK_VAULT_PATH"),
+                "unexpected error for mount={mount:?} path={path:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn desktop_profile_rejects_vault_settings() {
+        let vault = VaultSecretConfig::from_vars(
+            Some("https://vault.example.test".into()),
+            Some(OsString::from("/run/secrets/vault-token")),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let error = Config::from_vars(
+            None, None, None, None, None, None, None, None, None, None, None, vault,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("TIDEBREAK_PROFILE=self_host"));
     }
 
     #[test]

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -220,7 +220,7 @@ pub use computer_use::{
     COMPUTER_USE_CONTROL_TOOLS, COMPUTER_USE_TOOLS, COMPUTER_WAIT_TOOL, MAX_MARK, MAX_READ_DEPTH,
     MAX_READ_NODES, MAX_TYPE_TEXT_CHARS, MAX_WAIT_SECONDS,
 };
-pub use config::{Config, Profile};
+pub use config::{Config, Profile, VaultSecretConfig};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use db::DbStore;
 pub use deliverable::{

--- a/crates/tidebreak-server/src/code_execution/config.rs
+++ b/crates/tidebreak-server/src/code_execution/config.rs
@@ -879,10 +879,9 @@ pub async fn write_credential(
     api_key: &str,
 ) -> std::result::Result<ExecCredentialReadiness, ServerError> {
     let (key, label) = credential_spec(provider)?;
-    secrets
-        .set_secret(key, api_key)
-        .await
-        .map_err(|_| ServerError::internal(format!("{label} credential storage is unavailable")))?;
+    secrets.set_secret(key, api_key).await.map_err(|error| {
+        ServerError::credential_storage(error, format!("{label} credential storage is unavailable"))
+    })?;
     Ok(ExecCredentialReadiness {
         provider,
         has_credential: true,
@@ -894,10 +893,9 @@ pub async fn delete_credential(
     provider: ExecProviderKind,
 ) -> std::result::Result<ExecCredentialReadiness, ServerError> {
     let (key, label) = credential_spec(provider)?;
-    secrets
-        .delete_secret(key)
-        .await
-        .map_err(|_| ServerError::internal(format!("{label} credential storage is unavailable")))?;
+    secrets.delete_secret(key).await.map_err(|error| {
+        ServerError::credential_storage(error, format!("{label} credential storage is unavailable"))
+    })?;
     Ok(ExecCredentialReadiness {
         provider,
         has_credential: false,

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -183,6 +183,16 @@ impl ServerError {
             },
         }
     }
+
+    /// Keep secret-store setup errors that an operator can fix while redacting
+    /// all other backend details behind a route-specific fallback message.
+    pub(crate) fn credential_storage(error: AgentError, fallback: impl Into<String>) -> Self {
+        if matches!(error, AgentError::Config(_)) {
+            Self::from(error)
+        } else {
+            Self::internal(fallback)
+        }
+    }
 }
 
 /// Core errors surfacing from a handler are normally internal failures. The
@@ -220,5 +230,22 @@ mod tests {
         assert_eq!(error.status, StatusCode::NOT_FOUND);
         assert_eq!(error.info.kind, "not_found");
         assert!(error.info.message.contains(&project_id.to_string()));
+    }
+
+    #[test]
+    fn credential_storage_keeps_setup_guidance_and_redacts_backend_failures() {
+        let setup = ServerError::credential_storage(
+            AgentError::config("set TIDEBREAK_VAULT_ADDR"),
+            "credential storage is unavailable",
+        );
+        assert_eq!(setup.kind(), "config");
+        assert!(setup.message().contains("TIDEBREAK_VAULT_ADDR"));
+
+        let backend = ServerError::credential_storage(
+            AgentError::Secret("private keychain detail".into()),
+            "credential storage is unavailable",
+        );
+        assert_eq!(backend.kind(), "internal");
+        assert_eq!(backend.message(), "credential storage is unavailable");
     }
 }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1758,6 +1758,11 @@ async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_par
 /// restart. Its misses re-ask the store instead; an absent item answers
 /// `NoEntry` without an ACL prompt, so the slow-path rereads are cheap.
 fn secret_provider(config: &Config) -> Result<ProfileSecrets> {
+    if config.profile != Profile::SelfHost && config.vault_secrets.is_some() {
+        return Err(AgentError::config(
+            "Vault secret custody is available only with TIDEBREAK_PROFILE=self_host",
+        ));
+    }
     let storage: Arc<dyn SecretProvider> = match config.profile {
         Profile::Desktop => Arc::new(match &config.keychain_service {
             Some(service) => KeychainSecretProvider::with_service(service),
@@ -1858,6 +1863,25 @@ mod profile_secret_tests {
             .to_string();
         assert!(error.contains("desktop profile"));
         assert!(error.contains("OS keychain"));
+    }
+
+    #[test]
+    fn desktop_provider_rejects_programmatic_vault_settings() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut config = Config::desktop(directory.path());
+        config.vault_secrets = Some(tidebreak_core::VaultSecretConfig {
+            address: "https://vault.example.test".into(),
+            token_file: directory.path().join("vault-token"),
+            mount: "secret".into(),
+            path: "tidebreak".into(),
+            namespace: None,
+        });
+
+        let error = match secret_provider(&config) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("desktop accepted Vault settings"),
+        };
+        assert!(error.contains("TIDEBREAK_PROFILE=self_host"));
     }
 }
 

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -103,6 +103,7 @@ mod state;
 mod store_ownership;
 mod task_plan_tool;
 mod turn_worker;
+mod vault_secrets;
 mod view_frames;
 pub mod voice_transcription;
 /// Host-owned, inert web-search configuration and provider selection.
@@ -1741,11 +1742,11 @@ async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_par
 
 /// The secret store the configured profile keeps its credentials in.
 ///
-/// Two decorators over the OS keychain, and the order matters.
-/// [`BundledSecretProvider`] puts every key in one stored item, so an app
-/// update costs one access prompt rather than one per credential.
-/// [`CachingSecretProvider`] sits above it so a key costs one read of that
-/// item per process rather than one per turn: [`resolver::ConfiguredResolver`]
+/// Desktop stores one bundle in the OS keychain. Self-host stores the same
+/// bundle in Vault KV v2 when configured, or uses an unavailable provider that
+/// still lets provider environment variables act as read fallbacks.
+/// [`CachingSecretProvider`] sits above the bundle so a key costs one storage
+/// read per process rather than one per turn: [`resolver::ConfiguredResolver`]
 /// rebuilds its route set on every turn, and each candidate route reads its
 /// provider's credential to decide whether it exists.
 ///
@@ -1756,17 +1757,28 @@ async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_par
 /// cached `None` would then hide the session from the sync loop until
 /// restart. Its misses re-ask the store instead; an absent item answers
 /// `NoEntry` without an ACL prompt, so the slow-path rereads are cheap.
-fn secret_provider(config: &Config) -> ProfileSecrets {
-    let keychain: Arc<dyn SecretProvider> = Arc::new(match &config.keychain_service {
-        Some(service) => KeychainSecretProvider::with_service(service),
-        None => KeychainSecretProvider::new(),
-    });
-    let bundle = Arc::new(BundledSecretProvider::new(keychain));
+fn secret_provider(config: &Config) -> Result<ProfileSecrets> {
+    let storage: Arc<dyn SecretProvider> = match config.profile {
+        Profile::Desktop => Arc::new(match &config.keychain_service {
+            Some(service) => KeychainSecretProvider::with_service(service),
+            None => KeychainSecretProvider::new(),
+        }),
+        Profile::SelfHost => match &config.vault_secrets {
+            Some(vault) => Arc::new(vault_secrets::VaultSecretProvider::new(vault)?),
+            None => Arc::new(vault_secrets::UnavailableSelfHostSecretProvider),
+        },
+        _ => {
+            return Err(AgentError::config(
+                "the configured profile is not supported",
+            ))
+        }
+    };
+    let bundle = Arc::new(BundledSecretProvider::new(storage));
     let provider = Arc::new(
         CachingSecretProvider::new(bundle.clone())
             .with_miss_passthrough([crate::connectors::GATEWAY_SECRET_KEY]),
     );
-    ProfileSecrets { bundle, provider }
+    Ok(ProfileSecrets { bundle, provider })
 }
 
 /// The profile's credential store, at the two layers callers need.
@@ -1787,8 +1799,66 @@ struct ProfileSecrets {
 pub async fn rehome_configured_secrets(
     config: &Config,
 ) -> Result<Vec<(String, secret_rehome::RehomeOutcome)>> {
+    if config.profile != Profile::Desktop {
+        return Err(AgentError::config(
+            "rehome-secrets is available only for the desktop profile because self-host credentials never use the OS keychain",
+        ));
+    }
     let store = connect_store(config).await?;
-    secret_rehome::rehome_secrets(&*store, &secret_provider(config).bundle).await
+    secret_rehome::rehome_secrets(&*store, &secret_provider(config)?.bundle).await
+}
+
+#[cfg(test)]
+mod profile_secret_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn self_host_without_vault_allows_fallback_reads_but_rejects_changes() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut config = Config::desktop(directory.path());
+        config.profile = Profile::SelfHost;
+        let secrets = secret_provider(&config).unwrap().provider;
+
+        assert_eq!(secrets.get_secret("provider.test").await.unwrap(), None);
+        let error = secrets
+            .set_secret("provider.test", "value")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("TIDEBREAK_VAULT_ADDR"));
+
+        let web_search = web_search::write_credential(
+            &*secrets,
+            web_search::WebSearchProviderKind::Brave,
+            "value",
+        )
+        .await
+        .unwrap_err();
+        assert!(web_search.message().contains("TIDEBREAK_VAULT_ADDR"));
+
+        let code_execution = code_execution::write_credential(
+            &*secrets,
+            tidebreak_code_execution::ExecProviderKind::E2b,
+            "value",
+        )
+        .await
+        .unwrap_err();
+        assert!(code_execution.message().contains("TIDEBREAK_VAULT_ADDR"));
+    }
+
+    #[tokio::test]
+    async fn rehome_secrets_rejects_self_host_before_opening_its_store() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut config = Config::desktop(directory.path());
+        config.profile = Profile::SelfHost;
+
+        let error = rehome_configured_secrets(&config)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("desktop profile"));
+        assert!(error.contains("OS keychain"));
+    }
 }
 
 // Every parameter is one optional native bridge an embedding may supply;
@@ -1812,6 +1882,13 @@ async fn bind_inner(
     // routable interface, and that refusal should cost nothing and leave
     // nothing behind. See [`Config::bind_addr`].
     let bind_addr = config.bind_addr()?;
+    // Provider construction validates boot-only custody settings without
+    // reading a secret. Keep it before the lock and database so an invalid
+    // Vault address leaves no local or shared resources open.
+    let ProfileSecrets {
+        bundle: secret_bundle,
+        provider: secrets,
+    } = secret_provider(&config)?;
     // Desktop live delivery remains process-local. Turns, steering, and tool
     // approvals are durable, while one process still owns the complete data
     // directory and its worker set.
@@ -1821,10 +1898,6 @@ async fn bind_inner(
     let sandbox_spawn_execution_location = sandbox_container_admission.execution_location;
     let db = connect_db(&config).await?;
     let store: Arc<dyn Store> = db.clone();
-    let ProfileSecrets {
-        bundle: secret_bundle,
-        provider: secrets,
-    } = secret_provider(&config);
     // An app update replaces this binary, and macOS pins a keychain item's
     // access to the creating binary's signature — so the first boot of a new
     // binary re-homes the credential bundle before any consumer reads from
@@ -1833,8 +1906,10 @@ async fn bind_inner(
     // one read+rewrite of one item, once per binary, with later boots of the
     // same binary skipping it entirely.
     // Best-effort: a failure here must not take boot down with it.
-    if let Err(error) = secret_rehome::rehome_once_per_binary(&*store, &secret_bundle).await {
-        tracing::warn!("could not re-home stored credentials: {error}");
+    if config.profile == Profile::Desktop {
+        if let Err(error) = secret_rehome::rehome_once_per_binary(&*store, &secret_bundle).await {
+            tracing::warn!("could not re-home stored credentials: {error}");
+        }
     }
     // The product boot path is where this platform's OS-managed (MDM) policy
     // reader gets selected; directly assembled AppState stays hermetic. This

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1757,25 +1757,45 @@ async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_par
 /// cached `None` would then hide the session from the sync loop until
 /// restart. Its misses re-ask the store instead; an absent item answers
 /// `NoEntry` without an ACL prompt, so the slow-path rereads are cheap.
-fn secret_provider(config: &Config) -> Result<ProfileSecrets> {
+enum CredentialStoragePlan {
+    Desktop(Option<String>),
+    Vault(vault_secrets::ValidatedVaultConfig),
+    UnavailableSelfHost,
+}
+
+fn credential_storage_plan(config: &Config) -> Result<CredentialStoragePlan> {
     if config.profile != Profile::SelfHost && config.vault_secrets.is_some() {
         return Err(AgentError::config(
             "Vault secret custody is available only with TIDEBREAK_PROFILE=self_host",
         ));
     }
-    let storage: Arc<dyn SecretProvider> = match config.profile {
-        Profile::Desktop => Arc::new(match &config.keychain_service {
+    match config.profile {
+        Profile::Desktop => Ok(CredentialStoragePlan::Desktop(
+            config.keychain_service.clone(),
+        )),
+        Profile::SelfHost => match &config.vault_secrets {
+            Some(vault) => Ok(CredentialStoragePlan::Vault(
+                vault_secrets::VaultSecretProvider::validate(vault)?,
+            )),
+            None => Ok(CredentialStoragePlan::UnavailableSelfHost),
+        },
+        _ => Err(AgentError::config(
+            "the configured profile is not supported",
+        )),
+    }
+}
+
+fn secret_provider(plan: CredentialStoragePlan) -> ProfileSecrets {
+    let storage: Arc<dyn SecretProvider> = match plan {
+        CredentialStoragePlan::Desktop(keychain_service) => Arc::new(match keychain_service {
             Some(service) => KeychainSecretProvider::with_service(service),
             None => KeychainSecretProvider::new(),
         }),
-        Profile::SelfHost => match &config.vault_secrets {
-            Some(vault) => Arc::new(vault_secrets::VaultSecretProvider::new(vault)?),
-            None => Arc::new(vault_secrets::UnavailableSelfHostSecretProvider),
-        },
-        _ => {
-            return Err(AgentError::config(
-                "the configured profile is not supported",
-            ))
+        CredentialStoragePlan::Vault(config) => {
+            Arc::new(vault_secrets::VaultSecretProvider::new(config))
+        }
+        CredentialStoragePlan::UnavailableSelfHost => {
+            Arc::new(vault_secrets::UnavailableSelfHostSecretProvider)
         }
     };
     let bundle = Arc::new(BundledSecretProvider::new(storage));
@@ -1783,7 +1803,7 @@ fn secret_provider(config: &Config) -> Result<ProfileSecrets> {
         CachingSecretProvider::new(bundle.clone())
             .with_miss_passthrough([crate::connectors::GATEWAY_SECRET_KEY]),
     );
-    Ok(ProfileSecrets { bundle, provider })
+    ProfileSecrets { bundle, provider }
 }
 
 /// The profile's credential store, at the two layers callers need.
@@ -1809,8 +1829,9 @@ pub async fn rehome_configured_secrets(
             "rehome-secrets is available only for the desktop profile because self-host credentials never use the OS keychain",
         ));
     }
+    let plan = credential_storage_plan(config)?;
     let store = connect_store(config).await?;
-    secret_rehome::rehome_secrets(&*store, &secret_provider(config)?.bundle).await
+    secret_rehome::rehome_secrets(&*store, &secret_provider(plan).bundle).await
 }
 
 #[cfg(test)]
@@ -1822,7 +1843,7 @@ mod profile_secret_tests {
         let directory = tempfile::tempdir().unwrap();
         let mut config = Config::desktop(directory.path());
         config.profile = Profile::SelfHost;
-        let secrets = secret_provider(&config).unwrap().provider;
+        let secrets = secret_provider(credential_storage_plan(&config).unwrap()).provider;
 
         assert_eq!(secrets.get_secret("provider.test").await.unwrap(), None);
         let error = secrets
@@ -1866,7 +1887,7 @@ mod profile_secret_tests {
     }
 
     #[test]
-    fn desktop_provider_rejects_programmatic_vault_settings() {
+    fn desktop_storage_plan_rejects_programmatic_vault_settings() {
         let directory = tempfile::tempdir().unwrap();
         let mut config = Config::desktop(directory.path());
         config.vault_secrets = Some(tidebreak_core::VaultSecretConfig {
@@ -1877,7 +1898,7 @@ mod profile_secret_tests {
             namespace: None,
         });
 
-        let error = match secret_provider(&config) {
+        let error = match credential_storage_plan(&config) {
             Err(error) => error.to_string(),
             Ok(_) => panic!("desktop accepted Vault settings"),
         };
@@ -1906,13 +1927,14 @@ async fn bind_inner(
     // routable interface, and that refusal should cost nothing and leave
     // nothing behind. See [`Config::bind_addr`].
     let bind_addr = config.bind_addr()?;
-    // Provider construction validates boot-only custody settings without
+    // Storage planning validates boot-only custody settings without
     // reading a secret. Keep it before the lock and database so an invalid
     // Vault address leaves no local or shared resources open.
+    let credential_storage = credential_storage_plan(&config)?;
     let ProfileSecrets {
         bundle: secret_bundle,
         provider: secrets,
-    } = secret_provider(&config)?;
+    } = secret_provider(credential_storage);
     // Desktop live delivery remains process-local. Turns, steering, and tool
     // approvals are durable, while one process still owns the complete data
     // directory and its worker set.

--- a/crates/tidebreak-server/src/vault_secrets.rs
+++ b/crates/tidebreak-server/src/vault_secrets.rs
@@ -31,9 +31,18 @@ pub(crate) struct VaultSecretProvider {
     token_file: PathBuf,
 }
 
+pub(crate) struct ValidatedVaultConfig {
+    base_url: Url,
+    client: reqwest::Client,
+    mount: Vec<String>,
+    namespace: Option<HeaderValue>,
+    path: Vec<String>,
+    token_file: PathBuf,
+}
+
 impl VaultSecretProvider {
     /// Validate the operator configuration and build the no-redirect client.
-    pub(crate) fn new(config: &VaultSecretConfig) -> Result<Self> {
+    pub(crate) fn validate(config: &VaultSecretConfig) -> Result<ValidatedVaultConfig> {
         let base_url = validate_base_url(&config.address)?;
         let mount = validate_secret_path("TIDEBREAK_VAULT_MOUNT", &config.mount)?;
         let path = validate_secret_path("TIDEBREAK_VAULT_PATH", &config.path)?;
@@ -63,7 +72,7 @@ impl VaultSecretProvider {
             .user_agent(USER_AGENT)
             .build()
             .map_err(|_| AgentError::config("could not initialize the Vault HTTP client"))?;
-        Ok(Self {
+        Ok(ValidatedVaultConfig {
             base_url,
             client,
             mount,
@@ -71,6 +80,17 @@ impl VaultSecretProvider {
             path,
             token_file: config.token_file.clone(),
         })
+    }
+
+    pub(crate) fn new(config: ValidatedVaultConfig) -> Self {
+        Self {
+            base_url: config.base_url,
+            client: config.client,
+            mount: config.mount,
+            namespace: config.namespace,
+            path: config.path,
+            token_file: config.token_file,
+        }
     }
 
     fn secret_url(&self, key: &str) -> Result<Url> {
@@ -524,14 +544,14 @@ mod tests {
         token_file: PathBuf,
         namespace: Option<&str>,
     ) -> VaultSecretProvider {
-        VaultSecretProvider::new(&VaultSecretConfig {
+        let config = VaultSecretConfig {
             address: fixture.address.clone(),
             token_file,
             mount: "secret".into(),
             path: "tidebreak/production".into(),
             namespace: namespace.map(str::to_owned),
-        })
-        .unwrap()
+        };
+        VaultSecretProvider::new(VaultSecretProvider::validate(&config).unwrap())
     }
 
     #[tokio::test]
@@ -686,9 +706,9 @@ mod tests {
             namespace: None,
         };
 
-        assert!(VaultSecretProvider::new(&config("https://vault.example.test")).is_ok());
-        assert!(VaultSecretProvider::new(&config("http://127.0.0.1:8200")).is_ok());
-        assert!(VaultSecretProvider::new(&config("http://[::1]:8200")).is_ok());
+        assert!(VaultSecretProvider::validate(&config("https://vault.example.test")).is_ok());
+        assert!(VaultSecretProvider::validate(&config("http://127.0.0.1:8200")).is_ok());
+        assert!(VaultSecretProvider::validate(&config("http://[::1]:8200")).is_ok());
         for address in [
             "http://localhost:8200",
             "http://vault.example.test",
@@ -697,7 +717,7 @@ mod tests {
             "https://vault.example.test/#fragment",
         ] {
             assert!(
-                VaultSecretProvider::new(&config(address)).is_err(),
+                VaultSecretProvider::validate(&config(address)).is_err(),
                 "accepted {address}"
             );
         }

--- a/crates/tidebreak-server/src/vault_secrets.rs
+++ b/crates/tidebreak-server/src/vault_secrets.rs
@@ -1,0 +1,723 @@
+//! HashiCorp Vault KV v2 custody for self-host credentials.
+
+use std::io::Read as _;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt as _;
+use reqwest::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
+use reqwest::{Method, StatusCode, Url};
+use serde::{Deserialize, Serialize};
+use tidebreak_core::{AgentError, Result, SecretProvider, VaultSecretConfig};
+
+const USER_AGENT: &str = "tidebreak-vault/1";
+const TOKEN_FILE_LIMIT: u64 = 16 * 1024;
+const SECRET_VALUE_LIMIT: usize = 1024 * 1024;
+const REQUEST_BODY_LIMIT: usize = 2 * 1024 * 1024;
+const RESPONSE_BODY_LIMIT: usize = 2 * 1024 * 1024;
+const SECRET_KEY_LIMIT: usize = 512;
+
+const VAULT_TOKEN_HEADER: &str = "x-vault-token";
+const VAULT_NAMESPACE_HEADER: &str = "x-vault-namespace";
+
+/// A [`SecretProvider`] that stores one item per Vault KV v2 secret path.
+pub(crate) struct VaultSecretProvider {
+    base_url: Url,
+    client: reqwest::Client,
+    mount: Vec<String>,
+    namespace: Option<HeaderValue>,
+    path: Vec<String>,
+    token_file: PathBuf,
+}
+
+impl VaultSecretProvider {
+    /// Validate the operator configuration and build the no-redirect client.
+    pub(crate) fn new(config: &VaultSecretConfig) -> Result<Self> {
+        let base_url = validate_base_url(&config.address)?;
+        let mount = validate_secret_path("TIDEBREAK_VAULT_MOUNT", &config.mount)?;
+        let path = validate_secret_path("TIDEBREAK_VAULT_PATH", &config.path)?;
+        if config.token_file.as_os_str().is_empty() {
+            return Err(AgentError::config(
+                "TIDEBREAK_VAULT_TOKEN_FILE must name a mounted token file",
+            ));
+        }
+        let namespace = config
+            .namespace
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(HeaderValue::from_str)
+            .transpose()
+            .map_err(|_| {
+                AgentError::config(
+                    "TIDEBREAK_VAULT_NAMESPACE contains characters that are invalid in an HTTP header",
+                )
+            })?;
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .https_only(base_url.scheme() == "https")
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
+            .user_agent(USER_AGENT)
+            .build()
+            .map_err(|_| AgentError::config("could not initialize the Vault HTTP client"))?;
+        Ok(Self {
+            base_url,
+            client,
+            mount,
+            namespace,
+            path,
+            token_file: config.token_file.clone(),
+        })
+    }
+
+    fn secret_url(&self, key: &str) -> Result<Url> {
+        if key.is_empty() || key.len() > SECRET_KEY_LIMIT || matches!(key, "." | "..") {
+            return Err(AgentError::Secret(format!(
+                "the credential key must contain 1 to {SECRET_KEY_LIMIT} bytes"
+            )));
+        }
+        let mut url = self.base_url.clone();
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|_| AgentError::config("TIDEBREAK_VAULT_ADDR cannot be used as a base URL"))?;
+        segments.pop_if_empty();
+        segments.push("v1");
+        for segment in &self.mount {
+            segments.push(segment);
+        }
+        segments.push("data");
+        for segment in &self.path {
+            segments.push(segment);
+        }
+        segments.push(key);
+        drop(segments);
+        Ok(url)
+    }
+
+    async fn request(
+        &self,
+        method: Method,
+        key: &str,
+        body: Option<Vec<u8>>,
+    ) -> Result<reqwest::Response> {
+        let token = self.read_token().await?;
+        let mut request = self
+            .client
+            .request(method, self.secret_url(key)?)
+            .header(VAULT_TOKEN_HEADER, token)
+            .header(ACCEPT, "application/json");
+        if let Some(namespace) = &self.namespace {
+            request = request.header(VAULT_NAMESPACE_HEADER, namespace.clone());
+        }
+        if let Some(body) = body {
+            request = request.header(CONTENT_TYPE, "application/json").body(body);
+        }
+        request.send().await.map_err(|error| {
+            if error.is_timeout() {
+                AgentError::Secret("the Vault request timed out".into())
+            } else {
+                AgentError::Secret("the Vault request failed".into())
+            }
+        })
+    }
+
+    async fn read_token(&self) -> Result<HeaderValue> {
+        let path = self.token_file.clone();
+        let bytes = tokio::task::spawn_blocking(move || {
+            let file = std::fs::File::open(path)?;
+            let mut bytes = Vec::new();
+            file.take(TOKEN_FILE_LIMIT + 1).read_to_end(&mut bytes)?;
+            Ok::<_, std::io::Error>(bytes)
+        })
+        .await
+        .map_err(|_| AgentError::Secret("could not read the configured Vault token file".into()))?
+        .map_err(|_| AgentError::Secret("could not read the configured Vault token file".into()))?;
+        if bytes.len() as u64 > TOKEN_FILE_LIMIT {
+            return Err(AgentError::Secret(
+                "the configured Vault token file exceeds the size limit".into(),
+            ));
+        }
+        let token = std::str::from_utf8(&bytes)
+            .map_err(|_| AgentError::Secret("the configured Vault token is not UTF-8".into()))?
+            .trim();
+        if token.is_empty() {
+            return Err(AgentError::Secret(
+                "the configured Vault token file is empty".into(),
+            ));
+        }
+        HeaderValue::from_str(token).map_err(|_| {
+            AgentError::Secret("the configured Vault token is not a valid HTTP header value".into())
+        })
+    }
+}
+
+#[async_trait]
+impl SecretProvider for VaultSecretProvider {
+    async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+        let response = self.request(Method::GET, key, None).await?;
+        let status = response.status();
+        let body = read_bounded(response).await?;
+        if status == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        require_success("read", status)?;
+        let response: VaultReadResponse = serde_json::from_slice(&body).map_err(|_| {
+            AgentError::Secret("Vault returned an unreadable credential response".into())
+        })?;
+        if response.data.data.value.len() > SECRET_VALUE_LIMIT {
+            return Err(AgentError::Secret(
+                "Vault returned a credential that exceeds the size limit".into(),
+            ));
+        }
+        Ok(Some(response.data.data.value))
+    }
+
+    async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+        if value.len() > SECRET_VALUE_LIMIT {
+            return Err(AgentError::Secret(
+                "the credential exceeds the Vault storage size limit".into(),
+            ));
+        }
+        let body = serde_json::to_vec(&VaultWriteRequest {
+            data: VaultWriteData { value },
+        })
+        .map_err(|_| AgentError::Secret("could not encode the Vault credential request".into()))?;
+        if body.len() > REQUEST_BODY_LIMIT {
+            return Err(AgentError::Secret(
+                "the encoded Vault credential request exceeds the size limit".into(),
+            ));
+        }
+        let response = self.request(Method::POST, key, Some(body)).await?;
+        let status = response.status();
+        let _ = read_bounded(response).await?;
+        require_success("write", status)
+    }
+
+    async fn delete_secret(&self, key: &str) -> Result<()> {
+        let response = self.request(Method::DELETE, key, None).await?;
+        let status = response.status();
+        let _ = read_bounded(response).await?;
+        if status == StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        require_success("delete", status)
+    }
+}
+
+/// A self-host deployment without Vault can read environment fallbacks but
+/// cannot persist deployment credentials.
+pub(crate) struct UnavailableSelfHostSecretProvider;
+
+#[async_trait]
+impl SecretProvider for UnavailableSelfHostSecretProvider {
+    async fn get_secret(&self, _key: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    async fn set_secret(&self, _key: &str, _value: &str) -> Result<()> {
+        Err(vault_setup_error())
+    }
+
+    async fn delete_secret(&self, _key: &str) -> Result<()> {
+        Err(vault_setup_error())
+    }
+}
+
+fn vault_setup_error() -> AgentError {
+    AgentError::config(
+        "stored credentials are unavailable for this self-host deployment; set TIDEBREAK_VAULT_ADDR and TIDEBREAK_VAULT_TOKEN_FILE to enable Vault KV v2 custody"
+            .to_owned(),
+    )
+}
+
+#[derive(Deserialize)]
+struct VaultReadResponse {
+    data: VaultReadOuterData,
+}
+
+#[derive(Deserialize)]
+struct VaultReadOuterData {
+    data: VaultReadData,
+}
+
+#[derive(Deserialize)]
+struct VaultReadData {
+    value: String,
+}
+
+#[derive(Serialize)]
+struct VaultWriteRequest<'a> {
+    data: VaultWriteData<'a>,
+}
+
+#[derive(Serialize)]
+struct VaultWriteData<'a> {
+    value: &'a str,
+}
+
+fn validate_base_url(raw: &str) -> Result<Url> {
+    let mut url = Url::parse(raw.trim())
+        .map_err(|_| AgentError::config("TIDEBREAK_VAULT_ADDR is not a valid URL"))?;
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(AgentError::config(
+            "TIDEBREAK_VAULT_ADDR must not contain credentials, a query, or a fragment",
+        ));
+    }
+    if url.host_str().is_none() {
+        return Err(AgentError::config(
+            "TIDEBREAK_VAULT_ADDR must contain a host",
+        ));
+    }
+    let literal_loopback = url.host_str().is_some_and(|host| {
+        host.trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+    });
+    if url.scheme() != "https" && !(url.scheme() == "http" && literal_loopback) {
+        return Err(AgentError::config(
+            "TIDEBREAK_VAULT_ADDR must use https; http is allowed only for a literal loopback address",
+        ));
+    }
+    if !url.path().ends_with('/') {
+        let path = format!("{}/", url.path());
+        url.set_path(&path);
+    }
+    Ok(url)
+}
+
+fn validate_secret_path(name: &str, raw: &str) -> Result<Vec<String>> {
+    let trimmed = raw.trim();
+    let segments = trimmed.split('/').collect::<Vec<_>>();
+    if trimmed.is_empty()
+        || segments
+            .iter()
+            .any(|segment| segment.is_empty() || matches!(*segment, "." | ".."))
+    {
+        return Err(AgentError::config(format!(
+            "{name} must contain non-empty path segments and no `.` or `..` segment"
+        )));
+    }
+    Ok(segments.into_iter().map(str::to_owned).collect())
+}
+
+async fn read_bounded(response: reqwest::Response) -> Result<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > RESPONSE_BODY_LIMIT as u64)
+    {
+        return Err(AgentError::Secret(
+            "the Vault response exceeds the size limit".into(),
+        ));
+    }
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|_| AgentError::Secret("the Vault response could not be read".into()))?;
+        if body.len().saturating_add(chunk.len()) > RESPONSE_BODY_LIMIT {
+            return Err(AgentError::Secret(
+                "the Vault response exceeds the size limit".into(),
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn require_success(operation: &str, status: StatusCode) -> Result<()> {
+    if status.is_success() {
+        return Ok(());
+    }
+    if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+        return Err(AgentError::Secret(
+            "Vault refused the configured token".into(),
+        ));
+    }
+    Err(AgentError::Secret(format!(
+        "the Vault credential {operation} failed with HTTP {}",
+        status.as_u16()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use axum::body::Bytes;
+    use axum::extract::{Path, State};
+    use axum::http::{HeaderMap, Response};
+    use axum::response::IntoResponse as _;
+    use axum::routing::get;
+    use axum::Router;
+    use serde_json::json;
+    use tempfile::TempDir;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum ReadBehavior {
+        Malformed,
+        Oversized,
+        Redirect,
+    }
+
+    #[derive(Default)]
+    struct FixtureState {
+        items: Mutex<HashMap<String, String>>,
+        namespaces: Mutex<Vec<Option<String>>>,
+        next_read: Mutex<Option<ReadBehavior>>,
+        request_count: Mutex<usize>,
+        required_token: Mutex<String>,
+        tokens: Mutex<Vec<String>>,
+    }
+
+    impl FixtureState {
+        fn authorization_refusal(&self, headers: &HeaderMap) -> Option<Response<axum::body::Body>> {
+            *self.request_count.lock().unwrap() += 1;
+            let token = headers
+                .get(VAULT_TOKEN_HEADER)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            self.tokens.lock().unwrap().push(token.clone());
+            self.namespaces.lock().unwrap().push(
+                headers
+                    .get(VAULT_NAMESPACE_HEADER)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_owned),
+            );
+            if token != *self.required_token.lock().unwrap() {
+                return Some((StatusCode::FORBIDDEN, "denied").into_response());
+            }
+            None
+        }
+    }
+
+    struct Fixture {
+        address: String,
+        handle: tokio::task::JoinHandle<()>,
+        state: Arc<FixtureState>,
+    }
+
+    impl Fixture {
+        async fn start(token: &str) -> Self {
+            let state = Arc::new(FixtureState {
+                required_token: Mutex::new(token.to_owned()),
+                ..FixtureState::default()
+            });
+            let router = Router::new()
+                .route("/v1/{*path}", get(read).post(write).delete(remove))
+                .with_state(state.clone());
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = format!("http://{}", listener.local_addr().unwrap());
+            let handle = tokio::spawn(async move {
+                axum::serve(listener, router).await.unwrap();
+            });
+            Self {
+                address,
+                handle,
+                state,
+            }
+        }
+
+        fn require_token(&self, token: &str) {
+            *self.state.required_token.lock().unwrap() = token.to_owned();
+        }
+
+        fn next_read(&self, behavior: ReadBehavior) {
+            *self.state.next_read.lock().unwrap() = Some(behavior);
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            self.handle.abort();
+        }
+    }
+
+    async fn read(
+        State(state): State<Arc<FixtureState>>,
+        Path(path): Path<String>,
+        headers: HeaderMap,
+    ) -> Response<axum::body::Body> {
+        if let Some(response) = state.authorization_refusal(&headers) {
+            return response;
+        }
+        match state.next_read.lock().unwrap().take() {
+            Some(ReadBehavior::Malformed) => {
+                return (StatusCode::OK, "{not-json").into_response();
+            }
+            Some(ReadBehavior::Oversized) => {
+                return (StatusCode::OK, "x".repeat(RESPONSE_BODY_LIMIT + 1)).into_response();
+            }
+            Some(ReadBehavior::Redirect) => {
+                return Response::builder()
+                    .status(StatusCode::TEMPORARY_REDIRECT)
+                    .header(reqwest::header::LOCATION, "/followed")
+                    .body(axum::body::Body::empty())
+                    .unwrap();
+            }
+            None => {}
+        }
+        match state.items.lock().unwrap().get(&path).cloned() {
+            Some(value) => axum::Json(json!({
+                "data": {
+                    "data": { "value": value },
+                    "metadata": { "version": 1 }
+                }
+            }))
+            .into_response(),
+            None => StatusCode::NOT_FOUND.into_response(),
+        }
+    }
+
+    async fn write(
+        State(state): State<Arc<FixtureState>>,
+        Path(path): Path<String>,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Response<axum::body::Body> {
+        if let Some(response) = state.authorization_refusal(&headers) {
+            return response;
+        }
+        let value = serde_json::from_slice::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|body| body.pointer("/data/value")?.as_str().map(str::to_owned));
+        let Some(value) = value else {
+            return StatusCode::BAD_REQUEST.into_response();
+        };
+        state.items.lock().unwrap().insert(path, value);
+        StatusCode::NO_CONTENT.into_response()
+    }
+
+    async fn remove(
+        State(state): State<Arc<FixtureState>>,
+        Path(path): Path<String>,
+        headers: HeaderMap,
+    ) -> Response<axum::body::Body> {
+        if let Some(response) = state.authorization_refusal(&headers) {
+            return response;
+        }
+        state.items.lock().unwrap().remove(&path);
+        StatusCode::NO_CONTENT.into_response()
+    }
+
+    fn token_file(token: &str) -> (TempDir, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("vault-token");
+        std::fs::write(&path, format!("{token}\n")).unwrap();
+        (directory, path)
+    }
+
+    fn provider(
+        fixture: &Fixture,
+        token_file: PathBuf,
+        namespace: Option<&str>,
+    ) -> VaultSecretProvider {
+        VaultSecretProvider::new(&VaultSecretConfig {
+            address: fixture.address.clone(),
+            token_file,
+            mount: "secret".into(),
+            path: "tidebreak/production".into(),
+            namespace: namespace.map(str::to_owned),
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn missing_secret_returns_none() {
+        let fixture = Fixture::start("token-one").await;
+        let (_directory, token_file) = token_file("token-one");
+        let provider = provider(&fixture, token_file, None);
+
+        assert_eq!(provider.get_secret("missing").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn secret_can_be_created_and_overwritten() {
+        let fixture = Fixture::start("token-one").await;
+        let (_directory, token_file) = token_file("token-one");
+        let provider = provider(&fixture, token_file, None);
+
+        provider.set_secret("provider.test", "first").await.unwrap();
+        assert!(fixture
+            .state
+            .items
+            .lock()
+            .unwrap()
+            .contains_key("secret/data/tidebreak/production/provider.test"));
+        assert_eq!(
+            provider
+                .get_secret("provider.test")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("first")
+        );
+        provider
+            .set_secret("provider.test", "second")
+            .await
+            .unwrap();
+        assert_eq!(
+            provider
+                .get_secret("provider.test")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("second")
+        );
+    }
+
+    #[tokio::test]
+    async fn secret_can_be_deleted() {
+        let fixture = Fixture::start("token-one").await;
+        let (_directory, token_file) = token_file("token-one");
+        let provider = provider(&fixture, token_file, None);
+
+        provider.set_secret("provider.test", "value").await.unwrap();
+        provider.delete_secret("provider.test").await.unwrap();
+        assert_eq!(provider.get_secret("provider.test").await.unwrap(), None);
+        provider.delete_secret("provider.test").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn authentication_failure_redacts_token_and_value() {
+        let fixture = Fixture::start("expected-token").await;
+        let (_directory, token_file) = token_file("wrong-token");
+        let provider = provider(&fixture, token_file, None);
+
+        let error = provider
+            .set_secret("provider.test", "stored-secret-value")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("refused"));
+        assert!(!error.contains("wrong-token"));
+        assert!(!error.contains("stored-secret-value"));
+    }
+
+    #[tokio::test]
+    async fn malformed_and_oversized_responses_are_rejected() {
+        let fixture = Fixture::start("token-one").await;
+        let (_directory, token_file) = token_file("token-one");
+        let provider = provider(&fixture, token_file, None);
+
+        fixture.next_read(ReadBehavior::Malformed);
+        let malformed = provider
+            .get_secret("provider.test")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(malformed.contains("unreadable"));
+
+        fixture.next_read(ReadBehavior::Oversized);
+        let oversized = provider
+            .get_secret("provider.test")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(oversized.contains("size limit"));
+    }
+
+    #[tokio::test]
+    async fn token_file_is_read_for_every_request() {
+        let fixture = Fixture::start("token-one").await;
+        let (_directory, token_file) = token_file("token-one");
+        let provider = provider(&fixture, token_file.clone(), None);
+
+        assert_eq!(provider.get_secret("missing").await.unwrap(), None);
+        fixture.require_token("token-two");
+        std::fs::write(&token_file, "token-two\n").unwrap();
+        provider.set_secret("provider.test", "value").await.unwrap();
+
+        assert_eq!(
+            *fixture.state.tokens.lock().unwrap(),
+            vec!["token-one".to_owned(), "token-two".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn namespace_is_sent_on_each_request() {
+        let fixture = Fixture::start("token-one").await;
+        let (_directory, token_file) = token_file("token-one");
+        let provider = provider(&fixture, token_file, Some("platform/team-a"));
+
+        assert_eq!(provider.get_secret("missing").await.unwrap(), None);
+        assert_eq!(
+            *fixture.state.namespaces.lock().unwrap(),
+            vec![Some("platform/team-a".to_owned())]
+        );
+    }
+
+    #[tokio::test]
+    async fn redirects_are_not_followed() {
+        let fixture = Fixture::start("token-one").await;
+        let (_directory, token_file) = token_file("token-one");
+        let provider = provider(&fixture, token_file, None);
+        fixture.next_read(ReadBehavior::Redirect);
+
+        let error = provider
+            .get_secret("provider.test")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("307"));
+        assert_eq!(*fixture.state.request_count.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn vault_address_validation_requires_https_or_literal_loopback() {
+        let (_, token_file) = token_file("token-one");
+        let config = |address: &str| VaultSecretConfig {
+            address: address.into(),
+            token_file: token_file.clone(),
+            mount: "secret".into(),
+            path: "tidebreak".into(),
+            namespace: None,
+        };
+
+        assert!(VaultSecretProvider::new(&config("https://vault.example.test")).is_ok());
+        assert!(VaultSecretProvider::new(&config("http://127.0.0.1:8200")).is_ok());
+        assert!(VaultSecretProvider::new(&config("http://[::1]:8200")).is_ok());
+        for address in [
+            "http://localhost:8200",
+            "http://vault.example.test",
+            "https://name:secret@vault.example.test",
+            "https://vault.example.test?token=secret",
+            "https://vault.example.test/#fragment",
+        ] {
+            assert!(
+                VaultSecretProvider::new(&config(address)).is_err(),
+                "accepted {address}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unavailable_provider_allows_fallback_reads_but_rejects_changes() {
+        let provider = UnavailableSelfHostSecretProvider;
+
+        assert_eq!(provider.get_secret("provider.test").await.unwrap(), None);
+        for error in [
+            provider
+                .set_secret("provider.test", "value")
+                .await
+                .unwrap_err(),
+            provider.delete_secret("provider.test").await.unwrap_err(),
+        ] {
+            let message = error.to_string();
+            assert!(message.contains("TIDEBREAK_VAULT_ADDR"));
+            assert!(message.contains("TIDEBREAK_VAULT_TOKEN_FILE"));
+        }
+    }
+}

--- a/crates/tidebreak-server/src/web_search/host.rs
+++ b/crates/tidebreak-server/src/web_search/host.rs
@@ -450,7 +450,9 @@ pub async fn write_credential(
     secrets
         .set_secret(credential_key(provider)?, api_key)
         .await
-        .map_err(|_| ServerError::internal("web search credential storage is unavailable"))?;
+        .map_err(|error| {
+            ServerError::credential_storage(error, "web search credential storage is unavailable")
+        })?;
     Ok(WebSearchCredentialReadiness {
         provider,
         has_credential: true,
@@ -465,7 +467,9 @@ pub async fn delete_credential(
     secrets
         .delete_secret(credential_key(provider)?)
         .await
-        .map_err(|_| ServerError::internal("web search credential storage is unavailable"))?;
+        .map_err(|error| {
+            ServerError::credential_storage(error, "web search credential storage is unavailable")
+        })?;
     Ok(WebSearchCredentialReadiness {
         provider,
         has_credential: false,

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -64,9 +64,10 @@ services:
       TIDEBREAK_LISTEN_ADDR: 0.0.0.0:8080
       # Log filter; see the server's `logging` module for the syntax.
       TIDEBREAK_LOG: ${TIDEBREAK_LOG:-info}
-      # Model credentials. The container has no OS keychain, so a self-host
-      # deployment supplies provider keys through the environment. Only the
-      # ones you set are used; unset variables resolve to no credential.
+      # Model credential fallbacks for this minimal stack. To save shared
+      # credentials through Tidebreak instead, mount a Vault token file and
+      # pass the TIDEBREAK_VAULT_* variables described in docs/self-hosting.md.
+      # Only the variables you set are used.
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
     volumes:

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -567,6 +567,11 @@ export TIDEBREAK_SERVER_TOKEN=$(grep -m1 'token ' server.log | sed 's|.*token ||
 | `TIDEBREAK_PROFILE` | `desktop` (default, SQLite) or `self_host` (PostgreSQL). |
 | `TIDEBREAK_DATABASE_URL` | Required for `self_host`. |
 | `TIDEBREAK_AUTH_TOKENS_FILE` | Named bearer tokens for `self_host`. Required there. |
+| `TIDEBREAK_VAULT_ADDR` | Vault base URL for stored self-host credentials. Requires `TIDEBREAK_VAULT_TOKEN_FILE`; HTTPS is required except for literal loopback development. |
+| `TIDEBREAK_VAULT_TOKEN_FILE` | Mounted Vault token file. Tidebreak reads it for every request so rotation does not require a restart. |
+| `TIDEBREAK_VAULT_MOUNT` | Optional KV v2 mount path. Defaults to `secret`. |
+| `TIDEBREAK_VAULT_PATH` | Optional deployment path below the mount. Defaults to `tidebreak`. |
+| `TIDEBREAK_VAULT_NAMESPACE` | Optional Vault Enterprise or HCP namespace. |
 | `TIDEBREAK_MCP_CONFIG` | JSON file of external MCP server definitions to load at boot. |
 | `TIDEBREAK_KEYCHAIN_MOCK` | **Debug builds only.** Any non-empty value routes credentials to an in-memory store instead of the OS keychain, so a headless run never triggers a keychain prompt. Secrets do not survive the process. Release binaries ignore it. |
 | `TIDEBREAK_MODEL` | Overrides the model the process launches with. |
@@ -604,6 +609,11 @@ connect to a remote self-host deployment. The profile is for mutually trusting
 users of one operator's deployment — a household or a small team. It is not
 multi-tenant isolation.
 
-Document and blob storage on PostgreSQL, remote secret custody, object storage,
-and multi-process ownership are not finished. Treat self-hosting as
-experimental.
+Stored credentials use HashiCorp Vault KV v2 when
+`TIDEBREAK_VAULT_ADDR` and `TIDEBREAK_VAULT_TOKEN_FILE` are set. Without Vault,
+stored-secret reads return unset so provider environment variables remain
+fallbacks, while writes and deletes fail with setup guidance. The self-host
+profile never opens the desktop OS keychain.
+
+Document and blob storage on PostgreSQL, object storage, and multi-process
+ownership are not finished. Treat self-hosting as experimental.

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -104,7 +104,7 @@ The main local data is easy to recognize:
 | `orphaned-code-worktrees.json` | code worktrees a reset left on disk |
 | `blobs/` | retained immutable document bytes |
 | `tidebreak.lock` | proof that one process owns this data directory |
-| OS keychain | provider credentials, kept outside the database — one item per profile |
+| OS keychain | desktop provider credentials, kept outside the database — one item per profile |
 
 A schema change is an appended migration, so local data survives it
 ([decision 61](decisions/0061-schema-changes-are-migrations.md)). The marker
@@ -779,7 +779,7 @@ new session and publish its tool surface only for subsequent turns.
 The `Profile::SelfHost` shape and PostgreSQL database implementation exist, and
 CI exercises the durable turn state machine against PostgreSQL. Document/blob
 PostgreSQL parity is not comprehensively tested, and production Postgres
-wiring, remote secret custody, and object storage remain future integration
+wiring and object storage remain future integration
 work. A self-host server holds a PostgreSQL advisory lease for its lifetime, so
 another process cannot start duplicate workers against the same database;
 horizontal multi-process serving remains unsupported. Building
@@ -838,6 +838,17 @@ table configures the deployment itself, shared credentials are the point of a
 team deployment, and MCP servers are host processes. The profile targets one
 operator's small team, not adversarial tenants; multi-tenant isolation is
 explicitly not claimed.
+
+**Credential custody follows the profile.** Desktop keeps one credential
+bundle in the OS keychain. Self-host never opens that keychain. When
+`TIDEBREAK_VAULT_ADDR` and `TIDEBREAK_VAULT_TOKEN_FILE` are configured, the
+server stores the same bundle in HashiCorp Vault KV v2 under the configured
+mount and deployment path. It reads the mounted token file for every request,
+refuses redirects, bounds response bodies, and requires HTTPS except for a
+literal loopback development address. Without Vault, stored-secret reads
+return unset so provider environment variables remain fallbacks. Writes and
+deletes fail with setup guidance. The manual and boot-time keychain re-home
+paths run only for Desktop.
 
 **Where it listens.** The server binds loopback on an ephemeral port by
 default; a self-host deployment that must be reachable from outside its machine
@@ -919,7 +930,7 @@ The main next steps are:
 - add richer parsers;
 - finish the self-host profile — the request path resolves a principal and
   queries are owner-scoped (#853), so what remains is production integration:
-  Postgres document/blob parity, remote secret custody, object storage, and
+  Postgres document/blob parity, object storage, and
   distributed ownership for horizontal multi-process serving;
 - add health-aware provider failover;
 - add output deletion, version history, richer formats, and durable export

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -13,7 +13,7 @@ branch; where something is not built yet, it says so.
 
 ## What the self-host profile is
 
-Selecting `TIDEBREAK_PROFILE=self_host` changes three things about the server:
+Selecting `TIDEBREAK_PROFILE=self_host` changes four things about the server:
 
 - **The store is PostgreSQL**, opened from `TIDEBREAK_DATABASE_URL`, and the
   binary must be built with tidebreak-server's `postgres` feature for the
@@ -28,6 +28,10 @@ Selecting `TIDEBREAK_PROFILE=self_host` changes three things about the server:
   exactly one of `TIDEBREAK_AUTH_GATEWAY_URL` or
   `TIDEBREAK_AUTH_TOKENS_FILE` is valid — a shared database never comes up
   behind an API that cannot tell its callers apart.
+- **Stored credentials use Vault KV v2.** The server never opens the desktop
+  OS keychain. When Vault is not configured, provider environment variables
+  remain available as read fallbacks, but deployment-plane credential writes
+  and deletes fail with setup guidance.
 
 The deployment posture is stated in
 [decision record 6](decisions/0006-self-host-deployment-plane-authorization.md):
@@ -49,6 +53,8 @@ and for what is still integration work.
 - A machine that can reach your model provider's API.
 - Somewhere private to keep the database password, plus either a Model Gateway
   installation or a standalone tokens file.
+- A Vault KV v2 mount if administrators need to save shared credentials through
+  Tidebreak. Provider environment variables remain available without Vault.
 
 ## Model Gateway identity (hosted default)
 
@@ -182,6 +188,62 @@ umask 077
 printf 'alice %s admin\n' "$(openssl rand -hex 32)" > deploy/self-host/tokens
 ```
 
+## Vault credential custody
+
+To save provider, web-search, code-execution, and connected-app credentials
+through Tidebreak, give the self-host server a HashiCorp Vault KV v2 mount.
+The server stores no Vault token in its database or boot configuration. It
+reads the token from a mounted file for every Vault request, so an injector or
+Vault Agent can rotate the file without restarting Tidebreak.
+
+Tidebreak appends each internal credential key to the configured path. With a
+mount of `secret` and a path of `tidebreak/production`, the normal credential
+bundle lives under `secret/data/tidebreak/production/tidebreak.secret_bundle_v1`.
+Grant the path wildcard because migration-safe fallback reads can address
+other stable credential keys under the same prefix.
+
+If the `secret` mount does not exist, enable KV v2:
+
+```sh
+vault secrets enable -path=secret kv-v2
+```
+
+Create a policy for one deployment path:
+
+```hcl
+path "secret/data/tidebreak/production/*" {
+  capabilities = ["create", "read", "update", "delete"]
+}
+```
+
+Attach that policy to the Vault identity used by the server. Configure your
+Vault Agent, Kubernetes injector, or service supervisor to write the resulting
+token to a file that only the Tidebreak process can read. Then set:
+
+```sh
+export TIDEBREAK_VAULT_ADDR=https://vault.internal.example
+export TIDEBREAK_VAULT_TOKEN_FILE=/run/secrets/tidebreak-vault-token
+export TIDEBREAK_VAULT_MOUNT=secret
+export TIDEBREAK_VAULT_PATH=tidebreak/production
+# Optional for Vault Enterprise or HCP Vault:
+export TIDEBREAK_VAULT_NAMESPACE=platform/team-a
+```
+
+`TIDEBREAK_VAULT_ADDR` must use HTTPS. For local development, Tidebreak accepts
+HTTP only when the host is a literal loopback address such as `127.0.0.1` or
+`::1`; `localhost` does not qualify. The address cannot contain credentials, a
+query, or a fragment, and Tidebreak refuses redirects. Keep the Vault token out
+of environment variables and logs.
+
+Vault KV v2 keeps version history according to the mount's retention settings.
+Deleting a credential through Tidebreak deletes the latest version. If your
+policy requires historical values to be destroyed, configure Vault retention
+or destroy those versions through an operator-controlled Vault workflow.
+
+If Vault is absent, stored-secret reads return unset so provider environment
+variables keep working. Attempts to save or remove a credential fail and name
+`TIDEBREAK_VAULT_ADDR` and `TIDEBREAK_VAULT_TOKEN_FILE` as the required setup.
+
 ## Environment variables
 
 Every variable below is read by the server or the CLI; nothing here is
@@ -195,6 +257,11 @@ aspirational.
 | `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` | no | `TIDEBREAK_AUTH_GATEWAY_URL` | Optional server-to-server Gateway URL for principal validation when the public origin is not cluster-routable. Requires Gateway auth. |
 | `TIDEBREAK_AUTH_TOKENS_FILE` | one auth mode required | — | Standalone compatibility: path to the static token file above. Mutually exclusive with Gateway auth. |
 | `TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS` | no | unset | Comma-separated service bearers allowed to start an external channel connect handshake. Each value must be 32–512 header-safe characters. Leave unset to disable connect start. To rotate without downtime, add the new value, move the adapter, then remove the old value. |
+| `TIDEBREAK_VAULT_ADDR` | required with Vault custody | — | Vault base URL. HTTPS is required except for literal loopback development. Setting any Vault option enables Vault configuration and requires this variable plus `TIDEBREAK_VAULT_TOKEN_FILE`. |
+| `TIDEBREAK_VAULT_TOKEN_FILE` | required with Vault custody | — | Mounted file containing the Vault token. Tidebreak reads it for every request so rotation does not require a restart. |
+| `TIDEBREAK_VAULT_MOUNT` | no | `secret` | KV v2 mount path. |
+| `TIDEBREAK_VAULT_PATH` | no | `tidebreak` | Deployment-specific path below the mount. Tidebreak appends one encoded credential key. |
+| `TIDEBREAK_VAULT_NAMESPACE` | no | unset | Vault Enterprise or HCP namespace sent as `X-Vault-Namespace`. |
 | `TIDEBREAK_DATA_DIR` | no | `./.tidebreak` | Instance lock, logs, per-turn scratch. Durable state lives in PostgreSQL, not here. |
 | `TIDEBREAK_LOG` | no | built-in policy | `tracing` filter directives, e.g. `debug` or `warn,tidebreak_server=trace`. An invalid spec falls back to the default. |
 | `TIDEBREAK_DIAGNOSTICS_LOG` | no | `off,tidebreak_diagnostics=info` | `tracing` filter directives for the bounded structured JSONL log. See [Diagnostics](diagnostics.md). |
@@ -207,7 +274,7 @@ aspirational.
 | `TIDEBREAK_RUNTIME_CONCURRENCY_CAP` | no | `3` | Positive maximum number of live remote sandboxes each owner may hold. Restart Tidebreak after changing it. |
 | `TIDEBREAK_RUNTIME_SPAWN_SPEND_CEILING_MICROUSD` | no | `5000000` | Positive per-spawn spend ceiling in micro-USD. Set `none` to leave this ceiling to the runtime profile. Restart Tidebreak after changing it. |
 | `TIDEBREAK_RUNTIME_SESSION_SPEND_CEILING_MICROUSD` | no | `20000000` | Positive cumulative spend ceiling per remote session in micro-USD. Set `none` to remove Tidebreak's cumulative ceiling; the runtime profile still bounds each spawn. Restart Tidebreak after changing it. |
-| `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `GEMINI_API_KEY`, `FIREWORKS_API_KEY`, `TOGETHER_API_KEY` | no | unset | Fallback provider credentials, consulted when no credential is stored for that provider. A container has no OS keychain, so this is how a self-host deployment supplies model keys. |
+| `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `GEMINI_API_KEY`, `FIREWORKS_API_KEY`, `TOGETHER_API_KEY` | no | unset | Fallback provider credentials, consulted when Vault holds no credential for that provider or Vault custody is not configured. |
 | `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `OPENAI_COMPATIBLE_BASE_URL`, `OLLAMA_BASE_URL` | no | unset | Fallback provider endpoints, consulted when no base URL is stored for that provider. Point a provider at a compatible endpoint from your chart or compose file instead of setting it after first boot. Use HTTPS; Ollama also accepts HTTP on a loopback address. An unusable value is ignored, and the provider keeps its built-in endpoint. |
 | `TIDEBREAK_LISTEN_ADDR` | no | loopback, ephemeral port | Self-host only: the address and port the API binds, e.g. `0.0.0.0:8080`. The desktop profile refuses to boot with it set — that profile's loopback binding is what its per-launch token assumes. The image sets it to `0.0.0.0:8080` so the container is reachable at a known port. |
 
@@ -233,6 +300,11 @@ docker compose up -d --build
 # 4. Confirm it is up.
 curl -fsS http://127.0.0.1:8080/healthz     # -> ok
 ```
+
+This minimal Compose stack uses provider environment variables. To save
+credentials through Settings, mount a Vault token file into the server
+container and pass the `TIDEBREAK_VAULT_*` variables from the preceding
+section.
 
 `/healthz` is the one unauthenticated route. Everything else needs
 `Authorization: Bearer <token>` with a token from your file.
@@ -374,13 +446,6 @@ data in a self-host deployment yet:
 
 - Document and blob PostgreSQL parity is not comprehensively tested (the
   durable turn state machine is what CI exercises against PostgreSQL).
-- Remote secret custody is future work, and it shows up immediately in a
-  container: there is no OS keychain behind the credential store, so the
-  deployment-plane routes that write or read provider and web-search
-  credentials answer `500 web search credential storage is unavailable`
-  rather than storing anything. Supply model credentials through the
-  environment instead (see the table above) — which also means they are
-  visible to anyone who can inspect the container.
 - Object storage is not wired.
 - Tidebreak enforces one active server process per PostgreSQL database through
   a dedicated advisory lease. A second process refuses boot even when it uses


### PR DESCRIPTION
Closes #2906

Stores self-host credentials in HashiCorp Vault KV v2 without routing them through the desktop OS keychain.

- Selects Keychain for Desktop, Vault for configured SelfHost, and an unavailable stored-secret provider when Vault is absent.
- Reads the mounted Vault token file for every request, refuses redirects, requires HTTPS outside literal loopback development, bounds bodies, and redacts sensitive failures.
- Keeps provider environment variables as fallbacks when Vault is absent while returning setup guidance for credential writes and deletes.
- Skips boot-time and manual keychain re-home work for SelfHost.
- Documents the Vault policy, mount path, namespace, token rotation, and Compose integration.

Validation:
- `cargo test -p tidebreak-core config::tests --lib`
- `cargo test -p tidebreak-server vault_secrets::tests --lib`
- `cargo test -p tidebreak-server profile_secret_tests --lib`
- `cargo test -p tidebreak-server error::tests --lib`
- `cargo check -p tidebreak-server --features postgres`
- `cargo check -p tidebreak-cli`
- `cargo clippy -p tidebreak-server --all-targets --features postgres -- -D warnings -A dead-code`
- `cargo clippy -p tidebreak-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm --dir docs-site build`
- `pnpm --dir docs-site lint`