### PR TITLE
fix(code): respect model-specific Grok effort levels

### DIFF
--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -24,14 +24,31 @@ use crate::{HarnessAdapter, HarnessError, HarnessProbe, HarnessSession, SessionS
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// The ladder `grok --reasoning-effort` takes on the pinned 1.0.4. The CLI
-/// names them itself when it refuses one, and it tops out below `max`.
-pub(crate) const EFFORT_LADDER: &[ReasoningEffort] = &[
+/// The ladder `grok --reasoning-effort` takes through 1.0.4.
+pub(crate) const EFFORT_LADDER_1_0_4: &[ReasoningEffort] = &[
     ReasoningEffort::Low,
     ReasoningEffort::Medium,
     ReasoningEffort::High,
     ReasoningEffort::XHigh,
 ];
+
+/// Grok 1.0.5 replaced `medium` and `xhigh` with `max`.
+pub(crate) const EFFORT_LADDER_1_0_5: &[ReasoningEffort] = &[
+    ReasoningEffort::Low,
+    ReasoningEffort::High,
+    ReasoningEffort::Max,
+];
+
+pub(super) fn effort_ladder_for_version(version: Option<&str>) -> &'static [ReasoningEffort] {
+    match crate::probe::version_patch_line(version) {
+        Some(version) if version >= (1, 0, 5) => EFFORT_LADDER_1_0_5,
+        _ => EFFORT_LADDER_1_0_4,
+    }
+}
+
+fn effort_ladder(probe: &HarnessProbe) -> &'static [ReasoningEffort] {
+    effort_ladder_for_version(probe.version.as_deref())
+}
 
 /// Grok CLI adapter. Capabilities below are for the captured version
 /// 1.0.4: verified flags are `Supported`/`Unsupported`; anything not
@@ -119,8 +136,8 @@ impl HarnessAdapter for GrokAdapter {
         caps
     }
 
