### PR TITLE
feat(memory): add the record store, backend trait, and manager page

### DIFF
--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -2224,3 +2224,108 @@ pub mod code_workflow_run_fetch {
 
     impl ActiveModelBehavior for ActiveModel {}
 }
+
+pub mod memory_record {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "memory_record")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub owner: String,
+        pub scope_kind: String,
+        pub repo_id: Option<Uuid>,
+        pub kind: String,
+        pub status: String,
+        pub title: String,
+        #[sea_orm(column_type = "Text")]
+        pub body: String,
+        #[sea_orm(column_type = "JsonBinary")]
+        pub provenance: Json,
+        #[sea_orm(column_type = "JsonBinary")]
+        pub links: Json,
+        pub expires_at: Option<DateTimeUtc>,
+        pub superseded_by: Option<Uuid>,
+        pub observation_count: i64,
+        pub revision: i64,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(has_many = "super::memory_revision::Entity")]
+        Revision,
+    }
+
+    impl Related<super::memory_revision::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Revision.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod memory_scope_state {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "memory_scope_state")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub owner: String,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub scope_kind: String,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub scope_ref: String,
+        pub auto_commit: bool,
+        pub active_record_cap: i64,
+        pub digest_byte_cap: i64,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod memory_revision {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "memory_revision")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub record_id: Uuid,
+        pub owner: String,
+        pub ordinal: i64,
+        #[sea_orm(column_type = "JsonBinary")]
+        pub snapshot: Json,
+        pub created_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "super::memory_record::Entity",
+            from = "Column::RecordId",
+            to = "super::memory_record::Column::Id",
+            on_update = "NoAction",
+            on_delete = "Cascade"
+        )]
+        Record,
+    }
+
+    impl Related<super::memory_record::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Record.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -4049,7 +4049,7 @@ struct MemoryRecords;
 
 impl MigrationName for MemoryRecords {
     fn name(&self) -> &str {
-        "m20260901_000029_memory_records"
+        "m20260902_000004_memory_records"
     }
 }
 
@@ -4380,6 +4380,7 @@ mod tests {
                 "m20260902_000001_conversations_are_sessions",
                 "m20260902_000002_one_journal",
                 "m20260902_000003_one_approval_surface",
+                "m20260902_000004_memory_records",
             ]
         );
         assert!(db

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -73,6 +73,7 @@ impl MigratorTrait for Migrator {
             Box::new(ConversationsAreSessions),
             Box::new(one_journal::OneJournal),
             Box::new(one_approval_surface::OneApprovalSurface),
+            Box::new(MemoryRecords),
         ]
     }
 }
