### PR TITLE
refactor(cli): decode the code-mode API with the server's wire types

### DIFF
--- a/crates/tidebreak-cli/src/agent_mcp/code_follow.rs
+++ b/crates/tidebreak-cli/src/agent_mcp/code_follow.rs
@@ -255,7 +255,7 @@ async fn reconcile_lost_socket(
             pending: None,
             events_cursor,
             turn_id: Some(turn_id),
-            queue_position: Some(row.position),
+            queue_position: Some(i64::from(row.position)),
         });
     }
     Ok(running(assistant_text, events_cursor, Some(turn_id)))
@@ -363,7 +363,7 @@ pub(crate) async fn run_turn(
                             pending: None,
                             events_cursor: stream.last_seq(),
                             turn_id: Some(row.id),
-                            queue_position: Some(row.position),
+                            queue_position: Some(i64::from(row.position)),
                         });
                     }
                 }

--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -1,329 +1,49 @@
-//! Code-mode wire types and the HTTP+WebSocket client methods that speak them.
+//! Code mode as the CLI drives it: the server's wire types, and the HTTP and
+//! WebSocket client methods that speak them.
 //!
-//! These types mirror the renderer-facing snapshots in
-//! `tidebreak-server::routes::code::types`. They are decoded loosely on purpose:
-//! a field the CLI does not render is dropped, and an unrecognized event kind
-//! still advances the journal cursor.
+//! The snapshot, frame, and notice types are the server's own, re-exported
+//! from [`tidebreak_server::wire`]. The CLI used to keep a hand-written mirror
+//! here, and it drifted: a field the server renamed or made optional compiled
+//! on both sides and failed when the CLI next read it. Importing the server's
+//! types makes a rename a compile error, and brings the renderer's strictness
+//! with it (see the `wire` module doc): unknown keys fail a snapshot, an
+//! unknown notice tag fails the notice, and an unknown event type fails its
+//! frame. A reader drops a failed frame or notice and keeps the socket open.
+//!
+//! One tolerance stays, and it is the server's, not this crate's: the event
+//! union inside a frame is `tidebreak_core::CodeEvent`, which the server also
+//! reads back from its own journal, so a variant accepts keys it does not
+//! declare. The frame around it does not.
+//!
+//! `crates/tidebreak-server/fixtures/code-frames.json` holds one real value of
+//! every snapshot, notice, and event; the test at the bottom decodes each one.
 
 use serde::{Deserialize, Serialize};
 use tidebreak_core::{
-    AgentError, Attention, CapLevel, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
-    CodeEvent, CodeSessionId, CodeSessionLifecycle, CodeTurnId, CodeTurnStatus, CodeUsage,
-    CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps, HarnessKind,
-    HarnessTier, PermissionMode, PullRequestDigest, QuickAction, RepoId, Result, WorkspaceId,
+    AgentError, CapLevel, CodeApprovalId, CodeEvent, CodeSessionId, CodeTurnId, HarnessCaps,
+    HarnessKind, PermissionMode, RepoId, Result, WorkspaceId,
+};
+
+pub use tidebreak_server::wire::{
+    CodeActionSnapshot, CodeApprovalSnapshot, CodeCommitSnapshot, CodePushSnapshot,
+    CodeRepoSnapshot, CodeSessionDigest, CodeSessionSnapshot, CodeTurnSnapshot, CodeUpdateNotice,
+    CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot,
+    HarnessAuthMode, HarnessDoctorReport, QueuedCodeTurn, QueuedCodeTurnsSnapshot,
+    SequencedCodeEventFrame,
 };
 
 use super::client::{Client, EventSocket};
 
-/// A registered local git repository.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeRepoSnapshot {
-    pub id: RepoId,
-    pub root_path: String,
-    pub display_name: String,
-    pub default_base_ref: String,
-    pub branch_prefix: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub setup_script: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub archive_script: Option<String>,
-    #[serde(default)]
-    pub quick_actions: Vec<QuickAction>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-}
-
-/// One isolated workspace (worktree + branch) on a repo.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeWorkspaceSnapshot {
-    pub id: WorkspaceId,
-    pub repo_id: RepoId,
-    pub title: String,
-    pub worktree_path: String,
-    pub branch_name: String,
-    pub base_ref: String,
-    pub status: CodeWorkspaceStatus,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pr: Option<PullRequestDigest>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
-}
-
-/// One durable conversation with an external agent engine.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct CodeSessionSnapshot {
-    pub id: CodeSessionId,
-    pub workspace_id: WorkspaceId,
-    /// Defaults to interactive so older servers without the field still parse.
-    #[serde(default = "default_session_kind")]
-    pub kind: tidebreak_core::CodeSessionKind,
-    pub harness_kind: HarnessKind,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub harness_version: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub harness_resume_ref: Option<String>,
-    pub permission_mode: PermissionMode,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    pub lifecycle: CodeSessionLifecycle,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub fence_reason: Option<FenceReason>,
-    pub attention: Attention,
-    #[serde(default)]
-    pub unrecognized_event_count: i64,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-}
-
-fn default_session_kind() -> tidebreak_core::CodeSessionKind {
-    tidebreak_core::CodeSessionKind::Interactive
-}
-
-/// One user→engine turn.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct CodeTurnSnapshot {
-    pub id: CodeTurnId,
-    pub session_id: CodeSessionId,
-    pub ordinal: i64,
-    pub status: CodeTurnStatus,
-    pub user_input: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub usage: Option<CodeUsage>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub checkpoint_ref: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub diffstat: Option<Diffstat>,
-    pub started_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ended_at: Option<chrono::DateTime<chrono::Utc>>,
-}
-
-/// A follow-up parked while the session is already running a turn.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct QueuedCodeTurn {
-    /// Row id, and the turn id the promoted turn is inserted under.
-    pub id: CodeTurnId,
-    pub session_id: CodeSessionId,
-    pub message: String,
-    pub position: i64,
-}
-
-/// Result of `POST /code/sessions/{id}/turns`.
+/// Result of `POST /code/sessions/{id}/turns`: the turn that ran on `200`, or
+/// the follow-up the server parked on `202`. The server answers with one of
+/// two snapshots rather than a tagged union, so this is the one code-mode
+/// shape the client composes itself. Both arms reject unknown keys, so a
+/// snapshot that matches neither fails rather than folding into the other.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SubmitTurnResponse {
     Ran(CodeTurnSnapshot),
     Queued(QueuedCodeTurn),
