### PR TITLE
feat(code): host the internal engine behind the adapter contract

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -150,11 +150,21 @@ pub enum HarnessKind {
     Opencode,
     /// Grok CLI.
     Grok,
+    /// Tidebreak's own agent loop, run in-process behind the same adapter
+    /// contract as the external engines (decision 0048 step 5). A session
+    /// with no workspace selects it.
+    Internal,
 }
 
 impl HarnessKind {
     /// Every known engine, in adapter-tier order.
-    pub const ALL: &'static [Self] = &[Self::ClaudeCode, Self::Codex, Self::Opencode, Self::Grok];
+    pub const ALL: &'static [Self] = &[
+        Self::ClaudeCode,
+        Self::Codex,
+        Self::Opencode,
+        Self::Grok,
+        Self::Internal,
+    ];
 
     /// Stable database and wire token.
     #[must_use]
@@ -164,6 +174,7 @@ impl HarnessKind {
             Self::Codex => "codex",
             Self::Opencode => "opencode",
             Self::Grok => "grok",
+            Self::Internal => "internal",
         }
     }
 
@@ -185,7 +196,16 @@ impl HarnessKind {
             Self::Codex => HarnessTier::Secondary,
             Self::Opencode => HarnessTier::Tertiary,
             Self::Grok => HarnessTier::BestEffort,
+            Self::Internal => HarnessTier::Reference,
         }
+    }
+
+    /// Whether this engine runs inside the server process and spawns no
+    /// child. Such an engine probes as found with no binary, needs no pin,
+    /// and takes its inference from the server's own provider resolution.
+    #[must_use]
+    pub const fn is_in_process(self) -> bool {
+        matches!(self, Self::Internal)
     }
 }
 
@@ -1228,10 +1248,11 @@ pub fn bound_subagents(subagents: &mut Vec<CodeSubagentSummary>) {
 pub struct CodeSession {
     /// Stable id.
     pub id: CodeSessionId,
-    /// Principal this session belongs to, denormalized from its workspace.
+    /// Principal this session belongs to.
     pub owner: crate::OwnerId,
-    /// Owning workspace.
-    pub workspace_id: WorkspaceId,
+    /// Owning workspace, or `None` for a conversation with no repo-backed
+    /// workspace: one the in-process engine hosts (decision 0048 step 5).
+    pub workspace_id: Option<WorkspaceId>,
     /// Why the session exists: user conversation or watch task.
     pub kind: CodeSessionKind,
     /// Engine this session is bound to.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -101,6 +101,10 @@ pub mod chat {
         pub attachment_revision: i64,
         pub created_at: DateTimeUtc,
         pub owner: String,
+        /// True when the in-process engine owns this row as the durable
+        /// state behind a code session. Owner-scoped reads never see it:
+        /// the conversation is reachable only through its session.
+        pub engine_private: bool,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -1790,7 +1794,9 @@ pub mod code_session {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
         pub owner: String,
-        pub workspace_id: Uuid,
+        /// `None` for a session with no repo-backed workspace: one the
+        /// in-process engine hosts (decision 0048 step 5).
+        pub workspace_id: Option<Uuid>,
         pub kind: String,
         pub harness_kind: String,
         pub harness_version: Option<String>,

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -67,6 +67,7 @@ impl MigratorTrait for Migrator {
             Box::new(CodeExternalGrants),
             Box::new(CodeConnectHandshakes),
             Box::new(CodeTurnPark),
+            Box::new(InternalEngineSessions),
         ]
     }
 }
@@ -3570,6 +3571,222 @@ async fn rebuild_sqlite_code_turn_for_parks(_manager: &SchemaManager<'_>) -> Res
     ))
 }
 
