### PR TITLE
perf(desktop): drive UI refresh from push signals and pause polls when hidden

### DIFF
--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -3639,7 +3639,9 @@ const SAME_DOCUMENT_NAVIGATION_OBSERVER_SCRIPT: &str = r#"
   }
   addEventListener("popstate", capture, true);
   addEventListener("hashchange", capture, true);
-  state.interval = setInterval(capture, 100);
+  // The host reads (and captures) on its own cadence; this only catches a
+  // location change no listener saw, so it can be slow.
+  state.interval = setInterval(capture, 1000);
   addEventListener("pagehide", () => {
     state.cancelled = true;
     clearInterval(state.interval);
@@ -4740,7 +4742,7 @@ mod tests {
         assert!(script.contains("[\"pushState\", \"replaceState\"]"));
         assert!(script.contains("addEventListener(\"popstate\""));
         assert!(script.contains("addEventListener(\"hashchange\""));
-        assert!(script.contains("setInterval(capture, 100)"));
+        assert!(script.contains("setInterval(capture, 1000)"));
         assert!(script.contains("clearInterval(state.interval)"));
         assert!(!script.contains("__TAURI_INTERNALS__"));
         assert!(!script.contains("window.ipc"));

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -46,8 +46,15 @@ const MAX_BROWSER_URL_CHARS: usize = 8_192;
 const MAX_JS_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const AGENT_NAVIGATION_START_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const AGENT_NAVIGATION_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
+/// How often the host reads the in-page navigation observer while the tab is
+/// showing. The page captures `pushState` and friends the instant they happen;
+/// this is only the latency before the URL bar reflects it.
 const SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL: std::time::Duration =
-    std::time::Duration::from_millis(100);
+    std::time::Duration::from_millis(250);
+/// The cadence while the tab is hidden. Nothing shows the URL, so the read
+/// waits; a hidden tab only checks that it is still the same document.
+const SAME_DOCUMENT_NAVIGATION_HIDDEN_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(2);
 #[cfg(target_os = "macos")]
 const PROFILE_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 #[cfg(target_os = "macos")]
@@ -887,17 +894,24 @@ fn start_same_document_navigation_observer(
         let renderer_url = main.url().ok();
         let mut observer_installed = false;
         let mut last_sequence = None;
-        let mut interval = tokio::time::interval(SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut cadence = SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL;
 
         loop {
-            interval.tick().await;
+            tokio::time::sleep(cadence).await;
             let Ok(snapshot) = registry.snapshot(&browser_id, &workspace_id) else {
                 return;
             };
             if snapshot.document_epoch != Some(document_epoch) {
                 return;
             }
+            // A hidden tab shows no URL bar, so there is nothing to keep
+            // current; the page keeps capturing and the first visible read
+            // catches up on whatever moved.
+            if snapshot.visible == Some(false) {
+                cadence = SAME_DOCUMENT_NAVIGATION_HIDDEN_POLL_INTERVAL;
+                continue;
+            }
+            cadence = SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL;
 
             let observation = if observer_installed {
                 match browser_read_same_document_navigation_observer(&webview).await {

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -340,11 +340,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         warmPresentationConverter();
         return;
       case "turn_began":
+        signalRefresh("queuedTurns");
         signalTurnLifecycle(
           effect.startsDifferentTurn ? "began" : "began_same_turn",
         );
         return;
       case "turn_resolved":
+        signalRefresh("queuedTurns");
         signalTurnLifecycle("resolved");
         return;
       case "invalidate_terminal_hydration":
@@ -1150,6 +1152,7 @@ export async function queueComposerMessage(
     toast.error(friendlyErrorMessage(err, "Could not queue that message."));
     return;
   }
+  useRefreshSignals.getState().signal("queuedTurns");
   onQueued();
 }
 

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -151,7 +151,7 @@ describe("ManagedGate", () => {
 
     // The session watch notices the sign-out and lowers the gate again.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_100);
+      await vi.advanceTimersByTimeAsync(60_100);
     });
     expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
     expect(screen.queryByText("the open product")).not.toBeInTheDocument();
@@ -186,7 +186,7 @@ describe("ManagedGate", () => {
     expect(screen.getByText("policy: unmanaged")).toBeInTheDocument();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_100);
+      await vi.advanceTimersByTimeAsync(60_100);
     });
     await act(async () => {});
     expect(screen.getByText("policy: managed")).toBeInTheDocument();
@@ -214,7 +214,7 @@ describe("ManagedGate", () => {
     // Policy flips to managed with no session: the gate comes up on the same
     // watch tick rather than at the next launch.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_100);
+      await vi.advanceTimersByTimeAsync(60_100);
     });
     await act(async () => {});
     expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
@@ -456,7 +456,7 @@ describe("ManagedGate", () => {
 
     // The watch's next tick recovers the status and clears the stale error.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_100);
+      await vi.advanceTimersByTimeAsync(60_100);
     });
     expect(screen.queryByText(/503: starting/)).not.toBeInTheDocument();
     expect(screen.getByText("Sign in to continue")).toBeInTheDocument();

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
@@ -8,14 +8,17 @@ import { ManagedPolicyContext } from "./managedPolicy";
 import { onPairingChanged } from "./host";
 import { openInBrowser } from "./openInBrowser";
 import { disconnectRemoteMachine, remoteMachineState } from "./remoteMachine";
+import { useVisibilityGatedPoll } from "./useVisibilityGatedPoll";
 import { WindowDragStrip } from "./WindowDragStrip";
 
 /** While the browser flow is pending the exchange lands out of band, so the
  * poll is what turns the gate off. Matches the settings panel's cadence. */
 const PENDING_POLL_MS = 2_000;
 /** The session watch otherwise: signed in, it is what returns a signed-out
- * reader to the gate; signed out, it notices sign-ins completed elsewhere. */
-const SESSION_WATCH_MS = 5_000;
+ * reader to the gate; signed out, it notices sign-ins completed elsewhere.
+ * The shell's pairing nudge is the prompt path, so this is a safety net, and
+ * it pauses while the window is hidden. */
+const SESSION_WATCH_MS = 60_000;
 /** A policy read that hangs is a transport failure, not an answer. */
 const POLICY_TIMEOUT_MS = 5_000;
 const POLICY_RETRY_MIN_MS = 1_000;
@@ -208,8 +211,9 @@ export function ManagedGate({
   // app is running — an MDM push, or the deep-link pairing flow mid-session —
   // and until this the renderer went on presenting the whole open surface:
   // no sign-in gate, and Providers and MCP still editable against a server
-  // that had already started refusing them. `/policy` is a local read, so the
-  // session cadence is affordable.
+  // that had already started refusing them. `/policy` is a local read; the
+  // shell's pairing nudge below is the prompt path and this cadence is the
+  // net under it.
   const watching = policyState.kind === "resolved";
   const refreshPolicy = useCallback(() => {
     void client
@@ -230,11 +234,9 @@ export function ManagedGate({
         }
       });
   }, [client]);
-  useEffect(() => {
-    if (!watching) return;
-    const timer = window.setInterval(refreshPolicy, SESSION_WATCH_MS);
-    return () => window.clearInterval(timer);
-  }, [watching, refreshPolicy]);
+  useVisibilityGatedPoll(refreshPolicy, SESSION_WATCH_MS, {
+    enabled: watching,
+  });
 
   // The shell nudges when a provision link parks a pending pairing or a
   // confirmed re-pair replaces one; refetching now instead of on the next
@@ -269,17 +271,17 @@ export function ManagedGate({
   // fetch failed, the ticks are what recover from it. Each tick retries, and
   // a success clears any stale error. One timer covers both directions —
   // pending → signed in lifts the gate, a sign-out anywhere lowers it again.
+  // Hidden, it waits: the reader returning is what shows the gate, and the
+  // read on return is what it sees.
   const pendingFlow = status?.sign_in.state === "pending";
-  useEffect(() => {
-    if (!gateActive) return;
-    const timer = window.setInterval(
-      () => {
-        void reload().catch(() => undefined);
-      },
-      pendingFlow ? PENDING_POLL_MS : SESSION_WATCH_MS,
-    );
-    return () => window.clearInterval(timer);
-  }, [gateActive, pendingFlow, reload]);
+  const refreshStatus = useCallback(() => {
+    void reload().catch(() => undefined);
+  }, [reload]);
+  useVisibilityGatedPoll(
+    refreshStatus,
+    pendingFlow ? PENDING_POLL_MS : SESSION_WATCH_MS,
+    { enabled: gateActive },
+  );
 
   async function connect() {
     if (!policy) return;

--- a/crates/tidebreak-desktop/ui/src/QueueTray.tsx
+++ b/crates/tidebreak-desktop/ui/src/QueueTray.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ArrowUpRight,
   ChevronDown,
@@ -12,8 +12,13 @@ import { toast } from "sonner";
 
 import type { ApiClient } from "./api";
 import { friendlyErrorMessage } from "./lib/utils";
+import { useRefreshSignals } from "./RefreshSignals";
+import { useVisibilityGatedPoll } from "./useVisibilityGatedPoll";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+
+/** Safety net under the turn-boundary and enqueue signals, while a turn is live or rows show. */
+const QUEUE_POLL_MS = 15_000;
 
 /** One queued message, in the vocabulary the tray renders. */
 export type QueueTrayRow = { id: string; content: string };
@@ -104,7 +109,7 @@ export function QueueTray({
   const [editing, setEditing] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
   const [busy, setBusy] = useState(false);
-  const timerRef = useRef<number | null>(null);
+  const queuedSignal = useRefreshSignals((state) => state.queuedTurns);
 
   const refresh = useCallback(async () => {
     try {
@@ -116,15 +121,17 @@ export function QueueTray({
     }
   }, [queue]);
 
+  // Read when the queue or the turn ahead of it changes: a mount, the
+  // active turn starting or ending, and every `queuedTurns` signal (a send
+  // parked a row, a turn boundary let the promoter run). The slow timer
+  // below is the net under those, and only while there is anything to watch.
   useEffect(() => {
     void refresh();
-    // Poll while a turn is live (promotion imminent) or rows remain visible.
-    if (!active && queued.length === 0) return;
-    timerRef.current = window.setInterval(() => void refresh(), 1500);
-    return () => {
-      if (timerRef.current !== null) window.clearInterval(timerRef.current);
-    };
-  }, [refresh, active, queued.length > 0]);
+  }, [refresh, active]);
+  useVisibilityGatedPoll(() => void refresh(), QUEUE_POLL_MS, {
+    enabled: active || queued.length > 0,
+    revision: queuedSignal,
+  });
 
   async function act(action: () => Promise<unknown>, failure: string) {
     setBusy(true);

--- a/crates/tidebreak-desktop/ui/src/RefreshSignals.ts
+++ b/crates/tidebreak-desktop/ui/src/RefreshSignals.ts
@@ -9,7 +9,8 @@ export type RefreshTarget =
   | "userQuestions"
   | "planApprovals"
   | "taskPlan"
-  | "notifications";
+  | "notifications"
+  | "queuedTurns";
 
 /**
  * A revision counter per pollable target.
@@ -28,6 +29,8 @@ export type RefreshSignalStore = {
   planApprovals: number;
   taskPlan: number;
   notifications: number;
+  /** A queued turn was added, promoted, or the turn ahead of it ended. */
+  queuedTurns: number;
   signal: (target: RefreshTarget) => void;
 };
 
@@ -39,6 +42,7 @@ export function createRefreshSignalStore() {
     planApprovals: 0,
     taskPlan: 0,
     notifications: 0,
+    queuedTurns: 0,
     signal: (target) =>
       set(
         (state) =>

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -1,5 +1,6 @@
 import type { ApiClient } from "../api/client";
 import type { CodeTurnSnapshot, SequencedCodeEventFrame } from "../api/types";
+import { useRefreshSignals } from "../RefreshSignals";
 import { codeClientGeneration } from "./CodeClientGeneration";
 import { CodeSessionController } from "./CodeSessionController";
 import {
@@ -99,6 +100,11 @@ function createController(
       for (const effect of effects) {
         if (effect.type === "turn_began") fillPrompt(effect.turnId);
         if (effect.type === "turn_snapshot_needed") turnSnapshotNeeded = true;
+        // A turn boundary is when the promoter runs, so the queue tray reads
+        // on it instead of watching a fast timer.
+        if (effect.type === "turn_began" || effect.type === "turn_resolved") {
+          useRefreshSignals.getState().signal("queuedTurns");
+        }
       }
       if (turnSnapshotNeeded) controller.requestTurnRefresh();
     },

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -61,6 +61,7 @@ import type { LayoutState, PanelContent } from "@/panel/panelTypes";
 import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
 import { RouteFrame } from "@/RouteFrame";
 import { QueueTray, useCodeQueueApi } from "@/QueueTray";
+import { useRefreshSignals } from "@/RefreshSignals";
 import { followScrollBehavior } from "@/ChatScroll";
 import { useStreamStalled } from "@/useStreamStalled";
 import { useTranscriptFollow } from "@/useTranscriptFollow";
@@ -2487,8 +2488,8 @@ function CodeSessionPane({
     follow.requestSmoothFollow();
     // Outcome and refusal both belong to the composer: it says whether the
     // message ran or queued, and it holds the draft when the server refuses.
-    // A queued outcome needs no state here — the tray polls the durable queue
-    // and shows the row.
+    // A queued outcome needs no state here — the tray reads the durable queue
+    // on the signal below and shows the row.
     return submitAcceptedTurn(store.getState().update, () =>
       pendingReasoningEffort
         ? client.submitCodeTurn(
@@ -2505,6 +2506,9 @@ function CodeSessionPane({
             attachments,
           ),
     ).then((outcome) => {
+      if (outcome.kind === "queued") {
+        useRefreshSignals.getState().signal("queuedTurns");
+      }
       if (pendingReasoningEffortRef.current === pendingReasoningEffort) {
         pendingReasoningEffortRef.current = null;
       }

--- a/crates/tidebreak-desktop/ui/src/code/useCodeSubscriptionUsage.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useCodeSubscriptionUsage.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 import { useApp } from "@/AppContext";
 import type { ApiClient } from "@/api/client";
 import type { CodeSubscriptionUsage } from "@/api/types";
+import { startVisibilityGatedPoll } from "@/useVisibilityGatedPoll";
 import {
   codeClientGeneration,
   isCodeClientGenerationActive,
@@ -97,13 +98,37 @@ export function useCodeSubscriptionUsage() {
     [client, refreshStore],
   );
 
-  useEffect(() => {
-    void refresh();
-    const timer = window.setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
-    return () => window.clearInterval(timer);
-  }, [refresh]);
+  useEffect(() => acquireUsagePoller(client), [client]);
 
   return { report, refreshing, error, refresh };
+}
+
+/**
+ * One timer for every consumer. The rail and the analytics page both mount
+ * this hook; before this each ran its own minute clock, so an open analytics
+ * page doubled the quota reads. The first consumer reads at once and starts
+ * the clock; later ones join it; the last one leaving stops it. Hidden, the
+ * clock pauses — a quota bar nobody can see needs no refresh, and the read on
+ * return brings it current.
+ */
+let pollerConsumers = 0;
+let stopPoller: (() => void) | null = null;
+
+function acquireUsagePoller(client: ApiClient): () => void {
+  pollerConsumers += 1;
+  if (pollerConsumers === 1) {
+    const read = () =>
+      void useCodeSubscriptionUsageStore.getState().refresh(client);
+    read();
+    stopPoller = startVisibilityGatedPoll(read, REFRESH_INTERVAL_MS);
+  }
+  return () => {
+    pollerConsumers -= 1;
+    if (pollerConsumers === 0) {
+      stopPoller?.();
+      stopPoller = null;
+    }
+  };
 }
 
 export function resetCodeSubscriptionUsageStore() {

--- a/crates/tidebreak-desktop/ui/src/useAgentNotifications.ts
+++ b/crates/tidebreak-desktop/ui/src/useAgentNotifications.ts
@@ -15,8 +15,16 @@ import {
 import { desktopNotificationsEnabled } from "./NotificationPreferences";
 import { useNotifications } from "./NotificationStore";
 import { useRefreshSignals } from "./RefreshSignals";
+import { useVisibilityGatedPoll } from "./useVisibilityGatedPoll";
 
-const POLL_INTERVAL_MS = 10_000;
+/**
+ * Safety-net cadence. The open chat's stream and the code digest socket both
+ * signal a finished turn; the timer covers a background chat that finished
+ * with no stream open. Hidden, it slows rather than stops — the native notice
+ * for an away reader is exactly what a hidden window still owes.
+ */
+const POLL_INTERVAL_MS = 30_000;
+const HIDDEN_POLL_INTERVAL_MS = 60_000;
 
 const storeActions = useNotifications.getState();
 
@@ -90,21 +98,18 @@ export function useAgentNotifications(client: ApiClient | null): void {
       void read();
     };
     void read();
-    const interval = window.setInterval(() => void read(), POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
       seq += 1;
-      window.clearInterval(interval);
       refreshRef.current = null;
     };
   }, [client]);
 
-  const lastSignalRef = useRef(notificationsSignal);
-  useEffect(() => {
-    if (lastSignalRef.current === notificationsSignal) return;
-    lastSignalRef.current = notificationsSignal;
-    refreshRef.current?.();
-  }, [notificationsSignal]);
+  useVisibilityGatedPoll(() => refreshRef.current?.(), POLL_INTERVAL_MS, {
+    enabled: client !== null,
+    hiddenIntervalMs: HIDDEN_POLL_INTERVAL_MS,
+    revision: notificationsSignal,
+  });
 
   useEffect(() => {
     if (!client) return;

--- a/crates/tidebreak-desktop/ui/src/useChatPromptWatcher.ts
+++ b/crates/tidebreak-desktop/ui/src/useChatPromptWatcher.ts
@@ -6,8 +6,16 @@ import { requestUserAttention } from "./host";
 import { useInbox } from "./Inbox";
 import { usePendingPrompts } from "./PendingPrompts";
 import { useRefreshSignals } from "./RefreshSignals";
+import { useVisibilityGatedPoll } from "./useVisibilityGatedPoll";
 
-const POLL_INTERVAL_MS = 10_000;
+/**
+ * Safety-net cadence. The event stream signals the open chat's prompts as
+ * they park; the timer covers chats that are not open, whose parked work has
+ * no stream to announce it. Hidden, it slows rather than stops: a question
+ * parking in a background chat still wants the dock bounce.
+ */
+const POLL_INTERVAL_MS = 30_000;
+const HIDDEN_POLL_INTERVAL_MS = 60_000;
 
 const promptActions = usePendingPrompts.getState();
 const attentionActions = useChatAttention.getState();
@@ -99,12 +107,10 @@ export function useChatPromptWatcher(
 
     refreshRef.current = readAll;
     readAll();
-    const interval = window.setInterval(readAll, POLL_INTERVAL_MS);
 
     return () => {
       cancelled = true;
       summarySeq += 1;
-      window.clearInterval(interval);
       refreshRef.current = null;
     };
   }, [client]);
@@ -203,28 +209,11 @@ export function useChatPromptWatcher(
   }, [client, chatId]);
 
   // Only a signal raised after this mounted means anything; the counters are
-  // app-wide and may already be well past zero on arrival.
-  const lastSignalsRef = useRef({
-    questions: questionsSignal,
-    plans: plansSignal,
-    folder: folderSignal,
-    writeback: writebackSignal,
+  // app-wide and may already be well past zero on arrival. Counters only
+  // grow, so their sum moves on any one of them.
+  useVisibilityGatedPoll(() => refreshRef.current?.(), POLL_INTERVAL_MS, {
+    enabled: client !== null,
+    hiddenIntervalMs: HIDDEN_POLL_INTERVAL_MS,
+    revision: questionsSignal + plansSignal + folderSignal + writebackSignal,
   });
-  useEffect(() => {
-    const last = lastSignalsRef.current;
-    if (
-      last.questions === questionsSignal &&
-      last.plans === plansSignal &&
-      last.folder === folderSignal &&
-      last.writeback === writebackSignal
-    )
-      return;
-    lastSignalsRef.current = {
-      questions: questionsSignal,
-      plans: plansSignal,
-      folder: folderSignal,
-      writeback: writebackSignal,
-    };
-    refreshRef.current?.();
-  }, [questionsSignal, plansSignal, folderSignal, writebackSignal]);
 }

--- a/crates/tidebreak-desktop/ui/src/useVisibilityGatedPoll.test.ts
+++ b/crates/tidebreak-desktop/ui/src/useVisibilityGatedPoll.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  startVisibilityGatedPoll,
+  useVisibilityGatedPoll,
+} from "./useVisibilityGatedPoll";
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setHidden(false);
+});
+afterEach(() => {
+  vi.useRealTimers();
+  setHidden(false);
+});
+
+describe("useVisibilityGatedPoll", () => {
+  it("polls on the visible cadence, pauses hidden, and reads at once on return", () => {
+    const poll = vi.fn();
+    renderHook(() => useVisibilityGatedPoll(poll, 1_000));
+    expect(poll).not.toHaveBeenCalled();
+
+    act(() => void vi.advanceTimersByTime(2_000));
+    expect(poll).toHaveBeenCalledTimes(2);
+
+    act(() => setHidden(true));
+    act(() => void vi.advanceTimersByTime(10_000));
+    expect(poll).toHaveBeenCalledTimes(2);
+
+    act(() => setHidden(false));
+    expect(poll).toHaveBeenCalledTimes(3);
+    act(() => void vi.advanceTimersByTime(1_000));
+    expect(poll).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps a slower cadence hidden when one is given", () => {
+    const poll = vi.fn();
+    renderHook(() =>
+      useVisibilityGatedPoll(poll, 1_000, { hiddenIntervalMs: 5_000 }),
+    );
+    act(() => setHidden(true));
+    act(() => void vi.advanceTimersByTime(4_999));
+    expect(poll).not.toHaveBeenCalled();
+    act(() => void vi.advanceTimersByTime(1));
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads on a signal after mount, hidden or not, but not on the mount value", () => {
+    const poll = vi.fn();
+    const { rerender } = renderHook(
+      ({ revision }: { revision: number }) =>
+        useVisibilityGatedPoll(poll, 60_000, { revision }),
+      { initialProps: { revision: 7 } },
+    );
+    expect(poll).not.toHaveBeenCalled();
+
+    rerender({ revision: 8 });
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    act(() => setHidden(true));
+    rerender({ revision: 9 });
+    expect(poll).toHaveBeenCalledTimes(2);
+  });
+
+  it("does nothing while disabled and calls the latest poll function", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ poll, enabled }: { poll: () => void; enabled: boolean }) =>
+        useVisibilityGatedPoll(poll, 1_000, { enabled, revision: 0 }),
+      { initialProps: { poll: first, enabled: false } },
+    );
+    act(() => void vi.advanceTimersByTime(3_000));
+    expect(first).not.toHaveBeenCalled();
+
+    rerender({ poll: second, enabled: true });
+    act(() => void vi.advanceTimersByTime(1_000));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("startVisibilityGatedPoll", () => {
+  it("stops cleanly and ignores visibility changes afterwards", () => {
+    const poll = vi.fn();
+    const stop = startVisibilityGatedPoll(poll, 1_000);
+    vi.advanceTimersByTime(1_000);
+    expect(poll).toHaveBeenCalledTimes(1);
+    stop();
+    vi.advanceTimersByTime(5_000);
+    setHidden(true);
+    setHidden(false);
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/useVisibilityGatedPoll.ts
+++ b/crates/tidebreak-desktop/ui/src/useVisibilityGatedPoll.ts
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * A refresh cadence that respects whether anyone can see the result.
+ *
+ * Every poller in the shell has the same shape: read now, read again every N
+ * seconds, and read at once when the event stream says the state moved on.
+ * The stream is the primary signal; the timer is the safety net for a nudge
+ * that fired before the subscriber existed or a socket that dropped a frame.
+ * Nothing needs a fast timer to feel live, so the net runs slowly, and it
+ * stops (or slows) while the document is hidden — a minimized window has no
+ * reader to keep current, and the immediate read on return is what it sees.
+ *
+ * A signal-driven read always runs, hidden or not. Signals carry the changes a
+ * hidden window still acts on: a native notification or a dock bounce for a
+ * question that just parked.
+ */
+export type VisibilityGatedPollOptions = {
+  /**
+   * Cadence while the document is hidden. `null` (the default) pauses the
+   * timer entirely; a number keeps a slower one running for readers whose
+   * poll is what raises the out-of-app notice.
+   */
+  hiddenIntervalMs?: number | null;
+};
+
+export function documentHidden(): boolean {
+  return typeof document !== "undefined" && document.hidden;
+}
+
+/**
+ * Start the timer half of a poll outside React. Returns the stop function.
+ *
+ * The visible cadence arms while the document is visible; on hide it either
+ * pauses or swaps to the hidden cadence; on show it runs `poll` at once and
+ * re-arms. `poll` is never run from here at start — callers decide whether
+ * they already have a first read in flight.
+ */
+export function startVisibilityGatedPoll(
+  poll: () => void,
+  intervalMs: number,
+  options: VisibilityGatedPollOptions = {},
+): () => void {
+  const hiddenIntervalMs = options.hiddenIntervalMs ?? null;
+  let timer: number | null = null;
+
+  const disarm = () => {
+    if (timer !== null) window.clearInterval(timer);
+    timer = null;
+  };
+  const arm = () => {
+    disarm();
+    const cadence = documentHidden() ? hiddenIntervalMs : intervalMs;
+    if (cadence === null) return;
+    timer = window.setInterval(poll, cadence);
+  };
+  const onVisibilityChange = () => {
+    if (!documentHidden()) poll();
+    arm();
+  };
+
+  arm();
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibilityChange);
+  }
+  return () => {
+    disarm();
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    }
+  };
+}
+
+/**
+ * Poll `poll` on a visibility-gated cadence and on every change of `revision`.
+ *
+ * `revision` is a refresh-signal counter (or a sum of several — counters only
+ * grow, so any bump changes the sum). Its value on mount is not a signal;
+ * only later changes trigger a read. `enabled` false disarms everything.
+ * `poll` may change identity freely; the latest one is called.
+ */
+export function useVisibilityGatedPoll(
+  poll: () => void,
+  intervalMs: number,
+  options: VisibilityGatedPollOptions & {
+    enabled?: boolean;
+    revision?: number;
+  } = {},
+): void {
+  const { enabled = true, revision = 0, hiddenIntervalMs = null } = options;
+  const pollRef = useRef(poll);
+  pollRef.current = poll;
+
+  useEffect(() => {
+    if (!enabled) return;
+    return startVisibilityGatedPoll(() => pollRef.current(), intervalMs, {
+      hiddenIntervalMs,
+    });
+  }, [enabled, intervalMs, hiddenIntervalMs]);
+
+  const lastRevisionRef = useRef(revision);
+  useEffect(() => {
+    if (lastRevisionRef.current === revision) return;
+    lastRevisionRef.current = revision;
+    if (enabled) pollRef.current();
+  }, [enabled, revision]);
+}


### PR DESCRIPTION
Several shell timers polled where the event stream already carried the change, and none gated on document visibility. This makes the stream the primary trigger, stretches every poll to a safety-net cadence, and pauses or slows the net while the document is hidden.

## What changed

One shared helper, `useVisibilityGatedPoll` (with a non-React `startVisibilityGatedPoll` core), owns the cadence. It arms a slow timer while the document is visible, pauses or slows it while hidden, reads at once when the document returns, and reads on every change of a refresh-signal counter. A signal-driven read always runs, hidden or not, so a native notice for an away reader still fires.

| Site | Before | After |
| --- | --- | --- |
| `useChatPromptWatcher` | 5 requests / 10s per open chat | signals primary; 30s visible, 60s hidden |
| `useAgentNotifications` | 2 requests / 10s app-wide | signal primary; 30s visible, 60s hidden |
| `ManagedGate` policy + session watch | 5s × 2 | 60s, paused hidden; pairing nudge stays the prompt path; 2s pending sign-in poll unchanged but paused hidden |
| `QueueTray` | 1.5s during turns | new `queuedTurns` signal on chat and code turn boundaries and after a send parks a row; 15s net, paused hidden |
| `useCodeSubscriptionUsage` | one 60s clock per consumer | one refcounted 60s clock, paused hidden |
| `code_browser.rs` observer | 100ms JS read per tab | 250ms while the tab shows, 2s identity check while hidden; in-page fallback interval 100ms → 1s |

The browser observer stays a poll: the child webview has no IPC channel to the host, so the page cannot push. The visible cadence is only the URL-bar latency after a `pushState` the page already captured.

## Verification

- `pnpm exec biome format --write src`, `pnpm exec biome lint src`: clean
- `pnpm exec tsc --noEmit`: clean
- `pnpm test`: 262 files, 2304 tests passed (includes the new `useVisibilityGatedPoll.test.ts` covering hidden pauses, visible resumes, slower hidden cadence, and signal-triggered reads)
- `pnpm build`: built
- `cargo check -p tidebreak-desktop`; `cargo test -p tidebreak-desktop same_document_navigation_observer`: passed

Closes #2957
