### PR TITLE
feat(code): offer Uneff me everywhere and start its session for the reader

### DIFF
--- a/crates/tidebreak-desktop/ui/src/CommandPaletteDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/CommandPaletteDialog.tsx
@@ -23,7 +23,6 @@ import {
 import { codeWorkspaceIdFromPath, shellShortcutMode } from "./code/routes";
 import { arrangeWorkspaces } from "./code/workspaceCards";
 import { useWorkspaceCardCommands } from "./code/workspaceActions";
-import { tidebreakProductRepo } from "./code/uneffMe";
 import {
   chatNavigationPaletteRows,
   chatPaletteRows,
@@ -155,7 +154,6 @@ export function CommandPaletteDialog() {
             hasSession: Boolean(digest) || Boolean(sessions[workspace.id]),
             attentionPinned: digest?.attention.state.type === "manual",
             quickActions: repo?.quick_actions ?? [],
-            canUneff: Boolean(tidebreakProductRepo(repos)),
             onCommand: (command) =>
               workspaceRunner.run(command.id, {
                 workspace,

--- a/crates/tidebreak-desktop/ui/src/PastedText.test.ts
+++ b/crates/tidebreak-desktop/ui/src/PastedText.test.ts
@@ -6,6 +6,7 @@ import {
   pastedTextLineCount,
   pastedTextPreview,
   shouldAttachPastedText,
+  splitPastedText,
 } from "./PastedText";
 
 describe("PastedText", () => {
@@ -31,5 +32,20 @@ describe("PastedText", () => {
     expect(pastedTextPreview("\n  First useful line  \nSecond")).toBe(
       "First useful line",
     );
+  });
+
+  it("splits held paste back out of a sent message", () => {
+    const sent = messageWithPastedText("Summarize this", [
+      { id: "paste-1", text: "First line\nSecond line" },
+      { id: "paste-2", text: '{\n  "a": 1\n}' },
+    ]);
+    expect(splitPastedText(sent)).toEqual({
+      prose: "Summarize this",
+      pasted: ["First line\nSecond line", '{\n  "a": 1\n}'],
+    });
+    expect(splitPastedText("plain message")).toEqual({
+      prose: "plain message",
+      pasted: [],
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/PastedText.test.ts
+++ b/crates/tidebreak-desktop/ui/src/PastedText.test.ts
@@ -48,4 +48,27 @@ describe("PastedText", () => {
       pasted: [],
     });
   });
+
+  it("keeps a block whole when its body carries its own paste wrappers", () => {
+    // Uneff me pastes a debug report whose turns may hold earlier pastes.
+    const inner = messageWithPastedText("Summarize this", [
+      { id: "paste-1", text: "inner body" },
+    ]);
+    const report = JSON.stringify({ turns: [{ user_input: inner }] }, null, 2);
+    const sent = messageWithPastedText("The report follows.", [
+      { id: "report", text: report },
+    ]);
+    expect(splitPastedText(sent)).toEqual({
+      prose: "The report follows.",
+      pasted: [report],
+    });
+
+    // An opener that never balances runs to the end, not into the prose.
+    const unbalanced =
+      "Look\n\n<pasted_text>\n<pasted_text>\nstray\n</pasted_text>";
+    expect(splitPastedText(unbalanced)).toEqual({
+      prose: "Look",
+      pasted: ["<pasted_text>\nstray\n</pasted_text>"],
+    });
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/PastedText.ts
+++ b/crates/tidebreak-desktop/ui/src/PastedText.ts
@@ -42,20 +42,56 @@ export type SplitPastedText = {
   pasted: string[];
 };
 
-const PASTED_TEXT_BLOCK = /<pasted_text>\n?([\s\S]*?)\n?<\/pasted_text>/g;
+const OPEN_TAG = "<pasted_text>";
+const CLOSE_TAG = "</pasted_text>";
 
 /**
  * Take the paste blocks `messageWithPastedText` added back out of a message,
  * so a transcript can fold them the way the composer chip did.
+ *
+ * Blocks nest: a debug report pasted by Uneff me carries the source session's
+ * own turns, and those may hold wrappers from earlier pastes. A block ends at
+ * the closer that balances its opener, not at the first closer in sight, and
+ * an opener that never balances runs to the end of the message rather than
+ * spilling the rest of the paste into the prose.
  */
 export function splitPastedText(message: string): SplitPastedText {
   const pasted: string[] = [];
-  const prose = message
-    .replace(PASTED_TEXT_BLOCK, (_match, body: string) => {
-      pasted.push(body);
-      return "";
-    })
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-  return { prose, pasted };
+  let prose = "";
+  let cursor = 0;
+  while (cursor < message.length) {
+    const open = message.indexOf(OPEN_TAG, cursor);
+    if (open === -1) {
+      prose += message.slice(cursor);
+      break;
+    }
+    prose += message.slice(cursor, open);
+    let depth = 1;
+    let scan = open + OPEN_TAG.length;
+    let close = -1;
+    while (depth > 0) {
+      const nextOpen = message.indexOf(OPEN_TAG, scan);
+      const nextClose = message.indexOf(CLOSE_TAG, scan);
+      if (nextClose === -1) break;
+      if (nextOpen !== -1 && nextOpen < nextClose) {
+        depth += 1;
+        scan = nextOpen + OPEN_TAG.length;
+        continue;
+      }
+      depth -= 1;
+      scan = nextClose + CLOSE_TAG.length;
+      if (depth === 0) close = nextClose;
+    }
+    const bodyEnd = close === -1 ? message.length : close;
+    pasted.push(
+      trimBlockNewlines(message.slice(open + OPEN_TAG.length, bodyEnd)),
+    );
+    cursor = close === -1 ? message.length : close + CLOSE_TAG.length;
+  }
+  return { prose: prose.replace(/\n{3,}/g, "\n\n").trim(), pasted };
+}
+
+/** The wrapper adds one newline on each side of the body; take only those. */
+function trimBlockNewlines(body: string): string {
+  return body.replace(/^\n/, "").replace(/\n$/, "");
 }

--- a/crates/tidebreak-desktop/ui/src/PastedText.ts
+++ b/crates/tidebreak-desktop/ui/src/PastedText.ts
@@ -34,3 +34,28 @@ export function pastedTextPreview(text: string): string {
       .find(Boolean) ?? "Pasted text"
   );
 }
+
+/** A sent message, with each held paste separated back out of it. */
+export type SplitPastedText = {
+  /** What the reader typed, with the paste blocks removed. */
+  prose: string;
+  pasted: string[];
+};
+
+const PASTED_TEXT_BLOCK = /<pasted_text>\n?([\s\S]*?)\n?<\/pasted_text>/g;
+
+/**
+ * Take the paste blocks `messageWithPastedText` added back out of a message,
+ * so a transcript can fold them the way the composer chip did.
+ */
+export function splitPastedText(message: string): SplitPastedText {
+  const pasted: string[] = [];
+  const prose = message
+    .replace(PASTED_TEXT_BLOCK, (_match, body: string) => {
+      pasted.push(body);
+      return "";
+    })
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return { prose, pasted };
+}

--- a/crates/tidebreak-desktop/ui/src/PastedTextBlock.tsx
+++ b/crates/tidebreak-desktop/ui/src/PastedTextBlock.tsx
@@ -1,0 +1,64 @@
+import { useId, useState } from "react";
+import { ChevronDown, ChevronRight, FileText } from "lucide-react";
+
+import { pastedTextLineCount, pastedTextPreview } from "./PastedText";
+import { ToolOutputPreview } from "./ToolOutputPreview";
+import { cn } from "@/lib/utils";
+
+/**
+ * One long paste inside a sent message, folded the way the composer chip
+ * folded it before send.
+ *
+ * The chip promised the reader that a wall of text would stay out of the way;
+ * the transcript keeps that promise. Closed, it is the same card: an icon,
+ * the first line, the size. Open, it is the text itself with the copy control
+ * every output block has.
+ */
+export function PastedTextBlock({ text }: { text: string }) {
+  const [open, setOpen] = useState(false);
+  const bodyId = useId();
+  const lines = pastedTextLineCount(text);
+  const characters = [...text].length;
+  const detail = `${lines.toLocaleString()} ${lines === 1 ? "line" : "lines"} · ${characters.toLocaleString()} characters`;
+  const preview = pastedTextPreview(text);
+  const Chevron = open ? ChevronDown : ChevronRight;
+  return (
+    <div
+      className="border-border bg-muted/50 text-muted-foreground not-prose my-2 flex max-w-full flex-col gap-2 rounded-lg border px-2 py-1.5"
+      data-testid="pasted-text-block"
+    >
+      <button
+        type="button"
+        className={cn(
+          "flex min-w-0 cursor-pointer items-center gap-2 rounded-md text-left",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+        )}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="bg-background inline-flex size-9 shrink-0 items-center justify-center rounded-md">
+          <FileText className="size-4" aria-hidden="true" />
+        </span>
+        <span className="grid min-w-0 flex-1 gap-px">
+          <strong className="text-foreground text-xs font-semibold">
+            Pasted text
+          </strong>
+          <small className="text-2xs truncate" title={preview}>
+            {preview} · {detail}
+          </small>
+        </span>
+        <Chevron className="size-4 shrink-0" aria-hidden="true" />
+      </button>
+      {open && (
+        <div id={bodyId}>
+          <ToolOutputPreview
+            text={text}
+            label="Pasted text"
+            collapsedLines={24}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/UserMessage.tsx
+++ b/crates/tidebreak-desktop/ui/src/UserMessage.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 
 import { MessageMarkdown } from "./MessageMarkdown";
 import { MessageFooter } from "./MessageFooter";
+import { splitPastedText } from "./PastedText";
+import { PastedTextBlock } from "./PastedTextBlock";
 
 type UserMessageProps = {
   /** What the reader sent, rendered as Markdown like the rest of the turn. */
@@ -32,6 +34,8 @@ export function UserMessage({
   leading,
   trailing,
 }: UserMessageProps) {
+  // A long paste went out folded behind a chip; it comes back folded too.
+  const { prose, pasted } = splitPastedText(text);
   return (
     <div className="message-user-frame">
       <article
@@ -40,7 +44,10 @@ export function UserMessage({
         data-transcript-anchor={anchorId}
       >
         {leading}
-        <MessageMarkdown>{text}</MessageMarkdown>
+        {prose && <MessageMarkdown>{prose}</MessageMarkdown>}
+        {pasted.map((block, index) => (
+          <PastedTextBlock key={`${index}:${block.length}`} text={block} />
+        ))}
         {trailing}
       </article>
       <MessageFooter role="user" text={text} createdAt={createdAt} />

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -899,9 +899,12 @@ export function CodeComposer({
 
   useEffect(() => {
     if (!pendingPrompt || pendingPrompt.scope !== composerPromptScope) return;
+    if (pendingPrompt.sessionId && pendingPrompt.sessionId !== sessionId) {
+      return;
+    }
     const request = useCodeUiStore
       .getState()
-      .takeComposerPrompt(composerPromptScope);
+      .takeComposerPrompt(composerPromptScope, sessionId);
     if (!request) return;
     if (request.submit) {
       void submitOfferedPrompt(request.text);

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -35,7 +35,6 @@ import {
   workspaceBulkCommands,
   workspaceCommands,
 } from "./workspaceActions";
-import { tidebreakProductRepo } from "./uneffMe";
 import { WorkspaceCard, WorkspaceStatusMark } from "./WorkspaceCard";
 import {
   arrangeWorkspaces,
@@ -314,7 +313,6 @@ export function CodeSidebar() {
                                 sessions[workspace.id]?.attention
                               )?.state.type === "manual",
                             canOpenWorktree,
-                            canUneff: Boolean(tidebreakProductRepo(repos)),
                             setupFailed: workspace.status === "setup_failed",
                           })
                   }

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -341,6 +341,69 @@ describe("CodeTranscript", () => {
     expect(screen.getByTestId("code-turn-announcer")).toHaveTextContent("");
   });
 
+  it("offers File an issue on a failed turn and an engine error, not on a warning", async () => {
+    const onFileIssue = vi.fn();
+    const failed: CodeTranscriptItem[] = [
+      items[0],
+      {
+        kind: "notice",
+        id: "n-warn",
+        level: "warning",
+        message: "The engine is slow to answer.",
+      },
+      {
+        kind: "notice",
+        id: "n-err",
+        level: "error",
+        message: "The engine could not reach the model gateway.",
+      },
+      {
+        kind: "turn_boundary",
+        id: "b3",
+        turnId: "t1",
+        status: "failed",
+        durationMs: 4_000,
+        usage: null,
+        error: "claude exited with status 1",
+        diffstat: null,
+      },
+    ];
+    render(<CodeTranscript items={failed} onFileIssue={onFileIssue} />);
+    const buttons = screen.getAllByRole("button", { name: "File an issue" });
+    expect(buttons).toHaveLength(2);
+    expect(
+      within(screen.getByText("The engine is slow to answer.")).queryByRole(
+        "button",
+      ),
+    ).toBeNull();
+    await userEvent.click(buttons[1] as HTMLElement);
+    expect(onFileIssue).toHaveBeenCalledTimes(1);
+
+    // Without a handler the failure reads as it always did.
+    cleanup();
+    render(<CodeTranscript items={failed} />);
+    expect(screen.queryByRole("button", { name: "File an issue" })).toBeNull();
+  });
+
+  it("folds a long paste in a sent message behind its chip", async () => {
+    const pasted: CodeTranscriptItem[] = [
+      {
+        kind: "user",
+        id: "u-paste",
+        turnId: "t1",
+        text: 'Look at this\n\n<pasted_text>\n{\n  "session": "sess-1"\n}\n</pasted_text>',
+        createdAt: "2026-08-15T00:00:00.000Z",
+      },
+    ];
+    render(<CodeTranscript items={pasted} />);
+    expect(screen.getByText("Look at this")).toBeInTheDocument();
+    const toggle = screen.getByRole("button", { name: /Pasted text/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText(/"session": "sess-1"/)).toBeNull();
+    await userEvent.click(toggle);
+    expect(screen.getByText(/"session": "sess-1"/)).toBeInTheDocument();
+  });
+
   it("renders the prompt as markdown with a timestamped footer", () => {
     render(<CodeTranscript items={items} />);
     const prompt = screen.getByRole("article", { name: "You" });

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -44,6 +44,7 @@ import {
   formatElapsedDuration,
   formatTurnDuration,
   isCodexRevokedRefreshTokenError,
+  FileIssueButton,
   TurnReviewCard,
 } from "./TurnReviewCard";
 
@@ -70,6 +71,7 @@ export function CodeTranscript({
   animateStreaming = true,
   onOpenTurnDiff,
   onForkFromTurn,
+  onFileIssue,
   emptyState,
   sessionId,
   onReveal,
@@ -99,6 +101,8 @@ export function CodeTranscript({
   onOpenTurnDiff?: (turnId: string) => void;
   /** Fork the conversation at the end of one turn, from its seam row. */
   onForkFromTurn?: (turnId: string) => void;
+  /** Turn a failed turn or an engine error into a Tidebreak issue or fix. */
+  onFileIssue?: () => void;
   /** Copy for a filtered/read-only transcript with no captured rows. */
   emptyState?: { title: string; description: string };
   sessionId?: string;
@@ -216,6 +220,7 @@ export function CodeTranscript({
                   onDecide={onDecide}
                   onOpenTurnDiff={onOpenTurnDiff}
                   onForkFromTurn={onForkFromTurn}
+                  onFileIssue={onFileIssue}
                   sessionId={sessionId}
                   onReveal={onReveal}
                   recap={row.item.id === newestBoundaryId ? recap : undefined}
@@ -538,6 +543,7 @@ const TranscriptItem = memo(function TranscriptItem({
   onDecide,
   onOpenTurnDiff,
   onForkFromTurn,
+  onFileIssue,
   sessionId,
   onReveal,
   recap,
@@ -558,6 +564,7 @@ const TranscriptItem = memo(function TranscriptItem({
   ) => void;
   onOpenTurnDiff?: (turnId: string) => void;
   onForkFromTurn?: (turnId: string) => void;
+  onFileIssue?: () => void;
   sessionId?: string;
   onReveal?: () => void;
   /**
@@ -631,7 +638,13 @@ const TranscriptItem = memo(function TranscriptItem({
         />
       );
     case "notice":
-      return <HarnessNotice level={item.level} message={item.message} />;
+      return (
+        <HarnessNotice
+          level={item.level}
+          message={item.message}
+          onFileIssue={onFileIssue}
+        />
+      );
     case "approval": {
       const card = !approval ? (
         <p className="text-muted-foreground text-sm" role="status">
@@ -671,6 +684,7 @@ const TranscriptItem = memo(function TranscriptItem({
           turn={item}
           onOpenTurnDiff={onOpenTurnDiff}
           onForkFromTurn={onForkFromTurn}
+          onFileIssue={onFileIssue}
           narrative={
             recap ? (
               <span className="text-muted-foreground">{recap}</span>
@@ -941,9 +955,12 @@ export function CodeToolCard({
 export function HarnessNotice({
   level,
   message,
+  onFileIssue,
 }: {
   level: "info" | "warning" | "error";
   message: string;
+  /** An error is a reason to ask Tidebreak for help; only errors offer it. */
+  onFileIssue?: () => void;
 }) {
   const tone =
     level === "error" ? "critical" : level === "warning" ? "warning" : "info";
@@ -962,7 +979,16 @@ export function HarnessNotice({
           "border-info-border bg-info-background text-info-foreground",
       )}
     >
-      {message}
+      {level === "error" && onFileIssue ? (
+        <div className="flex flex-col gap-1.5">
+          <p>{message}</p>
+          <div className="flex items-center">
+            <FileIssueButton onClick={onFileIssue} />
+          </div>
+        </div>
+      ) : (
+        message
+      )}
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -114,11 +114,28 @@ export type PendingComposerImages = {
   files: readonly File[];
 };
 
-/** The new-workspace dialog is still preparing this workspace's first agent. */
+/** One line of the startup handoff's step list. */
+export type WorkspaceStartupStep = {
+  label: string;
+  state: "complete" | "active" | "pending";
+};
+
+/**
+ * A workspace is still getting its first agent.
+ *
+ * The new-workspace dialog keys this by the workspace it created. Uneff me
+ * keys it by the workspace it starts from while it collects the debug report
+ * and, when needed, clones Tidebreak — that is `preparing`, with the work so
+ * far in `preparation` — and moves it to the new workspace once that exists.
+ */
 export type WorkspaceStartup = {
   harness: HarnessKind;
   hasFirstMessage: boolean;
-  phase: "starting_session" | "sending_message";
+  phase: "preparing" | "starting_session" | "sending_message";
+  /** Heading over the steps. Omitted, the handoff reads as a plain create. */
+  heading?: string;
+  /** Steps that ran before the workspace existed, in order. */
+  preparation?: readonly WorkspaceStartupStep[];
 };
 
 function readStoredCreateDefaults(): CodeCreateDefaults | null {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -107,6 +107,12 @@ export type PendingComposerPrompt = {
   submit: boolean;
   /** Files to attach once a session exists to publish them. */
   images?: readonly File[];
+  /**
+   * The one session whose composer may take this. Panes in a workspace share
+   * a scope, so a prompt meant for an agent that is still being selected
+   * waits for that agent's composer rather than landing in the one on screen.
+   */
+  sessionId?: string;
 };
 
 export type PendingComposerImages = {
@@ -377,9 +383,14 @@ export type CodeUiStore = {
     scope: string,
     prompt: string,
     images?: readonly File[],
+    sessionId?: string,
   ) => void;
   runComposerPrompt: (scope: string, prompt: string) => boolean;
-  takeComposerPrompt: (scope: string) => PendingComposerPrompt | null;
+  /** `sessionId` is the taker's; a prompt addressed to another session stays. */
+  takeComposerPrompt: (
+    scope: string,
+    sessionId?: string,
+  ) => PendingComposerPrompt | null;
   takeComposerImages: (scope: string) => readonly File[] | null;
   finishComposerAction: (scope: string) => void;
   /**
@@ -564,13 +575,14 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
     set({ openFilePending: null });
     return pending;
   },
-  offerComposerPrompt: (scope, prompt, images) =>
+  offerComposerPrompt: (scope, prompt, images, sessionId) =>
     set({
       pendingComposerPrompt: {
         scope,
         text: prompt,
         submit: false,
         ...(images && images.length > 0 ? { images } : {}),
+        ...(sessionId ? { sessionId } : {}),
       },
       pendingComposerImages:
         images && images.length > 0
@@ -587,9 +599,10 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
     });
     return true;
   },
-  takeComposerPrompt: (scope): PendingComposerPrompt | null => {
+  takeComposerPrompt: (scope, sessionId): PendingComposerPrompt | null => {
     const prompt = get().pendingComposerPrompt;
     if (!prompt || prompt.scope !== scope) return null;
+    if (prompt.sessionId && prompt.sessionId !== sessionId) return null;
     set({ pendingComposerPrompt: null });
     return prompt;
   },

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -134,8 +134,13 @@ export type WorkspaceStartup = {
   phase: "preparing" | "starting_session" | "sending_message";
   /** Heading over the steps. Omitted, the handoff reads as a plain create. */
   heading?: string;
-  /** Steps that ran before the workspace existed, in order. */
+  /** Steps that ran before the session existed, in order. */
   preparation?: readonly WorkspaceStartupStep[];
+  /**
+   * Where the agent lands. A create hands the reader to a new workspace; an
+   * Uneff me with no Tidebreak checkout starts the agent where they are.
+   */
+  target?: "new_workspace" | "this_workspace";
 };
 
 function readStoredCreateDefaults(): CodeCreateDefaults | null {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -2242,6 +2242,39 @@ describe("CodeWorkspacePage", () => {
     ).toBeNull();
   });
 
+  it("holds the Uneff me prompt in the new agent's composer when only the first turn fails", async () => {
+    const client = makeClient();
+    enableStartHarness(client);
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.submitCodeTurn.mockRejectedValueOnce(new Error("engine hiccup"));
+    const { router } = await mountWorkspace(client);
+    const user = userEvent.setup();
+
+    await screen.findByRole("heading", { name: /Fix login/ });
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Uneff me" }));
+
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().workspaceStartups).toEqual({}),
+    );
+    expect(client.createCodeSession).toHaveBeenCalledTimes(1);
+    expect(client.submitCodeTurn).toHaveBeenCalledTimes(1);
+    // The new session is selected, and its empty composer gets the prompt.
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        task: CREATED_SESSION.id,
+      }),
+    );
+    await waitFor(() => {
+      const pending = useCodeUiStore.getState().pendingComposerPrompt;
+      const composer = screen.queryByRole("textbox", {
+        name: "Message",
+      }) as HTMLTextAreaElement | null;
+      const text = pending?.text ?? composer?.value ?? "";
+      expect(text).toContain("not a Tidebreak checkout");
+    });
+  });
+
   it("keeps git and comments in the review sidebar, and opens the terminal as a tab", async () => {
     const client = makeClient();
     const { router } = await mountWorkspace(client);

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -2207,6 +2207,41 @@ describe("CodeWorkspacePage", () => {
     expect(router.state.location.pathname).toBe(`/code/w/${WORKSPACE.id}`);
   });
 
+  it("says no workspace was created and holds no prompt when an in-place Uneff me fails", async () => {
+    const client = makeClient();
+    enableStartHarness(client);
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.createCodeSession.mockRejectedValueOnce(new Error("engine down"));
+    const debug =
+      deferred<Awaited<ReturnType<typeof client.getCodeSessionDebug>>>();
+    client.getCodeSessionDebug.mockReturnValueOnce(debug.promise);
+    await mountWorkspace(client);
+    const user = userEvent.setup();
+
+    await screen.findByRole("heading", { name: /Fix login/ });
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Uneff me" }));
+
+    // The handoff never claims a workspace is coming.
+    const status = await screen.findByRole("status", {
+      name: "Starting session",
+    });
+    expect(status).not.toHaveTextContent("new workspace");
+    expect(status).toHaveTextContent("takes over here");
+    debug.resolve({ session: { id: "sess-1" }, turns: [], events: [] });
+
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().workspaceStartups).toEqual({}),
+    );
+    expect(client.createCodeSession).toHaveBeenCalledTimes(1);
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+    // The generated prompt does not land in this workspace's composer.
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+    expect(
+      screen.queryByText(/Workspace created, but the session could not start/),
+    ).toBeNull();
+  });
+
   it("keeps git and comments in the review sidebar, and opens the terminal as a tab", async () => {
     const client = makeClient();
     const { router } = await mountWorkspace(client);

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -481,6 +481,11 @@ function makeClient() {
       gh_found: false,
       gh_remediation: "gh is not installed.",
     })),
+    startCodeClone: vi.fn(async () => ({
+      id: "job-1",
+      phase: "starting",
+      done: false,
+    })),
     openCodeUpdates: vi.fn(
       () =>
         ({
@@ -2087,8 +2092,9 @@ describe("CodeWorkspacePage", () => {
     expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", true);
   });
 
-  it("starts a Tidebreak fix workspace from Uneff me", async () => {
+  it("starts a Tidebreak session from Uneff me, showing the handoff meanwhile", async () => {
     const client = makeClient();
+    enableStartHarness(client);
     const created = {
       ...WORKSPACE,
       id: "ws-uneff",
@@ -2111,6 +2117,9 @@ describe("CodeWorkspacePage", () => {
     client.getCodeWorkspace.mockImplementation(async (id: string) =>
       id === created.id ? created : WORKSPACE,
     );
+    const debug =
+      deferred<Awaited<ReturnType<typeof client.getCodeSessionDebug>>>();
+    client.getCodeSessionDebug.mockReturnValueOnce(debug.promise);
     useCodeCatalogStore.setState({
       repos: [REPO, tidebreakRepo],
     });
@@ -2121,6 +2130,15 @@ describe("CodeWorkspacePage", () => {
     await user.click(screen.getByRole("button", { name: "Workspace actions" }));
     await user.click(await screen.findByRole("menuitem", { name: "Uneff me" }));
 
+    // The source workspace carries the handoff while the report is collected.
+    const status = await screen.findByRole("status", {
+      name: "Starting session",
+    });
+    expect(status).toHaveTextContent("Getting Tidebreak ready to help");
+    expect(status).toHaveTextContent("Collecting the debug report");
+    expect(client.createCodeWorkspace).not.toHaveBeenCalled();
+    debug.resolve({ session: { id: "sess-1" }, turns: [], events: [] });
+
     await waitFor(() =>
       expect(client.createCodeWorkspace).toHaveBeenCalledWith({
         repo_id: "repo-tb",
@@ -2128,17 +2146,65 @@ describe("CodeWorkspacePage", () => {
       }),
     );
     expect(client.getCodeSessionDebug).toHaveBeenCalledWith("sess-1");
+    // A connected checkout means no clone.
+    expect(client.startCodeClone).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(router.state.location.pathname).toBe(`/code/w/${created.id}`),
     );
-    await waitFor(() => {
-      const pending = useCodeUiStore.getState().pendingComposerPrompt;
-      const composer = screen.queryByRole("textbox", {
-        name: "Message",
-      }) as HTMLTextAreaElement | null;
-      const text = pending?.text ?? composer?.value ?? "";
-      expect(text).toContain("Open a pull request against main");
-    });
+    // The first turn is posted, not left in the composer.
+    await waitFor(() =>
+      expect(client.createCodeSession).toHaveBeenCalledWith(created.id, {
+        harness: "claude_code",
+        permission_mode: "allow",
+        model: undefined,
+      }),
+    );
+    await waitFor(() =>
+      expect(client.submitCodeTurn).toHaveBeenCalledWith(
+        CREATED_SESSION.id,
+        expect.stringContaining("Start by asking the user what went wrong"),
+      ),
+    );
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().workspaceStartups).toEqual({}),
+    );
+  });
+
+  it("starts Uneff me as a new agent here when no Tidebreak checkout is connected", async () => {
+    const client = makeClient();
+    enableStartHarness(client);
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    const { router } = await mountWorkspace(client);
+    const user = userEvent.setup();
+
+    await screen.findByRole("heading", { name: /Fix login/ });
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Uneff me" }));
+
+    // Nothing is created or cloned on the reader's behalf.
+    await waitFor(() =>
+      expect(client.createCodeSession).toHaveBeenCalledWith(WORKSPACE.id, {
+        harness: "claude_code",
+        permission_mode: "allow",
+        model: undefined,
+      }),
+    );
+    expect(client.createCodeWorkspace).not.toHaveBeenCalled();
+    expect(client.startCodeClone).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(client.submitCodeTurn).toHaveBeenCalledWith(
+        CREATED_SESSION.id,
+        expect.stringContaining("not a Tidebreak checkout"),
+      ),
+    );
+    // The new agent is the one shown.
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        task: CREATED_SESSION.id,
+      }),
+    );
+    expect(router.state.location.pathname).toBe(`/code/w/${WORKSPACE.id}`);
   });
 
   it("keeps git and comments in the review sidebar, and opens the terminal as a tab", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -91,7 +91,6 @@ import { findEditorPanel, offersSplitDrop } from "./editorDrag";
 import { fenceReasonText } from "./labels";
 import { forkTranscriptFile } from "./fork";
 import { isPutAway, sessionActivityLabel } from "./workspaceCards";
-import { tidebreakProductRepo } from "./uneffMe";
 import { toast } from "sonner";
 import { useApp } from "@/AppContext";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
@@ -310,7 +309,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         // A watch child is the harness's own run, not a conversation to
         // continue, so only an interactive agent offers a fork.
         canFork: session?.kind === "interactive",
-        canUneff: Boolean(tidebreakProductRepo(catalog.repos)),
         quickActions: repo?.quick_actions ?? [],
         setupFailed: workspace.status === "setup_failed",
       })
@@ -633,6 +631,16 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                     (entry) => entry.call_id === subagentParam,
                   )}
                   onBackFromSubagent={() => openWorkspaceSubagent(undefined)}
+                  onFileIssue={
+                    workspace
+                      ? () =>
+                          run("uneff-me", {
+                            workspace,
+                            title: title ?? workspace.title,
+                            session,
+                          })
+                      : undefined
+                  }
                   composerOverride={
                     session.kind === "watch" ? (
                       <WatchTaskBar

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -1094,6 +1094,7 @@ describe("NewWorkspaceDialog", () => {
       scope: "ws-held-image",
       text: "Review this screenshot",
       submit: false,
+      sessionId: expect.any(String),
       images: [image],
     });
   });
@@ -1199,6 +1200,7 @@ describe("NewWorkspaceDialog", () => {
       scope: "ws-held",
       text: "list the files",
       submit: false,
+      sessionId: expect.any(String),
     });
     expect(toastError).toHaveBeenCalledWith(
       "Session started, but the first message could not be sent. engine crashed on spawn",

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -29,16 +29,13 @@ import type {
 import { HttpError } from "../api/client";
 import { useApp } from "@/AppContext";
 import { ImageAttachmentList, shouldSubmitComposerKey } from "../Composer";
-import { publishCodeImage } from "../attachments";
 import {
   imageAttachmentName,
   imageAttachmentRejection,
   imageFilesFrom,
   queuedImageAttachment,
-  uploadImageAttachment,
   type ImageAttachment,
 } from "../ImageAttachments";
-import { hasLocalHostAuthority } from "../host";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
@@ -75,6 +72,7 @@ import {
 } from "./CodeComposer";
 import { HarnessInstallNote } from "./HarnessInstallNote";
 import { useWarmHarnessInstall } from "./useHarnessInstall";
+import { startFirstSession } from "./startWorkspaceSession";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import {
   createPermissionModes,
@@ -85,7 +83,6 @@ import {
   harnessUnusableReason,
   PERMISSION_MODE_POLICY_BLOCKED,
   preferredCodeModels,
-  requiresHarnessModelIds,
   CREATE_PERMISSION_MODE_FIXED,
   HARNESS_LABELS,
   type CodeModelOption,
@@ -223,7 +220,6 @@ export function NewWorkspaceDialog({
     (state) => state.replaceWorkspace,
   );
   const removeWorkspace = useCodeCatalogStore((state) => state.removeWorkspace);
-  const rememberSession = useCodeCatalogStore((state) => state.rememberSession);
   const ensureHarnessModels = useCodeCatalogStore(
     (state) => state.ensureHarnessModels,
   );
@@ -768,121 +764,34 @@ export function NewWorkspaceDialog({
       return;
     }
     replaceWorkspace(pending.id, workspace);
-    const prompt = attempt.startingPrompt.trim();
-    const setWorkspaceStartup = useCodeUiStore.getState().setWorkspaceStartup;
-    setWorkspaceStartup(workspace.id, {
-      harness: attempt.harness,
-      hasFirstMessage: Boolean(prompt),
-      phase: "starting_session",
-    });
-    try {
-      await revealCreatedWorkspace(workspace, attempt);
-      const gateway = gatewayCodeModels(
-        models,
-        attempt.harness,
-        defaultModelKey,
-      );
-      const native =
-        requiresHarnessModelIds(attempt.harness) || gateway.length === 0
-          ? await ensureHarnessModels(client, attempt.harness)
-          : [];
-      const listed = preferredCodeModels(attempt.harness, native, gateway);
-      const posted =
-        attempt.model ??
-        listed.find((option) => option.default)?.id ??
-        listed[0]?.id;
-      const session = await client.createCodeSession(workspace.id, {
+    await startFirstSession({
+      client,
+      workspace,
+      settings: {
         harness: attempt.harness,
-        permission_mode: attempt.permissionMode,
-        model: posted,
-        ...(attempt.reasoningEffort
-          ? { reasoning_effort: attempt.reasoningEffort }
-          : {}),
-        ...(attempt.fastMode ? { fast_mode: true } : {}),
-      });
-      rememberSession(session);
-      if (prompt) {
-        setWorkspaceStartup(workspace.id, {
-          harness: attempt.harness,
-          hasFirstMessage: true,
-          phase: "sending_message",
-        });
-      }
-      rememberCreate({
-        repoId: attempt.repoId,
-        harness: attempt.harness,
-        model: posted,
-        modelsByHarness: attempt.modelsByHarness,
         permissionMode: attempt.permissionMode,
+        model: attempt.model,
         reasoningEffort: attempt.reasoningEffort,
-        reasoningEffortByHarness: attempt.reasoningEffortByHarness,
         fastMode: attempt.fastMode,
-        fastModeByHarness: attempt.fastModeByHarness,
-      });
-      if (prompt) {
-        try {
-          const attachments = await publishFirstTurnImages(
-            session.id,
-            attempt.images,
-          );
-          if (attachments.length > 0) {
-            await client.submitCodeTurn(
-              session.id,
-              prompt,
-              undefined,
-              attachments,
-            );
-          } else {
-            await client.submitCodeTurn(session.id, prompt);
-          }
-        } catch (error) {
-          // Never drop typed words or pasted images: the workspace composer
-          // holds them.
-          useCodeUiStore
-            .getState()
-            .offerComposerPrompt(workspace.id, prompt, attempt.images);
-          toast.error(
-            `Session started, but the first message could not be sent. ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
-          );
-        }
-      }
-    } catch (error) {
-      // No session to send to; the workspace composer holds the text, images,
-      // and start-session on the workspace page picks them up.
-      if (prompt) {
-        useCodeUiStore
-          .getState()
-          .offerComposerPrompt(workspace.id, prompt, attempt.images);
-      }
-      toast.error(
-        `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
-      );
-    } finally {
-      setWorkspaceStartup(workspace.id, null);
-    }
-  }
-
-  async function publishFirstTurnImages(
-    sessionId: string,
-    files: readonly File[],
-  ): Promise<readonly { blob_id: string; media_type: string }[]> {
-    const published = await Promise.all(
-      files.map(async (file) => {
-        if (hasLocalHostAuthority()) {
-          return publishCodeImage(sessionId, file);
-        }
-        return uploadImageAttachment(client, sessionId, file, {
-          onProgress: () => undefined,
-          signal: new AbortController().signal,
-          path: (id) =>
-            `/code/sessions/${encodeURIComponent(id)}/attachments/images`,
-        });
-      }),
-    );
-    return published.map((image) => ({
-      blob_id: image.attachmentId,
-      media_type: image.mediaType,
-    }));
+      },
+      prompt: attempt.startingPrompt,
+      images: attempt.images,
+      models,
+      defaultModelKey,
+      reveal: () => revealCreatedWorkspace(workspace, attempt),
+      onSessionCreated: (_session, posted) =>
+        rememberCreate({
+          repoId: attempt.repoId,
+          harness: attempt.harness,
+          model: posted,
+          modelsByHarness: attempt.modelsByHarness,
+          permissionMode: attempt.permissionMode,
+          reasoningEffort: attempt.reasoningEffort,
+          reasoningEffortByHarness: attempt.reasoningEffortByHarness,
+          fastMode: attempt.fastMode,
+          fastModeByHarness: attempt.fastModeByHarness,
+        }),
+    });
   }
 
   async function revealCreatedWorkspace(

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -59,8 +59,11 @@ export function WorkspaceSessionStartingState({
   const preparing = startup.phase === "preparing";
   const sending = startup.phase === "sending_message";
   const preparation = startup.preparation ?? [];
+  const here = startup.target === "this_workspace";
   const creating =
-    preparing && preparation.every((step) => step.state === "complete");
+    preparing &&
+    !here &&
+    preparation.every((step) => step.state === "complete");
 
   return (
     <section
@@ -78,7 +81,7 @@ export function WorkspaceSessionStartingState({
                 {startup.heading ?? "Starting your session"}
               </h2>
               <p className="mt-1 text-sm text-muted-foreground">
-                {preparing
+                {preparing && !here
                   ? `Tidebreak is getting a workspace ready for ${label}.`
                   : `Tidebreak is preparing ${label} in this workspace.`}
               </p>
@@ -93,10 +96,14 @@ export function WorkspaceSessionStartingState({
                 state={step.state}
               />
             ))}
-            <StartupStep
-              label={creating ? "Creating workspace" : "Workspace ready"}
-              state={preparing ? (creating ? "active" : "pending") : "complete"}
-            />
+            {!here && (
+              <StartupStep
+                label={creating ? "Creating workspace" : "Workspace ready"}
+                state={
+                  !preparing ? "complete" : creating ? "active" : "pending"
+                }
+              />
+            )}
             <StartupStep
               label={sending ? `${label} ready` : `Starting ${label}`}
               state={sending ? "complete" : preparing ? "pending" : "active"}
@@ -113,9 +120,11 @@ export function WorkspaceSessionStartingState({
           </div>
 
           <p className="mt-6 text-sm text-muted-foreground">
-            {preparing
+            {preparing && !here
               ? "You move to the new workspace as soon as it exists."
-              : "Your conversation appears here as soon as the session is ready."}
+              : here
+                ? "The new agent takes over here as soon as it starts."
+                : "Your conversation appears here as soon as the session is ready."}
           </p>
         </div>
       </div>

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -42,7 +42,13 @@ const NO_ENGINE_EFFORTS: ReasoningEffort[] = [];
 
 const NO_CATALOG_MODELS: ModelInfo[] = [];
 
-/** The page-level handoff while a newly created workspace gets its first agent. */
+/**
+ * The page-level handoff while a workspace gets its first agent.
+ *
+ * A plain create starts at "Workspace ready". Uneff me arrives with
+ * preparation steps ahead of that and a heading of its own, and the same
+ * surface carries both through to the first message.
+ */
 export function WorkspaceSessionStartingState({
   startup,
 }: {
@@ -50,7 +56,11 @@ export function WorkspaceSessionStartingState({
 }) {
   const label = HARNESS_LABELS[startup.harness];
   const HarnessIcon = HARNESS_ICONS[startup.harness];
+  const preparing = startup.phase === "preparing";
   const sending = startup.phase === "sending_message";
+  const preparation = startup.preparation ?? [];
+  const creating =
+    preparing && preparation.every((step) => step.state === "complete");
 
   return (
     <section
@@ -64,18 +74,32 @@ export function WorkspaceSessionStartingState({
           <div className="flex items-start gap-3">
             <Spinner className="mt-1 size-4 text-live" aria-hidden />
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold">Starting your session</h2>
+              <h2 className="text-lg font-semibold">
+                {startup.heading ?? "Starting your session"}
+              </h2>
               <p className="mt-1 text-sm text-muted-foreground">
-                Tidebreak is preparing {label} in this workspace.
+                {preparing
+                  ? `Tidebreak is getting a workspace ready for ${label}.`
+                  : `Tidebreak is preparing ${label} in this workspace.`}
               </p>
             </div>
           </div>
 
           <div className="mt-6 ml-2 border-l border-border-subtle pl-5">
-            <StartupStep label="Workspace ready" state="complete" />
+            {preparation.map((step) => (
+              <StartupStep
+                key={step.label}
+                label={step.label}
+                state={step.state}
+              />
+            ))}
+            <StartupStep
+              label={creating ? "Creating workspace" : "Workspace ready"}
+              state={preparing ? (creating ? "active" : "pending") : "complete"}
+            />
             <StartupStep
               label={sending ? `${label} ready` : `Starting ${label}`}
-              state={sending ? "complete" : "active"}
+              state={sending ? "complete" : preparing ? "pending" : "active"}
             />
             <StartupStep
               label={
@@ -89,7 +113,9 @@ export function WorkspaceSessionStartingState({
           </div>
 
           <p className="mt-6 text-sm text-muted-foreground">
-            Your conversation appears here as soon as the session is ready.
+            {preparing
+              ? "You move to the new workspace as soon as it exists."
+              : "Your conversation appears here as soon as the session is ready."}
           </p>
         </div>
       </div>

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -9,6 +9,7 @@ import {
 
 import type { Diffstat } from "../api/types";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -57,6 +58,7 @@ export function TurnReviewCard({
   narrative,
   onOpenTurnDiff,
   onForkFromTurn,
+  onFileIssue,
 }: {
   turn: TurnBoundary;
   /**
@@ -73,6 +75,8 @@ export function TurnReviewCard({
   onOpenTurnDiff?: (turnId: string) => void;
   /** Hand everything up to this turn to a fresh agent, in a new tab. */
   onForkFromTurn?: (turnId: string) => void;
+  /** Turn a failure into a Tidebreak issue or fix, from the failure itself. */
+  onFileIssue?: () => void;
 }) {
   const duration = formatTurnDuration(turn.durationMs);
   const diffstat = turn.diffstat && hasFileChanges(turn.diffstat) && (
@@ -106,10 +110,11 @@ export function TurnReviewCard({
           <p>{turn.error ?? "The engine stopped without saying why."}</p>
         )}
         {narrative}
-        {(diffstat || actions) && (
+        {(diffstat || actions || onFileIssue) && (
           <div className="flex items-center gap-2">
             {diffstat}
             {actions}
+            {onFileIssue && <FileIssueButton onClick={onFileIssue} />}
           </div>
         )}
       </div>
@@ -142,6 +147,24 @@ export function TurnReviewCard({
 }
 
 /** Recovery for the revoked credential that belongs to Codex CLI. */
+/**
+ * The way out of a failure the reader cannot fix: hand the session to Uneff
+ * me, which asks what happened and files an issue or a fix.
+ */
+export function FileIssueButton({ onClick }: { onClick: () => void }) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      className="ml-auto"
+      onClick={onClick}
+    >
+      File an issue
+    </Button>
+  );
+}
+
 function CodexLoginRecovery() {
   return (
     <div className="flex flex-col gap-2">

--- a/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
@@ -170,7 +170,6 @@ export function workspaceActionPaletteRows(input: {
   hasSession: boolean;
   attentionPinned: boolean;
   quickActions: readonly { name: string }[];
-  canUneff?: boolean;
   /** This window can start an editor on the machine holding the worktree. */
   canOpenInEditor?: boolean;
   onCommand: (command: WorkspaceCommand) => void;
@@ -181,7 +180,6 @@ export function workspaceActionPaletteRows(input: {
     archived,
     hasSession: input.hasSession,
     attentionPinned: input.attentionPinned,
-    canUneff: input.canUneff,
     canOpenInEditor: input.canOpenInEditor,
     setupFailed: input.workspace.status === "setup_failed",
   });

--- a/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
@@ -82,8 +82,14 @@ export async function startFirstSession(input: {
   images?: readonly File[];
   models: readonly ModelInfo[];
   defaultModelKey?: string | null;
-  /** Heading and preparation steps the handoff keeps showing. */
-  startup?: Pick<WorkspaceStartup, "heading" | "preparation">;
+  /** Heading, preparation steps, and target the handoff keeps showing. */
+  startup?: Pick<WorkspaceStartup, "heading" | "preparation" | "target">;
+  /**
+   * Keep the prompt in the workspace composer when the start fails. True for
+   * words the reader typed. False for a generated prompt landing in a
+   * workspace whose composer already belongs to another conversation.
+   */
+  holdPromptOnFailure?: boolean;
   /** Open the workspace before its session starts. */
   reveal?: () => Promise<void>;
   onSessionCreated?: (
@@ -99,13 +105,24 @@ export async function startFirstSession(input: {
     harness: settings.harness,
   };
   const setWorkspaceStartup = useCodeUiStore.getState().setWorkspaceStartup;
+  const hold = input.holdPromptOnFailure ?? true;
   const holdPrompt = () => {
-    if (prompt) {
+    if (prompt && hold) {
       useCodeUiStore
         .getState()
         .offerComposerPrompt(workspace.id, prompt, images);
     }
   };
+  // The copy has to match what the reader just watched happen.
+  const created = input.startup?.target !== "this_workspace";
+  const sessionFailed = created
+    ? "Workspace created, but the session could not start."
+    : "The session could not start.";
+  const turnFailed =
+    "Session started, but the first message could not be sent.";
+  const retry = hold
+    ? "Send it from the workspace composer."
+    : "Try again from the workspace menu.";
   setWorkspaceStartup(workspace.id, {
     ...base,
     hasFirstMessage: Boolean(prompt),
@@ -159,9 +176,7 @@ export async function startFirstSession(input: {
         // Never drop typed words or pasted images: the workspace composer
         // holds them.
         holdPrompt();
-        toast.error(
-          `Session started, but the first message could not be sent. ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
-        );
+        toast.error(`${turnFailed} ${friendlyErrorMessage(error, retry)}`);
       }
     }
     return session;
@@ -170,7 +185,7 @@ export async function startFirstSession(input: {
     // and start-session on the workspace page picks them up.
     holdPrompt();
     toast.error(
-      `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
+      `${sessionFailed} ${friendlyErrorMessage(error, hold ? "Try again from the workspace." : retry)}`,
     );
     return null;
   } finally {

--- a/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
@@ -1,0 +1,203 @@
+import { toast } from "sonner";
+
+import type { ApiClient } from "../api/client";
+import type {
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessKind,
+  ModelInfo,
+  PermissionMode,
+  ReasoningEffort,
+} from "../api/types";
+import { publishCodeImage } from "../attachments";
+import { uploadImageAttachment } from "../ImageAttachments";
+import { hasLocalHostAuthority } from "../host";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore, type WorkspaceStartup } from "./CodeUiStore";
+import {
+  gatewayCodeModels,
+  preferredCodeModels,
+  requiresHarnessModelIds,
+} from "./labels";
+
+/** What the first session of a workspace is created with. */
+export type FirstSessionSettings = {
+  harness: HarnessKind;
+  permissionMode: PermissionMode;
+  /** A model the reader picked. Omitted, the engine's default is posted. */
+  model?: string;
+  reasoningEffort?: ReasoningEffort | null;
+  fastMode?: boolean;
+};
+
+/**
+ * The model to post for an engine: the reader's pick when there is one,
+ * else the default of the catalog the engine accepts.
+ *
+ * Engines that only take their own identifiers, and any engine the gateway
+ * lists nothing for, are asked for their listing first.
+ */
+export async function resolveSessionModel(input: {
+  client: ApiClient;
+  harness: HarnessKind;
+  requested?: string;
+  models: readonly ModelInfo[];
+  defaultModelKey?: string | null;
+}): Promise<string | undefined> {
+  const gateway = gatewayCodeModels(
+    input.models,
+    input.harness,
+    input.defaultModelKey,
+  );
+  const native =
+    requiresHarnessModelIds(input.harness) || gateway.length === 0
+      ? await useCodeCatalogStore
+          .getState()
+          .ensureHarnessModels(input.client, input.harness)
+      : [];
+  const listed = preferredCodeModels(input.harness, native, gateway);
+  return (
+    input.requested ??
+    listed.find((option) => option.default)?.id ??
+    listed[0]?.id
+  );
+}
+
+/**
+ * Start a workspace's first agent and, when there is one, post its first
+ * message, drawing the page-level handoff while that happens.
+ *
+ * The new-workspace dialog and Uneff me both end here. The handoff is keyed
+ * by the workspace, so `reveal` runs first: the page the reader lands on is
+ * the one carrying the steps. A failed session leaves the text with the
+ * workspace composer, and a failed first turn does the same, so typed words
+ * and pasted images are never dropped. The handoff clears on every exit.
+ */
+export async function startFirstSession(input: {
+  client: ApiClient;
+  workspace: CodeWorkspaceSnapshot;
+  settings: FirstSessionSettings;
+  prompt: string;
+  images?: readonly File[];
+  models: readonly ModelInfo[];
+  defaultModelKey?: string | null;
+  /** Heading and preparation steps the handoff keeps showing. */
+  startup?: Pick<WorkspaceStartup, "heading" | "preparation">;
+  /** Open the workspace before its session starts. */
+  reveal?: () => Promise<void>;
+  onSessionCreated?: (
+    session: CodeSessionSnapshot,
+    postedModel: string | undefined,
+  ) => void;
+}): Promise<CodeSessionSnapshot | null> {
+  const { client, workspace, settings } = input;
+  const prompt = input.prompt.trim();
+  const images = input.images ?? [];
+  const base: Omit<WorkspaceStartup, "phase" | "hasFirstMessage"> = {
+    ...input.startup,
+    harness: settings.harness,
+  };
+  const setWorkspaceStartup = useCodeUiStore.getState().setWorkspaceStartup;
+  const holdPrompt = () => {
+    if (prompt) {
+      useCodeUiStore
+        .getState()
+        .offerComposerPrompt(workspace.id, prompt, images);
+    }
+  };
+  setWorkspaceStartup(workspace.id, {
+    ...base,
+    hasFirstMessage: Boolean(prompt),
+    phase: "starting_session",
+  });
+  try {
+    await input.reveal?.();
+    const posted = await resolveSessionModel({
+      client,
+      harness: settings.harness,
+      requested: settings.model,
+      models: input.models,
+      defaultModelKey: input.defaultModelKey,
+    });
+    const session = await client.createCodeSession(workspace.id, {
+      harness: settings.harness,
+      permission_mode: settings.permissionMode,
+      model: posted,
+      ...(settings.reasoningEffort
+        ? { reasoning_effort: settings.reasoningEffort }
+        : {}),
+      ...(settings.fastMode ? { fast_mode: true } : {}),
+    });
+    useCodeCatalogStore.getState().rememberSession(session);
+    if (prompt) {
+      setWorkspaceStartup(workspace.id, {
+        ...base,
+        hasFirstMessage: true,
+        phase: "sending_message",
+      });
+    }
+    input.onSessionCreated?.(session, posted);
+    if (prompt) {
+      try {
+        const attachments = await publishFirstTurnImages(
+          client,
+          session.id,
+          images,
+        );
+        if (attachments.length > 0) {
+          await client.submitCodeTurn(
+            session.id,
+            prompt,
+            undefined,
+            attachments,
+          );
+        } else {
+          await client.submitCodeTurn(session.id, prompt);
+        }
+      } catch (error) {
+        // Never drop typed words or pasted images: the workspace composer
+        // holds them.
+        holdPrompt();
+        toast.error(
+          `Session started, but the first message could not be sent. ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
+        );
+      }
+    }
+    return session;
+  } catch (error) {
+    // No session to send to; the workspace composer holds the text, images,
+    // and start-session on the workspace page picks them up.
+    holdPrompt();
+    toast.error(
+      `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
+    );
+    return null;
+  } finally {
+    setWorkspaceStartup(workspace.id, null);
+  }
+}
+
+async function publishFirstTurnImages(
+  client: ApiClient,
+  sessionId: string,
+  files: readonly File[],
+): Promise<readonly { blob_id: string; media_type: string }[]> {
+  const published = await Promise.all(
+    files.map(async (file) => {
+      if (hasLocalHostAuthority()) {
+        return publishCodeImage(sessionId, file);
+      }
+      return uploadImageAttachment(client, sessionId, file, {
+        onProgress: () => undefined,
+        signal: new AbortController().signal,
+        path: (id) =>
+          `/code/sessions/${encodeURIComponent(id)}/attachments/images`,
+      });
+    }),
+  );
+  return published.map((image) => ({
+    blob_id: image.attachmentId,
+    media_type: image.mediaType,
+  }));
+}

--- a/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
@@ -85,11 +85,13 @@ export async function startFirstSession(input: {
   /** Heading, preparation steps, and target the handoff keeps showing. */
   startup?: Pick<WorkspaceStartup, "heading" | "preparation" | "target">;
   /**
-   * Keep the prompt in the workspace composer when the start fails. True for
-   * words the reader typed. False for a generated prompt landing in a
-   * workspace whose composer already belongs to another conversation.
+   * Keep the prompt in the workspace composer when no session could start.
+   * True for words the reader typed. False for a generated prompt that would
+   * land in a composer still belonging to another conversation. Once a
+   * session exists its composer is the empty one the reader now sees, so a
+   * failed first turn always holds the prompt there.
    */
-  holdPromptOnFailure?: boolean;
+  holdPromptWithoutSession?: boolean;
   /** Open the workspace before its session starts. */
   reveal?: () => Promise<void>;
   onSessionCreated?: (
@@ -105,12 +107,14 @@ export async function startFirstSession(input: {
     harness: settings.harness,
   };
   const setWorkspaceStartup = useCodeUiStore.getState().setWorkspaceStartup;
-  const hold = input.holdPromptOnFailure ?? true;
-  const holdPrompt = () => {
-    if (prompt && hold) {
+  const holdWithoutSession = input.holdPromptWithoutSession ?? true;
+  // Addressed to the session when there is one: the workspace's panes share
+  // a prompt scope, and the pane on screen may still be the old agent's.
+  const holdPrompt = (sessionId?: string) => {
+    if (prompt) {
       useCodeUiStore
         .getState()
-        .offerComposerPrompt(workspace.id, prompt, images);
+        .offerComposerPrompt(workspace.id, prompt, images, sessionId);
     }
   };
   // The copy has to match what the reader just watched happen.
@@ -120,9 +124,6 @@ export async function startFirstSession(input: {
     : "The session could not start.";
   const turnFailed =
     "Session started, but the first message could not be sent.";
-  const retry = hold
-    ? "Send it from the workspace composer."
-    : "Try again from the workspace menu.";
   setWorkspaceStartup(workspace.id, {
     ...base,
     hasFirstMessage: Boolean(prompt),
@@ -175,17 +176,19 @@ export async function startFirstSession(input: {
       } catch (error) {
         // Never drop typed words or pasted images: the workspace composer
         // holds them.
-        holdPrompt();
-        toast.error(`${turnFailed} ${friendlyErrorMessage(error, retry)}`);
+        holdPrompt(session.id);
+        toast.error(
+          `${turnFailed} ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
+        );
       }
     }
     return session;
   } catch (error) {
     // No session to send to; the workspace composer holds the text, images,
     // and start-session on the workspace page picks them up.
-    holdPrompt();
+    if (holdWithoutSession) holdPrompt();
     toast.error(
-      `${sessionFailed} ${friendlyErrorMessage(error, hold ? "Try again from the workspace." : retry)}`,
+      `${sessionFailed} ${friendlyErrorMessage(error, holdWithoutSession ? "Try again from the workspace." : "Try again from the workspace menu.")}`,
     );
     return null;
   } finally {

--- a/crates/tidebreak-desktop/ui/src/code/uneffMe.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/uneffMe.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { CodeRepoSnapshot, CodeWorkspaceSnapshot } from "../api/types";
+import type {
+  CodeRepoSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessDoctorEntry,
+} from "../api/types";
+import { splitPastedText } from "../PastedText";
 import {
   DEBUG_JSON_PROMPT_BUDGET,
   debugJsonForPrompt,
   isTidebreakProductRepo,
-  startUneffMeWorkspace,
+  prepareUneffMe,
   tidebreakProductRepo,
   uneffMePrompt,
   uneffMeWorkspaceTitle,
+  uneffPreparationSteps,
+  uneffSessionSettings,
+  type UneffProgress,
 } from "./uneffMe";
 
 const APP: CodeRepoSnapshot = {
@@ -26,6 +34,58 @@ const TIDEBREAK: CodeRepoSnapshot = {
   id: "repo-tb",
   root_path: "/Users/sam/src/tidebreak",
   display_name: "tidebreak",
+};
+
+const CREATED: CodeWorkspaceSnapshot = {
+  id: "ws-fix",
+  repo_id: TIDEBREAK.id,
+  title: "Uneff: Fix login",
+  worktree_path: "/tmp/tidebreak/.worktrees/uneff",
+  branch_name: "tidebreak/uneff-fix-login",
+  base_ref: "main",
+  status: "active",
+  created_at: "2026-08-26T00:00:00.000Z",
+};
+
+const CLAUDE: HarnessDoctorEntry = {
+  kind: "claude_code",
+  found: true,
+  installable: true,
+  authenticated: true,
+  tier: "reference",
+  caps: {
+    resume: "supported",
+    streaming_deltas: "supported",
+    mid_turn_steering: "unsupported",
+    plan_mode: "supported",
+    structured_approvals: "supported",
+    auto_mode: "supported",
+    allow_mode: "supported",
+    reasoning_levels: "unknown",
+    native_file_change_events: "unsupported",
+    native_interrupt: "supported",
+    image_input: "unknown",
+    slash_commands: "unknown",
+    durable_parks: "unsupported",
+    user_questions: "unsupported",
+    standing_grants: "unsupported",
+  },
+  commands: [],
+  auth_mode: "local_sign_in",
+  remediation: "",
+  stderr: "",
+  unrecognized_event_count: 0,
+  relaunch_composes_permission_mode: true,
+};
+
+const CODEX: HarnessDoctorEntry = { ...CLAUDE, kind: "codex" };
+
+const PROMPT_INPUT = {
+  sourceTitle: "Fix login",
+  sourceBranch: "tidebreak/fix-login",
+  sourceRepo: "app",
+  sessionId: "sess-1",
+  debug: { session: { id: "sess-1" }, turns: [], events: [] },
 };
 
 describe("tidebreak product repo", () => {
@@ -59,20 +119,51 @@ describe("tidebreak product repo", () => {
 });
 
 describe("uneff me prompt", () => {
-  it("names the source session and includes the debug JSON", () => {
+  it("asks what the user wants before acting, and offers issue or PR", () => {
     const prompt = uneffMePrompt({
-      sourceTitle: "Fix login",
-      sourceBranch: "tidebreak/fix-login",
-      sourceRepo: "app",
-      sessionId: "sess-1",
-      debug: { session: { id: "sess-1" }, turns: [], events: [] },
+      ...PROMPT_INPUT,
+      inTidebreakCheckout: true,
     });
     expect(prompt).toContain("Fix login");
     expect(prompt).toContain("tidebreak/fix-login");
-    expect(prompt).toContain("sess-1");
-    expect(prompt).toContain("Open a pull request against main");
-    expect(prompt).toContain('"id": "sess-1"');
+    expect(prompt).toContain("Start by asking the user what went wrong");
+    expect(prompt).toContain("gh issue create --repo brightwave-inc/tidebreak");
+    expect(prompt).toContain("open the pull request against main");
+    expect(prompt).toContain("gh repo fork --remote");
+    expect(prompt).toContain("Never paste the whole report");
     expect(prompt).not.toContain("omitted");
+    // The ask comes before the how-to and the report.
+    expect(prompt.indexOf("Start by asking")).toBeLessThan(
+      prompt.indexOf("gh issue create"),
+    );
+    expect(prompt.indexOf("gh issue create")).toBeLessThan(
+      prompt.indexOf("The debug report follows"),
+    );
+  });
+
+  it("folds the debug report the way a long paste is folded", () => {
+    const prompt = uneffMePrompt({
+      ...PROMPT_INPUT,
+      inTidebreakCheckout: true,
+    });
+    const { prose, pasted } = splitPastedText(prompt);
+    expect(pasted).toHaveLength(1);
+    expect(pasted[0]).toContain('"id": "sess-1"');
+    expect(prose).not.toContain('"id": "sess-1"');
+    expect(prose).toContain("Session: sess-1");
+  });
+
+  it("never clones for the user when there is no checkout", () => {
+    const prompt = uneffMePrompt({
+      ...PROMPT_INPUT,
+      inTidebreakCheckout: false,
+    });
+    expect(prompt).toContain("not a Tidebreak checkout");
+    expect(prompt).toContain("gh issue create --repo brightwave-inc/tidebreak");
+    expect(prompt).toContain("clone it only after they say yes");
+    expect(prompt).toContain("Do not clone anything without asking");
+    expect(prompt).toContain("adding the Tidebreak repository to Code");
+    expect(prompt).not.toContain("fresh workspace");
   });
 
   it("drops journal events when the dump is too large", () => {
@@ -91,11 +182,9 @@ describe("uneff me prompt", () => {
     expect(packed.text.length).toBeLessThanOrEqual(DEBUG_JSON_PROMPT_BUDGET);
 
     const prompt = uneffMePrompt({
-      sourceTitle: "Fix login",
-      sourceBranch: "tidebreak/fix-login",
-      sourceRepo: "app",
-      sessionId: "sess-1",
+      ...PROMPT_INPUT,
       debug: { session: { id: "sess-1" }, turns: [{ id: "turn-1" }], events },
+      inTidebreakCheckout: true,
     });
     expect(prompt).toContain("Journal events were omitted");
   });
@@ -107,22 +196,87 @@ describe("uneff me prompt", () => {
   });
 });
 
-describe("startUneffMeWorkspace", () => {
-  it("creates a Tidebreak workspace and returns the prompt", async () => {
-    const created: CodeWorkspaceSnapshot = {
-      id: "ws-fix",
-      repo_id: TIDEBREAK.id,
-      title: "Uneff: Fix login",
-      worktree_path: "/tmp/tidebreak/.worktrees/uneff",
-      branch_name: "tidebreak/uneff-fix-login",
-      base_ref: "main",
-      status: "active",
-      created_at: "2026-08-26T00:00:00.000Z",
-    };
-    const getDebug = vi.fn(async () => ({ session: { id: "sess-1" } }));
-    const createWorkspace = vi.fn(async () => created);
+describe("uneff me session settings", () => {
+  it("follows the source session's engine, then the last create, then any", () => {
+    const doctor = { harnesses: [CLAUDE, CODEX] };
+    expect(
+      uneffSessionSettings({
+        doctor,
+        sourceHarness: "codex",
+        lastCreate: { harness: "claude_code", modelsByHarness: {} },
+        ceiling: null,
+      })?.harness,
+    ).toBe("codex");
+    expect(
+      uneffSessionSettings({
+        doctor,
+        sourceHarness: "grok",
+        lastCreate: {
+          harness: "codex",
+          modelsByHarness: { codex: "gpt-5" },
+          permissionMode: "auto",
+        },
+        ceiling: null,
+      }),
+    ).toEqual({
+      harness: "codex",
+      permissionMode: "auto",
+      model: "gpt-5",
+      reasoningEffort: undefined,
+      fastMode: undefined,
+    });
+    expect(
+      uneffSessionSettings({
+        doctor,
+        lastCreate: null,
+        ceiling: null,
+      }),
+    ).toMatchObject({ harness: "claude_code", permissionMode: "allow" });
+  });
 
-    const result = await startUneffMeWorkspace({
+  it("returns null when no engine can start, and honors a plan ceiling", () => {
+    expect(
+      uneffSessionSettings({
+        doctor: { harnesses: [{ ...CLAUDE, found: false }] },
+        lastCreate: null,
+        ceiling: null,
+      }),
+    ).toBeNull();
+    expect(
+      uneffSessionSettings({ doctor: null, lastCreate: null, ceiling: null }),
+    ).toBeNull();
+    expect(
+      uneffSessionSettings({
+        doctor: { harnesses: [CLAUDE] },
+        lastCreate: null,
+        ceiling: "plan",
+      })?.permissionMode,
+    ).toBe("plan");
+  });
+});
+
+describe("uneff me preparation steps", () => {
+  it("collects the report, then hands over to the workspace step", () => {
+    const labels = (progress: UneffProgress) =>
+      uneffPreparationSteps(progress).map(
+        (step) => `${step.label}:${step.state}`,
+      );
+    expect(labels({ step: "debug" })).toEqual([
+      "Collecting the debug report:active",
+    ]);
+    expect(labels({ step: "create" })).toEqual([
+      "Collecting the debug report:complete",
+    ]);
+  });
+});
+
+describe("prepareUneffMe", () => {
+  it("creates a workspace on the connected Tidebreak checkout", async () => {
+    const getDebug = vi.fn(async () => ({ session: { id: "sess-1" } }));
+    const createWorkspace = vi.fn(async () => CREATED);
+    const progress: UneffProgress[] = [];
+
+    const result = await prepareUneffMe({
       repos: [APP, TIDEBREAK],
       sessionId: "sess-1",
       sourceTitle: "Fix login",
@@ -130,6 +284,7 @@ describe("startUneffMeWorkspace", () => {
       sourceRepo: "app",
       getDebug,
       createWorkspace,
+      onProgress: (step: UneffProgress) => progress.push(step),
     });
 
     expect(getDebug).toHaveBeenCalledWith("sess-1");
@@ -137,21 +292,29 @@ describe("startUneffMeWorkspace", () => {
       repo_id: TIDEBREAK.id,
       title: "Uneff: Fix login",
     });
-    expect(result.workspace).toEqual(created);
-    expect(result.prompt).toContain("sess-1");
+    expect(result.workspace).toEqual(CREATED);
+    expect(result.prompt).toContain("fresh workspace on the Tidebreak source");
+    expect(progress).toEqual([{ step: "debug" }, { step: "create" }]);
   });
 
-  it("refuses to start when Tidebreak is not connected", async () => {
-    await expect(
-      startUneffMeWorkspace({
-        repos: [APP],
-        sessionId: "sess-1",
-        sourceTitle: "Fix login",
-        sourceBranch: "tidebreak/fix-login",
-        sourceRepo: "app",
-        getDebug: vi.fn(),
-        createWorkspace: vi.fn(),
-      }),
-    ).rejects.toThrow("Add the Tidebreak repository to Code first.");
+  it("runs in place, and creates nothing, when no checkout is connected", async () => {
+    const createWorkspace = vi.fn();
+    const progress: UneffProgress[] = [];
+
+    const result = await prepareUneffMe({
+      repos: [APP],
+      sessionId: "sess-1",
+      sourceTitle: "Fix login",
+      sourceBranch: "tidebreak/fix-login",
+      sourceRepo: "app",
+      getDebug: vi.fn(async () => ({})),
+      createWorkspace,
+      onProgress: (step: UneffProgress) => progress.push(step),
+    });
+
+    expect(createWorkspace).not.toHaveBeenCalled();
+    expect(result.workspace).toBeNull();
+    expect(result.prompt).toContain("not a Tidebreak checkout");
+    expect(progress).toEqual([{ step: "debug" }]);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/uneffMe.ts
+++ b/crates/tidebreak-desktop/ui/src/code/uneffMe.ts
@@ -1,9 +1,30 @@
-import type { CodeRepoSnapshot, CodeWorkspaceSnapshot } from "../api/types";
+import type {
+  CodeRepoSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessDoctorReport,
+  HarnessKind,
+  PermissionMode,
+} from "../api/types";
+import { messageWithPastedText } from "../PastedText";
+import { clampPermissionMode } from "../PermissionModeMenu";
+import type { CodeCreateDefaults, WorkspaceStartupStep } from "./CodeUiStore";
+import {
+  createPermissionModes,
+  defaultCreatePermissionMode,
+  harnessCanStartNow,
+} from "./labels";
+import type { FirstSessionSettings } from "./startWorkspaceSession";
 
 /** Pretty JSON that still fits a first turn. Events are the usual overflow. */
 export const DEBUG_JSON_PROMPT_BUDGET = 100_000;
 
-const PRODUCT_REPO_NAMES = new Set(["tidebreak", "brightwave-inc/tidebreak"]);
+/** Where issues and pull requests go. */
+export const TIDEBREAK_GITHUB_REPO = "brightwave-inc/tidebreak";
+
+/** The heading the startup handoff shows while Uneff me gets going. */
+export const UNEFF_STARTUP_HEADING = "Getting Tidebreak ready to help";
+
+const PRODUCT_REPO_NAMES = new Set(["tidebreak", TIDEBREAK_GITHUB_REPO]);
 
 export function repoPathBasename(path: string): string {
   const trimmed = path.replace(/[\\/]+$/, "");
@@ -15,8 +36,9 @@ export function repoPathBasename(path: string): string {
  * The Tidebreak source checkout among connected repos.
  *
  * Match the folder or display name, not a worktree path: those live under
- * `workspaces/tidebreak/…` and are not the product repository. Record 78:
- * Uneff me stays this heuristic; it does not probe remotes or settings.
+ * `workspaces/tidebreak/…` and are not the product repository. Record 81:
+ * a connected checkout gets a fix workspace; without one, Uneff me runs in
+ * the session's own workspace and never clones on the reader's behalf.
  */
 export function isTidebreakProductRepo(repo: {
   display_name: string;
@@ -80,36 +102,122 @@ export function debugJsonForPrompt(debug: unknown): {
   return { text: truncateDebug(compact), omitted: "truncated" };
 }
 
+/**
+ * The first turn of an Uneff me session.
+ *
+ * The agent asks before it acts: what went wrong, and whether the user wants
+ * an issue or a pull request. Both land on the public Tidebreak repository,
+ * so the prompt also says what must not be pasted there. The debug report
+ * rides along the way a long clipboard paste does, so the transcript folds it
+ * instead of printing a hundred kilobytes of JSON.
+ */
 export function uneffMePrompt(input: {
   sourceTitle: string;
   sourceBranch: string;
   sourceRepo: string;
   sessionId: string;
   debug: unknown;
+  /** The session runs on a Tidebreak checkout, so a fix can start at once. */
+  inTidebreakCheckout: boolean;
 }): string {
   const json = debugJsonForPrompt(input.debug);
   const omission =
     json.omitted === "events"
-      ? "Journal events were omitted because the debug dump was too large. Session and turns are included."
+      ? "Journal events were omitted because the debug report was too large. Session and turns are included."
       : json.omitted === "truncated"
-        ? "The debug dump was truncated because it was too large."
+        ? "The debug report was truncated because it was too large."
         : null;
-  return [
-    "The user hit a problem in Tidebreak Code. You are in a fresh workspace of the Tidebreak source repository.",
-    "Diagnose the product bug from the debug JSON. Fix it. Open a pull request against main when the fix is ready.",
+  const where = input.inTidebreakCheckout
+    ? `You are in a fresh workspace on the Tidebreak source repository (${TIDEBREAK_GITHUB_REPO}). The repository is public.`
+    : `You are in the user's own workspace, not a Tidebreak checkout. Tidebreak's source is the public repository ${TIDEBREAK_GITHUB_REPO}.`;
+  const pullRequest = input.inTidebreakCheckout
+    ? "To open a pull request, diagnose the bug from the debug report, fix it, add a test only if a failure would change what we do, and open the pull request against main. If you cannot push to origin, fork with `gh repo fork --remote` and open the pull request from the fork."
+    : `To open a pull request, first ask the user where you may clone Tidebreak, and clone it only after they say yes: \`gh repo fork ${TIDEBREAK_GITHUB_REPO} --clone\` into that folder, or \`gh repo clone ${TIDEBREAK_GITHUB_REPO}\` if they have push access. Do not clone anything without asking. Then diagnose the bug from the debug report, fix it, add a test only if a failure would change what we do, and open the pull request against main. Mention that adding the Tidebreak repository to Code makes the next Uneff me start in a Tidebreak workspace directly.`;
+  const draft = [
+    `The user hit a problem in Tidebreak Code and asked for help. ${where}`,
+    "Start by asking the user what went wrong and what they want: a GitHub issue that describes the problem, or a pull request that fixes it. Keep the questions short and do not investigate or change anything until they answer. The debug report below already carries the session, its turns, and the journal events, so ask only for what it cannot tell you.",
+    `To file an issue, run \`gh issue create --repo ${TIDEBREAK_GITHUB_REPO}\` with a clear title, the steps, what happened, what was expected, and the parts of the debug report that show it. Never paste the whole report. Strip file paths, tokens, prompts, and anything else the user would not want public, and show the user the issue text before you file it.`,
+    pullRequest,
+    "If `gh` is missing or not signed in, tell the user how to fix that (`gh auth login`) before you file anything.",
     `Source workspace: ${input.sourceTitle}`,
     `Source branch: ${input.sourceBranch}`,
     `Source repository: ${input.sourceRepo}`,
     `Session: ${input.sessionId}`,
     omission,
-    "The debug JSON follows.",
-    json.text,
+    "The debug report follows as pasted text.",
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n\n");
+  return messageWithPastedText(draft, [
+    { id: "uneff-debug-report", text: json.text },
+  ]);
 }
 
-export async function startUneffMeWorkspace(input: {
+/** What Uneff me is doing before the session starts. */
+export type UneffProgress = { step: "debug" } | { step: "create" };
+
+/** The handoff's preparation steps for one point in the Uneff me flow. */
+export function uneffPreparationSteps(
+  progress: UneffProgress,
+): WorkspaceStartupStep[] {
+  const debug = "Collecting the debug report";
+  return [
+    { label: debug, state: progress.step === "debug" ? "active" : "complete" },
+  ];
+}
+
+/**
+ * The engine and posture an Uneff me session starts with.
+ *
+ * There is no dialog to pick in, so the choice follows what the reader was
+ * just using: the source session's engine when it can start, else the last
+ * create's, else any engine that can. Null means nothing can start, or the
+ * managed policy forbids every posture the engine honors.
+ */
+export function uneffSessionSettings(input: {
+  doctor: HarnessDoctorReport | null;
+  sourceHarness?: HarnessKind;
+  lastCreate: CodeCreateDefaults | null;
+  ceiling: PermissionMode | null | undefined;
+}): FirstSessionSettings | null {
+  const ready = (input.doctor?.harnesses ?? []).filter(harnessCanStartNow);
+  const entry =
+    ready.find((candidate) => candidate.kind === input.sourceHarness) ??
+    ready.find((candidate) => candidate.kind === input.lastCreate?.harness) ??
+    ready[0];
+  if (!entry) return null;
+  const available = createPermissionModes(entry.caps);
+  const remembered = input.lastCreate?.permissionMode;
+  const requested =
+    remembered && available.includes(remembered)
+      ? remembered
+      : defaultCreatePermissionMode(entry.caps);
+  const permissionMode = clampPermissionMode(
+    requested,
+    input.ceiling,
+    available,
+  );
+  if (!permissionMode) return null;
+  const harness = entry.kind;
+  return {
+    harness,
+    permissionMode,
+    model: input.lastCreate?.modelsByHarness[harness],
+    reasoningEffort: input.lastCreate?.reasoningEffortByHarness?.[harness],
+    fastMode: input.lastCreate?.fastModeByHarness?.[harness],
+  };
+}
+
+/**
+ * Collect the debug report and, when a Tidebreak checkout is connected,
+ * create the workspace the fix session runs in.
+ *
+ * With no checkout the session runs where the reader already is: `workspace`
+ * comes back null and the prompt says so. Nothing is cloned for them — an
+ * issue needs no source tree, and a pull request is the agent's to ask about.
+ * `onProgress` fires before each step so the caller can draw it.
+ */
+export async function prepareUneffMe(input: {
   repos: readonly CodeRepoSnapshot[];
   sessionId: string;
   sourceTitle: string;
@@ -120,11 +228,10 @@ export async function startUneffMeWorkspace(input: {
     repo_id: string;
     title?: string;
   }) => Promise<CodeWorkspaceSnapshot>;
-}): Promise<{ workspace: CodeWorkspaceSnapshot; prompt: string }> {
+  onProgress?: (progress: UneffProgress) => void;
+}): Promise<{ workspace: CodeWorkspaceSnapshot | null; prompt: string }> {
   const repo = tidebreakProductRepo(input.repos);
-  if (!repo) {
-    throw new Error("Add the Tidebreak repository to Code first.");
-  }
+  input.onProgress?.({ step: "debug" });
   const debug = await input.getDebug(input.sessionId);
   const prompt = uneffMePrompt({
     sourceTitle: input.sourceTitle,
@@ -132,7 +239,10 @@ export async function startUneffMeWorkspace(input: {
     sourceRepo: input.sourceRepo,
     sessionId: input.sessionId,
     debug,
+    inTidebreakCheckout: Boolean(repo),
   });
+  if (!repo) return { workspace: null, prompt };
+  input.onProgress?.({ step: "create" });
   const workspace = await input.createWorkspace({
     repo_id: repo.id,
     title: uneffMeWorkspaceTitle(input.sourceTitle),

--- a/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
@@ -76,6 +76,7 @@ export function CodeSessionPane({
   disabled,
   onOpenTurnDiff,
   onForkFromTurn,
+  onFileIssue,
   subagentCallId,
   subagentSummary,
   onBackFromSubagent,
@@ -91,6 +92,8 @@ export function CodeSessionPane({
   onOpenTurnDiff?: (turnId: string) => void;
   /** Fork this conversation at the end of one turn, from its seam row. */
   onForkFromTurn?: (turnId: string) => void;
+  /** Turn a failed turn or engine error into a Tidebreak issue or fix. */
+  onFileIssue?: () => void;
   /** The spanning Task call to inspect inside this still-mounted session. */
   subagentCallId?: string;
   /** Current bounded rail summary, when the Task is still in the digest. */
@@ -565,6 +568,7 @@ export function CodeSessionPane({
           approvalError={approvalError}
           onOpenTurnDiff={onOpenTurnDiff}
           onForkFromTurn={subagentCallId ? undefined : onForkFromTurn}
+          onFileIssue={subagentCallId ? undefined : onFileIssue}
           onReveal={follow.pauseFollow}
           scrollRef={follow.scrollRef}
           contentRef={follow.contentRef}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.test.ts
@@ -86,12 +86,11 @@ describe("workspace worktree actions", () => {
     ).toEqual({ id: "copy-worktree", label: "Copy worktree path" });
   });
 
-  it("offers Uneff me next to Copy debug JSON when Tidebreak is connected", () => {
+  it("offers Uneff me next to Copy debug JSON on every session", () => {
     const commands = workspaceCommands({
       hasPr: false,
       archived: false,
       hasSession: true,
-      canUneff: true,
     });
     const copy = commands.findIndex(
       (command) => command.id === "copy-debug-json",
@@ -101,11 +100,12 @@ describe("workspace worktree actions", () => {
     expect(commands[uneff]?.label).toBe("Uneff me");
     expect(uneff).toBe(copy + 1);
 
+    // Without a session there is no debug report to hand over.
     expect(
       workspaceCommands({
         hasPr: false,
         archived: false,
-        hasSession: true,
+        hasSession: false,
       }).some((command) => command.id === "uneff-me"),
     ).toBe(false);
 
@@ -114,7 +114,6 @@ describe("workspace worktree actions", () => {
       hasSession: true,
       attentionPinned: false,
       quickActions: [],
-      canUneff: true,
     });
     const headerCopy = header.findIndex(
       (command) => command.id === "copy-debug-json",

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -41,11 +41,21 @@ import {
   openInEditor,
 } from "./codeWorktreeHost";
 import { openInEditorLabel } from "./editorPreference";
-import { useCodeCatalogStore } from "./CodeCatalogStore";
-import { useCodeUiStore } from "./CodeUiStore";
+import { useManagedPolicy } from "../managedPolicy";
+import {
+  OPTIMISTIC_WORKSPACE_ID_PREFIX,
+  useCodeCatalogStore,
+} from "./CodeCatalogStore";
+import { useCodeUiStore, type WorkspaceStartupStep } from "./CodeUiStore";
 import { nextWorkspaceAfterLeaving, railWorkspaceIds } from "./railNavigation";
 import { codeWorkspaceIdFromPath } from "./routes";
-import { startUneffMeWorkspace } from "./uneffMe";
+import { startFirstSession } from "./startWorkspaceSession";
+import {
+  UNEFF_STARTUP_HEADING,
+  prepareUneffMe,
+  uneffPreparationSteps,
+  uneffSessionSettings,
+} from "./uneffMe";
 
 /**
  * Workspace commands shared by the card context menu and the workspace
@@ -107,8 +117,6 @@ export function workspaceCommands(input: {
   canOpenWorktree?: boolean;
   /** This window can start an editor on the machine holding the worktree. */
   canOpenInEditor?: boolean;
-  /** Tidebreak's own checkout is connected, so a debug dump can become a fix. */
-  canUneff?: boolean;
   /** The setup script failed, so the workspace has a worktree but no session. */
   setupFailed?: boolean;
 }): WorkspaceCommand[] {
@@ -149,9 +157,7 @@ export function workspaceCommands(input: {
         : { id: "pin-attention", label: "Pin attention" },
     );
     items.push({ id: "copy-debug-json", label: "Copy debug JSON" });
-    if (input.canUneff) {
-      items.push({ id: "uneff-me", label: "Uneff me" });
-    }
+    items.push({ id: "uneff-me", label: "Uneff me" });
   }
   items.push({
     id: "archive",
@@ -196,7 +202,6 @@ export function workspaceHeaderCommands(input: {
   canOpenInEditor?: boolean;
   /** The shown agent has a transcript worth handing to a sibling. */
   canFork?: boolean;
-  canUneff?: boolean;
   /** The setup script failed, so the workspace has a worktree but no session. */
   setupFailed?: boolean;
 }): WorkspaceCommand[] {
@@ -226,9 +231,7 @@ export function workspaceHeaderCommands(input: {
       items.push({ id: "fork-agent", label: "Fork this agent" });
     }
     items.push({ id: "copy-debug-json", label: "Copy debug JSON" });
-    if (input.canUneff) {
-      items.push({ id: "uneff-me", label: "Uneff me" });
-    }
+    items.push({ id: "uneff-me", label: "Uneff me" });
   }
   if (!input.archived) {
     for (const action of input.quickActions) {
@@ -413,13 +416,18 @@ export function useWorkspaceCardCommands(): {
   ) => void;
   dialogs: ReactElement;
 } {
-  const { client } = useApp();
+  const { client, models, defaultModelKey } = useApp();
   const navigate = useNavigate();
   const { confirm, dialog } = useConfirm();
+  const permissionCeiling = useManagedPolicy().permission_mode_ceiling;
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
   const upsertWorkspace = useCodeCatalogStore((state) => state.upsertWorkspace);
+  const replaceWorkspace = useCodeCatalogStore(
+    (state) => state.replaceWorkspace,
+  );
+  const removeWorkspace = useCodeCatalogStore((state) => state.removeWorkspace);
   const rememberSession = useCodeCatalogStore((state) => state.rememberSession);
   const forgetWorkspaceSession = useCodeCatalogStore(
     (state) => state.forgetWorkspaceSession,
@@ -608,41 +616,146 @@ export function useWorkspaceCardCommands(): {
     }
   }
 
+  /**
+   * Turn this session's debug report into a Tidebreak session that files an
+   * issue or opens a fix.
+   *
+   * The source workspace carries the startup handoff while the report is
+   * collected. With a Tidebreak checkout connected, a fix workspace is
+   * created on it and takes the handoff over as soon as it exists, the same
+   * way a workspace created from the dialog does. Without one, the session
+   * starts as a new agent right here, and nothing is cloned for the reader.
+   * Either way the first turn is posted for them: the agent's opening move is
+   * to ask what happened.
+   */
   async function runUneffMe(context: WorkspaceCommandContext) {
     const sessionId = contextSessionId(context);
     if (!sessionId) return;
-    if (useCodeUiStore.getState().composerActionScope !== null) {
-      toast.error("Another agent action is already running");
+    const sourceId = context.workspace.id;
+    if (useCodeUiStore.getState().workspaceStartups[sourceId]) {
+      toast.error("Uneff me is already running");
+      return;
+    }
+    const catalog = useCodeCatalogStore.getState();
+    let doctor = catalog.doctor;
+    if (!doctor) {
+      try {
+        doctor = await client.getHarnessDoctor();
+      } catch {
+        doctor = null;
+      }
+    }
+    const settings = uneffSessionSettings({
+      doctor,
+      sourceHarness: context.session?.harness_kind,
+      lastCreate: useCodeUiStore.getState().lastCreate,
+      ceiling: permissionCeiling,
+    });
+    if (!settings) {
+      toast.error(
+        "No coding engine can start right now. Install or sign in to one, then try again.",
+      );
       return;
     }
     const sourceRepo =
-      useCodeCatalogStore
-        .getState()
-        .repos.find((repo) => repo.id === context.workspace.repo_id)
+      catalog.repos.find((repo) => repo.id === context.workspace.repo_id)
         ?.display_name ?? context.workspace.repo_id;
+    const setWorkspaceStartup = useCodeUiStore.getState().setWorkspaceStartup;
+    const startup = {
+      harness: settings.harness,
+      heading: UNEFF_STARTUP_HEADING,
+    };
+    const showPreparation = (preparation: WorkspaceStartupStep[]) =>
+      setWorkspaceStartup(sourceId, {
+        ...startup,
+        hasFirstMessage: true,
+        phase: "preparing",
+        preparation,
+      });
+    showPreparation(uneffPreparationSteps({ step: "debug" }));
+    // The handoff draws on the source workspace, so the reader has to be on it.
+    if (pathname !== `/code/w/${sourceId}`) {
+      void navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId: sourceId },
+      });
+    }
+    let pendingId: string | null = null;
+    let prepared: Awaited<ReturnType<typeof prepareUneffMe>>;
     try {
-      const { workspace, prompt } = await startUneffMeWorkspace({
-        repos: useCodeCatalogStore.getState().repos,
+      prepared = await prepareUneffMe({
+        repos: catalog.repos,
         sessionId,
         sourceTitle: context.title,
         sourceBranch: context.workspace.branch_name,
         sourceRepo,
         getDebug: (id) => client.getCodeSessionDebug(id),
-        createWorkspace: (body) => client.createCodeWorkspace(body),
-      });
-      upsertWorkspace(workspace);
-      if (!useCodeUiStore.getState().runComposerPrompt(workspace.id, prompt)) {
-        useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
-      }
-      await navigate({
-        to: "/code/w/$workspaceId",
-        params: { workspaceId: workspace.id },
+        createWorkspace: async (body) => {
+          // The rail shows the same optimistic card a dialog create shows.
+          pendingId = `${OPTIMISTIC_WORKSPACE_ID_PREFIX}${crypto.randomUUID()}`;
+          upsertWorkspace({
+            id: pendingId,
+            repo_id: body.repo_id,
+            title: body.title ?? "Uneff",
+            worktree_path: "",
+            branch_name: "",
+            base_ref: "",
+            status: "creating",
+            created_at: new Date().toISOString(),
+          });
+          return client.createCodeWorkspace(body);
+        },
+        onProgress: (progress) =>
+          showPreparation(uneffPreparationSteps(progress)),
       });
     } catch (error) {
-      toast.error(
-        friendlyErrorMessage(error, "Could not start a Tidebreak fix"),
-      );
+      if (pendingId) removeWorkspace(pendingId);
+      setWorkspaceStartup(sourceId, null);
+      toast.error(friendlyErrorMessage(error, "Could not start Uneff me"));
+      return;
     }
+    const { workspace, prompt } = prepared;
+    const preparation = uneffPreparationSteps({ step: "create" });
+    setWorkspaceStartup(sourceId, null);
+    if (workspace) {
+      if (pendingId) replaceWorkspace(pendingId, workspace);
+      else upsertWorkspace(workspace);
+      await startFirstSession({
+        client,
+        workspace,
+        settings,
+        prompt,
+        models,
+        defaultModelKey,
+        startup: { heading: UNEFF_STARTUP_HEADING, preparation },
+        reveal: () =>
+          navigate({
+            to: "/code/w/$workspaceId",
+            params: { workspaceId: workspace.id },
+          }),
+      });
+      return;
+    }
+    // No checkout: a new agent in this workspace, shown once it exists.
+    await startFirstSession({
+      client,
+      workspace: context.workspace,
+      settings,
+      prompt,
+      models,
+      defaultModelKey,
+      startup: { heading: UNEFF_STARTUP_HEADING, preparation },
+      onSessionCreated: (session) =>
+        void navigate({
+          to: "/code/w/$workspaceId",
+          params: { workspaceId: sourceId },
+          search: (current: Record<string, unknown>) => ({
+            ...current,
+            task: session.id,
+            subagent: undefined,
+          }),
+        }),
+    });
   }
 
   /**

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -742,8 +742,9 @@ export function useWorkspaceCardCommands(): {
       return;
     }
     // No checkout: a new agent in this workspace, shown once it exists. The
-    // prompt is generated, so a failed start does not leave a hundred
-    // kilobytes of JSON in a composer that belongs to another conversation.
+    // prompt is generated, so when no session starts it does not land in a
+    // composer that still belongs to the original conversation. Once the
+    // session exists its own empty composer is the right place for it.
     await startFirstSession({
       client,
       workspace: context.workspace,
@@ -752,7 +753,7 @@ export function useWorkspaceCardCommands(): {
       models,
       defaultModelKey,
       startup: { heading: UNEFF_STARTUP_HEADING, preparation, target },
-      holdPromptOnFailure: false,
+      holdPromptWithoutSession: false,
       onSessionCreated: (session) =>
         void navigate({
           to: "/code/w/$workspaceId",

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -53,6 +53,7 @@ import { startFirstSession } from "./startWorkspaceSession";
 import {
   UNEFF_STARTUP_HEADING,
   prepareUneffMe,
+  tidebreakProductRepo,
   uneffPreparationSteps,
   uneffSessionSettings,
 } from "./uneffMe";
@@ -661,9 +662,13 @@ export function useWorkspaceCardCommands(): {
       catalog.repos.find((repo) => repo.id === context.workspace.repo_id)
         ?.display_name ?? context.workspace.repo_id;
     const setWorkspaceStartup = useCodeUiStore.getState().setWorkspaceStartup;
+    const target = tidebreakProductRepo(catalog.repos)
+      ? ("new_workspace" as const)
+      : ("this_workspace" as const);
     const startup = {
       harness: settings.harness,
       heading: UNEFF_STARTUP_HEADING,
+      target,
     };
     const showPreparation = (preparation: WorkspaceStartupStep[]) =>
       setWorkspaceStartup(sourceId, {
@@ -736,7 +741,9 @@ export function useWorkspaceCardCommands(): {
       });
       return;
     }
-    // No checkout: a new agent in this workspace, shown once it exists.
+    // No checkout: a new agent in this workspace, shown once it exists. The
+    // prompt is generated, so a failed start does not leave a hundred
+    // kilobytes of JSON in a composer that belongs to another conversation.
     await startFirstSession({
       client,
       workspace: context.workspace,
@@ -744,7 +751,8 @@ export function useWorkspaceCardCommands(): {
       prompt,
       models,
       defaultModelKey,
-      startup: { heading: UNEFF_STARTUP_HEADING, preparation },
+      startup: { heading: UNEFF_STARTUP_HEADING, preparation, target },
+      holdPromptOnFailure: false,
       onSessionCreated: (session) =>
         void navigate({
           to: "/code/w/$workspaceId",

--- a/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { CodeTranscript } from "@/code/CodeTranscript";
 import type { CodeTranscriptItem } from "@/code/CodeSessionReducer";
@@ -155,5 +155,121 @@ export const RewriteFailed: Story = {
         ? { ...item, rewriteState: "failed" }
         : item,
     ),
+  },
+};
+
+const failedTurn: CodeTranscriptItem[] = [
+  items[0],
+  {
+    kind: "assistant",
+    id: "assistant-failed",
+    turnId: "turn-1",
+    parentCallId: null,
+    text: "Loading the registry now.",
+    streaming: false,
+  },
+  {
+    kind: "turn_boundary",
+    id: "boundary-failed",
+    turnId: "turn-1",
+    status: "failed",
+    durationMs: 4_000,
+    usage: null,
+    error:
+      "claude exited with status 1: ENOENT: no such file or directory, open 'crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts'",
+    diffstat: null,
+  },
+];
+
+/**
+ * A failed turn is the one outcome that must never be silent, and the way
+ * out of it sits on the failure: File an issue hands the session to Uneff me.
+ */
+export const FailedTurnFilesIssue: Story = {
+  args: { items: failedTurn, onFileIssue: fn() },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole("alert");
+    await expect(alert).toHaveTextContent("Turn failed");
+    await userEvent.click(
+      within(alert).getByRole("button", { name: "File an issue" }),
+    );
+    await expect(args.onFileIssue).toHaveBeenCalledTimes(1);
+  },
+};
+
+const engineError: CodeTranscriptItem[] = [
+  items[0],
+  {
+    kind: "notice",
+    id: "notice-error",
+    level: "error",
+    message:
+      "The engine could not reach the model gateway: 502 Bad Gateway after 3 retries.",
+  },
+];
+
+/** An engine error carries the same way out. Warnings and asides do not. */
+export const EngineErrorFilesIssue: Story = {
+  args: { items: engineError, onFileIssue: fn() },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole("alert");
+    await expect(
+      within(alert).getByRole("button", { name: "File an issue" }),
+    ).toBeVisible();
+  },
+};
+
+const pastedReport = JSON.stringify(
+  {
+    session: { id: "sess-1", harness_kind: "claude_code" },
+    turns: Array.from({ length: 6 }, (_, index) => ({
+      id: `turn-${index + 1}`,
+      status: index === 5 ? "failed" : "completed",
+    })),
+    events: Array.from({ length: 40 }, (_, index) => ({
+      seq: index,
+      type: index % 2 ? "tool_started" : "tool_finished",
+    })),
+  },
+  null,
+  2,
+);
+
+const pastedTurn: CodeTranscriptItem[] = [
+  {
+    kind: "user",
+    id: "user-uneff",
+    turnId: "turn-uneff",
+    text: `The user hit a problem in Tidebreak Code and asked for help.\n\nStart by asking the user what went wrong and what they want.\n\nThe debug report follows as pasted text.\n\n<pasted_text>\n${pastedReport}\n</pasted_text>`,
+    createdAt: "2026-09-02T15:10:00.000Z",
+  },
+  {
+    kind: "assistant",
+    id: "assistant-uneff",
+    turnId: "turn-uneff",
+    parentCallId: null,
+    text: "Before I dig in: what went wrong, and would you like an issue filed or a fix opened as a pull request?",
+    streaming: false,
+  },
+];
+
+/**
+ * A long paste goes out folded behind a chip, and comes back folded: the
+ * Uneff me first turn carries its whole debug report without showing it.
+ */
+export const PastedTextFolded: Story = {
+  args: { items: pastedTurn },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole("button", {
+      name: /Pasted text/,
+    });
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(canvas.queryByText(/"harness_kind"/)).toBeNull();
+    await userEvent.click(toggle);
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(canvas.getByText(/"harness_kind"/)).toBeVisible();
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -994,6 +994,7 @@ function WorkspacePageStory({
         phase: "preparing",
         heading: UNEFF_STARTUP_HEADING,
         preparation: uneffPreparationSteps({ step: "debug" }),
+        target: "this_workspace",
       });
     }
     const client = storyClient(scenario);
@@ -1518,8 +1519,9 @@ export const StartingSession: Story = {
 };
 
 /**
- * Uneff me borrows the same surface before its session exists: the source
- * workspace shows the debug report being collected ahead of the usual steps.
+ * Uneff me borrows the same surface before its session exists. With no
+ * Tidebreak checkout the agent starts here, so the copy promises no new
+ * workspace: the report is collected, then the agent takes over in place.
  */
 export const UneffMePreparing: Story = {
   args: { scenario: "uneff-preparing", reviewOpen: false },
@@ -1530,7 +1532,10 @@ export const UneffMePreparing: Story = {
     });
     await expect(status).toHaveTextContent("Getting Tidebreak ready to help");
     await expect(status).toHaveTextContent("Collecting the debug report");
-    await expect(status).toHaveTextContent("Workspace ready");
+    await expect(status).toHaveTextContent(
+      "The new agent takes over here as soon as it starts.",
+    );
+    await expect(status).not.toHaveTextContent("new workspace");
   },
 };
 

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -26,6 +26,7 @@ import type {
 import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
 import { resetCodeSessionRegistry } from "@/code/CodeSessionRegistry";
 import { useCodeUiStore } from "@/code/CodeUiStore";
+import { UNEFF_STARTUP_HEADING, uneffPreparationSteps } from "@/code/uneffMe";
 import {
   disconnectCodeUpdates,
   useCodeUpdatesStore,
@@ -70,6 +71,7 @@ type WorkspaceScenario =
   | "start"
   | "workspace-starting"
   | "workspace-sending-message"
+  | "uneff-preparing"
   | "session-create-failure"
   | "first-turn-failure"
   | "fork-first-turn-failure"
@@ -985,6 +987,15 @@ function WorkspacePageStory({
             : "sending_message",
       });
     }
+    if (scenario === "uneff-preparing") {
+      useCodeUiStore.getState().setWorkspaceStartup(workspace.id, {
+        harness: "claude_code",
+        hasFirstMessage: true,
+        phase: "preparing",
+        heading: UNEFF_STARTUP_HEADING,
+        preparation: uneffPreparationSteps({ step: "debug" }),
+      });
+    }
     const client = storyClient(scenario);
     return { client, router: storyRouter(client, initialUrl) };
   });
@@ -1503,6 +1514,23 @@ export const StartingSession: Story = {
     });
     await expect(status).toHaveTextContent("Starting Claude Code");
     await expect(status).toHaveTextContent("Your first message is queued.");
+  },
+};
+
+/**
+ * Uneff me borrows the same surface before its session exists: the source
+ * workspace shows the debug report being collected ahead of the usual steps.
+ */
+export const UneffMePreparing: Story = {
+  args: { scenario: "uneff-preparing", reviewOpen: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const status = await canvas.findByRole("status", {
+      name: "Starting session",
+    });
+    await expect(status).toHaveTextContent("Getting Tidebreak ready to help");
+    await expect(status).toHaveTextContent("Collecting the debug report");
+    await expect(status).toHaveTextContent("Workspace ready");
   },
 };
 

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -150,7 +150,6 @@ function HeaderState({
             hasSession: true,
             attentionPinned: false,
             canFork: true,
-            canUneff: true,
             canOpenWorktree,
             canOpenInEditor,
             quickActions: [],

--- a/docs/decisions/0078-uneff-me-targets-the-tidebreak-product-repo.md
+++ b/docs/decisions/0078-uneff-me-targets-the-tidebreak-product-repo.md
@@ -1,6 +1,6 @@
 # 78. Uneff me targets the Tidebreak product repo
 
-- Status: Proposed
+- Status: Superseded by [`0081-uneff-me-works-without-a-tidebreak-checkout.md`](0081-uneff-me-works-without-a-tidebreak-checkout.md)
 - Date: 2026-08-27
 - Owners: code mode
 - Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),

--- a/docs/decisions/0081-uneff-me-works-without-a-tidebreak-checkout.md
+++ b/docs/decisions/0081-uneff-me-works-without-a-tidebreak-checkout.md
@@ -1,0 +1,155 @@
+# 81. Uneff me works without a Tidebreak checkout
+
+- Status: Accepted
+- Date: 2026-09-02
+- Owners: code mode
+- Related: [`0078-uneff-me-targets-the-tidebreak-product-repo.md`](0078-uneff-me-targets-the-tidebreak-product-repo.md),
+  [`crates/tidebreak-desktop/ui/src/code/uneffMe.ts`](../../crates/tidebreak-desktop/ui/src/code/uneffMe.ts),
+  [`crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts`](../../crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts),
+  [`crates/tidebreak-desktop/ui/src/PastedText.ts`](../../crates/tidebreak-desktop/ui/src/PastedText.ts)
+- Supersedes: 0078
+
+## Context
+
+Record 78 froze Uneff me as a dogfood path: the command was hidden until a
+Code repo named `tidebreak` was connected, and it refused to start without
+one. That made it invisible to the people it was for. A user who hit a
+product bug reported that they could not find the button; they had no
+Tidebreak checkout, so the menu never offered it.
+
+Three more things fell short of the intent. The command handed the first
+prompt to the new workspace's composer instead of sending it, so the reader
+landed on an empty conversation with a hundred kilobytes of JSON in the box
+and had to press send. Nothing on screen said what was happening between the
+click and the new workspace. And the debug report went into the first turn
+as bare text, so the transcript printed all of it, while a long clipboard
+paste in the same composer is folded behind a chip.
+
+Meanwhile workspace creation grew a handoff (`#2935`): an optimistic card in
+the rail while the worktree is created, then a page-level step list until the
+first session exists and the first message is sent. Uneff me should look like
+that, not like a second design.
+
+An earlier draft of this record cloned Tidebreak for the reader when no
+checkout was connected. That was dropped before it merged: an issue needs no
+source tree, a large clone spent on a question the agent has not asked yet
+is a poor trade, and a product that clones repositories onto people's disks
+because they asked for help reads as farming checkouts.
+
+## Decision
+
+Uneff me is offered on every workspace that has a session. It no longer
+depends on which repos are connected, and it never clones anything.
+
+When a connected repo is the Tidebreak product checkout by record 78's rule
+(display name `tidebreak` or `brightwave-inc/tidebreak`, or folder basename
+`tidebreak`, never a worktree path), the fix workspace is created there.
+When none is, the session starts as a new agent in the workspace the reader
+is already in, shown as the selected agent once it exists. The prompt says
+which case it is.
+
+The first turn is posted for the reader. The prompt tells the agent to ask
+what went wrong and whether the user wants an issue or a pull request before
+it investigates or changes anything. It names `gh issue create` against the
+product repo. For a pull request from a Tidebreak checkout it says to open
+the fix against `main` and to fork when the user cannot push. For a pull
+request from the user's own workspace it says to ask where Tidebreak may be
+cloned and to clone only after the user says yes, and to mention that adding
+the Tidebreak repository to Code makes the next Uneff me start there. Because
+the repository is public, the prompt also tells the agent never to paste the
+whole report and to show the user any issue text before filing it. The
+workspace title stays `Uneff: …`.
+
+The debug report travels in the first turn as pasted text: the same
+`<pasted_text>` wrapping the composer gives a long clipboard paste. A sent
+message is split back into prose and paste blocks when the transcript draws
+it, and each block renders as the folded chip the reader saw in the composer,
+opening to the text with a copy control. This applies to every user message
+in chat and code, not only to Uneff me.
+
+The flow reuses the creation handoff rather than adding a second loading
+state. The startup record gained a `preparing` phase with preparation steps
+ahead of "Workspace ready"; the source workspace carries it while the report
+is collected. With a checkout, the record moves to the new workspace once it
+exists, the rail shows the optimistic creating card, and the new workspace
+runs the shared first-session start — the same function the new-workspace
+dialog now calls — through engine start and first message. Without one, the
+same record stays on the source workspace through those steps.
+
+A failed turn and an error-level engine notice in the transcript carry a
+"File an issue" action that runs Uneff me on the session, so the way out of a
+failure sits on the failure. Warnings and asides do not carry it.
+
+The session's engine follows the source session's engine when it can start,
+else the last create's, else any engine that can. The permission posture is
+the last create's when the engine honors it, else the engine's create
+default, clamped by the managed policy ceiling. If no engine can start, the
+command reports that and does nothing.
+
+## Alternatives Considered
+
+### Keep the checkout gate and add a hint to connect Tidebreak
+
+Cheapest, but it leaves the button hidden for the people reporting bugs, and
+a hint to clone a repo by hand before asking for help is the errand the
+command exists to remove.
+
+### Clone Tidebreak for the reader when no checkout is connected
+
+Makes every Uneff me PR-capable from the first click. Rejected, as above: it
+spends a large clone before the agent has asked whether a PR is even wanted,
+it writes a checkout onto the reader's disk without asking, and it reads as
+farming clones. The agent can ask and clone when a PR is actually wanted.
+
+### A separate loading surface for Uneff me
+
+A toast or a dedicated dialog would have been quicker to write than
+generalizing the startup record. It was rejected because the creation
+handoff already answers "what is happening while my session appears", and a
+second answer is what the design-system notes in `CLAUDE.md` forbid.
+
+### Print the debug report in the transcript
+
+Leaving the report as bare text is what shipped in `#2762`. It made the first
+turn unreadable and made a code-mode user turn look unlike a chat turn with
+the same paste. Folding it reuses a shape the reader already knows.
+
+## Consequences
+
+A reader with no Tidebreak checkout gets an issue path with nothing installed
+or cloned, and a PR path that starts with the agent asking permission. The
+rail card for their workspace shows the Uneff agent as the workspace's
+remembered session until the page reloads, the same as any second agent
+started from the page.
+
+The debug report travels to a public repository only through the agent, which
+is told to redact and to show issue text first. The report itself stays in
+the session's first turn, folded.
+
+Record 78's identification rule survives unchanged; only its refusal is gone.
+The `canUneff` flag left the command menus, so nothing hides the item.
+
+Revisit this if Code repo snapshots grow a remote identity that makes the
+name heuristic unnecessary, if the first prompt should carry a redacted
+report rather than the full one, or if "File an issue" should reach chat
+errors outside code mode, which have no session debug report today.
+
+## Validation
+
+`uneffMe.test.ts` covers: the prompt asks before it acts and names both the
+issue and the pull request path; the report is folded as pasted text and the
+prose around it is not; the no-checkout prompt says to ask before cloning and
+never claims a fresh workspace; a connected checkout gets a workspace and no
+checkout gets none; engine choice follows source session, then last create,
+then any; a plan ceiling yields plan rather than a refusal.
+`workspaceActions.test.ts` pins that Uneff me appears next to Copy debug JSON
+whenever there is a session and never without one. `PastedText.test.ts` pins
+the split. `CodeTranscript.dom.test.tsx` pins the action on a failed turn and
+an error notice, its absence on a warning and without a handler, and the
+folded paste. The page test pins the handoff on the source workspace while
+the report is collected, the first turn submitted rather than left in the
+composer, and the no-checkout path creating a session here and nothing else.
+The `UneffMePreparing`, `FailedTurnFilesIssue`, `EngineErrorFilesIssue`, and
+`PastedTextFolded` stories show each surface. A plausible wrong
+implementation that still gated on the checkout would fail the menu test; one
+that cloned would fail the page test's clone assertion.

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -89,3 +89,4 @@
 0078  0078-uneff-me-targets-the-tidebreak-product-repo.md
 0079  0079-supervised-agent-declines-the-sandbox-protocol.md
 0080  0080-update-restarts-park-sessions-at-turn-boundaries.md
+0081  0081-uneff-me-works-without-a-tidebreak-checkout.md


### PR DESCRIPTION
## Summary

A user could not find the Uneff me button. It was hidden until a Code repo named `tidebreak` was connected (record 78), so anyone without a checkout never saw it.

- Uneff me shows on every workspace with a session. With a Tidebreak checkout connected it creates the fix workspace there; without one it starts a new agent in the current workspace and selects it. Nothing is cloned for the reader.
- The prompt tells the agent to ask what went wrong and whether the user wants an issue or a pull request before it investigates or changes anything. For a PR from a non-Tidebreak workspace it asks where it may clone and clones only after the user says yes.
- The first turn is sent rather than left in the composer, behind the same creation handoff new workspaces use. The startup record gained a `preparing` phase with steps ahead of "Workspace ready". Session start and first-turn send moved out of `NewWorkspaceDialog` into `startWorkspaceSession.ts` so both paths share one implementation.
- A failed turn and an error-level engine notice in the Code transcript carry a "File an issue" action that runs Uneff me on the session. Warnings do not.
- The debug report travels as pasted text, the same `<pasted_text>` wrapping a long clipboard paste gets. User messages in chat and code split those blocks back out and render them as the folded composer chip, opening to the text with a copy control.
- Record 0081 documents this and supersedes 0078.

## Stories

`Code/Workspace page › UneffMePreparing`; `Code/Transcript › FailedTurnFilesIssue`, `EngineErrorFilesIssue`, `PastedTextFolded`. Captured in light, dark, hc-light, and hc-dark.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome lint src`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/uneffMe.test.ts src/code/workspaceActions.test.ts src/code/CodeWorkspacePage.dom.test.tsx src/code/NewWorkspaceDialog.dom.test.tsx src/code/CodeTranscript.dom.test.tsx src/PastedText.test.ts src/ComposerPastedText.dom.test.tsx src/ChatView.dom.test.tsx src/stylesContract.test.ts`
- `python3 scripts/adr.py check`
