### PR TITLE
refactor(server): route worker logs through tracing

### DIFF
--- a/crates/tidebreak-server/src/agent_run_scratch_reaper.rs
+++ b/crates/tidebreak-server/src/agent_run_scratch_reaper.rs
@@ -138,7 +138,7 @@ impl AgentRunScratchReaper {
             let delay = match self.sweep_once().await {
                 Ok(report) => {
                     if report.reaped > 0 || !report.failures.is_empty() {
-                        eprintln!(
+                        tracing::info!(
                             "tidebreak: agent-run scratch sweep scanned {}, reaped {}, skipped {}, remaining {}, errors {}",
                             report.scanned,
                             report.reaped,
@@ -149,11 +149,11 @@ impl AgentRunScratchReaper {
                     }
                     for failure in &report.failures {
                         match failure.run_id {
-                            Some(run_id) => eprintln!(
+                            Some(run_id) => tracing::error!(
                                 "tidebreak: agent run {run_id} scratch reap failed: {}",
                                 failure.error
                             ),
-                            None => eprintln!(
+                            None => tracing::error!(
                                 "tidebreak: agent-run scratch scan failed: {}",
                                 failure.error
                             ),
@@ -162,7 +162,7 @@ impl AgentRunScratchReaper {
                     next_delay(self.config, &report)
                 }
                 Err(error) => {
-                    eprintln!("tidebreak: agent-run scratch sweep failed: {error}");
+                    tracing::error!("tidebreak: agent-run scratch sweep failed: {error}");
                     self.config.failure_delay
                 }
             };

--- a/crates/tidebreak-server/src/blob_orphan_auditor.rs
+++ b/crates/tidebreak-server/src/blob_orphan_auditor.rs
@@ -107,7 +107,10 @@ impl BlobOrphanAuditor {
                                 failure.error
                             ),
                             None => {
-                                tracing::error!("tidebreak: blob orphan scan failed: {}", failure.error)
+                                tracing::error!(
+                                    "tidebreak: blob orphan scan failed: {}",
+                                    failure.error
+                                )
                             }
                         }
                     }

--- a/crates/tidebreak-server/src/blob_orphan_auditor.rs
+++ b/crates/tidebreak-server/src/blob_orphan_auditor.rs
@@ -90,7 +90,7 @@ impl BlobOrphanAuditor {
             let delay = match self.audit_once().await {
                 Ok(report) => {
                     if report.enqueued > 0 || !report.failures.is_empty() {
-                        eprintln!(
+                        tracing::info!(
                             "tidebreak: blob orphan audit scanned {}, eligible {}, enqueued {}, skipped {}, remaining {}, errors {}",
                             report.scanned,
                             report.eligible,
@@ -102,19 +102,19 @@ impl BlobOrphanAuditor {
                     }
                     for failure in &report.failures {
                         match failure.blob_id {
-                            Some(blob_id) => eprintln!(
+                            Some(blob_id) => tracing::error!(
                                 "tidebreak: blob {blob_id} orphan audit failed: {}",
                                 failure.error
                             ),
                             None => {
-                                eprintln!("tidebreak: blob orphan scan failed: {}", failure.error)
+                                tracing::error!("tidebreak: blob orphan scan failed: {}", failure.error)
                             }
                         }
                     }
                     next_delay(self.config, &report)
                 }
                 Err(error) => {
-                    eprintln!("tidebreak: blob orphan audit failed: {error}");
+                    tracing::error!("tidebreak: blob orphan audit failed: {error}");
                     self.config.failure_delay
                 }
             };

--- a/crates/tidebreak-server/src/blob_retirement_worker.rs
+++ b/crates/tidebreak-server/src/blob_retirement_worker.rs
@@ -112,7 +112,7 @@ impl BlobRetirementWorker {
                     idle_delay = self.config.idle_min;
                 }
                 Err(error) => {
-                    eprintln!("tidebreak: blob retirement worker iteration failed: {error}");
+                    tracing::warn!("tidebreak: blob retirement worker iteration failed: {error}");
                     let delay = failure_backoff.next_delay();
                     tokio::select! {
                         _ = tokio::time::sleep(delay) => {}

--- a/crates/tidebreak-server/src/chat_titling.rs
+++ b/crates/tidebreak-server/src/chat_titling.rs
@@ -208,18 +208,18 @@ impl ChatTitler {
                 // database.
                 let should_run_pending = match titler.derive_title(chat_id, &utility).await {
                     Ok(Some(title)) => {
-                        eprintln!(
+                        tracing::info!(
                             "tidebreak: titled chat {chat_id} on {}: {title}",
                             utility.model
                         );
                         false
                     }
                     Ok(None) => {
-                        eprintln!("tidebreak: left chat {chat_id} untitled");
+                        tracing::warn!("tidebreak: left chat {chat_id} untitled");
                         true
                     }
                     Err(error) => {
-                        eprintln!(
+                        tracing::error!(
                             "tidebreak: could not derive a title for chat {chat_id}: {error}"
                         );
                         true
@@ -398,7 +398,7 @@ pub(crate) async fn derive_text_with_retries<P: Proposal>(
             Ok(Some(proposed)) => match normalize_derived(&proposed, P::MAX_CHARS) {
                 Some(text) => return Ok(Some(text)),
                 None if attempt < DERIVATION_ATTEMPTS => {
-                    eprintln!(
+                    tracing::warn!(
                         "tidebreak: {kind} attempt {attempt}/{DERIVATION_ATTEMPTS} returned an unusable answer for {subject}: {proposed:?}"
                     );
                     attempt += 1;
@@ -410,7 +410,7 @@ pub(crate) async fn derive_text_with_retries<P: Proposal>(
                 }
             },
             Err(error) if attempt < DERIVATION_ATTEMPTS => {
-                eprintln!(
+                tracing::error!(
                     "tidebreak: {kind} attempt {attempt}/{DERIVATION_ATTEMPTS} failed for {subject}: {error}"
                 );
                 attempt += 1;

--- a/crates/tidebreak-server/src/code/recap.rs
+++ b/crates/tidebreak-server/src/code/recap.rs
@@ -415,14 +415,14 @@ impl TurnRecap for TurnRecapper {
                 // database.
                 match recapper.derive(&owner, session_id, turn_id).await {
                     Ok(Outcome::Recapped(recap)) => {
-                        eprintln!("tidebreak: recapped code turn {turn_id}: {recap}");
+                        tracing::info!("tidebreak: recapped code turn {turn_id}: {recap}");
                     }
                     Ok(Outcome::Declined) => {
-                        eprintln!("tidebreak: left code turn {turn_id} without a recap");
+                        tracing::warn!("tidebreak: left code turn {turn_id} without a recap");
                     }
                     Ok(Outcome::NotApplicable) => {}
                     Err(error) => {
-                        eprintln!("tidebreak: could not recap code turn {turn_id}: {error}");
+                        tracing::error!("tidebreak: could not recap code turn {turn_id}: {error}");
                     }
                 }
                 // Always drain, unlike titling's retry-only follow-up: a turn

--- a/crates/tidebreak-server/src/code/rewrite.rs
+++ b/crates/tidebreak-server/src/code/rewrite.rs
@@ -316,7 +316,9 @@ impl TurnRewrite for TurnRewriter {
                     }
                     Ok(Outcome::NotApplicable) => {}
                     Err(error) => {
-                        tracing::error!("tidebreak: could not rewrite code turn {turn_id}: {error}");
+                        tracing::error!(
+                            "tidebreak: could not rewrite code turn {turn_id}: {error}"
+                        );
                     }
                 }
                 let Some(next) = claim.take_pending_or_release() else {

--- a/crates/tidebreak-server/src/code/rewrite.rs
+++ b/crates/tidebreak-server/src/code/rewrite.rs
@@ -309,14 +309,14 @@ impl TurnRewrite for TurnRewriter {
             loop {
                 match rewriter.derive(&owner, session_id, turn_id).await {
                     Ok(Outcome::Rewritten(_)) => {
-                        eprintln!("tidebreak: rewrote code turn {turn_id}");
+                        tracing::info!("tidebreak: rewrote code turn {turn_id}");
                     }
                     Ok(Outcome::Declined) => {
-                        eprintln!("tidebreak: left code turn {turn_id} without a rewrite");
+                        tracing::warn!("tidebreak: left code turn {turn_id} without a rewrite");
                     }
                     Ok(Outcome::NotApplicable) => {}
                     Err(error) => {
-                        eprintln!("tidebreak: could not rewrite code turn {turn_id}: {error}");
+                        tracing::error!("tidebreak: could not rewrite code turn {turn_id}: {error}");
                     }
                 }
                 let Some(next) = claim.take_pending_or_release() else {

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -83,14 +83,14 @@ pub(crate) fn spawn_for_turn(
     tokio::spawn(async move {
         match derive_workspace_title(&state, &code, &owner, session_id, &message).await {
             Ok(Outcome::Named(title)) => {
-                eprintln!("tidebreak: named a code workspace: {title}");
+                tracing::info!("tidebreak: named a code workspace: {title}");
             }
             Ok(Outcome::Declined) => {
-                eprintln!("tidebreak: left a code workspace on its generated name");
+                tracing::warn!("tidebreak: left a code workspace on its generated name");
             }
             Ok(Outcome::NotApplicable) => {}
             Err(error) => {
-                eprintln!("tidebreak: could not derive a workspace title: {error}");
+                tracing::error!("tidebreak: could not derive a workspace title: {error}");
             }
         }
     });

--- a/crates/tidebreak-server/src/durable_oplog.rs
+++ b/crates/tidebreak-server/src/durable_oplog.rs
@@ -213,7 +213,7 @@ impl OperationStore for DurableOperationStore {
             // committed claim, executing the effect would risk a double spend the
             // log could not later fence. Refuse conservatively.
             Err(error) => {
-                eprintln!("tidebreak: durable operation-log claim failed, refusing conservatively: {error}");
+                tracing::warn!("tidebreak: durable operation-log claim failed, refusing conservatively: {error}");
                 ClaimOutcome::ClaimedElsewhere
             }
         }
@@ -234,7 +234,7 @@ impl OperationStore for DurableOperationStore {
         match block_on(self.state_op(id)) {
             Ok(state) => state,
             Err(error) => {
-                eprintln!("tidebreak: durable operation-log state read failed: {error}");
+                tracing::error!("tidebreak: durable operation-log state read failed: {error}");
                 None
             }
         }
@@ -242,7 +242,7 @@ impl OperationStore for DurableOperationStore {
 
     fn evict(&self, id: OperationId) {
         if let Err(error) = block_on(self.evict_op(id)) {
-            eprintln!("tidebreak: durable operation-log eviction failed: {error}");
+            tracing::error!("tidebreak: durable operation-log eviction failed: {error}");
         }
     }
 
@@ -252,7 +252,7 @@ impl OperationStore for DurableOperationStore {
         match block_on(self.len_op()) {
             Ok(len) => len,
             Err(error) => {
-                eprintln!("tidebreak: durable operation-log length read failed: {error}");
+                tracing::error!("tidebreak: durable operation-log length read failed: {error}");
                 0
             }
         }
@@ -262,7 +262,7 @@ impl OperationStore for DurableOperationStore {
         match block_on(self.retained_body_count_op()) {
             Ok(count) => count,
             Err(error) => {
-                eprintln!("tidebreak: durable retained operation-body count failed: {error}");
+                tracing::error!("tidebreak: durable retained operation-body count failed: {error}");
                 0
             }
         }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -2392,7 +2392,7 @@ async fn bind_inner(
             loop {
                 tick.tick().await;
                 if let Err(error) = routes::promote_queued_turns(&state).await {
-                    eprintln!("tidebreak: queued-turn promotion failed: {error:?}");
+                    tracing::error!("tidebreak: queued-turn promotion failed: {error:?}");
                 }
             }
         })

--- a/crates/tidebreak-server/src/routes/projects_chats.rs
+++ b/crates/tidebreak-server/src/routes/projects_chats.rs
@@ -865,7 +865,9 @@ pub async fn delete_chat(
             match cleanup {
                 Ok(Ok(())) => {}
                 Ok(Err(error)) => {
-                    tracing::error!("tidebreak: could not remove private scratch for chat {id}: {error}");
+                    tracing::error!(
+                        "tidebreak: could not remove private scratch for chat {id}: {error}"
+                    );
                 }
                 Err(error) => {
                     tracing::error!(
@@ -986,6 +988,8 @@ async fn erase_deleted_chat_agent_run_workspaces(
     })
     .await;
     if let Err(error) = cleanup {
-        tracing::error!("tidebreak: agent-run scratch cleanup task stopped for chat {chat_id}: {error}");
+        tracing::error!(
+            "tidebreak: agent-run scratch cleanup task stopped for chat {chat_id}: {error}"
+        );
     }
 }

--- a/crates/tidebreak-server/src/routes/projects_chats.rs
+++ b/crates/tidebreak-server/src/routes/projects_chats.rs
@@ -865,10 +865,10 @@ pub async fn delete_chat(
             match cleanup {
                 Ok(Ok(())) => {}
                 Ok(Err(error)) => {
-                    eprintln!("tidebreak: could not remove private scratch for chat {id}: {error}");
+                    tracing::error!("tidebreak: could not remove private scratch for chat {id}: {error}");
                 }
                 Err(error) => {
-                    eprintln!(
+                    tracing::error!(
                         "tidebreak: private scratch cleanup task stopped for chat {id}: {error}"
                     );
                 }
@@ -963,7 +963,7 @@ async fn erase_deleted_chat_agent_run_workspaces(
             )
             .await
             {
-                eprintln!(
+                tracing::error!(
                     "tidebreak: could not destroy agent-run workspace for chat {chat_id} run {run_id}: {error}"
                 );
             }
@@ -978,7 +978,7 @@ async fn erase_deleted_chat_agent_run_workspaces(
             match std::fs::remove_dir_all(&path) {
                 Ok(()) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => eprintln!(
+                Err(error) => tracing::error!(
                     "tidebreak: could not remove agent-run scratch for chat {chat_id} run {run_id}: {error}"
                 ),
             }
@@ -986,6 +986,6 @@ async fn erase_deleted_chat_agent_run_workspaces(
     })
     .await;
     if let Err(error) = cleanup {
-        eprintln!("tidebreak: agent-run scratch cleanup task stopped for chat {chat_id}: {error}");
+        tracing::error!("tidebreak: agent-run scratch cleanup task stopped for chat {chat_id}: {error}");
     }
 }

--- a/crates/tidebreak-server/src/routes/turn_control.rs
+++ b/crates/tidebreak-server/src/routes/turn_control.rs
@@ -766,7 +766,7 @@ pub(crate) async fn promote_queued_turns(state: &AppState) -> Result<(), ServerE
             continue;
         };
         let dropped = |reason: &str| {
-            eprintln!(
+            tracing::warn!(
                 "tidebreak: dropping queued message {} for chat {chat_id}: {reason}",
                 next.id
             );

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
@@ -133,7 +133,7 @@ impl SandboxAgentRunWorker {
             LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         while let Some(result) = lanes.join_next().await {
             if let Err(error) = result {
-                eprintln!("tidebreak: sandbox agent worker lane stopped: {error}");
+                tracing::error!("tidebreak: sandbox agent worker lane stopped: {error}");
                 tokio::time::sleep(restart_backoff.next_delay()).await;
             }
             lanes.spawn(self.clone().run_lane());
@@ -159,7 +159,7 @@ impl SandboxAgentRunWorker {
                     idle_delay = self.config.idle_min;
                 }
                 Err(error) => {
-                    eprintln!("tidebreak: sandbox agent worker iteration failed: {error}");
+                    tracing::warn!("tidebreak: sandbox agent worker iteration failed: {error}");
                     let delay = failure_backoff.next_delay();
                     tokio::select! {
                         _ = tokio::time::sleep(delay) => {}
@@ -225,7 +225,7 @@ impl SandboxAgentRunWorker {
                 Ok(outcome) => break outcome,
                 Err(error) => {
                     recovering_ambiguous_commit = true;
-                    eprintln!(
+                    tracing::warn!(
                         "tidebreak: wait-set {wait_id} resume failed; retrying exact request: {error}"
                     );
                     tokio::select! {
@@ -1520,7 +1520,7 @@ impl SandboxAgentRunWorker {
             .append_agent_run_progress(run_id, key, narration)
             .await
         {
-            eprintln!("tidebreak: could not publish progress for run {run_id}: {error}");
+            tracing::error!("tidebreak: could not publish progress for run {run_id}: {error}");
         }
     }
 
@@ -1545,7 +1545,7 @@ impl SandboxAgentRunWorker {
                 .append_agent_run_progress(run_id, &format!("step:{depth}:tool:{index}"), &text)
                 .await
             {
-                eprintln!(
+                tracing::error!(
                     "tidebreak: could not publish provider-executed progress for run \
                      {run_id}: {error}"
                 );

--- a/crates/tidebreak-server/src/sandbox_container_run.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run.rs
@@ -2468,7 +2468,9 @@ impl SandboxContainerRunner {
         // destroyed, and idempotently for runs that never minted one.
         self.revoke_scoped_token(run_uuid).await;
         if let Err(error) = self.store.enqueue_sandbox_teardown(run_uuid).await {
-            tracing::error!("tidebreak: could not persist a container teardown obligation: {error}");
+            tracing::error!(
+                "tidebreak: could not persist a container teardown obligation: {error}"
+            );
         }
         for attempt in 0..3u32 {
             match self.backend.destroy(handle).await {
@@ -2619,7 +2621,9 @@ impl SandboxContainerRunner {
                 }
             }
             Err(error) => {
-                tracing::warn!("tidebreak: the sandbox orphan sweep proved nothing this pass: {error}");
+                tracing::warn!(
+                    "tidebreak: the sandbox orphan sweep proved nothing this pass: {error}"
+                );
             }
         }
         Ok(())

--- a/crates/tidebreak-server/src/sandbox_container_run.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run.rs
@@ -353,7 +353,7 @@ impl HostModelProxy {
             return Ok(!self.cancel.is_cancelled());
         };
         guard.authorize_egress(&self.cancel).await.map_err(|error| {
-            eprintln!(
+            tracing::error!(
                 "tidebreak: host model proxy could not revalidate its execution fence: {error}"
             );
         })
@@ -512,7 +512,7 @@ impl CapabilityResponder for HostModelProxy {
             Err(error) => {
                 // A transport-safe, retryable refusal: re-issuing the same
                 // operation identity may succeed once the provider is reachable.
-                eprintln!("tidebreak: host model proxy could not start inference: {error}");
+                tracing::error!("tidebreak: host model proxy could not start inference: {error}");
                 return Response::Error(ErrorResponse::new(
                     ErrorCode::Internal,
                     "host model inference could not start",
@@ -553,7 +553,7 @@ impl CapabilityResponder for HostModelProxy {
                             ));
                         }
                     }
-                    eprintln!(
+                    tracing::error!(
                         "tidebreak: host model proxy inference failed: {}",
                         error.message
                     );
@@ -2185,7 +2185,7 @@ impl SandboxContainerRunner {
     /// bounds the credential when the issuer cannot be reached.
     async fn revoke_scoped_token(&self, run_uuid: Uuid) {
         if let Err(error) = self.token_issuer.revoke(run_uuid).await {
-            eprintln!(
+            tracing::error!(
                 "tidebreak: could not revoke the scoped model token for run {run_uuid}: {error}"
             );
         }
@@ -2276,7 +2276,7 @@ impl SandboxContainerRunner {
                 return DrainOutcome::Failed("container no longer exists".to_owned());
             }
             Err(error) => {
-                eprintln!("tidebreak: container address unavailable, will reattach: {error}");
+                tracing::warn!("tidebreak: container address unavailable, will reattach: {error}");
                 return DrainOutcome::Disconnected;
             }
         };
@@ -2354,7 +2354,7 @@ impl SandboxContainerRunner {
                                 )
                                 .await
                             {
-                                eprintln!("tidebreak: could not publish progress for run {run_id}: {error}");
+                                tracing::error!("tidebreak: could not publish progress for run {run_id}: {error}");
                             }
                         }
                         _ => {}
@@ -2366,7 +2366,7 @@ impl SandboxContainerRunner {
                         // drive reattaches; the instruction is not re-sent,
                         // because guidance the run never saw is the caller's to
                         // repeat, not the host's to replay later out of context.
-                        eprintln!("tidebreak: a steering instruction was not delivered: {error}");
+                        tracing::warn!("tidebreak: a steering instruction was not delivered: {error}");
                     }
                 }
             }
@@ -2414,11 +2414,11 @@ impl SandboxContainerRunner {
                     .record_late_container_result_evidence(*run_id.as_uuid(), text)
                     .await
                 {
-                    Ok(true) => eprintln!(
+                    Ok(true) => tracing::info!(
                         "tidebreak: retained a late container result for run {run_id} as evidence"
                     ),
                     Ok(false) => {}
-                    Err(error) => eprintln!(
+                    Err(error) => tracing::error!(
                         "tidebreak: could not retain a late container result for run {run_id}: {error}"
                     ),
                 }
@@ -2468,27 +2468,27 @@ impl SandboxContainerRunner {
         // destroyed, and idempotently for runs that never minted one.
         self.revoke_scoped_token(run_uuid).await;
         if let Err(error) = self.store.enqueue_sandbox_teardown(run_uuid).await {
-            eprintln!("tidebreak: could not persist a container teardown obligation: {error}");
+            tracing::error!("tidebreak: could not persist a container teardown obligation: {error}");
         }
         for attempt in 0..3u32 {
             match self.backend.destroy(handle).await {
                 Ok(()) => {
                     if let Err(error) = self.store.complete_sandbox_teardown(run_uuid).await {
-                        eprintln!(
+                        tracing::warn!(
                             "tidebreak: container teardown confirmed but not recorded: {error}"
                         );
                     }
                     return;
                 }
                 Err(error) => {
-                    eprintln!(
+                    tracing::warn!(
                         "tidebreak: container teardown attempt {attempt} unconfirmed: {error}"
                     );
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
             }
         }
-        eprintln!(
+        tracing::warn!(
             "tidebreak: container teardown for {} left unconfirmed; the sweep re-drives it",
             handle.reference
         );
@@ -2557,7 +2557,7 @@ impl SandboxContainerRunner {
             .lapse_sandbox_provisions(chrono::Utc::now())
             .await?;
         for record in &lapsed {
-            eprintln!(
+            tracing::warn!(
                 "tidebreak: sandbox provisioning intent for run {} lapsed; its tag is reclaimable",
                 record.run_id
             );
@@ -2609,7 +2609,7 @@ impl SandboxContainerRunner {
         match self.backend.reclaim_orphans(&live).await {
             Ok(reclaimed) => {
                 for handle in &reclaimed {
-                    eprintln!(
+                    tracing::info!(
                         "tidebreak: reclaimed an orphaned sandbox container {}",
                         handle.reference
                     );
@@ -2619,7 +2619,7 @@ impl SandboxContainerRunner {
                 }
             }
             Err(error) => {
-                eprintln!("tidebreak: the sandbox orphan sweep proved nothing this pass: {error}");
+                tracing::warn!("tidebreak: the sandbox orphan sweep proved nothing this pass: {error}");
             }
         }
         Ok(())

--- a/crates/tidebreak-server/src/sandbox_container_run_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run_worker.rs
@@ -102,8 +102,8 @@ impl SandboxContainerRunWorker {
         lanes.spawn(self.run_maintenance_lane());
         while let Some(result) = lanes.join_next().await {
             match result {
-                Ok(()) => eprintln!("tidebreak: container worker lane stopped unexpectedly"),
-                Err(error) => eprintln!("tidebreak: container worker lane stopped: {error}"),
+                Ok(()) => tracing::error!("tidebreak: container worker lane stopped unexpectedly"),
+                Err(error) => tracing::error!("tidebreak: container worker lane stopped: {error}"),
             }
         }
     }
@@ -121,7 +121,7 @@ impl SandboxContainerRunWorker {
                     idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
                 }
                 Err(error) => {
-                    eprintln!("tidebreak: container worker iteration failed: {error}");
+                    tracing::warn!("tidebreak: container worker iteration failed: {error}");
                     tokio::select! {
                         _ = tokio::time::sleep(self.config.failure_delay) => {}
                         _ = self.wake.notified() => {}
@@ -152,14 +152,14 @@ impl SandboxContainerRunWorker {
             match self.runner.recover().await {
                 Ok(_) => {
                     if let Err(error) = self.runner.sweep().await {
-                        eprintln!("tidebreak: container worker sweep failed: {error}");
+                        tracing::error!("tidebreak: container worker sweep failed: {error}");
                     }
                 }
                 Err(error) => {
                     // Do not sweep after an incomplete recovery pass: a
                     // reclaimable run must be re-driven before its container
                     // can be considered an orphan.
-                    eprintln!("tidebreak: container worker recovery failed: {error}");
+                    tracing::error!("tidebreak: container worker recovery failed: {error}");
                 }
             }
             tokio::time::sleep(self.config.maintenance_interval).await;

--- a/crates/tidebreak-server/src/sandbox_exec_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_exec_worker.rs
@@ -256,7 +256,7 @@ impl SandboxExecWorker {
             LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         while let Some(result) = lanes.join_next().await {
             if let Err(error) = result {
-                eprintln!("tidebreak: sandbox exec worker lane stopped: {error}");
+                tracing::error!("tidebreak: sandbox exec worker lane stopped: {error}");
                 tokio::time::sleep(restart_backoff.next_delay()).await;
             }
             lanes.spawn(self.clone().run_lane());
@@ -282,7 +282,7 @@ impl SandboxExecWorker {
                     idle_delay = self.config.idle_min;
                 }
                 Err(error) => {
-                    eprintln!("tidebreak: sandbox exec worker iteration failed: {error}");
+                    tracing::warn!("tidebreak: sandbox exec worker iteration failed: {error}");
                     let delay = failure_backoff.next_delay();
                     tokio::select! {
                         _ = tokio::time::sleep(delay) => {}

--- a/crates/tidebreak-server/src/sandbox_task_plan_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_task_plan_worker.rs
@@ -87,7 +87,7 @@ impl SandboxTaskPlanWorker {
             LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         while let Some(result) = lanes.join_next().await {
             if let Err(error) = result {
-                eprintln!("tidebreak: sandbox task-plan worker lane stopped: {error}");
+                tracing::error!("tidebreak: sandbox task-plan worker lane stopped: {error}");
                 tokio::time::sleep(restart_backoff.next_delay()).await;
             }
             lanes.spawn(self.clone().run_lane());
@@ -113,7 +113,7 @@ impl SandboxTaskPlanWorker {
                     idle_delay = self.config.idle_min;
                 }
                 Err(error) => {
-                    eprintln!("tidebreak: sandbox task-plan worker iteration failed: {error}");
+                    tracing::warn!("tidebreak: sandbox task-plan worker iteration failed: {error}");
                     let delay = failure_backoff.next_delay();
                     tokio::select! {
                         _ = tokio::time::sleep(delay) => {}

--- a/crates/tidebreak-server/src/sandbox_web_search_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_web_search_worker.rs
@@ -195,7 +195,7 @@ impl SandboxWebSearchWorker {
             LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         while let Some(result) = lanes.join_next().await {
             if let Err(error) = result {
-                eprintln!("tidebreak: sandbox web-search worker lane stopped: {error}");
+                tracing::error!("tidebreak: sandbox web-search worker lane stopped: {error}");
                 tokio::time::sleep(restart_backoff.next_delay()).await;
             }
             lanes.spawn(self.clone().run_lane());
@@ -221,7 +221,7 @@ impl SandboxWebSearchWorker {
                     idle_delay = self.config.idle_min;
                 }
                 Err(error) => {
-                    eprintln!("tidebreak: sandbox web-search worker iteration failed: {error}");
+                    tracing::warn!("tidebreak: sandbox web-search worker iteration failed: {error}");
                     let delay = failure_backoff.next_delay();
                     tokio::select! {
                         _ = tokio::time::sleep(delay) => {}

--- a/crates/tidebreak-server/src/sandbox_web_search_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_web_search_worker.rs
@@ -221,7 +221,9 @@ impl SandboxWebSearchWorker {
                     idle_delay = self.config.idle_min;
                 }
                 Err(error) => {
-                    tracing::warn!("tidebreak: sandbox web-search worker iteration failed: {error}");
+                    tracing::warn!(
+                        "tidebreak: sandbox web-search worker iteration failed: {error}"
+                    );
                     let delay = failure_backoff.next_delay();
                     tokio::select! {
                         _ = tokio::time::sleep(delay) => {}

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -547,7 +547,7 @@ impl TurnWorker {
                         break;
                     }
                     Err(error) => {
-                        eprintln!("tidebreak: turn worker claim failed: {error}");
+                        tracing::warn!("tidebreak: turn worker claim failed: {error}");
                         scan_failed = true;
                         break;
                     }
@@ -764,7 +764,7 @@ impl TurnWorker {
                     // Prompt enrichment is not an authority boundary. A broker
                     // failure here leaves the list empty; the provider resolves
                     // again and returns the concrete error if `exec` is called.
-                    eprintln!(
+                    tracing::warn!(
                         "tidebreak: local exec folders unavailable for chat {}: {}",
                         chat.id, error
                     );
@@ -903,7 +903,7 @@ impl TurnWorker {
             web_search,
         );
         if let Some(prompt) = surface.agent_config.system_prompt.as_deref() {
-            eprintln!(
+            tracing::debug!(
                 "tidebreak: turn {} operating_prompt={}",
                 turn.id,
                 crate::foreground_prompt::identity(prompt)
@@ -1012,7 +1012,7 @@ impl TurnWorker {
                         turn.id,
                     )),
                     Err(error) => {
-                        eprintln!(
+                        tracing::warn!(
                             "tidebreak: private scratch unavailable for chat {}: {}",
                             chat.id, error
                         );
@@ -1157,7 +1157,7 @@ impl TurnWorker {
                             }
                             Ok(_) => {}
                             Err(error) => {
-                                eprintln!(
+                                tracing::error!(
                                     "tidebreak: turn {} steer poll failed: {error}",
                                     turn.id
                                 );
@@ -1202,7 +1202,7 @@ impl TurnWorker {
                     total_model_steps = checked_model_step_sum(total_model_steps, model_steps)?;
                     match checked_usage_sum(total_usage, usage) {
                         Ok(total) => total_usage = total,
-                        Err(error) => eprintln!(
+                        Err(error) => tracing::warn!(
                             "tidebreak: turn {} cancellation usage overflowed; acknowledging the durable baseline: {error}",
                             turn.id
                         ),
@@ -1406,7 +1406,7 @@ impl TurnWorker {
                                     // a miss never errors, it just costs more.
                                     // Logged with the durable field names so the
                                     // line is greppable across turns.
-                                    eprintln!(
+                                    tracing::debug!(
                                         "tidebreak: turn {} resolved usage input_tokens={} output_tokens={} cache_read_input_tokens={} cache_creation_input_tokens={}",
                                         turn.id,
                                         total_usage.input_tokens,
@@ -2263,7 +2263,7 @@ impl TurnWorker {
                     total_model_steps = checked_model_step_sum(total_model_steps, model_steps)?;
                     match checked_usage_sum(total_usage, usage) {
                         Ok(total) => total_usage = total,
-                        Err(error) => eprintln!(
+                        Err(error) => tracing::warn!(
                             "tidebreak: turn {} cancellation usage overflowed; acknowledging the durable baseline: {error}",
                             turn.id
                         ),
@@ -2802,7 +2802,7 @@ impl TurnWorker {
     }
 
     async fn retry_after(&self, operation: &str, turn_id: TurnId, error: &AgentError) {
-        eprintln!("tidebreak: turn {turn_id} {operation} failed; retrying exact request: {error}");
+        tracing::warn!("tidebreak: turn {turn_id} {operation} failed; retrying exact request: {error}");
         tokio::time::sleep(self.config.failure_delay).await;
     }
 
@@ -2980,8 +2980,8 @@ fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
 fn log_turn_result(result: std::result::Result<Result<TurnWorkerOutcome>, tokio::task::JoinError>) {
     match result {
         Ok(Ok(_)) => {}
-        Ok(Err(error)) => eprintln!("tidebreak: turn worker execution failed: {error}"),
-        Err(error) => eprintln!("tidebreak: turn worker task stopped: {error}"),
+        Ok(Err(error)) => tracing::error!("tidebreak: turn worker execution failed: {error}"),
+        Err(error) => tracing::error!("tidebreak: turn worker task stopped: {error}"),
     }
 }
 

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -766,7 +766,8 @@ impl TurnWorker {
                     // again and returns the concrete error if `exec` is called.
                     tracing::warn!(
                         "tidebreak: local exec folders unavailable for chat {}: {}",
-                        chat.id, error
+                        chat.id,
+                        error
                     );
                     Vec::new()
                 }
@@ -1014,7 +1015,8 @@ impl TurnWorker {
                     Err(error) => {
                         tracing::warn!(
                             "tidebreak: private scratch unavailable for chat {}: {}",
-                            chat.id, error
+                            chat.id,
+                            error
                         );
                         None
                     }
@@ -2802,7 +2804,9 @@ impl TurnWorker {
     }
 
     async fn retry_after(&self, operation: &str, turn_id: TurnId, error: &AgentError) {
-        tracing::warn!("tidebreak: turn {turn_id} {operation} failed; retrying exact request: {error}");
+        tracing::warn!(
+            "tidebreak: turn {turn_id} {operation} failed; retrying exact request: {error}"
+        );
         tokio::time::sleep(self.config.failure_delay).await;
     }
 


### PR DESCRIPTION
Closes #2947

Worker and other post-subscriber `tidebreak-server` paths were logging with `eprintln!`, so failures never reached the structured JSON / `TIDEBREAK_LOG` subscriber in `src/logging.rs`.

This converts those call sites to `tracing::{error,warn,info,debug}!`, keeping the existing message text. Retryable worker iterations and degraded conditions use `warn!`; hard failures and lane stops use `error!`; sweep summaries and successful titling/recap/rewrite use `info!`; operating-prompt and usage resolution remain `debug!`.

Left as `eprintln!`:
- `logging.rs` (runs while installing the subscriber)
- tests, including skip notices in `sandbox_docker.rs` and `sandbox_container_run/tests.rs`

Could not run `cargo check -p tidebreak-server` / `cargo test -p tidebreak-server` in this environment: Cargo is offline and fetching `symphonia` from GitHub returns 403.