### PR TITLE
ci(release): refresh the GitHub release notes template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,29 +1,29 @@
-name-template: "Tidebreak v$RESOLVED_VERSION"
+name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 tag-prefix: "v"
 include-pre-releases: true
 categories:
-  - title: "Breaking Changes"
+  - title: "💥 Breaking Changes"
     exclusive: true
     when:
       label: "semver:breaking"
-  - title: "New Features"
+  - title: "✨ New Features"
     exclusive: true
     when:
       label: "release-note:feature"
-  - title: "Bug Fixes"
+  - title: "🐛 Bug Fixes"
     exclusive: true
     when:
       label: "release-note:fix"
-  - title: "Performance Improvements"
+  - title: "⚡ Performance Improvements"
     exclusive: true
     when:
       label: "release-note:performance"
-  - title: "Dependency Updates"
+  - title: "📦 Dependency Updates"
     exclusive: true
     when:
       label: "release-note:dependencies"
-  - title: "Reverted Changes"
+  - title: "⏪ Reverted Changes"
     exclusive: true
     when:
       label: "release-note:revert"
@@ -31,13 +31,13 @@ categories:
   # invisible: a refactor can rebuild the local database or change build
   # requirements. Every merged PR is accounted for in the notes — nothing is
   # pre-excluded — with maintenance listed after the user-facing sections.
-  - title: "Maintenance"
+  - title: "🧰 Maintenance"
     exclusive: true
     when:
       label: "semver:none"
   # Historical PRs merged before managed labels existed remain visible here in
   # the first draft.
-  - title: "Other Changes"
+  - title: "📝 Other Changes"
   - type: version-resolver
     semver-increment: minor
     when:
@@ -58,9 +58,20 @@ category-template: "## $TITLE"
 change-template: "- $TITLE ([#$NUMBER]($URL)) by @$AUTHOR"
 change-title-escapes: '\<*_&'
 no-changes-template: "- No user-facing changes."
+exclude-contributors:
+  - "dependabot[bot]"
+  - "github-actions[bot]"
+new-contributor-template: "- $AUTHOR_MENTION made their first contribution in [#$NUMBER]($URL)"
+no-new-contributor-template: ""
 template: |
-  Thanks for using Tidebreak ❤️
-
-  # What's Changed
+  > ❤️ **Thanks for using Tidebreak.**
+  >
+  > If you filed an issue, reviewed a pull request, or shipped a change, you are in these notes.
 
   $CHANGES
+
+  ## 🙌 New Contributors
+
+  $NEW_CONTRIBUTORS
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,30 +2,30 @@
 # Keep these categories aligned with release-drafter.yml.
 changelog:
   categories:
-    - title: "Breaking Changes"
+    - title: "💥 Breaking Changes"
       labels:
         - "semver:breaking"
-    - title: "New Features"
+    - title: "✨ New Features"
       labels:
         - "release-note:feature"
-    - title: "Bug Fixes"
+    - title: "🐛 Bug Fixes"
       labels:
         - "release-note:fix"
-    - title: "Performance Improvements"
+    - title: "⚡ Performance Improvements"
       labels:
         - "release-note:performance"
-    - title: "Dependency Updates"
+    - title: "📦 Dependency Updates"
       labels:
         - "release-note:dependencies"
-    - title: "Reverted Changes"
+    - title: "⏪ Reverted Changes"
       labels:
         - "release-note:revert"
     # Maintenance changes are listed, not dropped: a refactor can rebuild the
     # local database or change build requirements, and a reader of the notes
     # must be able to account for every merged PR.
-    - title: "Maintenance"
+    - title: "🧰 Maintenance"
       labels:
         - "semver:none"
-    - title: "Other Changes"
+    - title: "📝 Other Changes"
       labels:
         - "*"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -57,29 +57,30 @@ User-facing PRs also receive a managed release-note label derived from the same
 validated title. These labels make the native release notes easier to scan
 without asking authors to classify a PR twice:
 
