### PR TITLE
feat(browser): add bounded foreground uploads

### DIFF
--- a/crates/tidebreak-core/src/browser.rs
+++ b/crates/tidebreak-core/src/browser.rs
@@ -37,9 +37,9 @@ pub const BROWSER_UPLOAD_TOOL: &str = "browser_upload";
 /// The complete set of browser tools this contract supports.
 ///
 /// Wait and screenshot are available on any engine that can inspect a page.
-/// Semantic act requires native input synthesis and is registered only when
-/// the engine adapter reports [`BrowserEngineCapabilities::semantic_actions`]
-/// as true.
+/// Semantic act and upload require trusted native interaction and register
+/// only when the engine adapter reports
+/// [`BrowserEngineCapabilities::semantic_actions`] as true.
 pub const BROWSER_TOOLS: [&str; 7] = [
     BROWSER_LIST_TOOL,
     BROWSER_NAVIGATE_TOOL,

--- a/crates/tidebreak-core/src/browser.rs
+++ b/crates/tidebreak-core/src/browser.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use url::Url;
+use uuid::Uuid;
 
 use crate::ToolSpec;
 
@@ -29,6 +30,9 @@ pub const BROWSER_SCREENSHOT_TOOL: &str = "browser_screenshot";
 /// native input behind origin consent and a live Stop latch. Until then
 /// it returns [`BrowserActStatus::UnsupportedNative`] for every action.
 pub const BROWSER_ACT_TOOL: &str = "browser_act";
+/// Attach one exact conversation output or connected file to a re-resolved
+/// file-input target after fresh native confirmation.
+pub const BROWSER_UPLOAD_TOOL: &str = "browser_upload";
 
 /// The complete set of browser tools this contract supports.
 ///
@@ -36,13 +40,14 @@ pub const BROWSER_ACT_TOOL: &str = "browser_act";
 /// Semantic act requires native input synthesis and is registered only when
 /// the engine adapter reports [`BrowserEngineCapabilities::semantic_actions`]
 /// as true.
-pub const BROWSER_TOOLS: [&str; 6] = [
+pub const BROWSER_TOOLS: [&str; 7] = [
     BROWSER_LIST_TOOL,
     BROWSER_NAVIGATE_TOOL,
     BROWSER_SNAPSHOT_TOOL,
     BROWSER_WAIT_TOOL,
     BROWSER_SCREENSHOT_TOOL,
     BROWSER_ACT_TOOL,
+    BROWSER_UPLOAD_TOOL,
 ];
 
 /// Maximum wire length of an opaque browser id.
@@ -59,6 +64,8 @@ pub const DEFAULT_BROWSER_WAIT_TIMEOUT_MS: u64 = 5_000;
 pub const MAX_BROWSER_WAIT_TIMEOUT_MS: u64 = 30_000;
 /// Maximum allowed value for typed action values (fill, select, press).
 pub const MAX_BROWSER_ACTION_VALUE_CHARS: usize = 8_192;
+/// Hard ceiling on a connected-file path proposed for browser upload.
+pub const MAX_BROWSER_UPLOAD_PATH_BYTES: usize = 1_024;
 /// Maximum width or height for a screenshot in CSS pixels.
 pub const MAX_BROWSER_SCREENSHOT_DIMENSION: u64 = 4_096;
 /// Hard ceiling for encoded image bytes before base64 (8 MiB).
@@ -608,6 +615,94 @@ pub struct BrowserActArgs {
     pub action: BrowserAction,
 }
 
+/// One logical Tidebreak resource that the native browser executor may attach.
+///
+/// Neither variant can represent a host path. The trusted foreground executor
+/// resolves the opaque identity inside the persisted conversation and checks
+/// the exact bytes again after native confirmation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum BrowserUploadResource {
+    /// One live output owned by the current conversation.
+    Output { output_id: Uuid },
+    /// One file below a root attached to the current conversation.
+    ConnectedFile { root_id: Uuid, path: String },
+}
+
+impl BrowserUploadResource {
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        match self {
+            Self::Output { output_id } => !output_id.is_nil(),
+            Self::ConnectedFile { root_id, path } => {
+                !root_id.is_nil() && valid_browser_upload_path(path)
+            }
+        }
+    }
+}
+
+/// Canonical arguments for [`BROWSER_UPLOAD_TOOL`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserUploadArgs {
+    /// Opaque id returned by `browser_list` for this exact capability.
+    #[schemars(
+        length(min = 1, max = MAX_BROWSER_ID_CHARS),
+        description = "Opaque browser id returned by browser_list."
+    )]
+    pub browser_id: String,
+    /// The snapshot id whose ref and epoch this upload targets.
+    pub snapshot_id: String,
+    /// The document epoch the snapshot was taken under.
+    pub document_epoch: u64,
+    /// Ephemeral file-input ref from the most recent snapshot.
+    #[schemars(description = "Ephemeral file-input ref from the most recent snapshot.")]
+    #[serde(rename = "ref")]
+    pub target_ref: String,
+    /// Logical conversation resource to attach. Host paths are never accepted.
+    pub resource: BrowserUploadResource,
+}
+
+impl BrowserUploadArgs {
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        valid_browser_id(&self.browser_id)
+            && !self.snapshot_id.is_empty()
+            && !self.target_ref.is_empty()
+            && self.resource.is_well_formed()
+    }
+}
+
+/// Model-facing outcome of [`BROWSER_UPLOAD_TOOL`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BrowserUploadStatus {
+    Uploaded,
+    StaleTarget,
+    HiddenTab,
+    InvalidTarget,
+    Declined,
+    EngineFailure,
+}
+
+/// Model-facing result of [`BROWSER_UPLOAD_TOOL`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserUploadResult {
+    pub browser_id: String,
+    pub snapshot_id: String,
+    pub document_epoch: u64,
+    #[serde(rename = "ref")]
+    pub target_ref: String,
+    pub status: BrowserUploadStatus,
+    pub message: String,
+    pub requires_resnapshot: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<u64>,
+}
+
 impl BrowserActArgs {
     #[must_use]
     pub fn is_well_formed(&self) -> bool {
@@ -785,6 +880,24 @@ pub fn valid_browser_url(value: &str) -> bool {
         && url.password().is_none()
 }
 
+/// Whether a connected-file upload proposal has the broker's portable
+/// root-relative path shape. The native executor repeats this check with the
+/// broker's authoritative [`RelativePath`](tidebreak_host_broker::RelativePath)
+/// parser before reading anything.
+#[must_use]
+pub fn valid_browser_upload_path(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_BROWSER_UPLOAD_PATH_BYTES
+        && !value.starts_with('/')
+        && !value.contains(['\0', '\\'])
+        && value.split('/').all(|part| {
+            !part.is_empty()
+                && !matches!(part, "." | "..")
+                && !part.contains(':')
+                && !part.chars().any(char::is_control)
+        })
+}
+
 /// Whether `name` is part of the initial browser tool contract.
 #[must_use]
 pub fn is_browser_tool(name: &str) -> bool {
@@ -829,6 +942,13 @@ pub fn validate_browser_screenshot_arguments(arguments: &Value) -> bool {
 #[must_use]
 pub fn validate_browser_act_arguments(arguments: &Value) -> bool {
     serde_json::from_value::<BrowserActArgs>(arguments.clone())
+        .is_ok_and(|arguments| arguments.is_well_formed())
+}
+
+/// Validate a canonical `browser_upload` payload.
+#[must_use]
+pub fn validate_browser_upload_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<BrowserUploadArgs>(arguments.clone())
         .is_ok_and(|arguments| arguments.is_well_formed())
 }
 
@@ -883,6 +1003,15 @@ pub fn browser_act_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<BrowserActArgs>(
         BROWSER_ACT_TOOL,
         "Perform one semantic action on a re-resolved interactive target. The target ref must come from the latest snapshot. Re-snapshot before the next action. This tool is available only when the browser engine can synthesise trusted native input.",
+    )
+}
+
+/// Tool contract for [`BROWSER_UPLOAD_TOOL`].
+#[must_use]
+pub fn browser_upload_tool_spec() -> ToolSpec {
+    ToolSpec::for_args::<BrowserUploadArgs>(
+        BROWSER_UPLOAD_TOOL,
+        "Attach one exact output or connected-folder file from this conversation to a file-input ref from the latest browser snapshot. Provide only an opaque output_id, or an opaque root_id with a bounded root-relative path. Tidebreak never accepts a host path, reauthorizes the exact resource immediately before attachment, and asks the user to confirm every upload.",
     )
 }
 
@@ -962,6 +1091,7 @@ mod tests {
             browser_wait_tool_spec(),
             browser_screenshot_tool_spec(),
             browser_act_tool_spec(),
+            browser_upload_tool_spec(),
         ] {
             assert_eq!(
                 spec.input_schema["additionalProperties"], false,
@@ -983,6 +1113,67 @@ mod tests {
         assert!(browser_act_tool_spec()
             .description
             .contains("semantic action"));
+        assert!(browser_upload_tool_spec()
+            .description
+            .contains("every upload"));
+    }
+
+    #[test]
+    fn browser_upload_accepts_only_logical_bounded_resources() {
+        let output_id = Uuid::new_v4();
+        let root_id = Uuid::new_v4();
+        assert!(validate_browser_upload_arguments(&json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2,
+            "ref": "@e4",
+            "resource": { "kind": "output", "output_id": output_id }
+        })));
+        assert!(validate_browser_upload_arguments(&json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2,
+            "ref": "@e4",
+            "resource": {
+                "kind": "connected_file",
+                "root_id": root_id,
+                "path": "reports/q3.pdf"
+            }
+        })));
+        for path in ["/tmp/secret", "../secret", "reports//q3.pdf", "a\\b"] {
+            assert!(
+                !validate_browser_upload_arguments(&json!({
+                    "browser_id": "browser-1",
+                    "snapshot_id": "snapshot-1",
+                    "document_epoch": 2,
+                    "ref": "@e4",
+                    "resource": {
+                        "kind": "connected_file",
+                        "root_id": root_id,
+                        "path": path
+                    }
+                })),
+                "{path}"
+            );
+        }
+        assert!(!validate_browser_upload_arguments(&json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2,
+            "ref": "@e4",
+            "resource": { "kind": "output", "output_id": Uuid::nil() }
+        })));
+        assert!(!validate_browser_upload_arguments(&json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2,
+            "ref": "@e4",
+            "resource": {
+                "kind": "connected_file",
+                "root_id": Uuid::nil(),
+                "path": "report.pdf"
+            }
+        })));
     }
 
     #[test]

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -134,10 +134,11 @@ pub use attention::{
 pub use blob::FsBlobStore;
 pub use browser::{
     browser_act_tool_spec, browser_list_tool_spec, browser_navigate_tool_spec,
-    browser_screenshot_tool_spec, browser_snapshot_tool_spec, browser_wait_tool_spec,
-    is_browser_tool, valid_browser_id, valid_browser_url, validate_browser_act_arguments,
-    validate_browser_list_arguments, validate_browser_navigate_arguments,
-    validate_browser_screenshot_arguments, validate_browser_snapshot_arguments,
+    browser_screenshot_tool_spec, browser_snapshot_tool_spec, browser_upload_tool_spec,
+    browser_wait_tool_spec, is_browser_tool, valid_browser_id, valid_browser_upload_path,
+    valid_browser_url, validate_browser_act_arguments, validate_browser_list_arguments,
+    validate_browser_navigate_arguments, validate_browser_screenshot_arguments,
+    validate_browser_snapshot_arguments, validate_browser_upload_arguments,
     validate_browser_wait_arguments, BrowserActArgs, BrowserActResult, BrowserActStatus,
     BrowserAction, BrowserContentTrust, BrowserControllerKind, BrowserControllerState,
     BrowserElementBounds, BrowserEngineCapabilities, BrowserEngineDescriptor, BrowserEngineName,
@@ -145,11 +146,13 @@ pub use browser::{
     BrowserLoadState, BrowserNavigateArgs, BrowserNavigateResult, BrowserOrigin,
     BrowserOriginScope, BrowserPageSnapshot, BrowserScreenshotArgs, BrowserScreenshotResult,
     BrowserSemanticFrame, BrowserSemanticNode, BrowserSemanticNodeKind, BrowserSessionSummary,
-    BrowserSnapshotArgs, BrowserViewport, BrowserWaitArgs, BrowserWaitCondition, BrowserWaitResult,
+    BrowserSnapshotArgs, BrowserUploadArgs, BrowserUploadResource, BrowserUploadResult,
+    BrowserUploadStatus, BrowserViewport, BrowserWaitArgs, BrowserWaitCondition, BrowserWaitResult,
     BrowserWaitStatus, BROWSER_ACT_TOOL, BROWSER_LIST_TOOL, BROWSER_NAVIGATE_TOOL,
-    BROWSER_SCREENSHOT_TOOL, BROWSER_SNAPSHOT_TOOL, BROWSER_TOOLS, BROWSER_WAIT_TOOL,
-    DEFAULT_BROWSER_SNAPSHOT_NODES, DEFAULT_BROWSER_WAIT_TIMEOUT_MS, MAX_BROWSER_ID_CHARS,
-    MAX_BROWSER_SNAPSHOT_NODES, MAX_BROWSER_URL_CHARS,
+    BROWSER_SCREENSHOT_TOOL, BROWSER_SNAPSHOT_TOOL, BROWSER_TOOLS, BROWSER_UPLOAD_TOOL,
+    BROWSER_WAIT_TOOL, DEFAULT_BROWSER_SNAPSHOT_NODES, DEFAULT_BROWSER_WAIT_TIMEOUT_MS,
+    MAX_BROWSER_ID_CHARS, MAX_BROWSER_SNAPSHOT_NODES, MAX_BROWSER_UPLOAD_PATH_BYTES,
+    MAX_BROWSER_URL_CHARS,
 };
 pub use cancel::{CancelToken, Cancelled};
 pub use citation::{

--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -301,9 +301,23 @@ struct BrowserConfirmationRecord {
     browser_id: String,
     workspace_id: String,
     origin: BrowserOrigin,
+    required_capability: BrowserGrantCapability,
     action_type: String,
     target_label: Option<String>,
+    binding: Option<BrowserConfirmationBinding>,
     expires_at: Instant,
+}
+
+/// Private exact-resource identity covered by one native confirmation.
+///
+/// The digest and length never enter renderer state or browser audit output.
+/// They only prevent a resource from changing between the prompt and native
+/// dispatch.
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct BrowserConfirmationBinding {
+    pub(crate) filename: String,
+    pub(crate) byte_len: u64,
+    pub(crate) sha256: [u8; 32],
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1304,31 +1318,45 @@ impl BrowserRegistry {
     /// Record one native act-time confirmation. Only native browser executor
     /// code can receive the returned opaque id; there is no renderer command
     /// for enumerating or redeeming confirmation records.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "confirmation scope and exact resource identity stay explicit at the native boundary"
+    )]
     pub(crate) fn record_native_confirmation(
         &self,
         capability_id: Uuid,
         browser_id: &str,
         origin: &BrowserOrigin,
+        required_capability: BrowserGrantCapability,
         action_type: &str,
         target_label: Option<&str>,
+        binding: Option<&BrowserConfirmationBinding>,
     ) -> Result<Uuid, String> {
         self.record_native_confirmation_for(
             capability_id,
             browser_id,
             origin,
+            required_capability,
             action_type,
             target_label,
+            binding,
             AGENT_CONFIRMATION_TTL,
         )
     }
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the expiry override extends the same explicit confirmation boundary"
+    )]
     fn record_native_confirmation_for(
         &self,
         capability_id: Uuid,
         browser_id: &str,
         origin: &BrowserOrigin,
+        required_capability: BrowserGrantCapability,
         action_type: &str,
         target_label: Option<&str>,
+        binding: Option<&BrowserConfirmationBinding>,
         ttl: Duration,
     ) -> Result<Uuid, String> {
         let mut state = self.lock();
@@ -1351,9 +1379,9 @@ impl BrowserRegistry {
             &state,
             &capability.workspace_id,
             origin,
-            BrowserGrantCapability::BrowserControlOrigin,
+            required_capability,
         ) {
-            return Err("browser origin is not shared for control".to_owned());
+            return Err("browser origin is not shared for this operation".to_owned());
         }
         let confirmation_id = Uuid::new_v4();
         state.confirmations.insert(
@@ -1363,6 +1391,7 @@ impl BrowserRegistry {
                 browser_id: browser_id.to_owned(),
                 workspace_id: capability.workspace_id,
                 origin: origin.clone(),
+                required_capability,
                 action_type: clean_audit_text(
                     action_type,
                     MAX_AUDIT_ACTION_CHARS,
@@ -1371,6 +1400,7 @@ impl BrowserRegistry {
                 target_label: target_label.map(|value| {
                     clean_audit_text(value, MAX_AUDIT_TARGET_CHARS, "unlabeled target")
                 }),
+                binding: binding.cloned(),
                 expires_at: Instant::now() + ttl,
             },
         );
@@ -1393,6 +1423,44 @@ impl BrowserRegistry {
         target_label: Option<&str>,
         effect: BrowserDispatchEffect,
         confirmation_id: Option<Uuid>,
+        dispatch: F,
+    ) -> Result<T, String>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, String>>,
+    {
+        self.dispatch_agent_with_confirmation_binding(
+            capability_id,
+            browser_id,
+            origin,
+            required_capability,
+            action_type,
+            target_label,
+            effect,
+            confirmation_id,
+            None,
+            dispatch,
+        )
+        .await
+    }
+
+    /// Dispatch one operation whose native confirmation covers an exact
+    /// resource identity in addition to the semantic browser target.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "security-sensitive authorization inputs stay explicit at the native dispatch boundary"
+    )]
+    pub(crate) async fn dispatch_agent_with_confirmation_binding<T, F, Fut>(
+        &self,
+        capability_id: Uuid,
+        browser_id: &str,
+        origin: &BrowserOrigin,
+        required_capability: BrowserGrantCapability,
+        action_type: &str,
+        target_label: Option<&str>,
+        effect: BrowserDispatchEffect,
+        confirmation_id: Option<Uuid>,
+        confirmation_binding: Option<BrowserConfirmationBinding>,
         dispatch: F,
     ) -> Result<T, String>
     where
@@ -1426,6 +1494,7 @@ impl BrowserRegistry {
                 target_label.as_deref(),
                 effect,
                 confirmation_id,
+                confirmation_binding.as_ref(),
                 false,
             )?
         };
@@ -1459,6 +1528,7 @@ impl BrowserRegistry {
                 target_label.as_deref(),
                 effect,
                 confirmation_id,
+                confirmation_binding.as_ref(),
                 true,
             )
         };
