### PR TITLE
fix(code): smooth workspace creation handoff

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -114,6 +114,13 @@ export type PendingComposerImages = {
   files: readonly File[];
 };
 
+/** The new-workspace dialog is still preparing this workspace's first agent. */
+export type WorkspaceStartup = {
+  harness: HarnessKind;
+  hasFirstMessage: boolean;
+  phase: "starting_session" | "sending_message";
+};
+
 function readStoredCreateDefaults(): CodeCreateDefaults | null {
   try {
     const raw = window.localStorage.getItem(LAST_CREATE_KEY);
@@ -305,6 +312,12 @@ export type CodeUiStore = {
   inspectorScope: InspectorScope | null;
   railPrefs: CodeRailPrefs;
   lastCreate: CodeCreateDefaults | null;
+  /** Optimistic first-agent handoffs, keyed by the workspace that owns them. */
+  workspaceStartups: Record<string, WorkspaceStartup>;
+  setWorkspaceStartup: (
+    workspaceId: string,
+    startup: WorkspaceStartup | null,
+  ) => void;
   /**
    * A terminal has been asked for from outside the workspace page — the
    * chord, or a rail command on a workspace that is not on screen yet. The
@@ -448,6 +461,21 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   inspectorScope: null,
   railPrefs: readStoredRailPrefs(),
   lastCreate: readStoredCreateDefaults(),
+  workspaceStartups: {},
+  setWorkspaceStartup: (workspaceId, startup) =>
+    set((state) => {
+      if (startup) {
+        return {
+          workspaceStartups: {
+            ...state.workspaceStartups,
+            [workspaceId]: startup,
+          },
+        };
+      }
+      const { [workspaceId]: _removed, ...workspaceStartups } =
+        state.workspaceStartups;
+      return { workspaceStartups };
+    }),
   terminalPending: false,
   pendingComposerPrompt: null,
   pendingComposerImages: null,
@@ -641,6 +669,7 @@ export function resetCodeUiHostState(): void {
     newWorkspaceOpen: false,
     newWorkspaceRepoId: undefined,
     newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT,
+    workspaceStartups: {},
     addRepoOpen: false,
     inspectorScope: null,
     terminalPending: false,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -725,6 +725,7 @@ afterEach(() => {
     pendingComposerPrompt: null,
     pendingComposerImages: null,
     composerActionScope: null,
+    workspaceStartups: {},
     workflowShortcutPending: null,
     archivePending: false,
     newTabMenuPending: false,
@@ -791,6 +792,42 @@ describe("CodeWorkspacePage", () => {
     // The start prompt is a flex child of the pane so `mt-auto` on the
     // composer can consume the empty region under the header.
     expect(pane?.firstElementChild?.className).toMatch(/flex-1/);
+  });
+
+  it("shows the workspace handoff while the first session starts", async () => {
+    useCodeUiStore.getState().setWorkspaceStartup("ws-1", {
+      harness: "claude_code",
+      hasFirstMessage: true,
+      phase: "starting_session",
+    });
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    await mountWorkspace(client);
+
+    const status = await screen.findByRole("status", {
+      name: "Starting session",
+    });
+    expect(status).toHaveTextContent("Starting your session");
+    expect(status).toHaveTextContent("Workspace ready");
+    expect(status).toHaveTextContent("Starting Claude Code");
+    expect(status).toHaveTextContent("Sending your first message");
+    expect(status).toHaveTextContent("Your first message is queued.");
+    expect(
+      screen.queryByText("Start a session on this workspace."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull();
+
+    act(() =>
+      useCodeUiStore.getState().setWorkspaceStartup("ws-1", {
+        harness: "claude_code",
+        hasFirstMessage: true,
+        phase: "sending_message",
+      }),
+    );
+
+    expect(status).toHaveTextContent("Claude Code ready");
+    expect(status).toHaveTextContent("Sending your first message");
+    expect(screen.queryByText("Idle")).not.toBeInTheDocument();
   });
 
   it("restores the start draft when session creation fails", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -164,7 +164,10 @@ import {
   EDITOR_SPLIT_DROP_ID,
 } from "./editorDrag";
 import { FOCUS_RING } from "./interactive";
-import { StartSessionPrompt } from "./StartSessionPrompt";
+import {
+  StartSessionPrompt,
+  WorkspaceSessionStartingState,
+} from "./StartSessionPrompt";
 import { TerminalPane } from "./TerminalPane";
 import { useCodeWorkspacePr } from "./useCodeWorkspacePr";
 import { useCodeContentRevision } from "./useLiveContent";
@@ -479,6 +482,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   );
   const rememberedSession = useCodeCatalogStore(
     (state) => state.sessionsByWorkspace[workspaceId] ?? null,
+  );
+  const workspaceStartup = useCodeUiStore(
+    (state) => state.workspaceStartups[workspaceId] ?? null,
   );
 
   layoutRef.current = layout;
@@ -1443,26 +1449,24 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   </Button>
                 </div>
               )}
-              {startingNewAgent && workspace?.status === "active" && (
-                <StartSessionPrompt
-                  workspaceId={workspaceId}
-                  harnesses={doctorHarnesses}
-                  starting={starting}
-                  selectedMode={createMode}
-                  onSelectMode={setCreateMode}
-                  client={client}
-                  catalogModels={models}
-                  defaultModelKey={defaultModelKey}
-                  onStart={(
-                    harness,
-                    mode,
-                    message,
-                    model,
-                    draft,
-                    reasoningEffort,
-                    fastMode,
-                  ) =>
-                    startSession(
+              {workspaceStartup &&
+                workspace?.status === "active" &&
+                !draftAgent && (
+                  <WorkspaceSessionStartingState startup={workspaceStartup} />
+                )}
+              {!workspaceStartup &&
+                startingNewAgent &&
+                workspace?.status === "active" && (
+                  <StartSessionPrompt
+                    workspaceId={workspaceId}
+                    harnesses={doctorHarnesses}
+                    starting={starting}
+                    selectedMode={createMode}
+                    onSelectMode={setCreateMode}
+                    client={client}
+                    catalogModels={models}
+                    defaultModelKey={defaultModelKey}
+                    onStart={(
                       harness,
                       mode,
                       message,
@@ -1470,19 +1474,28 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                       draft,
                       reasoningEffort,
                       fastMode,
-                    )
-                  }
-                  workspaceFiles={
-                    forkSource
-                      ? {
-                          items: [forkTranscriptFile(forkSource)],
-                          onRemove: () => setForkSource(null),
-                        }
-                      : undefined
-                  }
-                />
-              )}
-              {session && !draftAgent && (
+                    ) =>
+                      startSession(
+                        harness,
+                        mode,
+                        message,
+                        model,
+                        draft,
+                        reasoningEffort,
+                        fastMode,
+                      )
+                    }
+                    workspaceFiles={
+                      forkSource
+                        ? {
+                            items: [forkTranscriptFile(forkSource)],
+                            onRemove: () => setForkSource(null),
+                          }
+                        : undefined
+                    }
+                  />
+                )}
+              {!workspaceStartup && session && !draftAgent && (
                 <CodeSessionPane
                   key={session.id}
                   session={session}
@@ -1714,7 +1727,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           ) : undefined
         }
         sessionStatus={
-          session ? (
+          session && !workspaceStartup ? (
             <>
               <SessionAttentionBadge
                 sessionId={session.id}

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -81,6 +81,7 @@ afterEach(() => {
     pendingComposerPrompt: null,
     pendingComposerImages: null,
     newWorkspaceDraft: EMPTY_NEW_WORKSPACE_DRAFT,
+    workspaceStartups: {},
   });
   toastError.mockReset();
   toastSuccess.mockReset();
@@ -344,8 +345,18 @@ describe("NewWorkspaceDialog", () => {
     await waitFor(() =>
       expect(router.state.location.pathname).toBe("/code/w/ws-early"),
     );
+    expect(useCodeUiStore.getState().workspaceStartups["ws-early"]).toEqual({
+      harness: "claude_code",
+      hasFirstMessage: false,
+      phase: "starting_session",
+    });
     sessionStart.resolve(
       session("ws-early", "claude_code", "2026-08-24T12:00:00.000Z"),
+    );
+    await waitFor(() =>
+      expect(
+        useCodeUiStore.getState().workspaceStartups["ws-early"],
+      ).toBeUndefined(),
     );
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -768,9 +768,15 @@ export function NewWorkspaceDialog({
       return;
     }
     replaceWorkspace(pending.id, workspace);
-    await revealCreatedWorkspace(workspace, attempt);
     const prompt = attempt.startingPrompt.trim();
+    const setWorkspaceStartup = useCodeUiStore.getState().setWorkspaceStartup;
+    setWorkspaceStartup(workspace.id, {
+      harness: attempt.harness,
+      hasFirstMessage: Boolean(prompt),
+      phase: "starting_session",
+    });
     try {
+      await revealCreatedWorkspace(workspace, attempt);
       const gateway = gatewayCodeModels(
         models,
         attempt.harness,
@@ -795,6 +801,13 @@ export function NewWorkspaceDialog({
         ...(attempt.fastMode ? { fast_mode: true } : {}),
       });
       rememberSession(session);
+      if (prompt) {
+        setWorkspaceStartup(workspace.id, {
+          harness: attempt.harness,
+          hasFirstMessage: true,
+          phase: "sending_message",
+        });
+      }
       rememberCreate({
         repoId: attempt.repoId,
         harness: attempt.harness,
@@ -844,6 +857,8 @@ export function NewWorkspaceDialog({
       toast.error(
         `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
       );
+    } finally {
+      setWorkspaceStartup(workspace.id, null);
     }
   }
 

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Check, Circle } from "lucide-react";
 
 import type { ApiClient } from "../api/client";
 import type {
@@ -9,19 +10,23 @@ import type {
   ReasoningEffort,
 } from "../api/types";
 import type { ComposerWorkspaceFiles } from "@/Composer";
+import { LiveLabel } from "@/LiveLabel";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
 import { clampPermissionMode } from "../PermissionModeMenu";
 import { useManagedPolicy } from "../managedPolicy";
 import { CodeComposer } from "./CodeComposer";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
-import { useCodeUiStore } from "./CodeUiStore";
+import { useCodeUiStore, type WorkspaceStartup } from "./CodeUiStore";
 import { HarnessInstallNote } from "./HarnessInstallNote";
-import { HarnessPicker } from "./HarnessPicker";
+import { HARNESS_ICONS, HarnessPicker } from "./HarnessPicker";
 import {
   canInstallHarnesses,
   useWarmHarnessInstall,
 } from "./useHarnessInstall";
 import {
   CREATE_PERMISSION_MODE_FIXED,
+  HARNESS_LABELS,
   createPermissionModes,
   defaultCreatePermissionMode,
   effortLadder,
@@ -36,6 +41,123 @@ import {
 const NO_ENGINE_EFFORTS: ReasoningEffort[] = [];
 
 const NO_CATALOG_MODELS: ModelInfo[] = [];
+
+/** The page-level handoff while a newly created workspace gets its first agent. */
+export function WorkspaceSessionStartingState({
+  startup,
+}: {
+  startup: WorkspaceStartup;
+}) {
+  const label = HARNESS_LABELS[startup.harness];
+  const HarnessIcon = HARNESS_ICONS[startup.harness];
+  const sending = startup.phase === "sending_message";
+
+  return (
+    <section
+      className="flex min-h-0 flex-1 flex-col"
+      role="status"
+      aria-label="Starting session"
+      data-testid="workspace-session-starting"
+    >
+      <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-10">
+        <div className="w-full max-w-md">
+          <div className="flex items-start gap-3">
+            <Spinner className="mt-1 size-4 text-live" aria-hidden />
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold">Starting your session</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Tidebreak is preparing {label} in this workspace.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-6 ml-2 border-l border-border-subtle pl-5">
+            <StartupStep label="Workspace ready" state="complete" />
+            <StartupStep
+              label={sending ? `${label} ready` : `Starting ${label}`}
+              state={sending ? "complete" : "active"}
+            />
+            <StartupStep
+              label={
+                startup.hasFirstMessage
+                  ? "Sending your first message"
+                  : "Opening the conversation"
+              }
+              state={sending ? "active" : "pending"}
+              last
+            />
+          </div>
+
+          <p className="mt-6 text-sm text-muted-foreground">
+            Your conversation appears here as soon as the session is ready.
+          </p>
+        </div>
+      </div>
+
+      <div className="relative shrink-0 px-[clamp(0.5rem,4%,5rem)] pb-2">
+        <div
+          className="rounded-xl border border-border bg-background px-3 py-3"
+          aria-hidden
+        >
+          <p className="text-sm text-muted-foreground/70">
+            {startup.hasFirstMessage
+              ? "Your first message is queued."
+              : "The composer is almost ready."}
+          </p>
+          <div className="mt-4 flex items-center justify-between gap-3">
+            <span className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+              <HarnessIcon className="size-4 shrink-0" />
+              <span className="truncate">{label}</span>
+            </span>
+            <span className="size-8 shrink-0 rounded-md bg-muted" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StartupStep({
+  label,
+  state,
+  last = false,
+}: {
+  label: string;
+  state: "complete" | "active" | "pending";
+  last?: boolean;
+}) {
+  return (
+    <div
+      className={cn("relative flex items-center gap-2 pb-4", last && "pb-0")}
+    >
+      <span className="absolute -left-[1.625rem] flex size-3.5 items-center justify-center bg-page-background">
+        {state === "complete" ? (
+          <Check className="size-3.5 text-success" aria-hidden />
+        ) : state === "active" ? (
+          <Spinner className="size-3.5 text-live" aria-hidden />
+        ) : (
+          <Circle className="size-2.5 text-border" aria-hidden />
+        )}
+      </span>
+      {state === "active" ? (
+        <LiveLabel live className="text-sm">
+          {label}
+        </LiveLabel>
+      ) : (
+        <span
+          className={cn(
+            "text-sm",
+            state === "complete"
+              ? "text-foreground"
+              : "text-muted-foreground/65",
+          )}
+        >
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}
 
 /**
  * Create-time harness + permission mode for a workspace with no session.

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -107,10 +107,32 @@ describe("WorkspaceCard", () => {
     const row = screen.getByRole("button", {
       name: "Fix login · Creating workspace · app",
     });
+    const progress = screen.getByRole("status", {
+      name: "Creating workspace",
+    });
     expect(row).toBeDisabled();
-    expect(screen.getByText("Creating workspace")).toBeInTheDocument();
+    expect(progress).toHaveTextContent("Creating workspace");
+    expect(progress.querySelector(".live-label-shimmer")).not.toBeNull();
+    expect(
+      progress.querySelector(".workspace-creation-progress"),
+    ).not.toBeNull();
     await user.click(row);
     expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("keeps the creation transition visible in compact mode", () => {
+    renderCard({
+      density: "compact",
+      workspace: {
+        status: "creating",
+        branch_name: "",
+        worktree_path: "",
+      },
+    });
+
+    expect(
+      screen.getByRole("status", { name: "Creating workspace" }),
+    ).toBeInTheDocument();
   });
 
   it("keeps one menu: right-click carries every command", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -13,7 +13,6 @@ import {
   FolderOpen,
   GitBranch,
   GitPullRequest,
-  LoaderCircle,
   Radar,
   RotateCcw,
   Search,
@@ -22,6 +21,7 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { LiveLabel } from "@/LiveLabel";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -106,10 +106,7 @@ export function WorkspaceStatusMark({
   if (creating) {
     return (
       <span role="img" aria-label="Creating workspace">
-        <LoaderCircle
-          className={cn("size-3 animate-spin", STATUS_MARK.pending)}
-          aria-hidden
-        />
+        <Spinner className={cn("size-3", STATUS_MARK.running)} aria-hidden />
       </span>
     );
   }
@@ -224,6 +221,8 @@ export function WorkspaceCard({
     <article
       className={cn(
         "group/workspace relative rounded-xl border border-transparent transition-[background-color,border-color,box-shadow,opacity] duration-150",
+        creating &&
+          "workspace-creation-card border-live-border/35 bg-live-background/25",
         selected && "border-border bg-muted/60",
         active &&
           "shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_6%,transparent)]",
@@ -367,12 +366,16 @@ export function WorkspaceCard({
         </ContextMenuContent>
       </ContextMenu>
 
-      {density === "detailed" && (
-        <WorkspaceActivityLine
-          workspace={workspace}
-          digest={digest}
-          session={session}
-        />
+      {creating ? (
+        <WorkspaceCreationProgress />
+      ) : (
+        density === "detailed" && (
+          <WorkspaceActivityLine
+            workspace={workspace}
+            digest={digest}
+            session={session}
+          />
+        )
       )}
 
       {density === "detailed" &&
@@ -762,19 +765,6 @@ function WorkspaceActivityLine({
   digest: CodeSessionDigest | undefined;
   session: CodeSessionSnapshot | undefined;
 }) {
-  if (workspace.status === "creating") {
-    return (
-      <div
-        className={cn(
-          "flex min-w-0 items-center gap-1.5 px-2.5 pb-2 pl-7 text-xs",
-          STATUS_TEXT.pending,
-        )}
-      >
-        <LoaderCircle className="size-3 shrink-0 animate-spin" aria-hidden />
-        <span className="min-w-0 flex-1 truncate">Creating workspace</span>
-      </div>
-    );
-  }
   // The checkout survived, so the workspace is usable — but the setup script
   // never finished, and nothing else on the card would say so.
   if (workspace.status === "setup_failed") {
@@ -845,6 +835,26 @@ function WorkspaceActivityLine({
           {age === "now" ? "now" : age}
         </span>
       )}
+    </div>
+  );
+}
+
+/** A quiet, optimistic handoff while the server creates the worktree. */
+function WorkspaceCreationProgress() {
+  return (
+    <div
+      className="px-2.5 pb-2 pl-7"
+      role="status"
+      aria-label="Creating workspace"
+      data-testid="workspace-creation-progress"
+    >
+      <LiveLabel live className="block truncate text-xs">
+        Creating workspace
+      </LiveLabel>
+      <span
+        className="workspace-creation-progress mt-1.5 block h-0.5 overflow-hidden rounded-full bg-live-border/20"
+        aria-hidden
+      />
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -68,6 +68,8 @@ type WorkspaceScenario =
   | "active"
   | "nested"
   | "start"
+  | "workspace-starting"
+  | "workspace-sending-message"
   | "session-create-failure"
   | "first-turn-failure"
   | "fork-first-turn-failure"
@@ -134,6 +136,13 @@ function subagentStorySpec(
   return isSubagentScenario(scenario) ? SUBAGENT_STORIES[scenario] : null;
 }
 
+function isWorkspaceStartupScenario(scenario: WorkspaceScenario): boolean {
+  return (
+    scenario === "workspace-starting" ||
+    scenario === "workspace-sending-message"
+  );
+}
+
 const repo: CodeRepoSnapshot = {
   id: "repo-tidebreak",
   root_path: "/Users/sam/tidebreak",
@@ -171,6 +180,14 @@ const workspace: CodeWorkspaceSnapshot = {
   branch_name: "thet/ui-pane-redesign",
   base_ref: "main",
   pr: pullRequest,
+};
+
+const startupWorkspace: CodeWorkspaceSnapshot = {
+  ...workspace,
+  title: "Smooth workspace creation",
+  worktree_path: "/Users/sam/tidebreak/worktrees/smooth-workspace-creation",
+  branch_name: "thet/smooth-workspace-creation",
+  pr: undefined,
 };
 
 const otherWorkspaces: CodeWorkspaceSnapshot[] = [
@@ -570,14 +587,22 @@ function updateDigests(scenario: WorkspaceScenario): CodeSessionDigest[] {
     watch_detail: "storybook build is still running",
     watch_cycles: 1,
   };
+  if (isWorkspaceStartupScenario(scenario)) return [needsYou, shipped];
   return scenario === "nested"
     ? [current, watch, needsYou, shipped]
     : [current, needsYou, shipped];
 }
 
 function storyClient(scenario: WorkspaceScenario): ApiClient {
+  const currentWorkspace = isWorkspaceStartupScenario(scenario)
+    ? startupWorkspace
+    : workspace;
+  const currentPrSnapshot = isWorkspaceStartupScenario(scenario)
+    ? { ...prSnapshot, dirty: false, ahead: 0, pr: undefined }
+    : prSnapshot;
   const sessions =
     scenario === "start" ||
+    scenario === "workspace-starting" ||
     scenario === "session-create-failure" ||
     scenario === "first-turn-failure" ||
     scenario === "loading" ||
@@ -592,7 +617,7 @@ function storyClient(scenario: WorkspaceScenario): ApiClient {
       ? () => pending<CodeWorkspaceSnapshot>()
       : scenario === "failure"
         ? () => Promise.reject(new Error("Could not reach this workspace."))
-        : async () => workspace;
+        : async () => currentWorkspace;
 
   return {
     getCodeWorkspace: loadWorkspace,
@@ -611,7 +636,7 @@ function storyClient(scenario: WorkspaceScenario): ApiClient {
       }),
     getCodeRepo: async () => repo,
     listCodeRepos: async () => [repo],
-    listCodeWorkspaces: async () => [workspace, ...otherWorkspaces],
+    listCodeWorkspaces: async () => [currentWorkspace, ...otherWorkspaces],
     getHarnessDoctor: async () => harnessDoctor,
     listCodeHarnessModels: async (kind: CodeSessionSnapshot["harness_kind"]) =>
       scenario === "settings-pending"
@@ -635,8 +660,8 @@ function storyClient(scenario: WorkspaceScenario): ApiClient {
       socketAfterOpen(() =>
         onNotice({ type: "snapshot", sessions: updateDigests(scenario) }),
       ),
-    getCodeWorkspacePr: async () => prSnapshot,
-    refreshCodeWorkspacePr: async () => prSnapshot,
+    getCodeWorkspacePr: async () => currentPrSnapshot,
+    refreshCodeWorkspacePr: async () => currentPrSnapshot,
     getCodeDeliveryPullRequestDetail: async () => ({
       summary: {
         id: `github.com/example/tidebreak#${prSnapshot.pr?.number ?? 0}`,
@@ -790,8 +815,8 @@ function storyClient(scenario: WorkspaceScenario): ApiClient {
       branch: workspace.branch_name,
       remote: "origin",
     }),
-    createCodePullRequest: async () => prSnapshot,
-    mergeCodePr: async () => prSnapshot,
+    createCodePullRequest: async () => currentPrSnapshot,
+    mergeCodePr: async () => currentPrSnapshot,
     startCodeWatch: async () => ({
       id: "watch-pane-redesign",
       workspace_id: workspace.id,
@@ -916,6 +941,7 @@ function resetStoryState(
     inspectorScope: null,
     pendingComposerPrompt: null,
     composerActionScope: null,
+    workspaceStartups: {},
     newWorkspaceOpen: false,
     addRepoOpen: false,
   });
@@ -946,6 +972,19 @@ function WorkspacePageStory({
 }) {
   const [state] = useState(() => {
     resetStoryState(reviewOpen, sidebarCollapsed, storedInspectorLayout);
+    if (
+      scenario === "workspace-starting" ||
+      scenario === "workspace-sending-message"
+    ) {
+      useCodeUiStore.getState().setWorkspaceStartup(workspace.id, {
+        harness: "claude_code",
+        hasFirstMessage: true,
+        phase:
+          scenario === "workspace-starting"
+            ? "starting_session"
+            : "sending_message",
+      });
+    }
     const client = storyClient(scenario);
     return { client, router: storyRouter(client, initialUrl) };
   });
@@ -1452,6 +1491,32 @@ export const EmptySubagentTranscript: Story = {
 /** A workspace with no session keeps the first prompt calm and centered. */
 export const StartSession: Story = {
   args: { scenario: "start", reviewOpen: false },
+};
+
+/** The workspace page carries the handoff while the first agent starts. */
+export const StartingSession: Story = {
+  args: { scenario: "workspace-starting", reviewOpen: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const status = await canvas.findByRole("status", {
+      name: "Starting session",
+    });
+    await expect(status).toHaveTextContent("Starting Claude Code");
+    await expect(status).toHaveTextContent("Your first message is queued.");
+  },
+};
+
+/** Once the agent exists, the same surface carries the first message into chat. */
+export const SendingFirstMessage: Story = {
+  args: { scenario: "workspace-sending-message", reviewOpen: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const status = await canvas.findByRole("status", {
+      name: "Starting session",
+    });
+    await expect(status).toHaveTextContent("Claude Code ready");
+    await expect(status).toHaveTextContent("Sending your first message");
+  },
 };
 
 /** A creation failure leaves the start surface mounted and restores its draft. */

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -87,7 +87,7 @@ export const SelectedAndActive: Story = {
   args: { selected: true, active: true },
 };
 
-/** A create appears in the rail while the worktree and first session start. */
+/** The rail hands off from the composer while the server creates the worktree. */
 export const Creating: Story = {
   args: {
     workspace: {
@@ -101,6 +101,15 @@ export const Creating: Story = {
     },
     visibleMeta: { repoChip: true, branch: false },
     commands: [],
+  },
+};
+
+/** Compact rails keep the same transition instead of collapsing to a spinner. */
+export const CreatingCompact: Story = {
+  args: {
+    ...Creating.args,
+    density: "compact",
+    visibleMeta: { repoChip: false, branch: false },
   },
 };
 

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -1330,6 +1330,58 @@ body {
     }
   }
 
+  .workspace-creation-card {
+    animation: workspace-creation-enter 180ms ease-out both;
+  }
+
+  .workspace-creation-progress {
+    position: relative;
+  }
+
+  .workspace-creation-progress::after {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    left: 0;
+    width: 42%;
+    border-radius: inherit;
+    background: var(--live);
+    animation: workspace-creation-progress 1.6s ease-in-out infinite;
+  }
+
+  @keyframes workspace-creation-enter {
+    from {
+      opacity: 0;
+      transform: translateY(-0.125rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes workspace-creation-progress {
+    from {
+      transform: translateX(-120%);
+    }
+    to {
+      transform: translateX(340%);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .workspace-creation-card {
+      animation: none;
+    }
+
+    .workspace-creation-progress::after {
+      width: 100%;
+      opacity: 0.45;
+      animation: none;
+      transform: none;
+    }
+  }
+
   @keyframes code-reveal {
     from {
       opacity: 0;


### PR DESCRIPTION
## Summary

- animate the workspace rail while a worktree is being created
- show a page-level startup handoff until the first session and message are ready
- restore the manual session composer when automatic startup fails
- add Storybook coverage for detailed, compact, and page-level transition states

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeWorkspacePage.dom.test.tsx src/code/NewWorkspaceDialog.dom.test.tsx src/code/WorkspaceCard.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui build`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- reviewed 2x Storybook captures in light, dark, high-contrast light, and high-contrast dark