### PR TITLE
perf(core): journal streamed turn events in one transaction per burst

### DIFF
--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -63,7 +63,7 @@ use crate::storage::{
     RequestToolApprovalOutcome, RequestTurnCancellationOutcome, ReservedQueuedTurnOutcome,
     ReservedTurnAcceptanceOutcome, ResolveSandboxToolCallOutcome, ResolveToolCallOutcome,
     ResumeTurnForAgentRunWaitSetOutcome, RetrySandboxToolCallOutcome, Store,
-    SubmitAgentRunResultOutcome, TurnLeaseFence,
+    SubmitAgentRunResultOutcome, TurnEventAppend, TurnLeaseFence,
 };
 use crate::PermissionMode;
 
@@ -2767,6 +2767,18 @@ impl Store for DbStore {
             event,
         )
         .await
+    }
+
+    async fn append_turn_events(
+        &self,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        events: &[TurnEventAppend],
+    ) -> Result<Option<Vec<i64>>> {
+        ops::conversation::append_turn_events(self, chat_id, turn_id, lease_token, now, events)
+            .await
     }
 
     async fn recover_exact_turn_terminal_event(

--- a/crates/tidebreak-core/src/db/ops/conversation.rs
+++ b/crates/tidebreak-core/src/db/ops/conversation.rs
@@ -20,7 +20,7 @@ use crate::provider::MessageReasoning;
 use crate::storage::{
     ChatTerminalTurnSnapshot, ChatTerminalTurnStatus, ChatToolActivitySnapshot,
     ChatToolActivityStatus, ChatTranscriptSnapshot, DeleteChatOutcome, MessageInvokedSkills,
-    MoveChatOutcome,
+    MoveChatOutcome, TurnEventAppend,
 };
 use crate::PermissionMode;
 
@@ -1447,6 +1447,40 @@ pub(in crate::db) async fn append_turn_event(
     now: chrono::DateTime<Utc>,
     event: &AgentEvent,
 ) -> Result<Option<i64>> {
+    let entry = TurnEventAppend {
+        attempt_event_ordinal,
+        event: event.clone(),
+    };
+    Ok(append_turn_events(
+        store,
+        chat_id,
+        turn_id,
+        lease_token,
+        now,
+        std::slice::from_ref(&entry),
+    )
+    .await?
+    .map(|seqs| seqs[0]))
+}
+
+/// Journal a run of nonterminal turn events under one transaction.
+///
+/// The chat write lock, turn write lock, and lease check are taken once for the
+/// whole run, so a streaming turn pays one commit for however many text deltas
+/// arrived together instead of one per delta. Every entry is still identified
+/// by `(lease_token, attempt_event_ordinal)`: an entry whose identity already
+/// exists with the same payload recovers its original sequence, and one that
+/// exists with different data is an error. A batch that mixes recovered and
+/// fresh entries validates the lease before inserting the fresh ones, exactly
+/// as a single append would.
+pub(in crate::db) async fn append_turn_events(
+    store: &DbStore,
+    chat_id: ChatId,
+    turn_id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    events: &[TurnEventAppend],
+) -> Result<Option<Vec<i64>>> {
     if turn_id.0.is_nil() {
         return Err(AgentError::Store("event turn id must not be nil".into()));
     }
@@ -1455,30 +1489,39 @@ pub(in crate::db) async fn append_turn_event(
             "event lease token must not be nil".into(),
         ));
     }
