### PR TITLE
fix(desktop): parse sessions and digests that bind no workspace

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -388,6 +388,33 @@ describe("parseCodeSession attention states", () => {
   });
 });
 
+describe("parseCodeSession without a workspace", () => {
+  // The in-process engine's session binds no workspace (decision 0048
+  // step 5), so the server sends `workspace_id: null`; the key is present.
+  it("keeps the null workspace instead of dropping the session", () => {
+    const parsed = parseCodeSession({ ...SESSION, workspace_id: null });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.workspace_id).toBeNull();
+  });
+
+  it("accepts the in-process engine's harness kind", () => {
+    // The server fixture names `internal`, and the parser's own vocabulary
+    // had not caught up, so the session dropped for that reason too.
+    const parsed = parseCodeSession({
+      ...SESSION,
+      workspace_id: null,
+      harness_kind: "internal",
+    });
+    expect(parsed?.harness_kind).toBe("internal");
+  });
+
+  it("still requires the key and a real id when one is given", () => {
+    const { workspace_id: _omitted, ...missing } = SESSION;
+    expect(parseCodeSession(missing)).toBeNull();
+    expect(parseCodeSession({ ...SESSION, workspace_id: "" })).toBeNull();
+  });
+});
+
 describe("parseCodeSession external origin", () => {
   it("carries a well-formed origin through", () => {
     const parsed = parseCodeSession({
@@ -868,6 +895,27 @@ describe("pull request state in live updates", () => {
     expect(
       parseCodeUpdateNotice({ type: "snapshot", sessions: [digest] }),
     ).toEqual({ type: "snapshot", sessions: [digest] });
+  });
+
+  it("keeps a digest whose session binds no workspace", () => {
+    const orphan = { ...digest, workspace: null };
+    expect(parseCodeSessionDigest(orphan)).toEqual(orphan);
+    expect(parseCodeUpdateNotice({ type: "digest", ...orphan })).toEqual({
+      type: "digest",
+      ...orphan,
+    });
+    expect(
+      parseCodeUpdateNotice({ type: "snapshot", sessions: [orphan] }),
+    ).toEqual({ type: "snapshot", sessions: [orphan] });
+  });
+
+  it("still rejects a digest with the workspace key missing or empty", () => {
+    const { workspace: _omitted, ...missing } = digest;
+    expect(parseCodeSessionDigest(missing)).toBeNull();
+    expect(parseCodeUpdateNotice({ type: "digest", ...missing })).toBeNull();
+    expect(
+      parseCodeUpdateNotice({ type: "digest", ...digest, workspace: "" }),
+    ).toBeNull();
   });
 
   it("rejects malformed rich PR fields instead of silently dropping them", () => {
@@ -1808,17 +1856,10 @@ const CODE_FRAME_PARSERS: Record<string, (value: unknown) => unknown> = {
 };
 
 /**
- * Real server values the desktop still rejects. brightwave-inc/tidebreak#3027:
- * a session that binds no workspace (decision 0048 step 5) serializes
- * `workspace_id: null` on its snapshot and `workspace: null` on its digest
- * and digest notice, and the parsers still require an id there.
+ * Real server values the desktop still rejects, by fixture name. Empty
+ * today; an entry here is a bug with an issue number, not a skip.
  */
-const KNOWN_GAPS = new Set([
-  "fenced session",
-  "internal session digest",
-  "updates: snapshot",
-  "updates: internal session digest",
-]);
+const KNOWN_GAPS = new Set<string>([]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -270,6 +270,13 @@ const wireId = (value: unknown): value is string =>
   nonEmptyBounded(value, MAX_WIRE_ID_CHARS);
 const optionalWireId = (value: unknown): value is string | undefined =>
   value === undefined || nonEmptyBounded(value, MAX_WIRE_ID_CHARS);
+/**
+ * An id or `null`. A session that binds no workspace (the in-process
+ * engine's, decision 0048 step 5) serializes `workspace_id: null` on its
+ * snapshot and `workspace: null` on its digest; the key is always present.
+ */
+const nullableWireId = (value: unknown): value is string | null =>
+  value === null || nonEmptyBounded(value, MAX_WIRE_ID_CHARS);
 
 const timestamp = (value: unknown): value is string =>
   nonEmptyBounded(value, MAX_WIRE_TIMESTAMP_CHARS);
@@ -281,11 +288,15 @@ const nullableTimestamp = (value: unknown): value is string | null =>
 const optionalCursor = (value: unknown): value is string | undefined =>
   value === undefined || nonEmptyBounded(value, MAX_WIRE_CURSOR_CHARS);
 
+// Every kind the server can name on a session, not just the ones the create
+// picker offers: the in-process engine reports `internal` (decision 0048
+// step 5), and a session it runs must parse like any other.
 const HARNESS_KINDS = new Set<HarnessKind>([
   "claude_code",
   "codex",
   "opencode",
   "grok",
+  "internal",
 ]);
 const HARNESS_TIERS = new Set<HarnessTier>([
   "reference",
@@ -2595,7 +2606,7 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
       "external_origin",
     ]) ||
     !wireId(value.id) ||
-    !wireId(value.workspace_id) ||
+    !nullableWireId(value.workspace_id) ||
     !isMember(value.kind, SESSION_KINDS) ||
     !isMember(value.harness_kind, HARNESS_KINDS) ||
     !optionalLine(value.harness_version) ||
@@ -3960,7 +3971,7 @@ export function parseCodeSessionDigest(
       "subagents",
       "recap",
     ]) ||
-    !wireId(value.workspace) ||
+    !nullableWireId(value.workspace) ||
     !wireId(value.session) ||
     !isMember(value.kind, SESSION_KINDS) ||
     (value.harness_kind !== undefined &&
@@ -4062,7 +4073,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
           "subagents",
           "recap",
         ]) ||
-        !wireId(value.workspace) ||
+        !nullableWireId(value.workspace) ||
         !wireId(value.session) ||
         !isMember(value.kind, SESSION_KINDS) ||
         (value.harness_kind !== undefined &&


### PR DESCRIPTION
Closes #3027.

## What changed

Since decision 0048 step 5 (PR #3010) the server serializes `workspace_id: null` on the in-process engine's `CodeSessionSnapshot` and `workspace: null` on its `CodeSessionDigest` and on the `digest` notice on `/code/updates`, and names that engine's harness kind `internal`. The code-mode parsers in `crates/tidebreak-desktop/ui/src/code/parsers.ts` still required an id on those fields and did not list `internal`, so every one of those sessions dropped out of the session list, the updates rail, and the notification path.

- `parseCodeSession`, `parseCodeSessionDigest`, and the `digest` arm of `parseCodeUpdateNotice` read the workspace through a new `nullableWireId` reader beside `wireId`: `null` passes, a missing key or an empty string still fails.
- `HARNESS_KINDS` in the parser gains `internal`. The pick lists in `CodeUiStore` and `CodeCatalogStore` stay as they are; they decide what the create composer offers, not what the wire may carry. `HARNESS_LABELS` already named it.
- The app-level `CodeSessionSnapshot` and `CodeSessionDigest` types alias the generated wire types, which already declare `string | null`, and every consumer of `session.workspace_id` and `digest.workspace` (`CodeCatalogStore`, `CodeUpdatesStore`) already branches on `null`, so no consumer changed.
- `parsers.test.ts`: the four fixtures the server fixture test listed as known gaps (`fenced session`, `internal session digest`, `updates: snapshot`, `updates: internal session digest`) are removed from the list, so the set is empty and the real values must parse. New tests pin a null workspace on all three parsers, a missing or empty workspace still rejecting, and the `internal` harness kind.

Rail rows and notifications for these sessions stay with #3015.

## Verification

In `crates/tidebreak-desktop/ui`: `biome check src` and `pnpm lint` clean, `tsc --noEmit` clean, `pnpm test` 269 files / 2371 tests passed, `pnpm build` passed. `vitest run src/code/parsers.test.ts` fails on main at "accepts every value the server serializes" with the four fixtures rejected, and passes with this change.
