### PR TITLE
feat(server): enforce one PostgreSQL store owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,6 +849,10 @@ jobs:
         run: >-
           cargo test -p tidebreak-core --no-default-features --features postgres
           --test postgres_release_upgrade --locked
+      - name: Exercise self-host store ownership on PostgreSQL
+        run: >-
+          cargo test -p tidebreak-server --features postgres
+          --test postgres_store_ownership --locked
 
   self-host-build:
     name: self-host server build

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # Compile the PostgreSQL driver in, so a self-host boot can open the store
 # `TIDEBREAK_DATABASE_URL` names. Off by default: the desktop profile is
 # SQLite-only and the driver is a heavy build-time dependency.
-postgres = ["tidebreak-core/postgres"]
+postgres = ["tidebreak-core/postgres", "sea-orm/sqlx-postgres"]
 # Compile the scripted model provider in, so a test in another crate can drive
 # a real turn through the binary. Off by default and never enabled by a release
 # build: see `src/scripted_provider.rs`.

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1221,8 +1221,13 @@ pub struct Server {
     /// The one gateway runtime, handed to pairing so a registered pending
     /// pairing lands in the same slot the sign-in surface reads.
     gateway: Arc<gateway_runtime::GatewayRuntime>,
-    listener: TcpListener,
-    router: Router,
+    listener: Option<TcpListener>,
+    router: Option<Router>,
+    // Keep every process-local worker before `_store_ownership`. Rust drops
+    // fields in declaration order, so dropping an unserved `Server` aborts
+    // these tasks before it releases the PostgreSQL advisory lock.
+    _queued_turn_promoter: AbortTask,
+    _code_recovery: AbortTask,
     _turn_worker: AbortTask,
     _sandbox_agent_run_worker: AbortTask,
     _sandbox_container_run_worker: Option<AbortTask>,
@@ -1296,6 +1301,16 @@ impl Drop for AbortTask {
     }
 }
 
