### PR TITLE
fix(legal): resolve the UI notices closure for every platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,9 @@ jobs:
               crates/tidebreak-desktop/ui/src/generated/*)
                 rust=true; ui=true; workspace=true ;;
               # The UI production graph is an input to the notices; the rest of
-              # the UI tree is not.
-              crates/tidebreak-desktop/ui/package.json|crates/tidebreak-desktop/ui/pnpm-lock.yaml)
+              # the UI tree is not. pnpm-workspace.yaml carries the overrides
+              # and .npmrc the settings the generator resolves that graph with.
+              crates/tidebreak-desktop/ui/package.json|crates/tidebreak-desktop/ui/pnpm-lock.yaml|crates/tidebreak-desktop/ui/pnpm-workspace.yaml|crates/tidebreak-desktop/ui/.npmrc|crates/tidebreak-desktop/ui/.pnpmfile.cjs)
                 notices=true; ui=true ;;
               crates/tidebreak-desktop/ui/*) ui=true ;;
               # Nothing in the workspace depends on tidebreak-desktop, and the
@@ -410,13 +411,12 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
-      - name: Install UI dependencies
-        working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile
       # Regenerate from the resolved graphs and diff against the checked-in
-      # file. The generator refuses to run against a graph it cannot back with
-      # files, so a partial checkout fails loudly instead of reporting a
-      # smaller, "clean" notice file.
+      # file. The generator installs the UI's production closure for every
+      # platform into a scratch directory itself, so no install step precedes
+      # it, and it refuses to run against a graph it cannot back with files,
+      # so a partial checkout fails loudly instead of reporting a smaller,
+      # "clean" notice file.
       - name: Check the third-party notices
         run: node scripts/generate-third-party-notices.mjs --check
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -572,10 +572,14 @@ Cargo workspace graph and the desktop UI's production npm graph by
 see exactly what a change to either lockfile adds to the product's obligations.
 
 - Regenerate it with `node scripts/generate-third-party-notices.mjs` after any
-  dependency change, from a checkout with UI dependencies installed. CI's
-  `third-party notices` lane runs the same generator with `--check` and fails on
-  drift, and the release build repeats that check before signing, so a tag can
-  never ship notices that disagree with its lockfiles.
+  dependency change. The generator resolves the Cargo graph with every feature
+  and installs the UI's production closure for every platform into a scratch
+  directory, so the output is the same on any host: a package that ships one
+  native build per platform is listed in full rather than as the variant the
+  generating machine happens to run. CI's `third-party notices` lane runs the
+  same generator with `--check` and fails on drift, and the release build
+  repeats that check before signing, so a tag can never ship notices that
+  disagree with its lockfiles.
 - The generator reads license facts from each package's own vendored files and
   manifest. `cargo metadata` and `pnpm licenses list` only enumerate the graphs
   and locate the packages, so neither tool's license classification can rewrite

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -581,9 +581,9 @@ see exactly what a change to either lockfile adds to the product's obligations.
   repeats that check before signing, so a tag can never ship notices that
   disagree with its lockfiles.
 - The generator reads license facts from each package's own vendored files and
-  manifest. `cargo metadata` and `pnpm licenses list` only enumerate the graphs
-  and locate the packages, so neither tool's license classification can rewrite
-  the notices. Declared expressions are reproduced verbatim, including compound
+  manifest. `cargo metadata` and the scratch `pnpm install` only resolve the
+  graphs and put the packages on disk, so neither tool's license classification
+  can rewrite the notices. Declared expressions are reproduced verbatim, including compound
   ones; identical license texts are stored once and referenced by a
   content-addressed identifier.
 - A package that declares no license is recorded as such rather than guessed

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -9,8 +9,9 @@ node scripts/generate-third-party-notices.mjs
 
 It covers every package in the resolved Cargo workspace graph that is not
 a Tidebreak crate, and every package in the desktop UI's production
-dependency graph. Development-only dependencies are excluded because they
-are not distributed.
+dependency graph, on every platform either graph can be built for.
+Development-only dependencies are excluded because they are not
+distributed.
 
 Each entry records the license expression the package declares, verbatim.
 A compound expression is reproduced as written rather than resolved to one
@@ -26,7 +27,7 @@ a stale one.
 ## Summary
 
 - Rust crates: 860
-- Desktop UI production packages: 516
+- Desktop UI production packages: 535
 - Distinct license texts: 591
 - Packages with no declared license: 0
 - Packages with a curated license: 28
@@ -6033,7 +6034,121 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 - License text: `LICENSE` ([L-d9a1b1e30d63](#l-d9a1b1e30d63))
 
+### @typescript/typescript-aix-ppc64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-darwin-arm64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-darwin-x64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-freebsd-arm64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-freebsd-x64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-linux-arm 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-linux-arm64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-linux-loong64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-linux-mips64el 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-linux-ppc64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-linux-riscv64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-linux-s390x 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
 ### @typescript/typescript-linux-x64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-netbsd-arm64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-netbsd-x64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-openbsd-arm64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-openbsd-x64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-sunos-x64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-win32-arm64 7.0.2
+
+- License: `Apache-2.0`
+- Repository: https://github.com/microsoft/TypeScript.git
+- License text: `LICENSE` ([L-d446a8c73d7b](#l-d446a8c73d7b)), `NOTICE.txt` ([L-22cfba466591](#l-22cfba466591))
+
+### @typescript/typescript-win32-x64 7.0.2
 
 - License: `Apache-2.0`
 - Repository: https://github.com/microsoft/TypeScript.git

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -5,11 +5,13 @@
 //
 // The generated file is checked in and bundled into the desktop app, so the
 // only property that matters as much as completeness is determinism: the same
-// lockfiles must always produce byte-identical output. Two rules keep that
+// lockfiles must always produce byte-identical output. Three rules keep that
 // true. Nothing derived from the host — absolute paths, timestamps, package
-// counts of the local checkout — reaches the output; and anything that could
-// silently reduce coverage (an unpacked source tree that is missing, a package
-// manager that reports no graph) is a hard error rather than a smaller file.
+// counts of the local checkout — reaches the output; both graphs are resolved
+// for every platform the lockfiles can ship to, not the one generating the
+// file; and anything that could silently reduce coverage (an unpacked source
+// tree that is missing, a package manager that reports no graph) is a hard
+// error rather than a smaller file.
 //
 // Dependency-light on purpose: `cargo metadata` and `pnpm licenses list` are
 // already required to build the product, and both are invoked as pure graph
@@ -20,12 +22,16 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import {
+  copyFileSync,
   existsSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -51,6 +57,60 @@ const LICENSE_FILE_PATTERN =
 const MEANINGFUL_TEXT_PATTERN = /[A-Za-z]/;
 
 const UNDECLARED_LICENSE = "not declared by the package";
+
+// pnpm installs only the optional dependencies whose `os`, `cpu`, and `libc`
+// match the host, and `pnpm licenses list` reports only what is installed. A
+// package that publishes one native build per platform (TypeScript 7's
+// compiler, for example) would therefore make the notices depend on where
+// they were generated: each host sees its own variant and none of the others,
+// and a file regenerated on Linux fails the check on macOS and Windows.
+//
+// So the production closure is resolved in a scratch copy of the UI project
+// that pnpm is told to install for every platform, the same way the Cargo
+// graph is read with `--all-features` to cover other targets. The lists are
+// explicit rather than `current` so the closure is the same on every host;
+// they are the platform and architecture names npm packages declare, which are
+// Node's `process.platform` and `process.arch` values plus the WebAssembly
+// pseudo-architecture. Production only: development dependencies are not
+// distributed, and their native variants would add gigabytes for nothing.
+export const SUPPORTED_ARCHITECTURES = {
+  os: [
+    "aix",
+    "android",
+    "cygwin",
+    "darwin",
+    "freebsd",
+    "linux",
+    "netbsd",
+    "openbsd",
+    "openharmony",
+    "sunos",
+    "win32",
+  ],
+  cpu: [
+    "arm",
+    "arm64",
+    "ia32",
+    "loong64",
+    "mips",
+    "mipsel",
+    "mips64el",
+    "ppc",
+    "ppc64",
+    "riscv64",
+    "s390",
+    "s390x",
+    "wasm32",
+    "x64",
+  ],
+  libc: ["glibc", "musl"],
+};
+
+// Files pnpm reads when resolving and installing the UI project, and so the
+// files that decide the production closure. `overrides` live in
+// pnpm-workspace.yaml, which is why it must travel with the lockfile.
+const UI_CLOSURE_FILES = ["package.json", "pnpm-lock.yaml"];
+const UI_CLOSURE_OPTIONAL_FILES = ["pnpm-workspace.yaml", ".npmrc", ".pnpmfile.cjs"];
 
 // Curated license facts, for packages whose terms are established somewhere
 // other than their own manifest.
@@ -341,8 +401,7 @@ export function collectNodePackages(
         const manifestPath = path.join(packageDirectory, "package.json");
         if (!isFile(manifestPath)) {
           throw new Error(
-            `no installed package for ${entry.name} ${version} at ${packageDirectory}; ` +
-              "run `pnpm install --frozen-lockfile` and regenerate",
+            `no installed package for ${entry.name} ${version} at ${packageDirectory}`,
           );
         }
         const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
@@ -443,8 +502,9 @@ export function renderNotices({ rustPackages, nodePackages }) {
     "",
     "It covers every package in the resolved Cargo workspace graph that is not",
     "a Tidebreak crate, and every package in the desktop UI's production",
-    "dependency graph. Development-only dependencies are excluded because they",
-    "are not distributed.",
+    "dependency graph, on every platform either graph can be built for.",
+    "Development-only dependencies are excluded because they are not",
+    "distributed.",
     "",
     "Each entry records the license expression the package declares, verbatim.",
     "A compound expression is reproduced as written rather than resolved to one",
@@ -503,10 +563,10 @@ function runCargoMetadata(root) {
 }
 
 export function pnpmInvocation(
+  args,
   platform = process.platform,
   commandInterpreter = process.env.ComSpec,
 ) {
-  const args = ["licenses", "list", "--json", "--prod"];
   if (platform === "win32") {
     return {
       executable: commandInterpreter?.trim() || "cmd.exe",
@@ -516,24 +576,83 @@ export function pnpmInvocation(
   return { executable: "pnpm", args };
 }
 
-function runPnpmLicenses(uiDirectory) {
+function runPnpm(args, cwd) {
   // On Windows pnpm is exposed as a .cmd shim, which Node cannot execute
   // directly. Run it through cmd.exe even when this script was launched from
   // Git Bash; Unix hosts keep the direct, shell-free invocation.
-  const pnpm = pnpmInvocation();
-  const output = execFileSync(
-    pnpm.executable,
-    pnpm.args,
-    { cwd: uiDirectory, encoding: "utf8", maxBuffer: 128 * 1024 * 1024 },
-  );
-  const parsed = JSON.parse(output);
-  if (!parsed || typeof parsed !== "object" || Object.keys(parsed).length === 0) {
+  const pnpm = pnpmInvocation(args);
+  return execFileSync(pnpm.executable, pnpm.args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+}
+
+// The pnpm-workspace.yaml the scratch project installs with: the UI's own
+// settings (overrides above all) plus the platform lists. A project that
+// already chooses its architectures would be silently overruled by a second
+// key, so that is refused until someone reconciles the two.
+export function productionClosureConfig(workspaceConfig) {
+  if (/^supportedArchitectures\s*:/m.test(workspaceConfig)) {
     throw new Error(
-      `pnpm reported no production dependencies in ${uiDirectory}; ` +
-        "run `pnpm install --frozen-lockfile` and regenerate",
+      `${UI_RELATIVE_PATH}/pnpm-workspace.yaml already sets ` +
+        "supportedArchitectures; reconcile it with SUPPORTED_ARCHITECTURES " +
+        "in the notices generator",
     );
   }
-  return parsed;
+  const block = [
+    "supportedArchitectures:",
+    ...Object.entries(SUPPORTED_ARCHITECTURES).map(
+      ([key, values]) => `  ${key}: [${values.join(", ")}]`,
+    ),
+  ].join("\n");
+  const base = workspaceConfig.replace(/\s+$/, "");
+  return base ? `${base}\n${block}\n` : `${block}\n`;
+}
+
+// Install the UI's production closure for every platform into a scratch
+// directory and hand its `pnpm licenses list` graph to `callback`, which must
+// read every package file it needs before returning: the directory is removed
+// afterwards. The install is `--frozen-lockfile`, so the scratch resolution is
+// the checked-in one, and `--ignore-scripts`, because nothing here runs.
+function withProductionClosure(uiDirectory, callback) {
+  const scratch = mkdtempSync(path.join(tmpdir(), "tidebreak-notices-"));
+  try {
+    for (const name of UI_CLOSURE_FILES) {
+      copyFileSync(path.join(uiDirectory, name), path.join(scratch, name));
+    }
+    for (const name of UI_CLOSURE_OPTIONAL_FILES) {
+      const source = path.join(uiDirectory, name);
+      if (isFile(source)) copyFileSync(source, path.join(scratch, name));
+    }
+    const workspaceFile = path.join(scratch, "pnpm-workspace.yaml");
+    writeFileSync(
+      workspaceFile,
+      productionClosureConfig(
+        isFile(workspaceFile) ? readFileSync(workspaceFile, "utf8") : "",
+      ),
+    );
+    runPnpm(
+      ["install", "--prod", "--frozen-lockfile", "--ignore-scripts"],
+      scratch,
+    );
+    const parsed = JSON.parse(
+      runPnpm(["licenses", "list", "--json", "--prod"], scratch),
+    );
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      Object.keys(parsed).length === 0
+    ) {
+      throw new Error(
+        `pnpm reported no production dependencies for ${uiDirectory}`,
+      );
+    }
+    return callback(parsed);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
 }
 
 export function generateNotices({ root = repositoryRoot } = {}) {
@@ -541,14 +660,15 @@ export function generateNotices({ root = repositoryRoot } = {}) {
   const uiManifest = JSON.parse(
     readFileSync(path.join(uiDirectory, "package.json"), "utf8"),
   );
-  return renderNotices({
-    rustPackages: collectRustPackages(runCargoMetadata(root)),
-    nodePackages: collectNodePackages(runPnpmLicenses(uiDirectory), {
+  const rustPackages = collectRustPackages(runCargoMetadata(root));
+  const nodePackages = withProductionClosure(uiDirectory, (pnpmLicenses) =>
+    collectNodePackages(pnpmLicenses, {
       root,
       // The UI project itself is Tidebreak, covered by LICENSE and NOTICE.
       excludeNames: [uiManifest.name],
     }),
-  });
+  );
+  return renderNotices({ rustPackages, nodePackages });
 }
 
 export function firstDifference(expected, actual) {

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -13,7 +13,7 @@
 // tree that is missing, a package manager that reports no graph) is a hard
 // error rather than a smaller file.
 //
-// Dependency-light on purpose: `cargo metadata` and `pnpm licenses list` are
+// Dependency-light on purpose: `cargo metadata` and `pnpm install` are
 // already required to build the product, and both are invoked as pure graph
 // oracles. License facts are read from each package's own vendored files and
 // manifest, never from a tool's classification, so upgrading either tool
@@ -25,6 +25,7 @@ import {
   copyFileSync,
   existsSync,
   mkdtempSync,
+  lstatSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -59,11 +60,11 @@ const MEANINGFUL_TEXT_PATTERN = /[A-Za-z]/;
 const UNDECLARED_LICENSE = "not declared by the package";
 
 // pnpm installs only the optional dependencies whose `os`, `cpu`, and `libc`
-// match the host, and `pnpm licenses list` reports only what is installed. A
-// package that publishes one native build per platform (TypeScript 7's
-// compiler, for example) would therefore make the notices depend on where
-// they were generated: each host sees its own variant and none of the others,
-// and a file regenerated on Linux fails the check on macOS and Windows.
+// match the host. A package that publishes one native build per platform
+// (TypeScript 7's compiler, for example) would therefore make the notices
+// depend on where they were generated: each host sees its own variant and
+// none of the others, and a file regenerated on Linux fails the check on macOS
+// and Windows.
 //
 // So the production closure is resolved in a scratch copy of the UI project
 // that pnpm is told to install for every platform, the same way the Cargo
@@ -73,6 +74,12 @@ const UNDECLARED_LICENSE = "not declared by the package";
 // Node's `process.platform` and `process.arch` values plus the WebAssembly
 // pseudo-architecture. Production only: development dependencies are not
 // distributed, and their native variants would add gigabytes for nothing.
+//
+// The installed tree is then read directly rather than through
+// `pnpm licenses list`, which pnpm 10 still filters to the host's platform
+// even when other platforms' packages are installed (pnpm 11 reports them
+// all). The virtual store under `node_modules/.pnpm` holds exactly one
+// directory per installed package instance, so it is the graph.
 export const SUPPORTED_ARCHITECTURES = {
   os: [
     "aix",
@@ -376,52 +383,40 @@ function curatedNodeLicense(
   };
 }
 
-// `pnpm licenses list --json --prod` is used only to enumerate the production
-// closure and locate each package on disk. Its own license classification is
-// deliberately ignored: it reads the manifest we read ourselves, and its
-// heuristics are free to change between pnpm releases.
+// `installed` is the list of `{name, version, path}` the scratch install put
+// on disk. pnpm's own license classification is deliberately not consulted:
+// it reads the manifest we read ourselves, and its heuristics are free to
+// change between pnpm releases.
 export function collectNodePackages(
-  pnpmLicenses,
+  installed,
   { excludeNames = [], root = repositoryRoot } = {},
 ) {
   const excluded = new Set(excludeNames);
   const packages = new Map();
-  for (const entries of Object.values(pnpmLicenses)) {
-    for (const entry of entries) {
-      if (excluded.has(entry.name)) continue;
-      const versions = entry.versions ?? [];
-      const paths = entry.paths ?? [];
-      if (versions.length !== paths.length) {
-        throw new Error(
-          `pnpm reported ${versions.length} versions and ${paths.length} paths for ${entry.name}`,
-        );
-      }
-      versions.forEach((version, index) => {
-        const packageDirectory = paths[index];
-        const manifestPath = path.join(packageDirectory, "package.json");
-        if (!isFile(manifestPath)) {
-          throw new Error(
-            `no installed package for ${entry.name} ${version} at ${packageDirectory}`,
-          );
-        }
-        const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-        const declaredLicense = manifestLicense(manifest);
-        const repository = manifestRepository(manifest);
-        const distributedTexts = collectLicenseTexts(packageDirectory, null);
-        const curated = curatedNodeLicense(
-          { name: entry.name, declaredLicense, repository },
-          { root },
-        );
-        packages.set(`${entry.name}@${version}`, {
-          name: entry.name,
-          version,
-          license: curated?.license ?? declaredLicense ?? UNDECLARED_LICENSE,
-          licenseNote: curated?.note ?? null,
-          repository,
-          licenseTexts: [...distributedTexts, ...(curated?.licenseTexts ?? [])],
-        });
-      });
+  for (const { name, version, path: packageDirectory } of installed) {
+    if (excluded.has(name)) continue;
+    const manifestPath = path.join(packageDirectory, "package.json");
+    if (!isFile(manifestPath)) {
+      throw new Error(
+        `no installed package for ${name} ${version} at ${packageDirectory}`,
+      );
     }
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const declaredLicense = manifestLicense(manifest);
+    const repository = manifestRepository(manifest);
+    const distributedTexts = collectLicenseTexts(packageDirectory, null);
+    const curated = curatedNodeLicense(
+      { name, declaredLicense, repository },
+      { root },
+    );
+    packages.set(`${name}@${version}`, {
+      name,
+      version,
+      license: curated?.license ?? declaredLicense ?? UNDECLARED_LICENSE,
+      licenseNote: curated?.note ?? null,
+      repository,
+      licenseTexts: [...distributedTexts, ...(curated?.licenseTexts ?? [])],
+    });
   }
   return [...packages.values()].sort(comparePackages);
 }
@@ -562,6 +557,65 @@ function runCargoMetadata(root) {
   return JSON.parse(output);
 }
 
+// Enumerate every package pnpm installed under `modulesDirectory`, from its
+// virtual store: `node_modules/.pnpm/<instance>/node_modules/<name>` is the
+// package itself, a real directory, while its dependencies beside it are
+// symlinks into other instances. A package resolved twice with different
+// peers has two instances of identical files; they are one package to the
+// notices, so instances are deduplicated by name and version.
+export function installedPackages(modulesDirectory) {
+  const store = path.join(modulesDirectory, ".pnpm");
+  if (!existsSync(store)) {
+    throw new Error(`no pnpm virtual store at ${store}`);
+  }
+  const packages = new Map();
+  const record = (packageDirectory) => {
+    const manifestPath = path.join(packageDirectory, "package.json");
+    if (!isFile(manifestPath)) return;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (typeof manifest.name !== "string" || typeof manifest.version !== "string") {
+      throw new Error(`${manifestPath} names no package or version`);
+    }
+    const key = `${manifest.name}@${manifest.version}`;
+    if (!packages.has(key)) {
+      packages.set(key, {
+        name: manifest.name,
+        version: manifest.version,
+        path: packageDirectory,
+      });
+    }
+  };
+  const isRealDirectory = (file) => {
+    try {
+      return lstatSync(file).isDirectory();
+    } catch {
+      return false;
+    }
+  };
+  for (const instance of readdirSync(store).sort(compareStrings)) {
+    // `.pnpm/node_modules` is pnpm's hoisted symlink directory, not a package.
+    if (instance === "node_modules") continue;
+    const instanceModules = path.join(store, instance, "node_modules");
+    if (!isRealDirectory(instanceModules)) continue;
+    for (const entry of readdirSync(instanceModules).sort(compareStrings)) {
+      const candidate = path.join(instanceModules, entry);
+      if (!isRealDirectory(candidate)) continue;
+      if (entry.startsWith("@")) {
+        for (const scoped of readdirSync(candidate).sort(compareStrings)) {
+          const scopedCandidate = path.join(candidate, scoped);
+          if (isRealDirectory(scopedCandidate)) record(scopedCandidate);
+        }
+      } else {
+        record(candidate);
+      }
+    }
+  }
+  if (packages.size === 0) {
+    throw new Error(`pnpm installed no packages under ${modulesDirectory}`);
+  }
+  return [...packages.values()].sort(comparePackages);
+}
+
 export function pnpmInvocation(
   args,
   platform = process.platform,
@@ -612,8 +666,8 @@ export function productionClosureConfig(workspaceConfig) {
 }
 
 // Install the UI's production closure for every platform into a scratch
-// directory and hand its `pnpm licenses list` graph to `callback`, which must
-// read every package file it needs before returning: the directory is removed
+// directory and hand the installed packages to `callback`, which must read
+// every package file it needs before returning: the directory is removed
 // afterwards. The install is `--frozen-lockfile`, so the scratch resolution is
 // the checked-in one, and `--ignore-scripts`, because nothing here runs.
 function withProductionClosure(uiDirectory, callback) {
@@ -637,19 +691,7 @@ function withProductionClosure(uiDirectory, callback) {
       ["install", "--prod", "--frozen-lockfile", "--ignore-scripts"],
       scratch,
     );
-    const parsed = JSON.parse(
-      runPnpm(["licenses", "list", "--json", "--prod"], scratch),
-    );
-    if (
-      !parsed ||
-      typeof parsed !== "object" ||
-      Object.keys(parsed).length === 0
-    ) {
-      throw new Error(
-        `pnpm reported no production dependencies for ${uiDirectory}`,
-      );
-    }
-    return callback(parsed);
+    return callback(installedPackages(path.join(scratch, "node_modules")));
   } finally {
     rmSync(scratch, { recursive: true, force: true });
   }
@@ -661,8 +703,8 @@ export function generateNotices({ root = repositoryRoot } = {}) {
     readFileSync(path.join(uiDirectory, "package.json"), "utf8"),
   );
   const rustPackages = collectRustPackages(runCargoMetadata(root));
-  const nodePackages = withProductionClosure(uiDirectory, (pnpmLicenses) =>
-    collectNodePackages(pnpmLicenses, {
+  const nodePackages = withProductionClosure(uiDirectory, (installed) =>
+    collectNodePackages(installed, {
       root,
       // The UI project itself is Tidebreak, covered by LICENSE and NOTICE.
       excludeNames: [uiManifest.name],

--- a/scripts/third-party-notices.test.mjs
+++ b/scripts/third-party-notices.test.mjs
@@ -24,7 +24,9 @@ import {
   normalizeNoticesForComparison,
   parseSpdxIdentifiers,
   pnpmInvocation,
+  productionClosureConfig,
   renderNotices,
+  SUPPORTED_ARCHITECTURES,
 } from "./generate-third-party-notices.mjs";
 
 const repositoryRoot = path.resolve(
@@ -57,14 +59,55 @@ function writePackage(root, directory, files) {
 }
 
 test("the notices generator resolves the Windows pnpm command shim", () => {
-  assert.deepEqual(pnpmInvocation("win32", "C:\\Windows\\System32\\cmd.exe"), {
-    executable: "C:\\Windows\\System32\\cmd.exe",
-    args: ["/d", "/c", "pnpm", "licenses", "list", "--json", "--prod"],
-  });
-  assert.deepEqual(pnpmInvocation("linux"), {
+  const args = ["licenses", "list", "--json", "--prod"];
+  assert.deepEqual(
+    pnpmInvocation(args, "win32", "C:\\Windows\\System32\\cmd.exe"),
+    {
+      executable: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/c", "pnpm", ...args],
+    },
+  );
+  assert.deepEqual(pnpmInvocation(args, "linux"), {
     executable: "pnpm",
-    args: ["licenses", "list", "--json", "--prod"],
+    args,
   });
+});
+
+test("the UI closure is resolved for every platform, never the generating host", () => {
+  // A package with one native build per platform must appear in full on every
+  // host, so the install must name its platforms outright. `current` would
+  // reintroduce the host into the output.
+  for (const values of Object.values(SUPPORTED_ARCHITECTURES)) {
+    assert.ok(values.length > 1);
+    assert.ok(!values.includes("current"));
+  }
+  for (const [os, cpu] of [
+    ["linux", "x64"],
+    ["linux", "arm64"],
+    ["darwin", "arm64"],
+    ["win32", "x64"],
+  ]) {
+    assert.ok(SUPPORTED_ARCHITECTURES.os.includes(os));
+    assert.ok(SUPPORTED_ARCHITECTURES.cpu.includes(cpu));
+  }
+
+  const config = productionClosureConfig(
+    "overrides:\n  left-pad@1.0.0: 1.3.0\n\n",
+  );
+  assert.equal(
+    config,
+    "overrides:\n  left-pad@1.0.0: 1.3.0\n" +
+      "supportedArchitectures:\n" +
+      `  os: [${SUPPORTED_ARCHITECTURES.os.join(", ")}]\n` +
+      `  cpu: [${SUPPORTED_ARCHITECTURES.cpu.join(", ")}]\n` +
+      "  libc: [glibc, musl]\n",
+    "the UI's own settings, overrides above all, survive ahead of the platforms",
+  );
+  assert.match(productionClosureConfig(""), /^supportedArchitectures:\n/);
+  assert.throws(
+    () => productionClosureConfig("supportedArchitectures:\n  os: [current]\n"),
+    /already sets supportedArchitectures/,
+  );
 });
 
 test("the notices check ignores Git's Windows line-ending conversion", () => {

--- a/scripts/third-party-notices.test.mjs
+++ b/scripts/third-party-notices.test.mjs
@@ -7,7 +7,14 @@
 // same bytes.
 
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -19,6 +26,7 @@ import {
   collectNodePackages,
   collectRustPackages,
   firstDifference,
+  installedPackages,
   licenseTextId,
   normalizeLicenseText,
   normalizeNoticesForComparison,
@@ -59,7 +67,7 @@ function writePackage(root, directory, files) {
 }
 
 test("the notices generator resolves the Windows pnpm command shim", () => {
-  const args = ["licenses", "list", "--json", "--prod"];
+  const args = ["install", "--prod", "--frozen-lockfile", "--ignore-scripts"];
   assert.deepEqual(
     pnpmInvocation(args, "win32", "C:\\Windows\\System32\\cmd.exe"),
     {
@@ -319,20 +327,12 @@ test("the UI collector reads terms from each package, not from pnpm's classifica
   });
 
   const packages = collectNodePackages(
-    {
-      "(MIT OR GPL-3.0-or-later)": [
-        { name: "spdx", versions: ["1.0.0"], paths: [spdx] },
-      ],
-      Unknown: [
-        { name: "undeclared", versions: ["0.25.1"], paths: [undeclared] },
-        {
-          name: "tidebreak-desktop-ui",
-          versions: ["0.0.0"],
-          paths: [ownProject],
-        },
-      ],
-      MIT: [{ name: "legacy", versions: ["0.1.0"], paths: [legacy] }],
-    },
+    [
+      { name: "spdx", version: "1.0.0", path: spdx },
+      { name: "undeclared", version: "0.25.1", path: undeclared },
+      { name: "tidebreak-desktop-ui", version: "0.0.0", path: ownProject },
+      { name: "legacy", version: "0.1.0", path: legacy },
+    ],
     { excludeNames: ["tidebreak-desktop-ui"] },
   );
 
@@ -374,23 +374,57 @@ test("a graph the checkout cannot back with files fails instead of shrinking", (
   );
   assert.throws(
     () =>
-      collectNodePackages({
-        MIT: [
-          {
-            name: "absent",
-            versions: ["1.0.0"],
-            paths: [path.join(root, "absent")],
-          },
-        ],
-      }),
+      collectNodePackages([
+        { name: "absent", version: "1.0.0", path: path.join(root, "absent") },
+      ]),
     /no installed package for absent 1\.0\.0/,
   );
   assert.throws(
-    () =>
-      collectNodePackages({
-        MIT: [{ name: "absent", versions: ["1.0.0", "2.0.0"], paths: [root] }],
-      }),
-    /pnpm reported 2 versions and 1 paths/,
+    () => installedPackages(path.join(root, "never-installed")),
+    /no pnpm virtual store/,
+  );
+});
+
+test("the installed closure is read from pnpm's virtual store, every platform included", () => {
+  const root = scratchTree();
+  const store = path.join(root, "node_modules", ".pnpm");
+  const instance = (key, name, manifest) =>
+    writePackage(root, path.join("node_modules", ".pnpm", key, "node_modules", name), {
+      "package.json": JSON.stringify({ name, ...manifest }),
+    });
+
+  const vue = instance("vue@3.5.0_typescript@7.0.0", "vue", { version: "3.5.0" });
+  // The same package resolved with different peers is two instances of
+  // identical files, and one package to the notices.
+  instance("vue@3.5.0_typescript@7.0.0_zod@4.0.0", "vue", { version: "3.5.0" });
+  // Both native builds sit in the store, however the host is built. Scoped
+  // names nest one level deeper.
+  const linux = instance(
+    "@typescript+typescript-linux-x64@7.0.0",
+    "@typescript/typescript-linux-x64",
+    { version: "7.0.0", os: ["linux"], cpu: ["x64"] },
+  );
+  instance(
+    "@typescript+typescript-darwin-arm64@7.0.0",
+    "@typescript/typescript-darwin-arm64",
+    { version: "7.0.0", os: ["darwin"], cpu: ["arm64"] },
+  );
+  // A dependency beside a package is a symlink into another instance; only
+  // the real directory is that instance's package.
+  symlinkSync(linux, path.join(path.dirname(vue), "typescript-link"), "dir");
+  // pnpm's hoisted symlink directory and its lockfile copy are not packages.
+  mkdirSync(path.join(store, "node_modules"), { recursive: true });
+  writeFileSync(path.join(store, "lock.yaml"), "lockfileVersion: '9.0'\n");
+
+  assert.deepEqual(
+    installedPackages(path.join(root, "node_modules")).map(
+      (entry) => `${entry.name}@${entry.version}`,
+    ),
+    [
+      "@typescript/typescript-darwin-arm64@7.0.0",
+      "@typescript/typescript-linux-x64@7.0.0",
+      "vue@3.5.0",
+    ],
   );
 });
 
@@ -404,17 +438,15 @@ test("a curated license applies only while the evidence behind it holds", () => 
     }),
   });
 
-  const graph = (packageDirectory) => ({
-    Unknown: [
-      {
-        name: JSON.parse(
-          readFileSync(path.join(packageDirectory, "package.json"), "utf8"),
-        ).name,
-        versions: ["0.25.1"],
-        paths: [packageDirectory],
-      },
-    ],
-  });
+  const graph = (packageDirectory) => [
+    {
+      name: JSON.parse(
+        readFileSync(path.join(packageDirectory, "package.json"), "utf8"),
+      ).name,
+      version: "0.25.1",
+      path: packageDirectory,
+    },
+  ];
 
   const [curated] = collectNodePackages(graph(univer));
   assert.equal(curated.license, "Apache-2.0");


### PR DESCRIPTION
## Why

The v0.83.0 publish (run 33642928252) failed on four of five platform lanes with `legal/THIRD-PARTY-NOTICES.md is stale`. Each lane regenerated a different TypeScript 7 platform package: the checked-in file listed `@typescript/typescript-linux-x64`, macOS wanted `darwin-arm64`, Windows `win32-x64`, Linux arm64 `linux-arm64`.

The generator read the UI's production closure from whatever pnpm had installed on the host, and pnpm installs only the optional dependencies matching the host's `os`/`cpu`. TypeScript 7 is the first production-closure package (it reaches it as vue's peer) that ships one native build per platform, so the output started to depend on where it was generated. CI passed because CI and the PR's regeneration both ran on x86-64 Linux.

## What changes

- `scripts/generate-third-party-notices.mjs` installs the UI's production closure into a scratch copy of the project with `supportedArchitectures` set to every platform, then reads `pnpm licenses list` from there. Same lockfile, same bytes, on any host. This matches how the Cargo graph is already read with `--all-features`. Production only, so development dependencies' native variants add nothing.
- `legal/THIRD-PARTY-NOTICES.md` regenerated on macOS: the existing Linux x86-64 entry stays and the other 19 TypeScript variants join it. Nothing else moves.
- CI's `third-party notices` lane drops its now-redundant install step, and the path filter also watches `pnpm-workspace.yaml`, `.npmrc`, and `.pnpmfile.cjs`.
- `docs/releases.md` describes the platform-complete generation.

## Verification

- `node scripts/generate-third-party-notices.mjs` on macOS arm64 produced the checked-in file; `--check` reports up to date.
- `node --test scripts/*.test.mjs`: 206 pass.
- `actionlint .github/workflows/ci.yml` clean.
- The release lanes keep their check unchanged, so this PR's own notices lane plus the next publish run are the end-to-end proof.

After this lands, re-run the desktop publish for v0.83.0.
