### PR TITLE
refactor(cli): decode the REST records with the server's response types

### DIFF
--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -16,9 +16,9 @@ use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
 use super::wire::{
-    AgentActivityHistoryItem, AgentRunSnapshot, ApprovalGrantRung, Chat, ModelCatalog,
-    OutputPreview, OutputRevisions, OutputsCatalog, PendingPlanApproval, PendingUserQuestions,
-    ProviderInfo, ProvidersList,
+    AgentActivityHistoryItem, AgentRunSnapshot, ApprovalGrantRung, Chat, DeliverablePreview,
+    DeliverablesCatalog, ModelCatalog, OutputRevisionsCatalog, PendingPlanApproval,
+    PendingUserQuestions, ProviderInfo, ProvidersList,
 };
 
 /// The chat event stream once the upgrade completes.
@@ -757,7 +757,7 @@ impl Client {
     // ------------------------------------------------------------------
 
     /// The conversation's live outputs.
-    pub async fn list_outputs(&self, chat: ChatId) -> Result<OutputsCatalog> {
+    pub async fn list_outputs(&self, chat: ChatId) -> Result<DeliverablesCatalog> {
         self.get_json(format!("{}/chats/{chat}/outputs", self.base))
             .await
     }
@@ -768,7 +768,7 @@ impl Client {
         chat: ChatId,
         output: OutputId,
         revision: Option<OutputRevisionId>,
-    ) -> Result<OutputPreview> {
+    ) -> Result<DeliverablePreview> {
         let url = match revision {
             None => format!("{}/chats/{chat}/outputs/{output}", self.base),
             Some(revision) => format!(
@@ -784,7 +784,7 @@ impl Client {
         &self,
         chat: ChatId,
         output: OutputId,
-    ) -> Result<OutputRevisions> {
+    ) -> Result<OutputRevisionsCatalog> {
         self.get_json(format!(
             "{}/chats/{chat}/outputs/{output}/revisions",
             self.base

--- a/crates/tidebreak-cli/src/api/wire.rs
+++ b/crates/tidebreak-cli/src/api/wire.rs
@@ -1,247 +1,32 @@
 //! Client-side decode of the server's JSON.
 //!
-//! The chat event socket's frames are the server's own types, imported from
+//! Every shape this crate reads is the server's own type, imported from
 //! `tidebreak_server::wire`: one Rust definition serializes on the server and
 //! deserializes here, so a renamed field is a compile error in this crate the
 //! way it is a type error in the desktop renderer's generated `wire.ts`. The
 //! contract those types carry — closed vocabularies, unknown keys rejected, an
-//! unknown event type failing its frame — is documented on that module.
+//! unknown event type failing its frame — is documented on that module, along
+//! with the one record (`McpServerInfo`) that tolerates unknown keys because
+//! it flattens its definition.
 //!
-//! The REST records below are still hand-written mirrors. Their server types
-//! only serialize today, so they cannot be imported the same way; they read
-//! only the fields a CLI surface uses and let serde drop the rest, and the
-//! opaque strings they carry are bounded with the same
-//! [`tidebreak_server::wire::limits`] the renderer applies. Moving them onto
-//! the server's types is tracked in brightwave-inc/tidebreak#3005.
+//! The chat event socket's frames and the REST records (the model catalog,
+//! providers, MCP servers, agent runs, and conversation outputs) both come
+//! through here; the tests below decode the server's fixtures for each.
 
-use serde::Deserialize;
-use tidebreak_core::CallId;
 pub use tidebreak_core::{
     Chat, PendingPlanApproval, PendingUserQuestions, RendererToolName, ToolActionPreview,
     ToolApprovalKind,
 };
-pub use tidebreak_server::wire::limits;
 pub use tidebreak_server::wire::{
     AgentActivityHistoryItem, ApprovalGrantRung, RendererAgentEvent, RendererChatFrame,
     RendererToolStatus,
 };
-
-/// A timestamp string within [`limits::MAX_WIRE_TIMESTAMP_CHARS`] code points.
-///
-/// The output routes carry timestamps as preformatted strings rather than
-/// `DateTime`s, so the bound is the only check they get; the renderer applies
-/// the same number.
-fn bounded_timestamp<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = String::deserialize(deserializer)?;
-    if value.chars().count() > limits::MAX_WIRE_TIMESTAMP_CHARS {
-        return Err(serde::de::Error::custom(format!(
-            "timestamp exceeds {} characters",
-            limits::MAX_WIRE_TIMESTAMP_CHARS
-        )));
-    }
-    Ok(value)
-}
-
-/// One background agent run, from `GET /chats/{id}/agent-runs`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct AgentRunSnapshot {
-    pub id: tidebreak_core::AgentRunId,
-    #[serde(default)]
-    pub parent_id: Option<tidebreak_core::AgentRunId>,
-    #[serde(default)]
-    pub tier: Option<String>,
-    /// Where the agent run loop itself executes (`in_process` / `container`).
-    /// Not the code-exec backend — see [`Self::code_execution_provider`].
-    #[serde(default)]
-    pub execution_location: Option<String>,
-    /// Host code-execution backend for `exec` (`local` / `e2b` / `docker` /
-    /// `daytona` / `off`). Independent of [`Self::execution_location`].
-    #[serde(default)]
-    pub code_execution_provider: Option<String>,
-    pub status: String,
-    #[serde(default)]
-    pub task: Option<String>,
-    #[serde(default)]
-    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(default)]
-    pub finished_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(default)]
-    pub last_error_code: Option<String>,
-    /// Files the run named in its terminal `done` submission.
-    #[serde(default)]
-    pub submitted_outputs: Vec<SubmittedOutput>,
-    #[serde(default)]
-    pub terminal_text: Option<String>,
-    #[serde(default)]
-    pub spawn_call_id: Option<CallId>,
-    #[serde(default)]
-    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
-}
-
-/// One file a background run submitted, as the list route returns it.
-#[derive(Debug, Clone, Deserialize)]
-pub struct SubmittedOutput {
-    pub output_id: tidebreak_core::OutputId,
-    pub filename: String,
-}
-
-/// One selectable model, from `GET /models`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ModelInfo {
-    pub key: String,
-    pub id: String,
-    pub display_name: String,
-    /// The provider that serves the model; decoded for forward compatibility,
-    /// not yet grouped on in the picker.
-    #[allow(dead_code)]
-    #[serde(default)]
-    pub provider: String,
-    #[serde(default)]
-    pub available: bool,
-    #[serde(default)]
-    pub context_window: u32,
-    #[serde(default)]
-    pub reasoning_efforts: Vec<String>,
-}
-
-/// The model catalog response.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ModelCatalog {
-    #[serde(default)]
-    pub models: Vec<ModelInfo>,
-    /// Every named model role, its selection, and what it resolves to now.
-    #[serde(default)]
-    pub roles: Vec<ModelRoleInfo>,
-}
-
-/// One named model role, from `GET /models`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ModelRoleInfo {
-    pub role: String,
-    /// The catalog key pinned to this role, or `None` for automatic.
-    #[serde(default)]
-    pub selection: Option<String>,
-    /// What the role resolves to right now, selection or not.
-    #[serde(default)]
-    pub resolved_key: Option<String>,
-}
-
-/// One provider row from `GET /providers`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ProviderInfo {
-    /// Wire form of the provider kind (`anthropic`, `openai_compatible`, …),
-    /// which is also the path segment the write routes take.
-    pub kind: String,
-    #[serde(default)]
-    pub enabled: bool,
-    /// Whether a credential is stored — never the credential itself.
-    #[serde(default)]
-    pub has_credential: bool,
-    /// How the provider is authenticated (`api_key`, `chatgpt`, …), when it is.
-    #[serde(default)]
-    pub auth_mode: Option<String>,
-    #[serde(default)]
-    pub base_url: Option<String>,
-}
-
-/// The `GET /providers` envelope.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ProvidersList {
-    #[serde(default)]
-    pub providers: Vec<ProviderInfo>,
-}
-
-/// One mounted MCP server, from `GET /mcp/servers`. The response flattens each
-/// server's definition into its live projection, so both are read here.
-#[derive(Debug, Clone, Deserialize)]
-pub struct McpServerInfo {
-    pub name: String,
-    #[serde(default)]
-    pub enabled: bool,
-    /// `initializing` / `healthy` / `degraded` / `reconnecting` / `disabled`.
-    #[serde(default)]
-    pub health: String,
-    #[serde(default)]
-    pub tool_count: usize,
-    /// The plugin this server came from, when it is plugin-sourced. Those are
-    /// derived by the server and cannot be edited over the config route.
-    #[serde(default)]
-    pub plugin: Option<String>,
-    #[serde(default)]
-    pub command: Option<String>,
-    #[serde(default)]
-    pub url: Option<String>,
-    #[serde(default)]
-    pub gateway_endpoint: Option<String>,
-    #[serde(default)]
-    pub diagnostic: Option<String>,
-}
-
-/// The `GET /mcp/servers` envelope.
-#[derive(Debug, Clone, Deserialize)]
-pub struct McpServersInfo {
-    #[serde(default)]
-    pub servers: Vec<McpServerInfo>,
-}
-
-/// One row of a conversation's outputs catalog.
-///
-/// The output routes answer in the shape the desktop renderer already
-/// validates, which is why these fields are camelCase where the rest of the
-/// API is not — moving the surface off Tauri was a transport change, not a
-/// payload change.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OutputSummary {
-    pub output_id: tidebreak_core::OutputId,
-    pub filename: String,
-    pub media_type: String,
-    pub size_bytes: u64,
-    pub revision_count: u32,
-    #[serde(deserialize_with = "bounded_timestamp")]
-    pub updated_at: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OutputsCatalog {
-    pub deliverables: Vec<OutputSummary>,
-    /// Whether the conversation has more outputs than one answer carries.
-    pub truncated: bool,
-}
-
-/// One output's bounded text preview.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OutputPreview {
-    pub filename: String,
-    pub media_type: String,
-    pub revision_id: tidebreak_core::OutputRevisionId,
-    pub content: String,
-    pub truncated: bool,
-}
-
-/// One row of an output's version history.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OutputRevisionRow {
-    pub revision_id: tidebreak_core::OutputRevisionId,
-    pub ordinal: u32,
-    pub size_bytes: u64,
-    #[serde(deserialize_with = "bounded_timestamp")]
-    pub created_at: String,
-    pub produced_by: String,
-    pub is_current: bool,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OutputRevisions {
-    pub revisions: Vec<OutputRevisionRow>,
-}
+// REST records.
+pub use tidebreak_server::wire::{
+    AgentRunSnapshot, DeliverablePreview, DeliverableSummary, DeliverablesCatalog, McpServerInfo,
+    McpServersInfo, ModelCatalog, OutputRevisionInfo, OutputRevisionsCatalog, ProviderInfo,
+    ProvidersList,
+};
 
 #[cfg(test)]
 mod tests {
@@ -302,21 +87,98 @@ mod tests {
         assert!(events > 0 && metadata > 0);
     }
 
-    /// The hand-written output mirrors apply the renderer's timestamp bound.
-    #[test]
-    fn output_timestamps_are_bounded_like_the_renderer() {
-        let row = |updated_at: &str| {
-            serde_json::json!({
-                "outputId": "00000000-0000-0000-0000-000000000001",
-                "filename": "report.md",
-                "mediaType": "text/markdown",
-                "sizeBytes": 12,
-                "revisionCount": 1,
-                "updatedAt": updated_at,
+    /// Path of the server's REST record fixtures, relative to this crate.
+    const REST_RECORDS: &str = "../tidebreak-server/fixtures/rest-records.json";
+
+    fn rest_record_fixtures() -> Vec<(String, String, serde_json::Value)> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(REST_RECORDS);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+        let entries: Vec<serde_json::Value> =
+            serde_json::from_str(&text).expect("the fixture file is a JSON array");
+        entries
+            .into_iter()
+            .map(|entry| {
+                let field = |key: &str| {
+                    entry[key]
+                        .as_str()
+                        .unwrap_or_else(|| panic!("every fixture has a {key}"))
+                        .to_owned()
+                };
+                (field("name"), field("type"), entry["value"].clone())
             })
+            .collect()
+    }
+
+    /// Every REST record the server answers with decodes here through the
+    /// type the fixture names, and serializes back to the same bytes. The
+    /// server's own test renders the file from real values, so a response
+    /// field this crate cannot read fails here rather than at a prompt.
+    #[test]
+    fn every_server_rest_record_decodes() {
+        fn round_trip<T: serde::de::DeserializeOwned + serde::Serialize>(
+            name: &str,
+            value: &serde_json::Value,
+        ) {
+            let decoded: T = serde_json::from_value(value.clone())
+                .unwrap_or_else(|error| panic!("fixture {name} does not decode: {error}"));
+            let again = serde_json::to_value(&decoded).expect("a decoded record serializes");
+            assert_eq!(
+                &again, value,
+                "fixture {name} changed across the round trip"
+            );
+        }
+        let fixtures = rest_record_fixtures();
+        assert!(fixtures.len() >= 7, "the fixture list looks truncated");
+        for (name, kind, value) in &fixtures {
+            match kind.as_str() {
+                "ModelCatalog" => round_trip::<ModelCatalog>(name, value),
+                "ProvidersList" => round_trip::<ProvidersList>(name, value),
+                "McpServersInfo" => round_trip::<McpServersInfo>(name, value),
+                "AgentRunSnapshot" => round_trip::<AgentRunSnapshot>(name, value),
+                "DeliverablesCatalog" => round_trip::<DeliverablesCatalog>(name, value),
+                "DeliverablePreview" => round_trip::<DeliverablePreview>(name, value),
+                "OutputRevisionsCatalog" => round_trip::<OutputRevisionsCatalog>(name, value),
+                other => panic!("fixture {name} names a type this crate does not read: {other}"),
+            }
+        }
+    }
+
+    /// The fields the CLI prints are reachable on the server's types: the
+    /// flattened MCP definition, the typed output timestamp, and the producer
+    /// enum a hand-written mirror used to carry as a string.
+    #[test]
+    fn printed_fields_come_from_the_server_types() {
+        let fixtures = rest_record_fixtures();
+        let value = |wanted: &str| {
+            fixtures
+                .iter()
+                .find(|(name, _, _)| name == wanted)
+                .unwrap_or_else(|| panic!("the {wanted} fixture exists"))
+                .2
+                .clone()
         };
-        assert!(serde_json::from_value::<OutputSummary>(row("2026-09-01T12:00:00Z")).is_ok());
-        let too_long = "x".repeat(limits::MAX_WIRE_TIMESTAMP_CHARS + 1);
-        assert!(serde_json::from_value::<OutputSummary>(row(&too_long)).is_err());
+        let servers: McpServersInfo =
+            serde_json::from_value(value("mcp_servers")).expect("decodes");
+        let plugin = servers
+            .servers
+            .iter()
+            .find(|server| server.definition.plugin.is_some())
+            .expect("one server is plugin-sourced");
+        assert_eq!(
+            plugin.definition.gateway_endpoint.as_deref(),
+            Some("linear")
+        );
+        assert_eq!(plugin.health.as_str(), "disabled");
+
+        let revisions: OutputRevisionsCatalog =
+            serde_json::from_value(value("output_revisions")).expect("decodes");
+        let producers: Vec<&str> = revisions
+            .revisions
+            .iter()
+            .map(|revision| revision.produced_by.as_str())
+            .collect();
+        assert_eq!(producers, ["agent", "backgroundAgent", "user"]);
+        assert!(revisions.revisions[0].created_at < revisions.revisions[2].created_at);
     }
 }

--- a/crates/tidebreak-cli/src/outputs.rs
+++ b/crates/tidebreak-cli/src/outputs.rs
@@ -16,7 +16,7 @@ use tidebreak_core::{
 use uuid::Uuid;
 
 use crate::api::client::Client;
-use crate::api::wire::{OutputPreview, OutputRevisionRow, OutputSummary};
+use crate::api::wire::{DeliverablePreview, DeliverableSummary, OutputRevisionInfo};
 use crate::connect::{Server, Session};
 use crate::print::OutputFormat;
 
@@ -74,7 +74,7 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                     output.media_type,
                     output.size_bytes,
                     output.revision_count,
-                    output.updated_at
+                    output.updated_at.to_rfc3339()
                 );
             }
             if catalog.truncated {
@@ -132,8 +132,8 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                     revision.revision_id,
                     revision.ordinal,
                     revision.size_bytes,
-                    revision.produced_by,
-                    revision.created_at,
+                    revision.produced_by.as_str(),
+                    revision.created_at.to_rfc3339(),
                     if revision.is_current { "\tcurrent" } else { "" }
                 );
             }
@@ -163,7 +163,7 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
     }
 }
 
