### PR TITLE
perf(server): wake the queued-turn promoter instead of fast-polling

### DIFF
--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -2329,6 +2329,7 @@ async fn bind_inner(
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_run_wake.clone(),
+        state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         Some(state.config.data_dir.join("scratch")),
         turn_worker::TurnWorkerConfig {
@@ -2401,20 +2402,16 @@ async fn bind_inner(
     };
 
     // Queued-message promotion: a light sweep, wake-driven with a slow floor.
+    // `state.queued_turn_wake` fires on enqueue, turn-terminal, unpause, and
+    // cancellation commits; the floor only covers a lost notification.
     // Try-based on the idempotent turn acceptance, so it needs no lease of its
     // own — see `routes::promote_queued_turns`.
     let queued_turn_promoter = {
         let state = state.clone();
-        tokio::spawn(async move {
-            let mut tick = tokio::time::interval(std::time::Duration::from_millis(750));
-            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            loop {
-                tick.tick().await;
-                if let Err(error) = routes::promote_queued_turns(&state).await {
-                    tracing::error!("tidebreak: queued-turn promotion failed: {error:?}");
-                }
-            }
-        })
+        tokio::spawn(routes::run_queued_turn_promoter(
+            state,
+            std::time::Duration::from_secs(5),
+        ))
     };
     let server_store = state.store.clone();
     let data_dir = state.config.data_dir.clone();

--- a/crates/tidebreak-server/src/routes/turn_control.rs
+++ b/crates/tidebreak-server/src/routes/turn_control.rs
@@ -386,7 +386,10 @@ pub async fn post_message(
                 state.turn_job_wake.notify_one();
                 return Ok(StatusCode::ACCEPTED);
             }
-            BeginTurnAdmissionOutcome::Queued => return Ok(StatusCode::ACCEPTED),
+            BeginTurnAdmissionOutcome::Queued => {
+                state.queued_turn_wake.notify_one();
+                return Ok(StatusCode::ACCEPTED);
+            }
             BeginTurnAdmissionOutcome::IdentityConflict => {
                 return Err(ServerError::conflict(format!(
                     "turn {} was already reserved with different input or by another chat",
@@ -449,7 +452,8 @@ pub async fn post_message(
                             .await?
                         {
                             ReservedQueuedTurnOutcome::Queued(_) => {
-                                return Ok(StatusCode::ACCEPTED)
+                                state.queued_turn_wake.notify_one();
+                                return Ok(StatusCode::ACCEPTED);
                             }
                             ReservedQueuedTurnOutcome::LeaseLost => continue 'reserve,
                         }
@@ -565,6 +569,9 @@ pub async fn put_queue_paused(
         .store
         .set_setting(&queue_paused_setting(id), &serde_json::json!(body.paused))
         .await?;
+    if !body.paused {
+        state.queued_turn_wake.notify_one();
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -572,8 +579,8 @@ pub async fn put_queue_paused(
 /// promoter's next sweep starts the oldest queued message.
 ///
 /// Promotion stays with the sweep: the idempotent try-and-delete in
-/// [`promote_queued_turns`] owns the exact ordering guarantees, and the sweep
-/// runs on a sub-second cadence, so this route only needs to release the
+/// [`promote_queued_turns`] owns the exact ordering guarantees, and the wake
+/// below runs it near-immediately, so this route only needs to release the
 /// gate. A chat that was not paused is unaffected, making the call safe to
 /// repeat.
 pub async fn post_queue_send_now(
@@ -586,6 +593,7 @@ pub async fn post_queue_send_now(
         .store
         .set_setting(&queue_paused_setting(id), &serde_json::json!(false))
         .await?;
+    state.queued_turn_wake.notify_one();
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -741,6 +749,10 @@ pub async fn post_cancel(
     // child. Wake its worker promptly; durable claims remain the source of
     // truth if this notification is lost.
     state.agent_run_wake.notify_one();
+    // Cancelling not-yet-running work terminalizes it atomically above,
+    // freeing the chat's live slot without a worker segment; a cancelled
+    // running turn wakes the promoter again from its worker.
+    state.queued_turn_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
 
@@ -819,4 +831,23 @@ pub(crate) async fn promote_queued_turns(state: &AppState) -> Result<(), ServerE
         }
     }
     Ok(())
+}
+
+/// Run [`promote_queued_turns`] whenever `queued_turn_wake` fires, with
+/// `floor` as the fallback cadence for a lost or never-sent notification.
+///
+/// Sweep first, then wait: a notification that lands mid-sweep is held as the
+/// `Notify` permit, so the next `notified()` completes immediately instead of
+/// being lost between checks. The sweep is idempotent, so a coalesced or
+/// spurious wake only costs one cheap re-read.
+pub(crate) async fn run_queued_turn_promoter(state: AppState, floor: std::time::Duration) {
+    loop {
+        if let Err(error) = promote_queued_turns(&state).await {
+            tracing::error!("tidebreak: queued-turn promotion failed: {error:?}");
+        }
+        tokio::select! {
+            _ = state.queued_turn_wake.notified() => {}
+            _ = tokio::time::sleep(floor) => {}
+        }
+    }
 }

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -183,6 +183,13 @@ pub struct AppState {
     /// This is only a latency hint; the worker always uses its durable claim
     /// scan as the correctness source after a missed or coalesced wake-up.
     pub(crate) agent_run_wake: Arc<Notify>,
+    /// Wakes the queued-turn promoter when a queued message may have become
+    /// promotable: a row was enqueued, a running turn reached a terminal
+    /// state, or a chat's queue pause was released.
+    ///
+    /// This is only a latency hint; the promoter's sweep stays the
+    /// correctness source behind a slow fallback tick.
+    pub(crate) queued_turn_wake: Arc<Notify>,
     /// Wakes the source-blob retirement worker after a reference drop commits.
     pub(crate) blob_retirement_wake: Arc<Notify>,
     /// Coordinates source publication and retirement across server processes.
@@ -427,6 +434,7 @@ impl AppState {
             provisioned_policy,
             turn_job_wake: Arc::new(Notify::new()),
             agent_run_wake: Arc::new(Notify::new()),
+            queued_turn_wake: Arc::new(Notify::new()),
             blob_retirement_wake: Arc::new(Notify::new()),
             blob_writes,
             file_preview_permits: Arc::new(Semaphore::new(2)),

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -1913,6 +1913,7 @@ fn spawn_turn_worker_with_config(state: &AppState, config: turn_worker::TurnWork
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_run_wake.clone(),
+        state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
         config,

--- a/crates/tidebreak-server/src/tests/image_attachment.rs
+++ b/crates/tidebreak-server/src/tests/image_attachment.rs
@@ -142,6 +142,7 @@ fn spawn_turn_worker_with_image_blobs(state: &AppState) {
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_run_wake.clone(),
+        state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
         crate::turn_worker::TurnWorkerConfig::default(),

--- a/crates/tidebreak-server/src/tests/lifecycle.rs
+++ b/crates/tidebreak-server/src/tests/lifecycle.rs
@@ -3837,3 +3837,89 @@ async fn send_now_releases_a_paused_queue() {
     }
     panic!("send-now left rows in the queue");
 }
+
+/// The promoter is wake-driven: a message queued behind a running turn is
+/// promoted promptly once that turn completes, without waiting out the
+/// promoter's fallback tick.
+#[tokio::test]
+async fn queued_turn_promotes_on_completion_wake_without_the_fallback_tick() {
+    // The first turn parks in the provider, keeping the chat busy so the
+    // follow-up parks as a queued row instead of running immediately.
+    let gate = Arc::new(Notify::new());
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(GatedProvider {
+            gate: gate.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "gated".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    let router = app(state.clone());
+    spawn_turn_worker(&state);
+    // The real promoter loop, with a floor far beyond this test's timeout:
+    // only a wake can promote the row in time, so a promotion below proves
+    // the enqueue and turn-completion commits reach the promoter.
+    tokio::spawn(crate::routes::run_queued_turn_promoter(
+        state.clone(),
+        Duration::from_secs(300),
+    ));
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, TurnId::new(), "blocking turn").await,
+        StatusCode::ACCEPTED
+    );
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{}/messages", chat.id))
+                .header(header::AUTHORIZATION, bearer.as_str())
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "turn_id": TurnId::new(),
+                        "content": "queued follow-up",
+                        "queue": true,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(
+        store.list_queued_turns(chat.id).await.unwrap().len(),
+        1,
+        "the follow-up did not park as a queued row"
+    );
+
+    // Let the blocking turn finish. Its terminal commit must wake the
+    // promoter, which drains the queued row long before the 300s floor.
+    gate.notify_one();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while !store.list_queued_turns(chat.id).await.unwrap().is_empty() {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("the queued message was not promoted off the completion wake");
+}

--- a/crates/tidebreak-server/src/tests/workers.rs
+++ b/crates/tidebreak-server/src/tests/workers.rs
@@ -1802,6 +1802,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_run_wake.clone(),
+        state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
         turn_worker::TurnWorkerConfig {
@@ -1898,6 +1899,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_run_wake.clone(),
+        state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
         turn_worker::TurnWorkerConfig {
@@ -2216,6 +2218,7 @@ async fn cancellation_after_drive_result_persists_the_completed_model_step() {
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_run_wake.clone(),
+        state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
         turn_worker::TurnWorkerConfig::default(),

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -123,6 +123,9 @@ pub(crate) struct TurnWorker {
     titler: Arc<ChatTitler>,
     wake: Arc<Notify>,
     sandbox_agent_wake: Arc<Notify>,
+    /// Wakes the queued-turn promoter when a turn reaches a terminal state,
+    /// freeing the chat's live slot for its oldest queued message.
+    queued_turn_wake: Arc<Notify>,
     agent_config: AgentConfig,
     exec_folder_context: Option<Arc<crate::code_execution::ConfiguredExecProvider>>,
     private_scratch_root: Option<PathBuf>,
@@ -426,6 +429,7 @@ impl TurnWorker {
         signals: Arc<TurnGuard>,
         wake: Arc<Notify>,
         sandbox_agent_wake: Arc<Notify>,
+        queued_turn_wake: Arc<Notify>,
         agent_config: AgentConfig,
         private_scratch_root: Option<PathBuf>,
         config: TurnWorkerConfig,
@@ -457,6 +461,7 @@ impl TurnWorker {
             titler,
             wake,
             sandbox_agent_wake,
+            queued_turn_wake,
             agent_config,
             exec_folder_context: None,
             private_scratch_root,
@@ -752,6 +757,9 @@ impl TurnWorker {
         if let Some(terminal) = action.terminal_event {
             self.publish(terminal.chat_id, terminal.event);
             self.wake.notify_one();
+            // The expired turn's chat slot is free; its oldest queued message
+            // may now be promotable.
+            self.queued_turn_wake.notify_one();
             return Ok(ClaimAction::Terminalized);
         }
         let Some(turn) = action.turn else {
@@ -823,6 +831,17 @@ impl TurnWorker {
                 "foreground turn segment completed"
             );
         });
+        if matches!(
+            outcome,
+            Ok(TurnWorkerOutcome::Completed(_)
+                | TurnWorkerOutcome::Cancelled(_)
+                | TurnWorkerOutcome::Failed(_))
+        ) {
+            // The chat's live slot is free; its oldest queued message may now
+            // be promotable. Errored and lease-lost segments terminalize later
+            // through `claim_once`, which wakes the promoter itself.
+            self.queued_turn_wake.notify_one();
+        }
         outcome
     }
 


### PR DESCRIPTION
Closes #2949

The queued-turn promoter ran a 750ms `interval` over a DISTINCT `chats_with_queued_turns` query forever, with no wake wired despite its comment. This wires the repo's Notify pattern (as in `code/session_worker.rs`):

- New `AppState::queued_turn_wake`, fired from every commit that can make a queued message promotable:
  - both enqueue paths in `post_message` (`BeginTurnAdmissionOutcome::Queued` and `ReservedQueuedTurnOutcome::Queued`)
  - a turn reaching a terminal state — end of a worker segment (`Completed`/`Cancelled`/`Failed`) and lease-expiry terminalization in `claim_once`
  - `post_cancel`, which can terminalize not-yet-running work atomically without a worker segment
  - both unpause paths: `PUT …/queue-paused` with `paused: false` and `POST …/queued/send-now`
- The promoter loop (`run_queued_turn_promoter`) sweeps, then `select!`s on `notified()` with the fallback tick stretched from 750ms to a 5s floor. Sweep-then-wait means a notification landing mid-sweep is held as the `Notify` permit and the next `notified()` completes immediately, so no wakeup is lost between checks. An enqueue while idle still promotes near-immediately via the notify.

New test `queued_turn_promotes_on_completion_wake_without_the_fallback_tick` runs the real promoter loop with a 300s floor, queues a follow-up behind a gated turn, releases the gate, and asserts the row promotes within seconds — only the wake path can do that in time.

Ran locally:
- `cargo check -p tidebreak-server` — clean
- `cargo test -p tidebreak-server queue` — 26 passed; 8 failures (`tests::code::*`, `chat_titling`, `sandbox_container_run` loopback tests) are TCP-connect timeouts in my sandbox and reproduce identically on unmodified `main`
- `cargo test -p tidebreak-server -- queued_turn_promotes_on_completion_wake send_now_releases_a_paused_queue` — both pass; the new wake test finishes in ~3s against its 300s floor