### PR TITLE
perf(server): slow the GitHub reconcile sweep while no client is attached

### DIFF
--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -32,7 +32,7 @@ use tidebreak_core::{
     CodeSessionLifecycle, CodeSubagentSummary, CodeTurnId, CodeWatchState, HarnessKind, OwnerId,
     PullRequestDigest, RepoId, SequencedCodeEvent, WorkspaceId, MAX_EVENT_TEXT_CHARS,
 };
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Notify};
 
 const LIVE_BUFFER: usize = 256;
 const UPDATES_BUFFER: usize = 256;
@@ -137,6 +137,9 @@ pub(crate) enum TurnRewriteState {
 pub(crate) struct CodeEventBus {
     channels: Mutex<HashMap<CodeSessionId, LiveSession>>,
     updates: Mutex<HashMap<OwnerId, broadcast::Sender<CodeLiveUpdate>>>,
+    /// Fires when a `/code/updates` socket subscribes, so background work
+    /// that slows down while nobody is looking can speed back up at once.
+    updates_attached: Notify,
 }
 
 /// One session's live state: the channel, plus the small facts that only the
@@ -206,6 +209,7 @@ impl Default for CodeEventBus {
         Self {
             channels: Mutex::new(HashMap::new()),
             updates: Mutex::new(HashMap::new()),
+            updates_attached: Notify::new(),
         }
     }
 }
@@ -332,8 +336,40 @@ impl CodeEventBus {
 
     /// Subscribe to one owner's updates. The receiver is the only view of the
     /// channel a `/code/updates` socket gets, and it carries nothing else.
+    ///
+    /// Subscribing also wakes [`Self::updates_attached`] waiters. A
+    /// `/code/updates` socket is how a client says it is looking, and sweeps
+    /// that back off while nobody is use that moment to return to their fast
+    /// cadence.
     pub(crate) fn subscribe_updates(&self, owner: &OwnerId) -> broadcast::Receiver<CodeLiveUpdate> {
-        self.updates_sender(owner).subscribe()
+        let receiver = self.updates_sender(owner).subscribe();
+        self.updates_attached.notify_one();
+        receiver
+    }
+
+    /// Whether any client currently holds a `/code/updates` subscription.
+    ///
+    /// This is the server's "someone is looking" signal for code mode: the
+    /// desktop keeps that socket open for as long as it runs, and the CLI
+    /// opens it to watch. Counting receivers is exact because a dropped
+    /// socket drops its receiver with it.
+    pub(crate) fn has_updates_subscribers(&self) -> bool {
+        self.updates
+            .lock()
+            .expect("code updates bus lock")
+            .values()
+            .any(|sender| sender.receiver_count() > 0)
+    }
+
+    /// Resolve the next time a `/code/updates` socket subscribes.
+    ///
+    /// One pending wake is retained if nobody is waiting when a subscription
+    /// lands, so a caller that checks [`Self::has_updates_subscribers`] and
+    /// then waits cannot miss an attach that fell between the two. The cost
+    /// is at most one spurious wake, which callers absorb by re-reading the
+    /// subscriber count.
+    pub(crate) async fn updates_attached(&self) {
+        self.updates_attached.notified().await;
     }
 
     /// Publish a notice to one owner. Publishers name the owner the notice
@@ -373,5 +409,35 @@ fn append_bounded(buffer: &mut String, text: &str) {
     match text.char_indices().nth(room) {
         Some((cut, _)) => buffer.push_str(&text[..cut]),
         None => buffer.push_str(text),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn updates_subscribers_are_counted_and_attach_wakes_waiters() {
+        let bus = CodeEventBus::default();
+        let owner = OwnerId::new("owner-a").unwrap();
+        assert!(!bus.has_updates_subscribers());
+
+        let receiver = bus.subscribe_updates(&owner);
+        assert!(bus.has_updates_subscribers());
+        // The attach that landed before anyone waited is retained, so a sweep
+        // that checked the count first and then waited still wakes.
+        tokio::time::timeout(Duration::from_secs(1), bus.updates_attached())
+            .await
+            .expect("subscribing wakes the attach signal");
+
+        drop(receiver);
+        assert!(!bus.has_updates_subscribers());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), bus.updates_attached())
+                .await
+                .is_err(),
+            "a drop is not an attach"
+        );
     }
 }

