### PR TITLE
perf(ui): stop app-wide re-renders from context and drag

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import { Outlet, useNavigate, useRouter } from "@tanstack/react-router";
 import { getVersion } from "@tauri-apps/api/app";
 import { isTauri } from "@tauri-apps/api/core";
@@ -13,7 +19,7 @@ import {
   type ProviderInfo,
   type ServerInfo,
 } from "./api";
-import { AppContextProvider } from "./AppContext";
+import { AppContextProvider, type AppContextValue } from "./AppContext";
 
 import { resolveServerInfo } from "./boot";
 import {
@@ -150,6 +156,32 @@ function isMonacoFocused(): boolean {
 // calling actions only — never read state fields from them.
 const chatListActions = useChatListStore.getState();
 const projectListActions = useProjectListStore.getState();
+
+/**
+ * Every field of the app context that is invoked rather than read. The shell
+ * rebuilds these closures each render (they capture that render's state), but
+ * the context carries one stable set of forwarders so a callback changing
+ * identity never invalidates the context value — see {@link AppShell}.
+ */
+type AppContextActions = Pick<
+  AppContextValue,
+  | "refreshCatalog"
+  | "refreshChats"
+  | "newChat"
+  | "deleteChat"
+  | "startRename"
+  | "commitRename"
+  | "cancelRename"
+  | "newProject"
+  | "deleteProject"
+  | "startProjectRename"
+  | "commitProjectRename"
+  | "cancelProjectRename"
+  | "newChatInProject"
+  | "moveChatToProject"
+  | "checkForUpdate"
+  | "restartForUpdate"
+>;
 
 /**
  * The shell hooks that do work on their own — the parked-prompt poll and the
@@ -945,6 +977,92 @@ export function AppShell() {
     }
   }
 
+  // The context's mutations, rebound to this render's closures. Assigned into
+  // a ref every render — the same pattern as `useNativeHostEvent` — so the
+  // stable forwarders below always call the newest closure and never a stale
+  // one.
+  const contextActions: AppContextActions = {
+    refreshCatalog,
+    refreshChats,
+    newChat: () => void onNewChat(),
+    deleteChat: (target) => void onDeleteChat(target),
+    startRename: startChatRename,
+    commitRename: (target) => void commitChatRename(target),
+    cancelRename: cancelChatRename,
+    newProject: onNewProject,
+    deleteProject: (target) => void onDeleteProject(target),
+    startProjectRename,
+    commitProjectRename: (target) => void commitProjectRename(target),
+    cancelProjectRename,
+    newChatInProject: (projectId) => void onNewChatInProject(projectId),
+    moveChatToProject: (chat, projectId) =>
+      void onMoveChatToProject(chat, projectId),
+    checkForUpdate: desktopUpdates.check,
+    restartForUpdate: onRestartForUpdate,
+  };
+  const contextActionsRef = useRef(contextActions);
+  contextActionsRef.current = contextActions;
+  // One set of forwarders for the shell's lifetime. Each has a stable identity
+  // and delegates to whatever the ref holds now, which is what lets the
+  // context value below memoize on data alone.
+  const [stableActions] = useState<AppContextActions>(() => ({
+    refreshCatalog: () => contextActionsRef.current.refreshCatalog(),
+    refreshChats: () => contextActionsRef.current.refreshChats(),
+    newChat: () => contextActionsRef.current.newChat(),
+    deleteChat: (chat) => contextActionsRef.current.deleteChat(chat),
+    startRename: (chat) => contextActionsRef.current.startRename(chat),
+    commitRename: (chat) => contextActionsRef.current.commitRename(chat),
+    cancelRename: () => contextActionsRef.current.cancelRename(),
+    newProject: (title) => contextActionsRef.current.newProject(title),
+    deleteProject: (project) =>
+      contextActionsRef.current.deleteProject(project),
+    startProjectRename: (project) =>
+      contextActionsRef.current.startProjectRename(project),
+    commitProjectRename: (project) =>
+      contextActionsRef.current.commitProjectRename(project),
+    cancelProjectRename: () => contextActionsRef.current.cancelProjectRename(),
+    newChatInProject: (projectId) =>
+      contextActionsRef.current.newChatInProject(projectId),
+    moveChatToProject: (chat, projectId) =>
+      contextActionsRef.current.moveChatToProject(chat, projectId),
+    checkForUpdate: () => contextActionsRef.current.checkForUpdate(),
+    restartForUpdate: () => contextActionsRef.current.restartForUpdate(),
+  }));
+
+  // Memoized so the ~34 useApp() consumers re-render when the data they read
+  // changes, not whenever the shell does — before this, every shell render
+  // (a status line update, an update-state event) re-rendered every consumer,
+  // transcript included. `null` until boot lands a client; the shell early
+  // returns before the provider ever sees that.
+  const appContextValue = useMemo<AppContextValue | null>(
+    () =>
+      client && info
+        ? {
+            client,
+            attachment: info.attachment,
+            models,
+            defaultModelKey,
+            providers,
+            status,
+            setStatus,
+            updateState: desktopUpdates.state,
+            updateUpToDate: desktopUpdates.upToDate,
+            ...stableActions,
+          }
+        : null,
+    [
+      client,
+      info,
+      models,
+      defaultModelKey,
+      providers,
+      status,
+      desktopUpdates.state,
+      desktopUpdates.upToDate,
+      stableActions,
+    ],
+  );
+
   if (bootFailure) {
     return (
       <BootFailure
@@ -985,36 +1103,7 @@ export function AppShell() {
         shortcuts={shellShortcuts}
         shortcutMode={currentShortcutMode}
       />
-      <AppContextProvider
-        value={{
-          client,
-          attachment: info.attachment,
-          models,
-          defaultModelKey,
-          providers,
-          refreshCatalog,
-          refreshChats,
-          status,
-          setStatus,
-          newChat: () => void onNewChat(),
-          deleteChat: (target) => void onDeleteChat(target),
-          startRename: startChatRename,
-          commitRename: (target) => void commitChatRename(target),
-          cancelRename: cancelChatRename,
-          newProject: (title) => onNewProject(title),
-          deleteProject: (target) => void onDeleteProject(target),
-          startProjectRename,
-          commitProjectRename: (target) => void commitProjectRename(target),
-          cancelProjectRename,
-          newChatInProject: (projectId) => void onNewChatInProject(projectId),
-          moveChatToProject: (chat, projectId) =>
-            void onMoveChatToProject(chat, projectId),
-          updateState: desktopUpdates.state,
-          updateUpToDate: desktopUpdates.upToDate,
-          checkForUpdate: desktopUpdates.check,
-          restartForUpdate: onRestartForUpdate,
-        }}
-      >
+      <AppContextProvider value={appContextValue}>
         <div
           className={`app-shell${nativeTitlebar ? " with-titlebar" : ""}`}
           // Publish this as part of the shell's first render. An effect that

--- a/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { useNowWhile } from "./BackgroundAgentPanel";
 import { Button } from "@/components/ui/button";
 import {
   resumeComputerUseControl,
@@ -22,12 +23,15 @@ function appLabel(appName: string | null, bundleId: string): string {
 export function ComputerUseIndicator() {
   const snapshot = useComputerUseState();
   // The active banner re-arms to hidden once control has been idle past its
-  // window; the tick keeps that honest without a native timer.
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 5_000);
-    return () => clearInterval(timer);
-  }, []);
+  // window; the tick keeps that honest without a native timer. It only runs
+  // while the banner is up: with no session on record — the common case for a
+  // shell-mounted component — or one already idled out, nothing on screen
+  // depends on the time and nothing re-renders. The tick's job is the
+  // re-render itself, which re-evaluates this line; the crossing tick renders
+  // the banner away and stops the interval with it.
+  const showActive =
+    snapshot.active !== null && Date.now() < snapshot.active.visibleUntilMillis;
+  useNowWhile(showActive);
 
   // In-flight invokes, keyed per card (or "control" for Stop/Resume). The
   // ref is the guard against a second click landing while the first is
@@ -59,8 +63,6 @@ export function ComputerUseIndicator() {
       });
   }
 
-  const showActive =
-    snapshot.active !== null && now < snapshot.active.visibleUntilMillis;
   if (!snapshot.halted && !showActive) {
     return null;
   }

--- a/crates/tidebreak-desktop/ui/src/MessageList.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.tsx
@@ -271,6 +271,24 @@ type MessageListProps = {
   >;
 };
 
+// Defaults for the background-agent props feed the grouping memo below, so
+// they are module constants: a fresh `[]` or `() => {}` per render would be a
+// new dependency every time and the memo would never hold.
+const NO_BACKGROUND_AGENT_RUNS: AgentRun[] = [];
+const noRetryBackgroundAgentRuns = () => undefined;
+const noCancelBackgroundAgentRun = async () => undefined;
+const noLoadBackgroundAgentActivity = async (): Promise<
+  AgentActivityHistoryEntry[]
+> => [];
+const noLoadBackgroundAgentTaskPlan = async (): Promise<null> => null;
+const noLoadBackgroundAgentProgress = async (
+  _runId: string,
+  afterSequence: number,
+): Promise<AgentRunProgress> => ({
+  entries: [],
+  nextSequence: afterSequence,
+});
+
 export function MessageList({
   messages,
   chatId,
@@ -286,17 +304,14 @@ export function MessageList({
   decidingApprovalCalls,
   approvalErrors,
   grantScope,
-  backgroundAgentRuns = [],
+  backgroundAgentRuns = NO_BACKGROUND_AGENT_RUNS,
   backgroundAgentRunsLoading = false,
   backgroundAgentRunsError = null,
-  onRetryBackgroundAgentRuns = () => undefined,
-  onCancelBackgroundAgentRun = async () => undefined,
-  onLoadBackgroundAgentActivity = async () => [],
-  onLoadBackgroundAgentTaskPlan = async () => null,
-  onLoadBackgroundAgentProgress = async (_runId, afterSequence) => ({
-    entries: [],
-    nextSequence: afterSequence,
-  }),
+  onRetryBackgroundAgentRuns = noRetryBackgroundAgentRuns,
+  onCancelBackgroundAgentRun = noCancelBackgroundAgentRun,
+  onLoadBackgroundAgentActivity = noLoadBackgroundAgentActivity,
+  onLoadBackgroundAgentTaskPlan = noLoadBackgroundAgentTaskPlan,
+  onLoadBackgroundAgentProgress = noLoadBackgroundAgentProgress,
   onOpenBackgroundAgent,
   onOpenOutput,
   busy,
@@ -332,16 +347,8 @@ export function MessageList({
     if (!turn) return undefined;
     return { failureId: turn.failureId, onRetry: () => onRetryTurn(turn) };
   }, [messages, onRetryTurn]);
-  const { items: messageItems, lastTurnStart } = groupMessageItems(
-    messages,
-    busy,
-    animateStreaming,
-    onApproval,
-    approvalState,
-    imageClient,
-    chatId,
-    changeClient,
-    {
+  const backgroundAgents = useMemo(
+    () => ({
       runs: backgroundAgentRuns,
       loading: backgroundAgentRunsLoading,
       error: backgroundAgentRunsError,
@@ -353,8 +360,50 @@ export function MessageList({
       open: onOpenBackgroundAgent,
       openOutput: onOpenOutput,
       client: backgroundAgentClient,
-    },
-    retry,
+    }),
+    [
+      backgroundAgentRuns,
+      backgroundAgentRunsLoading,
+      backgroundAgentRunsError,
+      onRetryBackgroundAgentRuns,
+      onCancelBackgroundAgentRun,
+      onLoadBackgroundAgentActivity,
+      onLoadBackgroundAgentTaskPlan,
+      onLoadBackgroundAgentProgress,
+      onOpenBackgroundAgent,
+      onOpenOutput,
+      backgroundAgentClient,
+    ],
+  );
+  // Grouping walks the whole transcript and builds every row's element; memoized
+  // so a render whose inputs are unchanged (a scroll, a pending-card flag)
+  // reuses the rows instead of rebuilding a long conversation's worth.
+  const { items: messageItems, lastTurnStart } = useMemo(
+    () =>
+      groupMessageItems(
+        messages,
+        busy,
+        animateStreaming,
+        onApproval,
+        approvalState,
+        imageClient,
+        chatId,
+        changeClient,
+        backgroundAgents,
+        retry,
+      ),
+    [
+      messages,
+      busy,
+      animateStreaming,
+      onApproval,
+      approvalState,
+      imageClient,
+      chatId,
+      changeClient,
+      backgroundAgents,
+      retry,
+    ],
   );
   // Only greet a genuinely empty, fully-hydrated conversation. While an
   // existing chat's transcript is still loading it is transiently empty; showing

--- a/crates/tidebreak-desktop/ui/src/UiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/UiStore.ts
@@ -106,10 +106,11 @@ export type UiStore = {
   /** Expanded rail width in CSS pixels. Ignored while the rail is compact. */
   sidebarWidth: number;
   /**
-   * Set the expanded rail width. Pass `{ persist: false }` while dragging so
-   * localStorage is only written once the pointer is up.
+   * Set and persist the expanded rail width. Live drags bypass this — the
+   * resize handle writes the DOM directly per pointer frame and commits here
+   * once on release, so this always both re-renders and persists.
    */
-  setSidebarWidth: (width: number, options?: { persist?: boolean }) => void;
+  setSidebarWidth: (width: number) => void;
   /**
    * Whether the model picker's "Not connected" section is folded away. Open by
    * default — the section exists to be noticed once — and remembered after
@@ -140,9 +141,9 @@ export function createUiStore() {
         return { sidebarCollapsed };
       }),
     sidebarWidth: readStoredSidebarWidth(),
-    setSidebarWidth: (width, options) => {
+    setSidebarWidth: (width) => {
       const sidebarWidth = clampSidebarWidth(width);
-      if (options?.persist !== false) storeSidebarWidth(sidebarWidth);
+      storeSidebarWidth(sidebarWidth);
       set({ sidebarWidth });
     },
     modelMenuNotConnectedCollapsed: readStoredNotConnectedCollapsed(),

--- a/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
@@ -11,6 +11,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
+  clampSidebarWidth,
   SIDEBAR_DEFAULT_WIDTH,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_MIN_WIDTH,
@@ -42,6 +43,11 @@ function SidebarResizeHandle({
     pointerId: number;
     startX: number;
     startWidth: number;
+    /** The clamped width of the latest pointer frame, for the end-drag commit. */
+    width: number;
+    /** The shell publishes the width as a CSS variable; the titlebar reads it. */
+    shell: HTMLElement | null;
+    rail: HTMLElement | null;
   } | null>(null);
   const [dragging, setDragging] = useState(false);
 
@@ -52,8 +58,9 @@ function SidebarResizeHandle({
       dragRef.current = null;
       setDragging(false);
       onDraggingChange(false);
-      // Commit the live width once; moves during the drag skipped persistence.
-      setSidebarWidth(useUiStore.getState().sidebarWidth);
+      // The one store write of the whole drag: the moves wrote straight to the
+      // DOM, so this is where React and localStorage catch up — once.
+      setSidebarWidth(drag.width);
       try {
         event.currentTarget.releasePointerCapture(event.pointerId);
       } catch {
@@ -72,6 +79,11 @@ function SidebarResizeHandle({
       pointerId: event.pointerId,
       startX: event.clientX,
       startWidth: sidebarWidth,
+      width: sidebarWidth,
+      shell: event.currentTarget.closest<HTMLElement>(".app-shell"),
+      rail: event.currentTarget.closest<HTMLElement>(
+        '[data-sidebar="expanded"]',
+      ),
     };
     setDragging(true);
     onDraggingChange(true);
@@ -83,9 +95,22 @@ function SidebarResizeHandle({
   const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
     const drag = dragRef.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
-    setSidebarWidth(drag.startWidth + (event.clientX - drag.startX), {
-      persist: false,
-    });
+    // Written to the DOM, not the store: a store write per pointer frame
+    // re-renders the shell — it subscribes to the width for its CSS variable —
+    // and with it every route, transcript included. The rail's own styles and
+    // the shell variable together move everything the width drives; endDrag
+    // commits the same number to React, so the repaint lands on what the drag
+    // already left in place.
+    drag.width = clampSidebarWidth(
+      drag.startWidth + (event.clientX - drag.startX),
+    );
+    const px = `${drag.width}px`;
+    drag.shell?.style.setProperty("--sidebar-expanded-width", px);
+    if (drag.rail) {
+      drag.rail.style.flex = `0 0 ${px}`;
+      drag.rail.style.minWidth = px;
+      drag.rail.style.width = px;
+    }
   };
 
   const onDoubleClick = () => {


### PR DESCRIPTION
Closes #2942

## What changed

- **AppShell context** (`AppShell.tsx`): the `AppContextProvider` value was an inline object with ~15 fresh closures, so all ~34 `useApp()` consumers re-rendered on every shell render. The value is now built with `useMemo` keyed on the data it carries (client, catalog, status, update state). The mutations go through one stable set of forwarders that dispatch via a per-render ref, so their identities never change and their closures never go stale. Verified against consumers: the only context member appearing in a dependency array anywhere is `setStatus` (`ChatRoute.tsx`), which is a `useState` setter and was already stable — no consumer relied on the context identity changing per render.
- **Sidebar drag** (`sidebar/primitives.tsx`, `UiStore.ts`): pointermove wrote `sidebarWidth` to the store every frame, and AppShell subscribes to it for its `--sidebar-expanded-width` CSS variable — so a drag re-rendered the whole app, transcript included, per frame. The handle now writes the clamped width imperatively during the drag (the shell's CSS variable, which also moves the titlebar, plus the rail's own inline styles) and commits to the store once on release. Persistence is identical: one localStorage write per drag, on release; keyboard and double-click resizes are unchanged. The now-caller-less `persist: false` option is removed from `setSidebarWidth`.
- **MessageList** (`MessageList.tsx`): `groupMessageItems` — a full transcript walk that builds every row — ran un-memoized in the component body. It and the background-agent options object are now under `useMemo`; the background-agent prop defaults are hoisted to module constants so omitting those props no longer produces fresh identities that would bust the memo.
- **ComputerUseIndicator** (`ComputerUseIndicator.tsx`): an unconditional 5s `setNow` interval ticked from shell mount forever, even when no computer-use session ever ran. It now uses the existing `useNowWhile` pattern from `BackgroundAgentPanel`, gated on the active banner actually being on screen — no session, or a session already idled past its visibility window, means no timer and no re-renders. The crossing tick re-renders the banner away and stops the interval with it.

## What I ran

- `biome format` (no fixes) and `pnpm lint` — clean
- `tsc` and `pnpm build` — clean
- Targeted suites: `AppShell.dom.test.tsx`, `MessageList.test.tsx`, `MessageList.dom.test.tsx`, `MessageList.isolation.dom.test.tsx`, `sidebar/SettingsSidebar.dom.test.tsx` — 93/93 pass
- Full `pnpm test`: 2268 pass; 23 failures in 4 files (`CodeWorkspacePage`, `CodeDeliveryPage`, `PullRequestDetail`, `OutputsView`) were 5s timeouts from sandbox CPU starvation — each of those files passes in isolation on this branch (139/139), and one of them also flaked on a clean `main` checkout under the same load
- `pnpm storybook:build` — succeeds (Navigation/Sidebar and ConversationTranscript stories cover the touched surfaces)