### PR TITLE
fix(code): detect pull requests from changed checkouts

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -807,10 +807,13 @@ impl CodePullRequestState {
 
 /// How strongly a workspace is tied to a pull request (decision 77).
 ///
-/// Only two acts mint attribution: `gh pr create` (authored) and a push whose
-/// branch is or becomes a pull request's head (contributed). Reading,
-/// checking out, commenting on, closing, or merging a pull request never
-/// does, so review and triage agents stay out of the attributed set.
+/// `gh pr create` mints authored attribution. A push whose branch is or
+/// becomes a pull request's head mints contributed attribution. A changed,
+/// clean workspace checkout also mints contributed attribution when it remains
+/// on the workspace branch and its current commit exactly matches an open pull
+/// request head. Reading, checking out, commenting on, closing, or merging a
+/// pull request never does, so review and triage agents stay out of the
+/// attributed set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum CodePullRequestRelation {
@@ -847,7 +850,8 @@ impl CodePullRequestRelation {
 #[serde(rename_all = "snake_case")]
 pub enum CodePullRequestDiscovery {
     /// The post-turn detector saw the act in the session's journaled shell
-    /// commands and confirmed it against the host.
+    /// commands, or recovered the changed workspace checkout, and confirmed
+    /// it against the host.
     Command,
     /// The reconcile sweep matched the pull request to the workspace by
     /// number or head SHA.

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1501,10 +1501,13 @@ export type CodePrMergeMethod = "squash" | "merge" | "rebase";
 /**
  * How strongly a workspace is tied to a pull request (decision 77).
  *
- * Only two acts mint attribution: `gh pr create` (authored) and a push whose
- * branch is or becomes a pull request's head (contributed). Reading,
- * checking out, commenting on, closing, or merging a pull request never
- * does, so review and triage agents stay out of the attributed set.
+ * `gh pr create` mints authored attribution. A push whose branch is or
+ * becomes a pull request's head mints contributed attribution. A changed,
+ * clean workspace checkout also mints contributed attribution when it remains
+ * on the workspace branch and its current commit exactly matches an open pull
+ * request head. Reading, checking out, commenting on, closing, or merging a
+ * pull request never does, so review and triage agents stay out of the
+ * attributed set.
  */
 export type CodePullRequestRelation = "authored" | "contributed";
 

--- a/crates/tidebreak-server/src/code/pr_facts.rs
+++ b/crates/tidebreak-server/src/code/pr_facts.rs
@@ -1,10 +1,13 @@
 //! Post-turn pull-request fact detection (decision 77).
 //!
 //! After a turn closes, this module reads the turn's journaled shell
-//! commands, recognizes the two acts that mint attribution — `gh pr create`
-//! and `git push` — and confirms each against GitHub before writing a
-//! `code_pull_request` fact and its workspace attribution. The transcript is
-//! a hint, never the fact: no row is written without a confirming `gh` read.
+//! commands, recognizes `gh pr create` and `git push`, and confirms each
+//! against GitHub before writing a `code_pull_request` fact and its workspace
+//! attribution. It also checks a workspace checkout changed by the turn when
+//! the checkout is clean, still on the workspace branch, and its current
+//! commit exactly matches an open pull request head. The transcript and
+//! checkout are evidence, never the fact: no row is written without a
+//! confirming `gh` read.
 //!
 //! Everything here is best-effort. A detector failure never fails the turn,
 //! and a miss is corrected by the reconcile sweep's exact-tier matching.
@@ -17,8 +20,8 @@ use serde_json::Value;
 use tracing::debug;
 
 use tidebreak_core::db::code::{
-    insert_pull_request_attribution, list_recent_events, promote_attribution_to_authored,
-    save_pull_request_fact,
+    get_turn, get_workspace, insert_pull_request_attribution, list_recent_events,
+    promote_attribution_to_authored, save_pull_request_fact,
 };
 use tidebreak_core::{
     CodeEvent, CodePullRequestAttribution, CodePullRequestDiscovery, CodePullRequestFact,
@@ -68,7 +71,7 @@ struct PushAct {
     branch: Option<String>,
 }
 
-/// Scan one closed turn's journaled commands and mint confirmed facts.
+/// Scan one closed turn's commands and changed checkout for confirmed facts.
 ///
 /// Never returns an error and never touches the turn: every failure is a
 /// debug log. Runs after the turn's terminal event is journaled, so the
@@ -227,6 +230,17 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
         confirmed_any |= confirm_push(db, session, &command, &push, gh_search_path).await;
     }
 
+    // A long turn can push its create or push command out of the bounded
+    // journal tail. Other GitHub clients can also open the pull request
+    // without producing either command. The checkpoint records whether this
+    // turn changed the workspace checkout. A clean checkout still on the
+    // workspace branch whose local HEAD exactly matches an open host head is
+    // enough to recover that missed tie without attributing a read-only review
+    // or an unpushed edit.
+    if confirms < MAX_CONFIRM_READS_PER_TURN {
+        confirmed_any |= confirm_changed_checkout(db, session, turn_id, gh_search_path).await;
+    }
+
     // The turn moved this workspace's pull request. Nothing else marks it:
     // route mutations dirty the row for the user's own actions, and the
     // agent's push is neither. Left unmarked, the watch's next assessment
@@ -236,6 +250,120 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
             hot.mark(&session.owner, session.workspace_id);
         }
     }
+}
+
+/// Confirm the changed workspace checkout against an open pull request head.
+///
+/// Reports whether a fact landed, so the caller can mark the workspace hot.
+async fn confirm_changed_checkout(
+    db: &DbStore,
+    session: &CodeSession,
+    turn_id: CodeTurnId,
+    gh_search_path: Option<&str>,
+) -> bool {
+    let turn = match get_turn(db, &session.owner, turn_id).await {
+        Ok(Some(turn)) => turn,
+        Ok(None) => return false,
+        Err(err) => {
+            debug!("pr fact detector could not read the turn checkpoint: {err}");
+            return false;
+        }
+    };
+    if !turn
+        .diffstat
+        .as_ref()
+        .is_some_and(|diffstat| diffstat.files > 0)
+    {
+        return false;
+    }
+
+    let workspace = match get_workspace(db, &session.owner, session.workspace_id).await {
+        Ok(Some(workspace)) if !workspace.is_remote() => workspace,
+        Ok(_) => return false,
+        Err(err) => {
+            debug!("pr fact detector could not read the changed workspace: {err}");
+            return false;
+        }
+    };
+    let checkout = Path::new(&workspace.worktree_path);
+    match git_read(checkout, &["status", "--porcelain"]).await {
+        Ok(status) if status.is_empty() => {}
+        Ok(_) => return false,
+        Err(err) => {
+            debug!("pr fact detector could not inspect the changed checkout: {err}");
+            return false;
+        }
+    }
+
+    let Some(branch) = current_branch(checkout).await else {
+        return false;
+    };
+    if branch != workspace.branch_name {
+        return false;
+    }
+    let head = match git_read(checkout, &["rev-parse", "HEAD"]).await {
+        Ok(head) if !head.is_empty() => head,
+        Ok(_) => return false,
+        Err(err) => {
+            debug!("pr fact detector could not read the changed checkout head: {err}");
+            return false;
+        }
+    };
+    let target = match repository_target_from_path(checkout).await {
+        Ok(target) => target,
+        Err(err) => {
+            debug!("pr fact detector could not resolve the changed checkout: {err}");
+            return false;
+        }
+    };
+    let values = match list_pull_requests_for_head_raw(
+        &target.host,
+        &target.owner,
+        &target.name,
+        &branch,
+        gh_search_path,
+    )
+    .await
+    {
+        Ok(values) => values,
+        Err(err) => {
+            debug!("pr fact detector could not confirm the changed checkout: {err}");
+            return false;
+        }
+    };
+    let matching = values
+        .into_iter()
+        .filter(|value| {
+            value
+                .get("state")
+                .and_then(Value::as_str)
+                .is_some_and(|state| state.eq_ignore_ascii_case("open"))
+                && value
+                    .get("headRefName")
+                    .and_then(Value::as_str)
+                    .is_some_and(|candidate| candidate == branch)
+                && value
+                    .get("headRefOid")
+                    .and_then(Value::as_str)
+                    .is_some_and(|candidate| candidate == head)
+        })
+        .collect();
+    let Some(value) = newest_by_created(matching) else {
+        return false;
+    };
+    record_confirmed_fact(
+        db,
+        &session.owner,
+        session.workspace_id,
+        Some(session.id),
+        None,
+        &target,
+        &value,
+        CodePullRequestRelation::Contributed,
+        CodePullRequestDiscovery::Command,
+    )
+    .await
+    .is_some()
 }
 
 /// Confirm one `gh pr create` against the host and mint an authored fact.

