### PR TITLE
perf(server): bound the remote sweep and wake it on demand

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -15,7 +15,8 @@
 //! prevent.
 
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, Statement,
+    TransactionTrait,
 };
 
 use crate::code::{
@@ -464,6 +465,46 @@ pub async fn latest_incarnation(
         .map_err(store_err)?
         .map(incarnation_from_model)
         .transpose()
+}
+
+/// The latest incarnation of every session that is neither fenced nor
+/// ended, across every owner.
+///
+/// The remote sweep's system path. One query does what a session listing
+/// followed by a per-session [`latest_incarnation`] read would do, so the
+/// sweep's cost tracks the sessions still alive rather than the whole
+/// session history. Sessions with no incarnation at all are absent, which is
+/// the same answer the two-step read gives for them.
+pub async fn latest_incarnations_of_live_sessions_all_owners(
+    store: &DbStore,
+) -> Result<Vec<CodeSessionIncarnation>> {
+    let sql = format!(
+        r#"
+SELECT i.*
+FROM code_session_incarnation i
+JOIN code_session s ON s.id = i.session_id AND s.owner = i.owner
+WHERE s.lifecycle NOT IN ('{fenced}', '{ended}')
+  AND i.incarnation = (
+    SELECT MAX(later.incarnation)
+    FROM code_session_incarnation later
+    WHERE later.owner = i.owner AND later.session_id = i.session_id
+  )
+ORDER BY s.created_at DESC, i.id ASC
+"#,
+        fenced = crate::code::CodeSessionLifecycle::Fenced.as_str(),
+        ended = crate::code::CodeSessionLifecycle::Ended.as_str(),
+    );
+    entities::code_session_incarnation::Entity::find()
+        .from_raw_sql(Statement::from_string(
+            store.conn.get_database_backend(),
+            sql,
+        ))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(incarnation_from_model)
+        .collect()
 }
 
 /// The session's cumulative spend across every incarnation, in micro-USD.

--- a/crates/tidebreak-core/src/db/ops/code/queued.rs
+++ b/crates/tidebreak-core/src/db/ops/code/queued.rs
@@ -11,8 +11,8 @@
 //! nothing, and the promotion reports stale instead of running old content.
 
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
-    TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set, TransactionTrait,
 };
 
 use crate::code::{CodeQueuedTurn, CodeSessionId, CodeTurn, CodeTurnId};
@@ -67,6 +67,28 @@ pub async fn list_queued_turns(
     session_id: CodeSessionId,
 ) -> Result<Vec<CodeQueuedTurn>> {
     list_on(&store.conn, owner, session_id).await
+}
+
+/// Every session that has at least one queued message, across every owner.
+///
+/// The remote sweep's system path: promotion only matters where a queue
+/// exists, so the sweep asks for those sessions instead of walking every
+/// session row on the machine.
+pub async fn sessions_with_queued_turns_all_owners(
+    store: &DbStore,
+) -> Result<Vec<(OwnerId, CodeSessionId)>> {
+    entities::code_queued_turn::Entity::find()
+        .select_only()
+        .column(entities::code_queued_turn::Column::Owner)
+        .column(entities::code_queued_turn::Column::SessionId)
+        .distinct()
+        .into_tuple::<(String, uuid::Uuid)>()
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(|(owner, session_id)| Ok((OwnerId::new(&owner)?, CodeSessionId(session_id))))
+        .collect()
 }
 
 /// The FIFO head, or `None` when the queue is empty.

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -5097,6 +5097,118 @@ async fn ingest_journals_once_per_sandbox_event_and_resumes_from_the_cursor() {
     .is_err());
 }
 
