### PR TITLE
feat(code): show provenance on sessions an external channel created

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/binding.rs
+++ b/crates/tidebreak-core/src/db/ops/code/binding.rs
@@ -49,6 +49,32 @@ pub async fn get_external_binding(
         .transpose()
 }
 
+/// Every binding whose session is in `session_ids`, for the owner.
+///
+/// The desktop snapshot join: one query answers provenance for a whole
+/// workspace's session list instead of one lookup per session.
+pub async fn list_external_bindings_for_sessions(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_ids: &[CodeSessionId],
+) -> Result<Vec<CodeExternalBinding>> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    entities::code_external_binding::Entity::find()
+        .filter(entities::code_external_binding::Column::Owner.eq(owner.as_str()))
+        .filter(
+            entities::code_external_binding::Column::SessionId
+                .is_in(session_ids.iter().map(|id| id.0)),
+        )
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(binding_from_model)
+        .collect()
+}
+
 /// Whether `session_id` is bound under `grant_id`.
 ///
 /// The scope check every grant-authenticated session call runs: a grant may

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4718,6 +4718,18 @@ async fn a_binding_resolves_ends_and_scopes_by_grant() {
             .await
             .unwrap()
     );
+    // The desktop's provenance join answers for exactly the bound session
+    // and stays silent for a desktop-created one.
+    let joined = crate::db::code::list_external_bindings_for_sessions(
+        &store,
+        &owner,
+        &[session.id, crate::code::CodeSessionId::new()],
+    )
+    .await
+    .unwrap();
+    assert_eq!(joined.len(), 1);
+    assert_eq!(joined[0].id, binding.id);
+    assert_eq!(joined[0].external_key, "T1/C9/9.1");
     assert!(!crate::db::code::session_bound_to_grant(
         &store,
         &owner,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -149,6 +149,7 @@ import {
 import { submitAcceptedTurn } from "./CodeSessionSend";
 import { CodeSidebar } from "./CodeSidebar";
 import { CodeTranscript } from "./CodeTranscript";
+import { SessionOriginBanner } from "./SessionOriginBanner";
 import {
   applyTurnRewrite,
   mainAgentTranscriptItems,
@@ -2542,6 +2543,9 @@ function CodeSessionPane({
           status={selectedSubagent?.status ?? "unavailable"}
           onBack={onBackFromSubagent}
         />
+      )}
+      {!subagentCallId && session.external_origin && (
+        <SessionOriginBanner origin={session.external_origin} />
       )}
       <div className={cn("message-view", follow.fadeClass)}>
         {connectionState === "reconnecting" && (

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { externalThreadUrl } from "./SessionOriginBanner";
+
+describe("externalThreadUrl", () => {
+  it("derives the Slack permalink from a thread key", () => {
+    expect(
+      externalThreadUrl({
+        channel_kind: "slack",
+        external_key: "T0400000:C0812345:1724900000.123456",
+      }),
+    ).toBe("https://slack.com/archives/C0812345/p1724900000123456");
+  });
+
+  it("yields no link for a DM generation key", () => {
+    // A DM key carries a generation, not a thread timestamp; guessing a
+    // permalink from it would open the wrong place.
+    expect(
+      externalThreadUrl({
+        channel_kind: "slack",
+        external_key: "T0400000:D0898765:dm:2",
+      }),
+    ).toBeNull();
+  });
+
+  it("yields no link for another channel family", () => {
+    expect(
+      externalThreadUrl({
+        channel_kind: "matrix",
+        external_key: "!room:example.org",
+      }),
+    ).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.test.ts
@@ -7,9 +7,15 @@ describe("externalThreadUrl", () => {
     expect(
       externalThreadUrl({
         channel_kind: "slack",
-        external_key: "T0400000:C0812345:1724900000.123456",
+        external_key: "T0400000/C0812345/1724900000.123456",
       }),
     ).toBe("https://slack.com/archives/C0812345/p1724900000123456");
+    expect(
+      externalThreadUrl({
+        channel_kind: "slack",
+        external_key: "T1/C1/171.5",
+      }),
+    ).toBe("https://slack.com/archives/C1/p1715");
   });
 
   it("yields no link for a DM generation key", () => {
@@ -18,7 +24,7 @@ describe("externalThreadUrl", () => {
     expect(
       externalThreadUrl({
         channel_kind: "slack",
-        external_key: "T0400000:D0898765:dm:2",
+        external_key: "T0400000/D0898765/dm/2",
       }),
     ).toBeNull();
   });

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
@@ -1,0 +1,68 @@
+/**
+ * The provenance banner for a session an external channel created
+ * (docs/slack-sessions.md, desktop pickup).
+ *
+ * The journal such a session shows is coarse on purpose — turns, per-turn
+ * assistant records, artifacts, never tool activity. Without the banner a
+ * thin journal reads as corruption; with it, as provenance. One line, one
+ * link back to the thread, no further channel UI.
+ */
+
+import { MessageCircle } from "lucide-react";
+
+import { openExternal } from "@/host";
+import type { CodeSessionExternalOrigin } from "../generated/wire";
+
+function channelLabel(kind: string): string {
+  return kind === "slack" ? "Slack" : kind;
+}
+
+/**
+ * The thread permalink for a Slack origin, when the key carries one.
+ *
+ * The adapter's durable key is `workspace:channel:thread_ts`. A key in any
+ * other shape — a DM generation key, another channel family — yields no
+ * link, and the banner renders without one rather than guessing.
+ */
+export function externalThreadUrl(
+  origin: CodeSessionExternalOrigin,
+): string | null {
+  if (origin.channel_kind !== "slack") return null;
+  const parts = origin.external_key.split(":");
+  if (parts.length !== 3) return null;
+  const [, channel, ts] = parts;
+  if (!/^[A-Z0-9]+$/i.test(channel) || !/^\d+\.\d+$/.test(ts)) return null;
+  return `https://slack.com/archives/${channel}/p${ts.replace(".", "")}`;
+}
+
+export function SessionOriginBanner({
+  origin,
+}: {
+  origin: CodeSessionExternalOrigin;
+}) {
+  const url = externalThreadUrl(origin);
+  return (
+    <div
+      className="border-border-subtle bg-background/85 mx-auto mt-3 flex w-[calc(100%-2rem)] max-w-3xl items-center gap-2 rounded-lg border px-3 py-2"
+      data-testid="session-origin-banner"
+    >
+      <MessageCircle
+        className="text-muted-foreground size-3.5 shrink-0"
+        aria-hidden
+      />
+      <p className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
+        Started from {channelLabel(origin.channel_kind)}; engine activity stays
+        in the sandbox.
+      </p>
+      {url && (
+        <button
+          type="button"
+          className="text-foreground shrink-0 cursor-pointer text-xs underline underline-offset-2 hover:no-underline"
+          onClick={() => void openExternal(url).catch(() => undefined)}
+        >
+          Open the thread
+        </button>
+      )}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
@@ -20,7 +20,7 @@ function channelLabel(kind: string): string {
 /**
  * The thread permalink for a Slack origin, when the key carries one.
  *
- * The adapter's durable key is `workspace:channel:thread_ts`. A key in any
+ * The adapter's durable key is `workspace/channel/thread_ts`. A key in any
  * other shape — a DM generation key, another channel family — yields no
  * link, and the banner renders without one rather than guessing.
  */
@@ -28,7 +28,7 @@ export function externalThreadUrl(
   origin: CodeSessionExternalOrigin,
 ): string | null {
   if (origin.channel_kind !== "slack") return null;
-  const parts = origin.external_key.split(":");
+  const parts = origin.external_key.split("/");
   if (parts.length !== 3) return null;
   const [, channel, ts] = parts;
   if (!/^[A-Z0-9]+$/i.test(channel) || !/^\d+\.\d+$/.test(ts)) return null;

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -387,12 +387,12 @@ describe("parseCodeSession external origin", () => {
       ...SESSION,
       external_origin: {
         channel_kind: "slack",
-        external_key: "T04:C08:1724900000.123456",
+        external_key: "T04/C08/1724900000.123456",
       },
     });
     expect(parsed?.external_origin).toEqual({
       channel_kind: "slack",
-      external_key: "T04:C08:1724900000.123456",
+      external_key: "T04/C08/1724900000.123456",
     });
   });
 
@@ -408,7 +408,7 @@ describe("parseCodeSession external origin", () => {
         ...SESSION,
         external_origin: {
           channel_kind: "slack",
-          external_key: "T04:C08:1.2",
+          external_key: "T04/C08/1.2",
           extra: true,
         },
       }),

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -381,6 +381,41 @@ describe("parseCodeSession attention states", () => {
   });
 });
 
+describe("parseCodeSession external origin", () => {
+  it("carries a well-formed origin through", () => {
+    const parsed = parseCodeSession({
+      ...SESSION,
+      external_origin: {
+        channel_kind: "slack",
+        external_key: "T04:C08:1724900000.123456",
+      },
+    });
+    expect(parsed?.external_origin).toEqual({
+      channel_kind: "slack",
+      external_key: "T04:C08:1724900000.123456",
+    });
+  });
+
+  it("rejects an origin with unknown keys or empty parts", () => {
+    expect(
+      parseCodeSession({
+        ...SESSION,
+        external_origin: { channel_kind: "slack", external_key: "" },
+      }),
+    ).toBeNull();
+    expect(
+      parseCodeSession({
+        ...SESSION,
+        external_origin: {
+          channel_kind: "slack",
+          external_key: "T04:C08:1.2",
+          extra: true,
+        },
+      }),
+    ).toBeNull();
+  });
+});
+
 describe("parseCodeSessionList", () => {
   it("accepts GET /code/workspaces/{id}/sessions", () => {
     const ended = {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -111,6 +111,7 @@ import type {
   CodeEvent as WireCodeEvent,
   CodeRepoSnapshot as WireCodeRepoSnapshot,
   CodeSessionSnapshot as WireCodeSessionSnapshot,
+  CodeSessionExternalOrigin,
   CodeTurnSnapshot as WireCodeTurnSnapshot,
   QueuedCodeTurn as WireQueuedCodeTurn,
   CodeTerminalRead as WireCodeTerminalRead,
@@ -2567,6 +2568,7 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
       "attention",
       "unrecognized_event_count",
       "created_at",
+      "external_origin",
     ]) ||
     !nonEmpty(value.id) ||
     !nonEmpty(value.workspace_id) ||
@@ -2594,6 +2596,29 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
       ? undefined
       : parseFenceReason(value.fence_reason);
   if (value.fence_reason !== undefined && !fence_reason) return null;
+  if (
+    value.external_origin !== undefined &&
+    (!isRecord(value.external_origin) ||
+      !onlyKeys<CodeSessionExternalOrigin>(value.external_origin, [
+        "channel_kind",
+        "external_key",
+      ]) ||
+      !nonEmpty(value.external_origin.channel_kind) ||
+      !nonEmpty(value.external_origin.external_key))
+  ) {
+    return null;
+  }
+  const external_origin: CodeSessionExternalOrigin | undefined =
+    value.external_origin === undefined
+      ? undefined
+      : {
+          channel_kind: String(
+            (value.external_origin as Record<string, unknown>).channel_kind,
+          ),
+          external_key: String(
+            (value.external_origin as Record<string, unknown>).external_key,
+          ),
+        };
   return {
     id: value.id,
     workspace_id: value.workspace_id,
@@ -2616,6 +2641,7 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
       ? { reasoning_effort: value.reasoning_effort as ReasoningEffort }
       : {}),
     ...(fence_reason ? { fence_reason } : {}),
+    ...(external_origin !== undefined ? { external_origin } : {}),
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1599,6 +1599,22 @@ subagents?: Array<CodeSubagentSummary>,
 recap?: string, };
 
 /**
+ * Where an externally created session came from. The desktop renders it
+ * as the provenance banner; a session the desktop created carries none.
+ */
+export type CodeSessionExternalOrigin = { 
+/**
+ * The channel family, for example `slack`.
+ */
+channel_kind: string, 
+/**
+ * The channel's durable conversation identity, opaque to the server.
+ * For Slack this is `workspace:channel:thread_ts`, which the desktop
+ * turns into a thread permalink.
+ */
+external_key: string, };
+
+/**
  * Identifies one durable conversation with an external agent engine.
  */
 export type CodeSessionId = string;
@@ -1624,7 +1640,11 @@ reasoning_effort?: ReasoningEffort,
 /**
  * Whether this session runs its turns in the engine's fast mode.
  */
-fast_mode: boolean, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, };
+fast_mode: boolean, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, 
+/**
+ * Present when an external channel created the session.
+ */
+external_origin?: CodeSessionExternalOrigin, };
 
 /**
  * The next reclaim tier a workspace can take.

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1609,7 +1609,7 @@ export type CodeSessionExternalOrigin = {
 channel_kind: string, 
 /**
  * The channel's durable conversation identity, opaque to the server.
- * For Slack this is `workspace:channel:thread_ts`, which the desktop
+ * For Slack this is `workspace/channel/thread_ts`, which the desktop
  * turns into a thread permalink.
  */
 external_key: string, };

--- a/crates/tidebreak-desktop/ui/src/stories/SessionOriginBanner.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SessionOriginBanner.stories.tsx
@@ -28,7 +28,7 @@ export const SlackThread: Story = {
   args: {
     origin: {
       channel_kind: "slack",
-      external_key: "T0400000:C0812345:1724900000.123456",
+      external_key: "T0400000/C0812345/1724900000.123456",
     },
   },
 };
@@ -38,7 +38,7 @@ export const SlackDirectMessage: Story = {
   args: {
     origin: {
       channel_kind: "slack",
-      external_key: "T0400000:D0898765:dm:2",
+      external_key: "T0400000/D0898765/dm/2",
     },
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/SessionOriginBanner.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SessionOriginBanner.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SessionOriginBanner } from "@/code/SessionOriginBanner";
+
+/**
+ * The provenance banner for a session an external channel created. Its
+ * journal is coarse on purpose — the banner says why, and links back to the
+ * thread when the origin key carries one. A key without a derivable
+ * permalink still gets the banner, just without the link.
+ */
+const meta = {
+  title: "Code/Session origin banner",
+  component: SessionOriginBanner,
+  decorators: [
+    (Story) => (
+      <div className="bg-background w-[42rem] max-w-full pb-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SessionOriginBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A channel thread: the key yields a permalink, so the link renders. */
+export const SlackThread: Story = {
+  args: {
+    origin: {
+      channel_kind: "slack",
+      external_key: "T0400000:C0812345:1724900000.123456",
+    },
+  },
+};
+
+/** A DM generation key has no thread timestamp, so no link renders. */
+export const SlackDirectMessage: Story = {
+  args: {
+    origin: {
+      channel_kind: "slack",
+      external_key: "T0400000:D0898765:dm:2",
+    },
+  },
+};
+
+/** An unrecognized channel family falls back to its raw kind, linkless. */
+export const OtherChannel: Story = {
+  args: {
+    origin: {
+      channel_kind: "matrix",
+      external_key: "!room:example.org",
+    },
+  },
+};

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -5733,6 +5733,23 @@ impl CodeRuntime {
         Ok(list_sessions_for_workspace(&self.db, owner, workspace_id).await?)
     }
 
+    /// The external bindings behind `session_ids`, for provenance display.
+    /// Sessions the desktop created have none and are simply absent.
+    pub(crate) async fn external_bindings_for_sessions(
+        &self,
+        owner: &OwnerId,
+        session_ids: &[CodeSessionId],
+    ) -> Result<Vec<tidebreak_core::CodeExternalBinding>, ServerError> {
+        Ok(
+            tidebreak_core::db::code::list_external_bindings_for_sessions(
+                &self.db,
+                owner,
+                session_ids,
+            )
+            .await?,
+        )
+    }
+
     pub(crate) async fn list_session_turns(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -637,6 +637,15 @@ impl ScopedCode {
             .await
     }
 
+    pub(crate) async fn external_bindings_for_sessions(
+        &self,
+        session_ids: &[CodeSessionId],
+    ) -> Result<Vec<tidebreak_core::CodeExternalBinding>, ServerError> {
+        self.runtime
+            .external_bindings_for_sessions(&self.owner, session_ids)
+            .await
+    }
+
     pub(crate) async fn list_session_turns(
         &self,
         id: CodeSessionId,

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -15,7 +15,8 @@ use axum::http::{header, request::Parts, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 
 use super::types::{
-    CodeForkTranscript, CodeSessionSnapshot, CodeTurnSnapshot, CreateRemoteSessionBody,
+    CodeForkTranscript, CodeSessionExternalOrigin, CodeSessionSnapshot, CodeTurnSnapshot,
+    CreateRemoteSessionBody,
     CreateSessionBody, QueuePausedBody, QueuedCodeTurn, QueuedCodeTurnUpdate,
     QueuedCodeTurnsSnapshot, SequencedCodeEventFrame, SetAttentionBody, SetFastModeBody,
     SetPermissionModeBody, SetReasoningEffortBody, SteerBody, SubmitTurnBody,
@@ -110,10 +111,30 @@ pub async fn list_workspace_sessions(
     Path(workspace_id): Path<WorkspaceId>,
 ) -> Result<Json<Vec<CodeSessionSnapshot>>, ServerError> {
     let sessions = code.list_workspace_sessions(workspace_id).await?;
+    let ids: Vec<CodeSessionId> = sessions.iter().map(|session| session.id).collect();
+    let origins: std::collections::HashMap<CodeSessionId, CodeSessionExternalOrigin> = code
+        .external_bindings_for_sessions(&ids)
+        .await?
+        .into_iter()
+        .map(|binding| {
+            (
+                binding.session_id,
+                CodeSessionExternalOrigin {
+                    channel_kind: binding.channel_kind,
+                    external_key: binding.external_key,
+                },
+            )
+        })
+        .collect();
     Ok(Json(
         sessions
             .into_iter()
-            .map(CodeSessionSnapshot::from)
+            .map(|session| {
+                let origin = origins.get(&session.id).cloned();
+                let mut snapshot = CodeSessionSnapshot::from(session);
+                snapshot.external_origin = origin;
+                snapshot
+            })
             .collect(),
     ))
 }

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -106,6 +106,30 @@ pub async fn create_remote_session(
     ))
 }
 
+/// One session as a snapshot with its external origin attached.
+///
+/// Every handler that hands the desktop a single session goes through
+/// here: the desktop writes the answer over its listed row, so a snapshot
+/// that hard-coded no origin would erase the provenance banner on the
+/// next reap, mode change, or attention edit.
+async fn snapshot_with_origin(
+    code: &ScopedCode,
+    session: tidebreak_core::CodeSession,
+) -> Result<CodeSessionSnapshot, ServerError> {
+    let origin = code
+        .external_bindings_for_sessions(&[session.id])
+        .await?
+        .into_iter()
+        .next()
+        .map(|binding| CodeSessionExternalOrigin {
+            channel_kind: binding.channel_kind,
+            external_key: binding.external_key,
+        });
+    let mut snapshot = CodeSessionSnapshot::from(session);
+    snapshot.external_origin = origin;
+    Ok(snapshot)
+}
+
 pub async fn list_workspace_sessions(
     code: ScopedCode,
     Path(workspace_id): Path<WorkspaceId>,
@@ -354,7 +378,7 @@ pub async fn set_attention(
     Json(body): Json<SetAttentionBody>,
 ) -> Result<Json<CodeSessionSnapshot>, ServerError> {
     let session = code.set_attention(id, body.clear, body.note).await?;
-    Ok(Json(CodeSessionSnapshot::from(session)))
+    Ok(Json(snapshot_with_origin(&code, session).await?))
 }
 
 pub async fn reap_session(
@@ -362,7 +386,10 @@ pub async fn reap_session(
     Path(id): Path<CodeSessionId>,
 ) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
     let session = code.reap(id).await?;
-    Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
+    Ok((
+        StatusCode::OK,
+        Json(snapshot_with_origin(&code, session).await?),
+    ))
 }
 
 /// `POST /code/sessions/{id}/mode` — change a session's permission mode.
@@ -379,7 +406,10 @@ pub async fn set_session_permission_mode(
 ) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
     refuse_permission_mode_over_ceiling(&state, Some(body.permission_mode)).await?;
     let session = code.set_permission_mode(id, body.permission_mode).await?;
-    Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
+    Ok((
+        StatusCode::OK,
+        Json(snapshot_with_origin(&code, session).await?),
+    ))
 }
 
 /// `POST /code/sessions/{id}/effort` — change a session's reasoning effort.
@@ -393,7 +423,10 @@ pub async fn set_session_reasoning_effort(
     Json(body): Json<SetReasoningEffortBody>,
 ) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
     let session = code.set_reasoning_effort(id, body.reasoning_effort).await?;
-    Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
+    Ok((
+        StatusCode::OK,
+        Json(snapshot_with_origin(&code, session).await?),
+    ))
 }
 
 /// `POST /code/sessions/{id}/fast-mode` — arm or disarm the engine's fast mode.
@@ -408,7 +441,10 @@ pub async fn set_session_fast_mode(
     Json(body): Json<SetFastModeBody>,
 ) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
     let session = code.set_fast_mode(id, body.fast_mode).await?;
-    Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
+    Ok((
+        StatusCode::OK,
+        Json(snapshot_with_origin(&code, session).await?),
+    ))
 }
 
 /// `POST /code/sessions/{id}/attachments/images` — publish pixels a later

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -16,10 +16,9 @@ use axum::response::{IntoResponse, Response};
 
 use super::types::{
     CodeForkTranscript, CodeSessionExternalOrigin, CodeSessionSnapshot, CodeTurnSnapshot,
-    CreateRemoteSessionBody,
-    CreateSessionBody, QueuePausedBody, QueuedCodeTurn, QueuedCodeTurnUpdate,
-    QueuedCodeTurnsSnapshot, SequencedCodeEventFrame, SetAttentionBody, SetFastModeBody,
-    SetPermissionModeBody, SetReasoningEffortBody, SteerBody, SubmitTurnBody,
+    CreateRemoteSessionBody, CreateSessionBody, QueuePausedBody, QueuedCodeTurn,
+    QueuedCodeTurnUpdate, QueuedCodeTurnsSnapshot, SequencedCodeEventFrame, SetAttentionBody,
+    SetFastModeBody, SetPermissionModeBody, SetReasoningEffortBody, SteerBody, SubmitTurnBody,
 };
 use crate::code::runtime::{NewSessionSettings, SubmitTurnOutcome};
 use tidebreak_core::{CodeSessionId, PermissionMode, TurnSteer, WorkspaceId};

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -234,6 +234,18 @@ pub enum CodeStorageAction {
     Release,
 }
 
+/// Where an externally created session came from. The desktop renders it
+/// as the provenance banner; a session the desktop created carries none.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeSessionExternalOrigin {
+    /// The channel family, for example `slack`.
+    pub channel_kind: String,
+    /// The channel's durable conversation identity, opaque to the server.
+    /// For Slack this is `workspace:channel:thread_ts`, which the desktop
+    /// turns into a thread permalink.
+    pub external_key: String,
+}
+
 /// One durable conversation with an external agent engine.
 #[derive(Debug, Clone, PartialEq, Serialize, TS)]
 pub struct CodeSessionSnapshot {
@@ -265,6 +277,10 @@ pub struct CodeSessionSnapshot {
     pub attention: Attention,
     pub unrecognized_event_count: i64,
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Present when an external channel created the session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub external_origin: Option<CodeSessionExternalOrigin>,
 }
 
 impl From<CodeSession> for CodeSessionSnapshot {
@@ -285,6 +301,9 @@ impl From<CodeSession> for CodeSessionSnapshot {
             attention: session.attention,
             unrecognized_event_count: session.unrecognized_event_count,
             created_at: session.created_at,
+            // Provenance is a separate lookup; the handlers that serve the
+            // desktop attach it.
+            external_origin: None,
         }
     }
 }

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -241,7 +241,7 @@ pub struct CodeSessionExternalOrigin {
     /// The channel family, for example `slack`.
     pub channel_kind: String,
     /// The channel's durable conversation identity, opaque to the server.
-    /// For Slack this is `workspace:channel:thread_ts`, which the desktop
+    /// For Slack this is `workspace/channel/thread_ts`, which the desktop
     /// turns into a thread permalink.
     pub external_key: String,
 }


### PR DESCRIPTION
The session list join attaches the external binding's channel kind and
key to each snapshot, and the workspace page renders the provenance
banner — "Started from Slack; engine activity stays in the sandbox" —
with a link back to the thread when the origin key carries one. A DM
generation key or another channel family gets the banner without a
link rather than a guessed permalink.

Stage 4 (desktop pickup) of docs/slack-sessions.md, first half: the provenance banner and the thread link. The adapter-side turn attribution is model-gateway#1675.