-| Title type | Release-notes section       |
-| ---------- | --------------------------- |
-| `feat`     | New Features                |
-| `fix`      | Bug Fixes                   |
-| `perf`     | Performance Improvements    |
-| `deps`     | Dependency Updates          |
-| `revert`   | Reverted Changes            |
-| Any `!`    | Breaking Changes            |
+| Title type | Release-notes section          |
+| ---------- | ------------------------------ |
+| `feat`     | ✨ New Features                |
+| `fix`      | 🐛 Bug Fixes                   |
+| `perf`     | ⚡ Performance Improvements    |
+| `deps`     | 📦 Dependency Updates          |
+| `revert`   | ⏪ Reverted Changes            |
+| Any `!`    | 💥 Breaking Changes            |
 
 Documentation and other maintenance-only types carry no `release-note:*` label
-and appear in a trailing **Maintenance** section instead — listed, not dropped,
+and appear in a trailing **🧰 Maintenance** section instead — listed, not dropped,
 because a maintenance change can still matter to someone updating (a schema
 baseline rebuild, a toolchain requirement). Every merged PR is accounted for in
-the notes. The rendered notes open with a short thank-you. A large **What's
-Changed** heading introduces level-two release sections, and repeated scopes
-use level-three headings. The section heading supplies the type, so the draft
-formatter removes the redundant Conventional Commit prefix from each PR title.
-Maintenance entries
+the notes. The rendered notes open with a thank-you. Category headings carry a
+leading emoji so the sections scan quickly, and the draft does not wrap them in
+a page-level heading; the release title is the tag. First-time contributors get
+their own section, and the notes end with a compare link to the previous tag.
+The section heading supplies the type, so the draft formatter removes the
+redundant Conventional Commit prefix from each PR title. Maintenance entries
 keep their full prefixes: that section mixes types, so the prefix is the
 information. When a category has
 multiple user-facing changes with the same scope, the formatter groups them
 under a third-level heading: for example, multiple `feat(desktop)` changes are
-rendered under **New Features**, then **Desktop**. A singleton scope is kept
+rendered under **✨ New Features**, then **Desktop**. A singleton scope is kept
 compact as an inline prefix, and unscoped changes appear in the flat tail of the
 section.
 

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -4,27 +4,61 @@ import { pathToFileURL } from "node:url";
 
 import { parsePrTitle } from "./check-pr-title.mjs";
 
-const THANK_YOU = "Thanks for using Tidebreak ❤️";
+const THANK_YOU = `> ❤️ **Thanks for using Tidebreak.**
+>
+> If you filed an issue, reviewed a pull request, or shipped a change, you are in these notes.`;
 
-const CATEGORY_TITLES = new Set([
-  "Breaking Changes",
-  "New Features",
-  "Bug Fixes",
-  "Performance Improvements",
-  "Dependency Updates",
-  "Reverted Changes",
-  "Maintenance",
-  "Other Changes",
-]);
+const LEGACY_THANK_YOU = "Thanks for using Tidebreak ❤️";
 
