### PR TITLE
feat(ui): migrate notification rules to triggers

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.test.ts
@@ -33,17 +33,37 @@ describe("migrateLegacyNotificationRules", () => {
     const listCodeTriggers = vi.fn(async () => []);
     const createCodeTrigger = vi.fn(async () => ({}) as never);
 
-    await migrateLegacyNotificationRules(
-      { listCodeTriggers, createCodeTrigger },
-      [attentionRule],
-      [repository],
-    );
+    await expect(
+      migrateLegacyNotificationRules(
+        { listCodeTriggers, createCodeTrigger },
+        [attentionRule],
+        { repositories: [repository], errors: [] },
+      ),
+    ).resolves.toBe(true);
 
     expect(listCodeTriggers).toHaveBeenCalledWith("repo-1");
     expect(createCodeTrigger.mock.calls).toEqual([
       ["repo-1", "changes_requested", "notify"],
       ["repo-1", "conflicts", "notify"],
     ]);
+  });
+
+  it("keeps the migration pending when repository discovery is partial", async () => {
+    const listCodeTriggers = vi.fn(async () => []);
+    const createCodeTrigger = vi.fn(async () => ({}) as never);
+
+    await expect(
+      migrateLegacyNotificationRules(
+        { listCodeTriggers, createCodeTrigger },
+        [attentionRule],
+        {
+          repositories: [repository],
+          errors: [{ kind: "github", message: "one repository failed" }],
+        },
+      ),
+    ).resolves.toBe(false);
+
+    expect(createCodeTrigger).toHaveBeenCalledTimes(2);
   });
 
   it("retries only missing rows after a partial migration", async () => {
@@ -71,13 +91,13 @@ describe("migrateLegacyNotificationRules", () => {
       migrateLegacyNotificationRules(
         { listCodeTriggers, createCodeTrigger },
         [attentionRule],
-        [repository],
+        { repositories: [repository], errors: [] },
       ),
     ).rejects.toThrow("offline");
     await migrateLegacyNotificationRules(
       { listCodeTriggers, createCodeTrigger },
       [attentionRule],
-      [repository],
+      { repositories: [repository], errors: [] },
     );
 
     expect(createCodeTrigger.mock.calls).toEqual([

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.test.ts
@@ -1,11 +1,92 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import type { CodeDeliveryRunQuery } from "../api/types";
+import type {
+  CodeDeliveryRunQuery,
+  CodeGitHubRepositoryRef,
+} from "../api/types";
+import type { CodeDeliveryNotificationRule } from "./CodeDeliveryStore";
 import {
+  migrateLegacyNotificationRules,
   monitorRuns,
   monitorSince,
   nextMonitorDelayMs,
 } from "./CodeDeliveryMonitor";
+
+const repository: CodeGitHubRepositoryRef = {
+  host: "github.com",
+  owner: "brightwave-inc",
+  name: "tidebreak",
+  name_with_owner: "brightwave-inc/tidebreak",
+  url: "https://github.com/brightwave-inc/tidebreak",
+  tidebreak_repo_id: "repo-1",
+};
+
+const attentionRule: CodeDeliveryNotificationRule = {
+  id: "pull_request_attention",
+  enabled: true,
+  repositoryKeys: [],
+  tidebreakLinkedOnly: false,
+};
+
+describe("migrateLegacyNotificationRules", () => {
+  it("arms every mapped rule as a server notification trigger", async () => {
+    const listCodeTriggers = vi.fn(async () => []);
+    const createCodeTrigger = vi.fn(async () => ({}) as never);
+
+    await migrateLegacyNotificationRules(
+      { listCodeTriggers, createCodeTrigger },
+      [attentionRule],
+      [repository],
+    );
+
+    expect(listCodeTriggers).toHaveBeenCalledWith("repo-1");
+    expect(createCodeTrigger.mock.calls).toEqual([
+      ["repo-1", "changes_requested", "notify"],
+      ["repo-1", "conflicts", "notify"],
+    ]);
+  });
+
+  it("retries only missing rows after a partial migration", async () => {
+    const listCodeTriggers = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "trigger-existing",
+          repo_id: "repo-1",
+          condition: "changes_requested",
+          action: "notify",
+          enabled: false,
+          created_at: "2026-08-29T12:00:00Z",
+          updated_at: "2026-08-29T12:01:00Z",
+        },
+      ]);
+    const createCodeTrigger = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce({});
+
+    await expect(
+      migrateLegacyNotificationRules(
+        { listCodeTriggers, createCodeTrigger },
+        [attentionRule],
+        [repository],
+      ),
+    ).rejects.toThrow("offline");
+    await migrateLegacyNotificationRules(
+      { listCodeTriggers, createCodeTrigger },
+      [attentionRule],
+      [repository],
+    );
+
+    expect(createCodeTrigger.mock.calls).toEqual([
+      ["repo-1", "changes_requested", "notify"],
+      ["repo-1", "conflicts", "notify"],
+      ["repo-1", "conflicts", "notify"],
+    ]);
+  });
+});
 
 describe("nextMonitorDelayMs", () => {
   it("has no safety or hidden poll clock", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
@@ -3,6 +3,7 @@ import type { ApiClient } from "../api/client";
 import type {
   CodeDeliveryPullRequestSummary,
   CodeDeliveryRunSummary,
+  CodeDeliverySourceError,
   CodeGitHubRepositoryRef,
   CodeGitHubRepositoryTarget,
 } from "../api/types";
@@ -101,15 +102,20 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
         );
         const legacyRules = current.legacyNotificationRules;
         if (legacyRules) {
-          await migrateLegacyNotificationRules(
+          const migrationComplete = await migrateLegacyNotificationRules(
             client,
             legacyRules,
-            repositories,
+            {
+              repositories,
+              errors: discovered.errors,
+            },
           );
           if (!isCurrent()) return;
-          useCodeDeliveryStore
-            .getState()
-            .completeNotificationRuleMigration(legacyRules);
+          if (migrationComplete) {
+            useCodeDeliveryStore
+              .getState()
+              .completeNotificationRuleMigration(legacyRules);
+          }
         }
 
         const targets = repositories.map(codeDeliveryRepositoryTarget);
@@ -201,19 +207,27 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
   return null;
 }
 
-/** Arm every server trigger represented by the old client-side rules. */
+/**
+ * Arm every server trigger represented by the old client-side rules.
+ *
+ * A partial repository catalog may still arm the rows it found, but it cannot
+ * commit the one-way migration because a later retry may discover more repos.
+ */
 export async function migrateLegacyNotificationRules(
   client: Pick<ApiClient, "listCodeTriggers" | "createCodeTrigger">,
   rules: readonly CodeDeliveryNotificationRule[],
-  repositories: readonly CodeGitHubRepositoryRef[],
-): Promise<void> {
+  catalog: {
+    repositories: readonly CodeGitHubRepositoryRef[];
+    errors: readonly CodeDeliverySourceError[];
+  },
+): Promise<boolean> {
   const byRepository = new Map<
     string,
     ReturnType<typeof triggersForNotificationRules>
   >();
   for (const trigger of triggersForNotificationRules(
     [...rules],
-    [...repositories],
+    [...catalog.repositories],
   )) {
     const triggers = byRepository.get(trigger.repoId) ?? [];
     triggers.push(trigger);
@@ -233,6 +247,7 @@ export async function migrateLegacyNotificationRules(
       existing.add(trigger.condition);
     }
   }
+  return catalog.errors.length === 0;
 }
 
 /** Delay until the next monitor pass. `null` means there is no clock. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
@@ -3,6 +3,7 @@ import type { ApiClient } from "../api/client";
 import type {
   CodeDeliveryPullRequestSummary,
   CodeDeliveryRunSummary,
+  CodeGitHubRepositoryRef,
   CodeGitHubRepositoryTarget,
 } from "../api/types";
 import {
@@ -13,7 +14,9 @@ import {
   codeDeliveryRepositoryTarget,
   trackedCodeDeliveryRepositories,
   useCodeDeliveryStore,
+  type CodeDeliveryNotificationRule,
 } from "./CodeDeliveryStore";
+import { triggersForNotificationRules } from "./CodeTriggerMigration";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 
 // Freshness rides the `delivery` nudge on the updates socket (decision 66):
@@ -96,6 +99,19 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
           discovered.repositories,
           current,
         );
+        const legacyRules = current.legacyNotificationRules;
+        if (legacyRules) {
+          await migrateLegacyNotificationRules(
+            client,
+            legacyRules,
+            repositories,
+          );
+          if (!isCurrent()) return;
+          useCodeDeliveryStore
+            .getState()
+            .completeNotificationRuleMigration(legacyRules);
+        }
+
         const targets = repositories.map(codeDeliveryRepositoryTarget);
         if (targets.length === 0) {
           current.completeDeliveryPoll([], [], startedAt);
@@ -183,6 +199,40 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
   }, [client]);
 
   return null;
+}
+
+/** Arm every server trigger represented by the old client-side rules. */
+export async function migrateLegacyNotificationRules(
+  client: Pick<ApiClient, "listCodeTriggers" | "createCodeTrigger">,
+  rules: readonly CodeDeliveryNotificationRule[],
+  repositories: readonly CodeGitHubRepositoryRef[],
+): Promise<void> {
+  const byRepository = new Map<
+    string,
+    ReturnType<typeof triggersForNotificationRules>
+  >();
+  for (const trigger of triggersForNotificationRules(
+    [...rules],
+    [...repositories],
+  )) {
+    const triggers = byRepository.get(trigger.repoId) ?? [];
+    triggers.push(trigger);
+    byRepository.set(trigger.repoId, triggers);
+  }
+  for (const [repoId, triggers] of byRepository) {
+    const existing = new Set(
+      (await client.listCodeTriggers(repoId)).map(
+        (trigger) => trigger.condition,
+      ),
+    );
+    for (const trigger of triggers) {
+      // A retry leaves rows already written alone. Re-arming would enable a
+      // row that the user disabled after a partial migration.
+      if (existing.has(trigger.condition)) continue;
+      await client.createCodeTrigger(repoId, trigger.condition, trigger.action);
+      existing.add(trigger.condition);
+    }
+  }
 }
 
 /** Delay until the next monitor pass. `null` means there is no clock. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.test.ts
@@ -223,27 +223,9 @@ describe("delivery notifications", () => {
     ).toBe(0);
   });
 
-  it("applies repository and Tidebreak-link scopes before creating feed rows", () => {
+  it("keeps the client-side feed after rule evaluation moves to the server", () => {
     const alpha = repository("brightwave-inc", "alpha", "repo-alpha");
     const beta = repository("brightwave-inc", "beta", "repo-beta");
-    useCodeDeliveryStore
-      .getState()
-      .updateNotificationRule("pull_request_attention", {
-        repositoryKeys: [codeDeliveryRepositoryKey(alpha)],
-        tidebreakLinkedOnly: true,
-      });
-
-    expect(
-      useCodeDeliveryStore
-        .getState()
-        .ingestDeliveryPoll([pullRequest(1, beta)], [], NOW),
-    ).toBe(0);
-    expect(
-      useCodeDeliveryStore
-        .getState()
-        .ingestDeliveryPoll([pullRequest(2, alpha)], [], NOW),
-    ).toBe(0);
-
     const linked = pullRequest(3, alpha, {
       workspace_links: [
         {
@@ -257,11 +239,18 @@ describe("delivery notifications", () => {
       ],
     });
     expect(
-      useCodeDeliveryStore.getState().ingestDeliveryPoll([linked], [], NOW),
-    ).toBe(1);
-    expect(useCodeDeliveryStore.getState().notifications[0]?.workspaceId).toBe(
-      "ws-3",
-    );
+      useCodeDeliveryStore
+        .getState()
+        .ingestDeliveryPoll([pullRequest(1, beta), linked], [], NOW),
+    ).toBe(2);
+    expect(useCodeDeliveryStore.getState().notifications).toHaveLength(2);
+    expect(
+      useCodeDeliveryStore
+        .getState()
+        .notifications.find(
+          (notification) => notification.workspaceId === "ws-3",
+        ),
+    ).toBeDefined();
   });
 
   it("keeps at most 500 notifications and drops events older than 30 days", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.ts
@@ -124,42 +124,50 @@ export type CodeDeliveryNotification = {
   target: CodeDeliveryNotificationTarget;
 };
 
-export const DEFAULT_DELIVERY_NOTIFICATION_RULES: CodeDeliveryNotificationRule[] =
-  [
-    {
-      id: "pull_request_attention",
-      enabled: true,
-      repositoryKeys: [],
-      tidebreakLinkedOnly: false,
-    },
-    {
-      id: "pull_request_ready",
-      enabled: true,
-      repositoryKeys: [],
-      tidebreakLinkedOnly: false,
-    },
-    {
-      id: "run_failure",
-      enabled: true,
-      repositoryKeys: [],
-      tidebreakLinkedOnly: false,
-    },
-  ];
+const LEGACY_DEFAULT_NOTIFICATION_RULES: CodeDeliveryNotificationRule[] = [
+  {
+    id: "pull_request_attention",
+    enabled: true,
+    repositoryKeys: [],
+    tidebreakLinkedOnly: false,
+  },
+  {
+    id: "pull_request_ready",
+    enabled: true,
+    repositoryKeys: [],
+    tidebreakLinkedOnly: false,
+  },
+  {
+    id: "run_failure",
+    enabled: true,
+    repositoryKeys: [],
+    tidebreakLinkedOnly: false,
+  },
+];
 
-type PersistedCodeDeliveryState = {
-  version: 1;
+type StoredCodeDeliveryState = {
   manualRepositories: CodeGitHubRepositoryRef[];
   excludedRegisteredRepoIds: string[];
   pinnedRepositoryKeys: string[];
   savedViews: CodeDeliverySavedView[];
-  notificationRules: CodeDeliveryNotificationRule[];
   notifications: CodeDeliveryNotification[];
   seenFingerprints: Record<string, string>;
   lastPollAt: string | null;
   knownAuthors: CodeDeliveryAuthor[];
 };
 
-type CodeDeliveryStore = Omit<PersistedCodeDeliveryState, "version"> & {
+type PersistedCodeDeliveryState = StoredCodeDeliveryState & {
+  version: 1;
+  notificationRulesMigrated?: true;
+  notificationRules?: CodeDeliveryNotificationRule[];
+};
+
+type HydratedCodeDeliveryState = StoredCodeDeliveryState & {
+  /** Old rules stay here until every mapped server trigger is armed. */
+  legacyNotificationRules: CodeDeliveryNotificationRule[] | null;
+};
+
+type CodeDeliveryStore = HydratedCodeDeliveryState & {
   polling: boolean;
   monitorError: string | null;
   lastSuccessfulPollAt: string | null;
@@ -180,9 +188,8 @@ type CodeDeliveryStore = Omit<PersistedCodeDeliveryState, "version"> & {
   setRepositoryPinned: (key: string, pinned: boolean) => void;
   upsertSavedView: (view: CodeDeliverySavedView) => void;
   removeSavedView: (id: string) => void;
-  updateNotificationRule: (
-    id: CodeDeliveryNotificationRuleKind,
-    patch: Partial<Omit<CodeDeliveryNotificationRule, "id">>,
+  completeNotificationRuleMigration: (
+    rules: CodeDeliveryNotificationRule[],
   ) => void;
   ingestDeliveryPoll: (
     pullRequests: readonly CodeDeliveryPullRequestSummary[],
@@ -203,24 +210,21 @@ type CodeDeliveryStore = Omit<PersistedCodeDeliveryState, "version"> & {
   reset: () => void;
 };
 
-function emptyPersistedState(): PersistedCodeDeliveryState {
+function emptyPersistedState(): HydratedCodeDeliveryState {
   return {
-    version: STORAGE_VERSION,
     manualRepositories: [],
     excludedRegisteredRepoIds: [],
     pinnedRepositoryKeys: [],
     savedViews: [],
-    notificationRules: DEFAULT_DELIVERY_NOTIFICATION_RULES.map((rule) => ({
-      ...rule,
-    })),
     notifications: [],
     seenFingerprints: {},
     lastPollAt: null,
     knownAuthors: [],
+    legacyNotificationRules: null,
   };
 }
 
-function readPersistedState(): PersistedCodeDeliveryState {
+function readPersistedState(): HydratedCodeDeliveryState {
   if (typeof window === "undefined") return emptyPersistedState();
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
@@ -239,11 +243,13 @@ function persist(state: CodeDeliveryStore): string | null {
     excludedRegisteredRepoIds: state.excludedRegisteredRepoIds,
     pinnedRepositoryKeys: state.pinnedRepositoryKeys,
     savedViews: state.savedViews,
-    notificationRules: state.notificationRules,
     notifications: state.notifications,
     seenFingerprints: state.seenFingerprints,
     lastPollAt: state.lastPollAt,
     knownAuthors: state.knownAuthors,
+    ...(state.legacyNotificationRules
+      ? { notificationRules: state.legacyNotificationRules }
+      : { notificationRulesMigrated: true }),
   };
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
@@ -384,12 +390,9 @@ export const useCodeDeliveryStore = create<CodeDeliveryStore>()((set, get) => {
       set({ savedViews: get().savedViews.filter((view) => view.id !== id) });
       persistCurrent();
     },
-    updateNotificationRule: (id, patch) => {
-      set({
-        notificationRules: get().notificationRules.map((rule) =>
-          rule.id === id ? { ...rule, ...patch, id } : rule,
-        ),
-      });
+    completeNotificationRuleMigration: (rules) => {
+      if (get().legacyNotificationRules !== rules) return;
+      set({ legacyNotificationRules: null });
       persistCurrent();
     },
     ingestDeliveryPoll: (
@@ -540,10 +543,7 @@ export function rememberedPullRequestPage(
 }
 
 function buildDeliveryPoll(
-  state: Pick<
-    CodeDeliveryStore,
-    "notificationRules" | "notifications" | "seenFingerprints"
-  >,
+  state: Pick<CodeDeliveryStore, "notifications" | "seenFingerprints">,
   pullRequests: readonly CodeDeliveryPullRequestSummary[],
   runs: readonly CodeDeliveryRunSummary[],
   receivedAt: string,
@@ -557,7 +557,6 @@ function buildDeliveryPoll(
   const cutoff = now - MAX_NOTIFICATION_AGE_MS;
   const seen = { ...state.seenFingerprints };
   const incoming: CodeDeliveryNotification[] = [];
-  const rules = new Map(state.notificationRules.map((rule) => [rule.id, rule]));
 
   for (const pullRequest of pullRequests) {
     if (Date.parse(pullRequest.updated_at) < cutoff) continue;
@@ -571,7 +570,6 @@ function buildDeliveryPoll(
       maybeAddNotification(
         incoming,
         seen,
-        rules.get("pull_request_attention"),
         pullRequest,
         fingerprint,
         receivedAt,
@@ -591,7 +589,6 @@ function buildDeliveryPoll(
       maybeAddNotification(
         incoming,
         seen,
-        rules.get("pull_request_ready"),
         pullRequest,
         fingerprint,
         receivedAt,
@@ -618,14 +615,7 @@ function buildDeliveryPoll(
       run.status,
       run.conclusion ?? "",
     ].join(":");
-    maybeAddRunNotification(
-      incoming,
-      seen,
-      rules.get("run_failure"),
-      run,
-      fingerprint,
-      receivedAt,
-    );
+    maybeAddRunNotification(incoming, seen, run, fingerprint, receivedAt);
   }
 
   const notifications = [...incoming, ...state.notifications]
@@ -682,7 +672,6 @@ function deliveryErrorMessage(error: unknown): string {
 function maybeAddNotification(
   incoming: CodeDeliveryNotification[],
   seen: Record<string, string>,
-  rule: CodeDeliveryNotificationRule | undefined,
   pullRequest: CodeDeliveryPullRequestSummary,
   fingerprint: string,
   receivedAt: string,
@@ -692,15 +681,6 @@ function maybeAddNotification(
     detail: string;
   },
 ): void {
-  if (
-    !ruleApplies(
-      rule,
-      pullRequest.repository,
-      pullRequest.workspace_links.length > 0,
-    )
-  ) {
-    return;
-  }
   if (seen[fingerprint]) return;
   seen[fingerprint] = receivedAt;
   incoming.push({
@@ -727,13 +707,10 @@ function maybeAddNotification(
 function maybeAddRunNotification(
   incoming: CodeDeliveryNotification[],
   seen: Record<string, string>,
-  rule: CodeDeliveryNotificationRule | undefined,
   run: CodeDeliveryRunSummary,
   fingerprint: string,
   receivedAt: string,
 ): void {
-  if (!ruleApplies(rule, run.repository, run.workspace_links.length > 0))
-    return;
   if (seen[fingerprint]) return;
   seen[fingerprint] = receivedAt;
   incoming.push({
@@ -756,19 +733,6 @@ function maybeAddRunNotification(
       id: run.github_id,
     },
   });
-}
-
-function ruleApplies(
-  rule: CodeDeliveryNotificationRule | undefined,
-  repository: CodeGitHubRepositoryRef,
-  tidebreakLinked: boolean,
-): boolean {
-  if (!rule?.enabled) return false;
-  if (rule.tidebreakLinkedOnly && !tidebreakLinked) return false;
-  return (
-    rule.repositoryKeys.length === 0 ||
-    rule.repositoryKeys.includes(codeDeliveryRepositoryKey(repository))
-  );
 }
 
 export function codeDeliveryRepositoryKey(
@@ -917,41 +881,49 @@ function parseKnownAuthors(value: unknown): CodeDeliveryAuthor[] {
   return authors.slice(0, MAX_KNOWN_AUTHORS);
 }
 
-function parsePersistedState(
-  value: unknown,
-): PersistedCodeDeliveryState | null {
+function parsePersistedState(value: unknown): HydratedCodeDeliveryState | null {
   if (!isRecord(value) || value.version !== STORAGE_VERSION) return null;
   const manualRepositories = parseRepositoryRefs(value.manualRepositories);
   const savedViews = parseSavedViews(value.savedViews);
-  const notificationRules = parseNotificationRules(value.notificationRules);
   const notifications = parseNotifications(value.notifications);
+  const rulesMigrated = value.notificationRulesMigrated === true;
+  const notificationRules = rulesMigrated
+    ? null
+    : parseNotificationRules(value.notificationRules);
   if (
     !manualRepositories ||
     !stringArray(value.excludedRegisteredRepoIds) ||
     !stringArray(value.pinnedRepositoryKeys) ||
     !savedViews ||
-    !notificationRules ||
+    !(
+      value.notificationRulesMigrated === undefined ||
+      value.notificationRulesMigrated === true
+    ) ||
+    (!rulesMigrated && !notificationRules) ||
     !notifications ||
     !isStringRecord(value.seenFingerprints) ||
     !(value.lastPollAt === null || typeof value.lastPollAt === "string")
   ) {
     return null;
   }
-  const byRule = new Map(notificationRules.map((rule) => [rule.id, rule]));
-  for (const fallback of DEFAULT_DELIVERY_NOTIFICATION_RULES) {
-    if (!byRule.has(fallback.id)) byRule.set(fallback.id, { ...fallback });
+  const byRule = new Map(
+    (notificationRules ?? []).map((rule) => [rule.id, rule]),
+  );
+  if (!rulesMigrated) {
+    for (const fallback of LEGACY_DEFAULT_NOTIFICATION_RULES) {
+      if (!byRule.has(fallback.id)) byRule.set(fallback.id, { ...fallback });
+    }
   }
   return {
-    version: STORAGE_VERSION,
     manualRepositories,
     excludedRegisteredRepoIds: [...value.excludedRegisteredRepoIds],
     pinnedRepositoryKeys: [...value.pinnedRepositoryKeys],
     savedViews,
-    notificationRules: [...byRule.values()],
     notifications,
     seenFingerprints: { ...value.seenFingerprints },
     lastPollAt: value.lastPollAt,
     knownAuthors: parseKnownAuthors(value.knownAuthors),
+    legacyNotificationRules: rulesMigrated ? null : [...byRule.values()],
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStoreMigration.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStoreMigration.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "tidebreak.code-delivery";
+
+function legacyState() {
+  return {
+    version: 1,
+    manualRepositories: [],
+    excludedRegisteredRepoIds: [],
+    pinnedRepositoryKeys: [],
+    savedViews: [],
+    notificationRules: [
+      {
+        id: "pull_request_attention",
+        enabled: true,
+        repositoryKeys: [],
+        tidebreakLinkedOnly: false,
+      },
+      {
+        id: "pull_request_ready",
+        enabled: false,
+        repositoryKeys: ["github.com/brightwave-inc/tidebreak"],
+        tidebreakLinkedOnly: true,
+      },
+      {
+        id: "run_failure",
+        enabled: true,
+        repositoryKeys: [],
+        tidebreakLinkedOnly: false,
+      },
+    ],
+    notifications: [
+      {
+        id: "run-failure:1",
+        fingerprint: "run-failure:1",
+        rule: "run_failure",
+        title: "CI failed",
+        detail: "failure",
+        repositoryName: "brightwave-inc/tidebreak",
+        occurredAt: "2026-08-28T12:00:00Z",
+        receivedAt: "2026-08-28T12:00:01Z",
+        url: "https://github.com/brightwave-inc/tidebreak/actions/runs/1",
+        target: {
+          kind: "run",
+          repository: {
+            host: "github.com",
+            owner: "brightwave-inc",
+            name: "tidebreak",
+          },
+          runKind: "workflow_run",
+          id: 1,
+        },
+      },
+    ],
+    seenFingerprints: { "run-failure:1": "2026-08-28T12:00:01Z" },
+    lastPollAt: "2026-08-28T12:00:01Z",
+    knownAuthors: [{ login: "mara" }],
+  };
+}
+
+async function loadStore() {
+  vi.resetModules();
+  return import("./CodeDeliveryStore");
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.resetModules();
+});
+
+describe("delivery notification rule migration storage", () => {
+  it("keeps legacy rules until completion, then records the one-way migration", async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(legacyState()));
+    const { useCodeDeliveryStore } = await loadStore();
+    const rules = useCodeDeliveryStore.getState().legacyNotificationRules;
+
+    expect(rules).toHaveLength(3);
+    useCodeDeliveryStore.getState().markAllNotificationsRead();
+    expect(
+      JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}"),
+    ).toMatchObject({
+      notificationRules: legacyState().notificationRules,
+      notifications: [{ id: "run-failure:1" }],
+      seenFingerprints: {
+        "run-failure:1": "2026-08-28T12:00:01Z",
+      },
+    });
+
+    expect(rules).not.toBeNull();
+    useCodeDeliveryStore.getState().completeNotificationRuleMigration(rules!);
+    const migrated = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY) ?? "{}",
+    );
+    expect(migrated.notificationRulesMigrated).toBe(true);
+    expect(migrated).not.toHaveProperty("notificationRules");
+    expect(migrated.notifications[0].id).toBe("run-failure:1");
+    expect(migrated.seenFingerprints).toEqual({
+      "run-failure:1": "2026-08-28T12:00:01Z",
+    });
+
+    const reloaded = await loadStore();
+    expect(
+      reloaded.useCodeDeliveryStore.getState().legacyNotificationRules,
+    ).toBeNull();
+  });
+
+  it("does not invent legacy rules when no saved state exists", async () => {
+    const { useCodeDeliveryStore } = await loadStore();
+
+    expect(useCodeDeliveryStore.getState().legacyNotificationRules).toBeNull();
+    useCodeDeliveryStore.getState().finishPoll("2026-08-29T12:00:00Z");
+    const persisted = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY) ?? "{}",
+    );
+    expect(persisted.notificationRulesMigrated).toBe(true);
+    expect(persisted).not.toHaveProperty("notificationRules");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/RepositoryTriggerRules.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositoryTriggerRules.tsx
@@ -146,9 +146,6 @@ export function RepositoryTriggerRules({
           <p className="truncate text-xs font-medium text-muted-foreground">
             {repository.name_with_owner}
           </p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Legacy notification rules remain active separately.
-          </p>
         </div>
         {loading && <LoaderCircle className="size-4 animate-spin" />}
       </div>

--- a/crates/tidebreak-desktop/ui/src/stories/RepositoryTriggerRules.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/RepositoryTriggerRules.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { ApiClient } from "@/api/client";
+import type {
+  CodeGitHubRepositoryRef,
+  CodeTriggerAction,
+  CodeTriggerCondition,
+  CodeTriggerSnapshot,
+} from "@/api/types";
+import { RepositoryTriggerRules } from "@/code/RepositoryTriggerRules";
+
+const repository: CodeGitHubRepositoryRef = {
+  host: "github.com",
+  owner: "brightwave-inc",
+  name: "tidebreak",
+  name_with_owner: "brightwave-inc/tidebreak",
+  url: "https://github.com/brightwave-inc/tidebreak",
+  tidebreak_repo_id: "repo-storybook",
+};
+
+function trigger(
+  condition: CodeTriggerCondition,
+  action: CodeTriggerAction,
+  enabled = true,
+): CodeTriggerSnapshot {
+  return {
+    id: `trigger-${condition}`,
+    repo_id: "repo-storybook",
+    condition,
+    action,
+    enabled,
+    created_at: "2026-08-29T12:00:00Z",
+    updated_at: "2026-08-29T12:00:00Z",
+  };
+}
+
+type TriggerClient = Pick<
+  ApiClient,
+  | "listCodeTriggers"
+  | "createCodeTrigger"
+  | "setCodeTriggerEnabled"
+  | "deleteCodeTrigger"
+>;
+
+function client(
+  triggers: CodeTriggerSnapshot[],
+  options: { fail?: boolean; loading?: boolean } = {},
+): TriggerClient {
+  return {
+    listCodeTriggers: async () => {
+      if (options.loading) await new Promise(() => undefined);
+      if (options.fail)
+        throw new Error("Could not reach the Tidebreak server.");
+      return triggers;
+    },
+    createCodeTrigger: async (_repoId, condition, action) =>
+      trigger(condition, action),
+    setCodeTriggerEnabled: async (_repoId, id, enabled) => ({
+      ...(triggers.find((item) => item.id === id) ??
+        trigger("checks_failed", "deliver")),
+      enabled,
+    }),
+    deleteCodeTrigger: async () => undefined,
+  };
+}
+
+const armed = [
+  trigger("checks_failed", "deliver"),
+  trigger("conflicts", "deliver"),
+  trigger("ready_to_merge", "notify"),
+];
+
+const meta = {
+  title: "Code/Repository triggers",
+  component: RepositoryTriggerRules,
+  args: {
+    client: client(armed),
+    repository,
+    target: {
+      sessionTitle: "Fix the auth flow",
+      harnessLabel: "Codex CLI",
+      delivery: "steer",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-3xl px-5 py-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RepositoryTriggerRules>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The server owns the rules; the repository header names no legacy engine. */
+export const Armed: Story = {};
+
+/** A registered repository with no triggers yet. */
+export const NothingArmed: Story = {
+  args: { client: client([]) },
+};
+
+/** The server read is still in flight. */
+export const Loading: Story = {
+  args: { client: client([], { loading: true }) },
+};
+
+/** A failed read keeps its retry action visible. */
+export const LoadFailed: Story = {
+  args: { client: client([], { fail: true }) },
+};
+
+/** The tracked-repositories dialog can narrow without clipping controls. */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-80 px-3 py-4">
+        <Story />
+      </div>
+    ),
+  ],
+};


### PR DESCRIPTION
## Summary

- Migrate persisted client notification rules into server trigger rows once after repository discovery.
- Keep legacy rules recoverable until every missing trigger is armed, and skip existing disabled rows during a retry.
- Keep the one-way migration pending while repository discovery reports partial failures.
- Retire client-side rule evaluation while preserving notifications, seen fingerprints, and saved views.
- Remove the legacy-rule message and add Storybook coverage for the repository trigger states.

## Validation

- `pnpm test` (256 files and 2,265 tests passed before the review follow-up)
- `pnpm exec vitest run src/code/CodeDeliveryMonitor.test.ts src/code/CodeDeliveryStoreMigration.test.ts` (11 tests passed after the review follow-up)
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check` on the changed UI files
- `pnpm storybook:build`
- Storybook screenshot capture remains unavailable because no browser connection is available.

Closes #2504