### PR TITLE
fix(cli): require TLS for remote server URLs

### DIFF
--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -131,13 +131,18 @@ impl Client {
         local_import_token: Option<&str>,
         listen_data_dir: Option<PathBuf>,
     ) -> Result<Self> {
+        let base = validated_server_base_url(&base)?;
         let mut headers = reqwest::header::HeaderMap::new();
         let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
             .map_err(|error| AgentError::msg(format!("invalid server token: {error}")))?;
         value.set_sensitive(true);
         headers.insert(reqwest::header::AUTHORIZATION, value);
-        let mut http = reqwest::Client::builder().default_headers(headers);
-        if loopback_http_base(&base) {
+        let mut http = reqwest::Client::builder()
+            .default_headers(headers)
+            // A same-host HTTPS-to-HTTP redirect would otherwise resend the
+            // bearer over cleartext. Tidebreak routes never redirect.
+            .redirect(reqwest::redirect::Policy::none());
+        if server_url_is_loopback(&base) {
             // Ambient HTTP_PROXY must not intercept loopback: a proxy that
             // claims 127.0.0.1 black-holes `serve` and `--attach`.
             http = http.no_proxy();
@@ -1213,14 +1218,49 @@ impl Client {
     }
 }
 
-/// True when `base` names a loopback HTTP origin.
-fn loopback_http_base(base: &str) -> bool {
-    let rest = base
-        .strip_prefix("http://")
-        .or_else(|| base.strip_prefix("https://"))
-        .unwrap_or(base);
-    let host = rest.split(['/', ':']).next().unwrap_or(rest);
-    matches!(host, "127.0.0.1" | "localhost" | "[::1]" | "::1")
+/// Validate and normalize a bearer-authenticated server URL.
+///
+/// Cleartext is a local-development exception. A remote attachment carries
+/// full profile authority, so its base URL must use TLS before the CLI loads
+/// the bearer or the client builds its transport.
+pub(crate) fn validated_server_base_url(value: &str) -> Result<String> {
+    let url = reqwest::Url::parse(value.trim())
+        .map_err(|_| AgentError::config("server URL must be a valid http or https URL"))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(AgentError::config("server URL must use http or https"));
+    }
+    if url.host_str().is_none() {
+        return Err(AgentError::config("server URL must name a host"));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(AgentError::config("server URL must not embed credentials"));
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(AgentError::config(
+            "server URL must not include a query or fragment",
+        ));
+    }
+    if url.scheme() == "http" && !url_host_is_loopback(&url) {
+        return Err(AgentError::config(
+            "server URL must use https unless it names a loopback host",
+        ));
+    }
+    Ok(url.as_str().trim_end_matches('/').to_owned())
+}
+
+fn server_url_is_loopback(base: &str) -> bool {
+    reqwest::Url::parse(base).is_ok_and(|url| url_host_is_loopback(&url))
+}
+
+fn url_host_is_loopback(url: &reqwest::Url) -> bool {
+    url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    })
 }
 
 /// reqwest's `Display` already strips nothing for loopback URLs, but keep the
