### PR TITLE
chore(ci): let the headless-test policy accept cargo-nextest

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -493,12 +493,15 @@ test("PR lanes are scope-gated, never label-gated", () => {
   }
   assert.match(testJob, /save-if: \$\{\{ github\.ref == 'refs\/heads\/main' \}\}/);
   assert.match(testJob, /cache-on-failure: true/);
+  // The headless lane is migrating from `cargo test` under a shell retry
+  // loop to `cargo nextest run` with per-test retries. Accept either form
+  // here so the migration can land; the pull request that switches the
+  // command re-pins this assertion to the nextest form alone.
   assert.match(
     testJob,
-    /cargo test --workspace --exclude tidebreak-desktop --locked/,
+    /cargo (?:test|nextest run) --workspace --exclude tidebreak-desktop\s+--locked/,
   );
-  assert.match(testJob, /attempts=3/);
-  assert.match(testJob, /headless tests failed on attempt/);
+  assert.match(testJob, /attempts=3|--retries 2/);
   assert.doesNotMatch(ci, /^  parsers:$/m);
   assert.doesNotMatch(ci, /outputs\.parsers|echo "parsers=/);
   assert.match(changes, /\*\.md\|docs\/\*\|assets\/\*\|\.githooks\/\*/);


### PR DESCRIPTION
The release-policy lane judges a pull request's workflows with the base branch's trusted copy of `scripts/workflow-security.test.mjs`, so switching the `test` lane to cargo-nextest cannot land while that copy pins the exact `cargo test` command and the `attempts=3` retry loop.

Relax the assertion to accept either the current `cargo test` form or the incoming `cargo nextest run --retries 2` form. The follow-up PR switches the lane and re-pins the assertion to the nextest form alone.

Motivation: the `test` lane spends ~5.5 of its ~10 minutes running test binaries serially; nextest schedules tests from every binary in parallel and its per-test retries replace the whole-workspace ETXTBSY rerun.