### PR TITLE
refactor(server): share one lane-loop driver across workers

### DIFF
--- a/crates/tidebreak-server/src/blob_retirement_worker.rs
+++ b/crates/tidebreak-server/src/blob_retirement_worker.rs
@@ -9,7 +9,8 @@ use tidebreak_core::{AgentError, BlobRetirement, BlobRetirementStatus, BlobStore
 use tokio::sync::Notify;
 use uuid::Uuid;
 
-use crate::retry::{LaneBackoff, RetryAttempt, RetrySchedule};
+use crate::lane::{self, LaneOutcome, LanePacing, LaneStep};
+use crate::retry::{RetryAttempt, RetrySchedule};
 use crate::state::BlobWriteGuard;
 
 #[derive(Debug, Clone, Copy)]
@@ -59,6 +60,15 @@ pub(crate) enum BlobRetirementWorkerOutcome {
     LeaseLost(Uuid),
 }
 
+impl LaneOutcome for BlobRetirementWorkerOutcome {
+    fn lane_step(&self) -> LaneStep {
+        match self {
+            Self::Idle => LaneStep::Idle,
+            _ => LaneStep::Worked,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct BlobRetirementWorker {
     store: Arc<dyn Store>,
@@ -94,33 +104,17 @@ impl BlobRetirementWorker {
     }
 
     pub(crate) async fn run(self) {
-        let mut idle_delay = self.config.idle_min;
-        let mut failure_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        loop {
-            match self.run_once().await {
-                Ok(BlobRetirementWorkerOutcome::Idle) => {
-                    failure_backoff.reset();
-                    tokio::select! {
-                        _ = tokio::time::sleep(idle_delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
-                }
-                Ok(_) => {
-                    failure_backoff.reset();
-                    idle_delay = self.config.idle_min;
-                }
-                Err(error) => {
-                    tracing::warn!("tidebreak: blob retirement worker iteration failed: {error}");
-                    let delay = failure_backoff.next_delay();
-                    tokio::select! {
-                        _ = tokio::time::sleep(delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                }
-            }
-        }
+        let pacing = LanePacing::backoff(
+            self.config.idle_min,
+            self.config.idle_cap,
+            self.config.failure_delay,
+            self.config.failure_delay_cap,
+        );
+        let this = &self;
+        lane::run_lane("blob retirement worker", pacing, &self.wake, move || {
+            this.run_once()
+        })
+        .await;
     }
 
     pub(crate) async fn run_once(&self) -> Result<BlobRetirementWorkerOutcome> {

--- a/crates/tidebreak-server/src/lane.rs
+++ b/crates/tidebreak-server/src/lane.rs
@@ -1,0 +1,288 @@
+//! The lane loop every durable worker runs.
+//!
+//! A worker lane claims one item, works it, and goes back for the next. The
+//! scaffolding around that — how long to sleep when the queue is empty, how
+//! to back off when the store is struggling, how a wake signal cuts a sleep
+//! short, and how a lane that panics is put back — is the same for every
+//! worker. It lives here once so a fix to lane pacing or restart is one edit,
+//! and each worker keeps only its `run_once`.
+
+use std::future::Future;
+use std::time::Duration;
+
+use tidebreak_core::Result;
+use tokio::sync::Notify;
+
+use crate::retry::LaneBackoff;
+
+/// What one lane iteration did, as far as pacing is concerned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LaneStep {
+    /// Nothing was claimable. The lane sleeps, doubling its wait each time
+    /// until the cap, and a wake signal ends the sleep early.
+    Idle,
+    /// An item was worked. The lane goes straight back for the next one and
+    /// its idle wait returns to the minimum.
+    Worked,
+}
+
+/// A worker outcome the lane loop can pace on.
+pub(crate) trait LaneOutcome {
+    fn lane_step(&self) -> LaneStep;
+}
+
+impl LaneOutcome for bool {
+    /// `true` means an item was worked.
+    fn lane_step(&self) -> LaneStep {
+        if *self {
+            LaneStep::Worked
+        } else {
+            LaneStep::Idle
+        }
+    }
+}
+
+impl LaneOutcome for LaneStep {
+    fn lane_step(&self) -> LaneStep {
+        *self
+    }
+}
+
+/// How long a lane waits after an iteration error.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FailureWait {
+    /// The same wait after every failure.
+    Fixed(Duration),
+    /// [`LaneBackoff`]: doubled per consecutive failure up to `cap`, jittered,
+    /// and reset by one successful iteration.
+    Backoff { initial: Duration, cap: Duration },
+}
+
+/// The sleeps a lane takes between iterations.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LanePacing {
+    /// First idle wait, and the wait after any worked item.
+    pub(crate) idle_min: Duration,
+    /// Ceiling on the doubled idle wait.
+    pub(crate) idle_cap: Duration,
+    pub(crate) failure: FailureWait,
+}
+
+impl LanePacing {
+    /// Pacing whose failure wait is a [`LaneBackoff`] between `failure_delay`
+    /// and `failure_delay_cap` — the shape every durable worker config has.
+    pub(crate) const fn backoff(
+        idle_min: Duration,
+        idle_cap: Duration,
+        failure_delay: Duration,
+        failure_delay_cap: Duration,
+    ) -> Self {
+        Self {
+            idle_min,
+            idle_cap,
+            failure: FailureWait::Backoff {
+                initial: failure_delay,
+                cap: failure_delay_cap,
+            },
+        }
+    }
+}
+
+/// The idle wait of one lane: starts at the minimum, doubles per idle
+/// iteration up to the cap, and returns to the minimum whenever work appears.
+#[derive(Debug, Clone)]
+pub(crate) struct IdleDelay {
+    current: Duration,
+    min: Duration,
+    cap: Duration,
+}
+
+impl IdleDelay {
+    pub(crate) fn new(min: Duration, cap: Duration) -> Self {
+        Self {
+            current: min,
+            min,
+            cap,
+        }
+    }
+
+    /// The wait for the next idle sleep.
+    pub(crate) fn current(&self) -> Duration {
+        self.current
+    }
+
+    /// Work appeared: the next idle sleep is the minimum again.
+    pub(crate) fn reset(&mut self) {
+        self.current = self.min;
+    }
+
+    /// Another idle iteration: wait twice as long next time, up to the cap.
+    pub(crate) fn grow(&mut self) {
+        self.current = self.current.saturating_mul(2).min(self.cap);
+    }
+}
+
+enum FailureState {
+    Fixed(Duration),
+    Backoff(LaneBackoff),
+}
+
+impl FailureState {
+    fn new(wait: FailureWait) -> Self {
+        match wait {
+            FailureWait::Fixed(delay) => Self::Fixed(delay),
+            FailureWait::Backoff { initial, cap } => Self::Backoff(LaneBackoff::new(initial, cap)),
+        }
+    }
+
+    fn reset(&mut self) {
+        if let Self::Backoff(backoff) = self {
+            backoff.reset();
+        }
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        match self {
+            Self::Fixed(delay) => *delay,
+            Self::Backoff(backoff) => backoff.next_delay(),
+        }
+    }
+}
+
+/// Run one lane forever.
+///
+/// `run_once` claims and works at most one item. An idle iteration sleeps
+/// the current idle wait, then doubles it; a worked item resets the idle wait
+/// and the failure backoff; an error logs under `name` and sleeps the failure
+/// wait. Every sleep ends early when `wake` is notified, so a producer that
+/// just enqueued work never waits out a lane's idle cap.
+pub(crate) async fn run_lane<O, F, Fut>(
+    name: &'static str,
+    pacing: LanePacing,
+    wake: &Notify,
+    mut run_once: F,
+) where
+    O: LaneOutcome,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<O>>,
+{
+    let mut idle = IdleDelay::new(pacing.idle_min, pacing.idle_cap);
+    let mut failure = FailureState::new(pacing.failure);
+    loop {
+        match run_once().await {
+            Ok(outcome) => match outcome.lane_step() {
+                LaneStep::Idle => {
+                    failure.reset();
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle.current()) => {}
+                        _ = wake.notified() => {}
+                    }
+                    idle.grow();
+                }
+                LaneStep::Worked => {
+                    failure.reset();
+                    idle.reset();
+                }
+            },
+            Err(error) => {
+                tracing::warn!("tidebreak: {name} iteration failed: {error}");
+                let delay = failure.next_delay();
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = wake.notified() => {}
+                }
+            }
+        }
+    }
+}
+
+/// Keep `count` lanes running until the caller drops this future.
+///
+/// A lane only ever returns by panicking, since [`run_lane`] loops forever.
+/// The panic is logged under `name` and the lane respawned after `restart`'s
+/// next wait, so a lane that panics on every iteration does not spin. Dropping
+/// the future drops the [`tokio::task::JoinSet`] and aborts every lane rather
+/// than detaching background work.
+pub(crate) async fn supervise_lanes<F, Fut>(
+    name: &'static str,
+    count: usize,
+    mut restart: LaneBackoff,
+    mut lane: F,
+) where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let mut lanes = tokio::task::JoinSet::new();
+    for _ in 0..count {
+        lanes.spawn(lane());
+    }
+    while let Some(result) = lanes.join_next().await {
+        if let Err(error) = result {
+            tracing::error!("tidebreak: {name} lane stopped: {error}");
+            tokio::time::sleep(restart.next_delay()).await;
+        }
+        lanes.spawn(lane());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::sync::Arc;
+
+    use super::*;
+
+    /// The pacing contract the workers lost their own copies of: an idle lane
+    /// doubles its wait up to the cap, one worked item drops it back to the
+    /// minimum, and a wake ends an idle sleep at once instead of after the
+    /// current wait.
+    #[tokio::test(start_paused = true)]
+    async fn idle_wait_doubles_resets_on_work_and_yields_to_wake() {
+        let pacing = LanePacing::backoff(
+            Duration::from_millis(100),
+            Duration::from_millis(400),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        );
+        let wake = Arc::new(Notify::new());
+        // Idle five times (100, 200, 400, 400, then a woken sleep), work
+        // once, idle twice more, then hang so the loop stops iterating.
+        let script = RefCell::new(
+            vec![
+                LaneStep::Idle,
+                LaneStep::Idle,
+                LaneStep::Idle,
+                LaneStep::Idle,
+                LaneStep::Idle,
+                LaneStep::Worked,
+                LaneStep::Idle,
+                LaneStep::Idle,
+            ]
+            .into_iter(),
+        );
+        let started = tokio::time::Instant::now();
+        let calls = RefCell::new(Vec::new());
+        let waker = wake.clone();
+        let lane = run_lane("test worker", pacing, &wake, || {
+            let step = script.borrow_mut().next();
+            calls.borrow_mut().push(started.elapsed());
+            // Arm the wake while the fifth idle sleep is pending, so that
+            // sleep ends at once instead of after its 400ms wait.
+            if calls.borrow().len() == 5 {
+                waker.notify_one();
+            }
+            async move {
+                match step {
+                    Some(step) => Ok(step),
+                    None => std::future::pending().await,
+                }
+            }
+        });
+        let _ = tokio::time::timeout(Duration::from_secs(10), lane).await;
+
+        let ms: Vec<u128> = calls.borrow().iter().map(|d| d.as_millis()).collect();
+        // 0 → +100 → +200 → +400 (cap) → +400 → woken at once → worked, no
+        // sleep → +100 (reset) → +200.
+        assert_eq!(ms, vec![0, 100, 300, 700, 1100, 1100, 1100, 1200, 1400]);
+    }
+}

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -47,6 +47,7 @@ mod foreground_prompt;
 mod gateway_drafts;
 mod gateway_runtime;
 pub mod host_folders;
+mod lane;
 /// Per-launch `{data_dir}/listen.json` so a CLI can attach without argv tokens.
 pub mod listen_endpoint;
 pub mod logging;

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/config.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/config.rs
@@ -13,6 +13,7 @@ use tokio::sync::Notify;
 use crate::bus::EventBus;
 use crate::code_execution::ConfiguredExecProvider;
 use crate::foreground_prompt::skill_summary_catalog_lines;
+use crate::lane::{LaneOutcome, LaneStep};
 use crate::resolver::ProviderResolver;
 use crate::retry::RetrySchedule;
 use crate::state::SandboxAttemptGuard;
@@ -201,6 +202,15 @@ pub(crate) enum SandboxAgentRunWorkerOutcome {
     ParentWaitSetResumed(tidebreak_core::CallId),
     ToolCheckpointed(tidebreak_core::CallId),
     LeaseLost(tidebreak_core::AgentRunId),
+}
+
+impl LaneOutcome for SandboxAgentRunWorkerOutcome {
+    fn lane_step(&self) -> LaneStep {
+        match self {
+            Self::Idle => LaneStep::Idle,
+            _ => LaneStep::Worked,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
@@ -18,12 +18,16 @@ use tidebreak_core::{
 use tokio::sync::Notify;
 
 use crate::bus::EventBus;
+use crate::lane::{self, LanePacing};
 use crate::resolver::ProviderResolver;
 use crate::retry::{LaneBackoff, RetryAttempt};
 use crate::state::SandboxAttemptGuard;
 
 use super::config::*;
 use super::model_step::*;
+
+/// The name this worker's lanes log under.
+const LANE_NAME: &str = "sandbox agent worker";
 
 /// The receipt code the plan reminder writes, and the exact marker that says a
 /// run has already had its one push-back.
@@ -125,49 +129,30 @@ impl SandboxAgentRunWorker {
     }
 
     pub(crate) async fn run(self) {
-        let mut lanes = tokio::task::JoinSet::new();
-        for _ in 0..self.config.max_concurrency {
-            lanes.spawn(self.clone().run_lane());
-        }
-        let mut restart_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        while let Some(result) = lanes.join_next().await {
-            if let Err(error) = result {
-                tracing::error!("tidebreak: sandbox agent worker lane stopped: {error}");
-                tokio::time::sleep(restart_backoff.next_delay()).await;
-            }
-            lanes.spawn(self.clone().run_lane());
-        }
+        lane::supervise_lanes(
+            LANE_NAME,
+            self.config.max_concurrency,
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap),
+            move || self.clone().run_lane(),
+        )
+        .await;
     }
 
     async fn run_lane(self) {
-        let mut idle_delay = self.config.idle_min;
-        let mut failure_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        loop {
-            match self.run_once().await {
-                Ok(SandboxAgentRunWorkerOutcome::Idle) => {
-                    failure_backoff.reset();
-                    tokio::select! {
-                        _ = tokio::time::sleep(idle_delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
-                }
-                Ok(_) => {
-                    failure_backoff.reset();
-                    idle_delay = self.config.idle_min;
-                }
-                Err(error) => {
-                    tracing::warn!("tidebreak: sandbox agent worker iteration failed: {error}");
-                    let delay = failure_backoff.next_delay();
-                    tokio::select! {
-                        _ = tokio::time::sleep(delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                }
-            }
-        }
+        let this = &self;
+        lane::run_lane(LANE_NAME, self.pacing(), &self.wake, move || {
+            this.run_once()
+        })
+        .await;
+    }
+
+    fn pacing(&self) -> LanePacing {
+        LanePacing::backoff(
+            self.config.idle_min,
+            self.config.idle_cap,
+            self.config.failure_delay,
+            self.config.failure_delay_cap,
+        )
     }
 
     /// Claim and execute one sandbox run. It is exposed inside the server crate

--- a/crates/tidebreak-server/src/sandbox_container_run_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run_worker.rs
@@ -11,6 +11,7 @@ use tidebreak_core::{Result, Store};
 use tidebreak_sandbox_protocol::SandboxBackend;
 use tokio::sync::Notify;
 
+use crate::lane::{self, FailureWait, LanePacing};
 use crate::resolver::ProviderResolver;
 use crate::sandbox_container_run::{SandboxContainerRunConfig, SandboxContainerRunner};
 use crate::state::SandboxSteerGuard;
@@ -109,26 +110,18 @@ impl SandboxContainerRunWorker {
     }
 
     async fn run_drive_lane(self) {
-        let mut idle_delay = self.config.idle_min;
-        loop {
-            match self.drive_one().await {
-                Ok(true) => idle_delay = self.config.idle_min,
-                Ok(false) => {
-                    tokio::select! {
-                        _ = tokio::time::sleep(idle_delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
-                }
-                Err(error) => {
-                    tracing::warn!("tidebreak: container worker iteration failed: {error}");
-                    tokio::select! {
-                        _ = tokio::time::sleep(self.config.failure_delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                }
-            }
-        }
+        let pacing = LanePacing {
+            idle_min: self.config.idle_min,
+            idle_cap: self.config.idle_cap,
+            // A struggling store gets the same flat wait every time here; this
+            // worker has no failure cap to grow toward.
+            failure: FailureWait::Fixed(self.config.failure_delay),
+        };
+        let this = &self;
+        lane::run_lane("container worker", pacing, &self.wake, move || {
+            this.drive_one()
+        })
+        .await;
     }
 
     async fn drive_one(&self) -> Result<bool> {

--- a/crates/tidebreak-server/src/sandbox_exec_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_exec_worker.rs
@@ -23,6 +23,7 @@ use tidebreak_core::{
 use tokio::sync::Notify;
 
 use crate::code_execution::ConfiguredExecProvider;
+use crate::lane::{self, LaneOutcome, LanePacing, LaneStep};
 use crate::retry::LaneBackoff;
 use crate::state::SandboxAttemptGuard;
 
@@ -186,6 +187,18 @@ pub(crate) enum SandboxExecWorkerOutcome {
     LeaseLost(CallId),
 }
 
+impl LaneOutcome for SandboxExecWorkerOutcome {
+    fn lane_step(&self) -> LaneStep {
+        match self {
+            Self::Idle => LaneStep::Idle,
+            _ => LaneStep::Worked,
+        }
+    }
+}
+
+/// The name this worker's lanes log under.
+const LANE_NAME: &str = "sandbox exec worker";
+
 #[derive(Clone)]
 pub(crate) struct SandboxExecWorker {
     store: Arc<dyn Store>,
@@ -248,49 +261,30 @@ impl SandboxExecWorker {
     }
 
     pub(crate) async fn run(self) {
-        let mut lanes = tokio::task::JoinSet::new();
-        for _ in 0..self.config.max_concurrency {
-            lanes.spawn(self.clone().run_lane());
-        }
-        let mut restart_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        while let Some(result) = lanes.join_next().await {
-            if let Err(error) = result {
-                tracing::error!("tidebreak: sandbox exec worker lane stopped: {error}");
-                tokio::time::sleep(restart_backoff.next_delay()).await;
-            }
-            lanes.spawn(self.clone().run_lane());
-        }
+        lane::supervise_lanes(
+            LANE_NAME,
+            self.config.max_concurrency,
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap),
+            move || self.clone().run_lane(),
+        )
+        .await;
     }
 
     async fn run_lane(self) {
-        let mut idle_delay = self.config.idle_min;
-        let mut failure_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        loop {
-            match self.run_once().await {
-                Ok(SandboxExecWorkerOutcome::Idle) => {
-                    failure_backoff.reset();
-                    tokio::select! {
-                        _ = tokio::time::sleep(idle_delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
-                }
-                Ok(_) => {
-                    failure_backoff.reset();
-                    idle_delay = self.config.idle_min;
-                }
-                Err(error) => {
-                    tracing::warn!("tidebreak: sandbox exec worker iteration failed: {error}");
-                    let delay = failure_backoff.next_delay();
-                    tokio::select! {
-                        _ = tokio::time::sleep(delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                }
-            }
-        }
+        let this = &self;
+        lane::run_lane(LANE_NAME, self.pacing(), &self.wake, move || {
+            this.run_once()
+        })
+        .await;
+    }
+
+    fn pacing(&self) -> LanePacing {
+        LanePacing::backoff(
+            self.config.idle_min,
+            self.config.idle_cap,
+            self.config.failure_delay,
+            self.config.failure_delay_cap,
+        )
     }
 
     /// Claim and resolve one exact persisted exec checkpoint.

--- a/crates/tidebreak-server/src/sandbox_task_plan_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_task_plan_worker.rs
@@ -20,6 +20,7 @@ use tidebreak_core::{
 };
 use tokio::sync::Notify;
 
+use crate::lane::{self, LaneOutcome, LanePacing, LaneStep};
 use crate::retry::LaneBackoff;
 
 const CANDIDATE_BATCH_SIZE: u64 = 16;
@@ -56,6 +57,18 @@ pub(crate) enum SandboxTaskPlanWorkerOutcome {
     LeaseLost(tidebreak_core::CallId),
 }
 
+impl LaneOutcome for SandboxTaskPlanWorkerOutcome {
+    fn lane_step(&self) -> LaneStep {
+        match self {
+            Self::Idle => LaneStep::Idle,
+            _ => LaneStep::Worked,
+        }
+    }
+}
+
+/// The name this worker's lanes log under.
+const LANE_NAME: &str = "sandbox task-plan worker";
+
 #[derive(Clone)]
 pub(crate) struct SandboxTaskPlanWorker {
     store: Arc<dyn Store>,
@@ -79,49 +92,30 @@ impl SandboxTaskPlanWorker {
     }
 
     pub(crate) async fn run(self) {
-        let mut lanes = tokio::task::JoinSet::new();
-        for _ in 0..self.config.max_concurrency {
-            lanes.spawn(self.clone().run_lane());
-        }
-        let mut restart_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        while let Some(result) = lanes.join_next().await {
-            if let Err(error) = result {
-                tracing::error!("tidebreak: sandbox task-plan worker lane stopped: {error}");
-                tokio::time::sleep(restart_backoff.next_delay()).await;
-            }
-            lanes.spawn(self.clone().run_lane());
-        }
+        lane::supervise_lanes(
+            LANE_NAME,
+            self.config.max_concurrency,
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap),
+            move || self.clone().run_lane(),
+        )
+        .await;
     }
 
     async fn run_lane(self) {
-        let mut idle_delay = self.config.idle_min;
-        let mut failure_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        loop {
-            match self.run_once().await {
-                Ok(SandboxTaskPlanWorkerOutcome::Idle) => {
-                    failure_backoff.reset();
-                    tokio::select! {
-                        _ = tokio::time::sleep(idle_delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
-                }
-                Ok(_) => {
-                    failure_backoff.reset();
-                    idle_delay = self.config.idle_min;
-                }
-                Err(error) => {
-                    tracing::warn!("tidebreak: sandbox task-plan worker iteration failed: {error}");
-                    let delay = failure_backoff.next_delay();
-                    tokio::select! {
-                        _ = tokio::time::sleep(delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                }
-            }
-        }
+        let this = &self;
+        lane::run_lane(LANE_NAME, self.pacing(), &self.wake, move || {
+            this.run_once()
+        })
+        .await;
+    }
+
+    fn pacing(&self) -> LanePacing {
+        LanePacing::backoff(
+            self.config.idle_min,
+            self.config.idle_cap,
+            self.config.failure_delay,
+            self.config.failure_delay_cap,
+        )
     }
 
     /// Claim and resolve one exact persisted plan checkpoint.

--- a/crates/tidebreak-server/src/sandbox_web_search_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_web_search_worker.rs
@@ -20,6 +20,7 @@ use tidebreak_core::{
 };
 use tokio::sync::Notify;
 
+use crate::lane::{self, LaneOutcome, LanePacing, LaneStep};
 use crate::retry::LaneBackoff;
 use crate::state::SandboxAttemptGuard;
 use crate::web_search;
@@ -119,6 +120,18 @@ pub(crate) enum SandboxWebSearchWorkerOutcome {
     LeaseLost(tidebreak_core::CallId),
 }
 
+impl LaneOutcome for SandboxWebSearchWorkerOutcome {
+    fn lane_step(&self) -> LaneStep {
+        match self {
+            Self::Idle => LaneStep::Idle,
+            _ => LaneStep::Worked,
+        }
+    }
+}
+
+/// The name this worker's lanes log under.
+const LANE_NAME: &str = "sandbox web-search worker";
+
 #[derive(Clone)]
 pub(crate) struct SandboxWebSearchWorker {
     store: Arc<dyn Store>,
@@ -187,51 +200,30 @@ impl SandboxWebSearchWorker {
     }
 
     pub(crate) async fn run(self) {
-        let mut lanes = tokio::task::JoinSet::new();
-        for _ in 0..self.config.max_concurrency {
-            lanes.spawn(self.clone().run_lane());
-        }
-        let mut restart_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        while let Some(result) = lanes.join_next().await {
-            if let Err(error) = result {
-                tracing::error!("tidebreak: sandbox web-search worker lane stopped: {error}");
-                tokio::time::sleep(restart_backoff.next_delay()).await;
-            }
-            lanes.spawn(self.clone().run_lane());
-        }
+        lane::supervise_lanes(
+            LANE_NAME,
+            self.config.max_concurrency,
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap),
+            move || self.clone().run_lane(),
+        )
+        .await;
     }
 
     async fn run_lane(self) {
-        let mut idle_delay = self.config.idle_min;
-        let mut failure_backoff =
-            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
-        loop {
-            match self.run_once().await {
-                Ok(SandboxWebSearchWorkerOutcome::Idle) => {
-                    failure_backoff.reset();
-                    tokio::select! {
-                        _ = tokio::time::sleep(idle_delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
-                }
-                Ok(_) => {
-                    failure_backoff.reset();
-                    idle_delay = self.config.idle_min;
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        "tidebreak: sandbox web-search worker iteration failed: {error}"
-                    );
-                    let delay = failure_backoff.next_delay();
-                    tokio::select! {
-                        _ = tokio::time::sleep(delay) => {}
-                        _ = self.wake.notified() => {}
-                    }
-                }
-            }
-        }
+        let this = &self;
+        lane::run_lane(LANE_NAME, self.pacing(), &self.wake, move || {
+            this.run_once()
+        })
+        .await;
+    }
+
+    fn pacing(&self) -> LanePacing {
+        LanePacing::backoff(
+            self.config.idle_min,
+            self.config.idle_cap,
+            self.config.failure_delay,
+            self.config.failure_delay_cap,
+        )
     }
 
     /// Claim and resolve one exact persisted sandbox tool checkpoint.

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -39,6 +39,7 @@ use crate::approvals::ApprovalBroker;
 use crate::bus::EventBus;
 use crate::chat_titling::ChatTitler;
 use crate::exec_write_snapshot::TurnScratchJournal;
+use crate::lane::IdleDelay;
 use crate::mcp_config::McpRuntime;
 use crate::resolver::ProviderResolver;
 use crate::retry::{LaneBackoff, RetryAttempt, RetrySchedule};
@@ -576,7 +577,7 @@ impl TurnWorker {
 
     pub(crate) async fn run(self) {
         let mut turns = tokio::task::JoinSet::new();
-        let mut idle_delay = self.config.idle_min;
+        let mut idle_delay = IdleDelay::new(self.config.idle_min, self.config.idle_cap);
         let mut failure_backoff =
             LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         let mut pending_claim_token = None;
@@ -596,7 +597,7 @@ impl TurnWorker {
                 if let Some(quiesce) = &self.quiesce {
                     let _ = quiesce.drained.send(false);
                 }
-                idle_delay = self.config.idle_min;
+                idle_delay.reset();
                 continue;
             }
             let mut scan_failed = false;
@@ -623,11 +624,11 @@ impl TurnWorker {
                             let _entry = entry;
                             worker.process(*turn, lease_token).await
                         });
-                        idle_delay = self.config.idle_min;
+                        idle_delay.reset();
                     }
                     Ok(ClaimAction::Terminalized) => {
                         pending_claim_token = None;
-                        idle_delay = self.config.idle_min;
+                        idle_delay.reset();
                     }
                     Ok(ClaimAction::Idle) => {
                         pending_claim_token = None;
@@ -653,7 +654,7 @@ impl TurnWorker {
                     }
                     _ = Self::quiesce_flipped(quiesce_request.as_mut()) => {}
                 }
-                idle_delay = self.config.idle_min;
+                idle_delay.reset();
                 continue;
             }
 
@@ -661,25 +662,25 @@ impl TurnWorker {
                 failure_backoff.next_delay()
             } else {
                 failure_backoff.reset();
-                idle_delay
+                idle_delay.current()
             };
             tokio::select! {
                 result = turns.join_next(), if !turns.is_empty() => {
                     if let Some(result) = result {
                         log_turn_result(result);
                     }
-                    idle_delay = self.config.idle_min;
+                    idle_delay.reset();
                 }
                 _ = tokio::time::sleep(delay) => {
                     if !scan_failed {
-                        idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
+                        idle_delay.grow();
                     }
                 }
                 _ = self.wake.notified() => {
-                    idle_delay = self.config.idle_min;
+                    idle_delay.reset();
                 }
                 _ = Self::quiesce_flipped(quiesce_request.as_mut()) => {
-                    idle_delay = self.config.idle_min;
+                    idle_delay.reset();
                 }
             }
         }


### PR DESCRIPTION
## Summary

Seven durable workers each carried a verbatim copy of the lane scaffold: spawn N lanes in a JoinSet, respawn a panicked lane after a backoff, sleep a doubling idle wait when the queue is empty, back off after an iteration error, and cut any sleep short on a wake signal. A fix to lane pacing or restart needed seven edits.

The scaffold now lives once in `crates/tidebreak-server/src/lane.rs`, next to the retry schedules it uses.

- `run_lane` takes a worker's `run_once` closure and paces on a `LaneOutcome` that each worker's outcome enum implements.
- `supervise_lanes` owns the JoinSet and restart backoff.
- The exec, web-search, task-plan, agent-run, and blob-retirement workers keep only their `run_once`.
- The container-run drive lane keeps its flat failure wait through `FailureWait::Fixed` rather than picking up jittered backoff it never had.
- The turn worker's claim loop is structurally different (it multiplexes a JoinSet of turns with quiesce), so it adopts only the shared `IdleDelay`, giving the doubling policy one owner.
- Log lines keep their existing per-worker names.

No behavior change is intended.

## Test

One test pins the pacing contract the workers no longer carry themselves: the idle wait doubles up to the cap, one worked item resets it, and a wake ends an idle sleep at once.

## Ran

- `cargo fmt -p tidebreak-server`
- `cargo check -p tidebreak-server --tests`
- `cargo test -p tidebreak-server --lib -- lane:: retry:: blob_retirement_worker:: sandbox_exec_worker:: sandbox_web_search_worker:: sandbox_task_plan_worker:: sandbox_container_run_worker:: sandbox_agent_run_worker::` — 63 passed
- `cargo clippy -p tidebreak-server --tests --no-deps -- -D warnings` — only the pre-existing `scripted-harness` feature-gated dead-code findings, untouched here

Closes #2952