-    if !(1..i32::MAX).contains(&attempt_event_ordinal) {
+    if events.is_empty() {
         return Err(AgentError::Store(
-            "attempt event ordinal must be positive and below the terminal slot".into(),
+            "turn event batch must carry at least one event".into(),
         ));
     }
-    if matches!(
-        event,
-        AgentEvent::TurnCompleted { .. }
-            | AgentEvent::TurnRefused { .. }
-            | AgentEvent::TurnFailed { .. }
-            | AgentEvent::TurnCancelled { .. }
-    ) {
-        return Err(AgentError::Store(
-            "terminal turn events must be committed by turn resolution".into(),
-        ));
-    }
-    if let AgentEvent::TurnStarted {
-        turn_id: payload_turn_id,
-    } = event
-    {
-        if *payload_turn_id != turn_id {
-            return Err(AgentError::Store(format!(
-                "turn-started event names {payload_turn_id}, not authoritative turn {turn_id}"
-            )));
+    let mut previous_ordinal = None;
+    for entry in events {
+        let attempt_event_ordinal = entry.attempt_event_ordinal;
+        if !(1..i32::MAX).contains(&attempt_event_ordinal) {
+            return Err(AgentError::Store(
+                "attempt event ordinal must be positive and below the terminal slot".into(),
+            ));
+        }
+        if previous_ordinal.is_some_and(|previous| attempt_event_ordinal <= previous) {
+            return Err(AgentError::Store(
+                "turn event batch ordinals must ascend".into(),
+            ));
+        }
+        previous_ordinal = Some(attempt_event_ordinal);
+        if is_terminal_event(&entry.event) {
+            return Err(AgentError::Store(
+                "terminal turn events must be committed by turn resolution".into(),
+            ));
+        }
+        if let AgentEvent::TurnStarted {
+            turn_id: payload_turn_id,
+        } = &entry.event
+        {
+            if *payload_turn_id != turn_id {
+                return Err(AgentError::Store(format!(
+                    "turn-started event names {payload_turn_id}, not authoritative turn {turn_id}"
+                )));
+            }
         }
     }
     let now = canonical_db_timestamp(now)?;
@@ -1492,28 +1535,46 @@ pub(in crate::db) async fn append_turn_event(
         return Ok(None);
     }
 
-    if let Some(existing) = entities::event::Entity::find()
+    let existing = entities::event::Entity::find()
         .filter(entities::event::Column::LeaseToken.eq(lease_token))
-        .filter(entities::event::Column::AttemptEventOrdinal.eq(attempt_event_ordinal))
-        .one(&transaction)
+        .filter(
+            entities::event::Column::AttemptEventOrdinal
+                .is_in(events.iter().map(|entry| entry.attempt_event_ordinal)),
+        )
+        .all(&transaction)
         .await
-        .map_err(store_err)?
-    {
-        let payload = serde_json::from_value::<AgentEvent>(existing.payload.clone())?;
-        if existing.chat_id != chat_id.0
-            || existing.turn_id != Some(turn_id.0)
-            || existing.lease_token != Some(lease_token)
-            || existing.attempt_event_ordinal != Some(attempt_event_ordinal)
-            || existing.terminal
-            || payload != *event
+        .map_err(store_err)?;
+    let mut recovered: HashMap<i32, i64> = HashMap::with_capacity(existing.len());
+    for row in existing {
+        let Some(attempt_event_ordinal) = row.attempt_event_ordinal else {
+            continue;
+        };
+        let Some(entry) = events
+            .iter()
+            .find(|entry| entry.attempt_event_ordinal == attempt_event_ordinal)
+        else {
+            continue;
+        };
+        let payload = serde_json::from_value::<AgentEvent>(row.payload.clone())?;
+        if row.chat_id != chat_id.0
+            || row.turn_id != Some(turn_id.0)
+            || row.lease_token != Some(lease_token)
+            || row.terminal
+            || payload != entry.event
         {
             return Err(AgentError::Store(format!(
                 "turn event identity ({lease_token}, {attempt_event_ordinal}) was reused with different data"
             )));
         }
-        let seq = existing.seq;
+        recovered.insert(attempt_event_ordinal, row.seq);
+    }
+    if recovered.len() == events.len() {
+        let seqs = events
+            .iter()
+            .map(|entry| recovered[&entry.attempt_event_ordinal])
+            .collect();
         transaction.commit().await.map_err(store_err)?;
-        return Ok(Some(seq));
+        return Ok(Some(seqs));
     }
 
     let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
@@ -1551,18 +1612,32 @@ pub(in crate::db) async fn append_turn_event(
         return Ok(None);
     }
 
-    let seq = append_event_on(
-        &transaction,
-        chat_id,
-        Some(turn_id),
-        Some(lease_token),
-        Some(attempt_event_ordinal),
-        None,
-        event,
-    )
-    .await?;
+    let mut next_seq = next_event_seq(&transaction, chat_id).await?;
+    let mut seqs = Vec::with_capacity(events.len());
+    for entry in events {
+        if let Some(seq) = recovered.get(&entry.attempt_event_ordinal) {
+            seqs.push(*seq);
+            continue;
+        }
+        let seq = next_seq;
+        next_seq = next_seq.checked_add(1).ok_or_else(|| {
+            AgentError::Store(format!("event sequence exhausted for chat {chat_id}"))
+        })?;
+        insert_event_row(
+            &transaction,
+            chat_id,
+            seq,
+            Some(turn_id),
+            Some(lease_token),
+            Some(entry.attempt_event_ordinal),
+            None,
+            &entry.event,
+        )
+        .await?;
+        seqs.push(seq);
+    }
     transaction.commit().await.map_err(store_err)?;
-    Ok(Some(seq))
+    Ok(Some(seqs))
 }
 
 pub(in crate::db::ops) async fn append_event_on<C>(
@@ -1577,15 +1652,50 @@ pub(in crate::db::ops) async fn append_event_on<C>(
 where
     C: ConnectionTrait,
 {
+    let seq = next_event_seq(conn, chat_id).await?;
+    insert_event_row(
+        conn,
+        chat_id,
+        seq,
+        turn_id,
+        lease_token,
+        attempt_event_ordinal,
+        scan_token,
+        event,
+    )
+    .await?;
+    Ok(seq)
+}
+
+/// The sequence the next event appended to this chat takes.
+async fn next_event_seq<C>(conn: &C, chat_id: ChatId) -> Result<i64>
+where
+    C: ConnectionTrait,
+{
     let last = entities::event::Entity::find()
         .filter(entities::event::Column::ChatId.eq(chat_id.0))
         .order_by_desc(entities::event::Column::Seq)
         .one(conn)
         .await
         .map_err(store_err)?;
-    let seq = last
-        .map_or(Some(1), |model| model.seq.checked_add(1))
-        .ok_or_else(|| AgentError::Store(format!("event sequence exhausted for chat {chat_id}")))?;
+    last.map_or(Some(1), |model| model.seq.checked_add(1))
+        .ok_or_else(|| AgentError::Store(format!("event sequence exhausted for chat {chat_id}")))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_event_row<C>(
+    conn: &C,
+    chat_id: ChatId,
+    seq: i64,
+    turn_id: Option<TurnId>,
+    lease_token: Option<uuid::Uuid>,
+    attempt_event_ordinal: Option<i32>,
+    scan_token: Option<uuid::Uuid>,
+    event: &AgentEvent,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
     entities::event::ActiveModel {
         chat_id: Set(chat_id.0),
         seq: Set(seq),
@@ -1600,7 +1710,7 @@ where
     .insert(conn)
     .await
     .map_err(store_err)?;
-    Ok(seq)
+    Ok(())
 }
 
 fn is_terminal_event(event: &AgentEvent) -> bool {

--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -23,6 +23,7 @@ mod output;
 mod parent_terminal_guard;
 mod root_attachment;
 mod sandbox_spawn_checkpoint;
+mod turn_event_batch;
 mod turn_steer;
 mod turn_terminal_usage;
 

--- a/crates/tidebreak-core/src/db/tests/turn_event_batch.rs
+++ b/crates/tidebreak-core/src/db/tests/turn_event_batch.rs
@@ -1,0 +1,152 @@
+use super::*;
+use crate::event::AgentEvent;
+use crate::storage::TurnEventAppend;
+
+fn delta(attempt_event_ordinal: i32, text: &str) -> TurnEventAppend {
+    TurnEventAppend {
+        attempt_event_ordinal,
+        event: AgentEvent::TextDelta { text: text.into() },
+    }
+}
+
+/// Batched appends share one transaction but keep the per-event identity a
+/// single append has: contiguous sequences, exact-retry recovery, refusal to
+/// reuse an ordinal with different data, and the lease fence.
+#[tokio::test]
+async fn batched_turn_events_keep_single_append_identity() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = turn.available_at + chrono::Duration::seconds(1);
+    let lease_expires_at = claimed_at + chrono::Duration::minutes(1);
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(lease_token, claimed_at, lease_expires_at)
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let started = AgentEvent::TurnStarted { turn_id: turn.id };
+    assert_eq!(
+        store
+            .append_turn_event(chat.id, turn.id, lease_token, 1, claimed_at, &started)
+            .await
+            .unwrap(),
+        Some(1)
+    );
+
+    let batch = [delta(2, "Hel"), delta(3, "lo, "), delta(4, "world")];
+    assert_eq!(
+        store
+            .append_turn_events(chat.id, turn.id, lease_token, claimed_at, &batch)
+            .await
+            .unwrap(),
+        Some(vec![2, 3, 4]),
+        "a batch takes contiguous sequences in order"
+    );
+    assert_eq!(
+        store
+            .append_turn_events(
+                chat.id,
+                turn.id,
+                lease_token,
+                lease_expires_at + chrono::Duration::seconds(1),
+                &batch,
+            )
+            .await
+            .unwrap(),
+        Some(vec![2, 3, 4]),
+        "an exact ambiguous retry recovers every original sequence, even after lease loss"
+    );
+    assert_eq!(
+        store
+            .append_turn_events(
+                chat.id,
+                turn.id,
+                lease_token,
+                claimed_at,
+                &[delta(3, "lo, "), delta(4, "world"), delta(5, "!")],
+            )
+            .await
+            .unwrap(),
+        Some(vec![3, 4, 5]),
+        "a retry that overlaps a committed prefix appends only the fresh tail"
+    );
+    assert!(
+        store
+            .append_turn_events(
+                chat.id,
+                turn.id,
+                lease_token,
+                claimed_at,
+                &[delta(5, "?"), delta(6, "")],
+            )
+            .await
+            .is_err(),
+        "an ordinal reused with different data is refused"
+    );
+    assert!(
+        store
+            .append_turn_events(
+                chat.id,
+                turn.id,
+                lease_token,
+                claimed_at,
+                &[delta(7, "a"), delta(6, "b")],
+            )
+            .await
+            .is_err(),
+        "batch ordinals must ascend"
+    );
+    assert!(store
+        .append_turn_events(chat.id, turn.id, lease_token, claimed_at, &[])
+        .await
+        .is_err());
+    assert_eq!(
+        store
+            .append_turn_events(
+                chat.id,
+                turn.id,
+                lease_token,
+                lease_expires_at + chrono::Duration::seconds(1),
+                &[delta(6, "late")],
+            )
+            .await
+            .unwrap(),
+        None,
+        "a stale lease cannot append fresh events"
+    );
+
+    let events = store.list_events(chat.id, 0).await.unwrap();
+    assert_eq!(
+        events.iter().map(|event| event.seq).collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5]
+    );
+    let replayed: String = events
+        .iter()
+        .filter_map(|event| match &event.event {
+            AgentEvent::TextDelta { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(replayed, "Hello, world!");
+    for (seq, ordinal) in [(2, 2), (3, 3), (4, 4), (5, 5)] {
+        let stored = entities::event::Entity::find_by_id((chat.id.0, seq))
+            .one(&store.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.turn_id, Some(turn.id.0));
+        assert_eq!(stored.lease_token, Some(lease_token));
+        assert_eq!(stored.attempt_event_ordinal, Some(ordinal));
+        assert!(!stored.terminal);
+    }
+}

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -336,7 +336,7 @@ pub use storage::{
     ReservedTurnAcceptanceOutcome, ResolveSandboxToolCallOutcome, ResolveToolCallOutcome,
     ResumeTurnForAgentRunWaitSetOutcome, RetrySandboxToolCallOutcome, SandboxAdmissionMode,
     SandboxProvision, SandboxProvisionState, SecretProvider, Store, SubmitAgentRunResultOutcome,
-    TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+    TurnEventAppend, TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use task_plan::{
     open_task_plan_steps, parse_update_task_plan_arguments, sandbox_update_task_plan_tool_spec,

--- a/crates/tidebreak-core/src/storage/store.rs
+++ b/crates/tidebreak-core/src/storage/store.rs
@@ -3147,6 +3147,48 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// Append a run of nonterminal events owned by one live turn attempt in a
+    /// single transaction.
+    ///
+    /// Each entry carries the same `(lease_token, attempt_event_ordinal)`
+    /// identity as [`append_turn_event`](Self::append_turn_event) and follows
+    /// the same rules; ordinals must ascend within the batch. Stores that
+    /// override this commit the whole run under one chat write lock, one turn
+    /// write lock, and one lease check, so a streaming turn that produces many
+    /// small text deltas does not pay a transaction per delta. The default
+    /// appends one at a time and stops at the first entry the lease no longer
+    /// owns.
+    ///
+    /// Returns the sequence assigned to each entry, in order, or `None` when
+    /// the attempt no longer owns a live running lease.
+    async fn append_turn_events(
+        &self,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        events: &[TurnEventAppend],
+    ) -> Result<Option<Vec<i64>>> {
+        let mut seqs = Vec::with_capacity(events.len());
+        for entry in events {
+            match self
+                .append_turn_event(
+                    chat_id,
+                    turn_id,
+                    lease_token,
+                    entry.attempt_event_ordinal,
+                    now,
+                    &entry.event,
+                )
+                .await?
+            {
+                Some(seq) => seqs.push(seq),
+                None => return Ok(None),
+            }
+        }
+        Ok(Some(seqs))
+    }
+
     /// Recover a terminal event only when it was committed by this exact lease
     /// with the byte-equivalent payload.
     ///

--- a/crates/tidebreak-core/src/storage/types.rs
+++ b/crates/tidebreak-core/src/storage/types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::approval::ToolApproval;
 use crate::code::{CodeSessionId, CodeTurnId, WorkspaceId};
 use crate::error::Result;
-use crate::event::SequencedEvent;
+use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{AgentRunId, CallId, ChatId, MessageId, NotificationId, TurnId};
 use crate::model::{
     AgentRun, AgentRunInboxEntry, AgentRunResult, Message, MessageAttachment,
@@ -1166,6 +1166,20 @@ pub enum TurnLeaseFence {
     /// later claim, or the turn already reached a terminal state.
     Stale,
 }
+
+/// One nonterminal event queued for a batched turn append.
+///
+/// The `(lease_token, attempt_event_ordinal)` identity is the same one a single
+/// [`Store::append_turn_event`](crate::Store::append_turn_event) uses; batching
+/// only changes how many entries share a transaction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TurnEventAppend {
+    /// Position of this event within the attempt; ascends within a batch.
+    pub attempt_event_ordinal: i32,
+    /// The event to journal.
+    pub event: AgentEvent,
+}
+
 /// Where one entry of the durable reverse-RPC operation log stands.
 ///
 /// This is the storage-tier projection of the protocol's operation state

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -12,7 +12,7 @@ use cap_std::fs::{Dir, DirBuilder};
 #[cfg(unix)]
 use cap_std::fs::{DirBuilderExt as CapDirBuilderExt, PermissionsExt as CapPermissionsExt};
 use chrono::Utc;
-use futures::channel::mpsc::{unbounded, UnboundedReceiver};
+use futures::channel::mpsc::{unbounded, TryRecvError, UnboundedReceiver};
 use futures::StreamExt;
 use tidebreak_core::{
     Agent, AgentConfig, AgentError, AgentEvent, AgentRunExecutionLocation, AgentRunWaitCondition,
@@ -20,8 +20,9 @@ use tidebreak_core::{
     ClaimedAgentEvent, CompleteTurnRunOutcome, ForegroundAgentWaitRequest, MessageId,
     ParkTurnForAgentRunWaitSetOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
     Result, SandboxAgentSpawnRequest, SandboxSpawnCheckpointRequest, SecretProvider,
-    SequencedEvent, Store, ToolRegistry, ToolScratch, TurnCheckpointProgress, TurnFailureRetry,
-    TurnId, TurnRun, TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
+    SequencedEvent, Store, ToolRegistry, ToolScratch, TurnCheckpointProgress, TurnEventAppend,
+    TurnFailureRetry, TurnId, TurnRun, TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL,
+    WAIT_FOR_AGENTS_TOOL,
 };
 use tokio::sync::{watch, Notify};
 
@@ -149,6 +150,136 @@ enum EventAppend {
     Committed,
     Cancelling,
     LeaseLost,
+}
+
+/// Ceiling on how many pending events one journal transaction carries.
+const EVENT_BATCH_MAX: usize = 64;
+
+/// How long a batch made only of streamed deltas waits for the next one before
+/// it is journaled. Short enough that a reader cannot tell, long enough that a
+/// provider streaming a token every few milliseconds shares one commit across
+/// several of them.
+const EVENT_BATCH_WINDOW: Duration = Duration::from_millis(25);
+
+/// What the worker loop takes off the claimed-turn event channel next.
+///
+/// The variants differ in size, but a value lives for one loop iteration on the
+/// streaming hot path, so boxing the smaller one would trade a few stack bytes
+/// for an allocation per emission.
+#[allow(clippy::large_enum_variant)]
+enum Emission {
+    /// Adjacent pending events with ascending ordinals, journaled together.
+    Pending(Vec<TurnEventAppend>),
+    /// Anything that is not a pending append: a committed or recovered event,
+    /// or a flush request.
+    Other(ClaimedAgentEvent),
+}
+
+/// Groups adjacent [`ClaimedAgentEvent::Pending`] emissions so the worker can
+/// journal them in one transaction.
+///
+/// The agent enqueues one emission per streamed chunk. Draining whatever is
+/// already buffered, and waiting a short window for more when the run so far is
+/// only streamed deltas, turns a transaction per delta into a transaction per
+/// burst while keeping every emission in channel order: a non-pending emission
+/// ends the run and is handed back on the next call.
+///
+/// `next` is cancel-safe. Every partially collected run and every looked-ahead
+/// emission lives on the batcher, so a `select!` that drops the future loses
+/// nothing.
+struct EmissionBatcher {
+    receiver: UnboundedReceiver<ClaimedAgentEvent>,
+    pending: Vec<TurnEventAppend>,
+    lookahead: Option<ClaimedAgentEvent>,
+    closed: bool,
+    window: Duration,
+}
+
+impl EmissionBatcher {
+    fn new(receiver: UnboundedReceiver<ClaimedAgentEvent>, window: Duration) -> Self {
+        Self {
+            receiver,
+            pending: Vec::new(),
+            lookahead: None,
+            closed: false,
+            window,
+        }
+    }
+
+    async fn next(&mut self) -> Option<Emission> {
+        if self.pending.is_empty() {
+            let first = match self.lookahead.take() {
+                Some(item) => item,
+                None if self.closed => return None,
+                None => match self.receiver.next().await {
+                    Some(item) => item,
+                    None => {
+                        self.closed = true;
+                        return None;
+                    }
+                },
+            };
+            match first {
+                ClaimedAgentEvent::Pending { ordinal, event } => self.push_pending(ordinal, event),
+                other => return Some(Emission::Other(other)),
+            }
+        }
+        loop {
+            if self.pending.len() >= EVENT_BATCH_MAX {
+                return Some(self.flush());
+            }
+            let item = match self.receiver.try_recv() {
+                Ok(item) => Some(item),
+                Err(TryRecvError::Closed) => {
+                    self.closed = true;
+                    None
+                }
+                Err(TryRecvError::Empty) if self.closed || !self.pending_is_only_deltas() => None,
+                Err(TryRecvError::Empty) => {
+                    match tokio::time::timeout(self.window, self.receiver.next()).await {
+                        Ok(Some(item)) => Some(item),
+                        Ok(None) => {
+                            self.closed = true;
+                            None
+                        }
+                        Err(_) => None,
+                    }
+                }
+            };
+            match item {
+                Some(ClaimedAgentEvent::Pending { ordinal, event }) => {
+                    self.push_pending(ordinal, event);
+                }
+                Some(other) => {
+                    self.lookahead = Some(other);
+                    return Some(self.flush());
+                }
+                None => return Some(self.flush()),
+            }
+        }
+    }
+
+    fn push_pending(&mut self, ordinal: i32, event: AgentEvent) {
+        self.pending.push(TurnEventAppend {
+            attempt_event_ordinal: ordinal,
+            event,
+        });
+    }
+
+    fn flush(&mut self) -> Emission {
+        Emission::Pending(std::mem::take(&mut self.pending))
+    }
+
+    fn pending_is_only_deltas(&self) -> bool {
+        self.pending.iter().all(|entry| {
+            matches!(
+                entry.event,
+                AgentEvent::TextDelta { .. }
+                    | AgentEvent::ReasoningDelta { .. }
+                    | AgentEvent::ToolCallArgsDelta { .. }
+            )
+        })
+    }
 }
 
 enum ClaimAction {
@@ -279,20 +410,47 @@ fn freeze_foreground_turn_surface_with_folders(
 async fn drain_committed_events(
     events: &EventBus,
     chat_id: tidebreak_core::ChatId,
-    emissions: &mut UnboundedReceiver<ClaimedAgentEvent>,
+    emissions: &mut EmissionBatcher,
 ) {
-    while let Some(emission) = emissions.next().await {
-        match emission {
-            ClaimedAgentEvent::Committed { event, .. } => {
-                let _ = events.sender(chat_id).send(event);
-            }
-            ClaimedAgentEvent::Recovered { .. } => {}
-            ClaimedAgentEvent::Flush(acknowledge) => {
-                let _ = acknowledge.send(());
-            }
-            ClaimedAgentEvent::Pending { .. } => {}
+    // Pending events the batcher collected but never journaled are discarded
+    // exactly like pending emissions still in the channel.
+    emissions.pending.clear();
+    let drain = |emission: ClaimedAgentEvent| match emission {
+        ClaimedAgentEvent::Committed { event, .. } => {
+            let _ = events.sender(chat_id).send(event);
         }
+        ClaimedAgentEvent::Recovered { .. } => {}
+        ClaimedAgentEvent::Flush(acknowledge) => {
+            let _ = acknowledge.send(());
+        }
+        ClaimedAgentEvent::Pending { .. } => {}
+    };
+    if let Some(emission) = emissions.lookahead.take() {
+        drain(emission);
     }
+    if emissions.closed {
+        return;
+    }
+    while let Some(emission) = emissions.receiver.next().await {
+        drain(emission);
+    }
+}
+
+/// Check that a pending run continues the attempt's ordinal sequence exactly
+/// and return how many ordinals it consumes.
+fn expect_ordinal_run(turn_id: TurnId, ordinal: i32, batch: &[TurnEventAppend]) -> Result<i32> {
+    let exhausted = || AgentError::msg(format!("turn {turn_id} event ordinal exhausted"));
+    let mut expected = ordinal;
+    for entry in batch {
+        if entry.attempt_event_ordinal != expected {
+            return Err(AgentError::msg(format!(
+                "turn {turn_id} emitted event ordinal {}, expected {expected}",
+                entry.attempt_event_ordinal
+            )));
+        }
+        expected = expected.checked_add(1).ok_or_else(exhausted)?;
+    }
+    i32::try_from(batch.len()).map_err(|_| exhausted())
 }
 
 fn client_checkpoint_is_valid(
@@ -1220,7 +1378,8 @@ impl TurnWorker {
                 agent = agent.with_blobs(blobs);
             }
             let chat = chat.clone();
-            let (events_tx, mut events_rx) = unbounded();
+            let (events_tx, events_rx) = unbounded();
+            let mut events_rx = EmissionBatcher::new(events_rx, EVENT_BATCH_WINDOW);
             let mut drive = AbortOnDrop(tokio::spawn(async move {
                 agent
                     .run_claimed_turn(&chat, turn.id, output_message_id, ordinal, &events_tx)
@@ -1238,26 +1397,21 @@ impl TurnWorker {
                     }
                     emission = events_rx.next(), if channel_open => {
                         match emission {
-                            Some(ClaimedAgentEvent::Pending { ordinal: event_ordinal, event }) => {
-                                if event_ordinal != ordinal {
-                                    return Err(AgentError::msg(format!(
-                                        "turn {} emitted event ordinal {event_ordinal}, expected {ordinal}",
-                                        turn.id
-                                    )));
-                                }
-                                match self.append_event(&turn, lease_token, event_ordinal, &event).await? {
+                            Some(Emission::Pending(batch)) => {
+                                let consumed = expect_ordinal_run(turn.id, ordinal, &batch)?;
+                                match self.append_events(&turn, lease_token, &batch).await? {
                                     EventAppend::Committed => {
-                                        ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                        ordinal = ordinal.checked_add(consumed).ok_or_else(|| {
                                             AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
                                         })?;
                                     }
                                     EventAppend::Cancelling => {
-                                        // The agent assigns ordinals before enqueueing. This
-                                        // emission is consumed even though cancellation won its
-                                        // append, so advance past it before draining any already
-                                        // buffered emissions. A later atomically committed event
-                                        // may legitimately follow this journal gap.
-                                        ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                        // The agent assigns ordinals before enqueueing. These
+                                        // emissions are consumed even though cancellation won
+                                        // their append, so advance past them before draining any
+                                        // already buffered emissions. A later atomically committed
+                                        // event may legitimately follow this journal gap.
+                                        ordinal = ordinal.checked_add(consumed).ok_or_else(|| {
                                             AgentError::msg(format!(
                                                 "turn {} event ordinal exhausted",
                                                 turn.id
@@ -1280,7 +1434,7 @@ impl TurnWorker {
                                     }
                                 }
                             }
-                            Some(ClaimedAgentEvent::Committed { ordinal: event_ordinal, event }) => {
+                            Some(Emission::Other(ClaimedAgentEvent::Committed { ordinal: event_ordinal, event })) => {
                                 if event_ordinal != ordinal {
                                     return Err(AgentError::msg(format!(
                                         "turn {} committed event ordinal {event_ordinal}, expected {ordinal}",
@@ -1292,7 +1446,7 @@ impl TurnWorker {
                                     AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
                                 })?;
                             }
-                            Some(ClaimedAgentEvent::Recovered { ordinal: event_ordinal, event: _ }) => {
+                            Some(Emission::Other(ClaimedAgentEvent::Recovered { ordinal: event_ordinal, event: _ })) => {
                                 if event_ordinal != ordinal {
                                     return Err(AgentError::msg(format!(
                                         "turn {} recovered event ordinal {event_ordinal}, expected {ordinal}",
@@ -1303,8 +1457,11 @@ impl TurnWorker {
                                     AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
                                 })?;
                             }
-                            Some(ClaimedAgentEvent::Flush(acknowledge)) => {
+                            Some(Emission::Other(ClaimedAgentEvent::Flush(acknowledge))) => {
                                 let _ = acknowledge.send(());
+                            }
+                            Some(Emission::Other(ClaimedAgentEvent::Pending { .. })) => {
+                                unreachable!("the batcher never hands back a pending emission alone")
                             }
                             None => channel_open = false,
                         }
@@ -2535,27 +2692,38 @@ impl TurnWorker {
         ordinal: i32,
         event: &AgentEvent,
     ) -> Result<EventAppend> {
+        let entry = TurnEventAppend {
+            attempt_event_ordinal: ordinal,
+            event: event.clone(),
+        };
+        self.append_events(turn, lease_token, std::slice::from_ref(&entry))
+            .await
+    }
+
+    /// Journal a run of pending events in one store transaction and publish
+    /// each one in order once the run commits.
+    async fn append_events(
+        &self,
+        turn: &TurnRun,
+        lease_token: uuid::Uuid,
+        events: &[TurnEventAppend],
+    ) -> Result<EventAppend> {
         loop {
             match self
                 .store
-                .append_turn_event(
-                    turn.chat_id,
-                    turn.id,
-                    lease_token,
-                    ordinal,
-                    Utc::now(),
-                    event,
-                )
+                .append_turn_events(turn.chat_id, turn.id, lease_token, Utc::now(), events)
                 .await
             {
-                Ok(Some(seq)) => {
-                    self.publish(
-                        turn.chat_id,
-                        SequencedEvent {
-                            seq,
-                            event: event.clone(),
-                        },
-                    );
+                Ok(Some(seqs)) => {
+                    for (entry, seq) in events.iter().zip(seqs) {
+                        self.publish(
+                            turn.chat_id,
+                            SequencedEvent {
+                                seq,
+                                event: entry.event.clone(),
+                            },
+                        );
+                    }
                     return Ok(EventAppend::Committed);
                 }
                 Ok(None) => match self.lease_state_retry(turn, lease_token).await {
@@ -3447,7 +3615,7 @@ mod committed_event_drain_tests {
         let events = EventBus::default();
         let chat_id = tidebreak_core::ChatId::new();
         let mut live = events.subscribe(chat_id);
-        let (sender, mut receiver) = unbounded();
+        let (sender, receiver) = unbounded();
         sender
             .unbounded_send(ClaimedAgentEvent::Pending {
                 ordinal: 2,
@@ -3470,6 +3638,7 @@ mod committed_event_drain_tests {
             })
             .unwrap();
         drop(sender);
+        let mut receiver = EmissionBatcher::new(receiver, Duration::ZERO);
 
         drain_committed_events(&events, chat_id, &mut receiver).await;
 
@@ -3478,6 +3647,192 @@ mod committed_event_drain_tests {
             live.try_recv(),
             Err(tokio::sync::broadcast::error::TryRecvError::Empty)
         ));
+    }
+
+    fn pending_delta(ordinal: i32, text: &str) -> ClaimedAgentEvent {
+        ClaimedAgentEvent::Pending {
+            ordinal,
+            event: AgentEvent::TextDelta { text: text.into() },
+        }
+    }
+
+    fn batch_texts(emission: Option<Emission>) -> Vec<(i32, String)> {
+        match emission {
+            Some(Emission::Pending(batch)) => batch
+                .into_iter()
+                .map(|entry| match entry.event {
+                    AgentEvent::TextDelta { text } => (entry.attempt_event_ordinal, text),
+                    other => panic!("unexpected batched event {other:?}"),
+                })
+                .collect(),
+            other => panic!("expected a pending batch, got {}", describe(other.as_ref())),
+        }
+    }
+
+    fn describe(emission: Option<&Emission>) -> &'static str {
+        match emission {
+            None => "closed channel",
+            Some(Emission::Pending(_)) => "pending batch",
+            Some(Emission::Other(ClaimedAgentEvent::Committed { .. })) => "committed",
+            Some(Emission::Other(ClaimedAgentEvent::Recovered { .. })) => "recovered",
+            Some(Emission::Other(ClaimedAgentEvent::Flush(_))) => "flush",
+            Some(Emission::Other(ClaimedAgentEvent::Pending { .. })) => "lone pending",
+        }
+    }
+
+    /// Adjacent pending deltas already buffered on the channel come off as one
+    /// batch, and the emission that ends the run is handed back next, in order.
+    #[tokio::test]
+    async fn batcher_groups_adjacent_pending_events_and_preserves_order() {
+        let (sender, receiver) = unbounded();
+        let mut batcher = EmissionBatcher::new(receiver, Duration::ZERO);
+        for (ordinal, text) in [(2, "Hel"), (3, "lo"), (4, ", ")] {
+            sender.unbounded_send(pending_delta(ordinal, text)).unwrap();
+        }
+        let committed = SequencedEvent {
+            seq: 9,
+            event: AgentEvent::UserSteered {
+                message_id: MessageId::new(),
+                content: "steer".into(),
+            },
+        };
+        sender
+            .unbounded_send(ClaimedAgentEvent::Committed {
+                ordinal: 5,
+                event: committed.clone(),
+            })
+            .unwrap();
+        sender.unbounded_send(pending_delta(6, "world")).unwrap();
+        let (acknowledge, acknowledged) = futures::channel::oneshot::channel();
+        sender
+            .unbounded_send(ClaimedAgentEvent::Flush(acknowledge))
+            .unwrap();
+        drop(sender);
+
+        assert_eq!(
+            batch_texts(batcher.next().await),
+            vec![
+                (2, "Hel".to_owned()),
+                (3, "lo".to_owned()),
+                (4, ", ".to_owned())
+            ]
+        );
+        match batcher.next().await {
+            Some(Emission::Other(ClaimedAgentEvent::Committed { ordinal, event })) => {
+                assert_eq!(ordinal, 5);
+                assert_eq!(event, committed);
+            }
+            other => panic!(
+                "expected the committed event, got {}",
+                describe(other.as_ref())
+            ),
+        }
+        assert_eq!(
+            batch_texts(batcher.next().await),
+            vec![(6, "world".to_owned())]
+        );
+        match batcher.next().await {
+            Some(Emission::Other(ClaimedAgentEvent::Flush(acknowledge))) => {
+                acknowledge.send(()).unwrap();
+            }
+            other => panic!("expected the flush, got {}", describe(other.as_ref())),
+        }
+        acknowledged.await.unwrap();
+        assert!(batcher.next().await.is_none());
+        assert!(
+            batcher.next().await.is_none(),
+            "a closed batcher stays closed"
+        );
+    }
+
+    /// A run made only of streamed deltas waits the window for the next one; a
+    /// run holding anything else is journaled as soon as the channel is empty.
+    #[tokio::test]
+    async fn batcher_waits_for_more_deltas_but_not_behind_other_events() {
+        let (sender, receiver) = unbounded();
+        let mut batcher = EmissionBatcher::new(receiver, Duration::from_secs(5));
+        sender.unbounded_send(pending_delta(1, "a")).unwrap();
+        let late_sender = sender.clone();
+        let late = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            late_sender.unbounded_send(pending_delta(2, "b")).unwrap();
+            late_sender
+                .unbounded_send(ClaimedAgentEvent::Pending {
+                    ordinal: 3,
+                    event: AgentEvent::StreamInterrupted,
+                })
+                .unwrap();
+        });
+        let first = tokio::time::timeout(Duration::from_secs(2), batcher.next())
+            .await
+            .expect("a non-delta emission ends the wait before the window elapses");
+        late.await.unwrap();
+        match first {
+            Some(Emission::Pending(batch)) => {
+                assert_eq!(
+                    batch
+                        .iter()
+                        .map(|entry| entry.attempt_event_ordinal)
+                        .collect::<Vec<_>>(),
+                    vec![1, 2, 3],
+                    "the late delta and the interrupt joined the open batch"
+                );
+                assert!(matches!(batch[2].event, AgentEvent::StreamInterrupted));
+            }
+            other => panic!("expected a pending batch, got {}", describe(other.as_ref())),
+        }
+
+        sender
+            .unbounded_send(ClaimedAgentEvent::Pending {
+                ordinal: 4,
+                event: AgentEvent::StreamInterrupted,
+            })
+            .unwrap();
+        let second = tokio::time::timeout(Duration::from_millis(500), batcher.next())
+            .await
+            .expect("a run without deltas does not wait for the window");
+        assert_eq!(
+            match second {
+                Some(Emission::Pending(batch)) => batch.len(),
+                other => panic!("expected a pending batch, got {}", describe(other.as_ref())),
+            },
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn batcher_caps_one_transaction_at_the_batch_ceiling() {
+        let (sender, receiver) = unbounded();
+        let mut batcher = EmissionBatcher::new(receiver, Duration::ZERO);
+        let total = i32::try_from(EVENT_BATCH_MAX).unwrap() + 3;
+        for ordinal in 1..=total {
+            sender.unbounded_send(pending_delta(ordinal, "x")).unwrap();
+        }
+        drop(sender);
+
+        assert_eq!(batch_texts(batcher.next().await).len(), EVENT_BATCH_MAX);
+        let tail = batch_texts(batcher.next().await);
+        assert_eq!(tail.len(), 3);
+        assert_eq!(tail[0].0, i32::try_from(EVENT_BATCH_MAX).unwrap() + 1);
+        assert!(batcher.next().await.is_none());
+    }
+
+    #[test]
+    fn ordinal_run_must_continue_the_attempt_exactly() {
+        let turn = TurnId::new();
+        let run = |ordinals: &[i32]| {
+            ordinals
+                .iter()
+                .map(|ordinal| TurnEventAppend {
+                    attempt_event_ordinal: *ordinal,
+                    event: AgentEvent::TextDelta { text: "x".into() },
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(expect_ordinal_run(turn, 4, &run(&[4, 5, 6])).unwrap(), 3);
+        assert!(expect_ordinal_run(turn, 4, &run(&[5, 6])).is_err());
+        assert!(expect_ordinal_run(turn, 4, &run(&[4, 6])).is_err());
+        assert!(expect_ordinal_run(turn, i32::MAX - 1, &run(&[i32::MAX - 1, i32::MAX])).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Why

Every streamed event, each text delta included, committed its own SQLite transaction: chat write lock, turn write lock, dedupe select, claim select, insert. A turn streaming a token every few milliseconds paid that per token.

## What

- `Store::append_turn_events` journals a run of nonterminal events for one lease under one transaction. Locks and the lease check run once. Every entry keeps the `(lease_token, attempt_event_ordinal)` identity of a single append: an exact retry recovers each original sequence, an ordinal reused with different data is refused, and a stale lease appends nothing. The single-event op delegates to it. The trait default loops over `append_turn_event`, so wrapper stores in tests keep working.
- In the turn worker, an emission batcher groups adjacent pending emissions off the agent channel before appending. It drains what is already buffered, waits up to 25ms for more when the run so far is only streamed deltas, and stops at 64 events or at the first non-pending emission, which it hands back next so channel order is unchanged. Partial runs live on the batcher, so a `select!` dropping the future loses nothing. Lease loss still discards pending events and publishes committed ones.

## Tests

- `db::tests::turn_event_batch`: a batch takes contiguous sequences, an exact retry recovers them after lease loss, an overlapping retry appends only the fresh tail, reused ordinals and descending ordinals are refused, a stale lease returns `None`, and replay yields the same text.
- Turn worker: the batcher groups adjacent pending events and preserves order around committed and flush emissions, waits for more deltas but not behind other events, caps a batch at the ceiling, and the ordinal-run check rejects gaps.

Ran `cargo check`, `cargo clippy --tests`, `cargo fmt --check` for `tidebreak-core` and `tidebreak-server`, the new tests, and the server tests matching `stream`, `delta`, `durable_turn`, `claimed` plus core `agent::tests`, `durable_turn`, `multi_agent_wait` (30 and 113 passed).

Closes #2956