--- a/crates/tidebreak-server/src/tests/code_pr_facts.rs
+++ b/crates/tidebreak-server/src/tests/code_pr_facts.rs
@@ -10,14 +10,15 @@ use super::*;
 use std::os::unix::fs::PermissionsExt;
 
 use tidebreak_core::db::code::{
-    append_event, get_pull_request_fact, insert_repo, insert_session, insert_turn,
-    insert_workspace, list_attributed_facts_for_workspace,
+    append_event, get_pull_request_fact, get_turn, insert_repo, insert_session, insert_turn,
+    insert_workspace, list_attributed_facts_for_workspace, list_pull_request_attributions,
+    save_turn,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeEvent, CodePullRequestRelation, CodePullRequestState, CodeRepo,
     CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeTurn, CodeTurnId,
-    CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, HarnessKind, OwnerId, PermissionMode,
-    RepoId, ToolDetail, ToolOutcome, WorkspaceId,
+    CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, Diffstat, HarnessKind, OwnerId,
+    PermissionMode, RepoId, ToolDetail, ToolOutcome, WorkspaceId,
 };
 
 use crate::code::pr_facts;
@@ -68,6 +69,10 @@ fn init_github_shaped_repo(dir: &std::path::Path) -> std::path::PathBuf {
 /// A gh shim that answers auth, one view, and one head-scoped list, and logs
 /// every invocation. Anything else fails loudly.
 fn write_gh_shim(dir: &std::path::Path, log: &std::path::Path) {
+    write_gh_shim_with_view(dir, log, VIEW_JSON);
+}
+
+fn write_gh_shim_with_view(dir: &std::path::Path, log: &std::path::Path, view_json: &str) {
     let body = format!(
         "#!/bin/sh\n\
          echo \"$@\" >> {log}\n\
@@ -76,11 +81,11 @@ fn write_gh_shim(dir: &std::path::Path, log: &std::path::Path) {
            exit 0\n\
          fi\n\
          if [ \"$1\" = pr ] && [ \"$2\" = view ]; then\n\
-           echo '{VIEW_JSON}'\n\
+           echo '{view_json}'\n\
            exit 0\n\
          fi\n\
          if [ \"$1\" = pr ] && [ \"$2\" = list ]; then\n\
-           echo '[{VIEW_JSON}]'\n\
+           echo '[{view_json}]'\n\
            exit 0\n\
          fi\n\
          echo unexpected \"$@\" >&2\n\
@@ -88,6 +93,25 @@ fn write_gh_shim(dir: &std::path::Path, log: &std::path::Path) {
         log = log.display(),
     );
     write_executable(&dir.join("gh"), &body);
+}
+
+async fn mark_turn_checkout_changed(
+    store: &tidebreak_core::DbStore,
+    session: &CodeSession,
+    turn_id: CodeTurnId,
+) {
+    let mut turn = get_turn(store, &session.owner, turn_id)
+        .await
+        .unwrap()
+        .unwrap();
+    turn.checkpoint_ref = Some("refs/tidebreak/checkpoints/test".into());
+    turn.diffstat = Some(Diffstat {
+        files: 1,
+        insertions: 1,
+        deletions: 0,
+        truncated: false,
+    });
+    save_turn(store, &session.owner, &turn).await.unwrap();
 }
 
 async fn seeded(
@@ -409,6 +433,159 @@ async fn a_turn_that_pushed_nothing_leaves_the_hot_tier_alone() {
     .await;
 
     assert!(hot.live().is_empty());
+}
+
+#[tokio::test]
+async fn a_changed_clean_checkout_recovers_an_open_pull_request() {
+    let (dir, store) = temp_db_store("pr-facts-checkout.db").await;
+    let work = init_github_shaped_repo(dir.path());
+    let (session, turn_id) = seeded(&store, &work).await;
+
+    std::fs::write(work.join("changed.txt"), "from the turn\n").unwrap();
+    run(&work, &["git", "add", "changed.txt"]);
+    run(&work, &["git", "commit", "-m", "change from turn"]);
+    let head = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+    assert!(head.status.success());
+    let head = String::from_utf8(head.stdout).unwrap();
+    let head = head.trim();
+
+    let shim = dir.path().join("bin");
+    std::fs::create_dir_all(&shim).unwrap();
+    let view = VIEW_JSON.replace("aaa111", head);
+    write_gh_shim_with_view(&shim, &dir.path().join("gh.log"), &view);
+    mark_turn_checkout_changed(&store, &session, turn_id).await;
+
+    let hot = crate::code::pr_refresh::HotPullRequests::default();
+    let search_path = shim.display().to_string();
+    pr_facts::sweep_turn_for_pull_request_acts(
+        &store,
+        &session,
+        turn_id,
+        Some(&search_path),
+        Some(&hot),
+    )
+    .await;
+
+    let owner = OwnerId::local();
+    let attributed = list_attributed_facts_for_workspace(&store, &owner, session.workspace_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        attributed.len(),
+        1,
+        "gh calls:\n{}",
+        std::fs::read_to_string(dir.path().join("gh.log")).unwrap_or_default()
+    );
+    assert_eq!(attributed[0].0.number, 412);
+    assert_eq!(attributed[0].1, CodePullRequestRelation::Contributed);
+    let sources = list_pull_request_attributions(&store, &owner)
+        .await
+        .unwrap();
+    assert_eq!(sources.len(), 1);
+    assert_eq!(
+        sources[0].discovered_via,
+        tidebreak_core::CodePullRequestDiscovery::Command
+    );
+    assert_eq!(hot.live(), vec![(owner, session.workspace_id)]);
+}
+
+#[tokio::test]
+async fn a_changed_checkout_does_not_claim_a_different_pull_request_head() {
+    let (dir, store) = temp_db_store("pr-facts-checkout-head.db").await;
+    let work = init_github_shaped_repo(dir.path());
+    let shim = dir.path().join("bin");
+    std::fs::create_dir_all(&shim).unwrap();
+    write_gh_shim(&shim, &dir.path().join("gh.log"));
+    let (session, turn_id) = seeded(&store, &work).await;
+    mark_turn_checkout_changed(&store, &session, turn_id).await;
+
+    let search_path = shim.display().to_string();
+    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
+        .await;
+
+    assert!(
+        list_attributed_facts_for_workspace(&store, &session.owner, session.workspace_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn a_changed_dirty_checkout_does_not_claim_a_matching_pull_request_head() {
+    let (dir, store) = temp_db_store("pr-facts-checkout-dirty.db").await;
+    let work = init_github_shaped_repo(dir.path());
+    let head = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+    assert!(head.status.success());
+    let head = String::from_utf8(head.stdout).unwrap();
+    let view = VIEW_JSON.replace("aaa111", head.trim());
+
+    let shim = dir.path().join("bin");
+    std::fs::create_dir_all(&shim).unwrap();
+    let log = dir.path().join("gh.log");
+    write_gh_shim_with_view(&shim, &log, &view);
+    let (session, turn_id) = seeded(&store, &work).await;
+    mark_turn_checkout_changed(&store, &session, turn_id).await;
+    std::fs::write(work.join("unpushed.txt"), "not on the pull request\n").unwrap();
+
+    let search_path = shim.display().to_string();
+    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
+        .await;
+
+    assert!(
+        list_attributed_facts_for_workspace(&store, &session.owner, session.workspace_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(!log.exists(), "a dirty checkout should not reach GitHub");
+}
+
+#[tokio::test]
+async fn a_changed_checkout_on_another_branch_does_not_claim_its_pull_request() {
+    let (dir, store) = temp_db_store("pr-facts-checkout-branch.db").await;
+    let work = init_github_shaped_repo(dir.path());
+    let (session, turn_id) = seeded(&store, &work).await;
+    run(&work, &["git", "checkout", "-b", "review-branch"]);
+    let head = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+    assert!(head.status.success());
+    let head = String::from_utf8(head.stdout).unwrap();
+    let view = VIEW_JSON
+        .replace("feat/x", "review-branch")
+        .replace("aaa111", head.trim());
+
+    let shim = dir.path().join("bin");
+    std::fs::create_dir_all(&shim).unwrap();
+    let log = dir.path().join("gh.log");
+    write_gh_shim_with_view(&shim, &log, &view);
+    mark_turn_checkout_changed(&store, &session, turn_id).await;
+
+    let search_path = shim.display().to_string();
+    pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
+        .await;
+
+    assert!(
+        list_attributed_facts_for_workspace(&store, &session.owner, session.workspace_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        !log.exists(),
+        "a checkout on another branch should not reach GitHub"
+    );
 }
 
 #[tokio::test]

--- a/docs/decisions/0077-pull-request-facts-and-attribution.md
+++ b/docs/decisions/0077-pull-request-facts-and-attribution.md
@@ -51,28 +51,35 @@ Tidebreak wishes were true. Checks, review decisions, and mergeability are
 deliberately excluded — they stay live-only in the delivery reads, where a
 20–30 second cache is the right freshness.
 
-**Attribution is minted by exactly two acts.** `gh pr create` makes a
-workspace the pull request's author (`authored`); `git push` whose branch is
-or becomes a pull request's head makes it a contributor (`contributed`).
-Views, checkouts, comments, closes, and merges never mint attribution, so a
-review agent that triages thirty pull requests claims none of them, while an
-agent that pushes a fix commit to someone else's pull request correctly
-appears as working on it. One row per `(pull_request, workspace)` holds the
-strongest claim; a contributed row upgrades to authored when authoring
-evidence appears. Attribution rows carry the session and, when the act ran
-inside a subagent's `Task` span, its `parent_call_id` — so "which agent
-opened this" is answerable down to the child row.
+**Attribution comes from confirmed repository changes.** `gh pr create` makes
+a workspace the pull request's author (`authored`); `git push` whose branch is
+or becomes a pull request's head makes it a contributor (`contributed`). The
+post-turn detector also recovers a contributed tie from the workspace
+checkout when the turn checkpoint changed files, the checkout is clean, and
+it remains on the workspace branch with a current commit that exactly matches
+an open pull request head. This fallback catches create and push commands that
+fell outside the bounded journal tail, and pull requests opened through
+another GitHub client. Views, checkouts, comments, closes, and merges alone
+never mint attribution, so a review agent that triages thirty pull requests
+claims none of them. One row per
+`(pull_request, workspace)` holds the strongest claim; a contributed row
+upgrades to authored when authoring evidence appears. Attribution rows carry
+the session and, when the act ran inside a subagent's `Task` span, its
+`parent_call_id` — so "which agent opened this" is answerable down to the
+child row.
 
-**The transcript is a hint, never the fact.** A post-turn detector reads the
-closed turn's journaled commands, recognizes the two acts through
+**Local evidence is a hint, never the fact.** A post-turn detector reads the
+closed turn's journaled commands, recognizes create and push through
 `simple_command_argvs` (which fails closed on substitutions and parse
 errors), and then confirms each candidate against the host with one
-repository-qualified `gh` read before writing anything. A command whose
-completion the engine reported as failed is never confirmed — the read
-could match an older pull request on the same branch and mis-attribute it.
-The detector is best-effort and bounded (journal tail, parse count, and
-confirm count are capped per turn); it never fails or delays the turn, and
-it journals no new event kind. The user-initiated create and push routes
+repository-qualified `gh` read before writing anything. If the command tail
+does not carry either act, the detector can inspect the turn checkpoint and
+workspace checkout under the exact clean-checkout and matching-head rules
+above. A command whose completion the engine reported as failed is never
+confirmed — the read could match an older pull request on the same branch and
+mis-attribute it. The detector is best-effort and bounded (journal tail,
+parse count, and confirm count are capped per turn); it never fails the turn,
+and it journals no new event kind. The user-initiated create and push routes
 mint through the same confirm-then-record helper.
 
 **The reconcile sweep owns freshness and the misses.** A later slice adds a
@@ -133,15 +140,16 @@ produced.
 
 - Two new tables and three nullable `code_repo` columns, appended as
   migration `m20260822_000009_code_pull_request_facts` per record 61.
-- Every turn end runs a bounded journal scan; turns with no `gh pr create`
-  or `git push` cost a few hundred event deserializations and no GitHub
-  read. Turns with candidates cost up to four `gh` reads.
+- Every turn end runs a bounded journal scan. A turn with no create, push, or
+  changed checkpoint costs a few hundred event deserializations and no GitHub
+  read. A changed, clean checkout can add one read. Turns remain capped at
+  four confirming reads.
 - Attribution survives workspace archive and release (plain foreign keys to
   soft-removed rows), so the bird's-eye view keeps history the workspace
   list no longer shows.
-- `discovered_via` distinguishes a confirmed act (`command`) from sweep
-  matching (`reconcile`); the user-initiated routes record `command`, since
-  they confirm the same way.
+- `discovered_via` distinguishes post-turn confirmation (`command`) from
+  sweep matching (`reconcile`); the user-initiated routes record `command`,
+  since they confirm the same way.
 - A pull request opened from an auxiliary terminal in an untracked
   repository is invisible until something else makes the repository
   tracked. Revisit if that gap turns out to be common — the hook would be a
@@ -158,6 +166,10 @@ produced.
 - A journaled `git push` to a branch with an open pull request mints
   `contributed`; the same push when the branch has no pull request mints
   nothing.
+- A turn that changed the workspace checkout mints `contributed` when the
+  checkout is clean, remains on the workspace branch, and its current commit
+  exactly matches an open pull request head. Another branch, a different head,
+  or uncommitted work mints nothing.
 - A `gh pr view`, `gh pr comment`, or `gh pr merge` in the journal mints
   nothing — the case a wrong implementation most plausibly passes, since
   the strings look similar.


### PR DESCRIPTION
## Summary

- inspect a changed workspace checkout after each turn when command detection misses the create or push
- require a clean checkout whose branch and HEAD exactly match an open pull request
- cover successful recovery, different-head rejection, and dirty-checkout rejection

## Validation

- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- cargo test -p tidebreak-server code_pr_facts -- --nocapture