### PR TITLE
feat(code): add Git source control settings

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -261,6 +261,32 @@ pub async fn set_workspace_title_if(
     Ok(result.rows_affected == 1)
 }
 
+/// Set a workspace branch only while its generated title and branch still
+/// match the values the background naming task observed.
+pub async fn set_workspace_branch_if(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: WorkspaceId,
+    title: &str,
+    expected_branch: &str,
+    branch: &str,
+) -> Result<bool> {
+    let result = entities::code_workspace::Entity::update_many()
+        .col_expr(
+            entities::code_workspace::Column::BranchName,
+            sea_orm::sea_query::Expr::value(branch.to_owned()),
+        )
+        .filter(entities::code_workspace::Column::Id.eq(id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_workspace::Column::Title.eq(title))
+        .filter(entities::code_workspace::Column::BranchName.eq(expected_branch))
+        .filter(entities::code_workspace::Column::Status.eq(CodeWorkspaceStatus::Active.as_str()))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 /// Delete a workspace row. Used to roll back a failed create that left no checkout.
 pub async fn delete_workspace(store: &DbStore, owner: &OwnerId, id: WorkspaceId) -> Result<bool> {
     let result = entities::code_workspace::Entity::delete_many()

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -540,6 +540,11 @@ export class ApiClient {
     computer_use_enabled?: boolean;
     code_turn_recaps_enabled?: boolean;
     rewrite_closing_messages?: boolean;
+    git_source_control?: {
+      auto_rename_branches?: boolean;
+      branch_prefix_mode?: "account" | "custom" | "none";
+      custom_branch_prefix?: string | null;
+    };
   }): Promise<RuntimeSettings> {
     return this.json("/settings", {
       method: "PUT",

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -1,4 +1,5 @@
 import {
+  type BranchPrefixMode as WireBranchPrefixMode,
   type AppDetail as WireAppDetail,
   type AppGrantState as WireAppGrantState,
   type AppInvokeRefusalKind,
@@ -429,6 +430,7 @@ export type ModelCatalog = {
 
 /** Global runtime settings (`GET/PUT /settings`). */
 export type RuntimeSettings = Settings;
+export type BranchPrefixMode = WireBranchPrefixMode;
 
 /** Host-global compaction cadence, as `GET/PUT /settings` carries it. */
 export type { CompactionSettings };

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -4281,7 +4281,7 @@ code_turn_recaps_enabled: boolean,
  * Whether completed code turns rewrite their closing message into lucid
  * prose. Default off.
  */
-rewrite_closing_messages: boolean, 
+rewrite_closing_messages: boolean,
 /**
  * How new code repositories name workspace branches for this user.
  */

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -581,6 +581,8 @@ export type BoundedError = {
  */
 message: string, };
 
+export type BranchPrefixMode = "account" | "custom" | "none";
+
 /**
  * Identifies one tool call, stable across its request/approval/result.
  */
@@ -2610,6 +2612,8 @@ export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hin
  */
 member_catalog?: string, sign_in: SignInProgress, };
 
+export type GitSourceControlSettings = { auto_rename_branches: boolean, branch_prefix_mode: BranchPrefixMode, custom_branch_prefix?: string, account_prefix?: string, effective_branch_prefix: string, };
+
 /**
  * How far a standing grant reaches.
  *
@@ -4277,7 +4281,11 @@ code_turn_recaps_enabled: boolean,
  * Whether completed code turns rewrite their closing message into lucid
  * prose. Default off.
  */
-rewrite_closing_messages: boolean, };
+rewrite_closing_messages: boolean, 
+/**
+ * How new code repositories name workspace branches for this user.
+ */
+git_source_control: GitSourceControlSettings, };
 
 /**
  * Renderer-safe progress of the current sign-in attempt.

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -43,6 +43,11 @@ describe("AgentsPanel", () => {
       computer_use_enabled: true,
       code_turn_recaps_enabled: true,
       rewrite_closing_messages: false,
+      git_source_control: {
+        auto_rename_branches: true,
+        branch_prefix_mode: "account",
+        effective_branch_prefix: "tidebreak/",
+      },
     };
     const putSettings = vi.fn().mockResolvedValue({
       ...settings,
@@ -103,6 +108,11 @@ describe("AgentsPanel", () => {
       computer_use_enabled: true,
       code_turn_recaps_enabled: true,
       rewrite_closing_messages: false,
+      git_source_control: {
+        auto_rename_branches: true,
+        branch_prefix_mode: "account",
+        effective_branch_prefix: "tidebreak/",
+      },
     };
     const putSettings = vi.fn().mockResolvedValue({
       ...settings,

--- a/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.dom.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { RuntimeSettings } from "@/api/types";
+import { GitSourceControlPanel } from "./GitSourceControlPanel";
+
+const initial: RuntimeSettings = {
+  model: null,
+  has_api_key: false,
+  chat_defaults: {
+    model: null,
+    reasoning_effort: null,
+    permission_mode: null,
+    network_policy: null,
+  },
+  max_active_background_agents: 6,
+  sandbox_agent_checkin_steps: 18,
+  sandbox_agent_error_checkin: 4,
+  compaction: {
+    threshold_fraction: 0.78,
+    target_fraction: 0.52,
+    min_threshold_tokens: 16_000,
+    protect_recent_messages: 8,
+  },
+  model_visibility_overrides: {},
+  computer_use_enabled: true,
+  code_turn_recaps_enabled: true,
+  rewrite_closing_messages: false,
+  git_source_control: {
+    auto_rename_branches: true,
+    branch_prefix_mode: "account",
+    account_prefix: "alex/",
+    effective_branch_prefix: "alex/",
+  },
+};
+
+afterEach(cleanup);
+
+describe("GitSourceControlPanel", () => {
+  it("saves branch renaming and custom prefix choices", async () => {
+    const putSettings = vi.fn(async (body) => ({
+      ...initial,
+      git_source_control: {
+        ...initial.git_source_control,
+        ...body.git_source_control,
+        custom_branch_prefix: body.git_source_control?.custom_branch_prefix
+          ? `${body.git_source_control.custom_branch_prefix}/`
+          : undefined,
+        effective_branch_prefix: body.git_source_control?.custom_branch_prefix
+          ? `${body.git_source_control.custom_branch_prefix}/`
+          : initial.git_source_control.effective_branch_prefix,
+      },
+    }));
+    const user = userEvent.setup();
+    render(
+      <GitSourceControlPanel
+        client={{ getSettings: async () => initial, putSettings } as never}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("switch", {
+        name: "Rename generated branches automatically",
+      }),
+    );
+    expect(putSettings).toHaveBeenCalledWith({
+      git_source_control: { auto_rename_branches: false },
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Branch prefix" }));
+    await user.click(await screen.findByRole("option", { name: "Custom" }));
+    const input = await screen.findByLabelText("Custom prefix");
+    fireEvent.change(input, { target: { value: "team/alex" } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(putSettings).toHaveBeenCalledWith({
+        git_source_control: { custom_branch_prefix: "team/alex" },
+      }),
+    );
+    expect(screen.getByText("team/alex/fix-flaky-auth-retry")).toBeVisible();
+  });
+
+  it("restores a toggle when the server rejects the change", async () => {
+    const user = userEvent.setup();
+    render(
+      <GitSourceControlPanel
+        client={
+          {
+            getSettings: async () => initial,
+            putSettings: async () => {
+              throw new Error("Git settings could not be saved.");
+            },
+          } as never
+        }
+      />,
+    );
+
+    const toggle = await screen.findByRole("switch", {
+      name: "Rename generated branches automatically",
+    });
+    await user.click(toggle);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Git settings could not be saved.",
+    );
+    expect(toggle).toBeChecked();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import type { ApiClient } from "@/api/client";
+import type { BranchPrefixMode, RuntimeSettings } from "@/api/types";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { friendlyErrorMessage } from "@/lib/utils";
+import {
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+} from "./primitives";
+
+type GitSettingsClient = Pick<ApiClient, "getSettings" | "putSettings">;
+type GitSettings = RuntimeSettings["git_source_control"];
+
+function prefixStem(prefix: string | undefined): string {
+  return prefix?.replace(/\/+$/, "") ?? "";
+}
+
+export function GitSourceControlPanel({
+  client,
+}: {
+  client: GitSettingsClient;
+}) {
+  const [settings, setSettings] = useState<GitSettings | null>(null);
+  const [customPrefix, setCustomPrefix] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void client
+      .getSettings()
+      .then((next) => {
+        if (cancelled) return;
+        setSettings(next.git_source_control);
+        setCustomPrefix(
+          prefixStem(next.git_source_control.custom_branch_prefix),
+        );
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled) {
+          setError(
+            friendlyErrorMessage(caught, "Could not load Git settings."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  async function save(
+    update: Parameters<
+      GitSettingsClient["putSettings"]
+    >[0]["git_source_control"],
+    rollback?: { settings: GitSettings; customPrefix: string },
+  ) {
+    if (!update) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const next = await client.putSettings({ git_source_control: update });
+      setSettings(next.git_source_control);
+      setCustomPrefix(prefixStem(next.git_source_control.custom_branch_prefix));
+    } catch (caught) {
+      if (rollback) {
+        setSettings(rollback.settings);
+        setCustomPrefix(rollback.customPrefix);
+      }
+      const message = friendlyErrorMessage(
+        caught,
+        "Could not save Git settings.",
+      );
+      setError(message);
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function selectMode(mode: BranchPrefixMode) {
+    if (!settings) return;
+    const rollback = { settings, customPrefix };
+    if (mode === "custom") {
+      const custom =
+        customPrefix || prefixStem(settings.account_prefix) || "tidebreak";
+      setCustomPrefix(custom);
+      setSettings({
+        ...settings,
+        branch_prefix_mode: mode,
+        custom_branch_prefix: `${custom}/`,
+        effective_branch_prefix: `${custom}/`,
+      });
+      void save(
+        { branch_prefix_mode: mode, custom_branch_prefix: custom },
+        rollback,
+      );
+      return;
+    }
+    setSettings({
+      ...settings,
+      branch_prefix_mode: mode,
+      effective_branch_prefix:
+        mode === "none" ? "" : (settings.account_prefix ?? "tidebreak/"),
+    });
+    void save({ branch_prefix_mode: mode }, rollback);
+  }
+
+  const previewPrefix =
+    settings?.branch_prefix_mode === "custom"
+      ? `${customPrefix.trim().replace(/\/+$/, "")}${customPrefix.trim() ? "/" : ""}`
+      : (settings?.effective_branch_prefix ?? "");
+
+  return (
+    <SettingsPanel
+      title="Git & source control"
+      description="Choose how Tidebreak names branches for new code workspaces."
+      busy={loading || saving}
+    >
+      {error && <SettingsError>{error}</SettingsError>}
+      {loading && !settings ? (
+        <p className="text-sm text-muted-foreground">Loading Git settings…</p>
+      ) : (
+        settings && (
+          <SettingsSection
+            title="Branch names"
+            description="These defaults apply when you add a repository. Existing repositories keep their own branch prefix."
+          >
+            <SettingsField
+              label="Rename generated branches automatically"
+              hint="After Tidebreak names an untitled workspace, it updates the generated local branch. Pushed, remote, user-renamed, and pull request branches stay unchanged."
+            >
+              <Switch
+                checked={settings.auto_rename_branches}
+                disabled={saving}
+                onCheckedChange={(enabled) => {
+                  const rollback = { settings, customPrefix };
+                  setSettings({ ...settings, auto_rename_branches: enabled });
+                  void save({ auto_rename_branches: enabled }, rollback);
+                }}
+                aria-label="Rename generated branches automatically"
+              />
+            </SettingsField>
+            <SettingsField
+              label="Branch prefix"
+              hint={
+                settings.branch_prefix_mode === "account" &&
+                !settings.account_prefix
+                  ? "No Git account is available, so Tidebreak uses tidebreak/."
+                  : "The prefix is copied into each repository you add."
+              }
+            >
+              <Select
+                value={settings.branch_prefix_mode}
+                disabled={saving}
+                onValueChange={(value) => selectMode(value as BranchPrefixMode)}
+              >
+                <SelectTrigger aria-label="Branch prefix">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="account">
+                    Git account
+                    {settings.account_prefix
+                      ? ` (${prefixStem(settings.account_prefix)})`
+                      : ""}
+                  </SelectItem>
+                  <SelectItem value="custom">Custom</SelectItem>
+                  <SelectItem value="none">No prefix</SelectItem>
+                </SelectContent>
+              </Select>
+            </SettingsField>
+            {settings.branch_prefix_mode === "custom" && (
+              <SettingsField
+                label="Custom prefix"
+                hint="Use a valid Git branch prefix. Tidebreak adds the trailing slash."
+              >
+                <Input
+                  className="font-mono"
+                  aria-label="Custom prefix"
+                  value={customPrefix}
+                  disabled={saving}
+                  spellCheck={false}
+                  placeholder="team/alex"
+                  onChange={(event) => setCustomPrefix(event.target.value)}
+                  onBlur={() => {
+                    if (customPrefix.trim()) {
+                      void save({ custom_branch_prefix: customPrefix });
+                    }
+                  }}
+                />
+              </SettingsField>
+            )}
+            <div className="rounded-lg border border-border-subtle bg-muted px-3 py-2.5">
+              <p className="text-xs text-muted-foreground">Example branch</p>
+              <p className="mt-1 truncate font-mono text-sm text-foreground">
+                {previewPrefix}fix-flaky-auth-retry
+              </p>
+            </div>
+          </SettingsSection>
+        )
+      )}
+    </SettingsPanel>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -6,6 +6,7 @@ import {
   Cpu,
   Gauge,
   Globe,
+  GitBranch,
   KeyRound,
   Palette,
   RefreshCw,
@@ -37,6 +38,7 @@ import { VoiceTranscriptionPanel } from "./VoiceTranscriptionPanel";
 import { CodingHarnessesPanel } from "./CodingHarnessesPanel";
 import { QuickActionsPanel } from "./QuickActionsPanel";
 import { ChannelsPanel } from "./ChannelsPanel";
+import { GitSourceControlPanel } from "./GitSourceControlPanel";
 
 /**
  * Each section reads what it needs from the shell context rather than being
@@ -197,6 +199,11 @@ function ChannelsSection() {
   return <ChannelsPanel client={client} />;
 }
 
+function GitSourceControlSection() {
+  const { client } = useApp();
+  return <GitSourceControlPanel client={client} />;
+}
+
 export type SettingsSectionDef = {
   /** The path segment under `/settings`, and its address. */
   path: string;
@@ -328,6 +335,14 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     icon: Blocks,
     iconClass: "text-icon-blue",
     Component: ConnectedAppsSection,
+  },
+  {
+    path: "git-source-control",
+    label: "Git & source control",
+    group: "application",
+    icon: GitBranch,
+    iconClass: "text-icon-blue",
+    Component: GitSourceControlSection,
   },
   {
     path: "permissions",

--- a/crates/tidebreak-desktop/ui/src/sidebar/SettingsSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SettingsSidebar.dom.test.tsx
@@ -52,5 +52,10 @@ describe("SettingsSidebar", () => {
     expect(
       within(application).getByRole("button", { name: "Updates" }),
     ).toBeVisible();
+    expect(
+      within(application).getByRole("button", {
+        name: "Git & source control",
+      }),
+    ).toBeVisible();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/stories/GitSourceControlPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/GitSourceControlPanel.stories.tsx
@@ -1,0 +1,156 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import type { RuntimeSettings } from "@/api/types";
+import { GitSourceControlPanel } from "@/settings/GitSourceControlPanel";
+import { storySettings } from "./SettingsStoryHarness";
+
+function settings(
+  git: Partial<RuntimeSettings["git_source_control"]> = {},
+): RuntimeSettings {
+  return {
+    ...storySettings,
+    git_source_control: {
+      ...storySettings.git_source_control,
+      ...git,
+    },
+  };
+}
+
+function client(
+  initial: RuntimeSettings,
+  options: {
+    loading?: boolean;
+    loadFailure?: boolean;
+    saveFailure?: boolean;
+  } = {},
+) {
+  let stored = initial;
+  return {
+    getSettings: options.loading
+      ? () => new Promise<RuntimeSettings>(() => undefined)
+      : options.loadFailure
+        ? async () => {
+            throw new Error("Git settings could not be loaded.");
+          }
+        : async () => stored,
+    putSettings: fn(async (body) => {
+      if (options.saveFailure) {
+        throw new Error("Git settings could not be saved.");
+      }
+      const update = body.git_source_control ?? {};
+      const mode =
+        update.branch_prefix_mode ??
+        stored.git_source_control.branch_prefix_mode;
+      const custom =
+        update.custom_branch_prefix === undefined
+          ? stored.git_source_control.custom_branch_prefix
+          : update.custom_branch_prefix
+            ? `${update.custom_branch_prefix.replace(/\/+$/, "")}/`
+            : undefined;
+      const effective =
+        mode === "none"
+          ? ""
+          : mode === "custom"
+            ? (custom ?? "tidebreak/")
+            : (stored.git_source_control.account_prefix ?? "tidebreak/");
+      stored = {
+        ...stored,
+        git_source_control: {
+          ...stored.git_source_control,
+          ...update,
+          branch_prefix_mode: mode,
+          custom_branch_prefix: custom,
+          effective_branch_prefix: effective,
+        },
+      };
+      return stored;
+    }),
+  };
+}
+
+const accountClient = client(settings());
+
+const meta = {
+  title: "Settings/Git & source control",
+  component: GitSourceControlPanel,
+  parameters: { layout: "fullscreen" },
+  args: { client: accountClient as never },
+} satisfies Meta<typeof GitSourceControlPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AccountPrefix: Story = {};
+
+export const CustomPrefix: Story = {
+  args: {
+    client: client(
+      settings({
+        branch_prefix_mode: "custom",
+        custom_branch_prefix: "platform/alex/",
+        effective_branch_prefix: "platform/alex/",
+      }),
+    ) as never,
+  },
+};
+
+export const NoPrefix: Story = {
+  args: {
+    client: client(
+      settings({
+        branch_prefix_mode: "none",
+        effective_branch_prefix: "",
+      }),
+    ) as never,
+  },
+};
+
+export const AccountUnavailable: Story = {
+  args: {
+    client: client(
+      settings({
+        account_prefix: undefined,
+        effective_branch_prefix: "tidebreak/",
+      }),
+    ) as never,
+  },
+};
+
+export const Loading: Story = {
+  args: { client: client(settings(), { loading: true }) as never },
+};
+
+export const LoadFailed: Story = {
+  args: { client: client(settings(), { loadFailure: true }) as never },
+};
+
+export const SaveFailed: Story = {
+  args: { client: client(settings(), { saveFailure: true }) as never },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("switch", {
+        name: "Rename generated branches automatically",
+      }),
+    );
+    await expect(await canvas.findByRole("alert")).toHaveTextContent(
+      "Git settings could not be saved.",
+    );
+    await expect(
+      canvas.getByRole("switch", {
+        name: "Rename generated branches automatically",
+      }),
+    ).toBeChecked();
+  },
+};
+
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-screen w-[390px] border-r border-border">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
@@ -89,6 +89,12 @@ export const storySettings: RuntimeSettings = {
   computer_use_enabled: true,
   code_turn_recaps_enabled: true,
   rewrite_closing_messages: false,
+  git_source_control: {
+    auto_rename_branches: true,
+    branch_prefix_mode: "account",
+    account_prefix: "alex/",
+    effective_branch_prefix: "alex/",
+  },
 };
 
 function model(
@@ -456,6 +462,17 @@ function createSettingsStoryClient(
         compaction: body.compaction
           ? { ...settings.compaction, ...body.compaction }
           : settings.compaction,
+        git_source_control: body.git_source_control
+          ? {
+              ...settings.git_source_control,
+              ...body.git_source_control,
+              custom_branch_prefix:
+                body.git_source_control.custom_branch_prefix === null
+                  ? undefined
+                  : (body.git_source_control.custom_branch_prefix ??
+                    settings.git_source_control.custom_branch_prefix),
+            }
+          : settings.git_source_control,
       };
       return write(settings);
     },

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -1823,6 +1823,8 @@ body {
   }
 
   .settings-panel {
+    container-name: settings-panel;
+    container-type: inline-size;
     height: 100%;
     min-height: 0;
     overflow-y: auto;
@@ -1936,7 +1938,7 @@ body {
     text-wrap: pretty;
   }
 
-  @media (min-width: 960px) {
+  @container settings-panel (min-width: 48rem) {
     .settings-section[data-has-heading] {
       grid-template-columns: minmax(10rem, 12rem) minmax(0, 1fr);
       column-gap: 2rem;

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod gh;
 pub(crate) mod grants;
 pub(crate) mod harness_install;
 pub(crate) mod harness_llm;
+pub(crate) mod naming_settings;
 pub(crate) mod pr_facts;
 pub(crate) mod pr_fetch;
 pub(crate) mod pr_refresh;

--- a/crates/tidebreak-server/src/code/naming_settings.rs
+++ b/crates/tidebreak-server/src/code/naming_settings.rs
@@ -9,18 +9,13 @@ pub(crate) const AUTO_RENAME_BRANCHES_KEY: &str = "code.git.auto_rename_branches
 pub(crate) const BRANCH_PREFIX_MODE_KEY: &str = "code.git.branch_prefix_mode";
 pub(crate) const CUSTOM_BRANCH_PREFIX_KEY: &str = "code.git.custom_branch_prefix";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum BranchPrefixMode {
+    #[default]
     Account,
     Custom,
     None,
-}
-
-impl Default for BranchPrefixMode {
-    fn default() -> Self {
-        Self::Account
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]

--- a/crates/tidebreak-server/src/code/naming_settings.rs
+++ b/crates/tidebreak-server/src/code/naming_settings.rs
@@ -1,0 +1,185 @@
+//! Per-user defaults for workspace branch names.
+
+use serde::{Deserialize, Serialize};
+use tidebreak_core::{OwnerId, Store};
+
+use super::worktree::slugify;
+
+pub(crate) const AUTO_RENAME_BRANCHES_KEY: &str = "code.git.auto_rename_branches";
+pub(crate) const BRANCH_PREFIX_MODE_KEY: &str = "code.git.branch_prefix_mode";
+pub(crate) const CUSTOM_BRANCH_PREFIX_KEY: &str = "code.git.custom_branch_prefix";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchPrefixMode {
+    Account,
+    Custom,
+    None,
+}
+
+impl Default for BranchPrefixMode {
+    fn default() -> Self {
+        Self::Account
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+pub struct GitSourceControlSettings {
+    pub auto_rename_branches: bool,
+    pub branch_prefix_mode: BranchPrefixMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub custom_branch_prefix: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub account_prefix: Option<String>,
+    pub effective_branch_prefix: String,
+}
+
+pub(crate) fn user_setting_key(owner: &OwnerId, key: &str) -> String {
+    if owner.is_local() {
+        key.to_owned()
+    } else {
+        format!("{key}.owner.{}", owner.as_str())
+    }
+}
+
+async fn read_value<T: serde::de::DeserializeOwned>(
+    store: &dyn Store,
+    owner: &OwnerId,
+    key: &str,
+) -> tidebreak_core::Result<Option<T>> {
+    Ok(store
+        .get_setting(&user_setting_key(owner, key))
+        .await?
+        .and_then(|value| serde_json::from_value(value).ok()))
+}
+
+pub(crate) async fn auto_rename_branches(
+    store: &dyn Store,
+    owner: &OwnerId,
+) -> tidebreak_core::Result<bool> {
+    Ok(read_value(store, owner, AUTO_RENAME_BRANCHES_KEY)
+        .await?
+        .unwrap_or(true))
+}
+
+pub(crate) async fn read(
+    store: &dyn Store,
+    owner: &OwnerId,
+    account_name: Option<&str>,
+) -> tidebreak_core::Result<GitSourceControlSettings> {
+    let branch_prefix_mode = read_value(store, owner, BRANCH_PREFIX_MODE_KEY)
+        .await?
+        .unwrap_or_default();
+    let custom_branch_prefix = read_value(store, owner, CUSTOM_BRANCH_PREFIX_KEY).await?;
+    let account_prefix = account_name
+        .map(slugify)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("{value}/"));
+    let effective_branch_prefix = match branch_prefix_mode {
+        BranchPrefixMode::Account => account_prefix
+            .clone()
+            .unwrap_or_else(|| "tidebreak/".to_owned()),
+        BranchPrefixMode::Custom => custom_branch_prefix
+            .clone()
+            .unwrap_or_else(|| "tidebreak/".to_owned()),
+        BranchPrefixMode::None => String::new(),
+    };
+    Ok(GitSourceControlSettings {
+        auto_rename_branches: auto_rename_branches(store, owner).await?,
+        branch_prefix_mode,
+        custom_branch_prefix,
+        account_prefix,
+        effective_branch_prefix,
+    })
+}
+
+pub(crate) async fn write_auto_rename_branches(
+    store: &dyn Store,
+    owner: &OwnerId,
+    enabled: bool,
+) -> tidebreak_core::Result<()> {
+    store
+        .set_setting(
+            &user_setting_key(owner, AUTO_RENAME_BRANCHES_KEY),
+            &serde_json::json!(enabled),
+        )
+        .await
+}
+
+pub(crate) async fn write_branch_prefix_mode(
+    store: &dyn Store,
+    owner: &OwnerId,
+    mode: BranchPrefixMode,
+) -> tidebreak_core::Result<()> {
+    store
+        .set_setting(
+            &user_setting_key(owner, BRANCH_PREFIX_MODE_KEY),
+            &serde_json::json!(mode),
+        )
+        .await
+}
+
+pub(crate) async fn write_custom_branch_prefix(
+    store: &dyn Store,
+    owner: &OwnerId,
+    prefix: Option<&str>,
+) -> tidebreak_core::Result<()> {
+    store
+        .set_setting(
+            &user_setting_key(owner, CUSTOM_BRANCH_PREFIX_KEY),
+            &prefix
+                .map(|value| serde_json::Value::String(value.to_owned()))
+                .unwrap_or(serde_json::Value::Null),
+        )
+        .await
+}
+
+/// Normalize a custom prefix and reject names Git cannot use as a ref prefix.
+pub(crate) fn normalize_custom_prefix(value: &str) -> Option<String> {
+    let value = value.trim().trim_matches('/');
+    if value.is_empty() || value.len() > 120 || value.contains("@{") || value.contains("..") {
+        return None;
+    }
+    if value.bytes().any(|byte| {
+        byte <= b' '
+            || byte == 0x7f
+            || matches!(byte, b'~' | b'^' | b':' | b'?' | b'*' | b'[' | b'\\')
+    }) {
+        return None;
+    }
+    if value.split('/').any(|segment| {
+        segment.is_empty()
+            || segment.starts_with('.')
+            || segment.ends_with('.')
+            || segment.ends_with(".lock")
+    }) {
+        return None;
+    }
+    Some(format!("{value}/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_custom_prefix;
+
+    #[test]
+    fn custom_prefixes_follow_git_ref_rules() {
+        assert_eq!(
+            normalize_custom_prefix(" team/alex/ "),
+            Some("team/alex/".into())
+        );
+        for invalid in [
+            "",
+            "/",
+            ".hidden",
+            "team//alex",
+            "team..alex",
+            "bad name",
+            "x.lock",
+        ] {
+            assert_eq!(normalize_custom_prefix(invalid), None, "{invalid}");
+        }
+    }
+}

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -21,9 +21,9 @@ use tidebreak_core::db::code::{
     list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
     list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head,
     replace_session_execution_settings, save_repo, save_workspace,
-    set_active_workspace_pull_request, settle_approval_claim, update_trigger_enabled,
-    ClaimedApprovalSettlement, CodeSessionExecutionSettings, PermissionModeChangeIntent,
-    MAX_REPLAY_EVENTS,
+    set_active_workspace_pull_request, set_workspace_branch_if, settle_approval_claim,
+    update_trigger_enabled, ClaimedApprovalSettlement, CodeSessionExecutionSettings,
+    PermissionModeChangeIntent, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
@@ -52,6 +52,7 @@ use super::delivery::DeliveryCache;
 use super::fork;
 use super::gh::{self, ActionOutcome, CommitOutcome, GhError, PushOutcome, WorkspaceGitStatus};
 use super::harness_install::HarnessInstallJobs;
+use super::naming_settings;
 use super::recovery::{self, RecoveryAction};
 use super::session_worker::{
     attach_engine, spawn_session_worker, wake_queue, AttachmentStore, ExecutionSettingsSettlement,
@@ -61,8 +62,8 @@ use super::session_worker::{
 use super::worktree::repo_paths_equivalent;
 use super::worktree::{
     self, archive_blockers, branch_name, create_worktree, directory_bytes, prune_worktrees,
-    remove_worktree, run_archive_script, run_setup_script, slugify, unique_branch_bytes,
-    validate_repo_path, worktree_dir, WorktreeError,
+    remove_worktree, rename_local_only_branch, run_archive_script, run_setup_script, slugify,
+    unique_branch_bytes, validate_repo_path, worktree_dir, WorktreeError,
 };
 use crate::error::ServerError;
 use crate::managed_policy::ManagedPolicy;
@@ -1142,6 +1143,7 @@ impl CodeRuntime {
                     .map(|name| name.to_string_lossy().into_owned())
                     .unwrap_or_else(|| "repo".into())
             });
+        let default_branch_prefix = self.default_branch_prefix(owner).await;
         let repo = CodeRepo {
             id: RepoId::new(),
             owner: owner.clone(),
@@ -1152,7 +1154,7 @@ impl CodeRuntime {
                 .unwrap_or_else(|| "main".into()),
             branch_prefix: branch_prefix
                 .filter(|value| !value.trim().is_empty())
-                .unwrap_or_else(|| "tidebreak/".into()),
+                .unwrap_or(default_branch_prefix),
             setup_script,
             archive_script,
             quick_actions,
@@ -1790,6 +1792,59 @@ impl CodeRuntime {
         )
         .await;
         Ok(())
+    }
+
+    /// Rename the untouched placeholder branch after background titling names
+    /// the workspace. Every guard fails closed and leaves the original branch.
+    pub(crate) async fn rename_generated_workspace_branch(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+        title: &str,
+    ) -> Result<bool, ServerError> {
+        if !naming_settings::auto_rename_branches(&*self.db, owner).await? {
+            return Ok(false);
+        }
+        let turn = self.worktree_turn_lock(id);
+        let _turn_guard = turn.lock().await;
+        let lifecycle = self.workspace_lifecycle_lock(id);
+        let _lifecycle_guard = lifecycle.lock().await;
+        let workspace = self.get_workspace(owner, id).await?;
+        if workspace.is_remote()
+            || workspace.status != CodeWorkspaceStatus::Active
+            || workspace.pr.is_some()
+            || workspace.title != title
+        {
+            return Ok(false);
+        }
+        let repo = self.get_repo(owner, workspace.repo_id).await?;
+        let expected = branch_name(&repo.branch_prefix, "", id.0.as_u128());
+        if workspace.branch_name != expected {
+            return Ok(false);
+        }
+        let next = branch_name(&repo.branch_prefix, title, id.0.as_u128());
+        if next == expected {
+            return Ok(false);
+        }
+        let path = std::path::Path::new(&workspace.worktree_path);
+        if !rename_local_only_branch(path, &expected, &next)
+            .await
+            .map_err(map_worktree)?
+        {
+            return Ok(false);
+        }
+        if !set_workspace_branch_if(&self.db, owner, id, title, &expected, &next).await? {
+            if let Err(error) = rename_local_only_branch(path, &next, &expected).await {
+                tracing::error!(
+                    workspace = %id,
+                    error = %error,
+                    "could not restore a branch after its workspace update lost the race"
+                );
+            }
+            return Ok(false);
+        }
+        super::attention::emit_workspace_digests(&self.db, &self.bus, owner, id).await;
+        Ok(true)
     }
 
     pub(crate) async fn archive_workspace(
@@ -2439,6 +2494,34 @@ impl CodeRuntime {
         if let Err(error) = gh::configure_workspace_identity(worktree, &name, &email).await {
             tracing::debug!(error, "the workspace git identity was not configured");
         }
+    }
+
+    /// The forge login used for account-prefixed branches, when one is known.
+    pub(crate) async fn branch_account_name(&self, owner: &OwnerId) -> Option<String> {
+        #[cfg(test)]
+        if self.git_credentials().is_none() {
+            // Tests must not inherit the developer machine's `gh` login.
+            return None;
+        }
+        if let Some(lender) = self.git_credentials() {
+            let identity = lender.git_forge_identity(owner).await.ok()?;
+            return match identity.attribution {
+                crate::obo_gateway::GitForgeAttribution::Person { login, .. } => Some(login),
+                crate::obo_gateway::GitForgeAttribution::Bot { bot_login } => {
+                    bot_login.or(Some(identity.app_name))
+                }
+            };
+        }
+        let search_path = self.gh_search_path_owned();
+        gh::observe_gh(search_path.as_deref()).await.viewer_login
+    }
+
+    async fn default_branch_prefix(&self, owner: &OwnerId) -> String {
+        let account = self.branch_account_name(owner).await;
+        naming_settings::read(&*self.db, owner, account.as_deref())
+            .await
+            .map(|settings| settings.effective_branch_prefix)
+            .unwrap_or_else(|_| "tidebreak/".to_owned())
     }
 
     /// Borrow a repository-scoped forge credential for one git operation in

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -2499,10 +2499,8 @@ impl CodeRuntime {
     /// The forge login used for account-prefixed branches, when one is known.
     pub(crate) async fn branch_account_name(&self, owner: &OwnerId) -> Option<String> {
         #[cfg(test)]
-        if self.git_credentials().is_none() {
-            // Tests must not inherit the developer machine's `gh` login.
-            return None;
-        }
+        // Tests must not inherit the developer machine's `gh` login.
+        self.git_credentials()?;
         if let Some(lender) = self.git_credentials() {
             let identity = lender.git_forge_identity(owner).await.ok()?;
             return match identity.attribution {

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -14,9 +14,9 @@
 //! one, no matter when it lands. The placeholder never changes for the life of
 //! the workspace, so the swap stays valid on retries.
 //!
-//! Only the title moves. The branch and worktree path keep their two-word slug:
-//! they are contracts with git and the filesystem, and renaming them after
-//! creation is exactly the churn decision 0032 avoids.
+//! The worktree path keeps its two-word slug. When the user's Git settings
+//! allow it, the generated local branch follows the derived title only while
+//! it is still local-only and untouched.
 
 use std::sync::Arc;
 
@@ -156,6 +156,12 @@ async fn derive_workspace_title(
     if !set_workspace_title_if(&code.db, owner, workspace.id, &placeholder, &title).await? {
         // Renamed while the call ran; the chosen name has the floor.
         return Ok(Outcome::NotApplicable);
+    }
+    if let Err(error) = code
+        .rename_generated_workspace_branch(owner, workspace.id, &title)
+        .await
+    {
+        tracing::debug!(workspace = %workspace.id, error = ?error, "the generated branch was not renamed");
     }
     // Announced only once the write applied, on the digest channel every list
     // surface already watches.

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -1477,6 +1477,56 @@ pub(crate) async fn delete_branch(repo_root: &Path, branch: &str) -> Result<(), 
         .map_err(|err| WorktreeError::internal(format!("git branch -D {branch} failed: {err}")))
 }
 
+/// Rename the branch checked out in one worktree after proving it is still
+/// local-only. A branch with an upstream or an origin tracking ref has already
+/// crossed the boundary where a background rename is safe.
+pub(crate) async fn rename_local_only_branch(
+    worktree: &Path,
+    expected: &str,
+    next: &str,
+) -> Result<bool, WorktreeError> {
+    let current = git_stdout(
+        Some(worktree),
+        &["symbolic-ref", "--quiet", "--short", "HEAD"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|error| {
+        WorktreeError::internal(format!("could not read workspace branch: {error}"))
+    })?;
+    if current.trim() != expected {
+        return Ok(false);
+    }
+    if git_stdout(
+        Some(worktree),
+        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .is_ok()
+    {
+        return Ok(false);
+    }
+    let tracking_ref = format!("refs/remotes/origin/{expected}");
+    if git_stdout(
+        Some(worktree),
+        &["rev-parse", "--verify", "--quiet", &tracking_ref],
+        GIT_TIMEOUT,
+    )
+    .await
+    .is_ok()
+    {
+        return Ok(false);
+    }
+    if branch_exists(worktree, next).await? {
+        return Ok(false);
+    }
+    git(Some(worktree), &["branch", "-m", next], GIT_TIMEOUT)
+        .await
+        .map_err(|error| WorktreeError::internal(format!("could not rename branch: {error}")))?;
+    Ok(true)
+}
+
 /// Drop stale worktree registrations from the repo.
 pub(crate) async fn prune_worktrees(repo_root: &Path) -> Result<(), WorktreeError> {
     git(Some(repo_root), &["worktree", "prune"], GIT_TIMEOUT)
@@ -1510,7 +1560,7 @@ pub(crate) fn slugify(value: &str) -> String {
 /// Branch name: repo prefix plus a slug of the title, or a two-word fallback.
 pub(crate) fn branch_name(prefix: &str, title: &str, seed: u128) -> String {
     let prefix = if prefix.is_empty() {
-        "tidebreak/".to_owned()
+        String::new()
     } else if prefix.ends_with('/') {
         prefix.to_owned()
     } else {

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -13,6 +13,7 @@ use tidebreak_core::{
     DEFAULT_COMPACTION_TARGET_FRACTION, DEFAULT_COMPACTION_THRESHOLD_FRACTION,
 };
 
+use crate::code::naming_settings::{self, BranchPrefixMode, GitSourceControlSettings};
 use crate::code_execution::{
     self, ExecConfigInfo, ExecConfigUpdate, ExecCredentialReadiness, ExecCredentialsInfo,
 };
@@ -149,6 +150,8 @@ pub struct Settings {
     /// prose. Default off.
     #[serde(default)]
     pub rewrite_closing_messages: bool,
+    /// How new code repositories name workspace branches for this user.
+    pub git_source_control: GitSourceControlSettings,
 }
 
 /// The reader's last explicit per-chat choices — what an unspecified field of
@@ -203,6 +206,19 @@ pub struct SettingsUpdate {
     /// Default off.
     #[serde(default)]
     pub rewrite_closing_messages: Option<bool>,
+    /// Update branch naming defaults. Absent fields stay unchanged.
+    #[serde(default)]
+    pub git_source_control: Option<GitSourceControlSettingsUpdate>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct GitSourceControlSettingsUpdate {
+    #[serde(default)]
+    pub auto_rename_branches: Option<bool>,
+    #[serde(default)]
+    pub branch_prefix_mode: Option<BranchPrefixMode>,
+    #[serde(default, deserialize_with = "double_option")]
+    pub custom_branch_prefix: Option<Option<String>>,
 }
 
 /// Partial update for [`CompactionSettings`]. Absent fields leave the current
@@ -366,6 +382,40 @@ pub async fn put_settings(
             )
             .await?;
     }
+    if let Some(update) = body.git_source_control {
+        let custom_was_present = update.custom_branch_prefix.is_some();
+        let owner = auth.principal.owner_id();
+        let current = read_git_source_control_settings(&state, &owner).await?;
+        let mode = update
+            .branch_prefix_mode
+            .unwrap_or(current.branch_prefix_mode);
+        let custom = match update.custom_branch_prefix {
+            None => current.custom_branch_prefix,
+            Some(None) => None,
+            Some(Some(value)) => Some(
+                naming_settings::normalize_custom_prefix(&value).ok_or_else(|| {
+                    ServerError::bad_request(
+                        "custom_branch_prefix must be a valid Git branch prefix",
+                    )
+                })?,
+            ),
+        };
+        if mode == BranchPrefixMode::Custom && custom.is_none() {
+            return Err(ServerError::bad_request(
+                "custom_branch_prefix is required in custom mode",
+            ));
+        }
+        if let Some(enabled) = update.auto_rename_branches {
+            naming_settings::write_auto_rename_branches(&*state.store, &owner, enabled).await?;
+        }
+        if update.branch_prefix_mode.is_some() {
+            naming_settings::write_branch_prefix_mode(&*state.store, &owner, mode).await?;
+        }
+        if custom_was_present {
+            naming_settings::write_custom_branch_prefix(&*state.store, &owner, custom.as_deref())
+                .await?;
+        }
+    }
     Ok(Json(
         read_settings(&state, &auth.principal.owner_id()).await?,
     ))
@@ -387,11 +437,23 @@ async fn read_settings(state: &AppState, owner: &OwnerId) -> Result<Settings, Se
         code_turn_recaps_enabled: crate::code::recap::turn_recaps_enabled(&*state.store).await?,
         rewrite_closing_messages: crate::code::rewrite::rewrite_closing_enabled(&*state.store)
             .await?,
+        git_source_control: read_git_source_control_settings(state, owner).await?,
     })
 }
 
 const fn default_true() -> bool {
     true
+}
+
+async fn read_git_source_control_settings(
+    state: &AppState,
+    owner: &OwnerId,
+) -> Result<GitSourceControlSettings, ServerError> {
+    let account = match state.code.as_ref() {
+        Some(code) => code.branch_account_name(owner).await,
+        None => None,
+    };
+    Ok(naming_settings::read(&*state.store, owner, account.as_deref()).await?)
 }
 
 /// Whether computer use is enabled. Default on; an explicit `false` disables

--- a/crates/tidebreak-server/src/tests/code_titling.rs
+++ b/crates/tidebreak-server/src/tests/code_titling.rs
@@ -207,6 +207,7 @@ async fn a_first_turn_names_an_untitled_workspace() {
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let workspace: serde_json::Value = created.json().await.unwrap();
     let workspace_id = workspace["id"].as_str().unwrap().to_owned();
+    let original_branch = workspace["branch_name"].as_str().unwrap().to_owned();
     let placeholder = crate::code::worktree::two_word_name(
         uuid::Uuid::parse_str(&workspace_id).unwrap().as_u128(),
     );
@@ -247,6 +248,8 @@ async fn a_first_turn_names_an_untitled_workspace() {
 
     // The derived name lands in the store.
     let mut title = String::new();
+    let mut branch = original_branch.clone();
+    let mut worktree_path = String::new();
     for _ in 0..300 {
         let current: serde_json::Value = client
             .get(format!("http://{addr}/code/workspaces/{workspace_id}"))
@@ -258,12 +261,25 @@ async fn a_first_turn_names_an_untitled_workspace() {
             .await
             .unwrap();
         title = current["title"].as_str().unwrap().to_owned();
-        if title != placeholder {
+        branch = current["branch_name"].as_str().unwrap().to_owned();
+        worktree_path = current["worktree_path"].as_str().unwrap().to_owned();
+        if title != placeholder && branch != original_branch {
             break;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     assert_eq!(title, DERIVED_TITLE);
+    assert_eq!(branch, "tidebreak/fix-the-flaky-auth-retry-test");
+    let checked_out = std::process::Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(worktree_path)
+        .output()
+        .unwrap();
+    assert!(checked_out.status.success());
+    assert_eq!(
+        String::from_utf8(checked_out.stdout).unwrap().trim(),
+        branch
+    );
 
     // The naming call ran on the utility model and read the user's message.
     let requests = stub.requests.lock().unwrap().clone();

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -94,6 +94,15 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(settings["compaction"]["min_threshold_tokens"], 50000);
     assert_eq!(settings["compaction"]["protect_recent_messages"], 5);
     assert_eq!(settings["code_turn_recaps_enabled"], true);
+    assert_eq!(settings["git_source_control"]["auto_rename_branches"], true);
+    assert_eq!(
+        settings["git_source_control"]["branch_prefix_mode"],
+        "account"
+    );
+    assert_eq!(
+        settings["git_source_control"]["effective_branch_prefix"],
+        "tidebreak/"
+    );
     assert!(settings.get("code_mode_enabled").is_none());
 
     // PUT a model, and it comes back.
@@ -117,6 +126,11 @@ async fn settings_default_then_update_roundtrips() {
                             "target_fraction": 0.3,
                             "min_threshold_tokens": 40000,
                             "protect_recent_messages": 8
+                        },
+                        "git_source_control": {
+                            "auto_rename_branches": false,
+                            "branch_prefix_mode": "custom",
+                            "custom_branch_prefix": "team/alex"
                         }
                     })
                     .to_string(),
@@ -129,6 +143,22 @@ async fn settings_default_then_update_roundtrips() {
     let settings: serde_json::Value = json_body(response).await;
     assert_eq!(settings["model"], "claude-x");
     assert_eq!(settings["max_active_background_agents"], 7);
+    assert_eq!(
+        settings["git_source_control"]["auto_rename_branches"],
+        false
+    );
+    assert_eq!(
+        settings["git_source_control"]["branch_prefix_mode"],
+        "custom"
+    );
+    assert_eq!(
+        settings["git_source_control"]["custom_branch_prefix"],
+        "team/alex/"
+    );
+    assert_eq!(
+        settings["git_source_control"]["effective_branch_prefix"],
+        "team/alex/"
+    );
     assert_eq!(settings["sandbox_agent_checkin_steps"], 250);
     assert_eq!(settings["sandbox_agent_error_checkin"], 3);
     assert_eq!(settings["code_turn_recaps_enabled"], false);

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -167,6 +167,30 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(settings["compaction"]["min_threshold_tokens"], 40000);
     assert_eq!(settings["compaction"]["protect_recent_messages"], 8);
 
+    // A later Git-only update preserves the existing recap preference.
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/settings")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "git_source_control": { "branch_prefix_mode": "none" }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let settings: serde_json::Value = json_body(response).await;
+    assert_eq!(settings["code_turn_recaps_enabled"], false);
+    assert_eq!(settings["git_source_control"]["branch_prefix_mode"], "none");
+
     // GET reflects the update.
     let response = router
         .oneshot(


### PR DESCRIPTION
Adds an Application → Git & source control settings page.

- Enables automatic generated-branch renaming by default.
- Lets users select an account, custom, or empty branch prefix.
- Applies the selected prefix to newly added repositories.
- Renames only untouched local branches and skips pushed, remote, pull request, colliding, or user-renamed branches.
- Adds Storybook coverage for account, custom, none, unavailable, loading, failure, and narrow states.
- Makes settings sections respond to the pane width so narrow layouts stay single-column.

Validated with focused Rust and DOM tests, TypeScript checks, formatting, linting, and the Storybook production build.