### PR TITLE
perf(ci): run headless tests under cargo-nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,7 +741,11 @@ jobs:
     name: test
     needs: changes
     if: ${{ needs.changes.outputs.workspace == 'true' }}
-    runs-on: ubuntu-latest
+    # Prefer an 8 vCPU larger runner: this lane splits roughly evenly between
+    # compiling and running tests, and both scale with cores. Set
+    # CI_TEST_RUNNER to the provisioned label. If the variable is unset, the
+    # job uses ubuntu-latest so a missing larger runner cannot stall merges.
+    runs-on: ${{ vars.CI_TEST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     env:
       CARGO_INCREMENTAL: 0
@@ -755,6 +759,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
+        with:
+          tool: cargo-nextest@0.9.143
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
@@ -777,20 +785,17 @@ jobs:
       - name: Fetch the complete workspace lockfile
         if: ${{ github.ref == 'refs/heads/main' }}
         run: cargo fetch --locked
-      # Linux ETXTBSY still hits a freshly written fake harness binary on a
-      # loaded runner. Three attempts cover that without dropping the contract.
+      # nextest schedules tests from every binary in parallel, so the few
+      # long-running suites overlap instead of queuing behind each other, and
+      # its per-test retries absorb the Linux ETXTBSY race that still hits a
+      # freshly written fake harness binary on a loaded runner — without
+      # rerunning the whole workspace the way the old shell retry loop did.
+      # nextest does not run doctests; the workspace has none, and one added
+      # later must move its assertion into a unit test to be covered here.
       - name: headless tests
-        run: |
-          attempts=3
-          for attempt in $(seq 1 "$attempts"); do
-            if cargo test --workspace --exclude tidebreak-desktop --locked; then
-              exit 0
-            fi
-            echo "headless tests failed on attempt ${attempt}/${attempts}" >&2
-            if [[ "$attempt" -eq "$attempts" ]]; then
-              exit 1
-            fi
-          done
+        run: >-
+          cargo nextest run --workspace --exclude tidebreak-desktop
+          --locked --retries 2
 
   postgres:
     name: postgres state machine

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -493,15 +493,10 @@ test("PR lanes are scope-gated, never label-gated", () => {
   }
   assert.match(testJob, /save-if: \$\{\{ github\.ref == 'refs\/heads\/main' \}\}/);
   assert.match(testJob, /cache-on-failure: true/);
-  // The headless lane is migrating from `cargo test` under a shell retry
-  // loop to `cargo nextest run` with per-test retries. Accept either form
-  // here so the migration can land; the pull request that switches the
-  // command re-pins this assertion to the nextest form alone.
   assert.match(
     testJob,
-    /cargo (?:test|nextest run) --workspace --exclude tidebreak-desktop\s+--locked/,
+    /cargo nextest run --workspace --exclude tidebreak-desktop\n\s+--locked --retries 2/,
   );
-  assert.match(testJob, /attempts=3|--retries 2/);
   assert.doesNotMatch(ci, /^  parsers:$/m);
   assert.doesNotMatch(ci, /outputs\.parsers|echo "parsers=/);
   assert.match(changes, /\*\.md\|docs\/\*\|assets\/\*\|\.githooks\/\*/);


### PR DESCRIPTION
The `test` lane spends roughly 4 minutes compiling and 5.5 minutes running test binaries serially under `cargo test`. Three suites dominate — the tidebreak-server lib tests (174s), `tests/serve.rs` (64s), and one more at 41s — and dozens of small binaries queue behind them.

Switch the lane to `cargo nextest run`, which schedules tests from every binary in parallel. Its per-test `--retries 2` replaces the whole-workspace ETXTBSY retry loop: a flaky test reruns alone instead of rerunning all 3,700 tests. nextest does not run doctests; the workspace has none (every doc-test section in the current lane is empty).

Also let `CI_TEST_RUNNER` select a larger runner for this lane with `ubuntu-latest` as the fallback, matching the Windows lane's `CI_WINDOWS_RUNNER` pattern. Nothing changes until the variable is set.

Re-pins the workflow-security assertion that #2976 relaxed for this migration.

Validation: full `cargo nextest run --workspace --exclude tidebreak-desktop --locked --retries 2` locally — 3,716 tests, all passed (4 flaky recovered on retry), plus `node --test scripts/workflow-security.test.mjs` (46 pass).