+/// The sweep's one-query read matches the two-step listing it replaces:
+/// every session that is neither fenced nor ended shows exactly its latest
+/// incarnation, however many it holds, and terminal sessions show nothing.
+#[tokio::test]
+async fn live_session_incarnations_match_the_per_session_read() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+
+    // Two incarnations: only the second is the latest.
+    let (twice, _) = seed_owner(&store, &owner, "twice").await;
+    let superseded = admitted(admit(&store, &owner, twice, 1, 8).await);
+    crate::db::code::activate_incarnation(&store, &owner, superseded.id, "sb-twice-1")
+        .await
+        .unwrap();
+    crate::db::code::stop_incarnation(&store, &owner, superseded.id, Some("done"))
+        .await
+        .unwrap();
+    crate::db::code::mark_incarnation_terminal_events_journaled(&store, &owner, superseded.id)
+        .await
+        .unwrap();
+    let latest = admitted(admit(&store, &owner, twice, 2, 8).await);
+    crate::db::code::activate_incarnation(&store, &owner, latest.id, "sb-twice-2")
+        .await
+        .unwrap();
+
+    // A reservation that has not activated is still the latest row.
+    let (reserving, _) = seed_owner(&store, &owner, "reserving").await;
+    let reserved = admitted(admit(&store, &owner, reserving, 1, 8).await);
+
+    // No incarnation at all: absent from both reads.
+    let (_bare, _) = seed_owner(&store, &owner, "bare").await;
+
+    // Terminal sessions drop out even with a live incarnation.
+    let (ended, _) = seed_owner(&store, &owner, "ended").await;
+    let ended_row = admitted(admit(&store, &owner, ended, 1, 8).await);
+    crate::db::code::activate_incarnation(&store, &owner, ended_row.id, "sb-ended")
+        .await
+        .unwrap();
+    let mut ended_session = get_session(&store, &owner, ended).await.unwrap().unwrap();
+    ended_session.lifecycle = CodeSessionLifecycle::Ended;
+    assert!(save_session(&store, &ended_session).await.unwrap());
+    let (fenced, _) = seed_owner(&store, &owner, "fenced").await;
+    let fenced_row = admitted(admit(&store, &owner, fenced, 1, 8).await);
+    crate::db::code::activate_incarnation(&store, &owner, fenced_row.id, "sb-fenced")
+        .await
+        .unwrap();
+    let mut fenced_session = get_session(&store, &owner, fenced).await.unwrap().unwrap();
+    fenced_session.lifecycle = CodeSessionLifecycle::Fenced;
+    fenced_session.fence_reason = Some(FenceReason::OrphanAlive);
+    assert!(save_session(&store, &fenced_session).await.unwrap());
+
+    let mut expected = Vec::new();
+    for session in crate::db::code::list_sessions_all_owners(&store)
+        .await
+        .unwrap()
+    {
+        if matches!(
+            session.lifecycle,
+            CodeSessionLifecycle::Fenced | CodeSessionLifecycle::Ended
+        ) {
+            continue;
+        }
+        if let Some(row) = crate::db::code::latest_incarnation(&store, &session.owner, session.id)
+            .await
+            .unwrap()
+        {
+            expected.push(row.id);
+        }
+    }
+    let joined = crate::db::code::latest_incarnations_of_live_sessions_all_owners(&store)
+        .await
+        .unwrap();
+    let got: Vec<_> = joined.iter().map(|row| row.id).collect();
+    assert_eq!(got.len(), expected.len());
+    assert!(expected.iter().all(|id| got.contains(id)));
+    assert_eq!(got.len(), 2);
+    assert!(got.contains(&latest.id));
+    assert!(got.contains(&reserved.id));
+    assert!(!got.contains(&superseded.id));
+    // The joined rows carry the full incarnation, not just its key.
+    let live = joined.iter().find(|row| row.id == latest.id).unwrap();
+    assert_eq!(live.sandbox_id.as_deref(), Some("sb-twice-2"));
+    assert_eq!(live.state, crate::code::IncarnationState::Active);
+}
+
+/// Promotion only has work where a queue exists, so the sweep's listing
+/// names each queued session once and skips sessions with nothing parked.
+#[tokio::test]
+async fn queued_session_listing_names_each_queued_session_once() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let (twice, _) = seed_owner(&store, &owner, "queued-twice").await;
+    let (once, _) = seed_owner(&store, &owner, "queued-once").await;
+    let (_empty, _) = seed_owner(&store, &owner, "queued-none").await;
+    enqueue_queued_turn(&store, &owner, &queued_message(twice, "first"))
+        .await
+        .unwrap();
+    enqueue_queued_turn(&store, &owner, &queued_message(twice, "second"))
+        .await
+        .unwrap();
+    enqueue_queued_turn(&store, &owner, &queued_message(once, "only"))
+        .await
+        .unwrap();
+
+    let listed = crate::db::code::sessions_with_queued_turns_all_owners(&store)
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 2);
+    assert!(listed.contains(&(owner.clone(), twice)));
+    assert!(listed.contains(&(owner.clone(), once)));
+}
+
 /// A session bound to a fresh conversation, for the external message tests.
 async fn seed_external_session(
     store: &crate::db::DbStore,

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1,26 +1,39 @@
 //! Wire remote sessions into the running server: the configured transport,
-//! the per-session pump tasks, and the periodic sweep that reconciles both.
+//! the per-session pump tasks, and the sweep that reconciles both.
 //!
-//! The sweep is the only scheduler. Every tick it closes stale intents and
+//! The sweep is the only scheduler. Every pass it closes stale intents and
 //! makes sure each incarnation that still owes events has a pump task. Pump
 //! tasks hold the long event wait; everything else is a cheap store read, so
-//! a crashed or finished task is simply respawned on the next tick from
+//! a crashed or finished task is simply respawned on the next pass from
 //! durable state.
+//!
+//! Passes are wake-driven. A submit that provisioned, a parked follow-up, an
+//! external message, or a pump task exiting wakes the sweep at once; the
+//! timer between wakes is only a safety net, and it slows right down when no
+//! incarnation is draining so an idle deployment stops paying for a scan
+//! nobody needs.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Weak};
 
+use tokio::sync::Notify;
 use tracing::warn;
 
-use tidebreak_core::db::code::{get_session, latest_incarnation, list_sessions_all_owners};
+use tidebreak_core::db::code::{get_session, latest_incarnations_of_live_sessions_all_owners};
 use tidebreak_core::{CodeSessionId, CodeSessionLifecycle, DbStore, IncarnationState, OwnerId};
 
 use super::super::runtime::CodeRuntime;
 use super::driver::{sweep_stale_intents, RemoteDriver, RemoteSpawnSettings};
 use super::SandboxProvisioner;
 
-/// How often the sweep reconciles pump tasks.
-const REMOTE_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+/// The safety-net interval between passes while an incarnation is draining.
+/// Wakes carry the normal traffic; this bounds how long a missed wake or a
+/// pump that exited without one can go unnoticed.
+const ACTIVE_SWEEP_FLOOR: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// The safety-net interval between passes while nothing remote is draining.
+/// The stale-intent cutoff is measured in minutes, so this loses nothing.
+const IDLE_SWEEP_FLOOR: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// The held wait a pump task asks the events read to hold.
 const PUMP_HELD_WAIT_SECONDS: u16 = 20;
@@ -56,12 +69,16 @@ pub(crate) struct RemoteSessions {
     /// Spawn-time settings.
     pub(crate) settings: RemoteSpawnSettings,
     /// Live pump tasks by session. The sweep prunes finished entries and
-    /// spawns missing ones; nothing else writes here.
+    /// spawns missing ones; a pump task removes its own entry on the way out
+    /// so the pass it wakes sees the slot free.
     pumps: Mutex<HashMap<CodeSessionId, tokio::task::JoinHandle<()>>>,
     /// Sessions whose queue promotion is on hold until the given instant,
     /// after a machine-side refusal. In-memory on purpose: a restart retries
     /// once and re-arms the hold from the fresh refusal.
     promotion_holds: Mutex<HashMap<CodeSessionId, std::time::Instant>>,
+    /// Wakes the sweep for an immediate pass. A wake with no waiter is kept
+    /// until the sweep next listens, so none is lost between passes.
+    sweep_wake: Notify,
 }
 
 impl RemoteSessions {
@@ -74,7 +91,13 @@ impl RemoteSessions {
             settings,
             pumps: Mutex::new(HashMap::new()),
             promotion_holds: Mutex::new(HashMap::new()),
+            sweep_wake: Notify::new(),
         })
+    }
+
+    /// Ask the sweep for a pass now instead of at its next floor.
+    pub(crate) fn wake_sweep(&self) {
+        self.sweep_wake.notify_one();
     }
 
     /// The driver view over this context for one call.
