### PR TITLE
fix: address security and dependency alerts

### DIFF
--- a/.github/vercel-cli/package.json
+++ b/.github/vercel-cli/package.json
@@ -8,8 +8,17 @@
   },
   "pnpm": {
     "overrides": {
+      "@tootallnate/once@2.0.0": "2.0.1",
+      "ajv@8.6.3": "8.20.0",
+      "js-yaml@4.1.1": "4.3.1",
+      "minimatch@10.1.1": "10.2.6",
+      "path-to-regexp@6.1.0": "6.3.0",
       "path-to-regexp@8.2.0": "8.4.2",
-      "path-to-regexp@8.3.0": "8.4.2"
+      "path-to-regexp@8.3.0": "8.4.2",
+      "smol-toml@1.5.2": "1.8.0",
+      "tar@7.5.7": "7.5.22",
+      "undici@5.28.4": "6.28.0",
+      "undici@5.29.0": "6.28.0"
     }
   }
 }

--- a/.github/vercel-cli/pnpm-lock.yaml
+++ b/.github/vercel-cli/pnpm-lock.yaml
@@ -5,8 +5,17 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@tootallnate/once@2.0.0': 2.0.1
+  ajv@8.6.3: 8.20.0
+  js-yaml@4.1.1: 4.3.1
+  minimatch@10.1.1: 10.2.6
+  path-to-regexp@6.1.0: 6.3.0
   path-to-regexp@8.2.0: 8.4.2
   path-to-regexp@8.3.0: 8.4.2
+  smol-toml@1.5.2: 1.8.0
+  tar@7.5.7: 7.5.22
+  undici@5.28.4: 6.28.0
+  undici@5.29.0: 6.28.0
 
 importers:
 
@@ -205,18 +214,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.1':
-    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -540,8 +537,8 @@ packages:
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
   '@ts-morph/common@0.11.1':
@@ -720,8 +717,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv@8.6.3:
-    resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -909,6 +906,9 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1029,8 +1029,8 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-schema-to-ts@1.6.4:
@@ -1087,10 +1087,6 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
-
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -1206,9 +1202,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@6.1.0:
-    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
-
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -1241,10 +1234,6 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1327,8 +1316,8 @@ packages:
     resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
     engines: {node: '>=14'}
 
-  smol-toml@1.5.2:
-    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   srvx@0.11.16:
@@ -1363,11 +1352,6 @@ packages:
   tar@7.5.22:
     resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
-
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
-    engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -1423,14 +1407,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@5.28.4:
-    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
-    engines: {node: '>=14.0'}
-
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
@@ -1446,9 +1422,6 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
@@ -1633,14 +1606,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.0':
     optional: true
-
-  '@fastify/busboy@2.1.1': {}
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.1':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -1852,7 +1817,7 @@ snapshots:
 
   '@sinclair/typebox@0.25.24': {}
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@2.0.1': {}
 
   '@ts-morph/common@0.11.1':
     dependencies:
@@ -1982,7 +1947,7 @@ snapshots:
 
   '@vercel/fun@1.3.0':
     dependencies:
-      '@tootallnate/once': 2.0.0
+      '@tootallnate/once': 2.0.1
       async-listen: 1.2.0
       debug: 4.3.4
       generic-pool: 3.4.2
@@ -1994,7 +1959,7 @@ snapshots:
       semver: 7.5.4
       stat-mode: 0.3.0
       stream-to-promise: 2.2.0
-      tar: 7.5.7
+      tar: 7.5.22
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
@@ -2109,12 +2074,12 @@ snapshots:
       etag: 1.8.1
       mime-types: 2.1.35
       node-fetch: 2.6.9
-      path-to-regexp: 6.1.0
+      path-to-regexp: 6.3.0
       path-to-regexp-updated: path-to-regexp@6.3.0
       ts-morph: 12.0.0
       tsx: 4.21.0
       typescript: 5.9.3
-      undici: 5.28.4
+      undici: 6.28.0
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -2135,9 +2100,9 @@ snapshots:
       '@bytecodealliance/preview2-shim': 0.17.6
       '@renovatebot/pep440': 4.2.1
       fs-extra: 11.1.1
-      js-yaml: 4.1.1
-      minimatch: 10.1.1
-      smol-toml: 1.5.2
+      js-yaml: 4.3.1
+      minimatch: 10.2.6
+      smol-toml: 1.8.0
       zod: 3.22.4
 
   '@vercel/python@6.56.2':
@@ -2160,7 +2125,7 @@ snapshots:
       '@vercel/error-utils': 2.2.1
       '@vercel/nft': 1.10.0
       '@vercel/static-config': 3.4.1
-      path-to-regexp: 6.1.0
+      path-to-regexp: 6.3.0
       path-to-regexp-updated: path-to-regexp@6.3.0
       ts-morph: 12.0.0
     transitivePeerDependencies:
@@ -2174,7 +2139,7 @@ snapshots:
     dependencies:
       execa: 5.1.1
       get-port: 5.1.1
-      smol-toml: 1.5.2
+      smol-toml: 1.8.0
 
   '@vercel/sandbox@2.4.0':
     dependencies:
@@ -2202,7 +2167,7 @@ snapshots:
 
   '@vercel/static-config@3.4.1':
     dependencies:
-      ajv: 8.6.3
+      ajv: 8.20.0
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
@@ -2230,12 +2195,12 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv@8.6.3:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-      uri-js: 4.4.1
 
   any-promise@1.3.0: {}
 
@@ -2424,6 +2389,8 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-uri@3.1.6: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -2530,7 +2497,7 @@ snapshots:
 
   jose@6.2.3: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2581,10 +2548,6 @@ snapshots:
       mime-db: 1.52.0
 
   mimic-fn@2.1.0: {}
-
-  minimatch@10.1.1:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@10.2.6:
     dependencies:
@@ -2691,8 +2654,6 @@ snapshots:
       lru-cache: 11.5.2
       minipass: 7.1.3
 
-  path-to-regexp@6.1.0: {}
-
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
@@ -2717,8 +2678,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-
-  punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -2805,7 +2764,7 @@ snapshots:
 
   signal-exit@4.0.2: {}
 
-  smol-toml@1.5.2: {}
+  smol-toml@1.8.0: {}
 
   srvx@0.11.16: {}
 
@@ -2844,14 +2803,6 @@ snapshots:
       - react-native-b4a
 
   tar@7.5.22:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
-  tar@7.5.7:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -2906,14 +2857,6 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici@5.28.4:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
   undici@6.28.0: {}
 
   undici@7.29.0: {}
@@ -2921,10 +2864,6 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
-
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
 
   uuid@14.0.1: {}
 
@@ -2962,8 +2901,8 @@ snapshots:
       jsonc-parser: 3.3.1
       luxon: 3.7.2
       sandbox: 3.4.0
-      smol-toml: 1.5.2
-      undici: 5.29.0
+      smol-toml: 1.8.0
+      undici: 6.28.0
       uuid: 14.0.1
       zod: 4.1.11
     optionalDependencies:

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -26,7 +26,7 @@
  * same way but shown only here and on the result card, never on an approval
  * card — see `docs/decisions/0018-tool-call-narration.md`.
  */
-export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>, 
+export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>,
 /**
  * The model's own sentence about this step, when it wrote one.
  *
@@ -119,7 +119,7 @@ export type AgentRunId = string;
  * are not copied directly into it. Typed activity headlines are projected
  * separately.
  */