-    fn reasoning_efforts(&self, _probe: &HarnessProbe) -> Vec<ReasoningEffort> {
-        EFFORT_LADDER.to_vec()
+    fn reasoning_efforts(&self, probe: &HarnessProbe) -> Vec<ReasoningEffort> {
+        effort_ladder(probe).to_vec()
     }
 
     async fn list_models(&self, probe: &HarnessProbe) -> Vec<crate::ListedHarnessModel> {
@@ -131,7 +148,7 @@ impl HarnessAdapter for GrokAdapter {
             crate::prefer_gateway_models(
                 crate::list_cli_models(binary, &["models"], &probe.env).await,
             ),
-            EFFORT_LADDER,
+            effort_ladder(probe),
         )
     }
 
@@ -442,6 +459,22 @@ mod tests {
     }
 
     #[test]
+    fn reasoning_efforts_follow_the_installed_patch_release() {
+        assert_eq!(
+            effort_ladder_for_version(Some("grok 1.0.4 (d846eb93d94d) [stable]")),
+            EFFORT_LADDER_1_0_4
+        );
+        assert_eq!(
+            effort_ladder_for_version(Some("grok 1.0.5 (5115b46bc909) [stable]")),
+            EFFORT_LADDER_1_0_5
+        );
+        assert_eq!(
+            effort_ladder_for_version(Some("grok 1.1.0 [stable]")),
+            EFFORT_LADDER_1_0_5
+        );
+    }
+
+    #[test]
     fn checked_in_stop_reasons_are_allowlisted() {
         for version in ["1.0.4", "1.0.5"] {
             for entry in std::fs::read_dir(fixture_dir(version)).unwrap() {
@@ -538,6 +571,7 @@ mod tests {
             mode: PermissionMode::Auto,
             model: None,
             effort: None,
+            effort_ladder: EFFORT_LADDER_1_0_4,
         })
         .unwrap();
         assert!(!plan.argv.iter().any(|arg| {
@@ -572,6 +606,7 @@ mod tests {
             mode: PermissionMode::Allow,
             model: None,
             effort: None,
+            effort_ladder: EFFORT_LADDER_1_0_4,
         })
         .unwrap();
         assert!(plan.argv.iter().any(|arg| arg == "--always-approve"));

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -96,6 +96,7 @@ impl GrokSession {
             mode: self.permission_mode(),
             model: turn_model.or(self.spec.model.as_deref()),
             effort: turn_effort.or(self.spec.reasoning_effort),
+            effort_ladder: crate::grok::effort_ladder_for_version(Some(&self.version)),
         })
     }
 
@@ -279,6 +280,7 @@ pub(crate) struct PrintLaunch<'a> {
     pub mode: PermissionMode,
     pub model: Option<&'a str>,
     pub effort: Option<ReasoningEffort>,
+    pub effort_ladder: &'a [ReasoningEffort],
 }
 
 /// 1.0.4 honors Auto and Allow.
@@ -323,11 +325,11 @@ pub(crate) fn compose_print_plan(launch: PrintLaunch<'_>) -> Result<LaunchPlan, 
         argv.push("--model".into());
         argv.push(model.to_owned());
     }
-    // 1.0.4 refuses a level outside its own ladder by name, so degrade to the
-    // closest rung it takes rather than fail the turn on a hint.
+    // Grok refuses a level outside its version's ladder by name, so degrade to
+    // the closest rung it takes rather than fail the turn on a hint.
     if let Some(effort) = launch
         .effort
-        .and_then(|level| level.clamp_to(crate::grok::EFFORT_LADDER))
+        .and_then(|level| level.clamp_to(launch.effort_ladder))
     {
         argv.push("--reasoning-effort".into());
         argv.push(effort.as_str().to_owned());
@@ -687,6 +689,33 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
+    fn grok_1_0_5_never_receives_the_removed_xhigh_token() {
+        let plan = compose_print_plan(PrintLaunch {
+            binary: std::path::Path::new("/usr/bin/grok"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            extra_env: &[],
+            relay_auth: None,
+            relay_key_env: None,
+            resume_ref: None,
+            prompt_file: std::path::Path::new("/tmp/prompt.txt"),
+            mode: PermissionMode::Auto,
+            model: Some("model-gateway-model-gateway/glm-5.3"),
+            effort: Some(ReasoningEffort::XHigh),
+            effort_ladder: crate::grok::EFFORT_LADDER_1_0_5,
+        })
+        .unwrap();
+        assert!(
+            plan.argv
+                .windows(2)
+                .any(|pair| pair == ["--reasoning-effort", "high"]),
+            "{:#?}",
+            plan.argv
+        );
+        assert!(!plan.argv.iter().any(|arg| arg == "xhigh"));
+    }
+
+    #[test]
     fn relay_wiring_moves_the_key_into_an_auth_file_and_points_the_env_at_it() {
         let dir = tempfile::tempdir().unwrap();
         let auth_path = dir.path().join("auth.json");
@@ -708,6 +737,7 @@ mod tests {
             mode: PermissionMode::Auto,
             model: None,
             effort: None,
+            effort_ladder: crate::grok::EFFORT_LADDER_1_0_4,
         })
         .unwrap();
 

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -533,6 +533,27 @@ pub(crate) fn version_minor_line(version: Option<&str>) -> Option<(u64, u64)> {
         })
 }
 
+/// The first `major.minor.patch` a version line states.
+pub(crate) fn version_patch_line(version: Option<&str>) -> Option<(u64, u64, u64)> {
+    version
+        .into_iter()
+        .flat_map(str::split_whitespace)
+        .find_map(|candidate| {
+            let candidate = candidate.strip_prefix('v').unwrap_or(candidate);
+            let mut parts = candidate.split('.');
+            let major = parts.next()?.parse::<u64>().ok()?;
+            let minor = parts.next()?.parse::<u64>().ok()?;
+            let patch = parts
+                .next()?
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse::<u64>()
+                .ok()?;
+            Some((major, minor, patch))
+        })
+}
+
 /// Whether a probed version states a `major.minor` other than the pinned
 /// line. A missing or unparseable version is not off-line: with nothing to
 /// compare, an adapter keeps the pinned capture's flags rather than degrading
@@ -1413,6 +1434,12 @@ eval "$cmd"
             Some((1, 0))
         );
         assert_eq!(version_minor_line(Some("v1.18.18")), Some((1, 18)));
+        assert_eq!(version_minor_line(Some("v1.18")), Some((1, 18)));
+        assert_eq!(
+            version_patch_line(Some("grok 1.0.5 (5115b46bc909) [stable]")),
+            Some((1, 0, 5))
+        );
+        assert_eq!(version_patch_line(Some("v1.18")), None);
         assert_eq!(version_minor_line(Some("development build")), None);
         assert_eq!(version_minor_line(None), None);
         assert!(off_pinned_line(Some("3.0.1 (Claude Code)"), (2, 1)));

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -131,6 +131,15 @@ impl HarnessLlmRelay {
         self.obo.compat_listings(owner).await
     }
 
+    /// The caller's model catalog, including per-model reasoning ladders when
+    /// the gateway states them.
+    pub(crate) async fn catalog(
+        &self,
+        owner: &OwnerId,
+    ) -> tidebreak_core::Result<Option<crate::providers::GatewayModelSnapshot>> {
+        self.obo.snapshot_for(owner).await
+    }
+
     /// Mint the relay key for `subject`, replacing any prior key the same
     /// session held. Reissue-on-attach is what keeps a reaped or relaunched
     /// worker from extending the life of a key an old child still knows.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -5501,6 +5501,7 @@ impl CodeRuntime {
         };
         let engine_efforts = adapter.reasoning_efforts(probe);
         capabilities.reasoning_efforts = crate::providers::effective_gateway_reasoning_efforts(
+            self.harness_llm.is_some(),
             capabilities.listed_model_reasoning_efforts.as_deref(),
             &engine_efforts,
             model_efforts,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -5497,14 +5497,11 @@ impl CodeRuntime {
             return capabilities;
         };
         let engine_efforts = adapter.reasoning_efforts(probe);
-        capabilities.reasoning_efforts = if engine_efforts.is_empty() {
-            model_efforts.to_vec()
-        } else {
-            engine_efforts
-                .into_iter()
-                .filter(|effort| model_efforts.contains(effort))
-                .collect()
-        };
+        capabilities.reasoning_efforts = crate::providers::overlay_gateway_reasoning_efforts(
+            &capabilities.reasoning_efforts,
+            &engine_efforts,
+            model_efforts,
+        );
         capabilities.reasoning_known = true;
         tracing::debug!(
             harness = %adapter.kind(),
@@ -7257,6 +7254,7 @@ mod delivery_nudge_tests {
 mod selected_model_capabilities_tests {
     use super::*;
     use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+    use tidebreak_harness::ListedHarnessModel;
 
     #[derive(Default)]
     struct NoSecrets;
@@ -7389,6 +7387,50 @@ mod selected_model_capabilities_tests {
             ]
         );
         assert!(capabilities.reasoning_known);
+    }
+
+    #[tokio::test]
+    async fn a_codex_row_ladder_intersects_the_gateway_ladder() {
+        let (runtime, _directory) =
+            runtime_with_gateway_snapshot("https://gateway.example/", "https://gateway.example/")
+                .await;
+        let adapter = ScriptedAdapter::new(plain_text_script())
+            .with_kind(HarnessKind::Codex)
+            .with_reasoning_levels(CapLevel::Supported)
+            .with_engine_reasoning_efforts(Vec::new())
+            .with_models(vec![ListedHarnessModel {
+                id: "model-gateway-model-gateway/glm-5.3".into(),
+                label: "GLM 5.3".into(),
+                default: true,
+                reasoning_efforts: vec![
+                    ReasoningEffort::Low,
+                    ReasoningEffort::High,
+                    ReasoningEffort::Ultra,
+                ],
+                fast_mode: false,
+            }]);
+
+        let capabilities = runtime
+            .selected_model_capabilities_for_owner(
+                &OwnerId::new("alice").unwrap(),
+                &adapter,
+                &scripted_probe(),
+                Some("model-gateway-model-gateway/glm-5.3"),
+            )
+            .await;
+
+        assert_eq!(
+            capabilities.reasoning_efforts,
+            vec![ReasoningEffort::Low, ReasoningEffort::High]
+        );
+        assert!(capabilities.reasoning_known);
+        let mut settings = CodeSessionExecutionSettings {
+            model: Some("model-gateway-model-gateway/glm-5.3".into()),
+            reasoning_effort: Some(ReasoningEffort::High),
+            fast_mode: false,
+        };
+        capabilities.deactivate_unsupported(&mut settings);
+        assert_eq!(settings.reasoning_effort, Some(ReasoningEffort::High));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -411,6 +411,8 @@ pub(crate) struct NewSessionSettings {
 
 struct SelectedModelCapabilities {
     reasoning_efforts: Vec<ReasoningEffort>,
+    /// The selected row's own ladder, when the engine listed that row.
+    listed_model_reasoning_efforts: Option<Vec<ReasoningEffort>>,
     reasoning_known: bool,
     fast_mode: bool,
     fast_mode_known: bool,
@@ -5468,6 +5470,7 @@ impl CodeRuntime {
         };
         SelectedModelCapabilities {
             reasoning_efforts,
+            listed_model_reasoning_efforts: model.map(|model| model.reasoning_efforts.clone()),
             reasoning_known,
             fast_mode: model.is_some_and(|model| model.fast_mode),
             fast_mode_known: model.is_some() || catalog_known,
@@ -5497,8 +5500,8 @@ impl CodeRuntime {
             return capabilities;
         };
         let engine_efforts = adapter.reasoning_efforts(probe);
-        capabilities.reasoning_efforts = crate::providers::overlay_gateway_reasoning_efforts(
-            &capabilities.reasoning_efforts,
+        capabilities.reasoning_efforts = crate::providers::effective_gateway_reasoning_efforts(
+            capabilities.listed_model_reasoning_efforts.as_deref(),
             &engine_efforts,
             model_efforts,
         );
@@ -7390,14 +7393,13 @@ mod selected_model_capabilities_tests {
     }
 
     #[tokio::test]
-    async fn a_codex_row_ladder_intersects_the_gateway_ladder() {
+    async fn a_codex_rows_ladder_wins_over_the_engine_wide_ladder() {
         let (runtime, _directory) =
             runtime_with_gateway_snapshot("https://gateway.example/", "https://gateway.example/")
                 .await;
         let adapter = ScriptedAdapter::new(plain_text_script())
             .with_kind(HarnessKind::Codex)
             .with_reasoning_levels(CapLevel::Supported)
-            .with_engine_reasoning_efforts(Vec::new())
             .with_models(vec![ListedHarnessModel {
                 id: "model-gateway-model-gateway/glm-5.3".into(),
                 label: "GLM 5.3".into(),
@@ -7423,14 +7425,6 @@ mod selected_model_capabilities_tests {
             capabilities.reasoning_efforts,
             vec![ReasoningEffort::Low, ReasoningEffort::High]
         );
-        assert!(capabilities.reasoning_known);
-        let mut settings = CodeSessionExecutionSettings {
-            model: Some("model-gateway-model-gateway/glm-5.3".into()),
-            reasoning_effort: Some(ReasoningEffort::High),
-            fast_mode: false,
-        };
-        capabilities.deactivate_unsupported(&mut settings);
-        assert_eq!(settings.reasoning_effort, Some(ReasoningEffort::High));
     }
 
     #[tokio::test]
@@ -7460,6 +7454,7 @@ mod selected_model_capabilities_tests {
     fn an_authoritative_catalog_clears_unsupported_settings() {
         let capabilities = SelectedModelCapabilities {
             reasoning_efforts: vec![ReasoningEffort::Low],
+            listed_model_reasoning_efforts: Some(vec![ReasoningEffort::Low]),
             reasoning_known: true,
             fast_mode: false,
             fast_mode_known: true,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -211,6 +211,9 @@ pub(crate) struct CodeRuntime {
     /// machine (decision 71). `None` everywhere else: a machine whose engines
     /// carry their own provider credentials keeps using them.
     harness_llm: Option<Arc<super::harness_llm::HarnessLlmRelay>>,
+    /// Managed-policy-aware gateway catalog on a local machine. Hosted
+    /// machines use `harness_llm` because their catalog belongs to the caller.
+    gateway_runtime: Option<Arc<crate::gateway_runtime::GatewayRuntime>>,
     /// The configured remote-session context, on a deployment with a sandbox
     /// runtime endpoint (`docs/slack-sessions.md`). `None` everywhere else;
     /// remote workspaces then refuse turns rather than half-running.
@@ -471,6 +474,7 @@ impl CodeRuntime {
             host_tool_broker,
             git_credentials,
             harness_llm,
+            gateway_runtime: None,
             remote: None,
             grant_revocations: Arc::new(super::grants::GrantRevocations::default()),
             loopback_base: Mutex::new(None),
@@ -529,6 +533,20 @@ impl CodeRuntime {
     /// The engine inference relay, on a machine that has one.
     pub(crate) fn harness_llm(&self) -> Option<Arc<super::harness_llm::HarnessLlmRelay>> {
         self.harness_llm.clone()
+    }
+
+    /// The gateway model snapshot that applies to this caller. Hosted
+    /// machines read the caller's catalog; local machines use the synced
+    /// deployment snapshot.
+    pub(crate) async fn gateway_model_snapshot(
+        &self,
+        owner: &OwnerId,
+    ) -> Option<crate::providers::GatewayModelSnapshot> {
+        if let Some(relay) = self.harness_llm() {
+            return relay.catalog(owner).await.ok().flatten();
+        }
+        let gateway = self.gateway_runtime.as_ref()?;
+        gateway.model_snapshot().await.ok().flatten()
     }
 
     /// Boot: publish the bound loopback base now, and hand back the recovery
@@ -610,6 +628,7 @@ impl CodeRuntime {
             host_tool_broker: None,
             git_credentials: None,
             harness_llm: None,
+            gateway_runtime: None,
             remote: None,
             grant_revocations: Arc::new(super::grants::GrantRevocations::default()),
             loopback_base: Mutex::new(None),
@@ -670,6 +689,15 @@ impl CodeRuntime {
         relay: Arc<super::harness_llm::HarnessLlmRelay>,
     ) -> Self {
         self.harness_llm = Some(relay);
+        self
+    }
+
+    /// Wire the managed-policy-aware gateway catalog used by local engines.
+    pub(crate) fn with_gateway_runtime(
+        mut self,
+        gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
+    ) -> Self {
+        self.gateway_runtime = Some(gateway);
         self
     }
 
@@ -3669,12 +3697,14 @@ impl CodeRuntime {
             fast_mode,
         };
         if execution_settings.reasoning_effort.is_some() || execution_settings.fast_mode {
-            let selected = Self::selected_model_capabilities(
-                adapter.as_ref(),
-                &probe,
-                execution_settings.model.as_deref(),
-            )
-            .await;
+            let selected = self
+                .selected_model_capabilities_for_owner(
+                    owner,
+                    adapter.as_ref(),
+                    &probe,
+                    execution_settings.model.as_deref(),
+                )
+                .await;
             Self::validate_execution_settings(harness, &execution_settings, &selected)?;
         }
         let session = CodeSession {
@@ -3920,9 +3950,14 @@ impl CodeRuntime {
         {
             let adapter = self.adapter(session.harness_kind)?;
             let probe = self.probe(adapter.as_ref()).await;
-            let selected =
-                Self::selected_model_capabilities(adapter.as_ref(), &probe, next.model.as_deref())
-                    .await;
+            let selected = self
+                .selected_model_capabilities_for_owner(
+                    owner,
+                    adapter.as_ref(),
+                    &probe,
+                    next.model.as_deref(),
+                )
+                .await;
             if requested_effort.is_some() {
                 let requested = CodeSessionExecutionSettings {
                     model: next.model.clone(),
@@ -5309,9 +5344,14 @@ impl CodeRuntime {
         }
         let adapter = self.adapter(session.harness_kind)?;
         let probe = self.probe(adapter.as_ref()).await;
-        let selected =
-            Self::selected_model_capabilities(adapter.as_ref(), &probe, session.model.as_deref())
-                .await;
+        let selected = self
+            .selected_model_capabilities_for_owner(
+                owner,
+                adapter.as_ref(),
+                &probe,
+                session.model.as_deref(),
+            )
+            .await;
         let mut next = CodeSessionExecutionSettings::from(&session);
         selected.deactivate_unsupported(&mut next);
         next.reasoning_effort = effort;
@@ -5359,9 +5399,14 @@ impl CodeRuntime {
         }
         let adapter = self.adapter(session.harness_kind)?;
         let probe = self.probe(adapter.as_ref()).await;
-        let selected =
-            Self::selected_model_capabilities(adapter.as_ref(), &probe, session.model.as_deref())
-                .await;
+        let selected = self
+            .selected_model_capabilities_for_owner(
+                owner,
+                adapter.as_ref(),
+                &probe,
+                session.model.as_deref(),
+            )
+            .await;
         let mut next = CodeSessionExecutionSettings::from(&session);
         selected.deactivate_unsupported(&mut next);
         next.fast_mode = fast_mode;
@@ -5427,6 +5472,47 @@ impl CodeRuntime {
             fast_mode: model.is_some_and(|model| model.fast_mode),
             fast_mode_known: model.is_some() || catalog_known,
         }
+    }
+
+    async fn selected_model_capabilities_for_owner(
+        &self,
+        owner: &OwnerId,
+        adapter: &dyn HarnessAdapter,
+        probe: &HarnessProbe,
+        selected: Option<&str>,
+    ) -> SelectedModelCapabilities {
+        let mut capabilities = Self::selected_model_capabilities(adapter, probe, selected).await;
+        let Some(selected) = selected else {
+            return capabilities;
+        };
+        if adapter.capabilities(probe).reasoning_levels != CapLevel::Supported {
+            return capabilities;
+        }
+        let Some(snapshot) = self.gateway_model_snapshot(owner).await else {
+            return capabilities;
+        };
+        let Some(model_efforts) =
+            crate::providers::gateway_reasoning_efforts_for_model(&snapshot, selected)
+        else {
+            return capabilities;
+        };
+        let engine_efforts = adapter.reasoning_efforts(probe);
+        capabilities.reasoning_efforts = if engine_efforts.is_empty() {
+            model_efforts.to_vec()
+        } else {
+            engine_efforts
+                .into_iter()
+                .filter(|effort| model_efforts.contains(effort))
+                .collect()
+        };
+        capabilities.reasoning_known = true;
+        tracing::debug!(
+            harness = %adapter.kind(),
+            model = selected,
+            efforts = ?capabilities.reasoning_efforts,
+            "using the gateway model's reasoning effort ladder"
+        );
+        capabilities
     }
 
     fn validate_execution_settings(
@@ -6183,12 +6269,14 @@ impl CodeRuntime {
             ));
         }
         if session.reasoning_effort.is_some() || session.fast_mode {
-            let selected = Self::selected_model_capabilities(
-                adapter.as_ref(),
-                &probe,
-                session.model.as_deref(),
-            )
-            .await;
+            let selected = self
+                .selected_model_capabilities_for_owner(
+                    &session.owner,
+                    adapter.as_ref(),
+                    &probe,
+                    session.model.as_deref(),
+                )
+                .await;
             let mut next = CodeSessionExecutionSettings::from(&session);
             selected.deactivate_unsupported(&mut next);
             if next != CodeSessionExecutionSettings::from(&session) {
@@ -7170,6 +7258,84 @@ mod selected_model_capabilities_tests {
     use super::*;
     use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 
+    #[derive(Default)]
+    struct NoSecrets;
+
+    #[async_trait::async_trait]
+    impl tidebreak_core::SecretProvider for NoSecrets {
+        async fn get_secret(&self, _key: &str) -> tidebreak_core::Result<Option<String>> {
+            Ok(None)
+        }
+
+        async fn set_secret(&self, _key: &str, _value: &str) -> tidebreak_core::Result<()> {
+            Ok(())
+        }
+
+        async fn delete_secret(&self, _key: &str) -> tidebreak_core::Result<()> {
+            Ok(())
+        }
+    }
+
+    async fn runtime_with_gateway_snapshot(
+        gateway_url: &str,
+        policy_url: &str,
+    ) -> (CodeRuntime, tempfile::TempDir) {
+        let directory = tempfile::tempdir().expect("data dir");
+        let db = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("code.db").display()
+            ))
+            .await
+            .expect("db"),
+        );
+        crate::providers::write_gateway_snapshot(
+            &*db,
+            &crate::providers::GatewayModelSnapshot {
+                gateway_url: gateway_url.into(),
+                installation_id: None,
+                models: Vec::new(),
+                model_protocols: Default::default(),
+                model_reasoning_efforts: std::collections::BTreeMap::from([(
+                    "glm-5.3".into(),
+                    vec![
+                        ReasoningEffort::Low,
+                        ReasoningEffort::High,
+                        ReasoningEffort::Max,
+                    ],
+                )]),
+                member_catalog: Some("v1".into()),
+                catalog_etag: None,
+            },
+        )
+        .await
+        .expect("gateway snapshot");
+        let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+        crate::managed_policy::provision(&*provisioned, policy_url).expect("managed policy");
+        let gateway = crate::gateway_runtime::GatewayRuntime::new(
+            db.clone(),
+            Arc::new(NoSecrets),
+            provisioned,
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        );
+        let runtime =
+            CodeRuntime::with_registry(db, directory.path().to_path_buf(), AdapterRegistry::new())
+                .with_gateway_runtime(gateway);
+        (runtime, directory)
+    }
+
+    fn scripted_probe() -> HarnessProbe {
+        HarnessProbe {
+            found: true,
+            binary_path: Some(PathBuf::from("/scripted")),
+            version: Some("1.0.0".into()),
+            authenticated: Some(true),
+            stderr: String::new(),
+            env: Vec::new(),
+            commands: Vec::new(),
+        }
+    }
+
     #[tokio::test]
     async fn an_unavailable_catalog_does_not_clear_committed_settings() {
         let adapter =
@@ -7195,6 +7361,57 @@ mod selected_model_capabilities_tests {
 
         assert_eq!(settings.reasoning_effort, Some(ReasoningEffort::High));
         assert!(settings.fast_mode);
+    }
+
+    #[tokio::test]
+    async fn a_gateway_model_uses_the_model_and_engine_effort_intersection() {
+        let (runtime, _directory) =
+            runtime_with_gateway_snapshot("https://gateway.example/", "https://gateway.example/")
+                .await;
+        let adapter =
+            ScriptedAdapter::new(plain_text_script()).with_reasoning_levels(CapLevel::Supported);
+
+        let capabilities = runtime
+            .selected_model_capabilities_for_owner(
+                &OwnerId::new("alice").unwrap(),
+                &adapter,
+                &scripted_probe(),
+                Some("model-gateway-model-gateway/glm-5.3"),
+            )
+            .await;
+
+        assert_eq!(
+            capabilities.reasoning_efforts,
+            vec![
+                ReasoningEffort::Low,
+                ReasoningEffort::High,
+                ReasoningEffort::Max,
+            ]
+        );
+        assert!(capabilities.reasoning_known);
+    }
+
+    #[tokio::test]
+    async fn a_snapshot_from_another_gateway_does_not_change_engine_efforts() {
+        let (runtime, _directory) = runtime_with_gateway_snapshot(
+            "https://old.gateway.example/",
+            "https://gateway.example/",
+        )
+        .await;
+        let adapter =
+            ScriptedAdapter::new(plain_text_script()).with_reasoning_levels(CapLevel::Supported);
+
+        let capabilities = runtime
+            .selected_model_capabilities_for_owner(
+                &OwnerId::new("alice").unwrap(),
+                &adapter,
+                &scripted_probe(),
+                Some("model-gateway-model-gateway/glm-5.3"),
+            )
+            .await;
+
+        assert!(capabilities.reasoning_efforts.is_empty());
+        assert!(!capabilities.reasoning_known);
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -967,6 +967,12 @@ impl ScopedCode {
         self.runtime.harness_llm()
     }
 
+    pub(crate) async fn gateway_model_snapshot(
+        &self,
+    ) -> Option<crate::providers::GatewayModelSnapshot> {
+        self.runtime.gateway_model_snapshot(&self.owner).await
+    }
+
     /// Warm the pinned install of one engine. See
     /// [`CodeRuntime::start_harness_install`].
     ///

--- a/crates/tidebreak-server/src/connectors/gateway.rs
+++ b/crates/tidebreak-server/src/connectors/gateway.rs
@@ -266,6 +266,10 @@ pub struct GatewayCatalogModel {
     pub aliases: Vec<String>,
     pub supports_tools: bool,
     pub supports_vision: bool,
+    /// Reasoning effort tokens this model accepts. Older gateways omit this
+    /// field; an empty list means the model takes no explicit effort control.
+    #[serde(default)]
+    pub supported_reasoning_efforts: Option<Vec<tidebreak_core::ReasoningEffort>>,
     pub context_window: Option<i64>,
     pub max_output_tokens: Option<i64>,
     pub provider_name: String,

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -226,6 +226,12 @@ impl GatewayRuntime {
         crate::managed_policy::resolve(&*self.provisioned_policy, &*self.os_policy)
     }
 
+    /// The synced model snapshot for the deployment named by managed policy.
+    pub(crate) async fn model_snapshot(&self) -> Result<Option<providers::GatewayModelSnapshot>> {
+        let policy = self.policy()?;
+        providers::gateway_snapshot_for_policy(&*self.store, &policy).await
+    }
+
     /// Park a shell-validated pairing until a sign-in consents to it,
     /// replacing any earlier one — the latest link is the one the user acted
     /// on. Invalidate any in-flight browser flow the same way `sign_out`
@@ -801,6 +807,7 @@ impl GatewayRuntime {
                         installation_id: None,
                         models: Vec::new(),
                         model_protocols: Default::default(),
+                        model_reasoning_efforts: Default::default(),
                         member_catalog: None,
                         catalog_etag: None,
                     },
@@ -950,6 +957,7 @@ impl GatewayRuntime {
         // that predates it degrades to the per-protocol
         // `/api/v1/cli/models` read.
         let mut model_protocols = std::collections::BTreeMap::new();
+        let mut model_reasoning_efforts = std::collections::BTreeMap::new();
         let mut member_catalog = None;
         let mut catalog_etag = None;
         let models: Vec<CustomModelConfig> = match connection.catalog(held_etag.as_deref()).await? {
@@ -970,9 +978,10 @@ impl GatewayRuntime {
             GatewayCatalogFetch::Fresh { catalog, etag } => {
                 member_catalog = Some(MEMBER_CATALOG_V1.to_owned());
                 catalog_etag = etag;
-                let (models, protocols) = providers::member_catalog_models(catalog);
-                model_protocols = protocols;
-                models
+                let converted = providers::member_catalog_models(catalog);
+                model_protocols = converted.model_protocols;
+                model_reasoning_efforts = converted.model_reasoning_efforts;
+                converted.models
             }
             GatewayCatalogFetch::Unsupported => connection
                 .models(None)
@@ -1024,6 +1033,7 @@ impl GatewayRuntime {
                 installation_id: Some(session.installation_id.clone()),
                 models,
                 model_protocols,
+                model_reasoning_efforts,
                 member_catalog,
                 catalog_etag,
             },
@@ -1926,6 +1936,7 @@ mod tests {
                 ..Default::default()
             }],
             model_protocols: std::collections::BTreeMap::from([(model.into(), protocol)]),
+            model_reasoning_efforts: Default::default(),
             member_catalog: Some("v1".into()),
             catalog_etag: None,
         };
@@ -3150,6 +3161,7 @@ mod tests {
                     },
                 ],
                 model_protocols: Default::default(),
+                model_reasoning_efforts: Default::default(),
                 member_catalog: None,
                 catalog_etag: None,
             },

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -2190,7 +2190,8 @@ async fn bind_inner(
             .on_behalf_of_gateway
             .clone()
             .map(|gateway| Arc::new(code::harness_llm::HarnessLlmRelay::new(gateway))),
-    );
+    )
+    .with_gateway_runtime(state.gateway.clone());
     // A self-host machine owns its filesystem. Clones land under the data
     // directory unless an operator set a destination (decision 70).
     #[allow(unused_mut)]

--- a/crates/tidebreak-server/src/model_roles.rs
+++ b/crates/tidebreak-server/src/model_roles.rs
@@ -618,6 +618,7 @@ mod tests {
                 },
             ],
             model_protocols: Default::default(),
+            model_reasoning_efforts: Default::default(),
             member_catalog: None,
             catalog_etag: None,
         };

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -685,19 +685,20 @@ impl OboGateway {
                     "the Model Gateway returned an unreadable catalog: {error}"
                 ))
             })?;
-        let (models, model_protocols) = crate::providers::member_catalog_models(catalog);
+        let converted = crate::providers::member_catalog_models(catalog);
         // The gateway is trusted for entitlements, not for shapes: the
         // caller's set is held to the same bounds as user-entered custom
         // models, exactly like the managed sync.
-        crate::providers::validate_custom_models(&models).map_err(|error| {
+        crate::providers::validate_custom_models(&converted.models).map_err(|error| {
             AgentError::msg(format!("the Model Gateway catalog was rejected: {error:?}"))
         })?;
         Ok(CatalogFetch::Fresh {
             snapshot: crate::providers::GatewayModelSnapshot {
                 gateway_url: self.gateway_base_url.clone(),
                 installation_id: None,
-                models,
-                model_protocols,
+                models: converted.models,
+                model_protocols: converted.model_protocols,
+                model_reasoning_efforts: converted.model_reasoning_efforts,
                 member_catalog: Some(crate::connectors::MEMBER_CATALOG_V1.to_owned()),
                 catalog_etag: etag.clone(),
             },

--- a/crates/tidebreak-server/src/pairing.rs
+++ b/crates/tidebreak-server/src/pairing.rs
@@ -794,6 +794,7 @@ mod tests {
                     ..Default::default()
                 }],
                 model_protocols: Default::default(),
+                model_reasoning_efforts: Default::default(),
                 member_catalog: None,
                 catalog_etag: None,
             },
@@ -935,6 +936,7 @@ mod tests {
                 ..Default::default()
             }],
             model_protocols,
+            model_reasoning_efforts: Default::default(),
             member_catalog: Some("v1".into()),
             catalog_etag: Some("fixture".into()),
         };

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -170,6 +170,31 @@ pub(crate) fn gateway_reasoning_efforts_for_model<'a>(
         .map(|(_, efforts)| efforts.as_slice())
 }
 
+/// Intersect a gateway model's ladder with the ladder the engine already
+/// advertises for that pick.
+///
+/// Codex is the documented exception: `adapter.reasoning_efforts` is empty
+/// because each row carries its own ladder. Prefer that row when it is
+/// present. Fall back to the engine-wide ladder, then to the gateway ladder
+/// when neither the row nor the engine states one — hosted compat listings.
+pub(crate) fn overlay_gateway_reasoning_efforts(
+    row_efforts: &[ReasoningEffort],
+    engine_efforts: &[ReasoningEffort],
+    gateway_efforts: &[ReasoningEffort],
+) -> Vec<ReasoningEffort> {
+    let base = if !row_efforts.is_empty() {
+        row_efforts
+    } else if !engine_efforts.is_empty() {
+        engine_efforts
+    } else {
+        return gateway_efforts.to_vec();
+    };
+    base.iter()
+        .copied()
+        .filter(|effort| gateway_efforts.contains(effort))
+        .collect()
+}
+
 fn gateway_selection_matches(selection: &str, id: &str) -> bool {
     selection == id
         || selection
@@ -2587,6 +2612,59 @@ mod tests {
                 "{selection}"
             );
         }
+    }
+
+    #[test]
+    fn overlay_prefers_a_codex_row_ladder_over_an_empty_engine() {
+        assert_eq!(
+            overlay_gateway_reasoning_efforts(
+                &[
+                    ReasoningEffort::Low,
+                    ReasoningEffort::High,
+                    ReasoningEffort::Ultra,
+                ],
+                &[],
+                &[
+                    ReasoningEffort::Low,
+                    ReasoningEffort::High,
+                    ReasoningEffort::Max,
+                ],
+            ),
+            vec![ReasoningEffort::Low, ReasoningEffort::High]
+        );
+    }
+
+    #[test]
+    fn overlay_intersects_an_engine_wide_ladder_when_the_row_is_empty() {
+        assert_eq!(
+            overlay_gateway_reasoning_efforts(
+                &[],
+                ReasoningEffort::ALL,
+                &[
+                    ReasoningEffort::Low,
+                    ReasoningEffort::High,
+                    ReasoningEffort::Max,
+                ],
+            ),
+            vec![
+                ReasoningEffort::Low,
+                ReasoningEffort::High,
+                ReasoningEffort::Max,
+            ]
+        );
+    }
+
+    #[test]
+    fn overlay_uses_the_gateway_ladder_when_neither_row_nor_engine_states_one() {
+        let gateway = [
+            ReasoningEffort::Low,
+            ReasoningEffort::High,
+            ReasoningEffort::Max,
+        ];
+        assert_eq!(
+            overlay_gateway_reasoning_efforts(&[], &[], &gateway),
+            gateway.to_vec()
+        );
     }
 
     async fn gateway_migration_test_store() -> (

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -94,6 +94,11 @@ pub(crate) struct GatewayModelSnapshot {
     /// defaults to that protocol for backward compatibility.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) model_protocols: BTreeMap<String, GatewayModelProtocol>,
+    /// Per-model reasoning ladders stated by the member catalog. Presence is
+    /// significant: an empty list means no effort control, while absence
+    /// means an older gateway did not state a ladder.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) model_reasoning_efforts: BTreeMap<String, Vec<ReasoningEffort>>,
     /// The member-catalog contract revision the last sync read (`"v1"`),
     /// or `None` when the deployment predates `/api/v1/me/catalog` and the
     /// sync degraded to the per-surface CLI reads. Drives the "older
@@ -148,6 +153,37 @@ pub(crate) async fn read_gateway_snapshot(
         .and_then(|value| serde_json::from_value(value).ok()))
 }
 
+/// Find the model-specific reasoning ladder for a gateway-backed engine id.
+///
+/// Modelctl-generated Grok ids prefix the gateway route with the profile that
+/// owns it (`model-gateway-<profile>/...`). OpenCode uses a shorter provider
+/// prefix. The snapshot keeps the raw gateway ids, so match those wrappers
+/// without assuming that the raw id itself contains no slash.
+pub(crate) fn gateway_reasoning_efforts_for_model<'a>(
+    snapshot: &'a GatewayModelSnapshot,
+    selection: &str,
+) -> Option<&'a [ReasoningEffort]> {
+    snapshot
+        .model_reasoning_efforts
+        .iter()
+        .find(|(id, _)| gateway_selection_matches(selection, id))
+        .map(|(_, efforts)| efforts.as_slice())
+}
+
+fn gateway_selection_matches(selection: &str, id: &str) -> bool {
+    selection == id
+        || selection
+            .strip_prefix("model-gateway/")
+            .is_some_and(|raw| raw == id)
+        || selection
+            .strip_prefix("anthropic/")
+            .is_some_and(|raw| raw == id)
+        || selection
+            .strip_prefix("model-gateway-")
+            .and_then(|qualified| qualified.split_once('/'))
+            .is_some_and(|(_, raw)| raw == id)
+}
+
 /// Persist the entitled-model snapshot. Callers hold
 /// [`GATEWAY_STATE_WRITES`] across their policy recheck and this write.
 pub(crate) async fn write_gateway_snapshot(
@@ -164,13 +200,17 @@ pub(crate) async fn write_gateway_snapshot(
 /// One conversion for both consumers — the deployment-wide managed sync and
 /// the per-caller hosted fetch (decision 62) — so a model a hosted caller is
 /// offered is shaped exactly like a model the sync would have stored.
+pub(crate) struct MemberCatalogModels {
+    pub(crate) models: Vec<CustomModelConfig>,
+    pub(crate) model_protocols: BTreeMap<String, GatewayModelProtocol>,
+    pub(crate) model_reasoning_efforts: BTreeMap<String, Vec<ReasoningEffort>>,
+}
+
 pub(crate) fn member_catalog_models(
     catalog: crate::connectors::GatewayCatalog,
-) -> (
-    Vec<CustomModelConfig>,
-    BTreeMap<String, GatewayModelProtocol>,
-) {
+) -> MemberCatalogModels {
     let mut model_protocols = BTreeMap::new();
+    let mut model_reasoning_efforts = BTreeMap::new();
     let models = catalog
         .models
         .into_iter()
@@ -190,6 +230,12 @@ pub(crate) fn member_catalog_models(
             };
             let id = model.id;
             model_protocols.insert(id.clone(), protocol);
+            if let Some(efforts) = model.supported_reasoning_efforts {
+                model_reasoning_efforts.insert(id.clone(), efforts.clone());
+                for alias in &model.aliases {
+                    model_reasoning_efforts.insert(alias.clone(), efforts.clone());
+                }
+            }
             Some(CustomModelConfig {
                 id,
                 display_name: Some(model.name),
@@ -205,7 +251,11 @@ pub(crate) fn member_catalog_models(
             })
         })
         .collect();
-    (models, model_protocols)
+    MemberCatalogModels {
+        models,
+        model_protocols,
+        model_reasoning_efforts,
+    }
 }
 
 /// Clamp a gateway-reported limit into the u32 the config carries; zero and
@@ -343,6 +393,7 @@ pub(crate) async fn retire_legacy_gateway_row(
             installation_id: None,
             models: row.models,
             model_protocols: BTreeMap::new(),
+            model_reasoning_efforts: BTreeMap::new(),
             member_catalog: None,
             catalog_etag: None,
         },
@@ -2484,6 +2535,60 @@ mod tests {
         }
     }
 
+    #[test]
+    fn member_catalog_reasoning_efforts_match_generated_engine_ids() {
+        let catalog = crate::connectors::GatewayCatalog {
+            models: vec![crate::connectors::GatewayCatalogModel {
+                id: "glm-5.3".into(),
+                name: "GLM 5.3".into(),
+                protocols: vec!["openai_responses".into()],
+                aliases: vec!["zai-glm-5.3".into()],
+                supports_tools: true,
+                supports_vision: false,
+                supported_reasoning_efforts: Some(vec![
+                    ReasoningEffort::Low,
+                    ReasoningEffort::High,
+                    ReasoningEffort::Max,
+                ]),
+                context_window: Some(200_000),
+                max_output_tokens: Some(16_000),
+                provider_name: "Z.ai".into(),
+            }],
+            apps: Vec::new(),
+        };
+        let MemberCatalogModels {
+            models,
+            model_protocols,
+            model_reasoning_efforts,
+        } = member_catalog_models(catalog);
+        let snapshot = GatewayModelSnapshot {
+            gateway_url: "https://gateway.example/".into(),
+            installation_id: None,
+            models,
+            model_protocols,
+            model_reasoning_efforts,
+            member_catalog: Some("v1".into()),
+            catalog_etag: None,
+        };
+        let expected = [
+            ReasoningEffort::Low,
+            ReasoningEffort::High,
+            ReasoningEffort::Max,
+        ];
+        for selection in [
+            "glm-5.3",
+            "model-gateway/glm-5.3",
+            "model-gateway-model-gateway/glm-5.3",
+            "model-gateway-default/zai-glm-5.3",
+        ] {
+            assert_eq!(
+                gateway_reasoning_efforts_for_model(&snapshot, selection),
+                Some(expected.as_slice()),
+                "{selection}"
+            );
+        }
+    }
+
     async fn gateway_migration_test_store() -> (
         DbStore,
         tempfile::TempDir,
@@ -2514,6 +2619,7 @@ mod tests {
                     ..Default::default()
                 }],
                 model_protocols: BTreeMap::new(),
+                model_reasoning_efforts: BTreeMap::new(),
                 member_catalog: Some("v1".into()),
                 catalog_etag: None,
             },
@@ -2733,6 +2839,7 @@ mod tests {
             installation_id: Some(installation_id.into()),
             models,
             model_protocols: BTreeMap::new(),
+            model_reasoning_efforts: BTreeMap::new(),
             member_catalog: Some("v1".into()),
             catalog_etag: None,
         }

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -171,14 +171,18 @@ pub(crate) fn gateway_reasoning_efforts_for_model<'a>(
 }
 
 /// Intersect one gateway model's ladder with the harness surface that carries
-/// it. A listed row wins over the engine-wide ladder. If the harness did not
-/// list the gateway-only row and has no engine-wide ladder, use the gateway's
-/// ladder rather than treating the missing row as unsupported.
+/// it. A listed row wins over the engine-wide ladder. Hosted picker rows are
+/// empty compat listings, so ignore `adapter.list_models` on that path and
+/// intersect only when the picker actually used a Codex row. If the harness
+/// did not list the gateway-only row and has no engine-wide ladder, use the
+/// gateway's ladder rather than treating the missing row as unsupported.
 pub(crate) fn effective_gateway_reasoning_efforts(
+    hosted: bool,
     listed_model_efforts: Option<&[ReasoningEffort]>,
     engine_efforts: &[ReasoningEffort],
     gateway_efforts: &[ReasoningEffort],
 ) -> Vec<ReasoningEffort> {
+    let listed_model_efforts = if hosted { None } else { listed_model_efforts };
     let harness_efforts = listed_model_efforts.unwrap_or(engine_efforts);
     if harness_efforts.is_empty() && listed_model_efforts.is_none() {
         return gateway_efforts.to_vec();
@@ -2623,14 +2627,24 @@ mod tests {
         ];
 
         assert_eq!(
-            effective_gateway_reasoning_efforts(Some(&listed), ReasoningEffort::ALL, &gateway),
+            effective_gateway_reasoning_efforts(
+                false,
+                Some(&listed),
+                ReasoningEffort::ALL,
+                &gateway
+            ),
             vec![ReasoningEffort::Low, ReasoningEffort::High]
         );
         assert_eq!(
-            effective_gateway_reasoning_efforts(None, &[], &gateway),
+            effective_gateway_reasoning_efforts(false, None, &[], &gateway),
             gateway
         );
-        assert!(effective_gateway_reasoning_efforts(Some(&[]), &[], &gateway).is_empty());
+        assert!(effective_gateway_reasoning_efforts(false, Some(&[]), &[], &gateway).is_empty());
+        assert_eq!(
+            effective_gateway_reasoning_efforts(true, Some(&listed), &[], &gateway),
+            gateway,
+            "hosted compat rows do not overlay against Codex CLI ladders"
+        );
     }
 
     async fn gateway_migration_test_store() -> (

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -170,26 +170,21 @@ pub(crate) fn gateway_reasoning_efforts_for_model<'a>(
         .map(|(_, efforts)| efforts.as_slice())
 }
 
-/// Intersect a gateway model's ladder with the ladder the engine already
-/// advertises for that pick.
-///
-/// Codex is the documented exception: `adapter.reasoning_efforts` is empty
-/// because each row carries its own ladder. Prefer that row when it is
-/// present. Fall back to the engine-wide ladder, then to the gateway ladder
-/// when neither the row nor the engine states one — hosted compat listings.
-pub(crate) fn overlay_gateway_reasoning_efforts(
-    row_efforts: &[ReasoningEffort],
+/// Intersect one gateway model's ladder with the harness surface that carries
+/// it. A listed row wins over the engine-wide ladder. If the harness did not
+/// list the gateway-only row and has no engine-wide ladder, use the gateway's
+/// ladder rather than treating the missing row as unsupported.
+pub(crate) fn effective_gateway_reasoning_efforts(
+    listed_model_efforts: Option<&[ReasoningEffort]>,
     engine_efforts: &[ReasoningEffort],
     gateway_efforts: &[ReasoningEffort],
 ) -> Vec<ReasoningEffort> {
-    let base = if !row_efforts.is_empty() {
-        row_efforts
-    } else if !engine_efforts.is_empty() {
-        engine_efforts
-    } else {
+    let harness_efforts = listed_model_efforts.unwrap_or(engine_efforts);
+    if harness_efforts.is_empty() && listed_model_efforts.is_none() {
         return gateway_efforts.to_vec();
-    };
-    base.iter()
+    }
+    harness_efforts
+        .iter()
         .copied()
         .filter(|effort| gateway_efforts.contains(effort))
         .collect()
@@ -2615,56 +2610,27 @@ mod tests {
     }
 
     #[test]
-    fn overlay_prefers_a_codex_row_ladder_over_an_empty_engine() {
-        assert_eq!(
-            overlay_gateway_reasoning_efforts(
-                &[
-                    ReasoningEffort::Low,
-                    ReasoningEffort::High,
-                    ReasoningEffort::Ultra,
-                ],
-                &[],
-                &[
-                    ReasoningEffort::Low,
-                    ReasoningEffort::High,
-                    ReasoningEffort::Max,
-                ],
-            ),
-            vec![ReasoningEffort::Low, ReasoningEffort::High]
-        );
-    }
-
-    #[test]
-    fn overlay_intersects_an_engine_wide_ladder_when_the_row_is_empty() {
-        assert_eq!(
-            overlay_gateway_reasoning_efforts(
-                &[],
-                ReasoningEffort::ALL,
-                &[
-                    ReasoningEffort::Low,
-                    ReasoningEffort::High,
-                    ReasoningEffort::Max,
-                ],
-            ),
-            vec![
-                ReasoningEffort::Low,
-                ReasoningEffort::High,
-                ReasoningEffort::Max,
-            ]
-        );
-    }
-
-    #[test]
-    fn overlay_uses_the_gateway_ladder_when_neither_row_nor_engine_states_one() {
+    fn gateway_efforts_preserve_a_codex_rows_narrower_ladder() {
+        let listed = [
+            ReasoningEffort::Low,
+            ReasoningEffort::High,
+            ReasoningEffort::Ultra,
+        ];
         let gateway = [
             ReasoningEffort::Low,
             ReasoningEffort::High,
             ReasoningEffort::Max,
         ];
+
         assert_eq!(
-            overlay_gateway_reasoning_efforts(&[], &[], &gateway),
-            gateway.to_vec()
+            effective_gateway_reasoning_efforts(Some(&listed), ReasoningEffort::ALL, &gateway),
+            vec![ReasoningEffort::Low, ReasoningEffort::High]
         );
+        assert_eq!(
+            effective_gateway_reasoning_efforts(None, &[], &gateway),
+            gateway
+        );
+        assert!(effective_gateway_reasoning_efforts(Some(&[]), &[], &gateway).is_empty());
     }
 
     async fn gateway_migration_test_store() -> (

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -111,13 +111,9 @@ pub async fn list_harness_models(
             else {
                 continue;
             };
-            let listed_model_efforts = if hosted && model.reasoning_efforts.is_empty() {
-                None
-            } else {
-                Some(model.reasoning_efforts.as_slice())
-            };
             model.reasoning_efforts = crate::providers::effective_gateway_reasoning_efforts(
-                listed_model_efforts,
+                hosted,
+                Some(model.reasoning_efforts.as_slice()),
                 &engine_reasoning_efforts,
                 model_efforts,
             );

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -11,7 +11,7 @@ use super::types::{
 use crate::code::harness_label;
 use crate::code::harness_llm::relay_covered;
 use crate::obo_gateway::GatewayCompatModel;
-use tidebreak_core::HarnessKind;
+use tidebreak_core::{CapLevel, HarnessKind};
 
 /// The doctor surface, served from the memoized probes (decision 0034).
 pub async fn list_harnesses(code: ScopedCode) -> Result<Json<HarnessDoctorReport>, ServerError> {
@@ -71,7 +71,7 @@ pub async fn list_harness_models(
         ));
     }
     let hosted = code.harness_llm_relay_active();
-    let (models, source) = if hosted {
+    let (mut models, source) = if hosted {
         (
             hosted_models(&code, kind).await?,
             HarnessModelSource::ModelGateway,
@@ -93,10 +93,39 @@ pub async fn list_harness_models(
             HarnessModelSource::Harness,
         )
     };
+    let reasoning_supported = adapter.capabilities(&probe).reasoning_levels == CapLevel::Supported;
+    let engine_reasoning_efforts = if reasoning_supported {
+        adapter.reasoning_efforts(&probe)
+    } else {
+        Vec::new()
+    };
+    let snapshot = if reasoning_supported {
+        code.gateway_model_snapshot().await
+    } else {
+        None
+    };
+    if let Some(snapshot) = snapshot {
+        for model in &mut models {
+            let Some(model_efforts) =
+                crate::providers::gateway_reasoning_efforts_for_model(&snapshot, &model.id)
+            else {
+                continue;
+            };
+            model.reasoning_efforts = if engine_reasoning_efforts.is_empty() {
+                model_efforts.to_vec()
+            } else {
+                engine_reasoning_efforts
+                    .iter()
+                    .copied()
+                    .filter(|effort| model_efforts.contains(effort))
+                    .collect()
+            };
+        }
+    }
     // An engine that states one ladder for every model says so directly. One
     // that states a ladder per row — Codex — has no single answer, so the
     // outer bound is the union of what its rows advertise.
-    let mut reasoning_efforts = adapter.reasoning_efforts(&probe);
+    let mut reasoning_efforts = engine_reasoning_efforts;
     if reasoning_efforts.is_empty() {
         reasoning_efforts = models
             .iter()
@@ -123,11 +152,11 @@ pub async fn list_harness_models(
 /// when the unused listing is down. OpenCode ids are provider-qualified so
 /// its request body selects the provider wired to that listing:
 /// `anthropic/{raw}` for Anthropic and `model-gateway/{raw}` for OpenAI
-/// Responses. Duplicate raw ids prefer the Anthropic surface. Gateway rows
-/// carry no per-model effort ladder or fast-mode promise — the engine's
-/// own ladder above is the honest outer bound — and only the Anthropic
-/// surface's `is_family_default` annotation claims a default. The wiring
-/// per engine is [`crate::code::harness_llm::spawn_wiring`].
+/// Responses. Duplicate raw ids prefer the Anthropic surface. Compat rows
+/// carry no effort ladder, so [`list_harness_models`] overlays the member
+/// catalog before returning them. They carry no fast-mode promise. Only the
+/// Anthropic surface's `is_family_default` annotation claims a default. The
+/// wiring per engine is [`crate::code::harness_llm::spawn_wiring`].
 async fn hosted_models(
     code: &ScopedCode,
     kind: HarnessKind,

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -111,8 +111,13 @@ pub async fn list_harness_models(
             else {
                 continue;
             };
-            model.reasoning_efforts = crate::providers::overlay_gateway_reasoning_efforts(
-                &model.reasoning_efforts,
+            let listed_model_efforts = if hosted && model.reasoning_efforts.is_empty() {
+                None
+            } else {
+                Some(model.reasoning_efforts.as_slice())
+            };
+            model.reasoning_efforts = crate::providers::effective_gateway_reasoning_efforts(
+                listed_model_efforts,
                 &engine_reasoning_efforts,
                 model_efforts,
             );

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -111,15 +111,11 @@ pub async fn list_harness_models(
             else {
                 continue;
             };
-            model.reasoning_efforts = if engine_reasoning_efforts.is_empty() {
-                model_efforts.to_vec()
-            } else {
-                engine_reasoning_efforts
-                    .iter()
-                    .copied()
-                    .filter(|effort| model_efforts.contains(effort))
-                    .collect()
-            };
+            model.reasoning_efforts = crate::providers::overlay_gateway_reasoning_efforts(
+                &model.reasoning_efforts,
+                &engine_reasoning_efforts,
+                model_efforts,
+            );
         }
     }
     // An engine that states one ladder for every model says so directly. One

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -111,6 +111,9 @@ pub(crate) struct ScriptedAdapter {
     image_input: CapLevel,
     reasoning_levels: CapLevel,
     models: Vec<ListedHarnessModel>,
+    /// Engine-wide effort ladder when it differs from `ReasoningEffort::ALL`.
+    /// Codex leaves this empty and states the ladder on each model row.
+    engine_reasoning_efforts: Option<Vec<ReasoningEffort>>,
     /// Whether this engine takes a new mode without being relaunched.
     live_mode_switch: bool,
     /// Whether this engine fixes its posture when it creates its session and
@@ -170,6 +173,7 @@ impl ScriptedAdapter {
             image_input: CapLevel::Unknown,
             reasoning_levels: CapLevel::Unsupported,
             models: Vec::new(),
+            engine_reasoning_efforts: None,
             live_mode_switch: false,
             posture_fixed: false,
             turns: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -282,6 +286,13 @@ impl ScriptedAdapter {
     /// Publish an exact model catalog for capability-validation tests.
     pub(crate) fn with_models(mut self, models: Vec<ListedHarnessModel>) -> Self {
         self.models = models;
+        self
+    }
+
+    /// Codex-style: reasoning is supported, but the accepted ladder lives on
+    /// each model row rather than on the engine.
+    pub(crate) fn with_engine_reasoning_efforts(mut self, efforts: Vec<ReasoningEffort>) -> Self {
+        self.engine_reasoning_efforts = Some(efforts);
         self
     }
 
@@ -443,6 +454,9 @@ impl HarnessAdapter for ScriptedAdapter {
     }
 
     fn reasoning_efforts(&self, _probe: &HarnessProbe) -> Vec<ReasoningEffort> {
+        if let Some(efforts) = &self.engine_reasoning_efforts {
+            return efforts.clone();
+        }
         if self.reasoning_levels == CapLevel::Supported {
             ReasoningEffort::ALL.to_vec()
         } else {

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -111,9 +111,6 @@ pub(crate) struct ScriptedAdapter {
     image_input: CapLevel,
     reasoning_levels: CapLevel,
     models: Vec<ListedHarnessModel>,
-    /// Engine-wide effort ladder when it differs from `ReasoningEffort::ALL`.
-    /// Codex leaves this empty and states the ladder on each model row.
-    engine_reasoning_efforts: Option<Vec<ReasoningEffort>>,
     /// Whether this engine takes a new mode without being relaunched.
     live_mode_switch: bool,
     /// Whether this engine fixes its posture when it creates its session and
@@ -173,7 +170,6 @@ impl ScriptedAdapter {
             image_input: CapLevel::Unknown,
             reasoning_levels: CapLevel::Unsupported,
             models: Vec::new(),
-            engine_reasoning_efforts: None,
             live_mode_switch: false,
             posture_fixed: false,
             turns: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -286,13 +282,6 @@ impl ScriptedAdapter {
     /// Publish an exact model catalog for capability-validation tests.
     pub(crate) fn with_models(mut self, models: Vec<ListedHarnessModel>) -> Self {
         self.models = models;
-        self
-    }
-
-    /// Codex-style: reasoning is supported, but the accepted ladder lives on
-    /// each model row rather than on the engine.
-    pub(crate) fn with_engine_reasoning_efforts(mut self, efforts: Vec<ReasoningEffort>) -> Self {
-        self.engine_reasoning_efforts = Some(efforts);
         self
     }
 
@@ -454,9 +443,6 @@ impl HarnessAdapter for ScriptedAdapter {
     }
 
     fn reasoning_efforts(&self, _probe: &HarnessProbe) -> Vec<ReasoningEffort> {
-        if let Some(efforts) = &self.engine_reasoning_efforts {
-            return efforts.clone();
-        }
         if self.reasoning_levels == CapLevel::Supported {
             ReasoningEffort::ALL.to_vec()
         } else {

--- a/crates/tidebreak-server/src/tests/compaction.rs
+++ b/crates/tidebreak-server/src/tests/compaction.rs
@@ -168,6 +168,7 @@ async fn managed_compaction_and_message_admission_share_the_frozen_gateway_ident
                 ..Default::default()
             }],
             model_protocols: Default::default(),
+            model_reasoning_efforts: Default::default(),
             member_catalog: None,
             catalog_etag: None,
         },

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -2354,6 +2354,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
                 },
             ],
             model_protocols: Default::default(),
+            model_reasoning_efforts: Default::default(),
             member_catalog: None,
             catalog_etag: None,
         },
@@ -3786,6 +3787,7 @@ async fn a_superseded_gateway_session_never_reads_usable() {
                 ..Default::default()
             }],
             model_protocols: std::collections::BTreeMap::new(),
+            model_reasoning_efforts: Default::default(),
             member_catalog: Some("v1".into()),
             catalog_etag: None,
         },
@@ -3868,6 +3870,7 @@ async fn a_credential_appearance_cannot_admit_a_plain_gateway_execution_key() {
                 ..Default::default()
             }],
             model_protocols: Default::default(),
+            model_reasoning_efforts: Default::default(),
             member_catalog: Some("v1".into()),
             catalog_etag: None,
         },
@@ -5695,6 +5698,7 @@ fn caller_snapshot() -> providers::GatewayModelSnapshot {
         ]
         .into_iter()
         .collect(),
+        model_reasoning_efforts: Default::default(),
         member_catalog: Some("v1".into()),
         catalog_etag: None,
     }

--- a/crates/tidebreak-server/src/tests/image_attachment.rs
+++ b/crates/tidebreak-server/src/tests/image_attachment.rs
@@ -679,6 +679,7 @@ async fn an_exact_image_turn_retry_survives_a_managed_gateway_route_retarget() {
                 ..Default::default()
             }],
             model_protocols: Default::default(),
+            model_reasoning_efforts: Default::default(),
             member_catalog: Some("v1".into()),
             catalog_etag: None,
         },
@@ -770,6 +771,7 @@ async fn an_exact_image_turn_retry_survives_a_managed_gateway_route_retarget() {
                 ..Default::default()
             }],
             model_protocols: Default::default(),
+            model_reasoning_efforts: Default::default(),
             member_catalog: Some("v2".into()),
             catalog_etag: None,
         },

--- a/crates/tidebreak-server/src/tests/workers.rs
+++ b/crates/tidebreak-server/src/tests/workers.rs
@@ -639,6 +639,7 @@ async fn worker_rejects_an_already_accepted_plain_gateway_model_before_egress() 
                 ..Default::default()
             }],
             model_protocols: Default::default(),
+            model_reasoning_efforts: Default::default(),
             member_catalog: Some("v1".into()),
             catalog_etag: None,
         },


### PR DESCRIPTION
Fixes the Code turn failure from session `337c8a23-e6f6-4d27-bfba-dd8672c251a0`.

Tidebreak treated reasoning effort as a Grok-wide capability. Grok 1.0.5 removed `medium` and `xhigh` and accepts `low`, `high`, and `max`, while Model Gateway already reports each model’s own ladder.

This change:

- selects the Grok effort ladder from the installed patch version;
- preserves Model Gateway’s per-model effort ladder in synced and hosted catalogs;
- intersects the model ladder with the engine ladder for model lists and session validation;
- matches generated Grok and OpenCode model IDs back to their gateway model IDs;
- ignores local snapshots that do not match managed policy.

Tests:

- `cargo fmt --all -- --check`
- `cargo check -p tidebreak-harness -p tidebreak-server`
- `cargo test -p tidebreak-harness grok::`
- `cargo test -p tidebreak-server selected_model_capabilities_tests`
- `cargo test -p tidebreak-server member_catalog_reasoning_efforts_match_generated_engine_ids`
- `cargo test -p tidebreak-server a_hosted_machine_lists_the_gateway_catalog_as_an_engines_models`
- `cargo test -p tidebreak-server a_local_machine_keeps_the_engine_own_model_listing`

Model Gateway’s member catalog is already the source of truth for GLM 5.3 (`low`, `high`, `max`). Its sandbox Grok harness still has a separate older fixed ladder, so that path needs a Model Gateway follow-up.