### PR TITLE
refactor(desktop): extract the workspace and delivery page bodies into hooks

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -5,43 +5,27 @@ import {
   centerTabParts,
   CHAT_PANEL_ID,
   CodeCenterTabs,
-  type CodeConversationTab,
   conversationTabId,
   EDITOR_PANEL_ID,
   SPLIT_EDITOR_PANEL_ID,
 } from "./CodeCenterTabs";
 import {
-  adoptCodeTerminalId,
   closeAllEditorTabs,
   closeCodeChromeTab,
+  type CodeEditorRegion,
   closeEditorTab,
   closeEditorTabsToRight,
   closeOtherEditorTabs,
-  codeBrowserIds,
-  type CodeEditorRegion,
-  codeTerminalIds,
-  findCodeTerminalTab,
   focusCodeChromeTab,
   focusConversation,
-  focusedEditorPosition,
   focusEditorTab,
   mergeEditorSplit,
   moveEditorTab,
   openCodeEditor,
-  removedCodeBrowserIds,
-  removedCodeTerminalIds,
   reorderEditorTab,
   splitCodeChromeLayout,
 } from "./codeChrome";
-import type {
-  CodeForkTranscript,
-  CodeRepoSnapshot,
-  CodeSessionSnapshot,
-  CodeWorkspaceSnapshot,
-  HarnessKind,
-  PermissionMode,
-  ReasoningEffort,
-} from "../api/types";
+import type { PermissionMode } from "../api/types";
 import { CodeInspector, WorkspaceDeliveryPrTab } from "./CodeInspector";
 import { CodeQuickOpen } from "./CodeQuickOpen";
 import { CodeSessionPane } from "./workspace/CodeSessionPane";
@@ -58,25 +42,10 @@ import {
 } from "./inspectorLayout";
 import { DiffOverview } from "./DiffOverview";
 import { DiffPanel } from "./DiffPanel";
-import {
-  DndContext,
-  type DragEndEvent,
-  DragOverlay,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
+import { DndContext, DragOverlay, useSensor, useSensors } from "@dnd-kit/core";
 import { ErrorBoundary } from "@/ErrorBoundary";
-import {
-  clearFirstTurnRecovery,
-  type FirstTurnRecovery,
-  writeFirstTurnRecovery,
-} from "./workspace/firstTurnRecovery";
 import type { LayoutState, PanelContent } from "@/panel/panelTypes";
 import {
-  browserTitlesForLayout,
-  conversationTabLabel,
-  MAX_WORKSPACE_TERMINALS,
-  nameTerminals,
   renderCodePanel,
   useCodeShortcutHints,
   useMeasuredWidth,
@@ -105,15 +74,7 @@ import {
   StartSessionPrompt,
   WorkspaceSessionStartingState,
 } from "./StartSessionPrompt";
-import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { TerminalPane } from "./TerminalPane";
 import { WatchTaskBar } from "./workspace/subagents";
 import { WorkspaceHeader } from "./WorkspaceHeader";
@@ -124,38 +85,24 @@ import {
   WorkspaceOverflowMenu,
 } from "./workspaceActions";
 import { WorkspaceWorkflowControl } from "./WorkspaceWorkflowControl";
-import { attachedRemotely } from "@/host";
-import { attentionMarkForDigest } from "./statusTone";
 import { canOpenInExternalEditor } from "./codeWorktreeHost";
-import { closeCodeBrowser } from "./browser/browserHost";
-import { cn, friendlyErrorMessage } from "@/lib/utils";
-import { copyPlainText } from "@/ClipboardCopyButton";
-import { dropEditorTab, findEditorPanel, offersSplitDrop } from "./editorDrag";
-import {
-  fenceReasonText,
-  gatewayCodeModels,
-  preferredCodeModels,
-  requiresHarnessModelIds,
-} from "./labels";
-import { forkFraming, forkTranscriptFile } from "./fork";
-import { hasLocalHostAuthority } from "../host";
+import { cn } from "@/lib/utils";
+import { findEditorPanel, offersSplitDrop } from "./editorDrag";
+import { fenceReasonText } from "./labels";
+import { forkTranscriptFile } from "./fork";
 import { isPutAway, sessionActivityLabel } from "./workspaceCards";
-import { liveCodeSessions } from "./parsers";
-import { publishCodeImage } from "../attachments";
-import { seedBrowserSession } from "./browser/browserPersistence";
 import { tidebreakProductRepo } from "./uneffMe";
 import { toast } from "sonner";
-import { uploadImageAttachment } from "../ImageAttachments";
 import { useApp } from "@/AppContext";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeContentRevision } from "./useLiveContent";
 import { useCodeUiStore } from "./CodeUiStore";
-import {
-  useCodeUpdatesStore,
-  useConversationDigests,
-  useSessionDigest,
-} from "./CodeUpdatesStore";
+import { useCodeUpdatesStore, useSessionDigest } from "./CodeUpdatesStore";
+import { useBrowserTabs } from "./workspace/useBrowserTabs";
 import { useCodeWorkspacePr } from "./useCodeWorkspacePr";
+import { useEditorTabs } from "./workspace/useEditorTabs";
+import { useTerminalTabs } from "./workspace/useTerminalTabs";
+import { useWorkspaceSessions } from "./workspace/useWorkspaceSessions";
 import { useDefaultLayout, useGroupRef } from "react-resizable-panels";
 import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
 import { useNavigate, useSearch } from "@tanstack/react-router";
@@ -191,25 +138,11 @@ export function CodeWorkspacePage({ workspaceId }: { workspaceId: string }) {
 
 function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const { client, models, defaultModelKey } = useApp();
-  const clientRef = useRef(client);
-  clientRef.current = client;
   const catalog = useCodeCatalogStore();
   const { run, dialogs } = useWorkspaceCardCommands();
   const layout = useLayoutState();
   const { setLayout } = usePanelNav();
   const layoutRef = useRef(layout);
-  const previousLayoutRef = useRef(layout);
-  const closedBrowserIdsRef = useRef(new Set<string>());
-  const closedTerminalIdsRef = useRef(new Set<string>());
-  /** Where focus sat before the terminal chord jumped away from it. */
-  const beforeTerminalRef = useRef<{
-    region: CodeEditorRegion;
-    index: number;
-  } | null>(null);
-  const mountedRef = useRef(true);
-  const selectionRevisionRef = useRef(0);
-  const startRequestRef = useRef(0);
-  const workspaceBrowserIdsRef = useRef(new Set<string>());
   const chrome = splitCodeChromeLayout(layout);
   const workspaceOverlayOpen = usePortalOverlayOpen();
   const navigate = useNavigate();
@@ -232,86 +165,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const setReviewSidebarOpen = useCodeUiStore(
     (state) => state.setReviewSidebarOpen,
   );
-  const quickOpenPending = useCodeUiStore((state) => state.quickOpenPending);
-  const newTabMenuPending = useCodeUiStore((state) => state.newTabMenuPending);
-  const openFilePending = useCodeUiStore((state) => state.openFilePending);
   const archivePending = useCodeUiStore((state) => state.archivePending);
-  const terminalPending = useCodeUiStore((state) => state.terminalPending);
   const shortcutHints = useCodeShortcutHints();
-  const catalogWorkspace = catalog.workspaces.find(
-    (candidate) => candidate.id === workspaceId,
-  );
-  const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(
-    () => catalogWorkspace ?? null,
-  );
-  const catalogRepo = catalogWorkspace
-    ? catalog.repos.find(
-        (candidate) => candidate.id === catalogWorkspace.repo_id,
-      )
-    : undefined;
-  const [repo, setRepo] = useState<CodeRepoSnapshot | null>(
-    () => catalogRepo ?? null,
-  );
-  /**
-   * Every session the server knows about here, conversations and watches alike.
-   *
-   * A workspace runs several agents (record 55), so the page holds the list and
-   * picks one to show rather than tracking a single session.
-   */
-  const [sessions, setSessions] = useState<CodeSessionSnapshot[]>(() => {
-    const remembered = catalog.sessionsByWorkspace[workspaceId];
-    return remembered ? [remembered] : [];
-  });
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(
-    catalog.sessionsByWorkspace[workspaceId]?.id ?? null,
-  );
-  const [closedConversationIds, setClosedConversationIds] = useState<
-    Set<string>
-  >(() => new Set());
-
-  // Optimistic catalog mutations also govern the open page. Archive can hide
-  // the rail card before filesystem cleanup finishes; reflecting that same
-  // snapshot here stops the composer from offering work against a checkout
-  // that is being removed. A failed request puts the original snapshot back.
-  useEffect(() => {
-    if (!catalogWorkspace) return;
-    setWorkspace((current) =>
-      current?.id === catalogWorkspace.id ? catalogWorkspace : current,
-    );
-  }, [catalogWorkspace]);
-
-  useEffect(() => {
-    if (!catalogRepo) return;
-    setRepo((current) =>
-      current?.id === catalogRepo.id ? catalogRepo : current,
-    );
-  }, [catalogRepo]);
-  /** True while the reader is filling in a new agent that has no session yet. */
-  const [draftAgent, setDraftAgent] = useState(false);
-  /**
-   * True once the server's session list has arrived for this workspace.
-   *
-   * `?task=` can only be judged against a loaded list. Before it lands, a
-   * param that names nothing looks exactly like one naming a session the page
-   * has not heard of yet, and clearing it would drop a good link on reload.
-   */
-  const [sessionsLoaded, setSessionsLoaded] = useState(false);
-  /**
-   * The transcript a fork wrote, waiting for the draft agent to send it.
-   *
-   * It survives an engine change and a rewritten framing line, and clears
-   * once a session starts or the reader closes the draft.
-   */
-  const [forkSource, setForkSource] = useState<CodeForkTranscript | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [reloadToken, setReloadToken] = useState(0);
-  const [quickOpenRequest, setQuickOpenRequest] = useState(0);
-  const [quickOpenTarget, setQuickOpenTarget] =
-    useState<CodeEditorRegion>("primary");
-  const [newTabMenuRequest, setNewTabMenuRequest] = useState(0);
-  const [newTabMenuRegion, setNewTabMenuRegion] =
-    useState<CodeEditorRegion>("primary");
-  const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
   const tabDragSensors = useSensors(
     // Four pixels of travel before a press becomes a drag, so a click still
     // selects the tab it landed on.
@@ -335,29 +190,46 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
    * one brings the inspector straight back.
    */
   const inspectorOpen = reviewSidebarOpen && inspectorFits;
-  const [starting, setStarting] = useState(false);
   const [createMode, setCreateMode] = useState<PermissionMode | null>(null);
-  const [fileReveal, setFileReveal] = useState<{
-    path: string;
-    line: number;
-    revision: number;
-  } | null>(null);
-  const [browserTitles, setBrowserTitles] = useState<Record<string, string>>(
-    () => browserTitlesForLayout(layout),
-  );
-  const [browserInitialUrls, setBrowserInitialUrls] = useState<
-    Record<string, string>
-  >({});
-  const [terminalLabels, setTerminalLabels] = useState<Record<string, string>>(
-    () => nameTerminals({}, codeTerminalIds(layout)),
-  );
-  const conversations = useMemo(() => liveCodeSessions(sessions), [sessions]);
-  const session = useMemo(
-    () => sessions.find((entry) => entry.id === activeSessionId) ?? null,
-    [activeSessionId, sessions],
-  );
+
+  layoutRef.current = layout;
+
+  function setWorkspaceLayout(next: LayoutState) {
+    setLayout(next);
+  }
+
+  const {
+    workspace,
+    repo,
+    session,
+    conversationTabs,
+    activeConversationId,
+    draftAgent,
+    startingNewAgent,
+    starting,
+    forkSource,
+    clearForkSource,
+    error,
+    retry,
+    startSession,
+    reap,
+    selectConversation,
+    newConversation,
+    forkConversation,
+    closeConversation,
+    openWorkspaceTask,
+    openWorkspaceSubagent,
+  } = useWorkspaceSessions({
+    workspaceId,
+    client,
+    models,
+    defaultModelKey,
+    taskParam,
+    navigate,
+    focusConversationPane: () =>
+      setWorkspaceLayout(focusConversation(layoutRef.current)),
+  });
   const digest = useSessionDigest(workspaceId, session?.id ?? null);
-  const conversationDigests = useConversationDigests(workspaceId);
   const setViewedWorkspace = useCodeUpdatesStore(
     (state) => state.setViewedWorkspace,
   );
@@ -368,152 +240,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     contentRevision,
     digest?.pr_state,
   );
-  const rememberedSession = useCodeCatalogStore(
-    (state) => state.sessionsByWorkspace[workspaceId] ?? null,
-  );
   const workspaceStartup = useCodeUiStore(
     (state) => state.workspaceStartups[workspaceId] ?? null,
   );
-
-  layoutRef.current = layout;
-
-  useEffect(() => {
-    startRequestRef.current += 1;
-    setStarting(false);
-  }, [client]);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-      startRequestRef.current += 1;
-    };
-  }, []);
-
-  const closeBrowserPanels = useCallback(
-    (browserIds: readonly string[]) => {
-      for (const browserId of browserIds) {
-        if (closedBrowserIdsRef.current.has(browserId)) continue;
-        closedBrowserIdsRef.current.add(browserId);
-        void closeCodeBrowser(workspaceId, browserId);
-      }
-    },
-    [workspaceId],
-  );
-
-  /**
-   * End the shells whose tabs have gone.
-   *
-   * A workspace may only hold so many at once, so a closed tab has to give
-   * its shell back rather than leave it running with nothing pointing at it.
-   *
-   * Closing a tab is the only thing that ends a shell. Browsers also close
-   * when the page unmounts, because a native webview is worth nothing once it
-   * is off screen; a shell is the opposite. A build running in one has to
-   * survive a click on another workspace, and the tab's address names it, so
-   * coming back re-attaches to the same process with its output intact.
-   */
-  const closeTerminalPanels = useCallback(
-    (terminalIds: readonly string[]) => {
-      for (const terminalId of terminalIds) {
-        if (closedTerminalIdsRef.current.has(terminalId)) continue;
-        closedTerminalIdsRef.current.add(terminalId);
-        void client.deleteCodeTerminal(workspaceId, terminalId).catch(() => {
-          // A shell that is already gone is the outcome we wanted anyway.
-        });
-      }
-    },
-    [client, workspaceId],
-  );
-
-  function setWorkspaceLayout(next: LayoutState) {
-    setLayout(next);
-  }
-
-  useEffect(() => {
-    const ids = codeBrowserIds(layout);
-    for (const browserId of ids) {
-      closedBrowserIdsRef.current.delete(browserId);
-      workspaceBrowserIdsRef.current.add(browserId);
-    }
-    closeBrowserPanels(
-      removedCodeBrowserIds(previousLayoutRef.current, layout),
-    );
-    closeTerminalPanels(
-      removedCodeTerminalIds(previousLayoutRef.current, layout),
-    );
-    previousLayoutRef.current = layout;
-    setTerminalLabels((current) =>
-      nameTerminals(current, codeTerminalIds(layout)),
-    );
-    setBrowserTitles((current) => {
-      let changed = false;
-      const next: Record<string, string> = {};
-      for (const browserId of ids) {
-        const title = current[browserId] ?? "Browser";
-        next[browserId] = title;
-        if (current[browserId] !== title) changed = true;
-      }
-      if (Object.keys(current).length !== ids.length) changed = true;
-      return changed ? next : current;
-    });
-  }, [closeBrowserPanels, closeTerminalPanels, layout]);
-
-  useEffect(() => {
-    workspaceBrowserIdsRef.current = new Set(codeBrowserIds(layoutRef.current));
-    return () => closeBrowserPanels([...workspaceBrowserIdsRef.current]);
-  }, [closeBrowserPanels, workspaceId]);
 
   useEffect(() => {
     setViewedWorkspace(workspaceId);
     return () => setViewedWorkspace(null);
   }, [setViewedWorkspace, workspaceId]);
-
-  // A session started elsewhere — the new-workspace dialog, say — reaches the
-  // page through the catalog before the list request comes back.
-  useEffect(() => {
-    if (!rememberedSession) return;
-    setSessions((current) =>
-      current.some((entry) => entry.id === rememberedSession.id)
-        ? current
-        : [...current, rememberedSession],
-    );
-  }, [rememberedSession]);
-
-  // `?task=` names the session to show: a sibling agent, a watch child
-  // opened from the rail, or an archived conversation from search. The param
-  // is a request, not a fact — a link outlives the agent it points at, so it
-  // holds only while that agent is still listed.
-  const namedTask = useMemo(() => {
-    if (!taskParam) return null;
-    return sessions.find((entry) => entry.id === taskParam) ?? null;
-  }, [sessions, taskParam]);
-
-  // A param that names no listed session is stale. Drop it so the fallback
-  // below runs and the URL stops naming an agent that is not there. Replace
-  // rather than push, so Back does not lead to the same dead link. An ended
-  // session is still listed, so archive search can open its transcript.
-  useEffect(() => {
-    if (!sessionsLoaded || !taskParam || namedTask) return;
-    openWorkspaceTask(undefined, { replace: true });
-  }, [namedTask, sessionsLoaded, taskParam]);
-
-  // A named session wins over the default selection below.
-  useEffect(() => {
-    if (!namedTask) return;
-    setActiveSessionId(namedTask.id);
-    setDraftAgent(false);
-  }, [namedTask]);
-
-  // Nothing named, or the shown agent ended: fall back to the first one. The
-  // check reads the live conversations, not every session, so an agent that
-  // ended under the reader does not stay selected.
-  useEffect(() => {
-    if (namedTask || draftAgent) return;
-    const shown = conversations.some((entry) => entry.id === activeSessionId);
-    if (activeSessionId && shown) return;
-    setActiveSessionId(conversations[0]?.id ?? null);
-  }, [activeSessionId, conversations, draftAgent, namedTask]);
 
   useEffect(() => {
     return () => {
@@ -522,211 +256,44 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     };
   }, [workspaceId]);
 