-}
-
-/// Result of `GET /code/sessions/{id}/queued`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct QueuedCodeTurnsSnapshot {
-    pub queued: Vec<QueuedCodeTurn>,
-    #[serde(default)]
-    pub paused: bool,
-}
-
-/// One event on the per-session WebSocket.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SequencedCodeEventFrame {
-    /// Journal position, or — on a `transient` frame — the cursor the event
-    /// streamed behind. Resuming from it is correct either way.
-    pub seq: i64,
-    pub event: CodeEvent,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub replayed: Option<bool>,
-    /// Set on a live-only event no journal row holds: assistant deltas, and
-    /// the catch-up delta a mid-turn reader gets on connect. Render it without
-    /// advancing the cursor. A reconnect may receive the complete current
-    /// tail with `replacement` set.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transient: Option<bool>,
-    /// Set on a transient assistant delta that contains the complete live
-    /// tail. Replace buffered text instead of appending it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub replacement: Option<bool>,
-    /// Set on the first replayed frame of a capped window: history older than
-    /// this frame was dropped and is not coming.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub truncated: Option<bool>,
-}
-
-/// Doctor report for every registered engine adapter.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HarnessDoctorReport {
-    pub harnesses: Vec<HarnessDoctorEntry>,
-}
-
-/// One engine's probe, capabilities, and remediation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HarnessDoctorEntry {
-    pub kind: HarnessKind,
-    pub found: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    pub tier: HarnessTier,
-    pub caps: HarnessCaps,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub authenticated: Option<bool>,
-    /// How a session of this engine authenticates on the server's machine.
-    /// A server that predates the field knows only the local sign-in probe.
-    #[serde(default)]
-    pub auth_mode: HarnessAuthMode,
-    #[serde(default)]
-    pub remediation: String,
-    #[serde(default)]
-    pub stderr: String,
-    #[serde(default)]
-    pub unrecognized_event_count: i64,
-}
-
-/// How a session of one engine authenticates on the server's machine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum HarnessAuthMode {
-    /// The engine's own local sign-in.
-    #[default]
-    LocalSignIn,
-    /// A credential or endpoint override authenticates the engine without a
-    /// vendor login.
-    GatewayManaged,
-    /// The on-behalf-of relay carries turns as the caller.
-    GatewayRelay,
-    /// The relay does not cover this engine on a hosted machine.
-    HostedUnavailable,
-}
-
-/// Bounded changed-file list for `GET /code/workspaces/{id}/files`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeWorkspaceFiles {
-    pub files: Vec<CodeFileChange>,
-    pub truncated: bool,
-    pub stat: Diffstat,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub turn_id: Option<CodeTurnId>,
-}
-
-/// One changed path in a workspace or turn file list.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeFileChange {
-    pub path: String,
-    pub kind: FileChangeKind,
-    pub insertions: u32,
-    pub deletions: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub previous_path: Option<String>,
-}
-
-/// Bounded unified diff for `GET /code/workspaces/{id}/diff`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeWorkspaceDiff {
-    pub diff: String,
-    pub truncated: bool,
-    pub stat: Diffstat,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub turn_id: Option<CodeTurnId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
-}
-
-/// One parked or decided engine approval.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct CodeApprovalSnapshot {
-    pub id: CodeApprovalId,
-    pub session_id: CodeSessionId,
-    pub turn_id: CodeTurnId,
-    pub kind: CodeApprovalKind,
-    pub harness_raw_json: String,
-    pub state: CodeApprovalState,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub feedback: Option<String>,
-    pub requested_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub decided_at: Option<chrono::DateTime<chrono::Utc>>,
-}
-
-/// Result of staging and committing the workspace worktree.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeCommitSnapshot {
-    pub sha: String,
-    pub message: String,
-    pub stat: Diffstat,
-}
-
-/// Result of pushing the workspace branch.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodePushSnapshot {
-    pub branch: String,
-    pub remote: String,
-}
-
-/// PR + checks digest plus the local git facts the PR card needs.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeWorkspacePrSnapshot {
-    pub dirty: bool,
-    pub unpushed: bool,
-    pub ahead: u64,
-    pub has_upstream: bool,
-    pub suggested_commit_message: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pr: Option<PullRequestDigest>,
-    pub gh_found: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub gh_authenticated: Option<bool>,
-    #[serde(default)]
-    pub remediation: String,
-}
-
-/// Bounded output of one named quick action.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeActionSnapshot {
-    pub name: String,
-    pub success: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub exit_code: Option<i32>,
-    pub stdout: String,
-    pub stderr: String,
-    pub timed_out: bool,
-}
-
-/// Cheap per-session digest on `/code/updates`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct CodeSessionDigest {
-    pub workspace: WorkspaceId,
-    pub session: CodeSessionId,
-    pub lifecycle: CodeSessionLifecycle,
-    pub attention: Attention,
-    pub title: String,
-    pub turn_count: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pr_state: Option<PullRequestDigest>,
-}
-
-/// One unsequenced notice on `WS /code/updates`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum CodeUpdateNotice {
-    Snapshot {
-        sessions: Vec<CodeSessionDigest>,
-    },
-    Digest {
-        workspace: WorkspaceId,
-        session: CodeSessionId,
-        lifecycle: CodeSessionLifecycle,
-        attention: Attention,
-        title: String,
-        turn_count: i64,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pr_state: Option<Box<PullRequestDigest>>,
-    },
-    TerminalActivity {
-        workspace_id: WorkspaceId,
-        terminal_id: String,
-    },
-    #[serde(other)]
-    Unknown,
 }
 
 impl Client {
@@ -738,7 +458,7 @@ pub fn decode_update_notice(text: &str) -> Result<CodeUpdateNotice> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidebreak_core::{AttentionSource, AttentionState};
+    use tidebreak_core::{AttentionSource, AttentionState, CodeSessionLifecycle};
 
     #[test]
     fn a_sequenced_frame_round_trips_the_fields_agents_script_against() {
@@ -816,6 +536,7 @@ mod tests {
                 "type": "digest",
                 "workspace": "00000000-0000-0000-0000-000000000001",
                 "session": "00000000-0000-0000-0000-000000000002",
+                "kind": "interactive",
                 "lifecycle": "running",
                 "attention": {
                     "state": { "type": "working" },
@@ -845,9 +566,138 @@ mod tests {
         }
     }
 
+    /// An unknown notice tag fails the notice; the watch loop drops it and
+    /// keeps reading. The old mirror folded it to an `Unknown` variant, which
+    /// is the same outcome with a shape the server never declared.
     #[test]
-    fn an_unknown_update_tag_does_not_kill_the_stream() {
-        let notice = decode_update_notice(r#"{"type":"future_kind","extra":true}"#).unwrap();
-        assert!(matches!(notice, CodeUpdateNotice::Unknown));
+    fn an_unknown_update_tag_fails_the_notice() {
+        assert!(decode_update_notice(r#"{"type":"future_kind","extra":true}"#).is_err());
+    }
+
+    /// A key the server does not declare fails the snapshot, as it does in
+    /// the renderer.
+    #[test]
+    fn snapshots_reject_unknown_keys() {
+        let queued = serde_json::json!({
+            "id": "00000000-0000-0000-0000-000000000006",
+            "session_id": "00000000-0000-0000-0000-000000000003",
+            "message": "then the tests",
+            "position": 0,
+            "created_at": "2026-09-01T04:56:10Z",
+            "updated_at": "2026-09-01T04:56:10Z",
+        });
+        assert!(serde_json::from_value::<SubmitTurnResponse>(queued.clone()).is_ok());
+        let mut extra = queued;
+        extra["extra"] = serde_json::Value::Bool(true);
+        assert!(serde_json::from_value::<SubmitTurnResponse>(extra).is_err());
+    }
+
+    /// Path of the server's code-mode fixtures, relative to this crate.
+    const CODE_FRAMES: &str = "../tidebreak-server/fixtures/code-frames.json";
+
+    fn code_frame_fixtures() -> Vec<(String, String, serde_json::Value)> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(CODE_FRAMES);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+        let entries: Vec<serde_json::Value> =
+            serde_json::from_str(&text).expect("the fixture file is a JSON array");
+        entries
+            .into_iter()
+            .map(|entry| {
+                let name = entry["name"].as_str().expect("every fixture is named");
+                let kind = entry["kind"].as_str().expect("every fixture has a kind");
+                (name.to_owned(), kind.to_owned(), entry["value"].clone())
+            })
+            .collect()
+    }
+
+    fn round_trip<T: serde::de::DeserializeOwned + Serialize>(
+        name: &str,
+        value: &serde_json::Value,
+    ) {
+        let decoded: T = serde_json::from_value(value.clone())
+            .unwrap_or_else(|error| panic!("fixture {name} does not decode: {error}"));
+        let again = serde_json::to_value(&decoded).expect("a decoded value serializes");
+        assert_eq!(
+            &again, value,
+            "fixture {name} changed across the round trip"
+        );
+    }
+
+    /// Every snapshot, notice, and event the server serializes decodes here,
+    /// byte for byte. The fixtures come from the server's own types, and the
+    /// renderer's tests read the same file, so the three decoders cannot
+    /// drift apart without one of them failing.
+    #[test]
+    fn every_server_code_frame_decodes() {
+        let fixtures = code_frame_fixtures();
+        assert!(fixtures.len() > 40, "the fixture list looks truncated");
+        for (name, kind, value) in &fixtures {
+            match kind.as_str() {
+                "repo" => round_trip::<CodeRepoSnapshot>(name, value),
+                "workspace" => round_trip::<CodeWorkspaceSnapshot>(name, value),
+                "session" => round_trip::<CodeSessionSnapshot>(name, value),
+                "turn" => round_trip::<SubmitTurnResponse>(name, value),
+                "queued_turn" => round_trip::<SubmitTurnResponse>(name, value),
+                "queued_turns" => round_trip::<QueuedCodeTurnsSnapshot>(name, value),
+                "harness_doctor" => round_trip::<HarnessDoctorReport>(name, value),
+                "workspace_files" => round_trip::<CodeWorkspaceFiles>(name, value),
+                "workspace_diff" => round_trip::<CodeWorkspaceDiff>(name, value),
+                "approval" => round_trip::<CodeApprovalSnapshot>(name, value),
+                "commit" => round_trip::<CodeCommitSnapshot>(name, value),
+                "push" => round_trip::<CodePushSnapshot>(name, value),
+                "workspace_pr" => round_trip::<CodeWorkspacePrSnapshot>(name, value),
+                "action" => round_trip::<CodeActionSnapshot>(name, value),
+                "session_digest" => round_trip::<CodeSessionDigest>(name, value),
+                "update_notice" => {
+                    let notice = decode_update_notice(&value.to_string())
+                        .unwrap_or_else(|error| panic!("fixture {name}: {error}"));
+                    assert_eq!(&serde_json::to_value(&notice).unwrap(), value, "{name}");
+                }
+                "event_frame" => {
+                    let frame = decode_event_frame(&value.to_string())
+                        .unwrap_or_else(|error| panic!("fixture {name}: {error}"));
+                    assert_eq!(&serde_json::to_value(&frame).unwrap(), value, "{name}");
+                    assert_eq!(
+                        turn_exit_code(&frame.event).is_some(),
+                        is_turn_terminal(&frame.event)
+                    );
+                }
+                other => panic!("fixture {name} has no decoder for kind {other}"),
+            }
+        }
+    }
+
+    /// The submit response tells the two server answers apart by shape.
+    #[test]
+    fn submit_response_arms_follow_the_fixtures() {
+        let mut ran = 0;
+        let mut queued = 0;
+        for (name, kind, value) in code_frame_fixtures() {
+            match kind.as_str() {
+                "turn" => {
+                    assert!(
+                        matches!(
+                            serde_json::from_value(value).unwrap(),
+                            SubmitTurnResponse::Ran(_)
+                        ),
+                        "{name}"
+                    );
+                    ran += 1;
+                }
+                "queued_turn" => {
+                    assert!(
+                        matches!(
+                            serde_json::from_value(value).unwrap(),
+                            SubmitTurnResponse::Queued(_)
+                        ),
+                        "{name}"
+                    );
+                    queued += 1;
+                }
+                _ => {}
+            }
+        }
+        assert!(ran > 0 && queued > 0);
     }
 }

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -1382,19 +1382,32 @@ fn render_update(notice: &CodeUpdateNotice) {
             title,
             turn_count,
             pr_state,
+            ..
         } => {
             let pr = pr_state
                 .as_deref()
                 .map(|pr| format!("  pr #{} {}", pr.number, pr.state))
                 .unwrap_or_default();
             println!(
-                "{workspace}  {session}  {}  {}  {title}  turns={turn_count}{pr}",
+                "{}  {session}  {}  {}  {title}  turns={turn_count}{pr}",
+                workspace_label(workspace.as_ref()),
                 lifecycle.as_str(),
                 attention_label(attention)
             );
         }
-        CodeUpdateNotice::TerminalActivity { .. } | CodeUpdateNotice::Unknown => {}
+        // Progress, delivery, and rewrite notices drive desktop surfaces the
+        // watch does not render. Terminal activity is coalesced noise here.
+        CodeUpdateNotice::TerminalActivity { .. }
+        | CodeUpdateNotice::CloneProgress { .. }
+        | CodeUpdateNotice::HarnessInstall { .. }
+        | CodeUpdateNotice::Delivery
+        | CodeUpdateNotice::TurnRewrite { .. } => {}
     }
+}
+
+/// A session with no workspace (the in-process engine's) prints a dash.
+fn workspace_label(workspace: Option<&WorkspaceId>) -> String {
+    workspace.map_or_else(|| "-".to_owned(), ToString::to_string)
 }
 
 fn digest_line(digest: &CodeSessionDigest) -> String {
@@ -1405,7 +1418,7 @@ fn digest_line(digest: &CodeSessionDigest) -> String {
         .unwrap_or_default();
     format!(
         "{}  {}  {}  {}  {}  turns={}{pr}",
-        digest.workspace,
+        workspace_label(digest.workspace.as_ref()),
         digest.session,
         digest.lifecycle.as_str(),
         attention_label(&digest.attention),
@@ -1437,7 +1450,10 @@ fn print_workspace(workspace: &CodeWorkspaceSnapshot) {
 
 fn print_session(session: &CodeSessionSnapshot) {
     println!("id                   {}", session.id);
-    println!("workspace            {}", session.workspace_id);
+    println!(
+        "workspace            {}",
+        workspace_label(session.workspace_id.as_ref())
+    );
     println!("harness              {}", session.harness_kind.as_str());
     println!(
         "version              {}",

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -39,6 +41,12 @@ import {
   parseFenceReason,
   parseHarnessModelList,
   parseCodeCheckLogsSnapshot,
+  parseCodeRepo,
+  parseCodeSessionDigest,
+  parseCodeWorkspace,
+  parseHarnessDoctorReport,
+  parseQueuedCodeTurn,
+  parseSequencedCodeEvent,
 } from "./parsers";
 
 const DELIVERY_CAPABILITY = {
@@ -1753,5 +1761,140 @@ describe("string bounds", () => {
       truncated: false,
     };
     expect(parseCodeWorkspaceSearch(search)).toEqual(search);
+  });
+});
+
+/**
+ * One real value of every snapshot, update notice, and event frame the code
+ * surface serializes, written by the server's own types. The CLI's tests and
+ * the server's round trip read the same file, so the three decoders of this
+ * surface cannot drift apart without one of them failing.
+ */
+const CODE_FRAMES: { name: string; kind: string; value: unknown }[] =
+  JSON.parse(
+    readFileSync(
+      fileURLToPath(
+        new URL(
+          "../../../../tidebreak-server/fixtures/code-frames.json",
+          import.meta.url,
+        ),
+      ),
+      "utf8",
+    ),
+  );
+
+const CODE_FRAME_PARSERS: Record<string, (value: unknown) => unknown> = {
+  repo: parseCodeRepo,
+  workspace: parseCodeWorkspace,
+  session: parseCodeSession,
+  turn: parseCodeTurn,
+  queued_turn: parseQueuedCodeTurn,
+  // The queued list has no parser of its own; the rows do.
+  queued_turns: (value) =>
+    isRecord(value) && Array.isArray(value.queued)
+      ? value.queued.map(parseQueuedCodeTurn).every(Boolean) || null
+      : null,
+  harness_doctor: parseHarnessDoctorReport,
+  workspace_files: parseCodeWorkspaceFiles,
+  workspace_diff: parseCodeWorkspaceDiff,
+  approval: parseCodeApproval,
+  commit: parseCodeCommit,
+  push: parseCodePush,
+  workspace_pr: parseCodeWorkspacePr,
+  action: parseCodeAction,
+  session_digest: parseCodeSessionDigest,
+  update_notice: parseCodeUpdateNotice,
+  event_frame: parseSequencedCodeEvent,
+};
+
+/**
+ * Real server values the desktop still rejects. brightwave-inc/tidebreak#3027:
+ * a session that binds no workspace (decision 0048 step 5) serializes
+ * `workspace_id: null` on its snapshot and `workspace: null` on its digest
+ * and digest notice, and the parsers still require an id there.
+ */
+const KNOWN_GAPS = new Set([
+  "fenced session",
+  "internal session digest",
+  "updates: snapshot",
+  "updates: internal session digest",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+describe("code frames against real server output", () => {
+  it("carries every kind this file knows a parser for", () => {
+    expect(CODE_FRAMES.length).toBeGreaterThan(40);
+    const kinds = new Set(CODE_FRAMES.map(({ kind }) => kind));
+    for (const kind of Object.keys(CODE_FRAME_PARSERS)) {
+      expect(kinds.has(kind), kind).toBe(true);
+    }
+    for (const kind of kinds) {
+      expect(CODE_FRAME_PARSERS[kind], `no parser for ${kind}`).toBeDefined();
+    }
+  });
+
+  it("accepts every value the server serializes", () => {
+    // Every other test here builds its own input, which encodes what the
+    // author believed the wire looked like. These values come from the
+    // server, so a field renamed there fails here rather than in the app.
+    //
+    // The fixtures that fail today are listed, not skipped: each one is a
+    // real server value the desktop drops, and the entry has to go when its
+    // parser catches up. The set is compared exactly, so a fix shows up as a
+    // stale entry and a new gap shows up as a new name.
+    const rejected = new Set<string>();
+    for (const { name, kind, value } of CODE_FRAMES) {
+      if (CODE_FRAME_PARSERS[kind]?.(value) === null) rejected.add(name);
+    }
+    expect(rejected).toEqual(KNOWN_GAPS);
+  });
+
+  it("keeps the frame flags the reducer reads", () => {
+    // Before the fixtures, the socket parser dropped every frame that carried
+    // `transient`, `replacement`, or `truncated`, so a live delta and a
+    // capped replay never reached the reducer from this path.
+    const flagged = CODE_FRAMES.filter(
+      ({ kind, value }) =>
+        kind === "event_frame" &&
+        isRecord(value) &&
+        ("transient" in value || "truncated" in value),
+    );
+    expect(flagged.length).toBeGreaterThan(1);
+    for (const { name, value } of flagged) {
+      const frame = parseSequencedCodeEvent(value);
+      expect(frame, name).not.toBeNull();
+      for (const flag of [
+        "replayed",
+        "transient",
+        "replacement",
+        "truncated",
+      ]) {
+        expect(
+          (frame as Record<string, unknown>)[flag],
+          `${name} ${flag}`,
+        ).toBe((value as Record<string, unknown>)[flag]);
+      }
+    }
+    expect(
+      parseSequencedCodeEvent({
+        seq: 1,
+        event: { type: "turn_interrupted" },
+        transient: "yes",
+      }),
+    ).toBeNull();
+  });
+
+  it("submits a turn as ran or queued by the server's two shapes", () => {
+    const outcomes = new Set<string>();
+    for (const { kind, value } of CODE_FRAMES) {
+      if (kind !== "turn" && kind !== "queued_turn") continue;
+      const submission = parseCodeTurnSubmission(value);
+      expect(submission).not.toBeNull();
+      outcomes.add(submission?.kind ?? "null");
+    }
+    expect(outcomes).toEqual(new Set(["ran", "queued"]));
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -3437,19 +3437,37 @@ export function parseSequencedCodeEvent(
       "seq",
       "event",
       "replayed",
+      "transient",
+      "replacement",
+      "truncated",
     ]) ||
     !isFiniteNumber(value.seq) ||
-    (value.replayed !== undefined && typeof value.replayed !== "boolean")
+    !optionalBoolean(value.replayed) ||
+    !optionalBoolean(value.transient) ||
+    !optionalBoolean(value.replacement) ||
+    !optionalBoolean(value.truncated)
   ) {
     return null;
   }
   const event = parseCodeEvent(value.event);
   if (!event) return null;
+  // The reducer reads all four flags: `replayed` and `truncated` decide how
+  // a capped replay lands, `transient` keeps a live delta from advancing the
+  // cursor, and `replacement` swaps the buffered tail instead of appending.
   return {
     seq: value.seq,
     event,
     ...(value.replayed !== undefined ? { replayed: value.replayed } : {}),
+    ...(value.transient !== undefined ? { transient: value.transient } : {}),
+    ...(value.replacement !== undefined
+      ? { replacement: value.replacement }
+      : {}),
+    ...(value.truncated !== undefined ? { truncated: value.truncated } : {}),
   };
+}
+
+function optionalBoolean(value: unknown): value is boolean | undefined {
+  return value === undefined || typeof value === "boolean";
 }
 
 export function parseCodeEvent(value: unknown): CodeEvent | null {
@@ -4191,6 +4209,17 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         state: value.state,
         ...(value.rewrite !== undefined ? { rewrite: value.rewrite } : {}),
       };
+    }
+    case "delivery": {
+      // No payload: the delivery surface re-reads its query.
+      if (
+        !onlyKeys<Extract<WireCodeUpdateNotice, { type: "delivery" }>>(value, [
+          "type",
+        ])
+      ) {
+        return null;
+      }
+      return { type: "delivery" };
     }
     default:
       return null;

--- a/crates/tidebreak-server/fixtures/code-frames.json
+++ b/crates/tidebreak-server/fixtures/code-frames.json
@@ -1,0 +1,1016 @@
+[
+  {
+    "kind": "repo",
+    "name": "repo",
+    "value": {
+      "branch_prefix": "mara/",
+      "created_at": "2025-08-31T00:26:40Z",
+      "default_base_ref": "main",
+      "display_name": "tidebreak",
+      "id": "00000000-0000-0000-0000-000000000001",
+      "quick_actions": [
+        {
+          "auto_run_on_create": false,
+          "command": "cargo test",
+          "name": "test"
+        }
+      ],
+      "root_path": "/Users/mara/code/tidebreak",
+      "setup_script": "pnpm install"
+    }
+  },
+  {
+    "kind": "workspace",
+    "name": "workspace",
+    "value": {
+      "base_ref": "main",
+      "branch_name": "mara/code-parsers-bounded",
+      "created_at": "2025-09-01T01:26:40Z",
+      "id": "00000000-0000-0000-0000-000000000002",
+      "pr": {
+        "auto_merge_enabled": true,
+        "base_branch": "main",
+        "check_counts": {
+          "failing": 0,
+          "passing": 10,
+          "pending": 3,
+          "skipped": 2
+        },
+        "checks_summary": "3 pending",
+        "draft": false,
+        "head_branch": "thet/cli-wire-mirror",
+        "head_sha": "24b451ab7248eb057445718f2ad6304a43915f37",
+        "in_merge_queue": false,
+        "merge_state_status": "BLOCKED",
+        "mergeable": "MERGEABLE",
+        "merged": false,
+        "number": 3006,
+        "review_decision": "APPROVED",
+        "state": "open",
+        "title": "refactor(cli): decode the chat event socket",
+        "url": "https://github.com/brightwave-inc/tidebreak/pull/3006"
+      },
+      "repo_id": "00000000-0000-0000-0000-000000000001",
+      "status": "active",
+      "title": "Bound the code parser",
+      "worktree_path": "/Users/mara/code/tidebreak/.tidebreak/wt-2"
+    }
+  },
+  {
+    "kind": "workspace",
+    "name": "released workspace",
+    "value": {
+      "archived_at": "2025-08-25T05:33:20Z",
+      "base_ref": "main",
+      "branch_name": "mara/old-work",
+      "bundle_bytes": 48213,
+      "created_at": "2025-08-24T01:46:40Z",
+      "id": "00000000-0000-0000-0000-000000000012",
+      "released_at": "2025-08-26T09:20:00Z",
+      "released_tip": "0bace692f4b5a7e3d2c1f0a9b8c7d6e5f4a3b2c1",
+      "repo_id": "00000000-0000-0000-0000-000000000001",
+      "status": "released",
+      "title": "Old work",
+      "worktree_path": "/Users/mara/code/tidebreak/.tidebreak/wt-1"
+    }
+  },
+  {
+    "kind": "session",
+    "name": "session",
+    "value": {
+      "attention": {
+        "source": "lifecycle",
+        "state": {
+          "type": "working"
+        }
+      },
+      "created_at": "2025-09-01T04:13:20Z",
+      "external_origin": {
+        "channel_kind": "slack",
+        "external_key": "T0/C1/1756700000.000100"
+      },
+      "fast_mode": false,
+      "harness_kind": "claude_code",
+      "harness_resume_ref": "9f2c1d4e-resume",
+      "harness_version": "2.0.14",
+      "id": "00000000-0000-0000-0000-000000000003",
+      "kind": "interactive",
+      "lifecycle": "running",
+      "model": "claude-opus-5",
+      "permission_mode": "ask",
+      "reasoning_effort": "high",
+      "unrecognized_event_count": 0,
+      "workspace_id": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "kind": "session",
+    "name": "fenced session",
+    "value": {
+      "attention": {
+        "source": "lifecycle",
+        "state": {
+          "reason": {
+            "detail": "the engine forgot the resume ref",
+            "type": "resume_lost"
+          },
+          "type": "fenced"
+        }
+      },
+      "created_at": "2025-09-01T04:13:20Z",
+      "fast_mode": false,
+      "fence_reason": {
+        "detail": "the engine forgot the resume ref",
+        "type": "resume_lost"
+      },
+      "harness_kind": "internal",
+      "harness_resume_ref": "9f2c1d4e-resume",
+      "harness_version": "2.0.14",
+      "id": "00000000-0000-0000-0000-000000000003",
+      "kind": "interactive",
+      "lifecycle": "fenced",
+      "model": "claude-opus-5",
+      "permission_mode": "ask",
+      "reasoning_effort": "high",
+      "unrecognized_event_count": 0,
+      "workspace_id": null
+    }
+  },
+  {
+    "kind": "turn",
+    "name": "turn",
+    "value": {
+      "attachments": [
+        {
+          "blob_id": "00000000-0000-0000-0000-000000000030",
+          "byte_len": 51200,
+          "height": 480,
+          "media_type": "png",
+          "width": 640
+        }
+      ],
+      "checkpoint_ref": "refs/tidebreak/checkpoints/3",
+      "diffstat": {
+        "deletions": 3,
+        "files": 2,
+        "insertions": 14,
+        "truncated": false
+      },
+      "ended_at": "2025-09-01T04:16:00Z",
+      "fast_mode": false,
+      "id": "00000000-0000-0000-0000-000000000004",
+      "model": "claude-opus-5",
+      "ordinal": 3,
+      "rewrite": "Every code-mode string now has a bound.",
+      "session_id": "00000000-0000-0000-0000-000000000003",
+      "started_at": "2025-09-01T04:15:00Z",
+      "status": "completed",
+      "usage": {
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 900,
+        "context_tokens": 2440,
+        "first_call_context_tokens": 2100,
+        "input_tokens": 1200,
+        "output_tokens": 340
+      },
+      "user_input": "Bound every string the code parser draws."
+    }
+  },
+  {
+    "kind": "queued_turn",
+    "name": "queued turn",
+    "value": {
+      "created_at": "2025-09-01T04:16:10Z",
+      "id": "00000000-0000-0000-0000-000000000006",
+      "message": "Then add the fixture test.",
+      "position": 0,
+      "session_id": "00000000-0000-0000-0000-000000000003",
+      "updated_at": "2025-09-01T04:16:10Z"
+    }
+  },
+  {
+    "kind": "queued_turns",
+    "name": "queued turns",
+    "value": {
+      "paused": true,
+      "queued": [
+        {
+          "created_at": "2025-09-01T04:16:10Z",
+          "id": "00000000-0000-0000-0000-000000000006",
+          "message": "Then add the fixture test.",
+          "position": 0,
+          "session_id": "00000000-0000-0000-0000-000000000003",
+          "updated_at": "2025-09-01T04:16:10Z"
+        }
+      ]
+    }
+  },
+  {
+    "kind": "harness_doctor",
+    "name": "harness doctor",
+    "value": {
+      "harnesses": [
+        {
+          "auth_mode": "local_sign_in",
+          "authenticated": true,
+          "caps": {
+            "allow_mode": "supported",
+            "auto_mode": "supported",
+            "durable_parks": "unknown",
+            "image_input": "supported",
+            "mid_turn_steering": "supported",
+            "native_file_change_events": "unsupported",
+            "native_interrupt": "supported",
+            "plan_mode": "supported",
+            "reasoning_levels": "supported",
+            "resume": "supported",
+            "slash_commands": "supported",
+            "standing_grants": "supported",
+            "streaming_deltas": "supported",
+            "structured_approvals": "supported",
+            "user_questions": "supported"
+          },
+          "commands": [
+            {
+              "description": "Review the pending changes",
+              "name": "review"
+            }
+          ],
+          "found": true,
+          "installable": true,
+          "kind": "claude_code",
+          "path": "/opt/homebrew/bin/claude",
+          "relaunch_composes_permission_mode": true,
+          "remediation": "",
+          "stderr": "",
+          "tier": "reference",
+          "unrecognized_event_count": 0,
+          "version": "2.0.14"
+        },
+        {
+          "auth_mode": "hosted_unavailable",
+          "caps": {
+            "allow_mode": "supported",
+            "auto_mode": "supported",
+            "durable_parks": "unknown",
+            "image_input": "supported",
+            "mid_turn_steering": "supported",
+            "native_file_change_events": "unsupported",
+            "native_interrupt": "supported",
+            "plan_mode": "supported",
+            "reasoning_levels": "supported",
+            "resume": "supported",
+            "slash_commands": "supported",
+            "standing_grants": "supported",
+            "streaming_deltas": "supported",
+            "structured_approvals": "supported",
+            "user_questions": "supported"
+          },
+          "commands": [],
+          "found": false,
+          "installable": false,
+          "kind": "grok",
+          "relaunch_composes_permission_mode": false,
+          "remediation": "Install grok-build and sign in.",
+          "stderr": "grok: command not found",
+          "tier": "best_effort",
+          "unrecognized_event_count": 2
+        }
+      ]
+    }
+  },
+  {
+    "kind": "workspace_files",
+    "name": "workspace files",
+    "value": {
+      "files": [
+        {
+          "deletions": 3,
+          "insertions": 12,
+          "kind": "modified",
+          "path": "crates/tidebreak-cli/src/api/code.rs"
+        },
+        {
+          "deletions": 0,
+          "insertions": 2,
+          "kind": "renamed",
+          "path": "crates/tidebreak-server/fixtures/code-frames.json",
+          "previous_path": "crates/tidebreak-server/fixtures/code.json"
+        }
+      ],
+      "stat": {
+        "deletions": 3,
+        "files": 2,
+        "insertions": 14,
+        "truncated": false
+      },
+      "truncated": false,
+      "turn_id": "00000000-0000-0000-0000-000000000004"
+    }
+  },
+  {
+    "kind": "workspace_diff",
+    "name": "workspace diff",
+    "value": {
+      "diff": "--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-old\n+new\n",
+      "file": "README.md",
+      "stat": {
+        "deletions": 1,
+        "files": 1,
+        "insertions": 1,
+        "truncated": false
+      },
+      "truncated": false
+    }
+  },
+  {
+    "kind": "approval",
+    "name": "pending approval",
+    "value": {
+      "harness_raw_json": "{\"tool\":\"Bash\",\"command\":\"cargo test -p tidebreak-cli\"}",
+      "id": "00000000-0000-0000-0000-000000000005",
+      "kind": {
+        "cmd": "cargo test -p tidebreak-cli",
+        "cwd": "/Users/mara/code/tidebreak",
+        "type": "command"
+      },
+      "requested_at": "2025-09-01T04:15:20Z",
+      "session_id": "00000000-0000-0000-0000-000000000003",
+      "state": "pending",
+      "turn_id": "00000000-0000-0000-0000-000000000004"
+    }
+  },
+  {
+    "kind": "approval",
+    "name": "denied approval",
+    "value": {
+      "decided_at": "2025-09-01T04:15:40Z",
+      "feedback": "Not that file.",
+      "harness_raw_json": "{\"tool\":\"Write\",\"path\":\"/etc/hosts\"}",
+      "id": "00000000-0000-0000-0000-000000000015",
+      "kind": {
+        "paths": [
+          "/etc/hosts"
+        ],
+        "type": "file_write"
+      },
+      "requested_at": "2025-09-01T04:15:30Z",
+      "session_id": "00000000-0000-0000-0000-000000000003",
+      "state": "denied",
+      "turn_id": "00000000-0000-0000-0000-000000000004"
+    }
+  },
+  {
+    "kind": "commit",
+    "name": "commit",
+    "value": {
+      "message": "fix(desktop): bound every code-mode string",
+      "sha": "cec166ffc1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6",
+      "stat": {
+        "deletions": 3,
+        "files": 2,
+        "insertions": 14,
+        "truncated": false
+      }
+    }
+  },
+  {
+    "kind": "push",
+    "name": "push",
+    "value": {
+      "branch": "mara/code-parsers-bounded",
+      "remote": "origin"
+    }
+  },
+  {
+    "kind": "workspace_pr",
+    "name": "workspace pr",
+    "value": {
+      "ahead": 2,
+      "dirty": false,
+      "gh_authenticated": true,
+      "gh_found": true,
+      "has_upstream": true,
+      "pr": {
+        "auto_merge_enabled": true,
+        "base_branch": "main",
+        "check_counts": {
+          "failing": 0,
+          "passing": 10,
+          "pending": 3,
+          "skipped": 2
+        },
+        "checks_summary": "3 pending",
+        "draft": false,
+        "head_branch": "thet/cli-wire-mirror",
+        "head_sha": "24b451ab7248eb057445718f2ad6304a43915f37",
+        "in_merge_queue": false,
+        "merge_state_status": "BLOCKED",
+        "mergeable": "MERGEABLE",
+        "merged": false,
+        "number": 3006,
+        "review_decision": "APPROVED",
+        "state": "open",
+        "title": "refactor(cli): decode the chat event socket",
+        "url": "https://github.com/brightwave-inc/tidebreak/pull/3006"
+      },
+      "pushes_as": "mara",
+      "pushes_as_self": true,
+      "remediation": "",
+      "suggested_commit_message": "fix(desktop): bound every code-mode string",
+      "unpushed": true,
+      "watch": {
+        "created_at": "2025-09-01T04:16:40Z",
+        "cycles": 4,
+        "detail": "waiting on the desktop UI lane",
+        "id": "00000000-0000-0000-0000-000000000020",
+        "pr_number": 3006,
+        "session_id": "00000000-0000-0000-0000-000000000021",
+        "state": "watching",
+        "updated_at": "2025-09-01T04:17:40Z",
+        "workspace_id": "00000000-0000-0000-0000-000000000002"
+      }
+    }
+  },
+  {
+    "kind": "action",
+    "name": "action",
+    "value": {
+      "exit_code": 101,
+      "name": "test",
+      "stderr": "test parsers::bounds ... FAILED\n",
+      "stdout": "running 3 tests\n",
+      "success": false,
+      "timed_out": false
+    }
+  },
+  {
+    "kind": "session_digest",
+    "name": "session digest",
+    "value": {
+      "activity": "shell",
+      "attention": {
+        "source": "lifecycle",
+        "state": {
+          "type": "working"
+        }
+      },
+      "harness_kind": "claude_code",
+      "kind": "interactive",
+      "lifecycle": "running",
+      "pr_count": 1,
+      "pr_state": {
+        "auto_merge_enabled": true,
+        "base_branch": "main",
+        "check_counts": {
+          "failing": 0,
+          "passing": 10,
+          "pending": 3,
+          "skipped": 2
+        },
+        "checks_summary": "3 pending",
+        "draft": false,
+        "head_branch": "thet/cli-wire-mirror",
+        "head_sha": "24b451ab7248eb057445718f2ad6304a43915f37",
+        "in_merge_queue": false,
+        "merge_state_status": "BLOCKED",
+        "mergeable": "MERGEABLE",
+        "merged": false,
+        "number": 3006,
+        "review_decision": "APPROVED",
+        "state": "open",
+        "title": "refactor(cli): decode the chat event socket",
+        "url": "https://github.com/brightwave-inc/tidebreak/pull/3006"
+      },
+      "recap": "The parser bounds every field; the tests are next.",
+      "session": "00000000-0000-0000-0000-000000000003",
+      "subagents": [
+        {
+          "call_id": "call-explore",
+          "name": "Explore",
+          "status": "running"
+        }
+      ],
+      "title": "Bound the code parser",
+      "trigger_target_at": "2025-09-01T04:15:00Z",
+      "turn_count": 3,
+      "workspace": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "kind": "session_digest",
+    "name": "watch digest",
+    "value": {
+      "attention": {
+        "source": "lifecycle",
+        "state": {
+          "type": "working"
+        }
+      },
+      "harness_kind": "claude_code",
+      "kind": "watch",
+      "lifecycle": "running",
+      "pr_state": {
+        "auto_merge_enabled": true,
+        "base_branch": "main",
+        "check_counts": {
+          "failing": 0,
+          "passing": 10,
+          "pending": 3,
+          "skipped": 2
+        },
+        "checks_summary": "3 pending",
+        "draft": false,
+        "head_branch": "thet/cli-wire-mirror",
+        "head_sha": "24b451ab7248eb057445718f2ad6304a43915f37",
+        "in_merge_queue": false,
+        "merge_state_status": "BLOCKED",
+        "mergeable": "MERGEABLE",
+        "merged": false,
+        "number": 3006,
+        "review_decision": "APPROVED",
+        "state": "open",
+        "title": "refactor(cli): decode the chat event socket",
+        "url": "https://github.com/brightwave-inc/tidebreak/pull/3006"
+      },
+      "session": "00000000-0000-0000-0000-000000000021",
+      "title": "Watch #3006",
+      "trigger_target_at": "2025-09-01T04:15:00Z",
+      "turn_count": 3,
+      "watch_cycles": 4,
+      "watch_detail": "addressing the review",
+      "watch_state": "fixing",
+      "workspace": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "kind": "session_digest",
+    "name": "internal session digest",
+    "value": {
+      "activity": "agent",
+      "attention": {
+        "source": "lifecycle",
+        "state": {
+          "type": "working"
+        }
+      },
+      "harness_kind": "internal",
+      "kind": "interactive",
+      "lifecycle": "running",
+      "session": "00000000-0000-0000-0000-000000000022",
+      "title": "Plan the memory substrate",
+      "trigger_target_at": "2025-09-01T04:15:00Z",
+      "turn_count": 1,
+      "workspace": null
+    }
+  },
+  {
+    "kind": "update_notice",
+    "name": "updates: snapshot",
+    "value": {
+      "sessions": [
+        {
+          "activity": "shell",
+          "attention": {
+            "source": "lifecycle",
+            "state": {
+              "type": "working"
+            }
+          },
+          "harness_kind": "claude_code",
+          "kind": "interactive",
+          "lifecycle": "running",
+          "pr_count": 1,
+          "pr_state": {
+            "auto_merge_enabled": true,
+            "base_branch": "main",
+            "check_counts": {
+              "failing": 0,
+              "passing": 10,
+              "pending": 3,
+              "skipped": 2
+            },
+            "checks_summary": "3 pending",
+            "draft": false,
+            "head_branch": "thet/cli-wire-mirror",
+            "head_sha": "24b451ab7248eb057445718f2ad6304a43915f37",
+            "in_merge_queue": false,
+            "merge_state_status": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "merged": false,
+            "number": 3006,
+            "review_decision": "APPROVED",
+            "state": "open",
+            "title": "refactor(cli): decode the chat event socket",
+            "url": "https://github.com/brightwave-inc/tidebreak/pull/3006"
+          },
+          "recap": "The parser bounds every field; the tests are next.",
+          "session": "00000000-0000-0000-0000-000000000003",
+          "subagents": [
+            {
+              "call_id": "call-explore",
+              "name": "Explore",
+              "status": "running"
+            }
+          ],
+          "title": "Bound the code parser",
+          "trigger_target_at": "2025-09-01T04:15:00Z",
+          "turn_count": 3,
+          "workspace": "00000000-0000-0000-0000-000000000002"
+        },
+        {
+          "activity": "agent",
+          "attention": {
+            "source": "lifecycle",
+            "state": {
+              "type": "working"
+            }
+          },
+          "harness_kind": "internal",
+          "kind": "interactive",
+          "lifecycle": "running",
+          "session": "00000000-0000-0000-0000-000000000022",
+          "title": "Plan the memory substrate",
+          "trigger_target_at": "2025-09-01T04:15:00Z",
+          "turn_count": 1,
+          "workspace": null
+        }
+      ],
+      "type": "snapshot"
+    }
+  },
+  {
+    "kind": "update_notice",
+    "name": "updates: digest",
+    "value": {
+      "activity": "shell",
+      "attention": {
+        "source": "lifecycle",
+        "state": {
+          "type": "working"
+        }
+      },
+      "harness_kind": "claude_code",
+      "kind": "interactive",
+      "lifecycle": "running",
+      "pr_count": 1,
+      "pr_state": {
+        "auto_merge_enabled": true,
+        "base_branch": "main",
+        "check_counts": {
+          "failing": 0,
+          "passing": 10,
+          "pending": 3,
+          "skipped": 2
+        },
+        "checks_summary": "3 pending",
+        "draft": false,
+        "head_branch": "thet/cli-wire-mirror",
+        "head_sha": "24b451ab7248eb057445718f2ad6304a43915f37",
+        "in_merge_queue": false,
+        "merge_state_status": "BLOCKED",
+        "mergeable": "MERGEABLE",
+        "merged": false,
+        "number": 3006,
+        "review_decision": "APPROVED",
+        "state": "open",
+        "title": "refactor(cli): decode the chat event socket",
+        "url": "https://github.com/brightwave-inc/tidebreak/pull/3006"
+      },
+      "recap": "The parser bounds every field; the tests are next.",
+      "session": "00000000-0000-0000-0000-000000000003",
+      "subagents": [
+        {
+          "call_id": "call-explore",
+          "name": "Explore",
+          "status": "running"
+        }
+      ],
+      "title": "Bound the code parser",
+      "trigger_target_at": "2025-09-01T04:15:00Z",
+      "turn_count": 3,
+      "type": "digest",
+      "workspace": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "kind": "update_notice",
+    "name": "updates: internal session digest",
+    "value": {
+      "activity": "agent",
+      "attention": {
+        "source": "lifecycle",
+        "state": {
+          "type": "working"
+        }
+      },
+      "harness_kind": "internal",
+      "kind": "interactive",
+      "lifecycle": "running",
+      "session": "00000000-0000-0000-0000-000000000022",
+      "title": "Plan the memory substrate",
+      "trigger_target_at": "2025-09-01T04:15:00Z",
+      "turn_count": 1,
+      "type": "digest",
+      "workspace": null
+    }
+  },
+  {
+    "kind": "update_notice",
+    "name": "updates: terminal activity",
+    "value": {
+      "terminal_id": "00000000-0000-0000-0000-000000000040",
+      "type": "terminal_activity",
+      "workspace_id": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "kind": "update_notice",
+    "name": "updates: clone progress",
+    "value": {
+      "done": false,
+      "job": "clone-7",
+      "percent": 62,
+      "phase": "receiving objects",
+      "repo_id": "00000000-0000-0000-0000-000000000001",
+      "type": "clone_progress"
+    }
+  },
+  {
+    "kind": "update_notice",
+    "name": "updates: harness install",
+    "value": {
+      "done": true,
+      "error": "checksum mismatch",
+      "kind": "codex",
+      "phase": "failed",
+      "type": "harness_install",
+      "version": "0.42.0"
+    }
+  },
+  {
+    "kind": "update_notice",
+    "name": "updates: delivery",
+    "value": {
+      "type": "delivery"
+    }
+  },
+  {
+    "kind": "update_notice",
+    "name": "updates: turn rewrite",
+    "value": {
+      "rewrite": "Every code-mode string now has a bound.",
+      "session": "00000000-0000-0000-0000-000000000003",
+      "state": "rewritten",
+      "turn_id": "00000000-0000-0000-0000-000000000004",
+      "type": "turn_rewrite"
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: session_started (replayed, truncated)",
+    "value": {
+      "event": {
+        "harness_kind": "claude_code",
+        "harness_version": "2.0.14",
+        "resume_ref": "9f2c1d4e-resume",
+        "type": "session_started"
+      },
+      "replayed": true,
+      "seq": 40,
+      "truncated": true
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: turn_started",
+    "value": {
+      "event": {
+        "turn_id": "00000000-0000-0000-0000-000000000004",
+        "type": "turn_started"
+      },
+      "replayed": true,
+      "seq": 41
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: assistant_delta (transient replacement)",
+    "value": {
+      "event": {
+        "text": "Reading the parser",
+        "type": "assistant_delta"
+      },
+      "replacement": true,
+      "seq": 41,
+      "transient": true
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: assistant_message",
+    "value": {
+      "event": {
+        "text": "The parser checks presence only.",
+        "type": "assistant_message"
+      },
+      "seq": 42
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: reasoning_delta",
+    "value": {
+      "event": {
+        "text": "Which fields are drawn on one line?",
+        "type": "reasoning_delta"
+      },
+      "seq": 43
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: tool_started",
+    "value": {
+      "event": {
+        "call_id": "call-1",
+        "detail": {
+          "cmd": "cargo test -p tidebreak-cli",
+          "cwd": "/Users/mara/code/tidebreak",
+          "kind": "command"
+        },
+        "name": "Bash",
+        "type": "tool_started"
+      },
+      "seq": 44
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: tool_completed",
+    "value": {
+      "event": {
+        "call_id": "call-2",
+        "detail": {
+          "kind": "file_edit",
+          "path": "crates/tidebreak-cli/src/api/code.rs"
+        },
+        "outcome": "succeeded",
+        "parent_call_id": "call-1",
+        "preview": "1 file changed",
+        "type": "tool_completed"
+      },
+      "seq": 45
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: file_changed",
+    "value": {
+      "event": {
+        "diffstat": {
+          "deletions": 3,
+          "files": 2,
+          "insertions": 14,
+          "truncated": false
+        },
+        "kind": "modified",
+        "path": "crates/tidebreak-cli/src/api/code.rs",
+        "type": "file_changed"
+      },
+      "seq": 46
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: approval_requested",
+    "value": {
+      "event": {
+        "approval_id": "00000000-0000-0000-0000-000000000005",
+        "type": "approval_requested"
+      },
+      "seq": 47
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: approval_resolved",
+    "value": {
+      "event": {
+        "approval_id": "00000000-0000-0000-0000-000000000005",
+        "decision": {
+          "feedback": "Not that file.",
+          "type": "deny"
+        },
+        "type": "approval_resolved"
+      },
+      "seq": 48
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: user_steered",
+    "value": {
+      "event": {
+        "text": "Keep the raw tier for diffs.",
+        "type": "user_steered"
+      },
+      "seq": 49
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: turn_completed",
+    "value": {
+      "event": {
+        "checkpoint": {
+          "checkpoint_ref": "refs/tidebreak/checkpoints/3",
+          "diffstat": {
+            "deletions": 3,
+            "files": 2,
+            "insertions": 14,
+            "truncated": false
+          }
+        },
+        "type": "turn_completed",
+        "usage": {
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 900,
+          "context_tokens": 2440,
+          "first_call_context_tokens": 2100,
+          "input_tokens": 1200,
+          "output_tokens": 340
+        }
+      },
+      "seq": 50
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: turn_failed",
+    "value": {
+      "event": {
+        "error": {
+          "message": "the engine exited with status 1"
+        },
+        "type": "turn_failed"
+      },
+      "seq": 51
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: turn_interrupted",
+    "value": {
+      "event": {
+        "type": "turn_interrupted"
+      },
+      "seq": 52
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: checkpoint_recorded",
+    "value": {
+      "event": {
+        "diffstat": {
+          "deletions": 3,
+          "files": 2,
+          "insertions": 14,
+          "truncated": false
+        },
+        "turn_id": "00000000-0000-0000-0000-000000000004",
+        "type": "checkpoint_recorded"
+      },
+      "seq": 53
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: harness_notice",
+    "value": {
+      "event": {
+        "level": "warning",
+        "message": "context is 80% full",
+        "type": "harness_notice"
+      },
+      "seq": 54
+    }
+  },
+  {
+    "kind": "event_frame",
+    "name": "event: attention_changed",
+    "value": {
+      "event": {
+        "source": "structured",
+        "state": {
+          "prompt": "Approve the write to /etc/hosts?",
+          "source": "structured",
+          "type": "needs_you"
+        },
+        "type": "attention_changed"
+      },
+      "seq": 55
+    }
+  }
+]

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -112,6 +112,8 @@ pub mod voice_transcription;
 /// Host-owned, inert web-search configuration and provider selection.
 pub mod web_search;
 pub mod wire;
+#[cfg(test)]
+mod wire_code_fixtures;
 mod wire_types;
 
 use std::fs::{OpenOptions, TryLockError};

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -113,7 +113,8 @@ pub struct CodeConnectPage {
 }
 
 /// A registered local git repository.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeRepoSnapshot {
     pub id: RepoId,
     pub root_path: String,
@@ -147,7 +148,8 @@ impl From<CodeRepo> for CodeRepoSnapshot {
 }
 
 /// One isolated workspace (worktree + branch) on a repo.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeWorkspaceSnapshot {
     pub id: WorkspaceId,
     pub repo_id: RepoId,
@@ -199,7 +201,8 @@ impl From<CodeWorkspace> for CodeWorkspaceSnapshot {
 
 /// Where an externally created session came from. The desktop renders it
 /// as the provenance banner; a session the desktop created carries none.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeSessionExternalOrigin {
     /// The channel family, for example `slack`.
     pub channel_kind: String,
@@ -210,7 +213,8 @@ pub struct CodeSessionExternalOrigin {
 }
 
 /// One durable conversation with an external agent engine.
-#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeSessionSnapshot {
     pub id: tidebreak_core::CodeSessionId,
     /// `None` for a session that binds no workspace: the in-process
@@ -274,7 +278,8 @@ impl From<CodeSession> for CodeSessionSnapshot {
 }
 
 /// One user→engine turn.
-#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeTurnSnapshot {
     pub id: tidebreak_core::CodeTurnId,
     pub session_id: tidebreak_core::CodeSessionId,
@@ -443,7 +448,8 @@ pub struct CodeAnalyticsSnapshot {
 }
 
 /// One event on the per-session WebSocket.
-#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct SequencedCodeEventFrame {
     /// Journal position. On a `transient` frame this is the cursor the event
     /// streamed behind, not a position the frame occupies — resume from it
@@ -482,13 +488,14 @@ pub struct CodeSessionDebug {
 }
 
 /// Doctor report for every registered engine adapter.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct HarnessDoctorReport {
     pub harnesses: Vec<HarnessDoctorEntry>,
 }
 
 /// How a session of one engine authenticates on this machine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum HarnessAuthMode {
     /// The engine's own local sign-in — the probe result decides readiness.
@@ -510,7 +517,8 @@ pub enum HarnessAuthMode {
 }
 
 /// One engine's probe, capabilities, and remediation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct HarnessDoctorEntry {
     pub kind: HarnessKind,
     pub found: bool,
@@ -873,7 +881,8 @@ pub struct CreatePullRequestBody {
 }
 
 /// Result of staging and committing the workspace worktree.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeCommitSnapshot {
     pub sha: String,
     pub message: String,
@@ -881,14 +890,16 @@ pub struct CodeCommitSnapshot {
 }
 
 /// Result of pushing the workspace branch.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodePushSnapshot {
     pub branch: String,
     pub remote: String,
 }
 
 /// PR + checks digest plus the local git facts the PR card needs.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeWorkspacePrSnapshot {
     pub dirty: bool,
     pub unpushed: bool,
@@ -963,7 +974,8 @@ pub struct CodeWorkspacePullRequests {
 }
 
 /// One durable watch task on a workspace's pull request.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeWatchSnapshot {
     pub id: CodeWatchId,
     pub workspace_id: WorkspaceId,
@@ -1693,7 +1705,8 @@ pub struct CodeDeliveryRunActionBody {
 }
 
 /// Bounded output of one named quick action. Never journaled.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeActionSnapshot {
     pub name: String,
     pub success: bool,
@@ -1809,7 +1822,8 @@ pub struct SteerBody {
 /// `id` names the row for edits and retraction, and is the turn id the
 /// promoted turn is inserted under. `position` is 0-based and dense within
 /// the session.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct QueuedCodeTurn {
     pub id: tidebreak_core::CodeTurnId,
     pub session_id: tidebreak_core::CodeSessionId,
@@ -1833,7 +1847,8 @@ impl From<tidebreak_core::CodeQueuedTurn> for QueuedCodeTurn {
 }
 
 /// Response of `GET /code/sessions/{id}/queued`.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct QueuedCodeTurnsSnapshot {
     pub queued: Vec<QueuedCodeTurn>,
     pub paused: bool,
@@ -1967,7 +1982,8 @@ pub struct WorkspaceDiffQuery {
 }
 
 /// One changed path in a workspace or turn file list.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeFileChange {
     pub path: String,
     pub kind: FileChangeKind,
@@ -1979,7 +1995,8 @@ pub struct CodeFileChange {
 }
 
 /// Bounded changed-file list for `GET /code/workspaces/{id}/files`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeWorkspaceFiles {
     pub files: Vec<CodeFileChange>,
     pub truncated: bool,
@@ -1990,7 +2007,8 @@ pub struct CodeWorkspaceFiles {
 }
 
 /// Bounded unified diff for `GET /code/workspaces/{id}/diff`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeWorkspaceDiff {
     pub diff: String,
     pub truncated: bool,
@@ -2004,7 +2022,8 @@ pub struct CodeWorkspaceDiff {
 }
 
 /// One parked or decided engine approval.
-#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeApprovalSnapshot {
     pub id: CodeApprovalId,
     pub session_id: tidebreak_core::CodeSessionId,
@@ -2135,7 +2154,8 @@ pub struct CodeTerminalActivityNotice {
 }
 
 /// Cheap per-session digest on `/code/updates`.
-#[derive(Debug, Clone, PartialEq, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
 pub struct CodeSessionDigest {
     /// `None` for a session that binds no workspace.
     pub workspace: Option<WorkspaceId>,
@@ -2219,8 +2239,8 @@ impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
 /// One unsequenced notice on `WS /code/updates`.
 ///
 /// A connect is restated as [`Self::Snapshot`]; later notices are live only.
-#[derive(Debug, Clone, PartialEq, Serialize, TS)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CodeUpdateNotice {
     /// Full current digest of every non-ended session.
     Snapshot {
@@ -2328,7 +2348,7 @@ pub enum CodeUpdateNotice {
 }
 
 /// Where one closing-message rewrite stands.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum CodeTurnRewriteState {
     Rewriting,

--- a/crates/tidebreak-server/src/wire.rs
+++ b/crates/tidebreak-server/src/wire.rs
@@ -40,6 +40,15 @@
 //! record, serialized by the generator test in `wire_types.rs`, and the CLI
 //! decodes every entry.
 //!
+//! # Code mode
+//!
+//! The same module carries the code-mode surface the CLI drives: repo,
+//! workspace, session, turn, approval, and delivery snapshots, the sequenced
+//! event frame on `/code/sessions/{id}/events`, and the notices on
+//! `/code/updates`. They follow the strictness above. The one shape a client
+//! composes itself is the response to `POST /code/sessions/{id}/turns`, which
+//! is a [`CodeTurnSnapshot`] on `200` and a [`QueuedCodeTurn`] on `202`.
+//!
 //! # Limits
 //!
 //! [`limits`] holds the guard sizes the renderer applies to opaque strings on
@@ -69,6 +78,20 @@ pub use crate::routes::{
     ExecProviderSnapshot, ModelCatalog, ModelInfo, ModelRoleInfo, OutputRevisionInfo,
     OutputRevisionProducer, OutputRevisionSource, OutputRevisionsCatalog, ProvidersList,
     SubmittedOutputSnapshot,
+};
+
+// Code mode: the snapshots the REST routes return, the per-session event
+// frame, and the notices on `/code/updates`. Same contract as the chat
+// socket above: closed vocabularies, unknown keys rejected, an unknown notice
+// or event type failing its frame. The fixtures in `fixtures/code-frames.json`
+// are serialized from these types (see `wire_code_fixtures`).
+pub use crate::routes::code::types::{
+    CodeActionSnapshot, CodeApprovalSnapshot, CodeCommitSnapshot, CodeFileChange, CodePushSnapshot,
+    CodeRepoSnapshot, CodeSessionDigest, CodeSessionExternalOrigin, CodeSessionSnapshot,
+    CodeTurnRewriteState, CodeTurnSnapshot, CodeUpdateNotice, CodeWatchSnapshot, CodeWorkspaceDiff,
+    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot, HarnessAuthMode,
+    HarnessDoctorEntry, HarnessDoctorReport, QueuedCodeTurn, QueuedCodeTurnsSnapshot,
+    SequencedCodeEventFrame,
 };
 
 /// Guard sizes for the opaque strings a client draws from this surface.

--- a/crates/tidebreak-server/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server/src/wire_code_fixtures.rs
@@ -1,0 +1,1028 @@
+//! Shared fixtures for the code-mode wire surface.
+//!
+//! `fixtures/code-frames.json` holds one real value of every snapshot the code
+//! routes return, every notice on `/code/updates`, and every event the
+//! per-session socket can carry, serialized from the server's own types. Three
+//! decoders read the file: this crate's round trip, the CLI's
+//! `api::code` tests, and the renderer's `code/parsers.test.ts`. A shape
+//! change shows up as a failing test on whichever side did not follow it.
+//!
+//! Regenerate with `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server`, the
+//! same switch that rewrites `wire.ts`.
+
+use crate::wire::{
+    CodeActionSnapshot, CodeApprovalSnapshot, CodeCommitSnapshot, CodeFileChange, CodePushSnapshot,
+    CodeRepoSnapshot, CodeSessionDigest, CodeSessionExternalOrigin, CodeSessionSnapshot,
+    CodeTurnRewriteState, CodeTurnSnapshot, CodeUpdateNotice, CodeWatchSnapshot, CodeWorkspaceDiff,
+    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot, HarnessAuthMode,
+    HarnessDoctorEntry, HarnessDoctorReport, QueuedCodeTurn, QueuedCodeTurnsSnapshot,
+    SequencedCodeEventFrame,
+};
+use crate::wire_types::generate;
+use tidebreak_core::{
+    ApprovalDecisionKind, Attention, AttentionSource, AttentionState, BoundedError, CapLevel,
+    CheckpointHint, CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent,
+    CodeSessionActivity, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentStatus,
+    CodeSubagentSummary, CodeTerminalId, CodeTurnId, CodeTurnStatus, CodeUsage, CodeWatchId,
+    CodeWatchState, CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps,
+    HarnessCommand, HarnessKind, HarnessNoticeLevel, HarnessTier, ImageMediaType, ImageRef,
+    PermissionMode, PullRequestCheckCounts, PullRequestDigest, QuickAction, ReasoningEffort,
+    RepoId, ToolDetail, ToolOutcome, WorkspaceId,
+};
+
+/// Path of the shared code-mode fixtures, relative to this crate.
+const CODE_FRAMES: &str = "fixtures/code-frames.json";
+
+const REGENERATE: &str = "UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server";
+
+/// One fixture: a stable name, the kind a reader dispatches on, and the value.
+pub(crate) struct Fixture {
+    pub(crate) name: &'static str,
+    pub(crate) kind: &'static str,
+    pub(crate) value: serde_json::Value,
+}
+
+/// Fixed ids, so the file does not change on every run.
+fn id(n: u128) -> uuid::Uuid {
+    uuid::Uuid::from_u128(n)
+}
+
+fn at(secs: i64) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0).expect("a fixed timestamp")
+}
+
+fn fixture<T: serde::Serialize>(name: &'static str, kind: &'static str, value: &T) -> Fixture {
+    Fixture {
+        name,
+        kind,
+        value: serde_json::to_value(value).expect("a wire value serializes"),
+    }
+}
+
+fn repo_id() -> RepoId {
+    RepoId(id(0x01))
+}
+
+fn workspace_id() -> WorkspaceId {
+    WorkspaceId(id(0x02))
+}
+
+fn session_id() -> CodeSessionId {
+    CodeSessionId(id(0x03))
+}
+
+fn turn_id() -> CodeTurnId {
+    CodeTurnId(id(0x04))
+}
+
+fn approval_id() -> CodeApprovalId {
+    CodeApprovalId(id(0x05))
+}
+
+fn diffstat() -> Diffstat {
+    Diffstat {
+        files: 2,
+        insertions: 14,
+        deletions: 3,
+        truncated: false,
+    }
+}
+
+fn usage() -> CodeUsage {
+    CodeUsage {
+        input_tokens: 1_200,
+        output_tokens: 340,
+        cache_read_input_tokens: 900,
+        cache_creation_input_tokens: 0,
+        context_tokens: 2_440,
+        first_call_context_tokens: Some(2_100),
+    }
+}
+
+fn attention() -> Attention {
+    Attention {
+        state: AttentionState::Working,
+        source: AttentionSource::Lifecycle,
+    }
+}
+
+fn pull_request() -> PullRequestDigest {
+    PullRequestDigest {
+        number: 3006,
+        url: Some("https://github.com/brightwave-inc/tidebreak/pull/3006".to_owned()),
+        state: "open".to_owned(),
+        title: Some("refactor(cli): decode the chat event socket".to_owned()),
+        checks_summary: Some("3 pending".to_owned()),
+        check_counts: Some(PullRequestCheckCounts {
+            passing: 10,
+            pending: 3,
+            failing: 0,
+            skipped: 2,
+        }),
+        checks: None,
+        draft: Some(false),
+        merged: Some(false),
+        review_decision: Some("APPROVED".to_owned()),
+        mergeable: Some("MERGEABLE".to_owned()),
+        merge_state_status: Some("BLOCKED".to_owned()),
+        head_branch: Some("thet/cli-wire-mirror".to_owned()),
+        base_branch: Some("main".to_owned()),
+        head_sha: Some("24b451ab7248eb057445718f2ad6304a43915f37".to_owned()),
+        auto_merge_enabled: Some(true),
+        in_merge_queue: Some(false),
+    }
+}
+
+fn caps() -> HarnessCaps {
+    HarnessCaps {
+        resume: CapLevel::Supported,
+        streaming_deltas: CapLevel::Supported,
+        structured_approvals: CapLevel::Supported,
+        mid_turn_steering: CapLevel::Supported,
+        plan_mode: CapLevel::Supported,
+        auto_mode: CapLevel::Supported,
+        allow_mode: CapLevel::Supported,
+        reasoning_levels: CapLevel::Supported,
+        native_file_change_events: CapLevel::Unsupported,
+        native_interrupt: CapLevel::Supported,
+        image_input: CapLevel::Supported,
+        slash_commands: CapLevel::Supported,
+        durable_parks: CapLevel::Unknown,
+        user_questions: CapLevel::Supported,
+        standing_grants: CapLevel::Supported,
+    }
+}
+
+fn session() -> CodeSessionSnapshot {
+    CodeSessionSnapshot {
+        id: session_id(),
+        workspace_id: Some(workspace_id()),
+        kind: CodeSessionKind::Interactive,
+        harness_kind: HarnessKind::ClaudeCode,
+        harness_version: Some("2.0.14".to_owned()),
+        harness_resume_ref: Some("9f2c1d4e-resume".to_owned()),
+        permission_mode: PermissionMode::Ask,
+        model: Some("claude-opus-5".to_owned()),
+        reasoning_effort: Some(ReasoningEffort::High),
+        fast_mode: false,
+        lifecycle: CodeSessionLifecycle::Running,
+        fence_reason: None,
+        attention: attention(),
+        unrecognized_event_count: 0,
+        created_at: at(1_756_700_000),
+        external_origin: Some(CodeSessionExternalOrigin {
+            channel_kind: "slack".to_owned(),
+            external_key: "T0/C1/1756700000.000100".to_owned(),
+        }),
+    }
+}
+
+fn turn() -> CodeTurnSnapshot {
+    CodeTurnSnapshot {
+        id: turn_id(),
+        session_id: session_id(),
+        ordinal: 3,
+        status: CodeTurnStatus::Completed,
+        model: Some("claude-opus-5".to_owned()),
+        fast_mode: false,
+        user_input: "Bound every string the code parser draws.".to_owned(),
+        attachments: vec![ImageRef {
+            blob_id: id(0x30),
+            media_type: ImageMediaType::Png,
+            width: 640,
+            height: 480,
+            byte_len: 51_200,
+        }],
+        usage: Some(usage()),
+        checkpoint_ref: Some("refs/tidebreak/checkpoints/3".to_owned()),
+        diffstat: Some(diffstat()),
+        started_at: at(1_756_700_100),
+        ended_at: Some(at(1_756_700_160)),
+        rewrite: Some("Every code-mode string now has a bound.".to_owned()),
+    }
+}
+
+fn queued_turn() -> QueuedCodeTurn {
+    QueuedCodeTurn {
+        id: CodeTurnId(id(0x06)),
+        session_id: session_id(),
+        message: "Then add the fixture test.".to_owned(),
+        position: 0,
+        created_at: at(1_756_700_170),
+        updated_at: at(1_756_700_170),
+    }
+}
+
+fn digest() -> CodeSessionDigest {
+    CodeSessionDigest {
+        workspace: Some(workspace_id()),
+        session: session_id(),
+        kind: CodeSessionKind::Interactive,
+        harness_kind: Some(HarnessKind::ClaudeCode),
+        lifecycle: CodeSessionLifecycle::Running,
+        attention: attention(),
+        title: "Bound the code parser".to_owned(),
+        turn_count: 3,
+        trigger_target_at: Some(at(1_756_700_100)),
+        activity: Some(CodeSessionActivity::Shell),
+        pr_state: Some(pull_request()),
+        pr_count: Some(1),
+        watch_state: None,
+        watch_detail: None,
+        watch_cycles: None,
+        subagents: Some(vec![CodeSubagentSummary {
+            call_id: "call-explore".to_owned(),
+            name: "Explore".to_owned(),
+            status: CodeSubagentStatus::Running,
+        }]),
+        recap: Some("The parser bounds every field; the tests are next.".to_owned()),
+    }
+}
+
+/// The in-process engine's session binds no workspace (decision 0048 step 5).
+fn internal_digest() -> CodeSessionDigest {
+    CodeSessionDigest {
+        workspace: None,
+        session: CodeSessionId(id(0x22)),
+        harness_kind: Some(HarnessKind::Internal),
+        title: "Plan the memory substrate".to_owned(),
+        turn_count: 1,
+        activity: Some(CodeSessionActivity::Agent),
+        pr_state: None,
+        pr_count: None,
+        subagents: None,
+        recap: None,
+        ..digest()
+    }
+}
+
+fn digest_notice(d: CodeSessionDigest) -> CodeUpdateNotice {
+    CodeUpdateNotice::Digest {
+        workspace: d.workspace,
+        session: d.session,
+        kind: d.kind,
+        harness_kind: d.harness_kind,
+        lifecycle: d.lifecycle,
+        attention: d.attention,
+        title: d.title,
+        turn_count: d.turn_count,
+        trigger_target_at: d.trigger_target_at,
+        activity: d.activity,
+        pr_state: d.pr_state.map(Box::new),
+        pr_count: d.pr_count,
+        watch_state: d.watch_state,
+        watch_detail: d.watch_detail,
+        watch_cycles: d.watch_cycles,
+        subagents: d.subagents,
+        recap: d.recap,
+    }
+}
+
+fn frame(seq: i64, event: CodeEvent) -> SequencedCodeEventFrame {
+    SequencedCodeEventFrame {
+        seq,
+        event,
+        replayed: None,
+        transient: None,
+        replacement: None,
+        truncated: None,
+    }
+}
+
+/// Every snapshot, notice, and event the code surface serializes, once each.
+///
+/// [`the_code_frame_fixtures_cover_every_event`] proves the event and notice
+/// lists cannot silently fall behind their unions.
+pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
+    let mut out = vec![
+        fixture(
+            "repo",
+            "repo",
+            &CodeRepoSnapshot {
+                id: repo_id(),
+                root_path: "/Users/mara/code/tidebreak".to_owned(),
+                display_name: "tidebreak".to_owned(),
+                default_base_ref: "main".to_owned(),
+                branch_prefix: "mara/".to_owned(),
+                setup_script: Some("pnpm install".to_owned()),
+                archive_script: None,
+                quick_actions: vec![QuickAction {
+                    name: "test".to_owned(),
+                    command: "cargo test".to_owned(),
+                    auto_run_on_create: false,
+                }],
+                created_at: at(1_756_600_000),
+            },
+        ),
+        fixture(
+            "workspace",
+            "workspace",
+            &CodeWorkspaceSnapshot {
+                id: workspace_id(),
+                repo_id: repo_id(),
+                title: "Bound the code parser".to_owned(),
+                worktree_path: "/Users/mara/code/tidebreak/.tidebreak/wt-2".to_owned(),
+                branch_name: "mara/code-parsers-bounded".to_owned(),
+                base_ref: "main".to_owned(),
+                status: CodeWorkspaceStatus::Active,
+                pr: Some(pull_request()),
+                created_at: at(1_756_690_000),
+                archived_at: None,
+                released_at: None,
+                released_tip: None,
+                bundle_bytes: None,
+            },
+        ),
+        fixture(
+            "released workspace",
+            "workspace",
+            &CodeWorkspaceSnapshot {
+                id: WorkspaceId(id(0x12)),
+                repo_id: repo_id(),
+                title: "Old work".to_owned(),
+                worktree_path: "/Users/mara/code/tidebreak/.tidebreak/wt-1".to_owned(),
+                branch_name: "mara/old-work".to_owned(),
+                base_ref: "main".to_owned(),
+                status: CodeWorkspaceStatus::Released,
+                pr: None,
+                created_at: at(1_756_000_000),
+                archived_at: Some(at(1_756_100_000)),
+                released_at: Some(at(1_756_200_000)),
+                released_tip: Some("0bace692f4b5a7e3d2c1f0a9b8c7d6e5f4a3b2c1".to_owned()),
+                bundle_bytes: Some(48_213),
+            },
+        ),
+        fixture("session", "session", &session()),
+        fixture(
+            "fenced session",
+            "session",
+            &CodeSessionSnapshot {
+                workspace_id: None,
+                harness_kind: HarnessKind::Internal,
+                lifecycle: CodeSessionLifecycle::Fenced,
+                fence_reason: Some(FenceReason::ResumeLost {
+                    detail: "the engine forgot the resume ref".to_owned(),
+                }),
+                attention: Attention {
+                    state: AttentionState::Fenced {
+                        reason: FenceReason::ResumeLost {
+                            detail: "the engine forgot the resume ref".to_owned(),
+                        },
+                    },
+                    source: AttentionSource::Lifecycle,
+                },
+                external_origin: None,
+                ..session()
+            },
+        ),
+        fixture("turn", "turn", &turn()),
+        fixture("queued turn", "queued_turn", &queued_turn()),
+        fixture(
+            "queued turns",
+            "queued_turns",
+            &QueuedCodeTurnsSnapshot {
+                queued: vec![queued_turn()],
+                paused: true,
+            },
+        ),
+        fixture(
+            "harness doctor",
+            "harness_doctor",
+            &HarnessDoctorReport {
+                harnesses: vec![
+                    HarnessDoctorEntry {
+                        kind: HarnessKind::ClaudeCode,
+                        found: true,
+                        installable: true,
+                        path: Some("/opt/homebrew/bin/claude".to_owned()),
+                        version: Some("2.0.14".to_owned()),
+                        tier: HarnessTier::Reference,
+                        caps: caps(),
+                        commands: vec![HarnessCommand {
+                            name: "review".to_owned(),
+                            description: "Review the pending changes".to_owned(),
+                        }],
+                        authenticated: Some(true),
+                        auth_mode: HarnessAuthMode::LocalSignIn,
+                        remediation: String::new(),
+                        stderr: String::new(),
+                        unrecognized_event_count: 0,
+                        relaunch_composes_permission_mode: true,
+                    },
+                    HarnessDoctorEntry {
+                        kind: HarnessKind::Grok,
+                        found: false,
+                        installable: false,
+                        path: None,
+                        version: None,
+                        tier: HarnessTier::BestEffort,
+                        caps: caps(),
+                        commands: Vec::new(),
+                        authenticated: None,
+                        auth_mode: HarnessAuthMode::HostedUnavailable,
+                        remediation: "Install grok-build and sign in.".to_owned(),
+                        stderr: "grok: command not found".to_owned(),
+                        unrecognized_event_count: 2,
+                        relaunch_composes_permission_mode: false,
+                    },
+                ],
+            },
+        ),
+        fixture(
+            "workspace files",
+            "workspace_files",
+            &CodeWorkspaceFiles {
+                files: vec![
+                    CodeFileChange {
+                        path: "crates/tidebreak-cli/src/api/code.rs".to_owned(),
+                        kind: FileChangeKind::Modified,
+                        insertions: 12,
+                        deletions: 3,
+                        previous_path: None,
+                    },
+                    CodeFileChange {
+                        path: "crates/tidebreak-server/fixtures/code-frames.json".to_owned(),
+                        kind: FileChangeKind::Renamed,
+                        insertions: 2,
+                        deletions: 0,
+                        previous_path: Some(
+                            "crates/tidebreak-server/fixtures/code.json".to_owned(),
+                        ),
+                    },
+                ],
+                truncated: false,
+                stat: diffstat(),
+                turn_id: Some(turn_id()),
+            },
+        ),
+        fixture(
+            "workspace diff",
+            "workspace_diff",
+            &CodeWorkspaceDiff {
+                diff: "--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-old\n+new\n".to_owned(),
+                truncated: false,
+                stat: Diffstat {
+                    files: 1,
+                    insertions: 1,
+                    deletions: 1,
+                    truncated: false,
+                },
+                turn_id: None,
+                file: Some("README.md".to_owned()),
+            },
+        ),
+        fixture(
+            "pending approval",
+            "approval",
+            &CodeApprovalSnapshot {
+                id: approval_id(),
+                session_id: session_id(),
+                turn_id: turn_id(),
+                kind: CodeApprovalKind::Command {
+                    cmd: "cargo test -p tidebreak-cli".to_owned(),
+                    cwd: Some("/Users/mara/code/tidebreak".to_owned()),
+                },
+                harness_raw_json: r#"{"tool":"Bash","command":"cargo test -p tidebreak-cli"}"#
+                    .to_owned(),
+                state: CodeApprovalState::Pending,
+                feedback: None,
+                requested_at: at(1_756_700_120),
+                decided_at: None,
+            },
+        ),
+        fixture(
+            "denied approval",
+            "approval",
+            &CodeApprovalSnapshot {
+                id: CodeApprovalId(id(0x15)),
+                session_id: session_id(),
+                turn_id: turn_id(),
+                kind: CodeApprovalKind::FileWrite {
+                    paths: vec!["/etc/hosts".to_owned()],
+                },
+                harness_raw_json: r#"{"tool":"Write","path":"/etc/hosts"}"#.to_owned(),
+                state: CodeApprovalState::Denied,
+                feedback: Some("Not that file.".to_owned()),
+                requested_at: at(1_756_700_130),
+                decided_at: Some(at(1_756_700_140)),
+            },
+        ),
+        fixture(
+            "commit",
+            "commit",
+            &CodeCommitSnapshot {
+                sha: "cec166ffc1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6".to_owned(),
+                message: "fix(desktop): bound every code-mode string".to_owned(),
+                stat: diffstat(),
+            },
+        ),
+        fixture(
+            "push",
+            "push",
+            &CodePushSnapshot {
+                branch: "mara/code-parsers-bounded".to_owned(),
+                remote: "origin".to_owned(),
+            },
+        ),
+        fixture(
+            "workspace pr",
+            "workspace_pr",
+            &CodeWorkspacePrSnapshot {
+                dirty: false,
+                unpushed: true,
+                ahead: 2,
+                has_upstream: true,
+                suggested_commit_message: "fix(desktop): bound every code-mode string".to_owned(),
+                pr: Some(pull_request()),
+                gh_found: true,
+                gh_authenticated: Some(true),
+                remediation: String::new(),
+                pushes_as: Some("mara".to_owned()),
+                pushes_as_self: Some(true),
+                watch: Some(CodeWatchSnapshot {
+                    id: CodeWatchId(id(0x20)),
+                    workspace_id: workspace_id(),
+                    session_id: CodeSessionId(id(0x21)),
+                    pr_number: 3006,
+                    state: CodeWatchState::Watching,
+                    detail: Some("waiting on the desktop UI lane".to_owned()),
+                    cycles: 4,
+                    created_at: at(1_756_700_200),
+                    updated_at: at(1_756_700_260),
+                }),
+            },
+        ),
+        fixture(
+            "action",
+            "action",
+            &CodeActionSnapshot {
+                name: "test".to_owned(),
+                success: false,
+                exit_code: Some(101),
+                stdout: "running 3 tests\n".to_owned(),
+                stderr: "test parsers::bounds ... FAILED\n".to_owned(),
+                timed_out: false,
+            },
+        ),
+        fixture("session digest", "session_digest", &digest()),
+        fixture(
+            "watch digest",
+            "session_digest",
+            &CodeSessionDigest {
+                session: CodeSessionId(id(0x21)),
+                kind: CodeSessionKind::Watch,
+                title: "Watch #3006".to_owned(),
+                activity: None,
+                pr_count: None,
+                watch_state: Some(CodeWatchState::Fixing),
+                watch_detail: Some("addressing the review".to_owned()),
+                watch_cycles: Some(4),
+                subagents: None,
+                recap: None,
+                ..digest()
+            },
+        ),
+        fixture(
+            "internal session digest",
+            "session_digest",
+            &internal_digest(),
+        ),
+    ];
+    out.extend(update_notices());
+    out.extend(event_frames());
+    out
+}
+
+/// One notice per variant of [`CodeUpdateNotice`].
+fn update_notices() -> Vec<Fixture> {
+    vec![
+        fixture(
+            "updates: snapshot",
+            "update_notice",
+            &CodeUpdateNotice::Snapshot {
+                sessions: vec![digest(), internal_digest()],
+            },
+        ),
+        fixture("updates: digest", "update_notice", &digest_notice(digest())),
+        fixture(
+            "updates: internal session digest",
+            "update_notice",
+            &digest_notice(internal_digest()),
+        ),
+        fixture(
+            "updates: terminal activity",
+            "update_notice",
+            &CodeUpdateNotice::TerminalActivity {
+                workspace_id: workspace_id(),
+                terminal_id: CodeTerminalId(id(0x40)),
+            },
+        ),
+        fixture(
+            "updates: clone progress",
+            "update_notice",
+            &CodeUpdateNotice::CloneProgress {
+                job: "clone-7".to_owned(),
+                phase: "receiving objects".to_owned(),
+                percent: Some(62),
+                done: false,
+                error: None,
+                repo_id: Some(repo_id()),
+            },
+        ),
+        fixture(
+            "updates: harness install",
+            "update_notice",
+            &CodeUpdateNotice::HarnessInstall {
+                kind: HarnessKind::Codex,
+                version: Some("0.42.0".to_owned()),
+                phase: "failed".to_owned(),
+                done: true,
+                error: Some("checksum mismatch".to_owned()),
+            },
+        ),
+        fixture(
+            "updates: delivery",
+            "update_notice",
+            &CodeUpdateNotice::Delivery,
+        ),
+        fixture(
+            "updates: turn rewrite",
+            "update_notice",
+            &CodeUpdateNotice::TurnRewrite {
+                session: session_id(),
+                turn_id: turn_id(),
+                state: CodeTurnRewriteState::Rewritten,
+                rewrite: Some("Every code-mode string now has a bound.".to_owned()),
+            },
+        ),
+    ]
+}
+
+/// One frame per variant of [`CodeEvent`], plus the frame flags a reader
+/// has to honor: `replayed`, `transient` with `replacement`, and `truncated`.
+fn event_frames() -> Vec<Fixture> {
+    let started = CodeEvent::SessionStarted {
+        harness_kind: HarnessKind::ClaudeCode,
+        harness_version: "2.0.14".to_owned(),
+        resume_ref: Some("9f2c1d4e-resume".to_owned()),
+    };
+    let frames = vec![
+        (
+            "event: session_started (replayed, truncated)",
+            SequencedCodeEventFrame {
+                replayed: Some(true),
+                truncated: Some(true),
+                ..frame(40, started)
+            },
+        ),
+        (
+            "event: turn_started",
+            SequencedCodeEventFrame {
+                replayed: Some(true),
+                ..frame(41, CodeEvent::TurnStarted { turn_id: turn_id() })
+            },
+        ),
+        (
+            "event: assistant_delta (transient replacement)",
+            SequencedCodeEventFrame {
+                transient: Some(true),
+                replacement: Some(true),
+                ..frame(
+                    41,
+                    CodeEvent::AssistantDelta {
+                        text: "Reading the parser".to_owned(),
+                    },
+                )
+            },
+        ),
+        (
+            "event: assistant_message",
+            frame(
+                42,
+                CodeEvent::AssistantMessage {
+                    text: "The parser checks presence only.".to_owned(),
+                    parent_call_id: None,
+                },
+            ),
+        ),
+        (
+            "event: reasoning_delta",
+            frame(
+                43,
+                CodeEvent::ReasoningDelta {
+                    text: "Which fields are drawn on one line?".to_owned(),
+                },
+            ),
+        ),
+        (
+            "event: tool_started",
+            frame(
+                44,
+                CodeEvent::ToolStarted {
+                    call_id: "call-1".to_owned(),
+                    name: "Bash".to_owned(),
+                    detail: ToolDetail::Command {
+                        cmd: "cargo test -p tidebreak-cli".to_owned(),
+                        cwd: "/Users/mara/code/tidebreak".to_owned(),
+                    },
+                    parent_call_id: None,
+                },
+            ),
+        ),
+        (
+            "event: tool_completed",
+            frame(
+                45,
+                CodeEvent::ToolCompleted {
+                    call_id: "call-2".to_owned(),
+                    outcome: ToolOutcome::Succeeded,
+                    preview: "1 file changed".to_owned(),
+                    detail: Some(ToolDetail::FileEdit {
+                        path: "crates/tidebreak-cli/src/api/code.rs".to_owned(),
+                    }),
+                    parent_call_id: Some("call-1".to_owned()),
+                },
+            ),
+        ),
+        (
+            "event: file_changed",
+            frame(
+                46,
+                CodeEvent::FileChanged {
+                    path: "crates/tidebreak-cli/src/api/code.rs".to_owned(),
+                    kind: FileChangeKind::Modified,
+                    diffstat: diffstat(),
+                },
+            ),
+        ),
+        (
+            "event: approval_requested",
+            frame(
+                47,
+                CodeEvent::ApprovalRequested {
+                    approval_id: approval_id(),
+                },
+            ),
+        ),
+        (
+            "event: approval_resolved",
+            frame(
+                48,
+                CodeEvent::ApprovalResolved {
+                    approval_id: approval_id(),
+                    decision: ApprovalDecisionKind::Deny {
+                        feedback: Some("Not that file.".to_owned()),
+                    },
+                },
+            ),
+        ),
+        (
+            "event: user_steered",
+            frame(
+                49,
+                CodeEvent::UserSteered {
+                    text: "Keep the raw tier for diffs.".to_owned(),
+                },
+            ),
+        ),
+        (
+            "event: turn_completed",
+            frame(
+                50,
+                CodeEvent::TurnCompleted {
+                    usage: usage(),
+                    checkpoint: Some(CheckpointHint {
+                        checkpoint_ref: Some("refs/tidebreak/checkpoints/3".to_owned()),
+                        diffstat: Some(diffstat()),
+                    }),
+                },
+            ),
+        ),
+        (
+            "event: turn_failed",
+            frame(
+                51,
+                CodeEvent::TurnFailed {
+                    error: BoundedError {
+                        message: "the engine exited with status 1".to_owned(),
+                    },
+                },
+            ),
+        ),
+        (
+            "event: turn_interrupted",
+            frame(52, CodeEvent::TurnInterrupted),
+        ),
+        (
+            "event: checkpoint_recorded",
+            frame(
+                53,
+                CodeEvent::CheckpointRecorded {
+                    turn_id: turn_id(),
+                    diffstat: diffstat(),
+                },
+            ),
+        ),
+        (
+            "event: harness_notice",
+            frame(
+                54,
+                CodeEvent::HarnessNotice {
+                    level: HarnessNoticeLevel::Warning,
+                    message: "context is 80% full".to_owned(),
+                },
+            ),
+        ),
+        (
+            "event: attention_changed",
+            frame(
+                55,
+                CodeEvent::AttentionChanged {
+                    state: AttentionState::NeedsYou {
+                        prompt: "Approve the write to /etc/hosts?".to_owned(),
+                        source: AttentionSource::Structured,
+                    },
+                    source: AttentionSource::Structured,
+                },
+            ),
+        ),
+    ];
+    frames
+        .into_iter()
+        .map(|(name, frame)| fixture(name, "event_frame", &frame))
+        .collect()
+}
+
+/// The checked-in fixture file: a JSON array of `{ "name", "kind", "value" }`.
+fn rendered_code_frames() -> String {
+    let entries = code_frame_fixtures()
+        .into_iter()
+        .map(|entry| {
+            serde_json::json!({ "name": entry.name, "kind": entry.kind, "value": entry.value })
+        })
+        .collect::<Vec<_>>();
+    let mut rendered = serde_json::to_string_pretty(&entries).expect("the fixture list serializes");
+    rendered.push('\n');
+    rendered
+}
+
+/// Tags of a `#[serde(tag = "type")]` union, read from its generated
+/// declaration rather than a hand-kept list.
+fn declared_tags<T: ts_rs::TS + 'static>(name: &str) -> std::collections::BTreeSet<String> {
+    let cfg = generate::config();
+    let mut declarations = std::collections::BTreeMap::new();
+    generate::collect_from::<T>(&cfg, &mut declarations);
+    let declaration = &declarations[name];
+    let tags: std::collections::BTreeSet<String> = declaration
+        .split("\"type\": \"")
+        .skip(1)
+        .map(|rest| rest.split('"').next().expect("a closed tag").to_owned())
+        .collect();
+    assert!(
+        tags.len() > 3,
+        "the {name} union parse found too few tags: {tags:?}"
+    );
+    tags
+}
+
+fn fixture_tags(
+    kind: &str,
+    tag_at: fn(&serde_json::Value) -> Option<&serde_json::Value>,
+) -> std::collections::BTreeSet<String> {
+    code_frame_fixtures()
+        .iter()
+        .filter(|entry| entry.kind == kind)
+        .filter_map(|entry| tag_at(&entry.value))
+        .filter_map(|tag| tag.as_str())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn round_trip<T: serde::de::DeserializeOwned + serde::Serialize>(entry: &Fixture) {
+    let decoded: T = serde_json::from_value(entry.value.clone())
+        .unwrap_or_else(|error| panic!("fixture {} does not decode: {error}", entry.name));
+    let again = serde_json::to_value(&decoded).expect("a decoded value serializes");
+    assert_eq!(
+        again, entry.value,
+        "fixture {} changed across the round trip",
+        entry.name
+    );
+}
+
+/// Three decoders read these bytes. A diff here means the code surface's
+/// shape changed, and every client test that consumes the file re-runs
+/// against the new shape.
+#[test]
+fn the_code_frame_fixtures_are_current() {
+    generate::check_or_update(CODE_FRAMES, &rendered_code_frames(), REGENERATE);
+}
+
+/// Every event variant and every update-notice variant has a fixture, so a
+/// new variant fails here until it has one.
+#[test]
+fn the_code_frame_fixtures_cover_every_event() {
+    let declared = declared_tags::<CodeEvent>("CodeEvent");
+    let covered = fixture_tags("event_frame", |value| value.get("event")?.get("type"));
+    let missing: Vec<_> = declared.difference(&covered).collect();
+    assert!(
+        missing.is_empty(),
+        "event types without a code-frame fixture: {missing:?}"
+    );
+
+    let declared = declared_tags::<CodeUpdateNotice>("CodeUpdateNotice");
+    let covered = fixture_tags("update_notice", |value| value.get("type"));
+    let missing: Vec<_> = declared.difference(&covered).collect();
+    assert!(
+        missing.is_empty(),
+        "update notices without a code-frame fixture: {missing:?}"
+    );
+}
+
+/// Every fixture kind has a decoder here, so a new kind fails until the
+/// server can read what it wrote.
+#[test]
+fn every_code_frame_fixture_round_trips() {
+    for entry in &code_frame_fixtures() {
+        match entry.kind {
+            "repo" => round_trip::<CodeRepoSnapshot>(entry),
+            "workspace" => round_trip::<CodeWorkspaceSnapshot>(entry),
+            "session" => round_trip::<CodeSessionSnapshot>(entry),
+            "turn" => round_trip::<CodeTurnSnapshot>(entry),
+            "queued_turn" => round_trip::<QueuedCodeTurn>(entry),
+            "queued_turns" => round_trip::<QueuedCodeTurnsSnapshot>(entry),
+            "harness_doctor" => round_trip::<HarnessDoctorReport>(entry),
+            "workspace_files" => round_trip::<CodeWorkspaceFiles>(entry),
+            "workspace_diff" => round_trip::<CodeWorkspaceDiff>(entry),
+            "approval" => round_trip::<CodeApprovalSnapshot>(entry),
+            "commit" => round_trip::<CodeCommitSnapshot>(entry),
+            "push" => round_trip::<CodePushSnapshot>(entry),
+            "workspace_pr" => round_trip::<CodeWorkspacePrSnapshot>(entry),
+            "action" => round_trip::<CodeActionSnapshot>(entry),
+            "session_digest" => round_trip::<CodeSessionDigest>(entry),
+            "update_notice" => round_trip::<CodeUpdateNotice>(entry),
+            "event_frame" => round_trip::<SequencedCodeEventFrame>(entry),
+            other => panic!("fixture {} has no decoder for kind {other}", entry.name),
+        }
+    }
+}
+
+/// Unknown keys fail the value, at the snapshot, the notice, and the frame.
+///
+/// The one gap is serde's: a payload-less notice (`{"type":"delivery"}`) is
+/// a unit variant of an internally tagged enum, and serde reads no fields for
+/// it, so `deny_unknown_fields` has nothing to check. A stray key beside the
+/// tag is accepted there. The renderer's `onlyKeys` guard still rejects it.
+#[test]
+fn code_values_reject_unknown_keys() {
+    for entry in code_frame_fixtures() {
+        if entry.kind == "update_notice"
+            && entry.value.as_object().map(serde_json::Map::len) == Some(1)
+        {
+            continue;
+        }
+        let mut value = entry.value.clone();
+        let object = match entry.kind {
+            "event_frame" => value["event"].as_object_mut(),
+            _ => value.as_object_mut(),
+        }
+        .expect("every fixture is an object");
+        object.insert("extra".to_owned(), serde_json::Value::Bool(true));
+        let rejected = match entry.kind {
+            "repo" => serde_json::from_value::<CodeRepoSnapshot>(value).is_err(),
+            "workspace" => serde_json::from_value::<CodeWorkspaceSnapshot>(value).is_err(),
+            "session" => serde_json::from_value::<CodeSessionSnapshot>(value).is_err(),
+            "turn" => serde_json::from_value::<CodeTurnSnapshot>(value).is_err(),
+            "queued_turn" => serde_json::from_value::<QueuedCodeTurn>(value).is_err(),
+            "queued_turns" => serde_json::from_value::<QueuedCodeTurnsSnapshot>(value).is_err(),
+            "harness_doctor" => serde_json::from_value::<HarnessDoctorReport>(value).is_err(),
+            "workspace_files" => serde_json::from_value::<CodeWorkspaceFiles>(value).is_err(),
+            "workspace_diff" => serde_json::from_value::<CodeWorkspaceDiff>(value).is_err(),
+            "approval" => serde_json::from_value::<CodeApprovalSnapshot>(value).is_err(),
+            "commit" => serde_json::from_value::<CodeCommitSnapshot>(value).is_err(),
+            "push" => serde_json::from_value::<CodePushSnapshot>(value).is_err(),
+            "workspace_pr" => serde_json::from_value::<CodeWorkspacePrSnapshot>(value).is_err(),
+            "action" => serde_json::from_value::<CodeActionSnapshot>(value).is_err(),
+            "session_digest" => serde_json::from_value::<CodeSessionDigest>(value).is_err(),
+            "update_notice" => serde_json::from_value::<CodeUpdateNotice>(value).is_err(),
+            // The event union is `tidebreak_core`'s and tolerates extra keys
+            // inside a variant; the frame around it does not.
+            "event_frame" => {
+                let mut frame = entry.value.clone();
+                frame["extra"] = serde_json::Value::Bool(true);
+                serde_json::from_value::<SequencedCodeEventFrame>(frame).is_err()
+            }
+            other => panic!("fixture {} has no decoder for kind {other}", entry.name),
+        };
+        assert!(rejected, "fixture {} accepted an unknown key", entry.name);
+    }
+}
+
+/// A notice tag this build does not know fails the notice rather than
+/// folding to something a client would misread.
+#[test]
+fn unknown_update_notices_fail() {
+    let unknown = r#"{"type":"some_future_notice","extra":true}"#;
+    assert!(serde_json::from_str::<CodeUpdateNotice>(unknown).is_err());
+    let unknown_event = r#"{"seq":9,"event":{"type":"some_future_event"}}"#;
+    assert!(serde_json::from_str::<SequencedCodeEventFrame>(unknown_event).is_err());
+}

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -131,7 +131,7 @@ in the renderer. The module documents the strictness that comes with it:
 closed vocabularies, unknown keys rejected (`deny_unknown_fields`, matching the
 renderer's `onlyKeys` guards), and an unknown event type failing its frame.
 
-Two more things are shared through it:
+Four more things are shared through it:
 
 - **Guard limits.** `tidebreak_server::wire::limits` holds the id, timestamp,
   and cursor ceilings. They are generated into `wire.ts` as constants, and
@@ -158,6 +158,17 @@ Two more things are shared through it:
   round-trips every entry and the CLI decodes every entry. The renderer does
   not read this file: its REST validators are exercised against
   `generated/fixtures.ts` and the generated types.
+- **Code-mode fixtures.** The repo, workspace, session, turn, approval, and
+  delivery snapshots, the sequenced event frame, and the `/code/updates`
+  notices are re-exported from `tidebreak_server::wire` too, reject unknown
+  keys, and are written to `crates/tidebreak-server/fixtures/code-frames.json`
+  by `wire_code_fixtures` (a `CodeEvent` or `CodeUpdateNotice` variant without
+  a fixture fails `the_code_frame_fixtures_cover_every_event`). The server
+  round-trips every entry, the CLI's `api::code` tests decode every entry, and
+  the renderer's `code/parsers.test.ts` runs every entry through the matching
+  parser. The event union inside a frame is `tidebreak_core::CodeEvent`, which
+  the server also reads back from its journal, so a variant tolerates keys it
+  does not declare; the frame around it does not.
 
 ## Scope today
 


### PR DESCRIPTION
Follow-up to #2978 (PR #3006), which moved the CLI's chat event socket decoder onto the server's own types. `crates/tidebreak-cli/src/api/code.rs` kept a separate hand-written mirror of the code-mode API, about 850 lines, and it had already drifted: the server's `CodeSessionSnapshot.workspace_id` is `Option` since decision 0048 step 5, `QueuedCodeTurn` carries timestamps and an `i32` position, `HarnessDoctorEntry` gained `installable`, `commands`, and `relaunch_composes_permission_mode`, and `/code/updates` sends four notice kinds the mirror folded into `Unknown`.

## What changed

- **One source of truth.** `tidebreak_server::wire` re-exports the code-mode snapshots, the sequenced event frame, and `CodeUpdateNotice`. The server types derive `Deserialize` and reject unknown keys (`deny_unknown_fields`), matching the renderer's `onlyKeys` guards. The CLI imports them; the mirror is gone. `SubmitTurnResponse` stays in the CLI as the one composed shape, because the server answers `POST /code/sessions/{id}/turns` with a `CodeTurnSnapshot` on `200` or a `QueuedCodeTurn` on `202`.
- **Strictness.** An unknown notice tag now fails the notice instead of folding to `Unknown`; the watch loop already dropped what it could not decode, so the behavior is the same with a shape the server actually declares. The module doc records the one tolerance that stays: the event union inside a frame is `tidebreak_core::CodeEvent`, which the server reads back from its own journal, so a variant accepts undeclared keys while the frame around it does not. A payload-less notice (`{"type":"delivery"}`) also accepts a stray key beside the tag, which is serde's behavior for unit variants of an internally tagged enum; the test names it.
- **Shared fixtures.** `crates/tidebreak-server/fixtures/code-frames.json` holds 45 real values, one per snapshot kind, one per `CodeUpdateNotice` variant, and one frame per `CodeEvent` variant plus the `replayed`, `transient`/`replacement`, and `truncated` flags. `wire_code_fixtures.rs` writes it from the server's types under `UPDATE_WIRE_TYPES=1` and fails when a variant has no fixture. The server round-trips every entry, the CLI decodes every entry, and `code/parsers.test.ts` runs every entry through the matching desktop parser.
- **CLI call sites.** `code watch` and `code session show` print a dash for a session with no workspace; the digest arm ignores the four notice kinds the watch does not render; queue positions widen from `i32` to the `i64` the MCP result carries.
- `docs/wire-types.md` describes the code-mode sharing.

`wire.ts` is unchanged, so the mobile copy did not need a sync.

## What the fixtures found

Running the server's real values through the desktop parsers turned up three gaps, all older than this branch:

- `parseSequencedCodeEvent` accepted only `seq`, `event`, and `replayed`, so a frame carrying `transient`, `replacement`, or `truncated` was dropped as malformed at the socket, and the reducer's handling of live deltas and capped replays never saw them from that path. Fixed here: the parser keeps all four flags, and a test pins that they survive.
- `parseCodeUpdateNotice` had no `delivery` arm, so the notice the store already handles never arrived through the socket. Fixed here.
- A session that binds no workspace serializes `workspace_id: null` on its snapshot and `workspace: null` on its digest and digest notice, and the parsers still require an id there. That needs the app-level types and their consumers widened, so it is filed as #3027; the desktop test lists those four fixtures by name as known gaps and compares the rejected set exactly, so the list has to shrink when the parsers catch up.

## Verification

- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --lib wire`: 35 passed; `wire.ts` unchanged.
- `cargo test -p tidebreak-cli api::code`: 9 passed, including the fixture decode and the submit-response arm test.
- `cargo clippy -p tidebreak-server -p tidebreak-cli --all-targets --no-deps -- -D warnings`: clean. `cargo fmt --all --check`: clean.
- Desktop UI: biome, lint, `tsc --noEmit`, `pnpm test`, `pnpm build` (results in the PR's checks).

Closes #3022