@@ -2229,6 +2299,7 @@ fn authorize_agent_dispatch(
     target_label: Option<&str>,
     effect: BrowserDispatchEffect,
     confirmation_id: Option<Uuid>,
+    confirmation_binding: Option<&BrowserConfirmationBinding>,
     consume_confirmation: bool,
 ) -> Result<BrowserAgentCapability, String> {
     let capability = active_capability(state, capability_id)?.clone();
@@ -2267,8 +2338,10 @@ fn authorize_agent_dispatch(
             || confirmation.browser_id != browser_id
             || confirmation.workspace_id != capability.workspace_id
             || confirmation.origin != *origin
+            || confirmation.required_capability != required_capability
             || confirmation.action_type != action_type
             || confirmation.target_label.as_deref() != target_label
+            || confirmation.binding.as_ref() != confirmation_binding
         {
             return Err("browser confirmation does not match this action".to_owned());
         }
@@ -3540,8 +3613,10 @@ mod tests {
                 capability,
                 "browser-1",
                 &origin,
+                BrowserGrantCapability::BrowserControlOrigin,
                 "submit_form",
                 Some("Create deployment"),
+                None,
             )
             .unwrap();
         {
@@ -3551,8 +3626,13 @@ mod tests {
             assert_eq!(record.browser_id, "browser-1");
             assert_eq!(record.workspace_id, "workspace-1");
             assert_eq!(record.origin, origin);
+            assert_eq!(
+                record.required_capability,
+                BrowserGrantCapability::BrowserControlOrigin
+            );
             assert_eq!(record.action_type, "submit_form");
             assert_eq!(record.target_label.as_deref(), Some("Create deployment"));
+            assert!(record.binding.is_none());
         }
 
         let missing_ran = Arc::new(AtomicBool::new(false));
@@ -3638,8 +3718,10 @@ mod tests {
                 capability,
                 "browser-1",
                 &origin,
+                BrowserGrantCapability::BrowserControlOrigin,
                 "submit_form",
                 Some("Create deployment"),
+                None,
                 Duration::ZERO,
             )
             .unwrap();
@@ -3658,6 +3740,114 @@ mod tests {
             .await
             .unwrap_err();
         assert!(error.contains("confirmation is unavailable"));
+    }
+
+    #[tokio::test]
+    async fn upload_confirmations_bind_capability_and_exact_file_digest() {
+        let (registry, _, origin, capability, _private) = controlled_registry();
+        registry
+            .grant_browser_access(
+                "browser-1",
+                "workspace-1",
+                &origin,
+                BrowserOriginScope::Origin {
+                    origin: origin.clone(),
+                },
+                &[BrowserGrantCapability::BrowserTransferFiles],
+            )
+            .unwrap();
+        let binding = BrowserConfirmationBinding {
+            filename: "report.pdf".to_owned(),
+            byte_len: 4,
+            sha256: [7; 32],
+        };
+        let confirmation = registry
+            .record_native_confirmation(
+                capability,
+                "browser-1",
+                &origin,
+                BrowserGrantCapability::BrowserTransferFiles,
+                "upload_file",
+                Some("File input"),
+                Some(&binding),
+            )
+            .unwrap();
+
+        let capability_mismatch_ran = Arc::new(AtomicBool::new(false));
+        let error = registry
+            .dispatch_agent_with_confirmation_binding(
+                capability,
+                "browser-1",
+                &origin,
+                BrowserGrantCapability::BrowserControlOrigin,
+                "upload_file",
+                Some("File input"),
+                BrowserDispatchEffect::Consequential,
+                Some(confirmation),
+                Some(binding.clone()),
+                {
+                    let ran = Arc::clone(&capability_mismatch_ran);
+                    move || async move {
+                        ran.store(true, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(error.contains("does not match"));
+        assert!(!capability_mismatch_ran.load(Ordering::SeqCst));
+
+        let mut changed = binding.clone();
+        changed.sha256[0] ^= 1;
+        let digest_mismatch_ran = Arc::new(AtomicBool::new(false));
+        let error = registry
+            .dispatch_agent_with_confirmation_binding(
+                capability,
+                "browser-1",
+                &origin,
+                BrowserGrantCapability::BrowserTransferFiles,
+                "upload_file",
+                Some("File input"),
+                BrowserDispatchEffect::Consequential,
+                Some(confirmation),
+                Some(changed),
+                {
+                    let ran = Arc::clone(&digest_mismatch_ran);
+                    move || async move {
+                        ran.store(true, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(error.contains("does not match"));
+        assert!(!digest_mismatch_ran.load(Ordering::SeqCst));
+
+        let exact_ran = Arc::new(AtomicBool::new(false));
+        registry
+            .dispatch_agent_with_confirmation_binding(
+                capability,
+                "browser-1",
+                &origin,
+                BrowserGrantCapability::BrowserTransferFiles,
+                "upload_file",
+                Some("File input"),
+                BrowserDispatchEffect::Consequential,
+                Some(confirmation),
+                Some(binding),
+                {
+                    let ran = Arc::clone(&exact_ran);
+                    move || async move {
+                        ran.store(true, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+        assert!(exact_ran.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 
+use base64::Engine as _;
 use serde::Deserialize;
 use tauri::{AppHandle, Manager, Webview};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
@@ -23,8 +24,8 @@ use uuid::Uuid;
 
 use crate::{
     browser_control::{
-        BrowserDispatchEffect, BrowserLoadState, BrowserRegistry, BrowserSnapshot,
-        BrowserTargetError, BrowserTargetFingerprint, BrowserTargetRecord,
+        BrowserConfirmationBinding, BrowserDispatchEffect, BrowserLoadState, BrowserRegistry,
+        BrowserSnapshot, BrowserTargetError, BrowserTargetFingerprint, BrowserTargetRecord,
     },
     code_browser::browser_label,
 };
@@ -144,6 +145,24 @@ struct NativeActionResolution {
     scroll_delta_x: Option<f64>,
     #[serde(default)]
     scroll_delta_y: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawBrowserUploadResult {
+    status: tidebreak_core::BrowserUploadStatus,
+    message: String,
+}
+
+/// Exact file bytes resolved by the foreground native executor.
+///
+/// This value never crosses renderer IPC. The isolated WebKit evaluation
+/// receives it only while attaching the confirmed file to the target page.
+pub(crate) struct BrowserUploadFile {
+    pub(crate) filename: String,
+    pub(crate) media_type: String,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) binding: BrowserConfirmationBinding,
 }
 
 #[derive(Debug, Deserialize)]
@@ -399,6 +418,139 @@ async fn native_consequential_action_choice(
     receiver
         .await
         .map_err(|_| "the native browser confirmation closed unexpectedly".to_owned())
+}
+
+pub(crate) async fn native_browser_upload_choice(
+    app: &AppHandle,
+    origin: &BrowserOrigin,
+    target_label: &str,
+    file: &BrowserUploadFile,
+) -> Result<bool, String> {
+    let origin = crate::native_security_label(origin.as_str());
+    let target = crate::native_security_label(target_label);
+    let filename = crate::native_security_label(&file.filename);
+    let size = tidebreak_core::format_bytes(file.binding.byte_len);
+    let (sender, receiver) = oneshot::channel();
+    let mut dialog = app
+        .dialog()
+        .message(format!(
+            "Allow the agent to upload {filename} ({size}) to {origin}?\n\nTarget: {target}\n\nThe site controls the target and may react when the file is attached. Tidebreak will attach only these exact confirmed bytes. Every upload requires a separate confirmation."
+        ))
+        .title("Confirm browser upload")
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Upload file".to_owned(),
+            "Cancel".to_owned(),
+        ));
+    if let Some(window) = app.get_webview_window("main") {
+        dialog = dialog.parent(&window);
+    }
+    dialog.show(move |approved| {
+        let _ = sender.send(approved);
+    });
+    receiver
+        .await
+        .map_err(|_| "the native browser upload confirmation closed unexpectedly".to_owned())
+}
+
+pub(crate) async fn execute_browser_upload(
+    app: AppHandle,
+    registry: BrowserRegistry,
+    capability_id: Uuid,
+    workspace_id: String,
+    arguments: tidebreak_core::BrowserUploadArgs,
+    file: BrowserUploadFile,
+) -> Result<tidebreak_core::BrowserUploadResult, String> {
+    let target = match registry.semantic_target(
+        &arguments.browser_id,
+        &workspace_id,
+        &arguments.snapshot_id,
+        arguments.document_epoch,
+        &arguments.target_ref,
+    ) {
+        Ok(target) => target,
+        Err(error) => {
+            return Ok(browser_upload_result(
+                &arguments,
+                browser_upload_status_from_target_error(error),
+                target_error_message(error),
+                None,
+            ));
+        }
+    };
+    if !is_file_input(&target) {
+        return Ok(browser_upload_result(
+            &arguments,
+            tidebreak_core::BrowserUploadStatus::InvalidTarget,
+            "The selected target is not a file input. Use a file-input ref from the latest snapshot.",
+            None,
+        ));
+    }
+
+    registry.begin_agent_observation(capability_id, &arguments.browser_id)?;
+    let label = browser_label(&arguments.browser_id)?;
+    let webview = app
+        .get_webview(&label)
+        .ok_or_else(|| "browser session is not open".to_owned())?;
+    let script = browser_upload_script(&target, &file)?;
+    let raw: RawBrowserUploadResult = evaluate_json(&webview, &script).await?;
+    if raw.status == tidebreak_core::BrowserUploadStatus::Uploaded {
+        registry.invalidate_semantic_snapshot(
+            &arguments.browser_id,
+            &workspace_id,
+            &arguments.snapshot_id,
+        );
+        return Ok(browser_upload_result(
+            &arguments,
+            raw.status,
+            "File attached. Take a new snapshot before the next browser action.",
+            Some((&file.filename, file.binding.byte_len)),
+        ));
+    }
+    Ok(browser_upload_result(
+        &arguments,
+        raw.status,
+        &raw.message,
+        None,
+    ))
+}
+
+pub(crate) fn is_file_input(target: &BrowserTargetRecord) -> bool {
+    target.fingerprint.tag == "input"
+        && target.fingerprint.input_type.as_deref() == Some("file")
+        && target.fingerprint.sensitive
+}
+
+fn browser_upload_status_from_target_error(
+    error: BrowserTargetError,
+) -> tidebreak_core::BrowserUploadStatus {
+    match error {
+        BrowserTargetError::StaleTarget => tidebreak_core::BrowserUploadStatus::StaleTarget,
+        BrowserTargetError::BrowserHidden => tidebreak_core::BrowserUploadStatus::HiddenTab,
+    }
+}
+
+pub(crate) fn browser_upload_result(
+    request: &tidebreak_core::BrowserUploadArgs,
+    status: tidebreak_core::BrowserUploadStatus,
+    message: &str,
+    file: Option<(&str, u64)>,
+) -> tidebreak_core::BrowserUploadResult {
+    tidebreak_core::BrowserUploadResult {
+        browser_id: request.browser_id.clone(),
+        snapshot_id: request.snapshot_id.clone(),
+        document_epoch: request.document_epoch,
+        target_ref: request.target_ref.clone(),
+        status,
+        message: message.to_owned(),
+        requires_resnapshot: matches!(
+            status,
+            tidebreak_core::BrowserUploadStatus::Uploaded
+                | tidebreak_core::BrowserUploadStatus::StaleTarget
+        ),
+        filename: file.map(|(filename, _)| filename.to_owned()),
+        bytes: file.map(|(_, bytes)| bytes),
+    }
 }
 
 fn marker_for_snapshot(snapshot_id: &str) -> String {
@@ -1171,8 +1323,10 @@ pub(crate) async fn browser_native_act(
             capability_id,
             &arguments.browser_id,
             &origin,
+            BrowserGrantCapability::BrowserControlOrigin,
             &action_type,
             target_label.as_deref(),
+            None,
         )?)
     } else {
         None
@@ -2558,6 +2712,37 @@ fn native_action_resolution_script(
     });
     let payload = serde_json::to_string(&payload).map_err(|error| error.to_string())?;
     Ok(NATIVE_ACTION_RESOLUTION_SCRIPT
+        .replace("__TARGET_IDENTITY_STORE__", TARGET_IDENTITY_STORE_SCRIPT)
+        .replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY)
+        .replace("__PAYLOAD__", &payload))
+}
+
+fn browser_upload_script(
+    target: &BrowserTargetRecord,
+    file: &BrowserUploadFile,
+) -> Result<String, String> {
+    let payload = serde_json::json!({
+        "framePath": target.frame_path,
+        "selector": target.selector,
+        "marker": target.marker,
+        "markerValue": target.marker_value,
+        "fingerprint": {
+            "tag": target.fingerprint.tag,
+            "role": target.fingerprint.role,
+            "name": target.fingerprint.name,
+            "inputType": target.fingerprint.input_type,
+            "href": target.fingerprint.href,
+            "sensitive": target.fingerprint.sensitive,
+        },
+        "file": {
+            "name": file.filename,
+            "mediaType": file.media_type,
+            "byteLen": file.binding.byte_len,
+            "contentBase64": base64::engine::general_purpose::STANDARD.encode(&file.bytes),
+        },
+    });
+    let payload = serde_json::to_string(&payload).map_err(|error| error.to_string())?;
+    Ok(BROWSER_UPLOAD_SCRIPT
         .replace("__TARGET_IDENTITY_STORE__", TARGET_IDENTITY_STORE_SCRIPT)
         .replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY)
         .replace("__PAYLOAD__", &payload))
@@ -3985,6 +4170,136 @@ const NATIVE_ACTION_RESOLUTION_SCRIPT: &str = r#"
     optionIndex: payload.optionIndex ?? null,
     selectedIndex: payload.selectedIndex ?? null,
   });
+})()
+"#;
+
+const BROWSER_UPLOAD_SCRIPT: &str = r#"
+(() => {
+  const payload = __PAYLOAD__;
+  __TARGET_IDENTITY_STORE__
+  const clean = (value, limit = 240) => String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+  __SENSITIVE_FIELD_POLICY__
+  const roleFor = (element) => {
+    const explicit = clean(element.getAttribute("role"), 60);
+    if (explicit) return explicit;
+    const tag = element.localName;
+    const type = clean(element.getAttribute("type"), 40).toLowerCase();
+    if (tag === "input") {
+      if (type === "checkbox") return "checkbox";
+      if (type === "radio") return "radio";
+      if (["button", "submit", "reset", "image"].includes(type)) return "button";
+      return "textbox";
+    }
+    return tag || "element";
+  };
+  const result = (status, message) => JSON.stringify({ status, message });
+
+  let doc = document;
+  for (const selector of payload.framePath) {
+    const frame = doc.querySelector(selector);
+    if (!frame) return result("stale_target", "The target frame changed.");
+    try {
+      doc = frame.contentDocument;
+    } catch (_) {
+      return result("invalid_target", "The target is inside a cross-origin frame.");
+    }
+    if (!doc) return result("stale_target", "The target frame is unavailable.");
+  }
+
+  const element = doc.querySelector(payload.selector);
+  if (!element || !element.isConnected) {
+    return result("stale_target", "The target no longer exists.");
+  }
+  const targetIdentity = tidebreakTargetIdentityStore.get(element);
+  if (
+    !targetIdentity
+    || targetIdentity.snapshotMarker !== payload.marker
+    || targetIdentity.targetRef !== payload.markerValue
+  ) {
+    return result("stale_target", "The target element was replaced.");
+  }
+
+  const view = doc.defaultView;
+  if (!view) return result("stale_target", "The target document is unavailable.");
+  const isSensitive = tidebreakIsSensitiveField(element, doc);
+  const fresh = {
+    tag: element.localName || "element",
+    role: roleFor(element),
+    name: isSensitive ? "Sensitive field" : tidebreakAccessibleName(element, doc),
+    inputType: element.localName === "input"
+      ? clean(element.getAttribute("type") || "text", 40).toLowerCase()
+      : null,
+    href: element.href ? clean(element.href, 2048) : null,
+    sensitive: isSensitive,
+  };
+  if (
+    fresh.tag !== payload.fingerprint.tag
+    || fresh.role !== payload.fingerprint.role
+    || fresh.name !== payload.fingerprint.name
+    || fresh.inputType !== payload.fingerprint.inputType
+    || fresh.href !== payload.fingerprint.href
+    || fresh.sensitive !== payload.fingerprint.sensitive
+  ) {
+    return result("stale_target", "The target's identifying content changed.");
+  }
+  if (
+    !(element instanceof view.HTMLInputElement)
+    || fresh.inputType !== "file"
+    || !fresh.sensitive
+  ) {
+    return result("invalid_target", "The selected target is not a file input.");
+  }
+  if (element.disabled || element.getAttribute("aria-disabled") === "true") {
+    return result("invalid_target", "The file input is disabled.");
+  }
+
+  try {
+    if (
+      typeof view.File !== "function"
+      || typeof view.DataTransfer !== "function"
+      || typeof view.Event !== "function"
+    ) {
+      return result("engine_failure", "This browser cannot attach a file to the selected input.");
+    }
+    const decoded = view.atob(payload.file.contentBase64);
+    if (decoded.length !== payload.file.byteLen) {
+      return result("engine_failure", "The confirmed file bytes could not be decoded.");
+    }
+    const bytes = new Uint8Array(decoded.length);
+    for (let index = 0; index < decoded.length; index += 1) {
+      bytes[index] = decoded.charCodeAt(index);
+    }
+    const file = new view.File([bytes], payload.file.name, {
+      type: payload.file.mediaType,
+      lastModified: 0,
+    });
+    const transfer = new view.DataTransfer();
+    transfer.items.add(file);
+    const descriptor = Object.getOwnPropertyDescriptor(
+      view.HTMLInputElement.prototype,
+      "files",
+    );
+    if (!descriptor || typeof descriptor.set !== "function") {
+      return result("engine_failure", "This browser cannot set the selected input's files.");
+    }
+    descriptor.set.call(element, transfer.files);
+    if (
+      !element.files
+      || element.files.length !== 1
+      || element.files[0].name !== payload.file.name
+      || element.files[0].size !== payload.file.byteLen
+    ) {
+      return result("engine_failure", "The browser did not retain the confirmed file.");
+    }
+    element.dispatchEvent(new view.Event("input", { bubbles: true, composed: true }));
+    element.dispatchEvent(new view.Event("change", { bubbles: true, composed: true }));
+    return result("uploaded", "The confirmed file was attached.");
+  } catch (_) {
+    return result("engine_failure", "The browser could not attach the confirmed file.");
+  }
 })()
 "#;
 

--- a/crates/tidebreak-desktop/src/client_execution/browser.rs
+++ b/crates/tidebreak-desktop/src/client_execution/browser.rs
@@ -10,20 +10,28 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard};
 
 use base64::Engine as _;
+use sha2::{Digest as _, Sha256};
 use tauri::{AppHandle, Manager};
 use tidebreak_core::{
     validate_browser_act_arguments, validate_browser_list_arguments,
     validate_browser_navigate_arguments, validate_browser_screenshot_arguments,
-    validate_browser_snapshot_arguments, validate_browser_wait_arguments, BrowserActArgs,
-    BrowserListArgs, BrowserListResult, BrowserNavigateArgs, BrowserPageSnapshot,
-    BrowserScreenshotArgs, BrowserScreenshotResult, BrowserSnapshotArgs, BrowserWaitArgs,
-    BrowserWaitResult, CallId, ChatId, ImageRef, ToolCallExecution, ToolCallRecord, ToolCallStatus,
+    validate_browser_snapshot_arguments, validate_browser_upload_arguments,
+    validate_browser_wait_arguments, BrowserActArgs, BrowserGrantCapability, BrowserListArgs,
+    BrowserListResult, BrowserNavigateArgs, BrowserOrigin, BrowserPageSnapshot,
+    BrowserScreenshotArgs, BrowserScreenshotResult, BrowserSnapshotArgs, BrowserUploadArgs,
+    BrowserUploadResource, BrowserUploadStatus, BrowserWaitArgs, BrowserWaitResult, CallId, ChatId,
+    ImageRef, OutputId, OutputRevisionId, ToolCallExecution, ToolCallRecord, ToolCallStatus,
     BROWSER_ACT_TOOL, BROWSER_LIST_TOOL, BROWSER_NAVIGATE_TOOL, BROWSER_SCREENSHOT_TOOL,
-    BROWSER_SNAPSHOT_TOOL, BROWSER_WAIT_TOOL,
+    BROWSER_SNAPSHOT_TOOL, BROWSER_UPLOAD_TOOL, BROWSER_WAIT_TOOL,
+};
+use tidebreak_host_broker::{RelativePath, RootId, MAX_READ_FILE_BINARY_BYTES};
+use tidebreak_server::output_files::{
+    read_output_revision_bytes, require_exact_revision, require_live_output,
 };
 use uuid::Uuid;
 
-use crate::browser_control::BrowserRegistry;
+use crate::browser_control::{BrowserConfirmationBinding, BrowserRegistry};
+use crate::browser_semantics::BrowserUploadFile;
 use crate::host_access::{AuthoritativeContext, HostAccess};
 use crate::image_attachments::PublishedImageAttachment;
 use crate::AppState;
@@ -427,6 +435,7 @@ fn is_foreground_browser_call(call: &ToolCallRecord) -> bool {
         BROWSER_WAIT_TOOL => validate_browser_wait_arguments(&call.arguments),
         BROWSER_SCREENSHOT_TOOL => validate_browser_screenshot_arguments(&call.arguments),
         BROWSER_ACT_TOOL => validate_browser_act_arguments(&call.arguments),
+        BROWSER_UPLOAD_TOOL => validate_browser_upload_arguments(&call.arguments),
         _ => false,
     }
 }
@@ -537,8 +546,389 @@ async fn execute_operation(
                 Err(error) => map_native_error(Some(&arguments.browser_id), error),
             }
         }
+        BROWSER_UPLOAD_TOOL => {
+            let Ok(arguments) = serde_json::from_value::<BrowserUploadArgs>(call.arguments.clone())
+            else {
+                return invalid_request();
+            };
+            match execute_browser_upload_operation(
+                app,
+                state,
+                registry,
+                context,
+                capability_id,
+                arguments.clone(),
+            )
+            .await
+            {
+                Ok(result) => completed(&result),
+                Err(error) => map_native_error(Some(&arguments.browser_id), error),
+            }
+        }
         _ => invalid_request(),
     }
+}
+
+enum BrowserUploadSourceIdentity {
+    Output {
+        output_id: OutputId,
+        revision_id: OutputRevisionId,
+        filename: String,
+        media_type: String,
+        byte_len: u64,
+        sha256: [u8; 32],
+    },
+    ConnectedFile {
+        root_id: RootId,
+        path: RelativePath,
+    },
+}
+
+struct ResolvedBrowserUploadSource {
+    identity: BrowserUploadSourceIdentity,
+    file: BrowserUploadFile,
+}
+
+async fn execute_browser_upload_operation(
+    app: &AppHandle,
+    state: &HostAccess,
+    registry: &BrowserRegistry,
+    context: AuthoritativeContext,
+    capability_id: Uuid,
+    arguments: BrowserUploadArgs,
+) -> Result<tidebreak_core::BrowserUploadResult, String> {
+    if !arguments.is_well_formed() {
+        return Err("browser upload request is not valid".to_owned());
+    }
+    let host_snapshot = registry.begin_agent_observation(capability_id, &arguments.browser_id)?;
+    if !host_snapshot
+        .engine
+        .as_ref()
+        .is_some_and(|engine| engine.capabilities.semantic_actions)
+    {
+        return Ok(crate::browser_semantics::browser_upload_result(
+            &arguments,
+            BrowserUploadStatus::EngineFailure,
+            "Trusted browser file attachment is not available on this platform.",
+            None,
+        ));
+    }
+    if !host_snapshot
+        .agent_access
+        .as_ref()
+        .is_some_and(|access| access.can_transfer_files)
+    {
+        return Err("browser origin is not shared for this operation".to_owned());
+    }
+    let workspace_id = host_snapshot.workspace_id;
+    let origin = host_snapshot
+        .url
+        .as_deref()
+        .and_then(BrowserOrigin::from_url)
+        .ok_or_else(|| "browser has no authorized HTTP origin".to_owned())?;
+    let target = match registry.semantic_target(
+        &arguments.browser_id,
+        &workspace_id,
+        &arguments.snapshot_id,
+        arguments.document_epoch,
+        &arguments.target_ref,
+    ) {
+        Ok(target) => target,
+        Err(crate::browser_control::BrowserTargetError::StaleTarget) => {
+            return Ok(crate::browser_semantics::browser_upload_result(
+                &arguments,
+                BrowserUploadStatus::StaleTarget,
+                "The page or target changed. Take a new snapshot before uploading.",
+                None,
+            ));
+        }
+        Err(crate::browser_control::BrowserTargetError::BrowserHidden) => {
+            return Ok(crate::browser_semantics::browser_upload_result(
+                &arguments,
+                BrowserUploadStatus::HiddenTab,
+                "Bring this browser tab to the foreground before uploading.",
+                None,
+            ));
+        }
+    };
+    if !crate::browser_semantics::is_file_input(&target) {
+        return Ok(crate::browser_semantics::browser_upload_result(
+            &arguments,
+            BrowserUploadStatus::InvalidTarget,
+            "The selected target is not a file input. Use a file-input ref from the latest snapshot.",
+            None,
+        ));
+    }
+
+    let initial = resolve_browser_upload_source(app, state, context, &arguments.resource).await?;
+    let target_label = "File input".to_owned();
+    let _ = registry.set_agent_action(
+        capability_id,
+        &arguments.browser_id,
+        Some("Waiting for upload confirmation"),
+        false,
+    );
+    let approved = crate::browser_semantics::native_browser_upload_choice(
+        app,
+        &origin,
+        &target_label,
+        &initial.file,
+    )
+    .await?;
+    if !approved {
+        let _ = registry.set_agent_action(capability_id, &arguments.browser_id, None, false);
+        return Ok(crate::browser_semantics::browser_upload_result(
+            &arguments,
+            BrowserUploadStatus::Declined,
+            "The user declined this browser upload. Do not retry it without direction.",
+            None,
+        ));
+    }
+
+    let confirmation_binding = initial.file.binding.clone();
+    let confirmation_id = registry.record_native_confirmation(
+        capability_id,
+        &arguments.browser_id,
+        &origin,
+        BrowserGrantCapability::BrowserTransferFiles,
+        "upload_file",
+        Some(&target_label),
+        Some(&confirmation_binding),
+    )?;
+    let browser_id = arguments.browser_id.clone();
+    let dispatch_app = app.clone();
+    let dispatch_registry = registry.clone();
+    let identity = initial.identity;
+    drop(initial.file);
+    let result = registry
+        .dispatch_agent_with_confirmation_binding(
+            capability_id,
+            &browser_id,
+            &origin,
+            BrowserGrantCapability::BrowserTransferFiles,
+            "upload_file",
+            Some(&target_label),
+            crate::browser_control::BrowserDispatchEffect::Consequential,
+            Some(confirmation_id),
+            Some(confirmation_binding.clone()),
+            move || async move {
+                let confirmed =
+                    reresolve_browser_upload_source(&dispatch_app, state, context, &identity)
+                        .await
+                        .map_err(|_| {
+                            "browser upload resource changed before attachment".to_owned()
+                        })?;
+                if confirmed.binding != confirmation_binding {
+                    return Err("browser upload resource changed before attachment".to_owned());
+                }
+                crate::browser_semantics::execute_browser_upload(
+                    dispatch_app,
+                    dispatch_registry,
+                    capability_id,
+                    workspace_id,
+                    arguments,
+                    confirmed,
+                )
+                .await
+            },
+        )
+        .await;
+    if result.is_err() {
+        let _ = registry.set_agent_action(capability_id, &host_snapshot.browser_id, None, false);
+    }
+    result.map_err(|error| {
+        if error == "browser confirmation does not match this action" {
+            "browser upload resource changed before attachment".to_owned()
+        } else {
+            error
+        }
+    })
+}
+
+async fn resolve_browser_upload_source(
+    app: &AppHandle,
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    resource: &BrowserUploadResource,
+) -> Result<ResolvedBrowserUploadSource, String> {
+    match resource {
+        BrowserUploadResource::Output { output_id } => {
+            resolve_output_upload_source(app, state, context, OutputId::from(*output_id)).await
+        }
+        BrowserUploadResource::ConnectedFile { root_id, path } => {
+            let root_id = RootId::from_uuid(*root_id)
+                .map_err(|_| "browser upload resource is unavailable".to_owned())?;
+            let path = RelativePath::parse(path)
+                .map_err(|_| "browser upload resource is unavailable".to_owned())?;
+            if path.is_root() {
+                return Err("browser upload resource is unavailable".to_owned());
+            }
+            let file = resolve_connected_file_upload(state, context, root_id, &path).await?;
+            Ok(ResolvedBrowserUploadSource {
+                identity: BrowserUploadSourceIdentity::ConnectedFile { root_id, path },
+                file,
+            })
+        }
+    }
+}
+
+async fn reresolve_browser_upload_source(
+    app: &AppHandle,
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    identity: &BrowserUploadSourceIdentity,
+) -> Result<BrowserUploadFile, String> {
+    match identity {
+        BrowserUploadSourceIdentity::Output {
+            output_id,
+            revision_id,
+            filename,
+            media_type,
+            byte_len,
+            sha256,
+        } => {
+            let store = state
+                .store()
+                .ok_or_else(|| "browser upload resource is unavailable".to_owned())?;
+            let chat_id = ChatId::from(context.chat_id);
+            require_exact_revision(store, chat_id, *output_id, *revision_id, *byte_len, *sha256)
+                .await
+                .map_err(|_| "browser upload resource changed before attachment".to_owned())?;
+            let (output, revision) = require_live_output(store, chat_id, *output_id)
+                .await
+                .map_err(|_| "browser upload resource changed before attachment".to_owned())?;
+            if revision.id != *revision_id
+                || output.filename != *filename
+                || output.media_type != *media_type
+            {
+                return Err("browser upload resource changed before attachment".to_owned());
+            }
+            read_output_upload_file(app, chat_id, output, revision).await
+        }
+        BrowserUploadSourceIdentity::ConnectedFile { root_id, path } => {
+            resolve_connected_file_upload(state, context, *root_id, path).await
+        }
+    }
+}
+
+async fn resolve_output_upload_source(
+    app: &AppHandle,
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    output_id: OutputId,
+) -> Result<ResolvedBrowserUploadSource, String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "browser upload resource is unavailable".to_owned())?;
+    let chat_id = ChatId::from(context.chat_id);
+    let (output, revision) = require_live_output(store, chat_id, output_id)
+        .await
+        .map_err(|_| "browser upload resource is unavailable".to_owned())?;
+    let identity = BrowserUploadSourceIdentity::Output {
+        output_id,
+        revision_id: revision.id,
+        filename: output.filename.clone(),
+        media_type: output.media_type.clone(),
+        byte_len: revision.byte_len,
+        sha256: revision.sha256,
+    };
+    let file = read_output_upload_file(app, chat_id, output, revision).await?;
+    Ok(ResolvedBrowserUploadSource { identity, file })
+}
+
+async fn read_output_upload_file(
+    app: &AppHandle,
+    chat_id: ChatId,
+    output: tidebreak_core::OutputRecord,
+    revision: tidebreak_core::OutputRevision,
+) -> Result<BrowserUploadFile, String> {
+    if revision.byte_len > MAX_READ_FILE_BINARY_BYTES as u64
+        || tidebreak_core::validate_portable_filename(&output.filename).is_err()
+    {
+        return Err("browser upload resource is unavailable".to_owned());
+    }
+    let scratch_root = crate::data_dir(app)?.join("scratch");
+    let filename = output.filename.clone();
+    let media_type = output.media_type.clone();
+    let binding = BrowserConfirmationBinding {
+        filename: filename.clone(),
+        byte_len: revision.byte_len,
+        sha256: revision.sha256,
+    };
+    let bytes = tauri::async_runtime::spawn_blocking(move || {
+        read_output_revision_bytes(&scratch_root, chat_id, &output, &revision)
+    })
+    .await
+    .map_err(|_| "browser upload resource is unavailable".to_owned())?
+    .map_err(|_| "browser upload resource is unavailable".to_owned())?;
+    make_browser_upload_file(filename, media_type, bytes, binding)
+}
+
+async fn resolve_connected_file_upload(
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    root_id: RootId,
+    path: &RelativePath,
+) -> Result<BrowserUploadFile, String> {
+    let filename = path
+        .as_str()
+        .rsplit('/')
+        .next()
+        .filter(|name| tidebreak_core::validate_portable_filename(name).is_ok())
+        .ok_or_else(|| "browser upload resource is unavailable".to_owned())?
+        .to_owned();
+    let staged_root = super::source_import::current_staged_root(state, context, root_id);
+    if staged_root.is_some()
+        && !super::source_import::root_is_still_attached(state, context, root_id).await
+    {
+        return Err("browser upload resource is unavailable".to_owned());
+    }
+    let source = super::source_import::select_source_bytes(
+        staged_root,
+        path,
+        super::source_import::read_broker_file_bytes(state, context, root_id, path),
+    )
+    .await
+    .map_err(|_| "browser upload resource is unavailable".to_owned())?;
+    if !super::source_import::root_is_still_attached(state, context, root_id).await
+        || !super::source_import::selected_staging_is_current(
+            state,
+            context,
+            root_id,
+            source.staged_root.as_deref(),
+        )
+    {
+        return Err("browser upload resource is unavailable".to_owned());
+    }
+    let media_type = tidebreak_server::media_type::sniff_media_type(&source.bytes, Some(&filename));
+    let binding = BrowserConfirmationBinding {
+        filename: filename.clone(),
+        byte_len: source.bytes.len() as u64,
+        sha256: Sha256::digest(&source.bytes).into(),
+    };
+    make_browser_upload_file(filename, media_type, source.bytes, binding)
+}
+
+fn make_browser_upload_file(
+    filename: String,
+    media_type: String,
+    bytes: Vec<u8>,
+    binding: BrowserConfirmationBinding,
+) -> Result<BrowserUploadFile, String> {
+    if bytes.len() > MAX_READ_FILE_BINARY_BYTES
+        || bytes.len() as u64 != binding.byte_len
+        || <[u8; 32]>::from(Sha256::digest(&bytes)) != binding.sha256
+        || filename != binding.filename
+        || tidebreak_core::validate_portable_filename(&filename).is_err()
+    {
+        return Err("browser upload resource is unavailable".to_owned());
+    }
+    Ok(BrowserUploadFile {
+        filename,
+        media_type,
+        bytes,
+        binding,
+    })
 }
 
 fn completed_snapshot(result: &BrowserPageSnapshot) -> StoredResolution {
@@ -707,6 +1097,18 @@ fn map_native_error(browser_id: Option<&str>, error: String) -> StoredResolution
             "Browser access is not available right now. Try again.",
         );
     }
