### PR TITLE
feat(server): store self-host blobs in S3-compatible storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1036,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex 2.0.1",
 ]
 
@@ -1285,6 +1310,16 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
+]
 
 [[package]]
 name = "crc32fast"
@@ -2083,7 +2118,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2854,7 +2889,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3200,6 +3234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3396,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
 ]
 
 [[package]]
@@ -3716,16 +3769,6 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "md-5"
@@ -4244,14 +4287,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc-fast",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -4260,14 +4305,14 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools 0.14.0",
- "md-5 0.10.6",
+ "itertools 0.15.0",
+ "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml",
  "rand 0.10.2",
- "reqwest 0.12.28",
- "ring",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4622,7 +4667,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -4872,21 +4917,12 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -4915,6 +4951,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -5174,7 +5211,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -5188,7 +5224,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5218,6 +5253,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -5228,6 +5264,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -5385,6 +5422,7 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5448,6 +5486,7 @@ version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6294,6 +6333,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+
+[[package]]
 name = "sqlx"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6436,7 +6481,7 @@ dependencies = [
  "hmac 0.13.0",
  "itoa",
  "log",
- "md-5 0.11.0",
+ "md-5",
  "memchr",
  "rand 0.10.2",
  "rust_decimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,6 +2600,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +2808,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2832,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2828,6 +2854,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3692,6 +3719,16 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -4206,6 +4243,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5 0.10.6",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml 0.39.4",
+ "rand 0.10.2",
+ "reqwest 0.12.28",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4548,7 +4622,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -4795,6 +4869,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quick-xml"
@@ -5090,6 +5174,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -5103,6 +5188,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6350,7 +6436,7 @@ dependencies = [
  "hmac 0.13.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
  "rand 0.10.2",
  "rust_decimal",
@@ -7257,6 +7343,7 @@ dependencies = [
  "futures-timer",
  "jsonschema",
  "keyring",
+ "object_store",
  "schemars 1.2.2",
  "sea-orm",
  "sea-orm-migration",
@@ -7677,6 +7764,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ base64 = "=0.23.1"
 minisign-verify = "=0.2.5"
 libc = "=0.2.189"
 async-stream = "=0.3.6"
+object_store = { version = "=0.13.2", default-features = false, features = ["aws", "tls-webpki-roots"] }
 axum = { version = "=0.8.9", features = ["ws"] }
 tempfile = "=3.27.0"
 trash = { version = "=5.2.6", default-features = false, features = ["coinit_apartmentthreaded"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ base64 = "=0.23.1"
 minisign-verify = "=0.2.5"
 libc = "=0.2.189"
 async-stream = "=0.3.6"
-object_store = { version = "=0.13.2", default-features = false, features = ["aws", "tls-webpki-roots"] }
+object_store = { version = "=0.14.1", default-features = false, features = ["aws"] }
 axum = { version = "=0.8.9", features = ["ws"] }
 tempfile = "=3.27.0"
 trash = { version = "=5.2.6", default-features = false, features = ["coinit_apartmentthreaded"] }

--- a/crates/tidebreak-core/Cargo.toml
+++ b/crates/tidebreak-core/Cargo.toml
@@ -36,11 +36,14 @@ keychain = ["dep:keyring", "dep:tokio"]
 tools = ["dep:cap-fs-ext", "dep:cap-std", "dep:tokio"]
 # Durable local byte storage for desktop documents and artifacts.
 blob-fs = ["dep:async-stream", "dep:tokio", "dep:windows-sys"]
+# S3-compatible byte storage for self-hosted deployments.
+blob-object = ["dep:object_store", "dep:tokio"]
 
 [dependencies]
 tidebreak-shell-policy = { path = "../tidebreak-shell-policy" }
 async-trait = { workspace = true }
 async-stream = { workspace = true, optional = true }
+object_store = { workspace = true, optional = true }
 cap-std = { workspace = true, optional = true }
 cap-fs-ext = { workspace = true, optional = true }
 futures = { workspace = true }

--- a/crates/tidebreak-core/src/agent/tests/image_hydration.rs
+++ b/crates/tidebreak-core/src/agent/tests/image_hydration.rs
@@ -33,7 +33,7 @@ impl BlobStore for MemBlobs {
         Ok(self.bytes.lock().unwrap().get(&id).cloned())
     }
 
-    fn delete(&self, id: uuid::Uuid) -> Result<()> {
+    async fn delete(&self, id: uuid::Uuid) -> Result<()> {
         self.bytes.lock().unwrap().remove(&id);
         Ok(())
     }

--- a/crates/tidebreak-core/src/blob.rs
+++ b/crates/tidebreak-core/src/blob.rs
@@ -11,7 +11,9 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use uuid::Uuid;
 
-use crate::{AgentError, BlobMetadata, BlobStore, BlobStream, DocumentBlob, Result};
+use crate::{
+    AgentError, BlobInventoryItem, BlobMetadata, BlobStore, BlobStream, DocumentBlob, Result,
+};
 
 /// Filesystem-backed opaque byte storage.
 ///
@@ -228,19 +230,83 @@ impl BlobStore for FsBlobStore {
         Ok(Some(Box::pin(stream)))
     }
 
-    fn delete(&self, id: Uuid) -> Result<()> {
+    async fn inventory(&self) -> Result<Vec<BlobInventoryItem>> {
+        let root = Arc::clone(&self.root);
+        tokio::task::spawn_blocking(move || inventory(&root))
+            .await
+            .map_err(|error| AgentError::Store(format!("blob inventory task failed: {error}")))?
+    }
+
+    async fn modified_at(&self, id: Uuid) -> Result<Option<std::time::SystemTime>> {
+        let path = self.blob_path(id);
+        tokio::task::spawn_blocking(move || match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => metadata
+                .modified()
+                .map(Some)
+                .map_err(|error| blob_error("read modification time", error)),
+            Ok(_) => Ok(None),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(blob_error("read metadata", error)),
+        })
+        .await
+        .map_err(|error| AgentError::Store(format!("blob metadata task failed: {error}")))?
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<()> {
         let path = self.blob_path(id);
         let root = Arc::clone(&self.root);
         let access = Arc::clone(&self.access);
-        let _guard = access
-            .write()
-            .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
-        match fs::remove_file(path) {
-            Ok(()) => sync_directory(&root),
-            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(blob_error("delete file", error)),
-        }
+        tokio::task::spawn_blocking(move || {
+            let _guard = access
+                .write()
+                .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
+            match fs::remove_file(path) {
+                Ok(()) => sync_directory(&root),
+                Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(blob_error("delete file", error)),
+            }
+        })
+        .await
+        .map_err(|error| AgentError::Store(format!("blob delete task failed: {error}")))?
     }
+}
+
+fn inventory(root: &Path) -> Result<Vec<BlobInventoryItem>> {
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(blob_error("read directory", error)),
+    };
+    let mut items = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| blob_error("read directory entry", error))?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Some(id) = name.strip_suffix(".blob").and_then(|id| id.parse().ok()) else {
+            continue;
+        };
+        if name != format!("{id}.blob") {
+            continue;
+        }
+        let file_type = entry
+            .file_type()
+            .map_err(|error| blob_error("read file type", error))?;
+        if !file_type.is_file() {
+            continue;
+        }
+        let metadata = entry
+            .metadata()
+            .map_err(|error| blob_error("read metadata", error))?;
+        items.push(BlobInventoryItem {
+            id,
+            modified_at: metadata
+                .modified()
+                .map_err(|error| blob_error("read modification time", error))?,
+        });
+    }
+    items.sort_unstable_by_key(|item| item.id);
+    Ok(items)
 }
 
 fn write_streamed_blob(
@@ -422,8 +488,8 @@ mod tests {
             reopened.get(id).await.unwrap().as_deref(),
             Some(&b"first"[..])
         );
-        reopened.delete(id).unwrap();
-        reopened.delete(id).unwrap();
+        reopened.delete(id).await.unwrap();
+        reopened.delete(id).await.unwrap();
         assert_eq!(reopened.get(id).await.unwrap(), None);
     }
 

--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -726,6 +726,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         let expected = std::env::current_dir().unwrap().join(".tidebreak");
@@ -738,6 +739,7 @@ mod tests {
         let config = Config::from_vars(
             Some(String::new()),
             Some(OsString::from("/data")),
+            None,
             None,
             None,
             None,
@@ -869,6 +871,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -881,6 +884,7 @@ mod tests {
             Some("desktop".into()),
             Some(OsString::from("/data")),
             Some("s3://tidebreak/blobs".into()),
+            None,
             None,
             None,
             None,
@@ -910,7 +914,8 @@ mod tests {
             None,
             None,
             None,
-            None
+            None,
+            None,
         )
         .is_err());
     }
@@ -1120,6 +1125,7 @@ mod tests {
         let config = Config::from_vars(
             Some("self_host".into()),
             Some(OsString::from("/data")),
+            Some("s3://tidebreak/blobs".into()),
             None,
             None,
             None,
@@ -1195,7 +1201,7 @@ mod tests {
         )
         .unwrap();
         let error = Config::from_vars(
-            None, None, None, None, None, None, None, None, None, None, None, vault,
+            None, None, None, None, None, None, None, None, None, None, None, None, vault,
         )
         .unwrap_err()
         .to_string();

--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -129,6 +129,9 @@ pub struct Config {
     pub profile: Profile,
     /// Directory holding the app's data (database, blobs, …).
     pub data_dir: PathBuf,
+    /// S3 bucket and optional prefix used by the self-host blob store.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob_store_url: Option<String>,
     /// Keychain service name secrets are stored under; `None` uses the
     /// default (`tidebreak`). Host applications whose builds must not share
     /// secret state — a dev build running beside an installed release — set
@@ -340,6 +343,7 @@ impl Config {
         Self {
             profile: Profile::Desktop,
             data_dir: data_dir.into(),
+            blob_store_url: None,
             keychain_service: None,
             bundle_id: None,
             exec_scripts_dir: None,
@@ -368,6 +372,8 @@ impl Config {
     /// `TIDEBREAK_PROFILE` (default `desktop`), `TIDEBREAK_DATA_DIR` (default
     /// `./.tidebreak` under the current directory — desktop/CLI clients should set
     /// this to the platform's app-data location),
+    /// `TIDEBREAK_BLOB_STORE_URL` (required for self-host; an S3 bucket and
+    /// optional prefix),
     /// `TIDEBREAK_CONTAINER_EXECUTION_ENABLED` (default `false`),
     /// `TIDEBREAK_CONTAINER_IMAGE` (defaulting to the server's default agent
     /// image), `TIDEBREAK_AUTH_TOKENS_FILE` or `TIDEBREAK_AUTH_GATEWAY_URL`
@@ -394,6 +400,7 @@ impl Config {
         Self::from_vars(
             std::env::var("TIDEBREAK_PROFILE").ok(),
             std::env::var_os("TIDEBREAK_DATA_DIR"),
+            std::env::var("TIDEBREAK_BLOB_STORE_URL").ok(),
             std::env::var("TIDEBREAK_CONTAINER_EXECUTION_ENABLED").ok(),
             std::env::var("TIDEBREAK_CONTAINER_IMAGE").ok(),
             std::env::var_os("TIDEBREAK_AUTH_TOKENS_FILE"),
@@ -423,6 +430,7 @@ impl Config {
     fn from_vars(
         profile: Option<String>,
         data_dir: Option<OsString>,
+        blob_store_url: Option<String>,
         container_execution_enabled: Option<String>,
         container_image: Option<String>,
         auth_tokens_file: Option<OsString>,
@@ -445,6 +453,20 @@ impl Config {
                 .map_err(|e| AgentError::config(format!("no working directory: {e}")))?
                 .join(".tidebreak"),
         };
+        let blob_store_url = blob_store_url.filter(|value| !value.trim().is_empty());
+        match (profile, blob_store_url.as_deref()) {
+            (Profile::SelfHost, None) => {
+                return Err(AgentError::config(
+                    "TIDEBREAK_BLOB_STORE_URL is required for self-host",
+                ));
+            }
+            (Profile::Desktop, Some(_)) => {
+                return Err(AgentError::config(
+                    "TIDEBREAK_BLOB_STORE_URL is only valid for self-host",
+                ));
+            }
+            _ => {}
+        }
         let container_execution_enabled =
             match container_execution_enabled.filter(|value| !value.is_empty()) {
                 None => false,
@@ -486,6 +508,7 @@ impl Config {
         Ok(Self {
             profile,
             data_dir,
+            blob_store_url,
             keychain_service: None,
             bundle_id: None,
             exec_scripts_dir: None,
@@ -744,6 +767,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some("primary".into()),
             None,
             None,
@@ -752,6 +776,7 @@ mod tests {
         let config = Config::from_vars(
             None,
             Some(OsString::from("/data")),
+            None,
             None,
             None,
             None,
@@ -804,6 +829,7 @@ mod tests {
         let config = Config::from_vars(
             Some("self_host".into()),
             Some(OsString::from("/data")),
+            Some("s3://tidebreak/blobs".into()),
             None,
             None,
             Some(OsString::from("/etc/tidebreak/tokens")),
@@ -819,9 +845,55 @@ mod tests {
         assert_eq!(config.profile, Profile::SelfHost);
         assert_eq!(config.data_dir, PathBuf::from("/data"));
         assert_eq!(
+            config.blob_store_url.as_deref(),
+            Some("s3://tidebreak/blobs")
+        );
+        assert_eq!(
             config.auth_tokens_file,
             Some(PathBuf::from("/etc/tidebreak/tokens"))
         );
+    }
+
+    #[test]
+    fn self_host_requires_a_blob_store_url() {
+        let error = Config::from_vars(
+            Some("self_host".into()),
+            Some(OsString::from("/data")),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("TIDEBREAK_BLOB_STORE_URL is required for self-host"));
+    }
+
+    #[test]
+    fn desktop_rejects_a_blob_store_url() {
+        let error = Config::from_vars(
+            Some("desktop".into()),
+            Some(OsString::from("/data")),
+            Some("s3://tidebreak/blobs".into()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("TIDEBREAK_BLOB_STORE_URL is only valid for self-host"));
     }
 
     #[test]
@@ -864,6 +936,7 @@ mod tests {
         let config = Config::from_vars(
             Some("self_host".into()),
             Some(OsString::from("/data")),
+            Some("s3://tidebreak/blobs".into()),
             None,
             None,
             None,
@@ -886,6 +959,7 @@ mod tests {
         assert!(Config::from_vars(
             Some("self_host".into()),
             None,
+            Some("s3://tidebreak/blobs".into()),
             None,
             None,
             None,
@@ -911,6 +985,7 @@ mod tests {
     fn legacy_config_without_keychain_service_defaults_to_none() {
         let config = serde_json::from_str::<Config>(r#"{"data_dir":"/data"}"#).unwrap();
         assert_eq!(config.keychain_service, None);
+        assert_eq!(config.blob_store_url, None);
         assert_eq!(config.exec_scripts_dir, None);
         assert_eq!(config.exec_skills_dir, None);
         assert!(!config.container_execution_enabled);
@@ -956,6 +1031,7 @@ mod tests {
         let config = Config::from_vars(
             None,
             Some(OsString::from("/data")),
+            None,
             Some("true".into()),
             Some("tidebreak-sandbox-agent:dev".into()),
             None,
@@ -974,6 +1050,7 @@ mod tests {
             Some("tidebreak-sandbox-agent:dev")
         );
         assert!(Config::from_vars(
+            None,
             None,
             None,
             Some("yes".into()),
@@ -995,6 +1072,7 @@ mod tests {
         let config = Config::from_vars(
             Some("self_host".into()),
             Some(OsString::from("/data")),
+            Some("s3://tidebreak/blobs".into()),
             None,
             None,
             None,

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -64,6 +64,8 @@ pub mod context;
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub mod db;
 pub mod deliverable;
+#[cfg(feature = "blob-object")]
+mod object_blob;
 // Host-side acceptance writes bytes into private scratch, so it depends on the
 // capability filesystem and async runtime that only the `tools` feature pulls
 // in. The persisted contract and migration below stay available without it.
@@ -273,6 +275,8 @@ pub use model::{
     MAX_EXEC_SNAPSHOT_BYTES, MAX_EXEC_WORKSPACE_FILE_BYTES, MAX_MESSAGE_ATTACHMENTS,
     MAX_ROOT_ATTACHMENTS,
 };
+#[cfg(feature = "blob-object")]
+pub use object_blob::ObjectBlobStore;
 #[cfg(feature = "tools")]
 pub use output_scan::{
     sync_output_directory, OutputDirectorySync, OutputSyncEntry, OutputSyncStatus,
@@ -312,8 +316,8 @@ pub use storage::{
     AcceptAgentRunOutcome, AcceptClaimedToolCallOutcome, AcceptToolCallOutcome, AcceptTurnOutcome,
     AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome, AnswerUserQuestionsOutcome,
     AppendClaimedMessageOutcome, ApplyTurnSteerOutcome, BeginRootAttachmentChangeOutcome,
-    BeginSandboxProvisionOutcome, BeginTurnAdmissionOutcome, BlobMetadata, BlobStore, BlobStream,
-    ChatCitationSnapshot, ChatTerminalTurnSnapshot, ChatTerminalTurnStatus,
+    BeginSandboxProvisionOutcome, BeginTurnAdmissionOutcome, BlobInventoryItem, BlobMetadata,
+    BlobStore, BlobStream, ChatCitationSnapshot, ChatTerminalTurnSnapshot, ChatTerminalTurnStatus,
     ChatToolActivitySnapshot, ChatToolActivityStatus, ChatTranscriptSnapshot,
     CheckpointSandboxSpawnOutcome, ClaimClientToolCallOutcome, ClaimDelegatedFileReadOutcome,
     ClaimSandboxToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim,

--- a/crates/tidebreak-core/src/object_blob.rs
+++ b/crates/tidebreak-core/src/object_blob.rs
@@ -1,0 +1,448 @@
+//! S3-compatible [`BlobStore`](crate::BlobStore) implementation.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use object_store::aws::{AmazonS3Builder, S3CopyIfNotExists};
+use object_store::path::Path;
+use object_store::{Error as ObjectError, ObjectStore, ObjectStoreExt, PutMode, PutOptions};
+use sha2::{Digest, Sha256};
+use url::Url;
+use uuid::Uuid;
+
+use crate::{
+    AgentError, BlobInventoryItem, BlobMetadata, BlobStore, BlobStream, DocumentBlob, Result,
+};
+
+const MULTIPART_CHUNK_BYTES: usize = 5 * 1024 * 1024;
+
+#[derive(Clone)]
+pub struct ObjectBlobStore {
+    store: Arc<dyn ObjectStore>,
+    prefix: Path,
+}
+
+impl ObjectBlobStore {
+    #[must_use]
+    pub fn new(store: Arc<dyn ObjectStore>, prefix: Path) -> Self {
+        Self { store, prefix }
+    }
+
+    /// Build the self-host backend from `s3://bucket[/prefix]` and standard
+    /// `AWS_*` settings.
+    pub fn from_s3_url(value: &str) -> Result<Self> {
+        let prefix = parse_s3_prefix(value)?;
+        let store = AmazonS3Builder::from_env()
+            .with_url(value)
+            .with_copy_if_not_exists(S3CopyIfNotExists::Multipart)
+            .build()
+            .map_err(|_| AgentError::config("invalid S3 object-store configuration"))?;
+        Ok(Self::new(Arc::new(store), prefix))
+    }
+
+    pub async fn probe(&self) -> Result<()> {
+        if let Some(result) = self.store.list(Some(&self.prefix)).next().await {
+            result.map_err(|_| object_error("probe"))?;
+        }
+        Ok(())
+    }
+
+    fn path(&self, id: Uuid) -> Path {
+        self.prefix.clone().join(format!("{id}.blob"))
+    }
+
+    fn temporary_path(&self) -> Path {
+        self.prefix
+            .clone()
+            .join("_uploads")
+            .join(format!("{}.tmp", Uuid::new_v4()))
+    }
+
+    async fn existing_matches(&self, id: Uuid, expected: &[u8]) -> Result<bool> {
+        let Some(bytes) = self.get(id).await? else {
+            return Ok(false);
+        };
+        Ok(bytes == expected)
+    }
+
+    async fn existing_matches_source(&self, source: DocumentBlob) -> Result<bool> {
+        let path = self.path(source.id);
+        let result = match self.store.get(&path).await {
+            Ok(result) => result,
+            Err(ObjectError::NotFound { .. }) => return Ok(false),
+            Err(_) => return Err(object_error("read immutable object")),
+        };
+        let mut digest = Sha256::new();
+        let mut byte_len = 0_u64;
+        let mut stream = result.into_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|_| object_error("read immutable object"))?;
+            byte_len =
+                byte_len
+                    .checked_add(u64::try_from(chunk.len()).map_err(|_| {
+                        AgentError::Store("stored object length exceeds u64".into())
+                    })?)
+                    .ok_or_else(|| AgentError::Store("stored object length exceeds u64".into()))?;
+            digest.update(&chunk);
+        }
+        Ok(DocumentBlob::from_digest(digest.finalize().into(), byte_len) == source)
+    }
+}
+
+fn parse_s3_prefix(value: &str) -> Result<Path> {
+    let url =
+        Url::parse(value).map_err(|_| AgentError::config("invalid TIDEBREAK_BLOB_STORE_URL"))?;
+    if url.scheme() != "s3"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(AgentError::config(
+            "TIDEBREAK_BLOB_STORE_URL must be s3://bucket[/prefix] with no credentials, query, or fragment",
+        ));
+    }
+    Path::from_url_path(url.path())
+        .map_err(|_| AgentError::config("invalid TIDEBREAK_BLOB_STORE_URL prefix"))
+}
+
+#[async_trait]
+impl BlobStore for ObjectBlobStore {
+    async fn put(&self, id: Uuid, bytes: Vec<u8>) -> Result<()> {
+        let path = self.path(id);
+        match self
+            .store
+            .put_opts(
+                &path,
+                bytes.clone().into(),
+                PutOptions::from(PutMode::Create),
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(ObjectError::AlreadyExists { .. }) => {
+                if self.existing_matches(id, &bytes).await? {
+                    Ok(())
+                } else {
+                    Err(AgentError::Store(
+                        "immutable blob id already contains different bytes".into(),
+                    ))
+                }
+            }
+            Err(_) => Err(object_error("publish immutable object")),
+        }
+    }
+
+    async fn put_stream(&self, source: DocumentBlob, mut chunks: BlobStream) -> Result<()> {
+        if !source.has_content_addressed_id() {
+            return Err(AgentError::Store(
+                "streamed source blob id does not match its SHA-256 digest".into(),
+            ));
+        }
+
+        let temporary = self.temporary_path();
+        let mut upload = self
+            .store
+            .put_multipart(&temporary)
+            .await
+            .map_err(|_| object_error("start streamed object upload"))?;
+        let mut digest = Sha256::new();
+        let mut byte_len = 0_u64;
+        let mut buffered = Vec::with_capacity(MULTIPART_CHUNK_BYTES);
+        let mut multipart_completed = false;
+        let result: Result<()> = async {
+            while let Some(chunk) = chunks.next().await {
+                let chunk = chunk?;
+                byte_len = byte_len
+                    .checked_add(u64::try_from(chunk.len()).map_err(|_| {
+                        AgentError::Store("streamed blob chunk length exceeds u64".into())
+                    })?)
+                    .ok_or_else(|| AgentError::Store("streamed blob length exceeds u64".into()))?;
+                if byte_len > source.byte_len {
+                    return Err(AgentError::Store(
+                        "streamed blob exceeds its declared byte length".into(),
+                    ));
+                }
+                digest.update(&chunk);
+                let mut offset = 0;
+                while offset < chunk.len() {
+                    let available = MULTIPART_CHUNK_BYTES - buffered.len();
+                    let take = available.min(chunk.len() - offset);
+                    buffered.extend_from_slice(&chunk[offset..offset + take]);
+                    offset += take;
+                    if buffered.len() == MULTIPART_CHUNK_BYTES {
+                        upload
+                            .put_part(std::mem::take(&mut buffered).into())
+                            .await
+                            .map_err(|_| object_error("write streamed object part"))?;
+                        buffered = Vec::with_capacity(MULTIPART_CHUNK_BYTES);
+                    }
+                }
+            }
+            if DocumentBlob::from_digest(digest.finalize().into(), byte_len) != source {
+                return Err(AgentError::Store(
+                    "streamed blob does not match its declared digest".into(),
+                ));
+            }
+            if !buffered.is_empty() {
+                upload
+                    .put_part(std::mem::take(&mut buffered).into())
+                    .await
+                    .map_err(|_| object_error("write streamed object part"))?;
+            }
+            upload
+                .complete()
+                .await
+                .map_err(|_| object_error("complete streamed object upload"))?;
+            multipart_completed = true;
+
+            let destination = self.path(source.id);
+            match self
+                .store
+                .copy_if_not_exists(&temporary, &destination)
+                .await
+            {
+                Ok(()) => Ok(()),
+                Err(ObjectError::AlreadyExists { .. }) => {
+                    if self.existing_matches_source(source).await? {
+                        Ok(())
+                    } else {
+                        Err(AgentError::Store(
+                            "immutable blob id already contains different bytes".into(),
+                        ))
+                    }
+                }
+                Err(_) => Err(object_error("publish streamed object")),
+            }
+        }
+        .await;
+
+        if result.is_err() && !multipart_completed {
+            let _ = upload.abort().await;
+        }
+        let _ = self.store.delete(&temporary).await;
+        result
+    }
+
+    async fn get(&self, id: Uuid) -> Result<Option<Vec<u8>>> {
+        let result = match self.store.get(&self.path(id)).await {
+            Ok(result) => result,
+            Err(ObjectError::NotFound { .. }) => return Ok(None),
+            Err(_) => return Err(object_error("read object")),
+        };
+        let bytes = result
+            .bytes()
+            .await
+            .map_err(|_| object_error("read object body"))?;
+        Ok(Some(bytes.to_vec()))
+    }
+
+    async fn metadata(&self, id: Uuid) -> Result<Option<BlobMetadata>> {
+        match self.store.head(&self.path(id)).await {
+            Ok(metadata) => Ok(Some(BlobMetadata {
+                byte_len: metadata.size,
+            })),
+            Err(ObjectError::NotFound { .. }) => Ok(None),
+            Err(_) => Err(object_error("read object metadata")),
+        }
+    }
+
+    async fn read_range(
+        &self,
+        id: Uuid,
+        range: std::ops::Range<u64>,
+    ) -> Result<Option<BlobStream>> {
+        if range.start > range.end {
+            return Err(AgentError::Store("blob range start exceeds its end".into()));
+        }
+        let result = match self
+            .store
+            .get_opts(
+                &self.path(id),
+                object_store::GetOptions::new().with_range(Some(range)),
+            )
+            .await
+        {
+            Ok(result) => result,
+            Err(ObjectError::NotFound { .. }) => return Ok(None),
+            Err(_) => return Err(object_error("read object range")),
+        };
+        let stream = result.into_stream().map(|chunk| {
+            chunk
+                .map(|bytes| bytes.to_vec())
+                .map_err(|_| object_error("read object range body"))
+        });
+        Ok(Some(Box::pin(stream)))
+    }
+
+    async fn inventory(&self) -> Result<Vec<BlobInventoryItem>> {
+        let mut stream = self.store.list(Some(&self.prefix));
+        let mut items = Vec::new();
+        while let Some(metadata) = stream.next().await {
+            let metadata = metadata.map_err(|_| object_error("list objects"))?;
+            let Some(mut suffix) = metadata.location.prefix_match(&self.prefix) else {
+                continue;
+            };
+            let Some(part) = suffix.next() else {
+                continue;
+            };
+            if suffix.next().is_some() {
+                continue;
+            }
+            let name = part.as_ref();
+            let Some(id) = name.strip_suffix(".blob").and_then(|id| id.parse().ok()) else {
+                continue;
+            };
+            if name != format!("{id}.blob") {
+                continue;
+            }
+            items.push(BlobInventoryItem {
+                id,
+                modified_at: metadata.last_modified.into(),
+            });
+        }
+        items.sort_unstable_by_key(|item| item.id);
+        Ok(items)
+    }
+
+    async fn modified_at(&self, id: Uuid) -> Result<Option<std::time::SystemTime>> {
+        match self.store.head(&self.path(id)).await {
+            Ok(metadata) => Ok(Some(metadata.last_modified.into())),
+            Err(ObjectError::NotFound { .. }) => Ok(None),
+            Err(_) => Err(object_error("read object metadata")),
+        }
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<()> {
+        match self.store.delete(&self.path(id)).await {
+            Ok(()) | Err(ObjectError::NotFound { .. }) => Ok(()),
+            Err(_) => Err(object_error("delete object")),
+        }
+    }
+}
+
+fn object_error(action: &str) -> AgentError {
+    AgentError::Store(format!("failed to {action}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+    use object_store::memory::InMemory;
+
+    use super::*;
+
+    fn store() -> ObjectBlobStore {
+        ObjectBlobStore::new(Arc::new(InMemory::new()), Path::from("tidebreak/blobs"))
+    }
+
+    #[test]
+    fn s3_urls_accept_an_optional_prefix_and_redact_rejected_credentials() {
+        assert_eq!(parse_s3_prefix("s3://bucket").unwrap(), Path::default());
+        assert_eq!(
+            parse_s3_prefix("s3://bucket/company/tidebreak").unwrap(),
+            Path::from("company/tidebreak")
+        );
+
+        for value in [
+            "https://bucket/company",
+            "s3:///company",
+            "s3://bucket:9000/company",
+            "s3://access:secret@bucket/company",
+            "s3://bucket/company?token=secret",
+            "s3://bucket/company#secret",
+        ] {
+            let error = parse_s3_prefix(value).unwrap_err().to_string();
+            assert!(!error.contains("access"));
+            assert!(!error.contains("secret"));
+        }
+    }
+
+    #[tokio::test]
+    async fn immutable_puts_are_idempotent_and_reject_replacement() {
+        let store = store();
+        let id = Uuid::new_v4();
+        store.put(id, b"one".to_vec()).await.unwrap();
+        store.put(id, b"one".to_vec()).await.unwrap();
+        let error = store.put(id, b"two".to_vec()).await.unwrap_err();
+        assert!(error.to_string().contains("different bytes"));
+    }
+
+    #[tokio::test]
+    async fn streamed_sources_keep_ranges_inventory_and_delete() {
+        let store = store();
+        let bytes = vec![7_u8; MULTIPART_CHUNK_BYTES + 17];
+        let source = DocumentBlob::from_bytes(&bytes);
+        let chunks = stream::iter(vec![Ok(bytes[..31].to_vec()), Ok(bytes[31..].to_vec())]).boxed();
+        store.put_stream(source.clone(), chunks).await.unwrap();
+        store
+            .put_stream(
+                source.clone(),
+                stream::iter(vec![Ok(bytes.clone())]).boxed(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.metadata(source.id).await.unwrap().unwrap().byte_len,
+            source.byte_len
+        );
+        let range = store
+            .read_range(source.id, 4..19)
+            .await
+            .unwrap()
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(
+            range
+                .into_iter()
+                .collect::<Result<Vec<_>>>()
+                .unwrap()
+                .concat(),
+            bytes[4..19]
+        );
+        assert_eq!(store.inventory().await.unwrap()[0].id, source.id);
+        assert!(store
+            .store
+            .list(Some(&store.prefix.clone().join("_uploads")))
+            .next()
+            .await
+            .is_none());
+
+        store.delete(source.id).await.unwrap();
+        assert_eq!(store.get(source.id).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn streamed_sources_reject_wrong_declared_content() {
+        let store = store();
+        let source = DocumentBlob::from_bytes(b"expected");
+        let chunks = stream::iter(vec![Ok(b"changed!".to_vec())]).boxed();
+        let error = store.put_stream(source, chunks).await.unwrap_err();
+        assert!(error.to_string().contains("declared digest"));
+        assert!(store.inventory().await.unwrap().is_empty());
+        assert!(store
+            .store
+            .list(Some(&store.prefix.clone().join("_uploads")))
+            .next()
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn streamed_empty_sources_work_at_the_bucket_root() {
+        let store = ObjectBlobStore::new(Arc::new(InMemory::new()), Path::default());
+        let source = DocumentBlob::from_bytes(b"");
+        store
+            .put_stream(source.clone(), stream::empty::<Result<Vec<u8>>>().boxed())
+            .await
+            .unwrap();
+
+        assert_eq!(store.get(source.id).await.unwrap(), Some(Vec::new()));
+        assert_eq!(store.inventory().await.unwrap()[0].id, source.id);
+    }
+}

--- a/crates/tidebreak-core/src/storage/blob.rs
+++ b/crates/tidebreak-core/src/storage/blob.rs
@@ -4,6 +4,7 @@ use futures::{
     StreamExt,
 };
 use std::ops::Range;
+use std::time::SystemTime;
 
 use crate::error::{AgentError, Result};
 use crate::model::DocumentBlob;
@@ -15,6 +16,13 @@ use super::types::BlobStream;
 pub struct BlobMetadata {
     /// Number of bytes in the immutable blob.
     pub byte_len: u64,
+}
+
+/// One canonical blob discovered by a backend inventory scan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlobInventoryItem {
+    pub id: uuid::Uuid,
+    pub modified_at: SystemTime,
 }
 
 /// Opaque byte storage for documents, images, and exports.
@@ -92,10 +100,23 @@ pub trait BlobStore: Send + Sync {
         Ok(Some(stream::once(async move { Ok(bytes) }).boxed()))
     }
 
-    /// Delete a blob synchronously; a no-op if it doesn't exist.
-    ///
-    /// Async callers must move this operation to a blocking executor. This
-    /// boundary lets a lifecycle guard remain owned by the blocking operation
-    /// even when its awaiting worker is cancelled.
-    fn delete(&self, id: uuid::Uuid) -> Result<()>;
+    /// List canonical blobs for conservative orphan discovery.
+    async fn inventory(&self) -> Result<Vec<BlobInventoryItem>> {
+        Err(AgentError::Store(
+            "blob inventory is unavailable for this backend".into(),
+        ))
+    }
+
+    /// Read the modification time used to recheck orphan eligibility.
+    async fn modified_at(&self, id: uuid::Uuid) -> Result<Option<SystemTime>> {
+        Ok(self
+            .inventory()
+            .await?
+            .into_iter()
+            .find(|item| item.id == id)
+            .map(|item| item.modified_at))
+    }
+
+    /// Delete a blob; a no-op if it doesn't exist.
+    async fn delete(&self, id: uuid::Uuid) -> Result<()>;
 }

--- a/crates/tidebreak-core/src/storage/mod.rs
+++ b/crates/tidebreak-core/src/storage/mod.rs
@@ -20,7 +20,7 @@ mod secret;
 mod store;
 mod types;
 
-pub use blob::{BlobMetadata, BlobStore};
+pub use blob::{BlobInventoryItem, BlobMetadata, BlobStore};
 pub use secret::SecretProvider;
 pub use store::Store;
 pub use types::*;

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # Compile the PostgreSQL driver in, so a self-host boot can open the store
 # `TIDEBREAK_DATABASE_URL` names. Off by default: the desktop profile is
 # SQLite-only and the driver is a heavy build-time dependency.
-postgres = ["tidebreak-core/postgres", "sea-orm/sqlx-postgres"]
+postgres = ["tidebreak-core/postgres", "sea-orm/sqlx-postgres", "tidebreak-core/blob-object"]
 # Compile the scripted model provider in, so a test in another crate can drive
 # a real turn through the binary. Off by default and never enabled by a release
 # build: see `src/scripted_provider.rs`.

--- a/crates/tidebreak-server/src/blob_orphan_auditor.rs
+++ b/crates/tidebreak-server/src/blob_orphan_auditor.rs
@@ -1,12 +1,10 @@
 //! Conservative grace-period discovery of unreferenced source blobs.
 
 use std::collections::VecDeque;
-use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use tidebreak_core::{AgentError, Result, Store};
+use tidebreak_core::{AgentError, BlobInventoryItem, BlobStore, Result, Store};
 use tokio::sync::{Mutex, Notify};
 use uuid::Uuid;
 
@@ -52,7 +50,7 @@ pub(crate) struct BlobOrphanAuditFailure {
 #[derive(Clone)]
 pub(crate) struct BlobOrphanAuditor {
     store: Arc<dyn Store>,
-    blob_root: Arc<PathBuf>,
+    blobs: Arc<dyn BlobStore>,
     blob_writes: Arc<BlobWriteGuard>,
     wake: Arc<Notify>,
     audit: Arc<Mutex<()>>,
@@ -70,7 +68,7 @@ struct ScanResult {
 impl BlobOrphanAuditor {
     pub(crate) fn new(
         store: Arc<dyn Store>,
-        blob_root: impl Into<PathBuf>,
+        blobs: Arc<dyn BlobStore>,
         blob_writes: Arc<BlobWriteGuard>,
         wake: Arc<Notify>,
         config: BlobOrphanAuditorConfig,
@@ -78,7 +76,7 @@ impl BlobOrphanAuditor {
         assert!(config.batch_size > 0);
         Self {
             store,
-            blob_root: Arc::new(blob_root.into()),
+            blobs,
             blob_writes,
             wake,
             audit: Arc::new(Mutex::new(())),
@@ -131,12 +129,7 @@ impl BlobOrphanAuditor {
             .ok_or_else(|| AgentError::msg("blob orphan grace period exceeds system time"))?;
         let mut inventory = self.inventory.lock().await;
         let scan = if inventory.is_empty() {
-            let root = Arc::clone(&self.blob_root);
-            let scan = tokio::task::spawn_blocking(move || scan_candidates(&root, cutoff))
-                .await
-                .map_err(|error| {
-                    AgentError::Store(format!("blob orphan scan task failed: {error}"))
-                })??;
+            let scan = scan_inventory(self.blobs.inventory().await?, cutoff);
             inventory.extend(scan.candidates.iter().copied());
             Some(scan)
         } else {
@@ -173,12 +166,11 @@ impl BlobOrphanAuditor {
 
     async fn audit_blob(&self, blob_id: Uuid, cutoff: SystemTime) -> Result<bool> {
         let _permit = self.blob_writes.acquire(blob_id).await?;
-        let path = self.blob_root.join(format!("{blob_id}.blob"));
-        let still_eligible = tokio::task::spawn_blocking(move || eligible_file(&path, cutoff))
-            .await
-            .map_err(|error| {
-                AgentError::Store(format!("blob orphan metadata task failed: {error}"))
-            })??;
+        let still_eligible = self
+            .blobs
+            .modified_at(blob_id)
+            .await?
+            .is_some_and(|modified| modified <= cutoff);
         if !still_eligible {
             return Ok(false);
         }
@@ -196,95 +188,27 @@ fn next_delay(config: BlobOrphanAuditorConfig, report: &BlobOrphanAuditReport) -
     }
 }
 
-fn scan_candidates(root: &Path, cutoff: SystemTime) -> Result<ScanResult> {
-    let entries = match std::fs::read_dir(root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(ScanResult {
-                scanned: 0,
-                eligible: 0,
-                candidates: VecDeque::new(),
-                failures: Vec::new(),
-            });
-        }
-        Err(error) => return Err(scan_error("read blob directory", error)),
-    };
-    let mut scanned = 0;
-    let mut eligible = Vec::new();
-    let mut failures = Vec::new();
-    for entry in entries {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(error) => {
-                failures.push(BlobOrphanAuditFailure {
-                    blob_id: None,
-                    error: scan_error("read blob directory entry", error).to_string(),
-                });
-                continue;
-            }
-        };
-        let Some(blob_id) = blob_id_from_name(&entry.file_name()) else {
-            continue;
-        };
-        scanned += 1;
-        match entry.file_type().and_then(|kind| {
-            if kind.is_file() {
-                entry.metadata().map(Some)
-            } else {
-                Ok(None)
-            }
-        }) {
-            Ok(Some(metadata)) => match metadata.modified() {
-                Ok(modified) if modified <= cutoff => eligible.push(blob_id),
-                Ok(_) => {}
-                Err(error) => failures.push(BlobOrphanAuditFailure {
-                    blob_id: Some(blob_id),
-                    error: scan_error("read blob modification time", error).to_string(),
-                }),
-            },
-            Ok(None) => {}
-            Err(error) => failures.push(BlobOrphanAuditFailure {
-                blob_id: Some(blob_id),
-                error: scan_error("read blob metadata", error).to_string(),
-            }),
-        }
-    }
+fn scan_inventory(items: Vec<BlobInventoryItem>, cutoff: SystemTime) -> ScanResult {
+    let scanned = items.len();
+    let mut eligible = items
+        .into_iter()
+        .filter(|item| item.modified_at <= cutoff)
+        .map(|item| item.id)
+        .collect::<Vec<_>>();
     eligible.sort_unstable();
     let eligible_count = eligible.len();
-    let candidates = eligible.into();
-    Ok(ScanResult {
+    ScanResult {
         scanned,
         eligible: eligible_count,
-        candidates,
-        failures,
-    })
-}
-
-fn eligible_file(path: &Path, cutoff: SystemTime) -> Result<bool> {
-    match std::fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_file() => Ok(metadata
-            .modified()
-            .map_err(|error| scan_error("read blob modification time", error))?
-            <= cutoff),
-        Ok(_) => Ok(false),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(scan_error("read blob metadata", error)),
+        candidates: eligible.into(),
+        failures: Vec::new(),
     }
-}
-
-fn blob_id_from_name(name: &OsStr) -> Option<Uuid> {
-    let name = name.to_str()?;
-    let id = name.strip_suffix(".blob")?.parse::<Uuid>().ok()?;
-    (name == format!("{id}.blob")).then_some(id)
-}
-
-fn scan_error(action: &str, error: std::io::Error) -> AgentError {
-    AgentError::Store(format!("failed to {action}: {error}"))
 }
 
 #[cfg(test)]
 mod tests {
     use std::fs::{File, FileTimes};
+    use std::path::Path;
 
     use tidebreak_core::{
         BlobRetirementStatus, BlobStore, DbStore, DocumentBlob, DocumentId, DocumentSourceUpsert,
@@ -347,7 +271,7 @@ mod tests {
     ) -> BlobOrphanAuditor {
         BlobOrphanAuditor::new(
             store,
-            root,
+            Arc::new(FsBlobStore::new(root)),
             Arc::new(BlobWriteGuard::new(root.join("locks"))),
             wake,
             config(batch_size),
@@ -548,7 +472,7 @@ mod tests {
         std::fs::create_dir_all(lock_root.join(format!("{poison}.lock"))).unwrap();
         let auditor = BlobOrphanAuditor::new(
             store.clone(),
-            &root,
+            Arc::new(FsBlobStore::new(&root)),
             Arc::new(BlobWriteGuard::new(lock_root)),
             Arc::new(Notify::new()),
             config(2),

--- a/crates/tidebreak-server/src/blob_retirement_worker.rs
+++ b/crates/tidebreak-server/src/blob_retirement_worker.rs
@@ -188,20 +188,18 @@ impl BlobRetirementWorker {
 
         let blobs = Arc::clone(&self.blobs);
         let blob_id = retirement.blob_id;
+        let deletion_task = tokio::spawn(async move {
+            let result = blobs.delete(blob_id).await;
+            (permit, result)
+        });
         let deletion = self
-            .supervise(&retirement, lease_token, async move {
-                tokio::task::spawn_blocking(move || {
-                    let result = blobs.delete(blob_id);
-                    (permit, result)
-                })
-                .await
-                .map_err(|error| AgentError::Store(format!("blob delete task failed: {error}")))
-            })
+            .supervise(&retirement, lease_token, deletion_task)
             .await;
         match deletion {
             Supervised::LeaseLost => {
-                // Dropping the join future detaches the blocking operation, but
-                // that operation owns the file-lock permit until it exits.
+                // Dropping the join future detaches the delete task. The task
+                // owns the lifecycle permit until the backend resolves the
+                // request, including after an ambiguous network cancellation.
                 Ok(BlobRetirementWorkerOutcome::LeaseLost(retirement.blob_id))
             }
             Supervised::Completed(Err(error)) => {
@@ -334,7 +332,6 @@ fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Condvar, Mutex as StdMutex};
 
     use async_trait::async_trait;
     use tidebreak_core::{DbStore, DocumentBlob, DocumentId, DocumentSourceUpsert, FsBlobStore};
@@ -496,11 +493,11 @@ mod tests {
             self.inner.get(id).await
         }
 
-        fn delete(&self, id: Uuid) -> Result<()> {
+        async fn delete(&self, id: Uuid) -> Result<()> {
             if self.fail_delete.swap(false, Ordering::SeqCst) {
                 Err(AgentError::Store("injected blob delete failure".into()))
             } else {
-                self.inner.delete(id)
+                self.inner.delete(id).await
             }
         }
     }
@@ -536,8 +533,7 @@ mod tests {
 
     struct DeleteGate {
         entered: Notify,
-        released: StdMutex<bool>,
-        release: Condvar,
+        release: Notify,
     }
 
     struct BlockingDeleteBlobStore {
@@ -555,14 +551,10 @@ mod tests {
             self.inner.get(id).await
         }
 
-        fn delete(&self, id: Uuid) -> Result<()> {
+        async fn delete(&self, id: Uuid) -> Result<()> {
             self.gate.entered.notify_one();
-            let mut released = self.gate.released.lock().unwrap();
-            while !*released {
-                released = self.gate.release.wait(released).unwrap();
-            }
-            drop(released);
-            self.inner.delete(id)
+            self.gate.release.notified().await;
+            self.inner.delete(id).await
         }
     }
 
@@ -572,8 +564,7 @@ mod tests {
         let store = store(&dir).await;
         let gate = Arc::new(DeleteGate {
             entered: Notify::new(),
-            released: StdMutex::new(false),
-            release: Condvar::new(),
+            release: Notify::new(),
         });
         let blobs: Arc<dyn BlobStore> = Arc::new(BlockingDeleteBlobStore {
             inner: FsBlobStore::new(dir.path().join("blobs")),
@@ -628,11 +619,7 @@ mod tests {
         });
         tokio::time::sleep(Duration::from_millis(25)).await;
         assert!(!publisher.is_finished());
-        {
-            let mut released = gate.released.lock().unwrap();
-            *released = true;
-            gate.release.notify_all();
-        }
+        gate.release.notify_one();
         let _publisher = tokio::time::timeout(Duration::from_secs(1), publisher)
             .await
             .expect("publisher remained blocked after delete exited")

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -2033,7 +2033,7 @@ async fn bind_inner(
     let resolver: Arc<dyn resolver::ProviderResolver> = resolver;
     #[cfg(feature = "scripted-provider")]
     let resolver = scripted_provider::resolver_from_env()?.unwrap_or(resolver);
-    let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
+    let blobs = configured_blob_store(&config).await?;
     // The same lock root `AppState` uses. `BlobWriteGuard` rendezvouses through
     // permanent lock files, so a second handle over the directory excludes
     // against the first rather than shadowing it.
@@ -2294,7 +2294,7 @@ async fn bind_inner(
 
     let blob_orphan_auditor = blob_orphan_auditor::BlobOrphanAuditor::new(
         state.store.clone(),
-        state.config.data_dir.join("blobs"),
+        state.blobs.clone(),
         state.blob_writes.clone(),
         state.blob_retirement_wake.clone(),
         blob_orphan_auditor::BlobOrphanAuditorConfig::default(),
@@ -2489,6 +2489,30 @@ async fn bind_inner(
         _instance_lock: instance_lock,
         _listen_endpoint: listen_endpoint,
     })
+}
+
+async fn configured_blob_store(config: &Config) -> Result<Arc<dyn BlobStore>> {
+    let Some(url) = config.blob_store_url.as_deref() else {
+        return Ok(Arc::new(FsBlobStore::new(config.data_dir.join("blobs"))));
+    };
+    if config.profile != Profile::SelfHost {
+        return Err(AgentError::config(
+            "object storage is only available for the self-host profile",
+        ));
+    }
+    #[cfg(feature = "postgres")]
+    {
+        let store = tidebreak_core::ObjectBlobStore::from_s3_url(url)?;
+        store.probe().await?;
+        Ok(Arc::new(store))
+    }
+    #[cfg(not(feature = "postgres"))]
+    {
+        let _ = url;
+        Err(AgentError::config(
+            "self-host object storage requires the server's postgres feature",
+        ))
+    }
 }
 
 /// Assemble the tools and per-turn tuning for a real launch.

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -578,7 +578,7 @@ impl BlobStore for RangeOnlyBlobStore {
         Ok(Some(stream::once(async move { Ok(bytes) }).boxed()))
     }
 
-    fn delete(&self, _id: uuid::Uuid) -> Result<()> {
+    async fn delete(&self, _id: uuid::Uuid) -> Result<()> {
         Ok(())
     }
 }
@@ -633,7 +633,7 @@ impl BlobStore for CancellationAwareBlobStore {
         })))
     }
 
-    fn delete(&self, _id: uuid::Uuid) -> Result<()> {
+    async fn delete(&self, _id: uuid::Uuid) -> Result<()> {
         Ok(())
     }
 }
@@ -652,8 +652,8 @@ impl BlobStore for FirstPutGatedBlobStore {
         self.inner.get(id).await
     }
 
-    fn delete(&self, id: uuid::Uuid) -> Result<()> {
-        self.inner.delete(id)
+    async fn delete(&self, id: uuid::Uuid) -> Result<()> {
+        self.inner.delete(id).await
     }
 }
 
@@ -2376,6 +2376,37 @@ fn one_server_process_owns_a_desktop_data_directory() {
         .expect("a released directory is reclaimable even though the lock file is still there");
     assert!(dir.path().join("tidebreak.lock").exists());
     drop(reclaimed);
+}
+
+#[tokio::test]
+async fn desktop_profile_selects_the_filesystem_blob_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = Config::desktop(dir.path());
+    let blobs = configured_blob_store(&config).await.unwrap();
+    let id = Uuid::new_v4();
+    blobs.put(id, b"desktop blob".to_vec()).await.unwrap();
+
+    assert_eq!(
+        std::fs::read(dir.path().join("blobs").join(format!("{id}.blob"))).unwrap(),
+        b"desktop blob"
+    );
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn self_host_profile_selects_object_storage_and_redacts_url_credentials() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = Config::desktop(dir.path());
+    config.profile = Profile::SelfHost;
+    config.blob_store_url = Some("s3://access:secret@bucket/prefix".into());
+
+    let error = match configured_blob_store(&config).await {
+        Ok(_) => panic!("self-host must select the configured object store"),
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("TIDEBREAK_BLOB_STORE_URL"));
+    assert!(!error.contains("access"));
+    assert!(!error.contains("secret"));
 }
 
 /// The MCP App view frame contract, at the HTTP boundary: minting requires

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -59,8 +59,8 @@ impl BlobStore for GatedPutBlobStore {
         self.inner.get(id).await
     }
 
-    fn delete(&self, id: uuid::Uuid) -> tidebreak_core::Result<()> {
-        self.inner.delete(id)
+    async fn delete(&self, id: uuid::Uuid) -> tidebreak_core::Result<()> {
+        self.inner.delete(id).await
     }
 }
 

--- a/crates/tidebreak-server/src/tests/documents.rs
+++ b/crates/tidebreak-server/src/tests/documents.rs
@@ -615,6 +615,7 @@ async fn document_file_content_preserves_document_scope_before_blob_access() {
         .unwrap();
     tidebreak_core::FsBlobStore::new(dir.path().join("blobs"))
         .delete(source_blob.id)
+        .await
         .unwrap();
     assert_eq!(
         request_document_file_content(

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -56,6 +56,13 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # Static AWS keys and an optional compatible endpoint belong in `.env`
+    # when the deployment uses them. Do not pin those names to empty strings
+    # here: `AmazonS3Builder::from_env` treats an empty `AWS_ACCESS_KEY_ID` as
+    # a static credential and ignores instance credentials, and an empty
+    # `AWS_ENDPOINT_URL_S3` becomes the client endpoint.
+    env_file:
+      - .env
     environment:
       TIDEBREAK_PROFILE: self_host
       TIDEBREAK_DATABASE_URL: postgres://tidebreak:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/tidebreak
@@ -68,12 +75,6 @@ services:
       TIDEBREAK_LOG: ${TIDEBREAK_LOG:-info}
       # Standard AWS variables configure AWS S3 or an S3-compatible service.
       AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
-      # Leave optional values unset when the deployment uses workload or
-      # instance credentials. Empty static credentials disable that fallback.
-      AWS_ENDPOINT_URL_S3:
-      AWS_ACCESS_KEY_ID:
-      AWS_SECRET_ACCESS_KEY:
-      AWS_SESSION_TOKEN:
       AWS_ALLOW_HTTP: ${AWS_ALLOW_HTTP:-false}
       # Model credential fallbacks for this minimal stack. To save shared
       # credentials through Tidebreak instead, mount a Vault token file and

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -16,6 +16,7 @@
 #   - a tokens file at ./tokens, naming at least one `admin` user (see
 #     docs/self-hosting.md for the format; a file with no admin refuses to boot)
 #   - POSTGRES_PASSWORD set in the environment or a .env file beside this one
+#   - TIDEBREAK_BLOB_STORE_URL set to an operator-owned S3 bucket and prefix
 
 name: tidebreak-self-host
 
@@ -58,12 +59,22 @@ services:
     environment:
       TIDEBREAK_PROFILE: self_host
       TIDEBREAK_DATABASE_URL: postgres://tidebreak:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/tidebreak
+      TIDEBREAK_BLOB_STORE_URL: ${TIDEBREAK_BLOB_STORE_URL:?set TIDEBREAK_BLOB_STORE_URL in .env}
       TIDEBREAK_AUTH_TOKENS_FILE: /run/tidebreak/tokens
       TIDEBREAK_DATA_DIR: /var/lib/tidebreak
       # All interfaces of the container, published to loopback only below.
       TIDEBREAK_LISTEN_ADDR: 0.0.0.0:8080
       # Log filter; see the server's `logging` module for the syntax.
       TIDEBREAK_LOG: ${TIDEBREAK_LOG:-info}
+      # Standard AWS variables configure AWS S3 or an S3-compatible service.
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
+      # Leave optional values unset when the deployment uses workload or
+      # instance credentials. Empty static credentials disable that fallback.
+      AWS_ENDPOINT_URL_S3:
+      AWS_ACCESS_KEY_ID:
+      AWS_SECRET_ACCESS_KEY:
+      AWS_SESSION_TOKEN:
+      AWS_ALLOW_HTTP: ${AWS_ALLOW_HTTP:-false}
       # Model credential fallbacks for this minimal stack. To save shared
       # credentials through Tidebreak instead, mount a Vault token file and
       # pass the TIDEBREAK_VAULT_* variables described in docs/self-hosting.md.

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -615,7 +615,6 @@ stored-secret reads return unset so provider environment variables remain
 fallbacks, while writes and deletes fail with setup guidance. The self-host
 profile never opens the desktop OS keychain.
 
-Document and blob storage on PostgreSQL and multi-process
-ownership are not finished. Self-host blob bytes use
+Multi-process ownership is not finished. Self-host blob bytes use
 the S3-compatible bucket named by `TIDEBREAK_BLOB_STORE_URL`. Treat
 self-hosting as experimental.

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -615,5 +615,7 @@ stored-secret reads return unset so provider environment variables remain
 fallbacks, while writes and deletes fail with setup guidance. The self-host
 profile never opens the desktop OS keychain.
 
-Document and blob storage on PostgreSQL, object storage, and multi-process
-ownership are not finished. Treat self-hosting as experimental.
+Document and blob storage on PostgreSQL and multi-process
+ownership are not finished. Self-host blob bytes use
+the S3-compatible bucket named by `TIDEBREAK_BLOB_STORE_URL`. Treat
+self-hosting as experimental.

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -778,8 +778,7 @@ new session and publish its tool surface only for subsequent turns.
 
 The `Profile::SelfHost` shape and PostgreSQL database implementation exist. CI
 exercises both the durable turn state machine and the document and blob
-lifecycle against PostgreSQL. Object storage remains future integration
-work. A self-host server holds a PostgreSQL advisory lease
+lifecycle against PostgreSQL. A self-host server holds a PostgreSQL advisory lease
 for its lifetime, so another process cannot start duplicate workers against the
 same database; horizontal multi-process serving remains unsupported. Building
 `tidebreak-server` with its `postgres` feature compiles the driver in; the store
@@ -929,7 +928,7 @@ The main next steps are:
 - add richer parsers;
 - finish the self-host profile — the request path resolves a principal and
   queries are owner-scoped (#853), so what remains is production integration:
-  object storage, and distributed ownership for
+  distributed ownership for
   horizontal multi-process serving;
 - add health-aware provider failover;
 - add output deletion, version history, richer formats, and durable export

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -24,6 +24,9 @@ Selecting `TIDEBREAK_PROFILE=self_host` changes four things about the server:
   the operator-managed token file. Both resolve to a named principal carrying
   a role. Chats, projects, documents, transcripts, code workspaces, and event
   streams are owner-scoped to that principal.
+- **Blob bytes live in S3-compatible object storage**, selected by
+  `TIDEBREAK_BLOB_STORE_URL`. PostgreSQL keeps the document catalog and
+  references; the bucket keeps immutable source bytes, images, and artifacts.
 - **Boot fails closed.** The server refuses to open the shared store unless
   exactly one of `TIDEBREAK_AUTH_GATEWAY_URL` or
   `TIDEBREAK_AUTH_TOKENS_FILE` is valid — a shared database never comes up
@@ -253,6 +256,8 @@ aspirational.
 | --- | --- | --- | --- |
 | `TIDEBREAK_PROFILE` | yes | `desktop` | `self_host` (or `selfhost`) selects this profile. Anything else is desktop or a config error. |
 | `TIDEBREAK_DATABASE_URL` | yes (self-host) | — | PostgreSQL connection string for the shared store. |
+| `TIDEBREAK_BLOB_STORE_URL` | yes (self-host) | — | S3 bucket and optional prefix, for example `s3://company-tidebreak/production`. Credentials, region, and an optional compatible endpoint come from standard `AWS_*` variables. |
+| `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_ENDPOINT_URL_S3`, `AWS_ALLOW_HTTP` | depends on provider | AWS defaults | Configure AWS S3 or an S3-compatible endpoint. Keep `AWS_ALLOW_HTTP=false` outside isolated development networks. Role, web-identity, and container credential variables are also accepted. |
 | `TIDEBREAK_AUTH_GATEWAY_URL` | one auth mode required | — | Public Model Gateway identity URL exposed to clients and, by default, used for live validation. HTTPS required except for loopback development. |
 | `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` | no | `TIDEBREAK_AUTH_GATEWAY_URL` | Optional server-to-server Gateway URL for principal validation when the public origin is not cluster-routable. Requires Gateway auth. |
 | `TIDEBREAK_AUTH_TOKENS_FILE` | one auth mode required | — | Standalone compatibility: path to the static token file above. Mutually exclusive with Gateway auth. |
@@ -287,9 +292,13 @@ cd deploy/self-host
 umask 077
 printf 'alice %s admin\n' "$(openssl rand -hex 32)" > tokens
 
-# 2. Database password and provider key.
+# 2. Database password, object storage, and provider key.
 cat > .env <<'EOF'
 POSTGRES_PASSWORD=<a long random string>
+TIDEBREAK_BLOB_STORE_URL=s3://company-tidebreak/production
+AWS_DEFAULT_REGION=us-east-1
+AWS_ACCESS_KEY_ID=<your access key>
+AWS_SECRET_ACCESS_KEY=<your secret key>
 ANTHROPIC_API_KEY=<your key>
 EOF
 chmod 600 .env
@@ -397,8 +406,11 @@ that happens not to include request headers today.
 
 ## Backup
 
-**Back up the `tidebreak-postgres` volume.** All durable state — chats,
-projects, documents, transcripts, the event journal — lives in PostgreSQL.
+**Back up PostgreSQL and the object-store prefix.** PostgreSQL holds chats,
+projects, document records, transcripts, and the event journal. The bucket
+holds the immutable blob bytes those records reference. Restore both from the
+same backup window.
+
 The `tidebreak-data` volume holds only the instance lock, logs, and per-turn
 scratch, and is safe to lose.
 
@@ -413,6 +425,13 @@ Restore into a fresh, empty database before starting the server against it.
 The `.env` file is not in either volume. Back it up separately as a secret. In
 standalone compatibility mode, back up the tokens file too; Gateway-backed
 mode has no Tidebreak token file.
+
+Grant `s3:ListBucket` for the configured prefix. Grant `s3:GetObject`,
+`s3:PutObject`, `s3:DeleteObject`, and `s3:AbortMultipartUpload` only for
+objects below that prefix. Configure the bucket to abort incomplete multipart
+uploads after a day. Also expire completed objects in the `_uploads/` path
+below that prefix after a day because streamed writes publish through that
+temporary path.
 
 ## Upgrading
 
@@ -444,7 +463,7 @@ read the self-host section of
 account. In summary, and each of these is a reason not to put irreplaceable
 data in a self-host deployment yet:
 
-- Object storage is not wired.
+
 - Tidebreak enforces one active server process per PostgreSQL database through
   a dedicated advisory lease. A second process refuses boot even when it uses
   another data directory. Horizontal multi-process serving remains unsupported

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -13,7 +13,7 @@ branch; where something is not built yet, it says so.
 
 ## What the self-host profile is
 
-Selecting `TIDEBREAK_PROFILE=self_host` changes four things about the server:
+Selecting `TIDEBREAK_PROFILE=self_host` changes five things about the server:
 
 - **The store is PostgreSQL**, opened from `TIDEBREAK_DATABASE_URL`, and the
   binary must be built with tidebreak-server's `postgres` feature for the
@@ -462,7 +462,6 @@ read the self-host section of
 [how Tidebreak works](how-tidebreak-works.md#self-host) — it is the canonical
 account. In summary, and each of these is a reason not to put irreplaceable
 data in a self-host deployment yet:
-
 
 - Tidebreak enforces one active server process per PostgreSQL database through
   a dedicated advisory lease. A second process refuses boot even when it uses

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -25,9 +25,9 @@ a stale one.
 
 ## Summary
 
-- Rust crates: 849
+- Rust crates: 858
 - Desktop UI production packages: 515
-- Distinct license texts: 583
+- Distinct license texts: 589
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -311,6 +311,18 @@ License identifiers named across all declared expressions:
 - License: `Apache-2.0 OR MIT`
 - Repository: https://github.com/cuviper/autocfg
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-99afaa30c178](#l-99afaa30c178))
+
+### aws-lc-rs 1.18.0
+
+- License: `ISC AND (Apache-2.0 OR ISC)`
+- Repository: https://github.com/aws/aws-lc-rs
+- License text: `LICENSE` ([L-efbbbcefb4b8](#l-efbbbcefb4b8))
+
+### aws-lc-sys 0.44.0
+
+- License: `ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)`
+- Repository: https://github.com/aws/aws-lc-rs
+- License text: `LICENSE` ([L-49f5cc2a2e4d](#l-49f5cc2a2e4d))
 
 ### axum 0.8.9
 
@@ -785,6 +797,12 @@ License identifiers named across all declared expressions:
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/akhilles/crc-catalog.git
 - License text: not distributed with this package
+
+### crc-fast 1.10.0
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/awesomized/crc-fast-rust
+- License text: `LICENSE-Apache` ([L-43070e2d4e53](#l-43070e2d4e53)), `LICENSE-MIT` ([L-96febbdecdb0](#l-96febbdecdb0))
 
 ### crc32fast 1.5.1
 
@@ -1542,6 +1560,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/gtk-rs/gtk3-rs
 - License text: `COPYRIGHT` ([L-410f62c80f1b](#l-410f62c80f1b)), `LICENSE` ([L-21a2121221d2](#l-21a2121221d2))
 
+### h2 0.4.19
+
+- License: `MIT`
+- Repository: https://github.com/hyperium/h2
+- License text: `LICENSE` ([L-f5352eaa5597](#l-f5352eaa5597))
+
 ### half 2.7.1
 
 - License: `MIT OR Apache-2.0`
@@ -1673,6 +1697,12 @@ License identifiers named across all declared expressions:
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/pyfisch/httpdate
 - License text: `LICENSE-APACHE` ([L-793b7448f5be](#l-793b7448f5be)), `LICENSE-MIT` ([L-8ee77b53f701](#l-8ee77b53f701))
+
+### humantime 2.4.0
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/chronotope/humantime
+- License text: `LICENSE-APACHE` ([L-c5accbbd8546](#l-c5accbbd8546)), `LICENSE-MIT` ([L-4365cd3ca380](#l-4365cd3ca380))
 
 ### hybrid-array 0.4.14
 
@@ -1884,6 +1914,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/rust-itertools/itertools
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-fdd1c2117bcf](#l-fdd1c2117bcf))
 
+### itertools 0.15.0
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/rust-itertools/itertools
+- License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-fdd1c2117bcf](#l-fdd1c2117bcf))
+
 ### itoa 1.0.18
 
 - License: `MIT OR Apache-2.0`
@@ -1967,6 +2003,12 @@ License identifiers named across all declared expressions:
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/jni-rs/jni-sys
 - License text: not distributed with this package
+
+### jobserver 0.1.35
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/rust-lang/jobserver-rs
+- License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
 
 ### js-sys 0.3.104
 
@@ -2475,6 +2517,12 @@ License identifiers named across all declared expressions:
 - License: `Zlib OR Apache-2.0 OR MIT`
 - Repository: https://github.com/madsmtm/objc2
 - License text: not distributed with this package
+
+### object_store 0.14.1
+
+- License: `MIT/Apache-2.0`
+- Repository: https://github.com/apache/arrow-rs-object-store
+- License text: `LICENSE.txt` ([L-58d1e17ffe51](#l-58d1e17ffe51)), `NOTICE.txt` ([L-32837c206467](#l-32837c206467))
 
 ### once_cell 1.21.4
 
@@ -3549,6 +3597,12 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: https://gitlab.gnome.org/World/Rust/soup3-rs
 - License text: `LICENSE` ([L-4603441e4a5a](#l-4603441e4a5a))
+
+### spin 0.10.1
+
+- License: `MIT`
+- Repository: https://github.com/mvdnes/spin-rs.git
+- License text: `LICENSE` ([L-6ac8711fb340](#l-6ac8711fb340))
 
 ### spin 0.9.9
 
@@ -12628,6 +12682,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+### L-32837c206467
+
+```
+Apache Arrow Object Store
+Copyright 2020-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+```
+
 ### L-32979a7dea17
 
 ```
@@ -13908,6 +13972,37 @@ DEALINGS IN THE SOFTWARE.
    limitations under the License.
 ```
 
+### L-4365cd3ca380
+
+```
+Copyright (c) 2016 The humantime Developers
+
+Includes parts of http date with the following copyright:
+Copyright (c) 2016 Pyfisch
+
+Includes portions of musl libc with the following copyright:
+Copyright © 2005-2013 Rich Felker
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### L-4428cd87371a
 
 ```
@@ -14622,6 +14717,327 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
+
+### L-49f5cc2a2e4d
+
+````
+AWS Libcrypto (AWS-LC)
+
+AWS-LC is a fork of BoringSSL, which is itself a fork of OpenSSL.
+Content from these and other sources retains their original licensing,
+as described below. New files from AWS-LC are made available under the Apache-2.0 license OR the ISC
+license. These licenses are reproduced at the bottom of this file.
+
+```
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 OR ISC
+```
+
+
+================================================================================
+BoringSSL
+================================================================================
+
+BoringSSL is a Google-maintained fork of OpenSSL. Historically, code
+authored by Google for BoringSSL was licensed under the ISC License.
+BoringSSL has since relicensed upstream to Apache License 2.0. Existing
+AWS-LC code originating from BoringSSL retains its ISC license, while
+newer code taken from BoringSSL is licensed under Apache License 2.0.
+
+```
+Copyright (c) 2014-2024 Google Inc.
+SPDX-License-Identifier: ISC
+```
+
+Additional individual contributions to BoringSSL-derived code are
+covered under the ISC license:
+
+  - Brian Smith (Copyright 2016)
+  - Robert Nagy (Copyright 2022)
+  - Arm Ltd (Copyright 2020)
+
+```
+Copyright (c) 2025-2026 Google Inc.
+SPDX-License-Identifier: Apache-2.0
+```
+
+================================================================================
+OpenSSL
+================================================================================
+
+Code derived from the OpenSSL project is licensed under the
+Apache License, Version 2.0.
+
+```
+Copyright (c) 1998-2011 The OpenSSL Project. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+```
+
+Some OpenSSL-derived files also carry the original SSLeay copyright:
+
+```
+Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com). All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+```
+
+Portions of OpenSSL-derived code include contributions from:
+
+  - Sun Microsystems, Inc. (Copyright 2002)
+  - Nokia (Copyright 2005)
+  - Intel Corporation (Copyright 2012-2021)
+
+These contributions are covered under the Apache-2.0 license.
+
+================================================================================
+mlkem-native
+================================================================================
+
+Code from the mlkem-native project is licensed under Apache License 2.0 or MIT or ISC.
+
+```
+Copyright (c) The mlkem-native project authors.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+```
+
+================================================================================
+mldsa-native
+================================================================================
+
+Code from the mldsa-native project is licensed under Apache License 2.0 or MIT or ISC
+
+```
+Copyright (c) The mldsa-native project authors.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+```
+
+================================================================================
+Third-Party Libraries (compiled into libcrypto/libssl)
+================================================================================
+
+Fiat Cryptography
+-----------------
+Synthesizing Correct-by-Construction Code for Cryptographic Primitives.
+See third_party/fiat/LICENSE.
+
+```
+Copyright (c) 2015-2020 the fiat-crypto authors.
+SPDX-License-Identifier: MIT
+```
+
+s2n-bignum
+----------
+Integer arithmetic routines for cryptography.
+See third_party/s2n-bignum/s2n-bignum-imported/LICENSE.
+
+```
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+```
+
+Note: ML-KEM/SHA3 code within s2n-bignum is licensed as
+Apache-2.0 OR ISC OR MIT (with attribution), sourced from the
+mlkem-native project.
+
+Jitter Entropy RNG
+-------------------
+CPU Jitter Random Number Generator Library.
+See third_party/jitterentropy/jitterentropy-library/LICENSE.
+
+The Jitter Entropy library is dual-licensed under a BSD-style license
+and the GNU General Public License Version 2. Amazon expressly elects
+to distribute the package under the 3-Clause BSD License and NOT under
+GNU General Public License Version 2.
+
+```
+Copyright (C) 2017 - 2025, Stephan Mueller <smueller@chronox.de>.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Keccak / AES Reference Implementations
+---------------------------------------
+Public domain (CC0) contributions.
+https://creativecommons.org/public-domain/cc0
+
+Code from sources and by authors listed in comments on top of the respective files.
+
+
+================================================================================
+Third-Party Libraries (NOT compiled into libcrypto/libssl)
+================================================================================
+
+The following are used for testing and build tooling only. Distributing
+code linked against AWS-LC (libcrypto/libssl) does NOT trigger these
+license obligations.
+
+Google Test
+-----------
+See third_party/googletest/LICENSE.
+
+```
+Copyright 2008 Google Inc.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Go Standard Library
+-------------------
+Code in ssl/test/runner/ is derived from the Go standard library.
+
+```
+Copyright (c) The Go Authors. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+```
+
+Wycheproof Test Vectors
+------------------------
+Project Wycheproof is a community managed repository of test vectors that can be used by cryptography library
+developers to test against known attacks, specification inconsistencies, and other various implementation bugs.
+
+See third_party/wycheproof_testvectors/LICENSE.
+
+```
+SPDX-License-Identifier: Apache-2.0
+```
+
+
+================================================================================
+Full License Texts
+================================================================================
+
+Apache License 2.0
+------------------
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+    2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+    3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+    4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+        (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+        (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+        (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+        (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+    5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+    6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+    7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+    8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+    9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+ISC License
+-----------
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+MIT License
+-----------
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+BSD 3-Clause License
+--------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+MIT No Attribution (MIT-0)
+--------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+````
 
 ### L-4a4d43f3f90d
 
@@ -27733,6 +28149,29 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
    of your accepting any such warranty or additional liability.
 ```
 
+### L-96febbdecdb0
+
+```
+Copyright 2025 Don MacAskill
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
 ### L-99139a74daf9
 
 ```
@@ -36848,6 +37287,213 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+### L-efbbbcefb4b8
+
+```
+SPDX-License-Identifier: ISC AND (Apache-2.0 OR ISC)
+
+
+Apache 2.0 license
+-------------------------------------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+ISC license
+-------------------------------------
+
+
+Copyright Amazon.com, Inc. or its affiliates.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
 ### L-f04d53ae9397
 
 ```
@@ -37455,6 +38101,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### L-f5352eaa5597
+
+```
+Copyright (c) 2017 h2 authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ### L-f57e3a2cabf2


### PR DESCRIPTION
Closes #2908

## Summary

- Require `TIDEBREAK_BLOB_STORE_URL=s3://bucket[/prefix]` for self-host deployments and build the backend from standard `AWS_*` settings.
- Add immutable S3-compatible puts, streamed multipart uploads, bounded range reads, metadata, inventory, and deletion with redacted backend errors.
- Route orphan discovery and durable retirement through the configured `BlobStore`, while desktop keeps filesystem storage.
- Document Compose configuration, bucket permissions, multipart and temporary-object cleanup, and backup scope.

## Validation

- `cargo test -p tidebreak-core object_blob::tests --lib --features blob-object`
- `cargo test -p tidebreak-core config::tests --lib`
- `cargo test -p tidebreak-core blob::tests --lib --features blob-fs`
- `cargo test -p tidebreak-server blob_orphan_auditor::tests --lib --features postgres`
- `cargo test -p tidebreak-server blob_retirement_worker::tests --lib --features postgres`
- `cargo test -p tidebreak-server profile_selects --lib --features postgres`
- `cargo clippy -p tidebreak-core --features blob-object,blob-fs --lib --tests -- -D warnings`
- `cargo clippy -p tidebreak-server --features postgres --lib -- -D warnings`
- `cargo check -p tidebreak-server --features postgres --locked`
- `pnpm --dir docs-site build`, `types:check`, and `lint` with pnpm 10.18.3
- `docker compose ... config` with unset, shell-provided, and `.env`-provided AWS settings
- `cargo fmt --all -- --check`
- `git diff --check`