-export type AgentRunProgressLine = { 
+export type AgentRunProgressLine = {
 /**
  * Monotonic per-run ordering. Pass the page's `next_sequence` back as
  * `after_sequence` to read only what has arrived since.
@@ -129,7 +129,7 @@ sequence: number, text: string, at: string, };
 /**
  * One resumable page of a background run's live progress.
  */
-export type AgentRunProgressPage = { entries: Array<AgentRunProgressLine>, 
+export type AgentRunProgressPage = { entries: Array<AgentRunProgressLine>,
 /**
  * The cursor to resume from: the highest sequence in this page, or the
  * requested cursor when the page is empty. A reader that polls with this
@@ -143,31 +143,31 @@ next_sequence: number, };
  * Worker lease tokens, scheduling budgets, and other executor-facing fields
  * intentionally remain inside the server/store boundary.
  */
-export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, tier: AgentRunTier, execution_location: AgentRunExecutionLocation, 
+export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, tier: AgentRunTier, execution_location: AgentRunExecutionLocation,
 /**
  * Active host code-execution backend for `exec`, not the run-loop seat.
  *
  * See [`ExecProviderSnapshot`]. Read from the current host
  * setting at list time — the same selection the next `exec` would use.
  */
-code_execution_provider: ExecProviderSnapshot, status: AgentRunStatus, 
+code_execution_provider: ExecProviderSnapshot, status: AgentRunStatus,
 /**
  * Completed provider calls accumulated across every attempt.
  */
-model_steps: number, 
+model_steps: number,
 /**
  * Disjoint provider usage accumulated across every attempt. Providers
  * without cache telemetry leave both cache fields at zero.
  */
-usage: AgentRunUsageSnapshot, 
+usage: AgentRunUsageSnapshot,
 /**
  * The exact bounded task delegated by the visible spawn step.
  */
-task: string | null, started_at: string | null, finished_at: string | null, 
+task: string | null, started_at: string | null, finished_at: string | null,
 /**
  * Stable, bounded classification suitable for renderer display.
  */
-last_error_code: string | null, 
+last_error_code: string | null,
 /**
  * The currently checkpointed, renderer-safe activity, if any.
  *
@@ -175,7 +175,7 @@ last_error_code: string | null,
  * arguments, results, provider call identities, executor leases, or raw
  * executor diagnostics.
  */
-activity: AgentActivitySnapshot | null, 
+activity: AgentActivitySnapshot | null,
 /**
  * Files a background run submitted as its deliverables, in its own order.
  *
@@ -183,7 +183,7 @@ activity: AgentActivitySnapshot | null,
  * by name; nothing here is host-authored, and a run that submitted nothing
  * carries an empty list.
  */
-submitted_outputs: Array<SubmittedOutputSnapshot>, 
+submitted_outputs: Array<SubmittedOutputSnapshot>,
 /**
  * How far this run's own task plan has got, when it keeps one.
  *
@@ -194,7 +194,7 @@ submitted_outputs: Array<SubmittedOutputSnapshot>,
  * additive: every run before this field existed, and every foreground
  * coordinator, reads back in the shape it always had.
  */
-task_plan?: AgentRunTaskPlanProgress, 
+task_plan?: AgentRunTaskPlanProgress,
 /**
  * Bounded terminal display text returned to the parent, if settled.
  */
@@ -212,11 +212,11 @@ export type AgentRunStatus = "active" | "queued" | "running" | "cancelling" | "w
  * is one delegated task from start to finish, so the run is the only scope
  * its plan ever had.
  */
-export type AgentRunTaskPlan = { run_id: AgentRunId, 
+export type AgentRunTaskPlan = { run_id: AgentRunId,
 /**
  * The steps, in order.
  */
-steps: Array<TaskPlanStep>, 
+steps: Array<TaskPlanStep>,
 /**
  * When the last replacement committed.
  */
@@ -235,7 +235,7 @@ updated_at: string, };
  * Copying it as stored is therefore not a gap in the clamp; it is the same
  * rule enforced one surface earlier.
  */
-export type AgentRunTaskPlanProgress = { completed: number, total: number, 
+export type AgentRunTaskPlanProgress = { completed: number, total: number,
 /**
  * The one step marked `in_progress`, when there is one.
  */
@@ -264,15 +264,15 @@ export type AgentRunUsageSnapshot = { input_tokens: number, output_tokens: numbe
  * carries neither a selection nor an answer, which is how the card knows to
  * say so.
  */
-export type AnsweredUserQuestion = { 
+export type AnsweredUserQuestion = {
 /**
  * The prompt the reader answered.
  */
-question: string, 
+question: string,
 /**
  * Labels of the options chosen, in the order the question listed them.
  */
-selected?: Array<string>, 
+selected?: Array<string>,
 /**
  * The reader's own words, when the question allowed them.
  */
@@ -281,19 +281,19 @@ custom_answer?: string, };
 /**
  * One app's detail: the summary fields plus its revision history.
  */
-export type AppDetail = { id: AppId, name: string, 
+export type AppDetail = { id: AppId, name: string,
 /**
  * Creation time of the first revision.
  */
-created_at: string, 
+created_at: string,
 /**
  * Creation time of the current revision.
  */
-updated_at: string, 
+updated_at: string,
 /**
  * Revision currently presented as the app's content.
  */
-current_revision: AppRevisionId, 
+current_revision: AppRevisionId,
 /**
  * Every retained revision, newest first.
  */
@@ -312,12 +312,12 @@ export type AppGatewayPageOutcome = "ready" | "no_gateway" | "not_registered" | 
 /**
  * One answer: an outcome, and whatever came with it.
  */
-export type AppGatewayPageResult = { outcome: AppGatewayPageOutcome, 
+export type AppGatewayPageResult = { outcome: AppGatewayPageOutcome,
 /**
  * The app's page at the gateway, present exactly when `outcome` is
  * `ready`.
  */
-url?: string, 
+url?: string,
 /**
  * The gateway's own message, when the outcome carries one.
  */
@@ -337,43 +337,43 @@ message?: string, };
  * rows themselves: a manifest with both a folder row and a network row —
  * local or gateway — can read files and reach the network.
  */
-export type AppGrantBindingState = { 
+export type AppGrantBindingState = {
 /**
  * Connected app the manifest binds, by record id, for an app-keyed
  * binding.
  */
-app: ConnectedAppId | null, 
+app: ConnectedAppId | null,
 /**
  * Connected folder the manifest binds, by broker root id, for a folder
  * binding.
  */
-folder: HostRootId | null, 
+folder: HostRootId | null,
 /**
  * Gateway connected app the manifest binds, by the gateway's own app id,
  * for a gateway binding. The id alone — never the gateway that serves
  * it.
  */
-gateway_app: string | null, 
+gateway_app: string | null,
 /**
  * The access level a folder binding requests.
  */
-access: FolderAccess | null, 
+access: FolderAccess | null,
 /**
  * The bound connected app's, folder's, or gateway app's display name,
  * absent when nothing configured, approved, or readable answers to the
  * id — the sheet says so instead of showing a raw id alone.
  */
-name: string | null, 
+name: string | null,
 /**
  * Catalog `operationId`s the current manifest pins under this app, for a
  * `rest_api` or gateway binding.
  */
-operation_ids: Array<string> | null, 
+operation_ids: Array<string> | null,
 /**
  * Whether the live grant covers every listed capability under this
  * binding and its target still matches the granted fingerprint.
  */
-granted: boolean, 
+granted: boolean,
 /**
  * Whether a grant names this binding's target but it changed — a
  * reconfigured record, a disconnected folder — since consent: the
@@ -390,7 +390,7 @@ definition_changed: boolean, };
  * the folders, and any environment or credential values they select, are
  * deliberately absent from this projection.
  */
-export type AppGrantState = { 
+export type AppGrantState = {
 /**
  * Whether a live grant fully covers the current manifest with every
  * bound definition unchanged since consent — the "no sheet needed"
@@ -398,7 +398,7 @@ export type AppGrantState = {
  * nothing to consent to, so no sheet is shown. When `false`,
  * (re-)consent is required before every pinned capability is invokable.
  */
-granted: boolean, 
+granted: boolean,
 /**
  * The current manifest's bindings, one entry per bound connected app or
  * folder.
@@ -444,7 +444,7 @@ export type AppRevisionId = string;
  * One revision row: identity and position only. The manifest and the
  * bundle's content address stay server-side.
  */
-export type AppRevisionSummary = { id: AppRevisionId, 
+export type AppRevisionSummary = { id: AppRevisionId,
 /**
  * One-based position in the app's revision history.
  */
@@ -453,19 +453,19 @@ ordinal: number, created_at: string, };
 /**
  * One library row.
  */
-export type AppSummary = { id: AppId, 
+export type AppSummary = { id: AppId,
 /**
  * Display name, following the current revision's manifest.
  */
-name: string, 
+name: string,
 /**
  * Number of retained revisions, always at least one.
  */
-revision_count: number, 
+revision_count: number,
 /**
  * Creation time of the current revision.
  */
-updated_at: string, 
+updated_at: string,
 /**
  * Whether a live grant fully covers the app right now — the same
  * verdict `GET /apps/{id}/grant` reports, so the library badge and the
@@ -490,7 +490,7 @@ export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 /**
  * Outcome recorded on [`CodeEvent::ApprovalResolved`].
  */
-export type ApprovalDecisionKind = { "type": "approve" } | { "type": "deny", 
+export type ApprovalDecisionKind = { "type": "approve" } | { "type": "deny",
 /**
  * Feedback returned to the engine, when any.
  */
@@ -523,11 +523,11 @@ export type AssistantCitationSnapshot = { id: AssistantCitationId, ordinal: numb
  * must agree when the state is `NeedsYou`; [`Attention::needs_you`] enforces
  * that at construction.
  */
-export type Attention = { 
+export type Attention = {
 /**
  * The state.
  */
-state: AttentionState, 
+state: AttentionState,
 /**
  * Who or what set it.
  */
@@ -541,23 +541,23 @@ export type AttentionSource = "structured" | "heuristic" | "lifecycle" | "user";
 /**
  * Server-computed attention for one unit of supervised work.
  */
-export type AttentionState = { "type": "working" } | { "type": "needs_you", 
+export type AttentionState = { "type": "working" } | { "type": "needs_you",
 /**
  * Short prompt shown on the badge.
  */
-prompt: string, 
+prompt: string,
 /**
  * How this need was detected.
  */
-source: AttentionSource, } | { "type": "stalled", 
+source: AttentionSource, } | { "type": "stalled",
 /**
  * Seconds of observed silence.
  */
-idle_secs: number, } | { "type": "done_unreviewed" } | { "type": "idle" } | { "type": "fenced", 
+idle_secs: number, } | { "type": "done_unreviewed" } | { "type": "idle" } | { "type": "fenced",
 /**
  * Why it was fenced.
  */
-reason: FenceReason, } | { "type": "manual", 
+reason: FenceReason, } | { "type": "manual",
 /**
  * User-supplied note.
  */
@@ -575,7 +575,7 @@ export type AutoJudgeStatus = "judging" | "approved" | "declined";
 /**
  * Bounded error carried on [`CodeEvent::TurnFailed`].
  */
-export type BoundedError = { 
+export type BoundedError = {
 /**
  * Short message, already truncated by the adapter.
  */
@@ -594,47 +594,47 @@ export type CapLevel = "supported" | "unsupported" | "unknown";
 /**
  * A persistent conversation with an exact, ordered host-root projection.
  */
-export type Chat = { 
+export type Chat = {
 /**
  * Stable identifier.
  */
-id: ChatId, 
+id: ChatId,
 /**
  * The project this chat belongs to, or `None` for a loose (projectless) chat.
  */
-project_id: ProjectId | null, 
+project_id: ProjectId | null,
 /**
  * Human-facing title; `None` until one is set or derived.
  */
-title: string | null, 
+title: string | null,
 /**
  * The model this chat runs against, or `None` to use the configured default.
  */
-model: string | null, 
+model: string | null,
 /**
  * Reasoning-effort override for this chat, honored only by models that
  * expose the control; `None` leaves the provider's default in force.
  */
-reasoning_effort: ReasoningEffort | null, 
+reasoning_effort: ReasoningEffort | null,
 /**
  * How much this chat lets the agent do between approvals; `None` means
  * [`PermissionMode::Ask`].
  */
-permission_mode: PermissionMode | null, 
+permission_mode: PermissionMode | null,
 /**
  * Outbound network access for code execution in this chat.
  */
-network_policy: NetworkPolicy, 
+network_policy: NetworkPolicy,
 /**
  * CAS revision of this conversation's exact root projection.
  */
-attachment_revision: number, 
+attachment_revision: number,
 /**
  * Ordered opaque roots available for future broker-backed operations.
  * Live broker authorization remains mandatory and may revoke access at any
  * time, regardless of this projection.
  */
-root_attachments: Array<ChatRootAttachment>, 
+root_attachments: Array<ChatRootAttachment>,
 /**
  * When the chat was created.
  */
@@ -651,18 +651,18 @@ export type ChatId = string;
  * A renderer-safe durable transcript entry. Internal routing and tool state
  * deliberately remain behind the server boundary.
  */
-export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, content: string, created_at: string, citations: Array<AssistantCitationSnapshot>, 
+export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, content: string, created_at: string, citations: Array<AssistantCitationSnapshot>,
 /**
  * Images submitted with this user message. These are durable identity and
  * geometry only; image bytes remain behind a chat-scoped authenticated
  * endpoint and never enter the transcript payload.
  */
-image_attachments?: Array<TranscriptImageAttachment>, 
+image_attachments?: Array<TranscriptImageAttachment>,
 /**
  * Files submitted with this user message. Their bytes remain behind the
  * existing chat-scoped document endpoints.
  */
-file_attachments?: Array<TranscriptFileAttachment>, 
+file_attachments?: Array<TranscriptFileAttachment>,
 /**
  * Skills this user message explicitly invoked, in submitted order. Absent
  * for the ordinary message that invoked none.
@@ -672,11 +672,11 @@ invoked_skills?: Array<string>, };
 /**
  * One pathless root in a conversation's exact ordered projection.
  */
-export type ChatRootAttachment = { 
+export type ChatRootAttachment = {
 /**
  * Opaque broker root identity. This value grants no authority by itself.
  */
-root_id: HostRootId, 
+root_id: HostRootId,
 /**
  * Product-level provenance for ordering and future management UI.
  */
@@ -690,12 +690,12 @@ origin: RootAttachmentOrigin, };
  * message-less failed and cancelled turns remain first-class transcript entries
  * carrying the partial prose and reasoning the reader already saw live.
  */
-export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_detail?: string, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>, 
+export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_detail?: string, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>,
 /**
  * Skills the user explicitly invoked for this turn, in submitted order.
  * Absent for the ordinary turn that invoked none.
  */
-invoked_skills?: Array<string>, 
+invoked_skills?: Array<string>,
 /**
  * Token accounting for the turn, so a freshly opened chat can show
  * context usage without waiting for the next turn to finish.
@@ -709,7 +709,7 @@ export type ChatTerminalTurnStatus = "completed" | "failed" | "cancelled";
  * metadata, executor identity, lease, or diagnostic detail. The only action or
  * result it can carry is one a tool explicitly projects through a closed type.
  */
-export type ChatToolActivitySnapshot = { 
+export type ChatToolActivitySnapshot = {
 /**
  * Canonical call id, the same [`crate::id::CallId`] the live event stream
  * carried for this call.
@@ -721,7 +721,7 @@ export type ChatToolActivitySnapshot = {
  * and every replayed app view fetched a payload the server could only
  * reject.
  */
-call_id: CallId, 
+call_id: CallId,
 /**
  * Allowlisted renderer tool name, never a provider-supplied one.
  *
@@ -734,18 +734,18 @@ call_id: CallId,
  * on both sides while silently dropping the allowlist the renderer's copy
  * and icon tables are keyed on.
  */
-tool: RendererToolName, 
+tool: RendererToolName,
 /**
  * Closed projection of what the call did, when its tool has one. Rebuilt
  * from the arguments it ran with, so history describes the same action
  * the live stream did.
  */
-action?: ToolActionPreview, 
+action?: ToolActionPreview,
 /**
  * Closed projection of an actionable result. Arbitrary result text is
  * never included.
  */
-result?: ToolResultPreview, 
+result?: ToolResultPreview,
 /**
  * Set when this call retained a projection that no longer deserializes.
  *
@@ -770,12 +770,12 @@ export type ChatToolActivityStatus = "completed" | "failed" | "denied" | "cancel
  * The renderer uses the watermark to subscribe only to future events, avoiding
  * duplicate text when reopening a completed conversation.
  */
-export type ChatTranscript = { messages: Array<ChatMessageSnapshot>, 
+export type ChatTranscript = { messages: Array<ChatMessageSnapshot>,
 /**
  * Finished tool activity from terminal turns, projected through a fixed
  * renderer-safe allowlist. Canonical tool records never cross this API.
  */
-tool_activity: Array<ChatToolActivitySnapshot>, 
+tool_activity: Array<ChatToolActivitySnapshot>,
 /**
  * Status and streamed presentation for every terminal turn. This owns
  * terminal metadata even when no assistant message was committed.
@@ -785,11 +785,11 @@ terminal_turns: Array<ChatTerminalTurnSnapshot>, last_event_seq: number, };
 /**
  * Hint that a turn recorded a checkpoint. The diff body is loaded separately.
  */
-export type CheckpointHint = { 
+export type CheckpointHint = {
 /**
  * Hidden ref name, when known.
  */
-checkpoint_ref?: string, 
+checkpoint_ref?: string,
 /**
  * Bounded diffstat.
  */
@@ -866,23 +866,23 @@ export type CodeApprovalId = string;
 /**
  * Best-effort classification of what an approval is asking.
  */
-export type CodeApprovalKind = { "type": "command", 
+export type CodeApprovalKind = { "type": "command",
 /**
  * Command string.
  */
-cmd: string, 
+cmd: string,
 /**
  * Working directory, when reported.
  */
-cwd?: string | null, } | { "type": "file_write", 
+cwd?: string | null, } | { "type": "file_write",
 /**
  * Paths involved.
  */
-paths: Array<string>, } | { "type": "network", 
+paths: Array<string>, } | { "type": "network",
 /**
  * Host or summary the engine reported.
  */
-summary: string, } | { "type": "other", 
+summary: string, } | { "type": "other",
 /**
  * Engine-provided summary.
  */
@@ -891,7 +891,7 @@ summary: string, };
 /**
  * One parked or decided engine approval.
  */
-export type CodeApprovalSnapshot = { id: CodeApprovalId, session_id: CodeSessionId, turn_id: CodeTurnId, kind: CodeApprovalKind, 
+export type CodeApprovalSnapshot = { id: CodeApprovalId, session_id: CodeSessionId, turn_id: CodeTurnId, kind: CodeApprovalKind,
 /**
  * Exact JSON the engine sent, already size-capped. The card renders this.
  */
@@ -910,15 +910,15 @@ export type CodeApprovalState = "pending" | "approved" | "denied" | "abandoned";
  * storage a fork transcript uses. The prompt names it and the engine opens
  * it; nothing is uploaded and nothing is indexable.
  */
-export type CodeCheckLog = { 
+export type CodeCheckLog = {
 /**
  * Check name as the host reports it.
  */
-check: string, path: string, byte_len: number, 
+check: string, path: string, byte_len: number,
 /**
  * True when the file holds only the tail of the job log.
  */
-truncated: boolean, 
+truncated: boolean,
 /**
  * The job's host URL. A check without one has no log to download, so
  * every entry here has one.
@@ -937,7 +937,7 @@ export type CodeCheckLogError = { check: string, message: string, };
  * URL that names no Actions job — is simply absent from both lists. The
  * caller still names it in the prompt from the digest it already holds.
  */
-export type CodeCheckLogsSnapshot = { 
+export type CodeCheckLogsSnapshot = {
 /**
  * Head the logs were read against, when the host reported one.
  */
@@ -962,24 +962,24 @@ export type CodeCommitSnapshot = { sha: string, message: string, stat: Diffstat,
  * What the connect approval page renders: the identity being linked and
  * the CSRF token its "is this you?" POST must echo.
  */
-export type CodeConnectPage = { 
+export type CodeConnectPage = {
 /**
  * Which channel family is linking (for example `slack`).
  */
-channel_kind: string, 
+channel_kind: string,
 /**
  * The person's display name in the channel.
  */
-display_name: string, 
+display_name: string,
 /**
  * The channel workspace's human name.
  */
-workspace_name: string, avatar_url?: string, 
+workspace_name: string, avatar_url?: string,
 /**
  * `pending` or `approved`; a completed or expired link renders
  * nothing.
  */
-state: string, 
+state: string,
 /**
  * Echo this in the approve POST.
  */
@@ -1006,7 +1006,7 @@ export type CodeDeliveryPrAttentionReason = "changes_requested" | "checks_failed
  * User-initiated global PR action. Code-changing actions deliberately do not
  * exist here; they remain workspace-scoped agent prompts.
  */
-export type CodeDeliveryPullRequestAction = { "type": "mark_ready" } | { "type": "merge", method: CodePrMergeMethod, auto: boolean, admin: boolean, expected_head_sha: string, } | { "type": "create_stack", 
+export type CodeDeliveryPullRequestAction = { "type": "mark_ready" } | { "type": "merge", method: CodePrMergeMethod, auto: boolean, admin: boolean, expected_head_sha: string, } | { "type": "create_stack",
 /**
  * The chain to register, bottom to top. Every pull request's base
  * ref must match the previous one's head ref.
@@ -1019,18 +1019,18 @@ export type CodeDeliveryPullRequestActionBody = { target: CodeDeliveryPullReques
  * Full PR drawer payload. Conversation entries retain the existing bounded
  * comment contract used by workspace PRs.
  */
-export type CodeDeliveryPullRequestDetail = { summary: CodeDeliveryPullRequestSummary, body: string, labels: Array<string>, assignees: Array<string>, requested_reviewers: Array<string>, changed_files: number, additions: number, deletions: number, 
+export type CodeDeliveryPullRequestDetail = { summary: CodeDeliveryPullRequestSummary, body: string, labels: Array<string>, assignees: Array<string>, requested_reviewers: Array<string>, changed_files: number, additions: number, deletions: number,
 /**
  * The full stack chain this pull request belongs to, bottom to top,
  * when the host reported one. Absent on hosts without stacked pull
  * requests.
  */
-stack?: Array<CodeDeliveryStackMember>, commits: number, merged_by?: string, 
+stack?: Array<CodeDeliveryStackMember>, commits: number, merged_by?: string,
 /**
  * Empty when the diff could not be read. Truncated by `files_truncated`
  * rather than paged: the panel is a review aid, not a diff viewer.
  */
-files: Array<CodeDeliveryPullRequestFile>, files_truncated: boolean, comments: Array<PullRequestComment>, 
+files: Array<CodeDeliveryPullRequestFile>, files_truncated: boolean, comments: Array<PullRequestComment>,
 /**
  * Section reads that failed after the pull request itself loaded.
  */
@@ -1042,7 +1042,7 @@ errors: Array<CodeDeliverySourceError>, can_mark_ready: boolean, can_merge: bool
  * `patch` is the host's unified hunk text and is absent for binary files and
  * for diffs GitHub declines to render. It is bounded by the host, not stored.
  */
-export type CodeDeliveryPullRequestFile = { path: string, 
+export type CodeDeliveryPullRequestFile = { path: string,
 /**
  * `added`, `modified`, `removed`, `renamed`, `copied`, or `changed`.
  */
@@ -1052,7 +1052,7 @@ status: string, additions: number, deletions: number, previous_path?: string, pa
  * Server-side PR query. Saved views are client-owned; their resolved filters
  * are sent here so paging remains bounded across many repositories.
  */
-export type CodeDeliveryPullRequestQuery = { repositories: Array<CodeGitHubRepositoryTarget>, search?: string, states: Array<string>, review_states: Array<string>, check_states: Array<string>, authors: Array<string>, attention_only: boolean, ready_only: boolean, tidebreak_linked?: boolean, updated_after?: string, cursor?: string, limit?: number, 
+export type CodeDeliveryPullRequestQuery = { repositories: Array<CodeGitHubRepositoryTarget>, search?: string, states: Array<string>, review_states: Array<string>, check_states: Array<string>, authors: Array<string>, attention_only: boolean, ready_only: boolean, tidebreak_linked?: boolean, updated_after?: string, cursor?: string, limit?: number,
 /**
  * Skip the short list cache and reread GitHub.
  *
@@ -1064,27 +1064,27 @@ refresh: boolean, };
 /**
  * Pull request row shared by the overview and notification monitor.
  */
-export type CodeDeliveryPullRequestSummary = { id: string, repository: CodeGitHubRepositoryRef, number: number, url: string, title: string, state: string, draft: boolean, author?: string, author_avatar_url?: string, head_branch: string, base_branch: string, head_sha?: string, review_decision?: string, mergeable?: string, merge_state_status?: string, auto_merge_enabled: boolean, 
+export type CodeDeliveryPullRequestSummary = { id: string, repository: CodeGitHubRepositoryRef, number: number, url: string, title: string, state: string, draft: boolean, author?: string, author_avatar_url?: string, head_branch: string, base_branch: string, head_sha?: string, review_decision?: string, mergeable?: string, merge_state_status?: string, auto_merge_enabled: boolean,
 /**
  * True when the last reliable host observation placed the pull request
  * in its merge queue. Absent when the list read cannot answer.
  */
-in_merge_queue?: boolean, 
+in_merge_queue?: boolean,
 /**
  * Issue comments visible from the list read. Review and inline comments
  * remain detail-only, so an absent count means unknown rather than zero.
  */
-comment_count?: number, checks: Array<CodeDeliveryCheck>, attention_reasons: Array<CodeDeliveryPrAttentionReason>, ready_to_merge: boolean, workspace_links: Array<CodeDeliveryWorkspaceLink>, 
+comment_count?: number, checks: Array<CodeDeliveryCheck>, attention_reasons: Array<CodeDeliveryPrAttentionReason>, ready_to_merge: boolean, workspace_links: Array<CodeDeliveryWorkspaceLink>,
 /**
  * The host stack this pull request belongs to (GitHub stacked pull
  * requests), when the host reported one. Identifies the stack, not the
  * PR.
  */
-stack_number?: number, 
+stack_number?: number,
 /**
  * Total layers in that stack, bottom to top, including merged ones.
  */
-stack_size?: number, 
+stack_size?: number,
 /**
  * The pull request this one is stacked on. Host stack order wins when
  * the host reported a stack; branch inference from the durable fact set
@@ -1092,7 +1092,7 @@ stack_size?: number,
  * or filter still resolves. Absent when the base is the default branch
  * or nothing tracked owns it.
  */
-stack_parent_number?: number, 
+stack_parent_number?: number,
 /**
  * A stack-shaped chain of inferred edges the host has no stack for,
  * bottom to top, when one resolves gaplessly around this pull request
@@ -1101,7 +1101,7 @@ stack_parent_number?: number,
  * — without it, merging a layer lands it into the branch below rather
  * than the default branch, which is easy to do by accident.
  */
-unregistered_stack_numbers?: Array<number>, labels: Array<string>, created_at: string, updated_at: string, 
+unregistered_stack_numbers?: Array<number>, labels: Array<string>, created_at: string, updated_at: string,
 /**
  * Set only once the pull request merged. `state` alone cannot separate a
  * merged pull request from a closed one on every host response, and the
@@ -1136,7 +1136,7 @@ export type CodeDeliveryRunActionBody = { target: CodeDeliveryRunTarget, action:
 
 export type CodeDeliveryRunAttentionReason = "failure" | "timed_out" | "action_required" | "startup_failure";
 
-export type CodeDeliveryRunDetail = { summary: CodeDeliveryRunSummary, jobs: Array<CodeDeliveryWorkflowJob>, deployment_statuses: Array<CodeDeliveryDeploymentStatus>, can_rerun_failed: boolean, 
+export type CodeDeliveryRunDetail = { summary: CodeDeliveryRunSummary, jobs: Array<CodeDeliveryWorkflowJob>, deployment_statuses: Array<CodeDeliveryDeploymentStatus>, can_rerun_failed: boolean,
 /**
  * Section reads that failed after the run or deployment itself loaded.
  */
@@ -1144,7 +1144,7 @@ errors: Array<CodeDeliverySourceError>, };
 
 export type CodeDeliveryRunKind = "workflow_run" | "deployment";
 
-export type CodeDeliveryRunQuery = { repositories: Array<CodeGitHubRepositoryTarget>, search?: string, kinds: Array<CodeDeliveryRunKind>, statuses: Array<string>, conclusions: Array<string>, workflows: Array<string>, environments: Array<string>, branches: Array<string>, events: Array<string>, actors: Array<string>, attention_only: boolean, tidebreak_linked?: boolean, created_after?: string, cursor?: string, limit?: number, 
+export type CodeDeliveryRunQuery = { repositories: Array<CodeGitHubRepositoryTarget>, search?: string, kinds: Array<CodeDeliveryRunKind>, statuses: Array<string>, conclusions: Array<string>, workflows: Array<string>, environments: Array<string>, branches: Array<string>, events: Array<string>, actors: Array<string>, attention_only: boolean, tidebreak_linked?: boolean, created_after?: string, cursor?: string, limit?: number,
 /**
  * Skip the short list cache and reread GitHub. See the pull-request query.
  */
@@ -1167,15 +1167,15 @@ export type CodeDeliverySourceError = { repository?: CodeGitHubRepositoryTarget,
 /**
  * One layer of a pull-request stack, in bottom-to-top order.
  */
-export type CodeDeliveryStackMember = { number: number, 
+export type CodeDeliveryStackMember = { number: number,
 /**
  * Host state token (open, closed).
  */
-state: string, draft: boolean, 
+state: string, draft: boolean,
 /**
  * Set once this layer merged.
  */
-merged_at?: string, 
+merged_at?: string,
 /**
  * Head branch name.
  */
@@ -1186,7 +1186,7 @@ export type CodeDeliveryWorkflowJob = { id: number, name: string, status: string
 /**
  * One Tidebreak workspace that plausibly produced a remote delivery item.
  */
-export type CodeDeliveryWorkspaceLink = { workspace_id: WorkspaceId, repo_id: RepoId, title: string, branch_name: string, status: CodeWorkspaceStatus, exact: boolean, 
+export type CodeDeliveryWorkspaceLink = { workspace_id: WorkspaceId, repo_id: RepoId, title: string, branch_name: string, status: CodeWorkspaceStatus, exact: boolean,
 /**
  * Durable attribution behind this link, when one is stored: the
  * workspace authored or contributed to the pull request (decision 77).
@@ -1201,69 +1201,69 @@ relation?: CodePullRequestRelation, };
  * variant), and `#[non_exhaustive]` so new event kinds can be added without
  * breaking downstream consumers.
  */
-export type CodeEvent = { "type": "session_started", 
+export type CodeEvent = { "type": "session_started",
 /**
  * Which engine.
  */
-harness_kind: HarnessKind, 
+harness_kind: HarnessKind,
 /**
  * Version observed at launch.
  */
-harness_version: string, 
+harness_version: string,
 /**
  * Engine-native resume token, when the stream reported one.
  */
-resume_ref?: string, } | { "type": "turn_started", 
+resume_ref?: string, } | { "type": "turn_started",
 /**
  * The turn being processed.
  */
-turn_id: CodeTurnId, } | { "type": "assistant_delta", 
+turn_id: CodeTurnId, } | { "type": "assistant_delta",
 /**
  * The text fragment to append.
  */
-text: string, } | { "type": "assistant_message", 
+text: string, } | { "type": "assistant_message",
 /**
  * The message text.
  */
-text: string, 
+text: string,
 /**
  * The `Task` call this message ran inside, when a harness subagent
  * produced it (decision 52). Absent on the parent's own messages.
  */
-parent_call_id?: string, } | { "type": "reasoning_delta", 
+parent_call_id?: string, } | { "type": "reasoning_delta",
 /**
  * The reasoning fragment.
  */
-text: string, } | { "type": "tool_started", 
+text: string, } | { "type": "tool_started",
 /**
  * Engine-native call id.
  */
-call_id: string, 
+call_id: string,
 /**
  * Tool name as the engine reported it.
  */
-name: string, 
+name: string,
 /**
  * Display-oriented classification.
  */
-detail: ToolDetail, 
+detail: ToolDetail,
 /**
  * The `Task` call this call ran inside, when a harness subagent
  * issued it (decision 52). Absent on the parent's own calls.
  */
-parent_call_id?: string, } | { "type": "tool_completed", 
+parent_call_id?: string, } | { "type": "tool_completed",
 /**
  * Engine-native call id.
  */
-call_id: string, 
+call_id: string,
 /**
  * How it finished.
  */
-outcome: ToolOutcome, 
+outcome: ToolOutcome,
 /**
  * Bounded preview of the result.
  */
-preview: string, 
+preview: string,
 /**
  * Classification rebuilt from the call's complete arguments.
  *
@@ -1273,72 +1273,72 @@ preview: string,
  * and renderers merge it into the started call. It is `None` when
  * the engine's completion payload carries no arguments.
  */
-detail?: ToolDetail, 
+detail?: ToolDetail,
 /**
  * The `Task` call this call ran inside, when a harness subagent
  * issued it (decision 52). Absent on the parent's own calls.
  */
-parent_call_id?: string, } | { "type": "file_changed", 
+parent_call_id?: string, } | { "type": "file_changed",
 /**
  * Path relative to the worktree, when the engine reports one.
  */
-path: string, 
+path: string,
 /**
  * Kind of change.
  */
-kind: FileChangeKind, 
+kind: FileChangeKind,
 /**
  * Bounded diffstat.
  */
-diffstat: Diffstat, } | { "type": "approval_requested", 
+diffstat: Diffstat, } | { "type": "approval_requested",
 /**
  * Hint id; the row is the source of truth.
  */
-approval_id: CodeApprovalId, } | { "type": "approval_resolved", 
+approval_id: CodeApprovalId, } | { "type": "approval_resolved",
 /**
  * The approval that was decided.
  */
-approval_id: CodeApprovalId, 
+approval_id: CodeApprovalId,
 /**
  * The decision.
  */
-decision: ApprovalDecisionKind, } | { "type": "user_steered", 
+decision: ApprovalDecisionKind, } | { "type": "user_steered",
 /**
  * The steered user text, already bounded.
  */
-text: string, } | { "type": "turn_completed", 
+text: string, } | { "type": "turn_completed",
 /**
  * Token accounting as reported by the engine.
  */
-usage: CodeUsage, 
+usage: CodeUsage,
 /**
  * Checkpoint recorded at turn end, when any.
  */
-checkpoint?: CheckpointHint, } | { "type": "turn_failed", 
+checkpoint?: CheckpointHint, } | { "type": "turn_failed",
 /**
  * Bounded error.
  */
-error: BoundedError, } | { "type": "turn_interrupted" } | { "type": "checkpoint_recorded", 
+error: BoundedError, } | { "type": "turn_interrupted" } | { "type": "checkpoint_recorded",
 /**
  * The turn that ended at this checkpoint.
  */
-turn_id: CodeTurnId, 
+turn_id: CodeTurnId,
 /**
  * Bounded diffstat.
  */
-diffstat: Diffstat, } | { "type": "harness_notice", 
+diffstat: Diffstat, } | { "type": "harness_notice",
 /**
  * Severity.
  */
-level: HarnessNoticeLevel, 
+level: HarnessNoticeLevel,
 /**
  * Bounded message.
  */
-message: string, } | { "type": "attention_changed", 
+message: string, } | { "type": "attention_changed",
 /**
  * New state.
  */
-state: AttentionState, 
+state: AttentionState,
 /**
  * Who or what set it.
  */
@@ -1353,7 +1353,7 @@ export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: n
  * Body of `POST /code/sessions/{id}/fork`. An absent body forks at the
  * newest turn.
  */
-export type CodeForkBody = { 
+export type CodeForkBody = {
 /**
  * Fork at the end of this turn; later turns stay out of the handoff.
  */
@@ -1367,20 +1367,20 @@ at_turn?: CodeTurnId, };
  * is the fork's own directory, which also holds one full per-turn record —
  * `turn-0007.md` for turn 7 — and any retained image attachments.
  */
-export type CodeForkTranscript = { path: string, dir: string, byte_len: number, 
+export type CodeForkTranscript = { path: string, dir: string, byte_len: number,
 /**
  * Complete turn histories the condensed transcript renders in full.
  */
-turns: number, 
+turns: number,
 /**
  * Turns the fork covers, up to and including the fork point.
  */
-total_turns: number, 
+total_turns: number,
 /**
  * The fork point's turn ordinal, present when the conversation
  * continued past it — later turns are excluded from the handoff.
  */
-at_turn_ordinal?: number, 
+at_turn_ordinal?: number,
 /**
  * True when bounded replay omitted whole turn histories or the file size
  * cap reduced the oldest turns or the end of one oversized turn.
@@ -1429,33 +1429,33 @@ export type CodeGrantId = string;
  * secrets: the token pair exists only in the mint response the adapter
  * kept.
  */
-export type CodeGrantSnapshot = { id: CodeGrantId, 
+export type CodeGrantSnapshot = { id: CodeGrantId,
 /**
  * Which channel family linked (for example `slack`).
  */
-channel_kind: string, 
+channel_kind: string,
 /**
  * The channel's identity for the linked user.
  */
-external_identity: string, 
+external_identity: string,
 /**
  * The channel user's display name at connect time, when this grant came
  * from the connect flow.
  */
-display_name?: string, 
+display_name?: string,
 /**
  * The channel's workspace identity, shown so an owner can revoke a
  * whole workspace at once.
  */
-workspace_identity: string, 
+workspace_identity: string,
 /**
  * The channel workspace's display name at connect time.
  */
-workspace_name?: string, 
+workspace_name?: string,
 /**
  * The linked user's safe public avatar URL at connect time.
  */
-avatar_url?: string, rotated_at?: string, created_at: string, revoked_at?: string, 
+avatar_url?: string, rotated_at?: string, created_at: string, revoked_at?: string,
 /**
  * Why the grant was revoked, in owner-facing words. A theft-triggered
  * revoke reaches the owner here.
@@ -1470,7 +1470,7 @@ revoked_reason?: string, };
  * percentage to a pipe, so there is no bar to show — only which of the three
  * the engine is in.
  */
-export type CodeHarnessInstallSnapshot = { kind: HarnessKind, 
+export type CodeHarnessInstallSnapshot = { kind: HarnessKind,
 /**
  * The pinned version being installed.
  */
@@ -1480,11 +1480,11 @@ version?: string, phase: string, done: boolean, error?: string, };
  * `GET /code/workspaces/{id}/pr/comments`: the PR conversation, read live
  * from the host and never persisted.
  */
-export type CodePrCommentsSnapshot = { 
+export type CodePrCommentsSnapshot = {
 /**
  * PR number the comments belong to.
  */
-number: number, 
+number: number,
 /**
  * Issue comments, review bodies, and inline review comments, ordered by
  * creation time.
@@ -1560,37 +1560,37 @@ export type CodeSessionActivity = "agent" | "shell" | "monitor" | "subagents" | 
 /**
  * Cheap per-session digest on `/code/updates`.
  */
-export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind, 
+export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind,
 /**
  * Engine identity for list surfaces that collapse several sessions into
  * one workspace row. Optional on the wire so a desktop can still read a
  * digest from an older server during an update.
  */
-harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
+harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number,
 /**
  * Timestamp trigger delivery uses to rank candidate sessions: the newest
  * turn start, or session creation before the first turn. Optional so a
  * desktop can still read a digest from an older server during an update.
  */
-trigger_target_at?: string, 
+trigger_target_at?: string,
 /**
  * What the live turn is occupied with, while running.
  */
-activity?: CodeSessionActivity, pr_state?: PullRequestDigest, 
+activity?: CodeSessionActivity, pr_state?: PullRequestDigest,
 /**
  * How many pull requests hold a durable attribution to this workspace
  * (decision 77). Absent when none do.
  */
-pr_count?: number, 
+pr_count?: number,
 /**
  * Watch progress, present only on `kind: watch` digests.
  */
-watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number, 
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
 /**
  * Harness subagents on this session, present only when any were
  * observed (decision 52).
  */
-subagents?: Array<CodeSubagentSummary>, 
+subagents?: Array<CodeSubagentSummary>,
 /**
  * Where this session stands, in a sentence, derived from the newest turn
  * that carries one. Absent until a turn has been recapped, and on
@@ -1602,11 +1602,11 @@ recap?: string, };
  * Where an externally created session came from. The desktop renders it
  * as the provenance banner; a session the desktop created carries none.
  */
-export type CodeSessionExternalOrigin = { 
+export type CodeSessionExternalOrigin = {
 /**
  * The channel family, for example `slack`.
  */
-channel_kind: string, 
+channel_kind: string,
 /**
  * The channel's durable conversation identity, opaque to the server.
  * For Slack this is `workspace/channel/thread_ts`, which the desktop
@@ -1632,15 +1632,15 @@ export type CodeSessionLifecycle = "created" | "idle" | "running" | "fenced" | "
 /**
  * One durable conversation with an external agent engine.
  */
-export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string, 
+export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
 /**
  * Absent means the engine's own default, which is not any level.
  */
-reasoning_effort?: ReasoningEffort, 
+reasoning_effort?: ReasoningEffort,
 /**
  * Whether this session runs its turns in the engine's fast mode.
  */
-fast_mode: boolean, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, 
+fast_mode: boolean, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string,
 /**
  * Present when an external channel created the session.
  */
@@ -1668,15 +1668,15 @@ export type CodeSubagentStatus = "running" | "done" | "failed";
  * session: the harness owns its lifecycle, so the server can neither steer
  * nor resume it (decision 52).
  */
-export type CodeSubagentSummary = { 
+export type CodeSubagentSummary = {
 /**
  * The spanning `Task` call's engine-native id.
  */
-call_id: string, 
+call_id: string,
 /**
  * Display name: the Task's description or the tool name.
  */
-name: string, 
+name: string,
 /**
  * Status derived from the spanning call.
  */
@@ -1748,7 +1748,7 @@ export type CodeTurnRewriteState = "rewriting" | "rewritten" | "failed";
 /**
  * One user→engine turn.
  */
-export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: CodeUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string, 
+export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: CodeUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string,
 /**
  * Lucid rewrite of the closing message. The journal keeps the original.
  */
@@ -1764,42 +1764,42 @@ export type CodeTurnStatus = "running" | "completed" | "failed" | "interrupted";
  *
  * A connect is restated as [`Self::Snapshot`]; later notices are live only.
  */
-export type CodeUpdateNotice = { "type": "snapshot", 
+export type CodeUpdateNotice = { "type": "snapshot",
 /**
  * One row per live session.
  */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind, 
+sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind,
 /**
  * Engine identity for the session represented by this digest.
  */
-harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
+harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number,
 /**
  * Timestamp trigger delivery uses to rank candidate sessions.
  */
-trigger_target_at?: string, 
+trigger_target_at?: string,
 /**
  * What the live turn is occupied with, while running.
  */
-activity?: CodeSessionActivity, 
+activity?: CodeSessionActivity,
 /**
  * Boxed to keep the notice enum's variants near one size; the wire
  * shape is unchanged.
  */
-pr_state?: PullRequestDigest, 
+pr_state?: PullRequestDigest,
 /**
  * How many pull requests hold a durable attribution to this
  * workspace (decision 77). Absent when none do.
  */
-pr_count?: number, 
+pr_count?: number,
 /**
  * Watch progress, present only on `kind: watch` digests.
  */
-watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number, 
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
 /**
  * Harness subagents on this session, present only when any were
  * observed (decision 52).
  */
-subagents?: Array<CodeSubagentSummary>, 
+subagents?: Array<CodeSubagentSummary>,
 /**
  * Where this session stands, in a sentence, derived from the newest
  * turn that carries one.
@@ -1831,23 +1831,23 @@ recap?: string, } | { "type": "terminal_activity", workspace_id: WorkspaceId, te
  * multiple of the prompt that was actually resident. That reading has its own
  * field: [`CodeUsage::context_tokens`].
  */
-export type CodeUsage = { 
+export type CodeUsage = {
 /**
  * Fresh, uncached input tokens. Excludes both cache fields.
  */
-input_tokens: number, 
+input_tokens: number,
 /**
  * Output tokens, summed over the turn's model calls.
  */
-output_tokens: number, 
+output_tokens: number,
 /**
  * Cache-read input tokens, when the engine reports them.
  */
-cache_read_input_tokens: number, 
+cache_read_input_tokens: number,
 /**
  * Cache-write input tokens, when the engine reports them.
  */
-cache_creation_input_tokens: number, 
+cache_creation_input_tokens: number,
 /**
  * Prompt tokens resident on the turn's final model call — what actually
  * occupied the context window at the end of the turn.
@@ -1860,7 +1860,7 @@ cache_creation_input_tokens: number,
  *
  * Zero when the engine does not publish enough to compute it.
  */
-context_tokens: number, 
+context_tokens: number,
 /**
  * Prompt tokens resident on the turn's first model call, when the engine
  * publishes per-call usage. This exposes startup context separately from
@@ -1913,13 +1913,13 @@ export type CodeWorkspaceHistorySearchSource = "turn_user_input" | "turn_narrati
 /**
  * PR + checks digest plus the local git facts the PR card needs.
  */
-export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, 
+export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string,
 /**
  * The identity a push from this machine acts as: the deployment's
  * GitHub App bot account (decision 63) or the caller's own login
  * (decision 65). The UI states this plainly beside the push control.
  */
-pushes_as?: string, 
+pushes_as?: string,
 /**
  * Whether `pushes_as` is the caller's own account (decision 65)
  * rather than the deployment's App.
@@ -1930,15 +1930,15 @@ pushes_as_self?: boolean, watch?: CodeWatchSnapshot, };
  * One pull request attributed to a workspace, from the durable fact store
  * (decision 77). A projection of the stored snapshot — no live host read.
  */
-export type CodeWorkspacePullRequestFact = { host: string, repo_owner: string, repo_name: string, number: number, url: string, title: string, 
+export type CodeWorkspacePullRequestFact = { host: string, repo_owner: string, repo_name: string, number: number, url: string, title: string,
 /**
  * Coarse lifecycle: `open`, `merged`, or `closed`.
  */
-state: string, draft: boolean, author?: string, head_branch: string, base_branch: string, head_sha?: string, 
+state: string, draft: boolean, author?: string, head_branch: string, base_branch: string, head_sha?: string,
 /**
  * How the workspace is tied to it.
  */
-relation: CodePullRequestRelation, created_at: string, updated_at: string, merged_at?: string, closed_at?: string, 
+relation: CodePullRequestRelation, created_at: string, updated_at: string, merged_at?: string, closed_at?: string,
 /**
  * When the store last confirmed this snapshot against the host.
  */
@@ -1963,12 +1963,12 @@ export type CodeWorkspaceSearchMatch = { path: string, line_number: number, line
 /**
  * One isolated workspace (worktree + branch) on a repo.
  */
-export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string, 
+export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string,
 /**
  * Commit the released branch pointed at, so a client can name the work
  * without the branch existing.
  */
-released_tip?: string, 
+released_tip?: string,
 /**
  * Stored bundle size, for reporting what a release reclaimed.
  */
@@ -2004,7 +2004,7 @@ export type CodeWorktreeRoot = { root?: string, effective_root: string, default_
 /**
  * What one on-demand compaction did.
  */
-export type CompactionRun = { 
+export type CompactionRun = {
 /**
  * Whether a checkpoint was written. `false` is a complete, ordinary answer:
  * the chat had too little history to give up, its recent messages are all
@@ -2016,19 +2016,19 @@ compacted: boolean, };
 /**
  * Host-tunable chat compaction cadence and retention.
  */
-export type CompactionSettings = { 
+export type CompactionSettings = {
 /**
  * Compact when unabridged tokens exceed this fraction of the context window.
  */
-threshold_fraction: number, 
+threshold_fraction: number,
 /**
  * After compaction, keep about this fraction of the window as raw recent history.
  */
-target_fraction: number, 
+target_fraction: number,
 /**
  * Absolute floor applied before scaling by context window.
  */
-min_threshold_tokens: number, 
+min_threshold_tokens: number,
 /**
  * Newest durable messages that must never enter the compacted prefix.
  */
@@ -2051,33 +2051,33 @@ export type ConnectedAppId = string;
  * health projection, a `rest_api` entry carries catalog and credential
  * *status* — never transport definitions, documents, or values.
  */
-export type ConnectedAppInfo = { "kind": "mcp_server", 
+export type ConnectedAppInfo = { "kind": "mcp_server",
 /**
  * The record id app bindings name.
  */
-id: ConnectedAppId, 
+id: ConnectedAppId,
 /**
  * Display name — also the namespace the server's tools mount under.
  */
-name: string, health: McpHealth, tool_count: number, 
+name: string, health: McpHealth, tool_count: number,
 /**
  * The bare mounted tool names (after the `mcp__{server}__` prefix),
  * bounded by the per-server discovery cap. Names only — never
  * remote-authored descriptions — the consent sheet's posture.
  */
-tools: Array<string>, diagnostic: string | null, 
+tools: Array<string>, diagnostic: string | null,
 /**
  * The curated-list entry this server matched, when Tidebreak has
  * exercised it end to end. `null` is the community tier: mounted and
  * usable, just not something we have driven ourselves. A label, not
  * a gate — nothing about the mount changes either way.
  */
-curated: McpCuration | null, 
+curated: McpCuration | null,
 /**
  * The gateway MCP endpoint slug this record mounts, when it is
  * gateway-backed rather than a local stdio/HTTP definition.
  */
-gateway_endpoint: string | null, 
+gateway_endpoint: string | null,
 /**
  * Display names of the organization's entitled apps that ride this
  * record's gateway endpoint. Empty for local records — and, by
@@ -2085,32 +2085,32 @@ gateway_endpoint: string | null,
  * the apps surface: the entry then renders without org-app names
  * rather than erroring.
  */
-gateway_apps: Array<string>, 
+gateway_apps: Array<string>,
 /**
  * How many local mini-apps hold a live grant binding this record —
  * a count only, never app names or ids, the renderer-safety posture
  * of this surface. Grants of library-deleted apps do not count.
  */
-used_by_app_count: number, } | { "kind": "rest_api", 
+used_by_app_count: number, } | { "kind": "rest_api",
 /**
  * The record id app bindings name.
  */
-id: ConnectedAppId, name: string, base_url: string, 
+id: ConnectedAppId, name: string, base_url: string,
 /**
  * Operations the ingested catalog declares.
  */
-operation_count: number, 
+operation_count: number,
 /**
  * Hex SHA-256 of the raw OpenAPI document the catalog was ingested
  * from.
  */
-document_sha256: string, credential_status: RestCredentialStatus, 
+document_sha256: string, credential_status: RestCredentialStatus,
 /**
  * Where the stored credential value is placed at request time, when
  * one is referenced. The placement (and a custom header *name*) is
  * configuration; the value never appears on this surface.
  */
-placement: CredentialPlacement | null, updated_at: string, 
+placement: CredentialPlacement | null, updated_at: string,
 /**
  * How many local mini-apps hold a live grant binding this record —
  * a count only, never app names or ids, the renderer-safety posture
@@ -2121,7 +2121,7 @@ used_by_app_count: number, };
 /**
  * The renderer's listing of every configured connected app, across kinds.
  */
-export type ConnectedAppsInfo = { 
+export type ConnectedAppsInfo = {
 /**
  * MCP entries in the runtime's configuration order, then REST entries in
  * storage order (oldest first).
@@ -2153,28 +2153,28 @@ export type ConsentResource = { "kind": "action_scope", scope: GrantScope, } | {
  * One statement of consent the agent currently holds, whatever store it
  * lives in.
  */
-export type ConsentStatementSnapshot = { 
+export type ConsentStatementSnapshot = {
 /**
  * What a revocation of this statement names, and where to send it.
  */
-handle: ConsentHandle, 
+handle: ConsentHandle,
 /**
  * How far the statement reaches — one chat, or every chat in a project.
  */
-level: GrantLevel, 
+level: GrantLevel,
 /**
  * The name of whatever the level points at, for provenance. `None` when
  * that chat or project is untitled.
  */
-level_title: string | null, 
+level_title: string | null,
 /**
  * The class of action the user allowed.
  */
-verb: ConsentVerb, 
+verb: ConsentVerb,
 /**
  * What the verb is allowed to touch.
  */
-resource: ConsentResource, 
+resource: ConsentResource,
 /**
  * The trusted interaction through which consent was captured.
  */
@@ -2207,15 +2207,15 @@ export type CredentialPlacement = "bearer" | { "header": string };
  * xAI rows may opt into the capabilities its first-party Responses adapter
  * actually carries end to end.
  */
-export type CustomModelConfig = { 
+export type CustomModelConfig = {
 /**
  * Exact model id sent to the endpoint.
  */
-id: string, 
+id: string,
 /**
  * Optional human-facing label.
  */
-display_name?: string | null, 
+display_name?: string | null,
 /**
  * The provider-side id a managed gateway routes this model to, when the
  * gateway reports one that differs from `id`.
@@ -2224,7 +2224,7 @@ display_name?: string | null,
  * leaves it unset, and nothing in the settings UI offers it. It exists so
  * a deployment-aliased id can still be recognized as a curated model.
  */
-upstream_id?: string | null, 
+upstream_id?: string | null,
 /**
  * Alternate gateway ids that also resolve to this model — the
  * deployment-shaped spellings the member catalog reports, offered to
@@ -2233,23 +2233,23 @@ upstream_id?: string | null,
  * Populated only by gateway model sync from a catalog-serving gateway;
  * a user-entered custom model leaves it empty.
  */
-aliases?: Array<string>, 
+aliases?: Array<string>,
 /**
  * Context limit used by Tidebreak's reducer.
  */
-context_window: number, 
+context_window: number,
 /**
  * Maximum output sent to the endpoint.
  */
-max_output_tokens: number, 
+max_output_tokens: number,
 /**
  * Inputs Tidebreak may place on this model's request.
  */
-input_modalities: Array<InputModality>, 
+input_modalities: Array<InputModality>,
 /**
  * Whether the model uses xAI's reasoning request shape.
  */
-supports_reasoning: boolean, 
+supports_reasoning: boolean,
 /**
  * Reasoning-effort levels accepted by the model, ascending.
  */
@@ -2271,11 +2271,11 @@ export type DetachedAdmissionDenialReason = "no_scoped_model_token" | "no_extern
  * providers that cannot host background runs at all — every precondition is
  * simply unestablished for them, and the fail-closed evaluation names each.
  */
-export type DetachedAdmissionProviderInfo = { provider: ExecProviderKind, 
+export type DetachedAdmissionProviderInfo = { provider: ExecProviderKind,
 /**
  * Whether the gate would admit a detached run hosted by this provider.
  */
-admitted: boolean, 
+admitted: boolean,
 /**
  * Every unmet precondition, named — not just the first.
  */
@@ -2284,19 +2284,19 @@ denials: Array<DetachedAdmissionDenialReason>, };
 /**
  * Bounded add/delete counts for a diff. Bodies live on a GET route.
  */
-export type Diffstat = { 
+export type Diffstat = {
 /**
  * Files touched.
  */
-files: number, 
+files: number,
 /**
  * Lines added.
  */
-insertions: number, 
+insertions: number,
 /**
  * Lines deleted.
  */
-deletions: number, 
+deletions: number,
 /**
  * True when the underlying diff was truncated.
  */
@@ -2351,25 +2351,25 @@ export type ExecBackend = "local" | "e2b" | "daytona" | "docker";
 /**
  * Renderer-safe configuration and readiness.
  */
-export type ExecConfigInfo = { provider?: ExecProviderKind, timeout_ms: number, available: boolean, 
+export type ExecConfigInfo = { provider?: ExecProviderKind, timeout_ms: number, available: boolean,
 /**
  * Why the *selected* provider cannot run, when it cannot. Absent while
  * execution is available or no provider is selected at all.
  */
-unavailable_reason?: ExecUnavailableReason, has_credential: boolean, 
+unavailable_reason?: ExecUnavailableReason, has_credential: boolean,
 /**
  * One row per shipped provider: whether it could run here at all, and the
  * reason it could not. This is what makes an unusable host legible —
  * "paste an E2B key" is visible instead of being inferred from a generic
  * execution failure.
  */
-providers: Array<ExecProviderAvailability>, 
+providers: Array<ExecProviderAvailability>,
 /**
  * The configured egress policy and each managed provider's enforcement
  * status, so the renderer can present the policy and disclose which
  * providers actually restrict egress today.
  */
-egress: ExecEgressInfo, 
+egress: ExecEgressInfo,
 /**
  * Per-provider detached-admission evaluation: for each execution
  * provider, whether the fail-closed gate (issue #824) would admit a
@@ -2398,14 +2398,14 @@ export type ExecDegradation = "sandbox_image_unavailable";
  * A managed provider's egress-enforcement status, as host knowledge rather
  * than a claim the backend makes about itself.
  */
-export type ExecEgressEnforcement = { provider: ExecProviderKind, status: EgressEnforcementStatus, 
+export type ExecEgressEnforcement = { provider: ExecProviderKind, status: EgressEnforcementStatus,
 /**
  * Destinations the vendor's mechanism keeps reachable regardless of the
  * configured policy — each a short purpose string straight from the
  * enforcement model, so the settings surface can show the caveat inline
  * instead of burying it in prose the user skims past.
  */
-gaps: Array<string>, 
+gaps: Array<string>,
 /**
  * A precondition the boundary is gated on that the host cannot verify
  * statically ("Daytona org tier 3+"). Present only for a
@@ -2418,13 +2418,13 @@ requirement?: string, };
 /**
  * Renderer-safe egress policy plus per-provider enforcement disclosure.
  */
-export type ExecEgressInfo = { 
+export type ExecEgressInfo = {
 /**
  * The configured host policy. `Open` is the default: managed sandboxes are
  * created with open internet access. An allowlist restricts every managed
  * sandbox created afterwards.
  */
-policy: EgressConfig, 
+policy: EgressConfig,
 /**
  * One row per managed provider, stating whether its egress restriction is
  * confirmed against the live vendor API or still pending confirmation.
@@ -2512,31 +2512,31 @@ export type ExecUnavailableReason = "unsupported_platform" | "missing_sandbox_bi
  * Why a session is fenced: observed but not controlled, until an explicit
  * user reap resolves it.
  */
-export type FenceReason = { "type": "orphan_alive" } | { "type": "probe_ambiguous", 
+export type FenceReason = { "type": "orphan_alive" } | { "type": "probe_ambiguous",
 /**
  * Bounded human-readable detail.
  */
-detail: string, } | { "type": "resume_lost", 
+detail: string, } | { "type": "resume_lost",
 /**
  * Bounded human-readable detail, as the engine reported it.
  */
-detail: string, } | { "type": "repeated_turn_failures", 
+detail: string, } | { "type": "repeated_turn_failures",
 /**
  * How many turns failed in a row.
  */
-count: number, 
+count: number,
 /**
  * Bounded detail from the last failure, as the engine reported it.
  */
-detail: string, } | { "type": "incarnation_unresolved", 
+detail: string, } | { "type": "incarnation_unresolved",
 /**
  * Bounded human-readable detail.
  */
-detail: string, } | { "type": "sandbox_lost", 
+detail: string, } | { "type": "sandbox_lost",
 /**
  * Bounded detail, as the environment classified it.
  */
-detail: string, } | { "type": "terminal_flush_missing", 
+detail: string, } | { "type": "terminal_flush_missing",
 /**
  * Bounded human-readable detail.
  */
@@ -2565,7 +2565,7 @@ export type FolderAccess = "read" | "read_write";
  * One entitled connected app, with the slugs of the MCP endpoints that
  * aggregate it — the `mcp:<slug>` resources a mount would request.
  */
-export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabled: boolean, mcp_endpoint_slugs: Array<string>, 
+export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabled: boolean, mcp_endpoint_slugs: Array<string>,
 /**
  * The gateway's readiness for this app when the member catalog reports
  * one: `ready`, `not_connected`, or `authorization_required`. `None`
@@ -2573,7 +2573,7 @@ export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabl
  * no readiness rather than guessing. An unfamiliar value renders as
  * not-ready copy, never an error: the set is the gateway's to grow.
  */
-connection?: string, 
+connection?: string,
 /**
  * How many live local-app grants bind this gateway app — the same
  * "Used by N local apps" line the connected-apps page carries per record,
@@ -2586,7 +2586,7 @@ used_by_app_count: number, };
  * to, fetched live from the gateway (never cached: a revoked grant is gone
  * on the next request).
  */
-export type GatewayApps = { 
+export type GatewayApps = {
 /**
  * False when the connected gateway predates the JSON apps surface; the
  * renderer hides the section instead of showing an empty list as "none".
@@ -2600,7 +2600,7 @@ supported: boolean, apps: Array<GatewayAppInfo>, };
  * with a usable URL (the retired `configured`/`enabled` bits collapsed into
  * its presence).
  */
-export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, 
+export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number,
 /**
  * The member-catalog contract revision the last model sync read, or
  * `None` while unsynced or against a gateway that predates
@@ -2644,27 +2644,27 @@ export type HarnessAuthMode = "local_sign_in" | "gateway_managed" | "gateway_rel
  * Constructed exhaustively — there is no [`Default`] — so a new flag is a
  * compile break at every adapter.
  */
-export type HarnessCaps = { 
+export type HarnessCaps = {
 /**
  * The engine can resume a prior session from a native resume ref.
  */
-resume: CapLevel, 
+resume: CapLevel,
 /**
  * The engine streams partial assistant text.
  */
-streaming_deltas: CapLevel, 
+streaming_deltas: CapLevel,
 /**
  * The engine exposes a structured approval channel.
  */
-structured_approvals: CapLevel, 
+structured_approvals: CapLevel,
 /**
  * The engine accepts a mid-turn user message.
  */
-mid_turn_steering: CapLevel, 
+mid_turn_steering: CapLevel,
 /**
  * The engine has a read-only / plan posture the adapter can select.
  */
-plan_mode: CapLevel, 
+plan_mode: CapLevel,
 /**
  * The engine has a workspace-write / auto posture the adapter can select.
  *
@@ -2673,24 +2673,24 @@ plan_mode: CapLevel,
  * approval cards; without it, Auto runs unsupervised and the product
  * states so where the mode is chosen (decision 0038).
  */
-auto_mode: CapLevel, 
+auto_mode: CapLevel,
 /**
  * The engine has an allow-everything / bypass posture the adapter can
  * select. Composed only when the session is in Allow (decision 0039).
  */
-allow_mode: CapLevel, 
+allow_mode: CapLevel,
 /**
  * The engine accepts a reasoning-effort control.
  */
-reasoning_levels: CapLevel, 
+reasoning_levels: CapLevel,
 /**
  * The engine emits native file-change events.
  */
-native_file_change_events: CapLevel, 
+native_file_change_events: CapLevel,
 /**
  * The engine honors a native interrupt.
  */
-native_interrupt: CapLevel, 
+native_interrupt: CapLevel,
 /**
  * The engine consumes an image on its machine-readable input path.
  *
@@ -2698,7 +2698,7 @@ native_interrupt: CapLevel,
  * proves a captured image round-trip. The product must not offer
  * attachments otherwise.
  */
-image_input: CapLevel, 
+image_input: CapLevel,
 /**
  * The engine has a discoverable slash-command vocabulary.
  *
@@ -2711,11 +2711,11 @@ slash_commands: CapLevel, };
 /**
  * One engine-owned slash command, captured from the engine's own listing.
  */
-export type HarnessCommand = { 
+export type HarnessCommand = {
 /**
  * The word typed after `/`. No leading slash.
  */
-name: string, 
+name: string,
 /**
  * One-line description from the engine, already bounded.
  */
@@ -2724,7 +2724,7 @@ description: string, };
 /**
  * One engine's probe, capabilities, and remediation.
  */
-export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean, 
+export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean,
 /**
  * Whether Tidebreak ships a pin it can download for this engine.
  *
@@ -2732,7 +2732,7 @@ export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean,
  * the download starts; the doctor is not a gate the reader must clear
  * first.
  */
-installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, 
+installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean,
 /**
  * How a session of this engine authenticates here: the engine's own
  * local sign-in, a credential override that authenticates without one
@@ -2742,7 +2742,7 @@ installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: 
  * observation, which on a hosted or gateway-managed machine is not what
  * a session authenticates with.
  */
-auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, 
+auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number,
 /**
  * Whether relaunching a session applies a permission mode chosen after
  * it started. False for engines that fix the mode on session create
@@ -2766,11 +2766,11 @@ export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok";
 /**
  * One model row offered for a harness session.
  */
-export type HarnessModel = { id: string, label: string, default: boolean, 
+export type HarnessModel = { id: string, label: string, default: boolean,
 /**
  * Effort levels this row accepts, ascending. Empty hides the control.
  */
-reasoning_efforts: Array<ReasoningEffort>, 
+reasoning_efforts: Array<ReasoningEffort>,
 /**
  * Whether this row can serve the engine's fast mode. `false` hides the
  * control, the same way an empty effort ladder does.
@@ -2780,7 +2780,7 @@ fast_mode: boolean, };
 /**
  * `GET /code/harnesses/{kind}/models`.
  */
-export type HarnessModelList = { kind: HarnessKind, models: Array<HarnessModel>, 
+export type HarnessModelList = { kind: HarnessKind, models: Array<HarnessModel>,
 /**
  * Every effort level this engine accepts, ascending, across all models.
  *
@@ -2844,23 +2844,23 @@ export type ImageMediaType = "png" | "jpeg" | "webp" | "gif";
  * id is an opaque content-derived UUID, never a filesystem path, so it reveals
  * nothing about where the bytes live on disk.
  */
-export type ImageRef = { 
+export type ImageRef = {
 /**
  * Content-addressed blob holding the pixels.
  */
-blob_id: string, 
+blob_id: string,
 /**
  * Format the bytes were sniffed as at ingest.
  */
-media_type: ImageMediaType, 
+media_type: ImageMediaType,
 /**
  * Pixel width, read from the image header.
  */
-width: number, 
+width: number,
 /**
  * Pixel height, read from the image header.
  */
-height: number, 
+height: number,
 /**
  * Size of the stored bytes.
  */
@@ -2878,11 +2878,11 @@ export type InboxConversation = { "surface": "chat", chat_id: ChatId, } | { "sur
 /**
  * One conversation that wants the reader, and why.
  */
-export type InboxEntrySnapshot = { conversation: InboxConversation, 
+export type InboxEntrySnapshot = { conversation: InboxConversation,
 /**
  * Absent, not null, while the conversation is still untitled.
  */
-title?: string, attention: Attention, 
+title?: string, attention: Attention,
 /**
  * The parked calls behind this attention, oldest first.
  *
@@ -2890,7 +2890,7 @@ title?: string, attention: Attention,
  * code approval route, which carries the verbatim payload decision 33
  * requires and which a deep link reaches.
  */
-items: Array<InboxItemSnapshot>, 
+items: Array<InboxItemSnapshot>,
 /**
  * When the oldest thing here started waiting, for ordering.
  */
@@ -2908,12 +2908,12 @@ export type InboxItemKind = "tool_approval" | "question" | "plan_review" | "fold
 /**
  * One item waiting on the reader, and where to go to answer it.
  */
-export type InboxItemSnapshot = { 
+export type InboxItemSnapshot = {
 /**
  * With the entry's conversation, the deep link back to the exact
  * transcript position the item paused at.
  */
-turn_id: TurnId, call_id: CallId, kind: InboxItemKind, 
+turn_id: TurnId, call_id: CallId, kind: InboxItemKind,
 /**
  * The tool under review, for an approval. Absent for the other kinds,
  * whose tool is implied by the kind. Closed renderer vocabulary: an
@@ -2933,7 +2933,7 @@ export type InputModality = "text" | "image";
  * Renderer-safe resolved policy. Carries only what surfaces need to render
  * managed state: the verdict, the locked gateway URL, and its authority.
  */
-export type ManagedPolicy = { managed: boolean, gateway_url?: string, 
+export type ManagedPolicy = { managed: boolean, gateway_url?: string,
 /**
  * The gateway a hosted deployment authenticates its own callers against
  * (`docs/decisions/0049-gateway-authenticated-hosted-machines.md`).
@@ -2951,14 +2951,14 @@ export type ManagedPolicy = { managed: boolean, gateway_url?: string,
  * hosted machine locks nothing, and its stored provider configuration
  * still wins (decision 51, rule 3).
  */
-hosted_gateway_url?: string, source: ManagedPolicySource, 
+hosted_gateway_url?: string, source: ManagedPolicySource,
 /**
  * True when `source` asserted management but its gateway URL is missing,
  * unreadable, or invalid. The profile stays managed with no usable URL —
  * fail closed — and surfaces can name the authority that needs repair
  * instead of showing an opaque error.
  */
-misconfigured: boolean, 
+misconfigured: boolean,
 /**
  * A deep-link pairing awaiting the sign-in that is its consent. Runtime
  * state merged in by the `/policy` route from [`GatewayRuntime`]
@@ -2966,7 +2966,7 @@ misconfigured: boolean,
  * [`resolve`] always leaves it `None` — and only ever present while the
  * profile is unmanaged.
  */
-pending_gateway_url?: string, 
+pending_gateway_url?: string,
 /**
  * The highest permission mode any chat may run under, when the OS policy
  * asserts one. A ceiling, not a fixed mode: the reader may always pick a
@@ -2974,7 +2974,7 @@ pending_gateway_url?: string,
  * Asserted per key, so it binds even when no gateway URL is deployed and
  * the profile is otherwise unmanaged.
  */
-permission_mode_ceiling?: PermissionMode, 
+permission_mode_ceiling?: PermissionMode,
 /**
  * True when the OS policy explicitly allows local stdio MCP servers on a
  * managed profile. False by default — the managed lockdown covers every
@@ -2998,16 +2998,16 @@ export type MarkNotificationsReadResult = { marked: number, };
  * without one is "community". One field cannot disagree with itself the way
  * a separate boolean and a separate record could.
  */
-export type McpCuration = { 
+export type McpCuration = {
 /**
  * The curated list's own name for the server, which need not match the
  * namespace the reader configured it under.
  */
-display_name: string, 
+display_name: string,
 /**
  * `YYYY-MM-DD` the entry was last exercised end to end.
  */
-tested_on: string, 
+tested_on: string,
 /**
  * One sentence on what was exercised, for the reader deciding how much
  * the badge is worth.
@@ -3026,14 +3026,14 @@ export type McpHealth = "initializing" | "healthy" | "degraded" | "reconnecting"
  * [`validate_servers`] enforces that process fields stay with `command` and
  * `bearer_token_env` stays with `url`.
  */
-export type McpServerDefinition = { name: string, command: string | null, args: Array<string>, 
+export type McpServerDefinition = { name: string, command: string | null, args: Array<string>,
 /**
  * Names of the environment variables this server is given directly. The
  * values live in the secret store under [`env_secret_key`] and never
  * enter this type, so they neither persist in the connected-app record
  * nor project through the API.
  */
-env: Array<string>, 
+env: Array<string>,
 /**
  * Inbound-only: values for [`env`](Self::env) names being set or
  * changed. A commit writes these into the secret store and drops them; a
@@ -3041,27 +3041,27 @@ env: Array<string>,
  * which is what makes "leave blank to keep" work. `skip_serializing`
  * keeps them out of both the persisted record and every projection.
  */
-env_values?: { [key in string]: string }, 
+env_values?: { [key in string]: string },
 /**
  * Parent environment names to forward. Their values never enter this type.
  */
-env_from: Array<string>, cwd: string | null, 
+env_from: Array<string>, cwd: string | null,
 /**
  * Streamable HTTP endpoint for a remote server.
  */
-url: string | null, 
+url: string | null,
 /**
  * Parent environment name holding the HTTP bearer token. The value is
  * resolved at connect time and never enters this type.
  */
-bearer_token_env: string | null, 
+bearer_token_env: string | null,
 /**
  * Endpoint slug of a gateway MCP endpoint, mounted through the signed-in
  * model-gateway session. The endpoint URL and its short-lived bearer are
  * resolved from the session at every connection and never enter this
  * type.
  */
-gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, 
+gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean,
 /**
  * The plugin this server was synthesized from, when it is plugin-sourced.
  *
@@ -3075,21 +3075,21 @@ plugin: string | null, };
  * One renderer-safe server projection. Resolved `env_from` values and child
  * process details are intentionally absent.
  */
-export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null, 
+export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null,
 /**
  * The curated-list entry this definition matches, when Tidebreak has
  * exercised the server end to end. `null` means community: mounted and
  * usable, just not something we have driven ourselves. Derived from the
  * definition on every read, never stored.
  */
-curated: McpCuration | null, name: string, command: string | null, args: Array<string>, 
+curated: McpCuration | null, name: string, command: string | null, args: Array<string>,
 /**
  * Names of the environment variables this server is given directly. The
  * values live in the secret store under [`env_secret_key`] and never
  * enter this type, so they neither persist in the connected-app record
  * nor project through the API.
  */
-env: Array<string>, 
+env: Array<string>,
 /**
  * Inbound-only: values for [`env`](Self::env) names being set or
  * changed. A commit writes these into the secret store and drops them; a
@@ -3097,27 +3097,27 @@ env: Array<string>,
  * which is what makes "leave blank to keep" work. `skip_serializing`
  * keeps them out of both the persisted record and every projection.
  */
-env_values?: { [key in string]: string }, 
+env_values?: { [key in string]: string },
 /**
  * Parent environment names to forward. Their values never enter this type.
  */
-env_from: Array<string>, cwd: string | null, 
+env_from: Array<string>, cwd: string | null,
 /**
  * Streamable HTTP endpoint for a remote server.
  */
-url: string | null, 
+url: string | null,
 /**
  * Parent environment name holding the HTTP bearer token. The value is
  * resolved at connect time and never enters this type.
  */
-bearer_token_env: string | null, 
+bearer_token_env: string | null,
 /**
  * Endpoint slug of a gateway MCP endpoint, mounted through the signed-in
  * model-gateway session. The endpoint URL and its short-lived bearer are
  * resolved from the session at every connection and never enter this
  * type.
  */
-gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, 
+gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean,
 /**
  * The plugin this server was synthesized from, when it is plugin-sourced.
  *
@@ -3137,15 +3137,15 @@ export type McpViewSession = { frame_path: string, };
 /**
  * Body of `POST /code/workspaces/{id}/pr/merge`.
  */
-export type MergeCodePrBody = { 
+export type MergeCodePrBody = {
 /**
  * The repository and pull request shown in the confirmation.
  */
-target: CodeDeliveryPullRequestTarget, 
+target: CodeDeliveryPullRequestTarget,
 /**
  * The pull request head shown in the confirmation.
  */
-expected_head_sha: string, method: CodePrMergeMethod, 
+expected_head_sha: string, method: CodePrMergeMethod,
 /**
  * True arms host auto-merge instead of merging immediately.
  */
@@ -3159,34 +3159,34 @@ export type MessageId = string;
 /**
  * A selectable model in the catalog.
  */
-export type ModelInfo = { 
+export type ModelInfo = {
 /**
  * Stable provider-qualified selection key used by settings and chats.
  */
-key: string, 
+key: string,
 /**
  * The identifier passed to the provider and stored as `chat.model`.
  */
-id: string, 
+id: string,
 /**
  * Human-readable label for the selector (e.g. `"Claude Opus 4.8"`).
  */
-display_name: string, 
+display_name: string,
 /**
  * The provider that serves the model.
  */
-provider: ProviderKind, 
+provider: ProviderKind,
 /**
  * The vendor whose curated model this row is, when that differs from the
  * provider serving it — a gateway-served model whose id exactly matches a
  * curated one. For presentation only (icon and branding); routing still
  * uses `provider`, and a client falls back to it when this is null.
  */
-vendor: ProviderKind | null, 
+vendor: ProviderKind | null,
 /**
  * How thoroughly Tidebreak has exercised this provider/model combination.
  */
-verification: VerificationTier, 
+verification: VerificationTier,
 /**
  * Whether a picker shows this model without being asked for the full
  * catalog — the curated default-visible set.
@@ -3197,37 +3197,37 @@ verification: VerificationTier,
  * `model_visibility_overrides` setting; the server never filters the
  * catalog by it.
  */
-recommended: boolean, 
+recommended: boolean,
 /**
  * Whether the provider is enabled, configured, credentialed, and able to
  * serve this model at its configured endpoint/location.
  */
-available: boolean, 
+available: boolean,
 /**
  * Approximate context window in tokens.
  */
-context_window: number, 
+context_window: number,
 /**
  * Maximum model output in tokens.
  */
-max_output_tokens: number, 
+max_output_tokens: number,
 /**
  * Input modalities accepted by the model.
  */
-input_modalities: Array<InputModality>, 
+input_modalities: Array<InputModality>,
 /**
  * Whether the model can produce an internal reasoning stream.
  */
-supports_reasoning: boolean, 
+supports_reasoning: boolean,
 /**
  * Whether this provider/model route accepts function tools.
  */
-supports_tools: boolean, 
+supports_tools: boolean,
 /**
  * Whether this provider/model route can enforce the strict response schema
  * utility work depends on.
  */
-supports_structured_output: boolean, 
+supports_structured_output: boolean,
 /**
  * The reasoning-effort levels this model accepts, ascending. Empty when
  * the model exposes no effort control, which is what a client checks
@@ -3237,7 +3237,7 @@ supports_structured_output: boolean,
  * is the same union a chat's stored effort has, and a client cannot offer
  * a level it could not then set.
  */
-reasoning_efforts: Array<ReasoningEffort>, 
+reasoning_efforts: Array<ReasoningEffort>,
 /**
  * Whether the model accepts image input alongside text.
  */
@@ -3254,16 +3254,16 @@ export type ModelRole = "chat" | "utility";
 /**
  * One named model role and what it resolves to right now.
  */
-export type ModelRoleInfo = { 
+export type ModelRoleInfo = {
 /**
  * The role this row describes.
  */
-role: ModelRole, 
+role: ModelRole,
 /**
  * The catalog key the user selected for this role, or `None` when the role
  * is left automatic.
  */
-selection: string | null, 
+selection: string | null,
 /**
  * The catalog key this role resolves to right now, selection or not.
  *
@@ -3335,11 +3335,11 @@ export type OutputWriteMode = "create" | "replace";
  * an action, not to a sentence about one. See
  * `docs/decisions/0018-tool-call-narration.md`.
  */
-export type PendingApprovalSnapshot = { call_id: CallId, turn_id: TurnId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
+export type PendingApprovalSnapshot = { call_id: CallId, turn_id: TurnId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass,
 /**
  * Absent, not null, when the tool projects no action.
  */
-preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean, 
+preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean,
 /**
  * Complete standing-grant ladder for this exact call, narrowest first.
  *
@@ -3347,7 +3347,7 @@ preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean,
  * the whole ladder because command policy may refuse exact and whole-tool
  * grants as well as prefixes.
  */
-grant_rungs: Array<ApprovalGrantRung>, 
+grant_rungs: Array<ApprovalGrantRung>,
 /**
  * Where the Auto-mode judge stands, when one was engaged. Absent means
  * no judge ever owned this card.
@@ -3424,15 +3424,15 @@ export type PluginCapability = "write-files" | "network" | "host-install" | "liv
 /**
  * Everything this installation has, in the state it is in.
  */
-export type PluginCatalog = { 
+export type PluginCatalog = {
 /**
  * Bundles in load order (by slug), each with its members.
  */
-plugins: Array<PluginInfo>, 
+plugins: Array<PluginInfo>,
 /**
  * Skills no bundle claims — user-authored packages land here.
  */
-skills: Array<PluginSkillInfo>, 
+skills: Array<PluginSkillInfo>,
 /**
  * Every installed prompt, bundled or standalone, in one flat list.
  *
@@ -3468,11 +3468,11 @@ export type PluginCompatibilityStatus = "compatible" | "limited" | "unchecked";
 /**
  * Body of `PUT /plugins/enabled`. Absent names are left alone.
  */
-export type PluginEnableUpdate = { 
+export type PluginEnableUpdate = {
 /**
  * Bundle flags to set, by slug.
  */
-plugins: { [key in string]: boolean }, 
+plugins: { [key in string]: boolean },
 /**
  * Skill flags to set, by slug. Setting one inside a disabled bundle is
  * allowed and remembered; it takes effect when the bundle comes back.
@@ -3482,31 +3482,31 @@ skills: { [key in string]: boolean }, };
 /**
  * One bundle, as a management surface renders it.
  */
-export type PluginInfo = { 
+export type PluginInfo = {
 /**
  * The slug the toggle route addresses it by.
  */
-name: string, display_name: string, description: string, category: PluginCategory, 
+name: string, display_name: string, description: string, category: PluginCategory,
 /**
  * Where the bundle was loaded from; host-derived, never claimed.
  */
-origin: PluginOrigin, 
+origin: PluginOrigin,
 /**
  * What the bundle can do, derived by the host from what it contains.
  * Never self-declared: a manifest has no key for this.
  */
-capabilities: Array<PluginCapability>, 
+capabilities: Array<PluginCapability>,
 /**
  * Import-time static compatibility disclosure. A hand-authored bundle is
  * explicitly unchecked; imported bundles say whether they fit the
  * prepared sandbox image and why not.
  */
-compatibility: PluginCompatibility, 
+compatibility: PluginCompatibility,
 /**
  * Whether the bundle is on. Off gates every member regardless of the
  * member's own flag, which the member entries still report unchanged.
  */
-enabled: boolean, 
+enabled: boolean,
 /**
  * Member skills in manifest order.
  */
@@ -3529,24 +3529,24 @@ export type PluginOrigin = "builtin" | "user";
  * [`get_prompt_body`] when the user actually picks one, so the catalog stays
  * bytes per entry no matter how long the prompts are.
  */
-export type PluginPromptInfo = { 
+export type PluginPromptInfo = {
 /**
  * The slug the body route addresses it by.
  */
-name: string, 
+name: string,
 /**
  * The tip a card or popover shows.
  */
-description: string, 
+description: string,
 /**
  * Where the package was loaded from; host-derived, never claimed.
  */
-origin: PromptOrigin, 
+origin: PromptOrigin,
 /**
  * The bundle that claims this prompt, if any. `None` is a standalone
  * package — every user-authored prompt is one.
  */
-plugin: string | null, 
+plugin: string | null,
 /**
  * Whether the prompt is offered. A prompt has no flag of its own: a
  * bundled one follows its bundle, and a standalone one is always on.
@@ -3556,11 +3556,11 @@ enabled: boolean, };
 /**
  * One skill, inside a bundle or standing alone.
  */
-export type PluginSkillInfo = { name: string, description: string, 
+export type PluginSkillInfo = { name: string, description: string,
 /**
  * Where the package was loaded from; host-derived, never claimed.
  */
-origin: SkillOrigin, 
+origin: SkillOrigin,
 /**
  * The skill's *own* flag, independent of any owning bundle's — so a UI
  * can show the member choices that come back when a bundle is re-enabled.
@@ -3572,24 +3572,24 @@ enabled: boolean, };
  * corpus. A chat may belong to a project or stand alone — unlike some designs
  * that make a project mandatory, Tidebreak keeps loose, projectless chats.
  */
-export type Project = { 
+export type Project = {
 /**
  * Stable identifier.
  */
-id: ProjectId, 
+id: ProjectId,
 /**
  * Human-facing title.
  */
-title: string | null, 
+title: string | null,
 /**
  * CAS revision of the ordered root projection.
  */
-attachment_revision: number, 
+attachment_revision: number,
 /**
  * Ordered opaque root defaults for conversations created in this project.
  * These ids are product state, never host authorization.
  */
-root_attachments: Array<HostRootId>, 
+root_attachments: Array<HostRootId>,
 /**
  * When the project was created.
  */
@@ -3606,7 +3606,7 @@ export type ProjectId = string;
  * Its own route for the same reason skill instructions have one: the catalog
  * is fetched far more often than any one prompt is inserted.
  */
-export type PromptBody = { name: string, 
+export type PromptBody = { name: string,
 /**
  * The `PROMPT.md` markdown below the frontmatter — exactly what goes into
  * the composer. It is never composed into the model's operating prompt;
@@ -3630,27 +3630,27 @@ export type ProviderAuthMode = "api_key" | "chatgpt";
 /**
  * Public view of a provider — never includes the credential itself.
  */
-export type ProviderInfo = { 
+export type ProviderInfo = {
 /**
  * Provider kind.
  */
-kind: ProviderKind, 
+kind: ProviderKind,
 /**
  * Whether the provider is enabled for routing.
  */
-enabled: boolean, 
+enabled: boolean,
 /**
  * Configured base URL, if any.
  */
-base_url?: string, 
+base_url?: string,
 /**
  * Whether a credential is stored (never the credential itself).
  */
-has_credential: boolean, 
+has_credential: boolean,
 /**
  * How OpenAI (or similarly dual-mode providers) is authenticated.
  */
-auth_mode?: ProviderAuthMode, 
+auth_mode?: ProviderAuthMode,
 /**
  * Explicit configured model entries for this endpoint.
  */
@@ -3665,19 +3665,19 @@ export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "firework
 /**
  * One CI check on a pull request.
  */
-export type PullRequestCheck = { 
+export type PullRequestCheck = {
 /**
  * Check name as the host reports it.
  */
-name: string, 
+name: string,
 /**
  * pass, pending, fail, or skipped.
  */
-bucket: PullRequestCheckBucket, 
+bucket: PullRequestCheckBucket,
 /**
  * Host status phrase, when distinct from the bucket.
  */
-detail?: string, 
+detail?: string,
 /**
  * Host URL for this check, when known.
  */
@@ -3692,45 +3692,45 @@ export type PullRequestCheckBucket = "pass" | "pending" | "fail" | "skipped";
  * One pull-request comment: an issue comment, a review body, or an inline
  * review comment. Never persisted; fetched live from the host.
  */
-export type PullRequestComment = { 
+export type PullRequestComment = {
 /**
  * Where on the PR the comment lives.
  */
-kind: PullRequestCommentKind, 
+kind: PullRequestCommentKind,
 /**
  * Stable host identifier, normalized to text across GraphQL and REST
  * comment shapes.
  */
-id?: string, 
+id?: string,
 /**
  * Author login, when the host reported one.
  */
-author?: string, 
+author?: string,
 /**
  * Author avatar URL, when the host reported one.
  */
-avatar_url?: string, 
+avatar_url?: string,
 /**
  * Host page for the comment or review, when available.
  */
-url?: string, 
+url?: string,
 /**
  * Host creation timestamp, verbatim.
  */
-created_at?: string, 
+created_at?: string,
 /**
  * Comment body, markdown as the host stores it.
  */
-body: string, 
+body: string,
 /**
  * Lowercased review verdict (approved, changes_requested, commented), on
  * review bodies only.
  */
-review_state?: string, 
+review_state?: string,
 /**
  * File path, on inline review comments.
  */
-path?: string, 
+path?: string,
 /**
  * Line number, on inline review comments when the host reports one.
  */
@@ -3744,64 +3744,64 @@ export type PullRequestCommentKind = "issue" | "review" | "inline";
 /**
  * Bounded pull-request digest stored on a workspace.
  */
-export type PullRequestDigest = { 
+export type PullRequestDigest = {
 /**
  * PR number on the host.
  */
-number: number, 
+number: number,
 /**
  * Host URL, when known.
  */
-url?: string | null, 
+url?: string | null,
 /**
  * Host state token (open, merged, closed, …).
  */
-state: string, 
+state: string,
 /**
  * PR title, when the host reported one.
  */
-title?: string, 
+title?: string,
 /**
  * One-line checks summary.
  */
-checks_summary?: string | null, 
+checks_summary?: string | null,
 /**
  * Individual checks, when the host reported any.
  */
-checks?: Array<PullRequestCheck>, 
+checks?: Array<PullRequestCheck>,
 /**
  * True when the host reports the PR as a draft.
  */
-draft?: boolean, 
+draft?: boolean,
 /**
  * True when the host reports the PR merged.
  */
-merged?: boolean, 
+merged?: boolean,
 /**
  * Lowercased host review decision (approved, changes_requested, review_required).
  */
-review_decision?: string, 
+review_decision?: string,
 /**
  * Lowercased host mergeability (mergeable, conflicting, unknown).
  */
-mergeable?: string, 
+mergeable?: string,
 /**
  * Lowercased host merge-state status (clean, blocked, behind, dirty, …).
  */
-merge_state_status?: string, 
+merge_state_status?: string,
 /**
  * Head branch name on the host.
  */
-head_branch?: string, 
+head_branch?: string,
 /**
  * Base branch name on the host.
  */
-base_branch?: string, 
+base_branch?: string,
 /**
  * Head commit SHA the digest was read against, when the host reported
  * one. The watch sweep uses it to avoid re-fixing the same head.
  */
-head_sha?: string, 
+head_sha?: string,
 /**
  * True when auto-merge is enabled on the host.
  */
@@ -3823,43 +3823,43 @@ export type QueuedCodeTurn = { id: CodeTurnId, session_id: CodeSessionId, messag
  * turn. Rows are FIFO by `position` within a chat and fully durable: a queue
  * survives restarts and is visible to every client on the chat.
  */
-export type QueuedTurn = { 
+export type QueuedTurn = {
 /**
  * The turn id this row becomes when promoted.
  */
-id: TurnId, 
+id: TurnId,
 /**
  * Owning chat.
  */
-chat_id: ChatId, 
+chat_id: ChatId,
 /**
  * Byte-exact user message.
  */
-content: string, 
+content: string,
 /**
  * Image-attachment ids, in display order.
  */
-attachments: Array<string>, 
+attachments: Array<string>,
 /**
  * Chat-owned document ids.
  */
-file_attachments: Array<DocumentId>, 
+file_attachments: Array<DocumentId>,
 /**
  * Skills the user explicitly invoked.
  */
-invoked_skills: Array<string>, 
+invoked_skills: Array<string>,
 /**
  * Whether the message was dictated.
  */
-voice_input_used: boolean, 
+voice_input_used: boolean,
 /**
  * FIFO order within the chat.
  */
-position: number, 
+position: number,
 /**
  * When the message was queued.
  */
-created_at: string, 
+created_at: string,
 /**
  * When it was last edited or reordered.
  */
@@ -3868,15 +3868,15 @@ updated_at: string, };
 /**
  * A named command the user can run in a workspace.
  */
-export type QuickAction = { 
+export type QuickAction = {
 /**
  * Display name.
  */
-name: string, 
+name: string,
 /**
  * Command to run in the worktree.
  */
-command: string, 
+command: string,
 /**
  * When true, run once after workspace creation.
  */
@@ -3900,59 +3900,59 @@ auto_run_on_create: boolean, };
  */
 export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
 
-export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta", text: string, } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "plan_proposed", call_id: CallId, turn_id: TurnId, } | { "type": "task_plan_updated", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
+export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta", text: string, } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "plan_proposed", call_id: CallId, turn_id: TurnId, } | { "type": "task_plan_updated", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass,
 /**
  * Whether the Auto-mode judge owns this card right now. The card
  * stays fully actionable either way; this only adds the "deciding
  * automatically" hint.
  */
-auto_judging: boolean, 
+auto_judging: boolean,
 /**
  * Complete standing-grant ladder for this exact call, narrowest first.
  * Empty means only one-shot approval is available.
  */
-grant_rungs: Array<ApprovalGrantRung>, 
+grant_rungs: Array<ApprovalGrantRung>,
 /**
  * The one deliberate opening in this boundary. A human cannot consent
  * to a command they are not shown, so a tool may project a closed,
  * field-by-field view of the action under review. Tools without one
  * send nothing, as every tool did before.
  */
-preview?: ToolActionPreview, } | { "type": "approval_decided", call_id: CallId, approved: boolean, } | { "type": "tool_call_completed", call_id: CallId, status: RendererToolStatus, 
+preview?: ToolActionPreview, } | { "type": "approval_decided", call_id: CallId, approved: boolean, } | { "type": "tool_call_completed", call_id: CallId, status: RendererToolStatus,
 /**
  * A bounded, server-authored reason the renderer can act on without
  * receiving model-facing output or executor diagnostics.
  */
-failure?: RendererToolFailure, 
+failure?: RendererToolFailure,
 /**
  * What the call did, when its tool projects it. Approval is not the
  * only moment a person needs to see the action.
  */
-action?: ToolActionPreview, 
+action?: ToolActionPreview,
 /**
  * What the call produced. A command's output is the reason it ran;
  * withholding it leaves the transcript asserting that something
  * happened without ever showing what.
  */
-result?: ToolResultPreview, } | { "type": "turn_completed", usage: RendererTurnUsage, } | { "type": "turn_refused", refusal: RendererRefusal, usage: RendererTurnUsage, } | { "type": "turn_failed", 
+result?: ToolResultPreview, } | { "type": "turn_completed", usage: RendererTurnUsage, } | { "type": "turn_refused", refusal: RendererRefusal, usage: RendererTurnUsage, } | { "type": "turn_failed",
 /**
  * Why the turn failed, at the only resolution a client can act on.
  * The internal `kind` stays behind the server; allowlisted provider
  * diagnostics may cross separately as `detail`.
  */
-category: TurnFailureCategory, 
+category: TurnFailureCategory,
 /**
  * Bounded provider diagnostic, when the failure originated upstream.
  */
-detail?: string, model?: RendererModelIdentity, } | { "type": "turn_cancelled", usage: RendererTurnUsage, } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated", 
+detail?: string, model?: RendererModelIdentity, } | { "type": "turn_cancelled", usage: RendererTurnUsage, } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated",
 /**
  * Estimated transcript tokens before the reduction.
  */
-original_tokens: number, 
+original_tokens: number,
 /**
  * Estimated transcript tokens after fitting to the budget.
  */
-fitted_tokens: number, } | { "type": "compaction_started" } | { "type": "compaction_finished", 
+fitted_tokens: number, } | { "type": "compaction_started" } | { "type": "compaction_finished",
 /**
  * Whether a new (or confirmed) checkpoint was stored.
  */
@@ -4023,19 +4023,19 @@ export type RendererToolStatus = "completed" | "failed";
  * It is a faithful measure of what the turn cost and a ceiling on what the
  * window held.
  */
-export type RendererTurnUsage = { 
+export type RendererTurnUsage = {
 /**
  * Fresh prompt tokens, excluding both cache figures below.
  */
-input_tokens: number, 
+input_tokens: number,
 /**
  * Tokens the model generated.
  */
-output_tokens: number, 
+output_tokens: number,
 /**
  * Prompt tokens served from the provider's cache.
  */
-cache_read_input_tokens: number, 
+cache_read_input_tokens: number,
 /**
  * Prompt tokens written to the provider's cache.
  */
@@ -4072,19 +4072,19 @@ export type RestCredentialStatus = "none" | "configured" | "missing";
  * and how big or how many. A tool that wants to say more than that is
  * describing something this projection does not cover.
  */
-export type ResultEntry = { kind: ResultEntryKind, 
+export type ResultEntry = { kind: ResultEntryKind,
 /**
  * The row's name — a file name, a source title, a page title.
  */
-label: string, 
+label: string,
 /**
  * A secondary hint beside the name — a path, a domain, a section.
  */
-detail: string | null, 
+detail: string | null,
 /**
  * Trailing meta — a size, a count, a status word.
  */
-meta: string | null, 
+meta: string | null,
 /**
  * The document's media type, when the row is a document with one.
  *
@@ -4094,7 +4094,7 @@ meta: string | null,
  * own closed mapping with a generic fallback. `default` because retained
  * projections predate the field.
  */
-media_type: string | null, 
+media_type: string | null,
 /**
  * The durable record this row names, when the renderer can open one.
  *
@@ -4109,7 +4109,7 @@ media_type: string | null,
  * [`Output`]: ResultEntryKind::Output
  * [`App`]: ResultEntryKind::App
  */
-target_id: string | null, 
+target_id: string | null,
 /**
  * The public page this row opens, when it names one.
  *
@@ -4144,14 +4144,14 @@ export type ResultEntryKind = "file" | "folder" | "source" | "passage" | "link" 
  * Two fields because that is what a failure row reads as: the thing that
  * failed, and why.
  */
-export type ResultFailure = { 
+export type ResultFailure = {
 /**
  * What failed, when the tool can name it. `None` when the tool cannot —
  * a folder it could not even read the name of — and the row then leads
  * with a generic noun rather than being dropped. A failure the reader
  * never sees is worse than one it cannot fully name.
  */
-label: string | null, 
+label: string | null,
 /**
  * Why it failed, in the tool's own words.
  *
@@ -4178,25 +4178,25 @@ export type RootAttachmentOrigin = "project_default" | "conversation";
 /**
  * One event on the per-session WebSocket.
  */
-export type SequencedCodeEventFrame = { 
+export type SequencedCodeEventFrame = {
 /**
  * Journal position. On a `transient` frame this is the cursor the event
  * streamed behind, not a position the frame occupies — resume from it
  * and you lose nothing, because no row holds this event.
  */
-seq: number, event: CodeEvent, replayed?: boolean, 
+seq: number, event: CodeEvent, replayed?: boolean,
 /**
  * Set on a live-only event the journal does not hold: assistant deltas,
  * and the catch-up delta a mid-turn reader gets on connect. Apply it but
  * do not advance the resume cursor. A reconnect may receive the complete
  * current tail with `replacement` set (record 57).
  */
-transient?: boolean, 
+transient?: boolean,
 /**
  * Set on a transient assistant delta that contains the complete live
  * tail. Replace the current assistant buffer instead of appending it.
  */
-replacement?: boolean, 
+replacement?: boolean,
 /**
  * Set on the first replayed frame of a capped window: older events above
  * the requested cursor were dropped, and the history in front of this
@@ -4213,41 +4213,41 @@ export type SetCodeWorktreeRootBody = { root: string | null, };
  * Runtime settings a client can read. The API key itself is never returned —
  * it lives in the `SecretProvider`, not the store — only whether one is set.
  */
-export type Settings = { 
+export type Settings = {
 /**
  * The model turns run against, or `None` to use the server's default.
  */
-model: string | null, 
+model: string | null,
 /**
  * Whether a model API key is configured (never the key itself).
  */
-has_api_key: boolean, 
+has_api_key: boolean,
 /**
  * The sticky new-chat defaults, so a composer for a chat that does not
  * exist yet can show what `POST /chats` will seed.
  */
-chat_defaults: StickyChatDefaults, 
+chat_defaults: StickyChatDefaults,
 /**
  * Preferred maximum concurrent background agents. Spawn unsettled
  * children on one origin turn are further capped at
  * [`AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS`] (wait_for_agents membership).
  */
-max_active_background_agents: number, 
+max_active_background_agents: number,
 /**
  * Model steps a background agent takes before it must check in.
  *
  * A cadence, not a cap: reaching it never fails the run — the agent wraps
  * up with what it has and reports back for direction.
  */
-sandbox_agent_checkin_steps: number, 
+sandbox_agent_checkin_steps: number,
 /**
  * Consecutive failed tool calls after which a background agent checks in.
  */
-sandbox_agent_error_checkin: number, 
+sandbox_agent_error_checkin: number,
 /**
  * When and how hard semantic compaction may run.
  */
-compaction: CompactionSettings, 
+compaction: CompactionSettings,
 /**
  * Per-model deviations from the catalog's `recommended` flag, keyed by the
  * same provider-qualified selection key `ModelInfo.key` and a chat's model
@@ -4262,17 +4262,17 @@ compaction: CompactionSettings,
  * and never filters `GET /models` by it. A hidden model remains fully
  * valid for existing chats, replay, and explicit selection.
  */
-model_visibility_overrides: { [key in string]: ModelVisibility }, 
+model_visibility_overrides: { [key in string]: ModelVisibility },
 /**
  * Whether the computer-use capability (screen capture + app control) is
  * enabled. Read at boot; turning it off unregisters the tools on the next
  * launch.
  */
-computer_use_enabled: boolean, 
+computer_use_enabled: boolean,
 /**
  * Whether completed code turns receive a one-line recap. Default on.
  */
-code_turn_recaps_enabled: boolean, 
+code_turn_recaps_enabled: boolean,
 /**
  * Whether completed code turns rewrite their closing message into lucid
  * prose. Default off.
@@ -4291,7 +4291,7 @@ export type SignInProgress = { "state": "idle" } | { "state": "pending", authori
  * where a catalog row is bytes, and the catalog is fetched far more often
  * than any one skill is read.
  */
-export type SkillInstructions = { name: string, 
+export type SkillInstructions = { name: string,
 /**
  * The `SKILL.md` markdown body, with the frontmatter removed — what the
  * model is taught when the skill is staged, shown to the reader verbatim.
@@ -4311,23 +4311,23 @@ export type SkillOrigin = "builtin" | "user";
  * What a document declares, for the configuration form's operation picker.
  * Renderer-safe: ids, methods, paths, and truncated summaries only.
  */
-export type SpecPreviewInfo = { 
+export type SpecPreviewInfo = {
 /**
  * Hex SHA-256 of the raw document — the pin the upsert must carry back
  * with a URL source.
  */
-document_sha256: string, operations: Array<SpecPreviewOperation>, 
+document_sha256: string, operations: Array<SpecPreviewOperation>,
 /**
  * Operations the document declares that cannot be selected (no
  * well-formed `operationId`, an over-bound path, or a repeated id).
  */
-unlistable: number, 
+unlistable: number,
 /**
  * Whether the operation list was cut at the inventory bound.
  */
 truncated: boolean, };
 
-export type SpecPreviewOperation = { operation_id: string, 
+export type SpecPreviewOperation = { operation_id: string,
 /**
  * Lowercase HTTP method, as a path item declares it.
  */
@@ -4338,16 +4338,16 @@ method: string, path: string, summary: string | null, };
  * to recognize it later and withdraw it. Grant scopes are already closed
  * renderer-safe projections, so the snapshot carries them verbatim.
  */
-export type StandingGrantSnapshot = { 
+export type StandingGrantSnapshot = {
 /**
  * The approval decision that created the grant — also the handle a
  * revocation names.
  */
-source_call_id: CallId, 
+source_call_id: CallId,
 /**
  * How far the grant reaches — one chat, or every chat in a project.
  */
-level: GrantLevel, 
+level: GrantLevel,
 /**
  * The name of whatever the level points at, for provenance. `None` when
  * that chat or project is untitled.
@@ -4367,7 +4367,7 @@ export type StickyChatDefaults = { model: string | null, reasoning_effort: Reaso
 /**
  * One file a background run submitted, as the renderer sees it.
  */
-export type SubmittedOutputSnapshot = { output_id: OutputId, 
+export type SubmittedOutputSnapshot = { output_id: OutputId,
 /**
  * The name the run gave the file, which is the output's name.
  */
@@ -4376,15 +4376,15 @@ filename: string, };
 /**
  * Renderer-safe durable projection of a chat's current plan.
  */
-export type TaskPlan = { 
+export type TaskPlan = {
 /**
  * The turn whose call last replaced this plan.
  */
-turn_id: TurnId, 
+turn_id: TurnId,
 /**
  * The steps, in order.
  */
-steps: Array<TaskPlanStep>, 
+steps: Array<TaskPlanStep>,
 /**
  * When the last replacement committed.
  */
@@ -4393,11 +4393,11 @@ updated_at: string, };
 /**
  * One step of the plan.
  */
-export type TaskPlanStep = { 
+export type TaskPlanStep = {
 /**
  * What this step does, as one short imperative line.
  */
-content: string, 
+content: string,
 /**
  * Where the step stands: `pending` before it starts, `in_progress` while
  * it is being worked on (at most one step at a time), `completed` after.
@@ -4424,20 +4424,20 @@ export type TaskPlanStepStatus = "pending" | "in_progress" | "completed";
  * identity ([`Self::without_summary`]), because a call that could describe
  * itself to a consent decision could describe itself favourably.
  */
-export type ToolActionPreview = { "tool": "exec", 
+export type ToolActionPreview = { "tool": "exec",
 /**
  * Executable name or path the model chose.
  */
-command: string, 
+command: string,
 /**
  * Arguments passed directly to the executable.
  */
-args: Array<string>, 
+args: Array<string>,
 /**
  * Working directory relative to the chat's private scratch, never a
  * host path.
  */
-cwd: string, 
+cwd: string,
 /**
  * Scratch-relative files and directories staged into the sandbox
  * before the command runs, empty when the model staged none.
@@ -4454,49 +4454,49 @@ cwd: string,
  * nothing, which is narrower than what they were given for and so
  * sends a call that stages anything back to the person.
  */
-files: Array<string>, 
+files: Array<string>,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "search", query: string, 
+summary?: string, } | { "tool": "search", query: string,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "web_search", query: string, 
+summary?: string, } | { "tool": "web_search", query: string,
 /**
  * Sites the search is confined to, empty when the model named none.
  */
-domains: Array<string>, 
+domains: Array<string>,
 /**
  * Earliest publication date the search will accept, as the model
  * wrote it. Kept verbatim rather than reformatted: the card's job is
  * to show what the provider is actually told.
  */
-start_published_at: string | null, 
+start_published_at: string | null,
 /**
  * Latest publication date the search will accept.
  */
-end_published_at: string | null, 
+end_published_at: string | null,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "web_extract", url: string, 
+summary?: string, } | { "tool": "web_extract", url: string,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "write_file", 
+summary?: string, } | { "tool": "write_file",
 /**
  * Workspace-relative destination path, never a host path.
  */
-path: string, 
+path: string,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "delegate_agent", 
+summary?: string, } | { "tool": "delegate_agent",
 /**
  * The child's self-contained task, as the model wrote it.
  */
-task: string, 
+task: string,
 /**
  * The network policy the child inherits from this chat.
  */
@@ -4515,27 +4515,27 @@ export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_sear
 /**
  * Display-oriented classification of a tool the engine started.
  */
-export type ToolDetail = { "kind": "command", 
+export type ToolDetail = { "kind": "command",
 /**
  * Command string.
  */
-cmd: string, 
+cmd: string,
 /**
  * Working directory, when reported.
  */
-cwd: string, } | { "kind": "file_edit", 
+cwd: string, } | { "kind": "file_edit",
 /**
  * Path being edited.
  */
-path: string, } | { "kind": "file_read", 
+path: string, } | { "kind": "file_read",
 /**
  * Path being read.
  */
-path: string, } | { "kind": "search", 
+path: string, } | { "kind": "search",
 /**
  * Query string.
  */
-query: string, } | { "kind": "other", 
+query: string, } | { "kind": "other",
 /**
  * Bounded summary.
  */
@@ -4552,78 +4552,78 @@ export type ToolOutcome = "succeeded" | "failed" | "denied";
  * A command's output is the whole reason to run it. Withholding it leaves the
  * transcript asserting that something happened without ever showing what.
  */
-export type ToolResultPreview = { "tool": "exec", 
+export type ToolResultPreview = { "tool": "exec",
 /**
  * Process exit status, or `None` when it was killed by a signal.
  */
-exit_code: number | null, 
+exit_code: number | null,
 /**
  * Whether the provider stopped the command at its time limit.
  */
-timed_out: boolean, 
+timed_out: boolean,
 /**
  * Whether the provider dropped output past its capture limit.
  */
-output_truncated: boolean, stdout: string, stderr: string, 
+output_truncated: boolean, stdout: string, stderr: string,
 /**
  * Preview images emitted by the command, in model-facing priority order.
  */
-images?: Array<ImageRef>, 
+images?: Array<ImageRef>,
 /**
  * Durable outputs the command's `output/` files created or updated.
  * Files that still match their published version are not news and are
  * not listed. Defaulted so exec rows persisted before the field
  * existed read back unchanged.
  */
-outputs?: Array<ResultEntry>, 
+outputs?: Array<ResultEntry>,
 /**
  * How the execution backend fell short of its intended setup, when it
  * did. Reported on the first execution that degrades and not on the
  * ones after it, so a chat says this once rather than on every card.
  */
-degraded?: ExecDegradation, 
+degraded?: ExecDegradation,
 /**
  * Which backend ran the command. Defaulted so exec rows persisted
  * before the field existed read back unchanged.
  */
-backend?: ExecBackend, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
+backend?: ExecBackend, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app",
 /**
  * The configured MCP server namespace that serves the view.
  */
-server: string, 
+server: string,
 /**
  * The validated `ui://` document reference.
  */
-resource_uri: string, } | { "tool": "entries", entries: Array<ResultEntry>, 
+resource_uri: string, } | { "tool": "entries", entries: Array<ResultEntry>,
 /**
  * What the same call could not do. Bounded and counted on the same
  * terms as `entries`, and elided into the same tally: the card's job
  * is to be honest about how much it is not showing, and a hidden
  * failure is the worst thing to hide.
  */
-failures: Array<ResultFailure>, 
+failures: Array<ResultFailure>,
 /**
  * Rows past [`MAX_RESULT_ENTRIES`], counted rather than shown. A card
  * that silently lists the first fifty of two hundred results is
  * telling the reader something false.
  */
-elided: number, } | { "tool": "user_questions", answers: Array<AnsweredUserQuestion>, 
+elided: number, } | { "tool": "user_questions", answers: Array<AnsweredUserQuestion>,
 /**
  * Whatever the reader added on their own, when they added any.
  */
-additional_context?: string, } | { "tool": "plan_decision", title: string, plan: string, 
+additional_context?: string, } | { "tool": "plan_decision", title: string, plan: string,
 /**
  * Whether the reader approved the plan as proposed.
  */
-accepted: boolean, 
+accepted: boolean,
 /**
  * What the reader asked to change, when they sent it back.
  */
-feedback?: string, } | { "tool": "screen_capture", 
+feedback?: string, } | { "tool": "screen_capture",
 /**
  * The captured screenshot, content-addressed in the blob store.
  */
-image: ImageRef, 
+image: ImageRef,
 /**
  * How many interactive elements were marked on the capture, so the
  * card can say "capture with N controls" without the model's text.
@@ -4638,15 +4638,15 @@ export type TranscriptFileAttachment = { document_id: DocumentId, name: string, 
 /**
  * One renderer-safe image identity attached to a historical user message.
  */
-export type TranscriptImageAttachment = { 
+export type TranscriptImageAttachment = {
 /**
  * Content-addressed opaque attachment identity, not a host path.
  */
-attachment_id: string, 
+attachment_id: string,
 /**
  * Sniffed IANA media type from the trusted image ingest boundary.
  */
-media_type: string, 
+media_type: string,
 /**
  * Header-derived dimensions, bounded at image publication.
  */
@@ -4725,25 +4725,25 @@ export type VerificationTier = "verified" | "unverified";
  * selection, credential presence, and the configured instance URL — key
  * material never crosses the secret boundary.
  */
-export type WebSearchConfigInfo = { provider?: WebSearchProviderKind, 
+export type WebSearchConfigInfo = { provider?: WebSearchProviderKind,
 /**
  * Which search a turn gets. Orthogonal to the fields below, which report
  * only the host provider's readiness: a vendor turn is unaffected by all
  * of them.
  */
-mode: WebSearchMode, timeout_ms: number, 
+mode: WebSearchMode, timeout_ms: number,
 /**
  * Whether a key is stored for the selected provider. Always false for a
  * credential-free provider, which has no key slot at all — read
  * [`Self::available`] to know whether search will actually run.
  */
-has_credential: boolean, 
+has_credential: boolean,
 /**
  * Whether the selected provider has everything it needs to be invoked.
  *
  * A key for the credentialed providers, an instance URL for SearXNG.
  */
-available: boolean, 
+available: boolean,
 /**
  * The configured SearXNG instance URL, in the canonical form the host
  * stored. It is safe to return: validation forbids embedded credentials.

--- a/crates/tidebreak-server/src/connectors/chatgpt.rs
+++ b/crates/tidebreak-server/src/connectors/chatgpt.rs
@@ -96,6 +96,26 @@ impl ChatGptAuthConfig {
     pub fn for_test(auth_base: &str) -> Result<Self> {
         let base = reqwest::Url::parse(auth_base)
             .map_err(|_| chatgpt_error("configuration", "auth base URL is invalid"))?;
+        let loopback = base.host_str().is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        });
+        if base.scheme() != "http"
+            || !loopback
+            || !base.username().is_empty()
+            || base.password().is_some()
+            || base.query().is_some()
+            || base.fragment().is_some()
+        {
+            return Err(chatgpt_error(
+                "configuration",
+                "test auth base URL must use a credential-free loopback HTTP origin",
+            ));
+        }
         let join = |path: &str| -> Result<reqwest::Url> {
             let mut root = base.to_string();
             if !root.ends_with('/') {
@@ -728,5 +748,31 @@ mod tests {
         let config = ChatGptAuthConfig::production();
         assert_eq!(config.redirect_uri(), REDIRECT_URI);
         assert_eq!(config.originator(), ORIGINATOR);
+    }
+
+    #[test]
+    fn test_config_refuses_non_loopback_auth_origins() {
+        for invalid in [
+            "https://auth.example",
+            "http://localhost.attacker.example",
+            "http://user:password@localhost",
+            "http://localhost?redirect=https://auth.example",
+            "http://localhost#fragment",
+        ] {
+            assert!(
+                ChatGptAuthConfig::for_test(invalid).is_err(),
+                "accepted unsafe test auth origin: {invalid}"
+            );
+        }
+        for valid in [
+            "http://localhost",
+            "http://127.0.0.1:8080",
+            "http://[::1]:8080",
+        ] {
+            assert!(
+                ChatGptAuthConfig::for_test(valid).is_ok(),
+                "refused loopback test auth origin: {valid}"
+            );
+        }
     }
 }

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -64,8 +64,13 @@ pub(crate) mod generate {
             if declares {
                 let name = T::ident(self.cfg);
                 let docs = T::docs().unwrap_or_default();
+                let declaration = T::decl(self.cfg)
+                    .lines()
+                    .map(str::trim_end)
+                    .collect::<Vec<_>>()
+                    .join("\n");
                 self.out
-                    .insert(name, format!("{docs}export {}\n", T::decl(self.cfg)));
+                    .insert(name, format!("{docs}export {declaration}\n"));
             }
             T::visit_dependencies(self);
         }
@@ -504,6 +509,15 @@ mod tests {
     #[test]
     fn the_generated_bindings_are_current() {
         generate::check_or_update(BINDINGS, &rendered_bindings(), REGENERATE);
+    }
+
+    #[test]
+    fn the_generated_bindings_have_no_trailing_whitespace() {
+        let generated = rendered_bindings();
+        assert!(
+            generated.lines().all(|line| line == line.trim_end()),
+            "generated wire types contain trailing whitespace"
+        );
     }
 
     /// The runtime list is parsed out of the generated union, so the parse has to

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "main": "expo-router/entry",
+  "packageManager": "pnpm@10.18.3",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
@@ -40,5 +41,10 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.46.4",
     "vitest": "3.2.6"
+  },
+  "pnpm": {
+    "overrides": {
+      "uuid": "11.1.1"
+    }
   }
 }

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid: 11.1.1
+
 importers:
 
   .:
@@ -13,52 +16,52 @@ importers:
         version: 5.90.21(react@19.2.8)
       expo:
         specifier: 55.0.30
-        version: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       expo-constants:
         specifier: 55.0.17
-        version: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
       expo-crypto:
         specifier: 55.0.19
         version: 55.0.19(expo@55.0.30)
       expo-linking:
         specifier: 55.0.17
-        version: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)
+        version: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       expo-router:
         specifier: 55.0.18
-        version: 55.0.18(2a366c330a823ef5ee83e970d86cdc48)
+        version: 55.0.18(d1eb28996ec804987c9867b4b6360f90)
       expo-secure-store:
         specifier: 55.0.18
         version: 55.0.18(expo@55.0.30)
       expo-status-bar:
         specifier: 55.0.6
-        version: 55.0.6(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+        version: 55.0.6(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       expo-web-browser:
         specifier: 55.0.20
-        version: 55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))
+        version: 55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
       js-sha256:
         specifier: 1.0.0
         version: 1.0.0
       nativewind:
         specifier: 4.2.1
-        version: 4.2.1(bbc2a53f0b8f79bd3b95d476a68d03b5)
+        version: 4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(tailwindcss@3.4.17)
       react:
         specifier: 19.2.8
         version: 19.2.8
       react-native:
         specifier: 0.83.1
-        version: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+        version: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       react-native-gesture-handler:
         specifier: 2.30.0
-        version: 2.30.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+        version: 2.30.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       react-native-reanimated:
         specifier: 4.2.1
-        version: 4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+        version: 4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       react-native-safe-area-context:
         specifier: 5.6.2
-        version: 5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+        version: 5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       react-native-screens:
         specifier: 4.23.0
-        version: 4.23.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+        version: 4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       react-native-web:
         specifier: 0.21.2
         version: 0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -71,7 +74,7 @@ importers:
         version: 19.2.7
       eslint:
         specifier: 9.39.1
-        version: 9.39.1(jiti@1.21.7)(supports-color@8.1.1)
+        version: 9.39.1(jiti@1.21.7)
       tailwindcss:
         specifier: 3.4.17
         version: 3.4.17
@@ -80,10 +83,10 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 8.46.4
-        version: 8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(supports-color@8.1.1)(terser@5.51.0)(yaml@2.9.0)
+        version: 3.2.6(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(terser@5.51.0)(yaml@2.9.0)
 
 packages:
 
@@ -1050,7 +1053,6 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1481,79 +1483,66 @@ packages:
     resolution: {integrity: sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.63.0':
     resolution: {integrity: sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.63.0':
     resolution: {integrity: sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.63.0':
     resolution: {integrity: sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.63.0':
     resolution: {integrity: sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.63.0':
     resolution: {integrity: sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.63.0':
     resolution: {integrity: sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.63.0':
     resolution: {integrity: sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.63.0':
     resolution: {integrity: sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.63.0':
     resolution: {integrity: sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.63.0':
     resolution: {integrity: sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.63.0':
     resolution: {integrity: sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.63.0':
     resolution: {integrity: sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.63.0':
     resolution: {integrity: sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==}
@@ -2939,56 +2928,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.33.0:
     resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.27.0:
     resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.27.0:
     resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
@@ -4133,9 +4114,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@7.0.3:
-    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   validate-npm-package-name@5.0.1:
@@ -4375,20 +4355,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@8.1.1)':
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4415,32 +4395,32 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.8
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -4448,26 +4428,26 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4477,27 +4457,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-wrap-function': 7.29.7(supports-color@8.1.1)
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/helper-wrap-function': 7.29.7
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
@@ -4508,10 +4488,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.29.7': {}
 
-  '@babel/helper-wrap-function@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-wrap-function@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
@@ -4532,419 +4512,419 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
-  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
 
-  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-pure-annotations@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.8(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-regenerator@7.29.8(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-spread@7.29.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-spread@7.29.8(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/preset-react@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-react-jsx-development': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-react-pure-annotations': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-development': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-pure-annotations': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -4956,7 +4936,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
 
-  '@babel/traverse@7.29.8(supports-color@8.1.1)':
+  '@babel/traverse@7.29.8':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
@@ -4964,7 +4944,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5055,17 +5035,17 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.1(jiti@1.21.7))':
     dependencies:
-      eslint: 9.39.1(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2(supports-color@8.1.1)':
+  '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -5078,10 +5058,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.6(supports-color@8.1.1)':
+  '@eslint/eslintrc@3.3.6':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5103,29 +5083,29 @@ snapshots:
 
   '@expo-google-fonts/material-symbols@0.4.44': {}
 
-  '@expo/cli@55.0.36(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-constants@55.0.17)(expo-font@55.0.8)(expo-router@55.0.18)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@expo/cli@55.0.36(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-constants@55.0.17)(expo-font@55.0.8)(expo-router@55.0.18)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 55.0.21(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/config-plugins': 55.0.11(supports-color@8.1.1)
-      '@expo/devcert': 1.2.1(supports-color@8.1.1)
-      '@expo/env': 2.1.3(supports-color@8.1.1)
-      '@expo/image-utils': 0.8.17(supports-color@8.1.1)(typescript@5.9.3)
+      '@expo/config': 55.0.21(typescript@5.9.3)
+      '@expo/config-plugins': 55.0.11
+      '@expo/devcert': 1.2.1
+      '@expo/env': 2.1.3
+      '@expo/image-utils': 0.8.17(typescript@5.9.3)
       '@expo/json-file': 10.2.0
-      '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      '@expo/metro': 55.1.2(supports-color@8.1.1)
-      '@expo/metro-config': 55.0.27(expo@55.0.30)(supports-color@8.1.1)(typescript@5.9.3)
+      '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@expo/metro': 55.1.2
+      '@expo/metro-config': 55.0.27(expo@55.0.30)(typescript@5.9.3)
       '@expo/osascript': 2.7.1
       '@expo/package-manager': 1.13.1
       '@expo/plist': 0.5.4
-      '@expo/prebuild-config': 55.0.22(expo@55.0.30)(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/require-utils': 55.0.8(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/router-server': 55.0.19(@expo/metro-runtime@55.0.12)(expo-constants@55.0.17)(expo-font@55.0.8)(expo-router@55.0.18)(expo-server@55.0.12)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      '@expo/prebuild-config': 55.0.22(expo@55.0.30)(typescript@5.9.3)
+      '@expo/require-utils': 55.0.8(typescript@5.9.3)
+      '@expo/router-server': 55.0.19(@expo/metro-runtime@55.0.12)(expo-constants@55.0.17)(expo-font@55.0.8)(expo-router@55.0.18)(expo-server@55.0.12)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@expo/schema-utils': 55.0.5
       '@expo/spawn-async': 1.8.0
       '@expo/ws-tunnel': 1.0.6
       '@expo/xcpretty': 4.4.4
-      '@react-native/dev-middleware': 0.83.10(supports-color@8.1.1)
+      '@react-native/dev-middleware': 0.83.10
       accepts: 1.3.8
       agent-cli-detector: 0.1.7
       arg: 5.0.2
@@ -5134,11 +5114,11 @@ snapshots:
       bplist-parser: 0.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
-      compression: 1.8.1(supports-color@8.1.1)
-      connect: 3.7.0(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      compression: 1.8.1
+      connect: 3.7.0
+      debug: 4.4.3
       dnssd-advertise: 1.1.6
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       expo-server: 55.0.12
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -5154,7 +5134,7 @@ snapshots:
       prompts: 2.4.2
       resolve-from: 5.0.0
       semver: 7.8.5
-      send: 0.19.2(supports-color@8.1.1)
+      send: 0.19.2
       slugify: 1.6.9
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.11
@@ -5165,8 +5145,8 @@ snapshots:
       ws: 8.21.3
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.18(2a366c330a823ef5ee83e970d86cdc48)
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      expo-router: 55.0.18(d1eb28996ec804987c9867b4b6360f90)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
     transitivePeerDependencies:
       - '@expo/dom-webview'
       - '@expo/metro-runtime'
@@ -5184,14 +5164,14 @@ snapshots:
     dependencies:
       node-forge: 1.4.0
 
-  '@expo/config-plugins@55.0.11(supports-color@8.1.1)':
+  '@expo/config-plugins@55.0.11':
     dependencies:
       '@expo/config-types': 55.0.6
       '@expo/json-file': 10.0.16
       '@expo/plist': 0.5.4
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       getenv: 2.0.0
       glob: 13.0.6
       resolve-from: 5.0.0
@@ -5204,12 +5184,12 @@ snapshots:
 
   '@expo/config-types@55.0.6': {}
 
-  '@expo/config@55.0.21(supports-color@8.1.1)(typescript@5.9.3)':
+  '@expo/config@55.0.21(typescript@5.9.3)':
     dependencies:
-      '@expo/config-plugins': 55.0.11(supports-color@8.1.1)
+      '@expo/config-plugins': 55.0.11
       '@expo/config-types': 55.0.6
       '@expo/json-file': 10.2.0
-      '@expo/require-utils': 55.0.8(supports-color@8.1.1)(typescript@5.9.3)
+      '@expo/require-utils': 55.0.8(typescript@5.9.3)
       deepmerge: 4.3.1
       getenv: 2.0.0
       glob: 13.0.6
@@ -5220,49 +5200,49 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/devcert@1.2.1(supports-color@8.1.1)':
+  '@expo/devcert@1.2.1':
     dependencies:
       '@expo/sudo-prompt': 9.3.2
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@55.0.3(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@expo/devtools@55.0.3(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  '@expo/dom-webview@55.0.6(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@expo/dom-webview@55.0.6(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  '@expo/env@2.1.3(supports-color@8.1.1)':
+  '@expo/env@2.1.3':
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       getenv: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/env@2.4.2(supports-color@8.1.1)':
+  '@expo/env@2.4.2':
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       getenv: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/fingerprint@0.16.8(supports-color@8.1.1)':
+  '@expo/fingerprint@0.16.8':
     dependencies:
-      '@expo/env': 2.4.2(supports-color@8.1.1)
+      '@expo/env': 2.4.2
       '@expo/spawn-async': 1.8.0
       arg: 5.0.2
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       getenv: 2.0.0
       glob: 13.0.6
       ignore: 5.3.2
@@ -5272,9 +5252,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/image-utils@0.8.17(supports-color@8.1.1)(typescript@5.9.3)':
+  '@expo/image-utils@0.8.17(typescript@5.9.3)':
     dependencies:
-      '@expo/require-utils': 55.0.8(supports-color@8.1.1)(typescript@5.9.3)
+      '@expo/require-utils': 55.0.8(typescript@5.9.3)
       '@expo/spawn-async': 1.8.0
       chalk: 4.1.2
       getenv: 2.0.0
@@ -5300,36 +5280,36 @@ snapshots:
       '@babel/code-frame': 7.29.7
       json5: 2.2.3
 
-  '@expo/local-build-cache-provider@55.0.16(supports-color@8.1.1)(typescript@5.9.3)':
+  '@expo/local-build-cache-provider@55.0.16(typescript@5.9.3)':
     dependencies:
-      '@expo/config': 55.0.21(supports-color@8.1.1)(typescript@5.9.3)
+      '@expo/config': 55.0.21(typescript@5.9.3)
       chalk: 4.1.2
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@expo/log-box@55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@expo/log-box@55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@expo/dom-webview': 55.0.6(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@expo/dom-webview': 55.0.6(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       anser: 1.4.10
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       stacktrace-parser: 0.1.11
 
-  '@expo/metro-config@55.0.27(expo@55.0.30)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@expo/metro-config@55.0.27(expo@55.0.30)(typescript@5.9.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.8
-      '@expo/config': 55.0.21(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/env': 2.1.3(supports-color@8.1.1)
+      '@expo/config': 55.0.21(typescript@5.9.3)
+      '@expo/env': 2.1.3
       '@expo/json-file': 10.0.16
-      '@expo/metro': 55.1.2(supports-color@8.1.1)
+      '@expo/metro': 55.1.2
       '@expo/spawn-async': 1.8.0
       browserslist: 4.28.8
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       getenv: 2.0.0
       glob: 13.0.6
       hermes-parser: 0.32.1
@@ -5339,21 +5319,21 @@ snapshots:
       postcss: 8.5.26
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@expo/metro-runtime@55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@expo/metro-runtime@55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       anser: 1.4.10
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
@@ -5361,22 +5341,22 @@ snapshots:
     transitivePeerDependencies:
       - '@expo/dom-webview'
 
-  '@expo/metro@55.1.2(supports-color@8.1.1)':
+  '@expo/metro@55.1.2':
     dependencies:
-      metro: 0.83.8(supports-color@8.1.1)
-      metro-babel-transformer: 0.83.8(supports-color@8.1.1)
-      metro-cache: 0.83.8(supports-color@8.1.1)
+      metro: 0.83.8
+      metro-babel-transformer: 0.83.8
+      metro-cache: 0.83.8
       metro-cache-key: 0.83.8
-      metro-config: 0.83.8(supports-color@8.1.1)
+      metro-config: 0.83.8
       metro-core: 0.83.8
-      metro-file-map: 0.83.8(supports-color@8.1.1)
+      metro-file-map: 0.83.8
       metro-minify-terser: 0.83.8
       metro-resolver: 0.83.8
       metro-runtime: 0.83.8
-      metro-source-map: 0.83.8(supports-color@8.1.1)
-      metro-symbolicate: 0.83.8(supports-color@8.1.1)
-      metro-transform-plugins: 0.83.8(supports-color@8.1.1)
-      metro-transform-worker: 0.83.8(supports-color@8.1.1)
+      metro-source-map: 0.83.8
+      metro-symbolicate: 0.83.8
+      metro-transform-plugins: 0.83.8
+      metro-transform-worker: 0.83.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5401,16 +5381,16 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  '@expo/prebuild-config@55.0.22(expo@55.0.30)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@expo/prebuild-config@55.0.22(expo@55.0.30)(typescript@5.9.3)':
     dependencies:
-      '@expo/config': 55.0.21(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/config-plugins': 55.0.11(supports-color@8.1.1)
+      '@expo/config': 55.0.21(typescript@5.9.3)
+      '@expo/config-plugins': 55.0.11
       '@expo/config-types': 55.0.6
-      '@expo/image-utils': 0.8.17(supports-color@8.1.1)(typescript@5.9.3)
+      '@expo/image-utils': 0.8.17(typescript@5.9.3)
       '@expo/json-file': 10.2.0
       '@react-native/normalize-colors': 0.83.10
-      debug: 4.4.3(supports-color@8.1.1)
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      debug: 4.4.3
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.8.5
       xml2js: 0.6.0
@@ -5418,27 +5398,27 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/require-utils@55.0.8(supports-color@8.1.1)(typescript@5.9.3)':
+  '@expo/require-utils@55.0.8(typescript@5.9.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@55.0.19(@expo/metro-runtime@55.0.12)(expo-constants@55.0.17)(expo-font@55.0.8)(expo-router@55.0.18)(expo-server@55.0.12)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)':
+  '@expo/router-server@55.0.19(@expo/metro-runtime@55.0.12)(expo-constants@55.0.17)(expo-font@55.0.8)(expo-router@55.0.18)(expo-server@55.0.12)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(supports-color@8.1.1)
-      expo-font: 55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      debug: 4.4.3
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
+      expo-font: 55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       expo-server: 55.0.12
       react: 19.2.8
     optionalDependencies:
-      '@expo/metro-runtime': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      expo-router: 55.0.18(2a366c330a823ef5ee83e970d86cdc48)
+      '@expo/metro-runtime': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      expo-router: 55.0.18(d1eb28996ec804987c9867b4b6360f90)
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - supports-color
@@ -5453,11 +5433,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@15.1.1(expo-font@55.0.8)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@expo/vector-icons@15.1.1(expo-font@55.0.8)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
-      expo-font: 55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      expo-font: 55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -5519,12 +5499,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.12
 
-  '@jest/transform@29.7.0(supports-color@8.1.1)':
+  '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
+      babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -5776,113 +5756,113 @@ snapshots:
 
   '@react-native/assets-registry@0.83.1': {}
 
-  '@react-native/babel-plugin-codegen@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@react-native/babel-plugin-codegen@0.83.10(@babel/core@7.29.7)':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
-      '@react-native/codegen': 0.83.10(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/traverse': 7.29.8
+      '@react-native/codegen': 0.83.10(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@react-native/babel-plugin-codegen@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@react-native/babel-plugin-codegen@0.87.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
-      '@react-native/codegen': 0.87.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/traverse': 7.29.8
+      '@react-native/codegen': 0.87.0(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@react-native/babel-preset@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@react-native/babel-preset@0.83.10(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-regenerator': 7.29.8(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-spread': 7.29.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.29.8(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.29.8(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/template': 7.29.7
-      '@react-native/babel-plugin-codegen': 0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@react-native/babel-plugin-codegen': 0.83.10(@babel/core@7.29.7)
       babel-plugin-syntax-hermes-parser: 0.32.0
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
       react-refresh: 0.14.2
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/babel-preset@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@react-native/babel-preset@0.87.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-regenerator': 7.29.8(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@react-native/babel-plugin-codegen': 0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.29.8(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+      '@react-native/babel-plugin-codegen': 0.87.0(@babel/core@7.29.7)
       babel-plugin-syntax-hermes-parser: 0.36.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
       react-refresh: 0.14.2
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/codegen@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@react-native/codegen@0.83.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.8
       glob: 7.2.3
       hermes-parser: 0.32.0
@@ -5890,9 +5870,9 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.3
 
-  '@react-native/codegen@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@react-native/codegen@0.83.10(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.8
       glob: 7.2.3
       hermes-parser: 0.32.0
@@ -5900,9 +5880,9 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.3
 
-  '@react-native/codegen@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@react-native/codegen@0.87.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.8
       hermes-parser: 0.36.1
       invariant: 2.2.4
@@ -5910,17 +5890,17 @@ snapshots:
       tinyglobby: 0.2.17
       yargs: 17.7.3
 
-  '@react-native/community-cli-plugin@0.83.1(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@react-native/community-cli-plugin@0.83.1(@react-native/metro-config@0.87.0(@babel/core@7.29.7))':
     dependencies:
-      '@react-native/dev-middleware': 0.83.1(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      '@react-native/dev-middleware': 0.83.1
+      debug: 4.4.3
       invariant: 2.2.4
-      metro: 0.83.8(supports-color@8.1.1)
-      metro-config: 0.83.8(supports-color@8.1.1)
+      metro: 0.83.8
+      metro-config: 0.83.8
       metro-core: 0.83.8
       semver: 7.8.5
     optionalDependencies:
-      '@react-native/metro-config': 0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@react-native/metro-config': 0.87.0(@babel/core@7.29.7)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5940,38 +5920,38 @@ snapshots:
       cross-spawn: 7.0.6
       fb-dotslash: 0.5.8
 
-  '@react-native/dev-middleware@0.83.1(supports-color@8.1.1)':
+  '@react-native/dev-middleware@0.83.1':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.83.1
       '@react-native/debugger-shell': 0.83.1
-      chrome-launcher: 0.15.2(supports-color@8.1.1)
-      chromium-edge-launcher: 0.2.0(supports-color@8.1.1)
-      connect: 3.7.0(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      chrome-launcher: 0.15.2
+      chromium-edge-launcher: 0.2.0
+      connect: 3.7.0
+      debug: 4.4.3
       invariant: 2.2.4
       nullthrows: 1.1.1
       open: 7.4.2
-      serve-static: 1.16.3(supports-color@8.1.1)
+      serve-static: 1.16.3
       ws: 7.5.13
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@react-native/dev-middleware@0.83.10(supports-color@8.1.1)':
+  '@react-native/dev-middleware@0.83.10':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.83.10
       '@react-native/debugger-shell': 0.83.10
-      chrome-launcher: 0.15.2(supports-color@8.1.1)
-      chromium-edge-launcher: 0.2.0(supports-color@8.1.1)
-      connect: 3.7.0(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      chrome-launcher: 0.15.2
+      chromium-edge-launcher: 0.2.0
+      connect: 3.7.0
+      debug: 4.4.3
       invariant: 2.2.4
       nullthrows: 1.1.1
       open: 7.4.2
-      serve-static: 1.16.3(supports-color@8.1.1)
+      serve-static: 1.16.3
       ws: 7.5.13
     transitivePeerDependencies:
       - bufferutil
@@ -5984,20 +5964,20 @@ snapshots:
 
   '@react-native/js-polyfills@0.87.0': {}
 
-  '@react-native/metro-babel-transformer@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@react-native/metro-babel-transformer@0.87.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@react-native/babel-preset': 0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@react-native/babel-preset': 0.87.0(@babel/core@7.29.7)
       hermes-parser: 0.36.1
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@react-native/metro-config@0.87.0(@babel/core@7.29.7)':
     dependencies:
       '@react-native/js-polyfills': 0.87.0
-      '@react-native/metro-babel-transformer': 0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      metro-config: 0.87.0(supports-color@8.1.1)
+      '@react-native/metro-babel-transformer': 0.87.0(@babel/core@7.29.7)
+      metro-config: 0.87.0
       metro-runtime: 0.87.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -6011,24 +5991,24 @@ snapshots:
 
   '@react-native/normalize-colors@0.83.10': {}
 
-  '@react-native/virtualized-lists@0.83.1(@types/react@19.2.7)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@react-native/virtualized-lists@0.83.1(@types/react@19.2.7)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@react-navigation/bottom-tabs@7.18.17(c565874c296dbc16ee72ba24f55c4c6c)':
+  '@react-navigation/bottom-tabs@7.18.17(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-screens@4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@react-navigation/elements': 2.9.39(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      '@react-navigation/native': 7.3.17(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@react-navigation/elements': 2.9.39(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@react-navigation/native': 7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       color: 4.2.3
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      react-native-screens: 4.23.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      react-native-screens: 4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -6045,38 +6025,38 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@react-navigation/elements@2.9.39(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@react-navigation/elements@2.9.39(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@react-navigation/native': 7.3.17(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@react-navigation/native': 7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       color: 4.2.3
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       use-latest-callback: 0.2.6(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@react-navigation/native-stack@7.18.9(c565874c296dbc16ee72ba24f55c4c6c)':
+  '@react-navigation/native-stack@7.18.9(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-screens@4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@react-navigation/elements': 2.9.39(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      '@react-navigation/native': 7.3.17(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@react-navigation/elements': 2.9.39(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@react-navigation/native': 7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       color: 4.2.3
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      react-native-screens: 4.23.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      react-native-screens: 4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)':
+  '@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@react-navigation/core': 7.21.13(react@19.2.8)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.18
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       standard-navigation: 0.0.8(react@19.2.8)
       use-latest-callback: 0.2.6(react@19.2.8)
 
@@ -6240,15 +6220,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.46.4(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.46.4(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.4
-      '@typescript-eslint/type-utils': 8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.4
-      eslint: 9.39.1(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@1.21.7)
       graphemer: 1.4.0
       ignore: 7.0.6
       natural-compare: 1.4.0
@@ -6257,23 +6237,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.4
       '@typescript-eslint/types': 8.46.4
-      '@typescript-eslint/typescript-estree': 8.46.4(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.4
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1(jiti@1.21.7)(supports-color@8.1.1)
+      debug: 4.4.3
+      eslint: 9.39.1(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.46.4(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.46.4(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -6287,13 +6267,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.4
-      '@typescript-eslint/typescript-estree': 8.46.4(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1(jiti@1.21.7)(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.1(jiti@1.21.7)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -6301,13 +6281,13 @@ snapshots:
 
   '@typescript-eslint/types@8.46.4': {}
 
-  '@typescript-eslint/typescript-estree@8.46.4(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.46.4(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.46.4(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.46.4(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/visitor-keys': 8.46.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
@@ -6317,13 +6297,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.1(jiti@1.21.7))
       '@typescript-eslint/scope-manager': 8.46.4
       '@typescript-eslint/types': 8.46.4
-      '@typescript-eslint/typescript-estree': 8.46.4(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 9.39.1(jiti@1.21.7)(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      eslint: 9.39.1(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -6461,25 +6441,25 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  babel-jest@29.7.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-jest@29.7.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
-      babel-preset-jest: 29.6.3(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.29.7)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@6.1.1(supports-color@8.1.1):
+  babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
-      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
+      istanbul-lib-instrument: 5.2.1
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -6491,27 +6471,27 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.50.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -6533,69 +6513,69 @@ snapshots:
     dependencies:
       hermes-parser: 0.36.1
 
-  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.7(supports-color@8.1.1)):
+  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.7):
     dependencies:
-      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7(supports-color@8.1.1)):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/core': 7.29.7
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
-  babel-preset-expo@55.0.25(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(expo@55.0.30)(react-refresh@0.14.2)(supports-color@8.1.1):
+  babel-preset-expo@55.0.25(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@55.0.30)(react-refresh@0.14.2):
     dependencies:
       '@babel/generator': 7.29.8
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@react-native/babel-preset': 0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@react-native/babel-preset': 0.83.10(@babel/core@7.29.7)
       babel-plugin-react-compiler: 1.0.0
       babel-plugin-react-native-web: 0.21.2
       babel-plugin-syntax-hermes-parser: 0.32.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7(supports-color@8.1.1))
-      debug: 4.4.3(supports-color@8.1.1)
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
+      debug: 4.4.3
       react-refresh: 0.14.2
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  babel-preset-jest@29.6.3(@babel/core@7.29.7(supports-color@8.1.1)):
+  babel-preset-jest@29.6.3(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
   balanced-match@1.0.2: {}
 
@@ -6703,21 +6683,21 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chrome-launcher@0.15.2(supports-color@8.1.1):
+  chrome-launcher@0.15.2:
     dependencies:
       '@types/node': 26.3.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
-      lighthouse-logger: 1.4.2(supports-color@8.1.1)
+      lighthouse-logger: 1.4.2
     transitivePeerDependencies:
       - supports-color
 
-  chromium-edge-launcher@0.2.0(supports-color@8.1.1):
+  chromium-edge-launcher@0.2.0:
     dependencies:
       '@types/node': 26.3.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
-      lighthouse-logger: 1.4.2(supports-color@8.1.1)
+      lighthouse-logger: 1.4.2
       mkdirp: 1.0.4
       rimraf: 3.0.2
     transitivePeerDependencies:
@@ -6782,11 +6762,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1(supports-color@8.1.1):
+  compression@1.8.1:
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -6796,10 +6776,10 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  connect@3.7.0(supports-color@8.1.1):
+  connect@3.7.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
-      finalhandler: 1.1.2(supports-color@8.1.1)
+      debug: 2.6.9
+      finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -6833,23 +6813,17 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  debug@2.6.9(supports-color@8.1.1):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@3.2.7(supports-color@8.1.1):
+  debug@3.2.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@4.4.3(supports-color@8.1.1):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
   decode-uri-component@0.2.2: {}
 
@@ -6947,14 +6921,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1):
+  eslint@9.39.1(jiti@1.21.7):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.1(jiti@1.21.7))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
+      '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6(supports-color@8.1.1)
+      '@eslint/eslintrc': 3.3.6
       '@eslint/js': 9.39.1
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -6964,7 +6938,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -7018,72 +6992,74 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  expo-asset@55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3):
+  expo-asset@55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
     dependencies:
-      '@expo/image-utils': 0.8.17(supports-color@8.1.1)(typescript@5.9.3)
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(supports-color@8.1.1)
+      '@expo/image-utils': 0.8.17(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-constants@55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(supports-color@8.1.1):
+  expo-constants@55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)):
     dependencies:
-      '@expo/env': 2.1.3(supports-color@8.1.1)
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      '@expo/env': 2.1.3
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
     transitivePeerDependencies:
       - supports-color
 
   expo-crypto@55.0.19(expo@55.0.30):
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
 
-  expo-file-system@55.0.26(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)):
+  expo-file-system@55.0.26(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)):
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  expo-font@55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  expo-font@55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  expo-glass-effect@55.0.11(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  expo-glass-effect@55.0.11(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  expo-image@55.0.11(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  expo-image@55.0.11(expo@55.0.30)(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       sf-symbols-typescript: 2.2.0
+    optionalDependencies:
+      react-native-web: 0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   expo-keep-awake@55.0.8(expo@55.0.30)(react@19.2.8):
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react: 19.2.8
 
-  expo-linking@55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1):
+  expo-linking@55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
-      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(supports-color@8.1.1)
+      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
       invariant: 2.2.4
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
     transitivePeerDependencies:
       - expo
       - supports-color
 
-  expo-modules-autolinking@55.0.27(supports-color@8.1.1)(typescript@5.9.3):
+  expo-modules-autolinking@55.0.27(typescript@5.9.3):
     dependencies:
-      '@expo/require-utils': 55.0.8(supports-color@8.1.1)(typescript@5.9.3)
+      '@expo/require-utils': 55.0.8(typescript@5.9.3)
       '@expo/spawn-async': 1.8.0
       chalk: 4.1.2
       commander: 7.2.0
@@ -7091,44 +7067,44 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@55.0.25(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  expo-modules-core@55.0.25(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       invariant: 2.2.4
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
     optionalDependencies:
-      react-native-worklets: 0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
 
-  expo-router@55.0.18(2a366c330a823ef5ee83e970d86cdc48):
+  expo-router@55.0.18(d1eb28996ec804987c9867b4b6360f90):
     dependencies:
-      '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      '@expo/metro-runtime': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@expo/metro-runtime': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       '@expo/schema-utils': 55.0.5
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.8)
       '@radix-ui/react-tabs': 1.1.21(@types/react@19.2.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@react-navigation/bottom-tabs': 7.18.17(c565874c296dbc16ee72ba24f55c4c6c)
-      '@react-navigation/native': 7.3.17(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      '@react-navigation/native-stack': 7.18.9(c565874c296dbc16ee72ba24f55c4c6c)
+      '@react-navigation/bottom-tabs': 7.18.17(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-screens@4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@react-navigation/native': 7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@react-navigation/native-stack': 7.18.9(@react-navigation/native@7.3.17(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-screens@4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       client-only: 0.0.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(supports-color@8.1.1)
-      expo-glass-effect: 55.0.11(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      expo-image: 55.0.11(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      expo-linking: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
+      expo-glass-effect: 55.0.11(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      expo-image: 55.0.11(expo@55.0.30)(react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      expo-linking: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       expo-server: 55.0.12
-      expo-symbols: 55.0.9(expo-font@55.0.8)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      expo-symbols: 55.0.9(expo-font@55.0.8)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.8
       react-fast-compare: 3.2.2
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      react-native-screens: 4.23.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      react-native-screens: 4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       semver: 7.6.3
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
@@ -7137,8 +7113,9 @@ snapshots:
       vaul: 1.1.2(@types/react@19.2.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
-      react-native-gesture-handler: 2.30.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      react-native-reanimated: 4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native-gesture-handler: 2.30.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      react-native-reanimated: 4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      react-native-web: 0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
       - '@types/react'
@@ -7148,60 +7125,60 @@ snapshots:
 
   expo-secure-store@55.0.18(expo@55.0.30):
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
 
   expo-server@55.0.12: {}
 
-  expo-status-bar@55.0.6(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  expo-status-bar@55.0.6(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
 
-  expo-symbols@55.0.9(expo-font@55.0.8)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  expo-symbols@55.0.9(expo-font@55.0.8)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.44
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      expo-font: 55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-font: 55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       sf-symbols-typescript: 2.2.0
 
-  expo-web-browser@55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)):
+  expo-web-browser@55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)):
     dependencies:
-      expo: 55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  expo@55.0.30(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3):
+  expo@55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.8(react@19.2.8))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 55.0.36(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-constants@55.0.17)(expo-font@55.0.8)(expo-router@55.0.18)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/config': 55.0.21(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/config-plugins': 55.0.11(supports-color@8.1.1)
-      '@expo/devtools': 55.0.3(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      '@expo/fingerprint': 0.16.8(supports-color@8.1.1)
-      '@expo/local-build-cache-provider': 55.0.16(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      '@expo/metro': 55.1.2(supports-color@8.1.1)
-      '@expo/metro-config': 55.0.27(expo@55.0.30)(supports-color@8.1.1)(typescript@5.9.3)
-      '@expo/vector-icons': 15.1.1(expo-font@55.0.8)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@expo/cli': 55.0.36(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-constants@55.0.17)(expo-font@55.0.8)(expo-router@55.0.18)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      '@expo/config': 55.0.21(typescript@5.9.3)
+      '@expo/config-plugins': 55.0.11
+      '@expo/devtools': 55.0.3(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@expo/fingerprint': 0.16.8
+      '@expo/local-build-cache-provider': 55.0.16(typescript@5.9.3)
+      '@expo/log-box': 55.0.13(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@expo/metro': 55.1.2
+      '@expo/metro-config': 55.0.27(expo@55.0.30)(typescript@5.9.3)
+      '@expo/vector-icons': 15.1.1(expo-font@55.0.8)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       '@ungap/structured-clone': 1.3.4
-      babel-preset-expo: 55.0.25(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(expo@55.0.30)(react-refresh@0.14.2)(supports-color@8.1.1)
-      expo-asset: 55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@5.9.3)
-      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(supports-color@8.1.1)
-      expo-file-system: 55.0.26(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))
-      expo-font: 55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      babel-preset-expo: 55.0.25(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@55.0.30)(react-refresh@0.14.2)
+      expo-asset: 55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-constants: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
+      expo-file-system: 55.0.26(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
+      expo-font: 55.0.8(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       expo-keep-awake: 55.0.8(expo@55.0.30)(react@19.2.8)
-      expo-modules-autolinking: 55.0.27(supports-color@8.1.1)(typescript@5.9.3)
-      expo-modules-core: 55.0.25(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      expo-modules-autolinking: 55.0.27(typescript@5.9.3)
+      expo-modules-core: 55.0.25(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       pretty-format: 29.7.0
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.2
     optionalDependencies:
-      '@expo/dom-webview': 55.0.6(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      '@expo/metro-runtime': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@expo/dom-webview': 55.0.6(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      '@expo/metro-runtime': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.30)(react-dom@19.2.8(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -7270,9 +7247,9 @@ snapshots:
 
   filter-obj@1.1.0: {}
 
-  finalhandler@1.1.2(supports-color@8.1.1):
+  finalhandler@1.1.2:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -7401,10 +7378,10 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7470,9 +7447,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1(supports-color@8.1.1):
+  istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.8
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -7598,9 +7575,9 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lighthouse-logger@1.4.2(supports-color@8.1.1):
+  lighthouse-logger@1.4.2:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       marky: 1.3.0
     transitivePeerDependencies:
       - supports-color
@@ -7753,9 +7730,9 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  metro-babel-transformer@0.83.8(supports-color@8.1.1):
+  metro-babel-transformer@0.83.8:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.35.0
       metro-cache-key: 0.83.8
@@ -7763,9 +7740,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-babel-transformer@0.87.0(supports-color@8.1.1):
+  metro-babel-transformer@0.87.0:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.36.1
       metro-cache-key: 0.87.0
@@ -7781,31 +7758,31 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
 
-  metro-cache@0.83.8(supports-color@8.1.1):
+  metro-cache@0.83.8:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6
       metro-core: 0.83.8
     transitivePeerDependencies:
       - supports-color
 
-  metro-cache@0.87.0(supports-color@8.1.1):
+  metro-cache@0.87.0:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6
       metro-core: 0.87.0
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.83.8(supports-color@8.1.1):
+  metro-config@0.83.8:
     dependencies:
-      connect: 3.7.0(supports-color@8.1.1)
+      connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.83.8(supports-color@8.1.1)
-      metro-cache: 0.83.8(supports-color@8.1.1)
+      metro: 0.83.8
+      metro-cache: 0.83.8
       metro-core: 0.83.8
       metro-runtime: 0.83.8
       yaml: 2.9.0
@@ -7814,13 +7791,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.87.0(supports-color@8.1.1):
+  metro-config@0.87.0:
     dependencies:
-      connect: 3.7.0(supports-color@8.1.1)
+      connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.87.0(supports-color@8.1.1)
-      metro-cache: 0.87.0(supports-color@8.1.1)
+      metro: 0.87.0
+      metro-cache: 0.87.0
       metro-core: 0.87.0
       metro-runtime: 0.87.0
     transitivePeerDependencies:
@@ -7840,9 +7817,9 @@ snapshots:
       lodash.throttle: 4.1.1
       metro-resolver: 0.87.0
 
-  metro-file-map@0.83.8(supports-color@8.1.1):
+  metro-file-map@0.83.8:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -7854,9 +7831,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-file-map@0.87.0(supports-color@8.1.1):
+  metro-file-map@0.87.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -7896,13 +7873,13 @@ snapshots:
       '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
-  metro-source-map@0.83.8(supports-color@8.1.1):
+  metro-source-map@0.83.8:
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-symbolicate: 0.83.8(supports-color@8.1.1)
+      metro-symbolicate: 0.83.8
       nullthrows: 1.1.1
       ob1: 0.83.8
       source-map: 0.5.7
@@ -7910,13 +7887,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-source-map@0.87.0(supports-color@8.1.1):
+  metro-source-map@0.87.0:
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-symbolicate: 0.87.0(supports-color@8.1.1)
+      metro-symbolicate: 0.87.0
       nullthrows: 1.1.1
       ob1: 0.87.0
       source-map: 0.5.7
@@ -7924,103 +7901,103 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-symbolicate@0.83.8(supports-color@8.1.1):
+  metro-symbolicate@0.83.8:
     dependencies:
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-source-map: 0.83.8(supports-color@8.1.1)
+      metro-source-map: 0.83.8
       nullthrows: 1.1.1
       source-map: 0.5.7
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-symbolicate@0.87.0(supports-color@8.1.1):
+  metro-symbolicate@0.87.0:
     dependencies:
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-source-map: 0.87.0(supports-color@8.1.1)
+      metro-source-map: 0.87.0
       nullthrows: 1.1.1
       source-map: 0.5.7
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-plugins@0.83.8(supports-color@8.1.1):
+  metro-transform-plugins@0.83.8:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-plugins@0.87.0(supports-color@8.1.1):
+  metro-transform-plugins@0.87.0:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.83.8(supports-color@8.1.1):
+  metro-transform-worker@0.83.8:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
-      metro: 0.83.8(supports-color@8.1.1)
-      metro-babel-transformer: 0.83.8(supports-color@8.1.1)
-      metro-cache: 0.83.8(supports-color@8.1.1)
+      metro: 0.83.8
+      metro-babel-transformer: 0.83.8
+      metro-cache: 0.83.8
       metro-cache-key: 0.83.8
       metro-minify-terser: 0.83.8
-      metro-source-map: 0.83.8(supports-color@8.1.1)
-      metro-transform-plugins: 0.83.8(supports-color@8.1.1)
+      metro-source-map: 0.83.8
+      metro-transform-plugins: 0.83.8
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  metro-transform-worker@0.87.0(supports-color@8.1.1):
+  metro-transform-worker@0.87.0:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
-      metro: 0.87.0(supports-color@8.1.1)
-      metro-babel-transformer: 0.87.0(supports-color@8.1.1)
-      metro-cache: 0.87.0(supports-color@8.1.1)
+      metro: 0.87.0
+      metro-babel-transformer: 0.87.0
+      metro-cache: 0.87.0
       metro-cache-key: 0.87.0
       metro-minify-terser: 0.87.0
-      metro-source-map: 0.87.0(supports-color@8.1.1)
-      metro-transform-plugins: 0.87.0(supports-color@8.1.1)
+      metro-source-map: 0.87.0
+      metro-transform-plugins: 0.87.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  metro@0.83.8(supports-color@8.1.1):
+  metro@0.83.8:
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       accepts: 2.0.0
       ci-info: 2.0.0
-      connect: 3.7.0(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      connect: 3.7.0
+      debug: 4.4.3
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -8029,18 +8006,18 @@ snapshots:
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4
       lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.8(supports-color@8.1.1)
-      metro-cache: 0.83.8(supports-color@8.1.1)
+      metro-babel-transformer: 0.83.8
+      metro-cache: 0.83.8
       metro-cache-key: 0.83.8
-      metro-config: 0.83.8(supports-color@8.1.1)
+      metro-config: 0.83.8
       metro-core: 0.83.8
-      metro-file-map: 0.83.8(supports-color@8.1.1)
+      metro-file-map: 0.83.8
       metro-resolver: 0.83.8
       metro-runtime: 0.83.8
-      metro-source-map: 0.83.8(supports-color@8.1.1)
-      metro-symbolicate: 0.83.8(supports-color@8.1.1)
-      metro-transform-plugins: 0.83.8(supports-color@8.1.1)
-      metro-transform-worker: 0.83.8(supports-color@8.1.1)
+      metro-source-map: 0.83.8
+      metro-symbolicate: 0.83.8
+      metro-transform-plugins: 0.83.8
+      metro-transform-worker: 0.83.8
       mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
@@ -8053,19 +8030,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.87.0(supports-color@8.1.1):
+  metro@0.87.0:
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       accepts: 2.0.0
       ci-info: 2.0.0
-      connect: 3.7.0(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      connect: 3.7.0
+      debug: 4.4.3
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -8075,18 +8052,18 @@ snapshots:
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4
       lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.87.0(supports-color@8.1.1)
-      metro-cache: 0.87.0(supports-color@8.1.1)
+      metro-babel-transformer: 0.87.0
+      metro-cache: 0.87.0
       metro-cache-key: 0.87.0
-      metro-config: 0.87.0(supports-color@8.1.1)
+      metro-config: 0.87.0
       metro-core: 0.87.0
-      metro-file-map: 0.87.0(supports-color@8.1.1)
+      metro-file-map: 0.87.0
       metro-resolver: 0.87.0
       metro-runtime: 0.87.0
-      metro-source-map: 0.87.0(supports-color@8.1.1)
-      metro-symbolicate: 0.87.0(supports-color@8.1.1)
-      metro-transform-plugins: 0.87.0(supports-color@8.1.1)
-      metro-transform-worker: 0.87.0(supports-color@8.1.1)
+      metro-source-map: 0.87.0
+      metro-symbolicate: 0.87.0
+      metro-transform-plugins: 0.87.0
+      metro-transform-worker: 0.87.0
       mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
@@ -8150,11 +8127,11 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nativewind@4.2.1(bbc2a53f0b8f79bd3b95d476a68d03b5):
+  nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(tailwindcss@3.4.17):
     dependencies:
       comment-json: 4.6.2
-      debug: 4.4.3(supports-color@8.1.1)
-      react-native-css-interop: 0.2.1(bbc2a53f0b8f79bd3b95d476a68d03b5)
+      debug: 4.4.3
+      react-native-css-interop: 0.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(tailwindcss@3.4.17)
       tailwindcss: 3.4.17
     transitivePeerDependencies:
       - react
@@ -8419,59 +8396,59 @@ snapshots:
 
   react-is@19.2.8: {}
 
-  react-native-css-interop@0.2.1(bbc2a53f0b8f79bd3b95d476a68d03b5):
+  react-native-css-interop@0.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(tailwindcss@3.4.17):
     dependencies:
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
-      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       lightningcss: 1.27.0
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
-      react-native-reanimated: 4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
+      react-native-reanimated: 4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       semver: 7.8.5
       tailwindcss: 3.4.17
     optionalDependencies:
-      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - supports-color
 
-  react-native-gesture-handler@2.30.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  react-native-gesture-handler@2.30.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  react-native-is-edge-to-edge@1.2.1(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  react-native-is-edge-to-edge@1.2.1(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  react-native-reanimated@4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  react-native-reanimated@4.2.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
-      react-native-is-edge-to-edge: 1.2.1(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
+      react-native-is-edge-to-edge: 1.2.1(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       semver: 7.7.3
 
-  react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  react-native-safe-area-context@5.6.2(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
 
-  react-native-screens@4.23.0(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  react-native-screens@4.23.0(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-freeze: 1.0.4(react@19.2.8)
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       warn-once: 0.1.1
 
   react-native-web@0.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
@@ -8489,40 +8466,40 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1):
+  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@react-native/metro-config': 0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.87.0(@babel/core@7.29.7)
       convert-source-map: 2.0.0
       react: 19.2.8
-      react-native: 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1)
+      react-native: 0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8)
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1):
+  react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.83.1
-      '@react-native/codegen': 0.83.1(@babel/core@7.29.7(supports-color@8.1.1))
-      '@react-native/community-cli-plugin': 0.83.1(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
+      '@react-native/codegen': 0.83.1(@babel/core@7.29.7)
+      '@react-native/community-cli-plugin': 0.83.1(@react-native/metro-config@0.87.0(@babel/core@7.29.7))
       '@react-native/gradle-plugin': 0.83.1
       '@react-native/js-polyfills': 0.83.1
       '@react-native/normalize-colors': 0.83.1
-      '@react-native/virtualized-lists': 0.83.1(@types/react@19.2.7)(react-native@0.83.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.87.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.7)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      '@react-native/virtualized-lists': 0.83.1(@types/react@19.2.7)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
-      babel-jest: 29.7.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-jest: 29.7.0(@babel/core@7.29.7)
       babel-plugin-syntax-hermes-parser: 0.32.0
       base64-js: 1.5.1
       commander: 12.1.0
@@ -8533,7 +8510,7 @@ snapshots:
       jest-environment-node: 29.7.0
       memoize-one: 5.2.1
       metro-runtime: 0.83.8
-      metro-source-map: 0.83.8(supports-color@8.1.1)
+      metro-source-map: 0.83.8
       nullthrows: 1.1.1
       pretty-format: 29.7.0
       promise: 8.3.0
@@ -8693,9 +8670,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2(supports-color@8.1.1):
+  send@0.19.2:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -8713,12 +8690,12 @@ snapshots:
 
   serialize-error@2.1.0: {}
 
-  serve-static@1.16.3(supports-color@8.1.1):
+  serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2(supports-color@8.1.1)
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8954,13 +8931,13 @@ snapshots:
 
   type-fest@0.7.1: {}
 
-  typescript-eslint@8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
+  typescript-eslint@8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.4(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.46.4(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 9.39.1(jiti@1.21.7)(supports-color@8.1.1)
+      '@typescript-eslint/eslint-plugin': 8.46.4(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.1(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9021,7 +8998,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@7.0.3: {}
+  uuid@11.1.1: {}
 
   validate-npm-package-name@5.0.1: {}
 
@@ -9036,10 +9013,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  vite-node@3.2.4(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(supports-color@8.1.1)(terser@5.51.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(terser@5.51.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.6(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(terser@5.51.0)(yaml@2.9.0)
@@ -9073,7 +9050,7 @@ snapshots:
       terser: 5.51.0
       yaml: 2.9.0
 
-  vitest@3.2.6(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(supports-color@8.1.1)(terser@5.51.0)(yaml@2.9.0):
+  vitest@3.2.6(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(terser@5.51.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -9084,7 +9061,7 @@ snapshots:
       '@vitest/spy': 3.2.6
       '@vitest/utils': 3.2.6
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       expect-type: 1.4.0
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -9096,7 +9073,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.6(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(terser@5.51.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(supports-color@8.1.1)(terser@5.51.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.3.0)(jiti@1.21.7)(lightningcss@1.33.0)(terser@5.51.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.3.0
@@ -9168,7 +9145,7 @@ snapshots:
   xcode@3.0.1:
     dependencies:
       simple-plist: 1.3.1
-      uuid: 7.0.3
+      uuid: 11.1.1
 
   xml2js@0.6.0:
     dependencies:

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -26,7 +26,7 @@
  * same way but shown only here and on the result card, never on an approval
  * card — see `docs/decisions/0018-tool-call-narration.md`.
  */
-export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>, 
+export type AgentActivityDetail = { "kind": "exec", command: string, args: Array<string>,
 /**
  * The model's own sentence about this step, when it wrote one.
  *
@@ -119,7 +119,7 @@ export type AgentRunId = string;
  * are not copied directly into it. Typed activity headlines are projected
  * separately.
  */
-export type AgentRunProgressLine = { 
+export type AgentRunProgressLine = {
 /**
  * Monotonic per-run ordering. Pass the page's `next_sequence` back as
  * `after_sequence` to read only what has arrived since.
@@ -129,7 +129,7 @@ sequence: number, text: string, at: string, };
 /**
  * One resumable page of a background run's live progress.
  */
-export type AgentRunProgressPage = { entries: Array<AgentRunProgressLine>, 
+export type AgentRunProgressPage = { entries: Array<AgentRunProgressLine>,
 /**
  * The cursor to resume from: the highest sequence in this page, or the
  * requested cursor when the page is empty. A reader that polls with this
@@ -143,31 +143,31 @@ next_sequence: number, };
  * Worker lease tokens, scheduling budgets, and other executor-facing fields
  * intentionally remain inside the server/store boundary.
  */
-export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, tier: AgentRunTier, execution_location: AgentRunExecutionLocation, 
+export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, tier: AgentRunTier, execution_location: AgentRunExecutionLocation,
 /**
  * Active host code-execution backend for `exec`, not the run-loop seat.
  *
  * See [`ExecProviderSnapshot`]. Read from the current host
  * setting at list time — the same selection the next `exec` would use.
  */
-code_execution_provider: ExecProviderSnapshot, status: AgentRunStatus, 
+code_execution_provider: ExecProviderSnapshot, status: AgentRunStatus,
 /**
  * Completed provider calls accumulated across every attempt.
  */
-model_steps: number, 
+model_steps: number,
 /**
  * Disjoint provider usage accumulated across every attempt. Providers
  * without cache telemetry leave both cache fields at zero.
  */
-usage: AgentRunUsageSnapshot, 
+usage: AgentRunUsageSnapshot,
 /**
  * The exact bounded task delegated by the visible spawn step.
  */
-task: string | null, started_at: string | null, finished_at: string | null, 
+task: string | null, started_at: string | null, finished_at: string | null,
 /**
  * Stable, bounded classification suitable for renderer display.
  */
-last_error_code: string | null, 
+last_error_code: string | null,
 /**
  * The currently checkpointed, renderer-safe activity, if any.
  *
@@ -175,7 +175,7 @@ last_error_code: string | null,
  * arguments, results, provider call identities, executor leases, or raw
  * executor diagnostics.
  */
-activity: AgentActivitySnapshot | null, 
+activity: AgentActivitySnapshot | null,
 /**
  * Files a background run submitted as its deliverables, in its own order.
  *
@@ -183,7 +183,7 @@ activity: AgentActivitySnapshot | null,
  * by name; nothing here is host-authored, and a run that submitted nothing
  * carries an empty list.
  */
-submitted_outputs: Array<SubmittedOutputSnapshot>, 
+submitted_outputs: Array<SubmittedOutputSnapshot>,
 /**
  * How far this run's own task plan has got, when it keeps one.
  *
@@ -194,7 +194,7 @@ submitted_outputs: Array<SubmittedOutputSnapshot>,
  * additive: every run before this field existed, and every foreground
  * coordinator, reads back in the shape it always had.
  */
-task_plan?: AgentRunTaskPlanProgress, 
+task_plan?: AgentRunTaskPlanProgress,
 /**
  * Bounded terminal display text returned to the parent, if settled.
  */
@@ -212,11 +212,11 @@ export type AgentRunStatus = "active" | "queued" | "running" | "cancelling" | "w
  * is one delegated task from start to finish, so the run is the only scope
  * its plan ever had.
  */
-export type AgentRunTaskPlan = { run_id: AgentRunId, 
+export type AgentRunTaskPlan = { run_id: AgentRunId,
 /**
  * The steps, in order.
  */
-steps: Array<TaskPlanStep>, 
+steps: Array<TaskPlanStep>,
 /**
  * When the last replacement committed.
  */
@@ -235,7 +235,7 @@ updated_at: string, };
  * Copying it as stored is therefore not a gap in the clamp; it is the same
  * rule enforced one surface earlier.
  */
-export type AgentRunTaskPlanProgress = { completed: number, total: number, 
+export type AgentRunTaskPlanProgress = { completed: number, total: number,
 /**
  * The one step marked `in_progress`, when there is one.
  */
@@ -264,15 +264,15 @@ export type AgentRunUsageSnapshot = { input_tokens: number, output_tokens: numbe
  * carries neither a selection nor an answer, which is how the card knows to
  * say so.
  */
-export type AnsweredUserQuestion = { 
+export type AnsweredUserQuestion = {
 /**
  * The prompt the reader answered.
  */
-question: string, 
+question: string,
 /**
  * Labels of the options chosen, in the order the question listed them.
  */
-selected?: Array<string>, 
+selected?: Array<string>,
 /**
  * The reader's own words, when the question allowed them.
  */
@@ -281,19 +281,19 @@ custom_answer?: string, };
 /**
  * One app's detail: the summary fields plus its revision history.
  */
-export type AppDetail = { id: AppId, name: string, 
+export type AppDetail = { id: AppId, name: string,
 /**
  * Creation time of the first revision.
  */
-created_at: string, 
+created_at: string,
 /**
  * Creation time of the current revision.
  */
-updated_at: string, 
+updated_at: string,
 /**
  * Revision currently presented as the app's content.
  */
-current_revision: AppRevisionId, 
+current_revision: AppRevisionId,
 /**
  * Every retained revision, newest first.
  */
@@ -312,12 +312,12 @@ export type AppGatewayPageOutcome = "ready" | "no_gateway" | "not_registered" | 
 /**
  * One answer: an outcome, and whatever came with it.
  */
-export type AppGatewayPageResult = { outcome: AppGatewayPageOutcome, 
+export type AppGatewayPageResult = { outcome: AppGatewayPageOutcome,
 /**
  * The app's page at the gateway, present exactly when `outcome` is
  * `ready`.
  */
-url?: string, 
+url?: string,
 /**
  * The gateway's own message, when the outcome carries one.
  */
@@ -337,43 +337,43 @@ message?: string, };
  * rows themselves: a manifest with both a folder row and a network row —
  * local or gateway — can read files and reach the network.
  */
-export type AppGrantBindingState = { 
+export type AppGrantBindingState = {
 /**
  * Connected app the manifest binds, by record id, for an app-keyed
  * binding.
  */
-app: ConnectedAppId | null, 
+app: ConnectedAppId | null,
 /**
  * Connected folder the manifest binds, by broker root id, for a folder
  * binding.
  */
-folder: HostRootId | null, 
+folder: HostRootId | null,
 /**
  * Gateway connected app the manifest binds, by the gateway's own app id,
  * for a gateway binding. The id alone — never the gateway that serves
  * it.
  */
-gateway_app: string | null, 
+gateway_app: string | null,
 /**
  * The access level a folder binding requests.
  */
-access: FolderAccess | null, 
+access: FolderAccess | null,
 /**
  * The bound connected app's, folder's, or gateway app's display name,
  * absent when nothing configured, approved, or readable answers to the
  * id — the sheet says so instead of showing a raw id alone.
  */
-name: string | null, 
+name: string | null,
 /**
  * Catalog `operationId`s the current manifest pins under this app, for a
  * `rest_api` or gateway binding.
  */
-operation_ids: Array<string> | null, 
+operation_ids: Array<string> | null,
 /**
  * Whether the live grant covers every listed capability under this
  * binding and its target still matches the granted fingerprint.
  */
-granted: boolean, 
+granted: boolean,
 /**
  * Whether a grant names this binding's target but it changed — a
  * reconfigured record, a disconnected folder — since consent: the
@@ -390,7 +390,7 @@ definition_changed: boolean, };
  * the folders, and any environment or credential values they select, are
  * deliberately absent from this projection.
  */
-export type AppGrantState = { 
+export type AppGrantState = {
 /**
  * Whether a live grant fully covers the current manifest with every
  * bound definition unchanged since consent — the "no sheet needed"
@@ -398,7 +398,7 @@ export type AppGrantState = {
  * nothing to consent to, so no sheet is shown. When `false`,
  * (re-)consent is required before every pinned capability is invokable.
  */
-granted: boolean, 
+granted: boolean,
 /**
  * The current manifest's bindings, one entry per bound connected app or
  * folder.
@@ -444,7 +444,7 @@ export type AppRevisionId = string;
  * One revision row: identity and position only. The manifest and the
  * bundle's content address stay server-side.
  */
-export type AppRevisionSummary = { id: AppRevisionId, 
+export type AppRevisionSummary = { id: AppRevisionId,
 /**
  * One-based position in the app's revision history.
  */
@@ -453,19 +453,19 @@ ordinal: number, created_at: string, };
 /**
  * One library row.
  */
-export type AppSummary = { id: AppId, 
+export type AppSummary = { id: AppId,
 /**
  * Display name, following the current revision's manifest.
  */
-name: string, 
+name: string,
 /**
  * Number of retained revisions, always at least one.
  */
-revision_count: number, 
+revision_count: number,
 /**
  * Creation time of the current revision.
  */
-updated_at: string, 
+updated_at: string,
 /**
  * Whether a live grant fully covers the app right now — the same
  * verdict `GET /apps/{id}/grant` reports, so the library badge and the
@@ -490,7 +490,7 @@ export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 /**
  * Outcome recorded on [`CodeEvent::ApprovalResolved`].
  */
-export type ApprovalDecisionKind = { "type": "approve" } | { "type": "deny", 
+export type ApprovalDecisionKind = { "type": "approve" } | { "type": "deny",
 /**
  * Feedback returned to the engine, when any.
  */
@@ -523,11 +523,11 @@ export type AssistantCitationSnapshot = { id: AssistantCitationId, ordinal: numb
  * must agree when the state is `NeedsYou`; [`Attention::needs_you`] enforces
  * that at construction.
  */
-export type Attention = { 
+export type Attention = {
 /**
  * The state.
  */
-state: AttentionState, 
+state: AttentionState,
 /**
  * Who or what set it.
  */
@@ -541,23 +541,23 @@ export type AttentionSource = "structured" | "heuristic" | "lifecycle" | "user";
 /**
  * Server-computed attention for one unit of supervised work.
  */
-export type AttentionState = { "type": "working" } | { "type": "needs_you", 
+export type AttentionState = { "type": "working" } | { "type": "needs_you",
 /**
  * Short prompt shown on the badge.
  */
-prompt: string, 
+prompt: string,
 /**
  * How this need was detected.
  */
-source: AttentionSource, } | { "type": "stalled", 
+source: AttentionSource, } | { "type": "stalled",
 /**
  * Seconds of observed silence.
  */
-idle_secs: number, } | { "type": "done_unreviewed" } | { "type": "idle" } | { "type": "fenced", 
+idle_secs: number, } | { "type": "done_unreviewed" } | { "type": "idle" } | { "type": "fenced",
 /**
  * Why it was fenced.
  */
-reason: FenceReason, } | { "type": "manual", 
+reason: FenceReason, } | { "type": "manual",
 /**
  * User-supplied note.
  */
@@ -575,7 +575,7 @@ export type AutoJudgeStatus = "judging" | "approved" | "declined";
 /**
  * Bounded error carried on [`CodeEvent::TurnFailed`].
  */
-export type BoundedError = { 
+export type BoundedError = {
 /**
  * Short message, already truncated by the adapter.
  */
@@ -594,47 +594,47 @@ export type CapLevel = "supported" | "unsupported" | "unknown";
 /**
  * A persistent conversation with an exact, ordered host-root projection.
  */
-export type Chat = { 
+export type Chat = {
 /**
  * Stable identifier.
  */
-id: ChatId, 
+id: ChatId,
 /**
  * The project this chat belongs to, or `None` for a loose (projectless) chat.
  */
-project_id: ProjectId | null, 
+project_id: ProjectId | null,
 /**
  * Human-facing title; `None` until one is set or derived.
  */
-title: string | null, 
+title: string | null,
 /**
  * The model this chat runs against, or `None` to use the configured default.
  */
-model: string | null, 
+model: string | null,
 /**
  * Reasoning-effort override for this chat, honored only by models that
  * expose the control; `None` leaves the provider's default in force.
  */
-reasoning_effort: ReasoningEffort | null, 
+reasoning_effort: ReasoningEffort | null,
 /**
  * How much this chat lets the agent do between approvals; `None` means
  * [`PermissionMode::Ask`].
  */
-permission_mode: PermissionMode | null, 
+permission_mode: PermissionMode | null,
 /**
  * Outbound network access for code execution in this chat.
  */
-network_policy: NetworkPolicy, 
+network_policy: NetworkPolicy,
 /**
  * CAS revision of this conversation's exact root projection.
  */
-attachment_revision: number, 
+attachment_revision: number,
 /**
  * Ordered opaque roots available for future broker-backed operations.
  * Live broker authorization remains mandatory and may revoke access at any
  * time, regardless of this projection.
  */
-root_attachments: Array<ChatRootAttachment>, 
+root_attachments: Array<ChatRootAttachment>,
 /**
  * When the chat was created.
  */
@@ -651,18 +651,18 @@ export type ChatId = string;
  * A renderer-safe durable transcript entry. Internal routing and tool state
  * deliberately remain behind the server boundary.
  */
-export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, content: string, created_at: string, citations: Array<AssistantCitationSnapshot>, 
+export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, content: string, created_at: string, citations: Array<AssistantCitationSnapshot>,
 /**
  * Images submitted with this user message. These are durable identity and
  * geometry only; image bytes remain behind a chat-scoped authenticated
  * endpoint and never enter the transcript payload.
  */
-image_attachments?: Array<TranscriptImageAttachment>, 
+image_attachments?: Array<TranscriptImageAttachment>,
 /**
  * Files submitted with this user message. Their bytes remain behind the
  * existing chat-scoped document endpoints.
  */
-file_attachments?: Array<TranscriptFileAttachment>, 
+file_attachments?: Array<TranscriptFileAttachment>,
 /**
  * Skills this user message explicitly invoked, in submitted order. Absent
  * for the ordinary message that invoked none.
@@ -672,11 +672,11 @@ invoked_skills?: Array<string>, };
 /**
  * One pathless root in a conversation's exact ordered projection.
  */
-export type ChatRootAttachment = { 
+export type ChatRootAttachment = {
 /**
  * Opaque broker root identity. This value grants no authority by itself.
  */
-root_id: HostRootId, 
+root_id: HostRootId,
 /**
  * Product-level provenance for ordering and future management UI.
  */
@@ -690,12 +690,12 @@ origin: RootAttachmentOrigin, };
  * message-less failed and cancelled turns remain first-class transcript entries
  * carrying the partial prose and reasoning the reader already saw live.
  */
-export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_detail?: string, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>, 
+export type ChatTerminalTurnSnapshot = { turn_id: TurnId, message_id?: MessageId, status: ChatTerminalTurnStatus, partial_content: string, reasoning?: string, refusal?: RendererRefusal, failure_category?: TurnFailureCategory, failure_detail?: string, failure_model?: RendererModelIdentity, file_changes: Array<ExecFileChangeSummary>,
 /**
  * Skills the user explicitly invoked for this turn, in submitted order.
  * Absent for the ordinary turn that invoked none.
  */
-invoked_skills?: Array<string>, 
+invoked_skills?: Array<string>,
 /**
  * Token accounting for the turn, so a freshly opened chat can show
  * context usage without waiting for the next turn to finish.
@@ -709,7 +709,7 @@ export type ChatTerminalTurnStatus = "completed" | "failed" | "cancelled";
  * metadata, executor identity, lease, or diagnostic detail. The only action or
  * result it can carry is one a tool explicitly projects through a closed type.
  */
-export type ChatToolActivitySnapshot = { 
+export type ChatToolActivitySnapshot = {
 /**
  * Canonical call id, the same [`crate::id::CallId`] the live event stream
  * carried for this call.
@@ -721,7 +721,7 @@ export type ChatToolActivitySnapshot = {
  * and every replayed app view fetched a payload the server could only
  * reject.
  */
-call_id: CallId, 
+call_id: CallId,
 /**
  * Allowlisted renderer tool name, never a provider-supplied one.
  *
@@ -734,18 +734,18 @@ call_id: CallId,
  * on both sides while silently dropping the allowlist the renderer's copy
  * and icon tables are keyed on.
  */
-tool: RendererToolName, 
+tool: RendererToolName,
 /**
  * Closed projection of what the call did, when its tool has one. Rebuilt
  * from the arguments it ran with, so history describes the same action
  * the live stream did.
  */
-action?: ToolActionPreview, 
+action?: ToolActionPreview,
 /**
  * Closed projection of an actionable result. Arbitrary result text is
  * never included.
  */
-result?: ToolResultPreview, 
+result?: ToolResultPreview,
 /**
  * Set when this call retained a projection that no longer deserializes.
  *
@@ -770,12 +770,12 @@ export type ChatToolActivityStatus = "completed" | "failed" | "denied" | "cancel
  * The renderer uses the watermark to subscribe only to future events, avoiding
  * duplicate text when reopening a completed conversation.
  */
-export type ChatTranscript = { messages: Array<ChatMessageSnapshot>, 
+export type ChatTranscript = { messages: Array<ChatMessageSnapshot>,
 /**
  * Finished tool activity from terminal turns, projected through a fixed
  * renderer-safe allowlist. Canonical tool records never cross this API.
  */
-tool_activity: Array<ChatToolActivitySnapshot>, 
+tool_activity: Array<ChatToolActivitySnapshot>,
 /**
  * Status and streamed presentation for every terminal turn. This owns
  * terminal metadata even when no assistant message was committed.
@@ -785,11 +785,11 @@ terminal_turns: Array<ChatTerminalTurnSnapshot>, last_event_seq: number, };
 /**
  * Hint that a turn recorded a checkpoint. The diff body is loaded separately.
  */
-export type CheckpointHint = { 
+export type CheckpointHint = {
 /**
  * Hidden ref name, when known.
  */
-checkpoint_ref?: string, 
+checkpoint_ref?: string,
 /**
  * Bounded diffstat.
  */
@@ -866,23 +866,23 @@ export type CodeApprovalId = string;
 /**
  * Best-effort classification of what an approval is asking.
  */
-export type CodeApprovalKind = { "type": "command", 
+export type CodeApprovalKind = { "type": "command",
 /**
  * Command string.
  */
-cmd: string, 
+cmd: string,
 /**
  * Working directory, when reported.
  */
-cwd?: string | null, } | { "type": "file_write", 
+cwd?: string | null, } | { "type": "file_write",
 /**
  * Paths involved.
  */
-paths: Array<string>, } | { "type": "network", 
+paths: Array<string>, } | { "type": "network",
 /**
  * Host or summary the engine reported.
  */
-summary: string, } | { "type": "other", 
+summary: string, } | { "type": "other",
 /**
  * Engine-provided summary.
  */
@@ -891,7 +891,7 @@ summary: string, };
 /**
  * One parked or decided engine approval.
  */
-export type CodeApprovalSnapshot = { id: CodeApprovalId, session_id: CodeSessionId, turn_id: CodeTurnId, kind: CodeApprovalKind, 
+export type CodeApprovalSnapshot = { id: CodeApprovalId, session_id: CodeSessionId, turn_id: CodeTurnId, kind: CodeApprovalKind,
 /**
  * Exact JSON the engine sent, already size-capped. The card renders this.
  */
@@ -910,15 +910,15 @@ export type CodeApprovalState = "pending" | "approved" | "denied" | "abandoned";
  * storage a fork transcript uses. The prompt names it and the engine opens
  * it; nothing is uploaded and nothing is indexable.
  */
-export type CodeCheckLog = { 
+export type CodeCheckLog = {
 /**
  * Check name as the host reports it.
  */
-check: string, path: string, byte_len: number, 
+check: string, path: string, byte_len: number,
 /**
  * True when the file holds only the tail of the job log.
  */
-truncated: boolean, 
+truncated: boolean,
 /**
  * The job's host URL. A check without one has no log to download, so
  * every entry here has one.
@@ -937,7 +937,7 @@ export type CodeCheckLogError = { check: string, message: string, };
  * URL that names no Actions job — is simply absent from both lists. The
  * caller still names it in the prompt from the digest it already holds.
  */
-export type CodeCheckLogsSnapshot = { 
+export type CodeCheckLogsSnapshot = {
 /**
  * Head the logs were read against, when the host reported one.
  */
@@ -957,6 +957,33 @@ export type CodeCloneJobSnapshot = { id: string, phase: string, percent?: number
  * Result of staging and committing the workspace worktree.
  */
 export type CodeCommitSnapshot = { sha: string, message: string, stat: Diffstat, };
+
+/**
+ * What the connect approval page renders: the identity being linked and
+ * the CSRF token its "is this you?" POST must echo.
+ */
+export type CodeConnectPage = {
+/**
+ * Which channel family is linking (for example `slack`).
+ */
+channel_kind: string,
+/**
+ * The person's display name in the channel.
+ */
+display_name: string,
+/**
+ * The channel workspace's human name.
+ */
+workspace_name: string, avatar_url?: string,
+/**
+ * `pending` or `approved`; a completed or expired link renders
+ * nothing.
+ */
+state: string,
+/**
+ * Echo this in the approve POST.
+ */
+csrf: string, expires_at: string, };
 
 /**
  * Delivery mutation result. A partial rerun returns every per-run outcome.
@@ -979,7 +1006,7 @@ export type CodeDeliveryPrAttentionReason = "changes_requested" | "checks_failed
  * User-initiated global PR action. Code-changing actions deliberately do not
  * exist here; they remain workspace-scoped agent prompts.
  */
-export type CodeDeliveryPullRequestAction = { "type": "mark_ready" } | { "type": "merge", method: CodePrMergeMethod, auto: boolean, admin: boolean, expected_head_sha: string, } | { "type": "create_stack", 
+export type CodeDeliveryPullRequestAction = { "type": "mark_ready" } | { "type": "merge", method: CodePrMergeMethod, auto: boolean, admin: boolean, expected_head_sha: string, } | { "type": "create_stack",
 /**
  * The chain to register, bottom to top. Every pull request's base
  * ref must match the previous one's head ref.
@@ -992,18 +1019,18 @@ export type CodeDeliveryPullRequestActionBody = { target: CodeDeliveryPullReques
  * Full PR drawer payload. Conversation entries retain the existing bounded
  * comment contract used by workspace PRs.
  */
-export type CodeDeliveryPullRequestDetail = { summary: CodeDeliveryPullRequestSummary, body: string, labels: Array<string>, assignees: Array<string>, requested_reviewers: Array<string>, changed_files: number, additions: number, deletions: number, 
+export type CodeDeliveryPullRequestDetail = { summary: CodeDeliveryPullRequestSummary, body: string, labels: Array<string>, assignees: Array<string>, requested_reviewers: Array<string>, changed_files: number, additions: number, deletions: number,
 /**
  * The full stack chain this pull request belongs to, bottom to top,
  * when the host reported one. Absent on hosts without stacked pull
  * requests.
  */
-stack?: Array<CodeDeliveryStackMember>, commits: number, merged_by?: string, 
+stack?: Array<CodeDeliveryStackMember>, commits: number, merged_by?: string,
 /**
  * Empty when the diff could not be read. Truncated by `files_truncated`
  * rather than paged: the panel is a review aid, not a diff viewer.
  */
-files: Array<CodeDeliveryPullRequestFile>, files_truncated: boolean, comments: Array<PullRequestComment>, 
+files: Array<CodeDeliveryPullRequestFile>, files_truncated: boolean, comments: Array<PullRequestComment>,
 /**
  * Section reads that failed after the pull request itself loaded.
  */
@@ -1015,7 +1042,7 @@ errors: Array<CodeDeliverySourceError>, can_mark_ready: boolean, can_merge: bool
  * `patch` is the host's unified hunk text and is absent for binary files and
  * for diffs GitHub declines to render. It is bounded by the host, not stored.
  */
-export type CodeDeliveryPullRequestFile = { path: string, 
+export type CodeDeliveryPullRequestFile = { path: string,
 /**
  * `added`, `modified`, `removed`, `renamed`, `copied`, or `changed`.
  */
@@ -1025,7 +1052,7 @@ status: string, additions: number, deletions: number, previous_path?: string, pa
  * Server-side PR query. Saved views are client-owned; their resolved filters
  * are sent here so paging remains bounded across many repositories.
  */
-export type CodeDeliveryPullRequestQuery = { repositories: Array<CodeGitHubRepositoryTarget>, search?: string, states: Array<string>, review_states: Array<string>, check_states: Array<string>, authors: Array<string>, attention_only: boolean, ready_only: boolean, tidebreak_linked?: boolean, updated_after?: string, cursor?: string, limit?: number, 
+export type CodeDeliveryPullRequestQuery = { repositories: Array<CodeGitHubRepositoryTarget>, search?: string, states: Array<string>, review_states: Array<string>, check_states: Array<string>, authors: Array<string>, attention_only: boolean, ready_only: boolean, tidebreak_linked?: boolean, updated_after?: string, cursor?: string, limit?: number,
 /**
  * Skip the short list cache and reread GitHub.
  *
@@ -1037,27 +1064,27 @@ refresh: boolean, };
 /**
  * Pull request row shared by the overview and notification monitor.
  */
-export type CodeDeliveryPullRequestSummary = { id: string, repository: CodeGitHubRepositoryRef, number: number, url: string, title: string, state: string, draft: boolean, author?: string, author_avatar_url?: string, head_branch: string, base_branch: string, head_sha?: string, review_decision?: string, mergeable?: string, merge_state_status?: string, auto_merge_enabled: boolean, 
+export type CodeDeliveryPullRequestSummary = { id: string, repository: CodeGitHubRepositoryRef, number: number, url: string, title: string, state: string, draft: boolean, author?: string, author_avatar_url?: string, head_branch: string, base_branch: string, head_sha?: string, review_decision?: string, mergeable?: string, merge_state_status?: string, auto_merge_enabled: boolean,
 /**
  * True when the last reliable host observation placed the pull request
  * in its merge queue. Absent when the list read cannot answer.
  */
-in_merge_queue?: boolean, 
+in_merge_queue?: boolean,
 /**
  * Issue comments visible from the list read. Review and inline comments
  * remain detail-only, so an absent count means unknown rather than zero.
  */
-comment_count?: number, checks: Array<CodeDeliveryCheck>, attention_reasons: Array<CodeDeliveryPrAttentionReason>, ready_to_merge: boolean, workspace_links: Array<CodeDeliveryWorkspaceLink>, 
+comment_count?: number, checks: Array<CodeDeliveryCheck>, attention_reasons: Array<CodeDeliveryPrAttentionReason>, ready_to_merge: boolean, workspace_links: Array<CodeDeliveryWorkspaceLink>,
 /**
  * The host stack this pull request belongs to (GitHub stacked pull
  * requests), when the host reported one. Identifies the stack, not the
  * PR.
  */
-stack_number?: number, 
+stack_number?: number,
 /**
  * Total layers in that stack, bottom to top, including merged ones.
  */
-stack_size?: number, 
+stack_size?: number,
 /**
  * The pull request this one is stacked on. Host stack order wins when
  * the host reported a stack; branch inference from the durable fact set
@@ -1065,7 +1092,7 @@ stack_size?: number,
  * or filter still resolves. Absent when the base is the default branch
  * or nothing tracked owns it.
  */
-stack_parent_number?: number, 
+stack_parent_number?: number,
 /**
  * A stack-shaped chain of inferred edges the host has no stack for,
  * bottom to top, when one resolves gaplessly around this pull request
@@ -1074,7 +1101,7 @@ stack_parent_number?: number,
  * — without it, merging a layer lands it into the branch below rather
  * than the default branch, which is easy to do by accident.
  */
-unregistered_stack_numbers?: Array<number>, labels: Array<string>, created_at: string, updated_at: string, 
+unregistered_stack_numbers?: Array<number>, labels: Array<string>, created_at: string, updated_at: string,
 /**
  * Set only once the pull request merged. `state` alone cannot separate a
  * merged pull request from a closed one on every host response, and the
@@ -1109,7 +1136,7 @@ export type CodeDeliveryRunActionBody = { target: CodeDeliveryRunTarget, action:
 
 export type CodeDeliveryRunAttentionReason = "failure" | "timed_out" | "action_required" | "startup_failure";
 
-export type CodeDeliveryRunDetail = { summary: CodeDeliveryRunSummary, jobs: Array<CodeDeliveryWorkflowJob>, deployment_statuses: Array<CodeDeliveryDeploymentStatus>, can_rerun_failed: boolean, 
+export type CodeDeliveryRunDetail = { summary: CodeDeliveryRunSummary, jobs: Array<CodeDeliveryWorkflowJob>, deployment_statuses: Array<CodeDeliveryDeploymentStatus>, can_rerun_failed: boolean,
 /**
  * Section reads that failed after the run or deployment itself loaded.
  */
@@ -1117,7 +1144,7 @@ errors: Array<CodeDeliverySourceError>, };
 
 export type CodeDeliveryRunKind = "workflow_run" | "deployment";
 
-export type CodeDeliveryRunQuery = { repositories: Array<CodeGitHubRepositoryTarget>, search?: string, kinds: Array<CodeDeliveryRunKind>, statuses: Array<string>, conclusions: Array<string>, workflows: Array<string>, environments: Array<string>, branches: Array<string>, events: Array<string>, actors: Array<string>, attention_only: boolean, tidebreak_linked?: boolean, created_after?: string, cursor?: string, limit?: number, 
+export type CodeDeliveryRunQuery = { repositories: Array<CodeGitHubRepositoryTarget>, search?: string, kinds: Array<CodeDeliveryRunKind>, statuses: Array<string>, conclusions: Array<string>, workflows: Array<string>, environments: Array<string>, branches: Array<string>, events: Array<string>, actors: Array<string>, attention_only: boolean, tidebreak_linked?: boolean, created_after?: string, cursor?: string, limit?: number,
 /**
  * Skip the short list cache and reread GitHub. See the pull-request query.
  */
@@ -1140,15 +1167,15 @@ export type CodeDeliverySourceError = { repository?: CodeGitHubRepositoryTarget,
 /**
  * One layer of a pull-request stack, in bottom-to-top order.
  */
-export type CodeDeliveryStackMember = { number: number, 
+export type CodeDeliveryStackMember = { number: number,
 /**
  * Host state token (open, closed).
  */
-state: string, draft: boolean, 
+state: string, draft: boolean,
 /**
  * Set once this layer merged.
  */
-merged_at?: string, 
+merged_at?: string,
 /**
  * Head branch name.
  */
@@ -1159,7 +1186,7 @@ export type CodeDeliveryWorkflowJob = { id: number, name: string, status: string
 /**
  * One Tidebreak workspace that plausibly produced a remote delivery item.
  */
-export type CodeDeliveryWorkspaceLink = { workspace_id: WorkspaceId, repo_id: RepoId, title: string, branch_name: string, status: CodeWorkspaceStatus, exact: boolean, 
+export type CodeDeliveryWorkspaceLink = { workspace_id: WorkspaceId, repo_id: RepoId, title: string, branch_name: string, status: CodeWorkspaceStatus, exact: boolean,
 /**
  * Durable attribution behind this link, when one is stored: the
  * workspace authored or contributed to the pull request (decision 77).
@@ -1174,69 +1201,69 @@ relation?: CodePullRequestRelation, };
  * variant), and `#[non_exhaustive]` so new event kinds can be added without
  * breaking downstream consumers.
  */
-export type CodeEvent = { "type": "session_started", 
+export type CodeEvent = { "type": "session_started",
 /**
  * Which engine.
  */
-harness_kind: HarnessKind, 
+harness_kind: HarnessKind,
 /**
  * Version observed at launch.
  */
-harness_version: string, 
+harness_version: string,
 /**
  * Engine-native resume token, when the stream reported one.
  */
-resume_ref?: string, } | { "type": "turn_started", 
+resume_ref?: string, } | { "type": "turn_started",
 /**
  * The turn being processed.
  */
-turn_id: CodeTurnId, } | { "type": "assistant_delta", 
+turn_id: CodeTurnId, } | { "type": "assistant_delta",
 /**
  * The text fragment to append.
  */
-text: string, } | { "type": "assistant_message", 
+text: string, } | { "type": "assistant_message",
 /**
  * The message text.
  */
-text: string, 
+text: string,
 /**
  * The `Task` call this message ran inside, when a harness subagent
  * produced it (decision 52). Absent on the parent's own messages.
  */
-parent_call_id?: string, } | { "type": "reasoning_delta", 
+parent_call_id?: string, } | { "type": "reasoning_delta",
 /**
  * The reasoning fragment.
  */
-text: string, } | { "type": "tool_started", 
+text: string, } | { "type": "tool_started",
 /**
  * Engine-native call id.
  */
-call_id: string, 
+call_id: string,
 /**
  * Tool name as the engine reported it.
  */
-name: string, 
+name: string,
 /**
  * Display-oriented classification.
  */
-detail: ToolDetail, 
+detail: ToolDetail,
 /**
  * The `Task` call this call ran inside, when a harness subagent
  * issued it (decision 52). Absent on the parent's own calls.
  */
-parent_call_id?: string, } | { "type": "tool_completed", 
+parent_call_id?: string, } | { "type": "tool_completed",
 /**
  * Engine-native call id.
  */
-call_id: string, 
+call_id: string,
 /**
  * How it finished.
  */
-outcome: ToolOutcome, 
+outcome: ToolOutcome,
 /**
  * Bounded preview of the result.
  */
-preview: string, 
+preview: string,
 /**
  * Classification rebuilt from the call's complete arguments.
  *
@@ -1246,72 +1273,72 @@ preview: string,
  * and renderers merge it into the started call. It is `None` when
  * the engine's completion payload carries no arguments.
  */
-detail?: ToolDetail, 
+detail?: ToolDetail,
 /**
  * The `Task` call this call ran inside, when a harness subagent
  * issued it (decision 52). Absent on the parent's own calls.
  */
-parent_call_id?: string, } | { "type": "file_changed", 
+parent_call_id?: string, } | { "type": "file_changed",
 /**
  * Path relative to the worktree, when the engine reports one.
  */
-path: string, 
+path: string,
 /**
  * Kind of change.
  */
-kind: FileChangeKind, 
+kind: FileChangeKind,
 /**
  * Bounded diffstat.
  */
-diffstat: Diffstat, } | { "type": "approval_requested", 
+diffstat: Diffstat, } | { "type": "approval_requested",
 /**
  * Hint id; the row is the source of truth.
  */
-approval_id: CodeApprovalId, } | { "type": "approval_resolved", 
+approval_id: CodeApprovalId, } | { "type": "approval_resolved",
 /**
  * The approval that was decided.
  */
-approval_id: CodeApprovalId, 
+approval_id: CodeApprovalId,
 /**
  * The decision.
  */
-decision: ApprovalDecisionKind, } | { "type": "user_steered", 
+decision: ApprovalDecisionKind, } | { "type": "user_steered",
 /**
  * The steered user text, already bounded.
  */
-text: string, } | { "type": "turn_completed", 
+text: string, } | { "type": "turn_completed",
 /**
  * Token accounting as reported by the engine.
  */
-usage: CodeUsage, 
+usage: CodeUsage,
 /**
  * Checkpoint recorded at turn end, when any.
  */
-checkpoint?: CheckpointHint, } | { "type": "turn_failed", 
+checkpoint?: CheckpointHint, } | { "type": "turn_failed",
 /**
  * Bounded error.
  */
-error: BoundedError, } | { "type": "turn_interrupted" } | { "type": "checkpoint_recorded", 
+error: BoundedError, } | { "type": "turn_interrupted" } | { "type": "checkpoint_recorded",
 /**
  * The turn that ended at this checkpoint.
  */
-turn_id: CodeTurnId, 
+turn_id: CodeTurnId,
 /**
  * Bounded diffstat.
  */
-diffstat: Diffstat, } | { "type": "harness_notice", 
+diffstat: Diffstat, } | { "type": "harness_notice",
 /**
  * Severity.
  */
-level: HarnessNoticeLevel, 
+level: HarnessNoticeLevel,
 /**
  * Bounded message.
  */
-message: string, } | { "type": "attention_changed", 
+message: string, } | { "type": "attention_changed",
 /**
  * New state.
  */
-state: AttentionState, 
+state: AttentionState,
 /**
  * Who or what set it.
  */
@@ -1326,7 +1353,7 @@ export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: n
  * Body of `POST /code/sessions/{id}/fork`. An absent body forks at the
  * newest turn.
  */
-export type CodeForkBody = { 
+export type CodeForkBody = {
 /**
  * Fork at the end of this turn; later turns stay out of the handoff.
  */
@@ -1340,20 +1367,20 @@ at_turn?: CodeTurnId, };
  * is the fork's own directory, which also holds one full per-turn record —
  * `turn-0007.md` for turn 7 — and any retained image attachments.
  */
-export type CodeForkTranscript = { path: string, dir: string, byte_len: number, 
+export type CodeForkTranscript = { path: string, dir: string, byte_len: number,
 /**
  * Complete turn histories the condensed transcript renders in full.
  */
-turns: number, 
+turns: number,
 /**
  * Turns the fork covers, up to and including the fork point.
  */
-total_turns: number, 
+total_turns: number,
 /**
  * The fork point's turn ordinal, present when the conversation
  * continued past it — later turns are excluded from the handoff.
  */
-at_turn_ordinal?: number, 
+at_turn_ordinal?: number,
 /**
  * True when bounded replay omitted whole turn histories or the file size
  * cap reduced the oldest turns or the end of one oversized turn.
@@ -1393,6 +1420,49 @@ export type CodeGithubRepositories = { repositories: Array<CodeGithubRepository>
 export type CodeGithubRepository = { full_name: string, private: boolean, description?: string, };
 
 /**
+ * Identifies one adapter grant: a channel user's link to this machine.
+ */
+export type CodeGrantId = string;
+
+/**
+ * One adapter grant, as the desktop grants list renders it. Carries no
+ * secrets: the token pair exists only in the mint response the adapter
+ * kept.
+ */
+export type CodeGrantSnapshot = { id: CodeGrantId,
+/**
+ * Which channel family linked (for example `slack`).
+ */
+channel_kind: string,
+/**
+ * The channel's identity for the linked user.
+ */
+external_identity: string,
+/**
+ * The channel user's display name at connect time, when this grant came
+ * from the connect flow.
+ */
+display_name?: string,
+/**
+ * The channel's workspace identity, shown so an owner can revoke a
+ * whole workspace at once.
+ */
+workspace_identity: string,
+/**
+ * The channel workspace's display name at connect time.
+ */
+workspace_name?: string,
+/**
+ * The linked user's safe public avatar URL at connect time.
+ */
+avatar_url?: string, rotated_at?: string, created_at: string, revoked_at?: string,
+/**
+ * Why the grant was revoked, in owner-facing words. A theft-triggered
+ * revoke reaches the owner here.
+ */
+revoked_reason?: string, };
+
+/**
  * State of one warm harness install, returned by
  * `POST /code/harnesses/{kind}/install` and restated on the live bus.
  *
@@ -1400,7 +1470,7 @@ export type CodeGithubRepository = { full_name: string, private: boolean, descri
  * percentage to a pipe, so there is no bar to show — only which of the three
  * the engine is in.
  */
-export type CodeHarnessInstallSnapshot = { kind: HarnessKind, 
+export type CodeHarnessInstallSnapshot = { kind: HarnessKind,
 /**
  * The pinned version being installed.
  */
@@ -1410,11 +1480,11 @@ version?: string, phase: string, done: boolean, error?: string, };
  * `GET /code/workspaces/{id}/pr/comments`: the PR conversation, read live
  * from the host and never persisted.
  */
-export type CodePrCommentsSnapshot = { 
+export type CodePrCommentsSnapshot = {
 /**
  * PR number the comments belong to.
  */
-number: number, 
+number: number,
 /**
  * Issue comments, review bodies, and inline review comments, ordered by
  * creation time.
@@ -1490,37 +1560,59 @@ export type CodeSessionActivity = "agent" | "shell" | "monitor" | "subagents" | 
 /**
  * Cheap per-session digest on `/code/updates`.
  */
-export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind, 
+export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind,
 /**
  * Engine identity for list surfaces that collapse several sessions into
  * one workspace row. Optional on the wire so a desktop can still read a
  * digest from an older server during an update.
  */
-harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
+harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number,
+/**
+ * Timestamp trigger delivery uses to rank candidate sessions: the newest
+ * turn start, or session creation before the first turn. Optional so a
+ * desktop can still read a digest from an older server during an update.
+ */
+trigger_target_at?: string,
 /**
  * What the live turn is occupied with, while running.
  */
-activity?: CodeSessionActivity, pr_state?: PullRequestDigest, 
+activity?: CodeSessionActivity, pr_state?: PullRequestDigest,
 /**
  * How many pull requests hold a durable attribution to this workspace
  * (decision 77). Absent when none do.
  */
-pr_count?: number, 
+pr_count?: number,
 /**
  * Watch progress, present only on `kind: watch` digests.
  */
-watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number, 
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
 /**
  * Harness subagents on this session, present only when any were
  * observed (decision 52).
  */
-subagents?: Array<CodeSubagentSummary>, 
+subagents?: Array<CodeSubagentSummary>,
 /**
  * Where this session stands, in a sentence, derived from the newest turn
  * that carries one. Absent until a turn has been recapped, and on
  * machines with no utility model to derive one.
  */
 recap?: string, };
+
+/**
+ * Where an externally created session came from. The desktop renders it
+ * as the provenance banner; a session the desktop created carries none.
+ */
+export type CodeSessionExternalOrigin = {
+/**
+ * The channel family, for example `slack`.
+ */
+channel_kind: string,
+/**
+ * The channel's durable conversation identity, opaque to the server.
+ * For Slack this is `workspace/channel/thread_ts`, which the desktop
+ * turns into a thread permalink.
+ */
+external_key: string, };
 
 /**
  * Identifies one durable conversation with an external agent engine.
@@ -1540,15 +1632,19 @@ export type CodeSessionLifecycle = "created" | "idle" | "running" | "fenced" | "
 /**
  * One durable conversation with an external agent engine.
  */
-export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string, 
+export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
 /**
  * Absent means the engine's own default, which is not any level.
  */
-reasoning_effort?: ReasoningEffort, 
+reasoning_effort?: ReasoningEffort,
 /**
  * Whether this session runs its turns in the engine's fast mode.
  */
-fast_mode: boolean, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, };
+fast_mode: boolean, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string,
+/**
+ * Present when an external channel created the session.
+ */
+external_origin?: CodeSessionExternalOrigin, };
 
 /**
  * The next reclaim tier a workspace can take.
@@ -1572,15 +1668,15 @@ export type CodeSubagentStatus = "running" | "done" | "failed";
  * session: the harness owns its lifecycle, so the server can neither steer
  * nor resume it (decision 52).
  */
-export type CodeSubagentSummary = { 
+export type CodeSubagentSummary = {
 /**
  * The spanning `Task` call's engine-native id.
  */
-call_id: string, 
+call_id: string,
 /**
  * Display name: the Task's description or the tool name.
  */
-name: string, 
+name: string,
 /**
  * Status derived from the spanning call.
  */
@@ -1652,7 +1748,7 @@ export type CodeTurnRewriteState = "rewriting" | "rewritten" | "failed";
 /**
  * One user→engine turn.
  */
-export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: CodeUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string, 
+export type CodeTurnSnapshot = { id: CodeTurnId, session_id: CodeSessionId, ordinal: number, status: CodeTurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: CodeUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string,
 /**
  * Lucid rewrite of the closing message. The journal keeps the original.
  */
@@ -1668,38 +1764,42 @@ export type CodeTurnStatus = "running" | "completed" | "failed" | "interrupted";
  *
  * A connect is restated as [`Self::Snapshot`]; later notices are live only.
  */
-export type CodeUpdateNotice = { "type": "snapshot", 
+export type CodeUpdateNotice = { "type": "snapshot",
 /**
  * One row per live session.
  */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind, 
+sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind,
 /**
  * Engine identity for the session represented by this digest.
  */
-harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
+harness_kind?: HarnessKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number,
+/**
+ * Timestamp trigger delivery uses to rank candidate sessions.
+ */
+trigger_target_at?: string,
 /**
  * What the live turn is occupied with, while running.
  */
-activity?: CodeSessionActivity, 
+activity?: CodeSessionActivity,
 /**
  * Boxed to keep the notice enum's variants near one size; the wire
  * shape is unchanged.
  */
-pr_state?: PullRequestDigest, 
+pr_state?: PullRequestDigest,
 /**
  * How many pull requests hold a durable attribution to this
  * workspace (decision 77). Absent when none do.
  */
-pr_count?: number, 
+pr_count?: number,
 /**
  * Watch progress, present only on `kind: watch` digests.
  */
-watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number, 
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
 /**
  * Harness subagents on this session, present only when any were
  * observed (decision 52).
  */
-subagents?: Array<CodeSubagentSummary>, 
+subagents?: Array<CodeSubagentSummary>,
 /**
  * Where this session stands, in a sentence, derived from the newest
  * turn that carries one.
@@ -1731,23 +1831,23 @@ recap?: string, } | { "type": "terminal_activity", workspace_id: WorkspaceId, te
  * multiple of the prompt that was actually resident. That reading has its own
  * field: [`CodeUsage::context_tokens`].
  */
-export type CodeUsage = { 
+export type CodeUsage = {
 /**
  * Fresh, uncached input tokens. Excludes both cache fields.
  */
-input_tokens: number, 
+input_tokens: number,
 /**
  * Output tokens, summed over the turn's model calls.
  */
-output_tokens: number, 
+output_tokens: number,
 /**
  * Cache-read input tokens, when the engine reports them.
  */
-cache_read_input_tokens: number, 
+cache_read_input_tokens: number,
 /**
  * Cache-write input tokens, when the engine reports them.
  */
-cache_creation_input_tokens: number, 
+cache_creation_input_tokens: number,
 /**
  * Prompt tokens resident on the turn's final model call — what actually
  * occupied the context window at the end of the turn.
@@ -1760,7 +1860,7 @@ cache_creation_input_tokens: number,
  *
  * Zero when the engine does not publish enough to compute it.
  */
-context_tokens: number, 
+context_tokens: number,
 /**
  * Prompt tokens resident on the turn's first model call, when the engine
  * publishes per-call usage. This exposes startup context separately from
@@ -1813,13 +1913,13 @@ export type CodeWorkspaceHistorySearchSource = "turn_user_input" | "turn_narrati
 /**
  * PR + checks digest plus the local git facts the PR card needs.
  */
-export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, 
+export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string,
 /**
  * The identity a push from this machine acts as: the deployment's
  * GitHub App bot account (decision 63) or the caller's own login
  * (decision 65). The UI states this plainly beside the push control.
  */
-pushes_as?: string, 
+pushes_as?: string,
 /**
  * Whether `pushes_as` is the caller's own account (decision 65)
  * rather than the deployment's App.
@@ -1830,15 +1930,15 @@ pushes_as_self?: boolean, watch?: CodeWatchSnapshot, };
  * One pull request attributed to a workspace, from the durable fact store
  * (decision 77). A projection of the stored snapshot — no live host read.
  */
-export type CodeWorkspacePullRequestFact = { host: string, repo_owner: string, repo_name: string, number: number, url: string, title: string, 
+export type CodeWorkspacePullRequestFact = { host: string, repo_owner: string, repo_name: string, number: number, url: string, title: string,
 /**
  * Coarse lifecycle: `open`, `merged`, or `closed`.
  */
-state: string, draft: boolean, author?: string, head_branch: string, base_branch: string, head_sha?: string, 
+state: string, draft: boolean, author?: string, head_branch: string, base_branch: string, head_sha?: string,
 /**
  * How the workspace is tied to it.
  */
-relation: CodePullRequestRelation, created_at: string, updated_at: string, merged_at?: string, closed_at?: string, 
+relation: CodePullRequestRelation, created_at: string, updated_at: string, merged_at?: string, closed_at?: string,
 /**
  * When the store last confirmed this snapshot against the host.
  */
@@ -1863,12 +1963,12 @@ export type CodeWorkspaceSearchMatch = { path: string, line_number: number, line
 /**
  * One isolated workspace (worktree + branch) on a repo.
  */
-export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string, 
+export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string,
 /**
  * Commit the released branch pointed at, so a client can name the work
  * without the branch existing.
  */
-released_tip?: string, 
+released_tip?: string,
 /**
  * Stored bundle size, for reporting what a release reclaimed.
  */
@@ -1904,7 +2004,7 @@ export type CodeWorktreeRoot = { root?: string, effective_root: string, default_
 /**
  * What one on-demand compaction did.
  */
-export type CompactionRun = { 
+export type CompactionRun = {
 /**
  * Whether a checkpoint was written. `false` is a complete, ordinary answer:
  * the chat had too little history to give up, its recent messages are all
@@ -1916,19 +2016,19 @@ compacted: boolean, };
 /**
  * Host-tunable chat compaction cadence and retention.
  */
-export type CompactionSettings = { 
+export type CompactionSettings = {
 /**
  * Compact when unabridged tokens exceed this fraction of the context window.
  */
-threshold_fraction: number, 
+threshold_fraction: number,
 /**
  * After compaction, keep about this fraction of the window as raw recent history.
  */
-target_fraction: number, 
+target_fraction: number,
 /**
  * Absolute floor applied before scaling by context window.
  */
-min_threshold_tokens: number, 
+min_threshold_tokens: number,
 /**
  * Newest durable messages that must never enter the compacted prefix.
  */
@@ -1951,33 +2051,33 @@ export type ConnectedAppId = string;
  * health projection, a `rest_api` entry carries catalog and credential
  * *status* — never transport definitions, documents, or values.
  */
-export type ConnectedAppInfo = { "kind": "mcp_server", 
+export type ConnectedAppInfo = { "kind": "mcp_server",
 /**
  * The record id app bindings name.
  */
-id: ConnectedAppId, 
+id: ConnectedAppId,
 /**
  * Display name — also the namespace the server's tools mount under.
  */
-name: string, health: McpHealth, tool_count: number, 
+name: string, health: McpHealth, tool_count: number,
 /**
  * The bare mounted tool names (after the `mcp__{server}__` prefix),
  * bounded by the per-server discovery cap. Names only — never
  * remote-authored descriptions — the consent sheet's posture.
  */
-tools: Array<string>, diagnostic: string | null, 
+tools: Array<string>, diagnostic: string | null,
 /**
  * The curated-list entry this server matched, when Tidebreak has
  * exercised it end to end. `null` is the community tier: mounted and
  * usable, just not something we have driven ourselves. A label, not
  * a gate — nothing about the mount changes either way.
  */
-curated: McpCuration | null, 
+curated: McpCuration | null,
 /**
  * The gateway MCP endpoint slug this record mounts, when it is
  * gateway-backed rather than a local stdio/HTTP definition.
  */
-gateway_endpoint: string | null, 
+gateway_endpoint: string | null,
 /**
  * Display names of the organization's entitled apps that ride this
  * record's gateway endpoint. Empty for local records — and, by
@@ -1985,32 +2085,32 @@ gateway_endpoint: string | null,
  * the apps surface: the entry then renders without org-app names
  * rather than erroring.
  */
-gateway_apps: Array<string>, 
+gateway_apps: Array<string>,
 /**
  * How many local mini-apps hold a live grant binding this record —
  * a count only, never app names or ids, the renderer-safety posture
  * of this surface. Grants of library-deleted apps do not count.
  */
-used_by_app_count: number, } | { "kind": "rest_api", 
+used_by_app_count: number, } | { "kind": "rest_api",
 /**
  * The record id app bindings name.
  */
-id: ConnectedAppId, name: string, base_url: string, 
+id: ConnectedAppId, name: string, base_url: string,
 /**
  * Operations the ingested catalog declares.
  */
-operation_count: number, 
+operation_count: number,
 /**
  * Hex SHA-256 of the raw OpenAPI document the catalog was ingested
  * from.
  */
-document_sha256: string, credential_status: RestCredentialStatus, 
+document_sha256: string, credential_status: RestCredentialStatus,
 /**
  * Where the stored credential value is placed at request time, when
  * one is referenced. The placement (and a custom header *name*) is
  * configuration; the value never appears on this surface.
  */
-placement: CredentialPlacement | null, updated_at: string, 
+placement: CredentialPlacement | null, updated_at: string,
 /**
  * How many local mini-apps hold a live grant binding this record —
  * a count only, never app names or ids, the renderer-safety posture
@@ -2021,7 +2121,7 @@ used_by_app_count: number, };
 /**
  * The renderer's listing of every configured connected app, across kinds.
  */
-export type ConnectedAppsInfo = { 
+export type ConnectedAppsInfo = {
 /**
  * MCP entries in the runtime's configuration order, then REST entries in
  * storage order (oldest first).
@@ -2053,28 +2153,28 @@ export type ConsentResource = { "kind": "action_scope", scope: GrantScope, } | {
  * One statement of consent the agent currently holds, whatever store it
  * lives in.
  */
-export type ConsentStatementSnapshot = { 
+export type ConsentStatementSnapshot = {
 /**
  * What a revocation of this statement names, and where to send it.
  */
-handle: ConsentHandle, 
+handle: ConsentHandle,
 /**
  * How far the statement reaches — one chat, or every chat in a project.
  */
-level: GrantLevel, 
+level: GrantLevel,
 /**
  * The name of whatever the level points at, for provenance. `None` when
  * that chat or project is untitled.
  */
-level_title: string | null, 
+level_title: string | null,
 /**
  * The class of action the user allowed.
  */
-verb: ConsentVerb, 
+verb: ConsentVerb,
 /**
  * What the verb is allowed to touch.
  */
-resource: ConsentResource, 
+resource: ConsentResource,
 /**
  * The trusted interaction through which consent was captured.
  */
@@ -2107,15 +2207,15 @@ export type CredentialPlacement = "bearer" | { "header": string };
  * xAI rows may opt into the capabilities its first-party Responses adapter
  * actually carries end to end.
  */
-export type CustomModelConfig = { 
+export type CustomModelConfig = {
 /**
  * Exact model id sent to the endpoint.
  */
-id: string, 
+id: string,
 /**
  * Optional human-facing label.
  */
-display_name?: string | null, 
+display_name?: string | null,
 /**
  * The provider-side id a managed gateway routes this model to, when the
  * gateway reports one that differs from `id`.
@@ -2124,7 +2224,7 @@ display_name?: string | null,
  * leaves it unset, and nothing in the settings UI offers it. It exists so
  * a deployment-aliased id can still be recognized as a curated model.
  */
-upstream_id?: string | null, 
+upstream_id?: string | null,
 /**
  * Alternate gateway ids that also resolve to this model — the
  * deployment-shaped spellings the member catalog reports, offered to
@@ -2133,23 +2233,23 @@ upstream_id?: string | null,
  * Populated only by gateway model sync from a catalog-serving gateway;
  * a user-entered custom model leaves it empty.
  */
-aliases?: Array<string>, 
+aliases?: Array<string>,
 /**
  * Context limit used by Tidebreak's reducer.
  */
-context_window: number, 
+context_window: number,
 /**
  * Maximum output sent to the endpoint.
  */
-max_output_tokens: number, 
+max_output_tokens: number,
 /**
  * Inputs Tidebreak may place on this model's request.
  */
-input_modalities: Array<InputModality>, 
+input_modalities: Array<InputModality>,
 /**
  * Whether the model uses xAI's reasoning request shape.
  */
-supports_reasoning: boolean, 
+supports_reasoning: boolean,
 /**
  * Reasoning-effort levels accepted by the model, ascending.
  */
@@ -2171,11 +2271,11 @@ export type DetachedAdmissionDenialReason = "no_scoped_model_token" | "no_extern
  * providers that cannot host background runs at all — every precondition is
  * simply unestablished for them, and the fail-closed evaluation names each.
  */
-export type DetachedAdmissionProviderInfo = { provider: ExecProviderKind, 
+export type DetachedAdmissionProviderInfo = { provider: ExecProviderKind,
 /**
  * Whether the gate would admit a detached run hosted by this provider.
  */
-admitted: boolean, 
+admitted: boolean,
 /**
  * Every unmet precondition, named — not just the first.
  */
@@ -2184,19 +2284,19 @@ denials: Array<DetachedAdmissionDenialReason>, };
 /**
  * Bounded add/delete counts for a diff. Bodies live on a GET route.
  */
-export type Diffstat = { 
+export type Diffstat = {
 /**
  * Files touched.
  */
-files: number, 
+files: number,
 /**
  * Lines added.
  */
-insertions: number, 
+insertions: number,
 /**
  * Lines deleted.
  */
-deletions: number, 
+deletions: number,
 /**
  * True when the underlying diff was truncated.
  */
@@ -2251,25 +2351,25 @@ export type ExecBackend = "local" | "e2b" | "daytona" | "docker";
 /**
  * Renderer-safe configuration and readiness.
  */
-export type ExecConfigInfo = { provider?: ExecProviderKind, timeout_ms: number, available: boolean, 
+export type ExecConfigInfo = { provider?: ExecProviderKind, timeout_ms: number, available: boolean,
 /**
  * Why the *selected* provider cannot run, when it cannot. Absent while
  * execution is available or no provider is selected at all.
  */
-unavailable_reason?: ExecUnavailableReason, has_credential: boolean, 
+unavailable_reason?: ExecUnavailableReason, has_credential: boolean,
 /**
  * One row per shipped provider: whether it could run here at all, and the
  * reason it could not. This is what makes an unusable host legible —
  * "paste an E2B key" is visible instead of being inferred from a generic
  * execution failure.
  */
-providers: Array<ExecProviderAvailability>, 
+providers: Array<ExecProviderAvailability>,
 /**
  * The configured egress policy and each managed provider's enforcement
  * status, so the renderer can present the policy and disclose which
  * providers actually restrict egress today.
  */
-egress: ExecEgressInfo, 
+egress: ExecEgressInfo,
 /**
  * Per-provider detached-admission evaluation: for each execution
  * provider, whether the fail-closed gate (issue #824) would admit a
@@ -2298,14 +2398,14 @@ export type ExecDegradation = "sandbox_image_unavailable";
  * A managed provider's egress-enforcement status, as host knowledge rather
  * than a claim the backend makes about itself.
  */
-export type ExecEgressEnforcement = { provider: ExecProviderKind, status: EgressEnforcementStatus, 
+export type ExecEgressEnforcement = { provider: ExecProviderKind, status: EgressEnforcementStatus,
 /**
  * Destinations the vendor's mechanism keeps reachable regardless of the
  * configured policy — each a short purpose string straight from the
  * enforcement model, so the settings surface can show the caveat inline
  * instead of burying it in prose the user skims past.
  */
-gaps: Array<string>, 
+gaps: Array<string>,
 /**
  * A precondition the boundary is gated on that the host cannot verify
  * statically ("Daytona org tier 3+"). Present only for a
@@ -2318,13 +2418,13 @@ requirement?: string, };
 /**
  * Renderer-safe egress policy plus per-provider enforcement disclosure.
  */
-export type ExecEgressInfo = { 
+export type ExecEgressInfo = {
 /**
  * The configured host policy. `Open` is the default: managed sandboxes are
  * created with open internet access. An allowlist restricts every managed
  * sandbox created afterwards.
  */
-policy: EgressConfig, 
+policy: EgressConfig,
 /**
  * One row per managed provider, stating whether its egress restriction is
  * confirmed against the live vendor API or still pending confirmation.
@@ -2412,31 +2512,31 @@ export type ExecUnavailableReason = "unsupported_platform" | "missing_sandbox_bi
  * Why a session is fenced: observed but not controlled, until an explicit
  * user reap resolves it.
  */
-export type FenceReason = { "type": "orphan_alive" } | { "type": "probe_ambiguous", 
+export type FenceReason = { "type": "orphan_alive" } | { "type": "probe_ambiguous",
 /**
  * Bounded human-readable detail.
  */
-detail: string, } | { "type": "resume_lost", 
+detail: string, } | { "type": "resume_lost",
 /**
  * Bounded human-readable detail, as the engine reported it.
  */
-detail: string, } | { "type": "repeated_turn_failures", 
+detail: string, } | { "type": "repeated_turn_failures",
 /**
  * How many turns failed in a row.
  */
-count: number, 
+count: number,
 /**
  * Bounded detail from the last failure, as the engine reported it.
  */
-detail: string, } | { "type": "incarnation_unresolved", 
+detail: string, } | { "type": "incarnation_unresolved",
 /**
  * Bounded human-readable detail.
  */
-detail: string, } | { "type": "sandbox_lost", 
+detail: string, } | { "type": "sandbox_lost",
 /**
  * Bounded detail, as the environment classified it.
  */
-detail: string, } | { "type": "terminal_flush_missing", 
+detail: string, } | { "type": "terminal_flush_missing",
 /**
  * Bounded human-readable detail.
  */
@@ -2465,7 +2565,7 @@ export type FolderAccess = "read" | "read_write";
  * One entitled connected app, with the slugs of the MCP endpoints that
  * aggregate it — the `mcp:<slug>` resources a mount would request.
  */
-export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabled: boolean, mcp_endpoint_slugs: Array<string>, 
+export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabled: boolean, mcp_endpoint_slugs: Array<string>,
 /**
  * The gateway's readiness for this app when the member catalog reports
  * one: `ready`, `not_connected`, or `authorization_required`. `None`
@@ -2473,7 +2573,7 @@ export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabl
  * no readiness rather than guessing. An unfamiliar value renders as
  * not-ready copy, never an error: the set is the gateway's to grow.
  */
-connection?: string, 
+connection?: string,
 /**
  * How many live local-app grants bind this gateway app — the same
  * "Used by N local apps" line the connected-apps page carries per record,
@@ -2486,7 +2586,7 @@ used_by_app_count: number, };
  * to, fetched live from the gateway (never cached: a revoked grant is gone
  * on the next request).
  */
-export type GatewayApps = { 
+export type GatewayApps = {
 /**
  * False when the connected gateway predates the JSON apps surface; the
  * renderer hides the section instead of showing an empty list as "none".
@@ -2500,7 +2600,7 @@ supported: boolean, apps: Array<GatewayAppInfo>, };
  * with a usable URL (the retired `configured`/`enabled` bits collapsed into
  * its presence).
  */
-export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, 
+export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number,
 /**
  * The member-catalog contract revision the last model sync read, or
  * `None` while unsynced or against a gateway that predates
@@ -2544,27 +2644,27 @@ export type HarnessAuthMode = "local_sign_in" | "gateway_managed" | "gateway_rel
  * Constructed exhaustively — there is no [`Default`] — so a new flag is a
  * compile break at every adapter.
  */
-export type HarnessCaps = { 
+export type HarnessCaps = {
 /**
  * The engine can resume a prior session from a native resume ref.
  */
-resume: CapLevel, 
+resume: CapLevel,
 /**
  * The engine streams partial assistant text.
  */
-streaming_deltas: CapLevel, 
+streaming_deltas: CapLevel,
 /**
  * The engine exposes a structured approval channel.
  */
-structured_approvals: CapLevel, 
+structured_approvals: CapLevel,
 /**
  * The engine accepts a mid-turn user message.
  */
-mid_turn_steering: CapLevel, 
+mid_turn_steering: CapLevel,
 /**
  * The engine has a read-only / plan posture the adapter can select.
  */
-plan_mode: CapLevel, 
+plan_mode: CapLevel,
 /**
  * The engine has a workspace-write / auto posture the adapter can select.
  *
@@ -2573,24 +2673,24 @@ plan_mode: CapLevel,
  * approval cards; without it, Auto runs unsupervised and the product
  * states so where the mode is chosen (decision 0038).
  */
-auto_mode: CapLevel, 
+auto_mode: CapLevel,
 /**
  * The engine has an allow-everything / bypass posture the adapter can
  * select. Composed only when the session is in Allow (decision 0039).
  */
-allow_mode: CapLevel, 
+allow_mode: CapLevel,
 /**
  * The engine accepts a reasoning-effort control.
  */
-reasoning_levels: CapLevel, 
+reasoning_levels: CapLevel,
 /**
  * The engine emits native file-change events.
  */
-native_file_change_events: CapLevel, 
+native_file_change_events: CapLevel,
 /**
  * The engine honors a native interrupt.
  */
-native_interrupt: CapLevel, 
+native_interrupt: CapLevel,
 /**
  * The engine consumes an image on its machine-readable input path.
  *
@@ -2598,7 +2698,7 @@ native_interrupt: CapLevel,
  * proves a captured image round-trip. The product must not offer
  * attachments otherwise.
  */
-image_input: CapLevel, 
+image_input: CapLevel,
 /**
  * The engine has a discoverable slash-command vocabulary.
  *
@@ -2611,11 +2711,11 @@ slash_commands: CapLevel, };
 /**
  * One engine-owned slash command, captured from the engine's own listing.
  */
-export type HarnessCommand = { 
+export type HarnessCommand = {
 /**
  * The word typed after `/`. No leading slash.
  */
-name: string, 
+name: string,
 /**
  * One-line description from the engine, already bounded.
  */
@@ -2624,7 +2724,7 @@ description: string, };
 /**
  * One engine's probe, capabilities, and remediation.
  */
-export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean, 
+export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean,
 /**
  * Whether Tidebreak ships a pin it can download for this engine.
  *
@@ -2632,7 +2732,7 @@ export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean,
  * the download starts; the doctor is not a gate the reader must clear
  * first.
  */
-installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, 
+installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean,
 /**
  * How a session of this engine authenticates here: the engine's own
  * local sign-in, a credential override that authenticates without one
@@ -2642,7 +2742,7 @@ installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: 
  * observation, which on a hosted or gateway-managed machine is not what
  * a session authenticates with.
  */
-auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number, 
+auth_mode: HarnessAuthMode, remediation: string, stderr: string, unrecognized_event_count: number,
 /**
  * Whether relaunching a session applies a permission mode chosen after
  * it started. False for engines that fix the mode on session create
@@ -2666,11 +2766,11 @@ export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok";
 /**
  * One model row offered for a harness session.
  */
-export type HarnessModel = { id: string, label: string, default: boolean, 
+export type HarnessModel = { id: string, label: string, default: boolean,
 /**
  * Effort levels this row accepts, ascending. Empty hides the control.
  */
-reasoning_efforts: Array<ReasoningEffort>, 
+reasoning_efforts: Array<ReasoningEffort>,
 /**
  * Whether this row can serve the engine's fast mode. `false` hides the
  * control, the same way an empty effort ladder does.
@@ -2680,7 +2780,7 @@ fast_mode: boolean, };
 /**
  * `GET /code/harnesses/{kind}/models`.
  */
-export type HarnessModelList = { kind: HarnessKind, models: Array<HarnessModel>, 
+export type HarnessModelList = { kind: HarnessKind, models: Array<HarnessModel>,
 /**
  * Every effort level this engine accepts, ascending, across all models.
  *
@@ -2744,23 +2844,23 @@ export type ImageMediaType = "png" | "jpeg" | "webp" | "gif";
  * id is an opaque content-derived UUID, never a filesystem path, so it reveals
  * nothing about where the bytes live on disk.
  */
-export type ImageRef = { 
+export type ImageRef = {
 /**
  * Content-addressed blob holding the pixels.
  */
-blob_id: string, 
+blob_id: string,
 /**
  * Format the bytes were sniffed as at ingest.
  */
-media_type: ImageMediaType, 
+media_type: ImageMediaType,
 /**
  * Pixel width, read from the image header.
  */
-width: number, 
+width: number,
 /**
  * Pixel height, read from the image header.
  */
-height: number, 
+height: number,
 /**
  * Size of the stored bytes.
  */
@@ -2778,11 +2878,11 @@ export type InboxConversation = { "surface": "chat", chat_id: ChatId, } | { "sur
 /**
  * One conversation that wants the reader, and why.
  */
-export type InboxEntrySnapshot = { conversation: InboxConversation, 
+export type InboxEntrySnapshot = { conversation: InboxConversation,
 /**
  * Absent, not null, while the conversation is still untitled.
  */
-title?: string, attention: Attention, 
+title?: string, attention: Attention,
 /**
  * The parked calls behind this attention, oldest first.
  *
@@ -2790,7 +2890,7 @@ title?: string, attention: Attention,
  * code approval route, which carries the verbatim payload decision 33
  * requires and which a deep link reaches.
  */
-items: Array<InboxItemSnapshot>, 
+items: Array<InboxItemSnapshot>,
 /**
  * When the oldest thing here started waiting, for ordering.
  */
@@ -2808,12 +2908,12 @@ export type InboxItemKind = "tool_approval" | "question" | "plan_review" | "fold
 /**
  * One item waiting on the reader, and where to go to answer it.
  */
-export type InboxItemSnapshot = { 
+export type InboxItemSnapshot = {
 /**
  * With the entry's conversation, the deep link back to the exact
  * transcript position the item paused at.
  */
-turn_id: TurnId, call_id: CallId, kind: InboxItemKind, 
+turn_id: TurnId, call_id: CallId, kind: InboxItemKind,
 /**
  * The tool under review, for an approval. Absent for the other kinds,
  * whose tool is implied by the kind. Closed renderer vocabulary: an
@@ -2833,7 +2933,7 @@ export type InputModality = "text" | "image";
  * Renderer-safe resolved policy. Carries only what surfaces need to render
  * managed state: the verdict, the locked gateway URL, and its authority.
  */
-export type ManagedPolicy = { managed: boolean, gateway_url?: string, 
+export type ManagedPolicy = { managed: boolean, gateway_url?: string,
 /**
  * The gateway a hosted deployment authenticates its own callers against
  * (`docs/decisions/0049-gateway-authenticated-hosted-machines.md`).
@@ -2851,14 +2951,14 @@ export type ManagedPolicy = { managed: boolean, gateway_url?: string,
  * hosted machine locks nothing, and its stored provider configuration
  * still wins (decision 51, rule 3).
  */
-hosted_gateway_url?: string, source: ManagedPolicySource, 
+hosted_gateway_url?: string, source: ManagedPolicySource,
 /**
  * True when `source` asserted management but its gateway URL is missing,
  * unreadable, or invalid. The profile stays managed with no usable URL —
  * fail closed — and surfaces can name the authority that needs repair
  * instead of showing an opaque error.
  */
-misconfigured: boolean, 
+misconfigured: boolean,
 /**
  * A deep-link pairing awaiting the sign-in that is its consent. Runtime
  * state merged in by the `/policy` route from [`GatewayRuntime`]
@@ -2866,7 +2966,7 @@ misconfigured: boolean,
  * [`resolve`] always leaves it `None` — and only ever present while the
  * profile is unmanaged.
  */
-pending_gateway_url?: string, 
+pending_gateway_url?: string,
 /**
  * The highest permission mode any chat may run under, when the OS policy
  * asserts one. A ceiling, not a fixed mode: the reader may always pick a
@@ -2874,7 +2974,7 @@ pending_gateway_url?: string,
  * Asserted per key, so it binds even when no gateway URL is deployed and
  * the profile is otherwise unmanaged.
  */
-permission_mode_ceiling?: PermissionMode, 
+permission_mode_ceiling?: PermissionMode,
 /**
  * True when the OS policy explicitly allows local stdio MCP servers on a
  * managed profile. False by default — the managed lockdown covers every
@@ -2898,16 +2998,16 @@ export type MarkNotificationsReadResult = { marked: number, };
  * without one is "community". One field cannot disagree with itself the way
  * a separate boolean and a separate record could.
  */
-export type McpCuration = { 
+export type McpCuration = {
 /**
  * The curated list's own name for the server, which need not match the
  * namespace the reader configured it under.
  */
-display_name: string, 
+display_name: string,
 /**
  * `YYYY-MM-DD` the entry was last exercised end to end.
  */
-tested_on: string, 
+tested_on: string,
 /**
  * One sentence on what was exercised, for the reader deciding how much
  * the badge is worth.
@@ -2926,14 +3026,14 @@ export type McpHealth = "initializing" | "healthy" | "degraded" | "reconnecting"
  * [`validate_servers`] enforces that process fields stay with `command` and
  * `bearer_token_env` stays with `url`.
  */
-export type McpServerDefinition = { name: string, command: string | null, args: Array<string>, 
+export type McpServerDefinition = { name: string, command: string | null, args: Array<string>,
 /**
  * Names of the environment variables this server is given directly. The
  * values live in the secret store under [`env_secret_key`] and never
  * enter this type, so they neither persist in the connected-app record
  * nor project through the API.
  */
-env: Array<string>, 
+env: Array<string>,
 /**
  * Inbound-only: values for [`env`](Self::env) names being set or
  * changed. A commit writes these into the secret store and drops them; a
@@ -2941,27 +3041,27 @@ env: Array<string>,
  * which is what makes "leave blank to keep" work. `skip_serializing`
  * keeps them out of both the persisted record and every projection.
  */
-env_values?: { [key in string]: string }, 
+env_values?: { [key in string]: string },
 /**
  * Parent environment names to forward. Their values never enter this type.
  */
-env_from: Array<string>, cwd: string | null, 
+env_from: Array<string>, cwd: string | null,
 /**
  * Streamable HTTP endpoint for a remote server.
  */
-url: string | null, 
+url: string | null,
 /**
  * Parent environment name holding the HTTP bearer token. The value is
  * resolved at connect time and never enters this type.
  */
-bearer_token_env: string | null, 
+bearer_token_env: string | null,
 /**
  * Endpoint slug of a gateway MCP endpoint, mounted through the signed-in
  * model-gateway session. The endpoint URL and its short-lived bearer are
  * resolved from the session at every connection and never enter this
  * type.
  */
-gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, 
+gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean,
 /**
  * The plugin this server was synthesized from, when it is plugin-sourced.
  *
@@ -2975,21 +3075,21 @@ plugin: string | null, };
  * One renderer-safe server projection. Resolved `env_from` values and child
  * process details are intentionally absent.
  */
-export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null, 
+export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null,
 /**
  * The curated-list entry this definition matches, when Tidebreak has
  * exercised the server end to end. `null` means community: mounted and
  * usable, just not something we have driven ourselves. Derived from the
  * definition on every read, never stored.
  */
-curated: McpCuration | null, name: string, command: string | null, args: Array<string>, 
+curated: McpCuration | null, name: string, command: string | null, args: Array<string>,
 /**
  * Names of the environment variables this server is given directly. The
  * values live in the secret store under [`env_secret_key`] and never
  * enter this type, so they neither persist in the connected-app record
  * nor project through the API.
  */
-env: Array<string>, 
+env: Array<string>,
 /**
  * Inbound-only: values for [`env`](Self::env) names being set or
  * changed. A commit writes these into the secret store and drops them; a
@@ -2997,27 +3097,27 @@ env: Array<string>,
  * which is what makes "leave blank to keep" work. `skip_serializing`
  * keeps them out of both the persisted record and every projection.
  */
-env_values?: { [key in string]: string }, 
+env_values?: { [key in string]: string },
 /**
  * Parent environment names to forward. Their values never enter this type.
  */
-env_from: Array<string>, cwd: string | null, 
+env_from: Array<string>, cwd: string | null,
 /**
  * Streamable HTTP endpoint for a remote server.
  */
-url: string | null, 
+url: string | null,
 /**
  * Parent environment name holding the HTTP bearer token. The value is
  * resolved at connect time and never enters this type.
  */
-bearer_token_env: string | null, 
+bearer_token_env: string | null,
 /**
  * Endpoint slug of a gateway MCP endpoint, mounted through the signed-in
  * model-gateway session. The endpoint URL and its short-lived bearer are
  * resolved from the session at every connection and never enter this
  * type.
  */
-gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, 
+gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean,
 /**
  * The plugin this server was synthesized from, when it is plugin-sourced.
  *
@@ -3037,15 +3137,15 @@ export type McpViewSession = { frame_path: string, };
 /**
  * Body of `POST /code/workspaces/{id}/pr/merge`.
  */
-export type MergeCodePrBody = { 
+export type MergeCodePrBody = {
 /**
  * The repository and pull request shown in the confirmation.
  */
-target: CodeDeliveryPullRequestTarget, 
+target: CodeDeliveryPullRequestTarget,
 /**
  * The pull request head shown in the confirmation.
  */
-expected_head_sha: string, method: CodePrMergeMethod, 
+expected_head_sha: string, method: CodePrMergeMethod,
 /**
  * True arms host auto-merge instead of merging immediately.
  */
@@ -3059,34 +3159,34 @@ export type MessageId = string;
 /**
  * A selectable model in the catalog.
  */
-export type ModelInfo = { 
+export type ModelInfo = {
 /**
  * Stable provider-qualified selection key used by settings and chats.
  */
-key: string, 
+key: string,
 /**
  * The identifier passed to the provider and stored as `chat.model`.
  */
-id: string, 
+id: string,
 /**
  * Human-readable label for the selector (e.g. `"Claude Opus 4.8"`).
  */
-display_name: string, 
+display_name: string,
 /**
  * The provider that serves the model.
  */
-provider: ProviderKind, 
+provider: ProviderKind,
 /**
  * The vendor whose curated model this row is, when that differs from the
  * provider serving it — a gateway-served model whose id exactly matches a
  * curated one. For presentation only (icon and branding); routing still
  * uses `provider`, and a client falls back to it when this is null.
  */
-vendor: ProviderKind | null, 
+vendor: ProviderKind | null,
 /**
  * How thoroughly Tidebreak has exercised this provider/model combination.
  */
-verification: VerificationTier, 
+verification: VerificationTier,
 /**
  * Whether a picker shows this model without being asked for the full
  * catalog — the curated default-visible set.
@@ -3097,37 +3197,37 @@ verification: VerificationTier,
  * `model_visibility_overrides` setting; the server never filters the
  * catalog by it.
  */
-recommended: boolean, 
+recommended: boolean,
 /**
  * Whether the provider is enabled, configured, credentialed, and able to
  * serve this model at its configured endpoint/location.
  */
-available: boolean, 
+available: boolean,
 /**
  * Approximate context window in tokens.
  */
-context_window: number, 
+context_window: number,
 /**
  * Maximum model output in tokens.
  */
-max_output_tokens: number, 
+max_output_tokens: number,
 /**
  * Input modalities accepted by the model.
  */
-input_modalities: Array<InputModality>, 
+input_modalities: Array<InputModality>,
 /**
  * Whether the model can produce an internal reasoning stream.
  */
-supports_reasoning: boolean, 
+supports_reasoning: boolean,
 /**
  * Whether this provider/model route accepts function tools.
  */
-supports_tools: boolean, 
+supports_tools: boolean,
 /**
  * Whether this provider/model route can enforce the strict response schema
  * utility work depends on.
  */
-supports_structured_output: boolean, 
+supports_structured_output: boolean,
 /**
  * The reasoning-effort levels this model accepts, ascending. Empty when
  * the model exposes no effort control, which is what a client checks
@@ -3137,7 +3237,7 @@ supports_structured_output: boolean,
  * is the same union a chat's stored effort has, and a client cannot offer
  * a level it could not then set.
  */
-reasoning_efforts: Array<ReasoningEffort>, 
+reasoning_efforts: Array<ReasoningEffort>,
 /**
  * Whether the model accepts image input alongside text.
  */
@@ -3154,16 +3254,16 @@ export type ModelRole = "chat" | "utility";
 /**
  * One named model role and what it resolves to right now.
  */
-export type ModelRoleInfo = { 
+export type ModelRoleInfo = {
 /**
  * The role this row describes.
  */
-role: ModelRole, 
+role: ModelRole,
 /**
  * The catalog key the user selected for this role, or `None` when the role
  * is left automatic.
  */
-selection: string | null, 
+selection: string | null,
 /**
  * The catalog key this role resolves to right now, selection or not.
  *
@@ -3235,11 +3335,11 @@ export type OutputWriteMode = "create" | "replace";
  * an action, not to a sentence about one. See
  * `docs/decisions/0018-tool-call-narration.md`.
  */
-export type PendingApprovalSnapshot = { call_id: CallId, turn_id: TurnId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
+export type PendingApprovalSnapshot = { call_id: CallId, turn_id: TurnId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass,
 /**
  * Absent, not null, when the tool projects no action.
  */
-preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean, 
+preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean,
 /**
  * Complete standing-grant ladder for this exact call, narrowest first.
  *
@@ -3247,7 +3347,7 @@ preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean,
  * the whole ladder because command policy may refuse exact and whole-tool
  * grants as well as prefixes.
  */
-grant_rungs: Array<ApprovalGrantRung>, 
+grant_rungs: Array<ApprovalGrantRung>,
 /**
  * Where the Auto-mode judge stands, when one was engaged. Absent means
  * no judge ever owned this card.
@@ -3324,15 +3424,15 @@ export type PluginCapability = "write-files" | "network" | "host-install" | "liv
 /**
  * Everything this installation has, in the state it is in.
  */
-export type PluginCatalog = { 
+export type PluginCatalog = {
 /**
  * Bundles in load order (by slug), each with its members.
  */
-plugins: Array<PluginInfo>, 
+plugins: Array<PluginInfo>,
 /**
  * Skills no bundle claims — user-authored packages land here.
  */
-skills: Array<PluginSkillInfo>, 
+skills: Array<PluginSkillInfo>,
 /**
  * Every installed prompt, bundled or standalone, in one flat list.
  *
@@ -3368,11 +3468,11 @@ export type PluginCompatibilityStatus = "compatible" | "limited" | "unchecked";
 /**
  * Body of `PUT /plugins/enabled`. Absent names are left alone.
  */
-export type PluginEnableUpdate = { 
+export type PluginEnableUpdate = {
 /**
  * Bundle flags to set, by slug.
  */
-plugins: { [key in string]: boolean }, 
+plugins: { [key in string]: boolean },
 /**
  * Skill flags to set, by slug. Setting one inside a disabled bundle is
  * allowed and remembered; it takes effect when the bundle comes back.
@@ -3382,31 +3482,31 @@ skills: { [key in string]: boolean }, };
 /**
  * One bundle, as a management surface renders it.
  */
-export type PluginInfo = { 
+export type PluginInfo = {
 /**
  * The slug the toggle route addresses it by.
  */
-name: string, display_name: string, description: string, category: PluginCategory, 
+name: string, display_name: string, description: string, category: PluginCategory,
 /**
  * Where the bundle was loaded from; host-derived, never claimed.
  */
-origin: PluginOrigin, 
+origin: PluginOrigin,
 /**
  * What the bundle can do, derived by the host from what it contains.
  * Never self-declared: a manifest has no key for this.
  */
-capabilities: Array<PluginCapability>, 
+capabilities: Array<PluginCapability>,
 /**
  * Import-time static compatibility disclosure. A hand-authored bundle is
  * explicitly unchecked; imported bundles say whether they fit the
  * prepared sandbox image and why not.
  */
-compatibility: PluginCompatibility, 
+compatibility: PluginCompatibility,
 /**
  * Whether the bundle is on. Off gates every member regardless of the
  * member's own flag, which the member entries still report unchanged.
  */
-enabled: boolean, 
+enabled: boolean,
 /**
  * Member skills in manifest order.
  */
@@ -3429,24 +3529,24 @@ export type PluginOrigin = "builtin" | "user";
  * [`get_prompt_body`] when the user actually picks one, so the catalog stays
  * bytes per entry no matter how long the prompts are.
  */
-export type PluginPromptInfo = { 
+export type PluginPromptInfo = {
 /**
  * The slug the body route addresses it by.
  */
-name: string, 
+name: string,
 /**
  * The tip a card or popover shows.
  */
-description: string, 
+description: string,
 /**
  * Where the package was loaded from; host-derived, never claimed.
  */
-origin: PromptOrigin, 
+origin: PromptOrigin,
 /**
  * The bundle that claims this prompt, if any. `None` is a standalone
  * package — every user-authored prompt is one.
  */
-plugin: string | null, 
+plugin: string | null,
 /**
  * Whether the prompt is offered. A prompt has no flag of its own: a
  * bundled one follows its bundle, and a standalone one is always on.
@@ -3456,11 +3556,11 @@ enabled: boolean, };
 /**
  * One skill, inside a bundle or standing alone.
  */
-export type PluginSkillInfo = { name: string, description: string, 
+export type PluginSkillInfo = { name: string, description: string,
 /**
  * Where the package was loaded from; host-derived, never claimed.
  */
-origin: SkillOrigin, 
+origin: SkillOrigin,
 /**
  * The skill's *own* flag, independent of any owning bundle's — so a UI
  * can show the member choices that come back when a bundle is re-enabled.
@@ -3472,24 +3572,24 @@ enabled: boolean, };
  * corpus. A chat may belong to a project or stand alone — unlike some designs
  * that make a project mandatory, Tidebreak keeps loose, projectless chats.
  */
-export type Project = { 
+export type Project = {
 /**
  * Stable identifier.
  */
-id: ProjectId, 
+id: ProjectId,
 /**
  * Human-facing title.
  */
-title: string | null, 
+title: string | null,
 /**
  * CAS revision of the ordered root projection.
  */
-attachment_revision: number, 
+attachment_revision: number,
 /**
  * Ordered opaque root defaults for conversations created in this project.
  * These ids are product state, never host authorization.
  */
-root_attachments: Array<HostRootId>, 
+root_attachments: Array<HostRootId>,
 /**
  * When the project was created.
  */
@@ -3506,7 +3606,7 @@ export type ProjectId = string;
  * Its own route for the same reason skill instructions have one: the catalog
  * is fetched far more often than any one prompt is inserted.
  */
-export type PromptBody = { name: string, 
+export type PromptBody = { name: string,
 /**
  * The `PROMPT.md` markdown below the frontmatter — exactly what goes into
  * the composer. It is never composed into the model's operating prompt;
@@ -3530,27 +3630,27 @@ export type ProviderAuthMode = "api_key" | "chatgpt";
 /**
  * Public view of a provider — never includes the credential itself.
  */
-export type ProviderInfo = { 
+export type ProviderInfo = {
 /**
  * Provider kind.
  */
-kind: ProviderKind, 
+kind: ProviderKind,
 /**
  * Whether the provider is enabled for routing.
  */
-enabled: boolean, 
+enabled: boolean,
 /**
  * Configured base URL, if any.
  */
-base_url?: string, 
+base_url?: string,
 /**
  * Whether a credential is stored (never the credential itself).
  */
-has_credential: boolean, 
+has_credential: boolean,
 /**
  * How OpenAI (or similarly dual-mode providers) is authenticated.
  */
-auth_mode?: ProviderAuthMode, 
+auth_mode?: ProviderAuthMode,
 /**
  * Explicit configured model entries for this endpoint.
  */
@@ -3565,19 +3665,19 @@ export type ProviderKind = "anthropic" | "openai" | "xai" | "gemini" | "firework
 /**
  * One CI check on a pull request.
  */
-export type PullRequestCheck = { 
+export type PullRequestCheck = {
 /**
  * Check name as the host reports it.
  */
-name: string, 
+name: string,
 /**
  * pass, pending, fail, or skipped.
  */
-bucket: PullRequestCheckBucket, 
+bucket: PullRequestCheckBucket,
 /**
  * Host status phrase, when distinct from the bucket.
  */
-detail?: string, 
+detail?: string,
 /**
  * Host URL for this check, when known.
  */
@@ -3592,45 +3692,45 @@ export type PullRequestCheckBucket = "pass" | "pending" | "fail" | "skipped";
  * One pull-request comment: an issue comment, a review body, or an inline
  * review comment. Never persisted; fetched live from the host.
  */
-export type PullRequestComment = { 
+export type PullRequestComment = {
 /**
  * Where on the PR the comment lives.
  */
-kind: PullRequestCommentKind, 
+kind: PullRequestCommentKind,
 /**
  * Stable host identifier, normalized to text across GraphQL and REST
  * comment shapes.
  */
-id?: string, 
+id?: string,
 /**
  * Author login, when the host reported one.
  */
-author?: string, 
+author?: string,
 /**
  * Author avatar URL, when the host reported one.
  */
-avatar_url?: string, 
+avatar_url?: string,
 /**
  * Host page for the comment or review, when available.
  */
-url?: string, 
+url?: string,
 /**
  * Host creation timestamp, verbatim.
  */
-created_at?: string, 
+created_at?: string,
 /**
  * Comment body, markdown as the host stores it.
  */
-body: string, 
+body: string,
 /**
  * Lowercased review verdict (approved, changes_requested, commented), on
  * review bodies only.
  */
-review_state?: string, 
+review_state?: string,
 /**
  * File path, on inline review comments.
  */
-path?: string, 
+path?: string,
 /**
  * Line number, on inline review comments when the host reports one.
  */
@@ -3644,64 +3744,64 @@ export type PullRequestCommentKind = "issue" | "review" | "inline";
 /**
  * Bounded pull-request digest stored on a workspace.
  */
-export type PullRequestDigest = { 
+export type PullRequestDigest = {
 /**
  * PR number on the host.
  */
-number: number, 
+number: number,
 /**
  * Host URL, when known.
  */
-url?: string | null, 
+url?: string | null,
 /**
  * Host state token (open, merged, closed, …).
  */
-state: string, 
+state: string,
 /**
  * PR title, when the host reported one.
  */
-title?: string, 
+title?: string,
 /**
  * One-line checks summary.
  */
-checks_summary?: string | null, 
+checks_summary?: string | null,
 /**
  * Individual checks, when the host reported any.
  */
-checks?: Array<PullRequestCheck>, 
+checks?: Array<PullRequestCheck>,
 /**
  * True when the host reports the PR as a draft.
  */
-draft?: boolean, 
+draft?: boolean,
 /**
  * True when the host reports the PR merged.
  */
-merged?: boolean, 
+merged?: boolean,
 /**
  * Lowercased host review decision (approved, changes_requested, review_required).
  */
-review_decision?: string, 
+review_decision?: string,
 /**
  * Lowercased host mergeability (mergeable, conflicting, unknown).
  */
-mergeable?: string, 
+mergeable?: string,
 /**
  * Lowercased host merge-state status (clean, blocked, behind, dirty, …).
  */
-merge_state_status?: string, 
+merge_state_status?: string,
 /**
  * Head branch name on the host.
  */
-head_branch?: string, 
+head_branch?: string,
 /**
  * Base branch name on the host.
  */
-base_branch?: string, 
+base_branch?: string,
 /**
  * Head commit SHA the digest was read against, when the host reported
  * one. The watch sweep uses it to avoid re-fixing the same head.
  */
-head_sha?: string, 
+head_sha?: string,
 /**
  * True when auto-merge is enabled on the host.
  */
@@ -3723,43 +3823,43 @@ export type QueuedCodeTurn = { id: CodeTurnId, session_id: CodeSessionId, messag
  * turn. Rows are FIFO by `position` within a chat and fully durable: a queue
  * survives restarts and is visible to every client on the chat.
  */
-export type QueuedTurn = { 
+export type QueuedTurn = {
 /**
  * The turn id this row becomes when promoted.
  */
-id: TurnId, 
+id: TurnId,
 /**
  * Owning chat.
  */
-chat_id: ChatId, 
+chat_id: ChatId,
 /**
  * Byte-exact user message.
  */
-content: string, 
+content: string,
 /**
  * Image-attachment ids, in display order.
  */
-attachments: Array<string>, 
+attachments: Array<string>,
 /**
  * Chat-owned document ids.
  */
-file_attachments: Array<DocumentId>, 
+file_attachments: Array<DocumentId>,
 /**
  * Skills the user explicitly invoked.
  */
-invoked_skills: Array<string>, 
+invoked_skills: Array<string>,
 /**
  * Whether the message was dictated.
  */
-voice_input_used: boolean, 
+voice_input_used: boolean,
 /**
  * FIFO order within the chat.
  */
-position: number, 
+position: number,
 /**
  * When the message was queued.
  */
-created_at: string, 
+created_at: string,
 /**
  * When it was last edited or reordered.
  */
@@ -3768,15 +3868,15 @@ updated_at: string, };
 /**
  * A named command the user can run in a workspace.
  */
-export type QuickAction = { 
+export type QuickAction = {
 /**
  * Display name.
  */
-name: string, 
+name: string,
 /**
  * Command to run in the worktree.
  */
-command: string, 
+command: string,
 /**
  * When true, run once after workspace creation.
  */
@@ -3800,59 +3900,59 @@ auto_run_on_create: boolean, };
  */
 export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
 
-export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta", text: string, } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "plan_proposed", call_id: CallId, turn_id: TurnId, } | { "type": "task_plan_updated", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
+export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta", text: string, } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "plan_proposed", call_id: CallId, turn_id: TurnId, } | { "type": "task_plan_updated", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass,
 /**
  * Whether the Auto-mode judge owns this card right now. The card
  * stays fully actionable either way; this only adds the "deciding
  * automatically" hint.
  */
-auto_judging: boolean, 
+auto_judging: boolean,
 /**
  * Complete standing-grant ladder for this exact call, narrowest first.
  * Empty means only one-shot approval is available.
  */
-grant_rungs: Array<ApprovalGrantRung>, 
+grant_rungs: Array<ApprovalGrantRung>,
 /**
  * The one deliberate opening in this boundary. A human cannot consent
  * to a command they are not shown, so a tool may project a closed,
  * field-by-field view of the action under review. Tools without one
  * send nothing, as every tool did before.
  */
-preview?: ToolActionPreview, } | { "type": "approval_decided", call_id: CallId, approved: boolean, } | { "type": "tool_call_completed", call_id: CallId, status: RendererToolStatus, 
+preview?: ToolActionPreview, } | { "type": "approval_decided", call_id: CallId, approved: boolean, } | { "type": "tool_call_completed", call_id: CallId, status: RendererToolStatus,
 /**
  * A bounded, server-authored reason the renderer can act on without
  * receiving model-facing output or executor diagnostics.
  */
-failure?: RendererToolFailure, 
+failure?: RendererToolFailure,
 /**
  * What the call did, when its tool projects it. Approval is not the
  * only moment a person needs to see the action.
  */
-action?: ToolActionPreview, 
+action?: ToolActionPreview,
 /**
  * What the call produced. A command's output is the reason it ran;
  * withholding it leaves the transcript asserting that something
  * happened without ever showing what.
  */
-result?: ToolResultPreview, } | { "type": "turn_completed", usage: RendererTurnUsage, } | { "type": "turn_refused", refusal: RendererRefusal, usage: RendererTurnUsage, } | { "type": "turn_failed", 
+result?: ToolResultPreview, } | { "type": "turn_completed", usage: RendererTurnUsage, } | { "type": "turn_refused", refusal: RendererRefusal, usage: RendererTurnUsage, } | { "type": "turn_failed",
 /**
  * Why the turn failed, at the only resolution a client can act on.
  * The internal `kind` stays behind the server; allowlisted provider
  * diagnostics may cross separately as `detail`.
  */
-category: TurnFailureCategory, 
+category: TurnFailureCategory,
 /**
  * Bounded provider diagnostic, when the failure originated upstream.
  */
-detail?: string, model?: RendererModelIdentity, } | { "type": "turn_cancelled", usage: RendererTurnUsage, } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated", 
+detail?: string, model?: RendererModelIdentity, } | { "type": "turn_cancelled", usage: RendererTurnUsage, } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated",
 /**
  * Estimated transcript tokens before the reduction.
  */
-original_tokens: number, 
+original_tokens: number,
 /**
  * Estimated transcript tokens after fitting to the budget.
  */
-fitted_tokens: number, } | { "type": "compaction_started" } | { "type": "compaction_finished", 
+fitted_tokens: number, } | { "type": "compaction_started" } | { "type": "compaction_finished",
 /**
  * Whether a new (or confirmed) checkpoint was stored.
  */
@@ -3900,7 +4000,7 @@ export type RendererToolFailureReason = "lease_expired";
  * are all generated from this enum, so a variant added here cannot leave one of
  * them behind — see `docs/wire-types.md`.
  */
-export type RendererToolName = "search" | "list_documents" | "read_document" | "read_tool_result" | "web_search" | "web_extract" | "read_delegated_file" | "read_file" | "list_dir" | "write_file" | "request_folder_access" | "connect_folder" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file" | "write_output_to_connected_folder" | "spawn_sandbox_agent" | "wait_for_agents" | "ask_user_questions" | "exit_plan_mode" | "update_task_plan" | "exec" | "create_app" | "other";
+export type RendererToolName = "search" | "list_documents" | "read_document" | "read_tool_result" | "web_search" | "web_extract" | "read_delegated_file" | "read_file" | "list_dir" | "write_file" | "request_folder_access" | "connect_folder" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file" | "write_output_to_connected_folder" | "spawn_sandbox_agent" | "wait_for_agents" | "ask_user_questions" | "exit_plan_mode" | "update_task_plan" | "browser_list" | "browser_navigate" | "browser_snapshot" | "browser_wait" | "browser_screenshot" | "browser_act" | "exec" | "create_app" | "other";
 
 export type RendererToolStatus = "completed" | "failed";
 
@@ -3923,19 +4023,19 @@ export type RendererToolStatus = "completed" | "failed";
  * It is a faithful measure of what the turn cost and a ceiling on what the
  * window held.
  */
-export type RendererTurnUsage = { 
+export type RendererTurnUsage = {
 /**
  * Fresh prompt tokens, excluding both cache figures below.
  */
-input_tokens: number, 
+input_tokens: number,
 /**
  * Tokens the model generated.
  */
-output_tokens: number, 
+output_tokens: number,
 /**
  * Prompt tokens served from the provider's cache.
  */
-cache_read_input_tokens: number, 
+cache_read_input_tokens: number,
 /**
  * Prompt tokens written to the provider's cache.
  */
@@ -3972,19 +4072,19 @@ export type RestCredentialStatus = "none" | "configured" | "missing";
  * and how big or how many. A tool that wants to say more than that is
  * describing something this projection does not cover.
  */
-export type ResultEntry = { kind: ResultEntryKind, 
+export type ResultEntry = { kind: ResultEntryKind,
 /**
  * The row's name — a file name, a source title, a page title.
  */
-label: string, 
+label: string,
 /**
  * A secondary hint beside the name — a path, a domain, a section.
  */
-detail: string | null, 
+detail: string | null,
 /**
  * Trailing meta — a size, a count, a status word.
  */
-meta: string | null, 
+meta: string | null,
 /**
  * The document's media type, when the row is a document with one.
  *
@@ -3994,7 +4094,7 @@ meta: string | null,
  * own closed mapping with a generic fallback. `default` because retained
  * projections predate the field.
  */
-media_type: string | null, 
+media_type: string | null,
 /**
  * The durable record this row names, when the renderer can open one.
  *
@@ -4009,7 +4109,7 @@ media_type: string | null,
  * [`Output`]: ResultEntryKind::Output
  * [`App`]: ResultEntryKind::App
  */
-target_id: string | null, 
+target_id: string | null,
 /**
  * The public page this row opens, when it names one.
  *
@@ -4044,14 +4144,14 @@ export type ResultEntryKind = "file" | "folder" | "source" | "passage" | "link" 
  * Two fields because that is what a failure row reads as: the thing that
  * failed, and why.
  */
-export type ResultFailure = { 
+export type ResultFailure = {
 /**
  * What failed, when the tool can name it. `None` when the tool cannot —
  * a folder it could not even read the name of — and the row then leads
  * with a generic noun rather than being dropped. A failure the reader
  * never sees is worse than one it cannot fully name.
  */
-label: string | null, 
+label: string | null,
 /**
  * Why it failed, in the tool's own words.
  *
@@ -4078,25 +4178,25 @@ export type RootAttachmentOrigin = "project_default" | "conversation";
 /**
  * One event on the per-session WebSocket.
  */
-export type SequencedCodeEventFrame = { 
+export type SequencedCodeEventFrame = {
 /**
  * Journal position. On a `transient` frame this is the cursor the event
  * streamed behind, not a position the frame occupies — resume from it
  * and you lose nothing, because no row holds this event.
  */
-seq: number, event: CodeEvent, replayed?: boolean, 
+seq: number, event: CodeEvent, replayed?: boolean,
 /**
  * Set on a live-only event the journal does not hold: assistant deltas,
  * and the catch-up delta a mid-turn reader gets on connect. Apply it but
  * do not advance the resume cursor. A reconnect may receive the complete
  * current tail with `replacement` set (record 57).
  */
-transient?: boolean, 
+transient?: boolean,
 /**
  * Set on a transient assistant delta that contains the complete live
  * tail. Replace the current assistant buffer instead of appending it.
  */
-replacement?: boolean, 
+replacement?: boolean,
 /**
  * Set on the first replayed frame of a capped window: older events above
  * the requested cursor were dropped, and the history in front of this
@@ -4113,41 +4213,41 @@ export type SetCodeWorktreeRootBody = { root: string | null, };
  * Runtime settings a client can read. The API key itself is never returned —
  * it lives in the `SecretProvider`, not the store — only whether one is set.
  */
-export type Settings = { 
+export type Settings = {
 /**
  * The model turns run against, or `None` to use the server's default.
  */
-model: string | null, 
+model: string | null,
 /**
  * Whether a model API key is configured (never the key itself).
  */
-has_api_key: boolean, 
+has_api_key: boolean,
 /**
  * The sticky new-chat defaults, so a composer for a chat that does not
  * exist yet can show what `POST /chats` will seed.
  */
-chat_defaults: StickyChatDefaults, 
+chat_defaults: StickyChatDefaults,
 /**
  * Preferred maximum concurrent background agents. Spawn unsettled
  * children on one origin turn are further capped at
  * [`AgentRun::MAX_ACTIVE_BACKGROUND_AGENTS`] (wait_for_agents membership).
  */
-max_active_background_agents: number, 
+max_active_background_agents: number,
 /**
  * Model steps a background agent takes before it must check in.
  *
  * A cadence, not a cap: reaching it never fails the run — the agent wraps
  * up with what it has and reports back for direction.
  */
-sandbox_agent_checkin_steps: number, 
+sandbox_agent_checkin_steps: number,
 /**
  * Consecutive failed tool calls after which a background agent checks in.
  */
-sandbox_agent_error_checkin: number, 
+sandbox_agent_error_checkin: number,
 /**
  * When and how hard semantic compaction may run.
  */
-compaction: CompactionSettings, 
+compaction: CompactionSettings,
 /**
  * Per-model deviations from the catalog's `recommended` flag, keyed by the
  * same provider-qualified selection key `ModelInfo.key` and a chat's model
@@ -4162,13 +4262,17 @@ compaction: CompactionSettings,
  * and never filters `GET /models` by it. A hidden model remains fully
  * valid for existing chats, replay, and explicit selection.
  */
-model_visibility_overrides: { [key in string]: ModelVisibility }, 
+model_visibility_overrides: { [key in string]: ModelVisibility },
 /**
  * Whether the computer-use capability (screen capture + app control) is
  * enabled. Read at boot; turning it off unregisters the tools on the next
  * launch.
  */
-computer_use_enabled: boolean, 
+computer_use_enabled: boolean,
+/**
+ * Whether completed code turns receive a one-line recap. Default on.
+ */
+code_turn_recaps_enabled: boolean,
 /**
  * Whether completed code turns rewrite their closing message into lucid
  * prose. Default off.
@@ -4187,7 +4291,7 @@ export type SignInProgress = { "state": "idle" } | { "state": "pending", authori
  * where a catalog row is bytes, and the catalog is fetched far more often
  * than any one skill is read.
  */
-export type SkillInstructions = { name: string, 
+export type SkillInstructions = { name: string,
 /**
  * The `SKILL.md` markdown body, with the frontmatter removed — what the
  * model is taught when the skill is staged, shown to the reader verbatim.
@@ -4207,23 +4311,23 @@ export type SkillOrigin = "builtin" | "user";
  * What a document declares, for the configuration form's operation picker.
  * Renderer-safe: ids, methods, paths, and truncated summaries only.
  */
-export type SpecPreviewInfo = { 
+export type SpecPreviewInfo = {
 /**
  * Hex SHA-256 of the raw document — the pin the upsert must carry back
  * with a URL source.
  */
-document_sha256: string, operations: Array<SpecPreviewOperation>, 
+document_sha256: string, operations: Array<SpecPreviewOperation>,
 /**
  * Operations the document declares that cannot be selected (no
  * well-formed `operationId`, an over-bound path, or a repeated id).
  */
-unlistable: number, 
+unlistable: number,
 /**
  * Whether the operation list was cut at the inventory bound.
  */
 truncated: boolean, };
 
-export type SpecPreviewOperation = { operation_id: string, 
+export type SpecPreviewOperation = { operation_id: string,
 /**
  * Lowercase HTTP method, as a path item declares it.
  */
@@ -4234,16 +4338,16 @@ method: string, path: string, summary: string | null, };
  * to recognize it later and withdraw it. Grant scopes are already closed
  * renderer-safe projections, so the snapshot carries them verbatim.
  */
-export type StandingGrantSnapshot = { 
+export type StandingGrantSnapshot = {
 /**
  * The approval decision that created the grant — also the handle a
  * revocation names.
  */
-source_call_id: CallId, 
+source_call_id: CallId,
 /**
  * How far the grant reaches — one chat, or every chat in a project.
  */
-level: GrantLevel, 
+level: GrantLevel,
 /**
  * The name of whatever the level points at, for provenance. `None` when
  * that chat or project is untitled.
@@ -4263,7 +4367,7 @@ export type StickyChatDefaults = { model: string | null, reasoning_effort: Reaso
 /**
  * One file a background run submitted, as the renderer sees it.
  */
-export type SubmittedOutputSnapshot = { output_id: OutputId, 
+export type SubmittedOutputSnapshot = { output_id: OutputId,
 /**
  * The name the run gave the file, which is the output's name.
  */
@@ -4272,15 +4376,15 @@ filename: string, };
 /**
  * Renderer-safe durable projection of a chat's current plan.
  */
-export type TaskPlan = { 
+export type TaskPlan = {
 /**
  * The turn whose call last replaced this plan.
  */
-turn_id: TurnId, 
+turn_id: TurnId,
 /**
  * The steps, in order.
  */
-steps: Array<TaskPlanStep>, 
+steps: Array<TaskPlanStep>,
 /**
  * When the last replacement committed.
  */
@@ -4289,11 +4393,11 @@ updated_at: string, };
 /**
  * One step of the plan.
  */
-export type TaskPlanStep = { 
+export type TaskPlanStep = {
 /**
  * What this step does, as one short imperative line.
  */
-content: string, 
+content: string,
 /**
  * Where the step stands: `pending` before it starts, `in_progress` while
  * it is being worked on (at most one step at a time), `completed` after.
@@ -4320,20 +4424,20 @@ export type TaskPlanStepStatus = "pending" | "in_progress" | "completed";
  * identity ([`Self::without_summary`]), because a call that could describe
  * itself to a consent decision could describe itself favourably.
  */
-export type ToolActionPreview = { "tool": "exec", 
+export type ToolActionPreview = { "tool": "exec",
 /**
  * Executable name or path the model chose.
  */
-command: string, 
+command: string,
 /**
  * Arguments passed directly to the executable.
  */
-args: Array<string>, 
+args: Array<string>,
 /**
  * Working directory relative to the chat's private scratch, never a
  * host path.
  */
-cwd: string, 
+cwd: string,
 /**
  * Scratch-relative files and directories staged into the sandbox
  * before the command runs, empty when the model staged none.
@@ -4350,49 +4454,49 @@ cwd: string,
  * nothing, which is narrower than what they were given for and so
  * sends a call that stages anything back to the person.
  */
-files: Array<string>, 
+files: Array<string>,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "search", query: string, 
+summary?: string, } | { "tool": "search", query: string,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "web_search", query: string, 
+summary?: string, } | { "tool": "web_search", query: string,
 /**
  * Sites the search is confined to, empty when the model named none.
  */
-domains: Array<string>, 
+domains: Array<string>,
 /**
  * Earliest publication date the search will accept, as the model
  * wrote it. Kept verbatim rather than reformatted: the card's job is
  * to show what the provider is actually told.
  */
-start_published_at: string | null, 
+start_published_at: string | null,
 /**
  * Latest publication date the search will accept.
  */
-end_published_at: string | null, 
+end_published_at: string | null,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "web_extract", url: string, 
+summary?: string, } | { "tool": "web_extract", url: string,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "write_file", 
+summary?: string, } | { "tool": "write_file",
 /**
  * Workspace-relative destination path, never a host path.
  */
-path: string, 
+path: string,
 /**
  * Display-only narration; see the type's documentation.
  */
-summary?: string, } | { "tool": "delegate_agent", 
+summary?: string, } | { "tool": "delegate_agent",
 /**
  * The child's self-contained task, as the model wrote it.
  */
-task: string, 
+task: string,
 /**
  * The network policy the child inherits from this chat.
  */
@@ -4411,27 +4515,27 @@ export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_sear
 /**
  * Display-oriented classification of a tool the engine started.
  */
-export type ToolDetail = { "kind": "command", 
+export type ToolDetail = { "kind": "command",
 /**
  * Command string.
  */
-cmd: string, 
+cmd: string,
 /**
  * Working directory, when reported.
  */
-cwd: string, } | { "kind": "file_edit", 
+cwd: string, } | { "kind": "file_edit",
 /**
  * Path being edited.
  */
-path: string, } | { "kind": "file_read", 
+path: string, } | { "kind": "file_read",
 /**
  * Path being read.
  */
-path: string, } | { "kind": "search", 
+path: string, } | { "kind": "search",
 /**
  * Query string.
  */
-query: string, } | { "kind": "other", 
+query: string, } | { "kind": "other",
 /**
  * Bounded summary.
  */
@@ -4448,78 +4552,78 @@ export type ToolOutcome = "succeeded" | "failed" | "denied";
  * A command's output is the whole reason to run it. Withholding it leaves the
  * transcript asserting that something happened without ever showing what.
  */
-export type ToolResultPreview = { "tool": "exec", 
+export type ToolResultPreview = { "tool": "exec",
 /**
  * Process exit status, or `None` when it was killed by a signal.
  */
-exit_code: number | null, 
+exit_code: number | null,
 /**
  * Whether the provider stopped the command at its time limit.
  */
-timed_out: boolean, 
+timed_out: boolean,
 /**
  * Whether the provider dropped output past its capture limit.
  */
-output_truncated: boolean, stdout: string, stderr: string, 
+output_truncated: boolean, stdout: string, stderr: string,
 /**
  * Preview images emitted by the command, in model-facing priority order.
  */
-images?: Array<ImageRef>, 
+images?: Array<ImageRef>,
 /**
  * Durable outputs the command's `output/` files created or updated.
  * Files that still match their published version are not news and are
  * not listed. Defaulted so exec rows persisted before the field
  * existed read back unchanged.
  */
-outputs?: Array<ResultEntry>, 
+outputs?: Array<ResultEntry>,
 /**
  * How the execution backend fell short of its intended setup, when it
  * did. Reported on the first execution that degrades and not on the
  * ones after it, so a chat says this once rather than on every card.
  */
-degraded?: ExecDegradation, 
+degraded?: ExecDegradation,
 /**
  * Which backend ran the command. Defaulted so exec rows persisted
  * before the field existed read back unchanged.
  */
-backend?: ExecBackend, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
+backend?: ExecBackend, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app",
 /**
  * The configured MCP server namespace that serves the view.
  */
-server: string, 
+server: string,
 /**
  * The validated `ui://` document reference.
  */
-resource_uri: string, } | { "tool": "entries", entries: Array<ResultEntry>, 
+resource_uri: string, } | { "tool": "entries", entries: Array<ResultEntry>,
 /**
  * What the same call could not do. Bounded and counted on the same
  * terms as `entries`, and elided into the same tally: the card's job
  * is to be honest about how much it is not showing, and a hidden
  * failure is the worst thing to hide.
  */
-failures: Array<ResultFailure>, 
+failures: Array<ResultFailure>,
 /**
  * Rows past [`MAX_RESULT_ENTRIES`], counted rather than shown. A card
  * that silently lists the first fifty of two hundred results is
  * telling the reader something false.
  */
-elided: number, } | { "tool": "user_questions", answers: Array<AnsweredUserQuestion>, 
+elided: number, } | { "tool": "user_questions", answers: Array<AnsweredUserQuestion>,
 /**
  * Whatever the reader added on their own, when they added any.
  */
-additional_context?: string, } | { "tool": "plan_decision", title: string, plan: string, 
+additional_context?: string, } | { "tool": "plan_decision", title: string, plan: string,
 /**
  * Whether the reader approved the plan as proposed.
  */
-accepted: boolean, 
+accepted: boolean,
 /**
  * What the reader asked to change, when they sent it back.
  */
-feedback?: string, } | { "tool": "screen_capture", 
+feedback?: string, } | { "tool": "screen_capture",
 /**
  * The captured screenshot, content-addressed in the blob store.
  */
-image: ImageRef, 
+image: ImageRef,
 /**
  * How many interactive elements were marked on the capture, so the
  * card can say "capture with N controls" without the model's text.
@@ -4534,15 +4638,15 @@ export type TranscriptFileAttachment = { document_id: DocumentId, name: string, 
 /**
  * One renderer-safe image identity attached to a historical user message.
  */
-export type TranscriptImageAttachment = { 
+export type TranscriptImageAttachment = {
 /**
  * Content-addressed opaque attachment identity, not a host path.
  */
-attachment_id: string, 
+attachment_id: string,
 /**
  * Sniffed IANA media type from the trusted image ingest boundary.
  */
-media_type: string, 
+media_type: string,
 /**
  * Header-derived dimensions, bounded at image publication.
  */
@@ -4621,25 +4725,25 @@ export type VerificationTier = "verified" | "unverified";
  * selection, credential presence, and the configured instance URL — key
  * material never crosses the secret boundary.
  */
-export type WebSearchConfigInfo = { provider?: WebSearchProviderKind, 
+export type WebSearchConfigInfo = { provider?: WebSearchProviderKind,
 /**
  * Which search a turn gets. Orthogonal to the fields below, which report
  * only the host provider's readiness: a vendor turn is unaffected by all
  * of them.
  */
-mode: WebSearchMode, timeout_ms: number, 
+mode: WebSearchMode, timeout_ms: number,
 /**
  * Whether a key is stored for the selected provider. Always false for a
  * credential-free provider, which has no key slot at all — read
  * [`Self::available`] to know whether search will actually run.
  */
-has_credential: boolean, 
+has_credential: boolean,
 /**
  * Whether the selected provider has everything it needs to be invoked.
  *
  * A key for the credentialed providers, an instance URL for SearXNG.
  */
-available: boolean, 
+available: boolean,
 /**
  * The configured SearXNG instance URL, in the canonical form the host
  * stored. It is safe to return: validation forbids embedded credentials.
@@ -4708,6 +4812,12 @@ export const RENDERER_TOOL_NAMES = [
   "ask_user_questions",
   "exit_plan_mode",
   "update_task_plan",
+  "browser_list",
+  "browser_navigate",
+  "browser_snapshot",
+  "browser_wait",
+  "browser_screenshot",
+  "browser_act",
   "exec",
   "create_app",
   "other",


### PR DESCRIPTION
## Summary

- restrict test ChatGPT authentication endpoints to credential-free loopback HTTP URLs
- override vulnerable Vercel CLI transitive dependencies while retaining the trusted CLI pin
- override the vulnerable mobile `uuid` dependency and pin the mobile pnpm version
- regenerate desktop and mobile wire types without trailing whitespace

## Validation

- `cargo fmt --check`
- `cargo check -p tidebreak-server`
- focused ChatGPT authentication and wire-type tests
- mobile typecheck, lint, and 90 tests
- workflow security tests
- frozen pnpm installs, Vercel CLI smoke test, and dependency audits

## Remaining alerts

Two `image-size` advisories have no patched release. The patched `decode-uri-component` release is ESM-only and cannot safely replace the CommonJS dependency used by `query-string@7.1.3`. Eighteen Pillow advisories require Pillow 12.3.0, which does not support the Python 3.9 runtime that the local sandbox still guarantees.