@@ -4041,6 +4042,260 @@ async fn rebuild_sqlite_table(
     Err(DbErr::Custom(format!(
         "SQLite {table} rebuild support is not compiled"
     )))
+}
+
+/// Durable, owner-scoped memory records and immutable revision snapshots.
+struct MemoryRecords;
+
+impl MigrationName for MemoryRecords {
+    fn name(&self) -> &str {
+        "m20260901_000029_memory_records"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for MemoryRecords {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(idens::MemoryScopeState::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(idens::MemoryScopeState::Owner)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryScopeState::ScopeKind)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryScopeState::ScopeRef)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryScopeState::AutoCommit)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryScopeState::ActiveRecordCap)
+                            .big_integer()
+                            .not_null()
+                            .default(crate::DEFAULT_MEMORY_ACTIVE_RECORD_CAP as i64),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryScopeState::DigestByteCap)
+                            .big_integer()
+                            .not_null()
+                            .default(crate::DEFAULT_MEMORY_DIGEST_BYTES as i64),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryScopeState::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryScopeState::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(idens::MemoryScopeState::Owner)
+                            .col(idens::MemoryScopeState::ScopeKind)
+                            .col(idens::MemoryScopeState::ScopeRef),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_table(
+                Table::create()
+                    .table(idens::MemoryRecord::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(idens::MemoryRecord::Owner).text().not_null())
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::ScopeKind)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(idens::MemoryRecord::RepoId).uuid())
+                    .col(ColumnDef::new(idens::MemoryRecord::Kind).text().not_null())
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::Status)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(idens::MemoryRecord::Title).text().not_null())
+                    .col(ColumnDef::new(idens::MemoryRecord::Body).text().not_null())
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::Provenance)
+                            .json_binary()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::Links)
+                            .json_binary()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(idens::MemoryRecord::ExpiresAt).timestamp_with_time_zone())
+                    .col(ColumnDef::new(idens::MemoryRecord::SupersededBy).uuid())
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::ObservationCount)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::Revision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRecord::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_memory_record_repo")
+                            .from(idens::MemoryRecord::Table, idens::MemoryRecord::RepoId)
+                            .to(idens::CodeRepo::Table, idens::CodeRepo::Id)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_memory_record_superseded_by")
+                            .from(
+                                idens::MemoryRecord::Table,
+                                idens::MemoryRecord::SupersededBy,
+                            )
+                            .to(idens::MemoryRecord::Table, idens::MemoryRecord::Id)
+                            .on_delete(ForeignKeyAction::SetNull),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("ix_memory_record_owner_scope_status")
+                    .table(idens::MemoryRecord::Table)
+                    .col(idens::MemoryRecord::Owner)
+                    .col(idens::MemoryRecord::ScopeKind)
+                    .col(idens::MemoryRecord::RepoId)
+                    .col(idens::MemoryRecord::Status)
+                    .col(idens::MemoryRecord::UpdatedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("ix_memory_record_owner_status")
+                    .table(idens::MemoryRecord::Table)
+                    .col(idens::MemoryRecord::Owner)
+                    .col(idens::MemoryRecord::Status)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(idens::MemoryRevision::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(idens::MemoryRevision::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRevision::RecordId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRevision::Owner)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRevision::Ordinal)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRevision::Snapshot)
+                            .json_binary()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(idens::MemoryRevision::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_memory_revision_record")
+                            .from(
+                                idens::MemoryRevision::Table,
+                                idens::MemoryRevision::RecordId,
+                            )
+                            .to(idens::MemoryRecord::Table, idens::MemoryRecord::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("ix_memory_revision_record_ordinal")
+                    .table(idens::MemoryRevision::Table)
+                    .col(idens::MemoryRevision::RecordId)
+                    .col(idens::MemoryRevision::Ordinal)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("ix_memory_revision_owner_record")
+                    .table(idens::MemoryRevision::Table)
+                    .col(idens::MemoryRevision::Owner)
+                    .col(idens::MemoryRevision::RecordId)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Memory records are user data. A rollback must not delete them.
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -1209,3 +1209,48 @@ pub(crate) enum CodeConnectHandshake {
     ApprovedAt,
     CompletedAt,
 }
+
+#[derive(DeriveIden)]
+pub(crate) enum MemoryScopeState {
+    Table,
+    Owner,
+    ScopeKind,
+    ScopeRef,
+    AutoCommit,
+    ActiveRecordCap,
+    DigestByteCap,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub(crate) enum MemoryRecord {
+    Table,
+    Id,
+    Owner,
+    ScopeKind,
+    RepoId,
+    Kind,
+    Status,
+    Title,
+    Body,
+    Provenance,
+    Links,
+    ExpiresAt,
+    SupersededBy,
+    ObservationCount,
+    Revision,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub(crate) enum MemoryRevision {
+    Table,
+    Id,
+    RecordId,
+    Owner,
+    Ordinal,
+    Snapshot,
+    CreatedAt,
+}

--- a/crates/tidebreak-core/src/db/ops/memory.rs
+++ b/crates/tidebreak-core/src/db/ops/memory.rs
@@ -1,0 +1,891 @@
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::sea_query::{Expr, OnConflict};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DatabaseTransaction, EntityTrait,
+    QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+
+use crate::memory::{
+    MemoryBackend, MemoryCapLevel, MemoryCapability, MemoryCaps, MemoryDigest, MemoryError,
+    MemoryEvidence, MemoryIngestReceipt, MemoryIngestRequest, MemoryKind, MemoryLinkRelation,
+    MemoryListFilter, MemoryRecord, MemoryRecordId, MemoryRecordUpdate, MemoryResult,
+    MemoryRevision, MemoryRevisionId, MemoryScope, MemorySearchHit, MemorySearchRequest,
+    MemoryStatus, MemoryStatusChange, MemoryWriteReceipt, MemoryWriteState,
+    MAX_MEMORY_SEARCH_RESULTS,
+};
+use crate::{OwnerId, RepoId};
+
+use super::super::{entities, DbStore};
+
+#[derive(Debug, Clone, Copy)]
+struct ScopeState {
+    active_record_cap: usize,
+    digest_byte_cap: usize,
+}
+
+fn backend_err(error: impl std::fmt::Display) -> MemoryError {
+    MemoryError::Backend(error.to_string())
+}
+
+fn scope_ref(scope: MemoryScope) -> String {
+    scope
+        .repo_id()
+        .map_or_else(String::new, |repo_id| repo_id.to_string())
+}
+
+fn scope_condition(scope: MemoryScope) -> Condition {
+    let condition =
+        Condition::all().add(entities::memory_record::Column::ScopeKind.eq(scope.kind_str()));
+    match scope {
+        MemoryScope::Personal => condition.add(entities::memory_record::Column::RepoId.is_null()),
+        MemoryScope::Repo { repo_id } => {
+            condition.add(entities::memory_record::Column::RepoId.eq(repo_id.0))
+        }
+    }
+}
+
+async fn lock_scope(
+    transaction: &DatabaseTransaction,
+    owner: &OwnerId,
+    scope: MemoryScope,
+) -> MemoryResult<ScopeState> {
+    if let MemoryScope::Repo { repo_id } = scope {
+        let exists = entities::code_repo::Entity::find_by_id(repo_id.0)
+            .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
+            .one(transaction)
+            .await
+            .map_err(backend_err)?
+            .is_some();
+        if !exists {
+            return Err(MemoryError::ScopeNotFound);
+        }
+    }
+
+    let now = Utc::now();
+    let scope_ref = scope_ref(scope);
+    entities::memory_scope_state::Entity::insert(entities::memory_scope_state::ActiveModel {
+        owner: Set(owner.as_str().to_owned()),
+        scope_kind: Set(scope.kind_str().to_owned()),
+        scope_ref: Set(scope_ref.clone()),
+        auto_commit: Set(false),
+        active_record_cap: Set(crate::DEFAULT_MEMORY_ACTIVE_RECORD_CAP as i64),
+        digest_byte_cap: Set(crate::DEFAULT_MEMORY_DIGEST_BYTES as i64),
+        created_at: Set(now),
+        updated_at: Set(now),
+    })
+    .on_conflict(
+        OnConflict::columns([
+            entities::memory_scope_state::Column::Owner,
+            entities::memory_scope_state::Column::ScopeKind,
+            entities::memory_scope_state::Column::ScopeRef,
+        ])
+        .do_nothing()
+        .to_owned(),
+    )
+    .exec_without_returning(transaction)
+    .await
+    .map_err(backend_err)?;
+
+    let locked = entities::memory_scope_state::Entity::update_many()
+        .col_expr(
+            entities::memory_scope_state::Column::UpdatedAt,
+            Expr::col(entities::memory_scope_state::Column::UpdatedAt),
+        )
+        .filter(entities::memory_scope_state::Column::Owner.eq(owner.as_str()))
+        .filter(entities::memory_scope_state::Column::ScopeKind.eq(scope.kind_str()))
+        .filter(entities::memory_scope_state::Column::ScopeRef.eq(&scope_ref))
+        .exec(transaction)
+        .await
+        .map_err(backend_err)?;
+    if locked.rows_affected != 1 {
+        return Err(MemoryError::Backend(
+            "memory scope lock row did not persist".to_owned(),
+        ));
+    }
+
+    let state = entities::memory_scope_state::Entity::find()
+        .filter(entities::memory_scope_state::Column::Owner.eq(owner.as_str()))
+        .filter(entities::memory_scope_state::Column::ScopeKind.eq(scope.kind_str()))
+        .filter(entities::memory_scope_state::Column::ScopeRef.eq(scope_ref))
+        .one(transaction)
+        .await
+        .map_err(backend_err)?
+        .ok_or_else(|| MemoryError::Backend("memory scope lock row disappeared".to_owned()))?;
+    Ok(ScopeState {
+        active_record_cap: usize::try_from(state.active_record_cap)
+            .map_err(|_| MemoryError::Backend("memory active-record cap is invalid".to_owned()))?,
+        digest_byte_cap: usize::try_from(state.digest_byte_cap)
+            .map_err(|_| MemoryError::Backend("memory digest cap is invalid".to_owned()))?,
+    })
+}
+
+async fn read_scope_state<C>(
+    conn: &C,
+    owner: &OwnerId,
+    scope: MemoryScope,
+) -> MemoryResult<ScopeState>
+where
+    C: ConnectionTrait,
+{
+    if let Some(state) = entities::memory_scope_state::Entity::find()
+        .filter(entities::memory_scope_state::Column::Owner.eq(owner.as_str()))
+        .filter(entities::memory_scope_state::Column::ScopeKind.eq(scope.kind_str()))
+        .filter(entities::memory_scope_state::Column::ScopeRef.eq(scope_ref(scope)))
+        .one(conn)
+        .await
+        .map_err(backend_err)?
+    {
+        return Ok(ScopeState {
+            active_record_cap: usize::try_from(state.active_record_cap).map_err(|_| {
+                MemoryError::Backend("memory active-record cap is invalid".to_owned())
+            })?,
+            digest_byte_cap: usize::try_from(state.digest_byte_cap)
+                .map_err(|_| MemoryError::Backend("memory digest cap is invalid".to_owned()))?,
+        });
+    }
+    if let MemoryScope::Repo { repo_id } = scope {
+        let exists = entities::code_repo::Entity::find_by_id(repo_id.0)
+            .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
+            .one(conn)
+            .await
+            .map_err(backend_err)?
+            .is_some();
+        if !exists {
+            return Err(MemoryError::ScopeNotFound);
+        }
+    }
+    Ok(ScopeState {
+        active_record_cap: crate::DEFAULT_MEMORY_ACTIVE_RECORD_CAP,
+        digest_byte_cap: crate::DEFAULT_MEMORY_DIGEST_BYTES,
+    })
+}
+
+fn parse_scope(kind: &str, repo_id: Option<uuid::Uuid>) -> MemoryResult<MemoryScope> {
+    match (kind, repo_id) {
+        ("personal", None) => Ok(MemoryScope::Personal),
+        ("repo", Some(repo_id)) => Ok(MemoryScope::Repo {
+            repo_id: RepoId(repo_id),
+        }),
+        _ => Err(MemoryError::Backend(format!(
+            "invalid memory scope {kind:?} with repo {repo_id:?}"
+        ))),
+    }
+}
+
+fn parse_kind(kind: &str) -> MemoryResult<MemoryKind> {
+    match kind {
+        "fact" => Ok(MemoryKind::Fact),
+        "preference" => Ok(MemoryKind::Preference),
+        "lesson" => Ok(MemoryKind::Lesson),
+        "reference" => Ok(MemoryKind::Reference),
+        other => Err(MemoryError::Backend(format!(
+            "invalid memory kind {other:?}"
+        ))),
+    }
+}
+
+fn parse_status(status: &str) -> MemoryResult<MemoryStatus> {
+    match status {
+        "tracking" => Ok(MemoryStatus::Tracking),
+        "proposed" => Ok(MemoryStatus::Proposed),
+        "active" => Ok(MemoryStatus::Active),
+        "archived" => Ok(MemoryStatus::Archived),
+        "rejected" => Ok(MemoryStatus::Rejected),
+        other => Err(MemoryError::Backend(format!(
+            "invalid memory status {other:?}"
+        ))),
+    }
+}
+
+fn record_from_model(model: entities::memory_record::Model) -> MemoryResult<MemoryRecord> {
+    let observation_count = u32::try_from(model.observation_count)
+        .map_err(|_| MemoryError::Backend("memory observation count is invalid".to_owned()))?;
+    let record = MemoryRecord {
+        id: MemoryRecordId(model.id),
+        scope: parse_scope(&model.scope_kind, model.repo_id)?,
+        kind: parse_kind(&model.kind)?,
+        status: parse_status(&model.status)?,
+        title: model.title,
+        body: model.body,
+        provenance: serde_json::from_value(model.provenance).map_err(backend_err)?,
+        links: serde_json::from_value(model.links).map_err(backend_err)?,
+        expires_at: model.expires_at,
+        superseded_by: model.superseded_by.map(MemoryRecordId),
+        observation_count,
+        revision: model.revision,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    };
+    record
+        .validate()
+        .map_err(|error| MemoryError::Backend(error.to_string()))?;
+    Ok(record)
+}
+
+fn active_model(
+    owner: &OwnerId,
+    record: &MemoryRecord,
+) -> MemoryResult<entities::memory_record::ActiveModel> {
+    Ok(entities::memory_record::ActiveModel {
+        id: Set(record.id.0),
+        owner: Set(owner.as_str().to_owned()),
+        scope_kind: Set(record.scope.kind_str().to_owned()),
+        repo_id: Set(record.scope.repo_id().map(|repo_id| repo_id.0)),
+        kind: Set(record.kind.as_str().to_owned()),
+        status: Set(record.status.as_str().to_owned()),
+        title: Set(record.title.clone()),
+        body: Set(record.body.clone()),
+        provenance: Set(serde_json::to_value(&record.provenance).map_err(backend_err)?),
+        links: Set(serde_json::to_value(&record.links).map_err(backend_err)?),
+        expires_at: Set(record.expires_at),
+        superseded_by: Set(record.superseded_by.map(|id| id.0)),
+        observation_count: Set(i64::from(record.observation_count)),
+        revision: Set(record.revision),
+        created_at: Set(record.created_at),
+        updated_at: Set(record.updated_at),
+    })
+}
+
+async fn update_record_on(
+    transaction: &DatabaseTransaction,
+    owner: &OwnerId,
+    record: &MemoryRecord,
+    expected_revision: i64,
+) -> MemoryResult<()> {
+    let updated = entities::memory_record::Entity::update_many()
+        .set(entities::memory_record::ActiveModel {
+            kind: Set(record.kind.as_str().to_owned()),
+            status: Set(record.status.as_str().to_owned()),
+            title: Set(record.title.clone()),
+            body: Set(record.body.clone()),
+            provenance: Set(serde_json::to_value(&record.provenance).map_err(backend_err)?),
+            links: Set(serde_json::to_value(&record.links).map_err(backend_err)?),
+            expires_at: Set(record.expires_at),
+            superseded_by: Set(record.superseded_by.map(|id| id.0)),
+            observation_count: Set(i64::from(record.observation_count)),
+            revision: Set(record.revision),
+            updated_at: Set(record.updated_at),
+            ..Default::default()
+        })
+        .filter(entities::memory_record::Column::Id.eq(record.id.0))
+        .filter(entities::memory_record::Column::Owner.eq(owner.as_str()))
+        .filter(entities::memory_record::Column::Revision.eq(expected_revision))
+        .exec(transaction)
+        .await
+        .map_err(backend_err)?;
+    if updated.rows_affected == 1 {
+        Ok(())
+    } else {
+        let current = entities::memory_record::Entity::find_by_id(record.id.0)
+            .filter(entities::memory_record::Column::Owner.eq(owner.as_str()))
+            .one(transaction)
+            .await
+            .map_err(backend_err)?;
+        match current {
+            Some(current) => Err(MemoryError::RevisionConflict {
+                current_revision: current.revision,
+            }),
+            None => Err(MemoryError::NotFound),
+        }
+    }
+}
+
+async fn append_revision(
+    transaction: &DatabaseTransaction,
+    owner: &OwnerId,
+    record: &MemoryRecord,
+) -> MemoryResult<()> {
+    entities::memory_revision::ActiveModel {
+        id: Set(MemoryRevisionId::new().0),
+        record_id: Set(record.id.0),
+        owner: Set(owner.as_str().to_owned()),
+        ordinal: Set(record.revision),
+        snapshot: Set(serde_json::to_value(record).map_err(backend_err)?),
+        created_at: Set(record.updated_at),
+    }
+    .insert(transaction)
+    .await
+    .map_err(backend_err)?;
+    Ok(())
+}
+
+async fn find_record_on<C>(
+    conn: &C,
+    owner: &OwnerId,
+    id: MemoryRecordId,
+) -> MemoryResult<Option<MemoryRecord>>
+where
+    C: ConnectionTrait,
+{
+    entities::memory_record::Entity::find_by_id(id.0)
+        .filter(entities::memory_record::Column::Owner.eq(owner.as_str()))
+        .one(conn)
+        .await
+        .map_err(backend_err)?
+        .map(record_from_model)
+        .transpose()
+}
+
+async fn validate_evidence<C>(conn: &C, owner: &OwnerId, record: &MemoryRecord) -> MemoryResult<()>
+where
+    C: ConnectionTrait,
+{
+    for evidence in &record.provenance.evidence {
+        let resolves = match evidence {
+            MemoryEvidence::Message { message_id } => {
+                let Some(message) = entities::message::Entity::find_by_id(message_id.0)
+                    .one(conn)
+                    .await
+                    .map_err(backend_err)?
+                else {
+                    return Err(MemoryError::EvidenceNotFound(format!(
+                        "message {message_id}"
+                    )));
+                };
+                // A chat is a session (decision 48): the message's chat id
+                // names a `code_session` row, whose owner column gates it.
+                entities::code_session::Entity::find_by_id(message.chat_id)
+                    .filter(entities::code_session::Column::Owner.eq(owner.as_str()))
+                    .one(conn)
+                    .await
+                    .map_err(backend_err)?
+                    .is_some()
+            }
+            MemoryEvidence::CodeEvent { session_id, seq } => {
+                entities::code_event::Entity::find_by_id((session_id.0, *seq))
+                    .filter(entities::code_event::Column::Owner.eq(owner.as_str()))
+                    .one(conn)
+                    .await
+                    .map_err(backend_err)?
+                    .is_some()
+            }
+        };
+        if !resolves {
+            return Err(MemoryError::EvidenceNotFound(match evidence {
+                MemoryEvidence::Message { message_id } => format!("message {message_id}"),
+                MemoryEvidence::CodeEvent { session_id, seq } => {
+                    format!("code event {session_id}:{seq}")
+                }
+            }));
+        }
+    }
+    Ok(())
+}
+
+async fn validate_links<C>(conn: &C, owner: &OwnerId, record: &MemoryRecord) -> MemoryResult<()>
+where
+    C: ConnectionTrait,
+{
+    for link in &record.links {
+        let Some(target) = find_record_on(conn, owner, link.record_id).await? else {
+            return Err(MemoryError::InvalidRecord(format!(
+                "linked memory record {} does not exist",
+                link.record_id
+            )));
+        };
+        if matches!(
+            link.relation,
+            MemoryLinkRelation::Updates | MemoryLinkRelation::Supersedes
+        ) && target.scope != record.scope
+        {
+            return Err(MemoryError::InvalidRecord(
+                "an update or superseding link must stay in one memory scope".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn validate_references<C>(
+    conn: &C,
+    owner: &OwnerId,
+    record: &MemoryRecord,
+) -> MemoryResult<()>
+where
+    C: ConnectionTrait,
+{
+    record.validate()?;
+    validate_evidence(conn, owner, record).await?;
+    validate_links(conn, owner, record).await
+}
+
+async fn active_records_on<C>(
+    conn: &C,
+    owner: &OwnerId,
+    scope: MemoryScope,
+) -> MemoryResult<Vec<MemoryRecord>>
+where
+    C: ConnectionTrait,
+{
+    entities::memory_record::Entity::find()
+        .filter(entities::memory_record::Column::Owner.eq(owner.as_str()))
+        .filter(scope_condition(scope))
+        .filter(entities::memory_record::Column::Status.eq(MemoryStatus::Active.as_str()))
+        .order_by_desc(entities::memory_record::Column::UpdatedAt)
+        .order_by_asc(entities::memory_record::Column::Id)
+        .all(conn)
+        .await
+        .map_err(backend_err)?
+        .into_iter()
+        .map(record_from_model)
+        .collect()
+}
+
+fn render_digest(
+    scope: MemoryScope,
+    mut records: Vec<MemoryRecord>,
+    byte_cap: usize,
+) -> MemoryResult<MemoryDigest> {
+    records.sort_by(|left, right| {
+        kind_order(left.kind)
+            .cmp(&kind_order(right.kind))
+            .then_with(|| right.updated_at.cmp(&left.updated_at))
+            .then_with(|| left.id.0.cmp(&right.id.0))
+    });
+
+    let mut markdown = String::new();
+    if !records.is_empty() {
+        markdown.push_str("## Tidebreak memory\n\n");
+        markdown.push_str(
+            "These are dated point-in-time claims from Tidebreak. Treat this conversation as newer evidence.\n",
+        );
+        let mut previous_kind = None;
+        for record in &records {
+            if previous_kind != Some(record.kind) {
+                markdown.push_str("\n### ");
+                markdown.push_str(record.kind.heading());
+                markdown.push('\n');
+                previous_kind = Some(record.kind);
+            }
+            markdown.push_str("- ");
+            markdown.push_str(&record.updated_at.format("%Y-%m-%d").to_string());
+            markdown.push_str(" — ");
+            markdown.push_str(&record.title);
+            markdown.push('\n');
+        }
+    }
+    if markdown.len() > byte_cap {
+        return Err(MemoryError::DigestCapExceeded { cap: byte_cap });
+    }
+    Ok(MemoryDigest {
+        scope,
+        byte_len: markdown.len(),
+        byte_cap,
+        record_count: records.len(),
+        markdown,
+    })
+}
+
+const fn kind_order(kind: MemoryKind) -> u8 {
+    match kind {
+        MemoryKind::Fact => 0,
+        MemoryKind::Preference => 1,
+        MemoryKind::Lesson => 2,
+        MemoryKind::Reference => 3,
+    }
+}
+
+async fn validate_scope_caps(
+    transaction: &DatabaseTransaction,
+    owner: &OwnerId,
+    scope: MemoryScope,
+    state: ScopeState,
+) -> MemoryResult<()> {
+    let records = active_records_on(transaction, owner, scope).await?;
+    if records.len() > state.active_record_cap {
+        return Err(MemoryError::ActiveRecordCapExceeded {
+            cap: state.active_record_cap,
+        });
+    }
+    render_digest(scope, records, state.digest_byte_cap)?;
+    Ok(())
+}
+
+fn write_receipt(record: MemoryRecord) -> MemoryWriteReceipt {
+    MemoryWriteReceipt {
+        state: MemoryWriteState::Committed,
+        record,
+    }
+}
+
+#[async_trait]
+impl MemoryBackend for DbStore {
+    fn caps(&self) -> MemoryCaps {
+        MemoryCaps {
+            extraction: MemoryCapLevel::Unsupported,
+            lexical_search: MemoryCapLevel::Supported,
+            semantic_search: MemoryCapLevel::Unsupported,
+            consolidation: MemoryCapLevel::Unsupported,
+            context_assembly: MemoryCapLevel::Supported,
+            revision_history: MemoryCapLevel::Supported,
+            verified_delete: MemoryCapLevel::Supported,
+            asynchronous_writes: MemoryCapLevel::Unsupported,
+            agent_editable_surfaces: MemoryCapLevel::Supported,
+        }
+    }
+
+    async fn put(&self, owner: &OwnerId, record: MemoryRecord) -> MemoryResult<MemoryWriteReceipt> {
+        record.validate()?;
+        if record.revision != 1 {
+            return Err(MemoryError::InvalidRecord(
+                "a new memory record must start at revision 1".to_owned(),
+            ));
+        }
+        let transaction = self.conn.begin().await.map_err(backend_err)?;
+        let state = lock_scope(&transaction, owner, record.scope).await?;
+        if entities::memory_record::Entity::find_by_id(record.id.0)
+            .one(&transaction)
+            .await
+            .map_err(backend_err)?
+            .is_some()
+        {
+            return Err(MemoryError::AlreadyExists);
+        }
+        validate_references(&transaction, owner, &record).await?;
+        active_model(owner, &record)?
+            .insert(&transaction)
+            .await
+            .map_err(backend_err)?;
+        append_revision(&transaction, owner, &record).await?;
+        if record.status.is_authoritative() {
+            validate_scope_caps(&transaction, owner, record.scope, state).await?;
+        }
+        transaction.commit().await.map_err(backend_err)?;
+        Ok(write_receipt(record))
+    }
+
+    async fn ingest(
+        &self,
+        _owner: &OwnerId,
+        _request: MemoryIngestRequest,
+    ) -> MemoryResult<MemoryIngestReceipt> {
+        Err(MemoryError::Unsupported(MemoryCapability::Extraction))
+    }
+
+    async fn get(&self, owner: &OwnerId, id: MemoryRecordId) -> MemoryResult<Option<MemoryRecord>> {
+        find_record_on(&self.conn, owner, id).await
+    }
+
+    async fn list(
+        &self,
+        owner: &OwnerId,
+        filter: MemoryListFilter,
+    ) -> MemoryResult<Vec<MemoryRecord>> {
+        let mut query = entities::memory_record::Entity::find()
+            .filter(entities::memory_record::Column::Owner.eq(owner.as_str()));
+        if let Some(scope) = filter.scope {
+            query = query.filter(scope_condition(scope));
+        }
+        if !filter.statuses.is_empty() {
+            query = query.filter(
+                entities::memory_record::Column::Status
+                    .is_in(filter.statuses.into_iter().map(MemoryStatus::as_str)),
+            );
+        }
+        if !filter.kinds.is_empty() {
+            query = query.filter(
+                entities::memory_record::Column::Kind
+                    .is_in(filter.kinds.into_iter().map(MemoryKind::as_str)),
+            );
+        }
+        query
+            .order_by_desc(entities::memory_record::Column::UpdatedAt)
+            .order_by_asc(entities::memory_record::Column::Id)
+            .all(&self.conn)
+            .await
+            .map_err(backend_err)?
+            .into_iter()
+            .map(record_from_model)
+            .collect()
+    }
+
+    async fn update(
+        &self,
+        owner: &OwnerId,
+        update: MemoryRecordUpdate,
+    ) -> MemoryResult<MemoryWriteReceipt> {
+        let transaction = self.conn.begin().await.map_err(backend_err)?;
+        let Some(existing) = find_record_on(&transaction, owner, update.id).await? else {
+            return Err(MemoryError::NotFound);
+        };
+        let state = lock_scope(&transaction, owner, existing.scope).await?;
+        let Some(existing) = find_record_on(&transaction, owner, update.id).await? else {
+            return Err(MemoryError::NotFound);
+        };
+        if existing.revision != update.expected_revision {
+            return Err(MemoryError::RevisionConflict {
+                current_revision: existing.revision,
+            });
+        }
+        let revision = existing.revision.checked_add(1).ok_or_else(|| {
+            MemoryError::Backend("memory revision counter is exhausted".to_owned())
+        })?;
+        let record = MemoryRecord {
+            kind: update.kind,
+            title: update.title,
+            body: update.body,
+            provenance: update.provenance,
+            links: update.links,
+            expires_at: update.expires_at,
+            observation_count: update.observation_count,
+            revision,
+            updated_at: Utc::now(),
+            ..existing
+        };
+        validate_references(&transaction, owner, &record).await?;
+        update_record_on(&transaction, owner, &record, update.expected_revision).await?;
+        append_revision(&transaction, owner, &record).await?;
+        if record.status.is_authoritative() {
+            validate_scope_caps(&transaction, owner, record.scope, state).await?;
+        }
+        transaction.commit().await.map_err(backend_err)?;
+        Ok(write_receipt(record))
+    }
+
+    async fn set_status(
+        &self,
+        owner: &OwnerId,
+        change: MemoryStatusChange,
+    ) -> MemoryResult<MemoryWriteReceipt> {
+        let transaction = self.conn.begin().await.map_err(backend_err)?;
+        let Some(existing) = find_record_on(&transaction, owner, change.id).await? else {
+            return Err(MemoryError::NotFound);
+        };
+        let state = lock_scope(&transaction, owner, existing.scope).await?;
+        let Some(existing) = find_record_on(&transaction, owner, change.id).await? else {
+            return Err(MemoryError::NotFound);
+        };
+        if existing.revision != change.expected_revision {
+            return Err(MemoryError::RevisionConflict {
+                current_revision: existing.revision,
+            });
+        }
+        if existing.status == change.status {
+            transaction.commit().await.map_err(backend_err)?;
+            return Ok(write_receipt(existing));
+        }
+        if !existing.status.can_transition_to(change.status) {
+            return Err(MemoryError::InvalidStatusTransition {
+                from: existing.status,
+                to: change.status,
+            });
+        }
+
+        let now = Utc::now();
+        if change.status == MemoryStatus::Active {
+            let sources = existing
+                .links
+                .iter()
+                .filter(|link| {
+                    matches!(
+                        link.relation,
+                        MemoryLinkRelation::Updates | MemoryLinkRelation::Supersedes
+                    )
+                })
+                .map(|link| link.record_id)
+                .collect::<HashSet<_>>();
+            for source_id in sources {
+                let Some(source) = find_record_on(&transaction, owner, source_id).await? else {
+                    return Err(MemoryError::InvalidRecord(format!(
+                        "source memory record {source_id} does not exist"
+                    )));
+                };
+                if source.scope != existing.scope || source.status != MemoryStatus::Active {
+                    return Err(MemoryError::InvalidRecord(format!(
+                        "source memory record {source_id} is not active in this scope"
+                    )));
+                }
+                let source_revision = source.revision.checked_add(1).ok_or_else(|| {
+                    MemoryError::Backend("memory revision counter is exhausted".to_owned())
+                })?;
+                let archived = MemoryRecord {
+                    status: MemoryStatus::Archived,
+                    superseded_by: Some(existing.id),
+                    revision: source_revision,
+                    updated_at: now,
+                    ..source
+                };
+                update_record_on(&transaction, owner, &archived, source_revision - 1).await?;
+                append_revision(&transaction, owner, &archived).await?;
+            }
+        }
+
+        let revision = existing.revision.checked_add(1).ok_or_else(|| {
+            MemoryError::Backend("memory revision counter is exhausted".to_owned())
+        })?;
+        let record = MemoryRecord {
+            status: change.status,
+            revision,
+            updated_at: now,
+            ..existing
+        };
+        update_record_on(&transaction, owner, &record, change.expected_revision).await?;
+        append_revision(&transaction, owner, &record).await?;
+        if record.status.is_authoritative() {
+            validate_scope_caps(&transaction, owner, record.scope, state).await?;
+        }
+        transaction.commit().await.map_err(backend_err)?;
+        Ok(write_receipt(record))
+    }
+
+    async fn delete(&self, owner: &OwnerId, id: MemoryRecordId) -> MemoryResult<bool> {
+        let transaction = self.conn.begin().await.map_err(backend_err)?;
+        let Some(existing) = find_record_on(&transaction, owner, id).await? else {
+            transaction.commit().await.map_err(backend_err)?;
+            return Ok(false);
+        };
+        lock_scope(&transaction, owner, existing.scope).await?;
+        let deleted = entities::memory_record::Entity::delete_many()
+            .filter(entities::memory_record::Column::Id.eq(id.0))
+            .filter(entities::memory_record::Column::Owner.eq(owner.as_str()))
+            .exec(&transaction)
+            .await
+            .map_err(backend_err)?;
+        if deleted.rows_affected != 1 {
+            return Err(MemoryError::NotFound);
+        }
+        let record_remains = entities::memory_record::Entity::find_by_id(id.0)
+            .one(&transaction)
+            .await
+            .map_err(backend_err)?
+            .is_some();
+        let revision_remains = entities::memory_revision::Entity::find()
+            .filter(entities::memory_revision::Column::RecordId.eq(id.0))
+            .one(&transaction)
+            .await
+            .map_err(backend_err)?
+            .is_some();
+        if record_remains || revision_remains {
+            return Err(MemoryError::Backend(
+                "memory delete did not remove the record and revisions".to_owned(),
+            ));
+        }
+        transaction.commit().await.map_err(backend_err)?;
+        Ok(true)
+    }
+
+    async fn search(
+        &self,
+        owner: &OwnerId,
+        request: MemorySearchRequest,
+    ) -> MemoryResult<Vec<MemorySearchHit>> {
+        let query = request.query.trim().to_lowercase();
+        if query.is_empty() {
+            return Err(MemoryError::InvalidRecord(
+                "memory search query must not be empty".to_owned(),
+            ));
+        }
+        if request.limit == 0 || request.limit > MAX_MEMORY_SEARCH_RESULTS {
+            return Err(MemoryError::InvalidRecord(format!(
+                "memory search limit must be between 1 and {MAX_MEMORY_SEARCH_RESULTS}"
+            )));
+        }
+        let records = self
+            .list(
+                owner,
+                MemoryListFilter {
+                    scope: request.scope,
+                    statuses: request.statuses,
+                    kinds: Vec::new(),
+                },
+            )
+            .await?;
+        let tokens = query.split_whitespace().collect::<Vec<_>>();
+        let mut hits = records
+            .into_iter()
+            .filter_map(|record| lexical_hit(&record, &query, &tokens))
+            .collect::<Vec<_>>();
+        hits.sort_by(|left, right| {
+            right
+                .score
+                .cmp(&left.score)
+                .then_with(|| right.updated_at.cmp(&left.updated_at))
+                .then_with(|| left.record_id.0.cmp(&right.record_id.0))
+        });
+        hits.truncate(request.limit);
+        Ok(hits)
+    }
+
+    async fn assemble_context(
+        &self,
+        owner: &OwnerId,
+        scope: MemoryScope,
+    ) -> MemoryResult<MemoryDigest> {
+        let state = read_scope_state(&self.conn, owner, scope).await?;
+        let records = active_records_on(&self.conn, owner, scope).await?;
+        render_digest(scope, records, state.digest_byte_cap)
+    }
+
+    async fn revision_history(
+        &self,
+        owner: &OwnerId,
+        id: MemoryRecordId,
+    ) -> MemoryResult<Vec<MemoryRevision>> {
+        entities::memory_revision::Entity::find()
+            .filter(entities::memory_revision::Column::Owner.eq(owner.as_str()))
+            .filter(entities::memory_revision::Column::RecordId.eq(id.0))
+            .order_by_asc(entities::memory_revision::Column::Ordinal)
+            .all(&self.conn)
+            .await
+            .map_err(backend_err)?
+            .into_iter()
+            .map(|model| {
+                let snapshot = serde_json::from_value(model.snapshot).map_err(backend_err)?;
+                Ok(MemoryRevision {
+                    id: MemoryRevisionId(model.id),
+                    record_id: MemoryRecordId(model.record_id),
+                    ordinal: model.ordinal,
+                    snapshot,
+                    created_at: model.created_at,
+                })
+            })
+            .collect()
+    }
+}
+
+fn lexical_hit(record: &MemoryRecord, query: &str, tokens: &[&str]) -> Option<MemorySearchHit> {
+    let title = record.title.to_lowercase();
+    let body = record.body.to_lowercase();
+    if !tokens
+        .iter()
+        .all(|token| title.contains(token) || body.contains(token))
+    {
+        return None;
+    }
+
+    let phrase_title = title.match_indices(query).count() as u32;
+    let phrase_body = body.match_indices(query).count() as u32;
+    let token_title = tokens
+        .iter()
+        .map(|token| title.match_indices(token).count() as u32)
+        .sum::<u32>();
+    let token_body = tokens
+        .iter()
+        .map(|token| body.match_indices(token).count() as u32)
+        .sum::<u32>();
+    let score = phrase_title
+        .saturating_mul(12)
+        .saturating_add(phrase_body.saturating_mul(6))
+        .saturating_add(token_title.saturating_mul(3))
+        .saturating_add(token_body);
+    let matching_line = record
+        .body
+        .lines()
+        .find(|line| {
+            let normalized = line.to_lowercase();
+            normalized.contains(query) || tokens.iter().any(|token| normalized.contains(token))
+        })
+        .or_else(|| record.body.lines().find(|line| !line.trim().is_empty()))
+        .unwrap_or_default()
+        .to_owned();
+    Some(MemorySearchHit {
+        record_id: record.id,
+        title: record.title.clone(),
+        updated_at: record.updated_at,
+        matching_line,
+        score,
+    })
+}

--- a/crates/tidebreak-core/src/db/ops/mod.rs
+++ b/crates/tidebreak-core/src/db/ops/mod.rs
@@ -22,6 +22,7 @@ pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;
 pub(in crate::db) mod exec_file_change;
 pub(in crate::db) mod inbox;
+pub(in crate::db) mod memory;
 pub(in crate::db) mod message_attachment;
 pub(in crate::db) mod message_document_attachment;
 pub(in crate::db) mod notification;

--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -22,6 +22,7 @@ mod delegated_file_read;
 mod document;
 mod event_journal;
 mod file_change_journal;
+mod memory;
 mod message_attachment;
 mod multi_agent_wait;
 mod notification;

--- a/crates/tidebreak-core/src/db/tests/memory.rs
+++ b/crates/tidebreak-core/src/db/tests/memory.rs
@@ -1,0 +1,304 @@
+use super::{sample_chat, temp_store};
+use crate::memory::{
+    MemoryAuthor, MemoryBackend, MemoryError, MemoryEvidence, MemoryKind, MemoryLink,
+    MemoryLinkRelation, MemoryListFilter, MemoryOrigin, MemoryProvenance, MemoryRecord,
+    MemoryRecordId, MemoryRecordUpdate, MemoryScope, MemorySearchRequest, MemoryStatus,
+    MemoryStatusChange,
+};
+use crate::{Message, MessageId, OwnerId, Role, Store, TurnId};
+use chrono::{DateTime, Utc};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+fn at(minute: u32) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(&format!("2026-09-01T12:{minute:02}:00Z"))
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+fn user_record(
+    scope: MemoryScope,
+    status: MemoryStatus,
+    title: &str,
+    body: &str,
+    minute: u32,
+) -> MemoryRecord {
+    MemoryRecord {
+        id: MemoryRecordId::new(),
+        scope,
+        kind: MemoryKind::Fact,
+        status,
+        title: title.to_owned(),
+        body: body.to_owned(),
+        provenance: MemoryProvenance {
+            author: MemoryAuthor::User,
+            origin: MemoryOrigin::default(),
+            evidence: Vec::new(),
+        },
+        links: Vec::new(),
+        expires_at: None,
+        superseded_by: None,
+        observation_count: 0,
+        revision: 1,
+        created_at: at(minute),
+        updated_at: at(minute),
+    }
+}
+
+#[tokio::test]
+async fn model_evidence_must_resolve_for_the_same_owner() {
+    let (_directory, store) = temp_store().await;
+    let alice = OwnerId::new("user:alice").unwrap();
+    let bob = OwnerId::new("user:bob").unwrap();
+    let chat = sample_chat();
+    store.create_chat_scoped(&alice, &chat).await.unwrap();
+    let message = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        role: Role::User,
+        reasoning: Default::default(),
+        content: "Always run the release smoke test.".to_owned(),
+        llm_content: None,
+        created_at: at(0),
+    };
+    store.append_message(&message).await.unwrap();
+
+    let mut record = user_record(
+        MemoryScope::Personal,
+        MemoryStatus::Proposed,
+        "When preparing a release",
+        "Run the release smoke test before publishing.",
+        1,
+    );
+    record.provenance = MemoryProvenance {
+        author: MemoryAuthor::Model,
+        origin: MemoryOrigin {
+            chat_id: Some(chat.id),
+            turn_id: Some(message.turn_id),
+            ..Default::default()
+        },
+        evidence: vec![MemoryEvidence::Message {
+            message_id: message.id,
+        }],
+    };
+    store.put(&alice, record.clone()).await.unwrap();
+
+    record.id = MemoryRecordId::new();
+    assert_eq!(
+        store.put(&bob, record).await,
+        Err(MemoryError::EvidenceNotFound(format!(
+            "message {}",
+            message.id
+        )))
+    );
+}
+
+#[tokio::test]
+async fn update_search_digest_history_and_verified_delete_share_one_record() {
+    let (_directory, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let record = user_record(
+        MemoryScope::Personal,
+        MemoryStatus::Active,
+        "When changing database migrations",
+        "Run the migration chain test before publishing.",
+        2,
+    );
+    store.put(&owner, record.clone()).await.unwrap();
+
+    let updated = store
+        .update(
+            &owner,
+            MemoryRecordUpdate {
+                id: record.id,
+                expected_revision: 1,
+                kind: MemoryKind::Lesson,
+                title: "When changing the database schema".to_owned(),
+                body: "Run the stepwise migration test before publishing.".to_owned(),
+                provenance: record.provenance.clone(),
+                links: Vec::new(),
+                expires_at: None,
+                observation_count: 0,
+            },
+        )
+        .await
+        .unwrap()
+        .record;
+    assert_eq!(updated.revision, 2);
+
+    let hits = store
+        .search(
+            &owner,
+            MemorySearchRequest {
+                query: "stepwise migration".to_owned(),
+                scope: Some(MemoryScope::Personal),
+                statuses: vec![MemoryStatus::Active],
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].matching_line,
+        "Run the stepwise migration test before publishing."
+    );
+
+    let first_digest = store
+        .assemble_context(&owner, MemoryScope::Personal)
+        .await
+        .unwrap();
+    let second_digest = store
+        .assemble_context(&owner, MemoryScope::Personal)
+        .await
+        .unwrap();
+    assert_eq!(first_digest, second_digest);
+    let expected_line = format!(
+        "{} — When changing the database schema",
+        updated.updated_at.format("%Y-%m-%d")
+    );
+    assert!(
+        first_digest.markdown.contains(&expected_line),
+        "digest {:?} lacks {expected_line:?}",
+        first_digest.markdown
+    );
+    assert!(!first_digest.markdown.contains("stepwise migration test"));
+
+    let history = store.revision_history(&owner, record.id).await.unwrap();
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].snapshot.body, record.body);
+    assert_eq!(history[1].snapshot.body, updated.body);
+
+    assert!(store.delete(&owner, record.id).await.unwrap());
+    assert!(store.get(&owner, record.id).await.unwrap().is_none());
+    assert!(store
+        .revision_history(&owner, record.id)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(store
+        .search(
+            &owner,
+            MemorySearchRequest {
+                query: "stepwise migration".to_owned(),
+                scope: None,
+                statuses: Vec::new(),
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(store
+        .assemble_context(&owner, MemoryScope::Personal)
+        .await
+        .unwrap()
+        .markdown
+        .is_empty());
+}
+
+#[tokio::test]
+async fn activating_an_update_proposal_archives_its_source() {
+    let (_directory, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let source = user_record(
+        MemoryScope::Personal,
+        MemoryStatus::Active,
+        "When running checks",
+        "Run tests before publishing.",
+        3,
+    );
+    store.put(&owner, source.clone()).await.unwrap();
+
+    let mut proposal = user_record(
+        MemoryScope::Personal,
+        MemoryStatus::Proposed,
+        "When running focused checks",
+        "Run formatting and focused tests before publishing.",
+        4,
+    );
+    proposal.links = vec![MemoryLink {
+        record_id: source.id,
+        relation: MemoryLinkRelation::Updates,
+    }];
+    store.put(&owner, proposal.clone()).await.unwrap();
+    store
+        .set_status(
+            &owner,
+            MemoryStatusChange {
+                id: proposal.id,
+                expected_revision: 1,
+                status: MemoryStatus::Active,
+            },
+        )
+        .await
+        .unwrap();
+
+    let archived = store.get(&owner, source.id).await.unwrap().unwrap();
+    assert_eq!(archived.status, MemoryStatus::Archived);
+    assert_eq!(archived.superseded_by, Some(proposal.id));
+    assert_eq!(archived.revision, 2);
+    let active = store.get(&owner, proposal.id).await.unwrap().unwrap();
+    assert_eq!(active.status, MemoryStatus::Active);
+    assert_eq!(active.revision, 2);
+
+    let digest = store
+        .assemble_context(&owner, MemoryScope::Personal)
+        .await
+        .unwrap();
+    assert!(digest.markdown.contains(&proposal.title));
+    assert!(!digest.markdown.contains(&source.title));
+}
+
+#[tokio::test]
+async fn an_active_cap_failure_rolls_back_the_record_and_revision() {
+    let (_directory, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let first = user_record(
+        MemoryScope::Personal,
+        MemoryStatus::Active,
+        "First active record",
+        "First body.",
+        5,
+    );
+    store.put(&owner, first).await.unwrap();
+    crate::db::entities::memory_scope_state::Entity::update_many()
+        .col_expr(
+            crate::db::entities::memory_scope_state::Column::ActiveRecordCap,
+            sea_orm::sea_query::Expr::value(1_i64),
+        )
+        .filter(crate::db::entities::memory_scope_state::Column::Owner.eq(owner.as_str()))
+        .filter(
+            crate::db::entities::memory_scope_state::Column::ScopeKind
+                .eq(MemoryScope::Personal.kind_str()),
+        )
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let second = user_record(
+        MemoryScope::Personal,
+        MemoryStatus::Active,
+        "Second active record",
+        "Second body.",
+        6,
+    );
+    assert_eq!(
+        store.put(&owner, second.clone()).await,
+        Err(MemoryError::ActiveRecordCapExceeded { cap: 1 })
+    );
+    assert!(store.get(&owner, second.id).await.unwrap().is_none());
+    assert!(store
+        .revision_history(&owner, second.id)
+        .await
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        store
+            .list(&owner, MemoryListFilter::default())
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -81,6 +81,7 @@ pub mod image;
 #[cfg(feature = "keychain")]
 pub mod keychain;
 pub mod local_app;
+pub mod memory;
 pub mod model;
 pub mod permission;
 pub use permission::PermissionMode;
@@ -255,6 +256,16 @@ pub use image::{
 };
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
+pub use memory::{
+    MemoryAuthor, MemoryBackend, MemoryCapLevel, MemoryCapability, MemoryCaps, MemoryDigest,
+    MemoryError, MemoryEvidence, MemoryIngestReceipt, MemoryIngestRequest, MemoryKind, MemoryLink,
+    MemoryLinkRelation, MemoryListFilter, MemoryOrigin, MemoryProvenance, MemoryRecord,
+    MemoryRecordId, MemoryRecordUpdate, MemoryResult, MemoryRevision, MemoryRevisionId,
+    MemoryScope, MemorySearchHit, MemorySearchRequest, MemoryStatus, MemoryStatusChange,
+    MemoryWriteReceipt, MemoryWriteState, DEFAULT_MEMORY_ACTIVE_RECORD_CAP,
+    DEFAULT_MEMORY_DIGEST_BYTES, MAX_MEMORY_BODY_BYTES, MAX_MEMORY_EVIDENCE, MAX_MEMORY_LINKS,
+    MAX_MEMORY_SEARCH_RESULTS, MAX_MEMORY_TITLE_CHARS,
+};
 pub use model::{
     exec_attachment_file_name, AgentRun, AgentRunCancellationReason, AgentRunCancellationSignal,
     AgentRunCheckInReason, AgentRunExecutionLocation, AgentRunInboxEntry, AgentRunInboxStatus,

--- a/crates/tidebreak-core/src/memory.rs
+++ b/crates/tidebreak-core/src/memory.rs
@@ -1,0 +1,801 @@
+//! Durable, reviewable memory records behind one backend boundary.
+//!
+//! The domain contract stays independent of any one database or retrieval
+//! engine. Backends store markdown bodies verbatim, report every capability,
+//! and keep owner scoping at every operation boundary.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use ts_rs::TS;
+use uuid::Uuid;
+
+use crate::code::{CodeSessionId, CodeTurnId, RepoId, WorkspaceId};
+use crate::id::{ChatId, MessageId, TurnId};
+use crate::model::OwnerId;
+
+/// Largest markdown body accepted for one memory record.
+pub const MAX_MEMORY_BODY_BYTES: usize = 2 * 1_024;
+/// Largest retrieval-hook title accepted for one memory record.
+pub const MAX_MEMORY_TITLE_CHARS: usize = 160;
+/// Most evidence references one record may carry.
+pub const MAX_MEMORY_EVIDENCE: usize = 32;
+/// Most typed links one record may carry.
+pub const MAX_MEMORY_LINKS: usize = 16;
+/// Default number of active records allowed in one scope.
+pub const DEFAULT_MEMORY_ACTIVE_RECORD_CAP: usize = 64;
+/// Default maximum size of one rendered scope digest.
+pub const DEFAULT_MEMORY_DIGEST_BYTES: usize = 8 * 1_024;
+/// Largest result page one lexical search may return.
+pub const MAX_MEMORY_SEARCH_RESULTS: usize = 100;
+
+macro_rules! memory_id_type {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+        #[serde(transparent)]
+        pub struct $name(pub Uuid);
+
+        impl $name {
+            /// Generate a fresh identifier.
+            #[must_use]
+            #[allow(clippy::new_without_default)]
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+
+            /// Borrow the underlying UUID.
+            #[must_use]
+            pub const fn as_uuid(&self) -> &Uuid {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = uuid::Error;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Ok(Self(Uuid::parse_str(value)?))
+            }
+        }
+
+        impl From<Uuid> for $name {
+            fn from(value: Uuid) -> Self {
+                Self(value)
+            }
+        }
+    };
+}
+
+memory_id_type!(
+    /// Identifies one durable memory record.
+    MemoryRecordId
+);
+memory_id_type!(
+    /// Identifies one immutable record revision.
+    MemoryRevisionId
+);
+
+/// One durable memory scope.
+///
+/// The enum is non-exhaustive because wider scopes may arrive later. A
+/// repository scope binds to the registered repository, never a workspace.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MemoryScope {
+    /// Knowledge that follows the owner across every surface.
+    Personal,
+    /// Knowledge bound to one registered repository.
+    Repo {
+        /// Stable registered-repository identity.
+        repo_id: RepoId,
+    },
+}
+
+impl MemoryScope {
+    /// Stable database token for the scope variant.
+    #[must_use]
+    pub const fn kind_str(self) -> &'static str {
+        match self {
+            Self::Personal => "personal",
+            Self::Repo { .. } => "repo",
+        }
+    }
+
+    /// Repository identity carried by a repository scope.
+    #[must_use]
+    pub const fn repo_id(self) -> Option<RepoId> {
+        match self {
+            Self::Personal => None,
+            Self::Repo { repo_id } => Some(repo_id),
+        }
+    }
+}
+
+/// What kind of durable knowledge a record carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryKind {
+    /// A dated claim about the owner or repository.
+    Fact,
+    /// A stated choice or working preference.
+    Preference,
+    /// A reusable lesson learned from completed work.
+    Lesson,
+    /// A durable pointer or lookup hint.
+    Reference,
+}
+
+impl MemoryKind {
+    /// Stable database token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Fact => "fact",
+            Self::Preference => "preference",
+            Self::Lesson => "lesson",
+            Self::Reference => "reference",
+        }
+    }
+
+    /// Heading used by the deterministic digest renderer.
+    #[must_use]
+    pub const fn heading(self) -> &'static str {
+        match self {
+            Self::Fact => "Facts",
+            Self::Preference => "Preferences",
+            Self::Lesson => "Lessons",
+            Self::Reference => "References",
+        }
+    }
+}
+
+/// Lifecycle state for one memory record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryStatus {
+    /// A weak pattern that needs observations from more distinct sessions.
+    Tracking,
+    /// A model-authored candidate waiting for user review.
+    Proposed,
+    /// An authoritative record eligible for context assembly.
+    Active,
+    /// A retained historical record that no longer carries authority.
+    Archived,
+    /// A dismissed proposal retained long enough to suppress repetition.
+    Rejected,
+}
+
+impl MemoryStatus {
+    /// Stable database token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tracking => "tracking",
+            Self::Proposed => "proposed",
+            Self::Active => "active",
+            Self::Archived => "archived",
+            Self::Rejected => "rejected",
+        }
+    }
+
+    /// Whether this state contributes to the memory digest.
+    #[must_use]
+    pub const fn is_authoritative(self) -> bool {
+        matches!(self, Self::Active)
+    }
+
+    /// Whether `next` follows the persisted lifecycle.
+    #[must_use]
+    pub fn can_transition_to(self, next: Self) -> bool {
+        self == next
+            || matches!(
+                (self, next),
+                (
+                    Self::Tracking,
+                    Self::Proposed | Self::Rejected | Self::Archived
+                ) | (
+                    Self::Proposed,
+                    Self::Active | Self::Rejected | Self::Archived
+                ) | (Self::Active, Self::Archived)
+            )
+    }
+}
+
+/// Who authored a memory record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryAuthor {
+    /// The owner wrote or edited the record directly.
+    User,
+    /// Tidebreak's utility model derived the record.
+    Model,
+    /// A one-time import supplied the record.
+    Import,
+}
+
+impl MemoryAuthor {
+    /// Stable database token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Model => "model",
+            Self::Import => "import",
+        }
+    }
+}
+
+/// The product surface that produced a record, where known.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, TS)]
+pub struct MemoryOrigin {
+    /// Originating work-mode conversation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<ChatId>,
+    /// Originating work-mode turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<TurnId>,
+    /// Originating code session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_session_id: Option<CodeSessionId>,
+    /// Originating code turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_turn_id: Option<CodeTurnId>,
+    /// Workspace attached to the originating code session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<WorkspaceId>,
+}
+
+/// One exact source that justifies a model-authored record.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MemoryEvidence {
+    /// One durable work-mode message.
+    Message {
+        /// Exact message identity.
+        message_id: MessageId,
+    },
+    /// One durable code-journal event.
+    CodeEvent {
+        /// Session that owns the event sequence.
+        session_id: CodeSessionId,
+        /// One-based event sequence.
+        seq: i64,
+    },
+}
+
+/// Authorship and source evidence for one record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryProvenance {
+    /// Who authored the record.
+    pub author: MemoryAuthor,
+    /// Product origin, where known.
+    pub origin: MemoryOrigin,
+    /// Exact sources that justify the record.
+    pub evidence: Vec<MemoryEvidence>,
+}
+
+/// Meaning of one link to another memory record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryLinkRelation {
+    /// The linked record is relevant but remains independent.
+    Related,
+    /// This proposal updates the linked active record.
+    Updates,
+    /// Activating this proposal supersedes the linked source record.
+    Supersedes,
+}
+
+/// One typed link to another memory record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+pub struct MemoryLink {
+    /// Linked record identity.
+    pub record_id: MemoryRecordId,
+    /// Why this record links to it.
+    pub relation: MemoryLinkRelation,
+}
+
+/// One durable markdown memory with its typed envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryRecord {
+    /// Stable record identity.
+    pub id: MemoryRecordId,
+    /// Personal or repository scope.
+    pub scope: MemoryScope,
+    /// Knowledge category.
+    pub kind: MemoryKind,
+    /// Review and authority state.
+    pub status: MemoryStatus,
+    /// One-line retrieval hook that says when the record matters.
+    pub title: String,
+    /// Markdown body, stored verbatim.
+    pub body: String,
+    /// Authorship, origin, and exact evidence.
+    pub provenance: MemoryProvenance,
+    /// Typed relationships to other records.
+    pub links: Vec<MemoryLink>,
+    /// Mechanical expiry, when configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Active replacement for an archived record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<MemoryRecordId>,
+    /// Distinct supporting observations for a tracked hypothesis.
+    pub observation_count: u32,
+    /// Compare-and-swap revision. The first stored version is 1.
+    pub revision: i64,
+    /// Original creation time.
+    pub created_at: DateTime<Utc>,
+    /// Time of the latest committed mutation.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl MemoryRecord {
+    /// Validate the backend-independent record shape.
+    pub fn validate(&self) -> MemoryResult<()> {
+        if self.title.trim().is_empty() {
+            return Err(MemoryError::InvalidRecord(
+                "memory title must not be empty".to_owned(),
+            ));
+        }
+        if self.title.contains(['\r', '\n']) {
+            return Err(MemoryError::InvalidRecord(
+                "memory title must fit on one line".to_owned(),
+            ));
+        }
+        if self.title.chars().count() > MAX_MEMORY_TITLE_CHARS {
+            return Err(MemoryError::InvalidRecord(format!(
+                "memory title exceeds {MAX_MEMORY_TITLE_CHARS} characters"
+            )));
+        }
+        if self.body.trim().is_empty() {
+            return Err(MemoryError::InvalidRecord(
+                "memory body must not be empty".to_owned(),
+            ));
+        }
+        if self.body.len() > MAX_MEMORY_BODY_BYTES {
+            return Err(MemoryError::InvalidRecord(format!(
+                "memory body exceeds {MAX_MEMORY_BODY_BYTES} bytes"
+            )));
+        }
+        if self.provenance.evidence.len() > MAX_MEMORY_EVIDENCE {
+            return Err(MemoryError::InvalidRecord(format!(
+                "memory record exceeds {MAX_MEMORY_EVIDENCE} evidence references"
+            )));
+        }
+        if self.provenance.author == MemoryAuthor::Model && self.provenance.evidence.is_empty() {
+            return Err(MemoryError::InvalidRecord(
+                "model-authored memory requires resolvable evidence".to_owned(),
+            ));
+        }
+        if self.links.len() > MAX_MEMORY_LINKS {
+            return Err(MemoryError::InvalidRecord(format!(
+                "memory record exceeds {MAX_MEMORY_LINKS} links"
+            )));
+        }
+        let mut linked = std::collections::HashSet::with_capacity(self.links.len());
+        for link in &self.links {
+            if link.record_id == self.id {
+                return Err(MemoryError::InvalidRecord(
+                    "memory record cannot link to itself".to_owned(),
+                ));
+            }
+            if !linked.insert((link.record_id, link.relation)) {
+                return Err(MemoryError::InvalidRecord(
+                    "memory record contains a duplicate link".to_owned(),
+                ));
+            }
+        }
+        if self.status == MemoryStatus::Tracking && self.observation_count == 0 {
+            return Err(MemoryError::InvalidRecord(
+                "tracked memory requires at least one observation".to_owned(),
+            ));
+        }
+        if self.revision < 1 {
+            return Err(MemoryError::InvalidRecord(
+                "memory revision must be at least 1".to_owned(),
+            ));
+        }
+        if self.updated_at < self.created_at {
+            return Err(MemoryError::InvalidRecord(
+                "memory update time precedes its creation time".to_owned(),
+            ));
+        }
+        if self
+            .expires_at
+            .is_some_and(|expires_at| expires_at <= self.created_at)
+        {
+            return Err(MemoryError::InvalidRecord(
+                "memory expiry must follow its creation time".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Mutable fields supplied when editing one record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryRecordUpdate {
+    /// Record to update.
+    pub id: MemoryRecordId,
+    /// Revision the editor read.
+    pub expected_revision: i64,
+    /// Replacement knowledge category.
+    pub kind: MemoryKind,
+    /// Replacement one-line retrieval hook.
+    pub title: String,
+    /// Replacement markdown body.
+    pub body: String,
+    /// Replacement provenance.
+    pub provenance: MemoryProvenance,
+    /// Replacement links.
+    pub links: Vec<MemoryLink>,
+    /// Replacement expiry.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Replacement observation count.
+    pub observation_count: u32,
+}
+
+/// A compare-and-swap lifecycle mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryStatusChange {
+    /// Record to mutate.
+    pub id: MemoryRecordId,
+    /// Revision the caller read.
+    pub expected_revision: i64,
+    /// Desired lifecycle state.
+    pub status: MemoryStatus,
+}
+
+/// Filter for owner-scoped record listings.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, TS)]
+pub struct MemoryListFilter {
+    /// Exact scope, or every owner scope when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<MemoryScope>,
+    /// Included states. An empty list includes every state.
+    #[serde(default)]
+    pub statuses: Vec<MemoryStatus>,
+    /// Included kinds. An empty list includes every kind.
+    #[serde(default)]
+    pub kinds: Vec<MemoryKind>,
+}
+
+/// One full-content lexical-search request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemorySearchRequest {
+    /// Case-insensitive search text.
+    pub query: String,
+    /// Exact scope, or every owner scope when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<MemoryScope>,
+    /// Included states. An empty list includes every state.
+    #[serde(default)]
+    pub statuses: Vec<MemoryStatus>,
+    /// Maximum results to return.
+    pub limit: usize,
+}
+
+/// One injectable lexical-search result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemorySearchHit {
+    /// Matching record.
+    pub record_id: MemoryRecordId,
+    /// Retrieval-hook title.
+    pub title: String,
+    /// Date of the latest committed mutation.
+    pub updated_at: DateTime<Utc>,
+    /// First matching markdown line, kept verbatim.
+    pub matching_line: String,
+    /// Deterministic lexical score. Larger values sort first.
+    pub score: u32,
+}
+
+/// One deterministic active-record digest for a scope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryDigest {
+    /// Scope represented by this render.
+    pub scope: MemoryScope,
+    /// Rendered markdown.
+    pub markdown: String,
+    /// UTF-8 byte length of `markdown`.
+    pub byte_len: usize,
+    /// Maximum accepted render size.
+    pub byte_cap: usize,
+    /// Number of active records represented.
+    pub record_count: usize,
+}
+
+/// One immutable historical snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryRevision {
+    /// Stable revision-row identity.
+    pub id: MemoryRevisionId,
+    /// Record that owns the revision.
+    pub record_id: MemoryRecordId,
+    /// Monotonic per-record ordinal.
+    pub ordinal: i64,
+    /// Full record snapshot after the mutation committed.
+    pub snapshot: MemoryRecord,
+    /// Time the snapshot committed.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Whether a backend guarantees that a returned write is durable now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryWriteState {
+    /// The backend committed the record and revision before returning.
+    Committed,
+    /// The backend accepted the write for asynchronous completion.
+    Pending,
+}
+
+/// A record write plus the backend's durability guarantee.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryWriteReceipt {
+    /// Durability guarantee at the backend boundary.
+    pub state: MemoryWriteState,
+    /// Record state accepted by the backend.
+    pub record: MemoryRecord,
+}
+
+/// Intent supplied to an extraction-capable backend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryIngestRequest {
+    /// Scope to receive extracted records.
+    pub scope: MemoryScope,
+    /// Exact source origin.
+    pub origin: MemoryOrigin,
+    /// Source text supplied for bounded extraction.
+    pub content: String,
+}
+
+/// Accepted extraction work.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryIngestReceipt {
+    /// Durability guarantee at the backend boundary.
+    pub state: MemoryWriteState,
+    /// Records written synchronously, if any.
+    pub records: Vec<MemoryRecord>,
+}
+
+/// Whether a backend supports one declared operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryCapLevel {
+    /// The backend implements and verifies the capability.
+    Supported,
+    /// The backend is known not to implement the capability.
+    Unsupported,
+    /// The backend cannot state support honestly.
+    Unknown,
+}
+
+/// Named backend capability used in visible degradation errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryCapability {
+    Extraction,
+    LexicalSearch,
+    SemanticSearch,
+    Consolidation,
+    ContextAssembly,
+    RevisionHistory,
+    VerifiedDelete,
+    AsynchronousWrites,
+    AgentEditableSurfaces,
+}
+
+impl std::fmt::Display for MemoryCapability {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Extraction => "extraction",
+            Self::LexicalSearch => "lexical search",
+            Self::SemanticSearch => "semantic search",
+            Self::Consolidation => "consolidation",
+            Self::ContextAssembly => "context assembly",
+            Self::RevisionHistory => "revision history",
+            Self::VerifiedDelete => "verified delete",
+            Self::AsynchronousWrites => "asynchronous writes",
+            Self::AgentEditableSurfaces => "agent-editable surfaces",
+        };
+        formatter.write_str(name)
+    }
+}
+
+/// Complete capability vector for one memory backend.
+///
+/// This type has no `Default`. Adding a flag breaks every backend until the
+/// backend states a value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MemoryCaps {
+    pub extraction: MemoryCapLevel,
+    pub lexical_search: MemoryCapLevel,
+    pub semantic_search: MemoryCapLevel,
+    pub consolidation: MemoryCapLevel,
+    pub context_assembly: MemoryCapLevel,
+    pub revision_history: MemoryCapLevel,
+    pub verified_delete: MemoryCapLevel,
+    pub asynchronous_writes: MemoryCapLevel,
+    pub agent_editable_surfaces: MemoryCapLevel,
+}
+
+/// Failure at the memory-backend boundary.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MemoryError {
+    /// The backend does not implement the requested capability.
+    #[error("memory backend does not support {0}")]
+    Unsupported(MemoryCapability),
+    /// The caller supplied a malformed record or request.
+    #[error("invalid memory record: {0}")]
+    InvalidRecord(String),
+    /// One exact evidence reference does not resolve for this owner.
+    #[error("memory evidence does not resolve: {0}")]
+    EvidenceNotFound(String),
+    /// The requested scope does not exist for this owner.
+    #[error("memory scope does not exist")]
+    ScopeNotFound,
+    /// The requested record does not exist for this owner.
+    #[error("memory record not found")]
+    NotFound,
+    /// A new record reused an existing durable identity.
+    #[error("memory record already exists")]
+    AlreadyExists,
+    /// A compare-and-swap edit lost to a newer revision.
+    #[error("memory record has moved on to revision {current_revision}")]
+    RevisionConflict {
+        /// Revision that is current now.
+        current_revision: i64,
+    },
+    /// A lifecycle edge is not allowed.
+    #[error("memory status cannot move from {from:?} to {to:?}")]
+    InvalidStatusTransition {
+        from: MemoryStatus,
+        to: MemoryStatus,
+    },
+    /// The scope already contains its maximum active-record count.
+    #[error(
+        "memory scope has reached its active-record cap of {cap}; consolidate overlapping records, archive a record that is no longer true, or update an existing record"
+    )]
+    ActiveRecordCapExceeded { cap: usize },
+    /// The active title digest would exceed its byte budget.
+    #[error(
+        "memory digest would exceed its {cap}-byte cap; consolidate overlapping records, archive a record that is no longer true, or shorten a retrieval title"
+    )]
+    DigestCapExceeded { cap: usize },
+    /// Persistence or backend-internal failure.
+    #[error("memory backend error: {0}")]
+    Backend(String),
+}
+
+/// Result returned by a memory backend.
+pub type MemoryResult<T> = std::result::Result<T, MemoryError>;
+
+/// Storage, retrieval, review, and context assembly for durable memory.
+#[async_trait]
+pub trait MemoryBackend: Send + Sync {
+    /// State every capability explicitly.
+    fn caps(&self) -> MemoryCaps;
+
+    /// Store one caller-supplied record verbatim and append its first revision.
+    async fn put(&self, owner: &OwnerId, record: MemoryRecord) -> MemoryResult<MemoryWriteReceipt>;
+
+    /// Ask an extraction-capable backend to derive records from source text.
+    async fn ingest(
+        &self,
+        owner: &OwnerId,
+        request: MemoryIngestRequest,
+    ) -> MemoryResult<MemoryIngestReceipt>;
+
+    /// Load one owner-scoped record.
+    async fn get(&self, owner: &OwnerId, id: MemoryRecordId) -> MemoryResult<Option<MemoryRecord>>;
+
+    /// List owner-scoped records in deterministic newest-first order.
+    async fn list(
+        &self,
+        owner: &OwnerId,
+        filter: MemoryListFilter,
+    ) -> MemoryResult<Vec<MemoryRecord>>;
+
+    /// Replace one record's editable envelope and body.
+    async fn update(
+        &self,
+        owner: &OwnerId,
+        update: MemoryRecordUpdate,
+    ) -> MemoryResult<MemoryWriteReceipt>;
+
+    /// Move one record through its lifecycle.
+    async fn set_status(
+        &self,
+        owner: &OwnerId,
+        change: MemoryStatusChange,
+    ) -> MemoryResult<MemoryWriteReceipt>;
+
+    /// Hard-delete one record and every revision.
+    async fn delete(&self, owner: &OwnerId, id: MemoryRecordId) -> MemoryResult<bool>;
+
+    /// Search complete markdown bodies and retrieval titles in process.
+    async fn search(
+        &self,
+        owner: &OwnerId,
+        request: MemorySearchRequest,
+    ) -> MemoryResult<Vec<MemorySearchHit>>;
+
+    /// Render every active title in one scope into a deterministic digest.
+    async fn assemble_context(
+        &self,
+        owner: &OwnerId,
+        scope: MemoryScope,
+    ) -> MemoryResult<MemoryDigest>;
+
+    /// Return immutable snapshots, oldest first.
+    async fn revision_history(
+        &self,
+        owner: &OwnerId,
+        id: MemoryRecordId,
+    ) -> MemoryResult<Vec<MemoryRevision>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caps_are_constructed_exhaustively() {
+        let caps = MemoryCaps {
+            extraction: MemoryCapLevel::Unsupported,
+            lexical_search: MemoryCapLevel::Supported,
+            semantic_search: MemoryCapLevel::Unsupported,
+            consolidation: MemoryCapLevel::Unsupported,
+            context_assembly: MemoryCapLevel::Supported,
+            revision_history: MemoryCapLevel::Supported,
+            verified_delete: MemoryCapLevel::Supported,
+            asynchronous_writes: MemoryCapLevel::Unsupported,
+            agent_editable_surfaces: MemoryCapLevel::Supported,
+        };
+        assert_eq!(caps.lexical_search, MemoryCapLevel::Supported);
+        assert_eq!(caps.semantic_search, MemoryCapLevel::Unsupported);
+    }
+
+    #[test]
+    fn a_model_record_requires_evidence() {
+        let now = Utc::now();
+        let record = MemoryRecord {
+            id: MemoryRecordId::new(),
+            scope: MemoryScope::Personal,
+            kind: MemoryKind::Fact,
+            status: MemoryStatus::Proposed,
+            title: "When preparing releases".to_owned(),
+            body: "Use the release checklist.".to_owned(),
+            provenance: MemoryProvenance {
+                author: MemoryAuthor::Model,
+                origin: MemoryOrigin::default(),
+                evidence: Vec::new(),
+            },
+            links: Vec::new(),
+            expires_at: None,
+            superseded_by: None,
+            observation_count: 0,
+            revision: 1,
+            created_at: now,
+            updated_at: now,
+        };
+        assert_eq!(
+            record.validate(),
+            Err(MemoryError::InvalidRecord(
+                "model-authored memory requires resolvable evidence".to_owned()
+            ))
+        );
+    }
+}

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -13,6 +13,7 @@ import { withCodeGitApi } from "./client/code-git";
 import { withCodeGrantsApi } from "./client/code-grants";
 import { withCodeTerminalsApi } from "./client/code-terminals";
 import { withCodeEventsApi } from "./client/code-events";
