### PR TITLE
docs(decisions): amend 0048 to merge internals and keep two surfaces

### DIFF
--- a/docs/decisions/0048-one-interaction-model.md
+++ b/docs/decisions/0048-one-interaction-model.md
@@ -1,6 +1,6 @@
 # 48. One interaction model for chat and code
 
-- Status: Proposed
+- Status: Proposed (amended 2026-09-01, see [Amendment](#amendment-2026-09-01))
 - Date: 2026-08-19
 - Owners: server, code mode
 - Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
@@ -193,3 +193,32 @@ territory).
   involved.
 - Owner scoping (step 1) validates as in decision 47: no cross-owner rows,
   and no cross-owner events on the updates channel.
+
+## Amendment (2026-09-01)
+
+Step 5 lands as a stack, and two of its parts are now settled differently
+from the text above.
+
+**The internals merge; the surfaces stay separate for now.** Chat and code
+entities still merge into the code-shaped structures — session, turn,
+journal, approvals — and the id spaces still become one. The user-facing
+collapse into one surface, where context alone selects behavior, is
+deferred: the desktop keeps a chat page and a code page over the one
+model, and decision 30's "no user-facing mode choice" destination waits
+on that model having run in production. This is a sequencing choice, not
+a rejection; nothing in the merged model prevents the collapse later.
+
+**The chat routes become aliases, not a flag day.** Once chat rows are
+sessions, `/chats/*` handlers become thin aliases over the session routes
+and stay until every client reads sessions directly. That aliasing is
+permitted by this record's own criterion: it maps one route family onto
+one set of entities, not one side's entities into the other side's shapes.
+
+**The internal engine as first merged is transitional.** The first slice
+that put the internal loop behind the adapter (#3010) kept chat's tables
+as the engine's durable state and translated that journal into the code
+journal — the "one journal over two execution backends" fallback this
+record names. It is the bridge, not the end state: the entity merge
+retires those tables, and the engine writes the journal natively.
+
+The rest of this record stands.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -257,9 +257,12 @@ purpose:
 - **Chat–code convergence.** The plan of record is
   [decision 48](decisions/0048-one-interaction-model.md): five independently
   useful steps, with code-mode structures as the merge survivor and chat
-  contributing the content model. The work is no longer parked as a future
-  record; what remains deferred is the implementation, and whether the
-  internal engine later becomes an external harness process.
+  contributing the content model. Steps 1 through 4 and the internal engine
+  behind the adapter are in; the entity merge is under way. What stays
+  deferred: the collapse of the chat and code pages into one surface
+  (the record's 2026-09-01 amendment keeps two surfaces over one model),
+  and whether the internal engine later becomes an external harness
+  process.
 - **A per-repo worktree-location override.** Worktrees live under one root per
   install — `~/Tidebreak/workspaces` on the desktop, the Tidebreak data
   directory for a headless deployment — and an operator can move that root


### PR DESCRIPTION
Amends [decision 48](docs/decisions/0048-one-interaction-model.md) after the team discussion on 2026-09-01: the chat and code internals still merge onto the code-shaped structures, but the user-facing collapse into one surface is deferred, the `/chats/*` routes become aliases over the session routes rather than a flag day, and the internal engine as merged in #3010 is recorded as the transitional shape the entity merge retires.

Also updates the `docs/deferred.md` entry to match.

Part of #2313 / epic #2311. The entity merge (slice D) follows as its own stack.