### PR TITLE
feat(server): add the adapter pairing probe

### DIFF
--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -622,6 +622,11 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::connect_start)
                 .layer(RequestBodyLimitLayer::new(MAX_EXTERNAL_CONNECT_BODY_BYTES)),
         )
+        // The operator's pairing probe: bootstrap-authenticated, no writes.
+        .route(
+            "/external/connect/probe",
+            axum::routing::get(routes::code::connect_probe),
+        )
         .route(
             "/external/connect/{nonce}/status",
             get(routes::code::connect_status),

--- a/crates/tidebreak-server/src/routes/code/grants.rs
+++ b/crates/tidebreak-server/src/routes/code/grants.rs
@@ -130,6 +130,20 @@ pub struct ConnectStartResponse {
     pub expires_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// `GET /external/connect/probe` — the pairing check an operator's setup
+/// page runs. It proves three things and changes nothing: the machine is
+/// reachable, code mode is configured, and the presented bootstrap token
+/// is one this deployment accepts. An adapter whose token the machine
+/// refuses fails here, at setup time, instead of at a user's first
+/// connect card.
+pub async fn connect_probe(
+    State(state): State<AppState>,
+    _bootstrap: AdapterBootstrapAuth,
+) -> Result<StatusCode, ServerError> {
+    let _ = adapter_runtime(&state)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// `POST /external/connect` — the adapter parks a handshake and gets the
 /// one-time nonce for its connect card. On the external surface: the
 /// adapter holds no grant yet, and the handshake is inert until the owner

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -57,8 +57,8 @@ pub(crate) use git::{
     write_workspace_check_logs,
 };
 pub(crate) use grants::{
-    connect_approve, connect_complete, connect_start, connect_status, connect_view, list_grants,
-    revoke_grant, revoke_workspace_grants,
+    connect_approve, connect_complete, connect_probe, connect_start, connect_status, connect_view,
+    list_grants, revoke_grant, revoke_workspace_grants,
 };
 pub(crate) use harnesses::{
     install_harness, list_harness_models, list_harnesses, refresh_harnesses,

--- a/crates/tidebreak-server/src/tests/code_external.rs
+++ b/crates/tidebreak-server/src/tests/code_external.rs
@@ -589,6 +589,36 @@ async fn external_events_snapshot_then_replay_then_sever_on_revoke() {
 /// grant bound to the shown identity, but only at the adapter's closing
 /// confirm — a forwarded link that is merely approved binds nothing — and
 /// the desktop lists and revokes grants, whole workspaces included.
+/// The operator's pairing probe answers only to the bootstrap token and
+/// writes nothing: the setup page learns the pairing is wrong at setup
+/// time, not at a user's first connect card.
+#[tokio::test]
+async fn the_pairing_probe_answers_only_to_the_bootstrap_token() {
+    let (router, _fake, _runtime, _repo_id, _token, _dir) = external_app_with_token().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let missing = client
+        .get(format!("http://{addr}/external/connect/probe"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let wrong = client
+        .get(format!("http://{addr}/external/connect/probe"))
+        .bearer_auth("wrong-bootstrap-token-padded-to-thirty-two")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(wrong.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let ok = client
+        .get(format!("http://{addr}/external/connect/probe"))
+        .bearer_auth(ADAPTER_BOOTSTRAP_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), reqwest::StatusCode::NO_CONTENT);
+}
+
 #[tokio::test]
 async fn a_connect_handshake_mints_only_at_the_closing_confirm() {
     let (router, _fake, runtime, _repo_id, token, _dir) = external_app_with_token().await;


### PR DESCRIPTION
GET /external/connect/probe answers 204 to the deployment's bootstrap bearer and writes nothing, so an operator's Slack setup page can verify the adapter-machine pairing at setup time instead of at a user's first connect card.

Groundwork for the gateway console's Slack setup page.