### PR TITLE
feat(settings): let users disable turn recaps

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -538,6 +538,7 @@ export class ApiClient {
       protect_recent_messages?: number;
     };
     computer_use_enabled?: boolean;
+    code_turn_recaps_enabled?: boolean;
     rewrite_closing_messages?: boolean;
   }): Promise<RuntimeSettings> {
     return this.json("/settings", {

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -4250,6 +4250,10 @@ model_visibility_overrides: { [key in string]: ModelVisibility },
  */
 computer_use_enabled: boolean, 
 /**
+ * Whether completed code turns receive a one-line recap. Default on.
+ */
+code_turn_recaps_enabled: boolean, 
+/**
  * Whether completed code turns rewrite their closing message into lucid
  * prose. Default off.
  */

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -41,6 +41,7 @@ describe("AgentsPanel", () => {
       },
       model_visibility_overrides: {},
       computer_use_enabled: true,
+      code_turn_recaps_enabled: true,
       rewrite_closing_messages: false,
     };
     const putSettings = vi.fn().mockResolvedValue({
@@ -77,5 +78,54 @@ describe("AgentsPanel", () => {
         sandbox_agent_error_checkin: 3,
       }),
     );
+  });
+
+  it("turns off future code turn recaps", async () => {
+    const settings: RuntimeSettings = {
+      model: null,
+      has_api_key: false,
+      chat_defaults: {
+        model: null,
+        reasoning_effort: null,
+        permission_mode: null,
+        network_policy: null,
+      },
+      max_active_background_agents: 5,
+      sandbox_agent_checkin_steps: 100,
+      sandbox_agent_error_checkin: 5,
+      compaction: {
+        threshold_fraction: 0.75,
+        target_fraction: 0.25,
+        min_threshold_tokens: 50000,
+        protect_recent_messages: 5,
+      },
+      model_visibility_overrides: {},
+      computer_use_enabled: true,
+      code_turn_recaps_enabled: true,
+      rewrite_closing_messages: false,
+    };
+    const putSettings = vi.fn().mockResolvedValue({
+      ...settings,
+      code_turn_recaps_enabled: false,
+    });
+    const client = {
+      getSettings: vi.fn().mockResolvedValue(settings),
+      putSettings,
+    } as unknown as ApiClient;
+
+    render(<AgentsPanel client={client} />);
+    const toggle = await screen.findByRole("switch", {
+      name: "Write turn recaps",
+    });
+    expect(toggle).toBeChecked();
+
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(putSettings).toHaveBeenCalledWith({
+        code_turn_recaps_enabled: false,
+      }),
+    );
+    expect(toggle).not.toBeChecked();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
@@ -5,6 +5,7 @@ import type { ApiClient } from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Switch } from "@/components/ui/switch";
 import { useUiStore, type ActiveTurnSendMode } from "../UiStore";
 import {
   SettingsError,
@@ -28,8 +29,10 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
   const [limit, setLimit] = useState("");
   const [checkinSteps, setCheckinSteps] = useState("");
   const [errorCheckin, setErrorCheckin] = useState("");
+  const [turnRecapsEnabled, setTurnRecapsEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [savingTurnRecaps, setSavingTurnRecaps] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -41,6 +44,7 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
         setLimit(String(settings.max_active_background_agents));
         setCheckinSteps(String(settings.sandbox_agent_checkin_steps));
         setErrorCheckin(String(settings.sandbox_agent_error_checkin));
+        setTurnRecapsEnabled(settings.code_turn_recaps_enabled);
       })
       .catch((err) => {
         if (!cancelled) setError(String(err));
@@ -106,10 +110,28 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
     }
   }
 
+  async function saveTurnRecaps(enabled: boolean) {
+    const previous = turnRecapsEnabled;
+    setTurnRecapsEnabled(enabled);
+    setSavingTurnRecaps(true);
+    setError(null);
+    try {
+      const settings = await client.putSettings({
+        code_turn_recaps_enabled: enabled,
+      });
+      setTurnRecapsEnabled(settings.code_turn_recaps_enabled);
+    } catch (err) {
+      setTurnRecapsEnabled(previous);
+      setError(String(err));
+    } finally {
+      setSavingTurnRecaps(false);
+    }
+  }
+
   return (
     <SettingsPanel
       title="Agents"
-      description="Choose how messages behave around active work, how much delegated work a conversation may run, and how often agents report back."
+      description="Choose how messages behave around active work, whether coding turns write recaps, and how delegated agents report back."
       busy={loading}
     >
       <SettingsSection
@@ -151,6 +173,22 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
             </span>
           </label>
         </RadioGroup>
+      </SettingsSection>
+      <SettingsSection
+        title="Turn recaps"
+        description="After a coding turn finishes, Tidebreak can add a one-line update beside the turn result."
+      >
+        <SettingsField
+          label="Write turn recaps"
+          hint="Uses the utility model after each completed coding turn. Turning this off affects future turns; existing recaps stay in the transcript."
+        >
+          <Switch
+            checked={turnRecapsEnabled}
+            disabled={loading || savingTurnRecaps}
+            onCheckedChange={(enabled) => void saveTurnRecaps(enabled)}
+            aria-label="Write turn recaps"
+          />
+        </SettingsField>
       </SettingsSection>
       <SettingsSection>
         <SettingsField

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsPanels.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsPanels.stories.tsx
@@ -7,7 +7,7 @@ import { CompactionPanel } from "@/settings/CompactionPanel";
 import { UpdatesPanel } from "@/settings/UpdatesPanel";
 import type { ThemeMode } from "@/theme";
 import type { DesktopUpdateState } from "@/updates";
-import { SettingsStoryHarness } from "./SettingsStoryHarness";
+import { SettingsStoryHarness, storySettings } from "./SettingsStoryHarness";
 
 const idleUpdate: DesktopUpdateState = {
   status: "idle",
@@ -19,6 +19,7 @@ const idleUpdate: DesktopUpdateState = {
 type SettingsShowcaseProps = {
   panel: "appearance" | "agents" | "context" | "updates";
   loadState?: "ready" | "loading" | "failed";
+  turnRecapsEnabled?: boolean;
   theme?: ThemeMode;
   updateState?: DesktopUpdateState;
   upToDate?: boolean;
@@ -27,6 +28,7 @@ type SettingsShowcaseProps = {
 function SettingsShowcase({
   panel,
   loadState = "ready",
+  turnRecapsEnabled = true,
   theme = "system",
   updateState = idleUpdate,
   upToDate = false,
@@ -38,6 +40,11 @@ function SettingsShowcase({
     return (
       <SettingsStoryHarness
         state={loadState === "ready" ? "configured" : loadState}
+        settings={
+          turnRecapsEnabled
+            ? storySettings
+            : { ...storySettings, code_turn_recaps_enabled: false }
+        }
       >
         {(client) => <AgentsPanel client={client} />}
       </SettingsStoryHarness>
@@ -81,6 +88,10 @@ export const AppearanceDark: Story = {
 
 export const Agents: Story = {
   args: { panel: "agents" },
+};
+
+export const AgentsRecapsOff: Story = {
+  args: { panel: "agents", turnRecapsEnabled: false },
 };
 
 export const AgentsLoading: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
@@ -87,6 +87,7 @@ export const storySettings: RuntimeSettings = {
   },
   model_visibility_overrides: {},
   computer_use_enabled: true,
+  code_turn_recaps_enabled: true,
   rewrite_closing_messages: false,
 };
 
@@ -422,7 +423,11 @@ function pending<T>(): Promise<T> {
   return new Promise(() => undefined);
 }
 
-function createSettingsStoryClient(state: SettingsStoryState): ApiClient {
+function createSettingsStoryClient(
+  state: SettingsStoryState,
+  initialSettings: RuntimeSettings,
+): ApiClient {
+  let settings = initialSettings;
   const read = <T,>(value: T): Promise<T> => {
     if (state === "loading") return pending();
     if (state === "failed") {
@@ -443,8 +448,17 @@ function createSettingsStoryClient(state: SettingsStoryState): ApiClient {
   const servers = state === "managed" ? [gatewayServer] : [docsServer];
 
   const methods: SettingsClientMethods = {
-    getSettings: () => read(storySettings),
-    putSettings: () => write(storySettings),
+    getSettings: () => read(settings),
+    putSettings: (body) => {
+      settings = {
+        ...settings,
+        ...body,
+        compaction: body.compaction
+          ? { ...settings.compaction, ...body.compaction }
+          : settings.compaction,
+      };
+      return write(settings);
+    },
     putProvider: (kind) =>
       write(storyProviders.find((provider) => provider.kind === kind)!),
     deleteCredential: () => write(undefined),
@@ -561,12 +575,17 @@ function SettingsStoryRouter({ children }: { children: ReactNode }) {
 
 export function SettingsStoryHarness({
   state = "configured",
+  settings = storySettings,
   children,
 }: {
   state?: SettingsStoryState;
+  settings?: RuntimeSettings;
   children: (client: ApiClient) => ReactNode;
 }) {
-  const client = useMemo(() => createSettingsStoryClient(state), [state]);
+  const client = useMemo(
+    () => createSettingsStoryClient(state, settings),
+    [settings, state],
+  );
 
   useLayoutEffect(() => {
     useVoiceInputStore.setState({

--- a/crates/tidebreak-server/src/code/recap.rs
+++ b/crates/tidebreak-server/src/code/recap.rs
@@ -60,6 +60,10 @@ use crate::resolver::ProviderResolver;
 
 use super::bus::CodeEventBus;
 
+/// Store key. Default on: completed code turns receive a one-line recap unless
+/// the reader turns the feature off in agent settings.
+pub(crate) const TURN_RECAPS_SETTING: &str = "code.turn_recaps";
+
 /// Longest recap stored, and the bound the schema states.
 ///
 /// Two plain sentences fit comfortably; a third does not. The bound is enforced
@@ -129,8 +133,9 @@ pub(crate) enum Outcome {
     Recapped(String),
     /// The model declined: the turn is not worth a line.
     Declined,
-    /// Nothing to do — the turn is missing, unfinished, already recapped, has
-    /// nothing to describe, or this machine has no utility model.
+    /// Nothing to do — recaps are off, the turn is missing, unfinished,
+    /// already recapped, has nothing to describe, or this machine has no
+    /// utility model.
     NotApplicable,
 }
 
@@ -222,6 +227,9 @@ impl TurnRecapper {
         session_id: CodeSessionId,
         turn_id: CodeTurnId,
     ) -> Result<Outcome> {
+        if !turn_recaps_enabled(&*self.store).await? {
+            return Ok(Outcome::NotApplicable);
+        }
         let Some(turn) = get_turn(&self.db, owner, turn_id).await? else {
             return Ok(Outcome::NotApplicable);
         };
@@ -427,6 +435,17 @@ impl TurnRecap for TurnRecapper {
             }
         });
     }
+}
+
+/// Whether completed code turns receive one-line recaps. Default on.
+pub(crate) async fn turn_recaps_enabled(
+    store: &dyn tidebreak_core::Store,
+) -> tidebreak_core::Result<bool> {
+    Ok(store
+        .get_setting(TURN_RECAPS_SETTING)
+        .await?
+        .and_then(|value| value.as_bool())
+        .unwrap_or(true))
 }
 
 /// A session's place in [`TurnRecapper::in_flight`], released on drop.

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -142,6 +142,9 @@ pub struct Settings {
     /// enabled. Read at boot; turning it off unregisters the tools on the next
     /// launch.
     pub computer_use_enabled: bool,
+    /// Whether completed code turns receive a one-line recap. Default on.
+    #[serde(default = "default_true")]
+    pub code_turn_recaps_enabled: bool,
     /// Whether completed code turns rewrite their closing message into lucid
     /// prose. Default off.
     #[serde(default)]
@@ -193,6 +196,9 @@ pub struct SettingsUpdate {
     /// at the next boot (the tools register or not then).
     #[serde(default)]
     pub computer_use_enabled: Option<bool>,
+    /// Set the code-turn recap switch. Absent leaves it unchanged. Default on.
+    #[serde(default)]
+    pub code_turn_recaps_enabled: Option<bool>,
     /// Set the closing-message rewrite switch. Absent leaves it unchanged.
     /// Default off.
     #[serde(default)]
@@ -342,6 +348,15 @@ pub async fn put_settings(
             )
             .await?;
     }
+    if let Some(enabled) = body.code_turn_recaps_enabled {
+        state
+            .store
+            .set_setting(
+                crate::code::recap::TURN_RECAPS_SETTING,
+                &serde_json::json!(enabled),
+            )
+            .await?;
+    }
     if let Some(enabled) = body.rewrite_closing_messages {
         state
             .store
@@ -369,9 +384,14 @@ async fn read_settings(state: &AppState, owner: &OwnerId) -> Result<Settings, Se
         compaction: read_compaction_settings(&*state.store).await?,
         model_visibility_overrides: read_model_visibility_overrides(&*state.store).await?,
         computer_use_enabled: read_computer_use_enabled(&*state.store).await?,
+        code_turn_recaps_enabled: crate::code::recap::turn_recaps_enabled(&*state.store).await?,
         rewrite_closing_messages: crate::code::rewrite::rewrite_closing_enabled(&*state.store)
             .await?,
     })
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 /// Whether computer use is enabled. Default on; an explicit `false` disables

--- a/crates/tidebreak-server/src/tests/code_recap.rs
+++ b/crates/tidebreak-server/src/tests/code_recap.rs
@@ -299,6 +299,100 @@ async fn a_completed_turn_is_recapped_onto_the_digest() {
     );
 }
 
+/// Turning recaps off prevents the utility-model call for later turns.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_disabled_recap_setting_skips_the_model_call() {
+    let (router, token, stub, runtime, dir) = code_recap_app().await;
+    runtime
+        .db
+        .set_setting(
+            crate::code::recap::TURN_RECAPS_SETTING,
+            &serde_json::json!(false),
+        )
+        .await
+        .unwrap();
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "repo_id": repo_body["id"] }))
+        .send()
+        .await
+        .unwrap();
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            workspace["id"].as_str().unwrap()
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap();
+    let session: serde_json::Value = session.json().await.unwrap();
+    let session_id = tidebreak_core::CodeSessionId(
+        uuid::Uuid::parse_str(session["id"].as_str().unwrap()).unwrap(),
+    );
+
+    let turn = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "Fix the retry test" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let turns = tidebreak_core::db::code::list_turns(
+            &runtime.db,
+            &tidebreak_core::OwnerId::local(),
+            session_id,
+        )
+        .await
+        .unwrap();
+        if turns
+            .last()
+            .is_some_and(|turn| turn.status == tidebreak_core::CodeTurnStatus::Completed)
+        {
+            assert!(turns
+                .last()
+                .and_then(|turn| turn.narrative.as_ref())
+                .is_none());
+            break;
+        }
+        tokio::time::timeout_at(deadline, tokio::time::sleep(Duration::from_millis(20)))
+            .await
+            .expect("the scripted turn completes before the deadline");
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let recap_calls = stub
+        .requests
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|request| request.to_string().contains("session_recap"))
+        .count();
+    assert_eq!(recap_calls, 0);
+}
+
 /// No utility model, no recap — and no failed turn either.
 ///
 /// A machine with nothing to run background work on is the ordinary case for a

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -93,6 +93,7 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(settings["compaction"]["target_fraction"], 0.25);
     assert_eq!(settings["compaction"]["min_threshold_tokens"], 50000);
     assert_eq!(settings["compaction"]["protect_recent_messages"], 5);
+    assert_eq!(settings["code_turn_recaps_enabled"], true);
     assert!(settings.get("code_mode_enabled").is_none());
 
     // PUT a model, and it comes back.
@@ -110,6 +111,7 @@ async fn settings_default_then_update_roundtrips() {
                         "max_active_background_agents": 7,
                         "sandbox_agent_checkin_steps": 250,
                         "sandbox_agent_error_checkin": 3,
+                        "code_turn_recaps_enabled": false,
                         "compaction": {
                             "threshold_fraction": 0.8,
                             "target_fraction": 0.3,
@@ -129,6 +131,7 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(settings["max_active_background_agents"], 7);
     assert_eq!(settings["sandbox_agent_checkin_steps"], 250);
     assert_eq!(settings["sandbox_agent_error_checkin"], 3);
+    assert_eq!(settings["code_turn_recaps_enabled"], false);
     assert_eq!(settings["compaction"]["threshold_fraction"], 0.8);
     assert_eq!(settings["compaction"]["target_fraction"], 0.3);
     assert_eq!(settings["compaction"]["min_threshold_tokens"], 40000);
@@ -150,6 +153,7 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(settings["max_active_background_agents"], 7);
     assert_eq!(settings["sandbox_agent_checkin_steps"], 250);
     assert_eq!(settings["sandbox_agent_error_checkin"], 3);
+    assert_eq!(settings["code_turn_recaps_enabled"], false);
     assert_eq!(settings["compaction"]["threshold_fraction"], 0.8);
     assert_eq!(settings["compaction"]["protect_recent_messages"], 8);
 }


### PR DESCRIPTION
## What changed

- Add a **Write turn recaps** switch to Agent settings.
- Persist the choice in runtime settings and skip future utility-model recap calls when it is off.
- Keep existing stored recaps visible.
- Add enabled and disabled Storybook states plus server and UI coverage.

## Validation

- `cargo test -p tidebreak-server --lib tests::code_recap::`
- `cargo test -p tidebreak-server --lib tests::configuration::settings_default_then_update_roundtrips`
- `cargo test -p tidebreak-server --lib wire_types::tests::the_generated_bindings_are_current`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/settings/AgentsPanel.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `cargo fmt --all -- --check`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/api/client.ts src/settings/AgentsPanel.tsx src/settings/AgentsPanel.dom.test.tsx src/stories/SettingsStoryHarness.tsx src/stories/SettingsPanels.stories.tsx`
- Production UI build and Storybook build passed before the rebase; the rebase applied without conflicts.