@@ -137,7 +160,16 @@ impl RemoteSessions {
         pumps.insert(
             session,
             tokio::spawn(async move {
-                pump_session(runtime, remote, owner, session).await;
+                let wake = pump_session(runtime, Arc::clone(&remote), owner, session).await;
+                // Free the slot before waking: the pass this wake starts
+                // must see no entry, or it skips the respawn and waits out
+                // a floor instead. The entry is always this task's own —
+                // the sweep only inserts where none exists, and this one
+                // stands until here.
+                remote.pumps.lock().expect("remote pumps").remove(&session);
+                if wake {
+                    remote.wake_sweep();
+                }
             }),
         );
     }
@@ -154,24 +186,29 @@ impl Drop for RemoteSessions {
 /// One session's pump loop: drain events on the held wait until the session
 /// stops being pumpable. Exits on any fault or terminal condition — the
 /// sweep respawns from durable state, so an exit is never a leak.
+///
+/// Returns whether the exit is worth an immediate sweep pass. A stopped
+/// incarnation or a fence may leave a queue head to promote; a sign-in wait
+/// does not, and waking on it would respawn the pump in a tight loop until
+/// the owner signs in, so that exit waits for the floor.
 async fn pump_session(
     runtime: Weak<CodeRuntime>,
     remote: Arc<RemoteSessions>,
     owner: OwnerId,
     session_id: CodeSessionId,
-) {
+) -> bool {
     loop {
         let Some(runtime) = runtime.upgrade() else {
-            return;
+            return false;
         };
         let Ok(Some(mut session)) = get_session(&runtime.db, &owner, session_id).await else {
-            return;
+            return false;
         };
         if matches!(
             session.lifecycle,
             CodeSessionLifecycle::Fenced | CodeSessionLifecycle::Ended
         ) {
-            return;
+            return false;
         }
         let driver = remote.driver(&runtime.db, runtime.bus.as_ref());
         match driver.pump(&mut session, PUMP_HELD_WAIT_SECONDS).await {
@@ -179,10 +216,10 @@ async fn pump_session(
                 if report.sign_in_required {
                     // Nothing drains until the owner signs in; the sweep
                     // brings the task back to try again.
-                    return;
+                    return false;
                 }
                 if report.incarnation_stopped || report.fenced.is_some() {
-                    return;
+                    return true;
                 }
             }
             Err(error) => {
@@ -202,14 +239,25 @@ pub(crate) struct RemoteSweepGuard(Option<tokio::task::JoinHandle<()>>);
 impl RemoteSweepGuard {
     pub(crate) fn spawn(runtime: Weak<CodeRuntime>) -> Self {
         let handle = tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(REMOTE_SWEEP_INTERVAL);
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
-                ticker.tick().await;
                 let Some(runtime) = runtime.upgrade() else {
                     return;
                 };
-                sweep_remote(&runtime).await;
+                let activity = sweep_remote(&runtime).await;
+                let remote = runtime.remote_sessions();
+                // Drop the strong handle across the wait so shutdown is not
+                // held open by a sleeping sweep.
+                drop(runtime);
+                let floor = sweep_floor(activity);
+                match remote {
+                    Some(remote) => {
+                        tokio::select! {
+                            () = tokio::time::sleep(floor) => {}
+                            () = remote.sweep_wake.notified() => {}
+                        }
+                    }
+                    None => tokio::time::sleep(floor).await,
+                }
             }
         });
         Self(Some(handle))
@@ -224,46 +272,57 @@ impl Drop for RemoteSweepGuard {
     }
 }
 
-/// One sweep tick: expire stale intents and reconcile pump tasks against
+/// What one sweep pass found, which sets the floor before the next.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct RemoteSweepActivity {
+    /// Incarnations that still owe events and so hold a pump task.
+    pub(crate) draining: usize,
+}
+
+/// The safety-net wait after a pass: tight while something drains, slow
+/// when nothing does. Wakes cut either short.
+fn sweep_floor(activity: RemoteSweepActivity) -> std::time::Duration {
+    if activity.draining > 0 {
+        ACTIVE_SWEEP_FLOOR
+    } else {
+        IDLE_SWEEP_FLOOR
+    }
+}
+
+/// One sweep pass: expire stale intents and reconcile pump tasks against
 /// the incarnations that still owe events.
-pub(crate) async fn sweep_remote(runtime: &Arc<CodeRuntime>) {
+pub(crate) async fn sweep_remote(runtime: &Arc<CodeRuntime>) -> RemoteSweepActivity {
+    let mut activity = RemoteSweepActivity::default();
     let Some(remote) = runtime.remote_sessions() else {
-        return;
+        return activity;
     };
     if let Err(error) =
         sweep_stale_intents(&runtime.db, runtime.bus.as_ref(), chrono::Utc::now()).await
     {
         warn!(%error, "the stale-intent sweep failed");
     }
-    match list_sessions_all_owners(&runtime.db).await {
-        Ok(sessions) => {
-            for session in sessions {
-                if matches!(
-                    session.lifecycle,
-                    CodeSessionLifecycle::Fenced | CodeSessionLifecycle::Ended
-                ) {
-                    continue;
-                }
-                let Ok(Some(row)) =
-                    latest_incarnation(&runtime.db, &session.owner, session.id).await
-                else {
-                    continue;
-                };
+    // One join: the latest incarnation of every session that is neither
+    // fenced nor ended. The cost tracks live sessions, not session history.
+    match latest_incarnations_of_live_sessions_all_owners(&runtime.db).await {
+        Ok(rows) => {
+            for row in rows {
                 let drains = match row.state {
                     IncarnationState::Active => true,
                     IncarnationState::Stopped => !row.terminal_events_journaled,
                     IncarnationState::Intent => false,
                 };
                 if drains && row.sandbox_id.is_some() {
-                    remote.ensure_pump(runtime, session.owner.clone(), session.id);
+                    activity.draining += 1;
+                    remote.ensure_pump(runtime, row.owner.clone(), row.session_id);
                 }
             }
         }
-        Err(error) => warn!(%error, "could not list sessions for the remote sweep"),
+        Err(error) => warn!(%error, "could not list incarnations for the remote sweep"),
     }
     if let Err(error) = runtime.promote_remote_queue_heads().await {
         warn!(error = ?error, "remote queue promotion failed");
     }
+    activity
 }
 
 #[cfg(test)]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -4371,6 +4371,10 @@ impl CodeRuntime {
         let outcome = driver
             .submit_turn(&mut session, workspace, &repo, &message)
             .await?;
+        // A provisioned or delivered turn has events to drain and a parked
+        // one has a head to promote; either way the sweep should look now,
+        // not at its next floor.
+        remote.wake_sweep();
         self.relay_remote_outcome(owner, &session, outcome, message, queue_if_busy)
             .await
     }
@@ -4457,18 +4461,27 @@ impl CodeRuntime {
         )
         .await
         .map_err(ServerError::from)?;
+        if let Some(remote) = self.remote_sessions() {
+            remote.wake_sweep();
+        }
         Ok(SubmitTurnOutcome::Queued(Box::new(row)))
     }
 
-    /// Promote the queue head of every idle remote session. Called from the
-    /// remote sweep; local sessions drain their own queues through their
-    /// workers and are skipped here.
+    /// Promote the queue head of every idle remote session that has one.
+    /// Called from the remote sweep; local sessions drain their own queues
+    /// through their workers and are skipped here.
     pub(crate) async fn promote_remote_queue_heads(&self) -> Result<(), ServerError> {
         if self.remote.is_none() {
             return Ok(());
         }
-        let sessions = list_sessions_all_owners(&self.db).await?;
-        for session in sessions {
+        // Only sessions holding a queue can have a head to promote, so the
+        // pass reads those rather than every session on the machine.
+        for (owner, session_id) in
+            tidebreak_core::db::code::sessions_with_queued_turns_all_owners(&self.db).await?
+        {
+            let Some(session) = get_session(&self.db, &owner, session_id).await? else {
+                continue;
+            };
             self.try_promote_remote_head(session).await?;
         }
         Ok(())
@@ -4513,9 +4526,12 @@ impl CodeRuntime {
             .submit_turn_from(&mut session, &workspace, &repo, &message, Some(&head))
             .await
         {
-            // The claim was the atomic promotion; nothing to delete.
+            // The claim was the atomic promotion; nothing to delete. A
+            // reincarnation has a fresh sandbox to pump, so the sweep
+            // looks again now rather than at its next floor.
             Ok(Outcome::Delivered { .. }) | Ok(Outcome::Reincarnated { .. }) => {
                 remote.clear_promotion_hold(session.id);
+                remote.wake_sweep();
             }
             // Permanent for this session: nothing exposes a way to raise
             // the ceiling, and every retry would re-journal the refusal


### PR DESCRIPTION
## Summary

The remote sweep ticked every two seconds, listed every session on the machine, and read each one's latest incarnation in a loop. Its cost grew with session history and it ran flat out with nothing remote alive.

- One query now joins the latest incarnation of every session that is neither fenced nor ended (`latest_incarnations_of_live_sessions_all_owners`), replacing the full session scan plus a per-session read.
- The sweep is wake-driven. A provisioned or delivered turn, a parked follow-up, a promotion that ran, and a pump task exiting on a stop or fence wake it at once. The timer between wakes is a safety net: two seconds while an incarnation drains, twenty when none does.
- Queue promotion reads only the sessions that hold a queue (`sessions_with_queued_turns_all_owners`) instead of every session row.
- A pump exiting on a sign-in wait does not wake the sweep, because the respawn would meet the same wait and spin. That exit waits for the floor, as before.

What the sweep does with each stale intent and each draining incarnation is unchanged.

## Tests

- `live_session_incarnations_match_the_per_session_read` pins the join against the two-step read it replaces across sessions with zero, one, and two incarnations, and ended or fenced sessions holding live rows.
- `queued_session_listing_names_each_queued_session_once` covers the bounded promotion listing.
- The existing remote service tests exercise promotion through the new listing.

Ran `cargo check -p tidebreak-core -p tidebreak-server`, `cargo fmt --all`, the two new core tests, and the `code::remote::service` and `code_external` server tests. Local `cargo clippy --workspace` fails on `tidebreak-code-execution` at main with a pre-existing `too_many_arguments` lint unrelated to this change; the touched crates lint clean apart from that.

Closes #2955