-fn output_summary_json(output: &OutputSummary) -> serde_json::Value {
+fn output_summary_json(output: &DeliverableSummary) -> serde_json::Value {
     serde_json::json!({
         "outputId": output.output_id,
         "filename": output.filename,
@@ -174,7 +174,7 @@ fn output_summary_json(output: &OutputSummary) -> serde_json::Value {
     })
 }
 
-fn output_preview_json(preview: &OutputPreview) -> serde_json::Value {
+fn output_preview_json(preview: &DeliverablePreview) -> serde_json::Value {
     serde_json::json!({
         "filename": preview.filename,
         "mediaType": preview.media_type,
@@ -184,7 +184,7 @@ fn output_preview_json(preview: &OutputPreview) -> serde_json::Value {
     })
 }
 
-fn output_revision_json(revision: &OutputRevisionRow) -> serde_json::Value {
+fn output_revision_json(revision: &OutputRevisionInfo) -> serde_json::Value {
     serde_json::json!({
         "revisionId": revision.revision_id,
         "ordinal": revision.ordinal,

--- a/crates/tidebreak-cli/src/setup.rs
+++ b/crates/tidebreak-cli/src/setup.rs
@@ -151,9 +151,9 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                 return emit(&serde_json::json!({ "providers": providers_json(&providers) }));
             }
             for provider in providers {
-                let credential = match (provider.has_credential, provider.auth_mode.as_deref()) {
+                let credential = match (provider.has_credential, provider.auth_mode) {
                     (false, _) => "no credential".to_owned(),
-                    (true, Some(mode)) => format!("credential: {mode}"),
+                    (true, Some(mode)) => format!("credential: {}", mode.as_str()),
                     (true, None) => "credential: stored".to_owned(),
                 };
                 let base_url = provider
@@ -365,8 +365,8 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
         Command::McpRemove { name } => {
             let listing = client.get_mcp_servers().await?;
             if let Some(plugin) = decode_mcp(&listing)?.servers.iter().find_map(|server| {
-                (server.name == name)
-                    .then(|| server.plugin.clone())
+                (server.definition.name == name)
+                    .then(|| server.definition.plugin.clone())
                     .flatten()
             }) {
                 return Err(AgentError::msg(format!(
@@ -459,7 +459,7 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                 return Ok(());
             }
             for run in runs {
-                let tier = run.tier.as_deref().unwrap_or("-");
+                let tier = run.tier.as_str();
                 let task = run
                     .task
                     .as_deref()
@@ -477,7 +477,8 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
                 };
                 println!(
                     "{:<36}  {tier:<10}  {:<12}  outs={outs}  {task}",
-                    run.id, run.status
+                    run.id,
+                    run.status.as_str()
                 );
             }
         }
@@ -504,19 +505,16 @@ async fn execute(client: &Client, command: Command, format: OutputFormat) -> Res
             if let Some(parent) = snapshot.parent_id {
                 println!("parent              {parent}");
             }
-            println!(
-                "tier                {}",
-                snapshot.tier.as_deref().unwrap_or("-")
-            );
+            println!("tier                {}", snapshot.tier.as_str());
             println!(
                 "execution_location  {}",
-                snapshot.execution_location.as_deref().unwrap_or("-")
+                snapshot.execution_location.as_str()
             );
             println!(
                 "code_execution_provider  {}",
-                snapshot.code_execution_provider.as_deref().unwrap_or("-")
+                snapshot.code_execution_provider.as_str()
             );
-            println!("status              {}", snapshot.status);
+            println!("status              {}", snapshot.status.as_str());
             if let Some(error) = &snapshot.last_error_code {
                 println!("last_error_code     {error}");
             }
@@ -677,24 +675,25 @@ fn credentialed(readiness: &serde_json::Value) -> String {
 }
 
 fn print_mcp_server(server: &McpServerInfo) {
-    let transport = server
+    let definition = &server.definition;
+    let transport = definition
         .command
         .as_deref()
-        .or(server.url.as_deref())
-        .or(server.gateway_endpoint.as_deref())
+        .or(definition.url.as_deref())
+        .or(definition.gateway_endpoint.as_deref())
         .unwrap_or("-");
-    let source = match &server.plugin {
+    let source = match &definition.plugin {
         Some(plugin) => format!(" (from the {plugin} plugin)"),
         None => String::new(),
     };
-    let state = if server.enabled {
+    let state = if definition.enabled {
         server.health.as_str()
     } else {
         "disabled"
     };
     println!(
         "{:<24} {state:<14} {:>3} tools  {transport}{source}",
-        server.name, server.tool_count
+        definition.name, server.tool_count
     );
     if let Some(diagnostic) = &server.diagnostic {
         println!("    {diagnostic}");
@@ -755,6 +754,7 @@ fn providers_json(providers: &[crate::api::wire::ProviderInfo]) -> Vec<serde_jso
 mod tests {
     use super::*;
     use tidebreak_core::Config;
+    use tidebreak_server::wire::ProviderKind;
 
     /// The point of the whole family: a credential stored through the CLI is
     /// live on the profile the next command (and the next turn) resolves
@@ -775,7 +775,7 @@ mod tests {
         let before = client.list_providers().await.expect("list providers");
         let anthropic = before
             .iter()
-            .find(|provider| provider.kind == "anthropic")
+            .find(|provider| provider.kind == ProviderKind::Anthropic)
             .expect("anthropic is a known provider");
         assert!(
             !anthropic.has_credential && !anthropic.enabled,
@@ -799,7 +799,7 @@ mod tests {
         let after = client.list_providers().await.expect("list providers");
         let anthropic = after
             .iter()
-            .find(|provider| provider.kind == "anthropic")
+            .find(|provider| provider.kind == ProviderKind::Anthropic)
             .expect("anthropic is a known provider");
         assert!(
             anthropic.has_credential && anthropic.enabled,
@@ -819,7 +819,7 @@ mod tests {
         assert!(
             !after
                 .iter()
-                .any(|provider| provider.kind == "anthropic" && provider.has_credential),
+                .any(|provider| provider.kind == ProviderKind::Anthropic && provider.has_credential),
             "removing the credential must take it out of the listing"
         );
 

--- a/crates/tidebreak-server/fixtures/rest-records.json
+++ b/crates/tidebreak-server/fixtures/rest-records.json
@@ -1,0 +1,312 @@
+[
+  {
+    "name": "model_catalog",
+    "type": "ModelCatalog",
+    "value": {
+      "models": [
+        {
+          "available": true,
+          "context_window": 1000000,
+          "display_name": "Claude Opus 5",
+          "id": "claude-opus-5",
+          "input_modalities": [
+            "text",
+            "image"
+          ],
+          "key": "anthropic::claude-opus-5",
+          "max_output_tokens": 64000,
+          "multimodal": true,
+          "provider": "anthropic",
+          "reasoning_efforts": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "recommended": true,
+          "supports_reasoning": true,
+          "supports_structured_output": true,
+          "supports_tools": true,
+          "vendor": null,
+          "verification": "verified"
+        },
+        {
+          "available": false,
+          "context_window": 200000,
+          "display_name": "Claude Opus 5",
+          "id": "claude-opus-5",
+          "input_modalities": [
+            "text"
+          ],
+          "key": "model_gateway::claude-opus-5",
+          "max_output_tokens": 32000,
+          "multimodal": false,
+          "provider": "model_gateway",
+          "reasoning_efforts": [],
+          "recommended": false,
+          "supports_reasoning": false,
+          "supports_structured_output": false,
+          "supports_tools": true,
+          "vendor": "anthropic",
+          "verification": "unverified"
+        }
+      ],
+      "roles": [
+        {
+          "resolved_key": "anthropic::claude-opus-5",
+          "role": "chat",
+          "selection": "anthropic::claude-opus-5"
+        },
+        {
+          "resolved_key": null,
+          "role": "utility",
+          "selection": null
+        }
+      ]
+    }
+  },
+  {
+    "name": "providers",
+    "type": "ProvidersList",
+    "value": {
+      "providers": [
+        {
+          "auth_mode": "api_key",
+          "enabled": true,
+          "has_credential": true,
+          "kind": "anthropic",
+          "models": []
+        },
+        {
+          "base_url": "http://localhost:11434/v1",
+          "enabled": false,
+          "has_credential": false,
+          "kind": "openai_compatible",
+          "models": [
+            {
+              "context_window": 32768,
+              "display_name": "Llama",
+              "id": "llama",
+              "input_modalities": [
+                "text"
+              ],
+              "max_output_tokens": 4096,
+              "reasoning_efforts": [],
+              "supports_reasoning": false
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "mcp_servers",
+    "type": "McpServersInfo",
+    "value": {
+      "servers": [
+        {
+          "args": [
+            "-y",
+            "@modelcontextprotocol/server-filesystem"
+          ],
+          "bearer_token_env": null,
+          "command": "npx",
+          "curated": {
+            "display_name": "Filesystem",
+            "notes": "Read and write under one root.",
+            "tested_on": "2026-08-01"
+          },
+          "cwd": "/tmp",
+          "diagnostic": null,
+          "enabled": true,
+          "env": [
+            "FS_ROOT"
+          ],
+          "env_from": [
+            "HOME"
+          ],
+          "gateway_endpoint": null,
+          "health": "healthy",
+          "name": "filesystem",
+          "plugin": null,
+          "request_timeout_ms": 30000,
+          "tool_count": 11,
+          "url": null
+        },
+        {
+          "args": [],
+          "bearer_token_env": null,
+          "command": null,
+          "curated": null,
+          "cwd": null,
+          "diagnostic": "turned off",
+          "enabled": false,
+          "env": [],
+          "env_from": [],
+          "gateway_endpoint": "linear",
+          "health": "disabled",
+          "name": "linear",
+          "plugin": "linear-plugin",
+          "request_timeout_ms": 30000,
+          "tool_count": 0,
+          "url": null
+        }
+      ]
+    }
+  },
+  {
+    "name": "agent_run_running",
+    "type": "AgentRunSnapshot",
+    "value": {
+      "activity": {
+        "kind": "exec",
+        "status": "running"
+      },
+      "code_execution_provider": "docker",
+      "created_at": "2025-09-01T04:13:10Z",
+      "execution_location": "container",
+      "finished_at": null,
+      "id": "00000000-0000-0000-0000-000000000030",
+      "last_error_code": null,
+      "model_steps": 3,
+      "parent_id": null,
+      "spawn_call_id": "00000000-0000-0000-0000-000000000031",
+      "started_at": "2025-09-01T04:13:20Z",
+      "status": "running",
+      "submitted_outputs": [],
+      "task": "Summarize the quarterly report",
+      "task_plan": {
+        "completed": 1,
+        "current": "Read the report",
+        "total": 3,
+        "updated_at": "2025-09-01T04:13:50Z"
+      },
+      "terminal_text": null,
+      "tier": "background",
+      "updated_at": "2025-09-01T04:13:50Z",
+      "usage": {
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 800,
+        "input_tokens": 1200,
+        "output_tokens": 340
+      }
+    }
+  },
+  {
+    "name": "agent_run_completed",
+    "type": "AgentRunSnapshot",
+    "value": {
+      "activity": null,
+      "code_execution_provider": "off",
+      "created_at": "2025-09-01T04:14:50Z",
+      "execution_location": "in_process",
+      "finished_at": "2025-09-01T04:16:40Z",
+      "id": "00000000-0000-0000-0000-000000000032",
+      "last_error_code": "provider_rate_limited",
+      "model_steps": 7,
+      "parent_id": "00000000-0000-0000-0000-000000000030",
+      "spawn_call_id": null,
+      "started_at": "2025-09-01T04:15:00Z",
+      "status": "completed",
+      "submitted_outputs": [
+        {
+          "filename": "summary.md",
+          "output_id": "00000000-0000-0000-0000-000000000040"
+        }
+      ],
+      "task": null,
+      "terminal_text": "Done.",
+      "tier": "foreground",
+      "updated_at": "2025-09-01T04:16:40Z",
+      "usage": {
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "input_tokens": 0,
+        "output_tokens": 0
+      }
+    }
+  },
+  {
+    "name": "outputs",
+    "type": "DeliverablesCatalog",
+    "value": {
+      "deliverables": [
+        {
+          "filename": "summary.md",
+          "mediaType": "text/markdown",
+          "outputId": "00000000-0000-0000-0000-000000000040",
+          "producingRunId": "00000000-0000-0000-0000-000000000032",
+          "revisionCount": 3,
+          "sizeBytes": 1234,
+          "updatedAt": "2025-09-01T04:18:20Z"
+        }
+      ],
+      "truncated": false
+    }
+  },
+  {
+    "name": "output_preview",
+    "type": "DeliverablePreview",
+    "value": {
+      "content": "# Summary\n\nOne paragraph.\n",
+      "filename": "summary.md",
+      "mediaType": "text/markdown",
+      "outputId": "00000000-0000-0000-0000-000000000040",
+      "revisionCount": 3,
+      "revisionId": "00000000-0000-0000-0000-000000000043",
+      "truncated": true
+    }
+  },
+  {
+    "name": "output_revisions",
+    "type": "OutputRevisionsCatalog",
+    "value": {
+      "outputId": "00000000-0000-0000-0000-000000000040",
+      "revisions": [
+        {
+          "createdAt": "2025-09-01T04:15:00Z",
+          "isCurrent": false,
+          "ordinal": 1,
+          "producedBy": "agent",
+          "revisionId": "00000000-0000-0000-0000-000000000041",
+          "sizeBytes": 900,
+          "sources": [
+            {
+              "citationId": "00000000-0000-0000-0000-000000000050",
+              "documentId": "00000000-0000-0000-0000-000000000051",
+              "kind": "document",
+              "locator": {
+                "end": 3,
+                "kind": "pages",
+                "start": 2
+              }
+            },
+            {
+              "domain": "example.com",
+              "kind": "web",
+              "label": "Quarterly report",
+              "url": "https://example.com/report"
+            }
+          ]
+        },
+        {
+          "createdAt": "2025-09-01T04:16:40Z",
+          "isCurrent": false,
+          "ordinal": 2,
+          "producedBy": "backgroundAgent",
+          "revisionId": "00000000-0000-0000-0000-000000000042",
+          "sizeBytes": 1100,
+          "sources": []
+        },
+        {
+          "createdAt": "2025-09-01T04:18:20Z",
+          "isCurrent": true,
+          "ordinal": 3,
+          "producedBy": "user",
+          "revisionId": "00000000-0000-0000-0000-000000000043",
+          "sizeBytes": 1234,
+          "sources": []
+        }
+      ]
+    }
+  }
+]

--- a/crates/tidebreak-server/src/mcp_config/mod.rs
+++ b/crates/tidebreak-server/src/mcp_config/mod.rs
@@ -18,4 +18,4 @@ mod validation;
 mod tests;
 
 pub(crate) use runtime::*;
-pub(crate) use types::*;
+pub use types::*;

--- a/crates/tidebreak-server/src/mcp_config/types.rs
+++ b/crates/tidebreak-server/src/mcp_config/types.rs
@@ -141,54 +141,54 @@ pub(crate) struct McpServersConfig {
 /// `bearer_token_env` stays with `url`.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct McpServerDefinition {
-    pub(crate) name: String,
+pub struct McpServerDefinition {
+    pub name: String,
     #[serde(default)]
-    pub(crate) command: Option<String>,
+    pub command: Option<String>,
     #[serde(default)]
-    pub(crate) args: Vec<String>,
+    pub args: Vec<String>,
     /// Names of the environment variables this server is given directly. The
     /// values live in the secret store under [`env_secret_key`] and never
     /// enter this type, so they neither persist in the connected-app record
     /// nor project through the API.
     #[serde(default)]
-    pub(crate) env: BTreeSet<String>,
+    pub env: BTreeSet<String>,
     /// Inbound-only: values for [`env`](Self::env) names being set or
     /// changed. A commit writes these into the secret store and drops them; a
     /// name present in `env` but absent here keeps the value already stored,
     /// which is what makes "leave blank to keep" work. `skip_serializing`
     /// keeps them out of both the persisted record and every projection.
     #[serde(default, skip_serializing)]
-    pub(crate) env_values: BTreeMap<String, String>,
+    pub env_values: BTreeMap<String, String>,
     /// Parent environment names to forward. Their values never enter this type.
     #[serde(default)]
-    pub(crate) env_from: Vec<String>,
+    pub env_from: Vec<String>,
     #[serde(default)]
-    pub(crate) cwd: Option<PathBuf>,
+    pub cwd: Option<PathBuf>,
     /// Streamable HTTP endpoint for a remote server.
     #[serde(default)]
-    pub(crate) url: Option<String>,
+    pub url: Option<String>,
     /// Parent environment name holding the HTTP bearer token. The value is
     /// resolved at connect time and never enters this type.
     #[serde(default)]
-    pub(crate) bearer_token_env: Option<String>,
+    pub bearer_token_env: Option<String>,
     /// Endpoint slug of a gateway MCP endpoint, mounted through the signed-in
     /// model-gateway session. The endpoint URL and its short-lived bearer are
     /// resolved from the session at every connection and never enter this
     /// type.
     #[serde(default)]
-    pub(crate) gateway_endpoint: Option<String>,
+    pub gateway_endpoint: Option<String>,
     #[serde(default = "default_request_timeout_ms")]
-    pub(crate) request_timeout_ms: u64,
+    pub request_timeout_ms: u64,
     #[serde(default = "enabled_by_default")]
-    pub(crate) enabled: bool,
+    pub enabled: bool,
     /// The plugin this server was synthesized from, when it is plugin-sourced.
     ///
     /// Read-only over the API: `PUT /mcp/servers` refuses a body that sets it,
     /// and the runtime rebuilds these entries from the installed plugin tree
     /// rather than from anything a client sends or the store holds.
     #[serde(default)]
-    pub(crate) plugin: Option<String>,
+    pub plugin: Option<String>,
     /// Connect-time material for a plugin-sourced server: the two reserved
     /// directories, the literal environment and headers its `mcp.json`
     /// declared, and the reason it is inert when this client cannot run it.
@@ -714,9 +714,9 @@ pub(crate) enum McpReplaceOutcome {
 }
 
 /// Renderer-safe connection lifecycle.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum McpHealth {
+pub enum McpHealth {
     Initializing,
     Healthy,
     Degraded,
@@ -724,25 +724,47 @@ pub(crate) enum McpHealth {
     Disabled,
 }
 
+impl McpHealth {
+    /// The wire spelling, for a client that prints the state without a serde
+    /// round trip. Pinned to the serde form by a test in [`crate::wire`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            McpHealth::Initializing => "initializing",
+            McpHealth::Healthy => "healthy",
+            McpHealth::Degraded => "degraded",
+            McpHealth::Reconnecting => "reconnecting",
+            McpHealth::Disabled => "disabled",
+        }
+    }
+}
+
 /// One renderer-safe server projection. Resolved `env_from` values and child
 /// process details are intentionally absent.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
-pub(crate) struct McpServerInfo {
+//
+// Also read back by the CLI through [`crate::wire`]. This is the one record
+// on that surface that tolerates unknown keys: `definition` is flattened,
+// and serde does not support `deny_unknown_fields` on either side of a
+// flatten (the flattened struct's own guard is ignored on the way through).
+// The envelope, [`McpServersInfo`], still rejects them. A plain comment, not
+// a doc comment, so the generated `wire.ts` does not carry it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+pub struct McpServerInfo {
     #[serde(flatten)]
-    pub(crate) definition: McpServerDefinition,
-    pub(crate) health: McpHealth,
-    pub(crate) tool_count: usize,
-    pub(crate) diagnostic: Option<String>,
+    pub definition: McpServerDefinition,
+    pub health: McpHealth,
+    pub tool_count: usize,
+    pub diagnostic: Option<String>,
     /// The curated-list entry this definition matches, when Tidebreak has
     /// exercised the server end to end. `null` means community: mounted and
     /// usable, just not something we have driven ourselves. Derived from the
     /// definition on every read, never stored.
-    pub(crate) curated: Option<McpCuration>,
+    pub curated: Option<McpCuration>,
 }
 
-#[derive(Debug, Clone, Serialize, ts_rs::TS)]
-pub(crate) struct McpServersInfo {
-    pub(crate) servers: Vec<McpServerInfo>,
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
+pub struct McpServersInfo {
+    pub servers: Vec<McpServerInfo>,
 }
 
 /// One configured connected app's current namespace and definition

--- a/crates/tidebreak-server/src/mcp_curated.rs
+++ b/crates/tidebreak-server/src/mcp_curated.rs
@@ -13,7 +13,7 @@
 
 use std::path::Path;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// The curated-registry entry a configured server matched, projected to the
 /// renderer beside the server's health.
@@ -21,16 +21,17 @@ use serde::Serialize;
 /// Presence *is* the tier: a server with a curation is "tested", a server
 /// without one is "community". One field cannot disagree with itself the way
 /// a separate boolean and a separate record could.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
-pub(crate) struct McpCuration {
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
+pub struct McpCuration {
     /// The curated list's own name for the server, which need not match the
     /// namespace the reader configured it under.
-    pub(crate) display_name: String,
+    pub display_name: String,
     /// `YYYY-MM-DD` the entry was last exercised end to end.
-    pub(crate) tested_on: String,
+    pub tested_on: String,
     /// One sentence on what was exercised, for the reader deciding how much
     /// the badge is worth.
-    pub(crate) notes: String,
+    pub notes: String,
 }
 
 /// How a curated entry recognises a stdio definition.

--- a/crates/tidebreak-server/src/model_registry.rs
+++ b/crates/tidebreak-server/src/model_registry.rs
@@ -22,7 +22,7 @@ pub enum InputModality {
 }
 
 /// How thoroughly Tidebreak has exercised a model's agent-facing behavior.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum VerificationTier {
     /// Tool-calling and streaming have been exercised end to end.

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -1430,7 +1430,12 @@ pub struct CatalogModel {
 }
 
 /// Public view of a provider — never includes the credential itself.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+//
+// Also read back by the CLI through [`crate::wire`], so it rejects unknown
+// keys the way the renderer's guards do. A plain comment, not a doc comment,
+// so the generated `wire.ts` does not carry it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
 pub struct ProviderInfo {
     /// Provider kind.
     pub kind: ProviderKind,
@@ -1458,6 +1463,17 @@ pub enum ProviderAuthMode {
     ApiKey,
     /// ChatGPT subscription OAuth.
     Chatgpt,
+}
+
+impl ProviderAuthMode {
+    /// The wire spelling, for a client that prints the mode without a serde
+    /// round trip. Pinned to the serde form by a test in [`crate::wire`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProviderAuthMode::ApiKey => "api_key",
+            ProviderAuthMode::Chatgpt => "chatgpt",
+        }
+    }
 }
 
 /// Deserialize a present field (including JSON `null`) as `Some(..)`;

--- a/crates/tidebreak-server/src/routes/agent_runs.rs
+++ b/crates/tidebreak-server/src/routes/agent_runs.rs
@@ -36,6 +36,18 @@ pub enum ExecProviderSnapshot {
 }
 
 impl ExecProviderSnapshot {
+    /// The wire spelling, for a client that prints the backend without a serde
+    /// round trip. Pinned to the serde form by a test in [`crate::wire`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::E2b => "e2b",
+            Self::Daytona => "daytona",
+            Self::Docker => "docker",
+            Self::Off => "off",
+        }
+    }
+
     fn from_config(provider: Option<ExecProviderKind>) -> Self {
         match provider {
             Some(ExecProviderKind::Local) => Self::Local,
@@ -53,7 +65,12 @@ impl ExecProviderSnapshot {
 ///
 /// Worker lease tokens, scheduling budgets, and other executor-facing fields
 /// intentionally remain inside the server/store boundary.
-#[derive(Debug, Serialize, ts_rs::TS)]
+//
+// Also read back by the CLI through [`crate::wire`], so it rejects unknown
+// keys the way the renderer's guards do. A plain comment, not a doc comment,
+// so the generated `wire.ts` does not carry it.
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
 pub struct AgentRunSnapshot {
     pub id: tidebreak_core::AgentRunId,
     pub parent_id: Option<tidebreak_core::AgentRunId>,
@@ -143,7 +160,8 @@ impl AgentRunSnapshot {
 }
 
 /// Renderer-safe disjoint token accounting for one background run.
-#[derive(Debug, Clone, Copy, Default, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
 pub struct AgentRunUsageSnapshot {
     pub input_tokens: u32,
     pub output_tokens: u32,
@@ -163,7 +181,8 @@ impl From<tidebreak_core::Usage> for AgentRunUsageSnapshot {
 }
 
 /// One file a background run submitted, as the renderer sees it.
-#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
 pub struct SubmittedOutputSnapshot {
     pub output_id: tidebreak_core::OutputId,
     /// The name the run gave the file, which is the output's name.
@@ -181,7 +200,8 @@ pub struct SubmittedOutputSnapshot {
 /// separators, the bidi overrides and isolates — never becomes a stored step.
 /// Copying it as stored is therefore not a gap in the clamp; it is the same
 /// rule enforced one surface earlier.
-#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
 pub struct AgentRunTaskPlanProgress {
     pub completed: u32,
     pub total: u32,
@@ -250,7 +270,7 @@ impl AgentActivityKind {
 ///
 /// This intentionally does not mirror all durable executor states; only live
 /// work is represented, and terminal checkpoints produce no activity.
-#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentActivityStatus {
     Waiting,
@@ -258,7 +278,8 @@ pub enum AgentActivityStatus {
 }
 
 /// Renderer-safe projection of one live supported checkpoint.
-#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
 pub struct AgentActivitySnapshot {
     pub kind: AgentActivityKind,
     pub status: AgentActivityStatus,

--- a/crates/tidebreak-server/src/routes/outputs.rs
+++ b/crates/tidebreak-server/src/routes/outputs.rs
@@ -58,69 +58,99 @@ const MAX_OUTPUT_REVISION_SOURCES: usize = 20;
 pub const MAX_OUTPUT_REVISION_BODY_BYTES: usize = 2 * tidebreak_core::MAX_DELIVERABLE_BYTES;
 
 /// One row of the outputs catalog.
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
+///
+/// The output records are also read back by the CLI through [`crate::wire`],
+/// so they reject unknown keys the way the renderer's guards do.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeliverableSummary {
-    output_id: OutputId,
-    filename: String,
-    media_type: String,
-    size_bytes: u64,
-    revision_count: u32,
-    updated_at: String,
+    pub output_id: OutputId,
+    pub filename: String,
+    pub media_type: String,
+    pub size_bytes: u64,
+    pub revision_count: u32,
+    pub updated_at: chrono::DateTime<Utc>,
     /// Background run that produced the current revision, when the output was
     /// submitted by a background agent rather than a foreground turn. A display
     /// key, not authority.
-    producing_run_id: Option<uuid::Uuid>,
+    pub producing_run_id: Option<uuid::Uuid>,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeliverablesCatalog {
-    deliverables: Vec<DeliverableSummary>,
-    truncated: bool,
+    pub deliverables: Vec<DeliverableSummary>,
+    /// Whether the conversation has more outputs than one answer carries.
+    pub truncated: bool,
 }
 
 /// A bounded text preview of one exact revision.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeliverablePreview {
-    output_id: OutputId,
-    filename: String,
-    media_type: String,
+    pub output_id: OutputId,
+    pub filename: String,
+    pub media_type: String,
     /// Lets a detail view gate its version-history affordance without a second
     /// catalog fetch.
-    revision_count: u32,
+    pub revision_count: u32,
     /// The revision this preview (or empty binary placeholder) was built from,
     /// so a viewer can address the same immutable bytes.
-    revision_id: OutputRevisionId,
-    content: String,
-    truncated: bool,
+    pub revision_id: OutputRevisionId,
+    pub content: String,
+    pub truncated: bool,
 }
 
 /// One row of an output's version history.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OutputRevisionInfo {
-    revision_id: OutputRevisionId,
-    ordinal: u32,
-    size_bytes: u64,
-    created_at: String,
-    /// Who produced the revision: `agent` (a foreground turn),
-    /// `backgroundAgent` (a run), or `user` (an edit or a restore).
-    produced_by: &'static str,
-    is_current: bool,
+    pub revision_id: OutputRevisionId,
+    pub ordinal: u32,
+    pub size_bytes: u64,
+    pub created_at: chrono::DateTime<Utc>,
+    pub produced_by: OutputRevisionProducer,
+    pub is_current: bool,
     /// Durable evidence retrieved by the foreground turn that produced this
     /// revision. User and background-run revisions have no turn, so they carry
     /// an empty list rather than borrowing evidence from another producer.
-    sources: Vec<OutputRevisionSource>,
+    pub sources: Vec<OutputRevisionSource>,
+}
+
+/// Who produced a revision.
+///
+/// Spelled in camelCase on the wire because the output routes answer in the
+/// shape the desktop renderer already validates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OutputRevisionProducer {
+    /// A foreground turn.
+    Agent,
+    /// A background run.
+    BackgroundAgent,
+    /// An edit or a restore.
+    User,
+}
+
+impl OutputRevisionProducer {
+    /// The wire spelling, for a client that prints the producer without a
+    /// serde round trip. Pinned to the serde form by a test in [`crate::wire`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OutputRevisionProducer::Agent => "agent",
+            OutputRevisionProducer::BackgroundAgent => "backgroundAgent",
+            OutputRevisionProducer::User => "user",
+        }
+    }
 }
 
 /// One durable evidence reference belonging to a revision's producing turn.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(
     tag = "kind",
     rename_all = "camelCase",
-    rename_all_fields = "camelCase"
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
 )]
 pub enum OutputRevisionSource {
     Document {
@@ -135,11 +165,11 @@ pub enum OutputRevisionSource {
     },
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OutputRevisionsCatalog {
-    output_id: OutputId,
-    revisions: Vec<OutputRevisionInfo>,
+    pub output_id: OutputId,
+    pub revisions: Vec<OutputRevisionInfo>,
 }
 
 /// Publish a user's edit of a text output as a new user-authored revision.
@@ -315,13 +345,13 @@ pub async fn list_chat_output_revisions(
                 revision_id: revision.id,
                 ordinal: revision.ordinal,
                 size_bytes: revision.byte_len,
-                created_at: revision.created_at.to_rfc3339(),
+                created_at: revision.created_at,
                 produced_by: if revision.producing_run_id.is_some() {
-                    "backgroundAgent"
+                    OutputRevisionProducer::BackgroundAgent
                 } else if revision.turn_id.is_some() {
-                    "agent"
+                    OutputRevisionProducer::Agent
                 } else {
-                    "user"
+                    OutputRevisionProducer::User
                 },
                 is_current: revision.id == output.current_revision,
                 sources: revision
@@ -640,7 +670,7 @@ fn summary_from_record(
         media_type: output.media_type.clone(),
         size_bytes: revision.byte_len,
         revision_count: output.revision_count,
-        updated_at: output.updated_at.to_rfc3339(),
+        updated_at: output.updated_at,
         producing_run_id: revision.producing_run_id.map(|run_id| *run_id.as_uuid()),
     })
 }

--- a/crates/tidebreak-server/src/routes/providers_models.rs
+++ b/crates/tidebreak-server/src/routes/providers_models.rs
@@ -364,7 +364,12 @@ pub async fn delete_api_key(State(state): State<AppState>) -> Result<StatusCode,
 }
 
 /// Response for `GET /providers`.
-#[derive(Debug, Serialize)]
+//
+// Also read back by the CLI through [`crate::wire`], so it rejects unknown
+// keys the way the renderer's guards do. A plain comment, not a doc comment,
+// so the generated `wire.ts` does not carry it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProvidersList {
     pub providers: Vec<ProviderInfo>,
 }
@@ -521,7 +526,12 @@ pub async fn post_voice_transcription_install(
 }
 
 /// A selectable model in the catalog.
-#[derive(Debug, Serialize, ts_rs::TS)]
+//
+// Also read back by the CLI through [`crate::wire`], so it rejects unknown
+// keys the way the renderer's guards do. A plain comment, not a doc comment,
+// so the generated `wire.ts` does not carry it.
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
 pub struct ModelInfo {
     /// Stable provider-qualified selection key used by settings and chats.
     pub key: String,
@@ -576,7 +586,8 @@ pub struct ModelInfo {
 }
 
 /// One named model role and what it resolves to right now.
-#[derive(Debug, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
+#[serde(deny_unknown_fields)]
 pub struct ModelRoleInfo {
     /// The role this row describes.
     pub role: ModelRole,
@@ -594,7 +605,8 @@ pub struct ModelRoleInfo {
 }
 
 /// Response for `GET /models`.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelCatalog {
     /// The models a client can select from.
     pub models: Vec<ModelInfo>,

--- a/crates/tidebreak-server/src/wire.rs
+++ b/crates/tidebreak-server/src/wire.rs
@@ -27,6 +27,19 @@
 //!   the renderer ships with its server and never sees a newer event, so a
 //!   tolerant client would be the only surface with a different contract.
 //!
+//! # REST records
+//!
+//! The records the CLI reads over HTTP — the model catalog, the provider
+//! list, the MCP server listing, agent runs, and conversation outputs — are
+//! the same response types the routes serialize, re-exported below. They
+//! carry the same contract as the frames: closed vocabularies and
+//! `deny_unknown_fields` on every record but one. [`McpServerInfo`] flattens
+//! its definition, and serde cannot guard unknown keys across a flatten, so
+//! that record alone tolerates them; its envelope, [`McpServersInfo`], does
+//! not. The fixtures in `fixtures/rest-records.json` hold one real value per
+//! record, serialized by the generator test in `wire_types.rs`, and the CLI
+//! decodes every entry.
+//!
 //! # Limits
 //!
 //! [`limits`] holds the guard sizes the renderer applies to opaque strings on
@@ -42,6 +55,20 @@ pub use crate::event_projection::{
 pub use crate::providers::ProviderKind;
 pub use crate::routes::{
     AgentActivityHistoryItem, AgentActivityKind, AgentActivityOutcome, ApprovalGrantRung,
+};
+
+// REST records (brightwave-inc/tidebreak#3005). One block per route family.
+pub use crate::mcp_config::{McpHealth, McpServerDefinition, McpServerInfo, McpServersInfo};
+pub use crate::mcp_curated::McpCuration;
+pub use crate::model_registry::{InputModality, VerificationTier};
+pub use crate::model_roles::ModelRole;
+pub use crate::providers::{CustomModelConfig, ProviderAuthMode, ProviderInfo};
+pub use crate::routes::{
+    AgentActivitySnapshot, AgentActivityStatus, AgentRunSnapshot, AgentRunTaskPlanProgress,
+    AgentRunUsageSnapshot, DeliverablePreview, DeliverableSummary, DeliverablesCatalog,
+    ExecProviderSnapshot, ModelCatalog, ModelInfo, ModelRoleInfo, OutputRevisionInfo,
+    OutputRevisionProducer, OutputRevisionSource, OutputRevisionsCatalog, ProvidersList,
+    SubmittedOutputSnapshot,
 };
 
 /// Guard sizes for the opaque strings a client draws from this surface.
@@ -112,6 +139,43 @@ mod tests {
             AgentActivityOutcome::Cancelled,
         ] {
             assert_eq!(outcome.as_str(), wire_name(&outcome));
+        }
+    }
+
+    /// The REST records' `as_str` helpers exist for the same reason, and are
+    /// pinned the same way.
+    #[test]
+    fn rest_record_names_match_the_wire() {
+        for health in [
+            McpHealth::Initializing,
+            McpHealth::Healthy,
+            McpHealth::Degraded,
+            McpHealth::Reconnecting,
+            McpHealth::Disabled,
+        ] {
+            assert_eq!(health.as_str(), wire_name(&health));
+        }
+        for mode in [ProviderAuthMode::ApiKey, ProviderAuthMode::Chatgpt] {
+            assert_eq!(mode.as_str(), wire_name(&mode));
+        }
+        for producer in [
+            OutputRevisionProducer::Agent,
+            OutputRevisionProducer::BackgroundAgent,
+            OutputRevisionProducer::User,
+        ] {
+            assert_eq!(producer.as_str(), wire_name(&producer));
+        }
+        for role in ModelRole::ALL {
+            assert_eq!(role.as_str(), wire_name(role));
+        }
+        for provider in [
+            ExecProviderSnapshot::Local,
+            ExecProviderSnapshot::E2b,
+            ExecProviderSnapshot::Daytona,
+            ExecProviderSnapshot::Docker,
+            ExecProviderSnapshot::Off,
+        ] {
+            assert_eq!(provider.as_str(), wire_name(&provider));
         }
     }
 

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -1366,4 +1366,494 @@ mod tests {
             assert_eq!(again, frame, "fixture {name} changed across the round trip");
         }
     }
+
+    // ------------------------------------------------------------------
+    // REST records (brightwave-inc/tidebreak#3005): the response types the
+    // CLI reads over HTTP, fixtured the same way as the chat frames.
+    // ------------------------------------------------------------------
+
+    /// Path of the shared REST record fixtures, relative to this crate.
+    const REST_RECORDS: &str = "fixtures/rest-records.json";
+
+    /// The record types with a fixture, spelled as the fixture file tags them.
+    ///
+    /// A client decodes each entry through the type its tag names, so the
+    /// list is the contract: a type added to [`crate::wire`] without a tag
+    /// here has no fixture, and [`rest_record_fixtures_cover_every_type`]
+    /// fails until it gets one.
+    const REST_RECORD_TYPES: &[&str] = &[
+        "ModelCatalog",
+        "ProvidersList",
+        "McpServersInfo",
+        "AgentRunSnapshot",
+        "DeliverablesCatalog",
+        "DeliverablePreview",
+        "OutputRevisionsCatalog",
+    ];
+
+    fn at(seconds: i64) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::from_timestamp(seconds, 0).expect("a fixed timestamp")
+    }
+
+    /// One real value per REST record the CLI reads, plus the shapes inside
+    /// them that a hand-authored mirror habitually got wrong: an omitted
+    /// optional key, a flattened definition, a typed timestamp, and every
+    /// producer of an output revision.
+    ///
+    /// Each entry is `(name, type tag, value)`; the type tag names the
+    /// [`crate::wire`] type the entry decodes through.
+    fn rest_record_fixtures() -> Vec<(&'static str, &'static str, serde_json::Value)> {
+        use crate::wire::{
+            AgentActivityKind, AgentActivitySnapshot, AgentActivityStatus, AgentRunSnapshot,
+            AgentRunTaskPlanProgress, AgentRunUsageSnapshot, CustomModelConfig, DeliverablePreview,
+            DeliverableSummary, DeliverablesCatalog, ExecProviderSnapshot, InputModality,
+            McpCuration, McpHealth, McpServerDefinition, McpServerInfo, McpServersInfo,
+            ModelCatalog, ModelInfo, ModelRole, ModelRoleInfo, OutputRevisionInfo,
+            OutputRevisionProducer, OutputRevisionSource, OutputRevisionsCatalog, ProviderAuthMode,
+            ProviderInfo, ProviderKind, ProvidersList, SubmittedOutputSnapshot, VerificationTier,
+        };
+        use tidebreak_core::{
+            AgentRunExecutionLocation, AgentRunId, AgentRunStatus, AgentRunTier,
+            AssistantCitationId, CallId, CitationLocator, DocumentId, OutputId, OutputRevisionId,
+            ReasoningEffort,
+        };
+
+        let catalog = ModelCatalog {
+            models: vec![
+                ModelInfo {
+                    key: "anthropic::claude-opus-5".into(),
+                    id: "claude-opus-5".into(),
+                    display_name: "Claude Opus 5".into(),
+                    provider: ProviderKind::Anthropic,
+                    vendor: None,
+                    verification: VerificationTier::Verified,
+                    recommended: true,
+                    available: true,
+                    context_window: 1_000_000,
+                    max_output_tokens: 64_000,
+                    input_modalities: vec![InputModality::Text, InputModality::Image],
+                    supports_reasoning: true,
+                    supports_tools: true,
+                    supports_structured_output: true,
+                    reasoning_efforts: vec![
+                        ReasoningEffort::Low,
+                        ReasoningEffort::Medium,
+                        ReasoningEffort::High,
+                    ],
+                    multimodal: true,
+                },
+                ModelInfo {
+                    key: "model_gateway::claude-opus-5".into(),
+                    id: "claude-opus-5".into(),
+                    display_name: "Claude Opus 5".into(),
+                    provider: ProviderKind::ModelGateway,
+                    vendor: Some(ProviderKind::Anthropic),
+                    verification: VerificationTier::Unverified,
+                    recommended: false,
+                    available: false,
+                    context_window: 200_000,
+                    max_output_tokens: 32_000,
+                    input_modalities: vec![InputModality::Text],
+                    supports_reasoning: false,
+                    supports_tools: true,
+                    supports_structured_output: false,
+                    reasoning_efforts: Vec::new(),
+                    multimodal: false,
+                },
+            ],
+            roles: vec![
+                ModelRoleInfo {
+                    role: ModelRole::Chat,
+                    selection: Some("anthropic::claude-opus-5".into()),
+                    resolved_key: Some("anthropic::claude-opus-5".into()),
+                },
+                ModelRoleInfo {
+                    role: ModelRole::Utility,
+                    selection: None,
+                    resolved_key: None,
+                },
+            ],
+        };
+
+        let providers = ProvidersList {
+            providers: vec![
+                ProviderInfo {
+                    kind: ProviderKind::Anthropic,
+                    enabled: true,
+                    base_url: None,
+                    has_credential: true,
+                    auth_mode: Some(ProviderAuthMode::ApiKey),
+                    models: Vec::new(),
+                },
+                ProviderInfo {
+                    kind: ProviderKind::OpenaiCompatible,
+                    enabled: false,
+                    base_url: Some("http://localhost:11434/v1".into()),
+                    has_credential: false,
+                    auth_mode: None,
+                    models: vec![CustomModelConfig {
+                        id: "llama".into(),
+                        display_name: Some("Llama".into()),
+                        ..CustomModelConfig::default()
+                    }],
+                },
+            ],
+        };
+
+        let mut stdio = McpServerDefinition {
+            name: "filesystem".into(),
+            command: Some("npx".into()),
+            args: vec![
+                "-y".into(),
+                "@modelcontextprotocol/server-filesystem".into(),
+            ],
+            env: ["FS_ROOT".to_owned()].into_iter().collect(),
+            env_values: Default::default(),
+            env_from: vec!["HOME".into()],
+            cwd: Some("/tmp".into()),
+            url: None,
+            bearer_token_env: None,
+            gateway_endpoint: None,
+            request_timeout_ms: 30_000,
+            enabled: true,
+            plugin: None,
+            launch: None,
+        };
+        // The value never serializes; setting one proves the fixture does not
+        // carry it.
+        stdio
+            .env_values
+            .insert("FS_ROOT".into(), "never-on-the-wire".into());
+        let gateway = McpServerDefinition {
+            name: "linear".into(),
+            command: None,
+            args: Vec::new(),
+            env: Default::default(),
+            env_values: Default::default(),
+            env_from: Vec::new(),
+            cwd: None,
+            url: None,
+            bearer_token_env: None,
+            gateway_endpoint: Some("linear".into()),
+            request_timeout_ms: 30_000,
+            enabled: false,
+            plugin: Some("linear-plugin".into()),
+            launch: None,
+        };
+        let mcp = McpServersInfo {
+            servers: vec![
+                McpServerInfo {
+                    definition: stdio,
+                    health: McpHealth::Healthy,
+                    tool_count: 11,
+                    diagnostic: None,
+                    curated: Some(McpCuration {
+                        display_name: "Filesystem".into(),
+                        tested_on: "2026-08-01".into(),
+                        notes: "Read and write under one root.".into(),
+                    }),
+                },
+                McpServerInfo {
+                    definition: gateway,
+                    health: McpHealth::Disabled,
+                    tool_count: 0,
+                    diagnostic: Some("turned off".into()),
+                    curated: None,
+                },
+            ],
+        };
+
+        let running = AgentRunSnapshot {
+            id: AgentRunId(id(0x30)),
+            parent_id: None,
+            tier: AgentRunTier::Background,
+            execution_location: AgentRunExecutionLocation::Container,
+            code_execution_provider: ExecProviderSnapshot::Docker,
+            status: AgentRunStatus::Running,
+            model_steps: 3,
+            usage: AgentRunUsageSnapshot {
+                input_tokens: 1200,
+                output_tokens: 340,
+                cache_read_input_tokens: 800,
+                cache_creation_input_tokens: 0,
+            },
+            task: Some("Summarize the quarterly report".into()),
+            started_at: Some(at(1_756_700_000)),
+            finished_at: None,
+            last_error_code: None,
+            activity: Some(AgentActivitySnapshot {
+                kind: AgentActivityKind::Exec,
+                status: AgentActivityStatus::Running,
+            }),
+            submitted_outputs: Vec::new(),
+            task_plan: Some(AgentRunTaskPlanProgress {
+                completed: 1,
+                total: 3,
+                current: Some("Read the report".into()),
+                updated_at: at(1_756_700_030),
+            }),
+            terminal_text: None,
+            created_at: at(1_756_699_990),
+            updated_at: at(1_756_700_030),
+            spawn_call_id: Some(CallId(id(0x31))),
+        };
+        // The settled shape, with the omittable plan absent.
+        let completed = AgentRunSnapshot {
+            id: AgentRunId(id(0x32)),
+            parent_id: Some(AgentRunId(id(0x30))),
+            tier: AgentRunTier::Foreground,
+            execution_location: AgentRunExecutionLocation::InProcess,
+            code_execution_provider: ExecProviderSnapshot::Off,
+            status: AgentRunStatus::Completed,
+            model_steps: 7,
+            usage: AgentRunUsageSnapshot::default(),
+            task: None,
+            started_at: Some(at(1_756_700_100)),
+            finished_at: Some(at(1_756_700_200)),
+            last_error_code: Some("provider_rate_limited".into()),
+            activity: None,
+            submitted_outputs: vec![SubmittedOutputSnapshot {
+                output_id: OutputId(id(0x40)),
+                filename: "summary.md".into(),
+            }],
+            task_plan: None,
+            terminal_text: Some("Done.".into()),
+            created_at: at(1_756_700_090),
+            updated_at: at(1_756_700_200),
+            spawn_call_id: None,
+        };
+
+        let outputs = DeliverablesCatalog {
+            deliverables: vec![DeliverableSummary {
+                output_id: OutputId(id(0x40)),
+                filename: "summary.md".into(),
+                media_type: "text/markdown".into(),
+                size_bytes: 1234,
+                revision_count: 3,
+                updated_at: at(1_756_700_300),
+                producing_run_id: Some(id(0x32)),
+            }],
+            truncated: false,
+        };
+        let preview = DeliverablePreview {
+            output_id: OutputId(id(0x40)),
+            filename: "summary.md".into(),
+            media_type: "text/markdown".into(),
+            revision_count: 3,
+            revision_id: OutputRevisionId(id(0x43)),
+            content: "# Summary\n\nOne paragraph.\n".into(),
+            truncated: true,
+        };
+        let revisions = OutputRevisionsCatalog {
+            output_id: OutputId(id(0x40)),
+            revisions: vec![
+                OutputRevisionInfo {
+                    revision_id: OutputRevisionId(id(0x41)),
+                    ordinal: 1,
+                    size_bytes: 900,
+                    created_at: at(1_756_700_100),
+                    produced_by: OutputRevisionProducer::Agent,
+                    is_current: false,
+                    sources: vec![
+                        OutputRevisionSource::Document {
+                            citation_id: AssistantCitationId(id(0x50)),
+                            document_id: DocumentId(id(0x51)),
+                            locator: CitationLocator::Pages { start: 2, end: 3 },
+                        },
+                        OutputRevisionSource::Web {
+                            url: "https://example.com/report".into(),
+                            label: "Quarterly report".into(),
+                            domain: "example.com".into(),
+                        },
+                    ],
+                },
+                OutputRevisionInfo {
+                    revision_id: OutputRevisionId(id(0x42)),
+                    ordinal: 2,
+                    size_bytes: 1100,
+                    created_at: at(1_756_700_200),
+                    produced_by: OutputRevisionProducer::BackgroundAgent,
+                    is_current: false,
+                    sources: Vec::new(),
+                },
+                OutputRevisionInfo {
+                    revision_id: OutputRevisionId(id(0x43)),
+                    ordinal: 3,
+                    size_bytes: 1234,
+                    created_at: at(1_756_700_300),
+                    produced_by: OutputRevisionProducer::User,
+                    is_current: true,
+                    sources: Vec::new(),
+                },
+            ],
+        };
+
+        fn value<T: serde::Serialize>(record: &T) -> serde_json::Value {
+            serde_json::to_value(record).expect("a REST record serializes")
+        }
+        vec![
+            ("model_catalog", "ModelCatalog", value(&catalog)),
+            ("providers", "ProvidersList", value(&providers)),
+            ("mcp_servers", "McpServersInfo", value(&mcp)),
+            ("agent_run_running", "AgentRunSnapshot", value(&running)),
+            ("agent_run_completed", "AgentRunSnapshot", value(&completed)),
+            ("outputs", "DeliverablesCatalog", value(&outputs)),
+            ("output_preview", "DeliverablePreview", value(&preview)),
+            (
+                "output_revisions",
+                "OutputRevisionsCatalog",
+                value(&revisions),
+            ),
+        ]
+    }
+
+    /// The checked-in fixture file: a JSON array of `{ "name", "type", "value" }`.
+    fn rendered_rest_records() -> String {
+        let entries = rest_record_fixtures()
+            .into_iter()
+            .map(|(name, kind, value)| {
+                serde_json::json!({ "name": name, "type": kind, "value": value })
+            })
+            .collect::<Vec<_>>();
+        let mut rendered =
+            serde_json::to_string_pretty(&entries).expect("the fixture list serializes");
+        rendered.push('\n');
+        rendered
+    }
+
+    /// Two decoders read these bytes — the CLI's and this crate's own. A diff
+    /// here means a REST record's shape changed.
+    #[test]
+    fn the_rest_record_fixtures_are_current() {
+        generate::check_or_update(REST_RECORDS, &rendered_rest_records(), REGENERATE);
+    }
+
+    /// Every tag in the fixtures is a type the list declares, and every
+    /// declared type has at least one fixture.
+    #[test]
+    fn rest_record_fixtures_cover_every_type() {
+        let tagged: std::collections::BTreeSet<&str> = rest_record_fixtures()
+            .iter()
+            .map(|(_, kind, _)| *kind)
+            .collect();
+        let declared: std::collections::BTreeSet<&str> =
+            REST_RECORD_TYPES.iter().copied().collect();
+        assert_eq!(tagged, declared);
+    }
+
+    /// The server's own round trip through the public wire types, the same
+    /// way the CLI decodes them.
+    #[test]
+    fn every_rest_record_fixture_round_trips() {
+        fn round_trip<T: serde::de::DeserializeOwned + serde::Serialize>(
+            name: &str,
+            value: &serde_json::Value,
+        ) {
+            let decoded: T = serde_json::from_value(value.clone())
+                .unwrap_or_else(|error| panic!("fixture {name} does not decode: {error}"));
+            let again = serde_json::to_value(&decoded).expect("a decoded record serializes");
+            assert_eq!(
+                &again, value,
+                "fixture {name} changed across the round trip"
+            );
+        }
+        for (name, kind, value) in rest_record_fixtures() {
+            match kind {
+                "ModelCatalog" => round_trip::<crate::wire::ModelCatalog>(name, &value),
+                "ProvidersList" => round_trip::<crate::wire::ProvidersList>(name, &value),
+                "McpServersInfo" => round_trip::<crate::wire::McpServersInfo>(name, &value),
+                "AgentRunSnapshot" => round_trip::<crate::wire::AgentRunSnapshot>(name, &value),
+                "DeliverablesCatalog" => {
+                    round_trip::<crate::wire::DeliverablesCatalog>(name, &value)
+                }
+                "DeliverablePreview" => round_trip::<crate::wire::DeliverablePreview>(name, &value),
+                "OutputRevisionsCatalog" => {
+                    round_trip::<crate::wire::OutputRevisionsCatalog>(name, &value)
+                }
+                other => panic!("fixture {name} has an unknown type tag {other}"),
+            }
+        }
+    }
+
+    /// The fixtures carry the shapes a hand-written mirror got wrong: a
+    /// secret-bearing field that never serializes, an omitted optional key,
+    /// and every producer of an output revision.
+    #[test]
+    fn rest_record_fixtures_cover_the_awkward_shapes() {
+        let fixtures = rest_record_fixtures();
+        let by_name = |name: &str| {
+            &fixtures
+                .iter()
+                .find(|(entry, _, _)| *entry == name)
+                .unwrap_or_else(|| panic!("the {name} fixture exists"))
+                .2
+        };
+        let servers = by_name("mcp_servers");
+        assert!(servers["servers"][0].get("env_values").is_none());
+        assert!(servers["servers"][0].get("launch").is_none());
+        assert!(by_name("agent_run_running").get("task_plan").is_some());
+        assert!(by_name("agent_run_completed").get("task_plan").is_none());
+        assert!(by_name("providers")["providers"][0]
+            .get("base_url")
+            .is_none());
+        let producers: std::collections::BTreeSet<&str> = by_name("output_revisions")["revisions"]
+            .as_array()
+            .expect("revisions")
+            .iter()
+            .filter_map(|row| row["producedBy"].as_str())
+            .collect();
+        assert_eq!(
+            producers,
+            ["agent", "backgroundAgent", "user"].into_iter().collect()
+        );
+    }
+
+    /// Unknown keys fail every REST record but the flattened MCP server row,
+    /// which is documented on [`crate::wire`].
+    #[test]
+    fn rest_records_reject_unknown_keys() {
+        fn rejects<T: serde::de::DeserializeOwned>(name: &str, value: &serde_json::Value) {
+            let mut extra = value.clone();
+            extra["extra"] = serde_json::json!(1);
+            assert!(
+                serde_json::from_value::<T>(extra).is_err(),
+                "fixture {name} should reject an unknown key"
+            );
+        }
+        for (name, kind, value) in rest_record_fixtures() {
+            match kind {
+                "ModelCatalog" => rejects::<crate::wire::ModelCatalog>(name, &value),
+                "ProvidersList" => rejects::<crate::wire::ProvidersList>(name, &value),
+                "McpServersInfo" => rejects::<crate::wire::McpServersInfo>(name, &value),
+                "AgentRunSnapshot" => rejects::<crate::wire::AgentRunSnapshot>(name, &value),
+                "DeliverablesCatalog" => rejects::<crate::wire::DeliverablesCatalog>(name, &value),
+                "DeliverablePreview" => rejects::<crate::wire::DeliverablePreview>(name, &value),
+                "OutputRevisionsCatalog" => {
+                    rejects::<crate::wire::OutputRevisionsCatalog>(name, &value)
+                }
+                other => panic!("fixture {name} has an unknown type tag {other}"),
+            }
+        }
+        // Nested records too: a row inside the envelope is guarded on its own.
+        let mut model = rest_record_fixtures()[0].2["models"][0].clone();
+        model["extra"] = serde_json::json!(1);
+        assert!(serde_json::from_value::<crate::wire::ModelInfo>(model).is_err());
+        let mut source = rest_record_fixtures()
+            .iter()
+            .find(|(name, _, _)| *name == "output_revisions")
+            .expect("the revisions fixture")
+            .2["revisions"][0]["sources"][0]
+            .clone();
+        source["extra"] = serde_json::json!(1);
+        assert!(serde_json::from_value::<crate::wire::OutputRevisionSource>(source).is_err());
+        // The one tolerant record: a flattened definition cannot be guarded.
+        let mut server = rest_record_fixtures()
+            .iter()
+            .find(|(name, _, _)| *name == "mcp_servers")
+            .expect("the MCP fixture")
+            .2["servers"][0]
+            .clone();
+        server["extra"] = serde_json::json!(1);
+        assert!(serde_json::from_value::<crate::wire::McpServerInfo>(server).is_ok());
+    }
 }

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -145,9 +145,19 @@ Two more things are shared through it:
   its session reducer and metadata guard. A shape change shows up as a failing
   test on whichever side did not follow it.
 
-The REST records the CLI reads (models, providers, MCP servers, agent runs,
-outputs) are still hand-written mirrors, because their server types only
-serialize today. Moving them is brightwave-inc/tidebreak#3005.
+- **REST records.** The model catalog, the provider list, the MCP server
+  listing, agent runs, and conversation outputs are the routes' own response
+  types, re-exported from `tidebreak_server::wire` with `Deserialize` and
+  `deny_unknown_fields`. One record tolerates unknown keys: `McpServerInfo`
+  flattens its definition, and serde cannot guard across a flatten, so its
+  envelope `McpServersInfo` is the guarded shape. The output records carry
+  typed timestamps and a `producedBy` enum rather than preformatted strings.
+  `crates/tidebreak-server/fixtures/rest-records.json` holds one real value
+  per record (`{ name, type, value }`, the type naming the wire type it
+  decodes through), serialized by the same generator test; the server
+  round-trips every entry and the CLI decodes every entry. The renderer does
+  not read this file: its REST validators are exercised against
+  `generated/fixtures.ts` and the generated types.
 
 ## Scope today
 


### PR DESCRIPTION
Follow-up to #2978 and #3006. The CLI still redeclared the REST records it reads (the model catalog, providers, MCP servers, agent runs, and conversation outputs) as hand-written mirrors in `crates/tidebreak-cli/src/api/wire.rs`, because the server's response types only serialized. This PR makes those types round-trip and moves the CLI onto them, the way #3006 did for the chat event socket.

## What changed

- **Server response types deserialize.** `ModelCatalog`, `ModelInfo`, `ModelRoleInfo`, `ProvidersList`, `ProviderInfo`, `McpServersInfo`, `McpServerInfo`, `McpServerDefinition`, `McpHealth`, `McpCuration`, `AgentRunSnapshot` and the snapshot types it carries, and the five output records now derive `Deserialize`, are `pub`, and are re-exported from `tidebreak_server::wire` in their own block.
- **Strictness matches the renderer.** Every record carries `deny_unknown_fields` except `McpServerInfo`, which flattens its definition; serde cannot guard unknown keys across a flatten, so that one record tolerates them and its envelope `McpServersInfo` is the guarded shape. The exception is documented on the type and on the wire module.
- **Output records are typed.** `updatedAt` and `createdAt` are `DateTime<Utc>` rather than preformatted strings, and `producedBy` is an `OutputRevisionProducer` enum (`agent`, `backgroundAgent`, `user`) rather than a `&'static str`. The wire spelling of every field is unchanged; timestamps now serialize in the `Z` form chrono emits, which the renderer's `Date.parse` guard already accepts.
- **Shared fixtures.** `crates/tidebreak-server/fixtures/rest-records.json` holds one real value per record (`{ name, type, value }`), serialized by the generator test in `wire_types.rs`. The server round-trips every entry and rejects an unknown key on every record but the flattened one; the CLI decodes every entry through the type each tag names and pins the printed fields it reaches through the flattened definition and the producer enum.
- **CLI mirrors deleted.** `wire.rs` in the CLI is now re-exports only; `bounded_timestamp` is gone because the timestamps arrive typed. `setup.rs` and `outputs.rs` read the server's enums through their `as_str` helpers, each pinned to the serde spelling by `rest_record_names_match_the_wire`.
- `docs/wire-types.md` documents the REST records alongside the chat frames.

The generated `wire.ts` is byte-for-byte unchanged, so the mobile copy needs no sync.

## Verification

- `cargo test -p tidebreak-server --lib -- wire`: 36 passed (includes the new fixture, round-trip, coverage, and unknown-key tests).
- `cargo test -p tidebreak-server --lib -- tests::outputs tests::agent_runs tests::mcp tests::providers tests::models`: passed.
- `cargo test -p tidebreak-cli -- wire outputs setup`: passed, including the new `every_server_rest_record_decodes` and `printed_fields_come_from_the_server_types`.
- `cargo clippy -p tidebreak-server -p tidebreak-cli --all-targets --no-deps -- -D warnings`: clean. `cargo fmt --all --check`: clean.
- No desktop UI or mobile file changed; the desktop UI lane runs unchanged.

Closes #3005
