### PR TITLE
fix(desktop): show update checks in the corner card

### DIFF
--- a/crates/tidebreak-desktop/src/updater.rs
+++ b/crates/tidebreak-desktop/src/updater.rs
@@ -39,8 +39,8 @@ use crate::host_access::HostAccess;
 
 const UPDATE_STATE_EVENT: &str = "desktop-update-state";
 /// Raised to the renderer when the native "Check for Updates…" menu item is
-/// chosen; the UI opens the Updates settings panel and runs an explicit check
-/// there so the outcome (up to date, or an update staged) is visible.
+/// chosen; the UI opens a transient update card and runs an explicit check
+/// without moving the reader away from the current screen.
 pub(crate) const UPDATE_CHECK_REQUESTED_EVENT: &str = "desktop-update-check-requested";
 const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import {
+  act,
   cleanup,
   render,
   screen,
@@ -112,6 +113,15 @@ const desktopUpdateState = vi.hoisted(() => ({
   enabled: true,
 }));
 const restartDesktop = vi.hoisted(() => vi.fn(async () => {}));
+const checkDesktop = vi.hoisted(() => vi.fn());
+const tauriIsTauri = vi.hoisted(() => vi.fn(() => false));
+const nativeEventListeners = vi.hoisted(() => new Map<string, () => void>());
+const listenToNativeEvent = vi.hoisted(() =>
+  vi.fn(async (event: string, handler: () => void) => {
+    nativeEventListeners.set(event, handler);
+    return () => nativeEventListeners.delete(event);
+  }),
+);
 
 /** One waiting question, as the shell's cross-chat read returns it. */
 /** One chat-surface inbox entry holding a single parked question. */
@@ -255,15 +265,20 @@ vi.mock("./host", () => ({
   hasLocalHostAuthority: () => hasNativeHost(),
 }));
 
+vi.mock("@tauri-apps/api/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tauri-apps/api/core")>()),
+  isTauri: tauriIsTauri,
+}));
+
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(async () => () => {}),
+  listen: listenToNativeEvent,
 }));
 
 vi.mock("./updates", () => ({
   UPDATE_CHECK_REQUESTED_EVENT: "desktop-update-check-requested",
   useDesktopUpdates: () => ({
     state: desktopUpdateState,
-    check: vi.fn(),
+    check: checkDesktop,
     restart: restartDesktop,
     upToDate: false,
   }),
@@ -421,7 +436,13 @@ beforeEach(() => {
   desktopUpdateState.version = null;
   desktopUpdateState.error = null;
   desktopUpdateState.enabled = true;
+  checkDesktop.mockReset();
+  checkDesktop.mockImplementation(async () => ({ ...desktopUpdateState }));
   restartDesktop.mockClear();
+  tauriIsTauri.mockReset();
+  tauriIsTauri.mockReturnValue(false);
+  nativeEventListeners.clear();
+  listenToNativeEvent.mockClear();
   postMessage.mockClear();
   getPolicy.mockClear();
   getPolicy.mockResolvedValue(unmanaged);
@@ -1065,6 +1086,37 @@ describe("app shell", () => {
 
     await waitFor(() =>
       expect(router.state.location.pathname).toBe("/c/chat-1"),
+    );
+  });
+
+  it("checks for updates in a card without leaving the current screen", async () => {
+    tauriIsTauri.mockReturnValue(true);
+    let finishCheck = () => {};
+    checkDesktop.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishCheck = () => resolve({ ...desktopUpdateState });
+        }),
+    );
+    const { router } = await mountApp({ at: "/c/chat-1" });
+    await screen.findByTestId("transcript");
+    await waitFor(() =>
+      expect(nativeEventListeners.has("desktop-update-check-requested")).toBe(
+        true,
+      ),
+    );
+
+    act(() => nativeEventListeners.get("desktop-update-check-requested")?.());
+
+    expect(await screen.findByLabelText("Checking for updates")).toBeVisible();
+    expect(router.state.location.pathname).toBe("/c/chat-1");
+    expect(checkDesktop).toHaveBeenCalledOnce();
+
+    await act(async () => finishCheck());
+    await waitFor(() =>
+      expect(
+        screen.queryByLabelText("Checking for updates"),
+      ).not.toBeInTheDocument(),
     );
   });
 

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -250,6 +250,7 @@ export function AppShell() {
   const [dismissedUpdateVersion, setDismissedUpdateVersion] = useState(() =>
     window.localStorage.getItem(DISMISSED_UPDATE_VERSION_KEY),
   );
+  const [explicitUpdateCheckOpen, setExplicitUpdateCheckOpen] = useState(false);
   const openChatId = useActiveChatId();
   const savingTitle = useChatListStore((state) => state.savingTitle);
   const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
@@ -273,13 +274,14 @@ export function AppShell() {
   const currentShortcutMode = () =>
     shellShortcutMode(router.state.location.pathname);
 
-  // The native "Check for Updates…" menu item lands the reader on the
-  // Updates settings panel and runs the same explicit check the panel's
-  // button does, so the result (up to date, or an update staged) is visible.
+  // The native "Check for Updates…" menu item keeps the reader in place and
+  // raises the update card while the explicit check runs. Automatic checks
+  // stay quiet unless they stage an update.
   useNativeHostEvent(UPDATE_CHECK_REQUESTED_EVENT, () => {
-    const updatesPath: string = "/settings/updates";
-    void navigate({ to: updatesPath });
-    void desktopUpdates.check();
+    setExplicitUpdateCheckOpen(true);
+    void desktopUpdates
+      .check()
+      .finally(() => setExplicitUpdateCheckOpen(false));
   });
 
   /**
@@ -1129,6 +1131,18 @@ export function AppShell() {
           )}
           <SidebarExpandStrip macOverlay={macOverlayTitlebar} />
           <ComputerUseIndicator />
+          {explicitUpdateCheckOpen &&
+            desktopUpdates.state.status !== "ready" && (
+              <UpdateReadyCard
+                status={
+                  desktopUpdates.state.status === "downloading"
+                    ? "downloading"
+                    : "checking"
+                }
+                version={desktopUpdates.state.version}
+                onDismiss={() => setExplicitUpdateCheckOpen(false)}
+              />
+            )}
           {desktopUpdates.state.status === "ready" &&
             dismissedUpdateVersion !==
               (desktopUpdates.state.version ?? UNKNOWN_UPDATE_VERSION) && (

--- a/crates/tidebreak-desktop/ui/src/UpdateReadyCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/UpdateReadyCard.dom.test.tsx
@@ -1,14 +1,33 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { releaseNotesUrl, UpdateReadyCard } from "./UpdateReadyCard";
 
 const openInBrowser = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock("./openInBrowser", () => ({ openInBrowser }));
 
+afterEach(cleanup);
+
 describe("UpdateReadyCard", () => {
+  it("shows an indeterminate check without update actions", () => {
+    const { container } = render(
+      <UpdateReadyCard status="checking" version={null} onDismiss={vi.fn()} />,
+    );
+
+    expect(screen.getByLabelText("Checking for updates")).toHaveTextContent(
+      "Looking for a newer version of Tidebreak",
+    );
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Restart and update" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Dismiss update notice" }),
+    ).toBeInTheDocument();
+  });
+
   it("offers the update, release notes, and dismissal", async () => {
     const user = userEvent.setup();
     const onRestart = vi.fn();

--- a/crates/tidebreak-desktop/ui/src/UpdateReadyCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/UpdateReadyCard.tsx
@@ -1,9 +1,23 @@
 import { ExternalLink, RefreshCw, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { openInBrowser } from "@/openInBrowser";
 
 const RELEASES_URL = "https://github.com/brightwave-inc/tidebreak/releases";
+
+type UpdateReadyCardProps =
+  | {
+      status: "checking" | "downloading";
+      version: string | null;
+      onDismiss: () => void;
+    }
+  | {
+      status?: "ready";
+      version: string | null;
+      onRestart: () => void;
+      onDismiss: () => void;
+    };
 
 export function releaseNotesUrl(version: string | null): string {
   const normalized = version?.trim().replace(/^v/, "");
@@ -12,19 +26,32 @@ export function releaseNotesUrl(version: string | null): string {
     : `${RELEASES_URL}/latest`;
 }
 
-export function UpdateReadyCard({
-  version,
-  onRestart,
-  onDismiss,
-}: {
-  version: string | null;
-  onRestart: () => void;
-  onDismiss: () => void;
-}) {
+export function UpdateReadyCard(props: UpdateReadyCardProps) {
+  const { version, onDismiss } = props;
+  const status = props.status ?? "ready";
+  const loading = status !== "ready";
+  const title =
+    status === "checking"
+      ? "Checking for updates"
+      : status === "downloading"
+        ? "Downloading update"
+        : "Update ready";
+  const description =
+    status === "checking"
+      ? "Looking for a newer version of Tidebreak…"
+      : status === "downloading"
+        ? version
+          ? `Downloading and verifying Tidebreak ${version}…`
+          : "Downloading and verifying the update…"
+        : version
+          ? `Tidebreak ${version} is downloaded and ready to install.`
+          : "A Tidebreak update is downloaded and ready to install.";
+
   return (
     <aside
       className="fixed right-4 bottom-4 z-40 w-[min(22rem,calc(100vw-2rem))] rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-lg"
-      aria-label="Update ready"
+      aria-label={title}
+      aria-live={loading ? "polite" : undefined}
     >
       <button
         type="button"
@@ -36,34 +63,36 @@ export function UpdateReadyCard({
       </button>
 
       <div className="flex items-start gap-3 pr-7">
-        <RefreshCw
-          className="mt-0.5 size-4 shrink-0 text-muted-foreground"
-          aria-hidden="true"
-        />
+        {loading ? (
+          <Spinner className="mt-0.5 size-4" aria-hidden="true" />
+        ) : (
+          <RefreshCw
+            className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+        )}
         <div className="min-w-0">
-          <p className="text-md font-semibold">Update ready</p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {version
-              ? `Tidebreak ${version} is downloaded and ready to install.`
-              : "A Tidebreak update is downloaded and ready to install."}
-          </p>
+          <p className="text-md font-semibold">{title}</p>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
         </div>
       </div>
 
-      <div className="mt-4 flex flex-wrap items-center gap-2">
-        <Button type="button" size="sm" onClick={onRestart}>
-          Restart and update
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          onClick={() => void openInBrowser(releaseNotesUrl(version))}
-        >
-          Release notes
-          <ExternalLink aria-hidden="true" />
-        </Button>
-      </div>
+      {(props.status === undefined || props.status === "ready") && (
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <Button type="button" size="sm" onClick={props.onRestart}>
+            Restart and update
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => void openInBrowser(releaseNotesUrl(version))}
+          >
+            Release notes
+            <ExternalLink aria-hidden="true" />
+          </Button>
+        </div>
+      )}
     </aside>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/stories/UpdateReadyCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/UpdateReadyCard.stories.tsx
@@ -4,7 +4,13 @@ import { fn } from "storybook/test";
 
 import { UpdateReadyCard } from "@/UpdateReadyCard";
 
-function UpdateReadyCardStory({ version }: { version: string | null }) {
+function UpdateReadyCardStory({
+  status,
+  version,
+}: {
+  status: "checking" | "downloading" | "ready";
+  version: string | null;
+}) {
   const [visible, setVisible] = useState(true);
   return (
     <div className="h-screen bg-page-background p-8">
@@ -19,10 +25,17 @@ function UpdateReadyCardStory({ version }: { version: string | null }) {
           The card stays available without blocking the work underneath it.
         </p>
       </div>
-      {visible && (
+      {visible && status === "ready" && (
         <UpdateReadyCard
           version={version}
           onRestart={fn()}
+          onDismiss={() => setVisible(false)}
+        />
+      )}
+      {visible && status !== "ready" && (
+        <UpdateReadyCard
+          status={status}
+          version={version}
           onDismiss={() => setVisible(false)}
         />
       )}
@@ -31,16 +44,24 @@ function UpdateReadyCardStory({ version }: { version: string | null }) {
 }
 
 const meta = {
-  title: "Shell/Update ready card",
+  title: "Shell/Update card",
   component: UpdateReadyCardStory,
   parameters: { layout: "fullscreen" },
-  args: { version: "0.59.0" },
+  args: { status: "ready", version: "0.59.0" },
 } satisfies Meta<typeof UpdateReadyCardStory>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Ready: Story = {};
+
+export const Checking: Story = {
+  args: { status: "checking", version: null },
+};
+
+export const Downloading: Story = {
+  args: { status: "downloading", version: "0.59.0" },
+};
 
 export const VersionUnavailable: Story = {
   args: { version: null },


### PR DESCRIPTION
## Summary

- keep the macOS Check for Updates action on the current screen
- show checking and downloading states in the bottom-right update card
- add DOM coverage and Storybook stories for the loading states

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/UpdateReadyCard.dom.test.tsx src/AppShell.dom.test.tsx` (35 tests passed)
- `pnpm --dir crates/tidebreak-desktop/ui test` (2,299 tests passed)
- `pnpm --dir crates/tidebreak-desktop/ui lint`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- `git diff --check`

The Storybook loading story is `Shell/Update card / Checking`. Browser control was unavailable for screenshot capture in this session.