### PR TITLE
fix(code): repair agent controls and recovery

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -86,7 +86,7 @@ export type CodeConversationTab = {
   /** Absent on a draft, which has no engine until the reader picks one. */
   harness?: HarnessKind;
   attention?: Attention;
-  /** Only a draft closes here: ending a live agent is a server action. */
+  /** Closing removes the tab without ending the agent or its workspace. */
   closable?: boolean;
 };
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -411,6 +411,51 @@ describe("CodeComposer", () => {
     expect(box).toHaveValue("");
   });
 
+  it("accepts guidance once a pending submit becomes an active turn", async () => {
+    let resolveSend!: () => void;
+    const onSend = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = resolve;
+        }),
+    );
+    const onInterrupt = vi.fn();
+    const view = renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        onSend={onSend}
+        onInterrupt={onInterrupt}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "start the work" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("start the work"));
+
+    view.rerender(
+      <AppContextProvider value={app()}>
+        <CodeComposer
+          running
+          permissionMode="ask"
+          onSend={onSend}
+          onInterrupt={onInterrupt}
+        />
+      </AppContextProvider>,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeEnabled();
+    fireEvent.change(screen.getByRole("textbox", { name: "Message" }), {
+      target: { value: "use the smaller change" },
+    });
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "use the smaller change",
+    );
+
+    resolveSend();
+  });
+
   it("steers mid-turn when the harness supports it", async () => {
     useUiStore.setState({ activeTurnSendMode: "steer" });
     const onSteer = vi.fn().mockResolvedValue(undefined);

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1107,7 +1107,7 @@ export function CodeComposer({
         busy={running}
         cancelError={null}
         cancelPending={false}
-        disabled={Boolean(disabled || submitPending)}
+        disabled={Boolean(disabled || (submitPending && !running))}
         draft={draft}
         history={history}
         harnessMenu={harnessMenu}

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -2445,6 +2445,33 @@ describe("CodeWorkspacePage", () => {
     );
   });
 
+  it("closes a started non-Main agent tab without ending the session", async () => {
+    const client = makeClient();
+    const second: CodeSessionSnapshot = {
+      ...SESSION,
+      id: "sess-2",
+      harness_kind: "codex",
+      created_at: "2026-08-15T01:00:00.000Z",
+    };
+    client.listCodeWorkspaceSessions.mockResolvedValue([second, SESSION]);
+    const user = userEvent.setup();
+    const { router } = await mountWorkspace(client, "/code/w/ws-1?task=sess-2");
+
+    expect(
+      await screen.findByRole("tab", { name: "Codex CLI" }),
+    ).toHaveAttribute("aria-selected", "true");
+    await user.click(screen.getByRole("button", { name: "Close Codex CLI" }));
+
+    expect(screen.queryByRole("tab", { name: "Codex CLI" })).toBeNull();
+    expect(screen.getByRole("tab", { name: "Main agent" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await waitFor(() =>
+      expect(router.state.location.search).not.toHaveProperty("task"),
+    );
+  });
+
   it("opens the New tab menu from the chord instead of the file picker", async () => {
     const client = makeClient();
     await mountWorkspace(client);

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -373,6 +373,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(
     catalog.sessionsByWorkspace[workspaceId]?.id ?? null,
   );
+  const [closedConversationIds, setClosedConversationIds] = useState<
+    Set<string>
+  >(() => new Set());
 
   // Optimistic catalog mutations also govern the open page. Archive can hide
   // the rail card before filesystem cleanup finishes; reflecting that same
@@ -1096,16 +1099,21 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     }
   }
 
-  /**
-   * Close a conversation tab.
-   *
-   * Only the draft closes here. A started agent holds a worktree and a running
-   * engine, so ending one is a server action rather than a tab control.
-   */
+  /** Close a conversation tab without ending its agent or workspace. */
   function closeConversation(sessionId: string | null) {
-    if (sessionId !== null) return;
-    setDraftAgent(false);
-    setForkSource(null);
+    if (sessionId === null) {
+      setDraftAgent(false);
+      setForkSource(null);
+    } else {
+      const index = conversations.findIndex((entry) => entry.id === sessionId);
+      if (index <= 0) return;
+      setClosedConversationIds((current) => {
+        const next = new Set(current);
+        next.add(sessionId);
+        return next;
+      });
+      if (sessionId !== activeSessionId) return;
+    }
     const first = conversations[0];
     if (first) selectConversation(first.id);
     else setActiveSessionId(null);
@@ -1152,15 +1160,23 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       conversations[0]?.id ??
       null);
   const conversationTabs = useMemo<CodeConversationTab[]>(() => {
-    const tabs: CodeConversationTab[] = conversations.map((entry, index) => {
-      const digest = conversationDigests[entry.id];
-      return {
-        id: entry.id,
-        label: conversationTabLabel(entry, index, conversations),
-        harness: entry.harness_kind,
-        attention: attentionMarkForDigest(digest),
-      };
-    });
+    const tabs: CodeConversationTab[] = conversations
+      .filter(
+        (entry, index) => index === 0 || !closedConversationIds.has(entry.id),
+      )
+      .map((entry) => {
+        const index = conversations.findIndex(
+          (conversation) => conversation.id === entry.id,
+        );
+        const digest = conversationDigests[entry.id];
+        return {
+          id: entry.id,
+          label: conversationTabLabel(entry, index, conversations),
+          harness: entry.harness_kind,
+          attention: attentionMarkForDigest(digest),
+          closable: index > 0,
+        };
+      });
     // A draft has no engine yet, so it wears the generic agent glyph. It is
     // also the one closable tab: nothing is running behind it. A workspace
     // with no agents at all still gets one, so the strip always names the
@@ -1173,7 +1189,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       });
     }
     return tabs;
-  }, [conversationDigests, conversations, draftAgent]);
+  }, [closedConversationIds, conversationDigests, conversations, draftAgent]);
 
   /** The picker shows for a first agent and for every one added after it. */
   const startingNewAgent = draftAgent || !session;

--- a/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
@@ -160,12 +160,14 @@ export const ManyConversations: Story = {
         label: "Codex",
         harness: "codex",
         attention: attentionWorking,
+        closable: true,
       },
       {
         id: "session-3",
         label: "opencode",
         harness: "opencode",
         attention: attentionDoneUnreviewed,
+        closable: true,
       },
     ],
   },
