### PR TITLE
feat(code): accept image attachments on the internal engine

### DIFF
--- a/crates/tidebreak-server/src/engine/internal/adapter.rs
+++ b/crates/tidebreak-server/src/engine/internal/adapter.rs
@@ -69,9 +69,9 @@ impl HarnessAdapter for InternalAdapter {
             reasoning_levels: CapLevel::Supported,
             native_file_change_events: CapLevel::Unsupported,
             native_interrupt: CapLevel::Supported,
-            // Chat's attachment model is the image path for the internal
-            // engine; hydrated bytes on the turn input are not wired yet.
-            image_input: CapLevel::Unsupported,
+            // Hydrated bytes on the turn input publish through chat's
+            // attachment model and reach the model request as image blocks.
+            image_input: CapLevel::Supported,
             slash_commands: CapLevel::Unsupported,
             durable_parks: CapLevel::Supported,
             user_questions: CapLevel::Supported,

--- a/crates/tidebreak-server/src/engine/internal/session.rs
+++ b/crates/tidebreak-server/src/engine/internal/session.rs
@@ -24,14 +24,14 @@ use tidebreak_core::{
     chat_journal, AcceptTurnOutcome, AcceptTurnSteerOutcome, AnswerUserQuestions,
     AnswerUserQuestionsOutcome, AnswerUserQuestionsRequest, ApprovalDecisionKind, Attention,
     AttentionSource, BeginTurnAdmissionOutcome, CallId, ChatId, CodeApprovalKind, CodeEvent,
-    CodeSessionId, DecidePlanRequest, GrantLevel, GrantScope, InternalApprovalRequest, OwnerId,
-    PermissionMode, PlanDecision, PlanDecisionChoice, ReservedTurnAcceptanceOutcome,
+    CodeSessionId, DecidePlanRequest, GrantLevel, GrantScope, ImageRef, InternalApprovalRequest,
+    OwnerId, PermissionMode, PlanDecision, PlanDecisionChoice, ReservedTurnAcceptanceOutcome,
     SequencedCodeEvent, SequencedEvent, StandingGrant, ToolApprovalStatus, TurnAdmissionRequest,
     TurnId, TurnSteerId, DEFAULT_ACCEPTED_PLAN_MODE,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
-    HarnessSession, ParkWait, ResumeInput, SessionSpec, TurnInput, TurnOutcome,
+    HarnessSession, ParkWait, ResumeInput, SessionSpec, TurnImage, TurnInput, TurnOutcome,
 };
 
 use crate::code::bus::{CodeEventBus, CodeLiveEvent};
@@ -166,9 +166,48 @@ impl InternalSession {
         )
     }
 
+    /// Publish turn images through chat's attachment model: sniff and bound
+    /// them the way chat ingest does, put the bytes, and reserve the chat's
+    /// authority to attach each id.
+    async fn publish_turn_images(
+        &self,
+        images: Vec<TurnImage>,
+    ) -> Result<Vec<ImageRef>, HarnessError> {
+        let mut published = Vec::with_capacity(images.len());
+        for image in images {
+            let inspected = crate::routes::image_attachment::inspect_image_bytes(&image.bytes)
+                .map_err(|error| HarnessError::Other(error.message().to_owned()))?;
+            let _blob_write = self
+                .state
+                .blob_writes
+                .acquire(inspected.blob_id)
+                .await
+                .map_err(store_error)?;
+            self.state
+                .blobs
+                .put(inspected.blob_id, image.bytes)
+                .await
+                .map_err(store_error)?;
+            if !self
+                .state
+                .store
+                .publish_chat_image_scoped(&self.owner, self.chat_id, &inspected)
+                .await
+                .map_err(store_error)?
+            {
+                return Err(HarnessError::ResumeLost(format!(
+                    "conversation {} no longer exists",
+                    self.chat_id
+                )));
+            }
+            published.push(inspected);
+        }
+        Ok(published)
+    }
+
     /// Submit the user's message to the chat turn lane and return the turn
     /// it admitted.
