### PR TITLE
fix(mobile): sync generated wire types with desktop

### DIFF
--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -1535,10 +1535,13 @@ export type CodePrMergeMethod = "squash" | "merge" | "rebase";
 /**
  * How strongly a workspace is tied to a pull request (decision 77).
  *
- * Only two acts mint attribution: `gh pr create` (authored) and a push whose
- * branch is or becomes a pull request's head (contributed). Reading,
- * checking out, commenting on, closing, or merging a pull request never
- * does, so review and triage agents stay out of the attributed set.
+ * `gh pr create` mints authored attribution. A push whose branch is or
+ * becomes a pull request's head mints contributed attribution. A changed,
+ * clean workspace checkout also mints contributed attribution when it remains
+ * on the workspace branch and its current commit exactly matches an open pull
+ * request head. Reading, checking out, commenting on, closing, or merging a
+ * pull request never does, so review and triage agents stay out of the
+ * attributed set.
  */
 export type CodePullRequestRelation = "authored" | "contributed";
 


### PR DESCRIPTION
## Summary

The Mobile app lane on main failed because `mobile/src/generated/wire.ts` no longer matched the desktop bindings byte-for-byte. The only drift was the `CodePullRequestRelation` comment after the checkout-attribution doc change. This copies the desktop file onto mobile so the sync test passes.

## Test plan

- [x] Desktop and mobile `wire.ts` compare equal
- [ ] Mobile app CI lane is green