-  useEffect(() => {
-    let cancelled = false;
-    setError(null);
-    setSessionsLoaded(false);
-    void (async () => {
-      try {
-        const [next, listed] = await Promise.all([
-          client.getCodeWorkspace(workspaceId),
-          client.listCodeWorkspaceSessions(workspaceId),
-        ]);
-        if (cancelled) return;
-        setWorkspace(next);
-        const catalogState = useCodeCatalogStore.getState();
-        catalogState.upsertWorkspace(next);
-        // Create navigates as soon as the workspace exists, so a session the
-        // dialog just started can land in the catalog before this list does.
-        const remembered = catalogState.sessionsByWorkspace[workspaceId];
-        setSessions(
-          remembered && !listed.some((entry) => entry.id === remembered.id)
-            ? [remembered, ...listed]
-            : listed,
-        );
-        setSessionsLoaded(true);
-        // The card and the rail show one agent per workspace, so the catalog
-        // remembers the first — the one the workspace was started with.
-        const first = liveCodeSessions(listed)[0];
-        if (first) catalogState.rememberSession(first);
-        const nextRepo = await client.getCodeRepo(next.repo_id);
-        if (!cancelled) setRepo(nextRepo);
-      } catch (err) {
-        if (!cancelled) {
-          setError(friendlyErrorMessage(err, "Could not load this workspace"));
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [client, workspaceId, reloadToken]);
-
-  async function startSession(
-    harness: HarnessKind,
-    permissionMode: PermissionMode,
-    message: string,
-    model?: string,
-    draft = message,
-    reasoningEffort?: ReasoningEffort | null,
-    fastMode = false,
-  ) {
-    const request = startRequestRef.current + 1;
-    startRequestRef.current = request;
-    const startedWithClient = client;
-    const startedAtSelection = selectionRevisionRef.current;
-    const startedWithFork = forkSource;
-    const isCurrent = () =>
-      mountedRef.current &&
-      startRequestRef.current === request &&
-      clientRef.current === startedWithClient;
-    setStarting(true);
-    try {
-      let created: CodeSessionSnapshot;
-      try {
-        const gateway = gatewayCodeModels(models, harness, defaultModelKey);
-        const native =
-          requiresHarnessModelIds(harness) || gateway.length === 0
-            ? await catalog.ensureHarnessModels(startedWithClient, harness)
-            : [];
-        if (!isCurrent()) {
-          throw new Error(
-            "The Code connection changed before the session started. Send the message again.",
-          );
-        }
-        const listed = preferredCodeModels(harness, native, gateway);
-        const posted =
-          model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
-        created = await startedWithClient.createCodeSession(workspaceId, {
-          harness,
-          permission_mode: permissionMode,
-          model: posted,
-          ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
-          ...(fastMode ? { fast_mode: true } : {}),
-        });
-      } catch (err) {
-        if (isCurrent()) {
-          toast.error(friendlyErrorMessage(err, "Could not start a session"));
-        }
-        throw err;
-      }
-
-      const heldImages = useCodeUiStore
-        .getState()
-        .takeComposerImages(workspaceId);
-
-      const recovery: FirstTurnRecovery = {
-        id: `${created.id}:${request}`,
-        sessionId: created.id,
-        draft,
-        forkSource: startedWithFork,
-        message: "Sending your first message…",
-        status: "sending",
-      };
-      if (!isCurrent()) {
-        if (heldImages && heldImages.length > 0) {
-          useCodeUiStore
-            .getState()
-            .offerComposerPrompt(workspaceId, draft, heldImages);
-        }
-        const message =
-          "The Code connection changed after the session was created. Send the message again.";
-        writeFirstTurnRecovery(startedWithClient, {
-          ...recovery,
-          message,
-          status: "failed",
-        });
-        throw new Error(message);
-      }
-      writeFirstTurnRecovery(startedWithClient, recovery);
-
-      if (conversations.length === 0) catalog.rememberSession(created);
-      setSessions((current) =>
-        current.some((entry) => entry.id === created.id)
-          ? current
-          : [...current, created],
-      );
-      setForkSource((current) =>
-        current === startedWithFork ? null : current,
-      );
-      if (selectionRevisionRef.current === startedAtSelection) {
-        setActiveSessionId(created.id);
-        setDraftAgent(false);
-        // The first agent stays at a clean URL; a sibling names itself so a
-        // reload comes back to the tab the reader was on.
-        if (conversations.length > 0) openWorkspaceTask(created.id);
-      }
-
-      try {
-        const attachments = heldImages?.length
-          ? await Promise.all(
-              heldImages.map(async (file) => {
-                const published = hasLocalHostAuthority()
-                  ? await publishCodeImage(created.id, file)
-                  : await uploadImageAttachment(
-                      startedWithClient,
-                      created.id,
-                      file,
-                      {
-                        onProgress: () => undefined,
-                        signal: new AbortController().signal,
-                        path: (id) =>
-                          `/code/sessions/${encodeURIComponent(id)}/attachments/images`,
-                      },
-                    );
-                return {
-                  blob_id: published.attachmentId,
-                  media_type: published.mediaType,
-                };
-              }),
-            )
-          : [];
-        if (attachments.length > 0) {
-          await startedWithClient.submitCodeTurn(
-            created.id,
-            message,
-            undefined,
-            attachments,
-          );
-        } else {
-          await startedWithClient.submitCodeTurn(created.id, message);
-        }
-        clearFirstTurnRecovery(startedWithClient, created.id, recovery.id);
-      } catch (err) {
-        if (heldImages && heldImages.length > 0) {
-          useCodeUiStore
-            .getState()
-            .offerComposerPrompt(workspaceId, draft, heldImages);
-        }
-        const detail = friendlyErrorMessage(err, "Try sending it again.");
-        writeFirstTurnRecovery(startedWithClient, {
-          ...recovery,
-          message: `The first message was not sent. Review it, then choose Send to try again. ${detail}`,
-          status: "failed",
-        });
-        if (isCurrent()) {
-          toast.error(
-            `Session started, but the first message was not sent. ${detail}`,
-          );
-        }
-      }
-    } finally {
-      if (isCurrent()) setStarting(false);
-    }
-  }
-
-  async function reap() {
-    if (!session) return;
-    try {
-      const next = await client.reapCodeSession(session.id);
-      catalog.rememberSession(next);
-      setSessions((current) =>
-        current.map((entry) => (entry.id === next.id ? next : entry)),
-      );
-    } catch (err) {
-      toast.error(friendlyErrorMessage(err, "Could not reap the session"));
-    }
-  }
+  // Browsers close before shells: a native webview is worth nothing off
+  // screen, while a shell outlives the tab that opened it.
+  const {
+    browserTitles,
+    browserInitialUrls,
+    openBrowser,
+    setBrowserTitle,
+    canNewBrowser,
+  } = useBrowserTabs({ workspaceId, layout, setLayout: setWorkspaceLayout });
+  const {
+    terminalLabels,
+    openTerminal,
+    toggleTerminal,
+    adoptTerminal,
+    hasTerminal,
+    canNewTerminal,
+  } = useTerminalTabs({
+    workspaceId,
+    client,
+    layout,
+    setLayout: setWorkspaceLayout,
+  });
+  const {
+    fileReveal,
+    openFile,
+    openTurnDiff,
+    openFileDiff,
+    quickOpenRequest,
+    quickOpenTarget,
+    newTabMenuRequest,
+    newTabMenuRegion,
+    requestNewTab,
+    draggedTabId,
+    setDraggedTabId,
+    finishTabDrag,
+    copyEditorPath,
+    splitFocused,
+  } = useEditorTabs({ layout, setLayout: setWorkspaceLayout });
 
   const fenced =
     session?.lifecycle === "fenced" || session?.fence_reason !== undefined;
@@ -748,155 +315,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         setupFailed: workspace.status === "setup_failed",
       })
     : [];
-
-  function openTurnDiff(turnId: string) {
-    setWorkspaceLayout(openCodeEditor(layout, { type: "diff", turnId }));
-  }
-
-  function openFile(
-    path: string,
-    line?: number,
-    preferredRegion?: CodeEditorRegion,
-  ) {
-    setFileReveal((current) =>
-      line === undefined
-        ? null
-        : {
-            path,
-            line,
-            revision: (current?.revision ?? 0) + 1,
-          },
-    );
-    setWorkspaceLayout(
-      openCodeEditor(layout, { type: "file", path }, preferredRegion),
-    );
-  }
-
-  function openFileDiff(path: string) {
-    setWorkspaceLayout(openCodeEditor(layout, { type: "diff", path }));
-  }
-
-  function openBrowser(url?: string, preferredRegion?: CodeEditorRegion) {
-    const browserId = crypto.randomUUID();
-    seedBrowserSession({
-      browserId,
-      workspaceId,
-      initialUrl: url,
-    });
-    if (url) {
-      setBrowserInitialUrls((current) => ({
-        ...current,
-        [browserId]: url,
-      }));
-    }
-    setBrowserTitles((current) => ({
-      ...current,
-      [browserId]: "Browser",
-    }));
-    setWorkspaceLayout(
-      openCodeEditor(layout, { type: "browser", browserId }, preferredRegion),
-    );
-  }
-
-  /**
-   * Start a shell and give it a tab.
-   *
-   * The server names the shell, so the tab cannot exist before the call
-   * answers — unlike a browser, whose id the page mints itself.
-   */
-  async function openTerminal(preferredRegion?: CodeEditorRegion) {
-    try {
-      const snap = await client.createCodeTerminal(workspaceId);
-      setTerminalLabels((current) => nameTerminals(current, [snap.id]));
-      setWorkspaceLayout(
-        openCodeEditor(
-          layoutRef.current,
-          { type: "terminal", terminalId: snap.id },
-          preferredRegion,
-        ),
-      );
-    } catch (error) {
-      toast.error(friendlyErrorMessage(error, "Could not open a terminal"));
-    }
-  }
-
-  /**
-   * Jump to the terminal and back again.
-   *
-   * The chord used to show and hide a drawer. A terminal is a tab now, so the
-   * same press moves focus there and the next one returns it where it was —
-   * the flick there and back a drawer gave, without a second kind of surface.
-   */
-  function toggleTerminal() {
-    const found = findCodeTerminalTab(layoutRef.current);
-    if (!found) {
-      beforeTerminalRef.current = focusedEditorPosition(layoutRef.current);
-      void openTerminal("primary");
-      return;
-    }
-    const focused = focusedEditorPosition(layoutRef.current);
-    const onTerminal =
-      focused?.region === found.region && focused.index === found.index;
-    if (!onTerminal) {
-      beforeTerminalRef.current = focused;
-      setWorkspaceLayout(
-        focusEditorTab(layoutRef.current, found.index, found.region),
-      );
-      return;
-    }
-    const back = beforeTerminalRef.current;
-    beforeTerminalRef.current = null;
-    setWorkspaceLayout(
-      back
-        ? focusEditorTab(layoutRef.current, back.index, back.region)
-        : focusConversation(layoutRef.current),
-    );
-  }
-
-  function requestNewTab(region: CodeEditorRegion) {
-    setQuickOpenTarget(region);
-    setQuickOpenRequest((request) => request + 1);
-  }
-
-  function showNewTabMenu(region: CodeEditorRegion) {
-    setNewTabMenuRegion(region);
-    setNewTabMenuRequest((request) => request + 1);
-  }
-
-  // The shell keymap raises the ask above the route; the workspace is what can
-  // answer it. Taking the flag is what stops a remount from reopening the
-  // picker over whatever the reader moved on to.
-  const splitFocused =
-    Boolean(layout.editorSplit?.focused) && chrome.splitEditors.tabs.length > 0;
-  useEffect(() => {
-    if (!quickOpenPending) return;
-    if (!useCodeUiStore.getState().takeQuickOpen()) return;
-    requestNewTab(splitFocused ? "secondary" : "primary");
-  }, [quickOpenPending, splitFocused]);
-
-  useEffect(() => {
-    if (!newTabMenuPending) return;
-    if (!useCodeUiStore.getState().takeNewTabMenu()) return;
-    showNewTabMenu(splitFocused ? "secondary" : "primary");
-  }, [newTabMenuPending, splitFocused]);
-
-  // The palette ranks worktree files but has nowhere to put one; the tabs live
-  // here, so it names a path and this opens it.
-  useEffect(() => {
-    if (!openFilePending) return;
-    const path = useCodeUiStore.getState().takeOpenFilePath();
-    if (path) openFile(path);
-  }, [openFilePending]);
-
-  // The chord and the rail command both raise the ask above the route, because
-  // starting a shell is a server call neither of them can make.
-  useEffect(() => {
-    if (!terminalPending) return;
-    if (!useCodeUiStore.getState().takeTerminal()) return;
-    toggleTerminal();
-    // The flag is the trigger; the rest is state read when it arrives.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [terminalPending]);
 
   /**
    * Archive from the keyboard, through the same confirmation the menu uses.
@@ -921,174 +339,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [archivePending]);
 
-  /**
-   * Attach a child task's transcript (or the conversation when undefined).
-   *
-   * `replace` is for corrections rather than choices: clearing a stale param
-   * should not leave a history entry the reader can walk back into.
-   */
-  function openWorkspaceTask(
-    sessionId: string | undefined,
-    options?: { replace?: boolean },
-  ) {
-    void navigate({
-      to: "/code/w/$workspaceId",
-      params: { workspaceId },
-      replace: options?.replace ?? false,
-      search: (current: Record<string, unknown>) => ({
-        ...current,
-        task: sessionId,
-        subagent: undefined,
-      }),
-    });
-  }
-
-  /**
-   * Show one of the workspace's agents, or the unstarted draft when null.
-   *
-   * Selection lives in `?task=` so a reload or a shared link returns to the
-   * same agent. The first one is the workspace's default, so it stays unnamed.
-   */
-  function selectConversation(sessionId: string | null) {
-    selectionRevisionRef.current += 1;
-    setWorkspaceLayout(focusConversation(layout));
-    if (sessionId === null) {
-      setDraftAgent(true);
-      setActiveSessionId(null);
-      openWorkspaceTask(undefined);
-      return;
-    }
-    setDraftAgent(false);
-    setActiveSessionId(sessionId);
-    openWorkspaceTask(
-      sessionId === conversations[0]?.id ? undefined : sessionId,
-    );
-  }
-
-  /** Add a tab for an agent the reader has not filled in yet. */
-  function newConversation() {
-    setForkSource(null);
-    selectConversation(null);
-  }
-
-  /**
-   * Hand one agent's transcript to a fresh one.
-   *
-   * The server writes the fork into private storage — the condensed
-   * transcript plus a full record per turn — so the child reads it from an
-   * absolute path whatever engine it turns out to be. `atTurnId` forks at
-   * the end of that turn; omitted, the fork covers the whole conversation.
-   * Nothing is sent here: the draft tab opens with the transcript attached
-   * and framing lines the reader edits first.
-   */
-  async function forkConversation(sessionId: string, atTurnId?: string) {
-    try {
-      const written = await client.forkCodeSession(sessionId, atTurnId);
-      setForkSource(written);
-      selectConversation(null);
-      useCodeUiStore
-        .getState()
-        .offerComposerPrompt(workspaceId, forkFraming(written));
-    } catch (err) {
-      toast.error(friendlyErrorMessage(err, "Could not fork this agent"));
-    }
-  }
-
-  /** Close a conversation tab without ending its agent or workspace. */
-  function closeConversation(sessionId: string | null) {
-    if (sessionId === null) {
-      setDraftAgent(false);
-      setForkSource(null);
-    } else {
-      const index = conversations.findIndex((entry) => entry.id === sessionId);
-      if (index <= 0) return;
-      setClosedConversationIds((current) => {
-        const next = new Set(current);
-        next.add(sessionId);
-        return next;
-      });
-      if (sessionId !== activeSessionId) return;
-    }
-    const first = conversations[0];
-    if (first) selectConversation(first.id);
-    else setActiveSessionId(null);
-  }
-
-  /** Filter the parent transcript to one harness-owned child. */
-  function openWorkspaceSubagent(callId: string | undefined) {
-    void navigate({
-      to: "/code/w/$workspaceId",
-      params: { workspaceId },
-      search: (current: Record<string, unknown>) => ({
-        ...current,
-        task: undefined,
-        subagent: callId,
-      }),
-    });
-  }
-
-  function finishTabDrag(event: DragEndEvent) {
-    setDraggedTabId(null);
-    const next = dropEditorTab(
-      layout,
-      String(event.active.id),
-      event.over ? String(event.over.id) : null,
-    );
-    if (next) setWorkspaceLayout(next);
-  }
-
-  function copyEditorPath(path: string) {
-    void copyPlainText(path)
-      .then(() => toast.success("Copied path"))
-      .catch(() => toast.error("Could not copy path"));
-  }
-
-  /**
-   * The agent tab the strip should mark selected.
-   *
-   * A watch child opened from the rail is a drill-in with its own back bar, not
-   * a peer tab, so the first agent stays selected underneath it.
-   */
-  const activeConversationId = draftAgent
-    ? null
-    : (conversations.find((entry) => entry.id === session?.id)?.id ??
-      conversations[0]?.id ??
-      null);
-  const conversationTabs = useMemo<CodeConversationTab[]>(() => {
-    const tabs: CodeConversationTab[] = conversations
-      .filter(
-        (entry, index) => index === 0 || !closedConversationIds.has(entry.id),
-      )
-      .map((entry) => {
-        const index = conversations.findIndex(
-          (conversation) => conversation.id === entry.id,
-        );
-        const digest = conversationDigests[entry.id];
-        return {
-          id: entry.id,
-          label: conversationTabLabel(entry, index, conversations),
-          harness: entry.harness_kind,
-          attention: attentionMarkForDigest(digest),
-          closable: index > 0,
-        };
-      });
-    // A draft has no engine yet, so it wears the generic agent glyph. It is
-    // also the one closable tab: nothing is running behind it. A workspace
-    // with no agents at all still gets one, so the strip always names the
-    // panel below it.
-    if (draftAgent || tabs.length === 0) {
-      tabs.push({
-        id: null,
-        label: tabs.length === 0 ? "Main agent" : "New agent",
-        closable: tabs.length > 0,
-      });
-    }
-    return tabs;
-  }, [closedConversationIds, conversationDigests, conversations, draftAgent]);
-
-  /** The picker shows for a first agent and for every one added after it. */
-  const startingNewAgent = draftAgent || !session;
-
   const editorTabs = chrome.editors.tabs;
   const showingChat =
     editorTabs.length === 0 || Boolean(chrome.editors.conversationFocused);
@@ -1099,14 +349,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const activeSplitEditor =
     splitEditorTabs[chrome.splitEditors.activeIndex] ?? null;
   const hasEditorSplit = splitEditorTabs.length > 0;
-  const openTerminalCount = codeTerminalIds(layout).length;
-  const hasTerminal = findCodeTerminalTab(layout) !== null;
-  const canNewTerminal = openTerminalCount < MAX_WORKSPACE_TERMINALS;
-  // The browser opens as a child webview on this computer. A window working on
-  // another machine has no such screen to lend — sharing one with an agent that
-  // is not here shares the wrong browser — so the row is absent rather than
-  // present and refusing.
-  const canNewBrowser = !attachedRemotely();
 
   function editorPanel(
     panel: PanelContent,
@@ -1169,13 +411,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               browserId={panel.browserId}
               initialUrl={browserInitialUrls[panel.browserId]}
               obscured={workspaceOverlayOpen}
-              onTitleChange={(title) =>
-                setBrowserTitles((current) =>
-                  current[panel.browserId] === title
-                    ? current
-                    : { ...current, [panel.browserId]: title },
-                )
-              }
+              onTitleChange={(title) => setBrowserTitle(panel.browserId, title)}
             />
           </Suspense>
         ) : panel.type === "terminal" ? (
@@ -1184,13 +420,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             workspaceId={workspaceId}
             terminalId={panel.terminalId}
             onAttach={(terminalId) =>
-              setWorkspaceLayout(
-                adoptCodeTerminalId(
-                  layoutRef.current,
-                  panel.terminalId,
-                  terminalId,
-                ),
-              )
+              adoptTerminal(panel.terminalId, terminalId)
             }
             hideHeader
           />
@@ -1377,7 +607,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                       forkSource
                         ? {
                             items: [forkTranscriptFile(forkSource)],
-                            onRemove: () => setForkSource(null),
+                            onRemove: clearForkSource,
                           }
                         : undefined
                     }
@@ -1681,11 +911,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           <p className="text-muted-foreground max-w-sm text-center text-sm">
             {error}
           </p>
-          <Button
-            type="button"
-            size="sm"
-            onClick={() => setReloadToken((token) => token + 1)}
-          >
+          <Button type="button" size="sm" onClick={retry}>
             Retry
           </Button>
         </div>

--- a/crates/tidebreak-desktop/ui/src/code/delivery/PullRequestsSurface.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/PullRequestsSurface.tsx
@@ -3,16 +3,11 @@ import {
   type CodeDeliveryPrViewFilters,
   codeDeliveryRepositoryKey,
   codeDeliveryRepositoryTarget,
-  deliveryAuthorSightings,
   deliveryPullRequestPageKey,
-  rememberedPullRequestPage,
-  useCodeDeliveryStore,
 } from "../CodeDeliveryStore";
 import type {
-  CodeDeliveryPullRequestDetail,
   CodeDeliveryPullRequestSummary,
   CodeDeliveryPullRequestTarget,
-  CodeDeliverySourceError,
   CodeGitHubCapability,
   CodeGitHubRepositoryRef,
 } from "../../api/types";
@@ -42,10 +37,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import {
-  dedupeRows,
-  isEditableKeyboardTarget,
   pullRequestIdsInDisplayOrder,
-  pullRequestMatchesTarget,
   selectedRepositoryTargets,
 } from "./helpers";
 import {
@@ -54,26 +46,15 @@ import {
   prDirectMergeAction,
 } from "../prActions";
 import { friendlyErrorMessage } from "@/lib/utils";
-import {
-  isStackedPullRequest,
-  preservePullRequestStackMetadata,
-} from "../pullRequestStacks";
+import { isStackedPullRequest } from "../pullRequestStacks";
 import { toast } from "sonner";
 import { useApp } from "@/AppContext";
-import { useCodeUpdatesStore } from "../CodeUpdatesStore";
 import { useConfirm } from "@/components/ConfirmDialog";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-
-export type TargetDetailState<T> = {
-  key: string;
-  pending: boolean;
-  detail: T | null;
-};
-
-const PULL_REQUEST_DETAIL_SELECTION_DEBOUNCE_MS = 140;
-
-const MAX_PULL_REQUEST_DETAIL_CACHE = 24;
+import { usePullRequestDetail } from "./usePullRequestDetail";
+import { usePullRequestKeyboardNav } from "./usePullRequestKeyboardNav";
+import { usePullRequestQuery } from "./usePullRequestQuery";
 
 export function PullRequestsSurface({
   repositories,
@@ -100,43 +81,8 @@ export function PullRequestsSurface({
   const navigate = useNavigate();
   const { confirm, dialog } = useConfirm();
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [items, setItems] = useState<CodeDeliveryPullRequestSummary[]>([]);
-  const [errors, setErrors] = useState<CodeDeliverySourceError[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [nextCursor, setNextCursor] = useState<string | undefined>();
-  const [error, setError] = useState<string | null>(null);
-  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [detailLoadDelayMs, setDetailLoadDelayMs] = useState(0);
-  const [targetDetailState, setTargetDetailState] =
-    useState<TargetDetailState<CodeDeliveryPullRequestDetail> | null>(null);
-  const [revision, setRevision] = useState(0);
-  // The server nudges `delivery` whenever the pull-request store moves
-  // (decision 66). This list is a projection of that nudge, not a clock of
-  // its own: a fix turn, a watch, or another window's action reaches the
-  // page through the broadcast rather than waiting for a Refresh.
-  const deliveryRevision = useCodeUpdatesStore(
-    (state) => state.deliveryRevision,
-  );
-  // Set by Refresh and by a completed action; consumed by the next query that
-  // actually runs. Only those two reach past the server's short list cache —
-  // a filter change reruns against it, which is the whole point of caching a
-  // cross-repository read.
-  const forceRefresh = useRef(false);
-  const generation = useRef(0);
-  const routeSelectionFenced = useRef(false);
-  const skipQueryDebounce = useRef(true);
-  const adoptedSummaries = useRef(
-    new Map<string, CodeDeliveryPullRequestSummary>(),
-  );
-  const detailCache = useRef(new Map<string, CodeDeliveryPullRequestDetail>());
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  const selected = useMemo(
-    () => items.find((item) => item.id === selectedId) ?? null,
-    [items, selectedId],
-  );
   const selectedRepositories = useMemo(
     () =>
       selectedRepositoryTargets(
@@ -153,28 +99,48 @@ export function PullRequestsSurface({
     selectedRepositories.map(codeDeliveryRepositoryKey),
     filters,
   );
+
+  const detail = usePullRequestDetail(targetKey);
+  const {
+    items,
+    errors,
+    loading,
+    loadingMore,
+    nextCursor,
+    error,
+    fetchedAt,
+    query,
+    refreshList,
+    adoptSummary,
+  } = usePullRequestQuery({
+    client,
+    selectedRepositories,
+    filters,
+    target,
+    targetKey,
+    pageKey,
+    detail,
+  });
+  const { selectedId, detailLoadDelayMs, selectItem, closeDetail } = detail;
+
+  const selected = useMemo(
+    () => items.find((item) => item.id === selectedId) ?? null,
+    [items, selectedId],
+  );
   const displayIds = useMemo(
     () => pullRequestIdsInDisplayOrder(items, grouping),
     [grouping, items],
   );
 
-  useEffect(() => {
-    adoptedSummaries.current.clear();
-    const remembered = rememberedPullRequestPage(
-      useCodeDeliveryStore.getState().lastPullRequestPages,
-      pageKey,
-    );
-    setItems(remembered?.items ?? []);
-    setErrors(remembered?.errors ?? []);
-    setNextCursor(remembered?.nextCursor);
-    setFetchedAt(remembered?.fetchedAt ?? null);
-    setLoading(true);
-  }, [pageKey]);
-
-  const refreshList = () => {
-    forceRefresh.current = true;
-    setRevision((value) => value + 1);
-  };
+  usePullRequestKeyboardNav({
+    selectedId,
+    displayIds,
+    nextCursor,
+    loadingMore,
+    onSelect: (id) => selectItem(id, true),
+    onClose: closeDetail,
+    onLoadMore: (cursor) => void query(cursor, true),
+  });
 
   const runListMerge = async (item: CodeDeliveryPullRequestSummary) => {
     const action = prDirectMergeAction(deliveryPullRequestDigest(item), {
@@ -226,266 +192,6 @@ export function PullRequestsSurface({
     }
   };
 
-  useEffect(() => {
-    routeSelectionFenced.current = false;
-    setSelectedId(null);
-    setDetailLoadDelayMs(0);
-    setTargetDetailState(
-      targetKey ? { key: targetKey, pending: true, detail: null } : null,
-    );
-  }, [targetKey]);
-
-  const selectItem = (id: string, debounceDetail = false) => {
-    routeSelectionFenced.current = true;
-    setDetailLoadDelayMs(
-      debounceDetail ? PULL_REQUEST_DETAIL_SELECTION_DEBOUNCE_MS : 0,
-    );
-    setSelectedId(id);
-  };
-
-  const closeDetail = () => {
-    routeSelectionFenced.current = true;
-    setDetailLoadDelayMs(0);
-    setSelectedId(null);
-  };
-
-  const rememberDetail = (detail: CodeDeliveryPullRequestDetail) => {
-    detailCache.current.delete(detail.summary.id);
-    detailCache.current.set(detail.summary.id, detail);
-    if (detailCache.current.size > MAX_PULL_REQUEST_DETAIL_CACHE) {
-      const oldest = detailCache.current.keys().next().value;
-      if (oldest) detailCache.current.delete(oldest);
-    }
-  };
-
-  const applyAdopted = (rows: CodeDeliveryPullRequestSummary[]) =>
-    rows.map((item) => {
-      const adopted = adoptedSummaries.current.get(item.id);
-      if (!adopted) return item;
-      const merged = preservePullRequestStackMetadata(item, adopted);
-      adoptedSummaries.current.set(item.id, merged);
-      return merged;
-    });
-
-  const adoptSummary = (summary: CodeDeliveryPullRequestSummary) => {
-    const previous = items.find((item) => item.id === summary.id);
-    const adopted = previous
-      ? preservePullRequestStackMetadata(previous, summary)
-      : summary;
-    adoptedSummaries.current.set(adopted.id, adopted);
-    setItems((current) =>
-      current.map((item) =>
-        item.id === adopted.id
-          ? adopted
-          : (adoptedSummaries.current.get(item.id) ?? item),
-      ),
-    );
-
-    const cached = useCodeDeliveryStore
-      .getState()
-      .lastPullRequestPages.find((page) => page.key === pageKey);
-    if (cached) {
-      useCodeDeliveryStore.getState().rememberPullRequestPage({
-        ...cached,
-        items: cached.items.map((item) =>
-          item.id === adopted.id
-            ? adopted
-            : (adoptedSummaries.current.get(item.id) ?? item),
-        ),
-      });
-    }
-  };
-
-  const query = async (cursor?: string, append = false) => {
-    const token = ++generation.current;
-    // Paging never rereads: renumbering the aggregate under a cursor would
-    // skip or repeat rows.
-    const refresh = !append && !cursor && forceRefresh.current;
-    if (refresh) {
-      forceRefresh.current = false;
-      adoptedSummaries.current.clear();
-    }
-    if (append) setLoadingMore(true);
-    else setLoading(true);
-    setError(null);
-    try {
-      if (selectedRepositories.length === 0) {
-        setNextCursor(undefined);
-        setErrors([]);
-        return;
-      }
-      let detailRequest: Promise<{
-        detail?: CodeDeliveryPullRequestDetail;
-        detailError?: unknown;
-      }> = Promise.resolve({});
-      if (!append && target && targetKey) {
-        const requestKey = targetKey;
-        setTargetDetailState((current) => ({
-          key: requestKey,
-          pending: true,
-          detail: current?.key === requestKey ? current.detail : null,
-        }));
-        detailRequest = client
-          .getCodeDeliveryPullRequestDetail(target)
-          .then((detail) => {
-            if (token === generation.current) {
-              const previous = items.find(
-                (item) => item.id === detail.summary.id,
-              );
-              const summary = previous
-                ? preservePullRequestStackMetadata(previous, detail.summary)
-                : detail.summary;
-              const adoptedDetail =
-                summary === detail.summary ? detail : { ...detail, summary };
-              rememberDetail(adoptedDetail);
-              setTargetDetailState({
-                key: requestKey,
-                pending: false,
-                detail: adoptedDetail,
-              });
-              adoptedSummaries.current.set(summary.id, summary);
-              setItems((current) =>
-                applyAdopted(dedupeRows([summary, ...current])),
-              );
-              if (!routeSelectionFenced.current) {
-                setSelectedId(summary.id);
-              }
-            }
-            return { detail };
-          })
-          .catch((detailError: unknown) => {
-            if (token === generation.current) {
-              setTargetDetailState((current) =>
-                current?.key === requestKey
-                  ? { ...current, pending: false }
-                  : current,
-              );
-            }
-            return { detailError };
-          });
-      }
-      const page = await client.queryCodeDeliveryPullRequests({
-        repositories: selectedRepositories,
-        search: filters.search.trim() || undefined,
-        states: filters.states,
-        review_states: filters.reviewStates,
-        check_states: filters.checkStates,
-        authors: filters.authors,
-        attention_only: filters.attentionOnly,
-        ready_only: filters.readyOnly,
-        tidebreak_linked: filters.tidebreakLinked,
-        limit: 100,
-        refresh,
-        ...(cursor ? { cursor } : {}),
-      });
-      if (token !== generation.current) return;
-      useCodeDeliveryStore
-        .getState()
-        .rememberDeliveryAuthors(deliveryAuthorSightings(page.items, []));
-      let nextItems: CodeDeliveryPullRequestSummary[] = [];
-      setItems((current) => {
-        nextItems = append ? [...current, ...page.items] : page.items;
-        const exactItem = target
-          ? current.find((item) => pullRequestMatchesTarget(item, target))
-          : undefined;
-        if (exactItem) nextItems = [exactItem, ...nextItems];
-        nextItems = applyAdopted(dedupeRows(nextItems));
-        return nextItems;
-      });
-      useCodeDeliveryStore.getState().rememberPullRequestPage({
-        key: pageKey,
-        items: nextItems,
-        fetchedAt: page.fetched_at,
-        nextCursor: page.next_cursor,
-        errors: page.errors,
-      });
-      setNextCursor(page.next_cursor);
-      setErrors(page.errors);
-      setFetchedAt(page.fetched_at);
-      void detailRequest.then((targetResult) => {
-        if (
-          token === generation.current &&
-          target &&
-          targetResult.detailError
-        ) {
-          setError(
-            friendlyErrorMessage(
-              targetResult.detailError,
-              "Could not load this pull request.",
-            ),
-          );
-        }
-      });
-    } catch (caught) {
-      if (token !== generation.current) return;
-      setError(friendlyErrorMessage(caught, "Could not load pull requests."));
-      if (!append) {
-        setItems((current) =>
-          target
-            ? current.filter((item) => pullRequestMatchesTarget(item, target))
-            : [],
-        );
-      }
-    } finally {
-      if (token === generation.current) {
-        setLoading(false);
-        setLoadingMore(false);
-      }
-    }
-  };
-
-  useEffect(() => {
-    const delay = skipQueryDebounce.current ? 0 : 180;
-    skipQueryDebounce.current = false;
-    const timer = window.setTimeout(() => void query(), delay);
-    return () => {
-      window.clearTimeout(timer);
-      generation.current += 1;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    client,
-    selectedRepositories,
-    filters,
-    revision,
-    deliveryRevision,
-    targetKey,
-  ]);
-
-  useEffect(() => {
-    if (!selectedId) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.defaultPrevented ||
-        event.altKey ||
-        event.metaKey ||
-        event.ctrlKey
-      ) {
-        return;
-      }
-      if (isEditableKeyboardTarget(event.target)) return;
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeDetail();
-        return;
-      }
-      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
-      const index = displayIds.indexOf(selectedId);
-      if (index < 0) return;
-      const nextIndex = event.key === "ArrowDown" ? index + 1 : index - 1;
-      if (nextIndex < 0) return;
-      event.preventDefault();
-      if (nextIndex >= displayIds.length) {
-        if (nextCursor && !loadingMore) void query(nextCursor, true);
-        return;
-      }
-      const nextId = displayIds[nextIndex];
-      if (nextId) selectItem(nextId, true);
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [displayIds, loadingMore, nextCursor, selectedId]);
-
   if (loadingRepositories) return <DeliveryListSkeleton />;
   if (!repositoryLoaded && repositoryError) {
     return (
@@ -500,24 +206,8 @@ export function PullRequestsSurface({
   }
   if (repositories.length === 0) return <NoDeliveryRepositories />;
 
-  const pendingTargetDetail =
-    selected &&
-    target &&
-    targetDetailState?.key === targetKey &&
-    targetDetailState.pending &&
-    !targetDetailState.detail &&
-    pullRequestMatchesTarget(selected, target);
-  const cachedDetail = selected
-    ? detailCache.current.get(selected.id)
-    : undefined;
-  const initialDetail =
-    selected && targetDetailState?.detail?.summary.id === selected.id
-      ? targetDetailState.detail
-      : cachedDetail &&
-          selected &&
-          cachedDetail.summary.updated_at >= selected.updated_at
-        ? cachedDetail
-        : undefined;
+  const pendingTargetDetail = detail.pendingTargetDetail(selected, target);
+  const initialDetail = detail.initialDetail(selected);
 
   const list = (
     <div
@@ -579,41 +269,42 @@ export function PullRequestsSurface({
     </div>
   );
 
-  const detail = pendingTargetDetail ? (
-    <PendingDetailPane
-      context={`${selected.repository.name_with_owner} #${selected.number}`}
-      title={selected.title}
-      closeLabel="Close pull request details"
-      onClose={closeDetail}
-    />
-  ) : selected ? (
-    <PullRequestDetailPane
-      key={selected.id}
-      client={client}
-      summary={selected}
-      loadDelayMs={detailLoadDelayMs}
-      hasMergeQueue={deliveryRepositoryHasMergeQueue(
-        items,
-        selected.repository,
-      )}
-      initialDetail={initialDetail}
-      onClose={closeDetail}
-      onChanged={refreshList}
-      onDetail={rememberDetail}
-      onSummary={adoptSummary}
-      onOpenWorkspace={(workspaceId) =>
-        void navigate({
-          to: "/code/w/$workspaceId",
-          params: { workspaceId },
-        })
-      }
-    />
-  ) : null;
+  const detailPane =
+    pendingTargetDetail && selected ? (
+      <PendingDetailPane
+        context={`${selected.repository.name_with_owner} #${selected.number}`}
+        title={selected.title}
+        closeLabel="Close pull request details"
+        onClose={closeDetail}
+      />
+    ) : selected ? (
+      <PullRequestDetailPane
+        key={selected.id}
+        client={client}
+        summary={selected}
+        loadDelayMs={detailLoadDelayMs}
+        hasMergeQueue={deliveryRepositoryHasMergeQueue(
+          items,
+          selected.repository,
+        )}
+        initialDetail={initialDetail}
+        onClose={closeDetail}
+        onChanged={refreshList}
+        onDetail={detail.rememberDetail}
+        onSummary={adoptSummary}
+        onOpenWorkspace={(workspaceId) =>
+          void navigate({
+            to: "/code/w/$workspaceId",
+            params: { workspaceId },
+          })
+        }
+      />
+    ) : null;
 
   return (
     <div className="flex min-h-0 flex-1">
       {dialog}
-      {detail ? (
+      {detailPane ? (
         <ResizablePanelGroup
           key="with-detail"
           orientation="horizontal"
@@ -624,7 +315,7 @@ export function PullRequestsSurface({
           </ResizablePanel>
           <ResizableHandle />
           <ResizablePanel defaultSize={50} minSize={28} className="min-h-0">
-            {detail}
+            {detailPane}
           </ResizablePanel>
         </ResizablePanelGroup>
       ) : (

--- a/crates/tidebreak-desktop/ui/src/code/delivery/RunsSurface.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/RunsSurface.tsx
@@ -32,7 +32,7 @@ import { LoaderCircle, Workflow } from "lucide-react";
 import { PendingDetailSheet } from "./PendingDetail";
 import { RunDetailSheet } from "./RunDetailSheet";
 import { RunList } from "./RunList";
-import type { TargetDetailState } from "./PullRequestsSurface";
+import type { TargetDetailState } from "./usePullRequestDetail";
 import {
   dedupeRows,
   runMatchesTarget,

--- a/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestDetail.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestDetail.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  CodeDeliveryPullRequestDetail,
+  CodeDeliveryPullRequestSummary,
+} from "../../api/types";
+import { deliveryPullRequests } from "../../stories/fixtures";
+import { codeDeliveryRepositoryTarget } from "../CodeDeliveryStore";
+import {
+  MAX_PULL_REQUEST_DETAIL_CACHE,
+  PULL_REQUEST_DETAIL_SELECTION_DEBOUNCE_MS,
+  usePullRequestDetail,
+} from "./usePullRequestDetail";
+
+const first = deliveryPullRequests[0] as CodeDeliveryPullRequestSummary;
+const target = {
+  repository: codeDeliveryRepositoryTarget(first.repository),
+  number: first.number,
+};
+const targetKey = "github.com/brightwave-inc/tidebreak:pull-request:2251";
+
+function detailOf(
+  summary: CodeDeliveryPullRequestSummary,
+): CodeDeliveryPullRequestDetail {
+  return { summary } as unknown as CodeDeliveryPullRequestDetail;
+}
+
+function summaryWith(
+  id: string,
+  updated_at: string,
+): CodeDeliveryPullRequestSummary {
+  return { ...first, id, updated_at };
+}
+
+afterEach(cleanup);
+
+describe("usePullRequestDetail", () => {
+  it("selects by hand with a debounce for walks and none for clicks", () => {
+    const { result } = renderHook(() => usePullRequestDetail(null));
+    act(() => result.current.selectItem("pr-1", true));
+    expect(result.current.selectedId).toBe("pr-1");
+    expect(result.current.detailLoadDelayMs).toBe(
+      PULL_REQUEST_DETAIL_SELECTION_DEBOUNCE_MS,
+    );
+    act(() => result.current.selectItem("pr-2"));
+    expect(result.current.detailLoadDelayMs).toBe(0);
+    act(() => result.current.closeDetail());
+    expect(result.current.selectedId).toBeNull();
+  });
+
+  it("lets the route target pick the row until the reader picks one by hand", () => {
+    const { result } = renderHook(() => usePullRequestDetail(targetKey));
+    expect(result.current.pendingTargetDetail(first, target)).toBe(true);
+
+    act(() => result.current.adoptTargetDetail(targetKey, detailOf(first)));
+    expect(result.current.selectedId).toBe(first.id);
+    expect(result.current.pendingTargetDetail(first, target)).toBe(false);
+    expect(result.current.initialDetail(first)?.summary.id).toBe(first.id);
+
+    const other = summaryWith("pr-other", first.updated_at);
+    act(() => result.current.selectItem(other.id));
+    act(() =>
+      result.current.adoptTargetDetail(
+        targetKey,
+        detailOf(summaryWith(first.id, "2026-09-01T00:00:00Z")),
+      ),
+    );
+    expect(result.current.selectedId).toBe(other.id);
+  });
+
+  it("resets the selection and the fence when the route target changes", () => {
+    const { result, rerender } = renderHook(
+      ({ key }: { key: string | null }) => usePullRequestDetail(key),
+      { initialProps: { key: targetKey as string | null } },
+    );
+    act(() => result.current.selectItem("pr-by-hand"));
+    rerender({ key: `${targetKey}-next` });
+    expect(result.current.selectedId).toBeNull();
+    act(() =>
+      result.current.adoptTargetDetail(`${targetKey}-next`, detailOf(first)),
+    );
+    expect(result.current.selectedId).toBe(first.id);
+
+    rerender({ key: null });
+    expect(result.current.pendingTargetDetail(first, target)).toBe(false);
+  });
+
+  it("keeps a failed target from pending forever", () => {
+    const { result } = renderHook(() => usePullRequestDetail(targetKey));
+    act(() => result.current.beginTargetDetail(targetKey));
+    act(() => result.current.failTargetDetail(targetKey));
+    act(() => result.current.selectItem(first.id));
+    expect(result.current.pendingTargetDetail(first, target)).toBe(false);
+  });
+
+  it("seeds the pane from the cache only while the cached detail is as fresh as the row", () => {
+    const { result } = renderHook(() => usePullRequestDetail(null));
+    const stale = summaryWith("pr-1", "2026-08-01T00:00:00Z");
+    act(() => result.current.rememberDetail(detailOf(stale)));
+    expect(result.current.initialDetail(stale)?.summary.id).toBe("pr-1");
+    expect(
+      result.current.initialDetail(summaryWith("pr-1", "2026-08-02T00:00:00Z")),
+    ).toBeUndefined();
+    expect(result.current.initialDetail(null)).toBeUndefined();
+  });
+
+  it("evicts the least recently remembered detail past the cache size", () => {
+    const { result } = renderHook(() => usePullRequestDetail(null));
+    const at = "2026-08-01T00:00:00Z";
+    act(() => {
+      for (let index = 0; index < MAX_PULL_REQUEST_DETAIL_CACHE; index += 1) {
+        result.current.rememberDetail(detailOf(summaryWith(`pr-${index}`, at)));
+      }
+      // Touching the oldest moves it to the back of the queue.
+      result.current.rememberDetail(detailOf(summaryWith("pr-0", at)));
+      result.current.rememberDetail(detailOf(summaryWith("pr-extra", at)));
+    });
+    expect(result.current.initialDetail(summaryWith("pr-0", at))).toBeDefined();
+    expect(
+      result.current.initialDetail(summaryWith("pr-1", at)),
+    ).toBeUndefined();
+    expect(
+      result.current.initialDetail(summaryWith("pr-extra", at)),
+    ).toBeDefined();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestDetail.ts
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestDetail.ts
@@ -1,0 +1,148 @@
+import type {
+  CodeDeliveryPullRequestDetail,
+  CodeDeliveryPullRequestSummary,
+  CodeDeliveryPullRequestTarget,
+} from "../../api/types";
+import { pullRequestMatchesTarget } from "./helpers";
+import { useEffect, useRef, useState } from "react";
+
+export type TargetDetailState<T> = {
+  key: string;
+  pending: boolean;
+  detail: T | null;
+};
+
+/** Keyboard walks wait this long before the detail pane loads the next row. */
+export const PULL_REQUEST_DETAIL_SELECTION_DEBOUNCE_MS = 140;
+
+/** Details kept warm so walking back up the list does not refetch. */
+export const MAX_PULL_REQUEST_DETAIL_CACHE = 24;
+
+/**
+ * Which pull request the detail pane shows, and what it already knows about it.
+ *
+ * Selection has two sources. A route target (`?pr=` on a repository) picks
+ * the row the page opened on; a click or an arrow key picks one by hand. The
+ * hand-picked one wins: once the reader has chosen, a target detail that
+ * lands later does not steal the pane back. `targetKey` changing resets that
+ * fence along with the selection, because a new route is a new request.
+ *
+ * The cache is a small LRU keyed by pull request id. It seeds the pane with
+ * a detail the pane fetched earlier, but only when that detail is at least as
+ * fresh as the summary row now showing.
+ */
+export function usePullRequestDetail(targetKey: string | null) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detailLoadDelayMs, setDetailLoadDelayMs] = useState(0);
+  const [targetDetailState, setTargetDetailState] =
+    useState<TargetDetailState<CodeDeliveryPullRequestDetail> | null>(null);
+  const routeSelectionFenced = useRef(false);
+  const detailCache = useRef(new Map<string, CodeDeliveryPullRequestDetail>());
+
+  useEffect(() => {
+    routeSelectionFenced.current = false;
+    setSelectedId(null);
+    setDetailLoadDelayMs(0);
+    setTargetDetailState(
+      targetKey ? { key: targetKey, pending: true, detail: null } : null,
+    );
+  }, [targetKey]);
+
+  const selectItem = (id: string, debounceDetail = false) => {
+    routeSelectionFenced.current = true;
+    setDetailLoadDelayMs(
+      debounceDetail ? PULL_REQUEST_DETAIL_SELECTION_DEBOUNCE_MS : 0,
+    );
+    setSelectedId(id);
+  };
+
+  const closeDetail = () => {
+    routeSelectionFenced.current = true;
+    setDetailLoadDelayMs(0);
+    setSelectedId(null);
+  };
+
+  const rememberDetail = (detail: CodeDeliveryPullRequestDetail) => {
+    detailCache.current.delete(detail.summary.id);
+    detailCache.current.set(detail.summary.id, detail);
+    if (detailCache.current.size > MAX_PULL_REQUEST_DETAIL_CACHE) {
+      const oldest = detailCache.current.keys().next().value;
+      if (oldest) detailCache.current.delete(oldest);
+    }
+  };
+
+  /** A list query started fetching the route target's detail. */
+  const beginTargetDetail = (key: string) => {
+    setTargetDetailState((current) => ({
+      key,
+      pending: true,
+      detail: current?.key === key ? current.detail : null,
+    }));
+  };
+
+  /**
+   * The route target's detail arrived. It becomes the selection unless the
+   * reader already picked a row by hand.
+   */
+  const adoptTargetDetail = (
+    key: string,
+    detail: CodeDeliveryPullRequestDetail,
+  ) => {
+    rememberDetail(detail);
+    setTargetDetailState({ key, pending: false, detail });
+    if (!routeSelectionFenced.current) {
+      setSelectedId(detail.summary.id);
+    }
+  };
+
+  /** The route target's detail failed; the pane stops waiting for it. */
+  const failTargetDetail = (key: string) => {
+    setTargetDetailState((current) =>
+      current?.key === key ? { ...current, pending: false } : current,
+    );
+  };
+
+  /**
+   * True while the selected row is the route target and its detail is still
+   * on its way, so the pane can show a placeholder rather than a second fetch.
+   */
+  const pendingTargetDetail = (
+    selected: CodeDeliveryPullRequestSummary | null,
+    target: CodeDeliveryPullRequestTarget | undefined,
+  ): boolean =>
+    Boolean(
+      selected &&
+        target &&
+        targetDetailState?.key === targetKey &&
+        targetDetailState.pending &&
+        !targetDetailState.detail &&
+        pullRequestMatchesTarget(selected, target),
+    );
+
+  /** What the pane can render before its own fetch answers, if anything. */
+  const initialDetail = (
+    selected: CodeDeliveryPullRequestSummary | null,
+  ): CodeDeliveryPullRequestDetail | undefined => {
+    if (!selected) return undefined;
+    if (targetDetailState?.detail?.summary.id === selected.id) {
+      return targetDetailState.detail;
+    }
+    const cached = detailCache.current.get(selected.id);
+    return cached && cached.summary.updated_at >= selected.updated_at
+      ? cached
+      : undefined;
+  };
+
+  return {
+    selectedId,
+    detailLoadDelayMs,
+    selectItem,
+    closeDetail,
+    rememberDetail,
+    beginTargetDetail,
+    adoptTargetDetail,
+    failTargetDetail,
+    pendingTargetDetail,
+    initialDetail,
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestKeyboardNav.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestKeyboardNav.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { usePullRequestKeyboardNav } from "./usePullRequestKeyboardNav";
+
+function press(key: string, init: KeyboardEventInit = {}, target?: Element) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  (target ?? window).dispatchEvent(event);
+  return event;
+}
+
+function setup(
+  overrides: Partial<Parameters<typeof usePullRequestKeyboardNav>[0]> = {},
+) {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  const onLoadMore = vi.fn();
+  const props = {
+    selectedId: "b",
+    displayIds: ["a", "b", "c"],
+    nextCursor: undefined as string | undefined,
+    loadingMore: false,
+    onSelect,
+    onClose,
+    onLoadMore,
+    ...overrides,
+  };
+  const hook = renderHook(
+    (next: typeof props) => usePullRequestKeyboardNav(next),
+    {
+      initialProps: props,
+    },
+  );
+  return { ...hook, props, onSelect, onClose, onLoadMore };
+}
+
+afterEach(cleanup);
+
+describe("usePullRequestKeyboardNav", () => {
+  it("walks the display order with the arrow keys and clamps at the top", () => {
+    const { onSelect, unmount } = setup();
+    expect(press("ArrowDown").defaultPrevented).toBe(true);
+    expect(onSelect).toHaveBeenLastCalledWith("c");
+    expect(press("ArrowUp").defaultPrevented).toBe(true);
+    expect(onSelect).toHaveBeenLastCalledWith("a");
+    unmount();
+
+    const { onSelect: fromTop } = setup({ selectedId: "a" });
+    const up = press("ArrowUp");
+    expect(up.defaultPrevented).toBe(false);
+    expect(fromTop).not.toHaveBeenCalled();
+  });
+
+  it("asks for the next page instead of wrapping at the bottom", () => {
+    const { onLoadMore, onSelect } = setup({
+      selectedId: "c",
+      nextCursor: "page-2",
+    });
+    expect(press("ArrowDown").defaultPrevented).toBe(true);
+    expect(onLoadMore).toHaveBeenCalledWith("page-2");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not ask for a page it is already loading, or one that is not there", () => {
+    const loading = setup({
+      selectedId: "c",
+      nextCursor: "page-2",
+      loadingMore: true,
+    });
+    press("ArrowDown");
+    expect(loading.onLoadMore).not.toHaveBeenCalled();
+    loading.unmount();
+
+    const last = setup({ selectedId: "c" });
+    press("ArrowDown");
+    expect(last.onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("closes on Escape and ignores modified, handled, and typed keys", () => {
+    const { onClose, onSelect } = setup();
+    press("Escape");
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    press("ArrowDown", { metaKey: true });
+    press("ArrowDown", { ctrlKey: true });
+    press("ArrowDown", { altKey: true });
+    expect(onSelect).not.toHaveBeenCalled();
+
+    const handled = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    handled.preventDefault();
+    window.dispatchEvent(handled);
+    expect(onSelect).not.toHaveBeenCalled();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    press("ArrowDown", {}, input);
+    expect(onSelect).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it("listens only while a row is selected, and lets go on unmount", () => {
+    const { onSelect, onClose, rerender, props, unmount } = setup({
+      selectedId: null,
+    });
+    press("ArrowDown");
+    press("Escape");
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    rerender({ ...props, selectedId: "a" });
+    press("ArrowDown");
+    expect(onSelect).toHaveBeenCalledWith("b");
+
+    unmount();
+    press("ArrowDown");
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the handler from the latest render, not the one the listener saw", () => {
+    const { rerender, props } = setup({ selectedId: "a" });
+    const replacement = vi.fn();
+    act(() => rerender({ ...props, onSelect: replacement }));
+    press("ArrowDown");
+    expect(replacement).toHaveBeenCalledWith("b");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestKeyboardNav.ts
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestKeyboardNav.ts
@@ -1,0 +1,66 @@
+import { isEditableKeyboardTarget } from "./helpers";
+import { useEffect, useRef } from "react";
+
+/**
+ * Arrow keys walk the open detail through the list; Escape closes it.
+ *
+ * The listener exists only while a row is selected, so the keys mean nothing
+ * on a bare list. Walking off the bottom asks for the next page rather than
+ * wrapping; walking off the top does nothing. Keys with a modifier, keys the
+ * page already handled, and keys typed into a field are all left alone.
+ */
+export function usePullRequestKeyboardNav({
+  selectedId,
+  displayIds,
+  nextCursor,
+  loadingMore,
+  onSelect,
+  onClose,
+  onLoadMore,
+}: {
+  selectedId: string | null;
+  displayIds: readonly string[];
+  nextCursor: string | undefined;
+  loadingMore: boolean;
+  /** Select a neighbouring row; the detail load is debounced for a walk. */
+  onSelect: (id: string) => void;
+  onClose: () => void;
+  onLoadMore: (cursor: string) => void;
+}) {
+  const handlers = useRef({ onSelect, onClose, onLoadMore });
+  handlers.current = { onSelect, onClose, onLoadMore };
+
+  useEffect(() => {
+    if (!selectedId) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.altKey ||
+        event.metaKey ||
+        event.ctrlKey
+      ) {
+        return;
+      }
+      if (isEditableKeyboardTarget(event.target)) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handlers.current.onClose();
+        return;
+      }
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      const index = displayIds.indexOf(selectedId);
+      if (index < 0) return;
+      const nextIndex = event.key === "ArrowDown" ? index + 1 : index - 1;
+      if (nextIndex < 0) return;
+      event.preventDefault();
+      if (nextIndex >= displayIds.length) {
+        if (nextCursor && !loadingMore) handlers.current.onLoadMore(nextCursor);
+        return;
+      }
+      const nextId = displayIds[nextIndex];
+      if (nextId) handlers.current.onSelect(nextId);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [displayIds, loadingMore, nextCursor, selectedId]);
+}

--- a/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestQuery.ts
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestQuery.ts
@@ -1,0 +1,293 @@
+import type { ApiClient } from "../../api/client";
+import type {
+  CodeDeliveryPullRequestDetail,
+  CodeDeliveryPullRequestSummary,
+  CodeDeliveryPullRequestTarget,
+  CodeDeliverySourceError,
+  CodeGitHubRepositoryTarget,
+} from "../../api/types";
+import {
+  type CodeDeliveryPrViewFilters,
+  deliveryAuthorSightings,
+  rememberedPullRequestPage,
+  useCodeDeliveryStore,
+} from "../CodeDeliveryStore";
+import { dedupeRows, pullRequestMatchesTarget } from "./helpers";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { preservePullRequestStackMetadata } from "../pullRequestStacks";
+import { useCodeUpdatesStore } from "../CodeUpdatesStore";
+import { useEffect, useRef, useState } from "react";
+
+/** The list query's handle on the detail pane's target state. */
+export type PullRequestTargetDetailSink = {
+  beginTargetDetail: (key: string) => void;
+  adoptTargetDetail: (
+    key: string,
+    detail: CodeDeliveryPullRequestDetail,
+  ) => void;
+  failTargetDetail: (key: string) => void;
+};
+
+/**
+ * The pull-request list: its rows, its paging, and the summaries it adopts
+ * from the detail pane.
+ *
+ * The rows come from one aggregate query across the selected repositories.
+ * A page key (repositories plus filters) remembers the last answer in the
+ * delivery store so a return to the same view paints at once, then the query
+ * reruns behind it. The server nudges `delivery` whenever its pull-request
+ * store moves (decision 66); this list is a projection of that nudge, not a
+ * clock of its own.
+ *
+ * Adopted summaries are rows the detail pane has read more recently than the
+ * list. They overlay the list's rows until the next forced refresh, so a
+ * merge the pane just saw does not flicker back to "open" on the next nudge.
+ */
+export function usePullRequestQuery({
+  client,
+  selectedRepositories,
+  filters,
+  target,
+  targetKey,
+  pageKey,
+  detail,
+}: {
+  client: ApiClient;
+  selectedRepositories: CodeGitHubRepositoryTarget[];
+  filters: CodeDeliveryPrViewFilters;
+  target: CodeDeliveryPullRequestTarget | undefined;
+  targetKey: string | null;
+  pageKey: string;
+  detail: PullRequestTargetDetailSink;
+}) {
+  const [items, setItems] = useState<CodeDeliveryPullRequestSummary[]>([]);
+  const [errors, setErrors] = useState<CodeDeliverySourceError[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | undefined>();
+  const [error, setError] = useState<string | null>(null);
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+  const [revision, setRevision] = useState(0);
+  const deliveryRevision = useCodeUpdatesStore(
+    (state) => state.deliveryRevision,
+  );
+  // Set by Refresh and by a completed action; consumed by the next query that
+  // actually runs. Only those two reach past the server's short list cache —
+  // a filter change reruns against it, which is the whole point of caching a
+  // cross-repository read.
+  const forceRefresh = useRef(false);
+  const generation = useRef(0);
+  const skipQueryDebounce = useRef(true);
+  const adoptedSummaries = useRef(
+    new Map<string, CodeDeliveryPullRequestSummary>(),
+  );
+
+  useEffect(() => {
+    adoptedSummaries.current.clear();
+    const remembered = rememberedPullRequestPage(
+      useCodeDeliveryStore.getState().lastPullRequestPages,
+      pageKey,
+    );
+    setItems(remembered?.items ?? []);
+    setErrors(remembered?.errors ?? []);
+    setNextCursor(remembered?.nextCursor);
+    setFetchedAt(remembered?.fetchedAt ?? null);
+    setLoading(true);
+  }, [pageKey]);
+
+  const refreshList = () => {
+    forceRefresh.current = true;
+    setRevision((value) => value + 1);
+  };
+
+  const applyAdopted = (rows: CodeDeliveryPullRequestSummary[]) =>
+    rows.map((item) => {
+      const adopted = adoptedSummaries.current.get(item.id);
+      if (!adopted) return item;
+      const merged = preservePullRequestStackMetadata(item, adopted);
+      adoptedSummaries.current.set(item.id, merged);
+      return merged;
+    });
+
+  const adoptSummary = (summary: CodeDeliveryPullRequestSummary) => {
+    const previous = items.find((item) => item.id === summary.id);
+    const adopted = previous
+      ? preservePullRequestStackMetadata(previous, summary)
+      : summary;
+    adoptedSummaries.current.set(adopted.id, adopted);
+    setItems((current) =>
+      current.map((item) =>
+        item.id === adopted.id
+          ? adopted
+          : (adoptedSummaries.current.get(item.id) ?? item),
+      ),
+    );
+
+    const cached = useCodeDeliveryStore
+      .getState()
+      .lastPullRequestPages.find((page) => page.key === pageKey);
+    if (cached) {
+      useCodeDeliveryStore.getState().rememberPullRequestPage({
+        ...cached,
+        items: cached.items.map((item) =>
+          item.id === adopted.id
+            ? adopted
+            : (adoptedSummaries.current.get(item.id) ?? item),
+        ),
+      });
+    }
+  };
+
+  const query = async (cursor?: string, append = false) => {
+    const token = ++generation.current;
+    // Paging never rereads: renumbering the aggregate under a cursor would
+    // skip or repeat rows.
+    const refresh = !append && !cursor && forceRefresh.current;
+    if (refresh) {
+      forceRefresh.current = false;
+      adoptedSummaries.current.clear();
+    }
+    if (append) setLoadingMore(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      if (selectedRepositories.length === 0) {
+        setNextCursor(undefined);
+        setErrors([]);
+        return;
+      }
+      let detailRequest: Promise<{
+        detail?: CodeDeliveryPullRequestDetail;
+        detailError?: unknown;
+      }> = Promise.resolve({});
+      if (!append && target && targetKey) {
+        const requestKey = targetKey;
+        detail.beginTargetDetail(requestKey);
+        detailRequest = client
+          .getCodeDeliveryPullRequestDetail(target)
+          .then((loaded) => {
+            if (token === generation.current) {
+              const previous = items.find(
+                (item) => item.id === loaded.summary.id,
+              );
+              const summary = previous
+                ? preservePullRequestStackMetadata(previous, loaded.summary)
+                : loaded.summary;
+              const adoptedDetail =
+                summary === loaded.summary ? loaded : { ...loaded, summary };
+              detail.adoptTargetDetail(requestKey, adoptedDetail);
+              adoptedSummaries.current.set(summary.id, summary);
+              setItems((current) =>
+                applyAdopted(dedupeRows([summary, ...current])),
+              );
+            }
+            return { detail: loaded };
+          })
+          .catch((detailError: unknown) => {
+            if (token === generation.current) {
+              detail.failTargetDetail(requestKey);
+            }
+            return { detailError };
+          });
+      }
+      const page = await client.queryCodeDeliveryPullRequests({
+        repositories: selectedRepositories,
+        search: filters.search.trim() || undefined,
+        states: filters.states,
+        review_states: filters.reviewStates,
+        check_states: filters.checkStates,
+        authors: filters.authors,
+        attention_only: filters.attentionOnly,
+        ready_only: filters.readyOnly,
+        tidebreak_linked: filters.tidebreakLinked,
+        limit: 100,
+        refresh,
+        ...(cursor ? { cursor } : {}),
+      });
+      if (token !== generation.current) return;
+      useCodeDeliveryStore
+        .getState()
+        .rememberDeliveryAuthors(deliveryAuthorSightings(page.items, []));
+      let nextItems: CodeDeliveryPullRequestSummary[] = [];
+      setItems((current) => {
+        nextItems = append ? [...current, ...page.items] : page.items;
+        const exactItem = target
+          ? current.find((item) => pullRequestMatchesTarget(item, target))
+          : undefined;
+        if (exactItem) nextItems = [exactItem, ...nextItems];
+        nextItems = applyAdopted(dedupeRows(nextItems));
+        return nextItems;
+      });
+      useCodeDeliveryStore.getState().rememberPullRequestPage({
+        key: pageKey,
+        items: nextItems,
+        fetchedAt: page.fetched_at,
+        nextCursor: page.next_cursor,
+        errors: page.errors,
+      });
+      setNextCursor(page.next_cursor);
+      setErrors(page.errors);
+      setFetchedAt(page.fetched_at);
+      void detailRequest.then((targetResult) => {
+        if (
+          token === generation.current &&
+          target &&
+          targetResult.detailError
+        ) {
+          setError(
+            friendlyErrorMessage(
+              targetResult.detailError,
+              "Could not load this pull request.",
+            ),
+          );
+        }
+      });
+    } catch (caught) {
+      if (token !== generation.current) return;
+      setError(friendlyErrorMessage(caught, "Could not load pull requests."));
+      if (!append) {
+        setItems((current) =>
+          target
+            ? current.filter((item) => pullRequestMatchesTarget(item, target))
+            : [],
+        );
+      }
+    } finally {
+      if (token === generation.current) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    const delay = skipQueryDebounce.current ? 0 : 180;
+    skipQueryDebounce.current = false;
+    const timer = window.setTimeout(() => void query(), delay);
+    return () => {
+      window.clearTimeout(timer);
+      generation.current += 1;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    client,
+    selectedRepositories,
+    filters,
+    revision,
+    deliveryRevision,
+    targetKey,
+  ]);
+
+  return {
+    items,
+    errors,
+    loading,
+    loadingMore,
+    nextCursor,
+    error,
+    fetchedAt,
+    query,
+    refreshList,
+    adoptSummary,
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useBrowserTabs.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useBrowserTabs.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LayoutState } from "@/panel/panelTypes";
+import { closeEditorTab, openCodeEditor } from "../codeChrome";
+import { useBrowserTabs } from "./useBrowserTabs";
+
+const mocks = vi.hoisted(() => ({
+  close: vi.fn(async () => undefined),
+  seed: vi.fn(),
+}));
+vi.mock("../browser/browserHost", () => ({ closeCodeBrowser: mocks.close }));
+vi.mock("../browser/browserPersistence", () => ({
+  seedBrowserSession: mocks.seed,
+}));
+
+const EMPTY: LayoutState = { tabs: [], activeIndex: 0, fullscreen: false };
+
+function withBrowser(layout: LayoutState, browserId: string) {
+  return openCodeEditor(layout, { type: "browser", browserId });
+}
+
+function setup(initial: LayoutState) {
+  const setLayout = vi.fn();
+  const hook = renderHook(
+    ({ layout }: { layout: LayoutState }) =>
+      useBrowserTabs({ workspaceId: "ws-1", layout, setLayout }),
+    { initialProps: { layout: initial } },
+  );
+  return { ...hook, setLayout };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useBrowserTabs", () => {
+  it("titles every open browser and drops the title of a closed one", () => {
+    const one = withBrowser(EMPTY, "b1");
+    const { result, rerender } = setup(one);
+    expect(result.current.browserTitles).toEqual({ b1: "Browser" });
+
+    act(() => result.current.setBrowserTitle("b1", "Docs"));
+    expect(result.current.browserTitles).toEqual({ b1: "Docs" });
+
+    rerender({ layout: withBrowser(one, "b2") });
+    expect(result.current.browserTitles).toEqual({ b1: "Docs", b2: "Browser" });
+
+    rerender({ layout: closeEditorTab(withBrowser(one, "b2"), 0, "primary") });
+    expect(mocks.close).toHaveBeenCalledWith("ws-1", "b1");
+    expect(result.current.browserTitles).toEqual({ b2: "Browser" });
+  });
+
+  it("closes a native browser once per tab, and every open one on unmount", () => {
+    const one = withBrowser(EMPTY, "b1");
+    const two = withBrowser(one, "b2");
+    const { rerender, unmount } = setup(two);
+    rerender({ layout: one });
+    rerender({ layout: { ...one } });
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+    expect(mocks.close).toHaveBeenCalledWith("ws-1", "b2");
+
+    unmount();
+    expect(mocks.close).toHaveBeenCalledTimes(2);
+    expect(mocks.close).toHaveBeenLastCalledWith("ws-1", "b1");
+  });
+
+  it("seeds a new browser, remembers its start page, and opens its tab", () => {
+    const { result, setLayout } = setup(EMPTY);
+    act(() => result.current.openBrowser("https://example.test", "primary"));
+    const browserId = mocks.seed.mock.calls[0]?.[0].browserId as string;
+    expect(mocks.seed).toHaveBeenCalledWith({
+      browserId,
+      workspaceId: "ws-1",
+      initialUrl: "https://example.test",
+    });
+    expect(result.current.browserInitialUrls).toEqual({
+      [browserId]: "https://example.test",
+    });
+    expect(result.current.browserTitles).toEqual({ [browserId]: "Browser" });
+    const next = setLayout.mock.calls[0]?.[0] as LayoutState;
+    expect(next.tabs).toEqual([{ type: "browser", browserId }]);
+
+    act(() => result.current.openBrowser());
+    expect(Object.keys(result.current.browserInitialUrls)).toEqual([browserId]);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useBrowserTabs.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useBrowserTabs.ts
@@ -1,0 +1,127 @@
+import type { LayoutState } from "@/panel/panelTypes";
+import {
+  type CodeEditorRegion,
+  codeBrowserIds,
+  openCodeEditor,
+  removedCodeBrowserIds,
+} from "../codeChrome";
+import { attachedRemotely } from "@/host";
+import { browserTitlesForLayout } from "./layout";
+import { closeCodeBrowser } from "../browser/browserHost";
+import { seedBrowserSession } from "../browser/browserPersistence";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * The browser tabs one workspace has open: their titles, the address each
+ * started on, and the native webview behind each.
+ *
+ * A browser is a child webview the page mints an id for, so the tab exists
+ * before the view does. The view is worth nothing once it is off screen, so
+ * a browser closes when its tab goes and when the page unmounts — unlike a
+ * shell, which survives the reader looking elsewhere.
+ */
+export function useBrowserTabs({
+  workspaceId,
+  layout,
+  setLayout,
+}: {
+  workspaceId: string;
+  layout: LayoutState;
+  setLayout: (next: LayoutState) => void;
+}) {
+  const layoutRef = useRef(layout);
+  layoutRef.current = layout;
+  const previousLayoutRef = useRef(layout);
+  const closedBrowserIdsRef = useRef(new Set<string>());
+  const workspaceBrowserIdsRef = useRef(new Set<string>());
+  const [browserTitles, setBrowserTitles] = useState<Record<string, string>>(
+    () => browserTitlesForLayout(layout),
+  );
+  const [browserInitialUrls, setBrowserInitialUrls] = useState<
+    Record<string, string>
+  >({});
+
+  const closeBrowserPanels = useCallback(
+    (browserIds: readonly string[]) => {
+      for (const browserId of browserIds) {
+        if (closedBrowserIdsRef.current.has(browserId)) continue;
+        closedBrowserIdsRef.current.add(browserId);
+        void closeCodeBrowser(workspaceId, browserId);
+      }
+    },
+    [workspaceId],
+  );
+
+  useEffect(() => {
+    const ids = codeBrowserIds(layout);
+    for (const browserId of ids) {
+      closedBrowserIdsRef.current.delete(browserId);
+      workspaceBrowserIdsRef.current.add(browserId);
+    }
+    closeBrowserPanels(
+      removedCodeBrowserIds(previousLayoutRef.current, layout),
+    );
+    previousLayoutRef.current = layout;
+    setBrowserTitles((current) => {
+      let changed = false;
+      const next: Record<string, string> = {};
+      for (const browserId of ids) {
+        const title = current[browserId] ?? "Browser";
+        next[browserId] = title;
+        if (current[browserId] !== title) changed = true;
+      }
+      if (Object.keys(current).length !== ids.length) changed = true;
+      return changed ? next : current;
+    });
+  }, [closeBrowserPanels, layout]);
+
+  useEffect(() => {
+    workspaceBrowserIdsRef.current = new Set(codeBrowserIds(layoutRef.current));
+    return () => closeBrowserPanels([...workspaceBrowserIdsRef.current]);
+  }, [closeBrowserPanels, workspaceId]);
+
+  function openBrowser(url?: string, preferredRegion?: CodeEditorRegion) {
+    const browserId = crypto.randomUUID();
+    seedBrowserSession({
+      browserId,
+      workspaceId,
+      initialUrl: url,
+    });
+    if (url) {
+      setBrowserInitialUrls((current) => ({
+        ...current,
+        [browserId]: url,
+      }));
+    }
+    setBrowserTitles((current) => ({
+      ...current,
+      [browserId]: "Browser",
+    }));
+    setLayout(
+      openCodeEditor(layout, { type: "browser", browserId }, preferredRegion),
+    );
+  }
+
+  /** The page behind a tab reported its document title. */
+  function setBrowserTitle(browserId: string, title: string) {
+    setBrowserTitles((current) =>
+      current[browserId] === title
+        ? current
+        : { ...current, [browserId]: title },
+    );
+  }
+
+  // The browser opens as a child webview on this computer. A window working on
+  // another machine has no such screen to lend — sharing one with an agent that
+  // is not here shares the wrong browser — so the row is absent rather than
+  // present and refusing.
+  const canNewBrowser = !attachedRemotely();
+
+  return {
+    browserTitles,
+    browserInitialUrls,
+    openBrowser,
+    setBrowserTitle,
+    canNewBrowser,
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useEditorTabs.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useEditorTabs.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LayoutState } from "@/panel/panelTypes";
+import { focusEditorTab, moveEditorTab, openCodeEditor } from "../codeChrome";
+import { useCodeUiStore } from "../CodeUiStore";
+import { useEditorTabs } from "./useEditorTabs";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
+
+const EMPTY: LayoutState = { tabs: [], activeIndex: 0, fullscreen: false };
+
+function setup(initial: LayoutState) {
+  const setLayout = vi.fn();
+  const hook = renderHook(
+    ({ layout }: { layout: LayoutState }) =>
+      useEditorTabs({ layout, setLayout }),
+    { initialProps: { layout: initial } },
+  );
+  return { ...hook, setLayout };
+}
+
+beforeEach(() =>
+  useCodeUiStore.setState(useCodeUiStore.getInitialState(), true),
+);
+afterEach(cleanup);
+
+describe("useEditorTabs", () => {
+  it("reveals a line only when one is asked for, counting each ask", () => {
+    const { result, setLayout } = setup(EMPTY);
+    act(() => result.current.openFile("a.ts", 12));
+    expect(result.current.fileReveal).toEqual({
+      path: "a.ts",
+      line: 12,
+      revision: 1,
+    });
+    act(() => result.current.openFile("a.ts", 12));
+    expect(result.current.fileReveal?.revision).toBe(2);
+    act(() => result.current.openFile("b.ts"));
+    expect(result.current.fileReveal).toBeNull();
+    expect(setLayout).toHaveBeenCalledTimes(3);
+    const last = setLayout.mock.calls[2]?.[0] as LayoutState;
+    expect(last.tabs).toEqual([{ type: "file", path: "b.ts" }]);
+  });
+
+  it("counts quick-open asks per region", () => {
+    const { result } = setup(EMPTY);
+    expect(result.current.quickOpenRequest).toBe(0);
+    act(() => result.current.requestNewTab("secondary"));
+    expect(result.current.quickOpenRequest).toBe(1);
+    expect(result.current.quickOpenTarget).toBe("secondary");
+    act(() => result.current.requestNewTab("primary"));
+    expect(result.current.quickOpenRequest).toBe(2);
+    expect(result.current.quickOpenTarget).toBe("primary");
+  });
+
+  it("answers the shell's asks once, in the focused group", () => {
+    const file = openCodeEditor(EMPTY, { type: "file", path: "a.ts" });
+    const split = focusEditorTab(
+      moveEditorTab(file, "primary", 0, "secondary"),
+      0,
+      "secondary",
+    );
+    const { result } = setup(split);
+    expect(result.current.splitFocused).toBe(true);
+
+    act(() => useCodeUiStore.getState().requestQuickOpen());
+    expect(result.current.quickOpenRequest).toBe(1);
+    expect(result.current.quickOpenTarget).toBe("secondary");
+    expect(useCodeUiStore.getState().quickOpenPending).toBe(false);
+
+    act(() => useCodeUiStore.getState().requestNewTabMenu());
+    expect(result.current.newTabMenuRequest).toBe(1);
+    expect(result.current.newTabMenuRegion).toBe("secondary");
+    expect(useCodeUiStore.getState().newTabMenuPending).toBe(false);
+  });
+
+  it("opens the path the palette names", () => {
+    const { setLayout } = setup(EMPTY);
+    act(() => useCodeUiStore.getState().requestOpenFilePath("src/x.ts"));
+    const next = setLayout.mock.calls[0]?.[0] as LayoutState;
+    expect(next.tabs).toEqual([{ type: "file", path: "src/x.ts" }]);
+    expect(useCodeUiStore.getState().openFilePending).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useEditorTabs.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useEditorTabs.ts
@@ -1,0 +1,138 @@
+import type { DragEndEvent } from "@dnd-kit/core";
+import type { LayoutState } from "@/panel/panelTypes";
+import {
+  type CodeEditorRegion,
+  openCodeEditor,
+  splitCodeChromeLayout,
+} from "../codeChrome";
+import { copyPlainText } from "@/ClipboardCopyButton";
+import { dropEditorTab } from "../editorDrag";
+import { toast } from "sonner";
+import { useCodeUiStore } from "../CodeUiStore";
+import { useEffect, useState } from "react";
+
+/**
+ * The file, diff, and drag state of the editor groups, plus the asks the
+ * shell keymap raises for them.
+ *
+ * Quick open and the new-tab menu are requests counted upward: a listener
+ * acts when the number changes, and the region named alongside says which
+ * group the answer lands in. The shell raises each ask above the route, and
+ * taking the flag here is what stops a remount from reopening a picker over
+ * whatever the reader moved on to.
+ */
+export function useEditorTabs({
+  layout,
+  setLayout,
+}: {
+  layout: LayoutState;
+  setLayout: (next: LayoutState) => void;
+}) {
+  const chrome = splitCodeChromeLayout(layout);
+  const quickOpenPending = useCodeUiStore((state) => state.quickOpenPending);
+  const newTabMenuPending = useCodeUiStore((state) => state.newTabMenuPending);
+  const openFilePending = useCodeUiStore((state) => state.openFilePending);
+  const [quickOpenRequest, setQuickOpenRequest] = useState(0);
+  const [quickOpenTarget, setQuickOpenTarget] =
+    useState<CodeEditorRegion>("primary");
+  const [newTabMenuRequest, setNewTabMenuRequest] = useState(0);
+  const [newTabMenuRegion, setNewTabMenuRegion] =
+    useState<CodeEditorRegion>("primary");
+  const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
+  const [fileReveal, setFileReveal] = useState<{
+    path: string;
+    line: number;
+    revision: number;
+  } | null>(null);
+
+  function openTurnDiff(turnId: string) {
+    setLayout(openCodeEditor(layout, { type: "diff", turnId }));
+  }
+
+  function openFile(
+    path: string,
+    line?: number,
+    preferredRegion?: CodeEditorRegion,
+  ) {
+    setFileReveal((current) =>
+      line === undefined
+        ? null
+        : {
+            path,
+            line,
+            revision: (current?.revision ?? 0) + 1,
+          },
+    );
+    setLayout(openCodeEditor(layout, { type: "file", path }, preferredRegion));
+  }
+
+  function openFileDiff(path: string) {
+    setLayout(openCodeEditor(layout, { type: "diff", path }));
+  }
+
+  function requestNewTab(region: CodeEditorRegion) {
+    setQuickOpenTarget(region);
+    setQuickOpenRequest((request) => request + 1);
+  }
+
+  function showNewTabMenu(region: CodeEditorRegion) {
+    setNewTabMenuRegion(region);
+    setNewTabMenuRequest((request) => request + 1);
+  }
+
+  function finishTabDrag(event: DragEndEvent) {
+    setDraggedTabId(null);
+    const next = dropEditorTab(
+      layout,
+      String(event.active.id),
+      event.over ? String(event.over.id) : null,
+    );
+    if (next) setLayout(next);
+  }
+
+  function copyEditorPath(path: string) {
+    void copyPlainText(path)
+      .then(() => toast.success("Copied path"))
+      .catch(() => toast.error("Could not copy path"));
+  }
+
+  const splitFocused =
+    Boolean(layout.editorSplit?.focused) && chrome.splitEditors.tabs.length > 0;
+
+  useEffect(() => {
+    if (!quickOpenPending) return;
+    if (!useCodeUiStore.getState().takeQuickOpen()) return;
+    requestNewTab(splitFocused ? "secondary" : "primary");
+  }, [quickOpenPending, splitFocused]);
+
+  useEffect(() => {
+    if (!newTabMenuPending) return;
+    if (!useCodeUiStore.getState().takeNewTabMenu()) return;
+    showNewTabMenu(splitFocused ? "secondary" : "primary");
+  }, [newTabMenuPending, splitFocused]);
+
+  // The palette ranks worktree files but has nowhere to put one; the tabs live
+  // here, so it names a path and this opens it.
+  useEffect(() => {
+    if (!openFilePending) return;
+    const path = useCodeUiStore.getState().takeOpenFilePath();
+    if (path) openFile(path);
+  }, [openFilePending]);
+
+  return {
+    fileReveal,
+    openFile,
+    openTurnDiff,
+    openFileDiff,
+    quickOpenRequest,
+    quickOpenTarget,
+    newTabMenuRequest,
+    newTabMenuRegion,
+    requestNewTab,
+    draggedTabId,
+    setDraggedTabId,
+    finishTabDrag,
+    copyEditorPath,
+    splitFocused,
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useTerminalTabs.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useTerminalTabs.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LayoutState } from "@/panel/panelTypes";
+import {
+  closeEditorTab,
+  focusConversation,
+  focusEditorTab,
+  openCodeEditor,
+} from "../codeChrome";
+import { useCodeUiStore } from "../CodeUiStore";
+import { useTerminalTabs } from "./useTerminalTabs";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
+
+const EMPTY: LayoutState = { tabs: [], activeIndex: 0, fullscreen: false };
+
+function withTerminal(layout: LayoutState, terminalId: string) {
+  return openCodeEditor(layout, { type: "terminal", terminalId });
+}
+
+function setup(initial: LayoutState) {
+  let created = 0;
+  const client = {
+    createCodeTerminal: vi.fn(async () => ({ id: `term-${++created}` })),
+    deleteCodeTerminal: vi.fn(async () => undefined),
+  };
+  const setLayout = vi.fn();
+  const hook = renderHook(
+    ({ layout }: { layout: LayoutState }) =>
+      useTerminalTabs({
+        workspaceId: "ws-1",
+        client: client as never,
+        layout,
+        setLayout,
+      }),
+    { initialProps: { layout: initial } },
+  );
+  return { ...hook, client, setLayout };
+}
+
+beforeEach(() =>
+  useCodeUiStore.setState(useCodeUiStore.getInitialState(), true),
+);
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useTerminalTabs", () => {
+  it("numbers shells by the lowest free ordinal and keeps names across a close", () => {
+    const one = withTerminal(EMPTY, "t1");
+    const two = withTerminal(one, "t2");
+    const { result, rerender, client } = setup(two);
+    expect(result.current.terminalLabels).toEqual({
+      t1: "Terminal 1",
+      t2: "Terminal 2",
+    });
+
+    const withoutFirst = closeEditorTab(two, 0, "primary");
+    rerender({ layout: withoutFirst });
+    expect(client.deleteCodeTerminal).toHaveBeenCalledWith("ws-1", "t1");
+    expect(result.current.terminalLabels).toEqual({ t2: "Terminal 2" });
+
+    rerender({ layout: withTerminal(withoutFirst, "t3") });
+    expect(result.current.terminalLabels).toEqual({
+      t2: "Terminal 2",
+      t3: "Terminal 1",
+    });
+  });
+
+  it("ends a shell once even when the same layout renders again", () => {
+    const one = withTerminal(EMPTY, "t1");
+    const { rerender, client } = setup(one);
+    rerender({ layout: EMPTY });
+    rerender({ layout: { ...EMPTY } });
+    expect(client.deleteCodeTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a shell then a tab for it, reading the layout after the call", async () => {
+    const { result, client, setLayout, rerender } = setup(EMPTY);
+    const pending = result.current.openTerminal("primary");
+    // A tab opened while the create call is in flight is kept.
+    const meanwhile = openCodeEditor(EMPTY, { type: "file", path: "a.ts" });
+    rerender({ layout: meanwhile });
+    await pending;
+    expect(client.createCodeTerminal).toHaveBeenCalledWith("ws-1");
+    const next = setLayout.mock.calls[0]?.[0] as LayoutState;
+    expect(next.tabs).toEqual([
+      { type: "file", path: "a.ts" },
+      { type: "terminal", terminalId: "term-1" },
+    ]);
+    await waitFor(() =>
+      expect(result.current.terminalLabels).toEqual({ "term-1": "Terminal 1" }),
+    );
+  });
+
+  it("jumps to the terminal and back to where focus was", () => {
+    const file = openCodeEditor(EMPTY, { type: "file", path: "a.ts" });
+    const both = withTerminal(file, "t1");
+    const onFile = focusEditorTab(both, 0, "primary");
+    const { result, setLayout, rerender } = setup(onFile);
+
+    act(() => result.current.toggleTerminal());
+    const toTerminal = setLayout.mock.calls[0]?.[0] as LayoutState;
+    expect(toTerminal.activeIndex).toBe(1);
+
+    rerender({ layout: toTerminal });
+    act(() => result.current.toggleTerminal());
+    const back = setLayout.mock.calls[1]?.[0] as LayoutState;
+    expect(back.activeIndex).toBe(0);
+    expect(back.conversationFocused).toBeFalsy();
+  });
+
+  it("returns to the conversation when nothing had focus before the jump", () => {
+    const chat = focusConversation(withTerminal(EMPTY, "t1"));
+    const { result, setLayout, rerender } = setup(chat);
+    act(() => result.current.toggleTerminal());
+    const toTerminal = setLayout.mock.calls[0]?.[0] as LayoutState;
+    rerender({ layout: toTerminal });
+    act(() => result.current.toggleTerminal());
+    const back = setLayout.mock.calls[1]?.[0] as LayoutState;
+    expect(back.conversationFocused).toBe(true);
+  });
+
+  it("answers the shell's terminal chord once", async () => {
+    const { client } = setup(EMPTY);
+    act(() => useCodeUiStore.getState().requestTerminal());
+    await waitFor(() =>
+      expect(client.createCodeTerminal).toHaveBeenCalledTimes(1),
+    );
+    expect(useCodeUiStore.getState().terminalPending).toBe(false);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useTerminalTabs.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useTerminalTabs.ts
@@ -1,0 +1,164 @@
+import type { ApiClient } from "../../api/client";
+import type { LayoutState } from "@/panel/panelTypes";
+import {
+  adoptCodeTerminalId,
+  type CodeEditorRegion,
+  codeTerminalIds,
+  findCodeTerminalTab,
+  focusConversation,
+  focusedEditorPosition,
+  focusEditorTab,
+  openCodeEditor,
+  removedCodeTerminalIds,
+} from "../codeChrome";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { MAX_WORKSPACE_TERMINALS, nameTerminals } from "./layout";
+import { toast } from "sonner";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useCodeUiStore } from "../CodeUiStore";
+
+/**
+ * The shell tabs one workspace has open: their labels, the shell behind
+ * each, and the chord that jumps to one and back.
+ *
+ * The server names a shell, so its tab cannot exist before the create call
+ * answers — unlike a browser, whose id the page mints itself. Closing a tab
+ * is the only thing that ends a shell: a build running in one has to survive
+ * a click on another workspace, and the tab's address names it, so coming
+ * back re-attaches to the same process with its output intact.
+ */
+export function useTerminalTabs({
+  workspaceId,
+  client,
+  layout,
+  setLayout,
+}: {
+  workspaceId: string;
+  client: Pick<ApiClient, "createCodeTerminal" | "deleteCodeTerminal">;
+  layout: LayoutState;
+  setLayout: (next: LayoutState) => void;
+}) {
+  const layoutRef = useRef(layout);
+  layoutRef.current = layout;
+  const previousLayoutRef = useRef(layout);
+  const closedTerminalIdsRef = useRef(new Set<string>());
+  /** Where focus sat before the terminal chord jumped away from it. */
+  const beforeTerminalRef = useRef<{
+    region: CodeEditorRegion;
+    index: number;
+  } | null>(null);
+  const [terminalLabels, setTerminalLabels] = useState<Record<string, string>>(
+    () => nameTerminals({}, codeTerminalIds(layout)),
+  );
+  const terminalPending = useCodeUiStore((state) => state.terminalPending);
+
+  /**
+   * End the shells whose tabs have gone.
+   *
+   * A workspace may only hold so many at once, so a closed tab has to give
+   * its shell back rather than leave it running with nothing pointing at it.
+   */
+  const closeTerminalPanels = useCallback(
+    (terminalIds: readonly string[]) => {
+      for (const terminalId of terminalIds) {
+        if (closedTerminalIdsRef.current.has(terminalId)) continue;
+        closedTerminalIdsRef.current.add(terminalId);
+        void client.deleteCodeTerminal(workspaceId, terminalId).catch(() => {
+          // A shell that is already gone is the outcome we wanted anyway.
+        });
+      }
+    },
+    [client, workspaceId],
+  );
+
+  useEffect(() => {
+    closeTerminalPanels(
+      removedCodeTerminalIds(previousLayoutRef.current, layout),
+    );
+    previousLayoutRef.current = layout;
+    setTerminalLabels((current) =>
+      nameTerminals(current, codeTerminalIds(layout)),
+    );
+  }, [closeTerminalPanels, layout]);
+
+  /**
+   * Start a shell and give it a tab.
+   *
+   * The layout is read after the call answers, so a tab the reader opened
+   * meanwhile is not lost to a stale snapshot.
+   */
+  async function openTerminal(preferredRegion?: CodeEditorRegion) {
+    try {
+      const snap = await client.createCodeTerminal(workspaceId);
+      setTerminalLabels((current) => nameTerminals(current, [snap.id]));
+      setLayout(
+        openCodeEditor(
+          layoutRef.current,
+          { type: "terminal", terminalId: snap.id },
+          preferredRegion,
+        ),
+      );
+    } catch (error) {
+      toast.error(friendlyErrorMessage(error, "Could not open a terminal"));
+    }
+  }
+
+  /**
+   * Jump to the terminal and back again.
+   *
+   * The chord used to show and hide a drawer. A terminal is a tab now, so the
+   * same press moves focus there and the next one returns it where it was —
+   * the flick there and back a drawer gave, without a second kind of surface.
+   */
+  function toggleTerminal() {
+    const found = findCodeTerminalTab(layoutRef.current);
+    if (!found) {
+      beforeTerminalRef.current = focusedEditorPosition(layoutRef.current);
+      void openTerminal("primary");
+      return;
+    }
+    const focused = focusedEditorPosition(layoutRef.current);
+    const onTerminal =
+      focused?.region === found.region && focused.index === found.index;
+    if (!onTerminal) {
+      beforeTerminalRef.current = focused;
+      setLayout(focusEditorTab(layoutRef.current, found.index, found.region));
+      return;
+    }
+    const back = beforeTerminalRef.current;
+    beforeTerminalRef.current = null;
+    setLayout(
+      back
+        ? focusEditorTab(layoutRef.current, back.index, back.region)
+        : focusConversation(layoutRef.current),
+    );
+  }
+
+  /** A pane attached to a different shell than its tab named. */
+  function adoptTerminal(previousId: string | undefined, terminalId: string) {
+    setLayout(adoptCodeTerminalId(layoutRef.current, previousId, terminalId));
+  }
+
+  // The chord and the rail command both raise the ask above the route, because
+  // starting a shell is a server call neither of them can make.
+  useEffect(() => {
+    if (!terminalPending) return;
+    if (!useCodeUiStore.getState().takeTerminal()) return;
+    toggleTerminal();
+    // The flag is the trigger; the rest is state read when it arrives.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [terminalPending]);
+
+  const openTerminalCount = codeTerminalIds(layout).length;
+  const hasTerminal = findCodeTerminalTab(layout) !== null;
+  const canNewTerminal = openTerminalCount < MAX_WORKSPACE_TERMINALS;
+
+  return {
+    terminalLabels,
+    openTerminal,
+    toggleTerminal,
+    adoptTerminal,
+    hasTerminal,
+    canNewTerminal,
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodeSessionSnapshot } from "../../api/types";
+import {
+  codeSession,
+  codeWorkspace,
+  deliveryCodeRepo,
+} from "../../stories/fixtures";
+import { useCodeCatalogStore } from "../CodeCatalogStore";
+import { useWorkspaceSessions } from "./useWorkspaceSessions";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
+
+const main: CodeSessionSnapshot = { ...codeSession, id: "sess-main" };
+const sibling: CodeSessionSnapshot = {
+  ...codeSession,
+  id: "sess-sibling",
+  harness_kind: "codex",
+  created_at: "2026-08-20T09:10:00.000Z",
+};
+
+function setup(
+  listed: CodeSessionSnapshot[],
+  taskParam?: string,
+  options: { failFirstLoad?: boolean } = {},
+) {
+  let loads = 0;
+  const client = {
+    getCodeWorkspace: vi.fn(async () => {
+      loads += 1;
+      if (options.failFirstLoad && loads === 1) throw new Error("offline");
+      return codeWorkspace;
+    }),
+    listCodeWorkspaceSessions: vi.fn(async () => listed),
+    getCodeRepo: vi.fn(async () => deliveryCodeRepo),
+  };
+  const navigate = vi.fn();
+  const focusConversationPane = vi.fn();
+  const hook = renderHook(
+    ({ task }: { task: string | undefined }) =>
+      useWorkspaceSessions({
+        workspaceId: codeWorkspace.id,
+        client: client as never,
+        models: [],
+        defaultModelKey: null,
+        taskParam: task,
+        navigate: navigate as never,
+        focusConversationPane,
+      }),
+    { initialProps: { task: taskParam } },
+  );
+  return { ...hook, client, navigate, focusConversationPane };
+}
+
+function searchOf(call: unknown): Record<string, unknown> {
+  const args = call as {
+    search: (current: Record<string, unknown>) => Record<string, unknown>;
+    replace?: boolean;
+  };
+  return { ...args.search({ tabs: "kept" }), replace: args.replace };
+}
+
+beforeEach(() => useCodeCatalogStore.getState().reset());
+afterEach(cleanup);
+
+describe("useWorkspaceSessions", () => {
+  it("shows the first live agent when nothing is named", async () => {
+    const { result } = setup([main, sibling]);
+    await waitFor(() => expect(result.current.session?.id).toBe("sess-main"));
+    expect(result.current.activeConversationId).toBe("sess-main");
+    expect(result.current.conversationTabs.map((tab) => tab.label)).toEqual([
+      "Main agent",
+      "Codex CLI",
+    ]);
+    expect(useCodeCatalogStore.getState().sessionsByWorkspace["ws-1"]?.id).toBe(
+      "sess-main",
+    );
+  });
+
+  it("lets ?task= name the agent, and drops a param nothing answers to", async () => {
+    const named = setup([main, sibling], "sess-sibling");
+    await waitFor(() =>
+      expect(named.result.current.session?.id).toBe("sess-sibling"),
+    );
+    expect(named.navigate).not.toHaveBeenCalled();
+    named.unmount();
+
+    const stale = setup([main], "sess-gone");
+    await waitFor(() => expect(stale.navigate).toHaveBeenCalledTimes(1));
+    expect(searchOf(stale.navigate.mock.calls[0]?.[0])).toEqual({
+      tabs: "kept",
+      task: undefined,
+      subagent: undefined,
+      replace: true,
+    });
+    expect(stale.result.current.session?.id).toBe("sess-main");
+  });
+
+  it("selects by hand through the URL and keeps the first agent unnamed", async () => {
+    const { result, navigate, focusConversationPane } = setup([main, sibling]);
+    await waitFor(() => expect(result.current.session?.id).toBe("sess-main"));
+
+    act(() => result.current.selectConversation("sess-sibling"));
+    expect(focusConversationPane).toHaveBeenCalledTimes(1);
+    expect(result.current.session?.id).toBe("sess-sibling");
+    expect(searchOf(navigate.mock.calls.at(-1)?.[0]).task).toBe("sess-sibling");
+
+    act(() => result.current.selectConversation("sess-main"));
+    expect(searchOf(navigate.mock.calls.at(-1)?.[0]).task).toBeUndefined();
+
+    act(() => result.current.newConversation());
+    expect(result.current.draftAgent).toBe(true);
+    expect(result.current.session).toBeNull();
+    expect(result.current.conversationTabs.at(-1)).toMatchObject({
+      id: null,
+      label: "New agent",
+      closable: true,
+    });
+  });
+
+  it("closes a sibling tab and falls back to the first agent; the first never closes", async () => {
+    const { result } = setup([main, sibling]);
+    await waitFor(() => expect(result.current.session?.id).toBe("sess-main"));
+    act(() => result.current.selectConversation("sess-sibling"));
+
+    act(() => result.current.closeConversation("sess-main"));
+    expect(result.current.session?.id).toBe("sess-sibling");
+    expect(result.current.conversationTabs).toHaveLength(2);
+
+    act(() => result.current.closeConversation("sess-sibling"));
+    expect(result.current.session?.id).toBe("sess-main");
+    expect(result.current.conversationTabs.map((tab) => tab.id)).toEqual([
+      "sess-main",
+    ]);
+  });
+
+  it("reports a load failure and retries on request", async () => {
+    const { result, client } = setup([main], undefined, {
+      failFirstLoad: true,
+    });
+    await waitFor(() => expect(result.current.error).toBe("offline"));
+    act(() => result.current.retry());
+    await waitFor(() => expect(result.current.error).toBeNull());
+    expect(client.getCodeWorkspace).toHaveBeenCalledTimes(2);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
@@ -1,0 +1,592 @@
+import type { ApiClient } from "../../api/client";
+import type { ModelInfo } from "../../api/types";
+import type {
+  CodeForkTranscript,
+  CodeRepoSnapshot,
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessKind,
+  PermissionMode,
+  ReasoningEffort,
+} from "../../api/types";
+import type { CodeConversationTab } from "../CodeCenterTabs";
+import {
+  clearFirstTurnRecovery,
+  type FirstTurnRecovery,
+  writeFirstTurnRecovery,
+} from "./firstTurnRecovery";
+import { attentionMarkForDigest } from "../statusTone";
+import { conversationTabLabel } from "./layout";
+import { forkFraming } from "../fork";
+import { friendlyErrorMessage } from "@/lib/utils";
+import {
+  gatewayCodeModels,
+  preferredCodeModels,
+  requiresHarnessModelIds,
+} from "../labels";
+import { hasLocalHostAuthority } from "../../host";
+import { liveCodeSessions } from "../parsers";
+import { publishCodeImage } from "../../attachments";
+import { toast } from "sonner";
+import { uploadImageAttachment } from "../../ImageAttachments";
+import { useCodeCatalogStore } from "../CodeCatalogStore";
+import { useCodeUiStore } from "../CodeUiStore";
+import { useConversationDigests } from "../CodeUpdatesStore";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { useNavigate } from "@tanstack/react-router";
+
+/**
+ * The agents one workspace runs, and which of them the page shows.
+ *
+ * A workspace runs several agents (record 55), so the page holds the list
+ * and picks one to show rather than tracking a single session. Selection
+ * lives in `?task=` so a reload or a shared link returns to the same agent;
+ * the first agent is the workspace's default and stays unnamed.
+ *
+ * Starting an agent is the one multi-step write here: create the session,
+ * hand it any images the composer held, then send the first message. Each
+ * step checks that the page, the client, and the reader's selection are
+ * still the ones the start began with, because a connection change or a
+ * click on another tab mid-flight must not land a stranger's result.
+ */
+export function useWorkspaceSessions({
+  workspaceId,
+  client,
+  models,
+  defaultModelKey,
+  taskParam,
+  navigate,
+  focusConversationPane,
+}: {
+  workspaceId: string;
+  client: ApiClient;
+  models: ModelInfo[];
+  defaultModelKey: string | null;
+  /** `?task=` from the route: the session the link names, if any. */
+  taskParam: string | undefined;
+  navigate: ReturnType<typeof useNavigate>;
+  /** Bring the conversation tab to the front of the center strip. */
+  focusConversationPane: () => void;
+}) {
+  const clientRef = useRef(client);
+  clientRef.current = client;
+  const catalog = useCodeCatalogStore();
+  const mountedRef = useRef(true);
+  const selectionRevisionRef = useRef(0);
+  const startRequestRef = useRef(0);
+  const catalogWorkspace = catalog.workspaces.find(
+    (candidate) => candidate.id === workspaceId,
+  );
+  const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(
+    () => catalogWorkspace ?? null,
+  );
+  const catalogRepo = catalogWorkspace
+    ? catalog.repos.find(
+        (candidate) => candidate.id === catalogWorkspace.repo_id,
+      )
+    : undefined;
+  const [repo, setRepo] = useState<CodeRepoSnapshot | null>(
+    () => catalogRepo ?? null,
+  );
+  /**
+   * Every session the server knows about here, conversations and watches alike.
+   */
+  const [sessions, setSessions] = useState<CodeSessionSnapshot[]>(() => {
+    const remembered = catalog.sessionsByWorkspace[workspaceId];
+    return remembered ? [remembered] : [];
+  });
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(
+    catalog.sessionsByWorkspace[workspaceId]?.id ?? null,
+  );
+  const [closedConversationIds, setClosedConversationIds] = useState<
+    Set<string>
+  >(() => new Set());
+
+  // Optimistic catalog mutations also govern the open page. Archive can hide
+  // the rail card before filesystem cleanup finishes; reflecting that same
+  // snapshot here stops the composer from offering work against a checkout
+  // that is being removed. A failed request puts the original snapshot back.
+  useEffect(() => {
+    if (!catalogWorkspace) return;
+    setWorkspace((current) =>
+      current?.id === catalogWorkspace.id ? catalogWorkspace : current,
+    );
+  }, [catalogWorkspace]);
+
+  useEffect(() => {
+    if (!catalogRepo) return;
+    setRepo((current) =>
+      current?.id === catalogRepo.id ? catalogRepo : current,
+    );
+  }, [catalogRepo]);
+  /** True while the reader is filling in a new agent that has no session yet. */
+  const [draftAgent, setDraftAgent] = useState(false);
+  /**
+   * True once the server's session list has arrived for this workspace.
+   *
+   * `?task=` can only be judged against a loaded list. Before it lands, a
+   * param that names nothing looks exactly like one naming a session the page
+   * has not heard of yet, and clearing it would drop a good link on reload.
+   */
+  const [sessionsLoaded, setSessionsLoaded] = useState(false);
+  /**
+   * The transcript a fork wrote, waiting for the draft agent to send it.
+   *
+   * It survives an engine change and a rewritten framing line, and clears
+   * once a session starts or the reader closes the draft.
+   */
+  const [forkSource, setForkSource] = useState<CodeForkTranscript | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const [starting, setStarting] = useState(false);
+  const conversations = useMemo(() => liveCodeSessions(sessions), [sessions]);
+  const session = useMemo(
+    () => sessions.find((entry) => entry.id === activeSessionId) ?? null,
+    [activeSessionId, sessions],
+  );
+  const conversationDigests = useConversationDigests(workspaceId);
+  const rememberedSession = useCodeCatalogStore(
+    (state) => state.sessionsByWorkspace[workspaceId] ?? null,
+  );
+
+  useEffect(() => {
+    startRequestRef.current += 1;
+    setStarting(false);
+  }, [client]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      startRequestRef.current += 1;
+    };
+  }, []);
+
+  // A session started elsewhere — the new-workspace dialog, say — reaches the
+  // page through the catalog before the list request comes back.
+  useEffect(() => {
+    if (!rememberedSession) return;
+    setSessions((current) =>
+      current.some((entry) => entry.id === rememberedSession.id)
+        ? current
+        : [...current, rememberedSession],
+    );
+  }, [rememberedSession]);
+
+  // `?task=` names the session to show: a sibling agent, a watch child
+  // opened from the rail, or an archived conversation from search. The param
+  // is a request, not a fact — a link outlives the agent it points at, so it
+  // holds only while that agent is still listed.
+  const namedTask = useMemo(() => {
+    if (!taskParam) return null;
+    return sessions.find((entry) => entry.id === taskParam) ?? null;
+  }, [sessions, taskParam]);
+
+  // A param that names no listed session is stale. Drop it so the fallback
+  // below runs and the URL stops naming an agent that is not there. Replace
+  // rather than push, so Back does not lead to the same dead link. An ended
+  // session is still listed, so archive search can open its transcript.
+  useEffect(() => {
+    if (!sessionsLoaded || !taskParam || namedTask) return;
+    openWorkspaceTask(undefined, { replace: true });
+  }, [namedTask, sessionsLoaded, taskParam]);
+
+  // A named session wins over the default selection below.
+  useEffect(() => {
+    if (!namedTask) return;
+    setActiveSessionId(namedTask.id);
+    setDraftAgent(false);
+  }, [namedTask]);
+
+  // Nothing named, or the shown agent ended: fall back to the first one. The
+  // check reads the live conversations, not every session, so an agent that
+  // ended under the reader does not stay selected.
+  useEffect(() => {
+    if (namedTask || draftAgent) return;
+    const shown = conversations.some((entry) => entry.id === activeSessionId);
+    if (activeSessionId && shown) return;
+    setActiveSessionId(conversations[0]?.id ?? null);
+  }, [activeSessionId, conversations, draftAgent, namedTask]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    setSessionsLoaded(false);
+    void (async () => {
+      try {
+        const [next, listed] = await Promise.all([
+          client.getCodeWorkspace(workspaceId),
+          client.listCodeWorkspaceSessions(workspaceId),
+        ]);
+        if (cancelled) return;
+        setWorkspace(next);
+        const catalogState = useCodeCatalogStore.getState();
+        catalogState.upsertWorkspace(next);
+        // Create navigates as soon as the workspace exists, so a session the
+        // dialog just started can land in the catalog before this list does.
+        const remembered = catalogState.sessionsByWorkspace[workspaceId];
+        setSessions(
+          remembered && !listed.some((entry) => entry.id === remembered.id)
+            ? [remembered, ...listed]
+            : listed,
+        );
+        setSessionsLoaded(true);
+        // The card and the rail show one agent per workspace, so the catalog
+        // remembers the first — the one the workspace was started with.
+        const first = liveCodeSessions(listed)[0];
+        if (first) catalogState.rememberSession(first);
+        const nextRepo = await client.getCodeRepo(next.repo_id);
+        if (!cancelled) setRepo(nextRepo);
+      } catch (err) {
+        if (!cancelled) {
+          setError(friendlyErrorMessage(err, "Could not load this workspace"));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, workspaceId, reloadToken]);
+
+  async function startSession(
+    harness: HarnessKind,
+    permissionMode: PermissionMode,
+    message: string,
+    model?: string,
+    draft = message,
+    reasoningEffort?: ReasoningEffort | null,
+    fastMode = false,
+  ) {
+    const request = startRequestRef.current + 1;
+    startRequestRef.current = request;
+    const startedWithClient = client;
+    const startedAtSelection = selectionRevisionRef.current;
+    const startedWithFork = forkSource;
+    const isCurrent = () =>
+      mountedRef.current &&
+      startRequestRef.current === request &&
+      clientRef.current === startedWithClient;
+    setStarting(true);
+    try {
+      let created: CodeSessionSnapshot;
+      try {
+        const gateway = gatewayCodeModels(models, harness, defaultModelKey);
+        const native =
+          requiresHarnessModelIds(harness) || gateway.length === 0
+            ? await catalog.ensureHarnessModels(startedWithClient, harness)
+            : [];
+        if (!isCurrent()) {
+          throw new Error(
+            "The Code connection changed before the session started. Send the message again.",
+          );
+        }
+        const listed = preferredCodeModels(harness, native, gateway);
+        const posted =
+          model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
+        created = await startedWithClient.createCodeSession(workspaceId, {
+          harness,
+          permission_mode: permissionMode,
+          model: posted,
+          ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+          ...(fastMode ? { fast_mode: true } : {}),
+        });
+      } catch (err) {
+        if (isCurrent()) {
+          toast.error(friendlyErrorMessage(err, "Could not start a session"));
+        }
+        throw err;
+      }
+
+      const heldImages = useCodeUiStore
+        .getState()
+        .takeComposerImages(workspaceId);
+
+      const recovery: FirstTurnRecovery = {
+        id: `${created.id}:${request}`,
+        sessionId: created.id,
+        draft,
+        forkSource: startedWithFork,
+        message: "Sending your first message…",
+        status: "sending",
+      };
+      if (!isCurrent()) {
+        if (heldImages && heldImages.length > 0) {
+          useCodeUiStore
+            .getState()
+            .offerComposerPrompt(workspaceId, draft, heldImages);
+        }
+        const message =
+          "The Code connection changed after the session was created. Send the message again.";
+        writeFirstTurnRecovery(startedWithClient, {
+          ...recovery,
+          message,
+          status: "failed",
+        });
+        throw new Error(message);
+      }
+      writeFirstTurnRecovery(startedWithClient, recovery);
+
+      if (conversations.length === 0) catalog.rememberSession(created);
+      setSessions((current) =>
+        current.some((entry) => entry.id === created.id)
+          ? current
+          : [...current, created],
+      );
+      setForkSource((current) =>
+        current === startedWithFork ? null : current,
+      );
+      if (selectionRevisionRef.current === startedAtSelection) {
+        setActiveSessionId(created.id);
+        setDraftAgent(false);
+        // The first agent stays at a clean URL; a sibling names itself so a
+        // reload comes back to the tab the reader was on.
+        if (conversations.length > 0) openWorkspaceTask(created.id);
+      }
+
+      try {
+        const attachments = heldImages?.length
+          ? await Promise.all(
+              heldImages.map(async (file) => {
+                const published = hasLocalHostAuthority()
+                  ? await publishCodeImage(created.id, file)
+                  : await uploadImageAttachment(
+                      startedWithClient,
+                      created.id,
+                      file,
+                      {
+                        onProgress: () => undefined,
+                        signal: new AbortController().signal,
+                        path: (id) =>
+                          `/code/sessions/${encodeURIComponent(id)}/attachments/images`,
+                      },
+                    );
+                return {
+                  blob_id: published.attachmentId,
+                  media_type: published.mediaType,
+                };
+              }),
+            )
+          : [];
+        if (attachments.length > 0) {
+          await startedWithClient.submitCodeTurn(
+            created.id,
+            message,
+            undefined,
+            attachments,
+          );
+        } else {
+          await startedWithClient.submitCodeTurn(created.id, message);
+        }
+        clearFirstTurnRecovery(startedWithClient, created.id, recovery.id);
+      } catch (err) {
+        if (heldImages && heldImages.length > 0) {
+          useCodeUiStore
+            .getState()
+            .offerComposerPrompt(workspaceId, draft, heldImages);
+        }
+        const detail = friendlyErrorMessage(err, "Try sending it again.");
+        writeFirstTurnRecovery(startedWithClient, {
+          ...recovery,
+          message: `The first message was not sent. Review it, then choose Send to try again. ${detail}`,
+          status: "failed",
+        });
+        if (isCurrent()) {
+          toast.error(
+            `Session started, but the first message was not sent. ${detail}`,
+          );
+        }
+      }
+    } finally {
+      if (isCurrent()) setStarting(false);
+    }
+  }
+
+  async function reap() {
+    if (!session) return;
+    try {
+      const next = await client.reapCodeSession(session.id);
+      catalog.rememberSession(next);
+      setSessions((current) =>
+        current.map((entry) => (entry.id === next.id ? next : entry)),
+      );
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not reap the session"));
+    }
+  }
+
+  /**
+   * Attach a child task's transcript (or the conversation when undefined).
+   *
+   * `replace` is for corrections rather than choices: clearing a stale param
+   * should not leave a history entry the reader can walk back into.
+   */
+  function openWorkspaceTask(
+    sessionId: string | undefined,
+    options?: { replace?: boolean },
+  ) {
+    void navigate({
+      to: "/code/w/$workspaceId",
+      params: { workspaceId },
+      replace: options?.replace ?? false,
+      search: (current: Record<string, unknown>) => ({
+        ...current,
+        task: sessionId,
+        subagent: undefined,
+      }),
+    });
+  }
+
+  /**
+   * Show one of the workspace's agents, or the unstarted draft when null.
+   *
+   * Selection lives in `?task=` so a reload or a shared link returns to the
+   * same agent. The first one is the workspace's default, so it stays unnamed.
+   */
+  function selectConversation(sessionId: string | null) {
+    selectionRevisionRef.current += 1;
+    focusConversationPane();
+    if (sessionId === null) {
+      setDraftAgent(true);
+      setActiveSessionId(null);
+      openWorkspaceTask(undefined);
+      return;
+    }
+    setDraftAgent(false);
+    setActiveSessionId(sessionId);
+    openWorkspaceTask(
+      sessionId === conversations[0]?.id ? undefined : sessionId,
+    );
+  }
+
+  /** Add a tab for an agent the reader has not filled in yet. */
+  function newConversation() {
+    setForkSource(null);
+    selectConversation(null);
+  }
+
+  /**
+   * Hand one agent's transcript to a fresh one.
+   *
+   * The server writes the fork into private storage — the condensed
+   * transcript plus a full record per turn — so the child reads it from an
+   * absolute path whatever engine it turns out to be. `atTurnId` forks at
+   * the end of that turn; omitted, the fork covers the whole conversation.
+   * Nothing is sent here: the draft tab opens with the transcript attached
+   * and framing lines the reader edits first.
+   */
+  async function forkConversation(sessionId: string, atTurnId?: string) {
+    try {
+      const written = await client.forkCodeSession(sessionId, atTurnId);
+      setForkSource(written);
+      selectConversation(null);
+      useCodeUiStore
+        .getState()
+        .offerComposerPrompt(workspaceId, forkFraming(written));
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not fork this agent"));
+    }
+  }
+
+  /** Close a conversation tab without ending its agent or workspace. */
+  function closeConversation(sessionId: string | null) {
+    if (sessionId === null) {
+      setDraftAgent(false);
+      setForkSource(null);
+    } else {
+      const index = conversations.findIndex((entry) => entry.id === sessionId);
+      if (index <= 0) return;
+      setClosedConversationIds((current) => {
+        const next = new Set(current);
+        next.add(sessionId);
+        return next;
+      });
+      if (sessionId !== activeSessionId) return;
+    }
+    const first = conversations[0];
+    if (first) selectConversation(first.id);
+    else setActiveSessionId(null);
+  }
+
+  /** Filter the parent transcript to one harness-owned child. */
+  function openWorkspaceSubagent(callId: string | undefined) {
+    void navigate({
+      to: "/code/w/$workspaceId",
+      params: { workspaceId },
+      search: (current: Record<string, unknown>) => ({
+        ...current,
+        task: undefined,
+        subagent: callId,
+      }),
+    });
+  }
+
+  /**
+   * The agent tab the strip should mark selected.
+   *
+   * A watch child opened from the rail is a drill-in with its own back bar, not
+   * a peer tab, so the first agent stays selected underneath it.
+   */
+  const activeConversationId = draftAgent
+    ? null
+    : (conversations.find((entry) => entry.id === session?.id)?.id ??
+      conversations[0]?.id ??
+      null);
+  const conversationTabs = useMemo<CodeConversationTab[]>(() => {
+    const tabs: CodeConversationTab[] = conversations
+      .filter(
+        (entry, index) => index === 0 || !closedConversationIds.has(entry.id),
+      )
+      .map((entry) => {
+        const index = conversations.findIndex(
+          (conversation) => conversation.id === entry.id,
+        );
+        const digest = conversationDigests[entry.id];
+        return {
+          id: entry.id,
+          label: conversationTabLabel(entry, index, conversations),
+          harness: entry.harness_kind,
+          attention: attentionMarkForDigest(digest),
+          closable: index > 0,
+        };
+      });
+    // A draft has no engine yet, so it wears the generic agent glyph. It is
+    // also the one closable tab: nothing is running behind it. A workspace
+    // with no agents at all still gets one, so the strip always names the
+    // panel below it.
+    if (draftAgent || tabs.length === 0) {
+      tabs.push({
+        id: null,
+        label: tabs.length === 0 ? "Main agent" : "New agent",
+        closable: tabs.length > 0,
+      });
+    }
+    return tabs;
+  }, [closedConversationIds, conversationDigests, conversations, draftAgent]);
+
+  /** The picker shows for a first agent and for every one added after it. */
+  const startingNewAgent = draftAgent || !session;
+
+  return {
+    workspace,
+    repo,
+    session,
+    conversations,
+    conversationTabs,
+    activeConversationId,
+    draftAgent,
+    startingNewAgent,
+    starting,
+    forkSource,
+    clearForkSource: () => setForkSource(null),
+    error,
+    retry: () => setReloadToken((token) => token + 1),
+    startSession,
+    reap,
+    selectConversation,
+    newConversation,
+    forkConversation,
+    closeConversation,
+    openWorkspaceTask,
+    openWorkspaceSubagent,
+  };
+}


### PR DESCRIPTION
Closes #2991.

## What changed

`CodeWorkspaceBody` (about 1,570 lines) and `PullRequestsSurface` (about 560 lines) each mixed several independent state machines. Each concern now lives in its own hook, and the two composition roots only compose them. Rendered markup and child props are unchanged.

Workspace, under `src/code/workspace/`:

- `useWorkspaceSessions` owns the agent list, `?task=` selection, start, fork, reap, and tab close.
- `useBrowserTabs` owns browser titles and start pages, and closes the native webview when a tab or the page goes.
- `useTerminalTabs` owns shell labels, ends a shell with its tab, and answers the terminal chord.
- `useEditorTabs` owns file reveal, the quick-open and new-tab asks, and tab drag.

Delivery, under `src/code/delivery/`:

- `usePullRequestQuery` owns the list, paging, and adopted summaries.
- `usePullRequestDetail` owns selection, the route-target fence, and the detail cache.
- `usePullRequestKeyboardNav` owns arrow keys and Escape on the open detail.

Filters already live in the delivery page as props, so there is no filter hook. `RunsSurface` now imports `TargetDetailState` from the detail hook.

One behavior nudge: `selectConversation` focuses the conversation pane from the latest layout rather than the render closure, so a fork that resolves after a tab change no longer reverts that change.

## How verified

Each hook has `renderHook` tests pinning the edges the split had to reason about: shells end once per tab, browsers close on unmount, the terminal chord jumps and returns, keyboard walks clamp at the top and page at the bottom, a hand-picked row outranks a late route target, the detail cache evicts oldest first, and a stale `?task=` is replaced rather than pushed.

Ran in `crates/tidebreak-desktop/ui`: `biome format src`, `pnpm lint`, `pnpm test` (268 files, 2,345 tests before the sessions test; 250 in the focused rerun), `pnpm build`. The existing `CodeWorkspacePage.dom.test.tsx` (66) and `CodeDeliveryPage.dom.test.tsx` (41) pass unchanged.