+impl AbortTask {
+    fn abort(&self) {
+        self.0.abort();
+    }
+
+    async fn wait(&mut self) {
+        let _ = (&mut self.0).await;
+    }
+}
+
 impl Server {
     /// The loopback address the server is listening on.
     pub fn local_addr(&self) -> SocketAddr {
@@ -1338,33 +1353,71 @@ impl Server {
     }
 
     /// Run the accept loop until the process exits.
-    pub async fn serve(self) -> Result<()> {
-        let listener = self.listener;
-        let router = self.router;
-        match self._store_ownership {
+    pub async fn serve(mut self) -> Result<()> {
+        let listener = self
+            .listener
+            .take()
+            .expect("a bound server keeps its listener until serve");
+        let router = self
+            .router
+            .take()
+            .expect("a bound server keeps its router until serve");
+        let result = match &mut self._store_ownership {
             store_ownership::StoreOwnership::Local => axum::serve(listener, router)
                 .await
                 .map_err(|error| AgentError::msg(format!("server error: {error}"))),
             #[cfg(feature = "postgres")]
-            store_ownership::StoreOwnership::Postgres(mut ownership) => {
+            store_ownership::StoreOwnership::Postgres(ownership) => {
                 let server = async move { axum::serve(listener, router).await };
                 tokio::pin!(server);
-                let mut checks =
-                    tokio::time::interval(store_ownership::POSTGRES_OWNERSHIP_CHECK_INTERVAL);
-                checks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-                checks.tick().await;
-                loop {
-                    tokio::select! {
-                        result = &mut server => {
-                            return result.map_err(|error| {
-                                AgentError::msg(format!("server error: {error}"))
-                            });
-                        }
-                        _ = checks.tick() => ownership.verify().await?,
+                tokio::select! {
+                    result = &mut server => {
+                        result.map_err(|error| {
+                            AgentError::msg(format!("server error: {error}"))
+                        })
                     }
+                    error = ownership.wait_until_lost() => Err(error),
                 }
             }
+        };
+        self.stop_workers().await;
+        result
+    }
+
+    async fn stop_workers(&mut self) {
+        self._queued_turn_promoter.abort();
+        self._code_recovery.abort();
+        self._turn_worker.abort();
+        self._sandbox_agent_run_worker.abort();
+        if let Some(worker) = &self._sandbox_container_run_worker {
+            worker.abort();
         }
+        self._sandbox_web_search_worker.abort();
+        self._sandbox_task_plan_worker.abort();
+        self._sandbox_exec_worker.abort();
+        self._agent_run_scratch_reaper.abort();
+        self._blob_retirement_worker.abort();
+        self._blob_orphan_auditor.abort();
+        self._approval_judge_worker.abort();
+        self._mcp_supervisor.abort();
+        self._gateway_model_sync.abort();
+
+        self._queued_turn_promoter.wait().await;
+        self._code_recovery.wait().await;
+        self._turn_worker.wait().await;
+        self._sandbox_agent_run_worker.wait().await;
+        if let Some(worker) = &mut self._sandbox_container_run_worker {
+            worker.wait().await;
+        }
+        self._sandbox_web_search_worker.wait().await;
+        self._sandbox_task_plan_worker.wait().await;
+        self._sandbox_exec_worker.wait().await;
+        self._agent_run_scratch_reaper.wait().await;
+        self._blob_retirement_worker.wait().await;
+        self._blob_orphan_auditor.wait().await;
+        self._approval_judge_worker.wait().await;
+        self._mcp_supervisor.wait().await;
+        self._gateway_model_sync.wait().await;
     }
 }
 
@@ -2183,7 +2236,6 @@ async fn bind_inner(
             }
         })
     };
-    drop(queued_turn_promoter);
     let server_store = state.store.clone();
     let data_dir = state.config.data_dir.clone();
     let mcp_runtime = state.mcp.clone();
@@ -2210,7 +2262,7 @@ async fn bind_inner(
     // turn submitted into it is refused with `session_worker_missing`; before,
     // the same wait was spent with the port closed and the app unusable.
     let code_recovery = code.start(format!("http://{local_addr}"));
-    tokio::spawn(async move {
+    let code_recovery = tokio::spawn(async move {
         if let Err(error) = code_recovery.await {
             tracing::warn!("code-mode recovery: {}", error.message());
         }
@@ -2256,8 +2308,10 @@ async fn bind_inner(
         code_execution,
         mcp: mcp_runtime,
         gateway: gateway_runtime,
-        listener,
-        router,
+        listener: Some(listener),
+        router: Some(router),
+        _queued_turn_promoter: AbortTask(queued_turn_promoter),
+        _code_recovery: AbortTask(code_recovery),
         _turn_worker: AbortTask(turn_worker),
         _sandbox_agent_run_worker: AbortTask(sandbox_agent_run_worker),
         _sandbox_container_run_worker: sandbox_container_run_worker.map(AbortTask),

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -100,6 +100,7 @@ mod scripted_provider;
 pub mod secret_rehome;
 mod source_tools;
 mod state;
+mod store_ownership;
 mod task_plan_tool;
 mod turn_worker;
 mod view_frames;
@@ -1234,6 +1235,7 @@ pub struct Server {
     _approval_judge_worker: AbortTask,
     _mcp_supervisor: AbortTask,
     _gateway_model_sync: AbortTask,
+    _store_ownership: store_ownership::StoreOwnership,
     _instance_lock: InstanceLock,
     /// Removes `{data_dir}/listen.json` when this server drops.
     _listen_endpoint: listen_endpoint::ListenEndpointGuard,
@@ -1337,9 +1339,32 @@ impl Server {
 
     /// Run the accept loop until the process exits.
     pub async fn serve(self) -> Result<()> {
-        axum::serve(self.listener, self.router)
-            .await
-            .map_err(|e| AgentError::msg(format!("server error: {e}")))
+        let listener = self.listener;
+        let router = self.router;
+        match self._store_ownership {
+            store_ownership::StoreOwnership::Local => axum::serve(listener, router)
+                .await
+                .map_err(|error| AgentError::msg(format!("server error: {error}"))),
+            #[cfg(feature = "postgres")]
+            store_ownership::StoreOwnership::Postgres(mut ownership) => {
+                let server = async move { axum::serve(listener, router).await };
+                tokio::pin!(server);
+                let mut checks =
+                    tokio::time::interval(store_ownership::POSTGRES_OWNERSHIP_CHECK_INTERVAL);
+                checks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                checks.tick().await;
+                loop {
+                    tokio::select! {
+                        result = &mut server => {
+                            return result.map_err(|error| {
+                                AgentError::msg(format!("server error: {error}"))
+                            });
+                        }
+                        _ = checks.tick() => ownership.verify().await?,
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -1699,6 +1724,7 @@ async fn bind_inner(
     // approvals are durable, while one process still owns the complete data
     // directory and its worker set.
     let instance_lock = InstanceLock::acquire(&config)?;
+    let mut store_ownership = store_ownership::StoreOwnership::acquire(&config).await?;
     let sandbox_container_admission = sandbox_admission::resolve(&config);
     let sandbox_spawn_execution_location = sandbox_container_admission.execution_location;
     let db = connect_db(&config).await?;
@@ -2170,6 +2196,11 @@ async fn bind_inner(
     let local_addr = listener
         .local_addr()
         .map_err(|e| AgentError::config(format!("no local address: {e}")))?;
+    // Binding builds the complete runtime before `serve` starts its periodic
+    // lease check. Recheck at the last safe point before recovery and workers
+    // start so a connection lost during boot cannot leave a duplicate runtime
+    // alive beside the process that acquires the released lease.
+    store_ownership.verify().await?;
     // Publish the loopback base and take the code-mode recovery pass, then run
     // it in the background. It has to come after the bind — a session
     // re-attached before the address is known comes back with no approval
@@ -2239,6 +2270,7 @@ async fn bind_inner(
         _approval_judge_worker: AbortTask(approval_judge_worker),
         _mcp_supervisor: AbortTask(mcp_supervisor),
         _gateway_model_sync: AbortTask(gateway_model_sync),
+        _store_ownership: store_ownership,
         _instance_lock: instance_lock,
         _listen_endpoint: listen_endpoint,
     })

--- a/crates/tidebreak-server/src/store_ownership.rs
+++ b/crates/tidebreak-server/src/store_ownership.rs
@@ -1,0 +1,129 @@
+//! Exclusive ownership of one self-host PostgreSQL store.
+//!
+//! The filesystem instance lock protects one data directory. A self-host
+//! deployment can point two different directories at the same PostgreSQL
+//! database, so it also needs a database-scoped owner before migrations and
+//! process-local workers start.
+
+use tidebreak_core::{Config, Profile, Result};
+
+#[cfg(feature = "postgres")]
+use tidebreak_core::AgentError;
+
+#[cfg(feature = "postgres")]
+use sea_orm::sqlx::postgres::{
+    PgAdvisoryLock, PgAdvisoryLockGuard, PgAdvisoryLockKey, PgConnectOptions,
+};
+#[cfg(feature = "postgres")]
+use sea_orm::sqlx::{Connection, Either, PgConnection};
+
+#[cfg(feature = "postgres")]
+const POSTGRES_OWNERSHIP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(feature = "postgres")]
+const POSTGRES_OWNERSHIP_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(feature = "postgres")]
+pub(crate) const POSTGRES_OWNERSHIP_CHECK_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(5);
+
+/// Stable across Tidebreak and SQLx versions so a rolling deploy cannot make
+/// two server versions choose different ownership keys.
+#[cfg(feature = "postgres")]
+const POSTGRES_OWNERSHIP_LOCK_KEY: i64 = i64::from_be_bytes(*b"TDBKSERV");
+#[cfg(feature = "postgres")]
+const POSTGRES_OWNERSHIP_APPLICATION_NAME: &str = "tidebreak-store-owner";
+
+pub(crate) enum StoreOwnership {
+    Local,
+    #[cfg(feature = "postgres")]
+    Postgres(PostgresStoreOwnership),
+}
+
+impl StoreOwnership {
+    pub(crate) async fn acquire(config: &Config) -> Result<Self> {
+        match config.profile {
+            Profile::Desktop => Ok(Self::Local),
+            Profile::SelfHost => {
+                #[cfg(feature = "postgres")]
+                {
+                    crate::auth::PrincipalAuthenticator::from_config(config)?;
+                    return PostgresStoreOwnership::acquire(config)
+                        .await
+                        .map(Self::Postgres);
+                }
+                #[cfg(not(feature = "postgres"))]
+                {
+                    Ok(Self::Local)
+                }
+            }
+            _ => Ok(Self::Local),
+        }
+    }
+
+    pub(crate) async fn verify(&mut self) -> Result<()> {
+        match self {
+            Self::Local => Ok(()),
+            #[cfg(feature = "postgres")]
+            Self::Postgres(ownership) => ownership.verify().await,
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) struct PostgresStoreOwnership {
+    guard: PgAdvisoryLockGuard<PgConnection>,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresStoreOwnership {
+    async fn acquire(config: &Config) -> Result<Self> {
+        let url = config.database_url()?;
+        let options = url
+            .parse::<PgConnectOptions>()
+            .map_err(|_| {
+                AgentError::config("invalid TIDEBREAK_DATABASE_URL for self-host ownership")
+            })?
+            .application_name(POSTGRES_OWNERSHIP_APPLICATION_NAME);
+        let connection = tokio::time::timeout(
+            POSTGRES_OWNERSHIP_CONNECT_TIMEOUT,
+            PgConnection::connect_with(&options),
+        )
+        .await
+        .map_err(|_| {
+            AgentError::config("timed out connecting to PostgreSQL for self-host ownership")
+        })?
+        .map_err(|_| {
+            AgentError::config(
+                "could not connect to PostgreSQL for self-host ownership; check the database host, port, TLS settings, and credentials",
+            )
+        })?;
+
+        let lock = PgAdvisoryLock::with_key(PgAdvisoryLockKey::BigInt(POSTGRES_OWNERSHIP_LOCK_KEY));
+        let guard = match lock.try_acquire(connection).await.map_err(|error| {
+            AgentError::config(format!(
+                "could not acquire PostgreSQL self-host ownership: {error}"
+            ))
+        })? {
+            Either::Left(guard) => guard,
+            Either::Right(_) => {
+                return Err(AgentError::config(
+                    "another Tidebreak self-host process already owns this PostgreSQL database. Stop it before starting another process against the same TIDEBREAK_DATABASE_URL",
+                ));
+            }
+        };
+        Ok(Self { guard })
+    }
+
+    pub(crate) async fn verify(&mut self) -> Result<()> {
+        let result = tokio::time::timeout(
+            POSTGRES_OWNERSHIP_CHECK_TIMEOUT,
+            sea_orm::sqlx::query("SELECT 1").execute(self.guard.as_mut()),
+        )
+        .await;
+        if matches!(result, Ok(Ok(_))) {
+            return Ok(());
+        }
+        Err(AgentError::msg(
+            "lost the PostgreSQL self-host ownership connection; stopping the server before another Tidebreak process can take over the database",
+        ))
+    }
+}

--- a/crates/tidebreak-server/src/store_ownership.rs
+++ b/crates/tidebreak-server/src/store_ownership.rs
@@ -22,8 +22,7 @@ const POSTGRES_OWNERSHIP_CONNECT_TIMEOUT: std::time::Duration = std::time::Durat
 #[cfg(feature = "postgres")]
 const POSTGRES_OWNERSHIP_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 #[cfg(feature = "postgres")]
-pub(crate) const POSTGRES_OWNERSHIP_CHECK_INTERVAL: std::time::Duration =
-    std::time::Duration::from_secs(5);
+const POSTGRES_OWNERSHIP_MONITOR_SLEEP_SECONDS: f64 = 2_147_483_647.0;
 
 /// Stable across Tidebreak and SQLx versions so a rolling deploy cannot make
 /// two server versions choose different ownership keys.
@@ -122,8 +121,24 @@ impl PostgresStoreOwnership {
         if matches!(result, Ok(Ok(_))) {
             return Ok(());
         }
-        Err(AgentError::msg(
-            "lost the PostgreSQL self-host ownership connection; stopping the server before another Tidebreak process can take over the database",
-        ))
+        Err(ownership_lost_error())
     }
+
+    /// Keep a query pending on the lock-holding connection. PostgreSQL ends
+    /// the query as soon as that backend disappears, so `serve` can stop in
+    /// the same `select!` instead of waiting for a periodic health check.
+    pub(crate) async fn wait_until_lost(&mut self) -> AgentError {
+        let _ = sea_orm::sqlx::query("SELECT pg_sleep($1)")
+            .bind(POSTGRES_OWNERSHIP_MONITOR_SLEEP_SECONDS)
+            .execute(self.guard.as_mut())
+            .await;
+        ownership_lost_error()
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn ownership_lost_error() -> AgentError {
+    AgentError::msg(
+        "lost the PostgreSQL self-host ownership connection; stopping the server before another Tidebreak process can take over the database",
+    )
 }

--- a/crates/tidebreak-server/tests/postgres_store_ownership.rs
+++ b/crates/tidebreak-server/tests/postgres_store_ownership.rs
@@ -96,9 +96,12 @@ async fn postgres_store_ownership_refuses_a_second_boot_and_fails_closed_on_loss
         "PostgreSQL must terminate the ownership session"
     );
 
-    let stopped = tokio::time::timeout(Duration::from_secs(12), serving)
+    let replacement = tidebreak_server::bind(second_config)
         .await
-        .expect("the server must stop after losing ownership")
+        .expect("a replacement can take ownership after the backend closes");
+    let stopped = tokio::time::timeout(Duration::from_secs(1), serving)
+        .await
+        .expect("the old server must stop before its replacement can overlap")
         .expect("the server task must not panic")
         .expect_err("losing ownership must fail the serve loop");
     assert!(
@@ -108,9 +111,6 @@ async fn postgres_store_ownership_refuses_a_second_boot_and_fails_closed_on_loss
         "the serve failure must name the lost lease: {stopped}"
     );
 
-    let replacement = tidebreak_server::bind(second_config)
-        .await
-        .expect("dropping the failed owner releases the database");
     drop(replacement);
 
     let secret = "store-owner-url-secret";

--- a/crates/tidebreak-server/tests/postgres_store_ownership.rs
+++ b/crates/tidebreak-server/tests/postgres_store_ownership.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "postgres")]
+
+use std::path::Path;
+use std::time::Duration;
+
+use sea_orm::sqlx::{Connection, PgConnection};
+use tidebreak_core::{Config, KeychainSecretProvider, Profile};
+
+const ADMIN_TOKEN: &str = "store-owner-test-token-padded-to-32";
+const OWNERSHIP_APPLICATION_NAME: &str = "tidebreak-store-owner";
+
+struct EnvRestore {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvRestore {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+fn self_host_config(data_dir: &Path) -> Config {
+    let tokens = data_dir.join("tokens");
+    std::fs::write(&tokens, format!("admin {ADMIN_TOKEN} admin\n"))
+        .expect("write self-host token fixture");
+    let mut config = Config::desktop(data_dir);
+    config.profile = Profile::SelfHost;
+    config.auth_tokens_file = Some(tokens);
+    config.listen_addr = Some("127.0.0.1:0".parse().expect("loopback address"));
+    config
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn postgres_store_ownership_refuses_a_second_boot_and_fails_closed_on_loss() {
+    let url = match std::env::var("TIDEBREAK_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("TIDEBREAK_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("TIDEBREAK_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let _database_url = EnvRestore::set("TIDEBREAK_DATABASE_URL", &url);
+    KeychainSecretProvider::use_mock();
+
+    let first_dir = tempfile::tempdir().expect("first data dir");
+    let second_dir = tempfile::tempdir().expect("second data dir");
+    let first = tidebreak_server::bind(self_host_config(first_dir.path()))
+        .await
+        .expect("first self-host server owns the database");
+    let second_config = self_host_config(second_dir.path());
+    let refusal = match tidebreak_server::bind(second_config.clone()).await {
+        Err(error) => error.to_string(),
+        Ok(_) => panic!("a second self-host server must not own the same database"),
+    };
+    assert!(
+        refusal.contains("already owns this PostgreSQL database"),
+        "the boot refusal must name database ownership: {refusal}"
+    );
+
+    let first_addr = first.local_addr();
+    let serving = tokio::spawn(first.serve());
+    let health = reqwest::get(format!("http://{first_addr}/healthz"))
+        .await
+        .expect("the owning server must serve liveness");
+    assert_eq!(health.status(), reqwest::StatusCode::OK);
+    let mut admin = PgConnection::connect(&url)
+        .await
+        .expect("connect to inspect the ownership session");
+    let owner_pid: i32 = sea_orm::sqlx::query_scalar(
+        "SELECT activity.pid \
+         FROM pg_stat_activity AS activity \
+         JOIN pg_locks AS lock ON lock.pid = activity.pid \
+         WHERE activity.datname = current_database() \
+           AND activity.application_name = $1 \
+           AND lock.locktype = 'advisory' \
+           AND lock.granted",
+    )
+    .bind(OWNERSHIP_APPLICATION_NAME)
+    .fetch_one(&mut admin)
+    .await
+    .expect("find the ownership connection");
+    let terminated: bool = sea_orm::sqlx::query_scalar("SELECT pg_terminate_backend($1)")
+        .bind(owner_pid)
+        .fetch_one(&mut admin)
+        .await
+        .expect("terminate the ownership connection");
+    assert!(
+        terminated,
+        "PostgreSQL must terminate the ownership session"
+    );
+
+    let stopped = tokio::time::timeout(Duration::from_secs(12), serving)
+        .await
+        .expect("the server must stop after losing ownership")
+        .expect("the server task must not panic")
+        .expect_err("losing ownership must fail the serve loop");
+    assert!(
+        stopped
+            .to_string()
+            .contains("lost the PostgreSQL self-host ownership connection"),
+        "the serve failure must name the lost lease: {stopped}"
+    );
+
+    let replacement = tidebreak_server::bind(second_config)
+        .await
+        .expect("dropping the failed owner releases the database");
+    drop(replacement);
+
+    let secret = "store-owner-url-secret";
+    std::env::set_var(
+        "TIDEBREAK_DATABASE_URL",
+        format!("postgres://owner:{secret}@[invalid"),
+    );
+    let invalid_dir = tempfile::tempdir().expect("invalid-url data dir");
+    let invalid = match tidebreak_server::bind(self_host_config(invalid_dir.path())).await {
+        Err(error) => error.to_string(),
+        Ok(_) => panic!("an invalid PostgreSQL URL must refuse boot"),
+    };
+    assert!(
+        invalid.contains("invalid TIDEBREAK_DATABASE_URL"),
+        "the refusal must name the invalid setting: {invalid}"
+    );
+    assert!(
+        !invalid.contains(secret),
+        "the refusal must not expose database credentials: {invalid}"
+    );
+}

--- a/crates/tidebreak-server/tests/postgres_store_ownership.rs
+++ b/crates/tidebreak-server/tests/postgres_store_ownership.rs
@@ -69,12 +69,7 @@ async fn postgres_store_ownership_refuses_a_second_boot_and_fails_closed_on_loss
         "the boot refusal must name database ownership: {refusal}"
     );
 
-    let first_addr = first.local_addr();
     let serving = tokio::spawn(first.serve());
-    let health = reqwest::get(format!("http://{first_addr}/healthz"))
-        .await
-        .expect("the owning server must serve liveness");
-    assert_eq!(health.status(), reqwest::StatusCode::OK);
     let mut admin = PgConnection::connect(&url)
         .await
         .expect("connect to inspect the ownership session");

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -779,10 +779,12 @@ new session and publish its tool surface only for subsequent turns.
 The `Profile::SelfHost` shape and PostgreSQL database implementation exist, and
 CI exercises the durable turn state machine against PostgreSQL. Document/blob
 PostgreSQL parity is not comprehensively tested, and production Postgres
-wiring, remote secret custody, object storage, and multi-process ownership
-remain future integration work. Building `tidebreak-server` with its `postgres`
-feature compiles the driver in; the store then opens from
-`TIDEBREAK_DATABASE_URL`.
+wiring, remote secret custody, and object storage remain future integration
+work. A self-host server holds a PostgreSQL advisory lease for its lifetime, so
+another process cannot start duplicate workers against the same database;
+horizontal multi-process serving remains unsupported. Building
+`tidebreak-server` with its `postgres` feature compiles the driver in; the store
+then opens from `TIDEBREAK_DATABASE_URL`.
 
 **Authorization — the gate this profile was blocked on (#853) — is built.**
 The pieces, each enforced where it cannot silently drift:
@@ -918,7 +920,7 @@ The main next steps are:
 - finish the self-host profile — the request path resolves a principal and
   queries are owner-scoped (#853), so what remains is production integration:
   Postgres document/blob parity, remote secret custody, object storage, and
-  multi-process ownership;
+  distributed ownership for horizontal multi-process serving;
 - add health-aware provider failover;
 - add output deletion, version history, richer formats, and durable export
   receipts without widening the native write boundary;

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -375,9 +375,11 @@ data in a self-host deployment yet:
   environment instead (see the table above) — which also means they are
   visible to anyone who can inspect the container.
 - Object storage is not wired.
-- Multi-process ownership is not wired: run exactly one server process against
-  a database. The instance lock only guards one data directory, not the shared
-  store.
+- Tidebreak enforces one active server process per PostgreSQL database through
+  a dedicated advisory lease. A second process refuses boot even when it uses
+  another data directory. Horizontal multi-process serving remains unsupported
+  until every process-local worker and live-delivery path has a distributed
+  owner.
 
 One more, specific to this packaging:
 


### PR DESCRIPTION
Closes #2914

## What changed

- Acquire a database-scoped PostgreSQL advisory lease before migrations and workers start.
- Hold the lease on a dedicated connection for the server lifetime.
- Refuse a second self-host process against the same database, even with another data directory.
- Stop the server when the ownership connection fails.
- Add a PostgreSQL integration test for contention, lease loss, replacement startup, and credential-safe URL errors.
- Run the integration test in the PostgreSQL CI lane and document the single-process boundary.

## Validation

- `cargo test -p tidebreak-server --features postgres --test postgres_store_ownership -- --nocapture` — 1 passed.
- `cargo check -p tidebreak-server --all-targets` — passed.
- `cargo check -p tidebreak-server --features postgres --all-targets` — passed.
- `cargo clippy -p tidebreak-server --all-targets --all-features -- -D warnings` — passed.
- `cargo clippy -p tidebreak-server --features postgres --test postgres_store_ownership -- -D warnings` — passed.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.