-const SCOPED_CATEGORY_TITLES = new Set([
-  "Breaking Changes",
-  "New Features",
-  "Bug Fixes",
-  "Performance Improvements",
-  "Dependency Updates",
-  "Reverted Changes",
-]);
+const CATEGORIES = [
+  {
+    key: "Breaking Changes",
+    title: "💥 Breaking Changes",
+    scoped: true,
+  },
+  {
+    key: "New Features",
+    title: "✨ New Features",
+    scoped: true,
+  },
+  {
+    key: "Bug Fixes",
+    title: "🐛 Bug Fixes",
+    scoped: true,
+  },
+  {
+    key: "Performance Improvements",
+    title: "⚡ Performance Improvements",
+    scoped: true,
+  },
+  {
+    key: "Dependency Updates",
+    title: "📦 Dependency Updates",
+    scoped: true,
+  },
+  {
+    key: "Reverted Changes",
+    title: "⏪ Reverted Changes",
+    scoped: true,
+  },
+  {
+    key: "Maintenance",
+    title: "🧰 Maintenance",
+    scoped: false,
+  },
+  {
+    key: "Other Changes",
+    title: "📝 Other Changes",
+    scoped: false,
+  },
+];
+
+const CATEGORY_BY_KEY = new Map(
+  CATEGORIES.flatMap((category) => [
+    [category.key, category],
+    [category.title, category],
+  ]),
+);
 
 const CHANGE_LINE_PATTERN = /^- (.*?) \(\[#\d+\]\([^)]*\)\) by @\S+$/;
 
@@ -36,6 +70,18 @@ const SCOPE_ACRONYMS = new Map([
   ["ui", "UI"],
   ["ux", "UX"],
 ]);
+
+const NEW_CONTRIBUTORS_KEY = "New Contributors";
+const NEW_CONTRIBUTORS_TITLE = "🙌 New Contributors";
+const EMPTY_NEW_CONTRIBUTOR_LINES = new Set([
+  "",
+  "- No new contributors",
+  "* No new contributors",
+]);
+
+function headingKey(title) {
+  return title.replace(/^[^\p{L}\p{N}]+/u, "").trim();
+}
 
 function scopeHeading(scope) {
   return scope
@@ -120,51 +166,94 @@ function formatCategory(lines) {
   return [...formatted, ...trailingLines];
 }
 
+function stripLeadingThankYou(lines) {
+  if (lines[0] === LEGACY_THANK_YOU) {
+    lines = lines.slice(1);
+    if (lines[0] === "") lines = lines.slice(1);
+    return lines;
+  }
+
+  const thankYouLines = THANK_YOU.split("\n");
+  if (
+    thankYouLines.every((line, index) => lines[index] === line)
+  ) {
+    lines = lines.slice(thankYouLines.length);
+    if (lines[0] === "") lines = lines.slice(1);
+  }
+  return lines;
+}
+
+function dropEmptyNewContributors(lines) {
+  const headingIndex = lines.findIndex((line) => {
+    const heading = /^## (.+)$/.exec(line);
+    return heading && headingKey(heading[1]) === NEW_CONTRIBUTORS_KEY;
+  });
+  if (headingIndex === -1) return lines;
+
+  let end = headingIndex + 1;
+  while (end < lines.length && !/^## /.test(lines[end]) && !/^\*\*/.test(lines[end])) {
+    end += 1;
+  }
+  const content = lines.slice(headingIndex + 1, end);
+  if (content.every((line) => EMPTY_NEW_CONTRIBUTOR_LINES.has(line))) {
+    const before = lines.slice(0, headingIndex);
+    const after = lines.slice(end);
+    while (before.at(-1) === "") before.pop();
+    if (after[0] !== "" && after.length > 0 && before.length > 0) {
+      return [...before, "", ...after];
+    }
+    return [...before, ...after];
+  }
+
+  lines[headingIndex] = `## ${NEW_CONTRIBUTORS_TITLE}`;
+  return lines;
+}
+
 export function formatReleaseNotes(body) {
   if (typeof body !== "string") {
     throw new Error("release notes must be a string");
   }
 
-  const lines = body.split("\n");
-  if (lines[0] === THANK_YOU) {
-    lines.shift();
-    if (lines[0] === "") lines.shift();
-  }
-
+  let lines = stripLeadingThankYou(body.split("\n"));
   const formatted = [];
   for (let index = 0; index < lines.length; ) {
     if (/^#{1,2} What's Changed$/.test(lines[index])) {
-      formatted.push("# What's Changed");
       index += 1;
+      if (lines[index] === "") index += 1;
       continue;
     }
 
     const heading = /^#{2,3} (.+)$/.exec(lines[index]);
-    if (!heading || !CATEGORY_TITLES.has(heading[1])) {
+    const key = heading ? headingKey(heading[1]) : null;
+    const category = key ? CATEGORY_BY_KEY.get(key) : null;
+    if (!category) {
       formatted.push(lines[index]);
       index += 1;
       continue;
     }
 
-    formatted.push(`## ${heading[1]}`);
+    formatted.push(`## ${category.title}`);
     const categoryStart = index + 1;
     index = categoryStart;
     while (index < lines.length) {
       const nextHeading = /^#{2,3} (.+)$/.exec(lines[index]);
-      if (nextHeading && CATEGORY_TITLES.has(nextHeading[1])) break;
+      const nextKey = nextHeading ? headingKey(nextHeading[1]) : null;
+      if (nextKey && CATEGORY_BY_KEY.has(nextKey)) break;
+      if (nextKey === NEW_CONTRIBUTORS_KEY) break;
       index += 1;
     }
 
     const categoryLines = lines.slice(categoryStart, index);
     formatted.push(
-      ...(SCOPED_CATEGORY_TITLES.has(heading[1]) &&
-      !categoryLines.some((line) => /^### /.test(line))
+      ...(category.scoped && !categoryLines.some((line) => /^### /.test(line))
         ? formatCategory(categoryLines)
         : categoryLines),
     );
   }
 
-  return `${THANK_YOU}\n\n${formatted.join("\n")}`;
+  const bodyLines = dropEmptyNewContributors(formatted);
+  while (bodyLines[0] === "") bodyLines.shift();
+  return `${THANK_YOU}\n\n${bodyLines.join("\n")}`;
 }
 
 async function main() {

--- a/scripts/format-release-notes.test.mjs
+++ b/scripts/format-release-notes.test.mjs
@@ -3,6 +3,10 @@ import test from "node:test";
 
 import { formatReleaseNotes } from "./format-release-notes.mjs";
 
+const THANK_YOU = `> ❤️ **Thanks for using Tidebreak.**
+>
+> If you filed an issue, reviewed a pull request, or shipped a change, you are in these notes.`;
+
 test("separates grouped and singleton scopes into tight Markdown lists", () => {
   const notes = `## What's Changed
 
@@ -20,11 +24,9 @@ test("separates grouped and singleton scopes into tight Markdown lists", () => {
 
   assert.equal(
     formatReleaseNotes(notes),
-    `Thanks for using Tidebreak ❤️
+    `${THANK_YOU}
 
-# What's Changed
-
-## New Features
+## ✨ New Features
 ### Desktop
 - add document search ([#12](https://example.com/12)) by @octo
 - add keyboard shortcuts ([#15](https://example.com/15)) by @octo
@@ -33,9 +35,9 @@ test("separates grouped and singleton scopes into tight Markdown lists", () => {
 - add a default workspace ([#13](https://example.com/13)) by @octo
 - **Core:** add saved searches ([#14](https://example.com/14)) by @octo
 
-## Bug Fixes
+## 🐛 Bug Fixes
 - **Desktop:** prevent a startup crash ([#16](https://example.com/16)) by @octo
-## Other Changes
+## 📝 Other Changes
 - docs: update the setup guide ([#17](https://example.com/17)) by @octo
 `,
   );
@@ -48,9 +50,9 @@ test("keeps unscoped release entries in their category without a subheading", ()
 
   assert.equal(
     formatReleaseNotes(notes),
-    `Thanks for using Tidebreak ❤️
+    `${THANK_YOU}
 
-## Dependency Updates
+## 📦 Dependency Updates
 - update sqlite ([#17](https://example.com/17)) by @octo
 `,
   );
@@ -65,11 +67,11 @@ test("uses readable acronyms in singleton scope prefixes", () => {
 
   assert.equal(
     formatReleaseNotes(notes),
-    `Thanks for using Tidebreak ❤️
+    `${THANK_YOU}
 
-## Breaking Changes
+## 💥 Breaking Changes
 - **MCP:** replace the protocol ([#18](https://example.com/18)) by @octo
-## Other Changes
+## 📝 Other Changes
 - Plain historical change ([#19](https://example.com/19)) by @octo
 `,
   );
@@ -82,23 +84,74 @@ test("keeps historical titles with malformed scopes without crashing", () => {
 
   assert.equal(
     formatReleaseNotes(notes),
-    `Thanks for using Tidebreak ❤️
+    `${THANK_YOU}
 
-## Bug Fixes
+## 🐛 Bug Fixes
 - fix(ui/): keep release automation running ([#20](https://example.com/20)) by @octo
 `,
   );
 });
 
 test("keeps the larger hierarchy stable when formatting an existing draft", () => {
-  const notes = `Thanks for using Tidebreak ❤️
+  const notes = `${THANK_YOU}
 
-# What's Changed
-
-## New Features
+## ✨ New Features
 ### Desktop
 - add document search ([#12](https://example.com/12)) by @octo
 `;
 
   assert.equal(formatReleaseNotes(notes), notes);
+});
+
+test("drops the page heading and empty first-contributor section", () => {
+  const notes = `${THANK_YOU}
+
+# What's Changed
+
+## ✨ New Features
+- add document search ([#12](https://example.com/12)) by @octo
+
+## 🙌 New Contributors
+
+
+**Full Changelog**: https://github.com/brightwave-inc/tidebreak/compare/v0.1.0...v0.2.0
+`;
+
+  assert.equal(
+    formatReleaseNotes(notes),
+    `${THANK_YOU}
+
+## ✨ New Features
+- add document search ([#12](https://example.com/12)) by @octo
+
+**Full Changelog**: https://github.com/brightwave-inc/tidebreak/compare/v0.1.0...v0.2.0
+`,
+  );
+});
+
+test("keeps first-time contributors and a compare link", () => {
+  const notes = `## ✨ New Features
+- add document search ([#12](https://example.com/12)) by @octo
+
+## 🙌 New Contributors
+
+- @newbie made their first contribution in [#21](https://example.com/21)
+
+**Full Changelog**: https://github.com/brightwave-inc/tidebreak/compare/v0.1.0...v0.2.0
+`;
+
+  assert.equal(
+    formatReleaseNotes(notes),
+    `${THANK_YOU}
+
+## ✨ New Features
+- add document search ([#12](https://example.com/12)) by @octo
+
+## 🙌 New Contributors
+
+- @newbie made their first contribution in [#21](https://example.com/21)
+
+**Full Changelog**: https://github.com/brightwave-inc/tidebreak/compare/v0.1.0...v0.2.0
+`,
+  );
 });

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -306,8 +306,11 @@ test("third-party workflow actions use immutable commit SHAs", () => {
 });
 
 test("release-drafter retains a stable draft tag after formatting", () => {
+  assert.match(releaseDrafterConfig, /name-template: "v\$RESOLVED_VERSION"/);
   assert.match(releaseDrafterConfig, /tag-template: "v\$RESOLVED_VERSION"/);
   assert.match(releaseDrafterConfig, /^tag-prefix: "v"$/m);
+  assert.match(releaseDrafterConfig, /\$NEW_CONTRIBUTORS/);
+  assert.match(releaseDrafterConfig, /\*\*Full Changelog\*\*:/);
 
   const draftJob = workflowJob(workflows["release-draft.yml"], "draft");
   const requireBaselineAt = draftJob.indexOf(


### PR DESCRIPTION
## What

Refresh the native GitHub release notes so they match the shape people already know from GitHub's generator and Release Drafter's own template.

## Why

The draft title repeated the product name, the H1 fought the release heading, and first-time contributors never appeared.

## Changes

- Title is the tag (`v0.4.0`), not `Tidebreak v0.4.0`.
- Notes open with a blockquote thank-you instead of a page-level **What's Changed** heading.
- Category headings use leading emojis.
- First-time contributors get their own section; bots are excluded; an empty section is omitted.
- Notes end with a compare link to the previous tag.

The current draft updates on the next merge to `main`.