### PR TITLE
feat(desktop): improve release update notices

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -54,11 +54,13 @@ categories:
   # fallback in the first draft. The first release version is chosen manually.
   - type: version-resolver
     semver-increment: patch
-category-template: "### $TITLE"
+category-template: "## $TITLE"
 change-template: "- $TITLE ([#$NUMBER]($URL)) by @$AUTHOR"
 change-title-escapes: '\<*_&'
 no-changes-template: "- No user-facing changes."
 template: |
-  ## What's Changed
+  Thanks for using Tidebreak ❤️
+
+  # What's Changed
 
   $CHANGES

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -1074,6 +1074,10 @@ describe("app shell", () => {
     const user = userEvent.setup();
     await mountApp();
 
+    expect(await screen.findByLabelText("Update ready")).toHaveTextContent(
+      "Tidebreak 0.9.0 is downloaded and ready to install.",
+    );
+
     await user.click(
       await screen.findByRole("button", { name: "Settings, update ready" }),
     );
@@ -1099,6 +1103,32 @@ describe("app shell", () => {
       await screen.findByRole("button", { name: "Restart and update" }),
     );
     await waitFor(() => expect(restartDesktop).toHaveBeenCalledOnce());
+  });
+
+  it("keeps a dismissed update card hidden for the same version", async () => {
+    desktopUpdateState.status = "ready";
+    desktopUpdateState.version = "0.9.0";
+    const user = userEvent.setup();
+    const first = await mountApp();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Dismiss update notice" }),
+    );
+    expect(screen.queryByLabelText("Update ready")).not.toBeInTheDocument();
+    expect(
+      window.localStorage.getItem("tidebreak.dismissed-update-version"),
+    ).toBe("0.9.0");
+
+    first.unmount();
+    const second = await mountApp();
+    expect(screen.queryByLabelText("Update ready")).not.toBeInTheDocument();
+
+    second.unmount();
+    desktopUpdateState.version = "0.10.0";
+    await mountApp();
+    expect(await screen.findByLabelText("Update ready")).toHaveTextContent(
+      "Tidebreak 0.10.0 is downloaded and ready to install.",
+    );
   });
 
   it("creates a project from the dialog and opens a chat inside it", async () => {

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -89,6 +89,7 @@ import { CommandPaletteDialog } from "./CommandPaletteDialog";
 import { ShortcutsDialog } from "./ShortcutsDialog";
 import { useUiStore } from "./UiStore";
 import { UPDATE_CHECK_REQUESTED_EVENT, useDesktopUpdates } from "./updates";
+import { UpdateReadyCard } from "./UpdateReadyCard";
 
 /**
  * Raised by the native "Close Tab" menu item, which owns Cmd+W.
@@ -98,6 +99,8 @@ import { UPDATE_CHECK_REQUESTED_EVENT, useDesktopUpdates } from "./updates";
  * for Cmd+W means the tab in front of them.
  */
 const CLOSE_TAB_REQUESTED_EVENT = "desktop-close-tab-requested";
+const DISMISSED_UPDATE_VERSION_KEY = "tidebreak.dismissed-update-version";
+const UNKNOWN_UPDATE_VERSION = "unknown";
 
 /**
  * Run `handler` whenever the native host raises `event`.
@@ -212,6 +215,9 @@ export function AppShell() {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [status, setStatus] = useState("starting…");
+  const [dismissedUpdateVersion, setDismissedUpdateVersion] = useState(() =>
+    window.localStorage.getItem(DISMISSED_UPDATE_VERSION_KEY),
+  );
   const openChatId = useActiveChatId();
   const savingTitle = useChatListStore((state) => state.savingTitle);
   const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
@@ -894,6 +900,14 @@ export function AppShell() {
     if (confirmed) await desktopUpdates.restart();
   }
 
+  function dismissUpdateNotice() {
+    const version = desktopUpdates.state.version;
+    setDismissedUpdateVersion(version ?? UNKNOWN_UPDATE_VERSION);
+    if (version) {
+      window.localStorage.setItem(DISMISSED_UPDATE_VERSION_KEY, version);
+    }
+  }
+
   /**
    * Run boot again from the top.
    *
@@ -1026,6 +1040,15 @@ export function AppShell() {
           )}
           <SidebarExpandStrip macOverlay={macOverlayTitlebar} />
           <ComputerUseIndicator />
+          {desktopUpdates.state.status === "ready" &&
+            dismissedUpdateVersion !==
+              (desktopUpdates.state.version ?? UNKNOWN_UPDATE_VERSION) && (
+              <UpdateReadyCard
+                version={desktopUpdates.state.version}
+                onRestart={() => void onRestartForUpdate()}
+                onDismiss={dismissUpdateNotice}
+              />
+            )}
           {/* Each route renders its own rail beside its content — see RouteFrame. */}
           <div className="app-body">
             <Outlet />

--- a/crates/tidebreak-desktop/ui/src/UpdateReadyCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/UpdateReadyCard.dom.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { releaseNotesUrl, UpdateReadyCard } from "./UpdateReadyCard";
+
+const openInBrowser = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("./openInBrowser", () => ({ openInBrowser }));
+
+describe("UpdateReadyCard", () => {
+  it("offers the update, release notes, and dismissal", async () => {
+    const user = userEvent.setup();
+    const onRestart = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <UpdateReadyCard
+        version="0.59.0"
+        onRestart={onRestart}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(
+      screen.getByText("Tidebreak 0.59.0 is downloaded and ready to install."),
+    ).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Release notes" }));
+    expect(openInBrowser).toHaveBeenCalledWith(
+      "https://github.com/brightwave-inc/tidebreak/releases/tag/v0.59.0",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Restart and update" }),
+    );
+    expect(onRestart).toHaveBeenCalledOnce();
+
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss update notice" }),
+    );
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("links to the latest release when the version is unavailable", () => {
+    expect(releaseNotesUrl(null)).toBe(
+      "https://github.com/brightwave-inc/tidebreak/releases/latest",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/UpdateReadyCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/UpdateReadyCard.tsx
@@ -1,0 +1,69 @@
+import { ExternalLink, RefreshCw, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { openInBrowser } from "@/openInBrowser";
+
+const RELEASES_URL = "https://github.com/brightwave-inc/tidebreak/releases";
+
+export function releaseNotesUrl(version: string | null): string {
+  const normalized = version?.trim().replace(/^v/, "");
+  return normalized
+    ? `${RELEASES_URL}/tag/v${encodeURIComponent(normalized)}`
+    : `${RELEASES_URL}/latest`;
+}
+
+export function UpdateReadyCard({
+  version,
+  onRestart,
+  onDismiss,
+}: {
+  version: string | null;
+  onRestart: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <aside
+      className="fixed right-4 bottom-4 z-40 w-[min(22rem,calc(100vw-2rem))] rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-lg"
+      aria-label="Update ready"
+    >
+      <button
+        type="button"
+        className="absolute top-2.5 right-2.5 grid size-7 cursor-pointer place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/25"
+        aria-label="Dismiss update notice"
+        onClick={onDismiss}
+      >
+        <X className="size-4" aria-hidden="true" />
+      </button>
+
+      <div className="flex items-start gap-3 pr-7">
+        <RefreshCw
+          className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <p className="text-md font-semibold">Update ready</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {version
+              ? `Tidebreak ${version} is downloaded and ready to install.`
+              : "A Tidebreak update is downloaded and ready to install."}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <Button type="button" size="sm" onClick={onRestart}>
+          Restart and update
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => void openInBrowser(releaseNotesUrl(version))}
+        >
+          Release notes
+          <ExternalLink aria-hidden="true" />
+        </Button>
+      </div>
+    </aside>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/UpdateReadyCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/UpdateReadyCard.stories.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { UpdateReadyCard } from "@/UpdateReadyCard";
+
+function UpdateReadyCardStory({ version }: { version: string | null }) {
+  const [visible, setVisible] = useState(true);
+  return (
+    <div className="h-screen bg-page-background p-8">
+      <div className="mx-auto max-w-2xl rounded-xl border border-border-subtle bg-background p-8">
+        <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          Conversation
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight">
+          Plan the next release
+        </h1>
+        <p className="mt-2 max-w-lg text-sm text-muted-foreground">
+          The card stays available without blocking the work underneath it.
+        </p>
+      </div>
+      {visible && (
+        <UpdateReadyCard
+          version={version}
+          onRestart={fn()}
+          onDismiss={() => setVisible(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+const meta = {
+  title: "Shell/Update ready card",
+  component: UpdateReadyCardStory,
+  parameters: { layout: "fullscreen" },
+  args: { version: "0.59.0" },
+} satisfies Meta<typeof UpdateReadyCardStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ready: Story = {};
+
+export const VersionUnavailable: Story = {
+  args: { version: null },
+};

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -70,9 +70,11 @@ Documentation and other maintenance-only types carry no `release-note:*` label
 and appear in a trailing **Maintenance** section instead — listed, not dropped,
 because a maintenance change can still matter to someone updating (a schema
 baseline rebuild, a toolchain requirement). Every merged PR is accounted for in
-the notes. In the rendered
-notes, the section heading supplies the type, so the draft formatter removes the
-redundant Conventional Commit prefix from each PR title. Maintenance entries
+the notes. The rendered notes open with a short thank-you. A large **What's
+Changed** heading introduces level-two release sections, and repeated scopes
+use level-three headings. The section heading supplies the type, so the draft
+formatter removes the redundant Conventional Commit prefix from each PR title.
+Maintenance entries
 keep their full prefixes: that section mixes types, so the prefix is the
 information. When a category has
 multiple user-facing changes with the same scope, the formatter groups them

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -4,6 +4,19 @@ import { pathToFileURL } from "node:url";
 
 import { parsePrTitle } from "./check-pr-title.mjs";
 
+const THANK_YOU = "Thanks for using Tidebreak ❤️";
+
+const CATEGORY_TITLES = new Set([
+  "Breaking Changes",
+  "New Features",
+  "Bug Fixes",
+  "Performance Improvements",
+  "Dependency Updates",
+  "Reverted Changes",
+  "Maintenance",
+  "Other Changes",
+]);
+
 const SCOPED_CATEGORY_TITLES = new Set([
   "Breaking Changes",
   "New Features",
@@ -94,13 +107,13 @@ function formatCategory(lines) {
   const formatted = [];
   for (const [scope, scopeChanges] of groupedScopes) {
     if (formatted.length > 0) formatted.push("");
-    formatted.push(`#### ${scopeHeading(scope)}`, ...scopeChanges);
+    formatted.push(`### ${scopeHeading(scope)}`, ...scopeChanges);
   }
   if (flatLines.length > 0 && formatted.length > 0) {
     // A bare blank line between two bullet runs makes GitHub render both as
     // one loose list. A heading closes the grouped list before the compact
     // inline scope changes begin.
-    formatted.push("", "#### Other", ...flatLines);
+    formatted.push("", "### Other", ...flatLines);
   } else {
     formatted.push(...flatLines);
   }
@@ -113,23 +126,45 @@ export function formatReleaseNotes(body) {
   }
 
   const lines = body.split("\n");
+  if (lines[0] === THANK_YOU) {
+    lines.shift();
+    if (lines[0] === "") lines.shift();
+  }
+
   const formatted = [];
   for (let index = 0; index < lines.length; ) {
-    const heading = /^### (.+)$/.exec(lines[index]);
-    if (!heading || !SCOPED_CATEGORY_TITLES.has(heading[1])) {
+    if (/^#{1,2} What's Changed$/.test(lines[index])) {
+      formatted.push("# What's Changed");
+      index += 1;
+      continue;
+    }
+
+    const heading = /^#{2,3} (.+)$/.exec(lines[index]);
+    if (!heading || !CATEGORY_TITLES.has(heading[1])) {
       formatted.push(lines[index]);
       index += 1;
       continue;
     }
 
-    formatted.push(lines[index]);
+    formatted.push(`## ${heading[1]}`);
     const categoryStart = index + 1;
     index = categoryStart;
-    while (index < lines.length && !/^### /.test(lines[index])) index += 1;
-    formatted.push(...formatCategory(lines.slice(categoryStart, index)));
+    while (index < lines.length) {
+      const nextHeading = /^#{2,3} (.+)$/.exec(lines[index]);
+      if (nextHeading && CATEGORY_TITLES.has(nextHeading[1])) break;
+      index += 1;
+    }
+
+    const categoryLines = lines.slice(categoryStart, index);
+    formatted.push(
+      ...(SCOPED_CATEGORY_TITLES.has(heading[1]) &&
+      !categoryLines.some((line) => /^### /.test(line))
+        ? formatCategory(categoryLines)
+        : categoryLines),
+    );
   }
 
-  return formatted.join("\n");
+  return `${THANK_YOU}\n\n${formatted.join("\n")}`;
 }
 
 async function main() {

--- a/scripts/format-release-notes.test.mjs
+++ b/scripts/format-release-notes.test.mjs
@@ -20,20 +20,22 @@ test("separates grouped and singleton scopes into tight Markdown lists", () => {
 
   assert.equal(
     formatReleaseNotes(notes),
-    `## What's Changed
+    `Thanks for using Tidebreak ❤️
 
-### New Features
-#### Desktop
+# What's Changed
+
+## New Features
+### Desktop
 - add document search ([#12](https://example.com/12)) by @octo
 - add keyboard shortcuts ([#15](https://example.com/15)) by @octo
 
-#### Other
+### Other
 - add a default workspace ([#13](https://example.com/13)) by @octo
 - **Core:** add saved searches ([#14](https://example.com/14)) by @octo
 
-### Bug Fixes
+## Bug Fixes
 - **Desktop:** prevent a startup crash ([#16](https://example.com/16)) by @octo
-### Other Changes
+## Other Changes
 - docs: update the setup guide ([#17](https://example.com/17)) by @octo
 `,
   );
@@ -46,7 +48,9 @@ test("keeps unscoped release entries in their category without a subheading", ()
 
   assert.equal(
     formatReleaseNotes(notes),
-    `### Dependency Updates
+    `Thanks for using Tidebreak ❤️
+
+## Dependency Updates
 - update sqlite ([#17](https://example.com/17)) by @octo
 `,
   );
@@ -61,9 +65,11 @@ test("uses readable acronyms in singleton scope prefixes", () => {
 
   assert.equal(
     formatReleaseNotes(notes),
-    `### Breaking Changes
+    `Thanks for using Tidebreak ❤️
+
+## Breaking Changes
 - **MCP:** replace the protocol ([#18](https://example.com/18)) by @octo
-### Other Changes
+## Other Changes
 - Plain historical change ([#19](https://example.com/19)) by @octo
 `,
   );
@@ -72,6 +78,26 @@ test("uses readable acronyms in singleton scope prefixes", () => {
 test("keeps historical titles with malformed scopes without crashing", () => {
   const notes = `### Bug Fixes
 - fix(ui/): keep release automation running ([#20](https://example.com/20)) by @octo
+`;
+
+  assert.equal(
+    formatReleaseNotes(notes),
+    `Thanks for using Tidebreak ❤️
+
+## Bug Fixes
+- fix(ui/): keep release automation running ([#20](https://example.com/20)) by @octo
+`,
+  );
+});
+
+test("keeps the larger hierarchy stable when formatting an existing draft", () => {
+  const notes = `Thanks for using Tidebreak ❤️
+
+# What's Changed
+
+## New Features
+### Desktop
+- add document search ([#12](https://example.com/12)) by @octo
 `;
 
   assert.equal(formatReleaseNotes(notes), notes);


### PR DESCRIPTION
## Summary

- make generated release notes easier to scan with a thank-you and clearer heading levels
- show a dismissible update-ready card in the bottom-right corner
- link the card to the matching GitHub release and restore it for later versions
- add Storybook coverage for versioned and fallback release links

## Validation

- `node --test scripts/format-release-notes.test.mjs` (5 tests passed)
- focused desktop UI tests (33 tests passed)
- full desktop UI suite (2,289 tests passed)
- TypeScript and Biome lint passed
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- Storybook screenshots checked at desktop and narrow widths across all four themes
- `git diff --check`