### PR TITLE
fix(desktop): render one check summary in the delivery row and the Checks tab

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/PrCheckSummary.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCheckSummary.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+import { type CheckCounts, checkSummary } from "./prState";
+import { STATUS_TEXT } from "./statusTone";
+
+/**
+ * The check rollup as one phrase in its tone: `1 failed`, `2 pending`,
+ * `8 passed`, `3 skipped`, or `No checks`. The delivery row and the detail
+ * Checks tab both render this component, so the two cannot describe the
+ * same counts in different words. The wording itself lives in
+ * `checkSummary` in prState.ts.
+ */
+export function PrCheckSummary({
+  counts,
+  className,
+}: {
+  counts: CheckCounts;
+  className?: string;
+}) {
+  const summary = checkSummary(counts);
+  return (
+    <span className={cn("text-xs", STATUS_TEXT[summary.tone], className)}>
+      {summary.label}
+    </span>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
@@ -200,9 +200,9 @@ describe("PullRequestDetailSheet", () => {
     const checksTab = screen.getByRole("tab", { name: /Checks/ });
     expect(checksTab).toHaveTextContent("2/2");
     await userEvent.click(checksTab);
-    expect(
-      await screen.findByText("1 of 2 passed, 1 failed"),
-    ).toBeInTheDocument();
+    // The same words the delivery row uses for these counts.
+    const panel = await screen.findByRole("tabpanel");
+    expect(within(panel).getByText("1 failed")).toBeInTheDocument();
     const rows = screen.getAllByRole("button", { name: /desktop \// });
     expect(rows[0]).toHaveTextContent("desktop / storybook");
   });
@@ -212,9 +212,8 @@ describe("PullRequestDetailSheet", () => {
     const checksTab = await screen.findByRole("tab", { name: /Checks/ });
     expect(checksTab).toHaveTextContent("3/3");
     await userEvent.click(checksTab);
-    expect(
-      await screen.findByText("2 of 3 passed, 1 skipped"),
-    ).toBeInTheDocument();
+    const panel = await screen.findByRole("tabpanel");
+    expect(within(panel).getByText("2 passed")).toBeInTheDocument();
   });
 
   it("keeps pending checks out of progress and uses the running mark", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -76,6 +76,7 @@ import {
   type PrPromptAction,
 } from "./prActions";
 import { GithubAvatar } from "./GithubAvatar";
+import { PrCheckSummary } from "./PrCheckSummary";
 import { PrCommentCard } from "./PrCommentCard";
 import {
   expandGithubEmojiShortcodes,
@@ -1857,10 +1858,6 @@ function DiffPatch({ patch }: { patch: string }) {
 
 function PrChecks({ checks }: { checks: readonly CodeDeliveryCheck[] }) {
   const counts = checkCounts({ checks });
-  // The delivery list row summarizes the same counts through
-  // `checkSummary` in prState.ts with different wording ("passed" here,
-  // "passing" there). Folding the two into one component changes visible
-  // text, so it stays a follow-up rather than part of the file split.
   if (checks.length === 0) {
     return <p className="text-xs text-muted-foreground">No checks reported.</p>;
   }
@@ -1870,18 +1867,7 @@ function PrChecks({ checks }: { checks: readonly CodeDeliveryCheck[] }) {
     (left, right) => bucketRank(left.bucket) - bucketRank(right.bucket),
   );
   return (
-    <DetailSection
-      title="Checks"
-      action={
-        <span className="text-xs text-muted-foreground">
-          {`${counts.passing} of ${counts.total} passed${
-            counts.failing > 0 ? `, ${counts.failing} failed` : ""
-          }${counts.pending > 0 ? `, ${counts.pending} pending` : ""}${
-            counts.skipped > 0 ? `, ${counts.skipped} skipped` : ""
-          }`}
-        </span>
-      }
-    >
+    <DetailSection title="Checks" action={<PrCheckSummary counts={counts} />}>
       <div className="flex flex-col rounded-lg border border-border-subtle">
         {ordered.map((check, index) => (
           <button

--- a/crates/tidebreak-desktop/ui/src/code/delivery/PullRequestList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/PullRequestList.tsx
@@ -9,13 +9,9 @@ import {
   VirtualRows,
 } from "./VirtualRows";
 import { PrLifecycleIcon, relativeTime } from "../PullRequestDetail";
+import { PrCheckSummary } from "../PrCheckSummary";
 import type { PullRequestGrouping } from "./views";
-import {
-  checkCounts,
-  checkSummary,
-  prStatus,
-  type PullRequestListGroup,
-} from "../prState";
+import { checkCounts, prStatus, type PullRequestListGroup } from "../prState";
 import {
   STATUS_DOT,
   STATUS_MARK,
@@ -342,7 +338,7 @@ function PullRequestRow({
 }) {
   const status = prStatus(item);
   const lifecycle = status.lifecycle;
-  const checks = checkSummary(checkCounts(item));
+  const checks = checkCounts(item);
   const comments = item.comment_count;
   const mergeAction = item.head_sha
     ? prDirectMergeAction(deliveryPullRequestDigest(item), {
@@ -445,9 +441,7 @@ function PullRequestRow({
         </span>
       </span>
       <span className="flex items-center">
-        <span className={cn("text-xs", STATUS_TEXT[checks.tone])}>
-          {checks.label}
-        </span>
+        <PrCheckSummary counts={checks} />
       </span>
       <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
         <MessageSquare className="size-3.5 shrink-0" />

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -581,7 +581,7 @@ export const PullRequestRunningCheckDetail: Story = {
     await expect(checksTab).toHaveTextContent("0/1");
     await userEvent.click(checksTab);
     await expect(
-      await body.findByText("0 of 1 passed, 1 pending"),
+      within(await body.findByRole("tabpanel")).getByText("1 pending"),
     ).toBeVisible();
     const pending = await body.findByRole("button", {
       name: /Preview \/ Build preview image/,
@@ -935,7 +935,9 @@ export const PullRequestDetailChecks: Story = {
     const body = within(canvasElement.ownerDocument.body);
     await openPullRequest(canvasElement, "Build the delivery center");
     await userEvent.click(await body.findByRole("tab", { name: /Checks/ }));
-    await expect(await body.findByText(/1 of 2 passed/)).toBeVisible();
+    await expect(
+      within(await body.findByRole("tabpanel")).getByText("1 failed"),
+    ).toBeVisible();
   },
 };
 
@@ -951,7 +953,7 @@ export const PullRequestTerminalChecks: Story = {
     await expect(checksTab).toHaveTextContent("3/3");
     await userEvent.click(checksTab);
     await expect(
-      await body.findByText("2 of 3 passed, 1 skipped"),
+      within(await body.findByRole("tabpanel")).getByText("2 passed"),
     ).toBeVisible();
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/PrState.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/PrState.stories.tsx
@@ -18,6 +18,7 @@ import {
   pullRequestLifecycle,
   type PrStateInput,
 } from "@/code/prState";
+import { PrCheckSummary } from "@/code/PrCheckSummary";
 import { PrLifecycleIcon, StackMap } from "@/code/PullRequestDetail";
 import { STATUS_MARK, STATUS_TEXT, type StatusTone } from "@/code/statusTone";
 
@@ -344,6 +345,90 @@ const stackMembers: CodeDeliveryStackMember[] = [
     head_sha: "3f0c1b2a",
   },
 ];
+
+const checkSummaryInputs: { name: string; input: PrStateInput }[] = [
+  { name: "No checks", input: digestWith({ checks: [] }) },
+  {
+    name: "All passed",
+    input: digestWith({
+      checks: [
+        { name: "ci / rust", bucket: "pass" },
+        { name: "desktop UI", bucket: "pass" },
+      ],
+    }),
+  },
+  {
+    name: "Still running",
+    input: digestWith({
+      checks: [
+        { name: "ci / rust", bucket: "pass" },
+        { name: "desktop UI", bucket: "pending" },
+      ],
+    }),
+  },
+  {
+    name: "Failures first",
+    input: digestWith({
+      checks: [
+        { name: "ci / rust", bucket: "fail" },
+        { name: "desktop UI", bucket: "pending" },
+        { name: "docs", bucket: "pass" },
+      ],
+    }),
+  },
+  {
+    name: "Only skipped",
+    input: digestWith({
+      checks: [
+        { name: "release draft", bucket: "skipped" },
+        { name: "publish", bucket: "skipped" },
+      ],
+    }),
+  },
+  {
+    name: "Counts without a check list",
+    input: digestWith({
+      check_counts: { passing: 8, pending: 1, failing: 0, skipped: 2 },
+    }),
+  },
+];
+
+export const CheckSummary: StoryObj = {
+  name: "Check summary",
+  render: () => (
+    <Section
+      title="Check summary"
+      description="One phrase per rollup, failures first, then work in flight, then the settled result. The delivery row and the detail Checks tab render this same component, so a change to the wording here changes both."
+    >
+      <table className="w-full max-w-xl text-left text-sm">
+        <thead>
+          <tr className="text-muted-foreground text-2xs uppercase tracking-wide">
+            <th className="py-1.5 pr-4 font-medium">Checks</th>
+            <th className="py-1.5 pr-4 font-medium">Counts</th>
+            <th className="py-1.5 font-medium">Summary</th>
+          </tr>
+        </thead>
+        <tbody>
+          {checkSummaryInputs.map(({ name, input }) => {
+            const counts = checkCounts(input);
+            return (
+              <tr key={name} className="border-border-subtle border-t">
+                <td className="py-2 pr-4">{name}</td>
+                <td className="text-muted-foreground py-2 pr-4 text-xs tabular-nums">
+                  {counts.passing} pass · {counts.pending} pending ·{" "}
+                  {counts.failing} fail · {counts.skipped} skipped
+                </td>
+                <td className="py-2">
+                  <PrCheckSummary counts={counts} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </Section>
+  ),
+};
 
 export const Stack: StoryObj = {
   name: "Stack map",


### PR DESCRIPTION
## What changed

The delivery list row summarized check counts through `checkSummary` in `prState.ts` ("1 failed" / "1 pending" / "8 passed" with a tone) while the detail Checks tab built its own string ("1 of 2 passed, 1 failed"). Both read the same `checkCounts`, so the two could say different things about one pull request.

- `src/code/PrCheckSummary.tsx` renders the `checkSummary` phrase in its status tone. It is the one place both surfaces draw the summary from.
- The delivery row (`delivery/PullRequestList.tsx`) and the Checks tab header (`PrChecks` in `PullRequestDetail.tsx`) both render it. The tab loses the "N of M" prefix; the tab trigger already shows the settled-over-total progress and the per-check list below carries the breakdown, failures first.
- `Code/PR state` in Storybook gains a "Check summary" section showing the component across no checks, all passed, still running, failures first, only skipped, and counts without a check list.

## Why

Follow-up from #2954. Folding the two summaries changes visible text, so it stayed out of the mechanical split.

## Verification

In `crates/tidebreak-desktop/ui`: `biome format src`, `pnpm lint`, `pnpm test` (263 files, 2320 tests passed), `pnpm build`, and `pnpm storybook:build` all pass. `PullRequestDetail.dom.test.tsx` and the `DeliveryCenter` stories now assert the shared wording inside the Checks tab panel.

Closes #2990
