### PR TITLE
fix(connected-apps): import MCP JSON deterministically with field-level errors

### DIFF
--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
@@ -2,6 +2,7 @@
 import {
   act,
   cleanup,
+  fireEvent,
   render,
   screen,
   waitFor,
@@ -9,11 +10,12 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type {
-  ApiClient,
-  GatewayStatus,
-  McpServerInfo,
-  McpServersInfo,
+import {
+  HttpError,
+  type ApiClient,
+  type GatewayStatus,
+  type McpServerInfo,
+  type McpServersInfo,
 } from "../api";
 import { McpPanel } from "./McpPanel";
 
@@ -202,8 +204,8 @@ describe("McpPanel", () => {
       .getAllByRole("listitem")
       .map((item) => item.textContent);
     expect(skipped).toEqual([
-      "private_docs: Namespace already exists.",
-      "bad.name: Namespace must use 1–32 ASCII letters, numbers, underscores, or hyphens.",
+      "private_docs: mcpServers.private_docs: Namespace already exists. Choose a different name.",
+      'bad.name: mcpServers["bad.name"]: Name a server with 1–32 ASCII letters, numbers, underscores, or hyphens. "bad.name" contains a period. A valid value looks like docs or remote-tools.',
     ]);
     expect(screen.getByRole("heading", { name: "calendar" })).toBeVisible();
     expect(screen.getByRole("heading", { name: "remote" })).toBeVisible();
@@ -223,6 +225,87 @@ describe("McpPanel", () => {
     expect(
       within(calendarSection).getByLabelText("Environment value 1"),
     ).toHaveValue("");
+    expect(screen.getByLabelText("MCP JSON")).toHaveValue(await file.text());
+  });
+
+  it("keeps pasted JSON when import fails and lists field-level skips", async () => {
+    const client = api({ servers: [] });
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText(/No MCP servers configured/);
+    const json = `{
+  "mcpServers": {
+    "docs": { "command": "npx" },
+    "bad name": { "command": "npx" }
+  }
+}`;
+    fireEvent.change(screen.getByLabelText("MCP JSON"), {
+      target: { value: json },
+    });
+    await user.click(
+      screen.getByRole("button", { name: "Import pasted JSON" }),
+    );
+
+    expect(screen.getByLabelText("MCP JSON")).toHaveValue(json);
+    expect(await screen.findByRole("heading", { name: "docs" })).toBeVisible();
+    const skipped = within(
+      screen.getByRole("list", { name: "Skipped MCP servers" }),
+    )
+      .getAllByRole("listitem")
+      .map((item) => item.textContent);
+    expect(skipped).toEqual([
+      'bad name: mcpServers["bad name"]: Name a server with 1–32 ASCII letters, numbers, underscores, or hyphens. "bad name" contains a space. A valid value looks like docs or remote-tools.',
+    ]);
+  });
+
+  it("keeps pasted JSON and names the character when comments make it invalid", async () => {
+    const client = api({ servers: [] });
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText(/No MCP servers configured/);
+    const json = `{
+  // comment
+  "mcpServers": { "docs": { "command": "npx" } }
+}`;
+    fireEvent.change(screen.getByLabelText("MCP JSON"), {
+      target: { value: json },
+    });
+    await user.click(
+      screen.getByRole("button", { name: "Import pasted JSON" }),
+    );
+
+    expect(screen.getByLabelText("MCP JSON")).toHaveValue(json);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Couldn't import pasted JSON: JSON at character \d+: this JSON uses a comment/,
+    );
+  });
+
+  it("shows the server's field-level reason when save rejects a server", async () => {
+    const client = api(
+      { servers: [] },
+      {
+        putMcpServers: vi
+          .fn()
+          .mockRejectedValue(
+            new HttpError(
+              400,
+              '400: invalid external MCP server "docs": must configure exactly one of command, url, or gateway endpoint',
+            ),
+          ),
+      },
+    );
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText(/No MCP servers configured/);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await user.click(screen.getByRole("button", { name: "Save and verify" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      'invalid external MCP server "docs": must configure exactly one of command, url, or gateway endpoint',
+    );
   });
 
   it("sends argv and selected environment names as typed arrays", async () => {

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 import { Plus, RefreshCw, Trash2, Upload } from "lucide-react";
-import type {
-  ApiClient,
-  GatewayApps,
-  McpCuration,
-  McpHealth,
-  McpServerDefinition,
-  McpServerInfo,
+import {
+  HttpError,
+  type ApiClient,
+  type GatewayApps,
+  type McpCuration,
+  type McpHealth,
+  type McpServerDefinition,
+  type McpServerInfo,
 } from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -22,7 +23,7 @@ import {
   SettingsStatus,
 } from "./primitives";
 import {
-  parseMcpImport,
+  parseMcpImportText,
   type McpImportResult,
   type McpImportSecret,
 } from "./mcpImport";
@@ -212,6 +213,7 @@ export function McpPanel({
   const [importSummary, setImportSummary] = useState<McpImportSummary | null>(
     null,
   );
+  const [importDraft, setImportDraft] = useState("");
   const importInputRef = useRef<HTMLInputElement>(null);
   // Gateway session state, held here because the gateway endpoints section
   // shares this panel's one server list instead of owning a second copy.
@@ -390,6 +392,15 @@ export function McpPanel({
     }
   }
 
+  function applyImport(text: string, source: string) {
+    const result = parseMcpImportText(text, servers);
+    setImportSummary({ ...result, fileName: source });
+    if (result.servers.length > 0) {
+      markDirty(true);
+      setServers((current) => [...current, ...result.servers]);
+    }
+  }
+
   async function importConfiguration(file: File) {
     setImporting(true);
     setImportError(null);
@@ -399,20 +410,23 @@ export function McpPanel({
         throw new Error("Choose a JSON file no larger than 1 MB.");
       }
       const text = await file.text();
-      let value: unknown;
-      try {
-        value = JSON.parse(text);
-      } catch {
-        throw new Error("The file is not valid JSON.");
-      }
-      const result = parseMcpImport(value, servers);
-      setImportSummary({ ...result, fileName: file.name });
-      if (result.servers.length > 0) {
-        markDirty(true);
-        setServers((current) => [...current, ...result.servers]);
-      }
+      setImportDraft(text);
+      applyImport(text, file.name);
     } catch (err) {
       setImportError(`Couldn't import ${file.name}: ${errorMessage(err)}`);
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function importPastedJson() {
+    setImporting(true);
+    setImportError(null);
+    setImportSummary(null);
+    try {
+      applyImport(importDraft, "pasted JSON");
+    } catch (err) {
+      setImportError(`Couldn't import pasted JSON: ${errorMessage(err)}`);
     } finally {
       setImporting(false);
     }
@@ -670,32 +684,56 @@ export function McpPanel({
         <>
           <SettingsSection
             title="Import configuration"
-            description="Add servers from a Tidebreak, Claude, or Cursor JSON file. Imported servers stay unsaved until you review them and save."
+            description="Add servers from a Tidebreak, Claude, Cursor, Windsurf, or VS Code JSON file, or paste that JSON here. Imported servers stay unsaved until you review them and save."
           >
             <div className="flex flex-col items-start gap-2">
-              <input
-                ref={importInputRef}
-                type="file"
-                accept=".json,application/json"
-                className="sr-only"
-                aria-label="Import MCP configuration"
-                disabled={working}
-                onChange={(event) => {
-                  const input = event.currentTarget;
-                  const file = input.files?.[0];
-                  if (file !== undefined) void importConfiguration(file);
-                  input.value = "";
-                }}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                disabled={working}
-                onClick={() => importInputRef.current?.click()}
+              <SettingsField
+                label="MCP JSON"
+                hint="Paste a Claude Desktop, Cursor, Windsurf, VS Code, or Tidebreak MCP file. Failed imports keep this text so you can fix it."
               >
-                <Upload size={14} />
-                {importing ? "Importing…" : "Import JSON"}
-              </Button>
+                <textarea
+                  className="min-h-40 w-full rounded-md border bg-transparent p-2 font-mono text-xs"
+                  value={importDraft}
+                  disabled={working}
+                  spellCheck={false}
+                  aria-label="MCP JSON"
+                  placeholder='{ "mcpServers": { "docs": { "command": "npx" } } }'
+                  onChange={(event) => setImportDraft(event.target.value)}
+                />
+              </SettingsField>
+              <div className="flex flex-wrap gap-2">
+                <input
+                  ref={importInputRef}
+                  type="file"
+                  accept=".json,application/json"
+                  className="sr-only"
+                  aria-label="Import MCP configuration"
+                  disabled={working}
+                  onChange={(event) => {
+                    const input = event.currentTarget;
+                    const file = input.files?.[0];
+                    if (file !== undefined) void importConfiguration(file);
+                    input.value = "";
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={working}
+                  onClick={() => importInputRef.current?.click()}
+                >
+                  <Upload size={14} />
+                  {importing ? "Importing…" : "Import JSON file"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={working || importDraft.trim().length === 0}
+                  onClick={() => importPastedJson()}
+                >
+                  Import pasted JSON
+                </Button>
+              </div>
               <p className="text-xs text-muted-foreground">
                 Tidebreak imports environment variable names but never their
                 values. Enter secret values again before you save.
@@ -1158,8 +1196,12 @@ function mountStatus(mounted: McpServerInfo): string {
 }
 
 /** A message that can sit mid-sentence: `String(err)` would keep the error
- * class prefix ("HttpError: ...") in front of it. */
+ * class prefix ("HttpError: ...") in front of it. HTTP status prefixes stay
+ * off so a rejected save shows the server's field-level reason. */
 function errorMessage(err: unknown): string {
+  if (err instanceof HttpError) {
+    return err.message.replace(/^\d+:\s*/, "");
+  }
   return err instanceof Error ? err.message : String(err);
 }
 

--- a/crates/tidebreak-desktop/ui/src/settings/mcpImport.test.ts
+++ b/crates/tidebreak-desktop/ui/src/settings/mcpImport.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { McpServerInfo } from "../api";
-import { parseMcpImport } from "./mcpImport";
+import { parseMcpImport, parseMcpImportText } from "./mcpImport";
 
 function existing(name: string): McpServerInfo {
   return {
@@ -23,54 +23,316 @@ function existing(name: string): McpServerInfo {
   };
 }
 
-describe("parseMcpImport", () => {
-  it("imports Claude and Cursor servers without retaining environment values", () => {
-    const result = parseMcpImport(
-      {
-        mcpServers: {
-          docs: {
-            command: "npx",
-            args: ["-y", "@example/docs-mcp"],
-            env: { DOCS_TOKEN: "do-not-retain", LOG_LEVEL: "debug" },
-            cwd: "/Users/alex/Code/docs",
-          },
-          remote: {
-            url: "https://mcp.example.test/tools",
-            headers: { Authorization: "Bearer ${REMOTE_TOKEN}" },
-          },
-        },
-      },
-      [],
-    );
+function importJson(
+  text: string,
+  existingServers: readonly McpServerInfo[] = [],
+) {
+  return parseMcpImportText(text, existingServers);
+}
 
-    expect(result.skipped).toEqual([]);
-    expect(result.servers).toEqual([
-      expect.objectContaining({
+function importedNames(text: string): string[] {
+  return importJson(text).servers.map((server) => server.name);
+}
+
+describe("Claude Desktop mcpServers", () => {
+  it.each([
+    [
+      "a stdio server with args and env names",
+      `{
+        "mcpServers": {
+          "docs": {
+            "command": "npx",
+            "args": ["-y", "@example/docs-mcp"],
+            "env": { "DOCS_TOKEN": "do-not-retain", "LOG_LEVEL": "debug" },
+            "cwd": "/Users/alex/Code/docs"
+          }
+        }
+      }`,
+      {
         name: "docs",
         command: "npx",
         args: ["-y", "@example/docs-mcp"],
         env: ["DOCS_TOKEN", "LOG_LEVEL"],
+        env_from: [],
         cwd: "/Users/alex/Code/docs",
         url: null,
-      }),
-      expect.objectContaining({
-        name: "remote",
-        command: null,
-        args: [],
-        env: [],
-        cwd: null,
-        url: "https://mcp.example.test/tools",
-        bearer_token_env: "REMOTE_TOKEN",
-      }),
-    ]);
-    expect(result.secrets).toEqual([
-      { server: "docs", name: "DOCS_TOKEN" },
-      { server: "docs", name: "LOG_LEVEL" },
-    ]);
+        bearer_token_env: null,
+      },
+    ],
+    [
+      "an explicit stdio type",
+      `{
+        "mcpServers": {
+          "fs": { "type": "stdio", "command": "npx", "args": ["-y", "fs"] }
+        }
+      }`,
+      {
+        name: "fs",
+        command: "npx",
+        args: ["-y", "fs"],
+        url: null,
+      },
+    ],
+    [
+      "a command argv array",
+      `{
+        "mcpServers": {
+          "docs": { "command": ["npx", "-y", "@example/docs-mcp"] }
+        }
+      }`,
+      {
+        name: "docs",
+        command: "npx",
+        args: ["-y", "@example/docs-mcp"],
+      },
+    ],
+  ] as const)("imports %s", (_label, json, expected) => {
+    const result = importJson(json);
+    expect(result.skipped).toEqual([]);
+    expect(result.servers[0]).toEqual(expect.objectContaining(expected));
     expect(JSON.stringify(result)).not.toContain("do-not-retain");
     expect(JSON.stringify(result)).not.toContain("debug");
   });
+});
 
+describe("Cursor and Windsurf mcpServers HTTP", () => {
+  it.each([
+    [
+      "a url without a type",
+      `{
+        "mcpServers": {
+          "remote": {
+            "url": "https://mcp.example.test/tools",
+            "headers": { "Authorization": "Bearer \${REMOTE_TOKEN}" }
+          }
+        }
+      }`,
+      {
+        name: "remote",
+        command: null,
+        url: "https://mcp.example.test/tools",
+        bearer_token_env: "REMOTE_TOKEN",
+      },
+    ],
+    [
+      "type http",
+      `{
+        "mcpServers": {
+          "remote": {
+            "type": "http",
+            "url": "https://mcp.example.test/tools?x=1"
+          }
+        }
+      }`,
+      {
+        name: "remote",
+        url: "https://mcp.example.test/tools?x=1",
+        bearer_token_env: null,
+      },
+    ],
+    [
+      "type sse",
+      `{
+        "mcpServers": {
+          "remote": {
+            "type": "sse",
+            "url": "https://mcp.example.test/sse/"
+          }
+        }
+      }`,
+      {
+        name: "remote",
+        url: "https://mcp.example.test/sse/",
+      },
+    ],
+    [
+      "type streamable-http",
+      `{
+        "mcpServers": {
+          "remote": {
+            "type": "streamable-http",
+            "url": "https://mcp.example.test/mcp/"
+          }
+        }
+      }`,
+      {
+        name: "remote",
+        url: "https://mcp.example.test/mcp/",
+      },
+    ],
+    [
+      "a serverUrl alias and env placeholder header",
+      `{
+        "mcpServers": {
+          "remote": {
+            "serverUrl": "https://mcp.example.test/tools",
+            "headers": { "Authorization": "Bearer \${env:GATEWAY_TOKEN}" }
+          }
+        }
+      }`,
+      {
+        name: "remote",
+        url: "https://mcp.example.test/tools",
+        bearer_token_env: "GATEWAY_TOKEN",
+      },
+    ],
+  ] as const)("imports %s", (_label, json, expected) => {
+    const result = importJson(json);
+    expect(result.skipped).toEqual([]);
+    expect(result.servers[0]).toEqual(expect.objectContaining(expected));
+  });
+});
+
+describe("VS Code servers", () => {
+  it.each([
+    [
+      "a stdio object with inputs",
+      `{
+        "inputs": [
+          {
+            "type": "promptString",
+            "id": "docs-token",
+            "description": "Docs token",
+            "password": true
+          }
+        ],
+        "servers": {
+          "docs": {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["-y", "@example/docs-mcp"],
+            "env": { "DOCS_TOKEN": "\${input:docs-token}" }
+          }
+        }
+      }`,
+      {
+        name: "docs",
+        command: "npx",
+        args: ["-y", "@example/docs-mcp"],
+        env: ["DOCS_TOKEN"],
+        url: null,
+      },
+    ],
+    [
+      "an http object",
+      `{
+        "servers": {
+          "remote": {
+            "type": "http",
+            "url": "https://mcp.example.test/mcp"
+          }
+        }
+      }`,
+      {
+        name: "remote",
+        command: null,
+        url: "https://mcp.example.test/mcp",
+      },
+    ],
+    [
+      "settings.json nested under mcp.servers",
+      `{
+        "mcp": {
+          "servers": {
+            "docs": { "command": "npx", "args": ["-y", "docs"] }
+          }
+        }
+      }`,
+      {
+        name: "docs",
+        command: "npx",
+        args: ["-y", "docs"],
+      },
+    ],
+  ] as const)("imports %s", (_label, json, expected) => {
+    const result = importJson(json);
+    expect(result.skipped).toEqual([]);
+    expect(result.servers[0]).toEqual(expect.objectContaining(expected));
+  });
+});
+
+describe("bare servers and arrays", () => {
+  it.each([
+    [
+      "a single stdio object",
+      `{ "name": "docs", "command": "npx", "args": ["-y", "docs"] }`,
+      ["docs"],
+    ],
+    [
+      "a single HTTP object without a name",
+      `{ "url": "https://mcp.example.test/mcp" }`,
+      ["imported"],
+    ],
+    [
+      "a top-level array of stdio and HTTP servers",
+      `[
+        { "command": "npx", "args": ["-y", "docs"] },
+        { "url": "https://mcp.example.test/mcp" }
+      ]`,
+      ["imported_1", "imported_2"],
+    ],
+    [
+      "a Tidebreak servers array",
+      `{
+        "servers": [
+          { "name": "docs", "command": "/opt/mcp/docs" },
+          { "name": "remote", "url": "https://mcp.example.test/mcp" }
+        ]
+      }`,
+      ["docs", "remote"],
+    ],
+  ] as const)("imports %s", (_label, json, names) => {
+    expect(importedNames(json)).toEqual([...names]);
+  });
+});
+
+describe("placeholders and env forwarding", () => {
+  it.each([
+    [
+      "${env:VAR} matching the env key",
+      `{
+        "mcpServers": {
+          "docs": {
+            "command": "npx",
+            "env": { "DOCS_TOKEN": "\${env:DOCS_TOKEN}" }
+          }
+        }
+      }`,
+      { env: [], env_from: ["DOCS_TOKEN"] },
+    ],
+    [
+      "${VAR} matching the env key",
+      `{
+        "mcpServers": {
+          "docs": {
+            "command": "npx",
+            "env": { "DOCS_TOKEN": "\${DOCS_TOKEN}" }
+          }
+        }
+      }`,
+      { env: [], env_from: ["DOCS_TOKEN"] },
+    ],
+    [
+      "$VAR matching the env key",
+      `{
+        "mcpServers": {
+          "docs": {
+            "command": "npx",
+            "env": { "DOCS_TOKEN": "$DOCS_TOKEN" }
+          }
+        }
+      }`,
+      { env: [], env_from: ["DOCS_TOKEN"] },
+    ],
+  ] as const)("forwards %s", (_label, json, expected) => {
+    const result = importJson(json);
+    expect(result.skipped).toEqual([]);
+    expect(result.servers[0]).toEqual(expect.objectContaining(expected));
+    expect(result.secrets).toEqual([]);
+  });
+});
+
+describe("parseMcpImport", () => {
   it("imports Tidebreak fields and drops inbound secret values", () => {
     const result = parseMcpImport(
       {
@@ -124,15 +386,23 @@ describe("parseMcpImport", () => {
     );
 
     expect(result.servers.map((server) => server.name)).toEqual(["valid"]);
-    expect(result.skipped).toEqual([
-      { name: "existing", reason: "Namespace already exists." },
-      {
-        name: "bad.name",
-        reason:
-          "Namespace must use 1–32 ASCII letters, numbers, underscores, or hyphens.",
-      },
-      { name: "broken", reason: "Configure exactly one command or URL." },
+    expect(result.skipped.map((item) => item.name)).toEqual([
+      "existing",
+      "bad.name",
+      "broken",
     ]);
+    expect(result.skipped[0]).toEqual({
+      name: "existing",
+      path: "mcpServers.existing",
+      reason:
+        "mcpServers.existing: Namespace already exists. Choose a different name.",
+    });
+    expect(result.skipped[1]?.reason).toContain('mcpServers["bad.name"]');
+    expect(result.skipped[1]?.reason).toContain("a period");
+    expect(result.skipped[2]?.reason).toContain("mcpServers.broken");
+    expect(result.skipped[2]?.reason).toContain(
+      "Configure exactly one command or URL.",
+    );
   });
 
   it("imports the first Tidebreak server when a namespace repeats", () => {
@@ -152,7 +422,9 @@ describe("parseMcpImport", () => {
     expect(result.skipped).toEqual([
       {
         name: "calendar",
-        reason: "Namespace appears more than once in this file.",
+        path: "servers[1].name",
+        reason:
+          "servers[1].name: Namespace appears more than once in this file. Choose a different name.",
       },
     ]);
   });
@@ -179,13 +451,116 @@ describe("parseMcpImport", () => {
       "literal",
       "custom",
     ]);
+    expect(result.skipped[0]?.reason).toContain(
+      "mcpServers.literal.headers.Authorization",
+    );
+    expect(result.skipped[1]?.reason).toContain("mcpServers.custom.headers");
     expect(JSON.stringify(result)).not.toContain("do-not-retain");
     expect(JSON.stringify(result)).not.toContain("also-do-not-retain");
   });
 
   it("rejects files without a supported top-level shape", () => {
-    expect(() => parseMcpImport({ tools: [] }, [])).toThrow(
-      /Tidebreak.*Claude\/Cursor/,
+    expect(() => parseMcpImport({ tools: [] }, [])).toThrow(/mcpServers/);
+    expect(() => parseMcpImport({ mcpServers: {} }, [])).toThrow(
+      /contains no servers/,
     );
+  });
+});
+
+describe("rejected JSON names the path and the rule", () => {
+  it.each([
+    [
+      "JSON with a comment",
+      `{
+        // claude
+        "mcpServers": { "docs": { "command": "npx" } }
+      }`,
+      /JSON at character \d+: this JSON uses a comment/,
+    ],
+    [
+      "JSON with a trailing comma",
+      `{
+        "mcpServers": {
+          "docs": { "command": "npx", }
+        }
+      }`,
+      /JSON at character \d+: this JSON uses a trailing comma/,
+    ],
+    [
+      "a non-string env value",
+      `{
+        "mcpServers": {
+          "docs": { "command": "npx", "env": { "LOG_LEVEL": 1 } }
+        }
+      }`,
+      /mcpServers\.docs\.env\.LOG_LEVEL: Environment values are strings/,
+    ],
+    [
+      "a name with spaces",
+      `{
+        "mcpServers": {
+          "my server": { "command": "npx" }
+        }
+      }`,
+      /contains a space/,
+    ],
+    [
+      "a name with slashes",
+      `{
+        "mcpServers": {
+          "org\/docs": { "command": "npx" }
+        }
+      }`,
+      /contains a slash/,
+    ],
+    [
+      "stdio with a url",
+      `{
+        "mcpServers": {
+          "docs": { "type": "stdio", "url": "https://mcp.example.test/mcp" }
+        }
+      }`,
+      /mcpServers\.docs\.url: stdio servers set command, not url/,
+    ],
+    [
+      "http without a url",
+      `{
+        "mcpServers": {
+          "remote": { "type": "http", "command": "npx" }
+        }
+      }`,
+      /mcpServers\.remote\.command: http and sse servers set url, not command/,
+    ],
+  ])("rejects %s", (_label, json, pattern) => {
+    expect(() => {
+      const result = importJson(json);
+      if (result.servers.length === 0 && result.skipped.length > 0) {
+        throw new Error(result.skipped[0]?.reason ?? "skipped");
+      }
+    }).toThrow(pattern);
+  });
+
+  it("keeps valid siblings when one entry fails", () => {
+    const result = importJson(`{
+      "mcpServers": {
+        "docs": { "command": "npx" },
+        "bad name": { "command": "npx" },
+        "remote": { "url": "https://mcp.example.test/mcp" }
+      }
+    }`);
+    expect(result.servers.map((server) => server.name)).toEqual([
+      "docs",
+      "remote",
+    ]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.reason).toContain("a space");
+    expect(result.skipped[0]?.path).toContain("bad name");
+  });
+
+  it("strips a leading BOM", () => {
+    const result = importJson(
+      `\ufeff{"mcpServers":{"docs":{"command":"npx"}}}`,
+    );
+    expect(result.servers.map((server) => server.name)).toEqual(["docs"]);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/settings/mcpImport.ts
+++ b/crates/tidebreak-desktop/ui/src/settings/mcpImport.ts
@@ -9,6 +9,7 @@ const MAX_PROCESS_STRING_BYTES = 32 * 1024;
 const MAX_REQUEST_TIMEOUT_MS = 3_600_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 const MAX_NAMESPACE_BYTES = 32;
+const MAX_IMPORT_BYTES = 1024 * 1024;
 
 type ImportShape = "tidebreak" | "common";
 
@@ -16,10 +17,12 @@ type SourceEntry = {
   fallbackName: string;
   raw: unknown;
   shape: ImportShape;
+  path: string;
 };
 
 export type McpImportSkip = {
   name: string;
+  path: string;
   reason: string;
 };
 
@@ -41,11 +44,48 @@ type ParsedEntry = {
 
 type FieldResult<T> = { value: T } | { error: string };
 
+const SUPPORTED_SHAPES =
+  'Use a Claude Desktop or Cursor {"mcpServers": {"name": { ... }}} file, a VS Code {"servers": {"name": { ... }}} file, a Tidebreak {"servers": [{"name": "...", ...}]} file, a single server object, or an array of server objects.';
+
+const VALID_NAMESPACE = "A valid value looks like docs or remote-tools.";
+const VALID_COMMAND = "A valid value looks like npx or /usr/local/bin/server.";
+const VALID_URL = "A valid value looks like https://example.test/mcp.";
+const VALID_ENV_OBJECT =
+  'A valid value looks like { "LOG_LEVEL": "debug" } or ["LOG_LEVEL"].';
+const VALID_BEARER = "A valid value looks like Bearer ${env:TOKEN}.";
+
+export function parseMcpImportText(
+  text: string,
+  existingServers: readonly McpServerInfo[],
+): McpImportResult {
+  const document = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+  if (new TextEncoder().encode(document).length > MAX_IMPORT_BYTES) {
+    throw new Error("Use a JSON document no larger than 1 MB.");
+  }
+  if (document.trim().length === 0) {
+    throw new Error(
+      "Paste a JSON object or array of MCP servers. A valid file starts with { or [.",
+    );
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(document);
+  } catch (error) {
+    throw new Error(jsonSyntaxMessage(document, error));
+  }
+  return parseMcpImport(value, existingServers);
+}
+
 export function parseMcpImport(
   value: unknown,
   existingServers: readonly McpServerInfo[],
 ): McpImportResult {
   const entries = sourceEntries(value);
+  if (entries.length === 0) {
+    throw new Error(
+      "This file contains no servers. Add at least one named server.",
+    );
+  }
   const taken = new Set(existingServers.map((server) => server.name));
   const seen = new Set<string>();
   const remaining = Math.max(
@@ -63,40 +103,62 @@ export function parseMcpImport(
         ? entry.fallbackName
         : isRecord(entry.raw) && typeof entry.raw.name === "string"
           ? entry.raw.name
-          : "";
+          : entry.fallbackName;
+    const namePath =
+      entry.shape === "common"
+        ? entry.path
+        : joinPath(entry.path, "name") || "name";
     const label = rawName || `Server ${index + 1}`;
 
     if (!validNamespace(rawName)) {
       skipped.push({
         name: label,
-        reason:
-          "Namespace must use 1–32 ASCII letters, numbers, underscores, or hyphens.",
+        path: namePath,
+        reason: namespaceIssue(namePath, rawName),
       });
       continue;
     }
     if (seen.has(rawName)) {
       skipped.push({
         name: rawName,
-        reason: "Namespace appears more than once in this file.",
+        path: namePath,
+        reason: issue(
+          namePath,
+          "Namespace appears more than once in this file.",
+          "Choose a different name.",
+        ),
       });
       continue;
     }
     seen.add(rawName);
     if (taken.has(rawName)) {
-      skipped.push({ name: rawName, reason: "Namespace already exists." });
+      skipped.push({
+        name: rawName,
+        path: namePath,
+        reason: issue(
+          namePath,
+          "Namespace already exists.",
+          "Choose a different name.",
+        ),
+      });
       continue;
     }
     if (servers.length >= remaining) {
       skipped.push({
         name: rawName,
-        reason: `Tidebreak supports up to ${MAX_SERVERS} configured servers.`,
+        path: entry.path,
+        reason: issue(
+          entry.path,
+          `Tidebreak supports up to ${MAX_SERVERS} configured servers.`,
+          "Remove extra entries.",
+        ),
       });
       continue;
     }
 
-    const parsed = parseEntry(rawName, entry.raw, entry.shape);
+    const parsed = parseEntry(rawName, entry.raw, entry.shape, entry.path);
     if ("error" in parsed) {
-      skipped.push({ name: rawName, reason: parsed.error });
+      skipped.push({ name: rawName, path: entry.path, reason: parsed.error });
       continue;
     }
     servers.push(parsed.value.server);
@@ -108,25 +170,117 @@ export function parseMcpImport(
 }
 
 function sourceEntries(value: unknown): SourceEntry[] {
+  if (Array.isArray(value)) {
+    return value.map((raw, index) =>
+      namedEntry(raw, `imported_${index + 1}`, [index]),
+    );
+  }
   if (!isRecord(value)) {
-    throw new Error("The file must contain a JSON object.");
+    throw new Error(
+      "Use a JSON object or array. A valid file starts with { or [.",
+    );
   }
-  if (Array.isArray(value.servers)) {
-    return value.servers.map((raw, index) => ({
-      fallbackName: `Server ${index + 1}`,
-      raw,
-      shape: "tidebreak",
+  if (value.mcpServers !== undefined && value.servers !== undefined) {
+    throw new Error(
+      "Use either mcpServers or servers as the top-level key, not both. Pick the Claude/Cursor mcpServers object or the Tidebreak/VS Code servers value.",
+    );
+  }
+  if (value.mcpServers !== undefined) {
+    return namedMap(value.mcpServers, "mcpServers");
+  }
+  if (value.servers !== undefined) {
+    return serversEntries(value.servers, "servers");
+  }
+  if (
+    isRecord(value.mcp) &&
+    (value.mcp.servers !== undefined || value.mcp.mcpServers !== undefined)
+  ) {
+    return sourceEntries(value.mcp).map((entry) => ({
+      ...entry,
+      path: prefixPath("mcp", entry.path),
     }));
   }
-  if (isRecord(value.mcpServers)) {
-    return Object.entries(value.mcpServers).map(([name, raw]) => ({
-      fallbackName: name,
-      raw,
-      shape: "common",
-    }));
+  if (looksLikeServer(value)) {
+    const fallbackName =
+      typeof value.name === "string" && value.name.length > 0
+        ? value.name
+        : "imported";
+    return [
+      {
+        fallbackName,
+        raw: value,
+        shape: isTidebreakRaw(value) ? "tidebreak" : "common",
+        path: "",
+      },
+    ];
+  }
+  throw new Error(SUPPORTED_SHAPES);
+}
+
+function serversEntries(value: unknown, key: string): SourceEntry[] {
+  if (Array.isArray(value)) {
+    return value.map((raw, index) =>
+      namedEntry(raw, `imported_${index + 1}`, [key, index]),
+    );
+  }
+  if (isRecord(value)) {
+    return namedMap(value, key);
   }
   throw new Error(
-    'Use a Tidebreak {"servers": [...]} file or a Claude/Cursor {"mcpServers": {...}} file.',
+    issue(
+      key,
+      "Use a Tidebreak array of server objects or a VS Code object of named servers.",
+      'A valid value looks like [{ "name": "docs", "command": "npx" }] or { "docs": { "command": "npx" } }.',
+    ),
+  );
+}
+
+function namedMap(value: unknown, key: string): SourceEntry[] {
+  if (!isRecord(value)) {
+    throw new Error(
+      issue(
+        key,
+        "Wrap named servers in an object.",
+        'A valid value looks like { "docs": { "command": "npx" } }.',
+      ),
+    );
+  }
+  return Object.entries(value).map(([name, raw]) => ({
+    fallbackName: name,
+    raw,
+    shape: "common",
+    path: mcpJsonPath([key, name]),
+  }));
+}
+
+function namedEntry(
+  raw: unknown,
+  fallbackName: string,
+  parts: Array<string | number>,
+): SourceEntry {
+  return {
+    fallbackName,
+    raw,
+    shape: isTidebreakRaw(raw) ? "tidebreak" : "common",
+    path: mcpJsonPath(parts),
+  };
+}
+
+function isTidebreakRaw(raw: unknown): boolean {
+  return (
+    isRecord(raw) &&
+    (raw.gateway_endpoint !== undefined || typeof raw.name === "string")
+  );
+}
+
+function looksLikeServer(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.command === "string" ||
+    Array.isArray(value.command) ||
+    typeof value.url === "string" ||
+    typeof value.serverUrl === "string" ||
+    typeof value.gateway_endpoint === "string" ||
+    typeof value.type === "string"
   );
 }
 
@@ -134,41 +288,138 @@ function parseEntry(
   name: string,
   raw: unknown,
   shape: ImportShape,
+  path: string,
 ): FieldResult<ParsedEntry> {
-  if (!isRecord(raw)) return { error: "Server definition must be an object." };
-
-  const command = nullableString(raw, "command");
-  if ("error" in command) return command;
-  const url = nullableString(raw, "url");
-  if ("error" in url) return url;
-  const gateway =
-    shape === "tidebreak"
-      ? nullableString(raw, "gateway_endpoint")
-      : { value: null };
-  if ("error" in gateway) return gateway;
-
-  const transports = [command.value, url.value, gateway.value].filter(
-    (candidate) => candidate !== null,
-  );
-  if (transports.length !== 1) {
+  if (!isRecord(raw)) {
     return {
-      error:
-        shape === "tidebreak"
-          ? "Configure exactly one command, URL, or gateway endpoint."
-          : "Configure exactly one command or URL.",
+      error: issue(
+        path,
+        "Server definition must be an object.",
+        'A valid value looks like { "command": "npx" } or { "url": "https://example.test/mcp" }.',
+      ),
     };
   }
 
-  const args = stringArray(raw.args, "Arguments");
-  if ("error" in args) return args;
-  if (args.value.length > MAX_ARGS) {
-    return { error: `Arguments must contain at most ${MAX_ARGS} items.` };
+  const typeHint = readType(raw, path);
+  if ("error" in typeHint) return typeHint;
+  const commandSpec = readCommand(raw, path);
+  if ("error" in commandSpec) return commandSpec;
+  const url = readUrl(raw, path);
+  if ("error" in url) return url;
+  const gateway =
+    shape === "tidebreak"
+      ? nullableString(raw, "gateway_endpoint", path)
+      : { value: null };
+  if ("error" in gateway) return gateway;
+
+  const command = commandSpec.value.command;
+  if (typeHint.value === "stdio") {
+    if (url.value !== null) {
+      return {
+        error: issue(
+          joinPath(path, "url") || "url",
+          "stdio servers set command, not url.",
+          VALID_COMMAND,
+        ),
+      };
+    }
+    if (gateway.value !== null) {
+      return {
+        error: issue(
+          joinPath(path, "gateway_endpoint") || "gateway_endpoint",
+          "stdio servers set command, not a gateway endpoint.",
+          VALID_COMMAND,
+        ),
+      };
+    }
+    if (command === null) {
+      return {
+        error: issue(
+          joinPath(path, "command") || "command",
+          "stdio servers set command.",
+          VALID_COMMAND,
+        ),
+      };
+    }
+  } else if (typeHint.value === "http") {
+    if (command !== null) {
+      return {
+        error: issue(
+          joinPath(path, "command") || "command",
+          "http and sse servers set url, not command.",
+          VALID_URL,
+        ),
+      };
+    }
+    if (gateway.value !== null) {
+      return {
+        error: issue(
+          joinPath(path, "gateway_endpoint") || "gateway_endpoint",
+          "http and sse servers set url, not a gateway endpoint.",
+          VALID_URL,
+        ),
+      };
+    }
+    if (url.value === null) {
+      return {
+        error: issue(
+          joinPath(path, "url") || "url",
+          "http and sse servers set url.",
+          VALID_URL,
+        ),
+      };
+    }
+  } else {
+    const transports = [command, url.value, gateway.value].filter(
+      (candidate) => candidate !== null,
+    );
+    if (transports.length !== 1) {
+      return {
+        error: issue(
+          path,
+          shape === "tidebreak"
+            ? "Configure exactly one command, URL, or gateway endpoint."
+            : "Configure exactly one command or URL.",
+          "A stdio server sets command; an HTTP server sets url.",
+        ),
+      };
+    }
   }
 
-  const directEnvironment = environmentNames(raw.env, "Environment");
-  if ("error" in directEnvironment) return directEnvironment;
+  const argsField = stringArray(
+    raw.args,
+    joinPath(path, "args") || "args",
+    "Arguments",
+  );
+  if ("error" in argsField) return argsField;
+  if (
+    commandSpec.value.argsFromCommand.length > 0 &&
+    argsField.value.length > 0
+  ) {
+    return {
+      error: issue(
+        joinPath(path, "args") || "args",
+        "Set arguments on command or on args, not both.",
+        'A valid value looks like ["-y", "package"].',
+      ),
+    };
+  }
+  const args = [...commandSpec.value.argsFromCommand, ...argsField.value];
+  if (args.length > MAX_ARGS) {
+    return {
+      error: issue(
+        joinPath(path, "args") || "args",
+        `Arguments contain at most ${MAX_ARGS} items.`,
+        "Remove extra arguments.",
+      ),
+    };
+  }
+
+  const environment = readEnvironment(raw, path);
+  if ("error" in environment) return environment;
   const forwardedEnvironment = stringArray(
     raw.env_from,
+    joinPath(path, "env_from") || "env_from",
     "Forwarded environment",
   );
   if ("error" in forwardedEnvironment) return forwardedEnvironment;
@@ -176,53 +427,92 @@ function parseEntry(
   let secretValueNames: string[] = [];
   if (raw.env_values !== undefined && raw.env_values !== null) {
     if (!isRecord(raw.env_values)) {
-      return { error: "Environment values must be a JSON object." };
+      return {
+        error: issue(
+          joinPath(path, "env_values") || "env_values",
+          "Environment values must be a JSON object.",
+          'A valid value looks like { "LOG_LEVEL": "debug" }.',
+        ),
+      };
+    }
+    const envValuesPath = joinPath(path, "env_values") || "env_values";
+    for (const [key, item] of Object.entries(raw.env_values)) {
+      if (typeof item !== "string") {
+        return {
+          error: issue(
+            joinPath(envValuesPath, key),
+            "Environment values are strings.",
+            'Use a text value such as "debug".',
+          ),
+        };
+      }
     }
     secretValueNames = Object.keys(raw.env_values);
   }
-  const env = unique([...directEnvironment.value, ...secretValueNames]);
-  const envFrom = forwardedEnvironment.value;
+  const env = unique([...environment.value.env, ...secretValueNames]);
+  const envFrom = unique([
+    ...environment.value.envFrom,
+    ...forwardedEnvironment.value,
+  ]);
   if (env.length + envFrom.length > MAX_ENVIRONMENT_VARIABLES) {
     return {
-      error: `Environment must contain at most ${MAX_ENVIRONMENT_VARIABLES} names.`,
+      error: issue(
+        joinPath(path, "env") || "env",
+        `Environment contains at most ${MAX_ENVIRONMENT_VARIABLES} names.`,
+        "Remove extra names.",
+      ),
     };
   }
-  const environmentError = validateEnvironmentNames([...env, ...envFrom]);
+  const environmentError = validateEnvironmentNames(
+    [...env, ...envFrom],
+    joinPath(path, "env") || "env",
+  );
   if (environmentError !== null) return { error: environmentError };
   if (new Set([...env, ...envFrom]).size !== env.length + envFrom.length) {
     return {
-      error: "An environment variable name is configured more than once.",
+      error: issue(
+        joinPath(path, "env") || "env",
+        "An environment variable name is configured more than once.",
+        "Use each name once in env or env_from.",
+      ),
     };
   }
 
-  const cwd = nullableString(raw, "cwd");
+  const cwd = nullableString(raw, "cwd", path);
   if ("error" in cwd) return cwd;
-  const bearer = nullableString(raw, "bearer_token_env");
+  const bearer = nullableString(raw, "bearer_token_env", path);
   if ("error" in bearer) return bearer;
-  const headerBearer =
-    shape === "common"
-      ? bearerEnvironmentFromHeaders(raw.headers)
-      : { value: null };
+  const headerBearer = bearerEnvironmentFromHeaders(raw.headers, path);
   if ("error" in headerBearer) return headerBearer;
   if (
     bearer.value !== null &&
     headerBearer.value !== null &&
     bearer.value !== headerBearer.value
   ) {
-    return { error: "Bearer token variables are configured more than once." };
+    return {
+      error: issue(
+        joinPath(path, "bearer_token_env") || "bearer_token_env",
+        "Bearer token variables are configured more than once.",
+        "Set bearer_token_env or an Authorization header, not both.",
+      ),
+    };
   }
   const bearerEnvironment = bearer.value ?? headerBearer.value;
   if (bearerEnvironment !== null) {
-    const bearerError = validateEnvironmentNames([bearerEnvironment]);
+    const bearerError = validateEnvironmentNames(
+      [bearerEnvironment],
+      joinPath(path, "bearer_token_env") || "bearer_token_env",
+    );
     if (bearerError !== null) return { error: bearerError };
   }
 
-  const enabled = booleanField(raw, "enabled", true);
+  const enabled = booleanField(raw, "enabled", true, path);
   if ("error" in enabled) return enabled;
   const timeout = numberField(
     raw,
     "request_timeout_ms",
     DEFAULT_REQUEST_TIMEOUT_MS,
+    path,
   );
   if ("error" in timeout) return timeout;
   if (
@@ -231,57 +521,89 @@ function parseEntry(
     timeout.value > MAX_REQUEST_TIMEOUT_MS
   ) {
     return {
-      error: `Request timeout must be a whole number from 1 to ${MAX_REQUEST_TIMEOUT_MS.toLocaleString()}.`,
+      error: issue(
+        joinPath(path, "request_timeout_ms") || "request_timeout_ms",
+        `Request timeout is a whole number from 1 to ${MAX_REQUEST_TIMEOUT_MS.toLocaleString()}.`,
+        "A valid value looks like 60000.",
+      ),
     };
   }
 
-  if (command.value !== null) {
-    if (command.value.length === 0) {
-      return { error: "Command must not be empty." };
+  if (command !== null) {
+    if (command.length === 0) {
+      return {
+        error: issue(
+          joinPath(path, "command") || "command",
+          "Command must not be empty.",
+          VALID_COMMAND,
+        ),
+      };
     }
     if (bearerEnvironment !== null) {
-      return { error: "Bearer token variables apply only to URL servers." };
+      return {
+        error: issue(
+          joinPath(path, "bearer_token_env") || "bearer_token_env",
+          "Bearer token variables apply only to URL servers.",
+          "Remove the bearer variable or switch this server to HTTP.",
+        ),
+      };
     }
   } else if (
-    args.value.length > 0 ||
+    args.length > 0 ||
     env.length > 0 ||
     envFrom.length > 0 ||
     cwd.value !== null
   ) {
     return {
-      error:
+      error: issue(
+        path,
         "Arguments, environment, and working directory apply only to command servers.",
+        "Move those fields onto a stdio server, or remove them.",
+      ),
     };
   }
 
   if (url.value !== null) {
-    const urlError = validateUrl(url.value);
+    const urlError = validateUrl(
+      joinPath(path, "url") || "url",
+      url.value,
+      bearerEnvironment !== null,
+    );
     if (urlError !== null) return { error: urlError };
   } else if (bearerEnvironment !== null) {
-    return { error: "Bearer token variables apply only to URL servers." };
+    return {
+      error: issue(
+        joinPath(path, "bearer_token_env") || "bearer_token_env",
+        "Bearer token variables apply only to URL servers.",
+        "Remove the bearer variable or switch this server to HTTP.",
+      ),
+    };
   }
 
   if (gateway.value !== null && !validGatewayEndpoint(gateway.value)) {
     return {
-      error:
-        "Gateway endpoint must use 1–127 ASCII letters, numbers, underscores, or hyphens.",
+      error: issue(
+        joinPath(path, "gateway_endpoint") || "gateway_endpoint",
+        "Gateway endpoint uses 1–127 ASCII letters, numbers, underscores, or hyphens.",
+        "A valid value looks like tools or example-security_2.",
+      ),
     };
   }
 
-  const processStrings = [
-    command.value,
-    url.value,
-    cwd.value,
-    ...args.value,
-  ].filter((item): item is string => item !== null);
+  const processStrings = [command, url.value, cwd.value, ...args].filter(
+    (item): item is string => item !== null,
+  );
   if (
     processStrings.some(
       (item) => item.length > MAX_PROCESS_STRING_BYTES || item.includes("\0"),
     )
   ) {
     return {
-      error:
+      error: issue(
+        path,
         "Command, URL, arguments, and working directory must be valid text.",
+        "Use plain text without NUL characters.",
+      ),
     };
   }
 
@@ -289,8 +611,8 @@ function parseEntry(
     value: {
       server: {
         name,
-        command: command.value,
-        args: args.value,
+        command,
+        args,
         env,
         env_from: envFrom,
         cwd: cwd.value,
@@ -313,11 +635,168 @@ function parseEntry(
   };
 }
 
+function readType(
+  raw: Record<string, unknown>,
+  path: string,
+): FieldResult<"stdio" | "http" | null> {
+  const value = raw.type;
+  if (value === undefined || value === null) return { value: null };
+  const field = joinPath(path, "type") || "type";
+  if (typeof value !== "string") {
+    return {
+      error: issue(
+        field,
+        "Set type to a string.",
+        'Use "stdio", "http", or "sse".',
+      ),
+    };
+  }
+  const normalized = value.toLowerCase().replace(/_/g, "-");
+  if (normalized === "stdio") return { value: "stdio" };
+  if (
+    normalized === "http" ||
+    normalized === "sse" ||
+    normalized === "streamable-http" ||
+    normalized === "streamablehttp"
+  ) {
+    return { value: "http" };
+  }
+  return {
+    error: issue(
+      field,
+      `Tidebreak imports stdio, http, and sse; ${JSON.stringify(clip(value))} is not one of those.`,
+      'Set type to "stdio", "http", or "sse".',
+    ),
+  };
+}
+
+function readCommand(
+  raw: Record<string, unknown>,
+  path: string,
+): FieldResult<{ command: string | null; argsFromCommand: string[] }> {
+  const value = raw.command;
+  const field = joinPath(path, "command") || "command";
+  if (value === undefined || value === null) {
+    return { value: { command: null, argsFromCommand: [] } };
+  }
+  if (typeof value === "string") {
+    return { value: { command: value, argsFromCommand: [] } };
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return {
+        error: issue(field, "Command must not be empty.", VALID_COMMAND),
+      };
+    }
+    if (!value.every((item) => typeof item === "string")) {
+      return {
+        error: issue(
+          field,
+          "Command is a string or an array of strings.",
+          'A valid value looks like npx or ["npx", "-y", "package"].',
+        ),
+      };
+    }
+    const [command, ...argsFromCommand] = value as string[];
+    return { value: { command, argsFromCommand } };
+  }
+  return {
+    error: issue(
+      field,
+      "Command is a string or an array of strings.",
+      'A valid value looks like npx or ["npx", "-y", "package"].',
+    ),
+  };
+}
+
+function readUrl(
+  raw: Record<string, unknown>,
+  path: string,
+): FieldResult<string | null> {
+  const url = raw.url;
+  const serverUrl = raw.serverUrl;
+  const urlSet = url !== undefined && url !== null;
+  const serverUrlSet = serverUrl !== undefined && serverUrl !== null;
+  if (urlSet && serverUrlSet) {
+    return {
+      error: issue(
+        joinPath(path, "url") || "url",
+        "Set url or serverUrl, not both.",
+        VALID_URL,
+      ),
+    };
+  }
+  const value = urlSet ? url : serverUrl;
+  if (value === undefined || value === null) return { value: null };
+  const field = urlSet
+    ? joinPath(path, "url") || "url"
+    : joinPath(path, "serverUrl") || "serverUrl";
+  return typeof value === "string"
+    ? { value }
+    : { error: issue(field, "url must be a string.", VALID_URL) };
+}
+
+function readEnvironment(
+  raw: Record<string, unknown>,
+  path: string,
+): FieldResult<{ env: string[]; envFrom: string[] }> {
+  const value = raw.env;
+  const field = joinPath(path, "env") || "env";
+  if (value === undefined || value === null) {
+    return { value: { env: [], envFrom: [] } };
+  }
+  if (Array.isArray(value)) {
+    const names = stringArray(value, field, "Environment");
+    if ("error" in names) return names;
+    return { value: { env: names.value, envFrom: [] } };
+  }
+  if (!isRecord(value)) {
+    return {
+      error: issue(
+        field,
+        "Environment is an object of names to strings, or an array of names.",
+        VALID_ENV_OBJECT,
+      ),
+    };
+  }
+  const env: string[] = [];
+  const envFrom: string[] = [];
+  for (const [key, item] of Object.entries(value)) {
+    const itemPath = joinPath(field, key);
+    if (typeof item !== "string") {
+      return {
+        error: issue(
+          itemPath,
+          "Environment values are strings.",
+          'Use a text value such as "debug".',
+        ),
+      };
+    }
+    const placeholder = parsePlaceholder(item.trim());
+    if (placeholder?.kind === "env" && placeholder.name === key) {
+      envFrom.push(key);
+    } else {
+      env.push(key);
+    }
+  }
+  return { value: { env, envFrom } };
+}
+
 function bearerEnvironmentFromHeaders(
   value: unknown,
+  path: string,
 ): FieldResult<string | null> {
+  const field = joinPath(path, "headers") || "headers";
   if (value === undefined || value === null) return { value: null };
-  if (!isRecord(value)) return { error: "HTTP headers must be a JSON object." };
+  if (!isRecord(value)) {
+    return {
+      error: issue(
+        field,
+        "HTTP headers must be a JSON object.",
+        'A valid value looks like { "Authorization": "Bearer ${env:TOKEN}" }.',
+      ),
+    };
+  }
   const entries = Object.entries(value);
   if (entries.length === 0) return { value: null };
   if (
@@ -325,80 +804,130 @@ function bearerEnvironmentFromHeaders(
     entries[0]?.[0].toLowerCase() !== "authorization"
   ) {
     return {
-      error: "Custom HTTP headers are not supported. Add this server manually.",
+      error: issue(
+        field,
+        "Custom HTTP headers are not supported.",
+        "Add this server manually, or keep a single Authorization bearer header.",
+      ),
     };
   }
   const authorization = entries[0][1];
+  const authorizationPath = joinPath(field, "Authorization");
   if (typeof authorization !== "string") {
-    return { error: "The Authorization header must be a string." };
+    return {
+      error: issue(
+        authorizationPath,
+        "The Authorization header must be a string.",
+        VALID_BEARER,
+      ),
+    };
   }
-  const match = authorization.match(
-    /^Bearer\s+(?:\$\{(?:env:)?([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*))$/,
+  const bearer = authorization.match(/^Bearer\s+(.+)$/i);
+  const token = (bearer?.[1] ?? authorization).trim();
+  const placeholder = parsePlaceholder(token);
+  if (placeholder !== null) return { value: placeholder.name };
+  return {
+    error: issue(
+      authorizationPath,
+      "Authorization uses a bearer environment variable, not a saved token value.",
+      VALID_BEARER,
+    ),
+  };
+}
+
+function parsePlaceholder(
+  value: string,
+): { kind: "env" | "input"; name: string } | null {
+  const env = value.match(
+    /^(?:\$\{(?:env:)?([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*))$/,
   );
-  const environment = match?.[1] ?? match?.[2];
-  return environment
-    ? { value: environment }
-    : {
-        error:
-          "Authorization must use a bearer environment variable, not a saved token value.",
-      };
+  const envName = env?.[1] ?? env?.[2];
+  if (envName) return { kind: "env", name: envName };
+  const input = value.match(/^\$\{input:([A-Za-z0-9_-]+)\}$/);
+  return input?.[1] ? { kind: "input", name: input[1] } : null;
 }
 
 function nullableString(
   raw: Record<string, unknown>,
   field: string,
+  path: string,
 ): FieldResult<string | null> {
   const value = raw[field];
   if (value === undefined || value === null) return { value: null };
   return typeof value === "string"
     ? { value }
-    : { error: `${field} must be a string.` };
+    : {
+        error: issue(
+          joinPath(path, field) || field,
+          `${field} must be a string.`,
+          "Use a text value.",
+        ),
+      };
 }
 
-function stringArray(value: unknown, label: string): FieldResult<string[]> {
+function stringArray(
+  value: unknown,
+  path: string,
+  label: string,
+): FieldResult<string[]> {
   if (value === undefined || value === null) return { value: [] };
   if (
     !Array.isArray(value) ||
     !value.every((item) => typeof item === "string")
   ) {
-    return { error: `${label} must be an array of strings.` };
+    return {
+      error: issue(
+        path,
+        `${label} must be an array of strings.`,
+        'A valid value looks like ["-y", "package"].',
+      ),
+    };
   }
   return { value: value as string[] };
-}
-
-function environmentNames(
-  value: unknown,
-  label: string,
-): FieldResult<string[]> {
-  if (isRecord(value)) return { value: Object.keys(value) };
-  return stringArray(value, label);
 }
 
 function booleanField(
   raw: Record<string, unknown>,
   field: string,
   fallback: boolean,
+  path: string,
 ): FieldResult<boolean> {
   const value = raw[field];
   if (value === undefined || value === null) return { value: fallback };
   return typeof value === "boolean"
     ? { value }
-    : { error: `${field} must be true or false.` };
+    : {
+        error: issue(
+          joinPath(path, field) || field,
+          `${field} must be true or false.`,
+          "Use true or false.",
+        ),
+      };
 }
 
 function numberField(
   raw: Record<string, unknown>,
   field: string,
   fallback: number,
+  path: string,
 ): FieldResult<number> {
   const value = raw[field];
   if (value === undefined || value === null) return { value: fallback };
   return typeof value === "number"
     ? { value }
-    : { error: `${field} must be a number.` };
+    : {
+        error: issue(
+          joinPath(path, field) || field,
+          `${field} must be a number.`,
+          "A valid value looks like 60000.",
+        ),
+      };
 }
 
-function validateEnvironmentNames(names: string[]): string | null {
+function validateEnvironmentNames(
+  names: string[],
+  path: string,
+): string | null {
   const invalid = names.find(
     (name) =>
       name.length === 0 ||
@@ -408,23 +937,67 @@ function validateEnvironmentNames(names: string[]): string | null {
   );
   return invalid === undefined
     ? null
-    : `Environment variable name ${JSON.stringify(invalid)} is invalid.`;
+    : issue(
+        path,
+        `Environment variable name ${JSON.stringify(clip(invalid))} is invalid.`,
+        "Use a name without = or NUL, up to 256 characters.",
+      );
 }
 
-function validateUrl(value: string): string | null {
+function validateUrl(
+  path: string,
+  value: string,
+  hasCredentials: boolean,
+): string | null {
+  let parsed: URL;
   try {
-    const parsed = new URL(value);
-    if (!["http:", "https:"].includes(parsed.protocol)) {
-      return "URL must use http or https.";
-    }
-    if (parsed.username !== "" || parsed.password !== "") {
-      return "URL must not contain credentials.";
-    }
-    if (parsed.hostname === "") return "URL must name a host.";
-    return null;
+    parsed = new URL(value);
   } catch {
-    return "URL must be a valid HTTP or HTTPS URL.";
+    return issue(
+      path,
+      "Use an http or https URL without credentials.",
+      VALID_URL,
+    );
   }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    return issue(
+      path,
+      "Use an http or https URL without credentials.",
+      VALID_URL,
+    );
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    return issue(
+      path,
+      "Do not put credentials in the URL.",
+      "Set a bearer token variable instead.",
+    );
+  }
+  if (parsed.hostname === "") {
+    return issue(path, "Name a host in the URL.", VALID_URL);
+  }
+  if (
+    hasCredentials &&
+    parsed.protocol === "http:" &&
+    !isLiteralLoopbackHost(parsed.hostname)
+  ) {
+    return issue(
+      path,
+      "Credentialed URLs use https unless they name a literal loopback address.",
+      "Use an https URL, or a loopback http URL such as http://127.0.0.1:8080/mcp.",
+    );
+  }
+  return null;
+}
+
+function isLiteralLoopbackHost(host: string): boolean {
+  const bare =
+    host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  if (bare === "::1" || bare === "0:0:0:0:0:0:0:1") return true;
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(bare);
+  if (ipv4 === null) return false;
+  const octets = ipv4.slice(1).map(Number);
+  return octets.every((octet) => octet <= 255) && octets[0] === 127;
 }
 
 function validNamespace(name: string): boolean {
@@ -441,4 +1014,154 @@ function validGatewayEndpoint(slug: string): boolean {
 
 function unique(values: string[]): string[] {
   return [...new Set(values)];
+}
+
+function namespaceIssue(path: string, name: string): string {
+  const rule =
+    "Name a server with 1–32 ASCII letters, numbers, underscores, or hyphens.";
+  if (name.length === 0) {
+    return issue(path, `${rule} The name is empty.`, VALID_NAMESPACE);
+  }
+  if (name.length > MAX_NAMESPACE_BYTES) {
+    return issue(
+      path,
+      `${rule} This name is longer than ${MAX_NAMESPACE_BYTES} characters.`,
+      VALID_NAMESPACE,
+    );
+  }
+  const match = name.match(/[^A-Za-z0-9_-]/);
+  if (match) {
+    const char = match[0];
+    const label =
+      char === " "
+        ? "a space"
+        : char === "/"
+          ? "a slash"
+          : char === "."
+            ? "a period"
+            : JSON.stringify(char);
+    return issue(
+      path,
+      `${rule} ${JSON.stringify(clip(name))} contains ${label}.`,
+      VALID_NAMESPACE,
+    );
+  }
+  return issue(path, rule, VALID_NAMESPACE);
+}
+
+function issue(path: string, rule: string, expected: string): string {
+  const prefix = path === "" ? "" : `${path}: `;
+  return `${prefix}${rule} ${expected}`;
+}
+
+export function mcpJsonPath(parts: Array<string | number>): string {
+  let result = "";
+  for (const part of parts) {
+    if (typeof part === "number") {
+      result += `[${part}]`;
+      continue;
+    }
+    const ident = /^[A-Za-z_][A-Za-z0-9_]*$/.test(part);
+    if (result === "") {
+      result = ident ? part : `[${JSON.stringify(part)}]`;
+    } else if (ident) {
+      result += `.${part}`;
+    } else {
+      result += `[${JSON.stringify(part)}]`;
+    }
+  }
+  return result;
+}
+
+function joinPath(base: string, field: string): string {
+  if (base === "") return field;
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(field)
+    ? `${base}.${field}`
+    : `${base}[${JSON.stringify(field)}]`;
+}
+
+function prefixPath(prefix: string, path: string): string {
+  if (path === "") return prefix;
+  return path.startsWith("[") ? `${prefix}${path}` : `${prefix}.${path}`;
+}
+
+function clip(value: string): string {
+  return value.length > 40 ? `${value.slice(0, 40)}…` : value;
+}
+
+function jsonSyntaxMessage(text: string, error: unknown): string {
+  const scanned = scanNonStrictJson(text);
+  if (scanned?.kind === "comment") {
+    return `JSON at character ${scanned.index}: this JSON uses a comment. Use strict JSON without comments or trailing commas.`;
+  }
+  if (scanned?.kind === "trailing-comma") {
+    return `JSON at character ${scanned.index}: this JSON uses a trailing comma. Use strict JSON without comments or trailing commas.`;
+  }
+  const position = jsonErrorPosition(error, text);
+  if (position !== null) {
+    return `JSON at character ${position}: this JSON is not valid JSON. Use strict JSON without comments or trailing commas.`;
+  }
+  return "This JSON is not valid JSON. Use strict JSON without comments or trailing commas.";
+}
+
+function jsonErrorPosition(error: unknown, text: string): number | null {
+  if (!(error instanceof Error)) return null;
+  const atPosition = error.message.match(/position\s+(\d+)/i);
+  if (atPosition) return Number(atPosition[1]);
+  const lineCol = error.message.match(/line\s+(\d+)\s+column\s+(\d+)/i);
+  if (!lineCol) return null;
+  return indexFromLineColumn(text, Number(lineCol[1]), Number(lineCol[2]));
+}
+
+function indexFromLineColumn(
+  text: string,
+  line: number,
+  column: number,
+): number {
+  let currentLine = 1;
+  let index = 0;
+  while (index < text.length && currentLine < line) {
+    if (text[index] === "\n") currentLine += 1;
+    index += 1;
+  }
+  return Math.min(text.length, index + Math.max(0, column - 1));
+}
+
+function scanNonStrictJson(
+  text: string,
+): { kind: "comment" | "trailing-comma"; index: number } | null {
+  let inString = false;
+  let escape = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (char === "\\") {
+        escape = true;
+        continue;
+      }
+      if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "/" && (text[index + 1] === "/" || text[index + 1] === "*")) {
+      return { kind: "comment", index };
+    }
+    if (char === ",") {
+      let cursor = index + 1;
+      while (cursor < text.length && /[ \t\r\n]/.test(text[cursor] ?? "")) {
+        cursor += 1;
+      }
+      if (text[cursor] === "}" || text[cursor] === "]") {
+        return { kind: "trailing-comma", index };
+      }
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## Why

Importing MCP JSON failed for common editor shapes and hid the reason. You could not tell malformed JSON from an unsupported field, and a rejected file dropped your paste.

## What you get

The importer now accepts the shapes you actually export from Claude Desktop, Cursor, Windsurf, and VS Code, plus Tidebreak's own file. A rejected entry names the JSON path, the rule, and what a valid value looks like. Valid siblings stay in the editor. Pasted JSON stays in the import box so you can fix it. A save that the server rejects shows the server's field-level message instead of a generic failure.

### Shapes you can import

- Claude Desktop `{"mcpServers": {"name": {"command", "args", "env"}}}`
- Cursor and Windsurf `{"mcpServers": {"name": {"url", "headers"}}}` with or without `"type": "http" | "sse" | "stdio"` (and `streamable-http`)
- VS Code `{"servers": {"name": {"type", "command" | "url"}}}` with optional `inputs`, including `{"mcp": {"servers": ...}}`
- Tidebreak `{"servers": [{"name": "...", ...}]}`
- A single bare server object
- A top-level array of servers
- `${env:VAR}`, `${VAR}`, and `$VAR` placeholders
- A `url` with a trailing slash or query string
- `command` as a string or an argv array
- `serverUrl` as an alias for `url`

### Shapes you reject

- JSON with comments or trailing commas (the message names the character)
- `env` values that are not strings
- A name with spaces, slashes, periods, or other characters outside ASCII letters, digits, `_`, and `-`
- Custom HTTP headers other than a single Authorization bearer environment placeholder
- A literal bearer token in a header
- A server that sets both command and url, or a type that does not match those fields
- Both `mcpServers` and `servers` at the top level
- Credentials embedded in a URL
- Arguments, environment, or cwd on an HTTP server

## Checks

- `pnpm --dir crates/tidebreak-desktop/ui exec biome format src` — checked 866 files, no fixes applied
- `pnpm --dir crates/tidebreak-desktop/ui lint` — checked 866 files, no fixes applied
- `pnpm --dir crates/tidebreak-desktop/ui test` — 269 files, 2402 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui build` — `tsc` and Vite production build succeeded

Closes #3036