+    if inner == "browser upload resource is unavailable" {
+        return unavailable(
+            "browser_upload_resource_unavailable",
+            "That output or connected file is not available to this conversation. Choose a current resource and try again.",
+        );
+    }
+    if inner == "browser upload resource changed before attachment" {
+        return unavailable(
+            "browser_upload_resource_changed",
+            "That file changed before Tidebreak could attach it. Take a new browser snapshot, confirm the current file, and try again.",
+        );
+    }
     if inner == "browser is hidden" {
         return unavailable(
             "browser_hidden",
@@ -792,7 +1194,7 @@ mod tests {
     }
 
     #[test]
-    fn discovery_accepts_only_the_six_validated_foreground_browser_tools() {
+    fn discovery_accepts_only_the_seven_validated_foreground_browser_tools() {
         assert!(is_foreground_browser_call(&call(
             BROWSER_LIST_TOOL,
             serde_json::json!({}),
@@ -836,6 +1238,19 @@ mod tests {
                 "action": { "type": "click" }
             }),
         )));
+        assert!(is_foreground_browser_call(&call(
+            BROWSER_UPLOAD_TOOL,
+            serde_json::json!({
+                "browser_id": "browser-1",
+                "snapshot_id": "snapshot-1",
+                "document_epoch": 1,
+                "ref": "ref-1",
+                "resource": {
+                    "kind": "output",
+                    "output_id": Uuid::new_v4()
+                }
+            }),
+        )));
         assert!(!is_foreground_browser_call(&call(
             BROWSER_ACT_TOOL,
             serde_json::json!({
@@ -851,6 +1266,20 @@ mod tests {
             serde_json::json!({
                 "browser_id": "browser-1",
                 "url": "file:///etc/passwd"
+            }),
+        )));
+        assert!(!is_foreground_browser_call(&call(
+            BROWSER_UPLOAD_TOOL,
+            serde_json::json!({
+                "browser_id": "browser-1",
+                "snapshot_id": "snapshot-1",
+                "document_epoch": 1,
+                "ref": "ref-1",
+                "resource": {
+                    "kind": "connected_file",
+                    "root_id": Uuid::new_v4(),
+                    "path": "../secret.txt"
+                }
             }),
         )));
         let mut raw = call(BROWSER_LIST_TOOL, serde_json::json!({}));
@@ -908,6 +1337,75 @@ mod tests {
     }
 
     #[test]
+    fn upload_files_require_exact_portable_bounded_identity() {
+        let bytes = b"exact upload bytes".to_vec();
+        let binding = BrowserConfirmationBinding {
+            filename: "report.pdf".to_owned(),
+            byte_len: bytes.len() as u64,
+            sha256: Sha256::digest(&bytes).into(),
+        };
+        let file = make_browser_upload_file(
+            binding.filename.clone(),
+            "application/pdf".to_owned(),
+            bytes.clone(),
+            binding.clone(),
+        )
+        .unwrap();
+        assert_eq!(file.filename, "report.pdf");
+        assert_eq!(file.bytes, bytes);
+        assert!(file.binding == binding);
+
+        let mut changed_digest = binding.clone();
+        changed_digest.sha256[0] ^= 1;
+        assert!(make_browser_upload_file(
+            binding.filename.clone(),
+            "application/pdf".to_owned(),
+            bytes.clone(),
+            changed_digest,
+        )
+        .is_err());
+
+        let mut changed_length = binding.clone();
+        changed_length.byte_len += 1;
+        assert!(make_browser_upload_file(
+            binding.filename.clone(),
+            "application/pdf".to_owned(),
+            bytes.clone(),
+            changed_length,
+        )
+        .is_err());
+
+        for filename in ["../secret", ".hidden", "folder/report.pdf", "report?.pdf"] {
+            let malicious = BrowserConfirmationBinding {
+                filename: filename.to_owned(),
+                byte_len: bytes.len() as u64,
+                sha256: Sha256::digest(&bytes).into(),
+            };
+            assert!(make_browser_upload_file(
+                filename.to_owned(),
+                "application/octet-stream".to_owned(),
+                bytes.clone(),
+                malicious,
+            )
+            .is_err());
+        }
+
+        let oversized = vec![0; MAX_READ_FILE_BINARY_BYTES + 1];
+        let oversized_binding = BrowserConfirmationBinding {
+            filename: "large.bin".to_owned(),
+            byte_len: oversized.len() as u64,
+            sha256: Sha256::digest(&oversized).into(),
+        };
+        assert!(make_browser_upload_file(
+            oversized_binding.filename.clone(),
+            "application/octet-stream".to_owned(),
+            oversized,
+            oversized_binding,
+        )
+        .is_err());
+    }
+
+    #[test]
     fn screenshot_resolution_keeps_pixels_and_base64_out_of_durable_output() {
         let image = ImageRef {
             blob_id: Uuid::new_v4(),
@@ -958,6 +1456,22 @@ mod tests {
             panic!("another controller must fail");
         };
         assert_eq!(error_code, "browser_busy");
+
+        let StoredResolution::Failed { error_code, .. } = map_native_error(
+            Some("browser-1"),
+            "browser upload resource is unavailable".to_owned(),
+        ) else {
+            panic!("an unavailable logical resource must fail");
+        };
+        assert_eq!(error_code, "browser_upload_resource_unavailable");
+
+        let StoredResolution::Failed { error_code, .. } = map_native_error(
+            Some("browser-1"),
+            "browser upload resource changed before attachment".to_owned(),
+        ) else {
+            panic!("a changed logical resource must fail");
+        };
+        assert_eq!(error_code, "browser_upload_resource_changed");
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/client_execution/source_import.rs
+++ b/crates/tidebreak-desktop/src/client_execution/source_import.rs
@@ -42,9 +42,9 @@ pub(super) struct ImportRequest {
 }
 
 /// Exact bytes selected for one import and the overlay they came from, if any.
-struct SourceBytes {
-    bytes: Vec<u8>,
-    staged_root: Option<PathBuf>,
+pub(super) struct SourceBytes {
+    pub(super) bytes: Vec<u8>,
+    pub(super) staged_root: Option<PathBuf>,
 }
 
 enum PublishError {
@@ -137,15 +137,16 @@ async fn read_source_bytes(
     select_source_bytes(
         staged_root,
         &request.path,
-        read_broker_source_bytes(state, context, request),
+        read_broker_file_bytes(state, context, request.root_id, &request.path),
     )
     .await
 }
 
-async fn read_broker_source_bytes(
+pub(super) async fn read_broker_file_bytes(
     state: &HostAccess,
     context: AuthoritativeContext,
-    request: &ImportRequest,
+    root_id: RootId,
+    path: &RelativePath,
 ) -> Result<Vec<u8>, StoredResolution> {
     let result = state
         .broker
@@ -154,8 +155,8 @@ async fn read_broker_source_bytes(
             request_id: tidebreak_host_broker::RequestId::new(),
             context: context.execution,
             request: OperationRequest::ReadFileBinary(PathRequest {
-                root_id: request.root_id,
-                path: request.path.clone(),
+                root_id,
+                path: path.clone(),
             }),
         })
         .await;
@@ -180,7 +181,7 @@ async fn read_broker_source_bytes(
 /// A missing staged path may represent a deletion by exec. Polling the broker
 /// read in that case would resurrect the pre-turn file, so the fallback future
 /// is deliberately left untouched whenever an overlay was selected.
-async fn select_source_bytes<BrokerRead>(
+pub(super) async fn select_source_bytes<BrokerRead>(
     staged_root: Option<PathBuf>,
     path: &RelativePath,
     broker_read: BrokerRead,
@@ -215,7 +216,10 @@ where
 /// bytes do not cross its transport. The file handle is opened relative to a
 /// descriptor-pinned directory, and the second length check refuses a file
 /// that grows while it is being read rather than silently truncating it.
-async fn read_staged_file_bytes(overlay: &std::path::Path, path: &RelativePath) -> Option<Vec<u8>> {
+pub(super) async fn read_staged_file_bytes(
+    overlay: &std::path::Path,
+    path: &RelativePath,
+) -> Option<Vec<u8>> {
     let (prefix, name) = path
         .as_str()
         .rsplit_once('/')
@@ -248,7 +252,7 @@ async fn read_staged_file_bytes(overlay: &std::path::Path, path: &RelativePath) 
 /// `ListRoots` is the cheapest operation that answers exactly that: the broker
 /// filters its result by the same per-root read authorization an operation
 /// would need, so a detached or revoked root simply stops appearing.
-async fn root_is_still_attached(
+pub(super) async fn root_is_still_attached(
     state: &HostAccess,
     context: AuthoritativeContext,
     root_id: RootId,
@@ -268,7 +272,7 @@ async fn root_is_still_attached(
     )
 }
 
-fn current_staged_root(
+pub(super) fn current_staged_root(
     state: &HostAccess,
     context: AuthoritativeContext,
     root_id: RootId,
@@ -279,7 +283,7 @@ fn current_staged_root(
         .staged_root(ChatId::from(context.chat_id), root_id)
 }
 
-fn selected_staging_is_current(
+pub(super) fn selected_staging_is_current(
     state: &HostAccess,
     context: AuthoritativeContext,
     root_id: RootId,

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -933,7 +933,10 @@ async fn share_browser_with_agent(
         workspace_id,
         &origin,
         scope,
-        &[BrowserGrantCapability::BrowserControlOrigin],
+        &[
+            BrowserGrantCapability::BrowserControlOrigin,
+            BrowserGrantCapability::BrowserTransferFiles,
+        ],
     )?;
     let pending_navigation = registry.take_pending_navigation(browser_id, workspace_id)?;
     Ok((snapshot, pending_navigation))
@@ -948,7 +951,7 @@ async fn native_public_share_choice(
     let mut dialog = app
         .dialog()
         .message(format!(
-            "Allow agents in this workspace to inspect and navigate {origin}?\n\nPage content is untrusted. Password, file, and verification-code fields stay private and require human takeover. Screenshots pause when the host cannot prove that visible fields are safe."
+            "Allow agents in this workspace to inspect and navigate {origin}?\n\nPage content is untrusted. Password and verification-code fields stay private and require human takeover. Every file upload requires another confirmation. Screenshots pause when the host cannot prove that visible fields are safe."
         ))
         .title("Share this site with agents?")
         .kind(MessageDialogKind::Warning)
@@ -976,7 +979,7 @@ async fn native_loopback_share_choice(
     let mut dialog = app
         .dialog()
         .message(format!(
-            "Allow agents in this workspace to inspect and navigate {origin_label}?\n\nPassword, file, and verification-code fields stay private and require human takeover. Screenshots pause when the host cannot prove that visible fields are safe. Choose only this origin, or all loopback sites in this workspace so development ports can change without another prompt."
+            "Allow agents in this workspace to inspect and navigate {origin_label}?\n\nPassword and verification-code fields stay private and require human takeover. Every file upload requires another confirmation. Screenshots pause when the host cannot prove that visible fields are safe. Choose only this origin, or all loopback sites in this workspace so development ports can change without another share prompt."
         ))
         .title("Share a local site with agents?")
         .kind(MessageDialogKind::Warning)

--- a/crates/tidebreak-desktop/tests/browser-fixture/uploads.test.mjs
+++ b/crates/tidebreak-desktop/tests/browser-fixture/uploads.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const fixtureRoot = dirname(fileURLToPath(import.meta.url));
+const semanticsPath = resolve(fixtureRoot, "../../src/browser_semantics.rs");
+const semanticsSource = await readFile(semanticsPath, "utf8");
+const policyMatch = semanticsSource.match(
+  /const SENSITIVE_FIELD_POLICY: &str = r##"([\s\S]*?)"##;/,
+);
+const uploadMatch = semanticsSource.match(
+  /const BROWSER_UPLOAD_SCRIPT: &str = r#"([\s\S]*?)"#;/,
+);
+const identityStoreMatch = semanticsSource.match(
+  /const TARGET_IDENTITY_STORE_SCRIPT: &str = r#"([\s\S]*?)"#;/,
+);
+
+assert.ok(policyMatch, "the upload resolver must use the shared field policy");
+assert.ok(uploadMatch, "the isolated browser upload script must be present");
+assert.ok(identityStoreMatch, "the upload resolver must use private target identities");
+
+const targetIdentityStoreKey = Symbol.for(
+  "io.brightwave.tidebreak.browser.target-identities",
+);
+const targetIdentityStore = new WeakMap();
+Object.defineProperty(globalThis, targetIdentityStoreKey, {
+  value: targetIdentityStore,
+  configurable: false,
+  enumerable: false,
+  writable: false,
+});
+
+class FixtureInput {
+  constructor({ marker = "@e1", type = "file", disabled = false } = {}) {
+    this.localName = "input";
+    this.nodeType = 1;
+    this.childNodes = [];
+    this.isConnected = true;
+    this.type = type;
+    this.disabled = disabled;
+    this.labels = [];
+    this.form = null;
+    this.events = [];
+    this._files = [];
+    this.attributes = new Map([["type", type]]);
+    targetIdentityStore.set(this, {
+      snapshotMarker: "__tidebreak_marker__",
+      targetRef: marker,
+    });
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  closest() {
+    return null;
+  }
+
+  getRootNode() {
+    return this.ownerDocument;
+  }
+
+  matches() {
+    return true;
+  }
+
+  dispatchEvent(event) {
+    this.events.push(event.type);
+    return true;
+  }
+}
+
+Object.defineProperty(FixtureInput.prototype, "files", {
+  configurable: true,
+  get() {
+    return this._files;
+  },
+  set(files) {
+    this._files = files;
+  },
+});
+
+class FixtureFile {
+  constructor(chunks, name, options) {
+    this.bytes = Uint8Array.from(chunks[0]);
+    this.name = name;
+    this.size = this.bytes.length;
+    this.type = options.type;
+    this.lastModified = options.lastModified;
+  }
+}
+
+class FixtureDataTransfer {
+  constructor() {
+    this.files = [];
+    this.items = {
+      add: (file) => {
+        this.files.push(file);
+      },
+    };
+  }
+}
+
+class FixtureEvent {
+  constructor(type, options) {
+    this.type = type;
+    this.options = options;
+  }
+}
+
+function documentFor(input) {
+  const defaultView = {
+    HTMLInputElement: FixtureInput,
+    File: FixtureFile,
+    DataTransfer: FixtureDataTransfer,
+    Event: FixtureEvent,
+    atob,
+  };
+  const doc = {
+    defaultView,
+    getElementById() {
+      return null;
+    },
+    querySelector() {
+      return input;
+    },
+  };
+  input.ownerDocument = doc;
+  return doc;
+}
+
+function payload(overrides = {}) {
+  return {
+    framePath: [],
+    selector: "#upload-file",
+    marker: "__tidebreak_marker__",
+    markerValue: "@e1",
+    fingerprint: {
+      tag: "input",
+      role: "textbox",
+      name: "Sensitive field",
+      inputType: "file",
+      href: null,
+      sensitive: true,
+    },
+    file: {
+      name: "report.txt",
+      mediaType: "text/plain",
+      byteLen: 13,
+      contentBase64: Buffer.from("fixture bytes").toString("base64"),
+    },
+    ...overrides,
+  };
+}
+
+function executeUpload(doc, request) {
+  const script = uploadMatch[1]
+    .replace("__TARGET_IDENTITY_STORE__", identityStoreMatch[1])
+    .replace("__SENSITIVE_FIELD_POLICY__", policyMatch[1])
+    .replace("__PAYLOAD__", JSON.stringify(request));
+  const execute = new Function("document", "window", `return (${script});`);
+  return JSON.parse(execute(doc, doc.defaultView));
+}
+
+test("the isolated upload script attaches the exact file and dispatches both events", () => {
+  const input = new FixtureInput();
+  const result = executeUpload(documentFor(input), payload());
+
+  assert.equal(result.status, "uploaded");
+  assert.equal(input.files.length, 1);
+  assert.equal(input.files[0].name, "report.txt");
+  assert.equal(input.files[0].type, "text/plain");
+  assert.deepEqual(Buffer.from(input.files[0].bytes).toString(), "fixture bytes");
+  assert.deepEqual(input.events, ["input", "change"]);
+});
+
+test("the upload script refuses a replaced semantic target", () => {
+  const input = new FixtureInput({ marker: "@replacement" });
+  const result = executeUpload(documentFor(input), payload());
+
+  assert.equal(result.status, "stale_target");
+  assert.equal(input.files.length, 0);
+  assert.deepEqual(input.events, []);
+});
+
+test("the upload script refuses non-file and disabled inputs", () => {
+  const text = new FixtureInput({ type: "text" });
+  const textResult = executeUpload(
+    documentFor(text),
+    payload({
+      fingerprint: {
+        tag: "input",
+        role: "textbox",
+        name: "",
+        inputType: "text",
+        href: null,
+        sensitive: false,
+      },
+    }),
+  );
+  assert.equal(textResult.status, "invalid_target");
+
+  const disabled = new FixtureInput({ disabled: true });
+  const disabledResult = executeUpload(documentFor(disabled), payload());
+  assert.equal(disabledResult.status, "invalid_target");
+  assert.equal(disabled.files.length, 0);
+});

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -2535,8 +2535,8 @@ fn register_computer_use_tools(tools: &mut ToolRegistry) {
 /// The server checkpoints each call for the desktop foreground browser
 /// executor to claim, authorize, and dispatch through [`BrowserRegistry`].
 /// The server itself never drives a browser — it only validates arguments
-/// and parks the call. No semantic act tool is registered; that requires
-/// native input synthesis and is gated on a separate capability check.
+/// and parks the call. Semantic act and upload register only when a separate
+/// capability check confirms trusted native interaction.
 ///
 /// Registered only when an explicit foreground-browser availability flag is
 /// true (the desktop can bind a browser surface for foreground chat). When

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -127,24 +127,26 @@ use tidebreak_code_execution::ExecTool;
 use tidebreak_core::{
     ask_user_questions_tool_spec, browser_act_tool_spec, browser_list_tool_spec,
     browser_navigate_tool_spec, browser_screenshot_tool_spec, browser_snapshot_tool_spec,
-    browser_wait_tool_spec, computer_capture_screen_tool_spec, computer_click_tool_spec,
-    computer_focus_window_tool_spec, computer_key_press_tool_spec, computer_list_windows_tool_spec,
-    computer_read_app_content_tool_spec, computer_return_to_tidebreak_tool_spec,
-    computer_scroll_tool_spec, computer_type_text_tool_spec, computer_wait_tool_spec,
-    exit_plan_mode_tool_spec, import_connected_file_tool_spec, list_connected_folders_tool_spec,
-    list_folder_tool_spec, read_connected_file_tool_spec, request_folder_access_tool_spec,
+    browser_upload_tool_spec, browser_wait_tool_spec, computer_capture_screen_tool_spec,
+    computer_click_tool_spec, computer_focus_window_tool_spec, computer_key_press_tool_spec,
+    computer_list_windows_tool_spec, computer_read_app_content_tool_spec,
+    computer_return_to_tidebreak_tool_spec, computer_scroll_tool_spec,
+    computer_type_text_tool_spec, computer_wait_tool_spec, exit_plan_mode_tool_spec,
+    import_connected_file_tool_spec, list_connected_folders_tool_spec, list_folder_tool_spec,
+    read_connected_file_tool_spec, request_folder_access_tool_spec,
     validate_ask_user_questions_arguments, validate_browser_act_arguments,
     validate_browser_list_arguments, validate_browser_navigate_arguments,
     validate_browser_screenshot_arguments, validate_browser_snapshot_arguments,
-    validate_browser_wait_arguments, validate_computer_capture_screen_arguments,
-    validate_computer_click_arguments, validate_computer_focus_window_arguments,
-    validate_computer_key_press_arguments, validate_computer_list_windows_arguments,
-    validate_computer_read_app_content_arguments, validate_computer_return_to_tidebreak_arguments,
-    validate_computer_scroll_arguments, validate_computer_type_text_arguments,
-    validate_computer_wait_arguments, validate_exit_plan_mode_arguments,
-    validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
-    validate_list_folder_arguments, validate_read_connected_file_arguments,
-    validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
+    validate_browser_upload_arguments, validate_browser_wait_arguments,
+    validate_computer_capture_screen_arguments, validate_computer_click_arguments,
+    validate_computer_focus_window_arguments, validate_computer_key_press_arguments,
+    validate_computer_list_windows_arguments, validate_computer_read_app_content_arguments,
+    validate_computer_return_to_tidebreak_arguments, validate_computer_scroll_arguments,
+    validate_computer_type_text_arguments, validate_computer_wait_arguments,
+    validate_exit_plan_mode_arguments, validate_import_connected_file_arguments,
+    validate_list_connected_folders_arguments, validate_list_folder_arguments,
+    validate_read_connected_file_arguments, validate_request_folder_access_arguments,
+    validate_write_output_to_connected_folder_arguments,
     write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, ApprovalClass, BlobStore,
     BundledSecretProvider, CachingSecretProvider, Config, CreateAppTool, DbStore, FsBlobStore,
     KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool,
@@ -2528,7 +2530,7 @@ fn register_computer_use_tools(tools: &mut ToolRegistry) {
     }
 }
 
-/// Register exactly five observation browser tools as validated client tools.
+/// Register the foreground browser tools as validated client tools.
 ///
 /// The server checkpoints each call for the desktop foreground browser
 /// executor to claim, authorize, and dispatch through [`BrowserRegistry`].
@@ -2579,6 +2581,11 @@ fn register_foreground_browser_tools(tools: &mut ToolRegistry, semantic_actions:
             browser_act_tool_spec(),
             ApprovalClass::Sensitive,
             validate_browser_act_arguments,
+        );
+        tools.register_validated_client(
+            browser_upload_tool_spec(),
+            ApprovalClass::Sensitive,
+            validate_browser_upload_arguments,
         );
     }
 }

--- a/crates/tidebreak-server/src/tests/documents.rs
+++ b/crates/tidebreak-server/src/tests/documents.rs
@@ -2081,19 +2081,19 @@ async fn foreground_browser_tools_absent_by_default() {
 }
 
 #[tokio::test]
-async fn foreground_browser_tools_register_exactly_five() {
+async fn foreground_browser_tools_register_reads_and_navigate_without_semantic_actions() {
     let dir = tempfile::tempdir().unwrap();
     let (tools, _) = agent_deps_for_test(dir.path(), false, true, false).await;
 
-    // Exactly five observation tools register as client-executed.
-    let observation_tools = [
+    // The five non-semantic tools register as client-executed.
+    let base_tools = [
         tidebreak_core::BROWSER_LIST_TOOL,
         tidebreak_core::BROWSER_NAVIGATE_TOOL,
         tidebreak_core::BROWSER_SNAPSHOT_TOOL,
         tidebreak_core::BROWSER_WAIT_TOOL,
         tidebreak_core::BROWSER_SCREENSHOT_TOOL,
     ];
-    for &name in &observation_tools {
+    for &name in &base_tools {
         assert_eq!(
             tools.execution(name),
             Some(tidebreak_core::ToolCallExecution::Client),
@@ -2105,19 +2105,25 @@ async fn foreground_browser_tools_register_exactly_five() {
         );
     }
 
-    // The act tool must NOT be registered.
-    assert!(
-        tools.registered_class(tidebreak_core::BROWSER_ACT_TOOL).is_none(),
-        "browser_act must not register when foreground_browser is true — it requires separate semantic_actions capability"
-    );
-    assert!(
-        tools.execution(tidebreak_core::BROWSER_ACT_TOOL).is_none(),
-        "browser_act must not execute even if foreground_browser is true"
-    );
+    // Semantic actions and file attachment require the separate native engine
+    // capability. Foreground browser availability alone must expose neither.
+    for &name in &[
+        tidebreak_core::BROWSER_ACT_TOOL,
+        tidebreak_core::BROWSER_UPLOAD_TOOL,
+    ] {
+        assert!(
+            tools.registered_class(name).is_none(),
+            "{name} must not register without semantic_actions"
+        );
+        assert!(
+            tools.execution(name).is_none(),
+            "{name} must not execute without semantic_actions"
+        );
+    }
 }
 
 #[tokio::test]
-async fn foreground_browser_act_registers_only_with_semantic_actions() {
+async fn foreground_browser_semantic_tools_register_only_with_semantic_actions() {
     let dir = tempfile::tempdir().unwrap();
     let (tools, _) = agent_deps_for_test(dir.path(), false, true, true).await;
 
@@ -2143,6 +2149,34 @@ async fn foreground_browser_act_registers_only_with_semantic_actions() {
             "document_epoch": 1,
             "ref": "@e1",
             "action": { "type": "click" }
+        })
+    ));
+
+    assert_eq!(
+        tools.execution(tidebreak_core::BROWSER_UPLOAD_TOOL),
+        Some(tidebreak_core::ToolCallExecution::Client),
+        "browser_upload must be client-executed when semantic actions are available"
+    );
+    assert_eq!(
+        tools.registered_class(tidebreak_core::BROWSER_UPLOAD_TOOL),
+        Some(ApprovalClass::Sensitive),
+        "browser_upload attaches bytes to an untrusted site and must be Sensitive"
+    );
+    assert!(
+        tools.get(tidebreak_core::BROWSER_UPLOAD_TOOL).is_none(),
+        "browser_upload has no server-side executor"
+    );
+    assert!(tools.client_arguments_are_valid(
+        tidebreak_core::BROWSER_UPLOAD_TOOL,
+        &serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 1,
+            "ref": "@e2",
+            "resource": {
+                "kind": "output",
+                "output_id": uuid::Uuid::new_v4()
+            }
         })
     ));
 }
@@ -2176,6 +2210,11 @@ async fn foreground_browser_tools_have_correct_approval_classes() {
         tools.registered_class(tidebreak_core::BROWSER_ACT_TOOL),
         Some(ApprovalClass::Sensitive),
         "browser_act synthesizes native input and must be Sensitive"
+    );
+    assert_eq!(
+        tools.registered_class(tidebreak_core::BROWSER_UPLOAD_TOOL),
+        Some(ApprovalClass::Sensitive),
+        "browser_upload transfers confirmed bytes to a site and must be Sensitive"
     );
 }
 
@@ -2292,10 +2331,60 @@ async fn foreground_browser_tools_reject_malformed_arguments() {
             "action": { "type": "press", "key": "Ctrl+C" }
         })
     ));
+
+    // upload accepts only one logical conversation resource and never a host
+    // path or a malformed connected-root path.
+    assert!(tools.client_arguments_are_valid(
+        tidebreak_core::BROWSER_UPLOAD_TOOL,
+        &serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 0,
+            "ref": "@e2",
+            "resource": {
+                "kind": "output",
+                "output_id": uuid::Uuid::new_v4()
+            }
+        })
+    ));
+    assert!(tools.client_arguments_are_valid(
+        tidebreak_core::BROWSER_UPLOAD_TOOL,
+        &serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 0,
+            "ref": "@e2",
+            "resource": {
+                "kind": "connected_file",
+                "root_id": uuid::Uuid::new_v4(),
+                "path": "reports/q3.pdf"
+            }
+        })
+    ));
+    for resource in [
+        serde_json::json!({ "kind": "output", "output_id": uuid::Uuid::nil() }),
+        serde_json::json!({
+            "kind": "connected_file",
+            "root_id": uuid::Uuid::new_v4(),
+            "path": "../secret.txt"
+        }),
+        serde_json::json!({ "kind": "host_path", "path": "/tmp/secret.txt" }),
+    ] {
+        assert!(!tools.client_arguments_are_valid(
+            tidebreak_core::BROWSER_UPLOAD_TOOL,
+            &serde_json::json!({
+                "browser_id": "browser-1",
+                "snapshot_id": "snapshot-1",
+                "document_epoch": 0,
+                "ref": "@e2",
+                "resource": resource
+            })
+        ));
+    }
 }
 
 #[tokio::test]
-async fn foreground_browser_plan_mode_includes_reads_excludes_navigate() {
+async fn foreground_browser_plan_mode_includes_reads_excludes_effects() {
     let dir = tempfile::tempdir().unwrap();
     let (tools, _) = agent_deps_for_test(dir.path(), false, true, true).await;
 
@@ -2329,5 +2418,9 @@ async fn foreground_browser_plan_mode_includes_reads_excludes_navigate() {
     assert!(
         !plan_specs.contains(tidebreak_core::BROWSER_ACT_TOOL),
         "plan mode must not contain browser_act"
+    );
+    assert!(
+        !plan_specs.contains(tidebreak_core::BROWSER_UPLOAD_TOOL),
+        "plan mode must not contain browser_upload"
     );
 }

--- a/crates/tidebreak-server/src/tests/outputs.rs
+++ b/crates/tidebreak-server/src/tests/outputs.rs
@@ -431,3 +431,96 @@ async fn a_foreground_revision_projects_only_its_turns_durable_evidence() {
     );
     assert!(!history.to_string().contains("not-evidence"));
 }
+
+#[tokio::test]
+async fn exact_output_reauthorization_rejects_other_chats_and_stale_heads() {
+    use sha2::{Digest as _, Sha256};
+
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let other = make_chat(&router, &bearer).await;
+    let output_id = OutputId::new();
+    let first_revision = OutputRevisionId::new();
+    let first_bytes = b"first revision";
+    let first_digest: [u8; 32] = Sha256::digest(first_bytes).into();
+    let now = chrono::Utc::now();
+
+    store
+        .create_output(&CreateOutput {
+            id: output_id,
+            chat_id: chat.id,
+            filename: "report.txt".to_owned(),
+            kind: DeliverableKind::Text,
+            revision: NewOutputRevision {
+                id: first_revision,
+                byte_len: first_bytes.len() as u64,
+                sha256: first_digest,
+                turn_id: None,
+                producing_run_id: None,
+                created_at: now,
+            },
+        })
+        .await
+        .unwrap();
+
+    crate::output_files::require_exact_revision(
+        &store,
+        chat.id,
+        output_id,
+        first_revision,
+        first_bytes.len() as u64,
+        first_digest,
+    )
+    .await
+    .unwrap();
+    assert!(crate::output_files::require_exact_revision(
+        &store,
+        other.id,
+        output_id,
+        first_revision,
+        first_bytes.len() as u64,
+        first_digest,
+    )
+    .await
+    .is_err());
+
+    let second_revision = OutputRevisionId::new();
+    let second_bytes = b"second revision";
+    let second_digest: [u8; 32] = Sha256::digest(second_bytes).into();
+    store
+        .append_output_revision(
+            output_id,
+            &NewOutputRevision {
+                id: second_revision,
+                byte_len: second_bytes.len() as u64,
+                sha256: second_digest,
+                turn_id: None,
+                producing_run_id: None,
+                created_at: now + chrono::Duration::seconds(1),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(crate::output_files::require_exact_revision(
+        &store,
+        chat.id,
+        output_id,
+        first_revision,
+        first_bytes.len() as u64,
+        first_digest,
+    )
+    .await
+    .is_err());
+    crate::output_files::require_exact_revision(
+        &store,
+        chat.id,
+        output_id,
+        second_revision,
+        second_bytes.len() as u64,
+        second_digest,
+    )
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
## Summary

- add a foreground-only `browser_upload` tool for current conversation outputs and connected-folder files
- resolve and reauthorize the exact resource after native confirmation and inside the serialized browser dispatch
- bind confirmation to the transfer capability, filename, byte length, and SHA-256 digest
- attach the confirmed file through Tidebreak's isolated WebKit content world without exposing host paths or file bytes through renderer state or renderer-facing IPC
- keep the code-session browser tool surface unchanged

## Safety

Uploads accept only opaque output or root identifiers and bounded root-relative paths. The native executor enforces the broker's 8 MiB read ceiling, portable filenames, symlink-safe reads, live root attachment, stable staged-folder selection, current output revision, and a fresh confirmation for every upload.

Part of #2344. Complements the bounded download work in #2918.

## Tests

- `cargo test -p tidebreak-core browser_upload`
- `cargo test -p tidebreak-server foreground_browser_ --lib`
- `cargo test -p tidebreak-server exact_output_reauthorization_rejects_other_chats_and_stale_heads --lib`
- `cargo test -p tidebreak-desktop browser`
- `node --test crates/tidebreak-desktop/tests/browser-fixture/*.test.mjs`
- `cargo clippy -p tidebreak-desktop --all-targets -- -D warnings`
- `cargo clippy -p tidebreak-core -p tidebreak-server --lib -- -D warnings`