@@ -179,7 +181,7 @@ export const ForkFromTabMenu: Story = {
   args: { conversations: MAIN_AGENT },
 };
 
-/** A new agent the reader has opened but not started: the one closable tab. */
+/** A new agent the reader has opened but not started. */
 export const DraftConversation: Story = {
   args: {
     conversations: [

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -25,6 +25,7 @@ use crate::{
 use tidebreak_core::{PermissionMode, ReasoningEffort, MAX_NOTICE_CHARS};
 
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
+const THREAD_LOAD_TIMEOUT: Duration = Duration::from_secs(120);
 #[cfg(not(test))]
 const PROCESS_INTERRUPT_GRACE: Duration = Duration::from_secs(2);
 #[cfg(test)]
@@ -934,7 +935,7 @@ impl CodexSession {
                 }),
             )
             .await?;
-        self.read_until_rpc(init_id).await?;
+        self.read_until_rpc(init_id, HANDSHAKE_TIMEOUT).await?;
         self.notify("initialized", None).await?;
 
         // Resume only a thread the engine has actually written. A thread that
@@ -962,7 +963,7 @@ impl CodexSession {
         };
         let resumed = method == "thread/resume";
         let thread_req = self.request(method, params).await?;
-        self.read_until_rpc(thread_req).await?;
+        self.read_until_rpc(thread_req, THREAD_LOAD_TIMEOUT).await?;
         if let Some(detail) = self.lost_resume() {
             // The stored thread is gone on the engine side. Every turn on
             // this child would fail identically, so report the lost resume
@@ -979,8 +980,12 @@ impl CodexSession {
         Ok(())
     }
 
-    async fn read_until_rpc(&self, rpc_id: i64) -> Result<(), HarnessError> {
-        let deadline = tokio::time::Instant::now() + HANDSHAKE_TIMEOUT;
+    async fn read_until_rpc(
+        &self,
+        rpc_id: i64,
+        response_timeout: Duration,
+    ) -> Result<(), HarnessError> {
+        let deadline = tokio::time::Instant::now() + response_timeout;
         loop {
             if tokio::time::Instant::now() > deadline {
                 return Err(HarnessError::Other(format!(
@@ -1689,6 +1694,12 @@ mod tests {
             ("danger-full-access", "never")
         );
         let _ = PathBuf::from("/workspace");
+    }
+
+    #[test]
+    fn thread_loads_have_time_to_restore_large_sessions() {
+        assert!(THREAD_LOAD_TIMEOUT > HANDSHAKE_TIMEOUT);
+        assert_eq!(THREAD_LOAD_TIMEOUT, Duration::from_secs(120));
     }
 
     /// A stand-in `codex app-server --stdio` that speaks just enough of the

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1832,17 +1832,15 @@ impl CodeRuntime {
         // Blockers first: a refused archive must leave the workspace exactly as
         // it was, and running the hook script is not "exactly as it was".
         self.refuse_running_sessions(owner, id, force).await?;
-        if path.exists() {
+        if path.exists() && !force {
             if let Some(block) = archive_blockers(&path, &workspace.base_ref)
                 .await
                 .map_err(map_worktree)?
             {
-                if !force {
-                    return Err(ServerError::conflict_kind(
-                        block.as_str(),
-                        "workspace has uncommitted or unpushed work; pass force to discard it",
-                    ));
-                }
+                return Err(ServerError::conflict_kind(
+                    block.as_str(),
+                    "workspace has uncommitted or unpushed work; pass force to discard it",
+                ));
             }
         }
         {
@@ -1972,11 +1970,11 @@ impl CodeRuntime {
                     err.to_string(),
                 ));
             }
-            if let Some(block) = archive_blockers(path, &workspace.base_ref)
-                .await
-                .map_err(map_worktree)?
-            {
-                if !force {
+            if !force {
+                if let Some(block) = archive_blockers(path, &workspace.base_ref)
+                    .await
+                    .map_err(map_worktree)?
+                {
                     return Err(ServerError::conflict_kind(
                         block.as_str(),
                         "workspace changed during archive; the checkout was preserved",

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1741,6 +1741,42 @@ async fn archive_requires_force_when_the_tree_is_dirty() {
 }
 
 #[tokio::test]
+async fn force_archive_skips_ignored_content_inspection() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let path = workspace["worktree_path"].as_str().unwrap();
+
+    assert!(std::process::Command::new("git")
+        .args([
+            "config",
+            "--add",
+            "tidebreak.archiveDisposablePath",
+            "../outside-worktree",
+        ])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+
+    let forced = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/archive",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(forced.status(), reqwest::StatusCode::OK);
+    assert!(!std::path::Path::new(path).exists());
+}
+
+#[tokio::test]
 async fn no_force_archive_of_a_dirty_workspace_leaves_an_idle_session() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;


### PR DESCRIPTION
Fixes EJ’s three agent-workspace regressions.

- give Codex thread start and resume enough time to restore large sessions
- let Force Archive bypass ignored-content safety scans for workspace recovery
- let people dismiss started non-Main agent tabs without ending the agent
- keep the guidance composer enabled when a pending submission becomes an active turn

Closes #2924
Closes #2925
Closes #2926

Validation:
- `cargo fmt --all --check`
- `cargo check -p tidebreak-harness -p tidebreak-server`
- `cargo test -p tidebreak-harness thread_loads_have_time_to_restore_large_sessions`
- `cargo test -p tidebreak-server force_archive_skips_ignored_content_inspection`
- `pnpm --dir crates/tidebreak-desktop/ui test -- src/code/CodeComposer.dom.test.tsx src/code/CodeWorkspacePage.dom.test.tsx` (2,280 tests passed)
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check ...`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`

Visual verification: Storybook serves `Code/Center tabs — Many conversations`. Screenshot inspection was unavailable because this session had no browser or Playwright connection.