### PR TITLE
feat(desktop): park sessions before restart-to-update

### DIFF
--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -1803,6 +1803,15 @@ impl Store for DbStore {
         ops::turn::heartbeat_turn_run(self, id, lease_token, now, lease_expires_at).await
     }
 
+    async fn expire_turn_run_lease(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<bool> {
+        ops::turn::expire_turn_run_lease(self, id, lease_token, now).await
+    }
+
     async fn fence_turn_lease(
         &self,
         id: TurnId,

--- a/crates/tidebreak-core/src/db/ops/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/turn.rs
@@ -1082,6 +1082,35 @@ pub(in crate::db) async fn heartbeat_turn_run(
     Ok(heartbeat.rows_affected == 1)
 }
 
+pub(in crate::db) async fn expire_turn_run_lease(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> Result<bool> {
+    let now = canonical_db_timestamp(now)?;
+    let expired = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::turn_run::Column::Id.eq(id.0))
+        .filter(entities::turn_run::Column::Status.is_in([
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
+        ]))
+        .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(expired.rows_affected == 1)
+}
+
 pub(in crate::db) async fn fence_turn_lease(
     store: &DbStore,
     id: TurnId,

--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -3664,6 +3664,76 @@ async fn fence_turn_lease_reports_only_the_exact_live_segment() {
 }
 
 #[tokio::test]
+async fn an_expired_lease_handback_makes_the_turn_immediately_reclaimable() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    let expiry = claimed_at + chrono::Duration::minutes(1);
+    let claimed = store
+        .claim_turn_run(token, claimed_at, expiry)
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(claimed.lease_token, Some(token));
+
+    // A wrong token hands nothing back; the live lease stays untouched.
+    let handback_at = claimed_at + chrono::Duration::seconds(5);
+    assert!(!store
+        .expire_turn_run_lease(turn_id, uuid::Uuid::new_v4(), handback_at)
+        .await
+        .unwrap());
+    assert_eq!(
+        store
+            .get_turn_run(turn_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .lease_expires_at,
+        Some(expiry)
+    );
+
+    // The exact token hands the lease back: the expiry drops to now, and the
+    // next scan — the relaunched process — reclaims without waiting it out.
+    assert!(store
+        .expire_turn_run_lease(turn_id, token, handback_at)
+        .await
+        .unwrap());
+    let reclaim_at = handback_at + chrono::Duration::seconds(1);
+    let second_token = uuid::Uuid::new_v4();
+    let reclaimed = store
+        .claim_turn_run(
+            second_token,
+            reclaim_at,
+            reclaim_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(reclaimed.id, turn_id);
+    assert_eq!(reclaimed.status, TurnRunStatus::Running);
+    assert_eq!(reclaimed.lease_token, Some(second_token));
+
+    // Handing back an already-superseded lease is a no-op.
+    assert!(!store
+        .expire_turn_run_lease(turn_id, token, reclaim_at + chrono::Duration::seconds(1))
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
 async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();

--- a/crates/tidebreak-core/src/storage/store.rs
+++ b/crates/tidebreak-core/src/storage/store.rs
@@ -2032,6 +2032,24 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// Give up one exact live turn lease so the next claim scan reclaims it.
+    ///
+    /// Sets the lease expiry to `now` when the turn is still running or
+    /// cancelling under this exact token with a live lease, and returns
+    /// whether that write landed. The turn itself stays as it is; the next
+    /// worker to scan — this process after a restart, usually — re-claims it
+    /// as expired work and resumes the attempt ladder. Used when a process
+    /// knows it is about to exit (a restart-to-update) and does not want its
+    /// successor to wait out the lease.
+    async fn expire_turn_run_lease(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        turn_storage_unavailable()
+    }
+
     /// Report whether `lease_token` still owns the exact live segment of a turn.
     ///
     /// Returns [`TurnLeaseFence::Current`] only while the turn is running or

--- a/crates/tidebreak-desktop/src/host_access.rs
+++ b/crates/tidebreak-desktop/src/host_access.rs
@@ -33,6 +33,10 @@ pub(crate) struct HostAccess {
     pub(super) control_plane: OnceCell<ControlPlaneClient>,
     pub(super) receipts: ReceiptStore,
     staged_folders: OnceCell<std::sync::Arc<dyn tidebreak_server::code_execution::StagedFolders>>,
+    /// The embedded server's update-quiesce handle, installed at server boot.
+    /// [`Self::quiesce_for_update`] runs it before the broker drain so a
+    /// restart-to-update parks sessions at a safe point first.
+    server_quiesce: OnceCell<tidebreak_server::UpdateQuiesce>,
     /// Which machine this client is attached to. Host authority applies to the
     /// local one only, so every native command consults this first.
     remote: std::sync::Arc<crate::remote::RemoteAttachment>,
@@ -64,6 +68,7 @@ impl HostAccess {
             control_plane: OnceCell::new(),
             receipts,
             staged_folders: OnceCell::new(),
+            server_quiesce: OnceCell::new(),
             remote,
         })
     }
@@ -107,6 +112,16 @@ impl HostAccess {
         self.store
             .set(store)
             .map_err(|_| "host access store was initialized more than once".to_owned())
+    }
+
+    /// Install the embedded server's update-quiesce handle at server boot.
+    pub(crate) fn initialize_update_quiesce(
+        &self,
+        quiesce: tidebreak_server::UpdateQuiesce,
+    ) -> Result<(), String> {
+        self.server_quiesce
+            .set(quiesce)
+            .map_err(|_| "server update quiesce was initialized more than once".to_owned())
     }
 
     /// Drop conversation-scoped broker rows whose chats no longer exist.
@@ -217,14 +232,31 @@ impl HostAccess {
         self.broker.shutdown().await;
     }
 
+    /// Bring the process to a restart-safe point for an update.
+    ///
+    /// Session work first — code sessions park at a turn boundary, chat turn
+    /// leases are handed back — then the broker's admission barrier drains.
+    /// The error is a sentence the Updates panel shows as-is; a partial
+    /// quiesce is unwound before returning it. Before the server boots there
+    /// is no session work, so only the broker drains.
     pub(crate) async fn quiesce_for_update(&self) -> Result<(), String> {
-        self.broker
-            .quiesce_for_update()
-            .await
-            .map_err(|error| error.to_string())
+        if let Some(server) = self.server_quiesce.get() {
+            server.quiesce_for_update().await?;
+        }
+        if let Err(error) = self.broker.quiesce_for_update().await {
+            eprintln!("tidebreak-desktop: could not quiesce host broker for update: {error}");
+            if let Some(server) = self.server_quiesce.get() {
+                server.resume_after_failed_update();
+            }
+            return Err(crate::updater::UPDATE_PREPARE_ERROR.to_owned());
+        }
+        Ok(())
     }
 
     pub(crate) async fn resume_after_failed_update(&self) -> Result<(), String> {
+        if let Some(server) = self.server_quiesce.get() {
+            server.resume_after_failed_update();
+        }
         self.broker
             .resume_after_failed_update()
             .await

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -845,7 +845,6 @@ pub fn run() {
         .manage(deep_link::PairingStore::new(store_rx))
         .manage(documents::PendingLibraryDrop::default())
         .manage(updater::UpdateManager::default())
-        .manage(updater::ServerQuiesceSlot::default())
         .invoke_handler(tauri::generate_handler![
             server_info,
             remote_machine_state,
@@ -1064,8 +1063,8 @@ async fn boot_server(
     // Unblock any pairing task parked on a deep link that arrived pre-boot.
     let _ = store_tx.send(Some(server.pairing_handle()));
     // Let restart-to-update park sessions at a safe point before installing.
-    app.state::<updater::ServerQuiesceSlot>()
-        .install(server.update_quiesce());
+    app.state::<host_access::HostAccess>()
+        .initialize_update_quiesce(server.update_quiesce())?;
     let base_url = format!("http://{}", server.local_addr());
     let token = server.token().to_string();
     let executor_token = server.client_executor_token().to_string();

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -845,6 +845,7 @@ pub fn run() {
         .manage(deep_link::PairingStore::new(store_rx))
         .manage(documents::PendingLibraryDrop::default())
         .manage(updater::UpdateManager::default())
+        .manage(updater::ServerQuiesceSlot::default())
         .invoke_handler(tauri::generate_handler![
             server_info,
             remote_machine_state,
@@ -1062,6 +1063,9 @@ async fn boot_server(
     });
     // Unblock any pairing task parked on a deep link that arrived pre-boot.
     let _ = store_tx.send(Some(server.pairing_handle()));
+    // Let restart-to-update park sessions at a safe point before installing.
+    app.state::<updater::ServerQuiesceSlot>()
+        .install(server.update_quiesce());
     let base_url = format!("http://{}", server.local_addr());
     let token = server.token().to_string();
     let executor_token = server.client_executor_token().to_string();

--- a/crates/tidebreak-desktop/src/updater.rs
+++ b/crates/tidebreak-desktop/src/updater.rs
@@ -16,6 +16,13 @@
 //! prove that renderer-only drafts, dialogs, or editor state have been saved,
 //! so an unfocused window is not sufficient consent to replace and restart the
 //! application.
+//!
+//! The restart itself does not interrupt session work. Before the bundle is
+//! replaced the embedded server parks every code session at a turn boundary
+//! (the idle-park path of decision 0064) and hands back chat turn leases, so
+//! the relaunched process resumes sessions instead of fencing orphaned
+//! engine children. A code turn still running at the quiesce deadline fails
+//! the restart with a retryable message rather than being interrupted.
 
 use std::future::Future;
 #[cfg(any(test, target_os = "macos"))]
@@ -95,6 +102,22 @@ pub(crate) struct UpdateManager {
     state: Mutex<DesktopUpdateState>,
     staged: Mutex<Option<StagedUpdate>>,
     busy: AtomicBool,
+}
+
+/// The embedded server's update-quiesce handle, installed once the server
+/// boots. `None` until then — with no server there is no session work to
+/// bring to a safe point.
+#[derive(Default)]
+pub(crate) struct ServerQuiesceSlot(Mutex<Option<tidebreak_server::UpdateQuiesce>>);
+
+impl ServerQuiesceSlot {
+    pub(crate) fn install(&self, handle: tidebreak_server::UpdateQuiesce) {
+        *self.0.lock().expect("server quiesce slot poisoned") = Some(handle);
+    }
+
+    fn current(&self) -> Option<tidebreak_server::UpdateQuiesce> {
+        self.0.lock().expect("server quiesce slot poisoned").clone()
+    }
 }
 
 pub(crate) const fn updates_enabled() -> bool {
@@ -377,11 +400,11 @@ struct InstallResolutionError {
     message: &'static str,
 }
 
-fn retryable_update_state(version: String, message: &'static str) -> DesktopUpdateState {
+fn retryable_update_state(version: String, message: impl Into<String>) -> DesktopUpdateState {
     DesktopUpdateState {
         status: DesktopUpdateStatus::Ready,
         version: Some(version),
-        error: Some(message.to_owned()),
+        error: Some(message.into()),
         enabled: updates_enabled(),
     }
 }
@@ -391,9 +414,12 @@ struct FailedInstall<E> {
     resume_error: Option<String>,
 }
 
-/// Run the synchronous bundle replacement only after the broker's admission
-/// barrier has drained. The closures keep the ordering contract directly
-/// testable without constructing a packaged Tauri updater in unit tests.
+/// Run the synchronous bundle replacement only after the quiesce closure has
+/// brought the process to a safe point — session work parked at turn
+/// boundaries, then the broker's admission barrier drained. The closures keep
+/// the ordering contract directly testable without constructing a packaged
+/// Tauri updater in unit tests. The quiesce closure owns unwinding its own
+/// partial progress: an error from it must leave everything resumed.
 async fn install_behind_broker_barrier<E, Q, QF, I, R, RF, S, SF>(
     quiesce: Q,
     install: I,
@@ -477,23 +503,49 @@ async fn take_staged_and_restart(app: AppHandle) -> Result<(), String> {
 
     let version = staged.update.version.clone();
     let host_access = app.state::<HostAccess>();
+    // Bring session work to a safe point before the broker drains: code
+    // sessions park at a turn boundary and chat leases are handed back, so
+    // the relaunch resumes instead of fencing orphans. A quiesce refusal —
+    // a code turn still running at the deadline — arrives as a sentence the
+    // panel shows as-is, and the server has already resumed itself.
+    let server_quiesce = app.state::<ServerQuiesceSlot>().current();
+    let quiesce_server = server_quiesce.clone();
+    let resume_server = server_quiesce;
     let install_result = install_behind_broker_barrier(
-        || host_access.quiesce_for_update(),
+        || async {
+            if let Some(server) = &quiesce_server {
+                server.quiesce_for_update().await?;
+            }
+            if let Err(error) = host_access.quiesce_for_update().await {
+                eprintln!("tidebreak-desktop: could not quiesce host broker for update: {error}");
+                if let Some(server) = &quiesce_server {
+                    server.resume_after_failed_update();
+                }
+                return Err(UPDATE_PREPARE_ERROR.to_owned());
+            }
+            Ok(())
+        },
         || staged.update.install(&staged.bytes),
-        || host_access.resume_after_failed_update(),
+        || async {
+            let result = host_access.resume_after_failed_update().await;
+            if let Some(server) = &resume_server {
+                server.resume_after_failed_update();
+            }
+            result
+        },
         || host_access.shutdown(),
     )
     .await;
 
     match install_result {
         Err(error) => {
-            eprintln!("tidebreak-desktop: could not quiesce host broker for update: {error}");
+            eprintln!("tidebreak-desktop: could not quiesce for update: {error}");
             store_staged(&app, Some(staged));
-            set_update_state(&app, retryable_update_state(version, UPDATE_PREPARE_ERROR));
+            set_update_state(&app, retryable_update_state(version, error.clone()));
             app.state::<UpdateManager>()
                 .busy
                 .store(false, Ordering::Release);
-            Err(UPDATE_PREPARE_ERROR.to_owned())
+            Err(error)
         }
         Ok(Err(failure)) => {
             eprintln!(

--- a/crates/tidebreak-desktop/src/updater.rs
+++ b/crates/tidebreak-desktop/src/updater.rs
@@ -45,7 +45,7 @@ pub(crate) const UPDATE_CHECK_REQUESTED_EVENT: &str = "desktop-update-check-requ
 const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const UPDATE_CHECK_ERROR: &str = "Could not check for updates. Try again later.";
-const UPDATE_PREPARE_ERROR: &str = "Could not prepare the update. Try again later.";
+pub(crate) const UPDATE_PREPARE_ERROR: &str = "Could not prepare the update. Try again later.";
 const UPDATE_INSTALL_ERROR: &str = "Could not install the update. Try again later.";
 const UPDATE_WITHDRAWN_ERROR: &str =
     "The downloaded update is no longer published. Tidebreak will keep checking.";
@@ -102,22 +102,6 @@ pub(crate) struct UpdateManager {
     state: Mutex<DesktopUpdateState>,
     staged: Mutex<Option<StagedUpdate>>,
     busy: AtomicBool,
-}
-
-/// The embedded server's update-quiesce handle, installed once the server
-/// boots. `None` until then — with no server there is no session work to
-/// bring to a safe point.
-#[derive(Default)]
-pub(crate) struct ServerQuiesceSlot(Mutex<Option<tidebreak_server::UpdateQuiesce>>);
-
-impl ServerQuiesceSlot {
-    pub(crate) fn install(&self, handle: tidebreak_server::UpdateQuiesce) {
-        *self.0.lock().expect("server quiesce slot poisoned") = Some(handle);
-    }
-
-    fn current(&self) -> Option<tidebreak_server::UpdateQuiesce> {
-        self.0.lock().expect("server quiesce slot poisoned").clone()
-    }
 }
 
 pub(crate) const fn updates_enabled() -> bool {
@@ -503,36 +487,16 @@ async fn take_staged_and_restart(app: AppHandle) -> Result<(), String> {
 
     let version = staged.update.version.clone();
     let host_access = app.state::<HostAccess>();
-    // Bring session work to a safe point before the broker drains: code
-    // sessions park at a turn boundary and chat leases are handed back, so
-    // the relaunch resumes instead of fencing orphans. A quiesce refusal —
-    // a code turn still running at the deadline — arrives as a sentence the
-    // panel shows as-is, and the server has already resumed itself.
-    let server_quiesce = app.state::<ServerQuiesceSlot>().current();
-    let quiesce_server = server_quiesce.clone();
-    let resume_server = server_quiesce;
+    // The quiesce brings session work to a safe point before the broker
+    // drains — code sessions park at a turn boundary and chat leases are
+    // handed back (`HostAccess::quiesce_for_update`) — so the relaunch
+    // resumes work instead of fencing orphans. A refusal, such as a code
+    // turn still running at the deadline, arrives as a sentence the panel
+    // shows as-is, with the partial quiesce already unwound.
     let install_result = install_behind_broker_barrier(
-        || async {
-            if let Some(server) = &quiesce_server {
-                server.quiesce_for_update().await?;
-            }
-            if let Err(error) = host_access.quiesce_for_update().await {
-                eprintln!("tidebreak-desktop: could not quiesce host broker for update: {error}");
-                if let Some(server) = &quiesce_server {
-                    server.resume_after_failed_update();
-                }
-                return Err(UPDATE_PREPARE_ERROR.to_owned());
-            }
-            Ok(())
-        },
+        || host_access.quiesce_for_update(),
         || staged.update.install(&staged.bytes),
-        || async {
-            let result = host_access.resume_after_failed_update().await;
-            if let Some(server) = &resume_server {
-                server.resume_after_failed_update();
-            }
-            result
-        },
+        || host_access.resume_after_failed_update(),
         || host_access.shutdown(),
     )
     .await;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -1118,6 +1118,7 @@ mod tests {
                 engine_reads_images: false,
             },
             std::sync::Arc::new(tokio::sync::Mutex::new(())),
+            tokio::sync::watch::channel(false).1,
         );
         let (reply, _turn) = tokio::sync::oneshot::channel();
         handle

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -3850,6 +3850,37 @@ impl CodeRuntime {
     /// they never appear here — the worker map only holds local sessions.
     pub(crate) async fn await_update_quiesce(&self, deadline: Duration) -> Result<(), String> {
         let deadline_at = Instant::now() + deadline;
+        // Turn starts are fenced by the worktree lock, not by the database:
+        // a starting turn holds its workspace's lock from before it re-reads
+        // the quiesce flag until the turn ends, and the flag is already up.
+        // Acquiring and releasing every lock therefore proves each workspace
+        // is past any start that raced the flag — whoever takes a lock after
+        // this sees the flag and refuses. Without this pass, a poll of the
+        // stored lifecycle could observe Idle in the window between a turn
+        // winning its lock and persisting Running, and the update would exit
+        // over an engine turn that was about to start.
+        let worktree_turns: Vec<Arc<tokio::sync::Mutex<()>>> = self
+            .worktree_turns
+            .lock()
+            .expect("code worktree turn locks")
+            .values()
+            .cloned()
+            .collect();
+        for worktree_turn in worktree_turns {
+            let remaining = deadline_at.saturating_duration_since(Instant::now());
+            match tokio::time::timeout(remaining, worktree_turn.lock()).await {
+                Ok(guard) => drop(guard),
+                Err(_) => {
+                    return Err(
+                        "A code session is still working on a turn. Try again once it \
+                                finishes — the update stays ready."
+                            .to_owned(),
+                    );
+                }
+            }
+        }
+        // Past every turn boundary; now wait for the workers to park their
+        // engine children and for the stored rows to agree.
         loop {
             let ids: Vec<CodeSessionId> = self
                 .workers

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tokio::time::Instant as TokioInstant;
 
 use tidebreak_core::db::code::{
@@ -224,6 +224,11 @@ pub(crate) struct CodeRuntime {
     /// Last pin-install failure per kind. Cleared on a successful install.
     pin_install_errors: Mutex<HashMap<HarnessKind, String>>,
     workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
+    /// Flips true while the process quiesces for a restart-to-update. Every
+    /// session worker subscribes: the flag holds queue drains, refuses new
+    /// turn starts at the worktree boundary, and parks idle engine children
+    /// immediately. See `crate::update_quiesce`.
+    update_quiesce: watch::Sender<bool>,
     /// Serializes writer admission with workspace lifecycle transitions.
     workspace_lifecycles: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
     /// One turn at a time per worktree, shared by every session in it.
@@ -477,6 +482,7 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            update_quiesce: watch::channel(false).0,
             workspace_lifecycles: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: super::pr_refresh::HotPullRequests::default(),
@@ -616,6 +622,7 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            update_quiesce: watch::channel(false).0,
             workspace_lifecycles: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: super::pr_refresh::HotPullRequests::default(),
@@ -3810,6 +3817,84 @@ impl CodeRuntime {
         Ok(resolved)
     }
 
+    /// Begin an update quiesce: session workers hold their queue drains, no
+    /// new turn starts, and idle engine children park immediately. Turns
+    /// already in flight run to their boundary; [`Self::await_update_quiesce`]
+    /// is how the caller waits for that. See `crate::update_quiesce`.
+    pub(crate) fn begin_update_quiesce(&self) {
+        self.update_quiesce.send_replace(true);
+        self.wake_all_workers();
+    }
+
+    /// Reopen turn admission after an update that did not install. Parked
+    /// children stay parked; the next turn respawns and resumes them exactly
+    /// as an idle park does (decision 0064).
+    pub(crate) fn end_update_quiesce(&self) {
+        self.update_quiesce.send_replace(false);
+        self.wake_all_workers();
+    }
+
+    pub(crate) fn update_quiesce_active(&self) -> bool {
+        *self.update_quiesce.borrow()
+    }
+
+    fn wake_all_workers(&self) {
+        for handle in self.workers.lock().expect("code workers").values() {
+            wake_queue(handle);
+        }
+    }
+
+    /// Wait until no local session is mid-turn and no engine child is live,
+    /// or fail with a sentence the updater can show as-is. Remote sessions
+    /// run their engine in a sandbox and survive a restart on their own, so
+    /// they never appear here — the worker map only holds local sessions.
+    pub(crate) async fn await_update_quiesce(&self, deadline: Duration) -> Result<(), String> {
+        let deadline_at = Instant::now() + deadline;
+        loop {
+            let ids: Vec<CodeSessionId> = self
+                .workers
+                .lock()
+                .expect("code workers")
+                .keys()
+                .copied()
+                .collect();
+            let mut busy = 0usize;
+            for id in ids {
+                match tidebreak_core::db::code::get_session_all_owners(&self.db, id).await {
+                    Ok(Some(session)) => {
+                        if session.lifecycle == CodeSessionLifecycle::Running
+                            || session.child_pid.is_some()
+                        {
+                            busy += 1;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        return Err(format!(
+                            "could not read code sessions while preparing the update: {error}"
+                        ));
+                    }
+                }
+            }
+            if busy == 0 {
+                return Ok(());
+            }
+            if Instant::now() >= deadline_at {
+                return Err(if busy == 1 {
+                    "A code session is still working on a turn. Try again once it finishes — \
+                     the update stays ready."
+                        .to_owned()
+                } else {
+                    format!(
+                        "{busy} code sessions are still working on turns. Try again once they \
+                         finish — the update stays ready."
+                    )
+                });
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
     pub(crate) async fn submit_turn(
         &self,
         owner: &OwnerId,
@@ -3965,7 +4050,10 @@ impl CodeRuntime {
         let backlog = !tidebreak_core::db::code::list_queued_turns(&self.db, owner, id)
             .await?
             .is_empty();
-        if in_flight || backlog {
+        // An update quiesce parks the send too: the row survives the restart
+        // and drains after the relaunch, so nothing typed during the short
+        // install window is lost or refused.
+        if in_flight || backlog || self.update_quiesce_active() {
             if !queue_if_busy {
                 return Err(ServerError::conflict_kind(
                     "trigger_turn_busy",
@@ -4003,6 +4091,19 @@ impl CodeRuntime {
                     return Err(ServerError::conflict_kind(
                         "trigger_turn_busy",
                         "the trigger turn was not accepted because the workspace became busy",
+                    ));
+                }
+                return self
+                    .park_follow_up(owner, &handle, &session, message, attachments)
+                    .await;
+            }
+            // The quiesce flag flipped while this send was in flight. Park it
+            // the same way: the durable row runs after the relaunch.
+            Err(WorkerError::UpdateQuiesced) => {
+                if !queue_if_busy {
+                    return Err(ServerError::conflict_kind(
+                        "trigger_turn_busy",
+                        "the trigger turn was not accepted because the app is restarting to update",
                     ));
                 }
                 return self
@@ -6373,6 +6474,7 @@ impl CodeRuntime {
                     == CapLevel::Supported,
             },
             self.worktree_turn_lock(attached.workspace_id),
+            self.update_quiesce.subscribe(),
         );
         self.workers
             .lock()
@@ -7105,6 +7207,13 @@ fn map_worker(err: WorkerError) -> ServerError {
         WorkerError::WorktreeBusy => ServerError::conflict_kind(
             "workspace_busy",
             "another session in this workspace is mid-turn",
+        ),
+        // Also intercepted and parked by `submit_turn`. A caller that still
+        // sees it raced the restart itself; a conflict reads better than a
+        // 500 from a process that is about to relaunch.
+        WorkerError::UpdateQuiesced => ServerError::conflict_kind(
+            "update_quiesced",
+            "Tidebreak is restarting for an update; the turn starts after the relaunch",
         ),
     }
 }

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -135,6 +135,11 @@ pub(crate) enum WorkerError {
     /// length of someone else's turn.
     #[error("another session in this workspace is mid-turn")]
     WorktreeBusy,
+    /// The process is quiescing for a restart-to-update, so no new turn may
+    /// start. A send is parked as a durable queue row by `submit_turn`; a
+    /// queued row stays in the queue and drains after the relaunch.
+    #[error("Tidebreak is restarting for an update; the turn starts after the relaunch")]
+    UpdateQuiesced,
 }
 
 pub(crate) struct WorkerHandle {
@@ -158,13 +163,18 @@ pub(crate) struct WorkerHandle {
 pub(crate) struct TurnQueue {
     pub(crate) wake: Arc<Notify>,
     worktree: Arc<tokio::sync::Mutex<()>>,
+    /// Flips true while the process quiesces for a restart-to-update: the
+    /// drain holds, no new turn starts, and the idle loop parks the engine
+    /// child immediately instead of waiting out the idle timer.
+    quiesce: watch::Receiver<bool>,
 }
 
 impl TurnQueue {
-    fn new(worktree: Arc<tokio::sync::Mutex<()>>) -> Self {
+    fn new(worktree: Arc<tokio::sync::Mutex<()>>, quiesce: watch::Receiver<bool>) -> Self {
         Self {
             wake: Arc::new(Notify::new()),
             worktree,
+            quiesce,
         }
     }
 }
@@ -189,6 +199,9 @@ enum TurnWait {
 struct WorktreeTurn<'a> {
     lock: &'a tokio::sync::Mutex<()>,
     wait: TurnWait,
+    /// The process-wide update-quiesce flag, re-read after the lock is won:
+    /// a turn must not start while a restart-to-update waits for boundaries.
+    quiesce: &'a watch::Receiver<bool>,
 }
 
 /// Where a turn's attachments come from, and where they can be put.
@@ -700,10 +713,11 @@ pub(crate) fn spawn_session_worker(
     sink: Arc<LiveSink>,
     attachments: AttachmentStore,
     worktree_turn: Arc<tokio::sync::Mutex<()>>,
+    quiesce: watch::Receiver<bool>,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel(8);
     let spawn_epoch = session.spawn_epoch;
-    let queue = TurnQueue::new(worktree_turn);
+    let queue = TurnQueue::new(worktree_turn, quiesce);
     let approval_decisions = Arc::new(tokio::sync::Mutex::new(()));
     tokio::spawn(run_worker(
         session,
@@ -753,21 +767,39 @@ async fn run_worker(
         let _ = save_session(&sink.db, &session).await;
     }
 
+    let mut quiesce = queue.quiesce.clone();
+    // A dropped quiesce sender (tests, teardown) must not hot-loop the select.
+    let mut quiesce_live = true;
     loop {
         if session_was_ended(&sink.db, &mut session).await {
             break;
         }
-        drain_queued(
-            &mut session,
-            engine.as_ref(),
-            &sink,
-            &queue,
-            &store,
-            &mut commands,
-        )
-        .await;
+        let quiescing = *quiesce.borrow_and_update();
+        if quiescing {
+            // A restart-to-update is waiting on this session: hold the drain
+            // and release the engine child now rather than on the idle timer.
+            // Rows in the durable queue stay put and drain after the relaunch.
+            if engine.child_pid().is_some() {
+                park_idle_engine(&mut session, engine.as_ref(), &sink).await;
+            }
+        } else {
+            drain_queued(
+                &mut session,
+                engine.as_ref(),
+                &sink,
+                &queue,
+                &store,
+                &mut commands,
+            )
+            .await;
+        }
         tokio::select! {
             _ = queue.wake.notified() => {}
+            changed = quiesce.changed(), if quiesce_live => {
+                if changed.is_err() {
+                    quiesce_live = false;
+                }
+            }
             command = commands.recv() => match command {
                 Some(WorkerCommand::RunTurn {
                     message,
@@ -784,6 +816,7 @@ async fn run_worker(
                         WorktreeTurn {
                             lock: &queue.worktree,
                             wait: TurnWait::Send,
+                            quiesce: &queue.quiesce,
                         },
                         QueuedFollowUp {
                             message,
@@ -842,8 +875,9 @@ async fn run_worker(
             // An idle engine child is cache, not an invariant (decision 0064).
             // The timer only exists while the engine reports a live child, so
             // a parked session — or an engine with no between-turn child —
-            // arms nothing.
-            _ = tokio::time::sleep(PARK_AFTER_IDLE), if engine.child_pid().is_some() => {
+            // arms nothing. During an update quiesce the timer is only the
+            // retry for a park that failed above, so it comes back fast.
+            _ = tokio::time::sleep(if quiescing { QUIESCE_PARK_RETRY } else { PARK_AFTER_IDLE }), if engine.child_pid().is_some() => {
                 park_idle_engine(&mut session, engine.as_ref(), &sink).await;
             }
         }
@@ -920,6 +954,14 @@ const APPROVAL_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
 const PARK_AFTER_IDLE: Duration = Duration::from_secs(15 * 60);
 #[cfg(test)]
 const PARK_AFTER_IDLE: Duration = Duration::from_millis(150);
+
+/// Retry cadence for a park that failed while an update quiesce is waiting
+/// on this session. Outside a quiesce a failed park just waits for the next
+/// idle window.
+#[cfg(not(test))]
+const QUIESCE_PARK_RETRY: Duration = Duration::from_millis(500);
+#[cfg(test)]
+const QUIESCE_PARK_RETRY: Duration = Duration::from_millis(50);
 
 /// Release an idle engine child (decision 0064) and clear the row's pid so
 /// nothing reads the dead process as live. The next turn respawns and
@@ -1189,6 +1231,11 @@ async fn drain_queued(
         if session_was_ended(&sink.db, session).await {
             return;
         }
+        // An update quiesce holds the whole drain: the rows stay put, visibly
+        // queued, and the relaunched worker drains them.
+        if *queue.quiesce.borrow() {
+            return;
+        }
         match queue_paused(&sink.db, &session.owner, session.id).await {
             Ok(true) => return,
             Ok(false) => {}
@@ -1228,6 +1275,7 @@ async fn drain_queued(
             WorktreeTurn {
                 lock: &queue.worktree,
                 wait: TurnWait::Queued,
+                quiesce: &queue.quiesce,
             },
             follow_up,
         )
@@ -1442,6 +1490,13 @@ async fn drive_turn_inner(
     // read a session that may be minutes stale by now.
     if session_was_ended(&sink.db, session).await {
         return Err(WorkerError::Conflict("session has ended".into()));
+    }
+    // So does a restart-to-update that started during the wait: it is
+    // counting turn boundaries, and a turn that starts now holds it for the
+    // turn's whole length. The message is not lost — a send is parked by the
+    // route, and a queued row stays in the queue for the relaunch.
+    if *worktree.quiesce.borrow() {
+        return Err(WorkerError::UpdateQuiesced);
     }
     let workspace = get_workspace(&sink.db, &session.owner, session.workspace_id)
         .await
@@ -1961,6 +2016,7 @@ fn code_turn_outcome(result: &Result<CodeTurn, WorkerError>) -> &'static str {
         Err(WorkerError::Failed(_)) => "error",
         Err(WorkerError::TriggerDeliveryAccepted) => "trigger_delivery_accepted",
         Err(WorkerError::WorktreeBusy) => "worktree_busy",
+        Err(WorkerError::UpdateQuiesced) => "update_quiesced",
     }
 }
 
@@ -2959,6 +3015,7 @@ mod tests {
                 engine_reads_images: false,
             },
             Arc::new(tokio::sync::Mutex::new(())),
+            tokio::sync::watch::channel(false).1,
         );
 
         let committed = CodeSessionExecutionSettings {
@@ -3088,6 +3145,7 @@ mod tests {
                 engine_reads_images: false,
             },
             worktree_lock.clone(),
+            tokio::sync::watch::channel(false).1,
         );
 
         let later = CodeSessionExecutionSettings {
@@ -3645,5 +3703,100 @@ mod tests {
         // own terminal" would be wrong on a hosted machine.
         let kept = sink.legible_turn_error("authentication_error: sign in required".into());
         assert_eq!(kept.message, "authentication_error: sign in required");
+    }
+
+    #[tokio::test]
+    async fn an_update_quiesce_refuses_new_turns_until_resumed() {
+        let (directory, store, sink, session_id) = seeded_sink().await;
+        let owner = OwnerId::local();
+        let mut session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        session.lifecycle = CodeSessionLifecycle::Idle;
+        assert!(save_session(&store, &session).await.unwrap());
+
+        let worktree = directory.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let private = directory.path().join("private");
+        std::fs::create_dir(&private).unwrap();
+        let private_root =
+            super::super::scratch::ScratchRoot::open_for_test(&private).expect("scratch root");
+        let adapter = ScriptedAdapter::new(plain_text_script());
+        let engine = adapter
+            .launch(SessionSpec {
+                worktree,
+                allowed_read_roots: Vec::new(),
+                permission_mode: session.permission_mode,
+                model: session.model.clone(),
+                reasoning_effort: session.reasoning_effort,
+                fast_mode: session.fast_mode,
+                resume_ref: None,
+                extra_argv: Vec::new(),
+                extra_env: Vec::new(),
+                relay_key_env: None,
+                env: Vec::new(),
+                approval: None,
+                binary: std::path::PathBuf::from("/scripted/engine"),
+                sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+                browser: None,
+            })
+            .await
+            .unwrap();
+        let (quiesce_tx, quiesce_rx) = watch::channel(true);
+        let handle = spawn_session_worker(
+            session.clone(),
+            engine,
+            sink,
+            AttachmentStore {
+                blobs: None,
+                private_root,
+                engine_reads_images: false,
+            },
+            Arc::new(tokio::sync::Mutex::new(())),
+            quiesce_rx,
+        );
+
+        // While the quiesce holds, a send must not start a turn: the caller
+        // (submit_turn) parks it as a durable queue row instead.
+        let (reply, refused) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::RunTurn {
+                message: "hello".into(),
+                attachments: Vec::new(),
+                trigger_delivery: None,
+                reply,
+            })
+            .await
+            .unwrap();
+        match refused.await.unwrap() {
+            Err(WorkerError::UpdateQuiesced) => {}
+            other => panic!("expected an update-quiesced refusal, got {other:?}"),
+        }
+        assert!(list_turns(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Ending the quiesce (a failed install) reopens admission; the same
+        // send now runs to completion.
+        quiesce_tx.send_replace(false);
+        let (reply, ran) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::RunTurn {
+                message: "hello again".into(),
+                attachments: Vec::new(),
+                trigger_delivery: None,
+                reply,
+            })
+            .await
+            .unwrap();
+        ran.await.unwrap().expect("the turn runs after the resume");
+        assert_eq!(
+            list_turns(&store, &owner, session_id).await.unwrap().len(),
+            1
+        );
     }
 }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -103,6 +103,7 @@ mod state;
 mod store_ownership;
 mod task_plan_tool;
 mod turn_worker;
+mod update_quiesce;
 mod vault_secrets;
 mod view_frames;
 pub mod voice_transcription;
@@ -213,6 +214,7 @@ pub use pairing::{
     PendingRegistration,
 };
 pub use state::{AppState, LocalVoiceError, LocalVoiceRunner, LocalVoiceState, LocalVoiceStatus};
+pub use update_quiesce::UpdateQuiesce;
 
 pub(crate) const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES: usize = 16 * 1024;
@@ -1261,6 +1263,9 @@ pub struct Server {
     /// The one gateway runtime, handed to pairing so a registered pending
     /// pairing lands in the same slot the sign-in surface reads.
     gateway: Arc<gateway_runtime::GatewayRuntime>,
+    /// Brings live work to a restart-safe point before an update replaces
+    /// the bundle; see `update_quiesce`.
+    update_quiesce: update_quiesce::UpdateQuiesce,
     listener: Option<TcpListener>,
     router: Option<Router>,
     // Keep every process-local worker before `_store_ownership`. Rust drops
@@ -1390,6 +1395,12 @@ impl Server {
     /// beyond the store — see [`register_pending_pairing`].
     pub fn pairing_handle(&self) -> PairingHandle {
         PairingHandle::new(self.store.clone(), self.mcp.clone(), self.gateway.clone())
+    }
+
+    /// The handle a restart-to-update uses to park code sessions at a turn
+    /// boundary and hand back chat turn leases before replacing the bundle.
+    pub fn update_quiesce(&self) -> UpdateQuiesce {
+        self.update_quiesce.clone()
     }
 
     /// Run the accept loop until the process exits.
@@ -2299,6 +2310,7 @@ async fn bind_inner(
         state.blob_retirement_wake.clone(),
         blob_orphan_auditor::BlobOrphanAuditorConfig::default(),
     );
+    let (chat_quiesce_worker, chat_quiesce_control) = update_quiesce::chat_quiesce_pair();
     let turn_worker = turn_worker::TurnWorker::new(
         state.store.clone(),
         state.resolver.clone(),
@@ -2323,7 +2335,8 @@ async fn bind_inner(
     .with_blob_write_locks(state.blob_writes.clone())
     .with_mcp_runtime(state.mcp.clone())
     .with_exec_folder_context(code_execution.clone())
-    .with_diagnostics(state.diagnostics.clone());
+    .with_diagnostics(state.diagnostics.clone())
+    .with_update_quiesce(chat_quiesce_worker);
     let sandbox_worker_config = sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default()
         .with_delegated_file_executor(client_executor_id.is_some());
     let sandbox_agent_run_worker = sandbox_agent_run_worker::SandboxAgentRunWorker::with_attempts(
@@ -2469,6 +2482,7 @@ async fn bind_inner(
         code_execution,
         mcp: mcp_runtime,
         gateway: gateway_runtime,
+        update_quiesce: update_quiesce::UpdateQuiesce::new(code, chat_quiesce_control),
         listener: Some(listener),
         router: Some(router),
         _queued_turn_promoter: AbortTask(queued_turn_promoter),

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -960,6 +960,20 @@ impl TurnGuard {
         }
     }
 
+    /// Snapshot every attempt currently executing in this process.
+    ///
+    /// The update quiesce path uses this to know which durable leases this
+    /// process still holds before it exits, so it can hand them back rather
+    /// than make its successor wait out the lease.
+    pub fn active_claims(&self) -> Vec<(TurnId, Uuid)> {
+        self.active
+            .lock()
+            .unwrap()
+            .values()
+            .map(|handles| (handles.turn_id, handles.lease_token))
+            .collect()
+    }
+
     /// Trip cancellation only for the exact turn currently executing locally.
     pub fn cancel(&self, chat_id: ChatId, turn_id: TurnId) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -960,20 +960,6 @@ impl TurnGuard {
         }
     }
 
-    /// Snapshot every attempt currently executing in this process.
-    ///
-    /// The update quiesce path uses this to know which durable leases this
-    /// process still holds before it exits, so it can hand them back rather
-    /// than make its successor wait out the lease.
-    pub fn active_claims(&self) -> Vec<(TurnId, Uuid)> {
-        self.active
-            .lock()
-            .unwrap()
-            .values()
-            .map(|handles| (handles.turn_id, handles.lease_token))
-            .collect()
-    }
-
     /// Trip cancellation only for the exact turn currently executing locally.
     pub fn cancel(&self, chat_id: ChatId, turn_id: TurnId) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -1285,6 +1285,14 @@ impl Store for PauseTerminalStore {
     ) -> Result<tidebreak_core::TurnLeaseFence> {
         self.inner.fence_turn_lease(id, lease_token, now).await
     }
+    async fn expire_turn_run_lease(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        self.inner.expire_turn_run_lease(id, lease_token, now).await
+    }
     async fn complete_turn_run_and_append_event(
         &self,
         id: TurnId,

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -131,6 +131,13 @@ pub(crate) struct TurnWorker {
     /// Update-quiesce channel pair, when this worker serves a process that
     /// can restart to update. `None` in tests that install none.
     quiesce: Option<crate::update_quiesce::ChatQuiesceWorker>,
+    /// Every durable claim this worker currently executes, entered at claim
+    /// time — before the task is spawned — and removed when the task settles,
+    /// abort included. The update drain hands leases back from this set
+    /// rather than from [`TurnGuard`], whose registration happens only deep
+    /// inside `run_turn`: a claim aborted before it registered there would
+    /// otherwise keep its lease and make the relaunched worker wait it out.
+    update_claims: Arc<std::sync::Mutex<std::collections::HashMap<uuid::Uuid, TurnId>>>,
     #[cfg(test)]
     post_drive_pause: Option<(Arc<Notify>, Arc<Notify>)>,
 }
@@ -150,6 +157,22 @@ enum ClaimAction {
 enum HeartbeatOutcome {
     Cancelling,
     LeaseLost,
+}
+
+/// Removes one entry from the worker's claim set when its task settles —
+/// normal return and abort alike, because both drop the task's future.
+struct UpdateClaimEntry {
+    claims: Arc<std::sync::Mutex<std::collections::HashMap<uuid::Uuid, TurnId>>>,
+    lease_token: uuid::Uuid,
+}
+
+impl Drop for UpdateClaimEntry {
+    fn drop(&mut self) {
+        self.claims
+            .lock()
+            .expect("update claims")
+            .remove(&self.lease_token);
+    }
 }
 
 /// Exact foreground capability surface retained for one live turn execution.
@@ -440,6 +463,7 @@ impl TurnWorker {
             diagnostics: Arc::new(crate::diagnostics::Diagnostics::new()),
             config,
             quiesce: None,
+            update_claims: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             #[cfg(test)]
             post_drive_pause: None,
         }
@@ -579,7 +603,21 @@ impl TurnWorker {
                     Ok(ClaimAction::Claimed(turn, lease_token)) => {
                         pending_claim_token = None;
                         let worker = self.clone();
-                        turns.spawn(async move { worker.process(*turn, lease_token).await });
+                        // Enter the claim before the task exists, so the
+                        // update drain's snapshot can never miss a claim the
+                        // abort is about to orphan.
+                        self.update_claims
+                            .lock()
+                            .expect("update claims")
+                            .insert(lease_token, turn.id);
+                        let entry = UpdateClaimEntry {
+                            claims: self.update_claims.clone(),
+                            lease_token,
+                        };
+                        turns.spawn(async move {
+                            let _entry = entry;
+                            worker.process(*turn, lease_token).await
+                        });
                         idle_delay = self.config.idle_min;
                     }
                     Ok(ClaimAction::Terminalized) => {
@@ -678,7 +716,13 @@ impl TurnWorker {
                 _ = &mut grace => break,
             }
         }
-        let remaining = self.signals.active_claims();
+        let remaining: Vec<(TurnId, uuid::Uuid)> = self
+            .update_claims
+            .lock()
+            .expect("update claims")
+            .iter()
+            .map(|(lease_token, turn_id)| (*turn_id, *lease_token))
+            .collect();
         turns.shutdown().await;
         for (turn_id, lease_token) in remaining {
             if let Err(error) = self

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -23,7 +23,16 @@ use tidebreak_core::{
     SequencedEvent, Store, ToolRegistry, ToolScratch, TurnCheckpointProgress, TurnFailureRetry,
     TurnId, TurnRun, TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
 };
-use tokio::sync::Notify;
+use tokio::sync::{watch, Notify};
+
+/// How long running chat turns may keep going after a restart-to-update asks
+/// this worker to drain, before the rest are aborted and their leases handed
+/// back. Long enough for a turn that was already wrapping up; short enough
+/// that the restart never waits on a long agentic run it can safely resume.
+#[cfg(not(test))]
+const CHAT_QUIESCE_TURN_GRACE: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const CHAT_QUIESCE_TURN_GRACE: Duration = Duration::from_millis(100);
 use tracing::Instrument as _;
 
 use crate::approvals::ApprovalBroker;
@@ -119,6 +128,9 @@ pub(crate) struct TurnWorker {
     private_scratch_root: Option<PathBuf>,
     diagnostics: Arc<crate::diagnostics::Diagnostics>,
     config: TurnWorkerConfig,
+    /// Update-quiesce channel pair, when this worker serves a process that
+    /// can restart to update. `None` in tests that install none.
+    quiesce: Option<crate::update_quiesce::ChatQuiesceWorker>,
     #[cfg(test)]
     post_drive_pause: Option<(Arc<Notify>, Arc<Notify>)>,
 }
@@ -427,6 +439,7 @@ impl TurnWorker {
             private_scratch_root,
             diagnostics: Arc::new(crate::diagnostics::Diagnostics::new()),
             config,
+            quiesce: None,
             #[cfg(test)]
             post_drive_pause: None,
         }
@@ -508,6 +521,17 @@ impl TurnWorker {
         self
     }
 
+    /// Attach the update-quiesce channel pair: a restart-to-update flips
+    /// `request` and this worker stops claiming, drains, and reports on
+    /// `drained`. See [`crate::update_quiesce`].
+    pub(crate) fn with_update_quiesce(
+        mut self,
+        quiesce: crate::update_quiesce::ChatQuiesceWorker,
+    ) -> Self {
+        self.quiesce = Some(quiesce);
+        self
+    }
+
     /// Pause after a foreground drive has returned but before its outcome is
     /// interpreted. Tests use this exact seam to make terminal-state races
     /// deterministic instead of relying on scheduler timing.
@@ -527,9 +551,29 @@ impl TurnWorker {
         let mut failure_backoff =
             LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         let mut pending_claim_token = None;
+        let mut quiesce_request = self.quiesce.as_ref().map(|q| q.request.clone());
         loop {
+            if self.quiesce_requested(quiesce_request.as_mut()) {
+                self.drain_for_update(&mut turns).await;
+                // Parked until a failed install resumes; a successful install
+                // exits the process instead.
+                if let Some(request) = quiesce_request.as_mut() {
+                    while *request.borrow_and_update() {
+                        if request.changed().await.is_err() {
+                            return;
+                        }
+                    }
+                }
+                if let Some(quiesce) = &self.quiesce {
+                    let _ = quiesce.drained.send(false);
+                }
+                idle_delay = self.config.idle_min;
+                continue;
+            }
             let mut scan_failed = false;
-            while turns.len() < self.config.max_concurrency {
+            while turns.len() < self.config.max_concurrency
+                && !self.quiesce_requested(quiesce_request.as_mut())
+            {
                 let lease_token = *pending_claim_token.get_or_insert_with(uuid::Uuid::new_v4);
                 match self.claim_once(lease_token).await {
                     Ok(ClaimAction::Claimed(turn, lease_token)) => {
@@ -555,8 +599,16 @@ impl TurnWorker {
             }
 
             if turns.len() == self.config.max_concurrency {
-                if let Some(result) = turns.join_next().await {
-                    log_turn_result(result);
+                // Keep watching the quiesce request even while saturated, or
+                // a full complement of long turns would hold the drain past
+                // its deadline.
+                tokio::select! {
+                    result = turns.join_next() => {
+                        if let Some(result) = result {
+                            log_turn_result(result);
+                        }
+                    }
+                    _ = Self::quiesce_flipped(quiesce_request.as_mut()) => {}
                 }
                 idle_delay = self.config.idle_min;
                 continue;
@@ -583,7 +635,66 @@ impl TurnWorker {
                 _ = self.wake.notified() => {
                     idle_delay = self.config.idle_min;
                 }
+                _ = Self::quiesce_flipped(quiesce_request.as_mut()) => {
+                    idle_delay = self.config.idle_min;
+                }
             }
+        }
+    }
+
+    /// Whether a restart-to-update is asking this worker to stop claiming.
+    fn quiesce_requested(&self, request: Option<&mut watch::Receiver<bool>>) -> bool {
+        request.is_some_and(|request| *request.borrow_and_update())
+    }
+
+    /// Resolves when the quiesce request changes; pends forever without one,
+    /// or once its sender is gone.
+    async fn quiesce_flipped(request: Option<&mut watch::Receiver<bool>>) {
+        let Some(request) = request else {
+            return std::future::pending().await;
+        };
+        if request.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+
+    /// Drain for a restart-to-update: give running turns a short grace to
+    /// finish, then abort the rest and hand their durable leases back so the
+    /// relaunched worker re-claims them immediately. An abort is exactly the
+    /// crash the lease protocol recovers from — the retry rebuilds the
+    /// transcript and re-runs only the model call that was in flight — so the
+    /// drain never refuses; the grace only saves re-running that call for
+    /// turns that were about to finish anyway.
+    async fn drain_for_update(&self, turns: &mut tokio::task::JoinSet<Result<TurnWorkerOutcome>>) {
+        let grace = tokio::time::sleep(CHAT_QUIESCE_TURN_GRACE);
+        tokio::pin!(grace);
+        while !turns.is_empty() {
+            tokio::select! {
+                result = turns.join_next() => {
+                    if let Some(result) = result {
+                        log_turn_result(result);
+                    }
+                }
+                _ = &mut grace => break,
+            }
+        }
+        let remaining = self.signals.active_claims();
+        turns.shutdown().await;
+        for (turn_id, lease_token) in remaining {
+            if let Err(error) = self
+                .store
+                .expire_turn_run_lease(turn_id, lease_token, Utc::now())
+                .await
+            {
+                // The lease then simply expires on its own clock after the
+                // relaunch; slower, not lost.
+                eprintln!(
+                    "tidebreak: could not hand back the lease on turn {turn_id} for update: {error}"
+                );
+            }
+        }
+        if let Some(quiesce) = &self.quiesce {
+            let _ = quiesce.drained.send(true);
         }
     }
 

--- a/crates/tidebreak-server/src/update_quiesce.rs
+++ b/crates/tidebreak-server/src/update_quiesce.rs
@@ -1,0 +1,146 @@
+//! Quiesce live work before a restart-to-update.
+//!
+//! Restarting the process used to orphan every code engine child (boot
+//! recovery then fenced their sessions) and abandon chat turn leases their
+//! successor had to wait out. The embedder asks this handle to bring the
+//! process to a safe point first:
+//!
+//! - Code sessions park at a turn boundary. New turns stop starting (sends
+//!   queue durably instead), in-flight turns run to completion, and each
+//!   idle engine child is released through the same park-and-resume path
+//!   decision 0064 already proves. After the relaunch every session is
+//!   `Idle` with a stored resume ref and a queue that drains on its own.
+//! - Chat turns get a short grace to finish, then the remaining claims are
+//!   aborted and their durable leases handed back, so the relaunched worker
+//!   re-claims them immediately instead of waiting out the lease. An abort
+//!   is the crash the lease protocol already recovers from: the retry
+//!   rebuilds the transcript and re-runs only the model call in flight.
+//!
+//! No engine supports resuming mid-turn, so a code turn that outruns the
+//! deadline fails the quiesce rather than being interrupted: the update
+//! stays staged and the caller retries once the turn finishes.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+use crate::code::CodeRuntime;
+
+/// How long code turns may keep running before the quiesce gives up. Parking
+/// idle sessions takes well under a second; this deadline exists only for
+/// turns that were mid-flight when the restart was requested.
+const CODE_TURN_DEADLINE: Duration = Duration::from_secs(20);
+
+/// Upper bound on the chat drain, past the worker's own finish grace. The
+/// drain cannot refuse — claims that outlive the grace are aborted and their
+/// leases handed back — so this only guards against a wedged worker task.
+const CHAT_DRAIN_DEADLINE: Duration = Duration::from_secs(15);
+
+/// The chat turn worker's half: it watches `request` and reports on `drained`.
+pub(crate) struct ChatQuiesceWorker {
+    pub(crate) request: watch::Receiver<bool>,
+    pub(crate) drained: watch::Sender<bool>,
+}
+
+impl Clone for ChatQuiesceWorker {
+    fn clone(&self) -> Self {
+        Self {
+            request: self.request.clone(),
+            drained: self.drained.clone(),
+        }
+    }
+}
+
+/// The controller's half, held by [`UpdateQuiesce`].
+#[derive(Clone)]
+struct ChatQuiesceControl {
+    request: watch::Sender<bool>,
+    drained: watch::Receiver<bool>,
+}
+
+pub(crate) fn chat_quiesce_pair() -> (ChatQuiesceWorker, UpdateQuiesceChatHalf) {
+    let (request_tx, request_rx) = watch::channel(false);
+    let (drained_tx, drained_rx) = watch::channel(false);
+    (
+        ChatQuiesceWorker {
+            request: request_rx,
+            drained: drained_tx,
+        },
+        UpdateQuiesceChatHalf(ChatQuiesceControl {
+            request: request_tx,
+            drained: drained_rx,
+        }),
+    )
+}
+
+/// Opaque chat half handed to [`UpdateQuiesce::new`] by the binder.
+#[derive(Clone)]
+pub(crate) struct UpdateQuiesceChatHalf(ChatQuiesceControl);
+
+/// Brings the process's live work to a restart-safe point, and back.
+///
+/// Handed to native embedders so a restart-to-update can park code engine
+/// children at a turn boundary and release chat turn leases before the
+/// bundle is replaced. Cloneable; all clones drive the same process state.
+#[derive(Clone)]
+pub struct UpdateQuiesce {
+    code: Arc<CodeRuntime>,
+    chat: ChatQuiesceControl,
+}
+
+impl UpdateQuiesce {
+    pub(crate) fn new(code: Arc<CodeRuntime>, chat: UpdateQuiesceChatHalf) -> Self {
+        Self { code, chat: chat.0 }
+    }
+
+    /// Stop new turns, park code engine children at their next turn boundary,
+    /// and hand back chat turn leases.
+    ///
+    /// On success the process holds no engine child and no live chat lease,
+    /// so exiting loses nothing recovery cannot resume. On failure — a code
+    /// turn still running at the deadline — everything is resumed and the
+    /// error is a sentence the updater can show as-is.
+    pub async fn quiesce_for_update(&self) -> Result<(), String> {
+        self.chat.request.send_replace(true);
+        self.code.begin_update_quiesce();
+        let (code, chat) = tokio::join!(
+            self.code.await_update_quiesce(CODE_TURN_DEADLINE),
+            Self::await_chat_drained(self.chat.drained.clone()),
+        );
+        if let Err(error) = code.and(chat) {
+            self.resume_after_failed_update();
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    /// Reopen turn admission after an update that did not install.
+    ///
+    /// Parked engine children stay parked — the next turn respawns and
+    /// resumes them, exactly as an idle park does — so there is nothing to
+    /// relaunch eagerly here.
+    pub fn resume_after_failed_update(&self) {
+        self.chat.request.send_replace(false);
+        self.code.end_update_quiesce();
+    }
+
+    async fn await_chat_drained(mut drained: watch::Receiver<bool>) -> Result<(), String> {
+        let wait = async {
+            loop {
+                if *drained.borrow_and_update() {
+                    return Ok(());
+                }
+                if drained.changed().await.is_err() {
+                    return Err("the chat turn worker exited before it could drain".to_owned());
+                }
+            }
+        };
+        match tokio::time::timeout(CHAT_DRAIN_DEADLINE, wait).await {
+            Ok(result) => result,
+            Err(_) => {
+                Err("Chat turns could not be released in time. Try again in a moment.".to_owned())
+            }
+        }
+    }
+}

--- a/docs/decisions/0080-update-restarts-park-sessions-at-turn-boundaries.md
+++ b/docs/decisions/0080-update-restarts-park-sessions-at-turn-boundaries.md
@@ -1,0 +1,125 @@
+# 80. Update restarts park sessions at turn boundaries
+
+- Status: Accepted
+- Date: 2026-09-01
+- Owners: desktop updater, code mode, chat runtime
+- Related: [`0043-ship-arm64-packages-and-enable-cross-platform-updates.md`](0043-ship-arm64-packages-and-enable-cross-platform-updates.md),
+  [`0064-idle-engine-children-are-parked.md`](0064-idle-engine-children-are-parked.md),
+  [`0069-durable-code-session-queue.md`](0069-durable-code-session-queue.md),
+  [`0032-code-workspaces-worktrees-checkpoints.md`](0032-code-workspaces-worktrees-checkpoints.md)
+- Supersedes: none
+
+## Context
+
+Restart-to-update ([`0043`](0043-ship-arm64-packages-and-enable-cross-platform-updates.md))
+quiesces only the host-broker sidecar before replacing the bundle. Nothing
+brings session work to a safe point first, and the exit path makes that
+expensive:
+
+- Code engine children run in their own process groups, and the restart exits
+  through `app.exit`, so their kill-on-drop guards never run. Every child
+  survives as a live orphan. Boot recovery
+  (`crates/tidebreak-server/src/code/recovery.rs`) then fences each session
+  `OrphanAlive`, which blocks its whole workspace until the user reaps it by
+  hand ([`0055`](0055-multiple-sessions-per-workspace.md)). Updating with open
+  code sessions lands in the worst recovery branch there is.
+- Chat turns are durably leased with a 60-second expiry. The dead process's
+  leases are not handed back, so the relaunched worker waits out up to a
+  minute of dead time before it re-claims and resumes each mid-flight turn.
+
+Everything needed to do better already exists. Idle park
+([`0064`](0064-idle-engine-children-are-parked.md)) proves every engine child
+can be released between turns and rebuilt from a stored resume ref for about
+0.7 s of wake latency. The durable code queue ([`0069`](0069-durable-code-session-queue.md))
+survives restarts. Chat's lease protocol already recovers from a process that
+dies mid-turn by rebuilding the transcript and re-running only the model call
+in flight. What no engine supports is resuming *mid-turn*: a code turn's
+boundary is the only safe handoff point.
+
+## Decision
+
+The explicit restart-to-update brings the process to a safe point before the
+bundle is replaced, through a quiesce handle the embedded server exports
+(`crates/tidebreak-server/src/update_quiesce.rs`) and the desktop calls
+inside the existing install barrier, before the broker drain.
+
+Code mode parks at turn boundaries:
+
+- A process-wide quiesce flag holds every session worker's queue drain and
+  refuses any turn start that wins the worktree lock after the flag flips. A
+  send during the quiesce parks as a durable queue row — the same answer a
+  busy workspace gives — and runs after the relaunch.
+- Idle engine children park immediately through the 0064 path, which clears
+  the recorded pid, so recovery has nothing to fence. In-flight turns run to
+  completion and their workers park on the way back to idle.
+- The quiesce waits up to 20 s for in-flight turns to reach their boundary.
+  A turn still running then fails the quiesce: the update stays staged, the
+  panel shows a retryable message, and admission reopens. A code turn is
+  never interrupted for an update, because no engine can resume one.
+
+Chat drains and hands leases back:
+
+- The turn worker stops claiming, gives running turns a 5 s grace to finish,
+  then aborts the rest and sets each aborted claim's lease expiry to now. An
+  abort is exactly the crash the lease protocol recovers from; handing the
+  lease back only removes the up-to-60-s wait, so the relaunched worker
+  re-claims immediately.
+
+Deliberately excluded: ordinary quit (this covers only restart-for-update),
+MCP server children, sandbox agent-run workers (durably leased and
+crash-tolerant already), remote code sessions (their engine lives in a
+sandbox and survives on its own), and auxiliary terminals
+([`0036`](0036-code-mode-auxiliary-terminals.md) keeps them ephemeral).
+Installation stays an explicit user action; nothing here installs silently.
+
+## Alternatives Considered
+
+- **Do nothing.** Updating with open code sessions orphans children and
+  fences workspaces; users learn to fear the restart button, and updates are
+  deferred. That is the problem, not an option.
+- **Interrupt in-flight code turns at the deadline.** Converts a slow update
+  into lost agent work; an interrupt discards the turn's remaining plan.
+  Failing the quiesce with a retryable message loses nothing.
+- **Kill children silently and let recovery fence.** Today's behavior with
+  extra steps; reaping is manual and workspace-blocking.
+- **Split the engine into a daemon that outlives the UI.** The real
+  zero-interruption end state, and what remote sessions already do — but it
+  fights the one-server-per-data-directory advisory lock and the
+  native-only host authority (broker, keychain, client executor). The turn
+  boundary barrier gets most of the value for a fraction of the surface;
+  this record does not preclude the daemon later.
+- **Let chat turns run to completion like code turns.** A chat turn can run
+  for minutes and, unlike code, is provably resumable mid-turn; waiting adds
+  restart latency for no safety gain.
+
+## Consequences
+
+- Restart-to-update can now refuse, with a message, while a code turn runs
+  long. The staged update remains installable; the user retries at the next
+  boundary.
+- Sends that race the install window queue durably rather than failing;
+  users see them run after the relaunch.
+- The quiesce flag is one more admission gate every code turn start passes;
+  new turn-start paths must check it (the worktree-lock check catches any
+  that forget, since starts all take the lock).
+- Revisit when engines gain mid-turn resume (the deadline and refusal can
+  then disappear), or if a daemon split makes the barrier unnecessary.
+
+## Validation
+
+- `an_update_quiesce_refuses_new_turns_until_resumed`
+  (`crates/tidebreak-server/src/code/session_worker.rs`): while the flag is
+  up a turn that wins the worktree lock is refused `UpdateQuiesced` and no
+  turn row is written; clearing the flag lets the same send run. A wrong
+  implementation that only gated the queue drain would still start live
+  sends and fail this.
+- `an_expired_lease_handback_makes_the_turn_immediately_reclaimable`
+  (`crates/tidebreak-core/src/db/tests.rs`): the handback is token-exact —
+  a wrong token leaves the live lease untouched, the exact token makes the
+  turn claimable at once, and a superseded token no-ops.
+- The updater's barrier ordering tests
+  (`crates/tidebreak-desktop/src/updater.rs`) pin quiesce → install →
+  shutdown, with resume only on a failed install.
+- Manual: restart-to-update with an idle code session, with a mid-turn code
+  session (expect the retryable refusal), and with a streaming chat turn
+  (expect the turn to continue shortly after relaunch).

--- a/docs/decisions/0080-update-restarts-park-sessions-at-turn-boundaries.md
+++ b/docs/decisions/0080-update-restarts-park-sessions-at-turn-boundaries.md
@@ -52,10 +52,14 @@ Code mode parks at turn boundaries:
 - Idle engine children park immediately through the 0064 path, which clears
   the recorded pid, so recovery has nothing to fence. In-flight turns run to
   completion and their workers park on the way back to idle.
-- The quiesce waits up to 20 s for in-flight turns to reach their boundary.
-  A turn still running then fails the quiesce: the update stays staged, the
-  panel shows a retryable message, and admission reopens. A code turn is
-  never interrupted for an update, because no engine can resume one.
+- The quiesce waits up to 20 s for in-flight turns to reach their boundary,
+  and proves the boundary through the worktree locks themselves: after the
+  flag is up it acquires and releases every workspace's turn lock, so a
+  start that raced the flag has either finished or will re-read the flag
+  under its own acquisition and refuse. A turn still running at the
+  deadline fails the quiesce: the update stays staged, the panel shows a
+  retryable message, and admission reopens. A code turn is never
+  interrupted for an update, because no engine can resume one.
 
 Chat drains and hands leases back:
 

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -88,3 +88,4 @@
 0077  0077-pull-request-facts-and-attribution.md
 0078  0078-uneff-me-targets-the-tidebreak-product-repo.md
 0079  0079-supervised-agent-declines-the-sandbox-protocol.md
+0080  0080-update-restarts-park-sessions-at-turn-boundaries.md


### PR DESCRIPTION
## What

Restart-to-update now brings session work to a safe point before it replaces the bundle, so an update no longer interrupts code or chat work.

- **Code mode**: a process-wide quiesce flag holds queue drains, refuses turn starts at the worktree lock, and parks idle engine children immediately through the idle-park path (decision 0064). In-flight turns run to their boundary, then park. After the relaunch every session is `Idle` with a resume ref and an intact durable queue — no orphaned children, no `OrphanAlive` fences, no manual reap. A turn still running at the 20 s deadline fails the quiesce with a retryable message; a code turn is never interrupted for an update.
- **Chat mode**: the turn worker stops claiming, gives running turns a 5 s grace, then aborts the rest and hands their durable leases back (`expire_turn_run_lease` sets the expiry to now, token-guarded), so the relaunched worker re-claims immediately instead of waiting out up to 60 s of lease. An abort is the crash the lease protocol already recovers from.
- Sends that race the install window queue durably and run after the relaunch.
- On a failed install everything resumes: admission reopens, parked children respawn on the next turn.

## Why

Today `restart_for_update` quiesces only the host-broker sidecar. Engine children are grandchildren in their own process groups, so `app.exit` orphans them alive; boot recovery then fences each session and blocks its workspace until a manual reap. Updating with open code sessions lands in the worst recovery branch there is.

## How

`tidebreak-server` exports an `UpdateQuiesce` handle (`update_quiesce.rs`) built from the code runtime and a channel pair into the chat turn worker. The desktop installs it in a managed slot at server boot and calls it inside the existing `install_behind_broker_barrier`, before the broker drain; quiesce failures surface as the retryable message in the Updates panel.

Decision record 0080 states the contract, the alternatives (including the daemon split), and the revisit conditions.

## Testing

- `an_update_quiesce_refuses_new_turns_until_resumed` (session worker): a turn that wins the worktree lock during a quiesce is refused and no turn row is written; clearing the flag lets the same send run.
- `an_expired_lease_handback_makes_the_turn_immediately_reclaimable` (core db): the handback is token-exact and makes the turn claimable at once; wrong or superseded tokens no-op.
- Existing updater barrier ordering tests, session worker, turn worker, and lease suites all pass (`cargo test -p tidebreak-server --lib code::session_worker` 19 passed, `--lib lease` 28 passed, `-p tidebreak-core --lib lease` 33 passed, `-p tidebreak-desktop --lib updater` 12 passed).
- `python3 scripts/adr.py check --base origin/main` clean; clippy clean for the three crates.