### PR TITLE
fix(desktop): keep the composer draft across a Settings round trip

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.dom.test.tsx
@@ -1,6 +1,23 @@
 // @vitest-environment jsdom
-import { act, cleanup, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+  useNavigate,
+  useParams,
+  useRouter,
+} from "@tanstack/react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, Chat } from "./api";
 import { ChatView, type ChatViewProps } from "./ChatView";
@@ -109,9 +126,17 @@ async function renderChatView(overrides: Partial<ChatViewProps> = {}) {
   return props;
 }
 
+const otherChat = {
+  id: "chat-2",
+  title: "Other work",
+  project_id: null,
+} as unknown as Chat;
+
 beforeEach(() => {
   useChatSessionStore.getState().reset();
   useComposerDrafts.getState().clearDraft(chat.id);
+  useComposerDrafts.getState().clearDraft(otherChat.id);
+  window.sessionStorage.clear();
   usePendingPrompts.setState({
     chatId: null,
     userQuestions: [],
@@ -435,4 +460,178 @@ describe("ChatView", () => {
       expect(screen.queryByText(/steer rejected/)).not.toBeInTheDocument(),
     );
   });
+
+  it("keeps the composer draft across a Settings round trip", async () => {
+    const user = userEvent.setup();
+    const { router } = await mountConversationShell();
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "unsent thought",
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "unsent thought",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+    expect(await screen.findByTestId("settings")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: "Message" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Back to app" }));
+    expect(await screen.findByRole("textbox", { name: "Message" })).toHaveValue(
+      "unsent thought",
+    );
+    expect(router.state.location.pathname).toBe("/c/chat-1");
+  });
+
+  it("keeps drafts scoped to their conversation and forgets them on send", async () => {
+    const user = userEvent.setup();
+    const { router } = await mountConversationShell();
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "only for roadmap",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Other work" }));
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/c/chat-2"),
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "only for other",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Roadmap" }));
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/c/chat-1"),
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "only for roadmap",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+    await screen.findByTestId("settings");
+    await user.click(screen.getByRole("button", { name: "Back to app" }));
+
+    expect(await screen.findByRole("textbox", { name: "Message" })).toHaveValue(
+      "",
+    );
+    expect(useComposerDrafts.getState().drafts[chat.id]).toBeFalsy();
+
+    await user.click(screen.getByRole("button", { name: "Other work" }));
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/c/chat-2"),
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "only for other",
+    );
+
+    useComposerDrafts.getState().clearDraft(otherChat.id);
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+    await screen.findByTestId("settings");
+    await user.click(screen.getByRole("button", { name: "Back to app" }));
+    expect(await screen.findByRole("textbox", { name: "Message" })).toHaveValue(
+      "",
+    );
+  });
 });
+
+function ConversationChatPage() {
+  const navigate = useNavigate();
+  const { chatId } = useParams({ strict: false }) as { chatId: string };
+  const openChat = chatId === otherChat.id ? otherChat : chat;
+
+  return (
+    <>
+      <button type="button" onClick={() => void navigate({ to: "/settings" })}>
+        Settings
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })
+        }
+      >
+        Roadmap
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          void navigate({
+            to: "/c/$chatId",
+            params: { chatId: otherChat.id },
+          })
+        }
+      >
+        Other work
+      </button>
+      <ChatView
+        client={client}
+        chat={openChat}
+        hydrated
+        nativeHost={false}
+        deletingChat={false}
+        composerModelMenu={null}
+        composerPermissionMenu={null}
+        composerImages={noImages()}
+        files={noFiles()}
+        voiceInputUsed={false}
+        onVoiceInputAccepted={vi.fn()}
+        attachError={null}
+        onDraftChange={(value) =>
+          useComposerDrafts.getState().setDraft(openChat.id, value)
+        }
+        onSelectPrompt={vi.fn()}
+        onSend={async () => {
+          useComposerDrafts.getState().setDraft(openChat.id, "");
+        }}
+      />
+    </>
+  );
+}
+
+function SettingsPage() {
+  const router = useRouter();
+  return (
+    <>
+      <div data-testid="settings">settings</div>
+      <button
+        type="button"
+        onClick={() => {
+          if (router.history.canGoBack()) router.history.back();
+        }}
+      >
+        Back to app
+      </button>
+    </>
+  );
+}
+
+async function mountConversationShell() {
+  const rootRoute = createRootRoute();
+  const chatRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/c/$chatId",
+    component: ConversationChatPage,
+  });
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings",
+    component: SettingsPage,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([chatRoute, settingsRoute]),
+    history: createMemoryHistory({ initialEntries: ["/c/chat-1"] }),
+  });
+  await router.load();
+  const result = render(<RouterProvider router={router as never} />);
+  return { ...result, router };
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -74,7 +74,8 @@ afterEach(() => {
     pendingComposerImages: null,
     composerActionScope: null,
   });
-  useComposerDrafts.setState({ attachments: {} });
+  useComposerDrafts.setState({ drafts: {}, attachments: {} });
+  window.sessionStorage.clear();
 });
 
 const QUEUED = {
@@ -1069,6 +1070,78 @@ describe("CodeComposer", () => {
         { blob_id: attachmentId, media_type: "image/png" },
       ]),
     );
+  });
+
+  it("keeps the session draft across unmount and remount", async () => {
+    const user = userEvent.setup();
+    const first = renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "unsent code thought",
+    );
+    first.unmount();
+
+    const restored = renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "unsent code thought",
+    );
+    restored.unmount();
+
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-2"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+    cleanup();
+
+    const sending = renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "unsent code thought",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+    sending.unmount();
+
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -1143,6 +1143,43 @@ describe("CodeComposer", () => {
     );
     expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
   });
