### PR TITLE
perf(desktop): push same-document navigation from the browser view

### DIFF
--- a/crates/tidebreak-desktop/Cargo.toml
+++ b/crates/tidebreak-desktop/Cargo.toml
@@ -79,5 +79,5 @@ libc.workspace = true
 objc2 = "=0.6.4"
 objc2-app-kit = { version = "=0.3.2", default-features = false, features = ["NSAccessibility", "NSAccessibilityProtocols", "NSApplication", "NSEvent", "NSGraphicsContext", "NSResponder", "NSText", "NSView", "NSWindow", "objc2-core-graphics"] }
 objc2-core-graphics = { version = "=0.3.2", default-features = false, features = ["CGEvent", "CGEventSource", "CGEventTypes", "CGGeometry"] }
-objc2-foundation = { version = "=0.3.2", default-features = false, features = ["NSArray", "NSError", "NSGeometry", "NSString"] }
+objc2-foundation = { version = "=0.3.2", default-features = false, features = ["NSArray", "NSError", "NSGeometry", "NSKeyValueObserving", "NSString", "NSURL"] }
 objc2-web-kit = { version = "=0.3.2", default-features = false, features = ["WKContentWorld", "WKFrameInfo", "WKWebView", "block2"] }

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -180,54 +180,6 @@ struct RawTextProbe {
     uninspectable_regions: usize,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct SameDocumentNavigationObservation {
-    pub(crate) sequence: u64,
-    pub(crate) url: String,
-}
-
-pub(crate) async fn browser_install_same_document_navigation_observer(
-    webview: &Webview,
-) -> Result<SameDocumentNavigationObservation, String> {
-    #[cfg(target_os = "macos")]
-    {
-        evaluate_json(webview, same_document_navigation_observer_script()).await
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        webview
-            .eval(same_document_navigation_observer_script())
-            .map_err(|error| format!("browser host: {error}"))?;
-        let url = webview
-            .url()
-            .map_err(|error| format!("browser host: {error}"))?;
-        Ok(SameDocumentNavigationObservation {
-            sequence: 0,
-            url: url.to_string(),
-        })
-    }
-}
-
-pub(crate) async fn browser_read_same_document_navigation_observer(
-    webview: &Webview,
-) -> Result<Option<SameDocumentNavigationObservation>, String> {
-    #[cfg(target_os = "macos")]
-    {
-        evaluate_json(webview, same_document_navigation_observer_read_script()).await
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        let url = webview
-            .url()
-            .map_err(|error| format!("browser host: {error}"))?;
-        Ok(Some(SameDocumentNavigationObservation {
-            sequence: 0,
-            url: url.to_string(),
-        }))
-    }
-}
-
 pub(crate) async fn browser_semantic_snapshot(
     app: &AppHandle,
     registry: &BrowserRegistry,
@@ -2759,14 +2711,6 @@ fn inspect_overlay_script() -> String {
     INSPECT_OVERLAY_SCRIPT.replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY)
 }
 
-fn same_document_navigation_observer_script() -> &'static str {
-    SAME_DOCUMENT_NAVIGATION_OBSERVER_SCRIPT
-}
-
-fn same_document_navigation_observer_read_script() -> &'static str {
-    SAME_DOCUMENT_NAVIGATION_OBSERVER_READ_SCRIPT
-}
-
 fn screenshot_privacy_script(watch_key: &str, finish: bool) -> Result<String, String> {
     let watch_key = serde_json::to_string(watch_key).map_err(|error| error.to_string())?;
     Ok(SCREENSHOT_PRIVACY_SCRIPT
@@ -3601,64 +3545,6 @@ const REMOVE_INSPECT_OVERLAY_SCRIPT: &str = r#"
   document.getElementById("__tidebreak_inspect_style__")?.remove();
   delete window.__tidebreak_highlight_inspect__;
   return "removed";
-})()
-"#;
-
-const SAME_DOCUMENT_NAVIGATION_OBSERVER_SCRIPT: &str = r#"
-(() => {
-  const STATE_KEY = "__tidebreak_same_document_navigation__";
-  const active = window[STATE_KEY];
-  if (active && !active.cancelled) {
-    active.capture("reconcile");
-    return JSON.stringify({ sequence: active.sequence, url: active.url });
-  }
-
-  const state = {
-    cancelled: false,
-    interval: null,
-    sequence: 0,
-    url: String(location.href),
-    capture: null,
-  };
-  const capture = () => {
-    if (state.cancelled) return;
-    const next = String(location.href);
-    if (next === state.url) return;
-    state.url = next;
-    state.sequence += 1;
-  };
-  state.capture = capture;
-
-  for (const method of ["pushState", "replaceState"]) {
-    const original = history[method].bind(history);
-    history[method] = (...args) => {
-      const result = original(...args);
-      capture(method);
-      return result;
-    };
-  }
-  addEventListener("popstate", capture, true);
-  addEventListener("hashchange", capture, true);
-  // The host reads (and captures) on its own cadence; this only catches a
-  // location change no listener saw, so it can be slow.
-  state.interval = setInterval(capture, 1000);
-  addEventListener("pagehide", () => {
-    state.cancelled = true;
-    clearInterval(state.interval);
-    removeEventListener("popstate", capture, true);
-    removeEventListener("hashchange", capture, true);
-  }, { once: true });
-  window[STATE_KEY] = state;
-  return JSON.stringify({ sequence: state.sequence, url: state.url });
-})()
-"#;
-
-const SAME_DOCUMENT_NAVIGATION_OBSERVER_READ_SCRIPT: &str = r#"
-(() => {
-  const state = window.__tidebreak_same_document_navigation__;
-  if (!state || state.cancelled) return "null";
-  state.capture("native_read");
-  return JSON.stringify({ sequence: state.sequence, url: state.url });
 })()
 "#;
 