-    async fn submit(&self, text: &str) -> Result<TurnId, HarnessError> {
+    async fn submit(&self, text: &str, images: Vec<TurnImage>) -> Result<TurnId, HarnessError> {
         let chat = self
             .state
             .store
@@ -182,12 +221,13 @@ impl InternalSession {
             crate::routes::providers_models::resolve_executable_chat_model(&self.state, &chat)
                 .await
                 .map_err(|error| HarnessError::Other(error.message().to_owned()))?;
+        let attachments = self.publish_turn_images(images).await?;
         let turn_id = TurnId::new();
         let request = TurnAdmissionRequest {
             id: turn_id,
             chat_id: self.chat_id,
             content: text.to_owned(),
-            attachments: Vec::new(),
+            attachments: attachments.iter().map(|image| image.blob_id).collect(),
             file_attachments: Vec::new(),
             invoked_skills: Vec::new(),
             voice_input_used: false,
@@ -224,7 +264,7 @@ impl InternalSession {
                     self.chat_id,
                     &model,
                     text,
-                    &[],
+                    &attachments,
                     &[],
                     &[],
                     false,
@@ -684,11 +724,6 @@ impl InternalSession {
 #[async_trait]
 impl HarnessSession for InternalSession {
     async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
-        if !input.images.is_empty() {
-            return Err(HarnessError::Other(
-                "image input is not available on the internal engine yet".into(),
-            ));
-        }
         if self.active_turn().is_some() {
             return Err(HarnessError::Other(
                 "the internal engine is already running a turn".into(),
@@ -712,7 +747,7 @@ impl HarnessSession for InternalSession {
         // between the two.
         let (mut live, _tail) = self.bus.attach(self.session_id);
         let after = self.journal_tail().await?;
-        let turn_id = self.submit(&input.text).await?;
+        let turn_id = self.submit(&input.text, input.images).await?;
         *self.active.lock().expect("active turn") = Some(ActiveTurn {
             turn_id,
             last_seq: after,

--- a/crates/tidebreak-server/src/tests/code_internal.rs
+++ b/crates/tidebreak-server/src/tests/code_internal.rs
@@ -12,9 +12,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use tower::ServiceExt;
+
 use tidebreak_core::{
-    ApprovalClass, ChatRequest, CodeSessionId, DbStore, ModelProvider, ProviderEvent, ProviderId,
-    StopReason, Tool, ToolCtx, ToolOutput, ToolRegistry, ToolSpec,
+    ApprovalClass, ChatRequest, CodeSessionId, ContentBlock, DbStore, ModelProvider, ProviderEvent,
+    ProviderId, StopReason, Tool, ToolCtx, ToolOutput, ToolRegistry, ToolSpec,
 };
 use tidebreak_harness::AdapterRegistry;
 
@@ -34,6 +38,7 @@ enum Step {
 struct ScriptedProvider {
     steps: Mutex<Vec<Step>>,
     calls: AtomicUsize,
+    requests: Mutex<Vec<ChatRequest>>,
 }
 
 #[async_trait]
@@ -44,8 +49,9 @@ impl ModelProvider for ScriptedProvider {
 
     async fn stream(
         &self,
-        _request: ChatRequest,
+        request: ChatRequest,
     ) -> tidebreak_core::Result<BoxStream<'static, ProviderEvent>> {
+        self.requests.lock().unwrap().push(request);
         let call = self.calls.fetch_add(1, Ordering::SeqCst);
         let step = {
             let mut steps = self.steps.lock().unwrap();
@@ -132,6 +138,21 @@ async fn internal_engine_app(
     Arc<AtomicUsize>,
     tempfile::TempDir,
 ) {
+    let (router, token, runtime, ran, dir, _provider) = internal_engine_app_capturing(steps).await;
+    let addr = super::code::serve(router).await;
+    (addr, token, runtime, ran, dir)
+}
+
+async fn internal_engine_app_capturing(
+    steps: Vec<Step>,
+) -> (
+    axum::Router,
+    Arc<str>,
+    Arc<CodeRuntime>,
+    Arc<AtomicUsize>,
+    tempfile::TempDir,
+    Arc<ScriptedProvider>,
+) {
     let (dir, store) = temp_db_store("internal.db").await;
     let db = Arc::new(store);
     let store_trait: Arc<dyn Store> = db.clone();
@@ -152,11 +173,12 @@ async fn internal_engine_app(
     let provider = Arc::new(ScriptedProvider {
         steps: Mutex::new(steps),
         calls: AtomicUsize::new(0),
+        requests: Mutex::new(Vec::new()),
     });
     let mut state = AppState::new(
         Config::desktop(dir.path()),
         store_trait,
-        Arc::new(FixedResolver(provider)),
+        Arc::new(FixedResolver(provider.clone())),
         Arc::new(MemSecrets::default()),
         Arc::new(tools),
         AgentConfig {
@@ -164,7 +186,7 @@ async fn internal_engine_app(
             ..AgentConfig::default()
         },
     );
-    spawn_turn_worker(&state);
+    spawn_turn_worker_with_blobs(&state);
     let mut runtime =
         CodeRuntime::with_registry(db, dir.path().to_path_buf(), AdapterRegistry::new());
     // As in `lib.rs`: the engine follows the session's journal on the
@@ -178,8 +200,29 @@ async fn internal_engine_app(
     let runtime = Arc::new(runtime);
     state.code = Some(runtime.clone());
     let token = state.token.clone();
-    let addr = super::code::serve(app(state)).await;
-    (addr, token, runtime, ran, dir)
+    (app(state), token, runtime, ran, dir, provider)
+}
+
+fn spawn_turn_worker_with_blobs(state: &AppState) {
+    let worker = crate::turn_worker::TurnWorker::new(
+        state.store.clone(),
+        state.resolver.clone(),
+        state.secrets.clone(),
+        state.provisioned_policy.clone(),
+        state.os_policy.clone(),
+        state.tools.clone(),
+        state.approvals.clone(),
+        state.events.clone(),
+        state.active_turns.clone(),
+        state.turn_job_wake.clone(),
+        state.agent_run_wake.clone(),
+        state.queued_turn_wake.clone(),
+        state.agent_config.clone(),
+        None,
+        crate::turn_worker::TurnWorkerConfig::default(),
+    )
+    .with_blobs(state.blobs.clone());
+    tokio::spawn(worker.run());
 }
 
 async fn pending_approval_of_kind(
@@ -1007,6 +1050,112 @@ async fn the_internal_engine_is_only_reachable_without_a_workspace() {
     assert_eq!(internal["found"], true);
     assert!(internal["path"].is_null());
     assert_eq!(internal["caps"]["durable_parks"], "supported");
+    assert_eq!(internal["caps"]["image_input"], "supported");
+}
+
+/// A turn with an image attachment on the internal engine reaches the
+/// model request with the image bytes: the worker hydrates them onto
+/// the turn input, the engine publishes them through chat's attachment
+/// model, and the lane's existing resolution puts them on the request.
+#[tokio::test]
+async fn an_internal_turn_with_an_image_reaches_the_model_with_the_bytes() {
+    let (router, token, _runtime, _ran, _dir, provider) =
+        internal_engine_app_capturing(vec![Step::Text("i see it")]).await;
+    let bearer = format!("Bearer {token}");
+    let created = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/code/sessions")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "permission_mode": "ask" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let session: serde_json::Value = super::json_body(created).await;
+    let session_id = session["id"].as_str().unwrap().to_owned();
+    let pixels = crate::routes::image_attachment::png_header(4, 4);
+
+    let published = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/code/sessions/{session_id}/attachments/images"))
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "image/png")
+                .body(Body::from(pixels.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(published.status(), StatusCode::CREATED);
+    let attachment: serde_json::Value = super::json_body(published).await;
+    let blob_id: uuid::Uuid = attachment["attachment_id"]
+        .as_str()
+        .expect("the publication names the blob")
+        .parse()
+        .unwrap();
+
+    let response = tokio::time::timeout(Duration::from_secs(20), async {
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/code/sessions/{session_id}/turns"))
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "message": "what is in this",
+                            "attachments": [{
+                                "blob_id": blob_id,
+                                "media_type": "image/png",
+                            }],
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    })
+    .await
+    .expect("the turn completes");
+    assert!(
+        response.status().is_success(),
+        "turn was not accepted: {}",
+        response.status()
+    );
+
+    let request = provider
+        .requests
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|request| request.images.get(blob_id).is_some())
+        .cloned()
+        .expect("the model received a request that carries the image");
+    assert!(
+        request.messages.iter().any(|message| {
+            message.content.iter().any(
+                |block| matches!(block, ContentBlock::Image { image } if image.blob_id == blob_id),
+            )
+        }),
+        "the admitted user message must carry the image block"
+    );
+    let data = request
+        .images
+        .get(blob_id)
+        .expect("the model request must carry the image bytes");
+    assert_eq!(data.bytes(), pixels.as_slice());
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## What changed

Declare `image_input` as supported on the internal engine so a workspace-less session offers image attachment. When a code-session turn carries images, you publish the bytes through chat's attachment model, attach them to the admitted user message, and hand them to the model request through the existing resolution path. External harnesses stay as they were.

## Why

Chat already carries images. The internal engine (decision 48 step 5) dropped them on submit and advertised `Unsupported`. You need this wired before chat's UI collapses onto the session controller.

## Path from the turn request to the model call

1. `publish_session_image` sniffs and stores the bytes (`inspect_image_bytes`, then `BlobStore::put`) and reserves session authority.
2. The turn route accepts the attachment ids and the session worker hydrates them with `hydrate_turn_images`.
3. `InternalSession::run_turn` calls `submit`, which calls `publish_turn_images`: `inspect_image_bytes` (chat's size and type limits), `BlobStore::put`, then `publish_chat_image_scoped`.
4. `accept_reserved_turn_with_message_context` records the images on the admitted user message.
5. The chat turn lane rebuilds the transcript with `list_message_attachments` and `user_message_for_model`, then `hydrate_images` puts the bytes on `ChatRequest.images`.

## Commands

`cargo fmt --all --check` — clean.

`cargo clippy -p tidebreak-core -p tidebreak-server --all-targets -- -D warnings` — this environment cannot fetch the pinned Symphonia git rev. With that patch dropped locally, clippy compiles the crates and reports two existing findings outside this change (`result_large_err` in `harness_llm.rs`, `chunks_exact_to_as_chunks` in `exec_write_snapshot.rs`).

`cargo test -p tidebreak-server --lib an_internal_turn_with_an_image_reaches` — `ok`. 1 passed.

`cargo test -p tidebreak-core attachment` — `ok`. 42 passed.

`cargo test -p tidebreak-server code_` — this sandbox blocks loopback TCP, so HTTP `serve()` tests cannot connect. The new coverage uses in-process `oneshot` instead.

No wire types changed, so TypeScript was not regenerated.

Closes #3012