+
+  it("does not re-append first-turn recovery after a Settings remount", async () => {
+    const user = userEvent.setup();
+    const recovery = {
+      id: "rec-1",
+      draft: "Fix the exact failing test.",
+    };
+    const first = renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        recovery={recovery}
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    const box = screen.getByRole("textbox", { name: "Message" });
+    expect(box).toHaveValue("Fix the exact failing test.");
+    await user.type(box, " then retry");
+    expect(box).toHaveValue("Fix the exact failing test. then retry");
+    first.unmount();
+
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        recovery={recovery}
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "Fix the exact failing test. then retry",
+    );
+  });
 });
 
 describe("HarnessModelMenu", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -26,6 +26,7 @@ import { useApp } from "@/AppContext";
 import { HttpError } from "../api/client";
 import { Composer, type ComposerWorkspaceFiles } from "../Composer";
 import { messageWithWorkspaceFiles } from "./fork";
+import { useComposerDraft, useComposerDrafts } from "../ComposerDrafts";
 import {
   IMAGE_MEDIA_TYPES,
   readyImageAttachmentIds,
@@ -767,7 +768,10 @@ export function CodeComposer({
 }) {
   const { client } = useApp();
   const composerPromptScope = promptScope ?? sessionId ?? "code";
-  const [draft, setDraft] = useState("");
+  // Settings unmounts this composer. Keep the unsent text in the same
+  // store chat uses, keyed by session so one draft cannot leak into another.
+  const draftKey = sessionId ?? composerPromptScope;
+  const draft = useComposerDraft(draftKey);
   const [pastedTexts, setPastedTexts] = useState<PastedTextAttachment[]>([]);
   const [selectedModel, setSelectedModel] = useState(model ?? "");
   // Optimistic: the picker moves on click and the session row catches up when
@@ -782,7 +786,16 @@ export function CodeComposer({
   const [steerPending, setSteerPending] = useState(false);
   const [steerError, setSteerError] = useState<string | null>(null);
   const [steerStatus, setSteerStatus] = useState<string | null>(null);
-  const draftRef = useRef("");
+  const draftRef = useRef(draft);
+  const setDraft = useCallback(
+    (update: string | ((current: string) => string)) => {
+      const current = useComposerDrafts.getState().drafts[draftKey] ?? "";
+      const next = typeof update === "function" ? update(current) : update;
+      draftRef.current = next;
+      useComposerDrafts.getState().setDraft(draftKey, next);
+    },
+    [draftKey],
+  );
   const pastedTextsRef = useRef<PastedTextAttachment[]>([]);
   const appliedRecoveryRef = useRef<{
     id: string;

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -881,6 +881,9 @@ export function CodeComposer({
       return;
     }
     setDraft((current) => {
+      // A remount already restored this composer's store draft. Re-appending
+      // the recovered prompt would duplicate it after you edit and leave.
+      if (current) return current;
       const next = appendRecoveredDraft(current, recoveryDraft);
       draftRef.current = next;
       return next;

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -36,6 +36,7 @@ import { resetCodeSessionRegistry } from "./CodeSessionRegistry";
 import { useCodeUiStore } from "./CodeUiStore";
 import { resetWorkflowPromptStore } from "./workflowPrompts";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { useComposerDrafts } from "../ComposerDrafts";
 import { CodeWorkspacePage } from "./CodeWorkspacePage";
 import { MIN_INSPECTOR_PANE_WIDTH_PX } from "./inspectorLayout";
 import {
@@ -735,6 +736,8 @@ afterEach(() => {
     quickOpenPending: false,
   });
   resetWorkflowPromptStore();
+  useComposerDrafts.setState({ drafts: {}, attachments: {} });
+  window.sessionStorage.clear();
   browserMocks.close.mockClear();
   persistMocks.seed.mockClear();
   window.localStorage.clear();


### PR DESCRIPTION
## What you change

You keep unsent composer text across a Settings round trip. Settings replaces the main pane and unmounts the conversation. Chat already stored drafts in `ComposerDrafts`. Code sessions kept the text in `useState`, so that unmount dropped it.

You write those code-session drafts through the same store, keyed by session id (or the start composer's workspace). One session's draft cannot appear in another. Sending or clearing still removes the persisted draft.

You add a Settings round-trip test for the conversation composer. It types, opens Settings, comes back, and checks the text is still there. It also checks conversation scoping and that send or `clearDraft` forgets the stored text.

## Why

Opening Settings must not destroy an unsent message.

## Cause

Settings unmounts the composer. Chat already persisted unsent text in the zustand draft store backed by sessionStorage, so a remount restored it. CodeComposer held the draft in component state instead, so the remount started empty. You do not add a second draft mechanism.

## What you ran

`pnpm --dir crates/tidebreak-desktop/ui exec biome format src`

```
Checked 866 files in 920ms. No fixes applied.
```

`pnpm --dir crates/tidebreak-desktop/ui lint`

```
Checked 866 files in 1164ms. No fixes applied.
```

`pnpm --dir crates/tidebreak-desktop/ui test`

```
Test Files  269 passed (269)
      Tests  2376 passed (2376)
   Duration  237.34s
```

`pnpm --dir crates/tidebreak-desktop/ui build`

```
tsc succeeded
✓ 13113 modules transformed.
✓ built in 9.67s
```

Closes #3037