### PR TITLE
feat(code): persist durable turn parks and route rich decisions

### DIFF
--- a/crates/tidebreak-cli/src/agent_mcp/code_follow.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/code_follow.rs
@@ -137,7 +137,8 @@ fn from_turn_status(
         CodeTurnStatus::Completed => TurnStatus::Completed,
         CodeTurnStatus::Failed => TurnStatus::Failed,
         CodeTurnStatus::Interrupted => TurnStatus::Cancelled,
-        CodeTurnStatus::Running => TurnStatus::Running,
+        // A parked turn is still in flight from a follower's seat.
+        CodeTurnStatus::Running | CodeTurnStatus::Waiting => TurnStatus::Running,
     };
     CodeTurnResult {
         status,

--- a/crates/tidebreak-cli/src/agent_mcp/code_follow.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/code_follow.rs
@@ -226,7 +226,9 @@ async fn reconcile_lost_socket(
         return Err(stream_error);
     };
     if let Some(turn) = turn_by_id(client, session, turn_id).await? {
-        if turn.status != CodeTurnStatus::Running {
+        // A parked turn is open, not finished: fall through to the pending
+        // approval, which is the only thing that can release it.
+        if !turn.status.is_open() {
             return Ok(from_turn_status(
                 turn.status,
                 assistant_text,
@@ -467,7 +469,7 @@ async fn settled_or_parked(
     follow: &CodeFollowState,
 ) -> Result<Option<CodeTurnResult>> {
     if let Some(turn) = turn_by_id(client, session, follow.turn_id).await? {
-        if turn.status != CodeTurnStatus::Running {
+        if !turn.status.is_open() {
             return Ok(Some(from_turn_status(
                 turn.status,
                 follow.assistant_text.clone(),

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -330,6 +330,11 @@ impl CodeWorkspaceStatus {
 pub enum CodeTurnStatus {
     /// The engine is still working this turn.
     Running,
+    /// The engine durably checkpointed the turn and released it; it resumes
+    /// once the wait recorded on the turn resolves (decision 0048 step 5).
+    ///
+    /// Only engines declaring `durable_parks` produce this state.
+    Waiting,
     /// The turn finished successfully.
     Completed,
     /// The turn failed.
@@ -344,6 +349,7 @@ impl CodeTurnStatus {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Running => "running",
+            Self::Waiting => "waiting",
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Interrupted => "interrupted",
@@ -356,12 +362,45 @@ impl CodeTurnStatus {
     pub fn from_str(value: &str) -> Option<Self> {
         match value {
             "running" => Some(Self::Running),
+            "waiting" => Some(Self::Waiting),
             "completed" => Some(Self::Completed),
             "failed" => Some(Self::Failed),
             "interrupted" => Some(Self::Interrupted),
             _ => None,
         }
     }
+
+    /// Whether the turn is still open: the engine owes it a terminal event.
+    #[must_use]
+    pub const fn is_open(self) -> bool {
+        matches!(self, Self::Running | Self::Waiting)
+    }
+}
+
+/// The dependency a parked turn waits on, persisted beside its park ref.
+///
+/// The durable mirror of the adapter contract's park wait: the worker
+/// records it when an engine parks so a restarted server can see what the
+/// turn was waiting for.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TurnParkWait {
+    /// A pending approval: a tool approval, questions, or a plan. Named by
+    /// the engine-native call id the approval row records.
+    Approval {
+        /// Engine-native call id.
+        call_id: String,
+    },
+    /// A tool call executed outside the engine by a leased client.
+    ClientToolCall {
+        /// Durable tool call id, engine-scoped.
+        call_id: String,
+    },
+    /// A set of background agent runs; the turn resumes when all settle.
+    AgentRuns {
+        /// Durable agent run ids, engine-scoped.
+        run_ids: Vec<String>,
+    },
 }
 
 /// State of a persisted approval.
@@ -1304,6 +1343,13 @@ pub struct CodeTurn {
     pub started_at: chrono::DateTime<chrono::Utc>,
     /// End time, when terminal.
     pub ended_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Engine-owned checkpoint token while the turn is
+    /// [`CodeTurnStatus::Waiting`]; handed back verbatim on resume.
+    #[serde(default)]
+    pub park_ref: Option<String>,
+    /// What a waiting turn is parked on.
+    #[serde(default)]
+    pub park_wait: Option<TurnParkWait>,
 }
 
 /// One durable queued follow-up: a message accepted while its session or its

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1851,6 +1851,9 @@ pub mod code_turn {
         pub rewrite: Option<String>,
         pub started_at: DateTimeUtc,
         pub ended_at: Option<DateTimeUtc>,
+        pub park_ref: Option<String>,
+        #[sea_orm(column_type = "JsonBinary", nullable)]
+        pub park_wait: Option<Json>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -66,6 +66,7 @@ impl MigratorTrait for Migrator {
             Box::new(CodeTurnRewrite),
             Box::new(CodeExternalGrants),
             Box::new(CodeConnectHandshakes),
+            Box::new(CodeTurnPark),
         ]
     }
 }
@@ -3361,6 +3362,214 @@ impl MigrationTrait for CodeConnectHandshakes {
     }
 }
 
+/// Durable turn parks (decision 0048 step 5): an engine declaring
+/// `durable_parks` may checkpoint a turn and release it; the turn row then
+/// records the engine's checkpoint token and what it waits on, and the
+/// status check admits the new `waiting` state.
+struct CodeTurnPark;
+
+impl MigrationName for CodeTurnPark {
+    fn name(&self) -> &str {
+        "m20260901_000001_code_turn_park"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CodeTurnPark {
+    fn use_transaction(&self) -> Option<bool> {
+        // The SQLite branch rebuilds the table under a manually managed
+        // transaction with foreign keys disabled; PostgreSQL runs its own.
+        None
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.has_column("code_turn", "park_ref").await? {
+            return Ok(());
+        }
+        match manager.get_database_backend() {
+            DbBackend::Postgres => {
+                let transaction = manager.begin().await?;
+                transaction
+                    .get_connection()
+                    .execute_unprepared(
+                        r#"
+DO $repair$
+DECLARE
+    old_constraint text;
+BEGIN
+    FOR old_constraint IN
+        SELECT constraint_row.conname
+        FROM pg_constraint AS constraint_row
+        JOIN pg_attribute AS attribute_row
+          ON attribute_row.attrelid = constraint_row.conrelid
+         AND attribute_row.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'code_turn'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute_row.attname = 'status'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE "code_turn" DROP CONSTRAINT %I',
+            old_constraint
+        );
+    END LOOP;
+END
+$repair$;
+ALTER TABLE "code_turn"
+    ADD CONSTRAINT "code_turn_status_check"
+    CHECK ("status" IN (
+        'running', 'waiting', 'completed', 'failed', 'interrupted'
+    ));
+ALTER TABLE "code_turn" ADD COLUMN "park_ref" text;
+ALTER TABLE "code_turn" ADD COLUMN "park_wait" jsonb;
+"#,
+                    )
+                    .await?;
+                transaction.commit().await
+            }
+            DbBackend::Sqlite => rebuild_sqlite_code_turn_for_parks(manager).await,
+            backend => Err(DbErr::Custom(format!(
+                "unsupported database backend for turn park migration: {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // A downgrade keeps the columns and the widened check; a parked row
+        // would otherwise become unreadable instead of recoverable.
+        Ok(())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+async fn rebuild_sqlite_code_turn_for_parks(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    use sea_orm::sqlx::Acquire as _;
+    use sea_orm::DatabaseExecutor;
+
+    let DatabaseExecutor::Connection(database) = manager.get_connection() else {
+        return Err(DbErr::Custom(
+            "SQLite turn park rebuild requires the migration connection".to_owned(),
+        ));
+    };
+    let mut connection = database
+        .get_sqlite_connection_pool()
+        .acquire()
+        .await
+        .map_err(|error| DbErr::Custom(format!("acquire SQLite migration connection: {error}")))?;
+    sea_orm::sqlx::query("PRAGMA foreign_keys = OFF")
+        .execute(&mut *connection)
+        .await
+        .map_err(|error| DbErr::Custom(format!("disable SQLite foreign keys: {error}")))?;
+
+    let mut transaction = connection
+        .begin()
+        .await
+        .map_err(|error| DbErr::Custom(format!("begin SQLite turn park rebuild: {error}")))?;
+    let rebuild = async {
+        for statement in [
+            r#"DROP TABLE IF EXISTS "code_turn_park""#,
+            r#"
+CREATE TABLE "code_turn_park" (
+    "id" uuid_text NOT NULL PRIMARY KEY,
+    "owner" text NOT NULL DEFAULT 'local',
+    "session_id" uuid_text NOT NULL,
+    "ordinal" integer NOT NULL,
+    "status" text NOT NULL,
+    "user_input" text NOT NULL,
+    "user_input_blob_id" uuid_text,
+    "checkpoint_ref" text,
+    "diffstat" jsonb_text,
+    "usage" jsonb_text,
+    "narrative" text,
+    "started_at" timestamp_with_timezone_text NOT NULL,
+    "ended_at" timestamp_with_timezone_text,
+    "model" text,
+    "fast_mode" boolean NOT NULL DEFAULT FALSE,
+    "rewrite" text,
+    "park_ref" text,
+    "park_wait" jsonb_text,
+    FOREIGN KEY ("session_id") REFERENCES "code_session" ("id"),
+    CHECK ("status" IN ('running', 'waiting', 'completed', 'failed', 'interrupted')),
+    CHECK ("ordinal" >= 1)
+)"#,
+            r#"
+INSERT INTO "code_turn_park" (
+    "id", "owner", "session_id", "ordinal", "status", "user_input",
+    "user_input_blob_id", "checkpoint_ref", "diffstat", "usage", "narrative",
+    "started_at", "ended_at", "model", "fast_mode", "rewrite"
+)
+SELECT
+    "id", "owner", "session_id", "ordinal", "status", "user_input",
+    "user_input_blob_id", "checkpoint_ref", "diffstat", "usage", "narrative",
+    "started_at", "ended_at", "model", "fast_mode", "rewrite"
+FROM "code_turn""#,
+            r#"DROP TABLE "code_turn""#,
+            r#"ALTER TABLE "code_turn_park" RENAME TO "code_turn""#,
+            r#"CREATE UNIQUE INDEX "idx_code_turn_session_ordinal"
+                ON "code_turn" ("session_id", "ordinal")"#,
+        ] {
+            sea_orm::sqlx::query(statement)
+                .execute(&mut *transaction)
+                .await?;
+        }
+        Ok::<(), sea_orm::sqlx::Error>(())
+    }
+    .await;
+
+    let rebuild = match rebuild {
+        Ok(()) => transaction
+            .commit()
+            .await
+            .map_err(|error| DbErr::Custom(format!("commit SQLite turn park rebuild: {error}"))),
+        Err(error) => {
+            let rollback = transaction.rollback().await;
+            match rollback {
+                Ok(()) => Err(DbErr::Custom(format!(
+                    "rebuild SQLite turn table for parks: {error}"
+                ))),
+                Err(rollback) => Err(DbErr::Custom(format!(
+                    "rebuild SQLite turn table for parks: {error}; rollback failed: {rollback}"
+                ))),
+            }
+        }
+    };
+
+    let enable = match sea_orm::sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(&mut *connection)
+        .await
+    {
+        Ok(_) => {
+            sea_orm::sqlx::query_scalar::<_, i64>("PRAGMA foreign_keys")
+                .fetch_one(&mut *connection)
+                .await
+        }
+        Err(error) => Err(error),
+    }
+    .map_err(|error| DbErr::Custom(format!("restore SQLite foreign keys: {error}")))
+    .and_then(|enabled| {
+        if enabled == 1 {
+            Ok(())
+        } else {
+            Err(DbErr::Custom(
+                "restore SQLite foreign keys: PRAGMA remained disabled".to_owned(),
+            ))
+        }
+    });
+    match (rebuild, enable) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(rebuild), Err(enable)) => {
+            Err(DbErr::Custom(format!("{rebuild}; additionally, {enable}")))
+        }
+    }
+}
+
+#[cfg(not(feature = "sqlite"))]
+async fn rebuild_sqlite_code_turn_for_parks(_manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    Err(DbErr::Custom(
+        "SQLite turn park migration support is not compiled".to_owned(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
@@ -3438,6 +3647,7 @@ mod tests {
                 "m20260828_000026_code_turn_rewrite",
                 "m20260828_000027_code_external_grants",
                 "m20260828_000028_code_connect_handshakes",
+                "m20260901_000001_code_turn_park",
             ]
         );
         assert!(db
@@ -3465,7 +3675,8 @@ mod tests {
             .unwrap()
             .is_some());
 
-        Migrator::down(&db, Some(1)).await.unwrap();
+        // Two steps: the turn park migration sits above the handshake one.
+        Migrator::down(&db, Some(2)).await.unwrap();
         assert!(db
             .query_one_raw(Statement::from_string(
                 DbBackend::Sqlite,
@@ -3934,6 +4145,24 @@ mod tests {
         assert_eq!(attachment.try_get::<i32>("", "width").unwrap(), 1);
         assert_eq!(attachment.try_get::<i32>("", "height").unwrap(), 1);
         assert_eq!(attachment.try_get::<i64>("", "byte_len").unwrap(), 8);
+
+        // The park rebuild recreates code_turn; the seeded row must survive
+        // with its status intact and the new columns empty.
+        let turn = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT status, park_ref IS NULL AS park_ref_null, \
+                        park_wait IS NULL AS park_wait_null \
+                 FROM code_turn \
+                 WHERE id = '00000000-0000-0000-0000-000000000104'"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.try_get::<String>("", "status").unwrap(), "completed");
+        assert!(turn.try_get::<bool>("", "park_ref_null").unwrap());
+        assert!(turn.try_get::<bool>("", "park_wait_null").unwrap());
 
         let fire = db
             .query_one_raw(Statement::from_string(

--- a/crates/tidebreak-core/src/db/ops/code/recovery.rs
+++ b/crates/tidebreak-core/src/db/ops/code/recovery.rs
@@ -127,7 +127,13 @@ async fn settle_interrupted_session(
     let running_turns = entities::code_turn::Entity::find()
         .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
-        .filter(entities::code_turn::Column::Status.eq(CodeTurnStatus::Running.as_str()))
+        // Waiting counts: a parked turn's engine checkpoint survives, but
+        // its in-memory wait died with the worker, so recovery closes it
+        // the same way until an engine can resume from durable state.
+        .filter(entities::code_turn::Column::Status.is_in([
+            CodeTurnStatus::Running.as_str(),
+            CodeTurnStatus::Waiting.as_str(),
+        ]))
         .order_by_desc(entities::code_turn::Column::Ordinal)
         .limit(2)
         .all(&transaction)
@@ -160,7 +166,10 @@ async fn settle_interrupted_session(
             )
             .filter(entities::code_turn::Column::Id.eq(turn.id))
             .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
-            .filter(entities::code_turn::Column::Status.eq(CodeTurnStatus::Running.as_str()))
+            .filter(entities::code_turn::Column::Status.is_in([
+                CodeTurnStatus::Running.as_str(),
+                CodeTurnStatus::Waiting.as_str(),
+            ]))
             .exec(&transaction)
             .await
             .map_err(store_err)?;

--- a/crates/tidebreak-core/src/db/ops/code/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/code/turn.rs
@@ -68,6 +68,11 @@ where
         rewrite: Set(turn.rewrite.clone()),
         started_at: Set(turn.started_at),
         ended_at: Set(turn.ended_at),
+        park_ref: Set(turn.park_ref.clone()),
+        park_wait: Set(match &turn.park_wait {
+            Some(wait) => Some(serde_json::to_value(wait)?),
+            None => None,
+        }),
     }
     .insert(conn)
     .await
@@ -306,10 +311,7 @@ pub async fn get_open_turn(
     session_id: CodeSessionId,
 ) -> Result<Option<CodeTurn>> {
     let turns = list_turns(store, owner, session_id).await?;
-    Ok(turns
-        .into_iter()
-        .rev()
-        .find(|turn| turn.status == CodeTurnStatus::Running))
+    Ok(turns.into_iter().rev().find(|turn| turn.status.is_open()))
 }
 
 /// Next 1-based ordinal for a new turn on one of the owner's sessions.
@@ -375,6 +377,17 @@ pub async fn save_turn(store: &DbStore, owner: &OwnerId, turn: &CodeTurn) -> Res
         .col_expr(
             entities::code_turn::Column::EndedAt,
             sea_orm::sea_query::Expr::value(turn.ended_at),
+        )
+        .col_expr(
+            entities::code_turn::Column::ParkRef,
+            sea_orm::sea_query::Expr::value(turn.park_ref.clone()),
+        )
+        .col_expr(
+            entities::code_turn::Column::ParkWait,
+            sea_orm::sea_query::Expr::value(match &turn.park_wait {
+                Some(wait) => Some(serde_json::to_value(wait)?),
+                None => None,
+            }),
         )
         .filter(entities::code_turn::Column::Id.eq(turn.id.0))
         .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
@@ -469,6 +482,13 @@ pub(super) fn turn_from_row(row: entities::code_turn::Model) -> Result<CodeTurn>
         rewrite: row.rewrite,
         started_at: row.started_at,
         ended_at: row.ended_at,
+        park_ref: row.park_ref,
+        park_wait: match row.park_wait {
+            Some(value) => Some(serde_json::from_value(value).map_err(|err| {
+                AgentError::Store(format!("code_turn {} park_wait: {err}", row.id))
+            })?),
+            None => None,
+        },
     })
 }
 

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -236,6 +236,8 @@ async fn seed_owner(
             rewrite: None,
             started_at: now(),
             ended_at: None,
+            park_ref: None,
+            park_wait: None,
         },
     )
     .await
@@ -1705,6 +1707,8 @@ async fn a_turn_attachment_stays_live_after_its_session_ends() {
             rewrite: None,
             started_at: now(),
             ended_at: Some(now()),
+            park_ref: None,
+            park_wait: None,
         },
     )
     .await
@@ -4106,6 +4110,8 @@ fn turn_for(row: &CodeQueuedTurn, ordinal: i64) -> CodeTurn {
         rewrite: None,
         started_at: now(),
         ended_at: None,
+        park_ref: None,
+        park_wait: None,
     }
 }
 

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -816,6 +816,8 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
             rewrite: None,
             started_at: now,
             ended_at: Some(now),
+            park_ref: None,
+            park_wait: None,
         },
     )
     .await

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -194,7 +194,7 @@ pub use code::{
     FileChangeKind, GrantRotation, HarnessCaps, HarnessCommand, HarnessKind, HarnessNoticeLevel,
     HarnessTier, IncarnationAdmission, IncarnationState, PullRequestCheck, PullRequestCheckBucket,
     PullRequestCheckCounts, PullRequestComment, PullRequestCommentKind, PullRequestDigest,
-    QuickAction, RepoId, SequencedCodeEvent, ToolDetail, ToolOutcome, WorkspaceId,
+    QuickAction, RepoId, SequencedCodeEvent, ToolDetail, ToolOutcome, TurnParkWait, WorkspaceId,
     MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS, MAX_SESSION_SUBAGENTS,
     MAX_TOOL_SUMMARY_CHARS,
 };

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -16,13 +16,13 @@ use tidebreak_core::db::code::{
     append_event, get_approval, get_repo, get_repo_by_root_path, get_session, get_turn,
     get_workspace, insert_approval, insert_repo, insert_session, insert_turn, insert_workspace,
     list_approvals, list_events, list_repos, list_sessions, list_turns, mark_repo_removed,
-    set_workspace_title_if, MAX_REPLAY_EVENTS,
+    save_turn, set_workspace_title_if, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
     CodeEvent, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle,
     CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, DbStore, HarnessKind,
-    OwnerId, PermissionMode, RepoId, WorkspaceId,
+    OwnerId, PermissionMode, RepoId, TurnParkWait, WorkspaceId,
 };
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
@@ -125,6 +125,8 @@ async fn seed_owner(
             usage: None,
             narrative: None,
             rewrite: None,
+            park_ref: None,
+            park_wait: None,
             started_at: Utc::now(),
             ended_at: None,
         },
@@ -261,6 +263,46 @@ async fn postgres_code_queries_partition_by_owner() {
 /// Repository registration is unique per owner on PostgreSQL as well: the
 /// composite index is what allows a second user to register a path the first
 /// user already has.
+/// The park columns and the widened status check are the one piece of this
+/// slice whose PostgreSQL branch is a different statement from SQLite's: the
+/// constraint is swapped in place rather than rebuilt with the table. A turn
+/// that cannot park on this backend would strand the engine's checkpoint.
+#[tokio::test]
+async fn postgres_stores_a_parked_turn_and_reads_its_wait_back() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("TIDEBREAK_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("TIDEBREAK_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("TIDEBREAK_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let run = uuid::Uuid::new_v4().simple().to_string();
+    let owner = OwnerId::new(&format!("parker-{run}")).unwrap();
+    let (_repo, _workspace, _session, turn_id) =
+        seed_owner(&store, &owner, &format!("parker-{run}")).await;
+
+    let mut turn = get_turn(&store, &owner, turn_id).await.unwrap().unwrap();
+    assert_eq!(turn.park_ref, None);
+    turn.status = CodeTurnStatus::Waiting;
+    turn.park_ref = Some("cp-1".to_owned());
+    turn.park_wait = Some(TurnParkWait::Approval {
+        call_id: "call-1".to_owned(),
+    });
+    assert!(save_turn(&store, &owner, &turn).await.unwrap());
+
+    let parked = get_turn(&store, &owner, turn_id).await.unwrap().unwrap();
+    assert_eq!(parked.status, CodeTurnStatus::Waiting);
+    assert_eq!(parked.park_ref.as_deref(), Some("cp-1"));
+    assert_eq!(
+        parked.park_wait,
+        Some(TurnParkWait::Approval {
+            call_id: "call-1".to_owned()
+        })
+    );
+}
+
 #[tokio::test]
 async fn postgres_repository_paths_are_unique_per_owner() {
     let _guard = POSTGRES_TEST_LOCK.lock().await;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -1549,6 +1549,20 @@ describe("hydrate then replay", () => {
     });
   });
 
+  it("keeps a parked turn busy: waiting is open, not terminal", () => {
+    const waiting = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, status: "waiting", ended_at: undefined },
+    ]);
+    expect(waiting).toMatchObject({
+      busy: true,
+      activeTurnId: SNAPSHOT_TURN.id,
+      lifecycle: "running",
+    });
+    expect(
+      waiting.items.find((item) => item.kind === "turn_boundary"),
+    ).toBeUndefined();
+  });
+
   it("lets live timing replace a replay-only unknown boundary", () => {
     const now = vi
       .fn<() => string>()

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -219,7 +219,7 @@ export type PendingTerminalReconciliation = {
   candidateTurnId: string | null;
   /** The first retained start after an unassigned terminal, when one appears. */
   nextTurnId: string | null;
-  status: Exclude<CodeTurnStatus, "running">;
+  status: Exclude<CodeTurnStatus, "running" | "waiting">;
   usage: CodeUsage | null;
   error: string | null;
   diffstat: Diffstat | null;
@@ -302,13 +302,18 @@ export function markCodeSessionHydrated(
   return state.hydrated ? state : { ...state, hydrated: true };
 }
 
+/** Whether a turn is still open: live, or parked waiting on a decision. */
+function turnIsOpen(status: CodeTurnStatus): status is "running" | "waiting" {
+  return status === "running" || status === "waiting";
+}
+
 /** Record a turn that a live submit received before its journal start. */
 export function applyAcceptedTurn(
   state: CodeSessionState,
   turn: CodeTurnSnapshot,
 ): CodeSessionState {
   const next = upsertTurnPrompt(state, turn);
-  if (turn.status !== "running") return next;
+  if (!turnIsOpen(turn.status)) return next;
   const continuesObservedTurn =
     state.activeTurnId === turn.id && state.turnStartObservedLive;
   return {
@@ -335,7 +340,7 @@ export function applyCodeTurnSnapshot(
   turn: CodeTurnSnapshot,
 ): CodeSessionState {
   const next = upsertTurnPrompt(state, turn);
-  if (turn.status === "running") return next;
+  if (turnIsOpen(turn.status)) return next;
   const durableBoundaryTurnIds = new Set(next.durableBoundaryTurnIds);
   durableBoundaryTurnIds.add(turn.id);
   const withBoundary = {
@@ -391,7 +396,7 @@ function reconcileCodeTurnSnapshotWithPending(
   turn: CodeTurnSnapshot,
   pending: PendingTerminalReconciliation | undefined,
 ): CodeSessionState {
-  if (turn.status === "running") {
+  if (turnIsOpen(turn.status)) {
     return applyCodeTurnSnapshot(state, turn);
   }
 
@@ -635,7 +640,7 @@ function assignUnattributedTerminals(
       if (
         !item ||
         !turn ||
-        turn.status === "running" ||
+        turnIsOpen(turn.status) ||
         turn.status !== item.status ||
         claimed.has(turn.id)
       ) {
@@ -662,7 +667,7 @@ function applyAuthoritativeTurnActivity(
     : undefined;
   if (
     state.acceptedTurnFence &&
-    (!acceptedTurn || acceptedTurn.status === "running")
+    (!acceptedTurn || turnIsOpen(acceptedTurn.status))
   ) {
     return {
       ...state,
@@ -677,7 +682,7 @@ function applyAuthoritativeTurnActivity(
     .reverse()
     .find(
       (turn) =>
-        turn.status === "running" && !latestPendingForTurn(state, turn.id),
+        turnIsOpen(turn.status) && !latestPendingForTurn(state, turn.id),
     );
   const lastUsage = latestTurnUsage(state, turns);
   if (open) {
@@ -726,7 +731,7 @@ function latestTurnUsage(
   turns: readonly CodeTurnSnapshot[],
 ): CodeUsage | null {
   for (const turn of [...turns].reverse()) {
-    if (turn.status === "running") continue;
+    if (turnIsOpen(turn.status)) continue;
     if (turn.usage) return turn.usage;
     if (!state.durableBoundaryTurnIds.has(turn.id)) continue;
     const boundary = state.items.find(
@@ -1487,7 +1492,7 @@ function upsertTurnBoundary(
   items: CodeTranscriptItem[],
   boundary: {
     turnId: string;
-    status: Exclude<CodeTurnStatus, "running">;
+    status: Exclude<CodeTurnStatus, "running" | "waiting">;
     durationMs: number | null;
     usage: CodeUsage | null;
     error: string | null;
@@ -1534,7 +1539,7 @@ function replaceTurnBoundary(
   items: CodeTranscriptItem[],
   boundary: {
     turnId: string;
-    status: Exclude<CodeTurnStatus, "running">;
+    status: Exclude<CodeTurnStatus, "running" | "waiting">;
     durationMs: number | null;
     usage: CodeUsage | null;
     error: string | null;

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -291,6 +291,7 @@ const PULL_REQUEST_RELATIONS = new Set<CodePullRequestRelation>([
 const PULL_REQUEST_FACT_STATES = new Set<string>(["open", "merged", "closed"]);
 const TURN_STATUSES = new Set<CodeTurnStatus>([
   "running",
+  "waiting",
   "completed",
   "failed",
   "interrupted",

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -867,9 +867,26 @@ export type CodeAnalyticsSnapshot = { range: CodeAnalyticsRange, from?: string, 
 export type CodeAnalyticsTotals = { sessions: number, turns: number, completed_turns: number, failed_turns: number, interrupted_turns: number, running_turns: number, input_tokens: number, output_tokens: number, cache_read_tokens: number, cache_write_tokens: number, total_tokens: number, estimated_cost_microusd: number, pull_requests_opened: number, pull_requests_merged: number, };
 
 /**
- * `approve` or `deny`.
+ * The decision on one approval.
+ *
+ * The richer variants are capability-gated: the server refuses them for an
+ * engine whose capability vector does not declare the channel, and a grant
+ * is named by its index into the rungs the approval's own kind offered —
+ * a client can pick a rung the card showed, never invent a scope.
  */
-export type CodeApprovalDecision = "approve" | "deny";
+export type CodeApprovalDecision = "approve" | "deny" | { "approve_with_grant": {
+/**
+ * Index into the approval kind's `offered_grants`, narrowest first.
+ */
+grant_index: number, } } | { "answers": {
+/**
+ * Answers to a questions approval, validated server-side.
+ */
+answers: Array<UserQuestionAnswer>, } } | { "plan_decision": {
+/**
+ * Whether the proposed plan is accepted.
+ */
+approve: boolean, } };
 
 /**
  * Body of `POST /code/approvals/{id}/decision`.
@@ -1796,7 +1813,7 @@ rewrite?: string, };
 /**
  * Status of one user→engine turn.
  */
-export type CodeTurnStatus = "running" | "completed" | "failed" | "interrupted";
+export type CodeTurnStatus = "running" | "waiting" | "completed" | "failed" | "interrupted";
 
 /**
  * One unsequenced notice on `WS /code/updates`.

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -453,11 +453,13 @@ pub enum TurnOutcome {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ParkWait {
-    /// A pending approval row: a tool approval, a questions card, or a plan
-    /// proposal.
+    /// A pending approval: a tool approval, a questions card, or a plan
+    /// proposal. Named by the engine-native call id, because the engine
+    /// never learns the server's durable row id; the worker resolves it to
+    /// the approval row it recorded for that call.
     Approval {
-        /// Durable approval id.
-        approval_id: String,
+        /// Engine-native call id, as on [`HarnessApprovalRef`].
+        call_id: String,
     },
     /// A tool call executed outside the engine, by a client the server
     /// leases.
@@ -484,8 +486,8 @@ pub enum ParkWait {
 pub enum ResumeInput {
     /// The awaited approval was decided, with this decision.
     ApprovalDecided {
-        /// The approval that settled.
-        approval_id: String,
+        /// Engine-native call id of the approval that settled.
+        call_id: String,
         /// The decision, already durably recorded.
         decision: ApprovalDecision,
     },

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -2579,6 +2579,8 @@ mod tests {
             rewrite: None,
             started_at: chrono::Utc::now(),
             ended_at: None,
+            park_ref: None,
+            park_wait: None,
         };
         insert_turn(db, &session.owner, &turn).await.unwrap();
         turn

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -1211,6 +1211,8 @@ mod tests {
             rewrite: None,
             started_at: chrono::Utc::now(),
             ended_at: None,
+            park_ref: None,
+            park_wait: None,
         }
     }
 

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -568,6 +568,8 @@ mod tests {
                 rewrite: None,
                 started_at: now(),
                 ended_at: None,
+                park_ref: None,
+                park_wait: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -850,6 +850,8 @@ async fn start_turn_row(
         rewrite: None,
         started_at: chrono::Utc::now(),
         ended_at: None,
+        park_ref: None,
+        park_wait: None,
     };
     match promoted {
         // Claim the queue row and insert its turn in one transaction, the
@@ -1733,6 +1735,8 @@ mod tests {
             rewrite: None,
             started_at: chrono::Utc::now(),
             ended_at: None,
+            park_ref: None,
+            park_wait: None,
         };
         insert_turn(&db, &session.owner, &running).await.unwrap();
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -6967,7 +6967,7 @@ impl CodeRuntime {
         &self,
         owner: &OwnerId,
         id: CodeApprovalId,
-        decision: ApprovalDecision,
+        request: ApprovalDecisionRequest,
     ) -> Result<CodeApproval, ServerError> {
         let initial = self.get_approval(owner, id).await?;
         if !initial.state.is_pending() {
@@ -7025,6 +7025,9 @@ impl CodeRuntime {
                 "the worker that requested this approval is no longer attached",
             ));
         }
+        let adapter = self.adapter(session.harness_kind)?;
+        let probe = self.probe(adapter.as_ref()).await;
+        let decision = resolve_decision_request(&approval, &adapter.capabilities(&probe), request)?;
         let native_ref = Self::native_approval_ref(owner, &approval)?;
         let claim = uuid::Uuid::new_v4();
         let Some(_) = claim_approval(
@@ -8033,5 +8036,112 @@ mod managed_node_wait_tests {
                 .expect("existing harness"),
             harness_binary
         );
+    }
+}
+
+/// One decision as the wire requested it, before the server resolves it
+/// against the approval row and the engine's declared capabilities.
+///
+/// A grant is named by index into the rungs the approval's kind offered, so
+/// a client can only pick a scope the card showed (the same rule chat's
+/// grant rungs follow); the server resolves the concrete scope here.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ApprovalDecisionRequest {
+    Approve,
+    Deny {
+        feedback: Option<String>,
+    },
+    ApproveWithGrant {
+        grant_index: u32,
+    },
+    Answers {
+        answers: Vec<tidebreak_core::UserQuestionAnswer>,
+    },
+    PlanDecision {
+        approve: bool,
+        feedback: Option<String>,
+    },
+}
+
+/// Resolve a requested decision into the engine-channel decision, refusing
+/// anything the approval's kind or the engine's capability vector cannot
+/// carry. One approval surface, capability-gated decisions (decision 0048).
+fn resolve_decision_request(
+    approval: &CodeApproval,
+    caps: &tidebreak_core::HarnessCaps,
+    request: ApprovalDecisionRequest,
+) -> Result<ApprovalDecision, ServerError> {
+    use tidebreak_core::CodeApprovalKind as Kind;
+    let structured_mismatch = |wanted: &str| {
+        ServerError::unprocessable_kind(
+            "approval_decision_mismatch",
+            format!("this approval takes {wanted}"),
+        )
+    };
+    match request {
+        ApprovalDecisionRequest::Approve => match &approval.kind {
+            // Structured kinds have structured decisions; a bare approve on
+            // them would drop the payload the engine is waiting for.
+            Kind::Questions { .. } => Err(structured_mismatch("answers")),
+            Kind::Plan { .. } => Err(structured_mismatch("a plan decision")),
+            _ => Ok(ApprovalDecision::Approve),
+        },
+        // Denying is always expressible: it is the fail-closed path.
+        ApprovalDecisionRequest::Deny { feedback } => Ok(ApprovalDecision::Deny { feedback }),
+        ApprovalDecisionRequest::ApproveWithGrant { grant_index } => {
+            if caps.standing_grants != CapLevel::Supported {
+                return Err(ServerError::unprocessable_kind(
+                    "standing_grants_unavailable",
+                    "this engine keeps no standing grants",
+                ));
+            }
+            let Kind::ToolUse { offered_grants, .. } = &approval.kind else {
+                return Err(structured_mismatch("approve or deny"));
+            };
+            let scope = offered_grants
+                .get(usize::try_from(grant_index).unwrap_or(usize::MAX))
+                .cloned()
+                .ok_or_else(|| {
+                    ServerError::unprocessable_kind(
+                        "grant_rung_unknown",
+                        format!("this approval offered no grant rung {grant_index}"),
+                    )
+                })?;
+            Ok(ApprovalDecision::ApproveWithGrant { scope })
+        }
+        ApprovalDecisionRequest::Answers { answers } => {
+            if caps.user_questions != CapLevel::Supported {
+                return Err(ServerError::unprocessable_kind(
+                    "user_questions_unavailable",
+                    "this engine takes no structured answers",
+                ));
+            }
+            let Kind::Questions { questions } = &approval.kind else {
+                return Err(structured_mismatch("approve or deny"));
+            };
+            let asked: std::collections::HashSet<&str> = questions
+                .iter()
+                .map(|question| question.id.as_str())
+                .collect();
+            let mut seen = std::collections::HashSet::new();
+            let well_formed = answers.iter().all(|answer| {
+                answer.shape_is_well_formed()
+                    && asked.contains(answer.question_id.as_str())
+                    && seen.insert(answer.question_id.as_str())
+            });
+            if !well_formed || answers.is_empty() {
+                return Err(ServerError::unprocessable_kind(
+                    "answers_invalid",
+                    "the answers do not match the questions this approval asked",
+                ));
+            }
+            Ok(ApprovalDecision::Answers { answers })
+        }
+        ApprovalDecisionRequest::PlanDecision { approve, feedback } => {
+            let Kind::Plan { .. } = &approval.kind else {
+                return Err(structured_mismatch("approve or deny"));
+            };
+            Ok(ApprovalDecision::PlanDecision { approve, feedback })
+        }
     }
 }

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -27,7 +27,6 @@ use tidebreak_core::{
     CodeWorkspace, Diffstat, HarnessKind, OwnerId, PermissionMode, ReasoningEffort, RepoId,
     SequencedCodeEvent, WorkspaceId,
 };
-use tidebreak_harness::ApprovalDecision;
 
 use super::checkpoint::ChangedFile;
 use super::clone::CloneRequest;
@@ -893,7 +892,7 @@ impl ScopedCode {
     pub(crate) async fn decide_approval(
         &self,
         id: CodeApprovalId,
-        decision: ApprovalDecision,
+        decision: super::runtime::ApprovalDecisionRequest,
     ) -> Result<CodeApproval, ServerError> {
         self.runtime
             .decide_approval(&self.owner, id, decision)

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -875,7 +875,7 @@ async fn run_worker(
                     }
                 }
                 Some(command) => {
-                    if apply_control(engine.as_ref(), command, None).await
+                    if apply_control(engine.as_ref(), command, None, None).await
                         == ControlFlow::Shutdown
                     {
                         break;
@@ -1063,7 +1063,7 @@ async fn await_worktree_turn<'a>(
                 // belongs to whichever loop owns the session row.
                 // `apply_control` answers all three that way already.
                 Some(command) => {
-                    if apply_control(engine, command, None).await == ControlFlow::Shutdown {
+                    if apply_control(engine, command, None, None).await == ControlFlow::Shutdown {
                         return WorktreeWait::Shutdown;
                     }
                 }
@@ -1097,6 +1097,34 @@ async fn reserve_execution_settings(
     }
 }
 
+/// Decisions this turn already handed the engine, keyed by the engine's own
+/// call id.
+///
+/// A `Decide` can arrive after `ApprovalRequested` is published and before
+/// the engine returns `Parked`. That command is admitted on the running
+/// leg, so no second `Decide` follows. The park wait has to resume from
+/// this record or the turn stays `waiting`.
+type DeliveredDecisions =
+    Arc<std::sync::Mutex<std::collections::HashMap<String, ApprovalDecision>>>;
+
+fn resume_if_already_delivered(
+    wait: &tidebreak_core::TurnParkWait,
+    delivered: &DeliveredDecisions,
+) -> Option<tidebreak_harness::ResumeInput> {
+    let tidebreak_core::TurnParkWait::Approval { call_id } = wait else {
+        return None;
+    };
+    let decision = delivered
+        .lock()
+        .expect("delivered decisions")
+        .get(call_id)
+        .cloned()?;
+    Some(tidebreak_harness::ResumeInput::ApprovalDecided {
+        call_id: call_id.clone(),
+        decision,
+    })
+}
+
 /// Deliver one approval decision over the engine's native channel, with the
 /// same timeout and ambiguity classification wherever the decision is taken
 /// from — the concurrent control path or a parked turn's wait.
@@ -1104,9 +1132,20 @@ async fn deliver_decision(
     engine: &dyn HarnessSession,
     approval: HarnessApprovalRef,
     decision: ApprovalDecision,
+    delivered: Option<DeliveredDecisions>,
 ) -> Result<(), WorkerError> {
+    let call_id = approval.call_id.clone();
+    let recorded = decision.clone();
     match tokio::time::timeout(APPROVAL_CONTROL_TIMEOUT, engine.decide(approval, decision)).await {
-        Ok(Ok(())) => Ok(()),
+        Ok(Ok(())) => {
+            if let Some(delivered) = delivered {
+                delivered
+                    .lock()
+                    .expect("delivered decisions")
+                    .insert(call_id, recorded);
+            }
+            Ok(())
+        }
         Ok(Err(HarnessError::ApprovalAcknowledgementLost(message))) => {
             Err(WorkerError::ApprovalDeliveryUnknown(message))
         }
@@ -1168,7 +1207,11 @@ async fn await_park_resolution<'a>(
     commands_closed: &mut bool,
     wait: &tidebreak_core::TurnParkWait,
     turn_id: CodeTurnId,
+    delivered: &DeliveredDecisions,
 ) -> Option<tidebreak_harness::ResumeInput> {
+    if let Some(input) = resume_if_already_delivered(wait, delivered) {
+        return Some(input);
+    }
     loop {
         tokio::select! {
             biased;
@@ -1177,12 +1220,19 @@ async fn await_park_resolution<'a>(
                     *interrupted = true;
                     return None;
                 }
+                // The opening leg may still be delivering the awaited
+                // decision when the engine parks. That future lives in
+                // `controls`; once it finishes, resume from the record.
+                if let Some(input) = resume_if_already_delivered(wait, delivered) {
+                    return Some(input);
+                }
             }
             command = commands.recv(), if !*commands_closed => match command {
                 Some(WorkerCommand::Decide { approval, decision, reply }) => {
                     let call_id = approval.call_id.clone();
                     let decided = (*decision).clone();
-                    let result = deliver_decision(engine, approval, *decision).await;
+                    let result =
+                        deliver_decision(engine, approval, *decision, Some(delivered.clone())).await;
                     let delivered = result.is_ok();
                     let _ = reply.send(result);
                     let awaited = matches!(
@@ -1211,7 +1261,12 @@ async fn await_park_resolution<'a>(
                     return None;
                 }
                 Some(other) => {
-                    controls.push(Box::pin(apply_control(engine, other, Some(turn_id))));
+                    controls.push(Box::pin(apply_control(
+                        engine,
+                        other,
+                        Some(turn_id),
+                        Some(delivered.clone()),
+                    )));
                 }
                 None => {
                     *commands_closed = true;
@@ -1227,6 +1282,7 @@ async fn apply_control(
     engine: &dyn HarnessSession,
     command: WorkerCommand,
     active_turn_id: Option<CodeTurnId>,
+    delivered: Option<DeliveredDecisions>,
 ) -> ControlFlow {
     match command {
         WorkerCommand::Decide {
@@ -1234,7 +1290,7 @@ async fn apply_control(
             decision,
             reply,
         } => {
-            let result = deliver_decision(engine, approval, *decision).await;
+            let result = deliver_decision(engine, approval, *decision, delivered).await;
             let _ = reply.send(result);
             ControlFlow::Continue
         }
@@ -1797,6 +1853,8 @@ async fn drive_turn_inner(
     let mut controls: FuturesUnordered<BoxFuture<'_, ControlFlow>> = FuturesUnordered::new();
     let mut interrupted = false;
     let mut commands_closed = false;
+    let delivered: DeliveredDecisions =
+        Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
     // One leg per engine future: the opening `run_turn`, then one
     // `resume_turn` per resolved park. An engine that never parks runs one
     // leg, exactly the old shape.
@@ -1830,7 +1888,12 @@ async fn drive_turn_inner(
                 command = commands.recv(), if !commands_closed => match command {
                     Some(command) => {
                         interrupted |= matches!(command, WorkerCommand::Interrupt { .. });
-                        controls.push(Box::pin(apply_control(engine, command, Some(turn.id))));
+                        controls.push(Box::pin(apply_control(
+                            engine,
+                            command,
+                            Some(turn.id),
+                            Some(delivered.clone()),
+                        )));
                     }
                     None => {
                         commands_closed = true;
@@ -1873,6 +1936,7 @@ async fn drive_turn_inner(
             &mut commands_closed,
             &wait,
             turn.id,
+            &delivered,
         )
         .await
         {
@@ -2939,7 +3003,8 @@ mod tests {
     use chrono::Utc;
     use tidebreak_core::db::code::{
         enqueue_queued_turn, get_session, insert_repo, insert_session, insert_workspace,
-        list_events, list_turns, replace_session_execution_settings, MAX_REPLAY_EVENTS,
+        list_approvals, list_events, list_turns, replace_session_execution_settings,
+        MAX_REPLAY_EVENTS,
     };
     use tidebreak_core::{
         CodeRepo, CodeSessionKind, CodeUsage, CodeWorkspace, CodeWorkspaceStatus, HarnessKind,
@@ -3274,6 +3339,149 @@ mod tests {
                 .any(|event| matches!(event.event, CodeEvent::TurnCompleted { .. })),
             "the resumed leg reaches the journal"
         );
+        let _ = handle.commands.send(WorkerCommand::Shutdown).await;
+    }
+
+    #[tokio::test]
+    async fn a_decision_on_the_running_leg_resumes_the_park() {
+        let (directory, store, sink, session_id) = seeded_sink().await;
+        let owner = OwnerId::local();
+        let mut session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        session.lifecycle = CodeSessionLifecycle::Idle;
+        assert!(save_session(&store, &session).await.unwrap());
+
+        let worktree = directory.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let private = directory.path().join("private");
+        std::fs::create_dir(&private).unwrap();
+        let private_root =
+            super::super::scratch::ScratchRoot::open_for_test(&private).expect("scratch root");
+        let script = vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::ApprovalRequested {
+                harness_ref: tidebreak_harness::HarnessApprovalRef::engine("call-1"),
+                raw: serde_json::json!({ "tool_name": "Write" }),
+                kind: None,
+            },
+            // Holds the opening leg open after the request is journaled so
+            // Decide is admitted there, before `Parked` is persisted.
+            HarnessEvent::AssistantDelta {
+                text: "still running".into(),
+            },
+            HarnessEvent::AssistantMessage {
+                text: "resumed after the decision".into(),
+                parent_call_id: None,
+            },
+            HarnessEvent::TurnCompleted {
+                usage: CodeUsage::default(),
+            },
+        ];
+        let adapter = ScriptedAdapter::new(script)
+            .with_unattended_approvals()
+            .with_delay(Duration::from_millis(150))
+            .with_approval_ack_delay(Duration::from_millis(150))
+            .with_parked_turn(
+                3,
+                "cp-1",
+                tidebreak_harness::ParkWait::Approval {
+                    call_id: "call-1".into(),
+                },
+            );
+        let engine = adapter
+            .launch(SessionSpec {
+                worktree,
+                allowed_read_roots: Vec::new(),
+                permission_mode: session.permission_mode,
+                model: session.model.clone(),
+                reasoning_effort: session.reasoning_effort,
+                fast_mode: session.fast_mode,
+                resume_ref: None,
+                extra_argv: Vec::new(),
+                extra_env: Vec::new(),
+                relay_key_env: None,
+                env: Vec::new(),
+                approval: None,
+                binary: Some(std::path::PathBuf::from("/scripted/engine")),
+                sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+                browser: None,
+            })
+            .await
+            .unwrap();
+        let handle = spawn_session_worker(
+            session.clone(),
+            engine,
+            sink,
+            AttachmentStore {
+                blobs: None,
+                private_root,
+                engine_reads_images: false,
+            },
+            Arc::new(tokio::sync::Mutex::new(())),
+            tokio::sync::watch::channel(false).1,
+        );
+
+        let (turn_reply, turn_response) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::RunTurn {
+                message: "decide before the park".into(),
+                attachments: Vec::new(),
+                trigger_delivery: None,
+                reply: turn_reply,
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let pending = list_approvals(
+                    &store,
+                    &owner,
+                    Some(CodeApprovalState::Pending),
+                    Some(session_id),
+                )
+                .await
+                .unwrap();
+                if !pending.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the approval is published");
+        let turns = list_turns(&store, &owner, session_id).await.unwrap();
+        assert!(
+            turns
+                .iter()
+                .any(|turn| turn.status == CodeTurnStatus::Running),
+            "Decide must reach the opening leg while the turn is still running"
+        );
+
+        let (decide_reply, decide_response) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::Decide {
+                approval: tidebreak_harness::HarnessApprovalRef::engine("call-1"),
+                decision: Box::new(tidebreak_harness::ApprovalDecision::Approve),
+                reply: decide_reply,
+            })
+            .await
+            .unwrap();
+        decide_response.await.unwrap().unwrap();
+
+        let turn = tokio::time::timeout(Duration::from_secs(5), turn_response)
+            .await
+            .expect("the turn completes from the already-delivered decision")
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.status, CodeTurnStatus::Completed);
+        assert_eq!(turn.park_ref, None, "the resume clears the park");
+        assert_eq!(turn.park_wait, None);
+        assert_eq!(adapter.resumes().len(), 1, "one resume for one park");
         let _ = handle.commands.send(WorkerCommand::Shutdown).await;
     }
 

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -1097,6 +1097,132 @@ async fn reserve_execution_settings(
     }
 }
 
+/// Deliver one approval decision over the engine's native channel, with the
+/// same timeout and ambiguity classification wherever the decision is taken
+/// from — the concurrent control path or a parked turn's wait.
+async fn deliver_decision(
+    engine: &dyn HarnessSession,
+    approval: HarnessApprovalRef,
+    decision: ApprovalDecision,
+) -> Result<(), WorkerError> {
+    match tokio::time::timeout(APPROVAL_CONTROL_TIMEOUT, engine.decide(approval, decision)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(HarnessError::ApprovalAcknowledgementLost(message))) => {
+            Err(WorkerError::ApprovalDeliveryUnknown(message))
+        }
+        Ok(Err(err)) => Err(WorkerError::ApprovalDeliveryFailed(err.to_string())),
+        Err(_) => Err(WorkerError::ApprovalDeliveryUnknown(
+            "the native approval decision timed out; delivery could not be confirmed".into(),
+        )),
+    }
+}
+
+/// Persist a parked turn: status, the engine's checkpoint token, and the
+/// awaited dependency, mapped into the durable park-wait shape.
+async fn persist_turn_park(
+    db: &DbStore,
+    session: &CodeSession,
+    turn: &mut CodeTurn,
+    park_ref: &str,
+    waiting_on: &tidebreak_harness::ParkWait,
+) -> Result<tidebreak_core::TurnParkWait, String> {
+    let wait = match waiting_on {
+        tidebreak_harness::ParkWait::Approval { call_id } => {
+            tidebreak_core::TurnParkWait::Approval {
+                call_id: call_id.clone(),
+            }
+        }
+        tidebreak_harness::ParkWait::ClientToolCall { call_id } => {
+            tidebreak_core::TurnParkWait::ClientToolCall {
+                call_id: call_id.clone(),
+            }
+        }
+        tidebreak_harness::ParkWait::AgentRuns { run_ids } => {
+            tidebreak_core::TurnParkWait::AgentRuns {
+                run_ids: run_ids.clone(),
+            }
+        }
+    };
+    turn.status = CodeTurnStatus::Waiting;
+    turn.park_ref = Some(park_ref.to_owned());
+    turn.park_wait = Some(wait.clone());
+    save_turn(db, &session.owner, turn)
+        .await
+        .map_err(|err| format!("persisting the parked turn failed: {err}"))?;
+    Ok(wait)
+}
+
+/// Hold a parked turn until its wait resolves, the worker is interrupted, or
+/// the command channel closes.
+///
+/// A decision for the awaited approval is delivered to the engine first —
+/// the same native channel and classification as the concurrent control path
+/// — and only a confirmed delivery resumes the turn. Every other command
+/// takes the ordinary control path.
+#[allow(clippy::too_many_arguments)]
+async fn await_park_resolution<'a>(
+    engine: &'a dyn HarnessSession,
+    commands: &mut mpsc::Receiver<WorkerCommand>,
+    controls: &mut FuturesUnordered<BoxFuture<'a, ControlFlow>>,
+    interrupted: &mut bool,
+    commands_closed: &mut bool,
+    wait: &tidebreak_core::TurnParkWait,
+    turn_id: CodeTurnId,
+) -> Option<tidebreak_harness::ResumeInput> {
+    loop {
+        tokio::select! {
+            biased;
+            Some(flow) = controls.next(), if !controls.is_empty() => {
+                if flow == ControlFlow::Shutdown {
+                    *interrupted = true;
+                    return None;
+                }
+            }
+            command = commands.recv(), if !*commands_closed => match command {
+                Some(WorkerCommand::Decide { approval, decision, reply }) => {
+                    let call_id = approval.call_id.clone();
+                    let decided = (*decision).clone();
+                    let result = deliver_decision(engine, approval, *decision).await;
+                    let delivered = result.is_ok();
+                    let _ = reply.send(result);
+                    let awaited = matches!(
+                        wait,
+                        tidebreak_core::TurnParkWait::Approval { call_id: waited }
+                            if *waited == call_id
+                    );
+                    if delivered && awaited {
+                        return Some(tidebreak_harness::ResumeInput::ApprovalDecided {
+                            call_id,
+                            decision: decided,
+                        });
+                    }
+                }
+                Some(WorkerCommand::Interrupt { reply }) => {
+                    *interrupted = true;
+                    let result = engine
+                        .interrupt()
+                        .await
+                        .map_err(|err| WorkerError::Failed(err.to_string()));
+                    let _ = reply.send(result);
+                    return None;
+                }
+                Some(WorkerCommand::Shutdown) => {
+                    *interrupted = true;
+                    return None;
+                }
+                Some(other) => {
+                    controls.push(Box::pin(apply_control(engine, other, Some(turn_id))));
+                }
+                None => {
+                    *commands_closed = true;
+                    *interrupted = true;
+                    return None;
+                }
+            },
+        }
+    }
+}
+
 async fn apply_control(
     engine: &dyn HarnessSession,
     command: WorkerCommand,
@@ -1108,22 +1234,7 @@ async fn apply_control(
             decision,
             reply,
         } => {
-            let result = match tokio::time::timeout(
-                APPROVAL_CONTROL_TIMEOUT,
-                engine.decide(approval, *decision),
-            )
-            .await
-            {
-                Ok(Ok(())) => Ok(()),
-                Ok(Err(HarnessError::ApprovalAcknowledgementLost(message))) => {
-                    Err(WorkerError::ApprovalDeliveryUnknown(message))
-                }
-                Ok(Err(err)) => Err(WorkerError::ApprovalDeliveryFailed(err.to_string())),
-                Err(_) => Err(WorkerError::ApprovalDeliveryUnknown(
-                    "the native approval decision timed out; delivery could not be confirmed"
-                        .into(),
-                )),
-            };
+            let result = deliver_decision(engine, approval, *decision).await;
             let _ = reply.send(result);
             ControlFlow::Continue
         }
@@ -1568,6 +1679,8 @@ async fn drive_turn_inner(
         rewrite: None,
         started_at: Utc::now(),
         ended_at: None,
+        park_ref: None,
+        park_wait: None,
     };
 
     // Clear files a crashed worker left behind before this turn exposes any
@@ -1664,14 +1777,14 @@ async fn drive_turn_inner(
             Vec::new(),
         )
     };
-    let run = engine.run_turn(TurnInput {
+    let mut next_input = Some(TurnInput {
         text: engine_text,
         model: turn_settings.model.clone(),
         reasoning_effort: turn_settings.reasoning_effort,
         fast_mode: turn_settings.fast_mode,
         images,
     });
-    tokio::pin!(run);
+    let mut next_resume: Option<(String, tidebreak_harness::ResumeInput)> = None;
     // Adapters that spawn one child per turn have no pid to report until the
     // turn is under way. Record every transition as it happens: the session
     // row's pid is what boot recovery probes, and a NULL pid there is read as
@@ -1684,40 +1797,95 @@ async fn drive_turn_inner(
     let mut controls: FuturesUnordered<BoxFuture<'_, ControlFlow>> = FuturesUnordered::new();
     let mut interrupted = false;
     let mut commands_closed = false;
-    let run = loop {
-        tokio::select! {
-            // Once a control has been accepted from the command channel, poll
-            // it before allowing a simultaneously-terminal turn to win. Native
-            // steering registers its response waiter on that first poll; the
-            // turn reader can then drain and demultiplex the acknowledgement.
-            biased;
-            Some(flow) = controls.next(), if !controls.is_empty() => {
-                if flow == ControlFlow::Shutdown {
-                    interrupted = true;
-                    controls.push(Box::pin(interrupt_engine(engine)));
+    // One leg per engine future: the opening `run_turn`, then one
+    // `resume_turn` per resolved park. An engine that never parks runs one
+    // leg, exactly the old shape.
+    let run = 'legs: loop {
+        let leg: BoxFuture<'_, Result<TurnOutcome, HarnessError>> =
+            if let Some(input) = next_input.take() {
+                Box::pin(engine.run_turn(input))
+            } else if let Some((park_ref, input)) = next_resume.take() {
+                Box::pin(engine.resume_turn(park_ref, input))
+            } else {
+                unreachable!("every leg starts with an input or a resume");
+            };
+        tokio::pin!(leg);
+        let result = loop {
+            tokio::select! {
+                // Once a control has been accepted from the command channel, poll
+                // it before allowing a simultaneously-terminal turn to win. Native
+                // steering registers its response waiter on that first poll; the
+                // turn reader can then drain and demultiplex the acknowledgement.
+                biased;
+                Some(flow) = controls.next(), if !controls.is_empty() => {
+                    if flow == ControlFlow::Shutdown {
+                        interrupted = true;
+                        controls.push(Box::pin(interrupt_engine(engine)));
+                    }
+                }
+                // A terminal result wins over commands that have not yet been
+                // admitted. This prevents guidance for turn A from entering the
+                // control set after A has already completed and then reaching B.
+                result = &mut leg => break result,
+                command = commands.recv(), if !commands_closed => match command {
+                    Some(command) => {
+                        interrupted |= matches!(command, WorkerCommand::Interrupt { .. });
+                        controls.push(Box::pin(apply_control(engine, command, Some(turn.id))));
+                    }
+                    None => {
+                        commands_closed = true;
+                        interrupted = true;
+                        controls.push(Box::pin(interrupt_engine(engine)));
+                    }
+                },
+                pid = next_child_pid(pid_changes.as_mut()) => {
+                    if session.child_pid != pid {
+                        record_child_process(session, pid);
+                        let _ = save_session(db, session).await;
+                    }
                 }
             }
-            // A terminal result wins over commands that have not yet been
-            // admitted. This prevents guidance for turn A from entering the
-            // control set after A has already completed and then reaching B.
-            result = &mut run => break result,
-            command = commands.recv(), if !commands_closed => match command {
-                Some(command) => {
-                    interrupted |= matches!(command, WorkerCommand::Interrupt { .. });
-                    controls.push(Box::pin(apply_control(engine, command, Some(turn.id))));
-                }
-                None => {
-                    commands_closed = true;
-                    interrupted = true;
-                    controls.push(Box::pin(interrupt_engine(engine)));
-                }
-            },
-            pid = next_child_pid(pid_changes.as_mut()) => {
-                if session.child_pid != pid {
-                    record_child_process(session, pid);
-                    let _ = save_session(db, session).await;
-                }
+        };
+        let Ok(TurnOutcome::Parked {
+            park_ref,
+            waiting_on,
+        }) = result
+        else {
+            break 'legs result;
+        };
+        // The engine checkpointed durably and released the turn. Persist the
+        // park so the row says what the turn waits for, then hold here for
+        // the resolution. The session stays Running: a parked turn is open,
+        // and the decide route requires a live worker.
+        if interrupted {
+            // A stop raced the park; close the turn instead of waiting.
+            break 'legs Ok(TurnOutcome::Clean);
+        }
+        let wait = match persist_turn_park(db, session, &mut turn, &park_ref, &waiting_on).await {
+            Ok(wait) => wait,
+            Err(error) => break 'legs Err(HarnessError::Other(error)),
+        };
+        match await_park_resolution(
+            engine,
+            commands,
+            &mut controls,
+            &mut interrupted,
+            &mut commands_closed,
+            &wait,
+            turn.id,
+        )
+        .await
+        {
+            Some(input) => {
+                turn.status = CodeTurnStatus::Running;
+                turn.park_ref = None;
+                turn.park_wait = None;
+                let _ = save_turn(db, &session.owner, &turn).await;
+                next_resume = Some((park_ref, input));
             }
+            // Interrupted or shut down while parked: fall through to the
+            // shared closing code, which closes an open turn as interrupted.
+            None => break 'legs Ok(TurnOutcome::Clean),
         }
     };
     // A control command still in flight has a caller waiting on its reply.
@@ -1776,11 +1944,11 @@ async fn drive_turn_inner(
             let detail = match outcome {
                 TurnOutcome::Clean => None,
                 TurnOutcome::Incomplete { detail } => Some(detail),
-                // No registered engine declares durable_parks yet; a park
-                // reaching this worker is a contract violation, and failing
-                // the turn loudly beats stranding it open.
+                // Parks are intercepted by the leg loop above; one arriving
+                // here means the engine parked after the worker stopped
+                // waiting, and failing loudly beats stranding the turn open.
                 TurnOutcome::Parked { .. } => {
-                    Some("the engine parked the turn, which this worker does not support".into())
+                    Some("the engine parked a turn the worker was no longer waiting on".into())
                 }
             };
             // An engine that died on us says why on stderr. That belongs in
@@ -1800,7 +1968,7 @@ async fn drive_turn_inner(
                 )
                 .await;
             }
-            if turn.status == CodeTurnStatus::Running {
+            if turn.status.is_open() {
                 // The stream ended without closing the turn. Only the worker
                 // knows whether that was asked for.
                 let (status, event) = if interrupted {
@@ -1851,7 +2019,7 @@ async fn drive_turn_inner(
             }
         }
         Err(err) => {
-            if turn.status == CodeTurnStatus::Running {
+            if turn.status.is_open() {
                 turn.status = CodeTurnStatus::Failed;
                 turn.ended_at = Some(Utc::now());
                 let _ = save_turn(db, &session.owner, &turn).await;
@@ -2966,6 +3134,241 @@ mod tests {
             crate::code::pr_refresh::HotPullRequests::default(),
         );
         (directory, store, sink, session_id)
+    }
+
+    #[tokio::test]
+    async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
+        let (directory, store, sink, session_id) = seeded_sink().await;
+        let owner = OwnerId::local();
+        let mut session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        session.lifecycle = CodeSessionLifecycle::Idle;
+        assert!(save_session(&store, &session).await.unwrap());
+
+        let worktree = directory.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let private = directory.path().join("private");
+        std::fs::create_dir(&private).unwrap();
+        let private_root =
+            super::super::scratch::ScratchRoot::open_for_test(&private).expect("scratch root");
+        let script = vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::ApprovalRequested {
+                harness_ref: tidebreak_harness::HarnessApprovalRef::engine("call-1"),
+                raw: serde_json::json!({ "tool_name": "Write" }),
+                kind: None,
+            },
+            HarnessEvent::AssistantMessage {
+                text: "resumed after the decision".into(),
+                parent_call_id: None,
+            },
+            HarnessEvent::TurnCompleted {
+                usage: CodeUsage::default(),
+            },
+        ];
+        // The engine checkpoints after the request instead of blocking on it.
+        let adapter = ScriptedAdapter::new(script)
+            .with_unattended_approvals()
+            .with_parked_turn(
+                2,
+                "cp-1",
+                tidebreak_harness::ParkWait::Approval {
+                    call_id: "call-1".into(),
+                },
+            );
+        let engine = adapter
+            .launch(SessionSpec {
+                worktree,
+                allowed_read_roots: Vec::new(),
+                permission_mode: session.permission_mode,
+                model: session.model.clone(),
+                reasoning_effort: session.reasoning_effort,
+                fast_mode: session.fast_mode,
+                resume_ref: None,
+                extra_argv: Vec::new(),
+                extra_env: Vec::new(),
+                relay_key_env: None,
+                env: Vec::new(),
+                approval: None,
+                binary: Some(std::path::PathBuf::from("/scripted/engine")),
+                sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+                browser: None,
+            })
+            .await
+            .unwrap();
+        let handle = spawn_session_worker(
+            session.clone(),
+            engine,
+            sink,
+            AttachmentStore {
+                blobs: None,
+                private_root,
+                engine_reads_images: false,
+            },
+            Arc::new(tokio::sync::Mutex::new(())),
+            tokio::sync::watch::channel(false).1,
+        );
+
+        let (turn_reply, turn_response) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::RunTurn {
+                message: "park then resume".into(),
+                attachments: Vec::new(),
+                trigger_delivery: None,
+                reply: turn_reply,
+            })
+            .await
+            .unwrap();
+
+        // The turn must reach the durable park before the decision arrives.
+        let parked = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let turns = list_turns(&store, &owner, session_id).await.unwrap();
+                if let Some(turn) = turns.iter().find(|t| t.status == CodeTurnStatus::Waiting) {
+                    break turn.clone();
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("the turn parks");
+        assert_eq!(parked.park_ref.as_deref(), Some("cp-1"));
+        assert_eq!(
+            parked.park_wait,
+            Some(tidebreak_core::TurnParkWait::Approval {
+                call_id: "call-1".into()
+            })
+        );
+
+        let (decide_reply, decide_response) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::Decide {
+                approval: tidebreak_harness::HarnessApprovalRef::engine("call-1"),
+                decision: Box::new(tidebreak_harness::ApprovalDecision::Approve),
+                reply: decide_reply,
+            })
+            .await
+            .unwrap();
+        decide_response.await.unwrap().unwrap();
+
+        let turn = tokio::time::timeout(Duration::from_secs(5), turn_response)
+            .await
+            .expect("the turn completes after the resume")
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.status, CodeTurnStatus::Completed);
+        assert_eq!(turn.park_ref, None, "the resume clears the park");
+        assert_eq!(turn.park_wait, None);
+        assert_eq!(adapter.resumes().len(), 1, "one resume for one park");
+        let events = list_events(&store, &owner, session_id, 0, MAX_REPLAY_EVENTS)
+            .await
+            .unwrap();
+        assert!(
+            events
+                .events
+                .iter()
+                .any(|event| matches!(event.event, CodeEvent::TurnCompleted { .. })),
+            "the resumed leg reaches the journal"
+        );
+        let _ = handle.commands.send(WorkerCommand::Shutdown).await;
+    }
+
+    #[tokio::test]
+    async fn an_interrupt_closes_a_parked_turn() {
+        let (directory, store, sink, session_id) = seeded_sink().await;
+        let owner = OwnerId::local();
+        let mut session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        session.lifecycle = CodeSessionLifecycle::Idle;
+        assert!(save_session(&store, &session).await.unwrap());
+        let worktree = directory.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let private = directory.path().join("private");
+        std::fs::create_dir(&private).unwrap();
+        let private_root =
+            super::super::scratch::ScratchRoot::open_for_test(&private).expect("scratch root");
+        let adapter = ScriptedAdapter::new(vec![HarnessEvent::TurnStarted]).with_parked_turn(
+            1,
+            "cp-1",
+            tidebreak_harness::ParkWait::Approval {
+                call_id: "call-1".into(),
+            },
+        );
+        let engine = adapter
+            .launch(SessionSpec {
+                worktree,
+                allowed_read_roots: Vec::new(),
+                permission_mode: session.permission_mode,
+                model: None,
+                reasoning_effort: None,
+                fast_mode: false,
+                resume_ref: None,
+                extra_argv: Vec::new(),
+                extra_env: Vec::new(),
+                relay_key_env: None,
+                env: Vec::new(),
+                approval: None,
+                binary: Some(std::path::PathBuf::from("/scripted/engine")),
+                sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+                browser: None,
+            })
+            .await
+            .unwrap();
+        let handle = spawn_session_worker(
+            session.clone(),
+            engine,
+            sink,
+            AttachmentStore {
+                blobs: None,
+                private_root,
+                engine_reads_images: false,
+            },
+            Arc::new(tokio::sync::Mutex::new(())),
+            tokio::sync::watch::channel(false).1,
+        );
+        let (turn_reply, turn_response) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::RunTurn {
+                message: "park then interrupt".into(),
+                attachments: Vec::new(),
+                trigger_delivery: None,
+                reply: turn_reply,
+            })
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(turn) = get_open_turn(&store, &owner, session_id).await.unwrap() {
+                    if turn.status == CodeTurnStatus::Waiting {
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the turn parks");
+        let (stop_reply, stop_response) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::Interrupt { reply: stop_reply })
+            .await
+            .unwrap();
+        stop_response.await.unwrap().unwrap();
+        let turn = tokio::time::timeout(Duration::from_secs(5), turn_response)
+            .await
+            .expect("the parked turn closes")
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.status, CodeTurnStatus::Interrupted);
+        let _ = handle.commands.send(WorkerCommand::Shutdown).await;
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/routes/code/analytics.rs
+++ b/crates/tidebreak-server/src/routes/code/analytics.rs
@@ -141,7 +141,7 @@ fn build_snapshot(
             CodeTurnStatus::Interrupted => {
                 totals.interrupted_turns = totals.interrupted_turns.saturating_add(1)
             }
-            CodeTurnStatus::Running => {
+            CodeTurnStatus::Running | CodeTurnStatus::Waiting => {
                 totals.running_turns = totals.running_turns.saturating_add(1)
             }
         }

--- a/crates/tidebreak-server/src/routes/code/approvals.rs
+++ b/crates/tidebreak-server/src/routes/code/approvals.rs
@@ -2,11 +2,11 @@ use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
+use crate::code::runtime::ApprovalDecisionRequest;
 use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use tidebreak_core::CodeApprovalId;
-use tidebreak_harness::ApprovalDecision;
 
 use super::types::{
     CodeApprovalDecision, CodeApprovalDecisionBody, CodeApprovalSnapshot, ListApprovalsQuery,
@@ -31,8 +31,16 @@ pub async fn decide_approval(
     Json(body): Json<CodeApprovalDecisionBody>,
 ) -> Result<impl IntoResponse, ServerError> {
     let decision = match body.decision {
-        CodeApprovalDecision::Approve => ApprovalDecision::Approve,
-        CodeApprovalDecision::Deny => ApprovalDecision::Deny {
+        CodeApprovalDecision::Approve => ApprovalDecisionRequest::Approve,
+        CodeApprovalDecision::Deny => ApprovalDecisionRequest::Deny {
+            feedback: body.feedback,
+        },
+        CodeApprovalDecision::ApproveWithGrant { grant_index } => {
+            ApprovalDecisionRequest::ApproveWithGrant { grant_index }
+        }
+        CodeApprovalDecision::Answers { answers } => ApprovalDecisionRequest::Answers { answers },
+        CodeApprovalDecision::PlanDecision { approve } => ApprovalDecisionRequest::PlanDecision {
+            approve,
             feedback: body.feedback,
         },
     };

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -2070,12 +2070,29 @@ pub struct CodeApprovalDecisionBody {
     pub feedback: Option<String>,
 }
 
-/// `approve` or `deny`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, TS)]
+/// The decision on one approval.
+///
+/// The richer variants are capability-gated: the server refuses them for an
+/// engine whose capability vector does not declare the channel, and a grant
+/// is named by its index into the rungs the approval's own kind offered —
+/// a client can pick a rung the card showed, never invent a scope.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum CodeApprovalDecision {
     Approve,
     Deny,
+    ApproveWithGrant {
+        /// Index into the approval kind's `offered_grants`, narrowest first.
+        grant_index: u32,
+    },
+    Answers {
+        /// Answers to a questions approval, validated server-side.
+        answers: Vec<tidebreak_core::UserQuestionAnswer>,
+    },
+    PlanDecision {
+        /// Whether the proposed plan is accepted.
+        approve: bool,
+    },
 }
 
 /// Query for `POST /code/harnesses/{kind}/install`.

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -858,6 +858,7 @@ fn apply_scripted_writes(worktree: &Path, writes: &[ScriptedWrite]) -> Result<()
 /// Object form of [`SCRIPT_VAR`]: events plus optional delay, writes, and
 /// approval-channel flags. A bare JSON array of [`HarnessEvent`]s is also
 /// accepted so a short successful turn stays one line.
+#[cfg_attr(test, allow(dead_code))]
 #[derive(Debug, Deserialize)]
 struct ScriptedHarnessScript {
     events: Vec<HarnessEvent>,
@@ -876,6 +877,7 @@ struct ScriptedHarnessScript {
 /// A malformed script is an error rather than a silent fall-through to the
 /// real engines: a CLI e2e whose script did not parse would otherwise try to
 /// install pinned harness binaries.
+#[cfg_attr(test, allow(dead_code))]
 pub(crate) fn adapter_from_env() -> Result<Option<ScriptedAdapter>> {
     let Ok(script) = std::env::var(SCRIPT_VAR) else {
         return Ok(None);
@@ -905,6 +907,7 @@ pub(crate) fn adapter_from_env() -> Result<Option<ScriptedAdapter>> {
 /// Install the env-driven scripted engine in place of the matching built-in,
 /// so a spawned `tidebreak serve` can drive code-mode turns without a real
 /// harness binary.
+#[cfg_attr(test, allow(dead_code))]
 pub(crate) fn install_from_env(registry: &mut AdapterRegistry) -> Result<()> {
     if let Some(adapter) = adapter_from_env()? {
         registry.register(Arc::new(adapter));
@@ -912,6 +915,7 @@ pub(crate) fn install_from_env(registry: &mut AdapterRegistry) -> Result<()> {
     Ok(())
 }
 
+#[cfg_attr(test, allow(dead_code))]
 fn parse_script(script: &str) -> std::result::Result<ScriptedHarnessScript, serde_json::Error> {
     if let Ok(events) = serde_json::from_str::<Vec<HarnessEvent>>(script) {
         return Ok(ScriptedHarnessScript {
@@ -1020,7 +1024,7 @@ mod tests {
             2,
             "checkpoint-1",
             ParkWait::Approval {
-                approval_id: "approval-9".into(),
+                call_id: "call-9".into(),
             },
         );
         let sink = Arc::new(CollectingSink::default());
@@ -1041,7 +1045,7 @@ mod tests {
         assert_eq!(
             waiting_on,
             ParkWait::Approval {
-                approval_id: "approval-9".into()
+                call_id: "call-9".into()
             }
         );
         assert_eq!(sink.events.lock().unwrap().len(), 2, "prefix only");
@@ -1050,7 +1054,7 @@ mod tests {
             .resume_turn(
                 park_ref,
                 ResumeInput::ApprovalDecided {
-                    approval_id: "approval-9".into(),
+                    call_id: "call-9".into(),
                     decision: ApprovalDecision::Approve,
                 },
             )

--- a/crates/tidebreak-server/src/tests/code_pr_facts.rs
+++ b/crates/tidebreak-server/src/tests/code_pr_facts.rs
@@ -208,6 +208,8 @@ async fn seeded(
             rewrite: None,
             started_at: chrono::Utc::now(),
             ended_at: Some(chrono::Utc::now()),
+            park_ref: None,
+            park_wait: None,
         },
     )
     .await

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -867,9 +867,26 @@ export type CodeAnalyticsSnapshot = { range: CodeAnalyticsRange, from?: string, 
 export type CodeAnalyticsTotals = { sessions: number, turns: number, completed_turns: number, failed_turns: number, interrupted_turns: number, running_turns: number, input_tokens: number, output_tokens: number, cache_read_tokens: number, cache_write_tokens: number, total_tokens: number, estimated_cost_microusd: number, pull_requests_opened: number, pull_requests_merged: number, };
 
 /**
- * `approve` or `deny`.
+ * The decision on one approval.
+ *
+ * The richer variants are capability-gated: the server refuses them for an
+ * engine whose capability vector does not declare the channel, and a grant
+ * is named by its index into the rungs the approval's own kind offered —
+ * a client can pick a rung the card showed, never invent a scope.
  */
-export type CodeApprovalDecision = "approve" | "deny";
+export type CodeApprovalDecision = "approve" | "deny" | { "approve_with_grant": {
+/**
+ * Index into the approval kind's `offered_grants`, narrowest first.
+ */
+grant_index: number, } } | { "answers": {
+/**
+ * Answers to a questions approval, validated server-side.
+ */
+answers: Array<UserQuestionAnswer>, } } | { "plan_decision": {
+/**
+ * Whether the proposed plan is accepted.
+ */
+approve: boolean, } };
 
 /**
  * Body of `POST /code/approvals/{id}/decision`.
@@ -1793,7 +1810,7 @@ rewrite?: string, };
 /**
  * Status of one user→engine turn.
  */
-export type CodeTurnStatus = "running" | "completed" | "failed" | "interrupted";
+export type CodeTurnStatus = "running" | "waiting" | "completed" | "failed" | "interrupted";
 
 /**
  * One unsequenced notice on `WS /code/updates`.

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -1552,10 +1552,13 @@ export type CodePrMergeMethod = "squash" | "merge" | "rebase";
 /**
  * How strongly a workspace is tied to a pull request (decision 77).
  *
- * Only two acts mint attribution: `gh pr create` (authored) and a push whose
- * branch is or becomes a pull request's head (contributed). Reading,
- * checking out, commenting on, closing, or merging a pull request never
- * does, so review and triage agents stay out of the attributed set.
+ * `gh pr create` mints authored attribution. A push whose branch is or
+ * becomes a pull request's head mints contributed attribution. A changed,
+ * clean workspace checkout also mints contributed attribution when it remains
+ * on the workspace branch and its current commit exactly matches an open pull
+ * request head. Reading, checking out, commenting on, closing, or merging a
+ * pull request never does, so review and triage agents stay out of the
+ * attributed set.
  */
 export type CodePullRequestRelation = "authored" | "contributed";
 

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -400,7 +400,7 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
     !nonEmpty(turn.id) ||
     !nonEmpty(turn.session_id) ||
     !finiteNumber(turn.ordinal) ||
-    !["running", "completed", "failed", "interrupted"].includes(
+    !["running", "waiting", "completed", "failed", "interrupted"].includes(
       String(turn.status),
     ) ||
     !optionalString(turn.model) ||

--- a/mobile/src/lib/transcript.ts
+++ b/mobile/src/lib/transcript.ts
@@ -57,7 +57,9 @@ export function hydrateTurnHistory(
   }
   const running = [...turns]
     .sort((left, right) => right.ordinal - left.ordinal)
-    .find((turn) => turn.status === "running");
+    .find(
+      (turn) => turn.status === "running" || turn.status === "waiting",
+    );
   return {
     ...state,
     // The row request and event replay race. Once any replayed event has


### PR DESCRIPTION
## What

Second slice of #2313 (decision 48 step 5): the session worker learns durable
parks and the routes learn rich decisions.

- A turn whose engine returns `TurnOutcome::Parked` persists as a new
  `waiting` status with the engine's `park_ref` and a typed `park_wait`
  (approval by engine call id, client tool call, or agent runs). The worker
  releases the leg, then resumes through `resume_turn` when the awaited
  decision arrives; a resumed turn may park again. Interrupt closes a parked
  turn cleanly.
- `POST /code/approvals/{id}/decision` accepts `approve_with_grant`
  (resolves `grant_index` against the approval's offered scopes — clients
  never name scopes), `answers` (validated against the question shape), and
  `plan_decision`. Each is gated on the engine's declared capability and the
  approval's structured kind; bare `approve` is refused on questions and
  plans.
- Migration `m20260901_000001_code_turn_park` widens the `code_turn` status
  check to admit `waiting` and adds the park columns. SQLite takes a table
  rebuild (the check is anonymous); PostgreSQL swaps the constraint in
  place. The v0.60 upgrade test now asserts a seeded turn row survives the
  rebuild.
- Recovery closes a dead worker's `waiting` turn as interrupted; engines
  resume from their own durable state until slice C gives the internal
  engine real recovery.
- Desktop and mobile treat `waiting` as an open turn: the session stays
  busy, no boundary renders, and the pending approval card is the call to
  action.

## Deferred

The plan-approval → `set_permission_mode` follow-up lands with the internal
engine in slice C, where the first engine that can propose a plan arrives.

Part of #2313 / epic #2311.