+/// Sessions without a workspace and the engine-private conversation behind
+/// them (decision 0048 step 5): the in-process engine hosts a code session
+/// that binds no repo-backed workspace, and keeps its durable state in a
+/// `chat` row that owner-scoped reads never list.
+struct InternalEngineSessions;
+
+impl MigrationName for InternalEngineSessions {
+    fn name(&self) -> &str {
+        "m20260901_000002_internal_engine_sessions"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for InternalEngineSessions {
+    fn use_transaction(&self) -> Option<bool> {
+        // The SQLite branch rebuilds `code_session` under a manually managed
+        // transaction with foreign keys disabled; PostgreSQL runs its own.
+        None
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Both changes land together, so the chat column is the marker for
+        // the whole migration.
+        if manager.has_column("chat", "engine_private").await? {
+            return Ok(());
+        }
+        match manager.get_database_backend() {
+            DbBackend::Postgres => {
+                let transaction = manager.begin().await?;
+                transaction
+                    .get_connection()
+                    .execute_unprepared(
+                        r#"
+ALTER TABLE "code_session" ALTER COLUMN "workspace_id" DROP NOT NULL;
+ALTER TABLE "chat" ADD COLUMN "engine_private" boolean NOT NULL DEFAULT FALSE;
+"#,
+                    )
+                    .await?;
+                transaction.commit().await
+            }
+            DbBackend::Sqlite => {
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        r#"ALTER TABLE "chat" ADD COLUMN "engine_private" boolean NOT NULL DEFAULT FALSE"#,
+                    )
+                    .await?;
+                rebuild_sqlite_code_session_without_workspace(manager).await
+            }
+            backend => Err(DbErr::Custom(format!(
+                "unsupported database backend for internal engine session migration: {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // A downgrade keeps the nullable column and the marker; a
+        // workspace-less session would otherwise become unreadable.
+        Ok(())
+    }
+}
+
+/// SQLite cannot drop `NOT NULL` in place. Rebuild `code_session` from its
+/// own stored definition with that one constraint removed, so every column a
+/// prior migration appended survives verbatim, then restore its indexes.
+#[cfg(feature = "sqlite")]
+async fn rebuild_sqlite_code_session_without_workspace(
+    manager: &SchemaManager<'_>,
+) -> Result<(), DbErr> {
+    use sea_orm::sqlx::Acquire as _;
+    use sea_orm::sqlx::Row as _;
+    use sea_orm::DatabaseExecutor;
+
+    const TABLE: &str = "code_session";
+    const REBUILD: &str = "code_session_rebuild";
+    const COLUMN: &str = "workspace_id";
+
+    let DatabaseExecutor::Connection(database) = manager.get_connection() else {
+        return Err(DbErr::Custom(
+            "SQLite session rebuild requires the migration connection".to_owned(),
+        ));
+    };
+    let mut connection = database
+        .get_sqlite_connection_pool()
+        .acquire()
+        .await
+        .map_err(|error| DbErr::Custom(format!("acquire SQLite migration connection: {error}")))?;
+
+    let create: String = sea_orm::sqlx::query_scalar(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+    )
+    .bind(TABLE)
+    .fetch_one(&mut *connection)
+    .await
+    .map_err(|error| DbErr::Custom(format!("read SQLite {TABLE} definition: {error}")))?;
+    let constrained = format!("\"{COLUMN}\" uuid_text NOT NULL");
+    let relaxed = format!("\"{COLUMN}\" uuid_text");
+    if !create.contains(&constrained) {
+        return Err(DbErr::Custom(format!(
+            "SQLite {TABLE} definition does not declare {COLUMN} NOT NULL as expected"
+        )));
+    }
+    let create = create.replacen(&constrained, &relaxed, 1).replacen(
+        &format!("CREATE TABLE \"{TABLE}\""),
+        &format!("CREATE TABLE \"{REBUILD}\""),
+        1,
+    );
+    if !create.starts_with(&format!("CREATE TABLE \"{REBUILD}\"")) {
+        return Err(DbErr::Custom(format!(
+            "SQLite {TABLE} definition has an unexpected shape"
+        )));
+    }
+    let indexes: Vec<String> = sea_orm::sqlx::query_scalar(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = ? \
+         AND sql IS NOT NULL ORDER BY name",
+    )
+    .bind(TABLE)
+    .fetch_all(&mut *connection)
+    .await
+    .map_err(|error| DbErr::Custom(format!("read SQLite {TABLE} indexes: {error}")))?;
+    let columns: Vec<String> = sea_orm::sqlx::query(sea_orm::sqlx::AssertSqlSafe(format!(
+        "PRAGMA table_info(\"{TABLE}\")"
+    )))
+    .fetch_all(&mut *connection)
+    .await
+    .map_err(|error| DbErr::Custom(format!("read SQLite {TABLE} columns: {error}")))?
+    .into_iter()
+    .map(|row| row.try_get::<String, _>("name"))
+    .collect::<Result<_, _>>()
+    .map_err(|error| DbErr::Custom(format!("read SQLite {TABLE} column names: {error}")))?;
+    let column_list = columns
+        .iter()
+        .map(|name| format!("\"{name}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    sea_orm::sqlx::query("PRAGMA foreign_keys = OFF")
+        .execute(&mut *connection)
+        .await
+        .map_err(|error| DbErr::Custom(format!("disable SQLite foreign keys: {error}")))?;
+    let mut transaction = connection
+        .begin()
+        .await
+        .map_err(|error| DbErr::Custom(format!("begin SQLite session rebuild: {error}")))?;
+    let rebuild = async {
+        let mut statements = vec![
+            format!("DROP TABLE IF EXISTS \"{REBUILD}\""),
+            create,
+            format!(
+                "INSERT INTO \"{REBUILD}\" ({column_list}) SELECT {column_list} FROM \"{TABLE}\""
+            ),
+            format!("DROP TABLE \"{TABLE}\""),
+            format!("ALTER TABLE \"{REBUILD}\" RENAME TO \"{TABLE}\""),
+        ];
+        statements.extend(indexes);
+        for statement in statements {
+            sea_orm::sqlx::query(sea_orm::sqlx::AssertSqlSafe(statement))
+                .execute(&mut *transaction)
+                .await?;
+        }
+        Ok::<(), sea_orm::sqlx::Error>(())
+    }
+    .await;
+    let rebuild = match rebuild {
+        Ok(()) => transaction
+            .commit()
+            .await
+            .map_err(|error| DbErr::Custom(format!("commit SQLite session rebuild: {error}"))),
+        Err(error) => match transaction.rollback().await {
+            Ok(()) => Err(DbErr::Custom(format!(
+                "rebuild SQLite session table without a workspace: {error}"
+            ))),
+            Err(rollback) => Err(DbErr::Custom(format!(
+                "rebuild SQLite session table without a workspace: {error}; rollback failed: {rollback}"
+            ))),
+        },
+    };
+    let enable = match sea_orm::sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(&mut *connection)
+        .await
+    {
+        Ok(_) => {
+            sea_orm::sqlx::query_scalar::<_, i64>("PRAGMA foreign_keys")
+                .fetch_one(&mut *connection)
+                .await
+        }
+        Err(error) => Err(error),
+    }
+    .map_err(|error| DbErr::Custom(format!("restore SQLite foreign keys: {error}")))
+    .and_then(|enabled| {
+        if enabled == 1 {
+            Ok(())
+        } else {
+            Err(DbErr::Custom(
+                "restore SQLite foreign keys: PRAGMA remained disabled".to_owned(),
+            ))
+        }
+    });
+    match (rebuild, enable) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(rebuild), Err(enable)) => {
+            Err(DbErr::Custom(format!("{rebuild}; additionally, {enable}")))
+        }
+    }
+}
+
+#[cfg(not(feature = "sqlite"))]
+async fn rebuild_sqlite_code_session_without_workspace(
+    _manager: &SchemaManager<'_>,
+) -> Result<(), DbErr> {
+    Err(DbErr::Custom(
+        "SQLite internal engine session migration support is not compiled".to_owned(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
@@ -3648,6 +3865,7 @@ mod tests {
                 "m20260828_000027_code_external_grants",
                 "m20260828_000028_code_connect_handshakes",
                 "m20260901_000001_code_turn_park",
+                "m20260901_000002_internal_engine_sessions",
             ]
         );
         assert!(db
@@ -3675,8 +3893,9 @@ mod tests {
             .unwrap()
             .is_some());
 
-        // Two steps: the turn park migration sits above the handshake one.
-        Migrator::down(&db, Some(2)).await.unwrap();
+        // Three steps: the turn park and internal engine session migrations
+        // sit above the handshake one.
+        Migrator::down(&db, Some(3)).await.unwrap();
         assert!(db
             .query_one_raw(Statement::from_string(
                 DbBackend::Sqlite,

--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -698,6 +698,10 @@ impl Store for DbStore {
         ops::conversation::create_chat(self, chat, Some(owner)).await
     }
 
+    async fn create_engine_private_chat(&self, owner: &OwnerId, chat: &Chat) -> Result<()> {
+        ops::conversation::create_engine_private_chat(self, chat, owner).await
+    }
+
     async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat> {
         ops::conversation::create_chat_with_project_defaults(self, chat, None, &[]).await
     }

--- a/crates/tidebreak-core/src/db/ops/approval.rs
+++ b/crates/tidebreak-core/src/db/ops/approval.rs
@@ -128,6 +128,7 @@ fn owned_grants_condition(owner: &OwnerId) -> sea_orm::Condition {
         .column(entities::chat::Column::Id)
         .from(entities::chat::Entity)
         .and_where(entities::chat::Column::Owner.eq(owner.as_str()))
+        .and_where(entities::chat::Column::EnginePrivate.eq(false))
         .to_owned();
     let owned_projects = sea_orm::sea_query::Query::select()
         .column(entities::project::Column::Id)

--- a/crates/tidebreak-core/src/db/ops/chat_attention.rs
+++ b/crates/tidebreak-core/src/db/ops/chat_attention.rs
@@ -72,6 +72,7 @@ pub(in crate::db) async fn chat_attention(
         .map_err(store_err)?;
     let owned = entities::chat::Entity::find()
         .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+        .filter(entities::chat::Column::EnginePrivate.eq(false))
         .all(&store.conn)
         .await
         .map_err(store_err)?

--- a/crates/tidebreak-core/src/db/ops/chat_image_publication.rs
+++ b/crates/tidebreak-core/src/db/ops/chat_image_publication.rs
@@ -47,6 +47,7 @@ pub(in crate::db) async fn publish(
     if let Some(owner) = owner {
         let owned = entities::chat::Entity::find_by_id(chat_id.0)
             .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .filter(entities::chat::Column::EnginePrivate.eq(false))
             .one(&transaction)
             .await
             .map_err(store_err)?

--- a/crates/tidebreak-core/src/db/ops/chat_prompt.rs
+++ b/crates/tidebreak-core/src/db/ops/chat_prompt.rs
@@ -41,6 +41,7 @@ pub(in crate::db) async fn list_pending_chat_prompts(
         Some(owner) => Some(
             entities::chat::Entity::find()
                 .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+                .filter(entities::chat::Column::EnginePrivate.eq(false))
                 .all(&store.conn)
                 .await
                 .map_err(store_err)?

--- a/crates/tidebreak-core/src/db/ops/code/approval.rs
+++ b/crates/tidebreak-core/src/db/ops/code/approval.rs
@@ -227,6 +227,47 @@ pub async fn settle_approval_claim(
     .await
 }
 
+/// Settle a pending approval the engine decided on its own channel — a
+/// standing grant or an auto-approval judge answered before any route did —
+/// and append its matching event.
+///
+/// Only an unclaimed pending row with this engine-native call id on this
+/// session settles; a row a decide route already claimed belongs to that
+/// route. `None` when nothing matched.
+pub async fn settle_engine_observed_approval(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    worker_epoch: i64,
+    native_call_id: &str,
+    decision: ApprovalDecisionKind,
+    decided_at: chrono::DateTime<chrono::Utc>,
+) -> Result<Option<ApprovalSettlement>> {
+    let Some(row) = entities::code_approval::Entity::find()
+        .filter(entities::code_approval::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_approval::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_approval::Column::NativeCallId.eq(native_call_id))
+        .filter(entities::code_approval::Column::State.eq(CodeApprovalState::Pending.as_str()))
+        .filter(entities::code_approval::Column::DecisionClaim.is_null())
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    settle_approval(
+        store,
+        owner,
+        CodeApprovalId(row.id),
+        session_id,
+        worker_epoch,
+        ApprovalClaim::Unclaimed,
+        decision,
+        decided_at,
+    )
+    .await
+}
+
 /// Abandon one unclaimed pending approval and append its matching event.
 pub async fn abandon_pending_approval(
     store: &DbStore,

--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -102,8 +102,14 @@ async fn append_event_inner(
                 session.id, session.kind
             ))
         })?;
-        if crate::code_session_mints_notification(session_kind) {
-            let workspace_id = WorkspaceId(session.workspace_id);
+        // A session with no workspace mints no notification yet: the record
+        // names the workspace the turn ran in, and one without a workspace
+        // has nothing to name until the entity merge reshapes it.
+        if let Some(workspace_id) = session
+            .workspace_id
+            .map(WorkspaceId)
+            .filter(|_| crate::code_session_mints_notification(session_kind))
+        {
             let workspace_title = entities::code_workspace::Entity::find_by_id(workspace_id.0)
                 .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
                 .one(&transaction)

--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -71,7 +71,7 @@ where
     entities::code_session::ActiveModel {
         id: Set(session.id.0),
         owner: Set(session.owner.as_str().to_owned()),
-        workspace_id: Set(session.workspace_id.0),
+        workspace_id: Set(session.workspace_id.map(|workspace| workspace.0)),
         kind: Set(session.kind.as_str().to_owned()),
         harness_kind: Set(session.harness_kind.as_str().to_owned()),
         harness_version: Set(session.harness_version.clone()),
@@ -1079,7 +1079,7 @@ pub(super) fn session_from_row(row: entities::code_session::Model) -> Result<Cod
     Ok(CodeSession {
         id: CodeSessionId(row.id),
         owner: OwnerId::new(&row.owner)?,
-        workspace_id: WorkspaceId(row.workspace_id),
+        workspace_id: row.workspace_id.map(WorkspaceId),
         kind,
         harness_kind,
         harness_version: row.harness_version,

--- a/crates/tidebreak-core/src/db/ops/conversation.rs
+++ b/crates/tidebreak-core/src/db/ops/conversation.rs
@@ -113,10 +113,31 @@ pub(in crate::db) async fn create_chat(
     chat: &Chat,
     owner: Option<&OwnerId>,
 ) -> Result<()> {
+    create_chat_inner(store, chat, owner, false).await
+}
+
+/// Create the conversation the in-process engine keeps behind one code
+/// session. The row is the engine's durable state, not a conversation of
+/// the owner's: every owner-scoped chat read excludes it, so it is reachable
+/// only through the session that owns it (decision 0048 step 5).
+pub(in crate::db) async fn create_engine_private_chat(
+    store: &DbStore,
+    chat: &Chat,
+    owner: &OwnerId,
+) -> Result<()> {
+    create_chat_inner(store, chat, Some(owner), true).await
+}
+
+async fn create_chat_inner(
+    store: &DbStore,
+    chat: &Chat,
+    owner: Option<&OwnerId>,
+    engine_private: bool,
+) -> Result<()> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
     let project_roots = load_chat_project_roots(&transaction, chat.project_id, owner).await?;
     validate_chat_attachments(chat, &project_roots)?;
-    insert_chat_on(&transaction, chat, owner).await?;
+    insert_chat_on(&transaction, chat, owner, engine_private).await?;
     insert_foreground_agent_run_on(&transaction, chat.id, chat.created_at).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(())
@@ -147,7 +168,7 @@ pub(in crate::db) async fn create_chat_with_project_defaults(
         chat.attachment_revision = 1;
     }
     validate_chat_root_projection(&chat).map_err(|message| AgentError::Store(message.into()))?;
-    insert_chat_on(&transaction, &chat, owner).await?;
+    insert_chat_on(&transaction, &chat, owner, false).await?;
     insert_foreground_agent_run_on(&transaction, chat.id, chat.created_at).await?;
     for (key, value) in settings {
         entities::setting::Entity::insert(entities::setting::ActiveModel {
@@ -198,12 +219,18 @@ where
     Ok(project_from_models(model, roots)?.root_attachments)
 }
 
-async fn insert_chat_on<C>(conn: &C, chat: &Chat, owner: Option<&OwnerId>) -> Result<()>
+async fn insert_chat_on<C>(
+    conn: &C,
+    chat: &Chat,
+    owner: Option<&OwnerId>,
+    engine_private: bool,
+) -> Result<()>
 where
     C: ConnectionTrait,
 {
     entities::chat::ActiveModel {
         id: Set(chat.id.0),
+        engine_private: Set(engine_private),
         project_id: Set(chat.project_id.map(|p| p.0)),
         title: Set(chat.title.clone()),
         model: Set(chat.model.clone()),
@@ -290,7 +317,9 @@ pub(in crate::db) async fn move_chat_to_project(
     // (#853). The owner cannot change under the write lock above.
     let mut query = entities::chat::Entity::find_by_id(id.0);
     if let Some(owner) = owner {
-        query = query.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+        query = query
+            .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .filter(entities::chat::Column::EnginePrivate.eq(false));
     }
     let Some(model) = query.one(&transaction).await.map_err(store_err)? else {
         transaction.rollback().await.map_err(store_err)?;
@@ -461,7 +490,9 @@ pub(in crate::db) async fn update_chat_metadata(
     {
         let mut query = entities::chat::Entity::find_by_id(id.0);
         if let Some(owner) = owner {
-            query = query.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+            query = query
+                .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+                .filter(entities::chat::Column::EnginePrivate.eq(false));
         }
         return Ok(query.one(&store.conn).await.map_err(store_err)?.is_some());
     }
@@ -504,7 +535,9 @@ pub(in crate::db) async fn update_chat_metadata(
     }
     let mut update = update.filter(entities::chat::Column::Id.eq(id.0));
     if let Some(owner) = owner {
-        update = update.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+        update = update
+            .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .filter(entities::chat::Column::EnginePrivate.eq(false));
     }
     let result = update.exec(&store.conn).await.map_err(store_err)?;
     Ok(result.rows_affected == 1)
@@ -517,7 +550,9 @@ pub(in crate::db) async fn get_chat(
 ) -> Result<Option<Chat>> {
     let mut query = entities::chat::Entity::find_by_id(id.0);
     if let Some(owner) = owner {
-        query = query.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+        query = query
+            .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .filter(entities::chat::Column::EnginePrivate.eq(false));
     }
     let mut rows = query
         .find_with_related(entities::chat_root_attachment::Entity)
@@ -547,7 +582,9 @@ pub(in crate::db) async fn list_chats(
 ) -> Result<Vec<Chat>> {
     let mut query = entities::chat::Entity::find();
     if let Some(owner) = owner {
-        query = query.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+        query = query
+            .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .filter(entities::chat::Column::EnginePrivate.eq(false));
     }
     let mut chats = query
         .find_with_related(entities::chat_root_attachment::Entity)
@@ -590,6 +627,7 @@ pub(in crate::db) async fn delete_chat(
     if let Some(owner) = owner {
         let owned = entities::chat::Entity::find_by_id(chat_id.0)
             .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .filter(entities::chat::Column::EnginePrivate.eq(false))
             .one(&transaction)
             .await
             .map_err(store_err)?
@@ -941,6 +979,7 @@ pub(in crate::db) async fn get_chat_transcript(
     if let Some(owner) = owner {
         let owned = entities::chat::Entity::find_by_id(chat_id.0)
             .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .filter(entities::chat::Column::EnginePrivate.eq(false))
             .one(&transaction)
             .await
             .map_err(store_err)?

--- a/crates/tidebreak-core/src/db/ops/inbox.rs
+++ b/crates/tidebreak-core/src/db/ops/inbox.rs
@@ -32,6 +32,7 @@ pub(in crate::db) async fn list_inbox_items(
     // an item can never name a conversation the reader may not see.
     let chats = entities::chat::Entity::find()
         .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+        .filter(entities::chat::Column::EnginePrivate.eq(false))
         .all(&store.conn)
         .await
         .map_err(store_err)?

--- a/crates/tidebreak-core/src/db/tests/chat.rs
+++ b/crates/tidebreak-core/src/db/tests/chat.rs
@@ -51,6 +51,7 @@ async fn chats_stored_before_the_effort_scale_widened_still_load() {
             attachment_revision: Set(0),
             created_at: Set(chat.created_at),
             owner: sea_orm::ActiveValue::NotSet,
+            engine_private: Set(false),
         }
         .insert(&store.conn)
         .await

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -63,10 +63,14 @@ async fn repository_transcript_search_survives_workspace_release() {
         .await
         .unwrap()
         .unwrap();
-    let mut workspace = get_workspace(&store, &owner, session.workspace_id)
-        .await
-        .unwrap()
-        .unwrap();
+    let mut workspace = get_workspace(
+        &store,
+        &owner,
+        session.workspace_id.expect("session has a workspace"),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     let repo_id = workspace.repo_id;
     workspace.status = CodeWorkspaceStatus::Released;
     workspace.archived_at = Some(now());
@@ -193,7 +197,7 @@ async fn seed_owner(
         &CodeSession {
             id: session_id,
             owner: owner.clone(),
-            workspace_id,
+            workspace_id: Some(workspace_id),
             kind: CodeSessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: Some("2.1.233".into()),
@@ -262,10 +266,14 @@ async fn claimed_trigger_delivery(
         .await
         .unwrap()
         .unwrap();
-    let workspace = get_workspace(store, owner, session.workspace_id)
-        .await
-        .unwrap()
-        .unwrap();
+    let workspace = get_workspace(
+        store,
+        owner,
+        session.workspace_id.expect("session has a workspace"),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     let at = now();
     arm_trigger(
         store,
@@ -294,7 +302,7 @@ async fn claimed_trigger_delivery(
         &CodeTriggerFireIdentity {
             trigger_id: trigger.id,
             owner: owner.clone(),
-            workspace_id: session.workspace_id,
+            workspace_id: session.workspace_id.expect("session has a workspace"),
             pr_number: 42,
             head_sha: uuid::Uuid::new_v4().to_string(),
         },
@@ -697,7 +705,8 @@ async fn workspace_title_swap_replaces_only_the_expected_title() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     assert!(set_workspace_title_if(
         &store,
         &OwnerId::local(),
@@ -746,7 +755,8 @@ async fn pull_request_write_preserves_a_concurrent_workspace_rename() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     let refresh_snapshot = get_workspace(&store, &owner, workspace_id)
         .await
         .unwrap()
@@ -808,10 +818,14 @@ async fn entity_graph_round_trips() {
         .unwrap()
         .unwrap();
     assert_eq!(turn.user_input, "hello");
-    let workspace = get_workspace(&store, &OwnerId::local(), session.workspace_id)
-        .await
-        .unwrap()
-        .unwrap();
+    let workspace = get_workspace(
+        &store,
+        &OwnerId::local(),
+        session.workspace_id.expect("session has a workspace"),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(workspace.status, CodeWorkspaceStatus::Active);
     let repo = get_repo(&store, &OwnerId::local(), workspace.repo_id)
         .await
@@ -1470,7 +1484,8 @@ async fn a_terminal_code_event_mints_one_notification_in_its_transaction() {
                 .await
                 .unwrap()
                 .unwrap()
-                .workspace_id,
+                .workspace_id
+                .expect("session has a workspace"),
         }
     );
 }
@@ -2032,7 +2047,8 @@ async fn owner_scoped_code_queries_partition_every_table() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     assert!(get_workspace(&store, &bob, alice_workspace)
         .await
         .unwrap()
@@ -2317,14 +2333,15 @@ async fn latest_watch_for_session_matches_on_the_session_not_the_workspace() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     let watch_session_id = CodeSessionId::new();
     insert_session(
         &store,
         &CodeSession {
             id: watch_session_id,
             owner: owner.clone(),
-            workspace_id,
+            workspace_id: Some(workspace_id),
             kind: CodeSessionKind::Watch,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: None,
@@ -2414,7 +2431,8 @@ async fn watch_submission_failure_retries_without_consuming_the_head() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     let created_at = now() - chrono::Duration::minutes(1);
     let watch = CodeWatch {
         id: CodeWatchId::new(),
@@ -2527,7 +2545,8 @@ async fn a_removed_repo_keeps_its_workspaces_and_transcript() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
 
     assert!(mark_repo_removed(&store, &owner, repo.id, now())
         .await
@@ -2671,7 +2690,8 @@ async fn a_cloned_repo_records_where_it_came_from() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     let registered = get_workspace(&store, &owner, workspace_id)
         .await
         .unwrap()
@@ -2751,7 +2771,8 @@ async fn trigger_persistence_rejects_another_owner() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     let at = now();
 
     let foreign_repo_trigger = CodeTrigger {
@@ -2900,7 +2921,8 @@ async fn trigger_fire_identity_includes_pull_request_number() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
 
     let trigger = CodeTrigger {
         id: CodeTriggerId::new(),
@@ -2981,7 +3003,8 @@ async fn trigger_fire_delivery_retries_are_fenced_and_durable() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     let trigger = CodeTrigger {
         id: CodeTriggerId::new(),
         owner: owner.clone(),
@@ -3213,7 +3236,8 @@ async fn deleting_a_trigger_clears_its_fires() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
 
     let trigger = CodeTrigger {
         id: CodeTriggerId::new(),
@@ -3273,7 +3297,8 @@ async fn trigger_mutations_have_field_specific_serialization() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
     let created_at = now();
     let trigger = CodeTrigger {
         id: CodeTriggerId::new(),
@@ -3645,7 +3670,8 @@ async fn pull_request_facts_upsert_claim_and_promote() {
         .await
         .unwrap()
         .unwrap()
-        .workspace_id;
+        .workspace_id
+        .expect("session has a workspace");
 
     let first_seen = now();
     let fact = CodePullRequestFact {
@@ -4593,7 +4619,7 @@ fn external_pair(owner: &OwnerId, repo_id: RepoId, label: &str) -> (CodeWorkspac
     let session = CodeSession {
         id: CodeSessionId::new(),
         owner: owner.clone(),
-        workspace_id,
+        workspace_id: Some(workspace_id),
         kind: CodeSessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: None,
@@ -4628,10 +4654,14 @@ async fn two_racing_external_creates_yield_one_session() {
             .await
             .unwrap()
             .unwrap();
-        let workspace = crate::db::code::get_workspace(&store, &owner, stored.workspace_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let workspace = crate::db::code::get_workspace(
+            &store,
+            &owner,
+            stored.workspace_id.expect("session has a workspace"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
         (session, workspace.repo_id)
     };
     let grant = crate::code::CodeGrantId::new();
@@ -4698,10 +4728,14 @@ async fn a_binding_resolves_ends_and_scopes_by_grant() {
         let sessions = crate::db::code::list_sessions(&store, &owner)
             .await
             .unwrap();
-        let workspace = crate::db::code::get_workspace(&store, &owner, sessions[0].workspace_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let workspace = crate::db::code::get_workspace(
+            &store,
+            &owner,
+            sessions[0].workspace_id.expect("session has a workspace"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
         workspace.repo_id
     };
     let grant = crate::code::CodeGrantId::new();
@@ -5226,10 +5260,14 @@ async fn seed_external_session(
         .await
         .unwrap()
         .unwrap();
-    let workspace = crate::db::code::get_workspace(store, owner, stored.workspace_id)
-        .await
-        .unwrap()
-        .unwrap();
+    let workspace = crate::db::code::get_workspace(
+        store,
+        owner,
+        stored.workspace_id.expect("session has a workspace"),
+    )
+    .await
+    .unwrap()
+    .unwrap();
     let (external_workspace, external_session) = external_pair(owner, workspace.repo_id, label);
     match crate::db::code::resolve_external_session(
         store,

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -768,7 +768,7 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
         &CodeSession {
             id: session_id,
             owner: crate::OwnerId::local(),
-            workspace_id,
+            workspace_id: Some(workspace_id),
             kind: CodeSessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: Some("scripted".into()),

--- a/crates/tidebreak-core/src/db/tests/project.rs
+++ b/crates/tidebreak-core/src/db/tests/project.rs
@@ -242,6 +242,7 @@ async fn project_membership_fk_and_attachment_insertions_are_atomic() {
         attachment_revision: Set(0),
         created_at: Set(Utc::now()),
         owner: sea_orm::ActiveValue::NotSet,
+        engine_private: Set(false),
     };
     assert!(orphan.insert(&store.conn).await.is_err());
 

--- a/crates/tidebreak-core/src/storage/store.rs
+++ b/crates/tidebreak-core/src/storage/store.rs
@@ -413,6 +413,20 @@ pub trait Store: Send + Sync {
 
     /// Persist a new chat owned by `owner`. When `chat.project_id` is set,
     /// the project must belong to the same owner.
+    /// Create the conversation the in-process engine keeps behind one code
+    /// session (decision 0048 step 5).
+    ///
+    /// The row belongs to `owner` for provider resolution and grant scoping,
+    /// but it is the engine's durable state rather than a conversation of
+    /// theirs: every owner-scoped chat read excludes it, so it is reachable
+    /// only through the session that owns it. Engine-side reads use the
+    /// unscoped accessors.
+    async fn create_engine_private_chat(&self, _owner: &OwnerId, _chat: &Chat) -> Result<()> {
+        Err(AgentError::Store(
+            "engine-private conversations are not implemented by this Store".into(),
+        ))
+    }
+
     async fn create_chat_scoped(&self, owner: &OwnerId, chat: &Chat) -> Result<()> {
         let _ = owner;
         self.create_chat(chat).await

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -84,7 +84,7 @@ async fn seed_owner(
         &CodeSession {
             id: session_id,
             owner: owner.clone(),
-            workspace_id,
+            workspace_id: Some(workspace_id),
             kind: CodeSessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: None,

--- a/crates/tidebreak-desktop/ui/src/code/CodeAnalyticsPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeAnalyticsPage.tsx
@@ -989,6 +989,8 @@ function harnessLabel(kind: HarnessKind): string {
       return "opencode";
     case "grok":
       return "Grok";
+    case "internal":
+      return "Tidebreak";
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -294,6 +294,8 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     });
   },
   rememberSession: (session) => {
+    // A session with no workspace has no rail row to remember it under yet.
+    if (session.workspace_id === null) return;
     set({
       sessionsByWorkspace: {
         ...get().sessionsByWorkspace,

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -45,6 +45,7 @@ import {
   ProviderIcon,
   XaiIcon,
 } from "../ProviderIcons";
+import { Logomark } from "../Logomark";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -171,6 +172,7 @@ const HARNESS_ICONS: Record<HarnessKind, typeof ClaudeIcon> = {
   codex: OpenAIIcon,
   opencode: OpenCodeIcon,
   grok: XaiIcon,
+  internal: Logomark,
 };
 
 /** The mark for one picker row: vendor, then open-model family, then the engine. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -159,6 +159,8 @@ export function reduceCodeUpdates(
           digest.kind === "watch"
             ? childrenByWorkspace
             : conversationsByWorkspace;
+        // A digest for a session with no workspace has no rail row yet.
+        if (digest.workspace === null) continue;
         (map[digest.workspace] ??= {})[digest.session] = digest;
       }
       return {
@@ -252,6 +254,7 @@ function upsertDigest(
   digest: CodeSessionDigest,
   dropEnded: boolean,
 ): DigestsByWorkspace {
+  if (digest.workspace === null) return map;
   const forWorkspace = { ...map[digest.workspace] };
   if (dropEnded && digest.lifecycle === "ended") {
     delete forWorkspace[digest.session];
@@ -834,7 +837,7 @@ function maybeBumpAgentNotifications(
   previous: CodeUpdatesState,
   digest: CodeSessionDigest,
 ): void {
-  if (digest.kind === "watch") return;
+  if (digest.kind === "watch" || digest.workspace === null) return;
   const prior =
     previous.conversationsByWorkspace[digest.workspace]?.[digest.session]
       ?.attention;
@@ -849,6 +852,7 @@ function maybeNotify(
   previous: CodeUpdatesState,
   digest: CodeSessionDigest,
 ): void {
+  if (digest.workspace === null) return;
   const prior =
     previous.conversationsByWorkspace[digest.workspace]?.[digest.session]
       ?.attention;

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
@@ -8,6 +8,7 @@ import {
   OpenCodeIcon,
   XaiIcon,
 } from "../ProviderIcons";
+import { Logomark } from "../Logomark";
 import {
   Select,
   SelectContent,
@@ -32,6 +33,7 @@ export const HARNESS_ICONS: Record<
   codex: OpenAIIcon,
   opencode: OpenCodeIcon,
   grok: XaiIcon,
+  internal: Logomark,
 };
 
 /**
@@ -99,6 +101,9 @@ export function HarnessPicker({
         </SelectTrigger>
         <SelectContent scrollButtons={false}>
           {harnesses.map((entry) => {
+            // The in-process engine hosts conversations without a
+            // workspace; it is never a pick for a repo-bound session.
+            if (entry.kind === "internal") return null;
             const reason = harnessUnusableReason(entry);
             const note =
               reason ?? (harnessNeedsDownload(entry) ? DOWNLOAD_NOTE : null);

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -26,6 +26,7 @@ export const HARNESS_LABELS: Record<HarnessKind, string> = {
   codex: "Codex CLI",
   opencode: "opencode",
   grok: "Grok CLI",
+  internal: "Tidebreak",
 };
 
 export const HARNESS_TIER_LABELS: Record<HarnessTier, string> = {
@@ -304,6 +305,7 @@ export const HARNESS_VENDORS: Record<
   codex: ["openai"],
   grok: ["xai"],
   opencode: null,
+  internal: null,
 };
 
 /** The vendor a picker row is branded as: curated match first, then the id. */

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1611,7 +1611,11 @@ export type CodeSessionActivity = "agent" | "shell" | "monitor" | "subagents" | 
 /**
  * Cheap per-session digest on `/code/updates`.
  */
-export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind,
+export type CodeSessionDigest = {
+/**
+ * `None` for a session that binds no workspace.
+ */
+workspace: WorkspaceId | null, session: CodeSessionId, kind: CodeSessionKind,
 /**
  * Engine identity for list surfaces that collapse several sessions into
  * one workspace row. Optional on the wire so a desktop can still read a
@@ -1683,7 +1687,12 @@ export type CodeSessionLifecycle = "created" | "idle" | "running" | "fenced" | "
 /**
  * One durable conversation with an external agent engine.
  */
-export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
+export type CodeSessionSnapshot = { id: CodeSessionId,
+/**
+ * `None` for a session that binds no workspace: the in-process
+ * engine's (decision 0048 step 5).
+ */
+workspace_id: WorkspaceId | null, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
 /**
  * Absent means the engine's own default, which is not any level.
  */
@@ -1809,7 +1818,7 @@ export type CodeUpdateNotice = { "type": "snapshot",
 /**
  * One row per live session.
  */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind,
+sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId | null, session: CodeSessionId, kind: CodeSessionKind,
 /**
  * Engine identity for the session represented by this digest.
  */
@@ -2829,7 +2838,7 @@ export type HarnessDoctorReport = { harnesses: Array<HarnessDoctorEntry>, };
  * Named after the shipped adapters. The traits those adapters implement
  * stay engine-neutral; this enum is only the catalog of known engines.
  */
-export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok";
+export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok" | "internal";
 
 /**
  * One model row offered for a harness session.
@@ -2941,7 +2950,11 @@ byte_len: number, };
  * (the repository check `chat_and_code_entities_do_not_cross_reference`
  * enforces it). When step 5 merges the entities this collapses to one id.
  */
-export type InboxConversation = { "surface": "chat", chat_id: ChatId, } | { "surface": "code", session_id: CodeSessionId, workspace_id: WorkspaceId, };
+export type InboxConversation = { "surface": "chat", chat_id: ChatId, } | { "surface": "code", session_id: CodeSessionId,
+/**
+ * `None` for a session with no workspace: the in-process engine's.
+ */
+workspace_id: WorkspaceId | null, };
 
 /**
  * One conversation that wants the reader, and why.

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -1457,6 +1457,8 @@ mod tests {
         permission_mode: PermissionMode,
     ) -> ClaudeSession {
         ClaudeSession::new(SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: worktree.to_path_buf(),
             allowed_read_roots: Vec::new(),
             permission_mode,
@@ -1627,6 +1629,8 @@ done
     fn effort_rides_argv_and_ultra_composes_xhigh() {
         let dir = tempfile::tempdir().unwrap();
         let session = ClaudeSession::new(SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: dir.path().to_path_buf(),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Ask,
@@ -1830,6 +1834,8 @@ done
             PathBuf::from("/usr/local/bin/tidebreak"),
         );
         let session = ClaudeSession::new(SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: dir.path().to_path_buf(),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Plan,
@@ -1885,6 +1891,8 @@ done
     fn every_turn_reads_stream_json_from_a_stdin_that_stays_open() {
         let dir = tempfile::tempdir().unwrap();
         let session = ClaudeSession::new(SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: dir.path().to_path_buf(),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Plan,

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -1915,6 +1915,8 @@ done
 
     fn unit_session(sink: Arc<dyn crate::HarnessEventSink>) -> CodexSession {
         CodexSession::new(SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: PathBuf::from("."),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Auto,
@@ -1968,6 +1970,8 @@ done
         resume_ref: Option<String>,
     ) -> SessionSpec {
         SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: dir.to_path_buf(),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Auto,

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -16,9 +16,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tidebreak_core::{
-    BoundedError, CodeApprovalKind, CodeUsage, Diffstat, FileChangeKind, GrantScope, HarnessCaps,
-    HarnessCommand, HarnessKind, HarnessNoticeLevel, PermissionMode, ReasoningEffort, ToolDetail,
-    ToolOutcome, UserQuestionAnswer,
+    BoundedError, CodeApprovalKind, CodeSessionId, CodeUsage, Diffstat, FileChangeKind, GrantScope,
+    HarnessCaps, HarnessCommand, HarnessKind, HarnessNoticeLevel, OwnerId, PermissionMode,
+    ReasoningEffort, ToolDetail, ToolOutcome, UserQuestionAnswer,
 };
 
 pub mod browser_channel;
@@ -67,6 +67,10 @@ pub fn auth_override_present(
         HarnessKind::ClaudeCode => claude::auth_override_present(env),
         HarnessKind::Codex => codex::auth_override_present(env),
         HarnessKind::Opencode | HarnessKind::Grok => true,
+        // The in-process engine takes inference from the server's own
+        // provider resolution; there is no engine-side credential to
+        // override.
+        HarnessKind::Internal => false,
     }
 }
 
@@ -127,7 +131,7 @@ pub fn observe_auth_mode(
     let signal = match kind {
         HarnessKind::ClaudeCode => claude::observe_auth_override(env),
         HarnessKind::Codex => codex::observe_auth_override(env),
-        HarnessKind::Opencode | HarnessKind::Grok => None,
+        HarnessKind::Opencode | HarnessKind::Grok | HarnessKind::Internal => None,
     };
     signal.map_or(
         HarnessAuthObservation::Unknown,
@@ -680,6 +684,14 @@ impl BrowserChannelSpec {
 
 /// What an adapter needs to spawn or connect one session.
 pub struct SessionSpec {
+    /// Principal the session acts for. An in-process engine resolves its
+    /// inference and scopes its durable state by this; external engines
+    /// carry their own credentials and ignore it.
+    pub owner: OwnerId,
+    /// The durable session this launch serves. An in-process engine keys
+    /// its own durable state on it, so a relaunch finds the same state
+    /// without a native resume token; external engines ignore it.
+    pub session_id: CodeSessionId,
     /// Worktree the engine should use as its working directory.
     pub worktree: PathBuf,
     /// Absolute directory roots that engine tools may read outside the worktree.

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -1030,6 +1030,8 @@ mod tests {
 
     fn unit_session() -> OpencodeSession {
         OpencodeSession::new(SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: std::path::PathBuf::from("."),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Auto,

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -621,7 +621,9 @@ fn engine_auth_env_allowed(
                         || upper == "CLOUD_ML_REGION"))
         }
         tidebreak_core::HarnessKind::Codex => CODEX_AUTH_ENV_VARS.contains(&upper.as_str()),
-        tidebreak_core::HarnessKind::Opencode | tidebreak_core::HarnessKind::Grok => false,
+        tidebreak_core::HarnessKind::Opencode
+        | tidebreak_core::HarnessKind::Grok
+        | tidebreak_core::HarnessKind::Internal => false,
     }
 }
 

--- a/crates/tidebreak-harness/src/wiring.rs
+++ b/crates/tidebreak-harness/src/wiring.rs
@@ -91,6 +91,9 @@ pub fn spawn_wiring(
                 ("GROK_MODELS_BASE_URL".into(), format!("{openai}/v1")),
             ],
         ),
+        // The in-process engine spawns no child and resolves its inference
+        // through the server itself; there is nothing to wire.
+        HarnessKind::Internal => (Vec::new(), Vec::new()),
     }
 }
 

--- a/crates/tidebreak-server/src/approvals.rs
+++ b/crates/tidebreak-server/src/approvals.rs
@@ -150,6 +150,64 @@ impl ApprovalBroker {
 impl ApprovalBroker {
     /// Land the Auto-mode judge's verdict on one parked call.
     ///
+    /// Approve a parked call and mint a standing grant at an exact scope the
+    /// call already offered.
+    ///
+    /// The in-process engine's path: the adapter contract carries the chosen
+    /// [`GrantScope`] itself rather than a rung name, because the route layer
+    /// picked it from the ladder the approval published.
+    pub async fn resolve_with_scope(
+        &self,
+        chat_id: ChatId,
+        call_id: CallId,
+        scope: GrantScope,
+    ) -> Result<ResolveApprovalOutcome> {
+        let Some(current) = self.store.get_tool_call_approval(call_id).await? else {
+            return Ok(ResolveApprovalOutcome::NotPending);
+        };
+        if current.chat_id != chat_id {
+            return Ok(ResolveApprovalOutcome::WrongChat);
+        }
+        if !current.kind.is_approvable() {
+            return Ok(ResolveApprovalOutcome::NotApprovable);
+        }
+        let chat_project_id = self
+            .store
+            .get_chat(chat_id)
+            .await?
+            .and_then(|chat| chat.project_id);
+        let Some(grant) = StandingGrant::scoped(
+            GrantLevel::for_chat(current.chat_id, chat_project_id),
+            current.tool_name.clone(),
+            current.kind,
+            scope,
+            Utc::now(),
+        ) else {
+            return Ok(ResolveApprovalOutcome::GrantNotAvailable);
+        };
+        let outcome = self
+            .store
+            .decide_tool_call_approval_with_grant(
+                chat_id,
+                call_id,
+                &ApprovalDecision::Approve,
+                &grant,
+                Utc::now(),
+            )
+            .await?;
+        match outcome {
+            DecideToolApprovalOutcome::Decided(_) | DecideToolApprovalOutcome::Existing(_) => {
+                self.standing_grants.record(grant);
+                self.wake.notify_waiters();
+                Ok(ResolveApprovalOutcome::Resolved)
+            }
+            DecideToolApprovalOutcome::DecisionConflict => {
+                Ok(ResolveApprovalOutcome::DecisionConflict)
+            }
+            DecideToolApprovalOutcome::Unavailable => Ok(ResolveApprovalOutcome::NotPending),
+        }
+    }
+
     /// A pure compare-and-set against durable state: a human decision that
     /// already landed wins, and `false` reports the judge no longer owned the
     /// call. An approval wakes the parked waiter exactly like a human click.

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -395,14 +395,19 @@ async fn build_digest(
     db: &DbStore,
     session: &CodeSession,
 ) -> Result<SessionDigest, tidebreak_core::AgentError> {
-    let workspace = get_workspace(db, &session.owner, session.workspace_id)
-        .await?
-        .ok_or_else(|| {
-            tidebreak_core::AgentError::Store(format!(
-                "workspace {} missing for session {}",
-                session.workspace_id, session.id
-            ))
-        })?;
+    let workspace = match session.workspace_id {
+        Some(workspace_id) => Some(
+            get_workspace(db, &session.owner, workspace_id)
+                .await?
+                .ok_or_else(|| {
+                    tidebreak_core::AgentError::Store(format!(
+                        "workspace {workspace_id} missing for session {}",
+                        session.id
+                    ))
+                })?,
+        ),
+        None => None,
+    };
     let turn_count = count_turns(db, &session.owner, session.id).await?;
     // A watch session's lifecycle undersells it ("running" for hours), so its
     // digest carries the watch's own state. The row is small and local — this
@@ -421,8 +426,12 @@ async fn build_digest(
     };
     // One indexed count (decision 77). Zero stays absent so clients that
     // predate the field and workspaces that never shipped read the same.
-    let pr_count =
-        count_attributed_prs_for_workspace(db, &session.owner, session.workspace_id).await?;
+    let pr_count = match session.workspace_id {
+        Some(workspace_id) => {
+            count_attributed_prs_for_workspace(db, &session.owner, workspace_id).await?
+        }
+        None => 0,
+    };
     let turns = list_turns(db, &session.owner, session.id).await?;
     // Keep this timestamp aligned with trigger delivery's ranking rule. The
     // interface uses it to name the same session that a fire would reach.
@@ -432,6 +441,12 @@ async fn build_digest(
     // declined to recap, or one whose call is still in flight, leaves the
     // previous line standing rather than blanking the row mid-work.
     let recap = turns.into_iter().rev().find_map(|turn| turn.narrative);
+    // A session with no workspace is titled by its conversation, which
+    // nothing names yet; the client falls back to its own label.
+    let (title, pr_state) = match workspace {
+        Some(workspace) => (workspace.title, workspace.pr),
+        None => (String::new(), None),
+    };
     Ok(SessionDigest {
         workspace: session.workspace_id,
         session: session.id,
@@ -439,11 +454,11 @@ async fn build_digest(
         harness_kind: session.harness_kind,
         lifecycle: session.lifecycle,
         attention: session.attention.clone(),
-        title: workspace.title,
+        title,
         turn_count,
         trigger_target_at,
         activity,
-        pr_state: workspace.pr,
+        pr_state,
         pr_count: (pr_count > 0).then_some(pr_count),
         watch_state: watch.as_ref().map(|watch| watch.state),
         watch_detail: watch.as_ref().and_then(|watch| watch.detail.clone()),
@@ -594,7 +609,7 @@ mod tests {
         CodeSession {
             id: CodeSessionId::new(),
             owner: tidebreak_core::OwnerId::local(),
-            workspace_id: WorkspaceId::new(),
+            workspace_id: Some(WorkspaceId::new()),
             kind: CodeSessionKind::Interactive,
             harness_kind: tidebreak_core::HarnessKind::ClaudeCode,
             harness_version: None,

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -40,7 +40,8 @@ const UPDATES_BUFFER: usize = 256;
 /// Cheap per-session digest published on `/code/updates`.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SessionDigest {
-    pub workspace: WorkspaceId,
+    /// `None` for a session that binds no workspace.
+    pub workspace: Option<WorkspaceId>,
     pub session: CodeSessionId,
     pub kind: CodeSessionKind,
     /// Engine identity for list surfaces that collapse several sessions into

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -319,6 +319,10 @@ pub(crate) async fn after_turn_ended(
     if !terminal || turn.checkpoint_ref.is_some() {
         return;
     }
+    // No workspace, no checkout to snapshot.
+    if session.workspace_id.is_none() {
+        return;
+    }
     match record_for_turn(db, session, turn).await {
         Ok(recorded) => {
             turn.checkpoint_ref = Some(recorded.checkpoint_ref.clone());
@@ -369,7 +373,10 @@ async fn record_for_turn(
     session: &CodeSession,
     turn: &CodeTurn,
 ) -> Result<RecordedCheckpoint, CheckpointError> {
-    let workspace = get_workspace(db, &session.owner, session.workspace_id)
+    let workspace_id = session
+        .workspace_id
+        .ok_or_else(|| CheckpointError::user("session has no workspace"))?;
+    let workspace = get_workspace(db, &session.owner, workspace_id)
         .await
         .map_err(|err| CheckpointError::internal(err.to_string()))?
         .ok_or_else(|| CheckpointError::user("workspace not found"))?;
@@ -901,7 +908,7 @@ pub(crate) async fn resolve_diff_range(
                 .await
                 .map_err(|err| CheckpointError::internal(err.to_string()))?
                 .ok_or_else(|| CheckpointError::user("session not found"))?;
-            if session.workspace_id != workspace.id {
+            if session.workspace_id != Some(workspace.id) {
                 return Err(CheckpointError::user(
                     "turn does not belong to this workspace",
                 ));
@@ -2533,7 +2540,7 @@ mod tests {
         let session = CodeSession {
             id: CodeSessionId::new(),
             owner,
-            workspace_id,
+            workspace_id: Some(workspace_id),
             kind: CodeSessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: None,
@@ -2803,7 +2810,7 @@ mod tests {
         run(&repo, &["git", "commit", "-m", "receipts"]);
         let tree = add_worktree(&repo, "shared");
         let (db, bus, earlier) = seed_session(&repo, &tree).await;
-        record_session_baseline(&tree, earlier.workspace_id, earlier.id)
+        record_session_baseline(&tree, earlier.workspace_id.expect("workspace"), earlier.id)
             .await
             .unwrap();
 
@@ -2818,7 +2825,7 @@ mod tests {
 
         // A second session starts on the worktree the first one has edited.
         let later = seed_sibling_session(&db, &earlier).await;
-        record_session_baseline(&tree, later.workspace_id, later.id)
+        record_session_baseline(&tree, later.workspace_id.expect("workspace"), later.id)
             .await
             .unwrap();
 
@@ -2840,7 +2847,7 @@ mod tests {
         );
 
         // The read path agrees: `code diff --turn` resolves the same range.
-        let workspace = get_workspace(&db, &later.owner, later.workspace_id)
+        let workspace = get_workspace(&db, &later.owner, later.workspace_id.expect("workspace"))
             .await
             .unwrap()
             .unwrap();
@@ -2870,7 +2877,7 @@ mod tests {
         let (_dir, repo) = init_repo();
         let tree = add_worktree(&repo, "lone");
         let (db, bus, session) = seed_session(&repo, &tree).await;
-        record_session_baseline(&tree, session.workspace_id, session.id)
+        record_session_baseline(&tree, session.workspace_id.expect("workspace"), session.id)
             .await
             .unwrap();
 
@@ -2905,7 +2912,7 @@ mod tests {
         after_turn_ended(&db, &bus, &session, &mut turn).await;
 
         let r#ref = turn.checkpoint_ref.clone().expect("turn 1 keeps its ref");
-        let baseline = session_baseline_ref(session.workspace_id, session.id);
+        let baseline = session_baseline_ref(session.workspace_id.expect("workspace"), session.id);
         assert!(
             git_text(&tree, &["rev-parse", "--verify", &baseline], GIT_TIMEOUT)
                 .await
@@ -2927,9 +2934,10 @@ mod tests {
         let (_dir, repo) = init_repo();
         let tree = add_worktree(&repo, "chain-from-baseline");
         let (db, bus, session) = seed_session(&repo, &tree).await;
-        let baseline = record_session_baseline(&tree, session.workspace_id, session.id)
-            .await
-            .unwrap();
+        let baseline =
+            record_session_baseline(&tree, session.workspace_id.expect("workspace"), session.id)
+                .await
+                .unwrap();
 
         std::fs::write(tree.join("one.txt"), "one\n").unwrap();
         let mut first = seed_turn(&db, &session, 1, CodeTurnStatus::Completed).await;
@@ -2968,9 +2976,10 @@ mod tests {
         let (_dir, repo) = init_repo();
         let tree = add_worktree(&repo, "missing-previous");
         let (db, bus, session) = seed_session(&repo, &tree).await;
-        let baseline = record_session_baseline(&tree, session.workspace_id, session.id)
-            .await
-            .unwrap();
+        let baseline =
+            record_session_baseline(&tree, session.workspace_id.expect("workspace"), session.id)
+                .await
+                .unwrap();
 
         std::fs::write(tree.join("one.txt"), "one\n").unwrap();
         let mut first = seed_turn(&db, &session, 1, CodeTurnStatus::Completed).await;

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -1156,6 +1156,7 @@ fn harness_label(kind: HarnessKind) -> &'static str {
         HarnessKind::Codex => "Codex CLI",
         HarnessKind::Opencode => "opencode",
         HarnessKind::Grok => "Grok CLI",
+        HarnessKind::Internal => "Tidebreak",
     }
 }
 
@@ -1172,7 +1173,7 @@ mod tests {
         CodeSession {
             id: CodeSessionId::new(),
             owner: OwnerId::local(),
-            workspace_id: WorkspaceId::new(),
+            workspace_id: Some(WorkspaceId::new()),
             kind: CodeSessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: None,

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -412,10 +412,17 @@ pub(crate) fn spawn_wiring(
 /// sign-in and an uncovered one cannot run at all; everywhere else the local
 /// probe decides, and this answer does not matter.
 pub(crate) fn relay_covered(kind: HarnessKind) -> bool {
-    matches!(
-        kind,
-        HarnessKind::ClaudeCode | HarnessKind::Codex | HarnessKind::Opencode | HarnessKind::Grok
-    )
+    match kind {
+        HarnessKind::ClaudeCode
+        | HarnessKind::Codex
+        | HarnessKind::Opencode
+        | HarnessKind::Grok => true,
+        // The in-process engine never reaches the relay: it resolves
+        // inference through the server's own provider resolution, which on
+        // a hosted machine is the same gateway. Covered, in the sense the
+        // doctor asks about — it needs no local sign-in.
+        HarnessKind::Internal => true,
+    }
 }
 
 fn generate_key() -> String {

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -56,6 +56,23 @@ pub(crate) fn trigger_target_at(
     latest_turn_started_at.unwrap_or(session_created_at)
 }
 
+/// The workspace a session binds, when it binds one.
+///
+/// A session with no workspace (the in-process engine's) answers `None`
+/// rather than a missing-row error, so callers that need a checkout can
+/// skip the work instead of failing the session.
+pub(crate) async fn session_workspace(
+    db: &tidebreak_core::db::DbStore,
+    session: &tidebreak_core::CodeSession,
+) -> Result<Option<tidebreak_core::CodeWorkspace>, tidebreak_core::AgentError> {
+    match session.workspace_id {
+        Some(workspace_id) => {
+            tidebreak_core::db::code::get_workspace(db, &session.owner, workspace_id).await
+        }
+        None => Ok(None),
+    }
+}
+
 /// The display name the product uses for an engine, wherever copy names one.
 pub(crate) fn harness_label(kind: tidebreak_core::HarnessKind) -> &'static str {
     match kind {
@@ -63,6 +80,7 @@ pub(crate) fn harness_label(kind: tidebreak_core::HarnessKind) -> &'static str {
         tidebreak_core::HarnessKind::Codex => "Codex CLI",
         tidebreak_core::HarnessKind::Opencode => "opencode",
         tidebreak_core::HarnessKind::Grok => "Grok CLI",
+        tidebreak_core::HarnessKind::Internal => "Tidebreak",
     }
 }
 

--- a/crates/tidebreak-server/src/code/pr_facts.rs
+++ b/crates/tidebreak-server/src/code/pr_facts.rs
@@ -246,8 +246,8 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
     // agent's push is neither. Left unmarked, the watch's next assessment
     // reads the head from before the fix turn pushed (issue 2799).
     if confirmed_any {
-        if let Some(hot) = hot {
-            hot.mark(&session.owner, session.workspace_id);
+        if let (Some(hot), Some(workspace_id)) = (hot, session.workspace_id) {
+            hot.mark(&session.owner, workspace_id);
         }
     }
 }
@@ -277,7 +277,10 @@ async fn confirm_changed_checkout(
         return false;
     }
 
-    let workspace = match get_workspace(db, &session.owner, session.workspace_id).await {
+    let Some(workspace_id) = session.workspace_id else {
+        return false;
+    };
+    let workspace = match get_workspace(db, &session.owner, workspace_id).await {
         Ok(Some(workspace)) if !workspace.is_remote() => workspace,
         Ok(_) => return false,
         Err(err) => {
@@ -354,7 +357,7 @@ async fn confirm_changed_checkout(
     record_confirmed_fact(
         db,
         &session.owner,
-        session.workspace_id,
+        workspace_id,
         Some(session.id),
         None,
         &target,
@@ -377,6 +380,9 @@ async fn confirm_create(
     preview: Option<&str>,
     gh_search_path: Option<&str>,
 ) -> bool {
+    let Some(workspace_id) = session.workspace_id else {
+        return false;
+    };
     let sniffed = preview.and_then(sniff_pull_request_url);
     let target = match resolve_create_target(create, sniffed.as_ref(), &command.cwd).await {
         Some(target) => target,
@@ -430,7 +436,7 @@ async fn confirm_create(
     record_confirmed_fact(
         db,
         &session.owner,
-        session.workspace_id,
+        workspace_id,
         Some(session.id),
         command.parent_call_id.clone(),
         &target,
@@ -453,6 +459,9 @@ async fn confirm_push(
     push: &PushAct,
     gh_search_path: Option<&str>,
 ) -> bool {
+    let Some(workspace_id) = session.workspace_id else {
+        return false;
+    };
     let cwd = push
         .cwd_override
         .clone()
@@ -511,7 +520,7 @@ async fn confirm_push(
     record_confirmed_fact(
         db,
         &session.owner,
-        session.workspace_id,
+        workspace_id,
         Some(session.id),
         command.parent_call_id.clone(),
         &target,

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -56,10 +56,7 @@ pub(crate) async fn recover_running_sessions_with(
         // Running with no pid is its normal shape, and interrupting it here
         // would abandon a lease that is still spending. Its own lifecycle
         // (the pump, the stale-intent sweep, reap) settles it.
-        if let Some(workspace) =
-            tidebreak_core::db::code::get_workspace(store, &session.owner, session.workspace_id)
-                .await?
-        {
+        if let Some(workspace) = super::session_workspace(store, &session).await? {
             if workspace.is_remote() {
                 continue;
             }
@@ -639,7 +636,7 @@ mod tests {
             &CodeSession {
                 id: session_id,
                 owner: tidebreak_core::OwnerId::local(),
-                workspace_id,
+                workspace_id: Some(workspace_id),
                 kind: CodeSessionKind::Interactive,
                 harness_kind: HarnessKind::ClaudeCode,
                 harness_version: Some("2.1.233".into()),
@@ -675,11 +672,14 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let mut workspace =
-            tidebreak_core::db::code::get_workspace(&store, &owner, session.workspace_id)
-                .await
-                .unwrap()
-                .unwrap();
+        let mut workspace = tidebreak_core::db::code::get_workspace(
+            &store,
+            &owner,
+            session.workspace_id.expect("workspace"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
         workspace.worktree_path = String::new();
         tidebreak_core::db::code::save_workspace(&store, &workspace)
             .await
@@ -1092,6 +1092,8 @@ mod tests {
         // recovery runs; the test never waits for it.
         .with_delay(std::time::Duration::from_secs(30))
         .launch(tidebreak_harness::SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: _dir.path().join("wt"),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Plan,

--- a/crates/tidebreak-server/src/code/remote/driver.rs
+++ b/crates/tidebreak-server/src/code/remote/driver.rs
@@ -181,10 +181,13 @@ async fn occupying_names(
     let mut names = Vec::new();
     for id in running {
         let name = match tidebreak_core::db::code::get_session(db, owner, *id).await {
-            Ok(Some(session)) => match get_workspace(db, owner, session.workspace_id).await {
-                Ok(Some(workspace)) if !workspace.title.is_empty() => workspace.title,
-                Ok(Some(workspace)) => workspace.branch_name,
-                _ => id.to_string(),
+            Ok(Some(session)) => match session.workspace_id {
+                Some(workspace_id) => match get_workspace(db, owner, workspace_id).await {
+                    Ok(Some(workspace)) if !workspace.title.is_empty() => workspace.title,
+                    Ok(Some(workspace)) => workspace.branch_name,
+                    _ => id.to_string(),
+                },
+                None => id.to_string(),
             },
             _ => id.to_string(),
         };
@@ -1452,7 +1455,7 @@ mod tests {
         let (db, bus, session_a, workspace, repo) = seed(dir.path()).await;
         super::super::fixtures::seeded_incarnation(&db, &session_a).await;
         let mut session_b = super::super::fixtures::session_value();
-        session_b.workspace_id = workspace.id;
+        session_b.workspace_id = Some(workspace.id);
         tidebreak_core::db::code::insert_session(&db, &session_b)
             .await
             .unwrap();

--- a/crates/tidebreak-server/src/code/remote/fixtures.rs
+++ b/crates/tidebreak-server/src/code/remote/fixtures.rs
@@ -20,7 +20,7 @@ pub(crate) fn session_value() -> CodeSession {
     CodeSession {
         id: CodeSessionId::new(),
         owner: OwnerId::local(),
-        workspace_id: WorkspaceId::new(),
+        workspace_id: Some(WorkspaceId::new()),
         kind: CodeSessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: None,
@@ -97,7 +97,7 @@ pub(crate) async fn seed(
     };
     insert_workspace(&db, &workspace).await.unwrap();
     let mut session = session_value();
-    session.workspace_id = workspace.id;
+    session.workspace_id = Some(workspace.id);
     insert_session(&db, &session).await.unwrap();
     (db, CodeEventBus::default(), session, workspace, repo)
 }

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1228,7 +1228,7 @@ mod tests {
             .unwrap();
         assert_eq!(session.lifecycle, CodeSessionLifecycle::Idle);
         let workspace = runtime
-            .get_workspace(&owner, session.workspace_id)
+            .get_workspace(&owner, session.workspace_id.expect("workspace"))
             .await
             .unwrap();
         assert!(workspace.is_remote());
@@ -1525,7 +1525,7 @@ mod tests {
         // The promotion runs with the stale snapshot: B's text goes to the
         // sandbox, and the claim must consume B's row under its own id.
         let workspace = runtime
-            .get_workspace(&owner, live.workspace_id)
+            .get_workspace(&owner, live.workspace_id.expect("workspace"))
             .await
             .unwrap();
         let stored_repo = runtime.get_repo(&owner, workspace.repo_id).await.unwrap();

--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -15,10 +15,10 @@ impl CodeRuntime {
         if let Some(relay) = &self.harness_llm {
             relay.revoke(session.id);
         }
-        if let Some(runtime) = &self.browser_runtime {
+        if let (Some(runtime), Some(workspace)) = (&self.browser_runtime, session.workspace_id) {
             let scope = crate::code::browser_runtime::BrowserRuntimeScope {
                 owner: session.owner.clone(),
-                workspace: session.workspace_id,
+                workspace,
                 session: session.id,
             };
             runtime.revoke_session(&scope);
@@ -152,10 +152,7 @@ impl CodeRuntime {
             if !checked_workspaces.insert(session.workspace_id) {
                 continue;
             }
-            if let Ok(workspace) = self
-                .get_workspace(&session.owner, session.workspace_id)
-                .await
-            {
+            if let Ok(Some(workspace)) = self.session_workspace(session).await {
                 if workspace.is_remote() {
                     remote_workspaces.insert(session.workspace_id);
                 }

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -87,7 +87,7 @@ impl CodeRuntime {
         CodeSession {
             id: CodeSessionId::new(),
             owner: owner.clone(),
-            workspace_id,
+            workspace_id: Some(workspace_id),
             kind: CodeSessionKind::Interactive,
             harness_kind: harness,
             harness_version: None,
@@ -433,10 +433,7 @@ impl CodeRuntime {
         if session.lifecycle != CodeSessionLifecycle::Idle {
             return Ok(());
         }
-        let Ok(workspace) = self
-            .get_workspace(&session.owner, session.workspace_id)
-            .await
-        else {
+        let Ok(Some(workspace)) = self.session_workspace(&session).await else {
             return Ok(());
         };
         if !workspace.is_remote() {

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -40,6 +40,12 @@ impl CodeRuntime {
             permission_mode_ceiling,
         }: NewSessionSettings,
     ) -> Result<CodeSession, ServerError> {
+        if harness.is_in_process() {
+            return Err(ServerError::conflict_kind(
+                "harness_needs_no_workspace",
+                "the internal engine hosts conversations without a workspace; create one without a workspace instead",
+            ));
+        }
         let lifecycle = self.workspace_lifecycle_lock(workspace_id);
         let _lifecycle_guard = lifecycle.lock().await;
         let workspace = self.get_workspace(owner, workspace_id).await?;
@@ -86,7 +92,7 @@ impl CodeRuntime {
                     false
                 }
             };
-            if !skip_pin {
+            if !skip_pin && !harness.is_in_process() {
                 match self.ensure_pinned_harness(harness, false).await {
                     Ok(binary) => {
                         self.record_pin_install(harness, Ok(()));
@@ -131,7 +137,7 @@ impl CodeRuntime {
             }
         }
         refuse_unhonored_mode(harness, permission_mode, &caps)?;
-        if probe.binary_path.is_none() {
+        if probe.binary_path.is_none() && !harness.is_in_process() {
             return Err(ServerError::unprocessable_kind(
                 "harness_not_found",
                 format!("{harness} has no path"),
@@ -157,7 +163,7 @@ impl CodeRuntime {
         let session = CodeSession {
             id: CodeSessionId::new(),
             owner: owner.clone(),
-            workspace_id,
+            workspace_id: Some(workspace_id),
             kind,
             harness_kind: harness,
             harness_version: probe.version.clone(),
@@ -195,6 +201,78 @@ impl CodeRuntime {
                 "could not record the session baseline; its first turn diffs against the base ref"
             );
         }
+        self.attach_and_spawn_worker(session).await
+    }
+
+    /// Create a conversation with no workspace, hosted by the in-process
+    /// engine (decision 0048 step 5).
+    ///
+    /// The workspace-bound create path probes an installed engine and pins
+    /// a checkout; this one needs neither. Everything after the row — the
+    /// worker, the journal, approvals — is the same machinery.
+    pub(crate) async fn create_internal_session(
+        &self,
+        owner: &OwnerId,
+        NewSessionSettings {
+            permission_mode,
+            model,
+            reasoning_effort,
+            fast_mode,
+            permission_mode_ceiling,
+        }: NewSessionSettings,
+    ) -> Result<CodeSession, ServerError> {
+        let harness = HarnessKind::Internal;
+        let adapter = self.adapter(harness)?;
+        let probe = self.probe_for_session_create(adapter.as_ref()).await;
+        let caps = adapter.capabilities(&probe);
+        refuse_ceiling_with_no_offered_mode(permission_mode_ceiling, harness, &caps)?;
+        if let Some(ceiling) = permission_mode_ceiling {
+            if permission_mode > ceiling {
+                return Err(ServerError::conflict_kind(
+                    "permission_mode_locked",
+                    format!(
+                        "permission mode `{}` exceeds the maximum this managed profile allows (`{}`)",
+                        permission_mode.as_str(),
+                        ceiling.as_str()
+                    ),
+                ));
+            }
+        }
+        refuse_unhonored_mode(harness, permission_mode, &caps)?;
+        let execution_settings = CodeSessionExecutionSettings {
+            model: normalize_model(model),
+            reasoning_effort,
+            fast_mode,
+        };
+        if execution_settings.fast_mode {
+            return Err(ServerError::unprocessable_kind(
+                "fast_mode_unsupported",
+                "the internal engine has no fast mode",
+            ));
+        }
+        let session = CodeSession {
+            id: CodeSessionId::new(),
+            owner: owner.clone(),
+            workspace_id: None,
+            kind: CodeSessionKind::Interactive,
+            harness_kind: harness,
+            harness_version: probe.version.clone(),
+            harness_resume_ref: None,
+            permission_mode,
+            model: execution_settings.model,
+            reasoning_effort: execution_settings.reasoning_effort,
+            fast_mode: false,
+            lifecycle: CodeSessionLifecycle::Created,
+            fence_reason: None,
+            child_pid: None,
+            child_process_identity: None,
+            spawn_epoch: 0,
+            attention: Attention::working(AttentionSource::Lifecycle),
+            unrecognized_event_count: 0,
+            subagents: Vec::new(),
+            created_at: Utc::now(),
+        };
+        insert_session(&self.db, &session).await?;
         self.attach_and_spawn_worker(session).await
     }
 
@@ -326,7 +404,7 @@ impl CodeRuntime {
         if session.lifecycle == CodeSessionLifecycle::Ended {
             return Ok(());
         }
-        if let Ok(workspace) = self.get_workspace(owner, session.workspace_id).await {
+        if let Ok(Some(workspace)) = self.session_workspace(&session).await {
             if workspace.is_remote() {
                 self.cancel_remote_sandbox(&session).await;
             }
@@ -413,6 +491,18 @@ impl CodeRuntime {
         Ok(list_sessions_for_workspace(&self.db, owner, workspace_id).await?)
     }
 
+    /// The owner's sessions that bind no workspace, newest first.
+    pub(crate) async fn list_internal_sessions(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<Vec<CodeSession>, ServerError> {
+        Ok(tidebreak_core::db::code::list_sessions(&self.db, owner)
+            .await?
+            .into_iter()
+            .filter(|session| session.workspace_id.is_none())
+            .collect())
+    }
+
     /// The external bindings behind `session_ids`, for provenance display.
     /// Sessions the desktop created have none and are simply absent.
     pub(crate) async fn external_bindings_for_sessions(
@@ -492,7 +582,7 @@ impl CodeRuntime {
     ) -> Result<fork::WrittenTranscript, ServerError> {
         let session = self.get_session(owner, session_id).await?;
         let workspace = self
-            .require_live_workspace(owner, session.workspace_id)
+            .require_live_workspace(owner, Self::require_workspace_id(&session)?)
             .await?;
         let private_root = crate::code::scratch::workspace_root(&self.data_dir, workspace.id)
             .map_err(|err| {

--- a/crates/tidebreak-server/src/code/runtime/settings.rs
+++ b/crates/tidebreak-server/src/code/runtime/settings.rs
@@ -173,8 +173,11 @@ impl CodeRuntime {
             _ => {}
         }
 
-        let workspace = self.get_workspace(owner, session.workspace_id).await?;
-        if workspace.is_remote() {
+        let workspace = self.session_workspace(&session).await?;
+        if workspace
+            .as_ref()
+            .is_some_and(|workspace| workspace.is_remote())
+        {
             // The sandbox carries the engine. Persist the mode on the row and
             // do not relaunch a host harness against the empty worktree.
             let mut session = session;

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -152,12 +152,14 @@ impl CodeRuntime {
             }
         }
         let mut session = self.get_session(owner, id).await?;
-        let workspace = self.get_workspace(owner, session.workspace_id).await?;
-        if workspace.status != CodeWorkspaceStatus::Active {
-            return Err(ServerError::conflict_kind(
-                "workspace_not_ready",
-                format!("workspace is {}", workspace.status.as_str()),
-            ));
+        let workspace = self.session_workspace(&session).await?;
+        if let Some(workspace) = &workspace {
+            if workspace.status != CodeWorkspaceStatus::Active {
+                return Err(ServerError::conflict_kind(
+                    "workspace_not_ready",
+                    format!("workspace is {}", workspace.status.as_str()),
+                ));
+            }
         }
         if session.lifecycle == CodeSessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
@@ -171,7 +173,7 @@ impl CodeRuntime {
                 "session has ended",
             ));
         }
-        if workspace.is_remote() {
+        if let Some(workspace) = workspace.as_ref().filter(|workspace| workspace.is_remote()) {
             // The sandbox path: no local worker, no worktree lock, no
             // harness probe. Everything below this branch assumes a checkout
             // on this machine.
@@ -179,7 +181,7 @@ impl CodeRuntime {
                 .submit_remote_turn(
                     owner,
                     session,
-                    &workspace,
+                    workspace,
                     message,
                     model,
                     reasoning_effort,
@@ -458,10 +460,8 @@ impl CodeRuntime {
                 "session worker is not running",
             ));
         };
-        let workspace = self
-            .get_workspace(&session.owner, session.workspace_id)
-            .await?;
-        if !workspace.is_remote() {
+        let workspace = self.session_workspace(&session).await?;
+        if !workspace.is_some_and(|workspace| workspace.is_remote()) {
             return Err(ServerError::conflict_kind(
                 "session_worker_missing",
                 "session worker is not running",
@@ -532,7 +532,10 @@ impl CodeRuntime {
         owner: &OwnerId,
         session: &CodeSession,
     ) -> Result<Option<String>, ServerError> {
-        let siblings = list_sessions_for_workspace(&self.db, owner, session.workspace_id).await?;
+        let Some(workspace_id) = session.workspace_id else {
+            return Ok(None);
+        };
+        let siblings = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         Ok(siblings
             .iter()
             .find(|other| {
@@ -709,8 +712,11 @@ impl CodeRuntime {
                 "only a fenced session can be reaped",
             ));
         }
-        let workspace = self.get_workspace(owner, session.workspace_id).await?;
-        if workspace.is_remote() {
+        let workspace = self.session_workspace(&session).await?;
+        if workspace
+            .as_ref()
+            .is_some_and(|workspace| workspace.is_remote())
+        {
             // No worker to shut down and nothing to relaunch: the driver
             // cancels whatever the environment still holds, closes the
             // incarnation, and resolves the fence. The next turn

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -46,9 +46,7 @@ impl CodeRuntime {
         session: CodeSession,
     ) -> Result<CodeSession, ServerError> {
         let mut session = session;
-        let workspace = self
-            .get_workspace(&session.owner, session.workspace_id)
-            .await?;
+        let workspace = self.session_workspace(&session).await?;
         let adapter = self.adapter(session.harness_kind)?;
         // Cached, so the probe `create_session` already paid for is not paid
         // again on the way into the worker.
@@ -82,12 +80,17 @@ impl CodeRuntime {
                         })?;
             }
         }
-        let binary = probe.binary_path.clone().ok_or_else(|| {
-            ServerError::unprocessable_kind(
-                "harness_not_found",
-                format!("{} has no path", session.harness_kind),
-            )
-        })?;
+        let binary = match probe.binary_path.clone() {
+            Some(binary) => Some(binary),
+            // An in-process engine has no binary to resolve.
+            None if session.harness_kind.is_in_process() => None,
+            None => {
+                return Err(ServerError::unprocessable_kind(
+                    "harness_not_found",
+                    format!("{} has no path", session.harness_kind),
+                ))
+            }
+        };
         let attached = attach_engine(
             &self.db,
             &self.bus,
@@ -114,12 +117,18 @@ impl CodeRuntime {
             self.rewrite_hook(),
             self.hot_pull_requests(),
         );
-        let approval = self.approval_channel(
-            &attached.owner,
-            attached.id,
-            attached.spawn_epoch,
-            session.permission_mode,
-        );
+        // An in-process engine parks its approvals on the adapter's own
+        // channel; the loopback MCP prompt is for engines that speak MCP.
+        let approval = if session.harness_kind.is_in_process() {
+            None
+        } else {
+            self.approval_channel(
+                &attached.owner,
+                attached.id,
+                attached.spawn_epoch,
+                session.permission_mode,
+            )
+        };
 
         // Mint a browser channel only when both halves are present: the
         // native BrowserRuntime (the desktop adapter) and the trusted
@@ -129,11 +138,12 @@ impl CodeRuntime {
         let browser = match (
             self.browser_runtime.as_ref(),
             self.browser_bridge_command.as_ref(),
+            session.workspace_id,
         ) {
-            (Some(runtime), Some(bridge)) => {
+            (Some(runtime), Some(bridge), Some(workspace)) => {
                 let browser_subject = BrowserSubject {
                     owner: session.owner.clone(),
-                    workspace: session.workspace_id,
+                    workspace,
                     session: session.id,
                 };
                 Some(
@@ -149,16 +159,19 @@ impl CodeRuntime {
             _ => None,
         };
 
-        let private_root = crate::code::scratch::workspace_root(&self.data_dir, workspace.id)
-            .map_err(|err| {
-                ServerError::internal(format!("could not open private storage: {err}"))
-            })?;
+        let private_root = match &workspace {
+            Some(workspace) => crate::code::scratch::workspace_root(&self.data_dir, workspace.id),
+            None => crate::code::scratch::session_root(&self.data_dir, session.id),
+        }
+        .map_err(|err| ServerError::internal(format!("could not open private storage: {err}")))?;
 
         // On a gateway-authenticated machine, point the engine's own
         // inference at this server's relay (decision 71): a per-session key
         // stands in for provider credentials the hosted image does not have.
         let (extra_argv, extra_env, relay_key_env) = match self.harness_llm.as_ref() {
-            Some(relay) => {
+            // An in-process engine resolves inference through the server
+            // itself; there is no child to point at the relay.
+            Some(relay) if !session.harness_kind.is_in_process() => {
                 let base = self
                     .loopback_base
                     .lock()
@@ -179,11 +192,18 @@ impl CodeRuntime {
                     Some(crate::code::harness_llm::RELAY_KEY_ENV.to_owned()),
                 )
             }
-            None => (Vec::new(), Vec::new(), None),
+            _ => (Vec::new(), Vec::new(), None),
         };
 
         let spec = SessionSpec {
-            worktree: PathBuf::from(&workspace.worktree_path),
+            owner: session.owner.clone(),
+            session_id: session.id,
+            // With no workspace the private root doubles as the working
+            // directory; the in-process engine keeps its own scratch there.
+            worktree: match &workspace {
+                Some(workspace) => PathBuf::from(&workspace.worktree_path),
+                None => private_root.path().to_path_buf(),
+            },
             allowed_read_roots: vec![private_root.path().to_path_buf()],
             permission_mode: session.permission_mode,
             model: session.model.clone(),
@@ -195,7 +215,7 @@ impl CodeRuntime {
             relay_key_env,
             env: probe.env.clone(),
             approval,
-            binary: Some(binary),
+            binary,
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
             browser,
         };
@@ -252,7 +272,12 @@ impl CodeRuntime {
                 engine_reads_images: adapter.capabilities(&probe).image_input
                     == CapLevel::Supported,
             },
-            self.worktree_turn_lock(attached.workspace_id),
+            // A session with no workspace shares its working directory with
+            // nothing, so it takes a lock of its own.
+            match attached.workspace_id {
+                Some(workspace_id) => self.worktree_turn_lock(workspace_id),
+                None => Arc::new(tokio::sync::Mutex::new(())),
+            },
             self.update_quiesce.subscribe(),
         );
         self.workers

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -1040,6 +1040,31 @@ impl CodeRuntime {
         Ok(all_stopped)
     }
 
+    /// The workspace a session binds, when it binds one.
+    pub(crate) async fn session_workspace(
+        &self,
+        session: &CodeSession,
+    ) -> Result<Option<CodeWorkspace>, ServerError> {
+        match session.workspace_id {
+            Some(workspace_id) => self
+                .get_workspace(&session.owner, workspace_id)
+                .await
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// The workspace id a checkout-bound operation needs, or the conflict a
+    /// session without one answers.
+    pub(crate) fn require_workspace_id(session: &CodeSession) -> Result<WorkspaceId, ServerError> {
+        session.workspace_id.ok_or_else(|| {
+            ServerError::conflict_kind(
+                "session_has_no_workspace",
+                "this session runs without a workspace, so there is no checkout to act on",
+            )
+        })
+    }
+
     /// The turn lock for a workspace, minted on first use.
     ///
     /// Every session in the workspace hands the same `Arc` to its worker, so

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -600,6 +600,15 @@ impl ScopedCode {
             .await
     }
 
+    pub(crate) async fn create_internal_session(
+        &self,
+        settings: NewSessionSettings,
+    ) -> Result<CodeSession, ServerError> {
+        self.runtime
+            .create_internal_session(&self.owner, settings)
+            .await
+    }
+
     pub(crate) async fn create_remote_session(
         &self,
         workspace_id: WorkspaceId,
@@ -613,6 +622,10 @@ impl ScopedCode {
 
     pub(crate) async fn get_session(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
         self.runtime.get_session(&self.owner, id).await
+    }
+
+    pub(crate) async fn list_internal_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
+        self.runtime.list_internal_sessions(&self.owner).await
     }
 
     pub(crate) async fn list_workspace_sessions(

--- a/crates/tidebreak-server/src/code/scratch.rs
+++ b/crates/tidebreak-server/src/code/scratch.rs
@@ -17,6 +17,7 @@ use tokio::io::AsyncWriteExt as _;
 
 const CODE_DIR: &str = "code";
 const PRIVATE_DIR: &str = "private";
+const SESSIONS_DIR: &str = "sessions";
 
 /// A workspace's private storage root, pinned to the directory that passed
 /// validation.
@@ -141,6 +142,33 @@ pub(crate) fn workspace_root(
             .join(CODE_DIR)
             .join(PRIVATE_DIR)
             .join(workspace_name),
+    })
+}
+
+/// Create the private root for one session that binds no workspace, under
+/// the same tree as workspace roots: `{data_dir}/code/private/sessions/{id}`.
+///
+/// The in-process engine's working directory. Nothing in it is a checkout,
+/// and no other session shares it.
+pub(crate) fn session_root(
+    data_dir: &Path,
+    session_id: tidebreak_core::CodeSessionId,
+) -> io::Result<ScratchRoot> {
+    let data_dir = absolute_path(data_dir)?;
+    let root = open_root(&data_dir)?;
+    reject_git_indexable_root(&std::fs::canonicalize(&data_dir)?)?;
+    let code = ensure_child_dir(&root, OsStr::new(CODE_DIR))?;
+    let private = ensure_child_dir(&code, OsStr::new(PRIVATE_DIR))?;
+    let sessions = ensure_child_dir(&private, OsStr::new(SESSIONS_DIR))?;
+    let session_name = session_id.to_string();
+    let session = ensure_child_dir(&sessions, OsStr::new(&session_name))?;
+    Ok(ScratchRoot {
+        dir: Arc::new(session),
+        path: data_dir
+            .join(CODE_DIR)
+            .join(PRIVATE_DIR)
+            .join(SESSIONS_DIR)
+            .join(session_name),
     })
 }
 

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -23,11 +23,13 @@ use tokio::sync::{mpsc, oneshot, watch, Notify};
 use tracing::{warn, Instrument as _};
 
 use tidebreak_core::db::code::{
-    accept_trigger_turn_delivery, append_event, append_event_with_notification, bump_spawn_epoch,
-    delete_queued_turn, get_open_turn, get_session, get_session_all_owners, get_workspace,
-    insert_approval_for_worker, insert_turn, next_turn_ordinal, promote_queued_turn, queue_paused,
-    queued_turn_head, save_session, save_turn, set_queue_paused, set_session_harness_resume_ref,
-    set_session_subagents, CodeJournalError, CodeSessionExecutionSettings,
+    accept_trigger_turn_delivery, append_event, append_event_with_notification,
+    begin_permission_mode_change, bump_spawn_epoch, cancel_permission_mode_change,
+    confirm_permission_mode_change, delete_queued_turn, get_open_turn, get_session,
+    get_session_all_owners, get_workspace, insert_approval_for_worker, insert_turn, list_approvals,
+    next_turn_ordinal, promote_queued_turn, queue_paused, queued_turn_head, save_session,
+    save_turn, set_queue_paused, set_session_harness_resume_ref, set_session_subagents,
+    settle_engine_observed_approval, CodeJournalError, CodeSessionExecutionSettings,
 };
 use tidebreak_core::{
     bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
@@ -459,6 +461,40 @@ impl LiveSink {
             .await
     }
 
+    /// Settle a pending approval the engine decided itself, when one is
+    /// still waiting under this call id.
+    async fn settle_engine_observed(&self, call_id: &str, decision: ApprovalDecision) {
+        match settle_engine_observed_approval(
+            &self.db,
+            &self.owner,
+            self.session_id,
+            self.spawn_epoch,
+            call_id,
+            tidebreak_core::ApprovalDecisionKind::from(decision),
+            Utc::now(),
+        )
+        .await
+        {
+            Ok(Some(settlement)) => {
+                self.bus.publish(self.session_id, settlement.event);
+                let _ = super::attention::note_activity(
+                    &self.db,
+                    &self.bus,
+                    &self.owner,
+                    self.session_id,
+                )
+                .await;
+            }
+            Ok(None) => {}
+            Err(error) => warn!(
+                session = %self.session_id,
+                call_id,
+                error = %error,
+                "could not settle an engine-decided approval"
+            ),
+        }
+    }
+
     async fn record_approval(
         &self,
         approval_id: CodeApprovalId,
@@ -600,9 +636,18 @@ impl HarnessEventSink for LiveSink {
             }
             return;
         }
-        if matches!(event, HarnessEvent::ApprovalResolved { .. }) {
+        if let HarnessEvent::ApprovalResolved {
+            harness_ref,
+            decision,
+        } = &event
+        {
             // The decision route journals ApprovalResolved after the harness
-            // observes the decision. Ignore a duplicate emit from the engine.
+            // observes the decision, so a decided row is left alone. A row
+            // still pending and unclaimed was decided on the engine's own
+            // channel — a standing grant, an auto-approval judge — and this
+            // report is the only settlement it will get.
+            self.settle_engine_observed(&harness_ref.call_id, decision.clone())
+                .await;
             return;
         }
         if matches!(event, HarnessEvent::TurnStarted) && self.turn_id.lock().unwrap().is_some() {
@@ -1198,6 +1243,114 @@ async fn persist_turn_park(
 /// the same native channel and classification as the concurrent control path
 /// — and only a confirmed delivery resumes the turn. Every other command
 /// takes the ordinary control path.
+/// Follow an accepted plan with the permission-mode change it proposed.
+///
+/// The plan approval names the mode the engine would continue under; the
+/// decision alone leaves the posture untouched (decision 0048 step 5). So
+/// before the resume, the worker moves the engine onto that mode and
+/// persists it on the session row. A refusal from the engine is journaled
+/// and the turn still resumes: the plan was accepted, and the posture the
+/// user sees is the one the row keeps.
+async fn apply_accepted_plan_mode(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    session: &mut CodeSession,
+    engine: &dyn HarnessSession,
+    input: &tidebreak_harness::ResumeInput,
+) {
+    let tidebreak_harness::ResumeInput::ApprovalDecided {
+        call_id,
+        decision: ApprovalDecision::PlanDecision { approve: true, .. },
+    } = input
+    else {
+        return;
+    };
+    let proposed = match list_approvals(db, &session.owner, None, Some(session.id)).await {
+        Ok(approvals) => approvals.into_iter().find_map(|approval| {
+            match (&approval.native_call_id, &approval.kind) {
+                (Some(native), CodeApprovalKind::Plan { proposed_mode }) if native == call_id => {
+                    Some(*proposed_mode)
+                }
+                _ => None,
+            }
+        }),
+        Err(error) => {
+            warn!(session = %session.id, error = %error, "could not read the accepted plan");
+            None
+        }
+    };
+    let Some(mode) = proposed else {
+        return;
+    };
+    if mode == session.permission_mode {
+        return;
+    }
+    // The row's own intent protocol: reserve, re-posture the engine, then
+    // confirm — so a route-level change racing this one loses cleanly.
+    let intent = match begin_permission_mode_change(db, &session.owner, session, mode).await {
+        Ok(Some(intent)) => intent,
+        Ok(None) => {
+            warn!(session = %session.id, "the plan's permission mode change lost to a concurrent one");
+            return;
+        }
+        Err(error) => {
+            warn!(session = %session.id, error = %error, "could not reserve the plan's permission mode");
+            return;
+        }
+    };
+    match engine.set_permission_mode(mode).await {
+        Ok(()) => {
+            match confirm_permission_mode_change(db, &session.owner, &intent).await {
+                Ok(true) => session.permission_mode = mode,
+                Ok(false) => {
+                    warn!(session = %session.id, "the plan's permission mode change was not confirmed");
+                    return;
+                }
+                Err(error) => {
+                    warn!(session = %session.id, error = %error, "could not confirm the plan's permission mode");
+                    return;
+                }
+            }
+            if let Err(error) = super::attention::persist_session(db, bus, session).await {
+                warn!(session = %session.id, error = %error, "could not publish the plan's permission mode");
+            }
+            let _ = persist_and_publish(
+                db,
+                bus,
+                &session.owner,
+                session.id,
+                session.spawn_epoch,
+                CodeEvent::HarnessNotice {
+                    level: HarnessNoticeLevel::Info,
+                    message: format!(
+                        "Plan accepted; the session continues in {} mode.",
+                        mode.as_str()
+                    ),
+                },
+            )
+            .await;
+        }
+        Err(error) => {
+            let _ = cancel_permission_mode_change(db, &session.owner, &intent).await;
+            let _ = persist_and_publish(
+                db,
+                bus,
+                &session.owner,
+                session.id,
+                session.spawn_epoch,
+                CodeEvent::HarnessNotice {
+                    level: HarnessNoticeLevel::Warning,
+                    message: format!(
+                        "Plan accepted, but the engine kept its {} posture: {error}",
+                        session.permission_mode.as_str()
+                    ),
+                },
+            )
+            .await;
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn await_park_resolution<'a>(
     engine: &'a dyn HarnessSession,
@@ -1676,15 +1829,17 @@ async fn drive_turn_inner(
     if *worktree.quiesce.borrow() {
         return Err(WorkerError::UpdateQuiesced);
     }
-    let workspace = get_workspace(&sink.db, &session.owner, session.workspace_id)
-        .await
-        .map_err(|error| WorkerError::Failed(error.to_string()))?
-        .ok_or_else(|| WorkerError::Conflict("workspace no longer exists".into()))?;
-    if workspace.status != CodeWorkspaceStatus::Active {
-        return Err(WorkerError::Conflict(format!(
-            "workspace is {}",
-            workspace.status.as_str()
-        )));
+    if let Some(workspace_id) = session.workspace_id {
+        let workspace = get_workspace(&sink.db, &session.owner, workspace_id)
+            .await
+            .map_err(|error| WorkerError::Failed(error.to_string()))?
+            .ok_or_else(|| WorkerError::Conflict("workspace no longer exists".into()))?;
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return Err(WorkerError::Conflict(format!(
+                "workspace is {}",
+                workspace.status.as_str()
+            )));
+        }
     }
 
     // An idle send resolves settings after it owns the worktree, so a
@@ -1941,6 +2096,10 @@ async fn drive_turn_inner(
         .await
         {
             Some(input) => {
+                // An accepted plan re-postures the session before the turn
+                // continues: the decision itself never changes the mode, the
+                // engine's own channel does, and the row must say so too.
+                apply_accepted_plan_mode(db, bus, session, engine, &input).await;
                 turn.status = CodeTurnStatus::Running;
                 turn.park_ref = None;
                 turn.park_wait = None;
@@ -3145,7 +3304,7 @@ mod tests {
             &CodeSession {
                 id: session_id,
                 owner: owner.clone(),
-                workspace_id,
+                workspace_id: Some(workspace_id),
                 kind: CodeSessionKind::Interactive,
                 harness_kind,
                 harness_version: harness_version.map(str::to_owned),
@@ -3201,6 +3360,123 @@ mod tests {
         (directory, store, sink, session_id)
     }
 
+    /// An engine that answers its own approval — a standing grant, an
+    /// auto-approval judge — reports the decision on the stream, and that
+    /// report is the only settlement the row it opened will ever get.
+    #[tokio::test]
+    async fn an_engine_observed_decision_settles_its_own_approval_row() {
+        let (directory, store, sink, session_id) = seeded_sink().await;
+        let owner = OwnerId::local();
+        let mut session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        session.lifecycle = CodeSessionLifecycle::Idle;
+        assert!(save_session(&store, &session).await.unwrap());
+
+        let worktree = directory.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let private = directory.path().join("private");
+        std::fs::create_dir(&private).unwrap();
+        let private_root =
+            super::super::scratch::ScratchRoot::open_for_test(&private).expect("scratch root");
+        let script = vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::ApprovalRequested {
+                harness_ref: tidebreak_harness::HarnessApprovalRef::engine("call-1"),
+                raw: serde_json::Value::Null,
+                kind: Some(tidebreak_core::CodeApprovalKind::Other {
+                    summary: "exec".into(),
+                }),
+            },
+            HarnessEvent::ApprovalResolved {
+                harness_ref: tidebreak_harness::HarnessApprovalRef::engine("call-1"),
+                decision: ApprovalDecision::Approve,
+            },
+            HarnessEvent::AssistantMessage {
+                text: "ran under a standing grant".into(),
+                parent_call_id: None,
+            },
+            HarnessEvent::TurnCompleted {
+                usage: CodeUsage::default(),
+            },
+        ];
+        let adapter = ScriptedAdapter::new(script).with_unattended_approvals();
+        let engine = adapter
+            .launch(SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::CodeSessionId::new(),
+                worktree,
+                allowed_read_roots: Vec::new(),
+                permission_mode: session.permission_mode,
+                model: session.model.clone(),
+                reasoning_effort: session.reasoning_effort,
+                fast_mode: session.fast_mode,
+                resume_ref: None,
+                extra_argv: Vec::new(),
+                extra_env: Vec::new(),
+                relay_key_env: None,
+                env: Vec::new(),
+                approval: None,
+                binary: Some(std::path::PathBuf::from("/scripted/engine")),
+                sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+                browser: None,
+            })
+            .await
+            .unwrap();
+        let handle = spawn_session_worker(
+            session.clone(),
+            engine,
+            sink,
+            AttachmentStore {
+                blobs: None,
+                private_root,
+                engine_reads_images: false,
+            },
+            Arc::new(tokio::sync::Mutex::new(())),
+            tokio::sync::watch::channel(false).1,
+        );
+
+        let (turn_reply, turn_response) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::RunTurn {
+                message: "run it".into(),
+                attachments: Vec::new(),
+                trigger_delivery: None,
+                reply: turn_reply,
+            })
+            .await
+            .unwrap();
+        let turn = tokio::time::timeout(Duration::from_secs(5), turn_response)
+            .await
+            .expect("the turn completes")
+            .unwrap()
+            .unwrap();
+        assert_eq!(turn.status, CodeTurnStatus::Completed);
+
+        let approvals = list_approvals(&store, &owner, None, Some(session_id))
+            .await
+            .unwrap();
+        assert_eq!(approvals.len(), 1);
+        assert_eq!(approvals[0].state, CodeApprovalState::Approved);
+        assert_eq!(approvals[0].native_call_id.as_deref(), Some("call-1"));
+        let events = list_events(&store, &owner, session_id, 0, MAX_REPLAY_EVENTS)
+            .await
+            .unwrap();
+        assert!(
+            events.events.iter().any(|event| matches!(
+                &event.event,
+                CodeEvent::ApprovalResolved {
+                    approval_id,
+                    decision: tidebreak_core::ApprovalDecisionKind::Approve,
+                } if *approval_id == approvals[0].id
+            )),
+            "the journal records the engine's own decision"
+        );
+        let _ = handle.commands.send(WorkerCommand::Shutdown).await;
+    }
+
     #[tokio::test]
     async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
         let (directory, store, sink, session_id) = seeded_sink().await;
@@ -3245,6 +3521,8 @@ mod tests {
             );
         let engine = adapter
             .launch(SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::CodeSessionId::new(),
                 worktree,
                 allowed_read_roots: Vec::new(),
                 permission_mode: session.permission_mode,
@@ -3392,6 +3670,8 @@ mod tests {
             );
         let engine = adapter
             .launch(SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::CodeSessionId::new(),
                 worktree,
                 allowed_read_roots: Vec::new(),
                 permission_mode: session.permission_mode,
@@ -3510,6 +3790,8 @@ mod tests {
         );
         let engine = adapter
             .launch(SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::CodeSessionId::new(),
                 worktree,
                 allowed_read_roots: Vec::new(),
                 permission_mode: session.permission_mode,
@@ -3608,6 +3890,8 @@ mod tests {
         let adapter = ScriptedAdapter::new(plain_text_script());
         let engine = adapter
             .launch(SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::CodeSessionId::new(),
                 worktree,
                 allowed_read_roots: Vec::new(),
                 permission_mode: session.permission_mode,
@@ -3720,6 +4004,8 @@ mod tests {
         let adapter = ScriptedAdapter::new(plain_text_script());
         let engine = adapter
             .launch(SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::CodeSessionId::new(),
                 worktree,
                 allowed_read_roots: Vec::new(),
                 permission_mode: session.permission_mode,
@@ -4346,6 +4632,8 @@ mod tests {
         let adapter = ScriptedAdapter::new(plain_text_script());
         let engine = adapter
             .launch(SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::CodeSessionId::new(),
                 worktree,
                 allowed_read_roots: Vec::new(),
                 permission_mode: session.permission_mode,

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -109,11 +109,15 @@ async fn derive_workspace_title(
     let Some(session) = get_session(&code.db, owner, session_id).await? else {
         return Ok(Outcome::NotApplicable);
     };
-    let Some(claim) = TitlingClaim::acquire(code, session.workspace_id) else {
+    // A session without a workspace has no repository to name it after.
+    let Some(workspace_id) = session.workspace_id else {
+        return Ok(Outcome::NotApplicable);
+    };
+    let Some(claim) = TitlingClaim::acquire(code, workspace_id) else {
         return Ok(Outcome::NotApplicable);
     };
     let _held = claim;
-    let Some(workspace) = get_workspace(&code.db, owner, session.workspace_id).await? else {
+    let Some(workspace) = get_workspace(&code.db, owner, workspace_id).await? else {
         return Ok(Outcome::NotApplicable);
     };
     let placeholder = worktree::two_word_name(workspace.id.0.as_u128());

--- a/crates/tidebreak-server/src/engine/internal/adapter.rs
+++ b/crates/tidebreak-server/src/engine/internal/adapter.rs
@@ -1,0 +1,88 @@
+//! The adapter half: probe, capabilities, launch.
+
+use async_trait::async_trait;
+use tidebreak_core::{CapLevel, HarnessCaps, HarnessKind, ReasoningEffort};
+use tidebreak_harness::{
+    HarnessAdapter, HarnessError, HarnessProbe, HarnessSession, HostEnv, ListedHarnessModel,
+    SessionSpec,
+};
+
+use super::session::InternalSession;
+use crate::state::AppState;
+
+/// The in-process engine, registered under [`HarnessKind::Internal`].
+///
+/// Holds the application state the chat turn lane runs on: the store, the
+/// chat event bus, the approval broker, and the turn wake handles. It is
+/// installed after the state exists, like the recap and rewrite hooks, and
+/// the copy it keeps carries no code runtime, so nothing here can reach back
+/// into the runtime that owns it.
+pub(crate) struct InternalAdapter {
+    state: AppState,
+}
+
+impl InternalAdapter {
+    pub(crate) fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl HarnessAdapter for InternalAdapter {
+    fn kind(&self) -> HarnessKind {
+        HarnessKind::Internal
+    }
+
+    async fn probe(&self, _host: &HostEnv) -> HarnessProbe {
+        HarnessProbe {
+            found: true,
+            // In-process: no binary to resolve, nothing to pin or download.
+            binary_path: None,
+            version: Some(env!("CARGO_PKG_VERSION").to_owned()),
+            // The engine has no sign-in of its own. The provider that serves
+            // it is configured in Tidebreak's settings, and a turn with no
+            // usable provider fails the same way a chat turn does.
+            authenticated: Some(true),
+            stderr: String::new(),
+            env: Vec::new(),
+            commands: Vec::new(),
+        }
+    }
+
+    fn capabilities(&self, _probe: &HarnessProbe) -> HarnessCaps {
+        HarnessCaps {
+            resume: CapLevel::Supported,
+            streaming_deltas: CapLevel::Supported,
+            structured_approvals: CapLevel::Supported,
+            mid_turn_steering: CapLevel::Supported,
+            plan_mode: CapLevel::Supported,
+            auto_mode: CapLevel::Supported,
+            allow_mode: CapLevel::Supported,
+            reasoning_levels: CapLevel::Supported,
+            native_file_change_events: CapLevel::Unsupported,
+            native_interrupt: CapLevel::Supported,
+            // Chat's attachment model is the image path for the internal
+            // engine; hydrated bytes on the turn input are not wired yet.
+            image_input: CapLevel::Unsupported,
+            slash_commands: CapLevel::Unsupported,
+            durable_parks: CapLevel::Supported,
+            user_questions: CapLevel::Supported,
+            standing_grants: CapLevel::Supported,
+        }
+    }
+
+    fn reasoning_efforts(&self, _probe: &HarnessProbe) -> Vec<ReasoningEffort> {
+        ReasoningEffort::ALL.to_vec()
+    }
+
+    async fn list_models(&self, _probe: &HarnessProbe) -> Vec<ListedHarnessModel> {
+        // The chat model catalog already serves this engine's models through
+        // the models routes; it lists nothing engine-specific.
+        Vec::new()
+    }
+
+    async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
+        let session = InternalSession::launch(self.state.clone(), spec).await?;
+        Ok(Box::new(session))
+    }
+}

--- a/crates/tidebreak-server/src/engine/internal/mod.rs
+++ b/crates/tidebreak-server/src/engine/internal/mod.rs
@@ -1,0 +1,18 @@
+//! Tidebreak's own agent loop behind the adapter contract.
+//!
+//! The engine drives [`tidebreak_core::agent::Agent`] through the chat turn
+//! lane that already runs it — the durable `turn_run` queue, the
+//! [`crate::turn_worker::TurnWorker`], and the chat event journal — and
+//! translates what that lane journals into [`tidebreak_harness::HarnessEvent`]s
+//! for the session worker's sink. Its durable state is one engine-private
+//! conversation per session, keyed by the session id, which owner-scoped
+//! chat reads never list. Chat's continuations become durable parks: a
+//! user-questions card or a plan proposal ends the leg as
+//! [`tidebreak_harness::TurnOutcome::Parked`], and the answer or plan
+//! decision resumes it through [`tidebreak_harness::HarnessSession::resume_turn`].
+
+mod adapter;
+mod session;
+mod translate;
+
+pub(crate) use adapter::InternalAdapter;

--- a/crates/tidebreak-server/src/engine/internal/session.rs
+++ b/crates/tidebreak-server/src/engine/internal/session.rs
@@ -1,0 +1,895 @@
+//! One live internal-engine session: a conversation the chat turn lane runs,
+//! watched and steered through the adapter contract.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use tidebreak_core::storage::DecidePlanOutcome;
+use tidebreak_core::{
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent, AnswerUserQuestions,
+    AnswerUserQuestionsOutcome, AnswerUserQuestionsRequest, BeginTurnAdmissionOutcome, CallId,
+    Chat, ChatId, CodeApprovalKind, DecidePlanRequest, NetworkPolicy, PermissionMode, PlanDecision,
+    PlanDecisionChoice, ReservedTurnAcceptanceOutcome, SequencedEvent, TurnAdmissionRequest,
+    TurnId, TurnSteerId, DEFAULT_ACCEPTED_PLAN_MODE,
+};
+use tidebreak_harness::{
+    ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
+    HarnessSession, ParkWait, ResumeInput, SessionSpec, TurnInput, TurnOutcome,
+};
+
+use super::translate::{self, Lookup, Translated};
+use crate::approvals::ResolveApprovalOutcome;
+use crate::state::AppState;
+
+/// How long one admission reservation may sit before the engine gives up.
+const ADMISSION_LEASE: chrono::Duration = chrono::Duration::seconds(30);
+
+/// The turn the engine is driving right now, and how far along the chat
+/// journal it has translated.
+struct ActiveTurn {
+    turn_id: TurnId,
+    /// Last chat journal sequence translated, so a resume or a lagged bus
+    /// subscription picks up exactly after it.
+    last_seq: i64,
+    /// Whether this turn's own `TurnStarted` has been seen; events before it
+    /// belong to an earlier turn's tail.
+    started: bool,
+    /// Assistant prose streamed since the last message boundary.
+    prose: String,
+}
+
+pub(super) struct InternalSession {
+    state: AppState,
+    chat_id: ChatId,
+    sink: Arc<dyn HarnessEventSink>,
+    active: Mutex<Option<ActiveTurn>>,
+    /// Tool approvals decided through [`HarnessSession::decide`], so the
+    /// matching `ApprovalDecided` on the chat journal is not re-reported as
+    /// an engine-observed decision.
+    decided: Mutex<HashSet<CallId>>,
+    /// `UserSteered` emissions owed to [`HarnessSession::steer`]; the chat
+    /// journal's own echo of each is swallowed.
+    steers_emitted: AtomicUsize,
+}
+
+fn store_error(error: tidebreak_core::AgentError) -> HarnessError {
+    HarnessError::Other(format!("engine store: {error}"))
+}
+
+impl InternalSession {
+    pub(super) async fn launch(state: AppState, spec: SessionSpec) -> Result<Self, HarnessError> {
+        let chat_id = ChatId(spec.session_id.0);
+        let existing = state.store.get_chat(chat_id).await.map_err(store_error)?;
+        match (existing, spec.resume_ref.as_deref()) {
+            (Some(_), _) => {
+                // Relaunch: the session's posture and model are the spec's,
+                // and the conversation follows them.
+                state
+                    .store
+                    .update_chat_metadata(
+                        chat_id,
+                        None,
+                        Some(spec.model.clone()),
+                        Some(spec.reasoning_effort),
+                        Some(Some(spec.permission_mode)),
+                        None,
+                    )
+                    .await
+                    .map_err(store_error)?;
+            }
+            (None, Some(resume)) => {
+                return Err(HarnessError::ResumeLost(format!(
+                    "conversation {resume} no longer exists"
+                )));
+            }
+            (None, None) => {
+                let chat = Chat {
+                    id: chat_id,
+                    project_id: None,
+                    title: None,
+                    model: spec.model.clone(),
+                    reasoning_effort: spec.reasoning_effort,
+                    permission_mode: Some(spec.permission_mode),
+                    network_policy: NetworkPolicy::default(),
+                    attachment_revision: 0,
+                    root_attachments: Vec::new(),
+                    created_at: Utc::now(),
+                };
+                state
+                    .store
+                    .create_engine_private_chat(&spec.owner, &chat)
+                    .await
+                    .map_err(store_error)?;
+            }
+        }
+        Ok(Self {
+            state,
+            chat_id,
+            sink: spec.sink,
+            active: Mutex::new(None),
+            decided: Mutex::new(HashSet::new()),
+            steers_emitted: AtomicUsize::new(0),
+        })
+    }
+
+    fn active_turn(&self) -> Option<TurnId> {
+        self.active
+            .lock()
+            .expect("active turn")
+            .as_ref()
+            .map(|active| active.turn_id)
+    }
+
+    fn last_seq(&self) -> i64 {
+        self.active
+            .lock()
+            .expect("active turn")
+            .as_ref()
+            .map_or(0, |active| active.last_seq)
+    }
+
+    async fn emit(&self, event: HarnessEvent) {
+        self.sink.emit(event).await;
+    }
+
+    /// Flush streamed prose as one assistant message at a boundary.
+    async fn flush_prose(&self) {
+        let prose = {
+            let mut active = self.active.lock().expect("active turn");
+            match active.as_mut() {
+                Some(active) if !active.prose.trim().is_empty() => {
+                    std::mem::take(&mut active.prose)
+                }
+                Some(active) => {
+                    active.prose.clear();
+                    return;
+                }
+                None => return,
+            }
+        };
+        self.emit(translate::assistant_message(&prose)).await;
+    }
+
+    /// Submit the user's message to the chat turn lane and return the turn
+    /// it admitted.
+    async fn submit(&self, text: &str) -> Result<TurnId, HarnessError> {
+        let chat = self
+            .state
+            .store
+            .get_chat(self.chat_id)
+            .await
+            .map_err(store_error)?
+            .ok_or_else(|| {
+                HarnessError::ResumeLost(format!("conversation {} no longer exists", self.chat_id))
+            })?;
+        let model =
+            crate::routes::providers_models::resolve_executable_chat_model(&self.state, &chat)
+                .await
+                .map_err(|error| HarnessError::Other(error.message().to_owned()))?;
+        let turn_id = TurnId::new();
+        let request = TurnAdmissionRequest {
+            id: turn_id,
+            chat_id: self.chat_id,
+            content: text.to_owned(),
+            attachments: Vec::new(),
+            file_attachments: Vec::new(),
+            invoked_skills: Vec::new(),
+            voice_input_used: false,
+        };
+        loop {
+            let lease = match self
+                .state
+                .store
+                .begin_turn_admission(&request, uuid::Uuid::new_v4(), ADMISSION_LEASE)
+                .await
+                .map_err(store_error)?
+            {
+                BeginTurnAdmissionOutcome::Acquired(lease) => lease,
+                BeginTurnAdmissionOutcome::Pending { .. } => {
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    continue;
+                }
+                // A fresh turn id cannot already be accepted or queued; the
+                // lane says so only for a replayed identity.
+                BeginTurnAdmissionOutcome::Accepted | BeginTurnAdmissionOutcome::Queued => {
+                    return Ok(turn_id);
+                }
+                BeginTurnAdmissionOutcome::IdentityConflict => {
+                    return Err(HarnessError::Other(format!(
+                        "turn {turn_id} was reserved with different input"
+                    )));
+                }
+            };
+            match self
+                .state
+                .store
+                .accept_reserved_turn_with_message_context(
+                    lease,
+                    self.chat_id,
+                    &model,
+                    text,
+                    &[],
+                    &[],
+                    &[],
+                    false,
+                )
+                .await
+                .map_err(store_error)?
+            {
+                ReservedTurnAcceptanceOutcome::LeaseLost => continue,
+                ReservedTurnAcceptanceOutcome::Outcome(outcome) => match *outcome {
+                    AcceptTurnOutcome::Accepted(turn) | AcceptTurnOutcome::Existing(turn) => {
+                        self.state.turn_job_wake.notify_one();
+                        return Ok(turn.id);
+                    }
+                    AcceptTurnOutcome::IdentityConflict => {
+                        let _ = self.state.store.release_turn_admission(lease).await;
+                        return Err(HarnessError::Other(format!(
+                            "turn {turn_id} was reserved with different input"
+                        )));
+                    }
+                    AcceptTurnOutcome::ChatBusy(active) => {
+                        let _ = self.state.store.release_turn_admission(lease).await;
+                        return Err(HarnessError::Other(format!(
+                            "the conversation is still running turn {}",
+                            active.id
+                        )));
+                    }
+                },
+            }
+        }
+    }
+
+    /// Follow the chat journal for `turn_id` until it reaches a terminal
+    /// event or a durable park, translating as it goes.
+    ///
+    /// The live subscription is the wake-up; the durable journal is the
+    /// truth. A lagged subscription re-reads from the last translated
+    /// sequence, so nothing the lane journaled is skipped.
+    async fn watch(
+        &self,
+        turn_id: TurnId,
+        live: &mut broadcast::Receiver<SequencedEvent>,
+    ) -> Result<TurnOutcome, HarnessError> {
+        loop {
+            let after = self.last_seq();
+            let missed = self
+                .state
+                .store
+                .list_events(self.chat_id, after)
+                .await
+                .map_err(store_error)?;
+            for event in missed {
+                if let Some(outcome) = self.handle(turn_id, event).await? {
+                    return Ok(outcome);
+                }
+            }
+            loop {
+                match live.recv().await {
+                    Ok(event) => {
+                        if let Some(outcome) = self.handle(turn_id, event).await? {
+                            return Ok(outcome);
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(dropped)) => {
+                        debug!(
+                            chat_id = %self.chat_id,
+                            dropped,
+                            "internal engine re-reads the journal after a lagged subscription"
+                        );
+                        break;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        return Err(HarnessError::Other(
+                            "the chat event bus closed under a running turn".into(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Translate one journaled event. `Some` closes the leg.
+    async fn handle(
+        &self,
+        turn_id: TurnId,
+        sequenced: SequencedEvent,
+    ) -> Result<Option<TurnOutcome>, HarnessError> {
+        let SequencedEvent { seq, event } = sequenced;
+        {
+            let mut active = self.active.lock().expect("active turn");
+            let Some(active) = active.as_mut() else {
+                return Ok(None);
+            };
+            if seq <= active.last_seq {
+                return Ok(None);
+            }
+            active.last_seq = seq;
+            match &event {
+                AgentEvent::TurnStarted { turn_id: started } if *started == turn_id => {
+                    active.started = true;
+                }
+                _ if !active.started => return Ok(None),
+                AgentEvent::TextDelta { text } => active.prose.push_str(text),
+                _ => {}
+            }
+        }
+        match self.translate(&event).await? {
+            Translated::Emit(events) => {
+                for event in events {
+                    self.emit(event).await;
+                }
+            }
+            Translated::Lookup(lookup) => {
+                let park = self.park(lookup).await?;
+                return Ok(Some(park));
+            }
+        }
+        Ok(match event {
+            AgentEvent::TurnCompleted { .. }
+            | AgentEvent::TurnRefused { .. }
+            | AgentEvent::TurnFailed { .. }
+            | AgentEvent::TurnCancelled { .. } => {
+                *self.active.lock().expect("active turn") = None;
+                Some(TurnOutcome::Clean)
+            }
+            _ => None,
+        })
+    }
+
+    async fn translate(&self, event: &AgentEvent) -> Result<Translated, HarnessError> {
+        let emit = |events: Vec<HarnessEvent>| Ok(Translated::Emit(events));
+        match event {
+            AgentEvent::TurnStarted { .. } => emit(vec![HarnessEvent::TurnStarted]),
+            AgentEvent::TextDelta { text } => {
+                emit(vec![HarnessEvent::AssistantDelta { text: text.clone() }])
+            }
+            AgentEvent::ReasoningDelta { text } => {
+                emit(vec![HarnessEvent::ReasoningDelta { text: text.clone() }])
+            }
+            // The lane discards the deltas it showed; the prose it kept is
+            // already its own message, so the boundary lands here.
+            AgentEvent::StreamInterrupted => {
+                self.flush_prose().await;
+                emit(Vec::new())
+            }
+            AgentEvent::ToolCallStarted { call_id, name } => {
+                self.flush_prose().await;
+                emit(vec![translate::tool_started(call_id, name)])
+            }
+            AgentEvent::ToolCallArgsDelta { .. } | AgentEvent::TaskPlanUpdated { .. } => {
+                emit(Vec::new())
+            }
+            AgentEvent::ToolCallCompleted {
+                call_id,
+                output,
+                action,
+                ..
+            } => emit(vec![translate::tool_completed(
+                call_id,
+                output,
+                action.as_ref(),
+            )]),
+            AgentEvent::ApprovalRequired {
+                call_id,
+                tool_name,
+                grant_scopes,
+                preview,
+                ..
+            } => {
+                self.flush_prose().await;
+                emit(vec![translate::approval_requested(
+                    call_id,
+                    serde_json::Value::Null,
+                    translate::tool_use_kind(tool_name, preview.clone(), grant_scopes.clone()),
+                )])
+            }
+            AgentEvent::ApprovalDecided { call_id, approved } => {
+                let delivered = self.decided.lock().expect("decided").remove(call_id);
+                if delivered {
+                    emit(Vec::new())
+                } else {
+                    // Decided on the engine's own channel — a standing grant
+                    // or the auto-approval judge — so the row the worker
+                    // minted settles from this report.
+                    emit(vec![translate::approval_resolved(
+                        call_id,
+                        translate::observed_decision(*approved),
+                    )])
+                }
+            }
+            AgentEvent::UserQuestionsAsked { call_id, .. } => {
+                self.flush_prose().await;
+                Ok(Translated::Lookup(Lookup::Questions { call_id: *call_id }))
+            }
+            AgentEvent::PlanProposed { call_id, .. } => {
+                self.flush_prose().await;
+                Ok(Translated::Lookup(Lookup::Plan { call_id: *call_id }))
+            }
+            AgentEvent::UserSteered { content, .. } => {
+                self.flush_prose().await;
+                let owed = self.steers_emitted.load(Ordering::SeqCst);
+                if owed > 0 {
+                    self.steers_emitted.fetch_sub(1, Ordering::SeqCst);
+                    emit(Vec::new())
+                } else {
+                    emit(vec![HarnessEvent::UserSteered {
+                        text: content.clone(),
+                    }])
+                }
+            }
+            AgentEvent::TurnCompleted { usage, .. } => {
+                self.flush_prose().await;
+                emit(vec![HarnessEvent::TurnCompleted {
+                    usage: translate::code_usage(*usage),
+                }])
+            }
+            AgentEvent::TurnRefused { usage, refusal } => {
+                self.flush_prose().await;
+                emit(vec![
+                    translate::refusal_notice(refusal),
+                    HarnessEvent::TurnCompleted {
+                        usage: translate::code_usage(*usage),
+                    },
+                ])
+            }
+            AgentEvent::TurnFailed { error } => {
+                self.flush_prose().await;
+                emit(vec![translate::failure(error)])
+            }
+            AgentEvent::TurnCancelled { .. } => {
+                self.flush_prose().await;
+                emit(vec![HarnessEvent::TurnInterrupted])
+            }
+            AgentEvent::ContextTruncated {
+                original_tokens,
+                fitted_tokens,
+            } => emit(vec![translate::notice(&format!(
+                "Context was trimmed from {original_tokens} to {fitted_tokens} tokens."
+            ))]),
+            AgentEvent::CompactionStarted => emit(vec![translate::notice(
+                "Compacting the conversation to stay within the context window.",
+            )]),
+            AgentEvent::CompactionFinished { compacted } => emit(if *compacted {
+                vec![translate::notice("Conversation compacted.")]
+            } else {
+                Vec::new()
+            }),
+            _ => {
+                warn!(chat_id = %self.chat_id, "internal engine met an unmapped chat event");
+                emit(Vec::new())
+            }
+        }
+    }
+
+    /// Publish the parked continuation as an approval and end the leg.
+    async fn park(&self, lookup: Lookup) -> Result<TurnOutcome, HarnessError> {
+        let (call_id, raw, kind) = match lookup {
+            Lookup::Questions { call_id } => {
+                let pending = self
+                    .state
+                    .store
+                    .list_pending_user_questions(self.chat_id)
+                    .await
+                    .map_err(store_error)?
+                    .into_iter()
+                    .find(|pending| pending.call_id == call_id)
+                    .ok_or_else(|| {
+                        HarnessError::Other(format!("questions {call_id} are not pending"))
+                    })?;
+                (
+                    call_id,
+                    serde_json::Value::Null,
+                    CodeApprovalKind::Questions {
+                        questions: pending.questions,
+                    },
+                )
+            }
+            Lookup::Plan { call_id } => {
+                let pending = self
+                    .state
+                    .store
+                    .list_pending_plan_approvals(self.chat_id)
+                    .await
+                    .map_err(store_error)?
+                    .into_iter()
+                    .find(|pending| pending.call_id == call_id)
+                    .ok_or_else(|| HarnessError::Other(format!("plan {call_id} is not pending")))?;
+                // The plan body rides the raw payload: the approvals route
+                // serves it, and the kind stays small enough for the
+                // journal.
+                (
+                    call_id,
+                    serde_json::json!({
+                        "title": pending.title,
+                        "plan": pending.plan,
+                    }),
+                    CodeApprovalKind::Plan {
+                        proposed_mode: DEFAULT_ACCEPTED_PLAN_MODE,
+                    },
+                )
+            }
+        };
+        self.emit(translate::approval_requested(&call_id, raw, kind))
+            .await;
+        Ok(TurnOutcome::Parked {
+            park_ref: call_id.to_string(),
+            waiting_on: ParkWait::Approval {
+                call_id: call_id.to_string(),
+            },
+        })
+    }
+
+    /// Settle a parked continuation durably. Idempotent: the decision may
+    /// already have landed through [`HarnessSession::decide`] on the leg
+    /// that parked.
+    async fn settle_park(
+        &self,
+        call_id: CallId,
+        decision: &ApprovalDecision,
+    ) -> Result<(), HarnessError> {
+        match decision {
+            ApprovalDecision::Answers { answers } => {
+                let request = AnswerUserQuestionsRequest {
+                    chat_id: self.chat_id,
+                    call_id,
+                    answers: AnswerUserQuestions {
+                        answers: answers.clone(),
+                        additional_user_context: None,
+                    },
+                };
+                match self
+                    .state
+                    .store
+                    .answer_user_questions(&request, Utc::now())
+                    .await
+                    .map_err(store_error)?
+                {
+                    AnswerUserQuestionsOutcome::Answered {
+                        completion_event, ..
+                    } => {
+                        let _ = self
+                            .state
+                            .events
+                            .sender(self.chat_id)
+                            .send(*completion_event);
+                        self.state.turn_job_wake.notify_one();
+                        Ok(())
+                    }
+                    AnswerUserQuestionsOutcome::Existing(_) => Ok(()),
+                    AnswerUserQuestionsOutcome::AnswerConflict => Err(HarnessError::Other(
+                        "these questions were already answered differently".into(),
+                    )),
+                    AnswerUserQuestionsOutcome::InvalidAnswer => {
+                        Err(HarnessError::DecisionUnsupported(
+                            "the answers do not fit the questions".into(),
+                        ))
+                    }
+                    AnswerUserQuestionsOutcome::Unavailable => Err(
+                        HarnessError::ApprovalWaiterMissing(format!("questions {call_id}")),
+                    ),
+                }
+            }
+            ApprovalDecision::PlanDecision { approve, feedback } => {
+                let request = DecidePlanRequest {
+                    chat_id: self.chat_id,
+                    call_id,
+                    decision: PlanDecision {
+                        decision: if *approve {
+                            PlanDecisionChoice::Accept
+                        } else {
+                            PlanDecisionChoice::Reject
+                        },
+                        feedback: feedback.clone(),
+                        // The posture change itself is the caller's
+                        // `set_permission_mode`; naming the same mode here
+                        // keeps the lane's own transition idempotent with it.
+                        permission_mode: approve.then_some(DEFAULT_ACCEPTED_PLAN_MODE),
+                    },
+                };
+                match self
+                    .state
+                    .store
+                    .decide_plan(&request, Utc::now())
+                    .await
+                    .map_err(store_error)?
+                {
+                    DecidePlanOutcome::Decided {
+                        completion_event, ..
+                    } => {
+                        let _ = self
+                            .state
+                            .events
+                            .sender(self.chat_id)
+                            .send(*completion_event);
+                        self.state.turn_job_wake.notify_one();
+                        Ok(())
+                    }
+                    DecidePlanOutcome::Existing(_) => Ok(()),
+                    DecidePlanOutcome::DecisionConflict => Err(HarnessError::Other(
+                        "this plan was already decided differently".into(),
+                    )),
+                    DecidePlanOutcome::InvalidDecision => Err(HarnessError::DecisionUnsupported(
+                        "the plan decision is malformed".into(),
+                    )),
+                    DecidePlanOutcome::Unavailable => Err(HarnessError::ApprovalWaiterMissing(
+                        format!("plan {call_id}"),
+                    )),
+                }
+            }
+            ApprovalDecision::Approve
+            | ApprovalDecision::Deny { .. }
+            | ApprovalDecision::ApproveWithGrant { .. } => Err(HarnessError::DecisionUnsupported(
+                "a parked continuation takes answers or a plan decision".into(),
+            )),
+        }
+    }
+
+    /// Decide a tool approval on the chat lane's approval broker.
+    async fn decide_tool_call(
+        &self,
+        call_id: CallId,
+        decision: &ApprovalDecision,
+    ) -> Result<(), HarnessError> {
+        let Some(chat_decision) = translate::chat_decision(decision) else {
+            return Err(HarnessError::DecisionUnsupported(
+                "a tool approval takes approve, deny, or approve with a grant".into(),
+            ));
+        };
+        self.decided.lock().expect("decided").insert(call_id);
+        let outcome = match decision {
+            ApprovalDecision::ApproveWithGrant { scope } => {
+                self.state
+                    .approvals
+                    .resolve_with_scope(self.chat_id, call_id, scope.clone())
+                    .await
+            }
+            _ => {
+                self.state
+                    .approvals
+                    .resolve(self.chat_id, call_id, chat_decision)
+                    .await
+            }
+        }
+        .map_err(store_error)?;
+        match outcome {
+            ResolveApprovalOutcome::Resolved => Ok(()),
+            ResolveApprovalOutcome::NotPending
+            | ResolveApprovalOutcome::WrongChat
+            | ResolveApprovalOutcome::DecisionConflict => {
+                self.decided.lock().expect("decided").remove(&call_id);
+                Err(HarnessError::ApprovalWaiterMissing(format!(
+                    "tool call {call_id} is not waiting on a decision"
+                )))
+            }
+            ResolveApprovalOutcome::NotApprovable => {
+                self.decided.lock().expect("decided").remove(&call_id);
+                Err(HarnessError::DecisionUnsupported(format!(
+                    "tool call {call_id} cannot be approved"
+                )))
+            }
+            ResolveApprovalOutcome::GrantNotAvailable => {
+                self.decided.lock().expect("decided").remove(&call_id);
+                Err(HarnessError::DecisionUnsupported(
+                    "that grant scope is not available for this call".into(),
+                ))
+            }
+        }
+    }
+
+    fn parse_call_id(raw: &str) -> Result<CallId, HarnessError> {
+        raw.parse::<CallId>().map_err(|_| {
+            HarnessError::ApprovalBindingMismatch(format!("{raw} is not an engine call id"))
+        })
+    }
+}
+
+#[async_trait]
+impl HarnessSession for InternalSession {
+    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
+        if !input.images.is_empty() {
+            return Err(HarnessError::Other(
+                "image input is not available on the internal engine yet".into(),
+            ));
+        }
+        if self.active_turn().is_some() {
+            return Err(HarnessError::Other(
+                "the internal engine is already running a turn".into(),
+            ));
+        }
+        if input.model.is_some() || input.reasoning_effort.is_some() {
+            self.state
+                .store
+                .update_chat_metadata(
+                    self.chat_id,
+                    None,
+                    input.model.clone().map(Some),
+                    input.reasoning_effort.map(Some),
+                    None,
+                    None,
+                )
+                .await
+                .map_err(store_error)?;
+        }
+        // Subscribe before admission so the turn's first event cannot slip
+        // between the two.
+        let mut live = self.state.events.subscribe(self.chat_id);
+        let after = self
+            .state
+            .store
+            .list_events(self.chat_id, 0)
+            .await
+            .map_err(store_error)?
+            .last()
+            .map_or(0, |event| event.seq);
+        let turn_id = self.submit(&input.text).await?;
+        *self.active.lock().expect("active turn") = Some(ActiveTurn {
+            turn_id,
+            last_seq: after,
+            started: false,
+            prose: String::new(),
+        });
+        let outcome = self.watch(turn_id, &mut live).await;
+        if !matches!(outcome, Ok(TurnOutcome::Parked { .. })) {
+            *self.active.lock().expect("active turn") = None;
+        }
+        outcome
+    }
+
+    async fn resume_turn(
+        &self,
+        park_ref: String,
+        input: ResumeInput,
+    ) -> Result<TurnOutcome, HarnessError> {
+        let Some(turn_id) = self.active_turn() else {
+            return Err(HarnessError::Other(format!(
+                "no parked turn to resume for {park_ref}"
+            )));
+        };
+        let call_id = Self::parse_call_id(&park_ref)?;
+        let ResumeInput::ApprovalDecided {
+            call_id: decided,
+            decision,
+        } = input
+        else {
+            return Err(HarnessError::ParkResumeUnsupported);
+        };
+        if decided != park_ref {
+            return Err(HarnessError::ApprovalBindingMismatch(format!(
+                "park {park_ref} did not wait on {decided}"
+            )));
+        }
+        let mut live = self.state.events.subscribe(self.chat_id);
+        self.settle_park(call_id, &decision).await?;
+        let outcome = self.watch(turn_id, &mut live).await;
+        if !matches!(outcome, Ok(TurnOutcome::Parked { .. })) {
+            *self.active.lock().expect("active turn") = None;
+        }
+        outcome
+    }
+
+    async fn decide(
+        &self,
+        approval: HarnessApprovalRef,
+        decision: ApprovalDecision,
+    ) -> Result<(), HarnessError> {
+        let call_id = Self::parse_call_id(&approval.call_id)?;
+        match decision {
+            ApprovalDecision::Answers { .. } | ApprovalDecision::PlanDecision { .. } => {
+                // A continuation decided before its park landed settles the
+                // same durable row; the resume that follows finds it done.
+                self.settle_park(call_id, &decision).await
+            }
+            ApprovalDecision::Approve
+            | ApprovalDecision::Deny { .. }
+            | ApprovalDecision::ApproveWithGrant { .. } => {
+                self.decide_tool_call(call_id, &decision).await
+            }
+        }
+    }
+
+    async fn interrupt(&self) -> Result<(), HarnessError> {
+        let Some(turn_id) = self.active_turn() else {
+            return Ok(());
+        };
+        loop {
+            match self
+                .state
+                .store
+                .request_turn_cancellation_and_append_event(turn_id, Utc::now())
+                .await
+                .map_err(store_error)?
+            {
+                Some(resolution) => {
+                    if let Some(event) = resolution.terminal_event {
+                        let _ = self.state.events.sender(self.chat_id).send(event);
+                    }
+                    break;
+                }
+                None => {
+                    // A heartbeat moved the row under this request; retry with
+                    // fresh time unless the turn is gone.
+                    let present = self
+                        .state
+                        .store
+                        .get_turn_run(turn_id)
+                        .await
+                        .map_err(store_error)?
+                        .is_some();
+                    if !present {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+        self.state.active_turns.cancel(self.chat_id, turn_id);
+        self.state.turn_job_wake.notify_one();
+        self.state.agent_run_wake.notify_one();
+        self.state.queued_turn_wake.notify_one();
+        Ok(())
+    }
+
+    async fn set_permission_mode(&self, mode: PermissionMode) -> Result<(), HarnessError> {
+        self.state
+            .store
+            .update_chat_metadata(self.chat_id, None, None, None, Some(Some(mode)), None)
+            .await
+            .map_err(store_error)?;
+        Ok(())
+    }
+
+    async fn steer(&self, text: String) -> Result<(), HarnessError> {
+        let Some(turn_id) = self.active_turn() else {
+            return Err(HarnessError::SteeringRejected("no turn is running".into()));
+        };
+        match self
+            .state
+            .store
+            .accept_turn_steer_with_message_context(
+                TurnSteerId::new(),
+                turn_id,
+                self.chat_id,
+                &text,
+                &[],
+                false,
+                false,
+            )
+            .await
+            .map_err(store_error)?
+        {
+            AcceptTurnSteerOutcome::Accepted(_) | AcceptTurnSteerOutcome::Existing(_) => {
+                self.state
+                    .active_turns
+                    .signal_steer(self.chat_id, turn_id, false);
+                self.steers_emitted.fetch_add(1, Ordering::SeqCst);
+                self.emit(HarnessEvent::UserSteered { text }).await;
+                Ok(())
+            }
+            AcceptTurnSteerOutcome::TurnUnavailable => Err(HarnessError::SteeringRejected(
+                "the turn is not taking guidance right now".into(),
+            )),
+            AcceptTurnSteerOutcome::IdentityConflict => Err(HarnessError::SteeringRejected(
+                "the steer collided with another".into(),
+            )),
+        }
+    }
+
+    fn resume_ref(&self) -> Option<String> {
+        Some(self.chat_id.to_string())
+    }
+
+    fn unrecognized_events(&self) -> u64 {
+        0
+    }
+
+    async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
+        Ok(())
+    }
+}

--- a/crates/tidebreak-server/src/engine/internal/translate.rs
+++ b/crates/tidebreak-server/src/engine/internal/translate.rs
@@ -1,0 +1,282 @@
+//! Chat journal vocabulary → adapter vocabulary.
+//!
+//! The chat turn lane journals [`AgentEvent`]s; the session worker persists
+//! [`HarnessEvent`]s. This module is the total mapping between them, kept
+//! free of I/O so the shape can be pinned by tests. Events that need a store
+//! read to translate — a questions card, a plan proposal — are answered
+//! with [`Translated::Lookup`] and finished by the session.
+
+use tidebreak_core::{
+    AgentErrorInfo, ApprovalDecision as ChatDecision, BoundedError, CallId, CodeApprovalKind,
+    CodeUsage, GrantScope, HarnessNoticeLevel, RefusalOutcome, ToolActionPreview, ToolDetail,
+    ToolErrorCategory, ToolOutcome, ToolOutput, Usage, MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS,
+    MAX_PREVIEW_CHARS, MAX_TOOL_SUMMARY_CHARS,
+};
+use tidebreak_harness::{ApprovalDecision, HarnessApprovalRef, HarnessEvent};
+
+/// A chat event the engine could not translate on its own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Lookup {
+    /// `ask_user_questions` parked the turn; the questions live in the store.
+    Questions { call_id: CallId },
+    /// `exit_plan_mode` parked the turn; the plan body lives in the store.
+    Plan { call_id: CallId },
+}
+
+/// One chat event, translated.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum Translated {
+    /// Emit these, in order. Empty when the event has no adapter analogue.
+    Emit(Vec<HarnessEvent>),
+    /// Finish the translation with a store read.
+    Lookup(Lookup),
+}
+
+/// Cut `text` to at most `max` characters on a character boundary.
+pub(super) fn bounded(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_owned();
+    }
+    let mut cut = text.chars().take(max.saturating_sub(1)).collect::<String>();
+    cut.push('…');
+    cut
+}
+
+/// Token accounting in the adapter's shape.
+pub(super) fn code_usage(usage: Usage) -> CodeUsage {
+    CodeUsage {
+        input_tokens: u64::from(usage.input_tokens),
+        output_tokens: u64::from(usage.output_tokens),
+        cache_read_input_tokens: u64::from(usage.cache_read_input_tokens),
+        cache_creation_input_tokens: u64::from(usage.cache_creation_input_tokens),
+        context_tokens: 0,
+        first_call_context_tokens: None,
+    }
+}
+
+/// The display classification for a described action.
+pub(super) fn tool_detail(preview: &ToolActionPreview) -> ToolDetail {
+    match preview {
+        ToolActionPreview::Exec {
+            command, args, cwd, ..
+        } => ToolDetail::Command {
+            cmd: bounded(
+                &std::iter::once(command.as_str())
+                    .chain(args.iter().map(String::as_str))
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                MAX_TOOL_SUMMARY_CHARS,
+            ),
+            cwd: cwd.clone(),
+        },
+        ToolActionPreview::WriteFile { path, .. } => ToolDetail::FileEdit {
+            path: bounded(path, MAX_TOOL_SUMMARY_CHARS),
+        },
+        ToolActionPreview::Search { query, .. } | ToolActionPreview::WebSearch { query, .. } => {
+            ToolDetail::Search {
+                query: bounded(query, MAX_TOOL_SUMMARY_CHARS),
+            }
+        }
+        other => ToolDetail::Other {
+            summary: bounded(
+                other.summary().unwrap_or("tool call"),
+                MAX_TOOL_SUMMARY_CHARS,
+            ),
+        },
+    }
+}
+
+/// A completed tool call's outcome, from its output.
+pub(super) fn tool_outcome(output: &ToolOutput) -> ToolOutcome {
+    match (output.is_error, output.error_category) {
+        (false, _) => ToolOutcome::Succeeded,
+        (true, Some(ToolErrorCategory::UserDeclined | ToolErrorCategory::UserCancelled)) => {
+            ToolOutcome::Denied
+        }
+        (true, _) => ToolOutcome::Failed,
+    }
+}
+
+/// A tool approval as the adapter states it: the exact server-built preview
+/// and the grant ladder the engine offers, or a plain summary when the call
+/// could not be described (no ladder is offered without a description).
+pub(super) fn tool_use_kind(
+    tool_name: &str,
+    preview: Option<ToolActionPreview>,
+    grant_scopes: Vec<GrantScope>,
+) -> CodeApprovalKind {
+    match preview {
+        // The model's own narration never reaches a consent card (decision
+        // 0018): the card renders the literal action, and a call that could
+        // describe itself to a decision could describe itself favourably.
+        Some(preview) => CodeApprovalKind::ToolUse {
+            preview: preview.without_summary(),
+            offered_grants: grant_scopes,
+        },
+        None => CodeApprovalKind::Other {
+            summary: bounded(tool_name, MAX_TOOL_SUMMARY_CHARS),
+        },
+    }
+}
+
+/// The decision the engine observed on its own channel, in adapter terms.
+pub(super) fn observed_decision(approved: bool) -> ApprovalDecision {
+    if approved {
+        ApprovalDecision::Approve
+    } else {
+        ApprovalDecision::Deny { feedback: None }
+    }
+}
+
+/// The chat-side decision for an adapter decision on a tool approval.
+///
+/// Answers and plan decisions never reach here: they settle a parked
+/// continuation through its own store operation.
+pub(super) fn chat_decision(decision: &ApprovalDecision) -> Option<ChatDecision> {
+    match decision {
+        ApprovalDecision::Approve | ApprovalDecision::ApproveWithGrant { .. } => {
+            Some(ChatDecision::Approve)
+        }
+        ApprovalDecision::Deny { feedback } => Some(ChatDecision::Reject {
+            reason: feedback
+                .as_deref()
+                .filter(|feedback| !feedback.trim().is_empty())
+                .map_or_else(
+                    || tidebreak_core::ToolApproval::DEFAULT_REJECT_REASON.to_owned(),
+                    |feedback| bounded(feedback, tidebreak_core::ToolApproval::MAX_REASON_BYTES),
+                ),
+        }),
+        ApprovalDecision::Answers { .. } | ApprovalDecision::PlanDecision { .. } => None,
+    }
+}
+
+pub(super) fn failure(error: &AgentErrorInfo) -> HarnessEvent {
+    HarnessEvent::TurnFailed {
+        error: BoundedError {
+            message: bounded(
+                &format!("{}: {}", error.kind, error.message),
+                MAX_NOTICE_CHARS,
+            ),
+        },
+    }
+}
+
+pub(super) fn refusal_notice(refusal: &RefusalOutcome) -> HarnessEvent {
+    let category = refusal
+        .category()
+        .map_or(String::new(), |category| format!(" ({category})"));
+    HarnessEvent::HarnessNotice {
+        level: HarnessNoticeLevel::Warning,
+        message: bounded(
+            &format!("The model declined to continue{category}."),
+            MAX_NOTICE_CHARS,
+        ),
+    }
+}
+
+pub(super) fn notice(message: &str) -> HarnessEvent {
+    HarnessEvent::HarnessNotice {
+        level: HarnessNoticeLevel::Info,
+        message: bounded(message, MAX_NOTICE_CHARS),
+    }
+}
+
+pub(super) fn assistant_message(text: &str) -> HarnessEvent {
+    HarnessEvent::AssistantMessage {
+        text: bounded(text, MAX_EVENT_TEXT_CHARS),
+        parent_call_id: None,
+    }
+}
+
+pub(super) fn tool_started(call_id: &CallId, name: &str) -> HarnessEvent {
+    HarnessEvent::ToolStarted {
+        call_id: call_id.to_string(),
+        name: name.to_owned(),
+        detail: ToolDetail::Other {
+            summary: bounded(name, MAX_TOOL_SUMMARY_CHARS),
+        },
+        parent_call_id: None,
+    }
+}
+
+pub(super) fn tool_completed(
+    call_id: &CallId,
+    output: &ToolOutput,
+    action: Option<&ToolActionPreview>,
+) -> HarnessEvent {
+    HarnessEvent::ToolCompleted {
+        call_id: call_id.to_string(),
+        outcome: tool_outcome(output),
+        preview: bounded(&output.content, MAX_PREVIEW_CHARS),
+        detail: action.map(tool_detail),
+        parent_call_id: None,
+    }
+}
+
+pub(super) fn approval_requested(
+    call_id: &CallId,
+    raw: serde_json::Value,
+    kind: CodeApprovalKind,
+) -> HarnessEvent {
+    HarnessEvent::ApprovalRequested {
+        harness_ref: HarnessApprovalRef::engine(call_id.to_string()),
+        raw,
+        kind: Some(kind),
+    }
+}
+
+pub(super) fn approval_resolved(call_id: &CallId, decision: ApprovalDecision) -> HarnessEvent {
+    HarnessEvent::ApprovalResolved {
+        harness_ref: HarnessApprovalRef::engine(call_id.to_string()),
+        decision,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_cuts_on_a_character_boundary() {
+        assert_eq!(bounded("héllo", 10), "héllo");
+        assert_eq!(bounded("héllo wörld", 6), "héllo…");
+    }
+
+    #[test]
+    fn a_declined_tool_reads_as_denied() {
+        let declined = ToolOutput::failed(ToolErrorCategory::UserDeclined, "no");
+        assert_eq!(tool_outcome(&declined), ToolOutcome::Denied);
+        let broken = ToolOutput::failed(ToolErrorCategory::TransportFailed, "boom");
+        assert_eq!(tool_outcome(&broken), ToolOutcome::Failed);
+        assert_eq!(
+            tool_outcome(&ToolOutput::text("ok")),
+            ToolOutcome::Succeeded
+        );
+    }
+
+    #[test]
+    fn an_undescribed_call_offers_no_grant_ladder() {
+        let kind = tool_use_kind("mystery", None, vec![GrantScope::WholeTool]);
+        assert_eq!(
+            kind,
+            CodeApprovalKind::Other {
+                summary: "mystery".into()
+            }
+        );
+    }
+
+    #[test]
+    fn a_deny_without_feedback_carries_the_default_reason() {
+        let ChatDecision::Reject { reason } =
+            chat_decision(&ApprovalDecision::Deny { feedback: None }).unwrap()
+        else {
+            panic!("deny maps to reject");
+        };
+        assert_eq!(reason, tidebreak_core::ToolApproval::DEFAULT_REJECT_REASON);
+        assert!(chat_decision(&ApprovalDecision::PlanDecision {
+            approve: true,
+            feedback: None
+        })
+        .is_none());
+    }
+}

--- a/crates/tidebreak-server/src/engine/mod.rs
+++ b/crates/tidebreak-server/src/engine/mod.rs
@@ -1,0 +1,10 @@
+//! Engines that run inside the server process.
+//!
+//! An in-process engine implements the same adapter contract
+//! (`tidebreak_harness::HarnessAdapter` / `HarnessSession`) as the external
+//! CLIs, so the code runtime, its session worker, and every route speak to
+//! it exactly as they speak to Claude Code or Codex: sessions, turns, the
+//! journal, and approvals. Nothing reaches an engine here another way
+//! (decision 0048 step 5).
+
+pub(crate) mod internal;

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -39,6 +39,7 @@ mod desktop_schema;
 mod diagnostics;
 mod document_decode;
 mod durable_oplog;
+mod engine;
 mod error;
 mod event_projection;
 mod exec_write_snapshot;
@@ -1067,6 +1068,11 @@ pub fn app(state: AppState) -> Router {
             "/code/workspaces/{id}/sessions",
             post(routes::code::create_session).get(routes::code::list_workspace_sessions),
         )
+        .route(
+            "/code/sessions",
+            post(routes::code::create_internal_session).get(routes::code::list_internal_sessions),
+        )
+        .route("/code/sessions/{id}", get(routes::code::get_session))
         .route(
             "/code/sessions/{id}/turns",
             post(routes::code::submit_turn).get(routes::code::list_session_turns),
@@ -2206,12 +2212,19 @@ async fn bind_inner(
     .with_gateway_runtime(state.gateway.clone());
     // A self-host machine owns its filesystem. Clones land under the data
     // directory unless an operator set a destination (decision 70).
-    #[allow(unused_mut)]
     let mut runtime = if state.config.profile == Profile::SelfHost {
         runtime.with_clone_parent_default(state.config.data_dir.join("code").join("src"))
     } else {
         runtime
     };
+    // The in-process engine drives the chat turn lane, so it needs the app
+    // state that lane runs on. Registered here, after the state exists and
+    // before the runtime is shared; the copy it keeps has no code runtime.
+    runtime
+        .adapters
+        .register(Arc::new(engine::internal::InternalAdapter::new(
+            state.clone(),
+        )));
     #[cfg(feature = "scripted-harness")]
     scripted_harness::install_from_env(&mut runtime.adapters)?;
     // Remote sessions need both halves: the configured runtime endpoint and

--- a/crates/tidebreak-server/src/routes.rs
+++ b/crates/tidebreak-server/src/routes.rs
@@ -38,7 +38,7 @@ mod outputs;
 mod plans;
 mod plugins;
 mod projects_chats;
-mod providers_models;
+pub(crate) mod providers_models;
 mod root_attachment;
 mod settings;
 mod task_plan;

--- a/crates/tidebreak-server/src/routes/code/analytics.rs
+++ b/crates/tidebreak-server/src/routes/code/analytics.rs
@@ -89,8 +89,9 @@ fn build_snapshot(
     let session_by_id: HashMap<CodeSessionId, &CodeSession> = sessions
         .iter()
         .filter(|session| {
-            workspace_repos
-                .get(&session.workspace_id)
+            session
+                .workspace_id
+                .and_then(|workspace_id| workspace_repos.get(&workspace_id))
                 .is_some_and(|repo_id| repo_filter.is_none_or(|filter| filter == *repo_id))
         })
         .map(|session| (session.id, session))
@@ -123,7 +124,10 @@ fn build_snapshot(
         if !in_range(turn.started_at, from, through) {
             continue;
         }
-        let Some(repo_id) = workspace_repos.get(&session.workspace_id).copied() else {
+        let Some(repo_id) = session
+            .workspace_id
+            .and_then(|workspace_id| workspace_repos.get(&workspace_id).copied())
+        else {
             continue;
         };
         active_sessions.insert(session.id);
@@ -201,7 +205,10 @@ fn build_snapshot(
         let Some(session) = session_by_id.get(&session_id).copied() else {
             continue;
         };
-        let Some(repo_id) = workspace_repos.get(&session.workspace_id).copied() else {
+        let Some(repo_id) = session
+            .workspace_id
+            .and_then(|workspace_id| workspace_repos.get(&workspace_id).copied())
+        else {
             continue;
         };
         repo_metrics

--- a/crates/tidebreak-server/src/routes/code/browser.rs
+++ b/crates/tidebreak-server/src/routes/code/browser.rs
@@ -140,7 +140,7 @@ async fn authorize(state: &AppState, headers: &HeaderMap) -> Result<BrowserSubje
     ) {
         return Err(ServerError::forbidden("the browser session has ended"));
     }
-    if session.workspace_id != subject.workspace {
+    if session.workspace_id != Some(subject.workspace) {
         return Err(ServerError::not_found("browser target not found"));
     }
 

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -171,6 +171,10 @@ async fn hosted_models(
             .into_iter()
             .map(|row| hosted_model(row, None))
             .collect()),
+        // The in-process engine takes its model from the chat model
+        // catalog, which the models routes already serve; it lists nothing
+        // of its own here.
+        HarnessKind::Internal => Ok(Vec::new()),
         HarnessKind::Opencode => {
             let anthropic = anthropic?;
             let openai = openai?;

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -73,11 +73,12 @@ pub(crate) use repos::{
 };
 pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
-    create_remote_session, create_session, delete_queued_turn, fork_session, get_session_debug,
-    get_session_image, interrupt_session, list_queued_turns, list_session_turns,
-    list_workspace_sessions, patch_queued_turn, post_queue_send_now, publish_session_image,
-    put_queue_paused, reap_session, set_attention, set_session_fast_mode,
-    set_session_permission_mode, set_session_reasoning_effort, steer_session, submit_turn,
+    create_internal_session, create_remote_session, create_session, delete_queued_turn,
+    fork_session, get_session, get_session_debug, get_session_image, interrupt_session,
+    list_internal_sessions, list_queued_turns, list_session_turns, list_workspace_sessions,
+    patch_queued_turn, post_queue_send_now, publish_session_image, put_queue_paused, reap_session,
+    set_attention, set_session_fast_mode, set_session_permission_mode,
+    set_session_reasoning_effort, steer_session, submit_turn,
 };
 pub(crate) use terminals::{
     close_terminal, close_workspace_terminals, create_terminal, list_terminals, read_terminal,

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -16,9 +16,10 @@ use axum::response::{IntoResponse, Response};
 
 use super::types::{
     CodeForkTranscript, CodeSessionExternalOrigin, CodeSessionSnapshot, CodeTurnSnapshot,
-    CreateRemoteSessionBody, CreateSessionBody, QueuePausedBody, QueuedCodeTurn,
-    QueuedCodeTurnUpdate, QueuedCodeTurnsSnapshot, SequencedCodeEventFrame, SetAttentionBody,
-    SetFastModeBody, SetPermissionModeBody, SetReasoningEffortBody, SteerBody, SubmitTurnBody,
+    CreateInternalSessionBody, CreateRemoteSessionBody, CreateSessionBody, QueuePausedBody,
+    QueuedCodeTurn, QueuedCodeTurnUpdate, QueuedCodeTurnsSnapshot, SequencedCodeEventFrame,
+    SetAttentionBody, SetFastModeBody, SetPermissionModeBody, SetReasoningEffortBody, SteerBody,
+    SubmitTurnBody,
 };
 use crate::code::runtime::{NewSessionSettings, SubmitTurnOutcome};
 use tidebreak_core::{CodeSessionId, PermissionMode, TurnSteer, WorkspaceId};
@@ -69,6 +70,29 @@ pub async fn create_session(
                 permission_mode_ceiling,
             },
         )
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CodeSessionSnapshot::from(session)),
+    ))
+}
+
+/// `POST /code/sessions` — create a conversation with no workspace. The
+/// in-process engine hosts it (decision 0048 step 5).
+pub async fn create_internal_session(
+    State(state): State<AppState>,
+    code: ScopedCode,
+    Json(body): Json<CreateInternalSessionBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let permission_mode_ceiling = state.managed_policy()?.permission_mode_ceiling;
+    let session = code
+        .create_internal_session(NewSessionSettings {
+            permission_mode: body.permission_mode,
+            model: body.model,
+            reasoning_effort: body.reasoning_effort,
+            fast_mode: false,
+            permission_mode_ceiling,
+        })
         .await?;
     Ok((
         StatusCode::CREATED,
@@ -160,6 +184,40 @@ pub async fn list_workspace_sessions(
             })
             .collect(),
     ))
+}
+
+/// `GET /code/sessions` — the owner's conversations that bind no
+/// workspace, newest first.
+pub async fn list_internal_sessions(
+    code: ScopedCode,
+) -> Result<Json<Vec<CodeSessionSnapshot>>, ServerError> {
+    let sessions = code.list_internal_sessions().await?;
+    Ok(Json(
+        sessions
+            .into_iter()
+            .map(CodeSessionSnapshot::from)
+            .collect(),
+    ))
+}
+
+/// `GET /code/sessions/{id}` — one session by id, whatever it binds.
+pub async fn get_session(
+    code: ScopedCode,
+    Path(id): Path<CodeSessionId>,
+) -> Result<Json<CodeSessionSnapshot>, ServerError> {
+    let session = code.get_session(id).await?;
+    let origin = code
+        .external_bindings_for_sessions(&[id])
+        .await?
+        .into_iter()
+        .next()
+        .map(|binding| CodeSessionExternalOrigin {
+            channel_kind: binding.channel_kind,
+            external_key: binding.external_key,
+        });
+    let mut snapshot = CodeSessionSnapshot::from(session);
+    snapshot.external_origin = origin;
+    Ok(Json(snapshot))
 }
 
 pub async fn submit_turn(

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -213,7 +213,9 @@ pub struct CodeSessionExternalOrigin {
 #[derive(Debug, Clone, PartialEq, Serialize, TS)]
 pub struct CodeSessionSnapshot {
     pub id: tidebreak_core::CodeSessionId,
-    pub workspace_id: WorkspaceId,
+    /// `None` for a session that binds no workspace: the in-process
+    /// engine's (decision 0048 step 5).
+    pub workspace_id: Option<WorkspaceId>,
     pub kind: CodeSessionKind,
     pub harness_kind: HarnessKind,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1704,6 +1706,19 @@ pub struct CodeActionSnapshot {
 }
 
 /// Body of `POST /code/workspaces/{id}/sessions`.
+/// `POST /code/sessions`: a conversation with no workspace, hosted by the
+/// in-process engine (decision 0048 step 5). The engine is implied.
+#[derive(Debug, Deserialize, TS)]
+pub struct CreateInternalSessionBody {
+    pub permission_mode: PermissionMode,
+    #[serde(default)]
+    #[ts(optional)]
+    pub model: Option<String>,
+    #[serde(default)]
+    #[ts(optional)]
+    pub reasoning_effort: Option<ReasoningEffort>,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CreateSessionBody {
@@ -2122,7 +2137,8 @@ pub struct CodeTerminalActivityNotice {
 /// Cheap per-session digest on `/code/updates`.
 #[derive(Debug, Clone, PartialEq, Serialize, TS)]
 pub struct CodeSessionDigest {
-    pub workspace: WorkspaceId,
+    /// `None` for a session that binds no workspace.
+    pub workspace: Option<WorkspaceId>,
     pub session: tidebreak_core::CodeSessionId,
     pub kind: CodeSessionKind,
     /// Engine identity for list surfaces that collapse several sessions into
@@ -2213,7 +2229,7 @@ pub enum CodeUpdateNotice {
     },
     /// One session's current digest.
     Digest {
-        workspace: WorkspaceId,
+        workspace: Option<WorkspaceId>,
         session: tidebreak_core::CodeSessionId,
         kind: CodeSessionKind,
         /// Engine identity for the session represented by this digest.

--- a/crates/tidebreak-server/src/routes/inbox.rs
+++ b/crates/tidebreak-server/src/routes/inbox.rs
@@ -46,7 +46,8 @@ pub enum InboxConversation {
     /// workspace, so a session id alone is not a link the reader can follow.
     Code {
         session_id: CodeSessionId,
-        workspace_id: WorkspaceId,
+        /// `None` for a session with no workspace: the in-process engine's.
+        workspace_id: Option<WorkspaceId>,
     },
 }
 
@@ -167,7 +168,9 @@ pub async fn list_inbox(
                     continue;
                 }
                 entries.push(InboxEntrySnapshot {
-                    title: titles.get(&session.workspace_id).cloned(),
+                    title: session
+                        .workspace_id
+                        .and_then(|workspace_id| titles.get(&workspace_id).cloned()),
                     conversation: InboxConversation::Code {
                         session_id: session.id,
                         workspace_id: session.workspace_id,

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -974,6 +974,8 @@ mod tests {
 
     fn spec(sink: Arc<CollectingSink>, worktree: &Path) -> SessionSpec {
         SessionSpec {
+            owner: tidebreak_core::OwnerId::local(),
+            session_id: tidebreak_core::CodeSessionId::new(),
             worktree: worktree.to_path_buf(),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Ask,

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -50,6 +50,7 @@ mod code_doctor;
 mod code_external;
 #[cfg(unix)]
 mod code_git;
+mod code_internal;
 mod code_owner_scope;
 mod code_policy;
 #[cfg(unix)]

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -314,7 +314,7 @@ async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, C
     let s = CodeSession {
         id: CodeSessionId::new(),
         owner: OwnerId::local(),
-        workspace_id: ws.id,
+        workspace_id: Some(ws.id),
         kind: CodeSessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: None,

--- a/crates/tidebreak-server/src/tests/code_internal.rs
+++ b/crates/tidebreak-server/src/tests/code_internal.rs
@@ -1,0 +1,552 @@
+//! The internal engine behind the adapter contract (decision 0048 step 5).
+//!
+//! A conversation with no workspace selects the in-process engine and runs
+//! on the code structures: sessions, turns, the sequenced journal, and
+//! approval rows. This module is the tripwire for that: chat's plan
+//! proposals, user questions, tool approvals with grant ladders, and
+//! mid-turn steering all have to be reachable over `/code/*`, and nothing
+//! about the conversation may leak into the chat routes.
+
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tidebreak_core::{
+    ApprovalClass, ChatRequest, CodeSessionId, DbStore, ModelProvider, ProviderEvent, ProviderId,
+    StopReason, Tool, ToolCtx, ToolOutput, ToolRegistry, ToolSpec,
+};
+use tidebreak_harness::AdapterRegistry;
+
+use crate::code::CodeRuntime;
+use crate::engine::internal::InternalAdapter;
+
+/// One model completion the scripted provider answers with.
+enum Step {
+    Tool {
+        name: &'static str,
+        input: serde_json::Value,
+    },
+    Text(&'static str),
+}
+
+/// A provider that replays one scripted completion per model call.
+struct ScriptedProvider {
+    steps: Mutex<Vec<Step>>,
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl ModelProvider for ScriptedProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("scripted")
+    }
+
+    async fn stream(
+        &self,
+        _request: ChatRequest,
+    ) -> tidebreak_core::Result<BoxStream<'static, ProviderEvent>> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        let step = {
+            let mut steps = self.steps.lock().unwrap();
+            if steps.is_empty() {
+                None
+            } else {
+                Some(steps.remove(0))
+            }
+        };
+        let events = match step {
+            Some(Step::Tool { name, input }) => vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: format!("scripted_{call}"),
+                    name: name.to_owned(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: input.to_string(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ],
+            Some(Step::Text(text)) => vec![
+                ProviderEvent::TextDelta {
+                    text: text.to_owned(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ],
+            None => vec![
+                ProviderEvent::TextDelta {
+                    text: "the script ended".to_owned(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ],
+        };
+        Ok(stream::iter(events).boxed())
+    }
+}
+
+/// A sensitive `exec` stand-in: named so the server builds an exact action
+/// preview and a grant ladder for it, without running anything.
+struct FakeExec {
+    ran: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Tool for FakeExec {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "exec".into(),
+            description: "run a command".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(
+        &self,
+        _ctx: &ToolCtx,
+        _args: serde_json::Value,
+    ) -> tidebreak_core::Result<ToolOutput> {
+        self.ran.fetch_add(1, Ordering::SeqCst);
+        Ok(ToolOutput::text("hi"))
+    }
+}
+
+/// An app whose chat turn lane runs the scripted provider and whose code
+/// runtime knows only the internal engine.
+async fn internal_engine_app(
+    steps: Vec<Step>,
+) -> (
+    std::net::SocketAddr,
+    Arc<str>,
+    Arc<CodeRuntime>,
+    Arc<AtomicUsize>,
+    tempfile::TempDir,
+) {
+    let (dir, store) = temp_db_store("internal.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let ran = Arc::new(AtomicUsize::new(0));
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(FakeExec { ran: ran.clone() }));
+    tools.register_validated_foreground_client(
+        tidebreak_core::ask_user_questions_tool_spec(),
+        ApprovalClass::ReadOnly,
+        tidebreak_core::validate_ask_user_questions_arguments,
+    );
+    tools.register_validated_foreground_client(
+        tidebreak_core::exit_plan_mode_tool_spec(),
+        ApprovalClass::ReadOnly,
+        tidebreak_core::validate_exit_plan_mode_arguments,
+    );
+    tools.register_foreground_agent_orchestration();
+    let provider = Arc::new(ScriptedProvider {
+        steps: Mutex::new(steps),
+        calls: AtomicUsize::new(0),
+    });
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(provider)),
+        Arc::new(MemSecrets::default()),
+        Arc::new(tools),
+        AgentConfig {
+            model: "scripted".into(),
+            ..AgentConfig::default()
+        },
+    );
+    spawn_turn_worker(&state);
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(InternalAdapter::new(state.clone())));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db,
+        dir.path().to_path_buf(),
+        registry,
+    ));
+    state.code = Some(runtime.clone());
+    let token = state.token.clone();
+    let addr = super::code::serve(app(state)).await;
+    (addr, token, runtime, ran, dir)
+}
+
+async fn pending_approval_of_kind(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    session_id: CodeSessionId,
+    kind: &str,
+) -> serde_json::Value {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let approvals: Vec<serde_json::Value> = client
+                .get(format!(
+                    "http://{addr}/code/approvals?session_id={session_id}&state=pending"
+                ))
+                .bearer_auth(token)
+                .send()
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap();
+            if let Some(approval) = approvals
+                .into_iter()
+                .find(|approval| approval["kind"]["type"] == kind)
+            {
+                return approval;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("a pending {kind} approval appears"))
+}
+
+async fn turn_statuses(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    session_id: CodeSessionId,
+) -> Vec<String> {
+    let turns: Vec<serde_json::Value> = client
+        .get(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    turns
+        .iter()
+        .map(|turn| turn["status"].as_str().unwrap().to_owned())
+        .collect()
+}
+
+async fn decide(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    approval_id: &str,
+    body: serde_json::Value,
+) {
+    let response = client
+        .post(format!(
+            "http://{addr}/code/approvals/{approval_id}/decision"
+        ))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = response.status();
+    let text = response.text().await.unwrap();
+    assert_eq!(status, reqwest::StatusCode::OK, "{text}");
+}
+
+fn event_types(events: &[tidebreak_core::SequencedCodeEvent]) -> Vec<String> {
+    events
+        .iter()
+        .map(|event| {
+            serde_json::to_value(&event.event).unwrap()["type"]
+                .as_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect()
+}
+
+fn position(types: &[String], wanted: &str, after: usize) -> usize {
+    types
+        .iter()
+        .enumerate()
+        .skip(after)
+        .find(|(_, kind)| kind.as_str() == wanted)
+        .map(|(index, _)| index)
+        .unwrap_or_else(|| panic!("{wanted} after {after} in {types:?}"))
+}
+
+/// The whole chat interaction model, reached only through `/code/*`: a plan
+/// proposal parks the turn as an approval and its acceptance re-postures
+/// the session; a questions card parks and its answers resume; a sensitive
+/// tool waits on a structured approval that offers a grant ladder; a steer
+/// lands mid-turn; and the turn completes on the sequenced journal.
+#[tokio::test]
+async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
+    let (addr, token, runtime, ran, _dir) = internal_engine_app(vec![
+        Step::Tool {
+            name: "exit_plan_mode",
+            input: serde_json::json!({
+                "title": "Ship the greeting",
+                "plan": "1. Run the greeting command.\n2. Ask which greeting to use.\n3. Report back.",
+            }),
+        },
+        Step::Tool {
+            name: "ask_user_questions",
+            input: serde_json::json!({
+                "questions": [{
+                    "id": "greeting",
+                    "header": "Greeting",
+                    "question": "Which greeting?",
+                    "options": [
+                        {"id": "hi", "label": "hi", "description": "short"},
+                        {"id": "hello", "label": "hello", "description": "longer"}
+                    ]
+                }]
+            }),
+        },
+        Step::Tool {
+            name: "exec",
+            input: serde_json::json!({"command": "echo", "args": ["hi"]}),
+        },
+        Step::Text("all done"),
+    ])
+    .await;
+    let client = reqwest::Client::new();
+
+    let created = client
+        .post(format!("http://{addr}/code/sessions"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "permission_mode": "plan" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(session["harness_kind"], "internal");
+    assert!(session["workspace_id"].is_null(), "{session}");
+    let session_id: CodeSessionId = session["id"].as_str().unwrap().parse().unwrap();
+
+    // The conversation is the engine's, not the owner's: no chat route sees it.
+    let listed = client
+        .get(format!("http://{addr}/chats"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let status = listed.status();
+    let body = listed.text().await.unwrap();
+    assert_eq!(status, reqwest::StatusCode::OK, "{body}");
+    let chats: Vec<serde_json::Value> = serde_json::from_str(&body).unwrap();
+    assert!(chats.is_empty(), "engine-private chat listed: {chats:?}");
+    let by_id = client
+        .get(format!("http://{addr}/chats/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(by_id.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "plan it, then greet" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+
+    // 1. The plan proposal is a parked approval.
+    let plan = pending_approval_of_kind(&client, addr, &token, session_id, "plan").await;
+    assert_eq!(plan["kind"]["proposed_mode"], "auto");
+    let raw: serde_json::Value =
+        serde_json::from_str(plan["harness_raw_json"].as_str().unwrap()).unwrap();
+    assert_eq!(raw["title"], "Ship the greeting");
+    assert_eq!(
+        turn_statuses(&client, addr, &token, session_id).await,
+        vec!["waiting"]
+    );
+    decide(
+        &client,
+        addr,
+        &token,
+        plan["id"].as_str().unwrap(),
+        serde_json::json!({ "decision": { "plan_decision": { "approve": true } } }),
+    )
+    .await;
+
+    // 2. The questions card is the next park; answers resume it.
+    let questions = pending_approval_of_kind(&client, addr, &token, session_id, "questions").await;
+    assert_eq!(questions["kind"]["questions"][0]["id"], "greeting");
+    // Accepting the plan moved the session out of plan mode before the
+    // resume, so the questions could be asked at all.
+    let snapshot: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(snapshot["permission_mode"], "auto");
+    let listed: Vec<serde_json::Value> = client
+        .get(format!("http://{addr}/code/sessions"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["id"], session["id"]);
+    decide(
+        &client,
+        addr,
+        &token,
+        questions["id"].as_str().unwrap(),
+        serde_json::json!({ "decision": { "answers": { "answers": [
+            { "question_id": "greeting", "selected_option_ids": ["hi"] }
+        ] } } }),
+    )
+    .await;
+
+    // 3. The sensitive tool waits on a structured approval with a ladder,
+    //    on a turn that is running, not parked. A steer lands meanwhile.
+    let tool = pending_approval_of_kind(&client, addr, &token, session_id, "tool_use").await;
+    assert_eq!(tool["kind"]["preview"]["tool"], "exec");
+    assert!(
+        tool["kind"]["preview"]
+            .get("summary")
+            .is_none_or(serde_json::Value::is_null),
+        "model narration never reaches the card: {tool}"
+    );
+    let offered = tool["kind"]["offered_grants"].as_array().unwrap();
+    assert!(!offered.is_empty(), "exec offers a grant ladder: {tool}");
+    let statuses = turn_statuses(&client, addr, &token, session_id).await;
+    assert_eq!(statuses, vec!["running"]);
+    let turn_id = {
+        let turns: Vec<serde_json::Value> = client
+            .get(format!("http://{addr}/code/sessions/{session_id}/turns"))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        turns[0]["id"].as_str().unwrap().to_owned()
+    };
+    let steered = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": turn_id,
+            "guidance": "and say thanks",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(steered.status().is_success(), "{}", steered.status());
+    decide(
+        &client,
+        addr,
+        &token,
+        tool["id"].as_str().unwrap(),
+        serde_json::json!({ "decision": { "approve_with_grant": { "grant_index": 0 } } }),
+    )
+    .await;
+
+    let response = tokio::time::timeout(Duration::from_secs(20), turn)
+        .await
+        .expect("the turn completes")
+        .unwrap();
+    assert!(response.status().is_success(), "{}", response.status());
+    assert_eq!(ran.load(Ordering::SeqCst), 1, "the approved tool ran once");
+    assert_eq!(
+        turn_statuses(&client, addr, &token, session_id).await,
+        vec!["completed"]
+    );
+
+    // The journal is the one the code wire serves, in the code vocabulary.
+    let events = super::code::journaled_events(&runtime.db, session_id).await;
+    let types = event_types(&events);
+    let started = position(&types, "turn_started", 0);
+    let plan_requested = position(&types, "approval_requested", started);
+    let plan_resolved = position(&types, "approval_resolved", plan_requested);
+    let questions_requested = position(&types, "approval_requested", plan_resolved);
+    let questions_resolved = position(&types, "approval_resolved", questions_requested);
+    let tool_requested = position(&types, "approval_requested", questions_resolved);
+    let tool_resolved = position(&types, "approval_resolved", tool_requested);
+    let tool_completed = position(&types, "tool_completed", tool_resolved);
+    let steered = position(&types, "user_steered", tool_requested);
+    let message = position(&types, "assistant_message", tool_completed);
+    let completed = position(&types, "turn_completed", message);
+    assert_eq!(
+        types
+            .iter()
+            .filter(|kind| kind.as_str() == "user_steered")
+            .count(),
+        1,
+        "one steer, journaled once: {types:?}"
+    );
+    assert_eq!(completed + 1, types.len(), "{types:?}");
+    assert!(steered < completed);
+    let plan_decision = serde_json::to_value(&events[plan_resolved].event).unwrap();
+    assert_eq!(plan_decision["decision"]["type"], "plan_decided");
+    let grant_decision = serde_json::to_value(&events[tool_resolved].event).unwrap();
+    assert_eq!(grant_decision["decision"]["type"], "approved_with_grant");
+    let text = serde_json::to_value(&events[message].event).unwrap();
+    assert_eq!(text["text"], "all done");
+}
+
+/// The workspace-bound create path never selects the in-process engine,
+/// and the engine's own create path needs no engine binary.
+#[tokio::test]
+async fn the_internal_engine_is_only_reachable_without_a_workspace() {
+    let (addr, token, _runtime, _ran, dir) = internal_engine_app(Vec::new()).await;
+    let client = reqwest::Client::new();
+    let repo = super::code::init_git_repo(dir.path());
+    let (_repo, workspace) =
+        super::code::register_and_workspace(&client, addr, &token, &repo).await;
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            super::code::json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "harness": "internal", "permission_mode": "ask" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "harness_needs_no_workspace");
+
+    let doctor: serde_json::Value = client
+        .get(format!("http://{addr}/code/harnesses"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let internal = doctor["harnesses"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["kind"] == "internal")
+        .expect("the doctor lists the internal engine");
+    assert_eq!(internal["found"], true);
+    assert!(internal["path"].is_null());
+    assert_eq!(internal["caps"]["durable_parks"], "supported");
+}
+
+#[allow(dead_code)]
+fn _db_type_is_used(_: &DbStore) {}

--- a/crates/tidebreak-server/src/tests/code_pr_facts.rs
+++ b/crates/tidebreak-server/src/tests/code_pr_facts.rs
@@ -167,7 +167,7 @@ async fn seeded(
     let session = CodeSession {
         id: CodeSessionId::new(),
         owner: owner.clone(),
-        workspace_id,
+        workspace_id: Some(workspace_id),
         kind: CodeSessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: Some("2.1.233".into()),
@@ -305,18 +305,26 @@ async fn a_journaled_create_mints_an_authored_fact() {
     assert_eq!(fact.head_branch, "feat/x");
     let first_seen = fact.first_seen_at;
 
-    let attributed = list_attributed_facts_for_workspace(&store, &owner, session.workspace_id)
-        .await
-        .unwrap();
+    let attributed = list_attributed_facts_for_workspace(
+        &store,
+        &owner,
+        session.workspace_id.expect("workspace"),
+    )
+    .await
+    .unwrap();
     assert_eq!(attributed.len(), 1);
     assert_eq!(attributed[0].1, CodePullRequestRelation::Authored);
 
     // Re-running the sweep is idempotent: one row, first_seen_at holds.
     pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
         .await;
-    let attributed = list_attributed_facts_for_workspace(&store, &owner, session.workspace_id)
-        .await
-        .unwrap();
+    let attributed = list_attributed_facts_for_workspace(
+        &store,
+        &owner,
+        session.workspace_id.expect("workspace"),
+    )
+    .await
+    .unwrap();
     assert_eq!(attributed.len(), 1);
     let fact = get_pull_request_fact(&store, &owner, "github.com", "acme", "tools", 412)
         .await
@@ -351,9 +359,13 @@ async fn a_journaled_push_mints_a_contributed_fact() {
         .await;
 
     let owner = OwnerId::local();
-    let attributed = list_attributed_facts_for_workspace(&store, &owner, session.workspace_id)
-        .await
-        .unwrap();
+    let attributed = list_attributed_facts_for_workspace(
+        &store,
+        &owner,
+        session.workspace_id.expect("workspace"),
+    )
+    .await
+    .unwrap();
     assert_eq!(attributed.len(), 1);
     assert_eq!(attributed[0].1, CodePullRequestRelation::Contributed);
     assert_eq!(attributed[0].0.number, 412);
@@ -397,7 +409,7 @@ async fn a_confirmed_push_marks_the_workspace_hot() {
 
     assert_eq!(
         hot.live(),
-        vec![(OwnerId::local(), session.workspace_id)],
+        vec![(OwnerId::local(), session.workspace_id.expect("workspace"))],
         "the confirmed push puts the workspace on the hot refresh tier"
     );
 }
@@ -473,9 +485,13 @@ async fn a_changed_clean_checkout_recovers_an_open_pull_request() {
     .await;
 
     let owner = OwnerId::local();
-    let attributed = list_attributed_facts_for_workspace(&store, &owner, session.workspace_id)
-        .await
-        .unwrap();
+    let attributed = list_attributed_facts_for_workspace(
+        &store,
+        &owner,
+        session.workspace_id.expect("workspace"),
+    )
+    .await
+    .unwrap();
     assert_eq!(
         attributed.len(),
         1,
@@ -492,7 +508,10 @@ async fn a_changed_clean_checkout_recovers_an_open_pull_request() {
         sources[0].discovered_via,
         tidebreak_core::CodePullRequestDiscovery::Command
     );
-    assert_eq!(hot.live(), vec![(owner, session.workspace_id)]);
+    assert_eq!(
+        hot.live(),
+        vec![(owner, session.workspace_id.expect("workspace"))]
+    );
 }
 
 #[tokio::test]
@@ -509,12 +528,14 @@ async fn a_changed_checkout_does_not_claim_a_different_pull_request_head() {
     pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
         .await;
 
-    assert!(
-        list_attributed_facts_for_workspace(&store, &session.owner, session.workspace_id)
-            .await
-            .unwrap()
-            .is_empty()
-    );
+    assert!(list_attributed_facts_for_workspace(
+        &store,
+        &session.owner,
+        session.workspace_id.expect("workspace")
+    )
+    .await
+    .unwrap()
+    .is_empty());
 }
 
 #[tokio::test]
@@ -542,12 +563,14 @@ async fn a_changed_dirty_checkout_does_not_claim_a_matching_pull_request_head() 
     pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
         .await;
 
-    assert!(
-        list_attributed_facts_for_workspace(&store, &session.owner, session.workspace_id)
-            .await
-            .unwrap()
-            .is_empty()
-    );
+    assert!(list_attributed_facts_for_workspace(
+        &store,
+        &session.owner,
+        session.workspace_id.expect("workspace")
+    )
+    .await
+    .unwrap()
+    .is_empty());
     assert!(!log.exists(), "a dirty checkout should not reach GitHub");
 }
 
@@ -578,12 +601,14 @@ async fn a_changed_checkout_on_another_branch_does_not_claim_its_pull_request() 
     pr_facts::sweep_turn_for_pull_request_acts(&store, &session, turn_id, Some(&search_path), None)
         .await;
 
-    assert!(
-        list_attributed_facts_for_workspace(&store, &session.owner, session.workspace_id)
-            .await
-            .unwrap()
-            .is_empty()
-    );
+    assert!(list_attributed_facts_for_workspace(
+        &store,
+        &session.owner,
+        session.workspace_id.expect("workspace")
+    )
+    .await
+    .unwrap()
+    .is_empty());
     assert!(
         !log.exists(),
         "a checkout on another branch should not reach GitHub"
@@ -637,12 +662,14 @@ async fn reads_comments_and_failures_mint_nothing() {
         .await;
 
     let owner = OwnerId::local();
-    assert!(
-        list_attributed_facts_for_workspace(&store, &owner, session.workspace_id)
-            .await
-            .unwrap()
-            .is_empty()
-    );
+    assert!(list_attributed_facts_for_workspace(
+        &store,
+        &owner,
+        session.workspace_id.expect("workspace")
+    )
+    .await
+    .unwrap()
+    .is_empty());
     assert!(
         get_pull_request_fact(&store, &owner, "github.com", "acme", "tools", 412)
             .await

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -212,6 +212,8 @@ impl HarnessEngine {
             .spec
             .adapter
             .launch(SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::CodeSessionId::new(),
                 worktree: self.spec.worktree.clone(),
                 allowed_read_roots: self.spec.allowed_read_roots.clone(),
                 permission_mode: PermissionMode::Allow,

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -311,6 +311,32 @@ fixture manifests — deliberately not transcribed here, so this page cannot
 drift from captured reality
 ([`0031`](decisions/0031-harness-adapter-boundary.md)).
 
+### The internal engine
+
+Decision 48 step 5 puts Tidebreak's own agent loop behind the same contract.
+`HarnessKind::Internal` is registered by
+`crates/tidebreak-server/src/engine/internal/`, and a session created with
+no workspace (`POST /code/sessions`) selects it; the workspace-bound create
+path refuses it. The engine probes as found with no binary, needs no pin,
+and takes its inference from the server's own provider resolution.
+
+Its durable state is one engine-private conversation per session, keyed by
+the session id and hidden from every owner-scoped chat read. `run_turn`
+admits the message to the chat turn lane, follows the chat journal, and
+translates each event into a `HarnessEvent`; `decide` resolves a tool
+approval on the chat approval broker, answers a questions card, or decides
+a plan. A questions card or a plan proposal ends the leg as
+`TurnOutcome::Parked` on an approval the worker minted, and the answer or
+plan decision resumes it through `resume_turn`. An accepted plan re-postures
+the session: the worker calls `set_permission_mode` with the mode the
+approval proposed before it resumes the turn.
+
+The capability vector is what carries the difference from an external
+engine: `durable_parks`, `user_questions`, and `standing_grants` are
+`Supported`, so the decision route offers answers, plan decisions, and the
+grant ladder only here. Routes and workers speak only sessions, turns, the
+journal, and approvals to it; nothing reaches the loop another way.
+
 ## The event vocabulary
 
 `CodeEvent` (journal payload; internally tagged, `#[non_exhaustive]`,
@@ -355,6 +381,8 @@ to; transcribing every route here only buys a page that drifts.
 ```
 POST/GET        /code/repos                GET/PATCH/DELETE /code/repos/{id}
 GET             /code/repos/sources        POST /code/repos/clone    GET /code/repos/clone/{job}
+POST/GET        /code/sessions             a session with no workspace (internal engine)
+GET             /code/sessions/{id}
 GET             /code/harnesses            doctor    POST /code/harnesses/refresh
 POST            /code/harnesses/{kind}/install       warm the pinned install (0041)
 GET             /code/harnesses/{kind}/models

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -1611,7 +1611,11 @@ export type CodeSessionActivity = "agent" | "shell" | "monitor" | "subagents" | 
 /**
  * Cheap per-session digest on `/code/updates`.
  */
-export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind,
+export type CodeSessionDigest = {
+/**
+ * `None` for a session that binds no workspace.
+ */
+workspace: WorkspaceId | null, session: CodeSessionId, kind: CodeSessionKind,
 /**
  * Engine identity for list surfaces that collapse several sessions into
  * one workspace row. Optional on the wire so a desktop can still read a
@@ -1683,7 +1687,12 @@ export type CodeSessionLifecycle = "created" | "idle" | "running" | "fenced" | "
 /**
  * One durable conversation with an external agent engine.
  */
-export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
+export type CodeSessionSnapshot = { id: CodeSessionId,
+/**
+ * `None` for a session that binds no workspace: the in-process
+ * engine's (decision 0048 step 5).
+ */
+workspace_id: WorkspaceId | null, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
 /**
  * Absent means the engine's own default, which is not any level.
  */
@@ -1809,7 +1818,7 @@ export type CodeUpdateNotice = { "type": "snapshot",
 /**
  * One row per live session.
  */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind,
+sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId | null, session: CodeSessionId, kind: CodeSessionKind,
 /**
  * Engine identity for the session represented by this digest.
  */
@@ -2829,7 +2838,7 @@ export type HarnessDoctorReport = { harnesses: Array<HarnessDoctorEntry>, };
  * Named after the shipped adapters. The traits those adapters implement
  * stay engine-neutral; this enum is only the catalog of known engines.
  */
-export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok";
+export type HarnessKind = "claude_code" | "codex" | "opencode" | "grok" | "internal";
 
 /**
  * One model row offered for a harness session.
@@ -2941,7 +2950,11 @@ byte_len: number, };
  * (the repository check `chat_and_code_entities_do_not_cross_reference`
  * enforces it). When step 5 merges the entities this collapses to one id.
  */
-export type InboxConversation = { "surface": "chat", chat_id: ChatId, } | { "surface": "code", session_id: CodeSessionId, workspace_id: WorkspaceId, };
+export type InboxConversation = { "surface": "chat", chat_id: ChatId, } | { "surface": "code", session_id: CodeSessionId,
+/**
+ * `None` for a session with no workspace: the in-process engine's.
+ */
+workspace_id: WorkspaceId | null, };
 
 /**
  * One conversation that wants the reader, and why.

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -115,7 +115,7 @@ function codeWorkspaceStatus(value: unknown): value is CodeWorkspaceStatus {
 }
 
 function harnessKind(value: unknown): value is HarnessKind {
-  return ["claude_code", "codex", "opencode", "grok"].includes(
+  return ["claude_code", "codex", "opencode", "grok", "internal"].includes(
     String(value),
   );
 }

--- a/mobile/src/lib/codeLaunch.ts
+++ b/mobile/src/lib/codeLaunch.ts
@@ -10,6 +10,7 @@ export const HARNESS_LABELS: Record<HarnessKind, string> = {
   codex: "Codex CLI",
   opencode: "opencode",
   grok: "Grok CLI",
+  internal: "Tidebreak",
 };
 
 export const PERMISSION_MODE_LABELS: Record<PermissionMode, string> = {

--- a/mobile/src/lib/updates.ts
+++ b/mobile/src/lib/updates.ts
@@ -183,6 +183,8 @@ export function harnessLabel(kind: string | undefined): string {
       return "opencode";
     case "grok":
       return "Grok CLI";
+    case "internal":
+      return "Tidebreak";
     default:
       return kind ?? "Unknown harness";
   }


### PR DESCRIPTION
Decision 48 step 5, slice C of #2313 (epic #2311). Slices A (#2934) and B (#2982) are in.

## What changes

- **`HarnessKind::Internal`.** Tidebreak's own agent loop is registered as an engine behind the decision-31 adapter contract, in `crates/tidebreak-server/src/engine/internal/`. It probes as found with no binary, needs no pin, and takes inference from the server's own provider resolution. Capability vector: `durable_parks`, `user_questions`, `standing_grants`, `plan_mode`, `mid_turn_steering` all `Supported`; `image_input` `Unsupported` for now.
- **Sessions without a workspace.** `POST /code/sessions` creates one and selects the internal engine; `GET /code/sessions` and `GET /code/sessions/{id}` read them back. `code_session.workspace_id` is nullable, and every checkout-bound path (checkpoints, PR facts, titling, browser channel, notifications) skips a session that binds none. The workspace-bound create path refuses `internal`, and the desktop harness picker hides it.
- **Engine-private conversation.** The engine's durable state is one `chat` row per session, keyed by the session id, with a new `engine_private` column. Every owner-scoped chat read excludes it, so the conversation is reachable only through its session; the engine uses the unscoped accessors. `create_engine_private_chat` is the only writer.
- **Parks and decisions.** `run_turn` admits the message to the chat turn lane and translates the chat journal into `HarnessEvent`s. A questions card or a plan proposal ends the leg as `TurnOutcome::Parked` on an approval the worker minted; `resume_turn` applies the answers or plan decision durably (idempotent with a decision that landed on the running leg). Tool approvals ride the structured channel with the exact action preview (narration stripped, decision 18) and the grant ladder; `ApproveWithGrant` mints a standing grant on the chat broker.
- **Plan acceptance drives `set_permission_mode`** (deferred from slice B). Before resuming from an accepted plan, the worker reserves the session's permission-mode intent, re-postures the engine, and confirms it; the journal notes the change.
- **Engine-observed decisions settle their row.** An approval the engine decides on its own channel (standing grant, auto-approval judge) used to leave the code approval row pending forever; the sink now settles an unclaimed pending row from the engine's `ApprovalResolved`.
- **Migration** `m20260901_000002_internal_engine_sessions`: PostgreSQL drops the `NOT NULL`, SQLite rebuilds `code_session` from its stored definition; both add `chat.engine_private`.
- **Wire.** `HarnessKind` gains `internal`; `CodeSessionSnapshot.workspace_id`, the updates digest's `workspace`, and the inbox's code entry become nullable. Desktop and mobile handle the new kind and the null workspace; the desktop's workspace-keyed stores skip workspace-less digests until slice E.

## Tests

- `tests::code_internal::a_conversation_without_a_workspace_runs_on_the_code_wire` is the tripwire: plan approval → mode change → questions → answers → gated `exec` approval with a grant ladder and a mid-turn steer → approve-with-grant → completion, all over `/code/*`, plus the chat routes never seeing the conversation.
- `tests::code_internal::the_internal_engine_is_only_reachable_without_a_workspace`: the doctor row and the workspace-path refusal.
- `session_worker::tests::an_engine_observed_decision_settles_its_own_approval_row`.
- Translate-layer unit tests; the migration chain tests (stepwise vs fresh) cover the SQLite rebuild.

Ran: `cargo test -p tidebreak-server --lib` (1655 pass), `cargo test -p tidebreak-core --features sqlite --lib` (820 pass), `cargo test -p tidebreak-harness --all-targets` (328 pass; `interactive_profile_env_is_captured_and_stripped` fails identically on a pristine `main` checkout in this shell), clippy `--no-deps -D warnings` on the three crates, desktop biome/tsc/vitest (2320 pass) and Storybook build, mobile tsc/eslint/vitest (91 pass). Wire types regenerated and synced to mobile.

## Deferred (issues filed)

Image input on the internal engine, resuming a parked turn after a worker restart, sandbox agent runs from a workspace-less session, notifications and updates-rail rows for workspace-less sessions, and cleanup of engine-private conversations when their session is deleted.
