### PR TITLE
refactor(cli): decode the chat event socket with the server's wire types

### DIFF
--- a/crates/tidebreak-cli/src/agent_mcp/follow.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/follow.rs
@@ -15,7 +15,9 @@ use serde_json::json;
 use tidebreak_core::{AgentError, CallId, ChatId, Result, TurnId, REQUEST_FOLDER_ACCESS_TOOL};
 
 use crate::api::client::{Client, DurableTurn, DurableTurnStatus};
-use crate::api::wire::ClientEvent;
+use crate::api::wire::{
+    ApprovalGrantRung, RendererAgentEvent, RendererToolName, ToolActionPreview, ToolApprovalKind,
+};
 use crate::event_stream::{EventStream, StreamNext};
 use crate::print::protocol::Interaction;
 
@@ -103,7 +105,7 @@ pub(crate) async fn follow_open_stream(
         };
 
         let event = match frame {
-            StreamNext::Frame(_raw, event) => event,
+            StreamNext::Frame(_raw, event) => *event,
             StreamNext::Ignore => continue,
             StreamNext::Durable(turn) => {
                 return Ok(from_durable(turn, assistant_text));
@@ -111,25 +113,26 @@ pub(crate) async fn follow_open_stream(
         };
 
         if !ours {
-            if !matches!(&event, ClientEvent::TurnStarted { turn_id: id } if *id == turn_id) {
+            if !matches!(&event, RendererAgentEvent::TurnStarted { turn_id: id } if *id == turn_id)
+            {
                 continue;
             }
             ours = true;
         }
 
         match event {
-            ClientEvent::TextDelta { text } => assistant_text.push_str(&text),
-            ClientEvent::ToolCallStarted { call_id, name } => {
-                if name == REQUEST_FOLDER_ACCESS_TOOL {
+            RendererAgentEvent::TextDelta { text } => assistant_text.push_str(&text),
+            RendererAgentEvent::ToolCallStarted { call_id, name } => {
+                if name == RendererToolName::RequestFolderAccess {
                     folder_watch = Some(call_id);
                 }
             }
-            ClientEvent::ToolCallCompleted { call_id, .. } => {
+            RendererAgentEvent::ToolCallCompleted { call_id, .. } => {
                 if folder_watch == Some(call_id) {
                     folder_watch = None;
                 }
             }
-            ClientEvent::ApprovalRequired {
+            RendererAgentEvent::ApprovalRequired {
                 call_id,
                 action,
                 approval,
@@ -150,8 +153,8 @@ pub(crate) async fn follow_open_stream(
                     events_cursor: stream.last_seq(),
                 });
             }
-            ClientEvent::PlanProposed { call_id } => {
-                if let Some(interaction) = pending_plan(client, chat, call_id).await? {
+            RendererAgentEvent::PlanProposed { call_id, .. } => {
+                if let Some(interaction) = pending_plan(client, chat, Some(call_id)).await? {
                     return Ok(TurnResult {
                         status: TurnStatus::NeedsPlanDecision,
                         assistant_text,
@@ -160,8 +163,8 @@ pub(crate) async fn follow_open_stream(
                     });
                 }
             }
-            ClientEvent::UserQuestionsAsked { call_id } => {
-                if let Some(interaction) = pending_questions(client, chat, call_id).await? {
+            RendererAgentEvent::UserQuestionsAsked { call_id, .. } => {
+                if let Some(interaction) = pending_questions(client, chat, Some(call_id)).await? {
                     return Ok(TurnResult {
                         status: TurnStatus::NeedsAnswer,
                         assistant_text,
@@ -170,7 +173,7 @@ pub(crate) async fn follow_open_stream(
                     });
                 }
             }
-            ClientEvent::TurnCompleted { .. } => {
+            RendererAgentEvent::TurnCompleted { .. } => {
                 return Ok(TurnResult {
                     status: TurnStatus::Completed,
                     assistant_text,
@@ -178,7 +181,7 @@ pub(crate) async fn follow_open_stream(
                     events_cursor: stream.last_seq(),
                 });
             }
-            ClientEvent::TurnFailed { .. } | ClientEvent::TurnRefused { .. } => {
+            RendererAgentEvent::TurnFailed { .. } | RendererAgentEvent::TurnRefused { .. } => {
                 return Ok(TurnResult {
                     status: TurnStatus::Failed,
                     assistant_text,
@@ -186,7 +189,7 @@ pub(crate) async fn follow_open_stream(
                     events_cursor: stream.last_seq(),
                 });
             }
-            ClientEvent::TurnCancelled { .. } => {
+            RendererAgentEvent::TurnCancelled { .. } => {
                 return Ok(TurnResult {
                     status: TurnStatus::Cancelled,
                     assistant_text,
@@ -229,10 +232,10 @@ fn from_durable(turn: DurableTurn, assistant_text: String) -> TurnResult {
 
 fn pending_approval(
     call_id: CallId,
-    action: String,
-    approval: String,
-    grant_rungs: Vec<crate::api::wire::GrantRung>,
-    preview: Option<serde_json::Value>,
+    action: RendererToolName,
+    approval: ToolApprovalKind,
+    grant_rungs: Vec<ApprovalGrantRung>,
+    preview: Option<ToolActionPreview>,
 ) -> serde_json::Value {
     json!({
         "type": "approval",
@@ -254,8 +257,8 @@ fn pending_from_interaction(interaction: &Interaction) -> serde_json::Value {
             preview,
         } => pending_approval(
             *call_id,
-            action.clone(),
-            approval.clone(),
+            *action,
+            *approval,
             grant_rungs.clone(),
             preview.clone(),
         ),
@@ -404,7 +407,7 @@ pub(crate) enum Decision {
         call_id: CallId,
         approve: bool,
         reason: String,
-        grant: Option<crate::api::wire::GrantRung>,
+        grant: Option<ApprovalGrantRung>,
     },
     Plan {
         call_id: CallId,

--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -16,8 +16,9 @@ use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
 use super::wire::{
-    AgentActivityItem, AgentRunSnapshot, ChatSummary, GrantRung, ModelCatalog, OutputPreview,
-    OutputRevisions, OutputsCatalog, PendingPlan, PendingQuestions, ProviderInfo, ProvidersList,
+    AgentActivityHistoryItem, AgentRunSnapshot, ApprovalGrantRung, Chat, ModelCatalog,
+    OutputPreview, OutputRevisions, OutputsCatalog, PendingPlanApproval, PendingUserQuestions,
+    ProviderInfo, ProvidersList,
 };
 
 /// The chat event stream once the upgrade completes.
@@ -223,12 +224,12 @@ impl Client {
     }
 
     /// One chat's record (title, model, permission mode, …).
-    pub async fn get_chat(&self, chat: ChatId) -> Result<ChatSummary> {
+    pub async fn get_chat(&self, chat: ChatId) -> Result<Chat> {
         self.get_json(format!("{}/chats/{chat}", self.base)).await
     }
 
     /// Every chat, most recently active first (server ordering).
-    pub async fn list_chats(&self) -> Result<Vec<ChatSummary>> {
+    pub async fn list_chats(&self) -> Result<Vec<Chat>> {
         self.get_json(format!("{}/chats", self.base)).await
     }
 
@@ -246,11 +247,7 @@ impl Client {
     }
 
     /// Patch the chat's permission mode; `None` clears back to `ask`.
-    pub async fn set_chat_permission_mode(
-        &self,
-        chat: ChatId,
-        mode: Option<&str>,
-    ) -> Result<ChatSummary> {
+    pub async fn set_chat_permission_mode(&self, chat: ChatId, mode: Option<&str>) -> Result<Chat> {
         let response = self
             .http
             .patch(format!("{}/chats/{chat}", self.base))
@@ -260,7 +257,7 @@ impl Client {
             .map_err(request_error)?;
         Self::expect_success(response)
             .await?
-            .json::<ChatSummary>()
+            .json::<Chat>()
             .await
             .map_err(request_error)
     }
@@ -460,7 +457,7 @@ impl Client {
         &self,
         chat: ChatId,
         run: AgentRunId,
-    ) -> Result<Vec<AgentActivityItem>> {
+    ) -> Result<Vec<AgentActivityHistoryItem>> {
         self.get_json(format!(
             "{}/chats/{chat}/agent-runs/{run}/activity",
             self.base
@@ -509,7 +506,7 @@ impl Client {
     }
 
     /// Plans awaiting review on this chat.
-    pub async fn list_pending_plans(&self, chat: ChatId) -> Result<Vec<PendingPlan>> {
+    pub async fn list_pending_plans(&self, chat: ChatId) -> Result<Vec<PendingPlanApproval>> {
         self.get_json(format!("{}/chats/{chat}/plans/pending", self.base))
             .await
     }
@@ -550,7 +547,7 @@ impl Client {
     }
 
     /// Question blocks the model is waiting on.
-    pub async fn list_pending_questions(&self, chat: ChatId) -> Result<Vec<PendingQuestions>> {
+    pub async fn list_pending_questions(&self, chat: ChatId) -> Result<Vec<PendingUserQuestions>> {
         self.get_json(format!("{}/chats/{chat}/questions/pending", self.base))
             .await
     }
@@ -660,7 +657,7 @@ impl Client {
         call_id: CallId,
         approve: bool,
         reason: &str,
-        grant: Option<GrantRung>,
+        grant: Option<ApprovalGrantRung>,
     ) -> Result<()> {
         let body = if approve {
             match grant {

--- a/crates/tidebreak-cli/src/api/wire.rs
+++ b/crates/tidebreak-cli/src/api/wire.rs
@@ -1,206 +1,48 @@
-//! Client-side decode of the chat event socket's frames.
+//! Client-side decode of the server's JSON.
 //!
-//! The server sends `RendererChatFrame`s — the closed, renderer-safe projection
-//! of the internal journal (see `tidebreak_server::event_projection`). These
-//! types mirror that wire shape loosely on purpose: closed vocabularies the
-//! server may grow (tool names, approval kinds, preview variants) decode as
-//! plain strings or JSON here, and an unrecognized event type decodes as
-//! [`ClientEvent::Unknown`] instead of failing the whole stream.
+//! The chat event socket's frames are the server's own types, imported from
+//! `tidebreak_server::wire`: one Rust definition serializes on the server and
+//! deserializes here, so a renamed field is a compile error in this crate the
+//! way it is a type error in the desktop renderer's generated `wire.ts`. The
+//! contract those types carry — closed vocabularies, unknown keys rejected, an
+//! unknown event type failing its frame — is documented on that module.
+//!
+//! The REST records below are still hand-written mirrors. Their server types
+//! only serialize today, so they cannot be imported the same way; they read
+//! only the fields a CLI surface uses and let serde drop the rest, and the
+//! opaque strings they carry are bounded with the same
+//! [`tidebreak_server::wire::limits`] the renderer applies. Moving them onto
+//! the server's types is tracked in brightwave-inc/tidebreak#3005.
 
 use serde::Deserialize;
-use tidebreak_core::{CallId, TurnId};
+use tidebreak_core::CallId;
+pub use tidebreak_core::{
+    Chat, PendingPlanApproval, PendingUserQuestions, RendererToolName, ToolActionPreview,
+    ToolApprovalKind,
+};
+pub use tidebreak_server::wire::limits;
+pub use tidebreak_server::wire::{
+    AgentActivityHistoryItem, ApprovalGrantRung, RendererAgentEvent, RendererChatFrame,
+    RendererToolStatus,
+};
 
-/// One frame on the socket: a journaled event (carrying `seq`, the resume
-/// cursor) or out-of-band metadata (no sequence).
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(untagged)]
-pub enum ChatFrame {
-    Event(SequencedFrame),
-    Metadata(MetadataFrame),
-}
-
-/// A journaled event at its sequence.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-pub struct SequencedFrame {
-    pub seq: i64,
-    pub event: ClientEvent,
-}
-
-/// A metadata push: chat state that changed outside the turn journal.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(tag = "metadata", rename_all = "snake_case")]
-pub enum MetadataFrame {
-    /// The chat was named — by titling, for a chat that had no name.
-    Titled { title: String },
-    /// A post-turn file-change summary is ready; recognizing the frame keeps
-    /// the tag decode closed.
-    FileChangesRecorded,
-    /// Code execution is preparing its sandbox image, or has stopped.
-    SandboxPreparing { preparing: bool },
-    /// A newer metadata kind this build does not know.
-    #[serde(other)]
-    Unknown,
-}
-
-/// A turn's token accounting, as the terminal events carry it. The four
-/// counts are disjoint; the context footprint is their plain sum.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
-pub struct TurnUsage {
-    #[serde(default)]
-    pub input_tokens: u32,
-    #[serde(default)]
-    pub output_tokens: u32,
-    #[serde(default)]
-    pub cache_read_input_tokens: u32,
-    #[serde(default)]
-    pub cache_creation_input_tokens: u32,
-}
-
-/// The events the CLI renders. Only fields a CLI surface uses are declared;
-/// serde drops the rest, so a server-side field addition never breaks decoding.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum ClientEvent {
-    TurnStarted {
-        turn_id: TurnId,
-    },
-    TextDelta {
-        text: String,
-    },
-    ReasoningDelta {
-        text: String,
-    },
-    StreamInterrupted,
-    ToolCallStarted {
-        call_id: CallId,
-        name: String,
-    },
-    ToolCallArgsDelta,
-    UserQuestionsAsked {
-        #[serde(default)]
-        call_id: Option<CallId>,
-    },
-    PlanProposed {
-        #[serde(default)]
-        call_id: Option<CallId>,
-    },
-    ApprovalRequired {
-        call_id: CallId,
-        action: String,
-        approval: String,
-        #[serde(default)]
-        auto_judging: bool,
-        /// Standing-grant ladder for this exact call, narrowest first.
-        #[serde(default)]
-        grant_rungs: Vec<GrantRung>,
-        #[serde(default)]
-        preview: Option<serde_json::Value>,
-    },
-    ApprovalDecided {
-        call_id: CallId,
-        #[serde(default)]
-        approved: Option<bool>,
-    },
-    ToolCallCompleted {
-        call_id: CallId,
-        status: ToolCallStatus,
-        /// What the call did, when its tool projects it.
-        #[serde(default)]
-        action: Option<serde_json::Value>,
-        /// What the call produced, when its tool projects it.
-        #[serde(default)]
-        result: Option<serde_json::Value>,
-    },
-    TurnCompleted {
-        #[serde(default)]
-        usage: TurnUsage,
-    },
-    TurnRefused {
-        refusal: Refusal,
-        #[serde(default)]
-        usage: TurnUsage,
-    },
-    TurnFailed {
-        category: String,
-        #[serde(default)]
-        model: Option<ModelIdentity>,
-    },
-    TurnCancelled {
-        #[serde(default)]
-        usage: TurnUsage,
-    },
-    UserSteered {
-        text: String,
-    },
-    ContextTruncated {
-        original_tokens: u32,
-        fitted_tokens: u32,
-    },
-    /// A newer server's event this build does not know; the journal cursor
-    /// still advances past it.
-    #[serde(other)]
-    Unknown,
-}
-
-/// How wide a standing grant the server offers on an approval, mirroring
-/// `ApprovalGrantRung`. Decodes from and encodes to the same wire strings so
-/// the decision can name the rung back verbatim.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum GrantRung {
-    /// Exactly the action the card showed.
-    ExactAction,
-    /// A leading run of the command's argv tokens.
-    CommandPrefix { tokens: usize },
-    /// A leading run of a workspace write's path segments.
-    PathPrefix { segments: usize },
-    /// Every call to this tool.
-    WholeTool,
-}
-
-/// Exact model route involved in a provider failure.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub struct ModelIdentity {
-    pub id: String,
-    #[serde(default)]
-    pub provider: Option<String>,
-}
-
-/// Whether a finished tool call succeeded. Unknown statuses decode rather than
-/// failing; they render as failures (the conservative display).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ToolCallStatus {
-    Completed,
-    Failed,
-    Cancelled,
-    #[serde(other)]
-    Unknown,
-}
-
-/// Bounded refusal metadata, as much as a client can act on.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-pub struct Refusal {
-    #[serde(default)]
-    pub category: Option<String>,
-    #[serde(default)]
-    pub partial_output: bool,
-}
-
-/// The chat record, as `GET /chats` and `GET /chats/{id}` return it.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ChatSummary {
-    pub id: tidebreak_core::ChatId,
-    #[serde(default)]
-    pub project_id: Option<tidebreak_core::ProjectId>,
-    #[serde(default)]
-    pub title: Option<String>,
-    #[serde(default)]
-    pub model: Option<String>,
-    #[serde(default)]
-    pub permission_mode: Option<String>,
-    #[serde(default)]
-    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+/// A timestamp string within [`limits::MAX_WIRE_TIMESTAMP_CHARS`] code points.
+///
+/// The output routes carry timestamps as preformatted strings rather than
+/// `DateTime`s, so the bound is the only check they get; the renderer applies
+/// the same number.
+fn bounded_timestamp<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    if value.chars().count() > limits::MAX_WIRE_TIMESTAMP_CHARS {
+        return Err(serde::de::Error::custom(format!(
+            "timestamp exceeds {} characters",
+            limits::MAX_WIRE_TIMESTAMP_CHARS
+        )));
+    }
+    Ok(value)
 }
 
 /// One background agent run, from `GET /chats/{id}/agent-runs`.
@@ -244,93 +86,6 @@ pub struct AgentRunSnapshot {
 pub struct SubmittedOutput {
     pub output_id: tidebreak_core::OutputId,
     pub filename: String,
-}
-
-/// The renderer-safe activity vocabulary, closed like the server's.
-#[derive(Debug, Clone, Copy, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentActivityKind {
-    Exec,
-    WebSearch,
-    ReadDelegatedFile,
-    ListConnectedFolders,
-    ListFolder,
-    ReadConnectedFile,
-    ImportConnectedFile,
-    #[serde(other)]
-    Other,
-}
-
-impl AgentActivityKind {
-    /// Stable snake_case name for JSON drivers and text listings.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Exec => "exec",
-            Self::WebSearch => "web_search",
-            Self::ReadDelegatedFile => "read_delegated_file",
-            Self::ListConnectedFolders => "list_connected_folders",
-            Self::ListFolder => "list_folder",
-            Self::ReadConnectedFile => "read_connected_file",
-            Self::ImportConnectedFile => "import_connected_file",
-            Self::Other => "other",
-        }
-    }
-}
-
-/// One history entry in a background run's activity timeline.
-#[derive(Debug, Clone, Deserialize)]
-pub struct AgentActivityItem {
-    pub kind: AgentActivityKind,
-    pub outcome: String,
-    pub at: chrono::DateTime<chrono::Utc>,
-    /// Renderer-safe command/query detail when the server supplies it.
-    #[serde(default)]
-    pub detail: Option<serde_json::Value>,
-}
-
-/// One proposed plan awaiting review, from `GET /chats/{id}/plans/pending`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct PendingPlan {
-    pub call_id: CallId,
-    /// The turn that proposed it; part of the wire contract, not rendered.
-    pub turn_id: TurnId,
-    pub title: String,
-    pub plan: String,
-}
-
-/// One block of questions the model is asking, from
-/// `GET /chats/{id}/questions/pending`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct PendingQuestions {
-    pub call_id: CallId,
-    /// The turn that asked; part of the wire contract, not rendered.
-    pub turn_id: TurnId,
-    #[serde(default)]
-    pub questions: Vec<UserQuestion>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct UserQuestion {
-    pub id: String,
-    #[serde(default)]
-    pub header: String,
-    pub question: String,
-    #[serde(default)]
-    pub options: Vec<QuestionOption>,
-    /// `"single"` or `"multi"`; anything else treats as single.
-    #[serde(default)]
-    pub question_type: String,
-    #[serde(default)]
-    pub allow_free_form: bool,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct QuestionOption {
-    /// The option's identity, which the answer's `selected_option_ids` names.
-    pub id: String,
-    pub label: String,
-    #[serde(default)]
-    pub description: Option<String>,
 }
 
 /// One selectable model, from `GET /models`.
@@ -446,6 +201,7 @@ pub struct OutputSummary {
     pub media_type: String,
     pub size_bytes: u64,
     pub revision_count: u32,
+    #[serde(deserialize_with = "bounded_timestamp")]
     pub updated_at: String,
 }
 
@@ -475,6 +231,7 @@ pub struct OutputRevisionRow {
     pub revision_id: tidebreak_core::OutputRevisionId,
     pub ordinal: u32,
     pub size_bytes: u64,
+    #[serde(deserialize_with = "bounded_timestamp")]
     pub created_at: String,
     pub produced_by: String,
     pub is_current: bool,
@@ -490,155 +247,76 @@ pub struct OutputRevisions {
 mod tests {
     use super::*;
 
-    fn frame(json: &str) -> ChatFrame {
-        serde_json::from_str(json).expect("the frame decodes")
+    /// Path of the server's chat-frame fixtures, relative to this crate.
+    const CHAT_FRAMES: &str = "../tidebreak-server/fixtures/chat-frames.json";
+
+    fn chat_frame_fixtures() -> Vec<(String, serde_json::Value)> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(CHAT_FRAMES);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+        let entries: Vec<serde_json::Value> =
+            serde_json::from_str(&text).expect("the fixture file is a JSON array");
+        entries
+            .into_iter()
+            .map(|entry| {
+                let name = entry["name"]
+                    .as_str()
+                    .expect("every fixture is named")
+                    .to_owned();
+                (name, entry["frame"].clone())
+            })
+            .collect()
     }
 
-    /// Representative frames exactly as the server serializes them (untagged
-    /// frame union, internally-tagged snake_case events). This is the contract
-    /// across the wire boundary: a rename or tag change server-side fails here.
+    /// Every frame the server can send decodes here, byte for byte. The
+    /// fixtures are serialized from the server's own types by a test in
+    /// `tidebreak-server`, and the renderer's tests read the same file, so
+    /// the three decoders cannot drift apart without one of them failing.
     #[test]
-    fn representative_frames_decode() {
-        let metadata = frame(r#"{"metadata":"titled","title":"A chat"}"#);
-        assert_eq!(
-            metadata,
-            ChatFrame::Metadata(MetadataFrame::Titled {
-                title: "A chat".into()
-            })
-        );
+    fn every_server_chat_frame_decodes() {
+        let fixtures = chat_frame_fixtures();
+        assert!(fixtures.len() > 20, "the fixture list looks truncated");
+        for (name, frame) in fixtures {
+            let decoded: RendererChatFrame = serde_json::from_value(frame.clone())
+                .unwrap_or_else(|error| panic!("fixture {name} does not decode: {error}"));
+            let again = serde_json::to_value(&decoded).expect("a decoded frame serializes");
+            assert_eq!(again, frame, "fixture {name} changed across the round trip");
+        }
+    }
 
-        let turn_started = frame(
-            r#"{"seq":1,"event":{"type":"turn_started","turn_id":"00000000-0000-0000-0000-000000000002"}}"#,
-        );
-        let ChatFrame::Event(turn_started) = turn_started else {
-            panic!("expected an event frame: {turn_started:?}");
-        };
-        assert_eq!(turn_started.seq, 1);
-        assert!(matches!(
-            turn_started.event,
-            ClientEvent::TurnStarted { .. }
-        ));
-
-        let text = frame(r#"{"seq":2,"event":{"type":"text_delta","text":"Hello"}}"#);
-        assert_eq!(
-            text,
-            ChatFrame::Event(SequencedFrame {
-                seq: 2,
-                event: ClientEvent::TextDelta {
-                    text: "Hello".into()
+    /// The CLI reads the cursor from event frames and ignores metadata frames;
+    /// both kinds are in the fixtures, so pin which is which.
+    #[test]
+    fn fixtures_carry_both_frame_kinds() {
+        let mut events = 0;
+        let mut metadata = 0;
+        for (_, frame) in chat_frame_fixtures() {
+            match serde_json::from_value::<RendererChatFrame>(frame).expect("decodes") {
+                RendererChatFrame::Event(frame) => {
+                    assert!(frame.seq > 0);
+                    events += 1;
                 }
-            })
-        );
-
-        let tool = frame(
-            r#"{"seq":3,"event":{"type":"tool_call_started","call_id":"00000000-0000-0000-0000-000000000003","name":"exec"}}"#,
-        );
-        let ChatFrame::Event(tool) = tool else {
-            panic!("expected an event frame: {tool:?}");
-        };
-        let ClientEvent::ToolCallStarted { call_id, name } = &tool.event else {
-            panic!("expected tool_call_started: {tool:?}");
-        };
-        assert_eq!(name, "exec");
-        let started_call = *call_id;
-
-        // ApprovalRequired carries the one deliberate payload opening: the
-        // tool's closed preview of the action under review, plus the grant
-        // ladder the decision can name back.
-        let approval = frame(&format!(
-            r#"{{"seq":4,"event":{{"type":"approval_required","call_id":"{started_call}","action":"exec","approval":"exec_may_run_networked_command","class":"sensitive","grant_rungs":["exact_action",{{"command_prefix":{{"tokens":1}}}},"whole_tool"],"preview":{{"tool":"exec","command":"git","args":["status"],"cwd":".","files":[]}}}}}}"#
-        ));
-        let ChatFrame::Event(approval) = approval else {
-            panic!("expected an event frame: {approval:?}");
-        };
-        let ClientEvent::ApprovalRequired {
-            call_id,
-            action,
-            approval: kind,
-            auto_judging,
-            grant_rungs,
-            preview,
-        } = &approval.event
-        else {
-            panic!("expected approval_required: {approval:?}");
-        };
-        assert_eq!(*call_id, started_call);
-        assert_eq!(action, "exec");
-        assert_eq!(kind, "exec_may_run_networked_command");
-        assert!(!auto_judging);
-        assert_eq!(
-            grant_rungs,
-            &vec![
-                GrantRung::ExactAction,
-                GrantRung::CommandPrefix { tokens: 1 },
-                GrantRung::WholeTool,
-            ]
-        );
-        assert_eq!(
-            preview.as_ref().and_then(|p| p.get("tool")),
-            Some(&serde_json::json!("exec"))
-        );
-
-        // ToolCallCompleted carries the action and result projections.
-        let completed = frame(&format!(
-            r#"{{"seq":5,"event":{{"type":"tool_call_completed","call_id":"{started_call}","status":"completed","action":{{"tool":"exec","command":"git","args":["status"],"cwd":".","files":[]}},"result":{{"tool":"exec","exit_code":0,"timed_out":false,"output_truncated":false,"stdout":"ok","stderr":""}}}}}}"#
-        ));
-        let ChatFrame::Event(completed) = completed else {
-            panic!("expected an event frame: {completed:?}");
-        };
-        let ClientEvent::ToolCallCompleted {
-            status,
-            action,
-            result,
-            ..
-        } = &completed.event
-        else {
-            panic!("expected tool_call_completed: {completed:?}");
-        };
-        assert_eq!(*status, ToolCallStatus::Completed);
-        assert!(action.is_some());
-        assert!(result.is_some());
-
-        let done = frame(
-            r#"{"seq":6,"event":{"type":"turn_completed","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
-        );
-        assert_eq!(
-            done,
-            ChatFrame::Event(SequencedFrame {
-                seq: 6,
-                event: ClientEvent::TurnCompleted {
-                    usage: TurnUsage {
-                        input_tokens: 1,
-                        output_tokens: 2,
-                        cache_read_input_tokens: 0,
-                        cache_creation_input_tokens: 0,
-                    }
-                },
-            })
-        );
+                RendererChatFrame::Metadata(_) => metadata += 1,
+            }
+        }
+        assert!(events > 0 && metadata > 0);
     }
 
-    /// Forward compatibility: an event type this build doesn't know decodes as
-    /// `Unknown` (the cursor advances, the stream survives), and the
-    /// projection's own fail-closed `event_omitted` marker lands there too.
+    /// The hand-written output mirrors apply the renderer's timestamp bound.
     #[test]
-    fn unrecognized_event_types_decode_as_unknown() {
-        let future = frame(r#"{"seq":9,"event":{"type":"some_future_event","payload":{}}}"#);
-        assert_eq!(
-            future,
-            ChatFrame::Event(SequencedFrame {
-                seq: 9,
-                event: ClientEvent::Unknown,
+    fn output_timestamps_are_bounded_like_the_renderer() {
+        let row = |updated_at: &str| {
+            serde_json::json!({
+                "outputId": "00000000-0000-0000-0000-000000000001",
+                "filename": "report.md",
+                "mediaType": "text/markdown",
+                "sizeBytes": 12,
+                "revisionCount": 1,
+                "updatedAt": updated_at,
             })
-        );
-
-        let omitted = frame(r#"{"seq":10,"event":{"type":"event_omitted"}}"#);
-        assert_eq!(
-            omitted,
-            ChatFrame::Event(SequencedFrame {
-                seq: 10,
-                event: ClientEvent::Unknown,
-            })
-        );
+        };
+        assert!(serde_json::from_value::<OutputSummary>(row("2026-09-01T12:00:00Z")).is_ok());
+        let too_long = "x".repeat(limits::MAX_WIRE_TIMESTAMP_CHARS + 1);
+        assert!(serde_json::from_value::<OutputSummary>(row(&too_long)).is_err());
     }
 }

--- a/crates/tidebreak-cli/src/event_stream.rs
+++ b/crates/tidebreak-cli/src/event_stream.rs
@@ -11,7 +11,7 @@ use tokio_tungstenite::tungstenite::Message;
 
 use crate::api::client::{Client, DurableTurn, EventSocket};
 use crate::api::code::{decode_event_frame, SequencedCodeEventFrame};
-use crate::api::wire::{ChatFrame, ClientEvent};
+use crate::api::wire::{RendererAgentEvent, RendererChatFrame};
 
 /// Attempts to re-open the event socket after it closes mid-turn before giving
 /// up. The retries cover a transient hiccup — an accept-loop stumble when the
@@ -34,7 +34,8 @@ pub(crate) struct EventStream {
 }
 
 pub(crate) enum StreamNext {
-    Frame(String, ClientEvent),
+    /// Boxed: an event carries tool previews and dwarfs the other arms.
+    Frame(String, Box<RendererAgentEvent>),
     Durable(DurableTurn),
     Ignore,
 }
@@ -62,7 +63,9 @@ impl EventStream {
     pub(crate) async fn recv(&mut self) -> Option<String> {
         match self.socket.next().await {
             Some(Ok(Message::Text(text))) => {
-                if let Ok(ChatFrame::Event(frame)) = serde_json::from_str::<ChatFrame>(&text) {
+                if let Ok(RendererChatFrame::Event(frame)) =
+                    serde_json::from_str::<RendererChatFrame>(&text)
+                {
                     self.last_seq = frame.seq;
                 }
                 Some(text.to_string())
@@ -81,11 +84,13 @@ impl EventStream {
     ) -> Result<StreamNext> {
         match self.socket.next().await {
             Some(Ok(Message::Text(text))) => {
-                let Ok(ChatFrame::Event(frame)) = serde_json::from_str::<ChatFrame>(&text) else {
+                let Ok(RendererChatFrame::Event(frame)) =
+                    serde_json::from_str::<RendererChatFrame>(&text)
+                else {
                     return Ok(StreamNext::Ignore);
                 };
                 self.last_seq = frame.seq;
-                Ok(StreamNext::Frame(text.to_string(), frame.event))
+                Ok(StreamNext::Frame(text.to_string(), Box::new(frame.event)))
             }
             Some(Ok(_)) => Ok(StreamNext::Ignore),
             Some(Err(_)) | None => match self.reconnect(client, chat, turn_id).await? {

--- a/crates/tidebreak-cli/src/print.rs
+++ b/crates/tidebreak-cli/src/print.rs
@@ -44,7 +44,7 @@ use tidebreak_core::{
 };
 
 use crate::api::client::{Client, ClientExecutionOutcome, DurableTurn, DurableTurnStatus};
-use crate::api::wire::{ClientEvent, ToolCallStatus};
+use crate::api::wire::{RendererAgentEvent, RendererToolName, RendererToolStatus};
 use crate::event_stream::{EventStream as Stream, StreamNext};
 
 mod driver;
@@ -250,7 +250,7 @@ async fn one_turn(
         };
 
         let (raw, event) = match frame {
-            StreamNext::Frame(raw, event) => (raw, event),
+            StreamNext::Frame(raw, event) => (raw, *event),
             StreamNext::Ignore => continue,
             StreamNext::Durable(turn) => {
                 printer.reconciled(turn_id, &turn);
@@ -263,7 +263,8 @@ async fn one_turn(
             }
         };
         if !ours {
-            if !matches!(&event, ClientEvent::TurnStarted { turn_id: id } if *id == turn_id) {
+            if !matches!(&event, RendererAgentEvent::TurnStarted { turn_id: id } if *id == turn_id)
+            {
                 continue;
             }
             ours = true;
@@ -271,19 +272,19 @@ async fn one_turn(
         printer.raw(&raw);
 
         match event {
-            ClientEvent::TextDelta { text } => printer.text(&text),
-            ClientEvent::ToolCallStarted { call_id, name } => {
+            RendererAgentEvent::TextDelta { text } => printer.text(&text),
+            RendererAgentEvent::ToolCallStarted { call_id, name } => {
                 // Refused here, never routed through `settle`: a folder request
                 // is not an `Interaction`, so the driver is never asked and no
                 // decision line can answer it. Whoever is driving gets the same
                 // outcome an unattended run gets. The refusal runs off the loop,
                 // which keeps the turn's own output flowing while it waits.
-                if name == REQUEST_FOLDER_ACCESS_TOOL {
+                if name == RendererToolName::RequestFolderAccess {
                     declines.start(client, executor_token, chat, call_id, &mut printer);
                 }
                 printer.tool_started(call_id, name);
             }
-            ClientEvent::ToolCallCompleted {
+            RendererAgentEvent::ToolCallCompleted {
                 call_id, status, ..
             } => {
                 // The call is over however it ended, so a refusal still waiting
@@ -291,7 +292,7 @@ async fn one_turn(
                 declines.finished(call_id);
                 printer.tool_completed(call_id, status);
             }
-            ClientEvent::ApprovalRequired {
+            RendererAgentEvent::ApprovalRequired {
                 call_id,
                 action,
                 approval,
@@ -321,8 +322,8 @@ async fn one_turn(
             }
             // Neither can be answered without a driver, so both end the run
             // loudly if there is none.
-            ClientEvent::PlanProposed { call_id } => {
-                match pending_plan(client, chat, call_id).await {
+            RendererAgentEvent::PlanProposed { call_id, .. } => {
+                match pending_plan(client, chat, Some(call_id)).await {
                     Ok(Some(interaction)) => {
                         if let Some(halt) = settle(
                             client,
@@ -342,8 +343,8 @@ async fn one_turn(
                     Err(halt) => break halted(client, chat, turn_id, &halt, &mut printer).await,
                 }
             }
-            ClientEvent::UserQuestionsAsked { call_id } => {
-                match pending_questions(client, chat, call_id).await {
+            RendererAgentEvent::UserQuestionsAsked { call_id, .. } => {
+                match pending_questions(client, chat, Some(call_id)).await {
                     Ok(Some(interaction)) => {
                         if let Some(halt) = settle(
                             client,
@@ -362,19 +363,19 @@ async fn one_turn(
                     Err(halt) => break halted(client, chat, turn_id, &halt, &mut printer).await,
                 }
             }
-            ClientEvent::TurnCompleted { .. } => break 0,
-            ClientEvent::TurnFailed { category, .. } => {
+            RendererAgentEvent::TurnCompleted { .. } => break 0,
+            RendererAgentEvent::TurnFailed { category, .. } => {
                 printer.finish();
-                eprintln!("tidebreak: turn failed ({category})");
+                eprintln!("tidebreak: turn failed ({})", category.as_str());
                 break EXIT_TURN_UNSUCCESSFUL;
             }
-            ClientEvent::TurnRefused { refusal, .. } => {
+            RendererAgentEvent::TurnRefused { refusal, .. } => {
                 printer.finish();
                 let category = refusal.category.unwrap_or_else(|| "unspecified".to_owned());
                 eprintln!("tidebreak: turn refused ({category})");
                 break EXIT_TURN_UNSUCCESSFUL;
             }
-            ClientEvent::TurnCancelled { .. } => {
+            RendererAgentEvent::TurnCancelled { .. } => {
                 printer.finish();
                 eprintln!("tidebreak: turn cancelled");
                 break EXIT_TURN_UNSUCCESSFUL;
@@ -883,7 +884,7 @@ async fn resolve_declined(
 /// Writes the turn out in the selected format.
 struct Printer {
     format: OutputFormat,
-    tools: HashMap<CallId, String>,
+    tools: HashMap<CallId, &'static str>,
     /// Whether stdout's last text ended without a newline, so the final flush
     /// can leave the shell prompt on its own line.
     dangling_line: bool,
@@ -955,20 +956,15 @@ impl Printer {
         }));
     }
 
-    fn tool_started(&mut self, call_id: CallId, name: String) {
-        self.tools.insert(call_id, name);
+    fn tool_started(&mut self, call_id: CallId, name: RendererToolName) {
+        self.tools.insert(call_id, name.as_str());
     }
 
-    fn tool_completed(&mut self, call_id: CallId, status: ToolCallStatus) {
-        let name = self
-            .tools
-            .remove(&call_id)
-            .unwrap_or_else(|| "tool".to_owned());
+    fn tool_completed(&mut self, call_id: CallId, status: RendererToolStatus) {
+        let name = self.tools.remove(&call_id).unwrap_or("tool");
         let status = match status {
-            ToolCallStatus::Completed => "ok",
-            // An unrecognized status reads as a failure: the conservative note.
-            ToolCallStatus::Failed | ToolCallStatus::Unknown => "failed",
-            ToolCallStatus::Cancelled => "cancelled",
+            RendererToolStatus::Completed => "ok",
+            RendererToolStatus::Failed => "failed",
         };
         self.notice(&format!("tool: {name} {status}"));
     }

--- a/crates/tidebreak-cli/src/print/protocol.rs
+++ b/crates/tidebreak-cli/src/print/protocol.rs
@@ -14,7 +14,10 @@
 use serde::{Deserialize, Serialize};
 use tidebreak_core::CallId;
 
-use crate::api::wire::{GrantRung, PendingPlan, PendingQuestions};
+use crate::api::wire::{
+    ApprovalGrantRung, PendingPlanApproval, PendingUserQuestions, RendererToolName,
+    ToolActionPreview, ToolApprovalKind,
+};
 
 /// Version tag stamped on every event this module emits.
 pub const PROTOCOL_VERSION: &str = "v1";
@@ -24,10 +27,10 @@ pub const PROTOCOL_VERSION: &str = "v1";
 pub enum Interaction {
     Approval {
         call_id: CallId,
-        action: String,
-        approval: String,
-        grant_rungs: Vec<GrantRung>,
-        preview: Option<serde_json::Value>,
+        action: RendererToolName,
+        approval: ToolApprovalKind,
+        grant_rungs: Vec<ApprovalGrantRung>,
+        preview: Option<ToolActionPreview>,
     },
     Plan {
         call_id: CallId,
@@ -61,7 +64,7 @@ pub struct QuestionOptionPrompt {
 }
 
 impl Interaction {
-    pub fn from_plan(plan: PendingPlan) -> Self {
+    pub fn from_plan(plan: PendingPlanApproval) -> Self {
         Self::Plan {
             call_id: plan.call_id,
             title: plan.title,
@@ -69,7 +72,7 @@ impl Interaction {
         }
     }
 
-    pub fn from_questions(pending: PendingQuestions) -> Self {
+    pub fn from_questions(pending: PendingUserQuestions) -> Self {
         Self::Questions {
             call_id: pending.call_id,
             questions: pending
@@ -79,7 +82,7 @@ impl Interaction {
                     id: question.id,
                     question: question.question,
                     header: question.header,
-                    question_type: question.question_type,
+                    question_type: question.question_type.as_str().to_owned(),
                     allow_free_form: question.allow_free_form,
                     options: question
                         .options
@@ -87,7 +90,7 @@ impl Interaction {
                         .map(|option| QuestionOptionPrompt {
                             id: option.id,
                             label: option.label,
-                            description: option.description,
+                            description: Some(option.description),
                         })
                         .collect(),
                 })
@@ -189,7 +192,7 @@ pub enum Decision {
     Approval {
         approve: bool,
         reason: String,
-        grant: Option<GrantRung>,
+        grant: Option<ApprovalGrantRung>,
     },
     Plan {
         accept: bool,
@@ -294,7 +297,7 @@ enum DecisionLine {
         #[serde(default)]
         reason: Option<String>,
         #[serde(default)]
-        grant: Option<GrantRung>,
+        grant: Option<ApprovalGrantRung>,
     },
     Plan {
         #[serde(default)]

--- a/crates/tidebreak-cli/src/setup.rs
+++ b/crates/tidebreak-cli/src/setup.rs
@@ -16,7 +16,7 @@
 
 use std::io::Read as _;
 
-use tidebreak_core::{AgentError, AgentRunId, ChatId, Result, TurnId};
+use tidebreak_core::{AgentActivityDetail, AgentError, AgentRunId, ChatId, Result, TurnId};
 
 use crate::api::client::Client;
 use crate::api::wire::{McpServerInfo, McpServersInfo};
@@ -550,7 +550,7 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                         "  {}  {}  {}{}",
                         item.at,
                         item.kind.as_str(),
-                        item.outcome,
+                        item.outcome.as_str(),
                         headline
                     );
                 }
@@ -608,42 +608,30 @@ fn first_line(text: &str) -> String {
 }
 
 /// A short suffix for one activity row: the command or query when present.
-fn activity_headline(detail: Option<&serde_json::Value>) -> String {
-    let Some(detail) = detail else {
-        return String::new();
-    };
-    if let Some(command) = detail.get("command").and_then(|value| value.as_str()) {
-        let args = detail
-            .get("args")
-            .and_then(|value| value.as_array())
-            .map(|entries| {
-                entries
-                    .iter()
-                    .filter_map(|entry| entry.as_str())
-                    .take(4)
-                    .collect::<Vec<_>>()
-                    .join(" ")
-            })
-            .unwrap_or_default();
-        if args.is_empty() {
-            return format!("  {command}");
+fn activity_headline(detail: Option<&AgentActivityDetail>) -> String {
+    match detail {
+        Some(AgentActivityDetail::Exec { command, args, .. }) => {
+            let args = args.iter().take(4).cloned().collect::<Vec<_>>().join(" ");
+            if args.is_empty() {
+                return format!("  {command}");
+            }
+            let clipped = if args.len() > 60 {
+                format!("{}…", &args[..60])
+            } else {
+                args
+            };
+            format!("  {command} {clipped}")
         }
-        let clipped = if args.len() > 60 {
-            format!("{}…", &args[..60])
-        } else {
-            args
-        };
-        return format!("  {command} {clipped}");
+        Some(AgentActivityDetail::Search { query }) => {
+            let clipped = if query.len() > 72 {
+                format!("{}…", &query[..72])
+            } else {
+                query.clone()
+            };
+            format!("  {clipped}")
+        }
+        Some(AgentActivityDetail::File { .. }) | None => String::new(),
     }
-    if let Some(query) = detail.get("query").and_then(|value| value.as_str()) {
-        let clipped = if query.len() > 72 {
-            format!("{}…", &query[..72])
-        } else {
-            query.to_owned()
-        };
-        return format!("  {clipped}");
-    }
-    String::new()
 }
 
 /// Write one JSON object on stdout, matching print mode's one-object-per-line

--- a/crates/tidebreak-core/src/renderer_tool.rs
+++ b/crates/tidebreak-core/src/renderer_tool.rs
@@ -60,6 +60,47 @@ pub enum RendererToolName {
     Other,
 }
 
+impl RendererToolName {
+    /// The wire spelling, for a client that prints the name as text. Pinned to
+    /// the serde rendering by `as_str_matches_the_wire_spelling`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Search => "search",
+            Self::ListDocuments => "list_documents",
+            Self::ReadDocument => "read_document",
+            Self::ReadToolResult => "read_tool_result",
+            Self::WebSearch => "web_search",
+            Self::WebExtract => "web_extract",
+            Self::ReadDelegatedFile => "read_delegated_file",
+            Self::ReadFile => "read_file",
+            Self::ListDir => "list_dir",
+            Self::WriteFile => "write_file",
+            Self::RequestFolderAccess => "request_folder_access",
+            Self::ConnectFolder => "connect_folder",
+            Self::ListConnectedFolders => "list_connected_folders",
+            Self::ListFolder => "list_folder",
+            Self::ReadConnectedFile => "read_connected_file",
+            Self::ImportConnectedFile => "import_connected_file",
+            Self::WriteOutputToConnectedFolder => "write_output_to_connected_folder",
+            Self::SpawnSandboxAgent => "spawn_sandbox_agent",
+            Self::WaitForAgents => "wait_for_agents",
+            Self::AskUserQuestions => "ask_user_questions",
+            Self::ExitPlanMode => "exit_plan_mode",
+            Self::UpdateTaskPlan => "update_task_plan",
+            Self::BrowserList => "browser_list",
+            Self::BrowserNavigate => "browser_navigate",
+            Self::BrowserSnapshot => "browser_snapshot",
+            Self::BrowserWait => "browser_wait",
+            Self::BrowserScreenshot => "browser_screenshot",
+            Self::BrowserAct => "browser_act",
+            Self::Exec => "exec",
+            Self::CreateApp => "create_app",
+            Self::Other => "other",
+        }
+    }
+}
+
 impl From<&str> for RendererToolName {
     /// Fold a registered tool name onto the vocabulary.
     ///
@@ -106,6 +147,52 @@ impl From<&str> for RendererToolName {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `as_str` is what a text client prints; it must agree with what serde
+    /// writes on the wire for every variant.
+    #[test]
+    fn as_str_matches_the_wire_spelling() {
+        for name in [
+            "search",
+            "list_documents",
+            "read_document",
+            "read_tool_result",
+            "web_search",
+            crate::WEB_EXTRACT_TOOL,
+            crate::SANDBOX_READ_DELEGATED_FILE_TOOL,
+            "read_file",
+            "list_dir",
+            "write_file",
+            "request_folder_access",
+            "connect_folder",
+            "list_connected_folders",
+            "list_folder",
+            "read_connected_file",
+            "import_connected_file",
+            crate::WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
+            "spawn_sandbox_agent",
+            "wait_for_agents",
+            crate::ASK_USER_QUESTIONS_TOOL,
+            crate::EXIT_PLAN_MODE_TOOL,
+            crate::UPDATE_TASK_PLAN_TOOL,
+            crate::BROWSER_LIST_TOOL,
+            crate::BROWSER_NAVIGATE_TOOL,
+            crate::BROWSER_SNAPSHOT_TOOL,
+            crate::BROWSER_WAIT_TOOL,
+            crate::BROWSER_SCREENSHOT_TOOL,
+            crate::BROWSER_ACT_TOOL,
+            "exec",
+            crate::local_app::CREATE_APP_TOOL,
+            "anything_else",
+        ] {
+            let folded = RendererToolName::from(name);
+            let wire = serde_json::to_value(folded).expect("a tool name serializes");
+            assert_eq!(wire.as_str(), Some(folded.as_str()), "{name}");
+            if folded != RendererToolName::Other {
+                assert_eq!(folded.as_str(), name);
+            }
+        }
+    }
 
     /// Every registered tool name the renderer can present must survive the
     /// fold, both live and when a terminal card is rebuilt from the journal.

--- a/crates/tidebreak-desktop/ui/src/ChatSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatSessionController.ts
@@ -58,7 +58,7 @@ function isWellFormedFrame(frame: SequencedEvent): boolean {
  * thing they have in common with each other: a metadata frame has no sequence,
  * so any check based on one would classify it as malformed.
  */
-function metadataFrame(frame: ChatFrame): ChatMetadataFrame | null {
+export function metadataFrame(frame: ChatFrame): ChatMetadataFrame | null {
   if (typeof frame !== "object" || frame === null) return null;
   const metadata = (frame as { metadata?: unknown }).metadata;
   if (metadata === "titled") {

--- a/crates/tidebreak-desktop/ui/src/WireFixtures.test.ts
+++ b/crates/tidebreak-desktop/ui/src/WireFixtures.test.ts
@@ -1,5 +1,13 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { metadataFrame } from "./ChatSessionController";
 import {
+  initialChatSessionState,
+  reduceChatSessionEvent,
+} from "./ChatSessionReducer";
+import {
+  type ChatFrame,
   RENDERER_FOLDER_ACCESS_REASON,
   parseFolderAccessRequest,
   parsePendingToolApproval,
@@ -9,6 +17,24 @@ import {
   PENDING_APPROVAL_WITHOUT_PREVIEW,
   PENDING_FOLDER_ACCESS_REQUEST,
 } from "./generated/fixtures";
+
+/**
+ * One real frame of every kind the chat socket carries, serialized by the
+ * server's own types. The same file is decoded by the CLI's tests and by the
+ * server's round trip, so the three readers of this socket cannot drift apart
+ * without one of them failing.
+ */
+const CHAT_FRAMES: { name: string; frame: ChatFrame }[] = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL(
+        "../../../tidebreak-server/fixtures/chat-frames.json",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  ),
+);
 
 /**
  * The validators, run against the server's real output.
@@ -89,5 +115,47 @@ describe("validators against real server output", () => {
     expect(PENDING_FOLDER_ACCESS_REQUEST.reason).toBe(
       RENDERER_FOLDER_ACCESS_REASON,
     );
+  });
+});
+
+describe("chat frames against real server output", () => {
+  it("carries every frame kind", () => {
+    expect(CHAT_FRAMES.length).toBeGreaterThan(20);
+    const tags = new Set(
+      CHAT_FRAMES.map(({ frame }) =>
+        "event" in frame ? frame.event.type : `metadata:${frame.metadata}`,
+      ),
+    );
+    expect(tags.has("turn_started")).toBe(true);
+    expect(tags.has("tool_call_completed")).toBe(true);
+    expect(tags.has("metadata:titled")).toBe(true);
+  });
+
+  it("reduces every journaled frame without throwing", () => {
+    // The renderer parses each frame with a cast and no runtime validation,
+    // so the reducer is the first code that reads the payload. Every real
+    // frame has to be something it can take, in journal order.
+    let state = initialChatSessionState();
+    const deps = { nextId: () => "id", now: () => "2026-09-01T00:00:00Z" };
+    let reduced = 0;
+    for (const { name, frame } of CHAT_FRAMES) {
+      if (!("event" in frame)) continue;
+      const transition = reduceChatSessionEvent(state, frame, deps);
+      expect(transition.state.lastSeq, name).toBe(frame.seq);
+      state = transition.state;
+      reduced += 1;
+    }
+    expect(reduced).toBeGreaterThan(20);
+  });
+
+  it("recognizes every metadata frame and no event frame as metadata", () => {
+    for (const { name, frame } of CHAT_FRAMES) {
+      const metadata = metadataFrame(frame);
+      if ("metadata" in frame) {
+        expect(metadata, name).toEqual(frame);
+      } else {
+        expect(metadata, name).toBeNull();
+      }
+    }
   });
 });

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -4946,3 +4946,14 @@ export const RENDERER_TOOL_NAMES = [
   "create_app",
   "other",
 ] as const;
+
+/**
+ * Guard limits shared with the server and the CLI, in code points.
+ *
+ * The decoders bound every opaque string they will draw. These are the
+ * ceilings, generated from `tidebreak_server::wire::limits` so every
+ * client applies the same numbers.
+ */
+export const MAX_WIRE_ID_CHARS = 128;
+export const MAX_WIRE_TIMESTAMP_CHARS = 64;
+export const MAX_WIRE_CURSOR_CHARS = 256;

--- a/crates/tidebreak-desktop/ui/src/lib/wireDecode.ts
+++ b/crates/tidebreak-desktop/ui/src/lib/wireDecode.ts
@@ -30,14 +30,16 @@ export { isRecord, onlyKeys } from "./guards";
 // Shared guard limits
 // ---------------------------------------------------------------------------
 
-/** Longest opaque identifier the chat decoder accepts (call, turn, chat, run, workspace ids). */
-export const MAX_WIRE_ID_CHARS = 128;
-
-/** Longest timestamp string the chat decoder accepts. RFC 3339 needs about 35. */
-export const MAX_WIRE_TIMESTAMP_CHARS = 64;
-
-/** Longest opaque pagination cursor the chat decoder accepts. */
-export const MAX_WIRE_CURSOR_CHARS = 256;
+/**
+ * The id, timestamp, and cursor ceilings are generated from
+ * `tidebreak_server::wire::limits`, where the CLI reads the same numbers, so
+ * the two clients cannot disagree about what a valid payload is.
+ */
+export {
+  MAX_WIRE_CURSOR_CHARS,
+  MAX_WIRE_ID_CHARS,
+  MAX_WIRE_TIMESTAMP_CHARS,
+} from "../generated/wire";
 
 // ---------------------------------------------------------------------------
 // Presence-only string readers (code-mode convention)

--- a/crates/tidebreak-server/fixtures/chat-frames.json
+++ b/crates/tidebreak-server/fixtures/chat-frames.json
@@ -1,0 +1,354 @@
+[
+  {
+    "frame": {
+      "event": {
+        "turn_id": "00000000-0000-0000-0000-000000000010",
+        "type": "turn_started"
+      },
+      "seq": 1
+    },
+    "name": "turn_started"
+  },
+  {
+    "frame": {
+      "event": {
+        "text": "Hello",
+        "type": "text_delta"
+      },
+      "seq": 2
+    },
+    "name": "text_delta"
+  },
+  {
+    "frame": {
+      "event": {
+        "text": "Considering the request",
+        "type": "reasoning_delta"
+      },
+      "seq": 3
+    },
+    "name": "reasoning_delta"
+  },
+  {
+    "frame": {
+      "event": {
+        "type": "stream_interrupted"
+      },
+      "seq": 4
+    },
+    "name": "stream_interrupted"
+  },
+  {
+    "frame": {
+      "event": {
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "name": "exec",
+        "type": "tool_call_started"
+      },
+      "seq": 5
+    },
+    "name": "tool_call_started"
+  },
+  {
+    "frame": {
+      "event": {
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "type": "tool_call_args_delta"
+      },
+      "seq": 6
+    },
+    "name": "tool_call_args_delta"
+  },
+  {
+    "frame": {
+      "event": {
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "turn_id": "00000000-0000-0000-0000-000000000010",
+        "type": "user_questions_asked"
+      },
+      "seq": 7
+    },
+    "name": "user_questions_asked"
+  },
+  {
+    "frame": {
+      "event": {
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "turn_id": "00000000-0000-0000-0000-000000000010",
+        "type": "plan_proposed"
+      },
+      "seq": 8
+    },
+    "name": "plan_proposed"
+  },
+  {
+    "frame": {
+      "event": {
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "turn_id": "00000000-0000-0000-0000-000000000010",
+        "type": "task_plan_updated"
+      },
+      "seq": 9
+    },
+    "name": "task_plan_updated"
+  },
+  {
+    "frame": {
+      "event": {
+        "action": "exec",
+        "approval": "exec_may_run_networked_command",
+        "auto_judging": false,
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "class": "sensitive",
+        "grant_rungs": [
+          "exact_action",
+          {
+            "command_prefix": {
+              "tokens": 1
+            }
+          },
+          "whole_tool"
+        ],
+        "preview": {
+          "args": [
+            "status"
+          ],
+          "command": "git",
+          "cwd": ".",
+          "files": [],
+          "summary": "Checking the repository status",
+          "tool": "exec"
+        },
+        "type": "approval_required"
+      },
+      "seq": 10
+    },
+    "name": "approval_required"
+  },
+  {
+    "frame": {
+      "event": {
+        "action": "other",
+        "approval": "unsupported",
+        "auto_judging": true,
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "class": "sensitive",
+        "grant_rungs": [],
+        "type": "approval_required"
+      },
+      "seq": 11
+    },
+    "name": "approval_required_without_preview"
+  },
+  {
+    "frame": {
+      "event": {
+        "approved": true,
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "type": "approval_decided"
+      },
+      "seq": 12
+    },
+    "name": "approval_decided"
+  },
+  {
+    "frame": {
+      "event": {
+        "action": {
+          "args": [
+            "status"
+          ],
+          "command": "git",
+          "cwd": ".",
+          "files": [],
+          "summary": "Checking the repository status",
+          "tool": "exec"
+        },
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "result": {
+          "exit_code": 0,
+          "output_truncated": false,
+          "stderr": "",
+          "stdout": "ok\n",
+          "timed_out": false,
+          "tool": "exec"
+        },
+        "status": "completed",
+        "type": "tool_call_completed"
+      },
+      "seq": 13
+    },
+    "name": "tool_call_completed"
+  },
+  {
+    "frame": {
+      "event": {
+        "call_id": "00000000-0000-0000-0000-000000000011",
+        "failure": {
+          "code": "executor_unavailable",
+          "reason": "lease_expired"
+        },
+        "status": "failed",
+        "type": "tool_call_completed"
+      },
+      "seq": 14
+    },
+    "name": "tool_call_completed_with_failure"
+  },
+  {
+    "frame": {
+      "event": {
+        "type": "turn_completed",
+        "usage": {
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 800,
+          "input_tokens": 120,
+          "output_tokens": 34
+        }
+      },
+      "seq": 15
+    },
+    "name": "turn_completed"
+  },
+  {
+    "frame": {
+      "event": {
+        "refusal": {
+          "category": "safety",
+          "partial_output": true
+        },
+        "type": "turn_refused",
+        "usage": {
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 800,
+          "input_tokens": 120,
+          "output_tokens": 34
+        }
+      },
+      "seq": 16
+    },
+    "name": "turn_refused"
+  },
+  {
+    "frame": {
+      "event": {
+        "category": "rate_limited",
+        "detail": "rate limited; retry after 30s",
+        "model": {
+          "id": "claude-opus-4-8",
+          "provider": "anthropic"
+        },
+        "type": "turn_failed"
+      },
+      "seq": 17
+    },
+    "name": "turn_failed"
+  },
+  {
+    "frame": {
+      "event": {
+        "category": "unknown",
+        "type": "turn_failed"
+      },
+      "seq": 18
+    },
+    "name": "turn_failed_without_detail"
+  },
+  {
+    "frame": {
+      "event": {
+        "type": "turn_cancelled",
+        "usage": {
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 800,
+          "input_tokens": 120,
+          "output_tokens": 34
+        }
+      },
+      "seq": 19
+    },
+    "name": "turn_cancelled"
+  },
+  {
+    "frame": {
+      "event": {
+        "message_id": "00000000-0000-0000-0000-000000000012",
+        "text": "Focus on the tests",
+        "type": "user_steered"
+      },
+      "seq": 20
+    },
+    "name": "user_steered"
+  },
+  {
+    "frame": {
+      "event": {
+        "fitted_tokens": 120000,
+        "original_tokens": 180000,
+        "type": "context_truncated"
+      },
+      "seq": 21
+    },
+    "name": "context_truncated"
+  },
+  {
+    "frame": {
+      "event": {
+        "type": "compaction_started"
+      },
+      "seq": 22
+    },
+    "name": "compaction_started"
+  },
+  {
+    "frame": {
+      "event": {
+        "compacted": true,
+        "type": "compaction_finished"
+      },
+      "seq": 23
+    },
+    "name": "compaction_finished"
+  },
+  {
+    "frame": {
+      "event": {
+        "type": "event_omitted"
+      },
+      "seq": 24
+    },
+    "name": "event_omitted"
+  },
+  {
+    "frame": {
+      "event": {
+        "text": "from catch-up",
+        "type": "text_delta"
+      },
+      "replayed": true,
+      "seq": 25
+    },
+    "name": "replayed_event"
+  },
+  {
+    "frame": {
+      "metadata": "titled",
+      "title": "A chat"
+    },
+    "name": "metadata_titled"
+  },
+  {
+    "frame": {
+      "metadata": "file_changes_recorded",
+      "turn_id": "00000000-0000-0000-0000-000000000010"
+    },
+    "name": "metadata_file_changes_recorded"
+  },
+  {
+    "frame": {
+      "metadata": "sandbox_preparing",
+      "preparing": true
+    },
+    "name": "metadata_sandbox_preparing"
+  }
+]

--- a/crates/tidebreak-server/src/event_projection.rs
+++ b/crates/tidebreak-server/src/event_projection.rs
@@ -42,7 +42,7 @@ use ts_rs::TS;
 /// discriminator rather than by a sequence it would have to invent.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(untagged)]
-pub(crate) enum RendererChatFrame {
+pub enum RendererChatFrame {
     /// A journaled turn event at its sequence. Boxed: an event frame carries
     /// tool previews and dwarfs a metadata frame, and every frame is built
     /// once and serialized, so the indirection costs nothing on the hot path.
@@ -53,8 +53,8 @@ pub(crate) enum RendererChatFrame {
 
 /// Chat metadata pushed to an open client, outside the turn journal.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
-#[serde(tag = "metadata", rename_all = "snake_case")]
-pub(crate) enum RendererChatMetadata {
+#[serde(tag = "metadata", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RendererChatMetadata {
     /// The chat was named — by titling, for a chat that had no name.
     Titled { title: String },
     /// A post-turn file-change summary is ready for transcript hydration.
@@ -84,7 +84,8 @@ impl From<&crate::bus::ChatMetadataNotice> for RendererChatMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
-pub(crate) struct RendererSequencedEvent {
+#[serde(deny_unknown_fields)]
+pub struct RendererSequencedEvent {
     pub seq: i64,
     pub event: RendererAgentEvent,
     // True only when this frame came from durable catch-up rather than the live
@@ -113,7 +114,8 @@ pub(crate) struct RendererSequencedEvent {
 /// It is a faithful measure of what the turn cost and a ceiling on what the
 /// window held.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
-pub(crate) struct RendererTurnUsage {
+#[serde(deny_unknown_fields)]
+pub struct RendererTurnUsage {
     /// Fresh prompt tokens, excluding both cache figures below.
     pub input_tokens: u32,
     /// Tokens the model generated.
@@ -137,14 +139,16 @@ impl From<tidebreak_core::Usage> for RendererTurnUsage {
 
 /// Bounded refusal metadata safe to present in the desktop transcript.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-pub(crate) struct RendererRefusal {
+#[serde(deny_unknown_fields)]
+pub struct RendererRefusal {
     pub category: Option<String>,
     pub partial_output: bool,
 }
 
 /// Exact model route involved in a provider failure, with no diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
-pub(crate) struct RendererModelIdentity {
+#[serde(deny_unknown_fields)]
+pub struct RendererModelIdentity {
     pub id: String,
     pub provider: crate::providers::ProviderKind,
 }
@@ -167,8 +171,8 @@ impl From<&tidebreak_core::RefusalOutcome> for RendererRefusal {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub(crate) enum RendererAgentEvent {
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RendererAgentEvent {
     TurnStarted {
         turn_id: TurnId,
     },
@@ -309,7 +313,7 @@ pub(crate) enum RendererAgentEvent {
 /// category the scheduler acted on cannot drift apart.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum TurnFailureCategory {
+pub enum TurnFailureCategory {
     /// The provider throttled or shed the request. Automatic retries were
     /// already spent, but waiting and asking again is the actual remedy.
     RateLimited,
@@ -348,6 +352,19 @@ impl TurnFailureCategory {
     pub(crate) const fn retries_may_succeed(self) -> bool {
         matches!(self, Self::RateLimited | Self::Transient)
     }
+
+    /// The wire spelling, for a client that prints the category as text.
+    /// Pinned to the serde rendering by `turn_failure_category_names_match_the_wire`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RateLimited => "rate_limited",
+            Self::Auth => "auth",
+            Self::ProviderAccess => "provider_access",
+            Self::Transient => "transient",
+            Self::Unknown => "unknown",
+        }
+    }
 }
 
 /// Only provider-originated diagnostics cross to the renderer. These strings
@@ -371,26 +388,27 @@ pub(crate) fn renderer_provider_failure_detail(kind: &str, detail: &str) -> Opti
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum RendererToolStatus {
+pub enum RendererToolStatus {
     Completed,
     Failed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
-pub(crate) struct RendererToolFailure {
+#[serde(deny_unknown_fields)]
+pub struct RendererToolFailure {
     pub code: RendererToolFailureCode,
     pub reason: RendererToolFailureReason,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum RendererToolFailureCode {
+pub enum RendererToolFailureCode {
     ExecutorUnavailable,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum RendererToolFailureReason {
+pub enum RendererToolFailureReason {
     LeaseExpired,
 }
 

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -110,6 +110,7 @@ mod view_frames;
 pub mod voice_transcription;
 /// Host-owned, inert web-search configuration and provider selection.
 pub mod web_search;
+pub mod wire;
 mod wire_types;
 
 use std::fs::{OpenOptions, TryLockError};

--- a/crates/tidebreak-server/src/routes/agent_runs.rs
+++ b/crates/tidebreak-server/src/routes/agent_runs.rs
@@ -228,6 +228,24 @@ pub enum AgentActivityKind {
     ImportConnectedFile,
 }
 
+impl AgentActivityKind {
+    /// The wire spelling, for a client that lists activity as text. Pinned to
+    /// the serde rendering by `activity_names_match_the_wire`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Exec => "exec",
+            Self::WebSearch => "web_search",
+            Self::UpdateTaskPlan => "update_task_plan",
+            Self::ReadDelegatedFile => "read_delegated_file",
+            Self::ListConnectedFolders => "list_connected_folders",
+            Self::ListFolder => "list_folder",
+            Self::ReadConnectedFile => "read_connected_file",
+            Self::ImportConnectedFile => "import_connected_file",
+        }
+    }
+}
+
 /// Coarse checkpoint lifecycle suitable for display.
 ///
 /// This intentionally does not mirror all durable executor states; only live
@@ -291,6 +309,21 @@ pub enum AgentActivityOutcome {
     Completed,
     Failed,
     Cancelled,
+}
+
+impl AgentActivityOutcome {
+    /// The wire spelling, for a client that lists activity as text. Pinned to
+    /// the serde rendering by `activity_names_match_the_wire`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Waiting => "waiting",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
 }
 
 /// One renderer-safe entry in a background run's ordered activity history.

--- a/crates/tidebreak-server/src/wire.rs
+++ b/crates/tidebreak-server/src/wire.rs
@@ -1,0 +1,168 @@
+//! The chat event socket's wire contract, as a Rust client reads it.
+//!
+//! The desktop renderer decodes the server's JSON through TypeScript generated
+//! from these same definitions (see `docs/wire-types.md`). The CLI used to keep
+//! a third, hand-written mirror of the frame shapes, and nothing tied that
+//! mirror to the server: a field renamed here compiled, shipped, and failed at
+//! runtime. This module is the one place a Rust client imports the socket's
+//! types from, so a rename is a compile error in the CLI the way it is a type
+//! error in the renderer.
+//!
+//! # Strictness
+//!
+//! A client that decodes through these types gets the renderer's contract, not
+//! a looser one:
+//!
+//! - Every vocabulary is closed. Tool names, approval kinds, tool statuses,
+//!   failure categories, and grant rungs are the server's own enums, so a
+//!   value outside them fails to decode rather than folding to a string.
+//! - Every frame rejects unknown keys (`deny_unknown_fields`), matching the
+//!   renderer's `onlyKeys` guards. A field the server does not declare is not
+//!   part of the contract, and a client that silently dropped it could not
+//!   tell a newer server from a malformed frame.
+//! - An event type the client does not know fails the frame. The client drops
+//!   that frame and does not advance its cursor past it, so a reconnect replays
+//!   it and drops it again. This is the one place a version-skewed client (a
+//!   CLI attached to a newer desktop) loses information, and it is deliberate:
+//!   the renderer ships with its server and never sees a newer event, so a
+//!   tolerant client would be the only surface with a different contract.
+//!
+//! # Limits
+//!
+//! [`limits`] holds the guard sizes the renderer applies to opaque strings on
+//! this surface. They are generated into `wire.ts` from here, so the two
+//! clients cannot disagree about how long an id, a timestamp, or a cursor may
+//! be.
+
+pub use crate::event_projection::{
+    RendererAgentEvent, RendererChatFrame, RendererChatMetadata, RendererModelIdentity,
+    RendererRefusal, RendererSequencedEvent, RendererToolFailure, RendererToolFailureCode,
+    RendererToolFailureReason, RendererToolStatus, RendererTurnUsage, TurnFailureCategory,
+};
+pub use crate::providers::ProviderKind;
+pub use crate::routes::{
+    AgentActivityHistoryItem, AgentActivityKind, AgentActivityOutcome, ApprovalGrantRung,
+};
+
+/// Guard sizes for the opaque strings a client draws from this surface.
+///
+/// A renderer validates what it is about to draw rather than trusting that the
+/// sender already clamped it, and a CLI bounds the same fields before it prints
+/// them. Both read these numbers: the renderer through the constants generated
+/// into `wire.ts`, the CLI directly.
+pub mod limits {
+    /// Longest opaque identifier a client accepts (call, turn, chat, run, and
+    /// workspace ids). Every id the server sends is a UUID, so the ceiling is
+    /// well above what a valid payload ever needs.
+    pub const MAX_WIRE_ID_CHARS: usize = 128;
+
+    /// Longest timestamp string a client accepts. RFC 3339 needs about 35.
+    pub const MAX_WIRE_TIMESTAMP_CHARS: usize = 64;
+
+    /// Longest opaque pagination cursor a client accepts.
+    pub const MAX_WIRE_CURSOR_CHARS: usize = 256;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wire_name<T: serde::Serialize>(value: &T) -> String {
+        serde_json::to_value(value)
+            .expect("a wire enum serializes")
+            .as_str()
+            .expect("a unit variant serializes as a string")
+            .to_owned()
+    }
+
+    /// `as_str` exists so a client can print a category without a serde round
+    /// trip; this is what keeps it from drifting from the wire spelling.
+    #[test]
+    fn turn_failure_category_names_match_the_wire() {
+        for category in [
+            TurnFailureCategory::RateLimited,
+            TurnFailureCategory::Auth,
+            TurnFailureCategory::ProviderAccess,
+            TurnFailureCategory::Transient,
+            TurnFailureCategory::Unknown,
+        ] {
+            assert_eq!(category.as_str(), wire_name(&category));
+        }
+    }
+
+    #[test]
+    fn activity_names_match_the_wire() {
+        for kind in [
+            AgentActivityKind::Exec,
+            AgentActivityKind::WebSearch,
+            AgentActivityKind::UpdateTaskPlan,
+            AgentActivityKind::ReadDelegatedFile,
+            AgentActivityKind::ListConnectedFolders,
+            AgentActivityKind::ListFolder,
+            AgentActivityKind::ReadConnectedFile,
+            AgentActivityKind::ImportConnectedFile,
+        ] {
+            assert_eq!(kind.as_str(), wire_name(&kind));
+        }
+        for outcome in [
+            AgentActivityOutcome::Waiting,
+            AgentActivityOutcome::Running,
+            AgentActivityOutcome::Completed,
+            AgentActivityOutcome::Failed,
+            AgentActivityOutcome::Cancelled,
+        ] {
+            assert_eq!(outcome.as_str(), wire_name(&outcome));
+        }
+    }
+
+    /// The limits bound what the server actually sends. A limit below a real
+    /// value would make every client reject valid payloads.
+    #[test]
+    fn limits_admit_what_the_server_sends() {
+        let id = serde_json::to_value(tidebreak_core::TurnId(uuid::Uuid::from_u128(1)))
+            .expect("an id serializes");
+        assert!(id.as_str().expect("ids are strings").chars().count() <= limits::MAX_WIRE_ID_CHARS);
+
+        let timestamp = serde_json::to_value(chrono::DateTime::<chrono::Utc>::from_timestamp(
+            1_756_700_000,
+            123_456_789,
+        ))
+        .expect("a timestamp serializes");
+        assert!(
+            timestamp
+                .as_str()
+                .expect("timestamps are strings")
+                .chars()
+                .count()
+                <= limits::MAX_WIRE_TIMESTAMP_CHARS
+        );
+    }
+
+    /// Unknown keys fail the frame, at every level a client decodes.
+    #[test]
+    fn frames_reject_unknown_keys() {
+        let event = r#"{"seq":1,"event":{"type":"text_delta","text":"hi"}}"#;
+        assert!(serde_json::from_str::<RendererChatFrame>(event).is_ok());
+        for malformed in [
+            r#"{"seq":1,"event":{"type":"text_delta","text":"hi"},"extra":1}"#,
+            r#"{"seq":1,"event":{"type":"text_delta","text":"hi","extra":1}}"#,
+            r#"{"metadata":"titled","title":"A chat","extra":1}"#,
+            r#"{"seq":1,"event":{"type":"turn_completed","usage":{"input_tokens":1,"output_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"extra":1}}}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<RendererChatFrame>(malformed).is_err(),
+                "should reject: {malformed}"
+            );
+        }
+    }
+
+    /// An event type this build does not know fails the frame rather than
+    /// folding to something a client would misread.
+    #[test]
+    fn unknown_event_types_fail_the_frame() {
+        let unknown = r#"{"seq":9,"event":{"type":"some_future_event"}}"#;
+        assert!(serde_json::from_str::<RendererChatFrame>(unknown).is_err());
+        let unknown_status = r#"{"seq":9,"event":{"type":"tool_call_completed","call_id":"00000000-0000-0000-0000-000000000003","status":"cancelled"}}"#;
+        assert!(serde_json::from_str::<RendererChatFrame>(unknown_status).is_err());
+    }
+}

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -126,6 +126,30 @@ pub(crate) mod generate {
         )
     }
 
+    /// The guard limits, emitted beside the generated types.
+    ///
+    /// The renderer bounds every opaque string it draws — ids, timestamps,
+    /// cursors — and the CLI bounds the same fields before printing them. The
+    /// numbers live in `crate::wire::limits` and are generated here so the two
+    /// clients cannot disagree about what a valid payload is.
+    pub(crate) fn render_wire_limits() -> String {
+        use crate::wire::limits::{
+            MAX_WIRE_CURSOR_CHARS, MAX_WIRE_ID_CHARS, MAX_WIRE_TIMESTAMP_CHARS,
+        };
+        format!(
+            "/**\n\
+             \x20* Guard limits shared with the server and the CLI, in code points.\n\
+             \x20*\n\
+             \x20* The decoders bound every opaque string they will draw. These are the\n\
+             \x20* ceilings, generated from `tidebreak_server::wire::limits` so every\n\
+             \x20* client applies the same numbers.\n\
+             \x20*/\n\
+             export const MAX_WIRE_ID_CHARS = {MAX_WIRE_ID_CHARS};\n\
+             export const MAX_WIRE_TIMESTAMP_CHARS = {MAX_WIRE_TIMESTAMP_CHARS};\n\
+             export const MAX_WIRE_CURSOR_CHARS = {MAX_WIRE_CURSOR_CHARS};\n"
+        )
+    }
+
     /// Render the generated module, header and all, so ordering and preamble are
     /// part of the diff a reviewer sees.
     pub(crate) fn render(declarations: &Declarations, trailing: &[String]) -> String {
@@ -499,7 +523,13 @@ mod tests {
             .get("RendererToolName")
             .expect("the vocabulary is reachable from the event root");
         let names = generate::tool_names_from_union(union);
-        generate::render(&declarations, &[generate::render_tool_name_list(&names)])
+        generate::render(
+            &declarations,
+            &[
+                generate::render_tool_name_list(&names),
+                generate::render_wire_limits(),
+            ],
+        )
     }
 
     /// The WebSocket frame types, which until now had no contract at all: the
@@ -937,6 +967,403 @@ mod tests {
                 "{expected} was not reached from the root; generated: {:?}",
                 declarations.keys().collect::<Vec<_>>()
             );
+        }
+    }
+
+    /// Path of the shared chat-frame fixtures, relative to this crate.
+    ///
+    /// JSON rather than TypeScript because three decoders read it: the
+    /// renderer's tests, the CLI's tests, and this crate's own round trip.
+    const CHAT_FRAMES: &str = "fixtures/chat-frames.json";
+
+    /// One real frame of every kind the socket can carry.
+    ///
+    /// Serialized from the server's own types, so a client test that decodes
+    /// every entry proves its decoder accepts what the server sends today — and
+    /// [`the_chat_frame_fixtures_cover_every_event`] proves the list cannot
+    /// silently fall behind the event union.
+    fn chat_frame_fixtures() -> Vec<(&'static str, serde_json::Value)> {
+        use crate::event_projection::{
+            RendererAgentEvent, RendererChatFrame, RendererChatMetadata, RendererModelIdentity,
+            RendererRefusal, RendererSequencedEvent, RendererToolFailure, RendererToolFailureCode,
+            RendererToolFailureReason, RendererToolStatus, RendererTurnUsage, TurnFailureCategory,
+        };
+        use tidebreak_core::{
+            ApprovalClass, CallId, MessageId, RendererToolName, ToolActionPreview,
+            ToolApprovalKind, ToolResultPreview, TurnId,
+        };
+
+        let turn = TurnId(id(0x10));
+        let call = CallId(id(0x11));
+        let usage = RendererTurnUsage {
+            input_tokens: 120,
+            output_tokens: 34,
+            cache_read_input_tokens: 800,
+            cache_creation_input_tokens: 0,
+        };
+        let exec_preview = ToolActionPreview::Exec {
+            command: "git".into(),
+            args: vec!["status".into()],
+            cwd: ".".into(),
+            files: Vec::new(),
+            summary: Some("Checking the repository status".into()),
+        };
+        let event = |seq: i64, event: RendererAgentEvent| {
+            RendererChatFrame::Event(Box::new(RendererSequencedEvent {
+                seq,
+                event,
+                replayed: None,
+            }))
+        };
+        let frames: Vec<(&'static str, RendererChatFrame)> = vec![
+            (
+                "turn_started",
+                event(1, RendererAgentEvent::TurnStarted { turn_id: turn }),
+            ),
+            (
+                "text_delta",
+                event(
+                    2,
+                    RendererAgentEvent::TextDelta {
+                        text: "Hello".into(),
+                    },
+                ),
+            ),
+            (
+                "reasoning_delta",
+                event(
+                    3,
+                    RendererAgentEvent::ReasoningDelta {
+                        text: "Considering the request".into(),
+                    },
+                ),
+            ),
+            (
+                "stream_interrupted",
+                event(4, RendererAgentEvent::StreamInterrupted),
+            ),
+            (
+                "tool_call_started",
+                event(
+                    5,
+                    RendererAgentEvent::ToolCallStarted {
+                        call_id: call,
+                        name: RendererToolName::Exec,
+                    },
+                ),
+            ),
+            (
+                "tool_call_args_delta",
+                event(6, RendererAgentEvent::ToolCallArgsDelta { call_id: call }),
+            ),
+            (
+                "user_questions_asked",
+                event(
+                    7,
+                    RendererAgentEvent::UserQuestionsAsked {
+                        call_id: call,
+                        turn_id: turn,
+                    },
+                ),
+            ),
+            (
+                "plan_proposed",
+                event(
+                    8,
+                    RendererAgentEvent::PlanProposed {
+                        call_id: call,
+                        turn_id: turn,
+                    },
+                ),
+            ),
+            (
+                "task_plan_updated",
+                event(
+                    9,
+                    RendererAgentEvent::TaskPlanUpdated {
+                        call_id: call,
+                        turn_id: turn,
+                    },
+                ),
+            ),
+            (
+                "approval_required",
+                event(
+                    10,
+                    RendererAgentEvent::ApprovalRequired {
+                        call_id: call,
+                        action: RendererToolName::Exec,
+                        approval: ToolApprovalKind::ExecMayRunNetworkedCommand,
+                        class: ApprovalClass::Sensitive,
+                        auto_judging: false,
+                        grant_rungs: vec![
+                            crate::routes::ApprovalGrantRung::ExactAction,
+                            crate::routes::ApprovalGrantRung::CommandPrefix { tokens: 1 },
+                            crate::routes::ApprovalGrantRung::WholeTool,
+                        ],
+                        preview: Some(exec_preview.clone()),
+                    },
+                ),
+            ),
+            (
+                "approval_required_without_preview",
+                event(
+                    11,
+                    RendererAgentEvent::ApprovalRequired {
+                        call_id: call,
+                        action: RendererToolName::Other,
+                        approval: ToolApprovalKind::Unsupported,
+                        class: ApprovalClass::Sensitive,
+                        auto_judging: true,
+                        grant_rungs: Vec::new(),
+                        preview: None,
+                    },
+                ),
+            ),
+            (
+                "approval_decided",
+                event(
+                    12,
+                    RendererAgentEvent::ApprovalDecided {
+                        call_id: call,
+                        approved: true,
+                    },
+                ),
+            ),
+            (
+                "tool_call_completed",
+                event(
+                    13,
+                    RendererAgentEvent::ToolCallCompleted {
+                        call_id: call,
+                        status: RendererToolStatus::Completed,
+                        failure: None,
+                        action: Some(exec_preview),
+                        result: Some(ToolResultPreview::Exec {
+                            exit_code: Some(0),
+                            timed_out: false,
+                            output_truncated: false,
+                            stdout: "ok\n".into(),
+                            stderr: String::new(),
+                            images: Vec::new(),
+                            outputs: Vec::new(),
+                            degraded: None,
+                            backend: None,
+                        }),
+                    },
+                ),
+            ),
+            (
+                "tool_call_completed_with_failure",
+                event(
+                    14,
+                    RendererAgentEvent::ToolCallCompleted {
+                        call_id: call,
+                        status: RendererToolStatus::Failed,
+                        failure: Some(RendererToolFailure {
+                            code: RendererToolFailureCode::ExecutorUnavailable,
+                            reason: RendererToolFailureReason::LeaseExpired,
+                        }),
+                        action: None,
+                        result: None,
+                    },
+                ),
+            ),
+            (
+                "turn_completed",
+                event(15, RendererAgentEvent::TurnCompleted { usage }),
+            ),
+            (
+                "turn_refused",
+                event(
+                    16,
+                    RendererAgentEvent::TurnRefused {
+                        refusal: RendererRefusal {
+                            category: Some("safety".into()),
+                            partial_output: true,
+                        },
+                        usage,
+                    },
+                ),
+            ),
+            (
+                "turn_failed",
+                event(
+                    17,
+                    RendererAgentEvent::TurnFailed {
+                        category: TurnFailureCategory::RateLimited,
+                        detail: Some("rate limited; retry after 30s".into()),
+                        model: Some(RendererModelIdentity {
+                            id: "claude-opus-4-8".into(),
+                            provider: crate::providers::ProviderKind::Anthropic,
+                        }),
+                    },
+                ),
+            ),
+            (
+                "turn_failed_without_detail",
+                event(
+                    18,
+                    RendererAgentEvent::TurnFailed {
+                        category: TurnFailureCategory::Unknown,
+                        detail: None,
+                        model: None,
+                    },
+                ),
+            ),
+            (
+                "turn_cancelled",
+                event(19, RendererAgentEvent::TurnCancelled { usage }),
+            ),
+            (
+                "user_steered",
+                event(
+                    20,
+                    RendererAgentEvent::UserSteered {
+                        message_id: MessageId(id(0x12)),
+                        text: "Focus on the tests".into(),
+                    },
+                ),
+            ),
+            (
+                "context_truncated",
+                event(
+                    21,
+                    RendererAgentEvent::ContextTruncated {
+                        original_tokens: 180_000,
+                        fitted_tokens: 120_000,
+                    },
+                ),
+            ),
+            (
+                "compaction_started",
+                event(22, RendererAgentEvent::CompactionStarted),
+            ),
+            (
+                "compaction_finished",
+                event(
+                    23,
+                    RendererAgentEvent::CompactionFinished { compacted: true },
+                ),
+            ),
+            ("event_omitted", event(24, RendererAgentEvent::EventOmitted)),
+            (
+                "replayed_event",
+                RendererChatFrame::Event(Box::new(RendererSequencedEvent {
+                    seq: 25,
+                    event: RendererAgentEvent::TextDelta {
+                        text: "from catch-up".into(),
+                    },
+                    replayed: Some(true),
+                })),
+            ),
+            (
+                "metadata_titled",
+                RendererChatFrame::Metadata(RendererChatMetadata::Titled {
+                    title: "A chat".into(),
+                }),
+            ),
+            (
+                "metadata_file_changes_recorded",
+                RendererChatFrame::Metadata(RendererChatMetadata::FileChangesRecorded {
+                    turn_id: turn,
+                }),
+            ),
+            (
+                "metadata_sandbox_preparing",
+                RendererChatFrame::Metadata(RendererChatMetadata::SandboxPreparing {
+                    preparing: true,
+                }),
+            ),
+        ];
+        frames
+            .into_iter()
+            .map(|(name, frame)| {
+                (
+                    name,
+                    serde_json::to_value(&frame).expect("a chat frame serializes"),
+                )
+            })
+            .collect()
+    }
+
+    /// The checked-in fixture file: a JSON array of `{ "name", "frame" }`.
+    fn rendered_chat_frames() -> String {
+        let entries = chat_frame_fixtures()
+            .into_iter()
+            .map(|(name, frame)| serde_json::json!({ "name": name, "frame": frame }))
+            .collect::<Vec<_>>();
+        let mut rendered =
+            serde_json::to_string_pretty(&entries).expect("the fixture list serializes");
+        rendered.push('\n');
+        rendered
+    }
+
+    /// Three decoders read these bytes — the renderer's, the CLI's, and this
+    /// crate's own. A diff here means the socket's shape changed, and every
+    /// client test that consumes the file re-runs against the new shape.
+    #[test]
+    fn the_chat_frame_fixtures_are_current() {
+        generate::check_or_update(CHAT_FRAMES, &rendered_chat_frames(), REGENERATE);
+    }
+
+    /// Every event variant the generated union declares has a fixture, read
+    /// from the generated declaration rather than a hand-kept list so a new
+    /// variant fails here until it has one.
+    #[test]
+    fn the_chat_frame_fixtures_cover_every_event() {
+        let declarations = event_declarations();
+        let union = &declarations["RendererAgentEvent"];
+        let declared: std::collections::BTreeSet<String> = union
+            .split("\"type\": \"")
+            .skip(1)
+            .map(|rest| rest.split('"').next().expect("a closed tag").to_owned())
+            .collect();
+        assert!(
+            declared.len() > 10,
+            "the union parse found too few tags: {declared:?}"
+        );
+        let covered: std::collections::BTreeSet<String> = chat_frame_fixtures()
+            .iter()
+            .filter_map(|(_, frame)| frame.get("event"))
+            .filter_map(|event| event.get("type"))
+            .filter_map(|tag| tag.as_str())
+            .map(str::to_owned)
+            .collect();
+        let missing: Vec<_> = declared.difference(&covered).collect();
+        assert!(
+            missing.is_empty(),
+            "event types without a chat-frame fixture: {missing:?}"
+        );
+        let metadata: std::collections::BTreeSet<String> = chat_frame_fixtures()
+            .iter()
+            .filter_map(|(_, frame)| frame.get("metadata"))
+            .filter_map(|tag| tag.as_str())
+            .map(str::to_owned)
+            .collect();
+        let declared_metadata: std::collections::BTreeSet<String> = declarations
+            ["RendererChatMetadata"]
+            .split("\"metadata\": \"")
+            .skip(1)
+            .map(|rest| rest.split('"').next().expect("a closed tag").to_owned())
+            .collect();
+        let missing: Vec<_> = declared_metadata.difference(&metadata).collect();
+        assert!(
+            missing.is_empty(),
+            "metadata kinds without a chat-frame fixture: {missing:?}"
+        );
+    }
+
+    /// The server's own round trip: every fixture decodes through the public
+    /// wire types and serializes back to the same bytes, so a field that only
+    /// serializes, or only deserializes, shows up here rather than in a client.
+    #[test]
+    fn every_chat_frame_fixture_round_trips() {
+        for (name, frame) in chat_frame_fixtures() {
+            let decoded: crate::wire::RendererChatFrame = serde_json::from_value(frame.clone())
+                .unwrap_or_else(|error| panic!("fixture {name} does not decode: {error}"));
+            let again = serde_json::to_value(&decoded).expect("a decoded frame serializes");
+            assert_eq!(again, frame, "fixture {name} changed across the round trip");
         }
     }
 }

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -115,6 +115,38 @@ worth knowing before adding types.
   test, and the resulting per-id build warning is silenced by the
   `no-serde-warnings` feature.
 
+## The CLI reads the same types
+
+The CLI is the third consumer of this JSON, and it used to keep its own
+hand-written mirror of the event socket in `tidebreak-cli/src/api/wire.rs`.
+Nothing tied that mirror to the server either, so a renamed field compiled on
+both sides and failed when the CLI next followed a turn.
+
+The socket's frame, event, metadata, and status types are now imported from
+`tidebreak_server::wire`, the one public module a Rust client reads the
+contract from. A rename is a compile error in the CLI the way it is a type error
+in the renderer. The module documents the strictness that comes with it:
+closed vocabularies, unknown keys rejected (`deny_unknown_fields`, matching the
+renderer's `onlyKeys` guards), and an unknown event type failing its frame.
+
+Two more things are shared through it:
+
+- **Guard limits.** `tidebreak_server::wire::limits` holds the id, timestamp,
+  and cursor ceilings. They are generated into `wire.ts` as constants, and
+  `lib/wireDecode.ts` re-exports them, so the renderer and the CLI cannot apply
+  different numbers.
+- **Chat-frame fixtures.** `crates/tidebreak-server/fixtures/chat-frames.json`
+  is one real frame of every kind the socket carries, serialized from the
+  server's own types by the same generator test (a variant without a fixture
+  fails `the_chat_frame_fixtures_cover_every_event`). The server round-trips
+  it, the CLI decodes every entry, and the renderer runs every entry through
+  its session reducer and metadata guard. A shape change shows up as a failing
+  test on whichever side did not follow it.
+
+The REST records the CLI reads (models, providers, MCP servers, agent runs,
+outputs) are still hand-written mirrors, because their server types only
+serialize today. Moving them is brightwave-inc/tidebreak#3005.
+
 ## Scope today
 
 **Generated: the whole renderer surface.** The WebSocket frame and event union, the


### PR DESCRIPTION
Closes #2978.

The CLI kept a third, hand-written mirror of the chat event socket in `tidebreak-cli/src/api/wire.rs`, next to the server's Rust types and the renderer's generated `wire.ts`. Nothing tied the mirror to the server, so a renamed field compiled on both sides and failed the next time the CLI followed a turn.

## What changed

**One source of truth.** `tidebreak_server::wire` is a new public module that re-exports the renderer projection types (`RendererChatFrame`, `RendererAgentEvent`, `RendererChatMetadata`, statuses, failure categories), `ApprovalGrantRung`, and the agent-activity history types. The CLI imports those instead of redeclaring them: `event_stream`, print mode, `agent-mcp` follow, and the driver protocol now decode and emit the server's own enums (`RendererToolName`, `ToolApprovalKind`, `ToolActionPreview`), so a rename is a compile error in the CLI the way it is a type error in the renderer. Pending plans and question blocks decode as `tidebreak_core::PendingPlanApproval` / `PendingUserQuestions`, chats as `tidebreak_core::Chat`.

**Strictness.** The projection types carry `deny_unknown_fields`, matching the renderer's `onlyKeys` guards, and every vocabulary is the server's closed enum. An unknown event type now fails its frame rather than folding to an `Unknown` variant; the CLI drops that frame and does not advance its cursor past it. The module doc on `wire.rs` records why the CLI accepts that trade for a version-skewed attach.

**Shared guard limits.** `tidebreak_server::wire::limits` holds the id, timestamp, and cursor ceilings. They are generated into `wire.ts` as constants and `lib/wireDecode.ts` re-exports them; the CLI applies the timestamp bound to the output records that still arrive as preformatted strings.

**Fixtures read from three sides.** `crates/tidebreak-server/fixtures/chat-frames.json` is one real frame of every kind the socket carries, serialized by the same generator test that writes `wire.ts` (`UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server`). A variant without a fixture fails `the_chat_frame_fixtures_cover_every_event`, which reads the tags out of the generated union. The server round-trips every entry, the CLI decodes every entry byte for byte, and the renderer runs every entry through `reduceChatSessionEvent` and the metadata guard.

`as_str` helpers were added to `RendererToolName`, `TurnFailureCategory`, `AgentActivityKind`, and `AgentActivityOutcome` so the CLI can print them; each is pinned to the serde spelling by a test.

## Left out

The REST records the CLI reads (models, providers, MCP servers, agent runs, outputs) are still hand-written mirrors because their server types only serialize today. Filed as #3005.

## Verification

- `cargo clippy -p tidebreak-core -p tidebreak-server -p tidebreak-cli --all-targets --no-deps -- -D warnings`: clean.
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --lib wire`: 29 passed, regenerated `wire.ts` and the new fixture file; the plain run compares clean.
- `cargo test -p tidebreak-core --lib renderer_tool`, `cargo test -p tidebreak-cli`: pass. One `serve.rs` fixture test (`settings_show_reports_unavailable_hosted_credential_storage`) timed out once under the parallel run and passed alone; it does not touch the socket decoder.
- Desktop UI: `biome format src`, `biome lint src`, `vitest run`, `tsc`, `vite build`: clean.