@@ -4734,18 +4620,6 @@ mod tests {
         assert!(source.contains("TidebreakBrowserSemantics"));
         assert!(source.contains("BROWSER_SEMANTICS_CONTENT_WORLD"));
         assert!(source.contains("evaluateJavaScript_inFrame_inContentWorld_completionHandler"));
-    }
-
-    #[test]
-    fn same_document_navigation_observer_covers_history_and_location_events() {
-        let script = same_document_navigation_observer_script();
-        assert!(script.contains("[\"pushState\", \"replaceState\"]"));
-        assert!(script.contains("addEventListener(\"popstate\""));
-        assert!(script.contains("addEventListener(\"hashchange\""));
-        assert!(script.contains("setInterval(capture, 1000)"));
-        assert!(script.contains("clearInterval(state.interval)"));
-        assert!(!script.contains("__TAURI_INTERNALS__"));
-        assert!(!script.contains("window.ipc"));
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/browser_url_observer.rs
+++ b/crates/tidebreak-desktop/src/browser_url_observer.rs
@@ -7,8 +7,12 @@
 //! single-page app without a timer and without any page-side script.
 //!
 //! The observer object lives on the main thread and is retained here, keyed by
-//! webview label, until [`stop_observing_browser_url`] removes it. Remove it
-//! before the view closes so no observer outlives the view it watches.
+//! webview label, until [`stop_observing_browser_url`] removes it. The
+//! observer holds the view it watches, so the view cannot be deallocated
+//! while an observation is registered: a view that goes away outside the
+//! close path (the window tearing down, the host dropping it) stays alive
+//! until its observer is detached, and never trips KVO's deallocation check.
+//! [`detach_all_browser_url_observers`] runs at exit so nothing lingers.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -16,7 +20,7 @@ use std::ffi::c_void;
 
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject, NSObjectProtocol};
-use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
+use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly, Message};
 use objc2_foundation::{
     NSKeyValueObservingOptions, NSObjectNSKeyValueObserverRegistration, NSString,
 };