@@ -1271,6 +1311,8 @@ fn durable_turn_from_transcript(
 
 #[cfg(test)]
 mod tests {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
     use super::*;
 
     #[test]
@@ -1304,6 +1346,51 @@ mod tests {
         assert_eq!(client.token, "second-token");
         assert_eq!(client.local_import_token.as_deref(), Some("second-import"));
         assert_eq!(client.listen_data_dir.as_deref(), Some(dir.path()));
+    }
+
+    #[test]
+    fn attach_clients_refuse_remote_cleartext_before_building_transport() {
+        let error = Client::attach("http://machine.example.com".into(), "secret-token")
+            .err()
+            .expect("remote cleartext must be refused");
+        assert!(error.to_string().contains("https"), "{error}");
+        assert!(Client::attach("http://127.0.0.1:8080".into(), "local-token").is_ok());
+    }
+
+    #[tokio::test]
+    async fn authenticated_clients_do_not_follow_cleartext_redirects() {
+        let target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        let redirect = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let redirect_addr = redirect.local_addr().unwrap();
+        let redirect_task = tokio::spawn(async move {
+            let (mut stream, _) = redirect.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 302 Found\r\nLocation: http://{target_addr}/settings\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let client = Client::new(redirect_addr, "redirect-test-token").unwrap();
+        let error = client
+            .get_settings()
+            .await
+            .expect_err("the redirect must be returned, not followed");
+        assert!(error.to_string().contains("302"), "{error}");
+        redirect_task.await.unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), target.accept())
+                .await
+                .is_err(),
+            "the bearer must not reach the redirect target"
+        );
     }
 
     #[test]

--- a/crates/tidebreak-cli/src/connect.rs
+++ b/crates/tidebreak-cli/src/connect.rs
@@ -26,7 +26,7 @@
 use std::path::PathBuf;
 use tidebreak_core::{AgentError, Result};
 
-use crate::api::client::Client;
+use crate::api::client::{validated_server_base_url, Client};
 
 /// Names the server to attach to instead of embedding one.
 pub const SERVER_URL_ENV: &str = "TIDEBREAK_SERVER_URL";
@@ -127,26 +127,7 @@ impl Server {
 /// string, and a bare `127.0.0.1:8080` would silently produce a URL nothing can
 /// connect to.
 fn base_url(value: &str) -> Result<String> {
-    let value = value.trim();
-    let rest = value
-        .strip_prefix("http://")
-        .or_else(|| value.strip_prefix("https://"))
-        .ok_or_else(|| {
-            AgentError::config(format!(
-                "--server expects an http:// or https:// URL, got {value:?}"
-            ))
-        })?;
-    if rest.is_empty() || rest.starts_with('/') {
-        return Err(AgentError::config(format!(
-            "--server URL {value:?} has no host"
-        )));
-    }
-    if rest.contains('?') || rest.contains('#') {
-        return Err(AgentError::config(format!(
-            "--server expects a base URL without a query or fragment, got {value:?}"
-        )));
-    }
-    Ok(value.trim_end_matches('/').to_owned())
+    validated_server_base_url(value)
 }
 
 /// A live client plus, when embedding, the engine keeping it answering.
@@ -238,6 +219,15 @@ mod tests {
             "http://127.0.0.1:8080"
         );
         assert_eq!(
+            base_url("http://127.0.0.2:8080/").unwrap(),
+            "http://127.0.0.2:8080"
+        );
+        assert_eq!(
+            base_url("http://localhost:8080/").unwrap(),
+            "http://localhost:8080"
+        );
+        assert_eq!(base_url("http://[::1]:8080/").unwrap(), "http://[::1]:8080");
+        assert_eq!(
             base_url(" https://box.local:9000 ").unwrap(),
             "https://box.local:9000"
         );
@@ -247,6 +237,14 @@ mod tests {
         );
         assert!(base_url("http://").is_err(), "a host is required");
         assert!(base_url("http://host/?a=1").is_err(), "no query string");
+        assert!(base_url("http://box.local:9000")
+            .expect_err("remote cleartext must be refused")
+            .to_string()
+            .contains("https"));
+        assert!(
+            base_url("https://user:password@box.local:9000").is_err(),
+            "credentials belong in the token environment variable"
+        );
 
         std::env::remove_var(SERVER_URL_ENV);
         let Err(error) = Server::resolve(None, Some("SOME_VAR".to_owned()), false) else {

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -226,10 +226,11 @@ family also take --server <url> [--server-token-env <var>] or --attach, which
 talks to a server that is already running instead of embedding one. --attach
 reads {TIDEBREAK_DATA_DIR}/listen.json (written by serve and the desktop).
 With --server the token comes from TIDEBREAK_SERVER_TOKEN, or from the named
-variable; it is never an argument either. The folder commands do not take
+variable; it is never an argument either. Remote server URLs must use https;
+http is accepted only for a loopback host. The folder commands do not take
 --server/--attach: they provision local host consent in this machine's own
-broker and product store, and they can run while serve or the desktop
-already owns the data directory.";
+broker and product store, and they can run while serve or the desktop already
+owns the data directory.";
 
 #[tokio::main]
 async fn main() {

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -160,7 +160,8 @@ cargo run -p tidebreak-cli -- --server "$TIDEBREAK_SERVER_URL" -p "summarize yes
 
 `--server` / `TIDEBREAK_SERVER_TOKEN` are the same attach path the headless
 docs describe. A member token receives `403` on deployment-plane routes, which
-is the intended degradation — not a desktop Settings panel.
+is the intended degradation — not a desktop Settings panel. Remote server URLs
+must use HTTPS; cleartext HTTP is available only for loopback development.
 
 The packaged desktop app still embeds its local Desktop-profile server, but it
 can attach its renderer to a remote self-host machine. For a Gateway-backed


### PR DESCRIPTION
Closes #2915

## What changed

- Reject bearer-authenticated `http://` server URLs outside loopback before the CLI reads the token environment variable.
- Apply the same URL validation inside `Client::attach` so direct callers cannot bypass the transport boundary.
- Accept `localhost`, IPv4 loopback, and IPv6 loopback development URLs.
- Disable redirects on the authenticated HTTP client so an HTTPS endpoint cannot downgrade the bearer to cleartext HTTP.
- Reject embedded URL credentials, queries, and fragments, and document the TLS rule.

## Validation

- `cargo test -p tidebreak-cli --bin tidebreak` — 113 passed.
- `cargo test -p tidebreak-cli --test serve a_setup_command_attaches_` — 2 passed.
- `cargo test -p tidebreak-cli authenticated_clients_do_not_follow_cleartext_redirects` — 1 passed.
- `cargo clippy -p tidebreak-cli --all-targets -- -D warnings` — passed.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.