### PR TITLE
feat(ui): show repository trigger targets

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -28,6 +28,9 @@ import {
   deliveryRepositoriesSnapshot,
   deliveryRunDetails,
   deliveryRuns,
+  codeDigest,
+  codeWorkspace,
+  harnessDoctor,
 } from "../stories/fixtures";
 import {
   CodeDeliveryPage,
@@ -40,11 +43,13 @@ import {
   useCodeDeliveryStore,
 } from "./CodeDeliveryStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
 
 afterEach(() => {
   cleanup();
   useCodeDeliveryStore.getState().reset();
   useCodeUpdatesStore.getState().reset();
+  useCodeCatalogStore.getState().reset();
 });
 
 vi.mock("@/openInBrowser", () => ({ openInBrowser: vi.fn() }));
@@ -208,6 +213,32 @@ describe("delivery pull request list", () => {
   it("opens repository-scoped trigger rules from the production dialog", async () => {
     const user = userEvent.setup();
     const listCodeTriggers = vi.fn(async () => []);
+    const repoId =
+      deliveryRepositoriesSnapshot.repositories[0]!.tidebreak_repo_id!;
+    useCodeCatalogStore.setState({
+      workspaces: [
+        {
+          ...codeWorkspace,
+          id: "ws-trigger-target",
+          repo_id: repoId,
+          title: "Fix trigger delivery",
+          pr: { number: 2921, state: "open" },
+        },
+      ],
+      doctor: harnessDoctor,
+    });
+    useCodeUpdatesStore.getState().apply({
+      type: "snapshot",
+      sessions: [
+        codeDigest({
+          workspace: "ws-trigger-target",
+          session: "sess-trigger-target",
+          harness_kind: "codex",
+          title: "Fix trigger delivery",
+          trigger_target_at: "2026-08-29T12:30:00Z",
+        }),
+      ],
+    });
     const client = {
       ...storyClient(),
       listCodeTriggers,
@@ -227,9 +258,10 @@ describe("delivery pull request list", () => {
     expect(
       await screen.findByRole("heading", { name: "Triggers" }),
     ).toBeInTheDocument();
-    expect(listCodeTriggers).toHaveBeenCalledWith(
-      deliveryRepositoriesSnapshot.repositories[0]!.tidebreak_repo_id,
-    );
+    expect(listCodeTriggers).toHaveBeenCalledWith(repoId);
+    expect(
+      screen.getByText("Interrupts Fix trigger delivery mid-turn (Codex CLI)."),
+    ).toBeInTheDocument();
   });
 
   it("does not warn when only local-only repositories were skipped", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -95,6 +95,7 @@ import {
 import { CodeSidebar } from "./CodeSidebar";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { codeTriggerTargetForRepository } from "./CodeTriggerTarget";
 import { RepositorySettings } from "./RepositorySettings";
 import { RepositoryTriggerRules } from "./RepositoryTriggerRules";
 import { GithubAvatar } from "./GithubAvatar";
@@ -3239,6 +3240,11 @@ function DeliveryRepositoriesDialog({
   onRefresh: () => void;
 }) {
   const { client } = useApp();
+  const workspaces = useCodeCatalogStore((state) => state.workspaces);
+  const doctor = useCodeCatalogStore((state) => state.doctor);
+  const conversationsByWorkspace = useCodeUpdatesStore(
+    (state) => state.conversationsByWorkspace,
+  );
   const manualRepositories = useCodeDeliveryStore(
     (state) => state.manualRepositories,
   );
@@ -3253,6 +3259,16 @@ function DeliveryRepositoriesDialog({
     useState<CodeGitHubRepositoryRef | null>(null);
   const [settingsRepository, setSettingsRepository] =
     useState<CodeGitHubRepositoryRef | null>(null);
+  const triggerTarget = useMemo(
+    () =>
+      codeTriggerTargetForRepository({
+        repoId: triggerRepository?.tidebreak_repo_id,
+        workspaces,
+        conversationsByWorkspace,
+        doctor,
+      }),
+    [conversationsByWorkspace, doctor, triggerRepository, workspaces],
+  );
 
   const add = async () => {
     const repositories = input
@@ -3368,6 +3384,7 @@ function DeliveryRepositoriesDialog({
                 <RepositoryTriggerRules
                   client={client}
                   repository={triggerRepository}
+                  target={triggerTarget}
                 />
               </div>
             )}

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerTarget.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerTarget.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import type { CodeWorkspaceSnapshot } from "@/api/types";
+import { codeDigest, codeWorkspace, harnessDoctor } from "@/stories/fixtures";
+import { codeTriggerTargetForRepository } from "./CodeTriggerTarget";
+import type { DigestsByWorkspace } from "./CodeUpdatesStore";
+
+function workspace(
+  overrides: Partial<CodeWorkspaceSnapshot> = {},
+): CodeWorkspaceSnapshot {
+  return {
+    ...codeWorkspace,
+    id: "ws-trigger",
+    repo_id: "repo-trigger",
+    pr: { number: 42, state: "open" },
+    ...overrides,
+  };
+}
+
+describe("codeTriggerTargetForRepository", () => {
+  it("uses the newest eligible interactive session, not snapshot order", () => {
+    const conversationsByWorkspace: DigestsByWorkspace = {
+      "ws-trigger": {
+        "sess-created-later": codeDigest({
+          workspace: "ws-trigger",
+          session: "sess-created-later",
+          harness_kind: "claude_code",
+          title: "Older activity",
+          trigger_target_at: "2026-08-28T10:00:00Z",
+        }),
+        "sess-active-later": codeDigest({
+          workspace: "ws-trigger",
+          session: "sess-active-later",
+          harness_kind: "codex",
+          title: "Fix trigger delivery",
+          trigger_target_at: "2026-08-29T11:00:00Z",
+        }),
+        "sess-watch": codeDigest({
+          workspace: "ws-trigger",
+          session: "sess-watch",
+          kind: "watch",
+          harness_kind: "codex",
+          title: "Watch",
+          trigger_target_at: "2026-08-29T12:00:00Z",
+        }),
+        "sess-fenced": codeDigest({
+          workspace: "ws-trigger",
+          session: "sess-fenced",
+          lifecycle: "fenced",
+          harness_kind: "codex",
+          title: "Fenced",
+          trigger_target_at: "2026-08-29T13:00:00Z",
+        }),
+      },
+    };
+
+    expect(
+      codeTriggerTargetForRepository({
+        repoId: "repo-trigger",
+        workspaces: [workspace()],
+        conversationsByWorkspace,
+        doctor: harnessDoctor,
+      }),
+    ).toEqual({
+      sessionTitle: "Fix trigger delivery",
+      harnessLabel: "Codex CLI",
+      delivery: "steer",
+    });
+  });
+
+  it("waits for quiet unless the selected harness declares steering", () => {
+    const conversationsByWorkspace: DigestsByWorkspace = {
+      "ws-trigger": {
+        "sess-claude": codeDigest({
+          workspace: "ws-trigger",
+          session: "sess-claude",
+          harness_kind: "claude_code",
+          title: "Review notification rules",
+          trigger_target_at: "2026-08-29T11:00:00Z",
+        }),
+      },
+    };
+
+    expect(
+      codeTriggerTargetForRepository({
+        repoId: "repo-trigger",
+        workspaces: [workspace()],
+        conversationsByWorkspace,
+        doctor: harnessDoctor,
+      }),
+    ).toEqual({
+      sessionTitle: "Review notification rules",
+      harnessLabel: "Claude Code",
+      delivery: "next_turn",
+    });
+    expect(
+      codeTriggerTargetForRepository({
+        repoId: "repo-trigger",
+        workspaces: [workspace({ pr: undefined })],
+        conversationsByWorkspace,
+        doctor: harnessDoctor,
+      }),
+    ).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerTarget.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerTarget.ts
@@ -1,0 +1,79 @@
+import type {
+  CodeSessionDigest,
+  CodeWorkspaceSnapshot,
+  HarnessDoctorReport,
+  RepoId,
+} from "@/api/types";
+import { HARNESS_LABELS } from "./labels";
+import type { CodeTriggerTarget } from "./CodeTriggerRules";
+import type { DigestsByWorkspace } from "./CodeUpdatesStore";
+
+type TargetWorkspace = Pick<
+  CodeWorkspaceSnapshot,
+  "id" | "repo_id" | "status" | "pr"
+>;
+
+/**
+ * Name the session a repository trigger would reach right now.
+ *
+ * The server creates one fire per eligible workspace. This projection names
+ * the newest target across those workspaces, using the same timestamp that the
+ * delivery planner uses within each workspace.
+ */
+export function codeTriggerTargetForRepository({
+  repoId,
+  workspaces,
+  conversationsByWorkspace,
+  doctor,
+}: {
+  repoId: RepoId | null | undefined;
+  workspaces: readonly TargetWorkspace[];
+  conversationsByWorkspace: DigestsByWorkspace;
+  doctor: HarnessDoctorReport | null;
+}): CodeTriggerTarget | null {
+  if (!repoId) return null;
+
+  const eligibleWorkspaceIds = new Set(
+    workspaces
+      .filter(
+        (workspace) =>
+          workspace.repo_id === repoId &&
+          workspace.status === "active" &&
+          workspace.pr !== undefined,
+      )
+      .map((workspace) => workspace.id),
+  );
+
+  let target: CodeSessionDigest | undefined;
+  let targetAt = Number.NEGATIVE_INFINITY;
+  for (const workspaceId of eligibleWorkspaceIds) {
+    const conversations = conversationsByWorkspace[workspaceId];
+    if (!conversations) continue;
+    for (const digest of Object.values(conversations)) {
+      if (
+        digest.kind !== "interactive" ||
+        digest.lifecycle === "ended" ||
+        digest.lifecycle === "fenced" ||
+        !digest.harness_kind ||
+        !digest.trigger_target_at
+      ) {
+        continue;
+      }
+      const activeAt = Date.parse(digest.trigger_target_at);
+      if (!Number.isFinite(activeAt) || activeAt <= targetAt) continue;
+      target = digest;
+      targetAt = activeAt;
+    }
+  }
+
+  if (!target?.harness_kind) return null;
+  const harness = doctor?.harnesses.find(
+    (entry) => entry.kind === target.harness_kind,
+  );
+  return {
+    sessionTitle: target.title,
+    harnessLabel: HARNESS_LABELS[target.harness_kind],
+    delivery:
+      harness?.caps.mid_turn_steering === "supported" ? "steer" : "next_turn",
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -281,6 +281,7 @@ describe("reduceCodeUpdates", () => {
         attention: working,
         title: "first change",
         turn_count: 1,
+        trigger_target_at: "2026-08-29T12:30:00Z",
         activity: "monitor",
       }),
     ).toEqual({
@@ -294,6 +295,7 @@ describe("reduceCodeUpdates", () => {
         attention: working,
         title: "first change",
         turn_count: 1,
+        trigger_target_at: "2026-08-29T12:30:00Z",
         activity: "monitor",
       },
     });

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -417,6 +417,9 @@ export function noticeToAction(
         attention: notice.attention,
         title: notice.title,
         turn_count: notice.turn_count,
+        ...(notice.trigger_target_at !== undefined
+          ? { trigger_target_at: notice.trigger_target_at }
+          : {}),
         ...(notice.activity !== undefined ? { activity: notice.activity } : {}),
         ...(notice.pr_state !== undefined ? { pr_state: notice.pr_state } : {}),
         ...(notice.pr_count !== undefined ? { pr_count: notice.pr_count } : {}),

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -765,6 +765,7 @@ describe("pull request state in live updates", () => {
     attention: { state: { type: "working" }, source: "lifecycle" },
     title: "Fix login",
     turn_count: 3,
+    trigger_target_at: "2026-08-29T12:00:00Z",
     activity: "shell",
     pr_state: richPr,
   };
@@ -808,6 +809,16 @@ describe("pull request state in live updates", () => {
         type: "digest",
         ...digest,
         harness_kind: "cursor",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects a non-string trigger target timestamp", () => {
+    expect(
+      parseCodeUpdateNotice({
+        type: "digest",
+        ...digest,
+        trigger_target_at: 42,
       }),
     ).toBeNull();
   });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -3911,6 +3911,7 @@ export function parseCodeSessionDigest(
       "attention",
       "title",
       "turn_count",
+      "trigger_target_at",
       "activity",
       "pr_state",
       "pr_count",
@@ -3928,6 +3929,7 @@ export function parseCodeSessionDigest(
     !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
     typeof value.title !== "string" ||
     !isFiniteNumber(value.turn_count) ||
+    !optionalString(value.trigger_target_at) ||
     (value.activity !== undefined &&
       !isMember(value.activity, SESSION_ACTIVITIES)) ||
     (value.pr_count !== undefined && !isFiniteNumber(value.pr_count)) ||
@@ -3958,6 +3960,9 @@ export function parseCodeSessionDigest(
     attention,
     title: value.title,
     turn_count: value.turn_count,
+    ...(value.trigger_target_at !== undefined
+      ? { trigger_target_at: value.trigger_target_at }
+      : {}),
     ...(value.activity !== undefined ? { activity: value.activity } : {}),
     ...(pr_state ? { pr_state } : {}),
     ...(value.pr_count !== undefined ? { pr_count: value.pr_count } : {}),
@@ -4008,6 +4013,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
           "attention",
           "title",
           "turn_count",
+          "trigger_target_at",
           "activity",
           "pr_state",
           "pr_count",
@@ -4025,6 +4031,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
         typeof value.title !== "string" ||
         !isFiniteNumber(value.turn_count) ||
+        !optionalString(value.trigger_target_at) ||
         (value.activity !== undefined &&
           !isMember(value.activity, SESSION_ACTIVITIES)) ||
         (value.pr_count !== undefined && !isFiniteNumber(value.pr_count)) ||
@@ -4059,6 +4066,9 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         attention,
         title: value.title,
         turn_count: value.turn_count,
+        ...(value.trigger_target_at !== undefined
+          ? { trigger_target_at: value.trigger_target_at }
+          : {}),
         ...(value.activity !== undefined ? { activity: value.activity } : {}),
         ...(pr_state ? { pr_state } : {}),
         ...(value.pr_count !== undefined ? { pr_count: value.pr_count } : {}),

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1498,6 +1498,12 @@ export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId
  */
 harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
 /**
+ * Timestamp trigger delivery uses to rank candidate sessions: the newest
+ * turn start, or session creation before the first turn. Optional so a
+ * desktop can still read a digest from an older server during an update.
+ */
+trigger_target_at?: string, 
+/**
  * What the live turn is occupied with, while running.
  */
 activity?: CodeSessionActivity, pr_state?: PullRequestDigest, 
@@ -1677,6 +1683,10 @@ sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: Workspace
  * Engine identity for the session represented by this digest.
  */
 harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
+/**
+ * Timestamp trigger delivery uses to rank candidate sessions.
+ */
+trigger_target_at?: string, 
 /**
  * What the live turn is occupied with, while running.
  */

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -22,6 +22,7 @@ use tidebreak_core::{
 };
 
 use super::bus::{CodeEventBus, CodeLiveUpdate, SessionDigest};
+use super::trigger_target_at;
 
 /// Running-but-silent threshold. A periodic sweep applies
 /// [`AttentionState::Stalled`] past this many seconds.
@@ -422,14 +423,15 @@ async fn build_digest(
     // predate the field and workspaces that never shipped read the same.
     let pr_count =
         count_attributed_prs_for_workspace(db, &session.owner, session.workspace_id).await?;
+    let turns = list_turns(db, &session.owner, session.id).await?;
+    // Keep this timestamp aligned with trigger delivery's ranking rule. The
+    // interface uses it to name the same session that a fire would reach.
+    let trigger_target_at =
+        trigger_target_at(session.created_at, turns.last().map(|turn| turn.started_at));
     // The newest recapped turn speaks for the session: a turn the model
     // declined to recap, or one whose call is still in flight, leaves the
     // previous line standing rather than blanking the row mid-work.
-    let recap = list_turns(db, &session.owner, session.id)
-        .await?
-        .into_iter()
-        .rev()
-        .find_map(|turn| turn.narrative);
+    let recap = turns.into_iter().rev().find_map(|turn| turn.narrative);
     Ok(SessionDigest {
         workspace: session.workspace_id,
         session: session.id,
@@ -439,6 +441,7 @@ async fn build_digest(
         attention: session.attention.clone(),
         title: workspace.title,
         turn_count,
+        trigger_target_at,
         activity,
         pr_state: workspace.pr,
         pr_count: (pr_count > 0).then_some(pr_count),

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -50,6 +50,9 @@ pub(crate) struct SessionDigest {
     pub attention: Attention,
     pub title: String,
     pub turn_count: i64,
+    /// Timestamp trigger delivery uses to rank candidate sessions: the newest
+    /// turn start, or session creation before the first turn.
+    pub trigger_target_at: DateTime<Utc>,
     /// What the live turn is occupied with. Set only while lifecycle is
     /// running; older clients safely fall back to a generic running label.
     pub activity: Option<CodeSessionActivity>,

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -44,6 +44,17 @@ pub(crate) mod worktree_root;
 pub(crate) use runtime::CodeRuntime;
 pub(crate) use scoped::ScopedCode;
 
+/// Timestamp used to rank sessions for trigger delivery and its UI preview.
+///
+/// A session with turns ranks by its newest turn start. A session with no
+/// turns ranks by creation time.
+pub(crate) fn trigger_target_at(
+    session_created_at: chrono::DateTime<chrono::Utc>,
+    latest_turn_started_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> chrono::DateTime<chrono::Utc> {
+    latest_turn_started_at.unwrap_or(session_created_at)
+}
+
 /// The display name the product uses for an engine, wherever copy names one.
 pub(crate) fn harness_label(kind: tidebreak_core::HarnessKind) -> &'static str {
     match kind {
@@ -51,5 +62,21 @@ pub(crate) fn harness_label(kind: tidebreak_core::HarnessKind) -> &'static str {
         tidebreak_core::HarnessKind::Codex => "Codex CLI",
         tidebreak_core::HarnessKind::Opencode => "opencode",
         tidebreak_core::HarnessKind::Grok => "Grok CLI",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::trigger_target_at;
+
+    #[test]
+    fn trigger_target_time_prefers_the_latest_turn_and_falls_back_to_creation() {
+        let created = Utc.with_ymd_and_hms(2026, 8, 28, 9, 0, 0).unwrap();
+        let latest_turn = Utc.with_ymd_and_hms(2026, 8, 29, 11, 0, 0).unwrap();
+
+        assert_eq!(trigger_target_at(created, Some(latest_turn)), latest_turn);
+        assert_eq!(trigger_target_at(created, None), created);
     }
 }

--- a/crates/tidebreak-server/src/code/trigger.rs
+++ b/crates/tidebreak-server/src/code/trigger.rs
@@ -38,6 +38,7 @@ use super::attention::apply_trigger_attention;
 use super::delivery::{query_pull_requests_by_number, repository_target_from_local};
 use super::runtime::CodeRuntime;
 use super::session_worker::journal_event;
+use super::trigger_target_at;
 use crate::error::ServerError;
 use crate::routes::code::types::{
     CodeDeliveryPullRequestSummary, CodeDeliveryPullRequestsPage, CodeDeliveryWorkspaceLink,
@@ -1016,9 +1017,12 @@ async fn most_recently_active(
         ) {
             continue;
         }
-        let at = latest_turn(&runtime.db, owner, session.id)
-            .await?
-            .map_or(session.created_at, |turn| turn.started_at);
+        let at = trigger_target_at(
+            session.created_at,
+            latest_turn(&runtime.db, owner, session.id)
+                .await?
+                .map(|turn| turn.started_at),
+        );
         if best.as_ref().is_none_or(|(best_at, _)| at > *best_at) {
             best = Some((at, session.clone()));
         }

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -2014,6 +2014,12 @@ pub struct CodeSessionDigest {
     pub attention: Attention,
     pub title: String,
     pub turn_count: i64,
+    /// Timestamp trigger delivery uses to rank candidate sessions: the newest
+    /// turn start, or session creation before the first turn. Optional so a
+    /// desktop can still read a digest from an older server during an update.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub trigger_target_at: Option<chrono::DateTime<chrono::Utc>>,
     /// What the live turn is occupied with, while running.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -2060,6 +2066,7 @@ impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
             attention: digest.attention,
             title: digest.title,
             turn_count: digest.turn_count,
+            trigger_target_at: Some(digest.trigger_target_at),
             activity: digest.activity,
             pr_state: digest.pr_state,
             pr_count: digest.pr_count,
@@ -2096,6 +2103,10 @@ pub enum CodeUpdateNotice {
         attention: Attention,
         title: String,
         turn_count: i64,
+        /// Timestamp trigger delivery uses to rank candidate sessions.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        trigger_target_at: Option<chrono::DateTime<chrono::Utc>>,
         /// What the live turn is occupied with, while running.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
@@ -2221,6 +2232,7 @@ impl CodeUpdateNotice {
             attention: wire.attention,
             title: wire.title,
             turn_count: wire.turn_count,
+            trigger_target_at: wire.trigger_target_at,
             activity: wire.activity,
             pr_state: wire.pr_state.map(Box::new),
             pr_count: wire.pr_count,


### PR DESCRIPTION
## Summary

- Render repository trigger rules from the tracked-repositories dialog.
- Name the session a trigger would reach and whether delivery interrupts it or waits for a turn.
- Share the server timestamp used to rank trigger targets so the preview matches delivery.
- Preserve that timestamp through live digest updates.

## Validation

- `pnpm exec vitest run src/code/CodeUpdatesStore.test.ts src/code/CodeTriggerTarget.test.ts src/code/CodeDeliveryPage.dom.test.tsx src/code/parsers.test.ts` (141 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check` on the changed UI files
- Full UI suite (2,261 tests passed)
- `pnpm storybook:build`
- `cargo test -p tidebreak-server trigger_target_time_prefers_the_latest_turn_and_falls_back_to_creation`
- `cargo check -p tidebreak-server`
- `cargo clippy -p tidebreak-server --lib -- -D warnings`
- Storybook screenshots across four themes at desktop and narrow widths

Closes #2503