### PR TITLE
fix(harness): allowlist the coding-engine child environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7476,6 +7476,7 @@ dependencies = [
  "tidebreak-core",
  "tidebreak-managed-node",
  "tokio",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,12 @@ brush-parser = "=0.4.0"
 fancy-regex = "=0.19.0"
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
+# Parses the same `$CODEX_HOME/config.toml` the Codex engine parses, so
+# auth-override detection and the engine child-env filter agree with the
+# engine (and each other) about what the config declares. A substring scan
+# cannot tell a declared provider from a comment, and the filter must
+# forward exactly the env keys the declared providers name.
+toml = "=1.1.4"
 schemars = { version = "=1.2.2", features = ["uuid1"] }
 # Validates tool-call arguments against the advertised input_schema at
 # dispatch. No resolvers: schemas come from the registry or a mounted MCP

--- a/crates/tidebreak-harness/Cargo.toml
+++ b/crates/tidebreak-harness/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = { workspace = true }
 tidebreak-core = { path = "../tidebreak-core", default-features = false }
 tidebreak-managed-node = { path = "../tidebreak-managed-node" }
 tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync", "time"] }
+toml = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/tidebreak-harness/src/browser_channel.rs
+++ b/crates/tidebreak-harness/src/browser_channel.rs
@@ -22,8 +22,9 @@ pub const BROWSER_CAPFILE_ENV_KEY: &str = BrowserChannelSpec::ENV_KEY;
 /// single ordering every adapter must use:
 ///
 /// 1. Clear the inherited process environment.
-/// 2. Restore the probe snapshot through [`filter_child_env`], which strips
-///    the reserved `TIDEBREAK_` namespace (case-insensitively).
+/// 2. Restore the probe snapshot through [`filter_child_env`], which narrows
+///    it to the child allowlist — ambient shell-rc secrets and the reserved
+///    `TIDEBREAK_` namespace do not survive.
 /// 3. Apply the sanitized launch-plan environment. Settings already rejected
 ///    reserved keys via [`BrowserChannelSpec::is_reserved_env_key`], so this
 ///    step can carry no adapter-owned override.

--- a/crates/tidebreak-harness/src/browser_channel.rs
+++ b/crates/tidebreak-harness/src/browser_channel.rs
@@ -10,7 +10,7 @@
 
 use std::ffi::OsString;
 
-use crate::{filter_child_env, BrowserChannelSpec};
+use crate::{filter_engine_child_env, BrowserChannelSpec};
 
 /// Adapter must inject this exact key; engines must consume it.
 ///
@@ -22,9 +22,10 @@ pub const BROWSER_CAPFILE_ENV_KEY: &str = BrowserChannelSpec::ENV_KEY;
 /// single ordering every adapter must use:
 ///
 /// 1. Clear the inherited process environment.
-/// 2. Restore the probe snapshot through [`filter_child_env`], which narrows
-///    it to the child allowlist — ambient shell-rc secrets and the reserved
-///    `TIDEBREAK_` namespace do not survive.
+/// 2. Restore the probe snapshot through [`filter_engine_child_env`], which
+///    narrows it to the child allowlist plus `kind`'s own auth-signal
+///    variables — ambient shell-rc secrets, other engines' credentials, and
+///    the reserved `TIDEBREAK_` namespace do not survive.
 /// 3. Apply the sanitized launch-plan environment. Settings already rejected
 ///    reserved keys via [`BrowserChannelSpec::is_reserved_env_key`], so this
 ///    step can carry no adapter-owned override.
@@ -35,6 +36,7 @@ pub const BROWSER_CAPFILE_ENV_KEY: &str = BrowserChannelSpec::ENV_KEY;
 /// Some/None/final-override path. `None` adds no environment entry.
 pub fn apply_child_env_tokio<I>(
     cmd: &mut tokio::process::Command,
+    kind: tidebreak_core::HarnessKind,
     snapshot: I,
     plan_env: &[(String, String)],
     browser: Option<&BrowserChannelSpec>,
@@ -42,7 +44,7 @@ pub fn apply_child_env_tokio<I>(
     I: IntoIterator<Item = (OsString, OsString)>,
 {
     cmd.env_clear();
-    for (key, value) in filter_child_env(snapshot) {
+    for (key, value) in filter_engine_child_env(kind, snapshot) {
         cmd.env(key, value);
     }
     for (key, value) in plan_env {
@@ -67,8 +69,22 @@ mod tests {
         plan_env: &[(String, String)],
         browser: Option<&BrowserChannelSpec>,
     ) -> std::collections::BTreeMap<String, String> {
+        final_env_for(
+            tidebreak_core::HarnessKind::ClaudeCode,
+            snapshot,
+            plan_env,
+            browser,
+        )
+    }
+
+    fn final_env_for(
+        kind: tidebreak_core::HarnessKind,
+        snapshot: impl IntoIterator<Item = (OsString, OsString)>,
+        plan_env: &[(String, String)],
+        browser: Option<&BrowserChannelSpec>,
+    ) -> std::collections::BTreeMap<String, String> {
         let mut cmd = tokio::process::Command::new("/bin/true");
-        apply_child_env_tokio(&mut cmd, snapshot, plan_env, browser);
+        apply_child_env_tokio(&mut cmd, kind, snapshot, plan_env, browser);
         cmd.as_std()
             .get_envs()
             .filter_map(|(name, value)| {
@@ -140,7 +156,13 @@ mod tests {
         let mut cmd = tokio::process::Command::new("/bin/true");
         cmd.env(AMBIENT_SENTINEL, "must-be-cleared");
 
-        apply_child_env_tokio(&mut cmd, Vec::new(), &[], None);
+        apply_child_env_tokio(
+            &mut cmd,
+            tidebreak_core::HarnessKind::ClaudeCode,
+            Vec::new(),
+            &[],
+            None,
+        );
 
         assert!(
             cmd.as_std()
@@ -148,6 +170,39 @@ mod tests {
                 .all(|(name, _)| name != std::ffi::OsStr::new(AMBIENT_SENTINEL)),
             "the helper must clear command entries configured before its trusted environment is applied"
         );
+    }
+
+    #[test]
+    fn snapshot_auth_variables_reach_only_their_own_engine() {
+        // The launch path scopes the engine-auth exception per engine: the
+        // same snapshot hands each session child only the credentials its
+        // own auth-mode detection reads, never another engine's.
+        let snapshot = || {
+            vec![
+                (OsString::from("ANTHROPIC_API_KEY"), OsString::from("a")),
+                (OsString::from("OPENAI_API_KEY"), OsString::from("o")),
+            ]
+        };
+        let claude = final_env_for(
+            tidebreak_core::HarnessKind::ClaudeCode,
+            snapshot(),
+            &[],
+            None,
+        );
+        assert!(claude.contains_key("ANTHROPIC_API_KEY"));
+        assert!(!claude.contains_key("OPENAI_API_KEY"));
+        let codex = final_env_for(tidebreak_core::HarnessKind::Codex, snapshot(), &[], None);
+        assert!(codex.contains_key("OPENAI_API_KEY"));
+        assert!(!codex.contains_key("ANTHROPIC_API_KEY"));
+        for kind in [
+            tidebreak_core::HarnessKind::Opencode,
+            tidebreak_core::HarnessKind::Grok,
+        ] {
+            assert!(
+                final_env_for(kind, snapshot(), &[], None).is_empty(),
+                "{kind:?} detection reads no auth environment, so its child receives none"
+            );
+        }
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -86,14 +86,10 @@ fn read_settings(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> Option<ser
 }
 
 /// Environment variables that authenticate or reroute Claude Code without
-/// the vendor login [`observe_auth`] observes.
-const AUTH_OVERRIDE_VARS: &[&str] = &[
-    "ANTHROPIC_API_KEY",
-    "ANTHROPIC_AUTH_TOKEN",
-    "ANTHROPIC_BASE_URL",
-    "CLAUDE_CODE_USE_BEDROCK",
-    "CLAUDE_CODE_USE_VERTEX",
-];
+/// the vendor login [`observe_auth`] observes. Defined next to the child
+/// allowlist in [`crate::probe`] so a name detection counts as working auth
+/// is guaranteed to reach the spawned engine child.
+const AUTH_OVERRIDE_VARS: &[&str] = crate::probe::CLAUDE_AUTH_ENV_VARS;
 
 /// Whether this environment could authenticate Claude Code without the
 /// vendor login [`observe_auth`] observes: an API key, auth token, or

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -617,6 +617,7 @@ impl ClaudeSession {
             .stderr(Stdio::piped());
         apply_child_env_tokio(
             &mut command,
+            tidebreak_core::HarnessKind::ClaudeCode,
             self.spec.env.iter().cloned(),
             &plan.env,
             self.spec.browser.as_ref(),

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -438,10 +438,96 @@ pub(crate) fn observe_auth_override(
     config_declares_model_provider(env).then_some(crate::AuthOverrideSignal::EngineConfig)
 }
 
-/// `$CODEX_HOME/config.toml`, defaulting to `~/.codex/config.toml`, mentions
-/// `model_provider`. A comment mentioning it also matches; that over-reads
-/// toward "may authenticate some other way", which is the safe direction.
+/// `$CODEX_HOME/config.toml`, defaulting to `~/.codex/config.toml`, declares
+/// a model provider: a top-level or per-profile `model_provider` selection,
+/// or a `[model_providers.*]` table. Parsed as TOML rather than
+/// text-matched, because two decisions hang on the same answer and must
+/// agree: create admits a signed-out session on it, and
+/// [`crate::filter_engine_child_env`] forwards the declared providers'
+/// credentials ([`config_provider_env_keys`]) to the session child. A
+/// comment that merely mentions the word authenticates nothing, so counting
+/// it would admit a session whose first turn 401s — the failure issue 2653
+/// asked create to refuse.
+///
+/// An unparseable config still admits on the textual over-read: Codex
+/// itself refuses to start on it and prints its own config error, which is
+/// more legible than refusing with "sign in" on a gateway-managed machine
+/// with a typo.
 fn config_declares_model_provider(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> bool {
+    let Some(raw) = read_config(env) else {
+        return false;
+    };
+    let Ok(config) = raw.parse::<toml::Table>() else {
+        return raw.contains("model_provider");
+    };
+    config.contains_key("model_provider")
+        || config
+            .get("model_providers")
+            .and_then(toml::Value::as_table)
+            .is_some_and(|providers| !providers.is_empty())
+        || config
+            .get("profiles")
+            .and_then(toml::Value::as_table)
+            .is_some_and(|profiles| {
+                profiles.values().any(|profile| {
+                    profile
+                        .as_table()
+                        .is_some_and(|table| table.contains_key("model_provider"))
+                })
+            })
+}
+
+/// Environment names the config-declared model providers read credentials
+/// from: each `[model_providers.*]` entry's `env_key`, plus every variable
+/// its `env_http_headers` map draws a header value from.
+///
+/// This is the config half of the create/launch invariant: when
+/// [`config_declares_model_provider`] admits a signed-out session, the
+/// engine authenticates through a provider these names feed, so
+/// [`crate::filter_engine_child_env`] forwards exactly this set to a Codex
+/// child — bounded to what the config names, and to no other engine's
+/// child. A provider that names no environment key (ChatGPT OAuth, an auth
+/// helper, an unauthenticated local endpoint) reads its material from files
+/// under `$CODEX_HOME`, which the child already reaches, so it contributes
+/// nothing. An absent or unparseable config contributes nothing either.
+pub(crate) fn config_provider_env_keys(
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
+) -> Vec<String> {
+    let Some(config) = read_config(env).and_then(|raw| raw.parse::<toml::Table>().ok()) else {
+        return Vec::new();
+    };
+    let Some(providers) = config
+        .get("model_providers")
+        .and_then(toml::Value::as_table)
+    else {
+        return Vec::new();
+    };
+    let mut keys: Vec<String> = Vec::new();
+    let mut push = |name: &str| {
+        if !name.is_empty() && !keys.iter().any(|existing| existing == name) {
+            keys.push(name.to_owned());
+        }
+    };
+    for provider in providers.values().filter_map(toml::Value::as_table) {
+        if let Some(key) = provider.get("env_key").and_then(toml::Value::as_str) {
+            push(key);
+        }
+        if let Some(headers) = provider
+            .get("env_http_headers")
+            .and_then(toml::Value::as_table)
+        {
+            for name in headers.values().filter_map(toml::Value::as_str) {
+                push(name);
+            }
+        }
+    }
+    keys
+}
+
+/// Raw `$CODEX_HOME/config.toml`, defaulting to `~/.codex/config.toml`,
+/// resolved from the captured snapshot the same way for detection and for
+/// the child filter, so both read the file the launched engine will read.
+fn read_config(env: &[(std::ffi::OsString, std::ffi::OsString)]) -> Option<String> {
     let config_dir = crate::probe::env_value(env, std::ffi::OsStr::new("CODEX_HOME"))
         .filter(|value| !value.is_empty())
         .map(std::path::PathBuf::from)
@@ -451,12 +537,8 @@ fn config_declares_model_provider(env: &[(std::ffi::OsString, std::ffi::OsString
                 .find(|(key, _)| key.eq_ignore_ascii_case("HOME"))
                 .map(|(_, value)| std::path::PathBuf::from(value.as_os_str()).join(".codex"))
                 .filter(|dir| !dir.as_os_str().is_empty())
-        });
-    let Some(config_dir) = config_dir else {
-        return false;
-    };
-    std::fs::read_to_string(config_dir.join("config.toml"))
-        .is_ok_and(|raw| raw.contains("model_provider"))
+        })?;
+    std::fs::read_to_string(config_dir.join("config.toml")).ok()
 }
 
 #[cfg(test)]
@@ -949,6 +1031,53 @@ mod tests {
         )
         .unwrap();
         assert!(auth_override_present(&env));
+        // A profile-scoped selection is a declaration too.
+        std::fs::write(&config, "[profiles.gw]\nmodel_provider = \"gateway\"\n").unwrap();
+        assert!(auth_override_present(&env));
+        // A comment that merely mentions the word declares nothing: admitting
+        // on it would mint a session with no credential behind it and no
+        // config-named variable for the child filter to forward.
+        std::fs::write(
+            &config,
+            "# model_provider = \"gateway\"\nmodel = \"gpt-5\"\n",
+        )
+        .unwrap();
+        assert!(!auth_override_present(&env));
+        // An unparseable config keeps the textual over-read: the engine
+        // surfaces its own config error, which beats a "sign in" refusal.
+        std::fs::write(&config, "model_provider = [unclosed\n").unwrap();
+        assert!(auth_override_present(&env));
+    }
+
+    #[test]
+    fn config_provider_env_keys_are_exactly_what_providers_name() {
+        let os = std::ffi::OsString::from;
+        let codex_home = tempfile::tempdir().unwrap();
+        let env = vec![(os("CODEX_HOME"), codex_home.path().as_os_str().to_owned())];
+        assert!(config_provider_env_keys(&env).is_empty());
+        std::fs::write(
+            codex_home.path().join("config.toml"),
+            r#"model_provider = "gateway"
+
+[model_providers.gateway]
+base_url = "https://gateway.example/v1"
+env_key = "GATEWAY_TEST_KEY"
+env_http_headers = { "X-Gateway-Auth" = "GATEWAY_TEST_HEADER" }
+
+[model_providers.other]
+base_url = "https://other.example/v1"
+env_key = "GATEWAY_TEST_KEY"
+
+[model_providers.oauth]
+base_url = "https://oauth.example/v1"
+requires_openai_auth = true
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config_provider_env_keys(&env),
+            ["GATEWAY_TEST_KEY", "GATEWAY_TEST_HEADER"]
+        );
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -432,7 +432,7 @@ pub(crate) fn auth_override_present(env: &[(std::ffi::OsString, std::ffi::OsStri
 pub(crate) fn observe_auth_override(
     env: &[(std::ffi::OsString, std::ffi::OsString)],
 ) -> Option<crate::AuthOverrideSignal> {
-    if crate::probe::env_sets_any(env, &["OPENAI_API_KEY", "OPENAI_BASE_URL"]) {
+    if crate::probe::env_sets_any(env, crate::probe::CODEX_AUTH_ENV_VARS) {
         return Some(crate::AuthOverrideSignal::Environment);
     }
     config_declares_model_provider(env).then_some(crate::AuthOverrideSignal::EngineConfig)

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -883,6 +883,7 @@ impl CodexSession {
             .stderr(Stdio::piped());
         apply_child_env_tokio(
             &mut command,
+            tidebreak_core::HarnessKind::Codex,
             self.spec.env.iter().cloned(),
             &plan.env,
             self.spec.browser.as_ref(),

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -554,6 +554,7 @@ impl GrokSession {
             .stderr(Stdio::piped());
         apply_child_env_tokio(
             &mut command,
+            tidebreak_core::HarnessKind::Grok,
             self.spec.env.iter().cloned(),
             &plan.env,
             self.spec.browser.as_ref(),

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -44,9 +44,9 @@ pub use launch::{
 };
 pub use pin::{ensure_installed, managed_binary, pin_for, HarnessPin, PINS};
 pub use probe::{
-    display_model_label, filter_child_env, infer_listed_default, list_cli_models, observe_version,
-    prefer_gateway_models, probe_shell, resolve_binary, with_reasoning_efforts, DeclaredBinary,
-    HostEnv, ListedHarnessModel, ProbeCapture, ProbeError,
+    display_model_label, filter_child_env, filter_engine_child_env, infer_listed_default,
+    list_cli_models, observe_version, prefer_gateway_models, probe_shell, resolve_binary,
+    with_reasoning_efforts, DeclaredBinary, HostEnv, ListedHarnessModel, ProbeCapture, ProbeError,
 };
 
 /// Whether some auth mode besides the vendor login a probe observes could

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -476,8 +476,9 @@ impl BrowserChannelSpec {
     /// Adapter-owned environment key injected into every engine child.
     ///
     /// Adapters reject `TIDEBREAK_` keys from settings with
-    /// [`Self::is_reserved_env_key`], while [`filter_child_env`] strips the
-    /// same namespace from the shell snapshot. [`Self::inject_env_tokio`]
+    /// [`Self::is_reserved_env_key`], while [`filter_child_env`] narrows the
+    /// shell snapshot to an allowlist that excludes the same namespace.
+    /// [`Self::inject_env_tokio`]
     /// then runs after `plan.env`, making this the final child value.
     pub const ENV_KEY: &'static str = "TIDEBREAK_BROWSER_CAPFILE";
 
@@ -578,7 +579,10 @@ pub struct SessionSpec {
     /// namespace is stripped.
     pub relay_key_env: Option<String>,
     /// Shell-resolved environment captured by the probe. Children run under
-    /// this snapshot, not the GUI process environment.
+    /// the [`filter_child_env`] allowlist subset of this snapshot, not the
+    /// GUI process environment — ambient shell-rc credentials never reach an
+    /// engine child. A credential a session needs travels through
+    /// [`Self::extra_env`] or the relay instead.
     pub env: Vec<(std::ffi::OsString, std::ffi::OsString)>,
     /// Approval-channel wiring, when the server has one to offer.
     pub approval: Option<ApprovalChannelSpec>,
@@ -954,7 +958,11 @@ mod tests {
             ),
             (
                 std::ffi::OsString::from("GATEWAY_URL"),
-                std::ffi::OsString::from("keep"),
+                std::ffi::OsString::from("ambient"),
+            ),
+            (
+                std::ffi::OsString::from("HOME"),
+                std::ffi::OsString::from("/home/probe"),
             ),
         ];
         let env = filter_child_env(snapshot);
@@ -963,9 +971,12 @@ mod tests {
                 .to_ascii_uppercase()
                 .starts_with("TIDEBREAK_")
         }));
+        // The child filter is an allowlist: an arbitrary ambient variable is
+        // dropped alongside the reserved namespace, not just renamed around.
+        assert!(env.iter().all(|(key, _)| key != "GATEWAY_URL"));
         assert!(env
             .iter()
-            .any(|(key, value)| { key == "GATEWAY_URL" && value == "keep" }));
+            .any(|(key, value)| { key == "HOME" && value == "/home/probe" }));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -521,6 +521,7 @@ impl OpencodeSession {
             .stderr(Stdio::piped());
         apply_child_env_tokio(
             &mut command,
+            tidebreak_core::HarnessKind::Opencode,
             self.spec.env.iter().cloned(),
             &plan.env,
             self.spec.browser.as_ref(),

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -411,7 +411,32 @@ fn prepend_managed_node_path(
 }
 
 fn process_env_without_tidebreak() -> Vec<(OsString, OsString)> {
-    filter_child_env(std::env::vars_os())
+    strip_tidebreak_env(std::env::vars_os())
+}
+
+/// Drop only the reserved `TIDEBREAK_` namespace and malformed names from a
+/// captured snapshot. This keeps the stored probe environment complete —
+/// auth-override detection reads credentials like `ANTHROPIC_API_KEY` out
+/// of it — while [`filter_child_env`] separately narrows what a spawned
+/// child may inherit.
+fn strip_tidebreak_env<I, K, V>(vars: I) -> Vec<(OsString, OsString)>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<OsString>,
+    V: Into<OsString>,
+{
+    let filtered = vars.into_iter().filter_map(|(key, value)| {
+        let key = key.into();
+        let name = key.to_string_lossy();
+        if name.is_empty()
+            || name.contains('=')
+            || name.to_ascii_uppercase().starts_with("TIDEBREAK_")
+        {
+            return None;
+        }
+        Some((key, value.into()))
+    });
+    merge_environment(Vec::new(), filtered, cfg!(windows))
 }
 
 async fn capture_shell_env(host: &HostEnv) -> Result<Vec<(OsString, OsString)>, ProbeError> {
@@ -446,10 +471,76 @@ fn windows_process_env(host: &HostEnv) -> Vec<(OsString, OsString)> {
     } else {
         std::env::vars_os().collect()
     };
-    filter_child_env(merge_environment(base, host.env.iter().cloned(), true))
+    strip_tidebreak_env(merge_environment(base, host.env.iter().cloned(), true))
 }
 
-/// Drop Tidebreak-prefixed variables from a captured shell snapshot.
+/// Variables a spawned child may inherit from a captured shell snapshot,
+/// matched on the ASCII-uppercased name.
+///
+/// This is an allowlist for the same reason the exec path in
+/// `tidebreak-code-execution` builds on `env_clear()`: a coding-engine turn
+/// can read its whole environment with one `env` call, so every ambient
+/// credential the user's shell rc exports — `GITHUB_TOKEN`, `AWS_*`,
+/// `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` — is one prompt injection away
+/// from exfiltration. A variable missing from this list fails visibly in
+/// the child; a leaked secret fails silently, so anything not demonstrably
+/// required stays out. Everything Tidebreak itself wires into a child —
+/// settings `extra_env`, the session relay key, the browser capability
+/// file — is applied after this filter (see
+/// [`crate::browser_channel::apply_child_env_tokio`]) and never needs an
+/// entry here.
+const CHILD_ENV_ALLOWED_NAMES: &[&str] = &[
+    // Command resolution: the probe prepends the managed Node runtime and
+    // the login-shell PATH here, and every pinned engine entrypoint needs
+    // its interpreter found through it.
+    "PATH",
+    // Engine state lives under the home directory: `~/.claude`, `~/.codex`,
+    // and the `~/.config` fallbacks all resolve through HOME.
+    "HOME",
+    // POSIX session identity and terminal basics.
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TERM",
+    "LANG",
+    "TMPDIR",
+    // `tidebreak-server` spawns `gh` under this filter, and gh resolves a
+    // relocated config directory through this path (not a secret).
+    "GH_CONFIG_DIR",
+    // Windows children cannot start, resolve commands, or write temp files
+    // without these; on Unix they are simply absent.
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "PROGRAMDATA",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "USERNAME",
+    "TEMP",
+    "TMP",
+];
+
+/// Allowed name prefixes: locale configuration and the XDG base directories
+/// engines use to find their config and cache trees.
+const CHILD_ENV_ALLOWED_PREFIXES: &[&str] = &["LC_", "XDG_"];
+
+fn child_env_allowed(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    CHILD_ENV_ALLOWED_NAMES.contains(&upper.as_str())
+        || CHILD_ENV_ALLOWED_PREFIXES
+            .iter()
+            .any(|prefix| upper.starts_with(prefix))
+}
+
+/// Narrow a captured shell snapshot to the environment a spawned child may
+/// inherit: the [`CHILD_ENV_ALLOWED_NAMES`] allowlist, minus malformed
+/// names. The reserved `TIDEBREAK_` namespace is excluded by construction —
+/// nothing in the allowlist matches it.
 #[must_use]
 pub fn filter_child_env<I, K, V>(vars: I) -> Vec<(OsString, OsString)>
 where
@@ -460,10 +551,7 @@ where
     let filtered = vars.into_iter().filter_map(|(key, value)| {
         let key = key.into();
         let name = key.to_string_lossy();
-        if name.is_empty()
-            || name.contains('=')
-            || name.to_ascii_uppercase().starts_with("TIDEBREAK_")
-        {
+        if name.is_empty() || name.contains('=') || !child_env_allowed(&name) {
             return None;
         }
         Some((key, value.into()))
@@ -1210,19 +1298,26 @@ eval "$cmd"
         assert_eq!(profile.as_deref(), Some("from-profile"));
         assert!(std::env::var_os("PROFILE_ONLY_VAR").is_none());
         let filtered = filter_child_env(capture.env);
-        assert!(filtered
-            .iter()
-            .any(|(key, value)| { key == "PROFILE_ONLY_VAR" && value == "from-profile" }));
+        // The snapshot keeps profile-sourced variables for detection, but a
+        // child inherits only the allowlist: an arbitrary profile export
+        // stays out while the profile-built PATH survives.
+        assert!(filtered.iter().all(|(key, _)| key != "PROFILE_ONLY_VAR"));
         assert!(filtered.iter().all(|(key, _)| {
             !key.to_string_lossy()
                 .to_ascii_uppercase()
                 .starts_with("TIDEBREAK_")
         }));
+        let path = filtered
+            .iter()
+            .find(|(key, _)| key == "PATH")
+            .map(|(_, value)| value.clone())
+            .expect("profile-built PATH reaches the child");
+        assert!(std::env::split_paths(&path).any(|entry| entry == dir.path()));
 
         let mut child = Command::new("/bin/sh");
         child
             .arg("-c")
-            .arg("printf %s \"$PROFILE_ONLY_VAR\"")
+            .arg("printf %s \"${PROFILE_ONLY_VAR-unset}\"")
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -1232,7 +1327,7 @@ eval "$cmd"
             child.env(key, value);
         }
         let output = child.output().await.unwrap();
-        assert_eq!(String::from_utf8_lossy(&output.stdout), "from-profile");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "unset");
     }
 
     #[tokio::test]
@@ -1535,10 +1630,46 @@ mod environment_tests {
     fn filter_rejects_case_varied_tidebreak_and_invalid_environment_keys() {
         let filtered = filter_child_env([
             ("tidebreak_secret", "nope"),
-            ("GOOD", "yes"),
+            ("HOME", "/home/probe"),
             ("BAD=KEY", "nope"),
         ]);
-        assert_eq!(filtered, [(OsString::from("GOOD"), OsString::from("yes"))]);
+        assert_eq!(
+            filtered,
+            [(OsString::from("HOME"), OsString::from("/home/probe"))]
+        );
+    }
+
+    #[test]
+    fn child_env_is_an_allowlist_that_drops_planted_secrets() {
+        // A shell rc that exports ambient credentials must not hand them to
+        // an engine child, while the session basics still arrive.
+        let filtered = filter_child_env([
+            ("PATH", "/usr/bin"),
+            ("HOME", "/home/probe"),
+            ("LC_ALL", "en_US.UTF-8"),
+            ("XDG_CONFIG_HOME", "/home/probe/.config"),
+            ("AWS_SECRET_ACCESS_KEY", "planted"),
+            ("GITHUB_TOKEN", "planted"),
+            ("ANTHROPIC_API_KEY", "planted"),
+            ("OPENAI_API_KEY", "planted"),
+        ]);
+        for name in ["PATH", "HOME", "LC_ALL", "XDG_CONFIG_HOME"] {
+            assert!(
+                filtered.iter().any(|(key, _)| key == name),
+                "{name} must survive the child filter"
+            );
+        }
+        for name in [
+            "AWS_SECRET_ACCESS_KEY",
+            "GITHUB_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+        ] {
+            assert!(
+                filtered.iter().all(|(key, _)| key != name),
+                "{name} must not reach the child environment"
+            );
+        }
     }
 }
 

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -507,6 +507,15 @@ const CHILD_ENV_ALLOWED_NAMES: &[&str] = &[
     // `tidebreak-server` spawns `gh` under this filter, and gh resolves a
     // relocated config directory through this path (not a secret).
     "GH_CONFIG_DIR",
+    // Outbound-trust configuration `tidebreak-supervised-agent` merges into
+    // the session snapshot (`Trust::environment` via `HarnessEngine::launch`):
+    // behind the sidecar's TLS-intercepting egress, an engine child without
+    // these loses every HTTPS call. They carry CA-bundle paths, not secrets.
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "GIT_SSL_CAINFO",
+    "NODE_EXTRA_CA_CERTS",
     // Windows children cannot start, resolve commands, or write temp files
     // without these; on Unix they are simply absent.
     "SYSTEMROOT",
@@ -1648,12 +1657,23 @@ mod environment_tests {
             ("HOME", "/home/probe"),
             ("LC_ALL", "en_US.UTF-8"),
             ("XDG_CONFIG_HOME", "/home/probe/.config"),
+            ("SSL_CERT_FILE", "/run/trust/bundle.pem"),
+            ("NODE_EXTRA_CA_CERTS", "/run/trust/sidecar-ca.pem"),
             ("AWS_SECRET_ACCESS_KEY", "planted"),
             ("GITHUB_TOKEN", "planted"),
             ("ANTHROPIC_API_KEY", "planted"),
             ("OPENAI_API_KEY", "planted"),
         ]);
-        for name in ["PATH", "HOME", "LC_ALL", "XDG_CONFIG_HOME"] {
+        for name in [
+            "PATH",
+            "HOME",
+            "LC_ALL",
+            "XDG_CONFIG_HOME",
+            // The supervised runtime merges CA trust into the snapshot; a
+            // child that loses it cannot make outbound HTTPS calls.
+            "SSL_CERT_FILE",
+            "NODE_EXTRA_CA_CERTS",
+        ] {
             assert!(
                 filtered.iter().any(|(key, _)| key == name),
                 "{name} must survive the child filter"

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -480,7 +480,8 @@ fn windows_process_env(host: &HostEnv) -> Vec<(OsString, OsString)> {
 ///
 /// Defined here, next to [`CHILD_ENV_ALLOWED_NAMES`], so detection and the
 /// child filter cannot drift: whatever detection counts as working auth,
-/// the child actually receives.
+/// [`filter_engine_child_env`] hands to this engine's session child — and
+/// only this engine's.
 pub(crate) const CLAUDE_AUTH_ENV_VARS: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
@@ -511,19 +512,21 @@ pub(crate) const CODEX_AUTH_ENV_VARS: &[&str] = &["OPENAI_API_KEY", "OPENAI_BASE
 /// [`crate::browser_channel::apply_child_env_tokio`]) and never needs an
 /// entry here.
 ///
-/// The deliberate exception is the engine's own provider auth. Session
-/// create (`refuse_signed_out_harness`) and the doctor (`resolve_auth_mode`)
-/// read [`CLAUDE_AUTH_ENV_VARS`] and [`CODEX_AUTH_ENV_VARS`] out of the
-/// unfiltered snapshot and treat a hit as this machine's working auth mode:
-/// a signed-out engine with a shell-rc `ANTHROPIC_API_KEY` is allowed to
-/// start a session on that basis. Dropping those names here would admit a
-/// session that 401s on its first turn — the failure issue 2653 asked
-/// create to refuse — so [`child_env_allowed`] passes them through: a
-/// credential that detection already counts as the engine's configured auth
-/// is the engine's auth, not an ambient leak. Supporting credentials for the
-/// Bedrock/Vertex switches (`AWS_*`, `GOOGLE_*`) pass only when the
-/// corresponding mode flag is itself set, so an unrelated AWS secret stays
-/// out of a child that is not using Bedrock inference.
+/// The deliberate exception is the engine's own provider auth — but scoped
+/// to the engine that authenticates with it, never this shared base list.
+/// Session create (`refuse_signed_out_harness`) and the doctor
+/// (`resolve_auth_mode`) read [`CLAUDE_AUTH_ENV_VARS`] and
+/// [`CODEX_AUTH_ENV_VARS`] out of the unfiltered snapshot and treat a hit
+/// as that engine's working auth mode: a signed-out engine with a shell-rc
+/// `ANTHROPIC_API_KEY` is allowed to start a session on that basis, so the
+/// session child must actually receive the variable or its first turn 401s
+/// — the failure issue 2653 asked create to refuse. That per-engine
+/// invariant lives in [`filter_engine_child_env`]: whatever detection
+/// counts as working auth for engine X reaches engine X's session child,
+/// and nothing else's — an Anthropic credential handed to a Codex, Grok,
+/// or opencode child (or any probe/`gh` spawn under plain
+/// [`filter_child_env`]) would be exactly the cross-context disclosure this
+/// allowlist exists to stop.
 const CHILD_ENV_ALLOWED_NAMES: &[&str] = &[
     // Command resolution: the probe prepends the managed Node runtime and
     // the login-shell PATH here, and every pinned engine entrypoint needs
@@ -577,39 +580,90 @@ const CHILD_ENV_ALLOWED_NAMES: &[&str] = &[
 /// engines use to find their config and cache trees.
 const CHILD_ENV_ALLOWED_PREFIXES: &[&str] = &["LC_", "XDG_"];
 
-fn child_env_allowed(name: &str, bedrock: bool, vertex: bool) -> bool {
+fn child_env_allowed(name: &str) -> bool {
     let upper = name.to_ascii_uppercase();
-    if CHILD_ENV_ALLOWED_NAMES.contains(&upper.as_str())
-        || CLAUDE_AUTH_ENV_VARS.contains(&upper.as_str())
-        || CODEX_AUTH_ENV_VARS.contains(&upper.as_str())
+    CHILD_ENV_ALLOWED_NAMES.contains(&upper.as_str())
         || CHILD_ENV_ALLOWED_PREFIXES
             .iter()
             .any(|prefix| upper.starts_with(prefix))
-    {
-        return true;
+}
+
+/// Whether `name` is an auth variable `kind`'s own detection reads as this
+/// machine's working auth, mirrored exactly: opencode and Grok detection
+/// reads no environment names ([`crate::auth_override_present`] grants them
+/// the benefit of the doubt without looking), so their children receive no
+/// auth variables at all.
+///
+/// The Bedrock/Vertex switches are pure flags whose supporting credentials
+/// live under other names, so those pass only when the user set the switch:
+/// with `CLAUDE_CODE_USE_BEDROCK` the engine's inference runs on the AWS
+/// credential chain, so `AWS_*` is its configured auth; without the switch
+/// (or for any other engine) the same variables are unrelated secrets and
+/// stay out. Vertex likewise needs its project/region variables and the ADC
+/// pointer (`GOOGLE_APPLICATION_CREDENTIALS`).
+fn engine_auth_env_allowed(
+    kind: tidebreak_core::HarnessKind,
+    name: &str,
+    bedrock: bool,
+    vertex: bool,
+) -> bool {
+    let upper = name.to_ascii_uppercase();
+    match kind {
+        tidebreak_core::HarnessKind::ClaudeCode => {
+            CLAUDE_AUTH_ENV_VARS.contains(&upper.as_str())
+                || (bedrock && upper.starts_with("AWS_"))
+                || (vertex
+                    && (upper.starts_with("GOOGLE_")
+                        || upper.starts_with("ANTHROPIC_VERTEX_")
+                        || upper == "CLOUD_ML_REGION"))
+        }
+        tidebreak_core::HarnessKind::Codex => CODEX_AUTH_ENV_VARS.contains(&upper.as_str()),
+        tidebreak_core::HarnessKind::Opencode | tidebreak_core::HarnessKind::Grok => false,
     }
-    // Supporting credentials for a provider switch pass only when the user
-    // set that switch: with `CLAUDE_CODE_USE_BEDROCK` the engine's inference
-    // runs on the AWS credential chain, so `AWS_*` is its configured auth;
-    // without the switch the same variables are unrelated secrets and stay
-    // out. Vertex likewise needs its project/region variables and the ADC
-    // pointer (`GOOGLE_APPLICATION_CREDENTIALS`).
-    if bedrock && upper.starts_with("AWS_") {
-        return true;
-    }
-    vertex
-        && (upper.starts_with("GOOGLE_")
-            || upper.starts_with("ANTHROPIC_VERTEX_")
-            || upper == "CLOUD_ML_REGION")
 }
 
 /// Narrow a captured shell snapshot to the environment a spawned child may
-/// inherit: the [`CHILD_ENV_ALLOWED_NAMES`] allowlist plus the engines' own
-/// auth-signal variables, minus malformed names. The reserved `TIDEBREAK_`
-/// namespace is excluded by construction — nothing in the allowlist matches
-/// it.
+/// inherit: the [`CHILD_ENV_ALLOWED_NAMES`] allowlist, minus malformed
+/// names. The reserved `TIDEBREAK_` namespace is excluded by construction —
+/// nothing in the allowlist matches it.
+///
+/// No auth variable survives this filter. It is the right shape for probe
+/// spawns (`--version`, model listings, auth-status checks) and non-engine
+/// children (`gh`, the gateway usage CLI); an engine *session* child goes
+/// through [`filter_engine_child_env`] instead, which adds that one
+/// engine's own auth signals.
 #[must_use]
 pub fn filter_child_env<I, K, V>(vars: I) -> Vec<(OsString, OsString)>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<OsString>,
+    V: Into<OsString>,
+{
+    let filtered = vars.into_iter().filter_map(|(key, value)| {
+        let key = key.into();
+        let name = key.to_string_lossy();
+        if name.is_empty() || name.contains('=') || !child_env_allowed(&name) {
+            return None;
+        }
+        Some((key, value.into()))
+    });
+    merge_environment(Vec::new(), filtered, cfg!(windows))
+}
+
+/// [`filter_child_env`] plus the auth variables `kind`'s own auth-mode
+/// detection reads, for spawning that engine's session child.
+///
+/// This is where the create/doctor consistency invariant lives: a session
+/// that `refuse_signed_out_harness` admitted because detection saw
+/// engine-auth variables in the snapshot must hand those same variables to
+/// the engine child, or its first turn 401s (issue 2653). The pass-through
+/// is per engine — [`engine_auth_env_allowed`] — so one engine's credential
+/// is never disclosed to another engine's prompt-injectable child.
+#[must_use]
+pub fn filter_engine_child_env<I, K, V>(
+    kind: tidebreak_core::HarnessKind,
+    vars: I,
+) -> Vec<(OsString, OsString)>
 where
     I: IntoIterator<Item = (K, V)>,
     K: Into<OsString>,
@@ -619,11 +673,17 @@ where
         .into_iter()
         .map(|(key, value)| (key.into(), value.into()))
         .collect();
-    let bedrock = env_sets_any(&vars, &["CLAUDE_CODE_USE_BEDROCK"]);
-    let vertex = env_sets_any(&vars, &["CLAUDE_CODE_USE_VERTEX"]);
+    // The same non-empty rule detection's `env_sets_any` applies to the
+    // auth variables themselves.
+    let bedrock = kind == tidebreak_core::HarnessKind::ClaudeCode
+        && env_sets_any(&vars, &["CLAUDE_CODE_USE_BEDROCK"]);
+    let vertex = kind == tidebreak_core::HarnessKind::ClaudeCode
+        && env_sets_any(&vars, &["CLAUDE_CODE_USE_VERTEX"]);
     let filtered = vars.into_iter().filter(|(key, _)| {
         let name = key.to_string_lossy();
-        !name.is_empty() && !name.contains('=') && child_env_allowed(&name, bedrock, vertex)
+        !name.is_empty()
+            && !name.contains('=')
+            && (child_env_allowed(&name) || engine_auth_env_allowed(kind, &name, bedrock, vertex))
     });
     merge_environment(Vec::new(), filtered, cfg!(windows))
 }
@@ -1711,9 +1771,9 @@ mod environment_tests {
     #[test]
     fn child_env_is_an_allowlist_that_drops_planted_secrets() {
         // A shell rc that exports ambient credentials must not hand them to
-        // an engine child, while the session basics — and the provider auth
-        // variables that create/doctor detection treats as the engine's
-        // working auth mode — still arrive.
+        // a probe or non-engine child, while the session basics still
+        // arrive. Engine-auth variables pass only through the per-engine
+        // filter below, never this base one.
         let filtered = filter_child_env([
             ("PATH", "/usr/bin"),
             ("HOME", "/home/probe"),
@@ -1721,11 +1781,10 @@ mod environment_tests {
             ("XDG_CONFIG_HOME", "/home/probe/.config"),
             ("SSL_CERT_FILE", "/run/trust/bundle.pem"),
             ("NODE_EXTRA_CA_CERTS", "/run/trust/sidecar-ca.pem"),
-            ("ANTHROPIC_API_KEY", "sk-ant"),
-            ("OPENAI_API_KEY", "sk-oai"),
             ("AWS_SECRET_ACCESS_KEY", "planted"),
             ("GITHUB_TOKEN", "planted"),
-            ("NPM_TOKEN", "planted"),
+            ("ANTHROPIC_API_KEY", "planted"),
+            ("OPENAI_API_KEY", "planted"),
         ]);
         for name in [
             "PATH",
@@ -1736,29 +1795,100 @@ mod environment_tests {
             // child that loses it cannot make outbound HTTPS calls.
             "SSL_CERT_FILE",
             "NODE_EXTRA_CA_CERTS",
-            // Auth-mode detection reads these as the engine's live auth
-            // (issue 2653): a session admitted on their evidence must hand
-            // them to the child, or its first turn 401s.
-            "ANTHROPIC_API_KEY",
-            "OPENAI_API_KEY",
         ] {
             assert!(
                 filtered.iter().any(|(key, _)| key == name),
                 "{name} must survive the child filter"
             );
         }
-        for name in ["AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN", "NPM_TOKEN"] {
+        for name in [
+            "AWS_SECRET_ACCESS_KEY",
+            "GITHUB_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+        ] {
             assert!(
                 filtered.iter().all(|(key, _)| key != name),
-                "{name} must not reach the child environment"
+                "{name} must not reach a non-engine child environment"
+            );
+        }
+    }
+
+    #[test]
+    fn engine_children_receive_only_their_own_auth_signals() {
+        // Auth-mode detection reads each engine's variables as its live auth
+        // (issue 2653): a session admitted on their evidence must hand them
+        // to that engine's child, or its first turn 401s — and to no other
+        // engine's child, or one provider's credential is disclosed to an
+        // unrelated prompt-injectable process.
+        use tidebreak_core::HarnessKind;
+        let snapshot = [
+            ("HOME", "/home/probe"),
+            ("SSL_CERT_FILE", "/run/trust/bundle.pem"),
+            ("ANTHROPIC_API_KEY", "sk-ant"),
+            ("ANTHROPIC_BASE_URL", "https://gateway.example"),
+            ("OPENAI_API_KEY", "sk-oai"),
+            ("OPENAI_BASE_URL", "https://oai-gateway.example"),
+            ("GITHUB_TOKEN", "planted"),
+        ];
+        let claude = filter_engine_child_env(HarnessKind::ClaudeCode, snapshot);
+        for name in ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "SSL_CERT_FILE"] {
+            assert!(
+                claude.iter().any(|(key, _)| key == name),
+                "{name} must survive for a Claude Code launch"
+            );
+        }
+        for name in ["OPENAI_API_KEY", "OPENAI_BASE_URL", "GITHUB_TOKEN"] {
+            assert!(
+                claude.iter().all(|(key, _)| key != name),
+                "{name} must not reach a Claude Code child"
+            );
+        }
+        let codex = filter_engine_child_env(HarnessKind::Codex, snapshot);
+        for name in ["OPENAI_API_KEY", "OPENAI_BASE_URL", "SSL_CERT_FILE"] {
+            assert!(
+                codex.iter().any(|(key, _)| key == name),
+                "{name} must survive for a Codex launch"
+            );
+        }
+        for name in ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "GITHUB_TOKEN"] {
+            assert!(
+                codex.iter().all(|(key, _)| key != name),
+                "{name} must not reach a Codex child"
+            );
+        }
+        // Detection reads no environment names for these engines, so their
+        // children receive no auth variables at all.
+        for kind in [HarnessKind::Opencode, HarnessKind::Grok] {
+            let filtered = filter_engine_child_env(kind, snapshot);
+            for name in [
+                "ANTHROPIC_API_KEY",
+                "ANTHROPIC_BASE_URL",
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+                "GITHUB_TOKEN",
+            ] {
+                assert!(
+                    filtered.iter().all(|(key, _)| key != name),
+                    "{name} must not reach a {kind:?} child"
+                );
+            }
+            assert!(
+                filtered.iter().any(|(key, _)| key == "HOME"),
+                "session basics still reach a {kind:?} child"
             );
         }
     }
 
     #[test]
     fn provider_mode_flags_gate_their_supporting_credentials() {
-        // Without the Bedrock switch, AWS credentials are unrelated secrets.
-        let unrelated = filter_child_env([("AWS_SECRET_ACCESS_KEY", "planted")]);
+        use tidebreak_core::HarnessKind;
+        // Without the Bedrock switch, AWS credentials are unrelated secrets
+        // even for the engine that could use them.
+        let unrelated = filter_engine_child_env(
+            HarnessKind::ClaudeCode,
+            [("AWS_SECRET_ACCESS_KEY", "planted")],
+        );
         assert!(unrelated
             .iter()
             .all(|(key, _)| key != "AWS_SECRET_ACCESS_KEY"));
@@ -1766,12 +1896,13 @@ mod environment_tests {
         // With the switch set, the engine's inference runs on the AWS
         // credential chain: detection reads the flag as working auth, so the
         // chain the flag needs must reach the child with it.
-        let bedrock = filter_child_env([
+        let bedrock_snapshot = [
             ("CLAUDE_CODE_USE_BEDROCK", "1"),
             ("AWS_SECRET_ACCESS_KEY", "aws-secret"),
             ("AWS_REGION", "us-east-1"),
             ("GITHUB_TOKEN", "planted"),
-        ]);
+        ];
+        let bedrock = filter_engine_child_env(HarnessKind::ClaudeCode, bedrock_snapshot);
         for name in [
             "CLAUDE_CODE_USE_BEDROCK",
             "AWS_SECRET_ACCESS_KEY",
@@ -1786,13 +1917,25 @@ mod environment_tests {
             bedrock.iter().all(|(key, _)| key != "GITHUB_TOKEN"),
             "a mode switch must not widen the filter beyond its own provider"
         );
+        // The switch is Claude Code's auth mode: the same snapshot hands no
+        // AWS credential to another engine's child.
+        let codex = filter_engine_child_env(HarnessKind::Codex, bedrock_snapshot);
+        for name in ["CLAUDE_CODE_USE_BEDROCK", "AWS_SECRET_ACCESS_KEY"] {
+            assert!(
+                codex.iter().all(|(key, _)| key != name),
+                "{name} must not reach a Codex child"
+            );
+        }
 
-        let vertex = filter_child_env([
-            ("CLAUDE_CODE_USE_VERTEX", "1"),
-            ("GOOGLE_APPLICATION_CREDENTIALS", "/home/probe/adc.json"),
-            ("CLOUD_ML_REGION", "us-east5"),
-            ("ANTHROPIC_VERTEX_PROJECT_ID", "probe-project"),
-        ]);
+        let vertex = filter_engine_child_env(
+            HarnessKind::ClaudeCode,
+            [
+                ("CLAUDE_CODE_USE_VERTEX", "1"),
+                ("GOOGLE_APPLICATION_CREDENTIALS", "/home/probe/adc.json"),
+                ("CLOUD_ML_REGION", "us-east5"),
+                ("ANTHROPIC_VERTEX_PROJECT_ID", "probe-project"),
+            ],
+        );
         for name in [
             "CLAUDE_CODE_USE_VERTEX",
             "GOOGLE_APPLICATION_CREDENTIALS",
@@ -1806,10 +1949,13 @@ mod environment_tests {
         }
         // An empty switch is not set — the same non-empty rule detection's
         // `env_sets_any` applies.
-        let unset = filter_child_env([
-            ("CLAUDE_CODE_USE_BEDROCK", ""),
-            ("AWS_SECRET_ACCESS_KEY", "planted"),
-        ]);
+        let unset = filter_engine_child_env(
+            HarnessKind::ClaudeCode,
+            [
+                ("CLAUDE_CODE_USE_BEDROCK", ""),
+                ("AWS_SECRET_ACCESS_KEY", "planted"),
+            ],
+        );
         assert!(unset.iter().all(|(key, _)| key != "AWS_SECRET_ACCESS_KEY"));
     }
 }

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -493,7 +493,10 @@ pub(crate) const CLAUDE_AUTH_ENV_VARS: &[&str] = &[
 /// Environment variables Codex's auth-mode detection
 /// (`crate::codex::observe_auth_override`) reads as the engine's own live
 /// auth, shared with the child filter for the same no-drift reason as
-/// [`CLAUDE_AUTH_ENV_VARS`].
+/// [`CLAUDE_AUTH_ENV_VARS`]. Codex's config-file admission surface names
+/// its own environment keys inside `$CODEX_HOME/config.toml`; the filter
+/// reads those through [`crate::codex::config_provider_env_keys`] rather
+/// than this static list.
 pub(crate) const CODEX_AUTH_ENV_VARS: &[&str] = &["OPENAI_API_KEY", "OPENAI_BASE_URL"];
 
 /// Variables a spawned child may inherit from a captured shell snapshot,
@@ -659,6 +662,14 @@ where
 /// the engine child, or its first turn 401s (issue 2653). The pass-through
 /// is per engine — [`engine_auth_env_allowed`] — so one engine's credential
 /// is never disclosed to another engine's prompt-injectable child.
+///
+/// Codex has a second admission surface with the same obligation: detection
+/// admits on a `$CODEX_HOME/config.toml` that declares a model provider,
+/// and such a provider reads its credential from whatever environment key
+/// the config names (`env_key`, `env_http_headers`). Those config-named
+/// variables ([`crate::codex::config_provider_env_keys`], resolved from
+/// this same snapshot) are forwarded to a Codex child only — bounded to
+/// exactly the names the config declares.
 #[must_use]
 pub fn filter_engine_child_env<I, K, V>(
     kind: tidebreak_core::HarnessKind,
@@ -679,11 +690,20 @@ where
         && env_sets_any(&vars, &["CLAUDE_CODE_USE_BEDROCK"]);
     let vertex = kind == tidebreak_core::HarnessKind::ClaudeCode
         && env_sets_any(&vars, &["CLAUDE_CODE_USE_VERTEX"]);
+    let config_auth_keys = if kind == tidebreak_core::HarnessKind::Codex {
+        crate::codex::config_provider_env_keys(&vars)
+    } else {
+        Vec::new()
+    };
     let filtered = vars.into_iter().filter(|(key, _)| {
         let name = key.to_string_lossy();
         !name.is_empty()
             && !name.contains('=')
-            && (child_env_allowed(&name) || engine_auth_env_allowed(kind, &name, bedrock, vertex))
+            && (child_env_allowed(&name)
+                || engine_auth_env_allowed(kind, &name, bedrock, vertex)
+                || config_auth_keys
+                    .iter()
+                    .any(|named| env_key_eq(std::ffi::OsStr::new(named), key, cfg!(windows))))
     });
     merge_environment(Vec::new(), filtered, cfg!(windows))
 }
@@ -1957,6 +1977,77 @@ mod environment_tests {
             ],
         );
         assert!(unset.iter().all(|(key, _)| key != "AWS_SECRET_ACCESS_KEY"));
+    }
+
+    #[test]
+    fn codex_config_declared_provider_keys_reach_only_codex_children() {
+        use tidebreak_core::HarnessKind;
+        // A gateway-managed machine authenticates Codex through a
+        // config-declared provider whose credential lives under whatever
+        // environment key the config names. Detection admits the session on
+        // that declaration, so the child must receive exactly the named
+        // variables (issue 2653) — and no other engine's child may.
+        let codex_home = tempfile::tempdir().unwrap();
+        std::fs::write(
+            codex_home.path().join("config.toml"),
+            r#"model_provider = "gateway"
+
+[model_providers.gateway]
+name = "Gateway"
+base_url = "https://gateway.example/v1"
+env_key = "GATEWAY_TEST_KEY"
+env_http_headers = { "X-Gateway-Auth" = "GATEWAY_TEST_HEADER" }
+"#,
+        )
+        .unwrap();
+        let os = OsString::from;
+        let snapshot = vec![
+            (os("CODEX_HOME"), codex_home.path().as_os_str().to_owned()),
+            (os("GATEWAY_TEST_KEY"), os("gw-secret")),
+            (os("GATEWAY_TEST_HEADER"), os("gw-header-secret")),
+            (os("GITHUB_TOKEN"), os("planted")),
+        ];
+        let codex = filter_engine_child_env(HarnessKind::Codex, snapshot.clone());
+        for name in ["CODEX_HOME", "GATEWAY_TEST_KEY", "GATEWAY_TEST_HEADER"] {
+            assert!(
+                codex.iter().any(|(key, _)| key == name),
+                "{name} must survive for a Codex launch its config names"
+            );
+        }
+        assert!(
+            codex.iter().all(|(key, _)| key != "GITHUB_TOKEN"),
+            "a config-named key must not widen the filter beyond the config"
+        );
+        let claude = filter_engine_child_env(HarnessKind::ClaudeCode, snapshot);
+        for name in ["GATEWAY_TEST_KEY", "GATEWAY_TEST_HEADER"] {
+            assert!(
+                claude.iter().all(|(key, _)| key != name),
+                "{name} must not reach a Claude Code child"
+            );
+        }
+    }
+
+    #[test]
+    fn a_declared_provider_without_env_keys_widens_nothing() {
+        // A provider that names no environment key (OAuth, an auth helper,
+        // an unauthenticated local endpoint) authenticates through files
+        // under `$CODEX_HOME`; its declaration must not let ambient
+        // variables through.
+        let codex_home = tempfile::tempdir().unwrap();
+        std::fs::write(
+            codex_home.path().join("config.toml"),
+            "[model_providers.local]\nname = \"Local\"\nbase_url = \"http://127.0.0.1:8080/v1\"\n",
+        )
+        .unwrap();
+        let os = OsString::from;
+        let filtered = filter_engine_child_env(
+            tidebreak_core::HarnessKind::Codex,
+            vec![
+                (os("CODEX_HOME"), codex_home.path().as_os_str().to_owned()),
+                (os("AMBIENT_SECRET"), os("planted")),
+            ],
+        );
+        assert!(filtered.iter().all(|(key, _)| key != "AMBIENT_SECRET"));
     }
 }
 

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -474,21 +474,56 @@ fn windows_process_env(host: &HostEnv) -> Vec<(OsString, OsString)> {
     strip_tidebreak_env(merge_environment(base, host.env.iter().cloned(), true))
 }
 
+/// Environment variables Claude Code's auth-mode detection
+/// (`crate::claude::observe_auth_override`) reads as the engine's own live
+/// auth: a key, token, or endpoint override, or a Bedrock/Vertex switch.
+///
+/// Defined here, next to [`CHILD_ENV_ALLOWED_NAMES`], so detection and the
+/// child filter cannot drift: whatever detection counts as working auth,
+/// the child actually receives.
+pub(crate) const CLAUDE_AUTH_ENV_VARS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+];
+
+/// Environment variables Codex's auth-mode detection
+/// (`crate::codex::observe_auth_override`) reads as the engine's own live
+/// auth, shared with the child filter for the same no-drift reason as
+/// [`CLAUDE_AUTH_ENV_VARS`].
+pub(crate) const CODEX_AUTH_ENV_VARS: &[&str] = &["OPENAI_API_KEY", "OPENAI_BASE_URL"];
+
 /// Variables a spawned child may inherit from a captured shell snapshot,
 /// matched on the ASCII-uppercased name.
 ///
 /// This is an allowlist for the same reason the exec path in
 /// `tidebreak-code-execution` builds on `env_clear()`: a coding-engine turn
 /// can read its whole environment with one `env` call, so every ambient
-/// credential the user's shell rc exports — `GITHUB_TOKEN`, `AWS_*`,
-/// `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` — is one prompt injection away
-/// from exfiltration. A variable missing from this list fails visibly in
-/// the child; a leaked secret fails silently, so anything not demonstrably
-/// required stays out. Everything Tidebreak itself wires into a child —
-/// settings `extra_env`, the session relay key, the browser capability
-/// file — is applied after this filter (see
+/// credential the user's shell rc exports — `GITHUB_TOKEN`, an `AWS_*`
+/// secret for unrelated tooling, a random rc export — is one prompt
+/// injection away from exfiltration. A variable missing from this list
+/// fails visibly in the child; a leaked secret fails silently, so anything
+/// not demonstrably required stays out. Everything Tidebreak itself wires
+/// into a child — settings `extra_env`, the session relay key, the browser
+/// capability file — is applied after this filter (see
 /// [`crate::browser_channel::apply_child_env_tokio`]) and never needs an
 /// entry here.
+///
+/// The deliberate exception is the engine's own provider auth. Session
+/// create (`refuse_signed_out_harness`) and the doctor (`resolve_auth_mode`)
+/// read [`CLAUDE_AUTH_ENV_VARS`] and [`CODEX_AUTH_ENV_VARS`] out of the
+/// unfiltered snapshot and treat a hit as this machine's working auth mode:
+/// a signed-out engine with a shell-rc `ANTHROPIC_API_KEY` is allowed to
+/// start a session on that basis. Dropping those names here would admit a
+/// session that 401s on its first turn — the failure issue 2653 asked
+/// create to refuse — so [`child_env_allowed`] passes them through: a
+/// credential that detection already counts as the engine's configured auth
+/// is the engine's auth, not an ambient leak. Supporting credentials for the
+/// Bedrock/Vertex switches (`AWS_*`, `GOOGLE_*`) pass only when the
+/// corresponding mode flag is itself set, so an unrelated AWS secret stays
+/// out of a child that is not using Bedrock inference.
 const CHILD_ENV_ALLOWED_NAMES: &[&str] = &[
     // Command resolution: the probe prepends the managed Node runtime and
     // the login-shell PATH here, and every pinned engine entrypoint needs
@@ -507,6 +542,10 @@ const CHILD_ENV_ALLOWED_NAMES: &[&str] = &[
     // `tidebreak-server` spawns `gh` under this filter, and gh resolves a
     // relocated config directory through this path (not a secret).
     "GH_CONFIG_DIR",
+    // Codex resolves its config directory through this path (not a secret).
+    // Auth-mode detection reads the same `$CODEX_HOME/config.toml` for a
+    // custom model provider, so the child must look where detection looked.
+    "CODEX_HOME",
     // Outbound-trust configuration `tidebreak-supervised-agent` merges into
     // the session snapshot (`Trust::environment` via `HarnessEngine::launch`):
     // behind the sidecar's TLS-intercepting egress, an engine child without
@@ -538,18 +577,37 @@ const CHILD_ENV_ALLOWED_NAMES: &[&str] = &[
 /// engines use to find their config and cache trees.
 const CHILD_ENV_ALLOWED_PREFIXES: &[&str] = &["LC_", "XDG_"];
 
-fn child_env_allowed(name: &str) -> bool {
+fn child_env_allowed(name: &str, bedrock: bool, vertex: bool) -> bool {
     let upper = name.to_ascii_uppercase();
-    CHILD_ENV_ALLOWED_NAMES.contains(&upper.as_str())
+    if CHILD_ENV_ALLOWED_NAMES.contains(&upper.as_str())
+        || CLAUDE_AUTH_ENV_VARS.contains(&upper.as_str())
+        || CODEX_AUTH_ENV_VARS.contains(&upper.as_str())
         || CHILD_ENV_ALLOWED_PREFIXES
             .iter()
             .any(|prefix| upper.starts_with(prefix))
+    {
+        return true;
+    }
+    // Supporting credentials for a provider switch pass only when the user
+    // set that switch: with `CLAUDE_CODE_USE_BEDROCK` the engine's inference
+    // runs on the AWS credential chain, so `AWS_*` is its configured auth;
+    // without the switch the same variables are unrelated secrets and stay
+    // out. Vertex likewise needs its project/region variables and the ADC
+    // pointer (`GOOGLE_APPLICATION_CREDENTIALS`).
+    if bedrock && upper.starts_with("AWS_") {
+        return true;
+    }
+    vertex
+        && (upper.starts_with("GOOGLE_")
+            || upper.starts_with("ANTHROPIC_VERTEX_")
+            || upper == "CLOUD_ML_REGION")
 }
 
 /// Narrow a captured shell snapshot to the environment a spawned child may
-/// inherit: the [`CHILD_ENV_ALLOWED_NAMES`] allowlist, minus malformed
-/// names. The reserved `TIDEBREAK_` namespace is excluded by construction —
-/// nothing in the allowlist matches it.
+/// inherit: the [`CHILD_ENV_ALLOWED_NAMES`] allowlist plus the engines' own
+/// auth-signal variables, minus malformed names. The reserved `TIDEBREAK_`
+/// namespace is excluded by construction — nothing in the allowlist matches
+/// it.
 #[must_use]
 pub fn filter_child_env<I, K, V>(vars: I) -> Vec<(OsString, OsString)>
 where
@@ -557,13 +615,15 @@ where
     K: Into<OsString>,
     V: Into<OsString>,
 {
-    let filtered = vars.into_iter().filter_map(|(key, value)| {
-        let key = key.into();
+    let vars: Vec<(OsString, OsString)> = vars
+        .into_iter()
+        .map(|(key, value)| (key.into(), value.into()))
+        .collect();
+    let bedrock = env_sets_any(&vars, &["CLAUDE_CODE_USE_BEDROCK"]);
+    let vertex = env_sets_any(&vars, &["CLAUDE_CODE_USE_VERTEX"]);
+    let filtered = vars.into_iter().filter(|(key, _)| {
         let name = key.to_string_lossy();
-        if name.is_empty() || name.contains('=') || !child_env_allowed(&name) {
-            return None;
-        }
-        Some((key, value.into()))
+        !name.is_empty() && !name.contains('=') && child_env_allowed(&name, bedrock, vertex)
     });
     merge_environment(Vec::new(), filtered, cfg!(windows))
 }
@@ -1651,7 +1711,9 @@ mod environment_tests {
     #[test]
     fn child_env_is_an_allowlist_that_drops_planted_secrets() {
         // A shell rc that exports ambient credentials must not hand them to
-        // an engine child, while the session basics still arrive.
+        // an engine child, while the session basics — and the provider auth
+        // variables that create/doctor detection treats as the engine's
+        // working auth mode — still arrive.
         let filtered = filter_child_env([
             ("PATH", "/usr/bin"),
             ("HOME", "/home/probe"),
@@ -1659,10 +1721,11 @@ mod environment_tests {
             ("XDG_CONFIG_HOME", "/home/probe/.config"),
             ("SSL_CERT_FILE", "/run/trust/bundle.pem"),
             ("NODE_EXTRA_CA_CERTS", "/run/trust/sidecar-ca.pem"),
+            ("ANTHROPIC_API_KEY", "sk-ant"),
+            ("OPENAI_API_KEY", "sk-oai"),
             ("AWS_SECRET_ACCESS_KEY", "planted"),
             ("GITHUB_TOKEN", "planted"),
-            ("ANTHROPIC_API_KEY", "planted"),
-            ("OPENAI_API_KEY", "planted"),
+            ("NPM_TOKEN", "planted"),
         ]);
         for name in [
             "PATH",
@@ -1673,23 +1736,81 @@ mod environment_tests {
             // child that loses it cannot make outbound HTTPS calls.
             "SSL_CERT_FILE",
             "NODE_EXTRA_CA_CERTS",
+            // Auth-mode detection reads these as the engine's live auth
+            // (issue 2653): a session admitted on their evidence must hand
+            // them to the child, or its first turn 401s.
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
         ] {
             assert!(
                 filtered.iter().any(|(key, _)| key == name),
                 "{name} must survive the child filter"
             );
         }
-        for name in [
-            "AWS_SECRET_ACCESS_KEY",
-            "GITHUB_TOKEN",
-            "ANTHROPIC_API_KEY",
-            "OPENAI_API_KEY",
-        ] {
+        for name in ["AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN", "NPM_TOKEN"] {
             assert!(
                 filtered.iter().all(|(key, _)| key != name),
                 "{name} must not reach the child environment"
             );
         }
+    }
+
+    #[test]
+    fn provider_mode_flags_gate_their_supporting_credentials() {
+        // Without the Bedrock switch, AWS credentials are unrelated secrets.
+        let unrelated = filter_child_env([("AWS_SECRET_ACCESS_KEY", "planted")]);
+        assert!(unrelated
+            .iter()
+            .all(|(key, _)| key != "AWS_SECRET_ACCESS_KEY"));
+
+        // With the switch set, the engine's inference runs on the AWS
+        // credential chain: detection reads the flag as working auth, so the
+        // chain the flag needs must reach the child with it.
+        let bedrock = filter_child_env([
+            ("CLAUDE_CODE_USE_BEDROCK", "1"),
+            ("AWS_SECRET_ACCESS_KEY", "aws-secret"),
+            ("AWS_REGION", "us-east-1"),
+            ("GITHUB_TOKEN", "planted"),
+        ]);
+        for name in [
+            "CLAUDE_CODE_USE_BEDROCK",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_REGION",
+        ] {
+            assert!(
+                bedrock.iter().any(|(key, _)| key == name),
+                "{name} must survive the child filter in Bedrock mode"
+            );
+        }
+        assert!(
+            bedrock.iter().all(|(key, _)| key != "GITHUB_TOKEN"),
+            "a mode switch must not widen the filter beyond its own provider"
+        );
+
+        let vertex = filter_child_env([
+            ("CLAUDE_CODE_USE_VERTEX", "1"),
+            ("GOOGLE_APPLICATION_CREDENTIALS", "/home/probe/adc.json"),
+            ("CLOUD_ML_REGION", "us-east5"),
+            ("ANTHROPIC_VERTEX_PROJECT_ID", "probe-project"),
+        ]);
+        for name in [
+            "CLAUDE_CODE_USE_VERTEX",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "CLOUD_ML_REGION",
+            "ANTHROPIC_VERTEX_PROJECT_ID",
+        ] {
+            assert!(
+                vertex.iter().any(|(key, _)| key == name),
+                "{name} must survive the child filter in Vertex mode"
+            );
+        }
+        // An empty switch is not set — the same non-empty rule detection's
+        // `env_sets_any` applies.
+        let unset = filter_child_env([
+            ("CLAUDE_CODE_USE_BEDROCK", ""),
+            ("AWS_SECRET_ACCESS_KEY", "planted"),
+        ]);
+        assert!(unset.iter().all(|(key, _)| key != "AWS_SECRET_ACCESS_KEY"));
     }
 }
 


### PR DESCRIPTION
Closes #2943

`filter_child_env` previously stripped only the reserved `TIDEBREAK_` namespace, so anything the user's shell rc exports — `GITHUB_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` — reached every spawned coding-engine child, where a prompt-injected turn can read it with one `env` call. The child environment is now composed from an explicit allowlist, mirroring the `env_clear()` exec path in `tidebreak-code-execution/src/local.rs`.

Every spawn site is covered by the one shared filter: the four engine session children (via `apply_child_env_tokio`), the probe/version/auth/model-listing commands in `tidebreak-harness`, and the `gh`/usage spawns in `tidebreak-server`.

### What passes through now, and why

- `PATH` — command resolution; the probe prepends the managed Node runtime and the login-shell PATH here, and pinned engine entrypoints need their interpreter found through it.
- `HOME` — engine state lives under it (`~/.claude`, `~/.codex`, `~/.config` fallbacks).
- `USER`, `LOGNAME`, `SHELL`, `TERM`, `LANG`, `TMPDIR` — POSIX session identity, terminal, locale, temp basics.
- `LC_*` — locale configuration.
- `XDG_*` — base directories engines use for config and cache trees (e.g. opencode).
- `GH_CONFIG_DIR` — `tidebreak-server` spawns `gh` under this filter and gh resolves a relocated config directory through it; a path, not a secret (contract covered by an existing test).
- `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `NODE_EXTRA_CA_CERTS` — the supervised runtime merges `Trust::environment()` into the session snapshot (`HarnessEngine::launch`), not `extra_env`; behind the sidecar's TLS-intercepting egress an engine child without these loses every outbound HTTPS call. CA-bundle paths, not secrets.
- Windows session basics (`SYSTEMROOT`, `COMSPEC`, `PATHEXT`, `USERPROFILE`, `APPDATA`, `TEMP`, …) — children cannot start, resolve commands, or write temp files without them; absent on Unix.

Everything Tidebreak wires into a child through the launch plan — settings `extra_env`, the session relay key, the browser capability file — is applied after the filter, so it needs no allowlist entry. Anything else is dropped: a missing variable fails visibly in the child, a leaked secret fails silently.

### Deliberate consequences

- Ambient env credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, gateway base URLs from the shell rc) no longer reach engine children implicitly. A machine that authenticates that way should carry the credential through Tidebreak settings `extra_env` or the session relay instead. Auth-override *detection* is unaffected: the stored probe snapshot keeps its denylist-only strip (`strip_tidebreak_env`) and still sees the full captured environment.
- Proxy variables (`HTTP_PROXY` etc.) are not forwarded; nothing in the harness forwarded them deliberately before, and they can carry credentials in the URL. They can be added back per-engine via settings `extra_env` if needed.

### Tests

- New: `child_env_is_an_allowlist_that_drops_planted_secrets` plants `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` and asserts none reach the computed child env while `PATH`/`HOME`/`LC_*`/`XDG_*` and the supervised trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`) survive. It fails against the old denylist.
- Updated: the interactive-profile probe test now asserts a profile-only export stays out of the child while the profile-built `PATH` still arrives; the lib-level filter test asserts an arbitrary ambient variable is dropped.

`cargo check -p tidebreak-harness` and `cargo test -p tidebreak-harness` run clean locally except `cancelling_output_collection_kills_a_pipe_owning_descendant`, which fails in this sandbox's gVisor kernel independent of this change (untouched `child.rs`, process-group kill semantics).