@@ -32,6 +36,8 @@ const URL_KEY_PATH: &str = "URL";
 
 struct Ivars {
     handler: BrowserUrlChangeHandler,
+    /// The observed view. Held strongly so it outlives the observation.
+    view: Retained<WKWebView>,
 }
 
 define_class!(
@@ -51,19 +57,14 @@ define_class!(
         fn observe_value(
             &self,
             key_path: Option<&NSString>,
-            object: Option<&AnyObject>,
+            _object: Option<&AnyObject>,
             _change: Option<&AnyObject>,
             _context: *mut c_void,
         ) {
             if !key_path.is_some_and(|key_path| key_path.to_string() == URL_KEY_PATH) {
                 return;
             }
-            let Some(object) = object else {
-                return;
-            };
-            // SAFETY: the observer is only ever registered on a `WKWebView`,
-            // and KVO hands back the observed object.
-            let view: &WKWebView = unsafe { &*(object as *const AnyObject).cast() };
+            let view = &self.ivars().view;
             let url = unsafe { view.URL() }
                 .and_then(|url| url.absoluteString())
                 .map(|url| url.to_string());
@@ -77,10 +78,44 @@ define_class!(
 );
 
 impl BrowserUrlObserver {
-    fn new(mtm: MainThreadMarker, handler: BrowserUrlChangeHandler) -> Retained<Self> {
-        let this = Self::alloc(mtm).set_ivars(Ivars { handler });
+    fn new(
+        mtm: MainThreadMarker,
+        view: Retained<WKWebView>,
+        handler: BrowserUrlChangeHandler,
+    ) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(Ivars { handler, view });
         // SAFETY: `NSObject::init` on a freshly allocated instance.
         unsafe { msg_send![super(this), init] }
+    }
+
+    /// Register on the held view's `URL` key path.
+    fn attach(&self) {
+        let key_path = NSString::from_str(URL_KEY_PATH);
+        // SAFETY: the observer implements
+        // `observeValueForKeyPath:ofObject:change:context:` and holds the
+        // view, so both sides stay alive until `detach` runs.
+        unsafe {
+            self.ivars().view.addObserver_forKeyPath_options_context(
+                self,
+                &key_path,
+                NSKeyValueObservingOptions::New,
+                std::ptr::null_mut(),
+            );
+        }
+    }
+
+    /// Remove the registration made by `attach`. Dropping the observer
+    /// afterwards releases the view.
+    fn detach(&self) {
+        let key_path = NSString::from_str(URL_KEY_PATH);
+        // SAFETY: `attach` registered this observer on this key path.
+        unsafe {
+            self.ivars().view.removeObserver_forKeyPath_context(
+                self,
+                &key_path,
+                std::ptr::null_mut(),
+            );
+        }
     }
 }
 
@@ -104,53 +139,46 @@ pub(crate) fn observe_browser_url(
             // SAFETY: tauri hands the native `WKWebView` pointer to this
             // closure on the main thread.
             let view: &WKWebView = unsafe { &*platform.inner().cast() };
-            let observer = BrowserUrlObserver::new(mtm, handler);
-            let key_path = NSString::from_str(URL_KEY_PATH);
-            let previous = URL_OBSERVERS
-                .with(|observers| observers.borrow_mut().insert(label, observer.clone()));
+            let observer = BrowserUrlObserver::new(mtm, view.retain(), handler);
+            observer.attach();
+            let previous =
+                URL_OBSERVERS.with(|observers| observers.borrow_mut().insert(label, observer));
             if let Some(previous) = previous {
-                // SAFETY: `previous` was registered on this key path below.
-                unsafe {
-                    view.removeObserver_forKeyPath_context(
-                        &previous,
-                        &key_path,
-                        std::ptr::null_mut(),
-                    );
-                }
-            }
-            // SAFETY: the observer implements
-            // `observeValueForKeyPath:ofObject:change:context:` and stays
-            // retained in `URL_OBSERVERS` until it is removed.
-            unsafe {
-                view.addObserver_forKeyPath_options_context(
-                    &observer,
-                    &key_path,
-                    NSKeyValueObservingOptions::New,
-                    std::ptr::null_mut(),
-                );
+                previous.detach();
             }
         })
         .map_err(|error| format!("browser host: {error}"))
 }
 
 /// Remove the URL observer registered for this webview, if any. Call before
-/// closing the view.
+/// closing the view so the observer releases it.
 pub(crate) fn stop_observing_browser_url(webview: &Webview) -> Result<(), String> {
     let label = webview.label().to_owned();
     webview
-        .with_webview(move |platform| {
-            let Some(observer) =
+        .with_webview(move |_platform| {
+            if let Some(observer) =
                 URL_OBSERVERS.with(|observers| observers.borrow_mut().remove(&label))
-            else {
-                return;
-            };
-            // SAFETY: tauri hands the native `WKWebView` pointer to this
-            // closure on the main thread, and `observer` was registered on it.
-            let view: &WKWebView = unsafe { &*platform.inner().cast() };
-            let key_path = NSString::from_str(URL_KEY_PATH);
-            unsafe {
-                view.removeObserver_forKeyPath_context(&observer, &key_path, std::ptr::null_mut());
+            {
+                observer.detach();
             }
         })
         .map_err(|error| format!("browser host: {error}"))
+}
+
+/// Detach every registered observer and release the views they held. Runs on
+/// the main thread at exit, after which the host may drop the views freely.
+pub(crate) fn detach_all_browser_url_observers() {
+    if MainThreadMarker::new().is_none() {
+        return;
+    }
+    let observers: Vec<_> = URL_OBSERVERS.with(|observers| {
+        observers
+            .borrow_mut()
+            .drain()
+            .map(|(_, observer)| observer)
+            .collect()
+    });
+    for observer in observers {
+        observer.detach();
+    }
 }

--- a/crates/tidebreak-desktop/src/browser_url_observer.rs
+++ b/crates/tidebreak-desktop/src/browser_url_observer.rs
@@ -1,0 +1,156 @@
+//! Push URL changes out of a managed browser view.
+//!
+//! `WKWebView.URL` is key-value observable, and WebKit updates it for
+//! same-document navigations (`pushState`, `replaceState`, `popstate`,
+//! `hashchange`) as well as for cross-document loads. Observing it gives the
+//! host a native push for route changes, so the URL bar follows a
+//! single-page app without a timer and without any page-side script.
+//!
+//! The observer object lives on the main thread and is retained here, keyed by
+//! webview label, until [`stop_observing_browser_url`] removes it. Remove it
+//! before the view closes so no observer outlives the view it watches.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, NSObject, NSObjectProtocol};
+use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
+use objc2_foundation::{
+    NSKeyValueObservingOptions, NSObjectNSKeyValueObserverRegistration, NSString,
+};
+use objc2_web_kit::WKWebView;
+use tauri::Webview;
+
+use crate::code_browser::BrowserUrlChange;
+
+/// Runs on the main thread each time the observed view's URL changes.
+pub(crate) type BrowserUrlChangeHandler = Box<dyn Fn(BrowserUrlChange) + Send + 'static>;
+
+const URL_KEY_PATH: &str = "URL";
+
+struct Ivars {
+    handler: BrowserUrlChangeHandler,
+}
+
+define_class!(
+    // SAFETY:
+    // - `NSObject` has no subclassing requirements.
+    // - `BrowserUrlObserver` does not implement `Drop`.
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "TidebreakBrowserUrlObserver"]
+    #[ivars = Ivars]
+    struct BrowserUrlObserver;
+
+    unsafe impl NSObjectProtocol for BrowserUrlObserver {}
+
+    impl BrowserUrlObserver {
+        #[unsafe(method(observeValueForKeyPath:ofObject:change:context:))]
+        fn observe_value(
+            &self,
+            key_path: Option<&NSString>,
+            object: Option<&AnyObject>,
+            _change: Option<&AnyObject>,
+            _context: *mut c_void,
+        ) {
+            if !key_path.is_some_and(|key_path| key_path.to_string() == URL_KEY_PATH) {
+                return;
+            }
+            let Some(object) = object else {
+                return;
+            };
+            // SAFETY: the observer is only ever registered on a `WKWebView`,
+            // and KVO hands back the observed object.
+            let view: &WKWebView = unsafe { &*(object as *const AnyObject).cast() };
+            let url = unsafe { view.URL() }
+                .and_then(|url| url.absoluteString())
+                .map(|url| url.to_string());
+            let Some(url) = url else {
+                return;
+            };
+            let loading = unsafe { view.isLoading() };
+            (self.ivars().handler)(BrowserUrlChange { url, loading });
+        }
+    }
+);
+
+impl BrowserUrlObserver {
+    fn new(mtm: MainThreadMarker, handler: BrowserUrlChangeHandler) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(Ivars { handler });
+        // SAFETY: `NSObject::init` on a freshly allocated instance.
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+thread_local! {
+    static URL_OBSERVERS: RefCell<HashMap<String, Retained<BrowserUrlObserver>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Observe the view's URL and call `handler` on every change. Replaces any
+/// observer already registered for the same webview label.
+pub(crate) fn observe_browser_url(
+    webview: &Webview,
+    handler: BrowserUrlChangeHandler,
+) -> Result<(), String> {
+    let label = webview.label().to_owned();
+    webview
+        .with_webview(move |platform| {
+            let Some(mtm) = MainThreadMarker::new() else {
+                return;
+            };
+            // SAFETY: tauri hands the native `WKWebView` pointer to this
+            // closure on the main thread.
+            let view: &WKWebView = unsafe { &*platform.inner().cast() };
+            let observer = BrowserUrlObserver::new(mtm, handler);
+            let key_path = NSString::from_str(URL_KEY_PATH);
+            let previous = URL_OBSERVERS
+                .with(|observers| observers.borrow_mut().insert(label, observer.clone()));
+            if let Some(previous) = previous {
+                // SAFETY: `previous` was registered on this key path below.
+                unsafe {
+                    view.removeObserver_forKeyPath_context(
+                        &previous,
+                        &key_path,
+                        std::ptr::null_mut(),
+                    );
+                }
+            }
+            // SAFETY: the observer implements
+            // `observeValueForKeyPath:ofObject:change:context:` and stays
+            // retained in `URL_OBSERVERS` until it is removed.
+            unsafe {
+                view.addObserver_forKeyPath_options_context(
+                    &observer,
+                    &key_path,
+                    NSKeyValueObservingOptions::New,
+                    std::ptr::null_mut(),
+                );
+            }
+        })
+        .map_err(|error| format!("browser host: {error}"))
+}
+
+/// Remove the URL observer registered for this webview, if any. Call before
+/// closing the view.
+pub(crate) fn stop_observing_browser_url(webview: &Webview) -> Result<(), String> {
+    let label = webview.label().to_owned();
+    webview
+        .with_webview(move |platform| {
+            let Some(observer) =
+                URL_OBSERVERS.with(|observers| observers.borrow_mut().remove(&label))
+            else {
+                return;
+            };
+            // SAFETY: tauri hands the native `WKWebView` pointer to this
+            // closure on the main thread, and `observer` was registered on it.
+            let view: &WKWebView = unsafe { &*platform.inner().cast() };
+            let key_path = NSString::from_str(URL_KEY_PATH);
+            unsafe {
+                view.removeObserver_forKeyPath_context(&observer, &key_path, std::ptr::null_mut());
+            }
+        })
+        .map_err(|error| format!("browser host: {error}"))
+}

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -33,9 +33,10 @@ use crate::browser_profile::{BrowserProfileStore, ManagedBrowserProfile};
 use crate::browser_recovery::{
     LegacyBrowserImportResult, LegacyBrowserSession, RecoveredBrowserSession,
 };
-use crate::browser_semantics::{
-    browser_inject_inspect_overlay, browser_install_same_document_navigation_observer,
-    browser_read_same_document_navigation_observer, browser_remove_inspect_overlay,
+use crate::browser_semantics::{browser_inject_inspect_overlay, browser_remove_inspect_overlay};
+#[cfg(target_os = "macos")]
+use crate::browser_url_observer::{
+    observe_browser_url, stop_observing_browser_url, BrowserUrlChangeHandler,
 };
 
 const BROWSER_LABEL_PREFIX: &str = "code-browser-";
@@ -46,19 +47,30 @@ const MAX_BROWSER_URL_CHARS: usize = 8_192;
 const MAX_JS_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const AGENT_NAVIGATION_START_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const AGENT_NAVIGATION_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
-/// How often the host reads the in-page navigation observer while the tab is
-/// showing. The page captures `pushState` and friends the instant they happen;
-/// this is only the latency before the URL bar reflects it.
+/// How often the host reads the view's URL while the tab is showing, on the
+/// platforms without a native URL observer. macOS pushes every change through
+/// `browser_url_observer` and never polls.
+#[cfg(not(target_os = "macos"))]
 const SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL: std::time::Duration =
     std::time::Duration::from_millis(250);
 /// The cadence while the tab is hidden. Nothing shows the URL, so the read
 /// waits; a hidden tab only checks that it is still the same document.
+#[cfg(not(target_os = "macos"))]
 const SAME_DOCUMENT_NAVIGATION_HIDDEN_POLL_INTERVAL: std::time::Duration =
     std::time::Duration::from_secs(2);
 #[cfg(target_os = "macos")]
 const PROFILE_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 #[cfg(target_os = "macos")]
 const PROFILE_CLOSE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
+
+/// One URL change reported by the native view. `loading` is true while a
+/// cross-document navigation is in flight, so the page-load events own that
+/// URL and a same-document push must not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrowserUrlChange {
+    pub(crate) url: String,
+    pub(crate) loading: bool,
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -333,7 +345,7 @@ pub(crate) async fn code_browser_command(
             )?;
             if let Some(webview) = existing {
                 registry.ensure_workspace(&request.browser_id, &request.workspace_id)?;
-                webview.close().map_err(browser_error)?;
+                close_browser_webview(&webview)?;
             }
             registry.remove(&request.browser_id, &request.workspace_id)?;
             registry.forget_recovery(&owner_id, &request.browser_id, &request.workspace_id)?;
@@ -584,6 +596,8 @@ fn create_browser(
     let load_browser = browser_id.to_owned();
     let load_workspace = workspace_id.to_owned();
     let load_registry = registry.clone();
+    #[cfg(not(target_os = "macos"))]
+    let load_renderer_url = renderer_url.clone();
     let title_main = main.clone();
     let title_browser = browser_id.to_owned();
     let title_workspace = workspace_id.to_owned();
@@ -739,15 +753,21 @@ fn create_browser(
                     origin: None,
                 },
             );
+            // macOS observes the view's URL natively from creation; the
+            // fallback below only reads the view on the other platforms.
+            #[cfg(target_os = "macos")]
+            let _ = &webview;
+            #[cfg(not(target_os = "macos"))]
             if matches!(payload.event(), PageLoadEvent::Finished) {
                 if let Some(document_epoch) = snapshot.document_epoch {
-                    start_same_document_navigation_observer(
+                    start_same_document_navigation_poll(
                         load_main.clone(),
                         load_registry.clone(),
                         load_browser.clone(),
                         load_workspace.clone(),
                         instance_id,
                         document_epoch,
+                        load_renderer_url.clone(),
                         webview,
                     );
                 }
@@ -857,9 +877,25 @@ fn create_browser(
             return Err(browser_error(error));
         }
     };
+    #[cfg(target_os = "macos")]
+    if let Err(error) = observe_browser_url(
+        &webview,
+        same_document_navigation_handler(
+            main.clone(),
+            registry.clone(),
+            browser_id.to_owned(),
+            workspace_id.to_owned(),
+            instance_id,
+            renderer_url.clone(),
+        ),
+    ) {
+        let _ = close_browser_webview(&webview);
+        registry.remove_instance(browser_id, workspace_id, instance_id);
+        return Err(error);
+    }
     if !visible {
         if let Err(error) = webview.hide() {
-            let _ = webview.close();
+            let _ = close_browser_webview(&webview);
             registry.remove_instance(browser_id, workspace_id, instance_id);
             return Err(browser_error(error));
         }
@@ -867,35 +903,126 @@ fn create_browser(
     registry.snapshot(browser_id, workspace_id)
 }
 
+/// Close a managed browser view, detaching the native URL observer first so
+/// nothing keeps watching a view that is going away.
+fn close_browser_webview(webview: &Webview) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    let _ = stop_observing_browser_url(webview);
+    webview.close().map_err(browser_error)
+}
+
+/// Build the handler the native URL observer calls on the main thread. It
+/// hands each change to one ordered task so the registry sees pushes in the
+/// order the view reported them, and the main thread never waits on the
+/// registry or the recovery store.
+#[cfg(target_os = "macos")]
+fn same_document_navigation_handler(
+    main: Webview,
+    registry: BrowserRegistry,
+    browser_id: String,
+    workspace_id: String,
+    instance_id: u64,
+    renderer_url: Option<Url>,
+) -> BrowserUrlChangeHandler {
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<BrowserUrlChange>();
+    tauri::async_runtime::spawn(async move {
+        while let Some(change) = receiver.recv().await {
+            apply_browser_url_change(
+                &main,
+                &registry,
+                &browser_id,
+                &workspace_id,
+                instance_id,
+                renderer_url.as_ref(),
+                &change,
+            );
+        }
+    });
+    Box::new(move |change| {
+        let _ = sender.send(change);
+    })
+}
+
+/// Record one reported URL as a same-document navigation when it qualifies,
+/// and tell the renderer. Returns the snapshot it emitted, if any.
+fn apply_browser_url_change(
+    main: &Webview,
+    registry: &BrowserRegistry,
+    browser_id: &str,
+    workspace_id: &str,
+    instance_id: u64,
+    renderer_url: Option<&Url>,
+    change: &BrowserUrlChange,
+) -> Option<BrowserSnapshot> {
+    let snapshot = registry.snapshot(browser_id, workspace_id).ok()?;
+    let (document_epoch, url) = same_document_navigation_target(&snapshot, change, renderer_url)?;
+    let snapshot = registry.same_document_navigation(
+        browser_id,
+        workspace_id,
+        instance_id,
+        document_epoch,
+        url.to_string(),
+    )?;
+    emit_event(
+        main,
+        CodeBrowserEvent {
+            workspace_id: workspace_id.to_owned(),
+            browser_id: browser_id.to_owned(),
+            kind: "same_document_navigation",
+            url: snapshot.url.clone(),
+            title: snapshot.title.clone(),
+            message: None,
+            load_state: snapshot.load_state,
+            document_epoch: snapshot.document_epoch,
+            controller: snapshot.controller.clone(),
+            agent_access: snapshot.agent_access.clone(),
+            origin: None,
+        },
+    );
+    Some(snapshot)
+}
+
+/// Decide whether a reported URL is a same-document navigation of the
+/// document the registry currently holds. Cross-document loads are left to
+/// the page-load events: the view is still loading, or the registry has not
+/// seen the document finish, or the origin moved.
+fn same_document_navigation_target(
+    snapshot: &BrowserSnapshot,
+    change: &BrowserUrlChange,
+    renderer_url: Option<&Url>,
+) -> Option<(u64, Url)> {
+    if change.loading || snapshot.load_state != Some(BrowserLoadState::Ready) {
+        return None;
+    }
+    let document_epoch = snapshot.document_epoch?;
+    let current = snapshot.url.as_deref()?;
+    if current == change.url {
+        return None;
+    }
+    let expected_origin = BrowserOrigin::from_url(current)?;
+    let url = validated_same_document_url(&change.url, renderer_url, &expected_origin).ok()?;
+    Some((document_epoch, url))
+}
+
+/// Poll the view's URL for same-document navigation on the platforms that
+/// have no native URL observer. The loop ends when the document changes.
+#[cfg(not(target_os = "macos"))]
 #[allow(
     clippy::too_many_arguments,
-    reason = "the observer fence keeps native view, workspace, and document identity explicit"
+    reason = "the poll fence keeps native view, workspace, and document identity explicit"
 )]
-fn start_same_document_navigation_observer(
+fn start_same_document_navigation_poll(
     main: Webview,
     registry: BrowserRegistry,
     browser_id: String,
     workspace_id: String,
     instance_id: u64,
     document_epoch: u64,
+    renderer_url: Option<Url>,
     webview: Webview,
 ) {
     tauri::async_runtime::spawn(async move {
-        let Ok(snapshot) = registry.snapshot(&browser_id, &workspace_id) else {
-            return;
-        };
-        if snapshot.document_epoch != Some(document_epoch) {
-            return;
-        }
-        let Some(expected_origin) = snapshot.url.as_deref().and_then(BrowserOrigin::from_url)
-        else {
-            return;
-        };
-        let renderer_url = main.url().ok();
-        let mut observer_installed = false;
-        let mut last_sequence = None;
         let mut cadence = SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL;
-
         loop {
             tokio::time::sleep(cadence).await;
             let Ok(snapshot) = registry.snapshot(&browser_id, &workspace_id) else {
@@ -905,72 +1032,27 @@ fn start_same_document_navigation_observer(
                 return;
             }
             // A hidden tab shows no URL bar, so there is nothing to keep
-            // current; the page keeps capturing and the first visible read
-            // catches up on whatever moved.
+            // current; the first visible read catches up on whatever moved.
             if snapshot.visible == Some(false) {
                 cadence = SAME_DOCUMENT_NAVIGATION_HIDDEN_POLL_INTERVAL;
                 continue;
             }
             cadence = SAME_DOCUMENT_NAVIGATION_POLL_INTERVAL;
-
-            let observation = if observer_installed {
-                match browser_read_same_document_navigation_observer(&webview).await {
-                    Ok(Some(observation)) => Some(observation),
-                    Ok(None) | Err(_) => {
-                        observer_installed = false;
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-            let observation = match observation {
-                Some(observation) => observation,
-                None => match browser_install_same_document_navigation_observer(&webview).await {
-                    Ok(observation) => {
-                        observer_installed = true;
-                        observation
-                    }
-                    Err(_) => continue,
-                },
-            };
-            if last_sequence == Some(observation.sequence)
-                && snapshot.url.as_deref() == Some(observation.url.as_str())
-            {
-                continue;
-            }
-            last_sequence = Some(observation.sequence);
-            let Ok(url) = validated_same_document_url(
-                &observation.url,
-                renderer_url.as_ref(),
-                &expected_origin,
-            ) else {
+            let Ok(url) = webview.url() else {
                 continue;
             };
-            let Some(snapshot) = registry.same_document_navigation(
+            let change = BrowserUrlChange {
+                url: url.to_string(),
+                loading: false,
+            };
+            apply_browser_url_change(
+                &main,
+                &registry,
                 &browser_id,
                 &workspace_id,
                 instance_id,
-                document_epoch,
-                url.to_string(),
-            ) else {
-                continue;
-            };
-            emit_event(
-                &main,
-                CodeBrowserEvent {
-                    workspace_id: workspace_id.clone(),
-                    browser_id: browser_id.clone(),
-                    kind: "same_document_navigation",
-                    url: snapshot.url,
-                    title: snapshot.title,
-                    message: None,
-                    load_state: snapshot.load_state,
-                    document_epoch: snapshot.document_epoch,
-                    controller: snapshot.controller,
-                    agent_access: snapshot.agent_access,
-                    origin: None,
-                },
+                renderer_url.as_ref(),
+                &change,
             );
         }
     });
@@ -1209,7 +1291,7 @@ async fn close_profile_sessions(
         .collect::<Result<Vec<_>, _>>()?;
     for label in &labels {
         if let Some(webview) = app.get_webview(label) {
-            webview.close().map_err(browser_error)?;
+            close_browser_webview(&webview)?;
         }
     }
 
@@ -1642,6 +1724,90 @@ mod tests {
         assert!(validated_same_document_url("not a url", None, &origin).is_err());
         assert!(validated_same_document_url("javascript:alert(1)", None, &origin).is_err());
         assert!(validated_same_document_url("https://other.example/", None, &origin).is_err());
+    }
+
+    fn ready_snapshot(url: &str) -> BrowserSnapshot {
+        let mut snapshot = BrowserSnapshot::missing("browser-1", "workspace-1");
+        snapshot.exists = true;
+        snapshot.url = Some(url.to_owned());
+        snapshot.load_state = Some(BrowserLoadState::Ready);
+        snapshot.document_epoch = Some(3);
+        snapshot
+    }
+
+    fn change(url: &str, loading: bool) -> BrowserUrlChange {
+        BrowserUrlChange {
+            url: url.to_owned(),
+            loading,
+        }
+    }
+
+    #[test]
+    fn pushed_url_changes_become_same_document_navigation_on_the_ready_document() {
+        let snapshot = ready_snapshot("https://example.com/start");
+        let (epoch, url) = same_document_navigation_target(
+            &snapshot,
+            &change("https://example.com/start?view=details#summary", false),
+            None,
+        )
+        .unwrap();
+        assert_eq!(epoch, 3);
+        assert_eq!(
+            url.as_str(),
+            "https://example.com/start?view=details#summary"
+        );
+    }
+
+    #[test]
+    fn pushed_url_changes_leave_cross_document_loads_to_the_page_load_events() {
+        let ready = ready_snapshot("https://example.com/start");
+        // The view reports a provisional URL while it is still loading.
+        assert!(same_document_navigation_target(
+            &ready,
+            &change("https://example.com/next", true),
+            None
+        )
+        .is_none());
+        // The registry has not seen the document finish yet.
+        let mut loading = ready_snapshot("https://example.com/start");
+        loading.load_state = Some(BrowserLoadState::Loading);
+        assert!(same_document_navigation_target(
+            &loading,
+            &change("https://example.com/next", false),
+            None
+        )
+        .is_none());
+        let mut fresh = ready_snapshot("https://example.com/start");
+        fresh.document_epoch = None;
+        assert!(same_document_navigation_target(
+            &fresh,
+            &change("https://example.com/next", false),
+            None
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn pushed_url_changes_ignore_repeats_and_origin_moves() {
+        let snapshot = ready_snapshot("https://example.com/start");
+        assert!(same_document_navigation_target(
+            &snapshot,
+            &change("https://example.com/start", false),
+            None
+        )
+        .is_none());
+        assert!(same_document_navigation_target(
+            &snapshot,
+            &change("https://other.example/start", false),
+            None
+        )
+        .is_none());
+        assert!(same_document_navigation_target(
+            &snapshot,
+            &change("javascript:alert(1)", false),
+            None
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -33,6 +33,8 @@ mod browser_runtime_adapter;
     reason = "the staged browser bridge is test-covered and will be wired in #2339 and #2340"
 )]
 mod browser_semantics;
+#[cfg(target_os = "macos")]
+mod browser_url_observer;
 mod channel;
 mod chat_debug;
 mod client_execution;

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -958,6 +958,12 @@ pub fn run() {
         tauri::RunEvent::WindowEvent { label, event, .. } => {
             documents::handle_window_drag_drop(app, &label, &event);
         }
+        tauri::RunEvent::ExitRequested { .. } => {
+            // Browser views are torn down with the windows after this; let
+            // go of them before that happens.
+            #[cfg(target_os = "macos")]
+            browser_url_observer::detach_all_browser_url_observers();
+        }
         tauri::RunEvent::Exit => {
             tauri::async_runtime::block_on(app.state::<host_access::HostAccess>().shutdown());
         }


### PR DESCRIPTION
## What changed

The desktop host read the in-page same-document navigation observer on a timer: 250ms while the browser tab showed and a 2s identity check while hidden. The child webview has no IPC channel to the host, so the page could not push a `pushState`/`popstate` capture up.

`WKWebView.URL` is key-value observable, and WebKit updates it for `pushState`, `replaceState`, `popstate`, and `hashchange`. On macOS the host now registers a KVO observer on the view when the browser is created, so the URL bar follows a route change with no timer.

- `browser_url_observer.rs` (macOS): an `NSObject` subclass that observes the `URL` key path, reads the view's URL and `isLoading`, and calls a handler. Observers are retained per webview label and removed before the view closes.
- `code_browser.rs`: the handler feeds one ordered task per browser so pushes reach the registry in the order the view reported them and the main thread never waits on the registry or the recovery store. `same_document_navigation_target` decides which reported URLs qualify: the view must not be loading, the registry must hold a finished document, and the origin must not move. Cross-document URLs stay with the page-load events.
- Every close path goes through `close_browser_webview`, which detaches the observer first.
- The page-side observer script, its read script, and the read loop are gone. Linux and Windows keep a documented poll of the view's own URL (`webview.url()`), which already reflects same-document navigation on those engines, until they get a native push.
- `objc2-foundation` gains the `NSKeyValueObserving` and `NSURL` features. No new crates; `Cargo.lock` is unchanged.

## Why

Follow-up from #2957 and #2984. A timer read on every visible browser tab is the last poll in the browser host.

## How verified

- `cargo check -p tidebreak-desktop --locked`
- `cargo clippy -p tidebreak-desktop --all-targets --locked -- -D warnings` (clean for this crate; a pre-existing `too_many_arguments` in `tidebreak-code-execution/src/local.rs` fires locally on 1.97.1 and is unrelated)
- `cargo test -p tidebreak-desktop --lib --locked -- code_browser:: browser_semantics:: browser_control::` — 86 passed
- New tests pin the decision path: a pushed URL on the ready document becomes a same-document navigation; a URL reported while loading, before the document finished, on a repeat, on an origin move, or with a non-HTTP scheme is ignored.

Not verified: the KVO callback firing in the running desktop app. The `URL` property is documented as KVO-compliant and WebKit commits same-document navigations through the same page-load state that drives it, but I did not build and drive the app to watch a route change land in the URL bar.

Closes #2985
