### PR TITLE
chore(mobile): sync the generated wire types

### DIFF
--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -12,6 +12,8 @@ The TypeScript is now generated from the Rust definitions.
 ```sh
 # Rewrite the generated bindings after changing a wire type.
 UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server
+# Copy them into the mobile app, which pins its copy byte-for-byte.
+pnpm --dir mobile sync-wire
 ```
 
 Output is checked in under `crates/tidebreak-desktop/ui/src/generated/`. Without

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -4946,3 +4946,14 @@ export const RENDERER_TOOL_NAMES = [
   "create_app",
   "other",
 ] as const;
+
+/**
+ * Guard limits shared with the server and the CLI, in code points.
+ *
+ * The decoders bound every opaque string they will draw. These are the
+ * ceilings, generated from `tidebreak_server::wire::limits` so every
+ * client applies the same numbers.
+ */
+export const MAX_WIRE_ID_CHARS = 128;
+export const MAX_WIRE_TIMESTAMP_CHARS = 64;
+export const MAX_WIRE_CURSOR_CHARS = 256;


### PR DESCRIPTION
Follow-up to #3006, which added the shared guard-limit constants to the desktop's generated `wire.ts`. The mobile app keeps a byte-for-byte copy under `mobile/src/generated/wire.ts` and its `wireSync.test.ts` lane went red on `main` (run 33570380958). This copies the file over with `pnpm --dir mobile sync-wire` and adds that step to `docs/wire-types.md` next to the regenerate command.

No behavior change; the constants are additive.