--- a/crates/tidebreak-server/src/code/reconcile.rs
+++ b/crates/tidebreak-server/src/code/reconcile.rs
@@ -11,7 +11,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tracing::debug;
 
@@ -27,8 +27,40 @@ use crate::routes::code::types::{
 };
 
 /// Coprime with the 47s watch and 53s trigger sweeps, so three GitHub-reading
-/// sweeps never land on the same tick.
+/// sweeps never land on the same tick. This is the cadence while a client
+/// holds a `/code/updates` socket, meaning someone can see the result.
 pub(crate) const RECONCILE_SWEEP_INTERVAL: Duration = Duration::from_secs(61);
+
+/// The cadence while no client is attached.
+///
+/// Idle sweeps are mostly conditional 304s, but any repository that moved
+/// pays real per-pull-request reads, and with nobody looking the answer only
+/// has to be current by the time a window opens again. Subscribing to
+/// `/code/updates` wakes the sweep, so reopening the app does not wait this
+/// long. Prime, like the others, so the idle sweep does not fall into step
+/// with the watch and trigger sweeps.
+pub(crate) const RECONCILE_DETACHED_INTERVAL: Duration = Duration::from_secs(421);
+
+/// How long the sweep waits before its next pass.
+///
+/// `since_last_sweep` is `None` before the first pass, which runs at once the
+/// way the original fixed ticker did. Otherwise the wait is whatever remains
+/// of the cadence for the current attachment state: a client attaching after
+/// a long idle stretch gets an immediate pass, while a client that
+/// reconnects seconds after the last pass waits out the fast interval, so a
+/// flapping socket cannot make the sweep read GitHub faster than once per
+/// [`RECONCILE_SWEEP_INTERVAL`].
+pub(crate) fn reconcile_delay(attached: bool, since_last_sweep: Option<Duration>) -> Duration {
+    let interval = if attached {
+        RECONCILE_SWEEP_INTERVAL
+    } else {
+        RECONCILE_DETACHED_INTERVAL
+    };
+    match since_last_sweep {
+        None => Duration::ZERO,
+        Some(elapsed) => interval.saturating_sub(elapsed),
+    }
+}
 
 /// A live tier younger than this answers a sweep without a host read
 /// (decision 66): two reconcile intervals plus slack, so one missed pass
@@ -52,14 +84,29 @@ pub(crate) struct ReconcileSweepGuard(Option<tokio::task::JoinHandle<()>>);
 impl ReconcileSweepGuard {
     pub(crate) fn spawn(runtime: Weak<CodeRuntime>) -> Self {
         let handle = tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(RECONCILE_SWEEP_INTERVAL);
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut last_sweep: Option<Instant> = None;
             loop {
-                ticker.tick().await;
+                let Some(strong) = runtime.upgrade() else {
+                    return;
+                };
+                let attached = strong.bus.has_updates_subscribers();
+                let delay = reconcile_delay(attached, last_sweep.map(|at| at.elapsed()));
+                let bus = Arc::clone(&strong.bus);
+                // Drop the strong handle while waiting: this loop must not be
+                // what keeps the runtime alive.
+                drop(strong);
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    // A client attached (or reconnected). Re-read the count
+                    // and recompute the wait rather than sweeping blindly, so
+                    // the fast cadence still bounds how often GitHub is read.
+                    _ = bus.updates_attached() => continue,
+                }
                 let Some(runtime) = runtime.upgrade() else {
                     return;
                 };
                 sweep_reconcile(&runtime).await;
+                last_sweep = Some(Instant::now());
             }
         });
         Self(Some(handle))