+import { withMemoryApi } from "./client/memory";
 import { HttpCore } from "./client/http";
 export {
   ARCHIVE_FORCE_KINDS,
@@ -30,19 +31,23 @@ export { type CodeWorkspaceMergeRequest } from "./client/code-git";
  * methods through a mixin. This class only composes them, so call sites keep
  * `client.method()` and a change to one route family touches one file.
  */
-export class ApiClient extends withCodeEventsApi(
-  withCodeTerminalsApi(
-    withCodeGrantsApi(
-      withCodeGitApi(
-        withCodeFilesApi(
-          withCodeSessionsApi(
-            withCodeWorkspacesApi(
-              withCodeReposApi(
-                withDeliveryApi(
-                  withTurnsApi(
-                    withAgentRunsApi(
-                      withChatApi(
-                        withProjectsApi(withAppsApi(withSettingsApi(HttpCore))),
+export class ApiClient extends withMemoryApi(
+  withCodeEventsApi(
+    withCodeTerminalsApi(
+      withCodeGrantsApi(
+        withCodeGitApi(
+          withCodeFilesApi(
+            withCodeSessionsApi(
+              withCodeWorkspacesApi(
+                withCodeReposApi(
+                  withDeliveryApi(
+                    withTurnsApi(
+                      withAgentRunsApi(
+                        withChatApi(
+                          withProjectsApi(
+                            withAppsApi(withSettingsApi(HttpCore)),
+                          ),
+                        ),
                       ),
                     ),
                   ),

--- a/crates/tidebreak-desktop/ui/src/api/client/memory.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/memory.ts
@@ -1,0 +1,200 @@
+import {
+  parseMemoryCaps,
+  parseMemoryDigest,
+  parseMemoryRecord,
+  parseMemoryRevision,
+  parseMemorySearchHit,
+} from "../parsers";
+import type {
+  MemoryAuthor,
+  MemoryCaps,
+  MemoryDigest,
+  MemoryEvidence,
+  MemoryKind,
+  MemoryLink,
+  MemoryOrigin,
+  MemoryRecord,
+  MemoryRecordId,
+  MemoryRevision,
+  MemoryScope,
+  MemorySearchHit,
+  MemoryStatus,
+} from "../types";
+import { type Constructor, HttpCore, parseList, requireParsed } from "./http";
+
+/** The owner-scoped `/memory` route family: records, revisions, search, and digest. */
+export function withMemoryApi<TBase extends Constructor<HttpCore>>(
+  Base: TBase,
+) {
+  return class extends Base {
+    async getMemoryCaps(): Promise<MemoryCaps> {
+      return requireParsed(
+        parseMemoryCaps(
+          await this.json("/memory/capabilities", { headers: this.headers() }),
+        ),
+        "memory capabilities",
+      );
+    }
+
+    async listMemoryRecords(): Promise<MemoryRecord[]> {
+      const body = await this.json<unknown>("/memory/records", {
+        headers: this.headers(),
+      });
+      return parseList(body, parseMemoryRecord, "memory records");
+    }
+
+    async getMemoryRecord(recordId: MemoryRecordId): Promise<MemoryRecord> {
+      return requireParsed(
+        parseMemoryRecord(
+          await this.json(`/memory/records/${encodeURIComponent(recordId)}`, {
+            headers: this.headers(),
+          }),
+        ),
+        "memory record",
+      );
+    }
+
+    async createMemoryRecord(
+      scope: MemoryScope,
+      body: {
+        id: MemoryRecordId;
+        kind: MemoryKind;
+        status: MemoryStatus;
+        title: string;
+        body: string;
+        author: MemoryAuthor;
+        origin?: MemoryOrigin;
+        evidence?: MemoryEvidence[];
+        links?: MemoryLink[];
+        expires_at?: string | null;
+        observation_count?: number;
+      },
+    ): Promise<MemoryRecord> {
+      const params = new URLSearchParams();
+      if (scope.kind === "repo") params.set("repo_id", scope.repo_id);
+      const suffix = params.size > 0 ? `?${params}` : "";
+      return requireParsed(
+        parseMemoryRecord(
+          await this.json(`/memory/records${suffix}`, {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({
+              ...body,
+              origin: body.origin ?? {
+                chat_id: null,
+                turn_id: null,
+                code_session_id: null,
+                code_turn_id: null,
+                workspace_id: null,
+              },
+              evidence: body.evidence ?? [],
+              links: body.links ?? [],
+              expires_at: body.expires_at ?? null,
+              observation_count: body.observation_count ?? 0,
+            }),
+          }),
+        ),
+        "memory record",
+      );
+    }
+
+    async updateMemoryRecord(
+      recordId: MemoryRecordId,
+      body: {
+        expected_revision: number;
+        kind: MemoryKind;
+        title: string;
+        body: string;
+        author: MemoryAuthor;
+        origin: MemoryOrigin;
+        evidence: MemoryEvidence[];
+        links: MemoryLink[];
+        expires_at: string | null;
+        observation_count: number;
+      },
+    ): Promise<MemoryRecord> {
+      return requireParsed(
+        parseMemoryRecord(
+          await this.json(`/memory/records/${encodeURIComponent(recordId)}`, {
+            method: "PATCH",
+            headers: this.headers(true),
+            body: JSON.stringify(body),
+          }),
+        ),
+        "memory record",
+      );
+    }
+
+    async setMemoryRecordStatus(
+      recordId: MemoryRecordId,
+      body: { expected_revision: number; status: MemoryStatus },
+    ): Promise<MemoryRecord> {
+      return requireParsed(
+        parseMemoryRecord(
+          await this.json(
+            `/memory/records/${encodeURIComponent(recordId)}/status`,
+            {
+              method: "PUT",
+              headers: this.headers(true),
+              body: JSON.stringify(body),
+            },
+          ),
+        ),
+        "memory record",
+      );
+    }
+
+    async deleteMemoryRecord(recordId: MemoryRecordId): Promise<void> {
+      await this.json(`/memory/records/${encodeURIComponent(recordId)}`, {
+        method: "DELETE",
+        headers: this.headers(),
+      });
+    }
+
+    async searchMemory(
+      query: string,
+      options?: {
+        scope?: MemoryScope;
+        statuses?: MemoryStatus[];
+        limit?: number;
+      },
+    ): Promise<MemorySearchHit[]> {
+      const params = new URLSearchParams({ query });
+      if (options?.scope?.kind === "repo") {
+        params.set("repo_id", options.scope.repo_id);
+      } else if (options?.scope?.kind === "personal") {
+        params.set("scope_kind", "personal");
+      }
+      for (const status of options?.statuses ?? [])
+        params.append("statuses", status);
+      if (options?.limit != null) params.set("limit", String(options.limit));
+      const body = await this.json<unknown>(`/memory/search?${params}`, {
+        headers: this.headers(),
+      });
+      return parseList(body, parseMemorySearchHit, "memory search results");
+    }
+
+    async getMemoryDigest(scope: MemoryScope): Promise<MemoryDigest> {
+      const params = new URLSearchParams();
+      if (scope.kind === "repo") params.set("repo_id", scope.repo_id);
+      return requireParsed(
+        parseMemoryDigest(
+          await this.json(`/memory/digest?${params}`, {
+            headers: this.headers(),
+          }),
+        ),
+        "memory digest",
+      );
+    }
+
+    async getMemoryRevisions(
+      recordId: MemoryRecordId,
+    ): Promise<MemoryRevision[]> {
+      const body = await this.json<unknown>(
+        `/memory/records/${encodeURIComponent(recordId)}/revisions`,
+        { headers: this.headers() },
+      );
+      return parseList(body, parseMemoryRevision, "memory revisions");
+    }
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/api/client/settings.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/settings.ts
@@ -170,6 +170,10 @@ export function withSettingsApi<TBase extends Constructor<HttpCore>>(
         branch_prefix_mode?: "account" | "custom" | "none";
         custom_branch_prefix?: string | null;
       };
+      memory?: {
+        enabled?: boolean;
+        capture_enabled?: boolean;
+      };
     }): Promise<RuntimeSettings> {
       return this.json("/settings", {
         method: "PUT",

--- a/crates/tidebreak-desktop/ui/src/api/memoryParsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api/memoryParsers.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseMemoryCaps,
+  parseMemoryDigest,
+  parseMemoryRecord,
+  parseMemoryRevision,
+} from "./parsers";
+
+const record = {
+  id: "record-1",
+  scope: { kind: "personal" },
+  kind: "lesson",
+  status: "proposed",
+  title: "When changing database migrations",
+  body: "Run the migration chain test before publishing.",
+  provenance: {
+    author: "model",
+    origin: {
+      chat_id: "chat-1",
+      turn_id: null,
+      code_session_id: null,
+      code_turn_id: null,
+      workspace_id: null,
+    },
+    evidence: [{ kind: "message", message_id: "message-1" }],
+  },
+  links: [],
+  expires_at: null,
+  superseded_by: null,
+  observation_count: 0,
+  revision: 1,
+  created_at: "2026-09-01T12:00:00Z",
+  updated_at: "2026-09-01T12:00:00Z",
+};
+
+describe("memory parsers", () => {
+  it("accepts a valid record and preserves its typed provenance", () => {
+    expect(parseMemoryRecord(record)).toEqual(record);
+  });
+
+  it("rejects a model-authored record without evidence", () => {
+    const evidenceLess = structuredClone(record);
+    evidenceLess.provenance.evidence = [];
+    expect(parseMemoryRecord(evidenceLess)).toBeNull();
+  });
+
+  it("rejects unknown fields and invalid lifecycle states", () => {
+    const extra = { ...record, future_field: true };
+    expect(parseMemoryRecord(extra)).toBeNull();
+
+    const invalidStatus = { ...record, status: "authority" };
+    expect(parseMemoryRecord(invalidStatus)).toBeNull();
+  });
+
+  it("rejects a caps vector that does not state every capability", () => {
+    const caps = {
+      extraction: "unsupported",
+      lexical_search: "supported",
+      semantic_search: "unsupported",
+      consolidation: "unsupported",
+      context_assembly: "supported",
+      revision_history: "supported",
+      verified_delete: "supported",
+      asynchronous_writes: "unsupported",
+      agent_editable_surfaces: "supported",
+    };
+    expect(parseMemoryCaps(caps)).toEqual(caps);
+    expect(
+      parseMemoryCaps({ ...caps, asynchronous_writes: undefined }),
+    ).toBeNull();
+  });
+
+  it("rejects a digest whose byte count does not match its markdown", () => {
+    const markdown = "## Tidebreak memory\n";
+    const digest = {
+      scope: { kind: "personal" },
+      markdown,
+      byte_len: new TextEncoder().encode(markdown).length,
+      byte_cap: 8192,
+      record_count: 1,
+    };
+    expect(parseMemoryDigest(digest)).toEqual(digest);
+    expect(
+      parseMemoryDigest({ ...digest, byte_len: digest.byte_len + 1 }),
+    ).toBeNull();
+  });
+
+  it("rejects a revision that belongs to another record", () => {
+    const revision = {
+      id: "revision-1",
+      record_id: record.id,
+      ordinal: 1,
+      snapshot: record,
+      created_at: record.created_at,
+    };
+    expect(parseMemoryRevision(revision)).toEqual(revision);
+    expect(
+      parseMemoryRevision({ ...revision, record_id: "record-2" }),
+    ).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/api/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/api/parsers.ts
@@ -25,6 +25,14 @@ import {
   type PendingPlanApproval as WirePendingPlanApproval,
   type PendingUserQuestions as WirePendingUserQuestions,
   type AgentRunTaskPlan as WireAgentRunTaskPlan,
+  type MemoryCaps as WireMemoryCaps,
+  type MemoryDigest as WireMemoryDigest,
+  type MemoryLink as WireMemoryLink,
+  type MemoryOrigin as WireMemoryOrigin,
+  type MemoryProvenance as WireMemoryProvenance,
+  type MemoryRecord as WireMemoryRecord,
+  type MemoryRevision as WireMemoryRevision,
+  type MemorySearchHit as WireMemorySearchHit,
   type TaskPlan as WireTaskPlan,
   type TaskPlanStep as WireTaskPlanStep,
   type TaskPlanStepStatus,
@@ -49,6 +57,19 @@ import {
   type AgentNotificationPage,
   type NotificationKind,
   type NetworkPolicy,
+  type MemoryCaps,
+  type MemoryDigest,
+  type MemoryEvidence,
+  type MemoryKind,
+  type MemoryLink,
+  type MemoryLinkRelation,
+  type MemoryOrigin,
+  type MemoryProvenance,
+  type MemoryRecord,
+  type MemoryRevision,
+  type MemoryScope,
+  type MemorySearchHit,
+  type MemoryStatus,
   type PendingChatPrompt,
   type PendingFolderAccessRequest,
   type PendingOutputWritebackRequest,
@@ -70,6 +91,371 @@ import {
   type UserQuestion,
   type UserQuestionOption,
 } from "./types";
+
+const MEMORY_KINDS: ReadonlySet<MemoryKind> = new Set([
+  "fact",
+  "preference",
+  "lesson",
+  "reference",
+]);
+
+const MEMORY_STATUSES: ReadonlySet<MemoryStatus> = new Set([
+  "tracking",
+  "proposed",
+  "active",
+  "archived",
+  "rejected",
+]);
+
+const MEMORY_LINK_RELATIONS: ReadonlySet<MemoryLinkRelation> = new Set([
+  "related",
+  "updates",
+  "supersedes",
+]);
+
+const MEMORY_CAP_LEVELS = new Set(["supported", "unsupported", "unknown"]);
+
+/** Validate the backend capability vector without trusting a wire cast. */
+export function parseMemoryCaps(value: unknown): MemoryCaps | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireMemoryCaps>(value, [
+      "extraction",
+      "lexical_search",
+      "semantic_search",
+      "consolidation",
+      "context_assembly",
+      "revision_history",
+      "verified_delete",
+      "asynchronous_writes",
+      "agent_editable_surfaces",
+    ])
+  ) {
+    return null;
+  }
+  const caps = Object.values(value);
+  if (
+    caps.length !== 9 ||
+    caps.some(
+      (level) => typeof level !== "string" || !MEMORY_CAP_LEVELS.has(level),
+    )
+  ) {
+    return null;
+  }
+  return value as unknown as MemoryCaps;
+}
+
+function parseMemoryScope(value: unknown): MemoryScope | null {
+  if (!isRecord(value) || typeof value.kind !== "string") return null;
+  if (value.kind === "personal") {
+    return onlyKeys<{ kind: string }>(value, ["kind"])
+      ? { kind: "personal" }
+      : null;
+  }
+  if (value.kind === "repo") {
+    return onlyKeys<{ kind: string; repo_id: string }>(value, [
+      "kind",
+      "repo_id",
+    ]) && nonEmptyBounded(value.repo_id, 128)
+      ? { kind: "repo", repo_id: value.repo_id }
+      : null;
+  }
+  return null;
+}
+
+function parseMemoryEvidence(value: unknown): MemoryEvidence | null {
+  if (!isRecord(value)) return null;
+  if (value.kind === "message") {
+    return onlyKeys<{ kind: string; message_id: string }>(value, [
+      "kind",
+      "message_id",
+    ]) && nonEmptyBounded(value.message_id, 128)
+      ? { kind: "message", message_id: value.message_id }
+      : null;
+  }
+  if (value.kind === "code_event") {
+    return onlyKeys<{
+      kind: string;
+      session_id: string;
+      seq: number;
+    }>(value, ["kind", "session_id", "seq"]) &&
+      nonEmptyBounded(value.session_id, 128) &&
+      typeof value.seq === "number" &&
+      Number.isSafeInteger(value.seq) &&
+      value.seq > 0
+      ? { kind: "code_event", session_id: value.session_id, seq: value.seq }
+      : null;
+  }
+  return null;
+}
+
+function parseMemoryOrigin(value: unknown): MemoryOrigin | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireMemoryOrigin>(value, [
+      "chat_id",
+      "turn_id",
+      "code_session_id",
+      "code_turn_id",
+      "workspace_id",
+    ])
+  ) {
+    return null;
+  }
+  for (const id of [
+    value.chat_id,
+    value.turn_id,
+    value.code_session_id,
+    value.code_turn_id,
+    value.workspace_id,
+  ] as unknown[]) {
+    if (!(id === undefined || id === null || nonEmptyBounded(id, 128))) {
+      return null;
+    }
+  }
+  return {
+    chat_id: typeof value.chat_id === "string" ? value.chat_id : null,
+    turn_id: typeof value.turn_id === "string" ? value.turn_id : null,
+    code_session_id:
+      typeof value.code_session_id === "string" ? value.code_session_id : null,
+    code_turn_id:
+      typeof value.code_turn_id === "string" ? value.code_turn_id : null,
+    workspace_id:
+      typeof value.workspace_id === "string" ? value.workspace_id : null,
+  };
+}
+
+function parseMemoryProvenance(value: unknown): MemoryProvenance | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireMemoryProvenance>(value, ["author", "origin", "evidence"]) ||
+    typeof value.author !== "string" ||
+    !["user", "model", "import"].includes(value.author) ||
+    !Array.isArray(value.evidence)
+  ) {
+    return null;
+  }
+  const origin = parseMemoryOrigin(value.origin);
+  if (!origin) return null;
+  const evidence: MemoryEvidence[] = [];
+  for (const entry of value.evidence) {
+    const parsed = parseMemoryEvidence(entry);
+    if (!parsed) return null;
+    evidence.push(parsed);
+  }
+  return {
+    author: value.author as MemoryProvenance["author"],
+    origin,
+    evidence,
+  };
+}
+
+function parseMemoryLink(value: unknown): MemoryLink | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireMemoryLink>(value, ["record_id", "relation"]) ||
+    !nonEmptyBounded(value.record_id, 128) ||
+    typeof value.relation !== "string" ||
+    !MEMORY_LINK_RELATIONS.has(value.relation as MemoryLinkRelation)
+  ) {
+    return null;
+  }
+  return {
+    record_id: value.record_id,
+    relation: value.relation as MemoryLinkRelation,
+  };
+}
+
+/** Validate one durable record before it reaches review state. */
+export function parseMemoryRecord(value: unknown): MemoryRecord | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireMemoryRecord>(value, [
+      "id",
+      "scope",
+      "kind",
+      "status",
+      "title",
+      "body",
+      "provenance",
+      "links",
+      "expires_at",
+      "superseded_by",
+      "observation_count",
+      "revision",
+      "created_at",
+      "updated_at",
+    ]) ||
+    !nonEmptyBounded(value.id, 128) ||
+    typeof value.kind !== "string" ||
+    !MEMORY_KINDS.has(value.kind as MemoryKind) ||
+    typeof value.status !== "string" ||
+    !MEMORY_STATUSES.has(value.status as MemoryStatus) ||
+    !nonEmptyBounded(value.title, 160) ||
+    typeof value.body !== "string" ||
+    value.body.trim().length === 0 ||
+    !Array.isArray(value.links) ||
+    typeof value.observation_count !== "number" ||
+    !Number.isSafeInteger(value.observation_count) ||
+    value.observation_count < 0 ||
+    typeof value.revision !== "number" ||
+    !Number.isSafeInteger(value.revision) ||
+    value.revision < 1 ||
+    !nonEmptyBounded(value.created_at, 64) ||
+    !nonEmptyBounded(value.updated_at, 64)
+  ) {
+    return null;
+  }
+  const scope = parseMemoryScope(value.scope);
+  const provenance = parseMemoryProvenance(value.provenance);
+  if (!scope || !provenance) return null;
+  const links: MemoryLink[] = [];
+  for (const link of value.links) {
+    const parsed = parseMemoryLink(link);
+    if (!parsed || parsed.record_id === value.id) return null;
+    if (links.some((existing) => existing.record_id === parsed.record_id)) {
+      return null;
+    }
+    links.push(parsed);
+  }
+  if (
+    !(value.expires_at === undefined || value.expires_at === null) &&
+    !nonEmptyBounded(value.expires_at, 64)
+  ) {
+    return null;
+  }
+  if (
+    !(value.superseded_by === undefined || value.superseded_by === null) &&
+    !nonEmptyBounded(value.superseded_by, 128)
+  ) {
+    return null;
+  }
+  if (
+    value.status === "tracking" &&
+    (value.observation_count === 0 || provenance.evidence.length === 0)
+  ) {
+    return null;
+  }
+  if (provenance.author === "model" && provenance.evidence.length === 0) {
+    return null;
+  }
+  return {
+    id: value.id,
+    scope,
+    kind: value.kind as MemoryKind,
+    status: value.status as MemoryStatus,
+    title: value.title,
+    body: value.body,
+    provenance,
+    links,
+    expires_at: value.expires_at ?? null,
+    superseded_by: value.superseded_by ?? null,
+    observation_count: value.observation_count,
+    revision: value.revision,
+    created_at: value.created_at,
+    updated_at: value.updated_at,
+  };
+}
+
+/** Validate one search hit before it reaches the manager's index. */
+export function parseMemorySearchHit(value: unknown): MemorySearchHit | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireMemorySearchHit>(value, [
+      "record_id",
+      "title",
+      "updated_at",
+      "matching_line",
+      "score",
+    ]) ||
+    !nonEmptyBounded(value.record_id, 128) ||
+    !nonEmptyBounded(value.title, 160) ||
+    !nonEmptyBounded(value.updated_at, 64) ||
+    typeof value.matching_line !== "string" ||
+    typeof value.score !== "number" ||
+    !Number.isSafeInteger(value.score) ||
+    value.score < 0
+  ) {
+    return null;
+  }
+  return {
+    record_id: value.record_id,
+    title: value.title,
+    updated_at: value.updated_at,
+    matching_line: value.matching_line,
+    score: value.score,
+  };
+}
+
+/** Validate the derived scope digest the manager previews. */
+export function parseMemoryDigest(value: unknown): MemoryDigest | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireMemoryDigest>(value, [
+      "scope",
+      "markdown",
+      "byte_len",
+      "byte_cap",
+      "record_count",
+    ]) ||
+    typeof value.markdown !== "string" ||
+    typeof value.byte_len !== "number" ||
+    typeof value.byte_cap !== "number" ||
+    typeof value.record_count !== "number" ||
+    !Number.isSafeInteger(value.byte_len) ||
+    !Number.isSafeInteger(value.byte_cap) ||
+    !Number.isSafeInteger(value.record_count) ||
+    value.byte_len < 0 ||
+    value.byte_cap < 1 ||
+    value.record_count < 0 ||
+    value.byte_len > value.byte_cap
+  ) {
+    return null;
+  }
+  const scope = parseMemoryScope(value.scope);
+  if (!scope) return null;
+  if (new TextEncoder().encode(value.markdown).length !== value.byte_len) {
+    return null;
+  }
+  return {
+    scope,
+    markdown: value.markdown,
+    byte_len: value.byte_len,
+    byte_cap: value.byte_cap,
+    record_count: value.record_count,
+  };
+}
+
+/** Validate one immutable revision snapshot. */
+export function parseMemoryRevision(value: unknown): MemoryRevision | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireMemoryRevision>(value, [
+      "id",
+      "record_id",
+      "ordinal",
+      "snapshot",
+      "created_at",
+    ]) ||
+    !nonEmptyBounded(value.id, 128) ||
+    !nonEmptyBounded(value.record_id, 128) ||
+    typeof value.ordinal !== "number" ||
+    !Number.isSafeInteger(value.ordinal) ||
+    value.ordinal < 1 ||
+    !nonEmptyBounded(value.created_at, 64)
+  ) {
+    return null;
+  }
+  const snapshot = parseMemoryRecord(value.snapshot);
+  if (!snapshot || snapshot.id !== value.record_id) return null;
+  return {
+    id: value.id,
+    record_id: value.record_id,
+    ordinal: value.ordinal,
+    snapshot,
+    created_at: value.created_at,
+  };
+}
 
 export function parseFolderAccessRequest(
   value: unknown,

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -117,6 +117,22 @@ import {
   type ChatTerminalTurnSnapshot,
   type ChatToolActivitySnapshot,
   type ChatToolActivityStatus,
+  type MemoryCaps as WireMemoryCaps,
+  type MemoryDigest as WireMemoryDigest,
+  type MemoryAuthor as WireMemoryAuthor,
+  type MemoryEvidence as WireMemoryEvidence,
+  type MemoryKind as WireMemoryKind,
+  type MemoryLink as WireMemoryLink,
+  type MemoryLinkRelation as WireMemoryLinkRelation,
+  type MemoryOrigin as WireMemoryOrigin,
+  type MemoryProvenance as WireMemoryProvenance,
+  type MemoryRecord as WireMemoryRecord,
+  type MemoryRecordId as WireMemoryRecordId,
+  type MemoryRevision as WireMemoryRevision,
+  type MemorySettings as WireMemorySettings,
+  type MemoryScope as WireMemoryScope,
+  type MemorySearchHit as WireMemorySearchHit,
+  type MemoryStatus as WireMemoryStatus,
   type ExecBackend,
   type ExecDegradation,
   type ExecFileChangeSummary as WireExecFileChangeSummary,
@@ -1205,6 +1221,24 @@ export type CodeDeliveryDeploymentStatus = WireCodeDeliveryDeploymentStatus;
 export type CodeDeliveryRepositoriesSnapshot =
   WireCodeDeliveryRepositoriesSnapshot;
 export type CodeDeliveryActionResult = WireCodeDeliveryActionResult;
+
+/** Durable memory records and the backend capabilities that serve them. */
+export type MemoryCaps = WireMemoryCaps;
+export type MemoryDigest = WireMemoryDigest;
+export type MemoryAuthor = WireMemoryAuthor;
+export type MemoryEvidence = WireMemoryEvidence;
+export type MemoryKind = WireMemoryKind;
+export type MemoryLink = WireMemoryLink;
+export type MemoryLinkRelation = WireMemoryLinkRelation;
+export type MemoryOrigin = WireMemoryOrigin;
+export type MemoryProvenance = WireMemoryProvenance;
+export type MemoryRecord = WireMemoryRecord;
+export type MemoryRecordId = WireMemoryRecordId;
+export type MemoryRevision = WireMemoryRevision;
+export type MemorySettings = WireMemorySettings;
+export type MemoryScope = WireMemoryScope;
+export type MemorySearchHit = WireMemorySearchHit;
+export type MemoryStatus = WireMemoryStatus;
 
 /** One isolated worktree + branch on a repo. */
 export type CodeWorkspaceSnapshot = WireCodeWorkspaceSnapshot;

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2331,6 +2331,11 @@ export type ConsentVerb = { "kind": "tool", action: RendererToolName, approval: 
 export type CreateCodeTriggerBody = { condition: CodeTriggerCondition, action: CodeTriggerAction, };
 
 /**
+ * Body of `POST /memory/records`.
+ */
+export type CreateMemoryRecordBody = { id: MemoryRecordId, kind: MemoryKind, status: MemoryStatus, title: string, body: string, author: MemoryAuthor, origin: MemoryOrigin, evidence: Array<MemoryEvidence>, links: Array<MemoryLink>, expires_at: string | null, observation_count: number, };
+
+/**
  * Where the resolved credential value is placed on the request.
  *
  * Externally tagged and closed: `"bearer"` or `{"header": "X-Api-Key"}`; an
@@ -3354,6 +3359,315 @@ export type McpServersInfo = { servers: Array<McpServerInfo>, };
  * Where the sandboxed iframe should load one view from, valid once.
  */
 export type McpViewSession = { frame_path: string, };
+
+/**
+ * Who authored a memory record.
+ */
+export type MemoryAuthor = "user" | "model" | "import";
+
+/**
+ * Whether a backend supports one declared operation.
+ */
+export type MemoryCapLevel = "supported" | "unsupported" | "unknown";
+
+/**
+ * Complete capability vector for one memory backend.
+ *
+ * This type has no `Default`. Adding a flag breaks every backend until the
+ * backend states a value.
+ */
+export type MemoryCaps = { extraction: MemoryCapLevel, lexical_search: MemoryCapLevel, semantic_search: MemoryCapLevel, consolidation: MemoryCapLevel, context_assembly: MemoryCapLevel, revision_history: MemoryCapLevel, verified_delete: MemoryCapLevel, asynchronous_writes: MemoryCapLevel, agent_editable_surfaces: MemoryCapLevel, };
+
+/**
+ * One deterministic active-record digest for a scope.
+ */
+export type MemoryDigest = {
+/**
+ * Scope represented by this render.
+ */
+scope: MemoryScope,
+/**
+ * Rendered markdown.
+ */
+markdown: string,
+/**
+ * UTF-8 byte length of `markdown`.
+ */
+byte_len: number,
+/**
+ * Maximum accepted render size.
+ */
+byte_cap: number,
+/**
+ * Number of active records represented.
+ */
+record_count: number, };
+
+/**
+ * One exact source that justifies a model-authored record.
+ */
+export type MemoryEvidence = { "kind": "message",
+/**
+ * Exact message identity.
+ */
+message_id: MessageId, } | { "kind": "code_event",
+/**
+ * Session that owns the event sequence.
+ */
+session_id: CodeSessionId,
+/**
+ * One-based event sequence.
+ */
+seq: number, };
+
+/**
+ * Body of `POST /memory/ingest`.
+ */
+export type MemoryIngestBody = { scope: MemoryScope, origin: MemoryOrigin, content: string, };
+
+/**
+ * Accepted extraction work.
+ */
+export type MemoryIngestReceipt = {
+/**
+ * Durability guarantee at the backend boundary.
+ */
+state: MemoryWriteState,
+/**
+ * Records written synchronously, if any.
+ */
+records: Array<MemoryRecord>, };
+
+/**
+ * What kind of durable knowledge a record carries.
+ */
+export type MemoryKind = "fact" | "preference" | "lesson" | "reference";
+
+/**
+ * One typed link to another memory record.
+ */
+export type MemoryLink = {
+/**
+ * Linked record identity.
+ */
+record_id: MemoryRecordId,
+/**
+ * Why this record links to it.
+ */
+relation: MemoryLinkRelation, };
+
+/**
+ * Meaning of one link to another memory record.
+ */
+export type MemoryLinkRelation = "related" | "updates" | "supersedes";
+
+/**
+ * The product surface that produced a record, where known.
+ */
+export type MemoryOrigin = {
+/**
+ * Originating work-mode conversation.
+ */
+chat_id?: ChatId | null,
+/**
+ * Originating work-mode turn.
+ */
+turn_id?: TurnId | null,
+/**
+ * Originating code session.
+ */
+code_session_id?: CodeSessionId | null,
+/**
+ * Originating code turn.
+ */
+code_turn_id?: CodeTurnId | null,
+/**
+ * Workspace attached to the originating code session.
+ */
+workspace_id?: WorkspaceId | null, };
+
+/**
+ * Authorship and source evidence for one record.
+ */
+export type MemoryProvenance = {
+/**
+ * Who authored the record.
+ */
+author: MemoryAuthor,
+/**
+ * Product origin, where known.
+ */
+origin: MemoryOrigin,
+/**
+ * Exact sources that justify the record.
+ */
+evidence: Array<MemoryEvidence>, };
+
+/**
+ * One durable markdown memory with its typed envelope.
+ */
+export type MemoryRecord = {
+/**
+ * Stable record identity.
+ */
+id: MemoryRecordId,
+/**
+ * Personal or repository scope.
+ */
+scope: MemoryScope,
+/**
+ * Knowledge category.
+ */
+kind: MemoryKind,
+/**
+ * Review and authority state.
+ */
+status: MemoryStatus,
+/**
+ * One-line retrieval hook that says when the record matters.
+ */
+title: string,
+/**
+ * Markdown body, stored verbatim.
+ */
+body: string,
+/**
+ * Authorship, origin, and exact evidence.
+ */
+provenance: MemoryProvenance,
+/**
+ * Typed relationships to other records.
+ */
+links: Array<MemoryLink>,
+/**
+ * Mechanical expiry, when configured.
+ */
+expires_at?: string | null,
+/**
+ * Active replacement for an archived record.
+ */
+superseded_by?: MemoryRecordId | null,
+/**
+ * Distinct supporting observations for a tracked hypothesis.
+ */
+observation_count: number,
+/**
+ * Compare-and-swap revision. The first stored version is 1.
+ */
+revision: number,
+/**
+ * Original creation time.
+ */
+created_at: string,
+/**
+ * Time of the latest committed mutation.
+ */
+updated_at: string, };
+
+/**
+ * Identifies one durable memory record.
+ */
+export type MemoryRecordId = string;
+
+/**
+ * One immutable historical snapshot.
+ */
+export type MemoryRevision = {
+/**
+ * Stable revision-row identity.
+ */
+id: MemoryRevisionId,
+/**
+ * Record that owns the revision.
+ */
+record_id: MemoryRecordId,
+/**
+ * Monotonic per-record ordinal.
+ */
+ordinal: number,
+/**
+ * Full record snapshot after the mutation committed.
+ */
+snapshot: MemoryRecord,
+/**
+ * Time the snapshot committed.
+ */
+created_at: string, };
+
+/**
+ * Identifies one immutable record revision.
+ */
+export type MemoryRevisionId = string;
+
+/**
+ * One durable memory scope.
+ *
+ * The enum is non-exhaustive because wider scopes may arrive later. A
+ * repository scope binds to the registered repository, never a workspace.
+ */
+export type MemoryScope = { "kind": "personal" } | { "kind": "repo",
+/**
+ * Stable registered-repository identity.
+ */
+repo_id: RepoId, };
+
+/**
+ * One injectable lexical-search result.
+ */
+export type MemorySearchHit = {
+/**
+ * Matching record.
+ */
+record_id: MemoryRecordId,
+/**
+ * Retrieval-hook title.
+ */
+title: string,
+/**
+ * Date of the latest committed mutation.
+ */
+updated_at: string,
+/**
+ * First matching markdown line, kept verbatim.
+ */
+matching_line: string,
+/**
+ * Deterministic lexical score. Larger values sort first.
+ */
+score: number, };
+
+/**
+ * Durable memory settings a client can read.
+ */
+export type MemorySettings = {
+/**
+ * Whether memory records and digests are available.
+ */
+enabled: boolean,
+/**
+ * Whether post-turn capture is enabled.
+ */
+capture_enabled: boolean,
+/**
+ * Whether capture can run now. This is false when the capture switch is
+ * on but no utility model resolves.
+ */
+capture_ready: boolean, };
+
+/**
+ * Lifecycle state for one memory record.
+ */
+export type MemoryStatus = "tracking" | "proposed" | "active" | "archived" | "rejected";
+
+/**
+ * Body of `PUT /memory/records/{id}/status`.
+ */
+export type MemoryStatusBody = { expected_revision: number, status: MemoryStatus, };
+
+/**
+ * Whether a backend guarantees that a returned write is durable now.
+ */
+export type MemoryWriteState = "committed" | "pending";
 
 /**
  * Body of `POST /code/workspaces/{id}/pr/merge`.
@@ -4564,7 +4878,12 @@ rewrite_closing_messages: boolean,
 /**
  * How new code repositories name workspace branches for this user.
  */
-git_source_control: GitSourceControlSettings, };
+git_source_control: GitSourceControlSettings,
+/**
+ * Durable memory settings, including whether the utility role can run
+ * post-turn capture.
+ */
+memory: MemorySettings, };
 
 /**
  * Renderer-safe progress of the current sign-in attempt.
@@ -5061,6 +5380,11 @@ export type TurnId = string;
  * does not have to be rebuilt to turn a rule back on.
  */
 export type UpdateCodeTriggerBody = { enabled: boolean, };
+
+/**
+ * Body of `PATCH /memory/records/{id}`.
+ */
+export type UpdateMemoryRecordBody = { expected_revision: number, kind: MemoryKind, title: string, body: string, author: MemoryAuthor, origin: MemoryOrigin, evidence: Array<MemoryEvidence>, links: Array<MemoryLink>, expires_at: string | null, observation_count: number, };
 
 /**
  * One bounded question shown to the user.

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -49,6 +49,7 @@ describe("AgentsPanel", () => {
         branch_prefix_mode: "account",
         effective_branch_prefix: "tidebreak/",
       },
+      memory: { enabled: true, capture_enabled: false, capture_ready: false },
     };
     const putSettings = vi.fn().mockResolvedValue({
       ...settings,
@@ -115,6 +116,7 @@ describe("AgentsPanel", () => {
         branch_prefix_mode: "account",
         effective_branch_prefix: "tidebreak/",
       },
+      memory: { enabled: true, capture_enabled: false, capture_ready: false },
     };
     const putSettings = vi.fn().mockResolvedValue({
       ...settings,

--- a/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.dom.test.tsx
@@ -42,6 +42,7 @@ const initial: RuntimeSettings = {
     account_prefix: "alex/",
     effective_branch_prefix: "alex/",
   },
+  memory: { enabled: true, capture_enabled: false, capture_ready: false },
 };
 
 afterEach(cleanup);

--- a/crates/tidebreak-desktop/ui/src/settings/MemoryPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/MemoryPanel.tsx
@@ -1,0 +1,560 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Brain, Search } from "lucide-react";
+import { toast } from "sonner";
+
+import type {
+  ApiClient,
+  MemoryDigest,
+  MemorySettings,
+  MemoryRecord,
+  MemoryRevision,
+  MemoryScope,
+  MemoryStatus,
+} from "../api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Input } from "@/components/ui/input";
+import { friendlyErrorMessage } from "@/lib/utils";
+import {
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+  SettingsStatus,
+} from "./primitives";
+
+type MemoryView = "review" | "records";
+
+const VIEW_OPTIONS: { id: MemoryView; label: string }[] = [
+  { id: "review", label: "Review" },
+  { id: "records", label: "Records" },
+];
+
+export function MemoryPanel({ client }: { client: ApiClient }) {
+  const [settings, setSettings] = useState<MemorySettings | null>(null);
+  const [view, setView] = useState<MemoryView>("review");
+  const [records, setRecords] = useState<MemoryRecord[] | null>(null);
+  const [digest, setDigest] = useState<MemoryDigest | null>(null);
+  const [search, setSearch] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [revisions, setRevisions] = useState<MemoryRevision[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scope: MemoryScope = { kind: "personal" };
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextSettings, nextRecords, nextDigest] = await Promise.all([
+        client.getSettings(),
+        client.listMemoryRecords(),
+        client.getMemoryDigest(scope),
+      ]);
+      setSettings(nextSettings.memory);
+      setRecords(nextRecords);
+      setDigest(nextDigest);
+      setSelectedId((current) => {
+        const exists =
+          current != null &&
+          nextRecords.some((record) => record.id === current);
+        if (exists) return current;
+        return (
+          nextRecords.find((record) => record.status === "proposed")?.id ??
+          nextRecords[0]?.id ??
+          null
+        );
+      });
+    } catch (caught) {
+      setError(friendlyErrorMessage(caught, "Could not read memory records."));
+    } finally {
+      setLoading(false);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  useEffect(() => {
+    if (selectedId == null) {
+      setRevisions(null);
+      return;
+    }
+    let cancelled = false;
+    void client
+      .getMemoryRevisions(selectedId)
+      .then((nextRevisions) => {
+        if (!cancelled) setRevisions(nextRevisions);
+      })
+      .catch((caught) => {
+        if (!cancelled) {
+          setError(
+            friendlyErrorMessage(caught, "Could not read record history."),
+          );
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, selectedId]);
+
+  const filteredRecords = useMemo(() => {
+    if (records == null) return null;
+    const query = search.trim().toLowerCase();
+    if (!query) return records;
+    return records.filter(
+      (record) =>
+        record.title.toLowerCase().includes(query) ||
+        record.body.toLowerCase().includes(query),
+    );
+  }, [records, search]);
+
+  const selectedRecord =
+    records?.find((record) => record.id === selectedId) ?? null;
+  const proposals =
+    records?.filter((record) => record.status === "proposed") ?? [];
+
+  async function setStatus(record: MemoryRecord, status: MemoryStatus) {
+    setWorking(true);
+    setError(null);
+    try {
+      const updated = await client.setMemoryRecordStatus(record.id, {
+        expected_revision: record.revision,
+        status,
+      });
+      toast.success(
+        status === "active"
+          ? "Memory record activated"
+          : status === "archived"
+            ? "Memory record archived"
+            : "Memory record rejected",
+      );
+      await reload();
+      setSelectedId(updated.id);
+    } catch (caught) {
+      setError(
+        friendlyErrorMessage(caught, "Could not change the record status."),
+      );
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function updateSettings(update: {
+    enabled?: boolean;
+    capture_enabled?: boolean;
+  }) {
+    setWorking(true);
+    setError(null);
+    try {
+      const settings = await client.putSettings({ memory: update });
+      setSettings(settings.memory);
+      toast.success("Saved memory settings");
+    } catch (caught) {
+      setError(friendlyErrorMessage(caught, "Could not save memory settings."));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Memory"
+      description="Review durable records before they gain authority, inspect their evidence, and see the digest conversations receive."
+      busy={loading || working}
+    >
+      {loading && records == null ? (
+        <p className="text-sm text-muted-foreground" role="status">
+          Loading memory…
+        </p>
+      ) : records == null || digest == null ? (
+        <div className="flex flex-col items-start gap-3">
+          <SettingsError>{error}</SettingsError>
+          <Button type="button" variant="outline" size="sm" onClick={reload}>
+            Try again
+          </Button>
+        </div>
+      ) : (
+        <>
+          {digest.record_count === 0 ? (
+            <SettingsStatus
+              tone="disabled"
+              label="No active memory"
+              description="Nothing is injected into conversations yet."
+            />
+          ) : (
+            <SettingsStatus
+              tone="ready"
+              label={`${digest.record_count} active record${digest.record_count === 1 ? "" : "s"}`}
+              description="Personal memory is injected as dated claims; the current conversation always overrides it."
+            />
+          )}
+
+          <SettingsSection
+            title="Memory settings"
+            description="Explicit records and digests stay available even when capture is off."
+          >
+            {settings == null ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : (
+              <>
+                <SettingsField
+                  label="Enable memory"
+                  hint="Turn off to stop records and digests without deleting anything."
+                >
+                  <Switch
+                    checked={settings.enabled}
+                    disabled={working}
+                    onCheckedChange={(enabled) =>
+                      void updateSettings({ enabled })
+                    }
+                  />
+                </SettingsField>
+                <SettingsField
+                  label="Capture new records after turns"
+                  hint="Capture uses the utility model and always starts as a proposal."
+                >
+                  <Switch
+                    checked={settings.capture_enabled}
+                    disabled={working || !settings.enabled}
+                    onCheckedChange={(enabled) =>
+                      void updateSettings({ capture_enabled: enabled })
+                    }
+                  />
+                </SettingsField>
+                {settings.enabled &&
+                  settings.capture_enabled &&
+                  !settings.capture_ready && (
+                    <SettingsStatus
+                      tone="not-configured"
+                      label="Capture is waiting on a utility model"
+                      description="Choose a model for the utility role, then capture starts on the next completed turn."
+                    />
+                  )}
+              </>
+            )}
+          </SettingsSection>
+
+          <SettingsSection title="Review">
+            <div className="flex flex-wrap items-center gap-2">
+              {VIEW_OPTIONS.map((option) => (
+                <Button
+                  key={option.id}
+                  type="button"
+                  variant={view === option.id ? "default" : "outline"}
+                  size="sm"
+                  disabled={working}
+                  onClick={() => setView(option.id)}
+                >
+                  {option.label}
+                  {option.id === "review" && proposals.length > 0 && (
+                    <span className="ml-1 tabular-nums opacity-70">
+                      {proposals.length}
+                    </span>
+                  )}
+                </Button>
+              ))}
+            </div>
+            {view === "review" ? (
+              proposals.length === 0 ? (
+                <Empty className="min-h-48">
+                  <EmptyHeader>
+                    <EmptyMedia variant="icon" className="text-icon-violet">
+                      <Brain />
+                    </EmptyMedia>
+                    <EmptyTitle>No memory waiting for review</EmptyTitle>
+                    <EmptyDescription>
+                      New model-authored records appear here before they can
+                      enter a conversation.
+                    </EmptyDescription>
+                  </EmptyHeader>
+                </Empty>
+              ) : (
+                <ul className="flex flex-col gap-2">
+                  {proposals.map((record) => (
+                    <MemoryRecordRow
+                      key={record.id}
+                      record={record}
+                      selected={record.id === selectedId}
+                      onSelect={() => setSelectedId(record.id)}
+                    />
+                  ))}
+                </ul>
+              )
+            ) : (
+              <div className="flex flex-col gap-3">
+                <label className="flex items-center gap-2 rounded-lg border border-input pr-2 pl-3 text-sm">
+                  <Search
+                    className="size-4 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <Input
+                    className="h-control border-0 bg-transparent pr-0 pl-0 shadow-none focus-visible:border-transparent focus-visible:ring-0"
+                    placeholder="Search records…"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                  />
+                </label>
+                {filteredRecords?.length === 0 ? (
+                  <Empty className="min-h-48">
+                    <EmptyHeader>
+                      <EmptyMedia variant="icon" className="text-icon-violet">
+                        <Brain />
+                      </EmptyMedia>
+                      <EmptyTitle>No matching records</EmptyTitle>
+                      <EmptyDescription>
+                        Try another word or clear the search.
+                      </EmptyDescription>
+                    </EmptyHeader>
+                  </Empty>
+                ) : (
+                  <ul className="flex flex-col gap-2">
+                    {filteredRecords?.map((record) => (
+                      <MemoryRecordRow
+                        key={record.id}
+                        record={record}
+                        selected={record.id === selectedId}
+                        onSelect={() => setSelectedId(record.id)}
+                      />
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </SettingsSection>
+
+          {selectedRecord && (
+            <MemoryDetail
+              record={selectedRecord}
+              revisions={revisions}
+              working={working}
+              onActivate={() => void setStatus(selectedRecord, "active")}
+              onReject={() => void setStatus(selectedRecord, "rejected")}
+              onArchive={() => void setStatus(selectedRecord, "archived")}
+            />
+          )}
+
+          <SettingsSection
+            title="Digest preview"
+            description="The exact markdown injected at a conversation boundary."
+          >
+            <div className="flex flex-col gap-3">
+              <div
+                className="flex items-center gap-2"
+                role="status"
+                aria-label="Digest size"
+              >
+                <div className="h-1.5 min-w-16 grow overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    style={{
+                      width: `${Math.min(100, (digest.byte_len / digest.byte_cap) * 100)}%`,
+                    }}
+                  />
+                </div>
+                <span className="font-mono text-xs text-muted-foreground">
+                  {digest.byte_len}/{digest.byte_cap} bytes
+                </span>
+              </div>
+              <pre className="max-h-64 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs whitespace-pre-wrap">
+                {digest.markdown || "No active memory."}
+              </pre>
+            </div>
+          </SettingsSection>
+          {error && <SettingsError>{error}</SettingsError>}
+        </>
+      )}
+    </SettingsPanel>
+  );
+}
+
+function MemoryRecordRow({
+  record,
+  selected,
+  onSelect,
+}: {
+  record: MemoryRecord;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <li>
+      <button
+        type="button"
+        className={`flex w-full items-start justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors ${
+          selected || hovered ? "border-ring bg-accent" : ""
+        }`}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onFocus={() => setHovered(true)}
+        onBlur={() => setHovered(false)}
+        onClick={onSelect}
+      >
+        <span className="min-w-0">
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-sm font-medium">{record.title}</span>
+          </span>
+          <span className="mt-1 block truncate text-xs text-muted-foreground">
+            {record.body}
+          </span>
+        </span>
+        <span className="flex shrink-0 items-center gap-2">
+          <Badge variant={statusVariant(record.status)} size="sm">
+            {record.status}
+          </Badge>
+          <span className="font-mono text-xs text-muted-foreground">
+            {formatDay(record.updated_at)}
+          </span>
+        </span>
+      </button>
+    </li>
+  );
+}
+
+function MemoryDetail({
+  record,
+  revisions,
+  working,
+  onActivate,
+  onReject,
+  onArchive,
+}: {
+  record: MemoryRecord;
+  revisions: MemoryRevision[] | null;
+  working: boolean;
+  onActivate: () => void;
+  onReject: () => void;
+  onArchive: () => void;
+}) {
+  return (
+    <SettingsSection
+      title="Record detail"
+      description={`${record.kind} · ${record.provenance.author} · revision ${record.revision}`}
+    >
+      <div className="flex flex-col gap-4">
+        <div>
+          <h3 className="text-sm font-semibold">{record.title}</h3>
+          <p className="mt-2 text-sm whitespace-pre-wrap">{record.body}</p>
+        </div>
+        <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs">
+          <dt className="text-muted-foreground">Status</dt>
+          <dd>
+            <Badge variant={statusVariant(record.status)} size="sm">
+              {record.status}
+            </Badge>
+          </dd>
+          <dt className="text-muted-foreground">Author</dt>
+          <dd>{record.provenance.author}</dd>
+          {record.provenance.evidence.length > 0 && (
+            <>
+              <dt className="text-muted-foreground">Evidence</dt>
+              <dd className="font-mono">
+                {record.provenance.evidence
+                  .map((entry) =>
+                    entry.kind === "message"
+                      ? `message ${entry.message_id}`
+                      : `code event ${entry.session_id}:${entry.seq}`,
+                  )
+                  .join(", ")}
+              </dd>
+            </>
+          )}
+          {record.links.length > 0 && (
+            <>
+              <dt className="text-muted-foreground">Links</dt>
+              <dd className="font-mono">
+                {record.links
+                  .map((link) => `${link.relation} ${link.record_id}`)
+                  .join(", ")}
+              </dd>
+            </>
+          )}
+          {record.expires_at && (
+            <>
+              <dt className="text-muted-foreground">Expires</dt>
+              <dd>{formatDay(record.expires_at)}</dd>
+            </>
+          )}
+        </dl>
+        {record.status === "proposed" && (
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              size="sm"
+              disabled={working}
+              onClick={onActivate}
+            >
+              Activate
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={working}
+              onClick={onReject}
+            >
+              Reject
+            </Button>
+          </div>
+        )}
+        {record.status === "active" && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={working}
+            onClick={onArchive}
+          >
+            Archive
+          </Button>
+        )}
+        {revisions != null && (
+          <div>
+            <h3 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+              History
+            </h3>
+            <ol className="mt-2 flex flex-col gap-1">
+              {revisions.map((revision) => (
+                <li
+                  key={revision.id}
+                  className="flex items-center justify-between gap-3 text-xs"
+                >
+                  <span className="truncate">{revision.snapshot.title}</span>
+                  <span className="shrink-0 font-mono text-muted-foreground">
+                    {formatDay(revision.created_at)} · revision{" "}
+                    {revision.ordinal}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+      </div>
+    </SettingsSection>
+  );
+}
+
+function statusVariant(
+  status: MemoryStatus,
+): "success" | "warning" | "secondary" | "critical" {
+  if (status === "active") return "success";
+  if (status === "proposed") return "warning";
+  if (status === "rejected") return "critical";
+  return "secondary";
+}
+
+function formatDay(timestamp: string): string {
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? timestamp : date.toLocaleDateString();
+}

--- a/crates/tidebreak-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -140,6 +140,7 @@ const runtimeSettings: RuntimeSettings = {
     account_prefix: "alex/",
     effective_branch_prefix: "alex/",
   },
+  memory: { enabled: true, capture_enabled: false, capture_ready: false },
 };
 
 afterEach(() => {

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -17,6 +17,7 @@ import {
   Waypoints,
   Zap,
   MessagesSquare,
+  Brain,
 } from "lucide-react";
 
 import { useApp } from "@/AppContext";
@@ -39,6 +40,7 @@ import { CodingHarnessesPanel } from "./CodingHarnessesPanel";
 import { QuickActionsPanel } from "./QuickActionsPanel";
 import { ChannelsPanel } from "./ChannelsPanel";
 import { GitSourceControlPanel } from "./GitSourceControlPanel";
+import { MemoryPanel } from "./MemoryPanel";
 
 /**
  * Each section reads what it needs from the shell context rather than being
@@ -204,6 +206,11 @@ function GitSourceControlSection() {
   return <GitSourceControlPanel client={client} />;
 }
 
+function MemorySection() {
+  const { client } = useApp();
+  return <MemoryPanel client={client} />;
+}
+
 export type SettingsSectionDef = {
   /** The path segment under `/settings`, and its address. */
   path: string;
@@ -327,6 +334,14 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     icon: MessagesSquare,
     iconClass: "text-icon-green",
     Component: ChannelsSection,
+  },
+  {
+    path: "memory",
+    label: "Memory",
+    group: "capabilities",
+    icon: Brain,
+    iconClass: "text-icon-violet",
+    Component: MemorySection,
   },
   {
     path: "connected-apps",

--- a/crates/tidebreak-desktop/ui/src/stories/MemoryPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/MemoryPanel.stories.tsx
@@ -1,0 +1,188 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type {
+  ApiClient,
+  MemoryRecord,
+  MemoryRevision,
+  MemorySettings,
+} from "@/api";
+import { MemoryPanel } from "@/settings/MemoryPanel";
+
+function origin() {
+  return {
+    chat_id: "9d5d84a0-6ba6-4c73-9e10-000000000001",
+    turn_id: null,
+    code_session_id: null,
+    code_turn_id: null,
+    workspace_id: null,
+  };
+}
+
+const proposal: MemoryRecord = {
+  id: "3f19d0d5-8f46-4f57-a35a-000000000001",
+  scope: { kind: "personal" },
+  kind: "lesson",
+  status: "proposed",
+  title: "When changing database migrations",
+  body: "Run the migration chain test before publishing.",
+  provenance: {
+    author: "model",
+    origin: origin(),
+    evidence: [
+      { kind: "message", message_id: "c6a0d000-0000-4000-8000-000000000001" },
+    ],
+  },
+  links: [],
+  expires_at: null,
+  superseded_by: null,
+  observation_count: 0,
+  revision: 1,
+  created_at: "2026-09-01T09:00:00Z",
+  updated_at: "2026-09-01T09:00:00Z",
+};
+
+const active: MemoryRecord = {
+  ...proposal,
+  id: "3f19d0d5-8f46-4f57-a35a-000000000002",
+  status: "active",
+  title: "When preparing a release",
+  body: "Run the release smoke test before publishing.",
+  revision: 2,
+  updated_at: "2026-08-30T14:00:00Z",
+};
+
+const hypothesis: MemoryRecord = {
+  ...proposal,
+  id: "3f19d0d5-8f46-4f57-a35a-000000000003",
+  status: "tracking",
+  title: "When reviewing pull requests",
+  body: "The reader prefers concrete migration checks over general praise.",
+  provenance: {
+    author: "model",
+    origin: origin(),
+    evidence: [
+      { kind: "message", message_id: "c6a0d000-0000-4000-8000-000000000002" },
+    ],
+  },
+  observation_count: 2,
+};
+
+const revisions: MemoryRevision[] = [
+  {
+    id: "7f586e60-0000-4000-8000-000000000001",
+    record_id: proposal.id,
+    ordinal: 1,
+    snapshot: proposal,
+    created_at: proposal.created_at,
+  },
+];
+
+function digestFor(records: MemoryRecord[], byteCap = 8192) {
+  const markdown = records
+    .map((record) => `- ${record.updated_at.slice(0, 10)} — ${record.title}`)
+    .join("\n");
+  return {
+    scope: { kind: "personal" },
+    markdown,
+    byte_len: new TextEncoder().encode(markdown).length,
+    byte_cap: byteCap,
+    record_count: records.length,
+  };
+}
+
+const settingsWith = (memory: MemorySettings) =>
+  ({ memory }) as unknown as Awaited<ReturnType<ApiClient["getSettings"]>>;
+
+function stubClient(
+  records: MemoryRecord[],
+  options?: {
+    fail?: boolean;
+    revisions?: MemoryRevision[];
+    memory?: MemorySettings;
+  },
+): ApiClient {
+  let memory: MemorySettings = options?.memory ?? {
+    enabled: true,
+    capture_enabled: false,
+    capture_ready: false,
+  };
+  return {
+    getSettings: async () => {
+      if (options?.fail) throw new Error("The memory backend is unavailable.");
+      return settingsWith(memory);
+    },
+    putSettings: async (body: { memory?: Partial<MemorySettings> }) => {
+      memory = { ...memory, ...body.memory };
+      return settingsWith(memory);
+    },
+    setMemoryRecordStatus: async () => records[0],
+    deleteMemoryRecord: async () => undefined,
+    listMemoryRecords: async () => {
+      if (options?.fail) throw new Error("The memory backend is unavailable.");
+      return records;
+    },
+    getMemoryDigest: async () => {
+      if (options?.fail) throw new Error("The memory backend is unavailable.");
+      return digestFor(records.filter((record) => record.status === "active"));
+    },
+    getMemoryRevisions: async () => options?.revisions ?? [],
+  } as unknown as ApiClient;
+}
+
+const meta = {
+  title: "Settings/Memory",
+  component: MemoryPanel,
+  parameters: { layout: "fullscreen" },
+  args: { client: stubClient([proposal, active, hypothesis], { revisions }) },
+} satisfies Meta<typeof MemoryPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** One model proposal waiting for review beside active and tracked records. */
+export const ReviewQueue: Story = {};
+
+/** A first-run install: no records and no digest. */
+export const Empty: Story = {
+  args: { client: stubClient([], { revisions: [] }) },
+};
+
+/** An active record with its provenance and revision history. */
+export const ActiveRecord: Story = {
+  args: {
+    client: stubClient([active, proposal], {
+      revisions: [
+        {
+          id: "7f586e60-0000-4000-8000-000000000002",
+          record_id: active.id,
+          ordinal: 2,
+          snapshot: active,
+          created_at: active.updated_at,
+        },
+      ],
+    }),
+  },
+};
+
+/** The backend read failed; retry is the only action. */
+export const LoadFailed: Story = {
+  args: { client: stubClient([], { fail: true, revisions: [] }) },
+};
+
+/** A digest near its byte budget, so the meter reads as a real limit. */
+export const DigestNearCap: Story = {
+  args: {
+    client: {
+      getSettings: async () =>
+        settingsWith({
+          enabled: true,
+          capture_enabled: true,
+          capture_ready: true,
+        }),
+      listMemoryRecords: async () => [active, proposal],
+      getMemoryDigest: async () =>
+        digestFor([active], Math.max(1, digestFor([active]).byte_len - 1)),
+      getMemoryRevisions: async () => revisions,
+    } as unknown as ApiClient,
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
@@ -96,6 +96,7 @@ export const storySettings: RuntimeSettings = {
     account_prefix: "alex/",
     effective_branch_prefix: "alex/",
   },
+  memory: { enabled: true, capture_enabled: false, capture_ready: false },
 };
 
 function model(
@@ -474,6 +475,16 @@ function createSettingsStoryClient(
                     settings.git_source_control.custom_branch_prefix),
             }
           : settings.git_source_control,
+        memory: body.memory
+          ? {
+              ...settings.memory,
+              ...body.memory,
+              capture_ready:
+                (body.memory.enabled ?? settings.memory.enabled) &&
+                (body.memory.capture_enabled ??
+                  settings.memory.capture_enabled),
+            }
+          : settings.memory,
       };
       return write(settings);
     },

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -213,6 +213,36 @@ impl From<AgentError> for ServerError {
     }
 }
 
+/// Memory errors carry product meaning at the route boundary.
+impl From<tidebreak_core::MemoryError> for ServerError {
+    fn from(error: tidebreak_core::MemoryError) -> Self {
+        use tidebreak_core::{MemoryCapability, MemoryError};
+
+        match &error {
+            MemoryError::Unsupported(MemoryCapability::Extraction) => {
+                Self::not_implemented(error.to_string())
+            }
+            MemoryError::Unsupported(_) => Self::not_implemented(error.to_string()),
+            MemoryError::InvalidRecord(_)
+            | MemoryError::EvidenceNotFound(_)
+            | MemoryError::ScopeNotFound => Self::bad_request(error.to_string()),
+            MemoryError::NotFound => Self::not_found("memory record not found"),
+            MemoryError::AlreadyExists => Self::conflict("memory record already exists"),
+            MemoryError::RevisionConflict { .. } => {
+                Self::conflict_kind("memory_revision_conflict", error.to_string())
+            }
+            MemoryError::InvalidStatusTransition { .. } => {
+                Self::conflict_kind("memory_status_conflict", error.to_string())
+            }
+            MemoryError::ActiveRecordCapExceeded { .. } | MemoryError::DigestCapExceeded { .. } => {
+                Self::conflict_kind("memory_cap_exceeded", error.to_string())
+            }
+            MemoryError::Backend(_) => Self::internal("memory storage failed"),
+            _ => Self::internal("memory storage failed"),
+        }
+    }
+}
+
 impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         (self.status, Json(self.info)).into_response()

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -2173,11 +2173,23 @@ async fn bind_inner(
     // instance (two instances over the same keychain entry can race a stale
     // refresh token into the gateway's reuse detection, a spurious full
     // sign-out).
-    let mut state =
-        AppState::new_with_db_store(config, db.clone(), resolver, secrets, tools, agent_config)?
-            .with_on_behalf_of_gateway(on_behalf_of_gateway);
-    state.client_executor_id = client_executor_id.unwrap_or_else(Uuid::new_v4);
-    state.root_attachment_routes_enabled = client_executor_id.is_some();
+    let mut state = AppState::with_gateway_runtime(
+        config,
+        store,
+        resolver,
+        secrets,
+        tools,
+        agent_config,
+        client_executor_id.unwrap_or_else(Uuid::new_v4),
+        gateway,
+        chatgpt,
+        provisioned_policy,
+        os_policy,
+    )?
+    .with_on_behalf_of_gateway(on_behalf_of_gateway);
+    // Memory routes need the backend trait the concrete database implements;
+    // the same connection `store` wraps, not a second one.
+    state.memory = Some(db.clone());
     state.adapter_bootstrap_tokens = auth::AdapterBootstrapTokens::from_env()?.map(Arc::new);
     state.agent_run_wake = agent_run_wake;
     state.sandbox_attempts = sandbox_attempts;

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -92,6 +92,7 @@ pub mod sandbox_docker;
 mod sandbox_exec_worker;
 mod sandbox_task_plan_worker;
 mod sandbox_web_search_worker;
+mod scoped_memory;
 mod scoped_model_token;
 mod scoped_store;
 #[cfg(any(test, feature = "scripted-harness"))]
@@ -664,6 +665,28 @@ pub fn app(state: AppState) -> Router {
                 )),
         )
         .route("/models", get(routes::list_models))
+        .route("/memory/capabilities", get(routes::capabilities))
+        .route(
+            "/memory/records",
+            get(routes::list_records).post(routes::create_record),
+        )
+        .route(
+            "/memory/records/{id}",
+            get(routes::get_record)
+                .patch(routes::update_record)
+                .delete(routes::delete_record),
+        )
+        .route(
+            "/memory/records/{id}/status",
+            axum::routing::put(routes::set_record_status),
+        )
+        .route("/memory/records/{id}/revisions", get(routes::revisions))
+        .route("/memory/search", get(routes::search))
+        .route("/memory/digest", get(routes::digest))
+        .route(
+            "/memory/ingest",
+            post(routes::ingest).layer(DefaultBodyLimit::max(routes::MAX_MEMORY_BODY_BYTES)),
+        )
         .route("/web-search", get(routes::get_web_search_config))
         .route(
             "/code-execution",
@@ -2150,20 +2173,11 @@ async fn bind_inner(
     // instance (two instances over the same keychain entry can race a stale
     // refresh token into the gateway's reuse detection, a spurious full
     // sign-out).
-    let mut state = AppState::with_gateway_runtime(
-        config,
-        store,
-        resolver,
-        secrets,
-        tools,
-        agent_config,
-        client_executor_id.unwrap_or_else(Uuid::new_v4),
-        gateway,
-        chatgpt,
-        provisioned_policy,
-        os_policy,
-    )?
-    .with_on_behalf_of_gateway(on_behalf_of_gateway);
+    let mut state =
+        AppState::new_with_db_store(config, db.clone(), resolver, secrets, tools, agent_config)?
+            .with_on_behalf_of_gateway(on_behalf_of_gateway);
+    state.client_executor_id = client_executor_id.unwrap_or_else(Uuid::new_v4);
+    state.root_attachment_routes_enabled = client_executor_id.is_some();
     state.adapter_bootstrap_tokens = auth::AdapterBootstrapTokens::from_env()?.map(Arc::new);
     state.agent_run_wake = agent_run_wake;
     state.sandbox_attempts = sandbox_attempts;

--- a/crates/tidebreak-server/src/routes.rs
+++ b/crates/tidebreak-server/src/routes.rs
@@ -16,6 +16,12 @@ pub(crate) const PROMPT_CACHE_RETENTION_SETTING: &str = "models.prompt_cache_ret
 /// Master switch for the computer-use capability (screen capture + app
 /// control). Default on; setting it false unregisters the tools at boot.
 pub(crate) const COMPUTER_USE_ENABLED_SETTING: &str = "computer_use.enabled";
+/// Master switch for durable memory. Default on; explicit reads and writes
+/// stay available even when no utility model is configured.
+pub(crate) const MEMORY_ENABLED_SETTING: &str = "memory.enabled";
+/// Master switch for post-turn memory capture. Capture also requires a
+/// resolvable utility model.
+pub(crate) const MEMORY_CAPTURE_ENABLED_SETTING: &str = "memory.capture.enabled";
 
 mod agent_runs;
 mod app_gateway_page;
@@ -33,6 +39,7 @@ mod events;
 pub(crate) mod image_attachment;
 mod inbox;
 mod mcp_gateway;
+mod memory;
 mod notifications;
 mod outputs;
 mod plans;
@@ -60,6 +67,7 @@ pub use events::*;
 pub use image_attachment::*;
 pub use inbox::*;
 pub use mcp_gateway::*;
+pub use memory::*;
 pub use notifications::*;
 pub use outputs::*;
 pub use plans::*;

--- a/crates/tidebreak-server/src/routes/memory.rs
+++ b/crates/tidebreak-server/src/routes/memory.rs
@@ -1,0 +1,310 @@
+//! Owner-scoped HTTP routes for durable memory records.
+
+use axum::extract::Query;
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use tidebreak_core::{
+    MemoryAuthor, MemoryEvidence, MemoryIngestRequest, MemoryLink, MemoryListFilter, MemoryOrigin,
+    MemoryProvenance, MemoryRecord, MemoryRecordId, MemoryRecordUpdate, MemoryScope,
+    MemorySearchRequest, MemoryStatus, MemoryStatusChange,
+};
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path};
+use crate::scoped_memory::ScopedMemory;
+
+/// Largest memory request body. A record body is capped at 2 KiB, and the
+/// envelope adds provenance, links, and JSON overhead.
+pub const MAX_MEMORY_BODY_BYTES: usize = 64 * 1024;
+
+/// Body of `POST /memory/records`.
+#[derive(Debug, Deserialize, ts_rs::TS)]
+pub struct CreateMemoryRecordBody {
+    pub id: MemoryRecordId,
+    pub kind: tidebreak_core::MemoryKind,
+    pub status: MemoryStatus,
+    pub title: String,
+    pub body: String,
+    pub author: MemoryAuthor,
+    #[serde(default)]
+    pub origin: MemoryOrigin,
+    #[serde(default)]
+    pub evidence: Vec<MemoryEvidence>,
+    #[serde(default)]
+    pub links: Vec<MemoryLink>,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub observation_count: u32,
+}
+
+impl CreateMemoryRecordBody {
+    fn into_record(self, scope: MemoryScope) -> MemoryRecord {
+        let now = Utc::now();
+        MemoryRecord {
+            id: self.id,
+            scope,
+            kind: self.kind,
+            status: self.status,
+            title: self.title,
+            body: self.body,
+            provenance: MemoryProvenance {
+                author: self.author,
+                origin: self.origin,
+                evidence: self.evidence,
+            },
+            links: self.links,
+            expires_at: self.expires_at,
+            superseded_by: None,
+            observation_count: self.observation_count,
+            revision: 1,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+/// Body of `PATCH /memory/records/{id}`.
+#[derive(Debug, Deserialize, ts_rs::TS)]
+pub struct UpdateMemoryRecordBody {
+    pub expected_revision: i64,
+    pub kind: tidebreak_core::MemoryKind,
+    pub title: String,
+    pub body: String,
+    pub author: MemoryAuthor,
+    #[serde(default)]
+    pub origin: MemoryOrigin,
+    #[serde(default)]
+    pub evidence: Vec<MemoryEvidence>,
+    #[serde(default)]
+    pub links: Vec<MemoryLink>,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub observation_count: u32,
+}
+
+impl UpdateMemoryRecordBody {
+    fn into_update(self, id: MemoryRecordId) -> MemoryRecordUpdate {
+        MemoryRecordUpdate {
+            id,
+            expected_revision: self.expected_revision,
+            kind: self.kind,
+            title: self.title,
+            body: self.body,
+            provenance: MemoryProvenance {
+                author: self.author,
+                origin: self.origin,
+                evidence: self.evidence,
+            },
+            links: self.links,
+            expires_at: self.expires_at,
+            observation_count: self.observation_count,
+        }
+    }
+}
+
+/// Body of `PUT /memory/records/{id}/status`.
+#[derive(Debug, Deserialize, ts_rs::TS)]
+pub struct MemoryStatusBody {
+    pub expected_revision: i64,
+    pub status: MemoryStatus,
+}
+
+/// `GET /memory/records` filters.
+#[derive(Debug, Default, Deserialize)]
+pub struct MemoryListQuery {
+    #[serde(flatten)]
+    pub filter: MemoryListFilter,
+}
+
+/// `GET /memory/search` filters.
+///
+/// Query strings cannot carry a nested struct, so the scope is two flat
+/// fields: `repo_id` selects one repository scope, `scope_kind=personal`
+/// selects the personal scope, and neither searches every scope the owner
+/// has.
+#[derive(Debug, Deserialize)]
+pub struct MemorySearchQuery {
+    pub query: String,
+    #[serde(default)]
+    pub scope_kind: Option<MemorySearchScopeKind>,
+    #[serde(default)]
+    pub repo_id: Option<tidebreak_core::RepoId>,
+    #[serde(default)]
+    pub statuses: Vec<MemoryStatus>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+/// The scope kinds a search can name without a repository id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemorySearchScopeKind {
+    Personal,
+    Repo,
+}
+
+impl MemorySearchQuery {
+    /// The exact scope to search, or `None` for every owner scope.
+    fn scope(&self) -> Result<Option<MemoryScope>, ServerError> {
+        match (self.scope_kind, self.repo_id) {
+            (_, Some(repo_id)) => Ok(Some(MemoryScope::Repo { repo_id })),
+            (Some(MemorySearchScopeKind::Personal), None) => Ok(Some(MemoryScope::Personal)),
+            (Some(MemorySearchScopeKind::Repo), None) => Err(ServerError::bad_request(
+                "repo_id is required to search a repository scope",
+            )),
+            (None, None) => Ok(None),
+        }
+    }
+}
+
+/// Body of `POST /memory/ingest`.
+#[derive(Debug, Deserialize, ts_rs::TS)]
+pub struct MemoryIngestBody {
+    pub scope: MemoryScope,
+    #[serde(default)]
+    pub origin: MemoryOrigin,
+    pub content: String,
+}
+
+/// Scope parsed from a route segment or query field.
+#[derive(Debug, Default, Deserialize)]
+pub struct MemoryScopeQuery {
+    #[serde(default)]
+    pub repo_id: Option<tidebreak_core::RepoId>,
+}
+
+impl MemoryScopeQuery {
+    fn scope(&self) -> Result<MemoryScope, ServerError> {
+        match self.repo_id {
+            None => Ok(MemoryScope::Personal),
+            Some(repo_id) => Ok(MemoryScope::Repo { repo_id }),
+        }
+    }
+}
+
+/// `GET /memory/capabilities` — every operation the backend reports.
+pub async fn capabilities(memory: ScopedMemory) -> Json<tidebreak_core::MemoryCaps> {
+    Json(memory.caps())
+}
+
+/// `GET /memory/records` — list the caller's records.
+pub async fn list_records(
+    memory: ScopedMemory,
+    Query(query): Query<MemoryListQuery>,
+) -> Result<Json<Vec<MemoryRecord>>, ServerError> {
+    Ok(Json(memory.list(query.filter).await?))
+}
+
+/// `POST /memory/records` — store one caller-supplied record.
+pub async fn create_record(
+    memory: ScopedMemory,
+    Query(scope): Query<MemoryScopeQuery>,
+    Json(body): Json<CreateMemoryRecordBody>,
+) -> Result<(StatusCode, Json<MemoryRecord>), ServerError> {
+    let receipt = memory.put(body.into_record(scope.scope()?)).await?;
+    Ok((StatusCode::CREATED, Json(receipt.record)))
+}
+
+/// `GET /memory/records/{id}` — load one caller-owned record.
+pub async fn get_record(
+    memory: ScopedMemory,
+    Path(id): Path<MemoryRecordId>,
+) -> Result<Json<MemoryRecord>, ServerError> {
+    let record = memory
+        .get(id)
+        .await?
+        .ok_or_else(|| ServerError::not_found(format!("memory record {id} not found")))?;
+    Ok(Json(record))
+}
+
+/// `PATCH /memory/records/{id}` — replace one editable record envelope.
+pub async fn update_record(
+    memory: ScopedMemory,
+    Path(id): Path<MemoryRecordId>,
+    Json(body): Json<UpdateMemoryRecordBody>,
+) -> Result<Json<MemoryRecord>, ServerError> {
+    let receipt = memory.update(body.into_update(id)).await?;
+    Ok(Json(receipt.record))
+}
+
+/// `PUT /memory/records/{id}/status` — move one record through its lifecycle.
+pub async fn set_record_status(
+    memory: ScopedMemory,
+    Path(id): Path<MemoryRecordId>,
+    Json(body): Json<MemoryStatusBody>,
+) -> Result<Json<MemoryRecord>, ServerError> {
+    let receipt = memory
+        .set_status(MemoryStatusChange {
+            id,
+            expected_revision: body.expected_revision,
+            status: body.status,
+        })
+        .await?;
+    Ok(Json(receipt.record))
+}
+
+/// `DELETE /memory/records/{id}` — hard-delete one record and its revisions.
+pub async fn delete_record(
+    memory: ScopedMemory,
+    Path(id): Path<MemoryRecordId>,
+) -> Result<StatusCode, ServerError> {
+    if memory.delete(id).await? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ServerError::not_found(format!(
+            "memory record {id} not found"
+        )))
+    }
+}
+
+/// `GET /memory/search` — search full titles and bodies.
+pub async fn search(
+    memory: ScopedMemory,
+    Query(query): Query<MemorySearchQuery>,
+) -> Result<Json<Vec<tidebreak_core::MemorySearchHit>>, ServerError> {
+    Ok(Json(
+        memory
+            .search(MemorySearchRequest {
+                scope: query.scope()?,
+                query: query.query,
+                statuses: query.statuses,
+                limit: query.limit.unwrap_or(20),
+            })
+            .await?,
+    ))
+}
+
+/// `GET /memory/digest` — render one scope's active-record digest.
+pub async fn digest(
+    memory: ScopedMemory,
+    Query(scope): Query<MemoryScopeQuery>,
+) -> Result<Json<tidebreak_core::MemoryDigest>, ServerError> {
+    Ok(Json(memory.assemble_context(scope.scope()?).await?))
+}
+
+/// `GET /memory/records/{id}/revisions` — return an owned record's history.
+pub async fn revisions(
+    memory: ScopedMemory,
+    Path(id): Path<MemoryRecordId>,
+) -> Result<Json<Vec<tidebreak_core::MemoryRevision>>, ServerError> {
+    Ok(Json(memory.revision_history(id).await?))
+}
+
+/// `POST /memory/ingest` — ask an extraction-capable backend to derive records.
+pub async fn ingest(
+    memory: ScopedMemory,
+    Json(body): Json<MemoryIngestBody>,
+) -> Result<Json<tidebreak_core::MemoryIngestReceipt>, ServerError> {
+    Ok(Json(
+        memory
+            .ingest(MemoryIngestRequest {
+                scope: body.scope,
+                origin: body.origin,
+                content: body.content,
+            })
+            .await?,
+    ))
+}

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -159,6 +159,10 @@ pub struct Settings {
     pub rewrite_closing_messages: bool,
     /// How new code repositories name workspace branches for this user.
     pub git_source_control: GitSourceControlSettings,
+    /// Durable memory settings, including whether the utility role can run
+    /// post-turn capture.
+    #[serde(default)]
+    pub memory: MemorySettings,
 }
 
 /// The reader's last explicit per-chat choices — what an unspecified field of
@@ -220,6 +224,10 @@ pub struct SettingsUpdate {
     /// Update branch naming defaults. Absent fields stay unchanged.
     #[serde(default)]
     pub git_source_control: Option<GitSourceControlSettingsUpdate>,
+    /// Set the memory master and capture switches. Absent fields stay
+    /// unchanged.
+    #[serde(default)]
+    pub memory: Option<MemorySettingsUpdate>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -244,6 +252,28 @@ pub struct CompactionSettingsUpdate {
     pub min_threshold_tokens: Option<u32>,
     #[serde(default)]
     pub protect_recent_messages: Option<u32>,
+}
+
+/// Durable memory settings a client can read.
+#[derive(Debug, Default, Serialize, Deserialize, ts_rs::TS)]
+pub struct MemorySettings {
+    /// Whether memory records and digests are available.
+    pub enabled: bool,
+    /// Whether post-turn capture is enabled.
+    pub capture_enabled: bool,
+    /// Whether capture can run now. This is false when the capture switch is
+    /// on but no utility model resolves.
+    pub capture_ready: bool,
+}
+
+/// Partial update for [`MemorySettings`]. Absent fields leave the current
+/// value unchanged.
+#[derive(Debug, Default, Deserialize)]
+pub struct MemorySettingsUpdate {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub capture_enabled: Option<bool>,
 }
 
 /// Deserialize a present field (including JSON `null`) as `Some(..)`; `#[serde(default)]`
@@ -436,6 +466,26 @@ pub async fn put_settings(
                 .await?;
         }
     }
+    if let Some(memory) = body.memory {
+        if let Some(enabled) = memory.enabled {
+            state
+                .store
+                .set_setting(
+                    crate::routes::MEMORY_ENABLED_SETTING,
+                    &serde_json::json!(enabled),
+                )
+                .await?;
+        }
+        if let Some(enabled) = memory.capture_enabled {
+            state
+                .store
+                .set_setting(
+                    crate::routes::MEMORY_CAPTURE_ENABLED_SETTING,
+                    &serde_json::json!(enabled),
+                )
+                .await?;
+        }
+    }
     Ok(Json(
         read_settings(&state, &auth.principal.owner_id()).await?,
     ))
@@ -459,6 +509,37 @@ async fn read_settings(state: &AppState, owner: &OwnerId) -> Result<Settings, Se
         rewrite_closing_messages: crate::code::rewrite::rewrite_closing_enabled(&*state.store)
             .await?,
         git_source_control: read_git_source_control_settings(state, owner).await?,
+        memory: read_memory_settings(state).await?,
+    })
+}
+
+/// Read the stored memory switches and report capture readiness.
+async fn read_memory_settings(state: &AppState) -> Result<MemorySettings, ServerError> {
+    let enabled = state
+        .store
+        .get_setting(crate::routes::MEMORY_ENABLED_SETTING)
+        .await?
+        .and_then(|value| value.as_bool())
+        .unwrap_or(true);
+    let capture_enabled = state
+        .store
+        .get_setting(crate::routes::MEMORY_CAPTURE_ENABLED_SETTING)
+        .await?
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let utility_model = crate::model_roles::resolve_utility_model(
+        &*state.store,
+        &*state.secrets,
+        &*state.provisioned_policy,
+        &*state.os_policy,
+        None,
+    )
+    .await?
+    .is_some();
+    Ok(MemorySettings {
+        enabled,
+        capture_enabled,
+        capture_ready: enabled && capture_enabled && utility_model,
     })
 }
 

--- a/crates/tidebreak-server/src/scoped_memory.rs
+++ b/crates/tidebreak-server/src/scoped_memory.rs
@@ -1,0 +1,177 @@
+//! The request-facing memory backend, bound to one authenticated principal.
+//!
+//! Route handlers do not touch [`AppState::store`]. They extract a
+//! [`ScopedMemory`], and every memory operation carries the requesting
+//! principal's [`OwnerId`]. The inner handle never escapes this type, so route
+//! code cannot express a query that crosses owners.
+
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+
+use tidebreak_core::{
+    MemoryBackend, MemoryCaps, MemoryDigest, MemoryIngestReceipt, MemoryIngestRequest,
+    MemoryListFilter, MemoryRecord, MemoryRecordId, MemoryRecordUpdate, MemoryRevision,
+    MemorySearchHit, MemorySearchRequest, MemoryStatusChange, MemoryWriteReceipt, OwnerId,
+};
+
+use crate::error::ServerError;
+use crate::principal::AuthContext;
+use crate::state::AppState;
+
+/// Memory as one authenticated principal may see it.
+///
+/// The field stays private and no method returns the inner backend handle.
+#[derive(Clone)]
+pub(crate) struct ScopedMemory {
+    backend: Arc<dyn MemoryBackend>,
+    owner: OwnerId,
+}
+
+impl ScopedMemory {
+    /// Bind the process's memory backend to the request's principal.
+    fn new(state: &AppState, auth: &AuthContext) -> Result<Self, ServerError> {
+        Ok(Self {
+            backend: memory_backend(state)?,
+            owner: auth.principal.owner_id(),
+        })
+    }
+
+    /// Every capability the memory backend reports.
+    pub(crate) fn caps(&self) -> MemoryCaps {
+        self.backend.caps()
+    }
+
+    /// Ask an extraction-capable backend to derive owned records.
+    pub(crate) async fn ingest(
+        &self,
+        request: MemoryIngestRequest,
+    ) -> Result<MemoryIngestReceipt, ServerError> {
+        self.backend
+            .ingest(&self.owner, request)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// Store one caller-supplied record for the requesting principal.
+    pub(crate) async fn put(
+        &self,
+        record: MemoryRecord,
+    ) -> Result<MemoryWriteReceipt, ServerError> {
+        self.backend
+            .put(&self.owner, record)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// Load one record owned by the requesting principal.
+    pub(crate) async fn get(
+        &self,
+        id: MemoryRecordId,
+    ) -> Result<Option<MemoryRecord>, ServerError> {
+        self.backend
+            .get(&self.owner, id)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// List records owned by the requesting principal.
+    pub(crate) async fn list(
+        &self,
+        filter: MemoryListFilter,
+    ) -> Result<Vec<MemoryRecord>, ServerError> {
+        self.backend
+            .list(&self.owner, filter)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// Replace one record owned by the requesting principal.
+    pub(crate) async fn update(
+        &self,
+        update: MemoryRecordUpdate,
+    ) -> Result<MemoryWriteReceipt, ServerError> {
+        self.backend
+            .update(&self.owner, update)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// Move one owned record through its lifecycle.
+    pub(crate) async fn set_status(
+        &self,
+        change: MemoryStatusChange,
+    ) -> Result<MemoryWriteReceipt, ServerError> {
+        self.backend
+            .set_status(&self.owner, change)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// Hard-delete one owned record.
+    pub(crate) async fn delete(&self, id: MemoryRecordId) -> Result<bool, ServerError> {
+        self.backend
+            .delete(&self.owner, id)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// Search owned records.
+    pub(crate) async fn search(
+        &self,
+        request: MemorySearchRequest,
+    ) -> Result<Vec<MemorySearchHit>, ServerError> {
+        self.backend
+            .search(&self.owner, request)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// Render the owned scope's active-record digest.
+    pub(crate) async fn assemble_context(
+        &self,
+        scope: tidebreak_core::MemoryScope,
+    ) -> Result<MemoryDigest, ServerError> {
+        self.backend
+            .assemble_context(&self.owner, scope)
+            .await
+            .map_err(ServerError::from)
+    }
+
+    /// Return an owned record's immutable history.
+    pub(crate) async fn revision_history(
+        &self,
+        id: MemoryRecordId,
+    ) -> Result<Vec<MemoryRevision>, ServerError> {
+        self.backend
+            .revision_history(&self.owner, id)
+            .await
+            .map_err(ServerError::from)
+    }
+}
+
+impl FromRequestParts<AppState> for ScopedMemory {
+    type Rejection = ServerError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        let auth = parts
+            .extensions
+            .get::<AuthContext>()
+            .cloned()
+            .ok_or_else(|| ServerError::unauthorized("memory routes require a principal"))?;
+        Self::new(state, &auth)
+    }
+}
+
+/// Build the memory backend behind [`AppState`].
+fn memory_backend(state: &AppState) -> Result<Arc<dyn MemoryBackend>, ServerError> {
+    let store = state
+        .memory
+        .clone()
+        .ok_or_else(|| ServerError::internal("memory storage is not configured on this server"))?;
+    Ok(store)
+}

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, Weak};
 
 use tidebreak_core::{
-    AgentConfig, AgentError, AgentRunId, BlobStore, CallId, CancelToken, ChatId, Config,
+    AgentConfig, AgentError, AgentRunId, BlobStore, CallId, CancelToken, ChatId, Config, DbStore,
     FsBlobStore, Profile, Result, SecretProvider, SteerInbox, Store, ToolRegistry, TurnId,
 };
 use tokio::sync::{mpsc, Notify, Semaphore};
@@ -118,6 +118,10 @@ pub struct AppState {
     pub(crate) diagnostics: Arc<crate::diagnostics::Diagnostics>,
     /// Durable metadata, conversation state, and the event journal.
     pub store: Arc<dyn Store>,
+    /// The same database as [`Self::store`], where memory routes need the
+    /// backend trait. `None` keeps the public constructor compatible with
+    /// test adapters; production binds through [`Self::new_with_db_store`].
+    pub(crate) memory: Option<Arc<DbStore>>,
     /// Durable raw bytes and generated artifacts under the configured data directory.
     pub blobs: Arc<dyn BlobStore>,
     /// Builds the model provider for each turn from the configured credentials.
@@ -341,6 +345,32 @@ impl AppState {
         )
     }
 
+    /// Assemble state around the concrete database, enabling memory routes.
+    ///
+    /// Production binds this way. Tests that construct state from
+    /// [`Self::new`] keep their existing fixture shape; their memory routes
+    /// answer "not configured" instead of bypassing the database.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_db_store(
+        config: Config,
+        store: Arc<DbStore>,
+        resolver: Arc<dyn ProviderResolver>,
+        secrets: Arc<dyn SecretProvider>,
+        tools: Arc<ToolRegistry>,
+        agent_config: AgentConfig,
+    ) -> Result<Self> {
+        let mut state = Self::new(
+            config,
+            store.clone(),
+            resolver,
+            secrets,
+            tools,
+            agent_config,
+        );
+        state.memory = Some(store);
+        Ok(state)
+    }
+
     /// Assemble state around the one process-wide gateway runtime and the OS
     /// policy source it was built from.
     ///
@@ -421,6 +451,7 @@ impl AppState {
             config: Arc::new(config),
             diagnostics,
             store: store.clone(),
+            memory: None,
             blobs,
             resolver,
             secrets,

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -120,7 +120,7 @@ pub struct AppState {
     pub store: Arc<dyn Store>,
     /// The same database as [`Self::store`], where memory routes need the
     /// backend trait. `None` keeps the public constructor compatible with
-    /// test adapters; production binds through [`Self::new_with_db_store`].
+    /// test adapters; production boot installs it beside the store.
     pub(crate) memory: Option<Arc<DbStore>>,
     /// Durable raw bytes and generated artifacts under the configured data directory.
     pub blobs: Arc<dyn BlobStore>,
@@ -343,32 +343,6 @@ impl AppState {
             provisioned_policy,
             os_policy,
         )
-    }
-
-    /// Assemble state around the concrete database, enabling memory routes.
-    ///
-    /// Production binds this way. Tests that construct state from
-    /// [`Self::new`] keep their existing fixture shape; their memory routes
-    /// answer "not configured" instead of bypassing the database.
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new_with_db_store(
-        config: Config,
-        store: Arc<DbStore>,
-        resolver: Arc<dyn ProviderResolver>,
-        secrets: Arc<dyn SecretProvider>,
-        tools: Arc<ToolRegistry>,
-        agent_config: AgentConfig,
-    ) -> Result<Self> {
-        let mut state = Self::new(
-            config,
-            store.clone(),
-            resolver,
-            secrets,
-            tools,
-            agent_config,
-        );
-        state.memory = Some(store);
-        Ok(state)
     }
 
     /// Assemble state around the one process-wide gateway runtime and the OS

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -78,6 +78,7 @@ mod documents;
 mod gateway_drafts;
 mod image_attachment;
 mod lifecycle;
+mod memory;
 mod outputs;
 mod root_attachment;
 mod sandbox;

--- a/crates/tidebreak-server/src/tests/memory.rs
+++ b/crates/tidebreak-server/src/tests/memory.rs
@@ -1,0 +1,301 @@
+//! Memory route contracts: owner isolation, review lifecycle, and honest
+//! capability responses.
+
+use super::*;
+
+use crate::principal::{AuthContext, Principal, Role, UserId};
+use axum::http::Request;
+use axum::response::Response;
+use serde_json::json;
+use std::path::Path;
+use tidebreak_core::memory::{
+    MemoryAuthor, MemoryBackend, MemoryKind, MemoryRecord, MemoryRecordId, MemoryScope,
+    MemoryStatus,
+};
+use tidebreak_core::OwnerId;
+
+async fn memory_app() -> (
+    Router,
+    Arc<str>,
+    Arc<tidebreak_core::DbStore>,
+    tempfile::TempDir,
+) {
+    let (dir, store) = temp_db_store("memory-routes.db").await;
+    let db = Arc::new(store);
+    let state = AppState::new_with_db_store(
+        Config::desktop(dir.path()),
+        db.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    )
+    .unwrap();
+    let token = state.token.clone();
+    (app(state), token, db, dir)
+}
+
+fn user_record(id: MemoryRecordId) -> MemoryRecord {
+    MemoryRecord {
+        id,
+        scope: MemoryScope::Personal,
+        kind: MemoryKind::Lesson,
+        status: MemoryStatus::Active,
+        title: "When changing database migrations".to_owned(),
+        body: "Run the migration chain test before publishing.".to_owned(),
+        provenance: tidebreak_core::MemoryProvenance {
+            author: MemoryAuthor::User,
+            origin: Default::default(),
+            evidence: Vec::new(),
+        },
+        links: Vec::new(),
+        expires_at: None,
+        superseded_by: None,
+        observation_count: 0,
+        revision: 1,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    }
+}
+
+async fn request(router: &Router, bearer: &str, method: &str, uri: String) -> Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header(header::AUTHORIZATION, bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn request_json(
+    router: &Router,
+    bearer: &str,
+    method: &str,
+    uri: String,
+    body: serde_json::Value,
+) -> Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn assert_ok(response: Response) -> serde_json::Value {
+    let status = response.status();
+    let body: serde_json::Value = json_body(response).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    body
+}
+
+#[tokio::test]
+async fn memory_routes_isolate_records_by_owner() {
+    let (_router, _token, store, _dir) = memory_app().await;
+    let alice = OwnerId::new("user:alice").unwrap();
+    let id = MemoryRecordId::new();
+
+    store.put(&alice, user_record(id)).await.unwrap();
+
+    let bob_router = Router::new()
+        .route("/memory/records", get(crate::routes::list_records))
+        .route(
+            "/memory/records/{id}",
+            get(crate::routes::get_record).delete(crate::routes::delete_record),
+        )
+        .with_state(
+            AppState::new_with_db_store(
+                Config::desktop(Path::new("/tmp/tidebreak-memory-test")),
+                tidebreak_core::DbStore::connect("sqlite::memory:")
+                    .await
+                    .unwrap()
+                    .into(),
+                Arc::new(FixedResolver(Arc::new(FakeProvider))),
+                Arc::new(MemSecrets::default()),
+                Arc::new(ToolRegistry::new()),
+                AgentConfig::default(),
+            )
+            .unwrap(),
+        )
+        .layer(axum::middleware::from_fn(
+            |mut request: Request<Body>, next: axum::middleware::Next| async move {
+                request.extensions_mut().insert(AuthContext {
+                    principal: Principal::User {
+                        id: UserId::new("bob").unwrap(),
+                        role: Role::Member,
+                    },
+                    client_executor: false,
+                });
+                next.run(request).await
+            },
+        ));
+
+    let listed =
+        assert_ok(request(&bob_router, "ignored", "GET", "/memory/records".into()).await).await;
+    assert_eq!(listed, json!([]));
+    let detail = request(
+        &bob_router,
+        "ignored",
+        "GET",
+        format!("/memory/records/{id}"),
+    )
+    .await;
+    assert_eq!(detail.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn memory_routes_reject_bad_bodies_and_id_reuse() {
+    let (router, token, _store, _dir) = memory_app().await;
+    let bearer = format!("Bearer {token}");
+    let id = MemoryRecordId::new();
+
+    let invalid = json!({
+        "id": id,
+        "kind": "lesson",
+        "status": "active",
+        "title": "",
+        "body": "Run the migration chain test before publishing.",
+        "author": "user"
+    });
+    let rejected = request_json(&router, &bearer, "POST", "/memory/records".into(), invalid).await;
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+
+    let valid = json!({
+        "id": id,
+        "kind": "lesson",
+        "status": "active",
+        "title": "When changing database migrations",
+        "body": "Run the migration chain test before publishing.",
+        "author": "user"
+    });
+    let created = request_json(&router, &bearer, "POST", "/memory/records".into(), valid).await;
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let replay = request_json(
+        &router,
+        &bearer,
+        "POST",
+        "/memory/records".into(),
+        json!({
+            "id": id,
+            "kind": "lesson",
+            "status": "active",
+            "title": "Duplicate",
+            "body": "Duplicate.",
+            "author": "user"
+        }),
+    )
+    .await;
+    assert_eq!(replay.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn memory_routes_move_proposals_and_report_revision_conflicts() {
+    let (router, token, store, _dir) = memory_app().await;
+    let bearer = format!("Bearer {token}");
+    let id = MemoryRecordId::new();
+    let mut record = user_record(id);
+    record.status = MemoryStatus::Proposed;
+    store.put(&OwnerId::local(), record).await.unwrap();
+
+    let stale = json!({"expected_revision": 1, "status": "active"});
+    let activation = request_json(
+        &router,
+        &bearer,
+        "PUT",
+        format!("/memory/records/{id}/status"),
+        stale,
+    )
+    .await;
+    assert_eq!(activation.status(), StatusCode::OK);
+    let activated: serde_json::Value = json_body(activation).await;
+    assert_eq!(activated["status"], json!("active"));
+    assert_eq!(activated["revision"], json!(2));
+
+    let conflict = json!({"expected_revision": 1, "status": "archived"});
+    let stale_activation = request_json(
+        &router,
+        &bearer,
+        "PUT",
+        format!("/memory/records/{id}/status"),
+        conflict,
+    )
+    .await;
+    assert_eq!(stale_activation.status(), StatusCode::CONFLICT);
+    let error: serde_json::Value = json_body(stale_activation).await;
+    assert_eq!(error["kind"], json!("memory_revision_conflict"));
+}
+
+#[tokio::test]
+async fn memory_search_digest_and_history_read_only_owner_rows() {
+    let (router, token, store, _dir) = memory_app().await;
+    let bearer = format!("Bearer {token}");
+    let id = MemoryRecordId::new();
+    store.put(&OwnerId::local(), user_record(id)).await.unwrap();
+
+    let search = assert_ok(
+        request(
+            &router,
+            &bearer,
+            "GET",
+            "/memory/search?query=migration&limit=10".into(),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(search[0]["record_id"], json!(id));
+
+    let digest = assert_ok(request(&router, &bearer, "GET", "/memory/digest".into()).await).await;
+    assert_eq!(digest["record_count"], json!(1));
+    assert!(digest["markdown"]
+        .as_str()
+        .unwrap()
+        .contains("When changing database migrations"));
+
+    let history = assert_ok(
+        request(
+            &router,
+            &bearer,
+            "GET",
+            format!("/memory/records/{id}/revisions"),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(history[0]["snapshot"]["id"], json!(id));
+}
+
+#[tokio::test]
+async fn memory_ingest_answers_not_implemented_for_the_default_backend() {
+    let (router, token, _store, _dir) = memory_app().await;
+    let bearer = format!("Bearer {token}");
+    let response = request_json(
+        &router,
+        &bearer,
+        "POST",
+        "/memory/ingest".into(),
+        json!({
+            "scope": {"kind": "personal"},
+            "content": "Always run the release smoke test."
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    let error: serde_json::Value = json_body(response).await;
+    assert_eq!(error["kind"], json!("not_implemented"));
+}

--- a/crates/tidebreak-server/src/tests/memory.rs
+++ b/crates/tidebreak-server/src/tests/memory.rs
@@ -14,6 +14,25 @@ use tidebreak_core::memory::{
 };
 use tidebreak_core::OwnerId;
 
+/// State over one database, with memory routes bound to that same database
+/// the way production boot binds them.
+fn state_with_memory(
+    config: Config,
+    db: Arc<tidebreak_core::DbStore>,
+    agent_config: AgentConfig,
+) -> AppState {
+    let mut state = AppState::new(
+        config,
+        db.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        agent_config,
+    );
+    state.memory = Some(db);
+    state
+}
+
 async fn memory_app() -> (
     Router,
     Arc<str>,
@@ -22,18 +41,14 @@ async fn memory_app() -> (
 ) {
     let (dir, store) = temp_db_store("memory-routes.db").await;
     let db = Arc::new(store);
-    let state = AppState::new_with_db_store(
+    let state = state_with_memory(
         Config::desktop(dir.path()),
         db.clone(),
-        Arc::new(FixedResolver(Arc::new(FakeProvider))),
-        Arc::new(MemSecrets::default()),
-        Arc::new(ToolRegistry::new()),
         AgentConfig {
             model: "fake".into(),
             ..AgentConfig::default()
         },
-    )
-    .unwrap();
+    );
     let token = state.token.clone();
     (app(state), token, db, dir)
 }
@@ -119,20 +134,14 @@ async fn memory_routes_isolate_records_by_owner() {
             "/memory/records/{id}",
             get(crate::routes::get_record).delete(crate::routes::delete_record),
         )
-        .with_state(
-            AppState::new_with_db_store(
-                Config::desktop(Path::new("/tmp/tidebreak-memory-test")),
-                tidebreak_core::DbStore::connect("sqlite::memory:")
-                    .await
-                    .unwrap()
-                    .into(),
-                Arc::new(FixedResolver(Arc::new(FakeProvider))),
-                Arc::new(MemSecrets::default()),
-                Arc::new(ToolRegistry::new()),
-                AgentConfig::default(),
-            )
-            .unwrap(),
-        )
+        .with_state(state_with_memory(
+            Config::desktop(Path::new("/tmp/tidebreak-memory-test")),
+            tidebreak_core::DbStore::connect("sqlite::memory:")
+                .await
+                .unwrap()
+                .into(),
+            AgentConfig::default(),
+        ))
         .layer(axum::middleware::from_fn(
             |mut request: Request<Body>, next: axum::middleware::Next| async move {
                 request.extensions_mut().insert(AuthContext {

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -391,6 +391,18 @@ mod tests {
         generate::collect_from::<tidebreak_core::QueuedTurn>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ModelInfo>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ModelRoleInfo>(&cfg, &mut out);
+        // Memory: backend capabilities, records, search, context, revisions,
+        // and the request bodies the manager UI sends.
+        generate::collect_from::<tidebreak_core::MemoryCaps>(&cfg, &mut out);
+        generate::collect_from::<tidebreak_core::MemoryRecord>(&cfg, &mut out);
+        generate::collect_from::<tidebreak_core::MemorySearchHit>(&cfg, &mut out);
+        generate::collect_from::<tidebreak_core::MemoryDigest>(&cfg, &mut out);
+        generate::collect_from::<tidebreak_core::MemoryRevision>(&cfg, &mut out);
+        generate::collect_from::<tidebreak_core::MemoryIngestReceipt>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::CreateMemoryRecordBody>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::UpdateMemoryRecordBody>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::MemoryStatusBody>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::MemoryIngestBody>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ChatTranscript>(&cfg, &mut out);
         generate::collect_from::<crate::providers::ProviderInfo>(&cfg, &mut out);
         generate::collect_from::<crate::providers::ProviderAuthMode>(&cfg, &mut out);

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2331,6 +2331,11 @@ export type ConsentVerb = { "kind": "tool", action: RendererToolName, approval: 
 export type CreateCodeTriggerBody = { condition: CodeTriggerCondition, action: CodeTriggerAction, };
 
 /**
+ * Body of `POST /memory/records`.
+ */
+export type CreateMemoryRecordBody = { id: MemoryRecordId, kind: MemoryKind, status: MemoryStatus, title: string, body: string, author: MemoryAuthor, origin: MemoryOrigin, evidence: Array<MemoryEvidence>, links: Array<MemoryLink>, expires_at: string | null, observation_count: number, };
+
+/**
  * Where the resolved credential value is placed on the request.
  *
  * Externally tagged and closed: `"bearer"` or `{"header": "X-Api-Key"}`; an
@@ -3354,6 +3359,315 @@ export type McpServersInfo = { servers: Array<McpServerInfo>, };
  * Where the sandboxed iframe should load one view from, valid once.
  */
 export type McpViewSession = { frame_path: string, };
+
+/**
+ * Who authored a memory record.
+ */
+export type MemoryAuthor = "user" | "model" | "import";
+
+/**
+ * Whether a backend supports one declared operation.
+ */
+export type MemoryCapLevel = "supported" | "unsupported" | "unknown";
+
+/**
+ * Complete capability vector for one memory backend.
+ *
+ * This type has no `Default`. Adding a flag breaks every backend until the
+ * backend states a value.
+ */
+export type MemoryCaps = { extraction: MemoryCapLevel, lexical_search: MemoryCapLevel, semantic_search: MemoryCapLevel, consolidation: MemoryCapLevel, context_assembly: MemoryCapLevel, revision_history: MemoryCapLevel, verified_delete: MemoryCapLevel, asynchronous_writes: MemoryCapLevel, agent_editable_surfaces: MemoryCapLevel, };
+
+/**
+ * One deterministic active-record digest for a scope.
+ */
+export type MemoryDigest = {
+/**
+ * Scope represented by this render.
+ */
+scope: MemoryScope,
+/**
+ * Rendered markdown.
+ */
+markdown: string,
+/**
+ * UTF-8 byte length of `markdown`.
+ */
+byte_len: number,
+/**
+ * Maximum accepted render size.
+ */
+byte_cap: number,
+/**
+ * Number of active records represented.
+ */
+record_count: number, };
+
+/**
+ * One exact source that justifies a model-authored record.
+ */
+export type MemoryEvidence = { "kind": "message",
+/**
+ * Exact message identity.
+ */
+message_id: MessageId, } | { "kind": "code_event",
+/**
+ * Session that owns the event sequence.
+ */
+session_id: CodeSessionId,
+/**
+ * One-based event sequence.
+ */
+seq: number, };
+
+/**
+ * Body of `POST /memory/ingest`.
+ */
+export type MemoryIngestBody = { scope: MemoryScope, origin: MemoryOrigin, content: string, };
+
+/**
+ * Accepted extraction work.
+ */
+export type MemoryIngestReceipt = {
+/**
+ * Durability guarantee at the backend boundary.
+ */
+state: MemoryWriteState,
+/**
+ * Records written synchronously, if any.
+ */
+records: Array<MemoryRecord>, };
+
+/**
+ * What kind of durable knowledge a record carries.
+ */
+export type MemoryKind = "fact" | "preference" | "lesson" | "reference";
+
+/**
+ * One typed link to another memory record.
+ */
+export type MemoryLink = {
+/**
+ * Linked record identity.
+ */
+record_id: MemoryRecordId,
+/**
+ * Why this record links to it.
+ */
+relation: MemoryLinkRelation, };
+
+/**
+ * Meaning of one link to another memory record.
+ */
+export type MemoryLinkRelation = "related" | "updates" | "supersedes";
+
+/**
+ * The product surface that produced a record, where known.
+ */
+export type MemoryOrigin = {
+/**
+ * Originating work-mode conversation.
+ */
+chat_id?: ChatId | null,
+/**
+ * Originating work-mode turn.
+ */
+turn_id?: TurnId | null,
+/**
+ * Originating code session.
+ */
+code_session_id?: CodeSessionId | null,
+/**
+ * Originating code turn.
+ */
+code_turn_id?: CodeTurnId | null,
+/**
+ * Workspace attached to the originating code session.
+ */
+workspace_id?: WorkspaceId | null, };
+
+/**
+ * Authorship and source evidence for one record.
+ */
+export type MemoryProvenance = {
+/**
+ * Who authored the record.
+ */
+author: MemoryAuthor,
+/**
+ * Product origin, where known.
+ */
+origin: MemoryOrigin,
+/**
+ * Exact sources that justify the record.
+ */
+evidence: Array<MemoryEvidence>, };
+
+/**
+ * One durable markdown memory with its typed envelope.
+ */
+export type MemoryRecord = {
+/**
+ * Stable record identity.
+ */
+id: MemoryRecordId,
+/**
+ * Personal or repository scope.
+ */
+scope: MemoryScope,
+/**
+ * Knowledge category.
+ */
+kind: MemoryKind,
+/**
+ * Review and authority state.
+ */
+status: MemoryStatus,
+/**
+ * One-line retrieval hook that says when the record matters.
+ */
+title: string,
+/**
+ * Markdown body, stored verbatim.
+ */
+body: string,
+/**
+ * Authorship, origin, and exact evidence.
+ */
+provenance: MemoryProvenance,
+/**
+ * Typed relationships to other records.
+ */
+links: Array<MemoryLink>,
+/**
+ * Mechanical expiry, when configured.
+ */
+expires_at?: string | null,
+/**
+ * Active replacement for an archived record.
+ */
+superseded_by?: MemoryRecordId | null,
+/**
+ * Distinct supporting observations for a tracked hypothesis.
+ */
+observation_count: number,
+/**
+ * Compare-and-swap revision. The first stored version is 1.
+ */
+revision: number,
+/**
+ * Original creation time.
+ */
+created_at: string,
+/**
+ * Time of the latest committed mutation.
+ */
+updated_at: string, };
+
+/**
+ * Identifies one durable memory record.
+ */
+export type MemoryRecordId = string;
+
+/**
+ * One immutable historical snapshot.
+ */
+export type MemoryRevision = {
+/**
+ * Stable revision-row identity.
+ */
+id: MemoryRevisionId,
+/**
+ * Record that owns the revision.
+ */
+record_id: MemoryRecordId,
+/**
+ * Monotonic per-record ordinal.
+ */
+ordinal: number,
+/**
+ * Full record snapshot after the mutation committed.
+ */
+snapshot: MemoryRecord,
+/**
+ * Time the snapshot committed.
+ */
+created_at: string, };
+
+/**
+ * Identifies one immutable record revision.
+ */
+export type MemoryRevisionId = string;
+
+/**
+ * One durable memory scope.
+ *
+ * The enum is non-exhaustive because wider scopes may arrive later. A
+ * repository scope binds to the registered repository, never a workspace.
+ */
+export type MemoryScope = { "kind": "personal" } | { "kind": "repo",
+/**
+ * Stable registered-repository identity.
+ */
+repo_id: RepoId, };
+
+/**
+ * One injectable lexical-search result.
+ */
+export type MemorySearchHit = {
+/**
+ * Matching record.
+ */
+record_id: MemoryRecordId,
+/**
+ * Retrieval-hook title.
+ */
+title: string,
+/**
+ * Date of the latest committed mutation.
+ */
+updated_at: string,
+/**
+ * First matching markdown line, kept verbatim.
+ */
+matching_line: string,
+/**
+ * Deterministic lexical score. Larger values sort first.
+ */
+score: number, };
+
+/**
+ * Durable memory settings a client can read.
+ */
+export type MemorySettings = {
+/**
+ * Whether memory records and digests are available.
+ */
+enabled: boolean,
+/**
+ * Whether post-turn capture is enabled.
+ */
+capture_enabled: boolean,
+/**
+ * Whether capture can run now. This is false when the capture switch is
+ * on but no utility model resolves.
+ */
+capture_ready: boolean, };
+
+/**
+ * Lifecycle state for one memory record.
+ */
+export type MemoryStatus = "tracking" | "proposed" | "active" | "archived" | "rejected";
+
+/**
+ * Body of `PUT /memory/records/{id}/status`.
+ */
+export type MemoryStatusBody = { expected_revision: number, status: MemoryStatus, };
+
+/**
+ * Whether a backend guarantees that a returned write is durable now.
+ */
+export type MemoryWriteState = "committed" | "pending";
 
 /**
  * Body of `POST /code/workspaces/{id}/pr/merge`.
@@ -4564,7 +4878,12 @@ rewrite_closing_messages: boolean,
 /**
  * How new code repositories name workspace branches for this user.
  */
-git_source_control: GitSourceControlSettings, };
+git_source_control: GitSourceControlSettings,
+/**
+ * Durable memory settings, including whether the utility role can run
+ * post-turn capture.
+ */
+memory: MemorySettings, };
 
 /**
  * Renderer-safe progress of the current sign-in attempt.
@@ -5061,6 +5380,11 @@ export type TurnId = string;
  * does not have to be rebuilt to turn a rule back on.
  */
 export type UpdateCodeTriggerBody = { enabled: boolean, };
+
+/**
+ * Body of `PATCH /memory/records/{id}`.
+ */
+export type UpdateMemoryRecordBody = { expected_revision: number, kind: MemoryKind, title: string, body: string, author: MemoryAuthor, origin: MemoryOrigin, evidence: Array<MemoryEvidence>, links: Array<MemoryLink>, expires_at: string | null, observation_count: number, };
 
 /**
  * One bounded question shown to the user.


### PR DESCRIPTION
Closes #2553. Part of #2551.

Decision records [67](docs/decisions/0067-memory-records-and-scopes.md) and [68](docs/decisions/0068-memory-backend-boundary.md) specify durable, reviewable memory. This PR lands the substrate they describe. It was written on 2026-09-01 in a local worktree and never published; this rebases it onto today's `main`.

## What lands

- **Migration.** Appended `memory_records` migration: owner-scoped `memory_record` rows, `memory_scope_state` (per-scope auto-commit and caps), and immutable `memory_revision` snapshots.
- **Core.** `tidebreak_core::memory`: record, scope, status, provenance, evidence, and link types; the `MemoryBackend` trait; `MemoryCaps` with every capability answered as supported, unsupported, or unknown and no `Default`; the default backend (rows plus in-process lexical search) that commits row, digest, and revision in one transaction, enforces evidence at the storage layer, and coaches at the cap instead of evicting.
- **Server.** Owner-scoped `/memory` routes: capabilities, records (list, create, get, update, status, delete), search, digest, and revisions; `memory.enabled` and `memory.capture_enabled` on the settings document with a `capture_ready` readiness flag that reports whether a utility model resolves.
- **Desktop.** A Memory settings page: master and capture switches, review queue, scoped record list and detail with provenance and revision history, and a digest preview with a byte meter. `Settings/Memory` stories cover the review queue, empty, active record, load failed, and digest-near-cap states.

## Changes made while rebasing

- Evidence for a work-mode message now resolves through the `code_session` row, since a chat is a session after #3030.
- The search route reads its scope from flat `repo_id` and `scope_kind` query fields. The original nested query struct could not be parsed from a query string, so a repository-scoped search never worked.
- The digest test derives its expected date from the record instead of hard-coding 2026-09-01.
- The story stub client gained the settings methods the panel reads.
- The review-tab count inherits the button's text color; the warning-badge treatment was invisible on the active tab.

## Not in this PR

Capture, injection, materialization, and maintenance are the sibling slices #2554, #2555, and #2556.

## Checks run

- `cargo check`, `cargo clippy`, and `cargo test -p tidebreak-core memory`, `-p tidebreak-server memory`, `-p tidebreak-server settings`
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server wire_types`, copied to `mobile/src/generated/wire.ts`
- UI: biome format and lint, `tsc --noEmit`, full `vitest run` (270 files), `storybook:build`
- Screenshots of every `Settings/Memory` story in all four themes at 1100px, plus light and dark at 420px
