### PR TITLE
feat(server): open the grant-authenticated adapter routes

### DIFF
--- a/crates/tidebreak-server/src/code/grants.rs
+++ b/crates/tidebreak-server/src/code/grants.rs
@@ -64,8 +64,6 @@ impl Default for GrantRevocations {
 }
 
 impl GrantRevocations {
-    /// The events WebSocket route (#2894) is the production subscriber.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn subscribe(&self) -> tokio::sync::broadcast::Receiver<CodeGrantId> {
         self.sender.subscribe()
     }
@@ -105,7 +103,6 @@ impl super::runtime::CodeRuntime {
 
     /// The live grant a presented access token authenticates. A revoked
     /// grant's next call dies here.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn authenticate_adapter_token(
         &self,
         token: &str,
@@ -120,7 +117,6 @@ impl super::runtime::CodeRuntime {
     /// Rotate a token pair against a presented refresh token. A replayed
     /// rotated token revokes the grant durably and severs its live event
     /// streams before this returns.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn rotate_adapter_token(
         &self,
         refresh: &str,

--- a/crates/tidebreak-server/src/code/grants.rs
+++ b/crates/tidebreak-server/src/code/grants.rs
@@ -164,6 +164,24 @@ impl super::runtime::CodeRuntime {
     pub(crate) fn grant_revocations(&self) -> Arc<GrantRevocations> {
         self.grant_revocations.clone()
     }
+
+    /// Whether the grant's durable row is still live.
+    ///
+    /// The event stream's handshake recheck: a revocation that commits
+    /// between token authentication and the revocation subscription
+    /// published into a channel nobody held, so the stream re-reads the
+    /// row while holding its subscription before it starts.
+    pub(crate) async fn adapter_grant_is_live(
+        &self,
+        owner: &OwnerId,
+        grant_id: CodeGrantId,
+    ) -> Result<bool, ServerError> {
+        Ok(
+            tidebreak_core::db::code::get_external_grant(&self.db, owner, grant_id)
+                .await?
+                .is_some_and(|grant| grant.revoked_at.is_none()),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -288,5 +306,40 @@ mod tests {
         assert_ne!(a, hash_adapter_token("tbg_other"));
         assert_eq!(a.len(), 64);
         assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    /// The event stream's handshake recheck: a revocation that lands after
+    /// token authentication but before the revocation subscription must
+    /// still refuse the stream, because it published into a channel nobody
+    /// held yet.
+    #[tokio::test]
+    async fn a_revocation_racing_the_handshake_fails_the_recheck() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = runtime(dir.path()).await;
+        let owner = OwnerId::local();
+        let (grant, _pair) = runtime
+            .mint_adapter_grant(&owner, "slack", "U9", "T9")
+            .await
+            .unwrap();
+        assert!(runtime
+            .adapter_grant_is_live(&owner, grant.id)
+            .await
+            .unwrap());
+        // The revocation commits with no subscriber listening — exactly the
+        // window between the extractor's auth and the stream's subscribe.
+        runtime
+            .revoke_adapter_grant(&owner, grant.id, "owner unlinked the workspace")
+            .await
+            .unwrap()
+            .expect("the grant exists");
+        let severed = runtime.grant_revocations().subscribe();
+        assert!(
+            !runtime
+                .adapter_grant_is_live(&owner, grant.id)
+                .await
+                .unwrap(),
+            "the recheck under the subscription must see the revoked row"
+        );
+        drop(severed);
     }
 }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -152,7 +152,6 @@ pub(crate) enum SubmitTurnOutcome {
 /// Result of one external message delivery (`docs/slack-sessions.md`,
 /// stage 2). A replayed delivery answers with the same shape the first one
 /// earned, derived from the row's current state.
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug)]
 pub(crate) enum ExternalMessageOutcome {
     /// The message became a running turn.
@@ -1400,7 +1399,6 @@ impl CodeRuntime {
     /// resurrecting, and a binding under another grant refuses. Two racing
     /// creates converge on one session through the binding's unique
     /// conversation key.
-    #[cfg_attr(not(test), allow(dead_code))]
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn external_get_or_create(
         &self,
@@ -4306,7 +4304,6 @@ impl CodeRuntime {
     /// row's current state — still queued, promoted into a turn, or
     /// retracted — without writing a second row. An idle session promotes
     /// the head immediately; a busy one queues durably.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn external_submit_message(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -580,6 +580,36 @@ pub fn app(state: AppState) -> Router {
         ))
         .with_state(state.clone());
 
+    // The channel-adapter surface (docs/slack-sessions.md, stage 2).
+    // Authenticated per request by adapter grant tokens, so it stays outside
+    // `require_token` like the inference relay above.
+    let external_adapter_api = Router::new()
+        .route(
+            "/external/code/sessions",
+            post(routes::code::external_get_or_create),
+        )
+        .route(
+            "/external/code/sessions/{id}/messages",
+            post(routes::code::external_messages),
+        )
+        .route(
+            "/external/code/sessions/{id}/events",
+            get(routes::code::external_events),
+        )
+        .route(
+            "/external/code/sessions/{id}/interrupt",
+            post(routes::code::external_interrupt),
+        )
+        .route(
+            "/external/code/sessions/{id}/reap",
+            post(routes::code::external_reap),
+        )
+        .route(
+            "/external/grants/rotate",
+            post(routes::code::external_rotate),
+        )
+        .with_state(state.clone());
+
     let api = Router::new()
         .route("/settings", get(routes::get_settings))
         .route(
@@ -1099,7 +1129,8 @@ pub fn app(state: AppState) -> Router {
         // The inference relay authenticates the same way with its own
         // per-session key.
         .merge(browser_api)
-        .merge(harness_llm_api);
+        .merge(harness_llm_api)
+        .merge(external_adapter_api);
     let frame_state = state.clone();
     let auth_discovery = Router::new()
         .route("/auth/discovery", get(auth::discovery))

--- a/crates/tidebreak-server/src/routes/code/external.rs
+++ b/crates/tidebreak-server/src/routes/code/external.rs
@@ -238,7 +238,18 @@ pub async fn external_events(
     let session = runtime.get_session(&grant.owner, id).await?;
     let owner = grant.owner.clone();
     let grant_id = grant.id;
+    // Subscribe before deciding to serve, then re-read the durable row while
+    // holding the subscription. A revocation that committed before this point
+    // published into a channel nobody held; the recheck catches it, and one
+    // that commits after it reaches the subscription. Without this ordering,
+    // a revocation racing the handshake leaves the stream connected.
     let revocations = runtime.grant_revocations();
+    let mut severed = revocations.subscribe();
+    if !runtime.adapter_grant_is_live(&owner, grant_id).await? {
+        return Err(ServerError::unauthorized(
+            "the adapter token matches no live grant",
+        ));
+    }
     Ok(upgrade.on_upgrade(move |mut socket| async move {
         // The renderer needs the session's standing before the journal:
         // lifecycle and the attention snapshot arrive first, as their own
@@ -255,7 +266,6 @@ pub async fn external_events(
                 return;
             }
         }
-        let mut severed = revocations.subscribe();
         let stream =
             super::session_events::stream_events(socket, state, owner, id, query.after, None);
         tokio::pin!(stream);

--- a/crates/tidebreak-server/src/routes/code/external.rs
+++ b/crates/tidebreak-server/src/routes/code/external.rs
@@ -1,0 +1,344 @@
+//! The route surface a channel adapter speaks (docs/slack-sessions.md,
+//! stage 2): external get-or-create, messages, session events over
+//! WebSocket, interrupt, and reap — nothing else. No settings, no
+//! repository administration.
+//!
+//! Every route authenticates by adapter token, and every session route
+//! then checks that the token's grant tags the session through a binding.
+//! A session another grant holds answers "not found", the same shape as a
+//! session that does not exist, so the surface leaks nothing about other
+//! grants' work.
+
+use axum::extract::ws::WebSocketUpgrade;
+use axum::extract::{FromRequestParts, State};
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::Response;
+
+use tidebreak_core::{
+    CodeExternalGrant, CodeSessionId, ExternalSessionResolution, GrantRotation, HarnessKind,
+    PermissionMode, RepoId,
+};
+
+use crate::code::runtime::{ExternalMessageOutcome, NewSessionSettings};
+use crate::error::ServerError;
+use crate::extract::{Json, Path, Query};
+use crate::state::AppState;
+
+use super::types::{CodeSessionSnapshot, QueuedCodeTurn, SessionEventsQuery};
+
+/// The authenticated grant behind an adapter request.
+///
+/// Fails closed: no code runtime, no bearer token, or a token matching no
+/// live grant all answer 401 before any handler runs. A revoked grant's
+/// token stops matching, so its next call dies here — the shape the grant
+/// slice promises.
+pub struct ExternalGrantAuth(pub CodeExternalGrant);
+
+impl FromRequestParts<AppState> for ExternalGrantAuth {
+    type Rejection = ServerError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let Some(runtime) = state.code.clone() else {
+            return Err(ServerError::unauthorized(
+                "adapter access is not configured",
+            ));
+        };
+        let token = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| ServerError::unauthorized("an adapter token is required"))?;
+        let grant = runtime
+            .authenticate_adapter_token(token)
+            .await?
+            .ok_or_else(|| ServerError::unauthorized("the adapter token matches no live grant"))?;
+        Ok(Self(grant))
+    }
+}
+
+/// Refuse a session the grant does not tag, with the not-found shape.
+async fn require_bound(
+    state: &AppState,
+    grant: &CodeExternalGrant,
+    session: CodeSessionId,
+) -> Result<std::sync::Arc<crate::code::runtime::CodeRuntime>, ServerError> {
+    let runtime = state
+        .code
+        .clone()
+        .ok_or_else(|| ServerError::unauthorized("adapter access is not configured"))?;
+    let bound = tidebreak_core::db::code::session_bound_to_grant(
+        &runtime.db,
+        &grant.owner,
+        session,
+        grant.id,
+    )
+    .await?;
+    if !bound {
+        return Err(ServerError::not_found("code session not found"));
+    }
+    Ok(runtime)
+}
+
+#[derive(serde::Deserialize)]
+pub struct ExternalSessionBody {
+    /// The channel's durable conversation identity, opaque here.
+    pub external_key: String,
+    /// The repository the sandbox clones. Required in v1.
+    pub repo_id: RepoId,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub harness: Option<HarnessKind>,
+}
+
+#[derive(serde::Serialize)]
+pub struct ExternalSessionResponse {
+    /// `created`, `existing`, or `ended`.
+    pub status: &'static str,
+    pub session_id: CodeSessionId,
+}
+
+/// `POST /external/code/sessions` — idempotent get-or-create for one
+/// conversation. An ended session answers `ended` rather than
+/// resurrecting; a conversation bound under another grant answers "not
+/// found" like any other session outside this grant's scope.
+pub async fn external_get_or_create(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Json(body): Json<ExternalSessionBody>,
+) -> Result<(StatusCode, Json<ExternalSessionResponse>), ServerError> {
+    let runtime = state
+        .code
+        .clone()
+        .ok_or_else(|| ServerError::unauthorized("adapter access is not configured"))?;
+    let resolution = runtime
+        .external_get_or_create(
+            &grant.owner,
+            grant.id,
+            &grant.channel_kind,
+            &body.external_key,
+            body.repo_id,
+            body.title,
+            body.harness.unwrap_or(HarnessKind::ClaudeCode),
+            NewSessionSettings {
+                permission_mode: PermissionMode::Allow,
+                model: None,
+                reasoning_effort: None,
+                fast_mode: false,
+                permission_mode_ceiling: None,
+            },
+        )
+        .await?;
+    let (status, response) = match resolution {
+        ExternalSessionResolution::Created(binding) => (
+            StatusCode::CREATED,
+            ExternalSessionResponse {
+                status: "created",
+                session_id: binding.session_id,
+            },
+        ),
+        ExternalSessionResolution::Existing(binding) => (
+            StatusCode::OK,
+            ExternalSessionResponse {
+                status: "existing",
+                session_id: binding.session_id,
+            },
+        ),
+        ExternalSessionResolution::Ended { session_id } => (
+            StatusCode::OK,
+            ExternalSessionResponse {
+                status: "ended",
+                session_id,
+            },
+        ),
+        ExternalSessionResolution::GrantMismatch => {
+            return Err(ServerError::not_found("code session not found"));
+        }
+    };
+    Ok((status, Json(response)))
+}
+
+#[derive(serde::Deserialize)]
+pub struct ExternalMessageBody {
+    pub text: String,
+    /// The channel's delivery id; replays of it answer from the first row.
+    pub event_id: String,
+    /// The channel's ordering token; still-queued messages apply in its
+    /// order.
+    pub channel_ts: String,
+}
+
+#[derive(serde::Serialize)]
+pub struct ExternalMessageResponse {
+    /// `new_turn`, `queued`, or `dropped`.
+    pub outcome: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<tidebreak_core::CodeTurnId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queued: Option<QueuedCodeTurn>,
+}
+
+/// `POST /external/code/sessions/{id}/messages` — deliver one message.
+/// Idempotent on `event_id`; queue-default when the session is busy.
+pub async fn external_messages(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path(id): Path<CodeSessionId>,
+    Json(body): Json<ExternalMessageBody>,
+) -> Result<Json<ExternalMessageResponse>, ServerError> {
+    let runtime = require_bound(&state, &grant, id).await?;
+    let outcome = runtime
+        .external_submit_message(
+            &grant.owner,
+            grant.id,
+            id,
+            body.text,
+            &body.event_id,
+            &body.channel_ts,
+        )
+        .await?;
+    let response = match outcome {
+        ExternalMessageOutcome::NewTurn(turn) => ExternalMessageResponse {
+            outcome: "new_turn",
+            turn_id: Some(turn.id),
+            queued: None,
+        },
+        ExternalMessageOutcome::Queued(row) => ExternalMessageResponse {
+            outcome: "queued",
+            turn_id: Some(row.id),
+            queued: Some(QueuedCodeTurn::from(*row)),
+        },
+        ExternalMessageOutcome::Dropped => ExternalMessageResponse {
+            outcome: "dropped",
+            turn_id: None,
+            queued: None,
+        },
+    };
+    Ok(Json(response))
+}
+
+/// `WS /external/code/sessions/{id}/events?after=` — the desktop event
+/// stream, scoped by grant, prefixed with a session snapshot (lifecycle
+/// and attention), and severed the moment the grant is revoked.
+pub async fn external_events(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path(id): Path<CodeSessionId>,
+    Query(query): Query<SessionEventsQuery>,
+    upgrade: WebSocketUpgrade,
+) -> Result<Response, ServerError> {
+    let runtime = require_bound(&state, &grant, id).await?;
+    let session = runtime.get_session(&grant.owner, id).await?;
+    let owner = grant.owner.clone();
+    let grant_id = grant.id;
+    let revocations = runtime.grant_revocations();
+    Ok(upgrade.on_upgrade(move |mut socket| async move {
+        // The renderer needs the session's standing before the journal:
+        // lifecycle and the attention snapshot arrive first, as their own
+        // frame shape.
+        let snapshot = serde_json::json!({
+            "snapshot": CodeSessionSnapshot::from(session),
+        });
+        if let Ok(json) = serde_json::to_string(&snapshot) {
+            if socket
+                .send(axum::extract::ws::Message::Text(json.into()))
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+        let mut severed = revocations.subscribe();
+        let stream =
+            super::session_events::stream_events(socket, state, owner, id, query.after, None);
+        tokio::pin!(stream);
+        loop {
+            tokio::select! {
+                () = &mut stream => break,
+                hit = severed.recv() => match hit {
+                    // Dropping the stream future drops the socket, which
+                    // closes the connection: revocation severs live.
+                    Ok(revoked) if revoked == grant_id => break,
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        stream.await;
+                        break;
+                    }
+                },
+            }
+        }
+    }))
+}
+
+/// `POST /external/code/sessions/{id}/interrupt` — stop the active turn,
+/// exactly as the desktop button does. The session stays live.
+pub async fn external_interrupt(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path(id): Path<CodeSessionId>,
+) -> Result<StatusCode, ServerError> {
+    let runtime = require_bound(&state, &grant, id).await?;
+    let _ = runtime.get_session(&grant.owner, id).await?;
+    runtime.interrupt(id).await?;
+    Ok(StatusCode::ACCEPTED)
+}
+
+/// `POST /external/code/sessions/{id}/reap` — clear a fenced session,
+/// exactly as the desktop button does.
+pub async fn external_reap(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path(id): Path<CodeSessionId>,
+) -> Result<Json<CodeSessionSnapshot>, ServerError> {
+    let runtime = require_bound(&state, &grant, id).await?;
+    let session = runtime.reap(&grant.owner, id).await?;
+    Ok(Json(CodeSessionSnapshot::from(session)))
+}
+
+#[derive(serde::Deserialize)]
+pub struct ExternalRotateBody {
+    pub refresh: String,
+}
+
+#[derive(serde::Serialize)]
+pub struct ExternalRotateResponse {
+    pub token: String,
+    pub refresh: String,
+}
+
+/// `POST /external/grants/rotate` — trade the refresh token for a new
+/// pair. A replayed rotated token revokes the grant before this answers,
+/// and the answer says so.
+pub async fn external_rotate(
+    State(state): State<AppState>,
+    Json(body): Json<ExternalRotateBody>,
+) -> Result<Json<ExternalRotateResponse>, ServerError> {
+    let runtime = state
+        .code
+        .clone()
+        .ok_or_else(|| ServerError::unauthorized("adapter access is not configured"))?;
+    let (outcome, pair) = runtime.rotate_adapter_token(&body.refresh).await?;
+    match outcome {
+        GrantRotation::Rotated(_) => {
+            let pair = pair.ok_or_else(|| ServerError::internal("rotation issued no pair"))?;
+            Ok(Json(ExternalRotateResponse {
+                token: pair.token,
+                refresh: pair.refresh,
+            }))
+        }
+        GrantRotation::ReuseDetected(_) => Err(ServerError::unauthorized(
+            "this refresh token was already rotated; the grant is revoked",
+        )),
+        GrantRotation::Unknown => Err(ServerError::unauthorized(
+            "the refresh token matches no live grant",
+        )),
+    }
+}

--- a/crates/tidebreak-server/src/routes/code/external.rs
+++ b/crates/tidebreak-server/src/routes/code/external.rs
@@ -266,8 +266,15 @@ pub async fn external_events(
                 return;
             }
         }
-        let stream =
-            super::session_events::stream_events(socket, state, owner, id, query.after, None);
+        let stream = super::session_events::stream_events(
+            socket,
+            state,
+            owner,
+            id,
+            query.after,
+            None,
+            super::session_events::Viewer::Adapter,
+        );
         tokio::pin!(stream);
         loop {
             tokio::select! {

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -16,6 +16,7 @@ mod analytics;
 mod approvals;
 mod browser;
 mod delivery;
+mod external;
 mod git;
 mod harnesses;
 mod llm;
@@ -41,6 +42,10 @@ pub(crate) use delivery::{
     pull_request_detail as delivery_pull_request_detail,
     query_pull_requests as query_delivery_pull_requests, query_runs as query_delivery_runs,
     resolve_repositories as resolve_delivery_repositories, run_detail as delivery_run_detail,
+};
+pub(crate) use external::{
+    external_events, external_get_or_create, external_interrupt, external_messages, external_reap,
+    external_rotate,
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -1,14 +1,16 @@
 //! `/code/*` routes: repos, workspaces, sessions, doctor, event stream.
 //!
-//! Every route here is owner-scoped through `ScopedCode`, with two
-//! exceptions. The routes that change what the machine *is* — installing
-//! pinned harness binaries, and the clone-parent and worktree-root
-//! directories every principal shares — are registered on the
-//! deployment-plane router in `crate::lib` instead, behind `require_admin`.
-//! And the `/code/browser/*` routes in [`browser`] and the `/code/llm/*`
-//! routes in [`llm`] authenticate with a per-session capability bearer
-//! rather than the launch token, so they are registered outside
-//! `require_token` and derive their owner from the session-key registry.
+//! App-token routes here are owner-scoped through `ScopedCode`. Three route
+//! families use narrower bearer capabilities instead. The `/code/browser/*`
+//! routes in [`browser`] and `/code/llm/*` routes in [`llm`] derive the owner
+//! from a session-private capability. The `/external/code/*` routes in
+//! [`external`] derive the owner from an adapter grant and require that grant
+//! to bind every requested session.
+//!
+//! Routes that change what the machine *is* — installing pinned harness
+//! binaries, and the clone-parent and worktree-root directories every
+//! principal shares — are registered on the deployment-plane router in
+//! `crate::lib` instead, behind `require_admin`.
 
 pub(crate) use super::settings::double_option;
 
@@ -112,9 +114,10 @@ pub(crate) use workspaces::{
     set_worktree_root,
 };
 
-// Nothing here reaches `AppState.code` directly. Every handler in this module
-// extracts a `crate::code::ScopedCode`, which binds the process runtime to the
-// requesting principal and refuses when code mode is not configured — so a new
-// `/code/*` route is owner-scoped by construction rather than by remembering
-// to filter (decision 6's "enforcement is a router property, not a handler
-// habit", applied to data scoping).
+// App-token handlers do not reach `AppState.code` directly. They extract a
+// `crate::code::ScopedCode`, which binds the process runtime to the requesting
+// principal and refuses when code mode is not configured. Capability handlers
+// validate their narrower bearer and derive the owner before reading data. A
+// new route is therefore scoped by construction rather than by remembering to
+// filter (decision 6's "enforcement is a router property, not a handler habit",
+// applied to data scoping).

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -45,8 +45,25 @@ pub async fn session_events(
     } else {
         upgrade
     };
-    Ok(upgrade
-        .on_upgrade(move |socket| stream_events(socket, state, owner, id, query.after, auth_lease)))
+    Ok(upgrade.on_upgrade(move |socket| {
+        stream_events(
+            socket,
+            state,
+            owner,
+            id,
+            query.after,
+            auth_lease,
+            Viewer::Owner,
+        )
+    }))
+}
+
+/// Who is on the other end of an events socket. The owner's own reader
+/// counts as looking at the session; an adapter's follower does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Viewer {
+    Owner,
+    Adapter,
 }
 
 pub(super) async fn stream_events(
@@ -56,13 +73,19 @@ pub(super) async fn stream_events(
     session: CodeSessionId,
     after: i64,
     auth_lease: Option<GatewayAuthLease>,
+    viewer: Viewer,
 ) {
     let mut auth_revalidation = gateway_auth_revalidation_timer(auth_lease.as_ref());
     let Some(runtime) = state.code.clone() else {
         return;
     };
     let (mut live, tail) = runtime.bus.attach(session);
-    let _ = runtime.mark_session_viewed(&owner, session).await;
+    // Only the desktop's own socket means the owner is looking at the
+    // session. The adapter's follower is a renderer, not a viewer: its
+    // connects and resyncs must not clear `DoneUnreviewed` for the owner.
+    if viewer == Viewer::Owner {
+        let _ = runtime.mark_session_viewed(&owner, session).await;
+    }
     let mut last_seq = after;
     if replay_after(&mut socket, &runtime.db, &owner, session, &mut last_seq)
         .await

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -49,7 +49,7 @@ pub async fn session_events(
         .on_upgrade(move |socket| stream_events(socket, state, owner, id, query.after, auth_lease)))
 }
 
-async fn stream_events(
+pub(super) async fn stream_events(
     mut socket: WebSocket,
     state: AppState,
     owner: OwnerId,

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -44,6 +44,7 @@ mod code;
 mod code_browser;
 #[cfg(unix)]
 mod code_clone;
+mod code_external;
 #[cfg(unix)]
 mod code_git;
 #[cfg(unix)]

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -9828,10 +9828,11 @@ fn code_routes_go_through_the_owner_scoped_view() {
         // `types.rs` declare and shape, and serve nothing.
         let serves_data = text.contains("pub async fn") && name != "mod.rs";
         if serves_data && !text.contains("ScopedCode") {
-            // Browser and harness inference are capability-bearer routes.
-            // Each resolves a session-private token to the owning session
-            // instead of accepting the app-token `ScopedCode` extractor.
-            // Require each route's own authorization path here.
+            // Browser, harness inference, and external adapters are
+            // capability-bearer routes. Each derives the owner from a
+            // narrower credential instead of accepting the app-token
+            // `ScopedCode` extractor. Require each route's own authorization
+            // path here.
             if name == "browser.rs" {
                 if !text.contains("fn authorize(")
                     || !text.contains("BrowserSubject")
@@ -9851,7 +9852,18 @@ fn code_routes_go_through_the_owner_scoped_view() {
                     findings.push(format!(
                         "{name} is the capability-bearer harness inference \
                          route but is missing its `HarnessLlmRelay` / \
-                         `HeaderMap` / `relay.forward` authorization path"
+                        `HeaderMap` / `relay.forward` authorization path"
+                    ));
+                }
+            } else if name == "external.rs" {
+                if !text.contains("ExternalGrantAuth")
+                    || !text.contains("authenticate_adapter_token")
+                    || !text.contains("session_bound_to_grant")
+                {
+                    findings.push(format!(
+                        "{name} is the adapter grant route but is missing its \
+                         `ExternalGrantAuth` / `authenticate_adapter_token` / \
+                         `session_bound_to_grant` authorization path"
                     ));
                 }
             } else {

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -560,7 +560,7 @@ fn json_id(value: &serde_json::Value) -> &str {
     value["id"].as_str().expect("id is a string")
 }
 
-async fn serve(router: Router) -> std::net::SocketAddr {
+pub(super) async fn serve(router: Router) -> std::net::SocketAddr {
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {

--- a/crates/tidebreak-server/src/tests/code_external.rs
+++ b/crates/tidebreak-server/src/tests/code_external.rs
@@ -173,6 +173,18 @@ async fn external_app() -> (
     (app(state), fake, runtime, repo_id, dir)
 }
 
+async fn bound_session_id(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    external_key: &str,
+) -> tidebreak_core::CodeSessionId {
+    tidebreak_core::db::code::get_external_binding(&runtime.db, owner, "slack", external_key)
+        .await
+        .unwrap()
+        .expect("the external session request committed its binding")
+        .session_id
+}
+
 /// The whole adapter surface over HTTP: bad tokens refuse, get-or-create
 /// is idempotent, messages are idempotent on the event id, a foreign grant
 /// sees "not found", interrupt reaches the sandbox, and rotation with a
@@ -216,7 +228,12 @@ async fn external_routes_scope_by_grant_and_replay_idempotently() {
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let created: serde_json::Value = created.json().await.unwrap();
     assert_eq!(created["status"], "created");
-    let session_id = created["session_id"].as_str().unwrap().to_owned();
+    let session_id = bound_session_id(&runtime, &owner, "T1/C1/1.1").await;
+    let session_id_text = session_id.to_string();
+    assert_eq!(
+        created["session_id"].as_str(),
+        Some(session_id_text.as_str())
+    );
     let again: serde_json::Value = client
         .post(format!("http://{addr}/external/code/sessions"))
         .bearer_auth(&pair.token)
@@ -228,7 +245,7 @@ async fn external_routes_scope_by_grant_and_replay_idempotently() {
         .await
         .unwrap();
     assert_eq!(again["status"], "existing");
-    assert_eq!(again["session_id"].as_str().unwrap(), session_id);
+    assert_eq!(again["session_id"].as_str(), Some(session_id_text.as_str()));
 
     // Messages: the idle session runs the message; the replay answers the
     // same turn without a second spawn.
@@ -379,7 +396,12 @@ async fn external_events_snapshot_then_replay_then_sever_on_revoke() {
         .json()
         .await
         .unwrap();
-    let session_id = created["session_id"].as_str().unwrap().to_owned();
+    let session_id = bound_session_id(&runtime, &owner, "T1/C2/9.9").await;
+    let session_id_text = session_id.to_string();
+    assert_eq!(
+        created["session_id"].as_str(),
+        Some(session_id_text.as_str())
+    );
     let first: serde_json::Value = client
         .post(format!(
             "http://{addr}/external/code/sessions/{session_id}/messages"
@@ -426,7 +448,10 @@ async fn external_events_snapshot_then_replay_then_sever_on_revoke() {
         .unwrap()
         .unwrap();
     let value: serde_json::Value = serde_json::from_str(frame.to_text().unwrap()).unwrap();
-    assert_eq!(value["snapshot"]["id"].as_str().unwrap(), session_id);
+    assert_eq!(
+        value["snapshot"]["id"].as_str(),
+        Some(session_id_text.as_str())
+    );
     assert!(value["snapshot"]["attention"].is_object());
     assert!(value["snapshot"]["lifecycle"].is_string());
 
@@ -457,8 +482,7 @@ async fn external_events_snapshot_then_replay_then_sever_on_revoke() {
             },
         ],
     });
-    let parsed: tidebreak_core::CodeSessionId = session_id.parse().unwrap();
-    let mut live = runtime.get_session(&owner, parsed).await.unwrap();
+    let mut live = runtime.get_session(&owner, session_id).await.unwrap();
     runtime
         .remote_sessions()
         .unwrap()
@@ -489,7 +513,11 @@ async fn external_events_snapshot_then_replay_then_sever_on_revoke() {
     // The adapter is a renderer, not a viewer: its reconnect — the resync
     // path — must not clear `DoneUnreviewed`, which the desktop inbox and
     // the channel's own success render both read.
-    let before = runtime.get_session(&owner, parsed).await.unwrap().attention;
+    let before = runtime
+        .get_session(&owner, session_id)
+        .await
+        .unwrap()
+        .attention;
     let mut request = format!("ws://{addr}/external/code/sessions/{session_id}/events")
         .into_client_request()
         .unwrap();
@@ -504,7 +532,11 @@ async fn external_events_snapshot_then_replay_then_sever_on_revoke() {
         .unwrap()
         .unwrap();
     assert!(frame.to_text().unwrap().contains("snapshot"));
-    let after = runtime.get_session(&owner, parsed).await.unwrap().attention;
+    let after = runtime
+        .get_session(&owner, session_id)
+        .await
+        .unwrap()
+        .attention;
     assert_eq!(
         after.state, before.state,
         "an adapter connect must not count as the owner viewing the session"

--- a/crates/tidebreak-server/src/tests/code_external.rs
+++ b/crates/tidebreak-server/src/tests/code_external.rs
@@ -486,6 +486,31 @@ async fn external_events_snapshot_then_replay_then_sever_on_revoke() {
         "the per-turn assistant record must reach the socket"
     );
 
+    // The adapter is a renderer, not a viewer: its reconnect — the resync
+    // path — must not clear `DoneUnreviewed`, which the desktop inbox and
+    // the channel's own success render both read.
+    let before = runtime.get_session(&owner, parsed).await.unwrap().attention;
+    let mut request = format!("ws://{addr}/external/code/sessions/{session_id}/events")
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {}", pair.token).parse().unwrap(),
+    );
+    let (mut resync, _) = connect_async(request).await.unwrap();
+    let frame = tokio::time::timeout(Duration::from_secs(5), resync.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(frame.to_text().unwrap().contains("snapshot"));
+    let after = runtime.get_session(&owner, parsed).await.unwrap().attention;
+    assert_eq!(
+        after.state, before.state,
+        "an adapter connect must not count as the owner viewing the session"
+    );
+    drop(resync);
+
     // Revocation severs the live stream promptly.
     runtime
         .revoke_adapter_grant(&owner, grant.id, "owner unlinked the workspace")

--- a/crates/tidebreak-server/src/tests/code_external.rs
+++ b/crates/tidebreak-server/src/tests/code_external.rs
@@ -1,0 +1,509 @@
+//! The channel-adapter route surface end to end (docs/slack-sessions.md,
+//! stage 2): adapter-token authentication, grant scoping, idempotent
+//! messages, the snapshot-prefixed event stream, revocation severing it,
+//! and token rotation with reuse detection.
+
+use super::*;
+
+use super::code::serve;
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use axum::Router;
+use futures::StreamExt;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+use crate::code::remote::service::RemoteSessions;
+use crate::code::remote::wire::{
+    EventCursor, MessageReceipt, SandboxEvent, SandboxEvents, SandboxLease, SandboxMessage,
+    SandboxState, SandboxStatus, SpawnArguments,
+};
+use crate::code::remote::{RemoteSandboxError, SandboxProvisioner};
+use crate::code::CodeRuntime;
+use tidebreak_core::db::code::insert_repo;
+use tidebreak_core::{CodeRepo, OwnerId, RepoId};
+
+#[derive(Default)]
+struct FakeProvisioner {
+    spawns: StdMutex<Vec<SpawnArguments>>,
+    sends: StdMutex<Vec<SandboxMessage>>,
+    event_reads: StdMutex<VecDeque<SandboxEvents>>,
+}
+
+#[async_trait::async_trait]
+impl SandboxProvisioner for FakeProvisioner {
+    async fn spawn(
+        &self,
+        _owner: &OwnerId,
+        arguments: &SpawnArguments,
+    ) -> Result<SandboxLease, RemoteSandboxError> {
+        self.spawns.lock().unwrap().push(arguments.clone());
+        Ok(SandboxLease {
+            sandbox_id: "sb-ext".to_owned(),
+            state: SandboxState::Pending,
+            latest_event_seq: 0,
+            expires_in_seconds: 7200,
+        })
+    }
+
+    async fn status(
+        &self,
+        _owner: &OwnerId,
+        sandbox_id: &str,
+    ) -> Result<SandboxStatus, RemoteSandboxError> {
+        Ok(SandboxStatus {
+            sandbox_id: sandbox_id.to_owned(),
+            state: SandboxState::Running,
+            failure_reason: None,
+            termination_reason: None,
+            latest_event_seq: 0,
+            pending_messages: 0,
+            spend_microusd: None,
+            spend_ceiling_microusd: None,
+            possibly_stalled: false,
+            repository_url: None,
+            completed_at: None,
+        })
+    }
+
+    async fn events(
+        &self,
+        _owner: &OwnerId,
+        _sandbox_id: &str,
+        _cursor: EventCursor,
+    ) -> Result<SandboxEvents, RemoteSandboxError> {
+        self.event_reads
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or(RemoteSandboxError::Unavailable {
+                operation: "events",
+                detail: "no scripted read".to_owned(),
+            })
+    }
+
+    async fn send(
+        &self,
+        _owner: &OwnerId,
+        _sandbox_id: &str,
+        message: &SandboxMessage,
+    ) -> Result<MessageReceipt, RemoteSandboxError> {
+        self.sends.lock().unwrap().push(message.clone());
+        Ok(MessageReceipt {
+            seq: 1,
+            interrupt: message.interrupt,
+            pending_messages: 0,
+        })
+    }
+
+    async fn cancel(&self, _owner: &OwnerId, _sandbox_id: &str) -> Result<(), RemoteSandboxError> {
+        Ok(())
+    }
+}
+
+fn remote_settings() -> crate::code::remote::driver::RemoteSpawnSettings {
+    crate::code::remote::driver::RemoteSpawnSettings {
+        profile: "tidebreak-remote".to_owned(),
+        incarnation_cap: 2,
+        spend_ceiling_microusd: None,
+        session_spend_ceiling_microusd: None,
+    }
+}
+
+/// An app whose code runtime carries a fake sandbox provisioner and one
+/// origin-bearing repository, ready for the adapter surface.
+async fn external_app() -> (
+    Router,
+    Arc<FakeProvisioner>,
+    Arc<CodeRuntime>,
+    RepoId,
+    tempfile::TempDir,
+) {
+    let (dir, store) = temp_db_store("code.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let fake = Arc::new(FakeProvisioner::default());
+    let runtime = Arc::new(
+        CodeRuntime::new(
+            db,
+            dir.path().to_path_buf(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .with_remote_sessions(RemoteSessions::new(fake.clone(), remote_settings())),
+    );
+    let owner = OwnerId::local();
+    let repo = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: dir.path().join("repo").display().to_string(),
+        display_name: "tools".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "tidebreak/".into(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: chrono::Utc::now(),
+        removed_at: None,
+        cloned_from: None,
+        origin_host: Some("github.com".into()),
+        origin_owner: Some("acme".into()),
+        origin_name: Some("tools".into()),
+    };
+    insert_repo(&runtime.db, &repo).await.unwrap();
+    let repo_id = repo.id;
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime.clone());
+    (app(state), fake, runtime, repo_id, dir)
+}
+
+/// The whole adapter surface over HTTP: bad tokens refuse, get-or-create
+/// is idempotent, messages are idempotent on the event id, a foreign grant
+/// sees "not found", interrupt reaches the sandbox, and rotation with a
+/// replayed refresh kills the grant.
+#[tokio::test]
+async fn external_routes_scope_by_grant_and_replay_idempotently() {
+    let (router, fake, runtime, repo_id, _dir) = external_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+
+    // No token and a bogus token both refuse before any handler runs.
+    let refused = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .json(&serde_json::json!({ "external_key": "T1/C1/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let refused = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth("tbg_not_a_token")
+        .json(&serde_json::json!({ "external_key": "T1/C1/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    // Get-or-create: created once, existing on the retry.
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C1/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let created: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(created["status"], "created");
+    let session_id = created["session_id"].as_str().unwrap().to_owned();
+    let again: serde_json::Value = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C1/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(again["status"], "existing");
+    assert_eq!(again["session_id"].as_str().unwrap(), session_id);
+
+    // Messages: the idle session runs the message; the replay answers the
+    // same turn without a second spawn.
+    let first: serde_json::Value = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/messages"
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "text": "start", "event_id": "Ev1", "channel_ts": "1700000001.000100"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(first["outcome"], "new_turn");
+    assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+    let replay: serde_json::Value = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/messages"
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "text": "start", "event_id": "Ev1", "channel_ts": "1700000001.000100"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(replay["outcome"], "new_turn");
+    assert_eq!(replay["turn_id"], first["turn_id"]);
+    assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+
+    // A foreign grant sees the session as not found, and its get-or-create
+    // on the same conversation refuses the same way.
+    let (_foreign, foreign_pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U2", "T1")
+        .await
+        .unwrap();
+    let hidden = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/messages"
+        ))
+        .bearer_auth(&foreign_pair.token)
+        .json(&serde_json::json!({
+            "text": "mine now", "event_id": "EvX", "channel_ts": "1700000002.000100"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(hidden.status(), reqwest::StatusCode::NOT_FOUND);
+    let mismatch = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&foreign_pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C1/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(mismatch.status(), reqwest::StatusCode::NOT_FOUND);
+
+    // Interrupt reaches the sandbox as its desktop equivalent does.
+    let interrupted = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/interrupt"
+        ))
+        .bearer_auth(&pair.token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(interrupted.status(), reqwest::StatusCode::ACCEPTED);
+    assert!(fake
+        .sends
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|message| message.interrupt));
+
+    // Rotation trades the pair; the old access token stops working.
+    let rotated: serde_json::Value = client
+        .post(format!("http://{addr}/external/grants/rotate"))
+        .json(&serde_json::json!({ "refresh": pair.refresh }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let new_token = rotated["token"].as_str().unwrap().to_owned();
+    let stale = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/interrupt"
+        ))
+        .bearer_auth(&pair.token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(stale.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    // A replayed rotated refresh kills the grant: the rotation refuses and
+    // the new access token stops working too.
+    let theft = client
+        .post(format!("http://{addr}/external/grants/rotate"))
+        .json(&serde_json::json!({ "refresh": pair.refresh }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(theft.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let dead = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/interrupt"
+        ))
+        .bearer_auth(&new_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dead.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let revoked = tidebreak_core::db::code::get_external_grant(&runtime.db, &owner, grant.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(revoked.revoked_at.is_some());
+}
+
+/// The event stream opens with the session snapshot (lifecycle and
+/// attention), replays the journal — the per-turn assistant record a
+/// renderer needs — and drops the moment the grant is revoked.
+#[tokio::test]
+async fn external_events_snapshot_then_replay_then_sever_on_revoke() {
+    let (router, fake, runtime, repo_id, _dir) = external_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let created: serde_json::Value = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C2/9.9", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let session_id = created["session_id"].as_str().unwrap().to_owned();
+    let first: serde_json::Value = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/messages"
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "text": "start", "event_id": "Ev1", "channel_ts": "1700000001.000100"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(first["outcome"], "new_turn");
+
+    // A token that holds no binding cannot even upgrade.
+    let (_foreign, foreign_pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U2", "T1")
+        .await
+        .unwrap();
+    let mut request = format!("ws://{addr}/external/code/sessions/{session_id}/events")
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {}", foreign_pair.token).parse().unwrap(),
+    );
+    assert!(connect_async(request).await.is_err());
+
+    let mut request = format!("ws://{addr}/external/code/sessions/{session_id}/events")
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {}", pair.token).parse().unwrap(),
+    );
+    let (mut socket, _) = connect_async(request).await.unwrap();
+
+    // First frame: the session snapshot with its attention.
+    let frame = tokio::time::timeout(Duration::from_secs(5), socket.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let value: serde_json::Value = serde_json::from_str(frame.to_text().unwrap()).unwrap();
+    assert_eq!(value["snapshot"]["id"].as_str().unwrap(), session_id);
+    assert!(value["snapshot"]["attention"].is_object());
+    assert!(value["snapshot"]["lifecycle"].is_string());
+
+    // The sandbox streams the turn; ingest journals it, and the frames —
+    // the per-turn assistant record a renderer needs — reach the socket.
+    fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+        sandbox_id: "sb-ext".to_owned(),
+        state: SandboxState::Running,
+        latest_event_seq: 3,
+        events: vec![
+            SandboxEvent {
+                seq: 1,
+                kind: "turn_started".to_owned(),
+                payload: serde_json::json!({ "turn": 1 }),
+                created_at: String::new(),
+            },
+            SandboxEvent {
+                seq: 2,
+                kind: "assistant_record".to_owned(),
+                payload: serde_json::json!({ "turn": 1, "body": "done: shipped" }),
+                created_at: String::new(),
+            },
+            SandboxEvent {
+                seq: 3,
+                kind: "turn_completed".to_owned(),
+                payload: serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                created_at: String::new(),
+            },
+        ],
+    });
+    let parsed: tidebreak_core::CodeSessionId = session_id.parse().unwrap();
+    let mut live = runtime.get_session(&owner, parsed).await.unwrap();
+    runtime
+        .remote_sessions()
+        .unwrap()
+        .driver(&runtime.db, runtime.bus.as_ref())
+        .pump(&mut live, 0)
+        .await
+        .unwrap();
+    let mut saw_assistant_record = false;
+    for _ in 0..20 {
+        let Ok(Some(Ok(frame))) = tokio::time::timeout(Duration::from_secs(5), socket.next()).await
+        else {
+            break;
+        };
+        let Ok(text) = frame.to_text() else { continue };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
+            continue;
+        };
+        if value["event"]["type"] == "assistant_message" || text.contains("done: shipped") {
+            saw_assistant_record = true;
+            break;
+        }
+    }
+    assert!(
+        saw_assistant_record,
+        "the per-turn assistant record must reach the socket"
+    );
+
+    // Revocation severs the live stream promptly.
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "owner unlinked the workspace")
+        .await
+        .unwrap();
+    let severed = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match socket.next().await {
+                None => break,
+                Some(Err(_)) => break,
+                Some(Ok(tokio_tungstenite::tungstenite::Message::Close(_))) => break,
+                Some(Ok(_)) => {}
+            }
+        }
+    })
+    .await;
+    assert!(
+        severed.is_ok(),
+        "the revoked grant's stream must drop immediately"
+    );
+}


### PR DESCRIPTION
The route surface a channel adapter speaks (stage 2 of
`docs/slack-sessions.md`, slice 4 of #2890).

- A separate unauthenticated router, outside `require_token` on the
  inference relay's pattern: external get-or-create, messages, session
  events over WebSocket, interrupt, reap, and grant rotation — nothing
  else.
- Every route authenticates per request by adapter token (fail-closed
  401), and every session route then checks that the token's grant tags
  the session through a binding. A session another grant holds answers
  the not-found shape, so the surface says nothing about other grants'
  work.
- The events WebSocket sends the session snapshot first, then the
  desktop event stream, and is severed the moment the grant is revoked
  via the `GrantRevocations` broadcast.

The connect handshake and the desktop grants panel follow in the next
slice.

Closes #2894