@@ -413,6 +460,49 @@ impl StackParentIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_first_pass_runs_at_once_in_either_state() {
+        assert_eq!(reconcile_delay(true, None), Duration::ZERO);
+        assert_eq!(reconcile_delay(false, None), Duration::ZERO);
+    }
+
+    #[test]
+    fn an_attached_client_keeps_the_fast_cadence() {
+        assert_eq!(
+            reconcile_delay(true, Some(Duration::from_secs(1))),
+            RECONCILE_SWEEP_INTERVAL - Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn no_client_backs_the_sweep_off_to_minutes() {
+        let delay = reconcile_delay(false, Some(Duration::from_secs(1)));
+        assert_eq!(delay, RECONCILE_DETACHED_INTERVAL - Duration::from_secs(1));
+        assert!(delay >= Duration::from_secs(5 * 60));
+        assert!(delay <= Duration::from_secs(10 * 60));
+    }
+
+    #[test]
+    fn attaching_after_an_idle_stretch_sweeps_immediately() {
+        // Two fast intervals into an idle stretch a window opens: the wait
+        // recomputed against the fast cadence has already elapsed.
+        let idle = RECONCILE_SWEEP_INTERVAL * 2;
+        assert_eq!(
+            reconcile_delay(false, Some(idle)),
+            RECONCILE_DETACHED_INTERVAL - idle
+        );
+        assert_eq!(reconcile_delay(true, Some(idle)), Duration::ZERO);
+    }
+
+    #[test]
+    fn a_reconnect_right_after_a_pass_waits_out_the_fast_interval() {
+        let just_swept = Duration::from_secs(5);
+        assert_eq!(
+            reconcile_delay(true, Some(just_swept)),
+            RECONCILE_SWEEP_INTERVAL - just_swept
+        );
+    }
 
     fn repository(owner: &str, name: &str) -> StackRepositoryIdentity {
         StackRepositoryIdentity::new("github.com", owner, name).unwrap()


### PR DESCRIPTION
## What

The reconcile sweep (`code/reconcile.rs`) re-read every tracked repository every 61 seconds forever. Idle cost was mostly ETag'd 304s, but any repository that changed paid real per-pull-request reads each minute with nobody looking.

The sweep now uses the `/code/updates` subscriber count on `CodeEventBus` as its "a client is attached" signal. That socket is the desktop's install-wide digest channel, held open for as long as the app runs, and the CLI opens it to watch, so it is the existing answer to "is someone looking" rather than a new one.

- While a client holds a `/code/updates` socket, the cadence stays at 61 seconds.
- While none does, the sweep waits 421 seconds between passes (prime, so it stays out of step with the 47 s watch and 53 s trigger sweeps).
- Subscribing to `/code/updates` wakes the sweep. The wake recomputes the wait against the fast cadence instead of sweeping blindly, so reopening the app after an idle stretch gets an immediate pass, while a socket that reconnects seconds after a pass waits out the fast interval. A flapping client cannot make the sweep read GitHub faster than once per 61 seconds.

## Why the bus, not a new signal

`CodeEventBus` already owns one broadcast sender per owner for `/code/updates`. `receiver_count()` on those senders is exact: a dropped socket drops its receiver. The new `Notify` fires from `subscribe_updates`, so the attach transition needs no extra bookkeeping in the route.

## Tests

- `code::reconcile::tests`: five unit tests pin the cadence choice without sleeping: first pass runs at once, attached keeps 61 s, detached backs off to 5–10 minutes, attaching after an idle stretch yields a zero wait, reconnecting right after a pass waits out the fast interval.
- `code::bus::tests`: the subscriber count flips on subscribe and drop, subscribing wakes a waiter even when the attach landed first, and a drop is not an attach.

Ran `cargo check -p tidebreak-server`, `cargo test -p tidebreak-server --lib -- code::reconcile::tests code::bus::tests tests::code_reconcile` (19 passed), `cargo fmt -p tidebreak-server -- --check`, and `cargo clippy -p tidebreak-server --all-targets` (no findings in the changed files).

Closes #2958
