### PR TITLE
fix(connected-apps): name the failure when MCP verification fails

### DIFF
--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -180,7 +180,9 @@ function McpAppEntry({
         )}
       </div>
       {!detailInAdvanced && unhealthy && entry.diagnostic !== null && (
-        <p className="text-xs text-muted-foreground">{entry.diagnostic}</p>
+        <p className="text-xs text-muted-foreground break-words">
+          {entry.diagnostic}
+        </p>
       )}
       {entry.tools.length > 0 && (
         <>

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
@@ -136,7 +136,9 @@ describe("McpPanel", () => {
     expect(screen.getByDisplayValue("PRIVATE_DOCS_TOKEN")).toBeInTheDocument();
     expect(screen.queryByLabelText(/API key/i)).not.toBeInTheDocument();
     expect(
-      screen.getByText(/values are resolved in the host process/i),
+      screen.getByText(
+        /Tidebreak reads their values from the process environment/i,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -437,6 +439,26 @@ describe("McpPanel", () => {
     expect(
       screen.getByRole("radio", { name: "Remote endpoint (HTTP)" }),
     ).toBeChecked();
+    expect(
+      screen.getByText(/Export it in the shell you start Tidebreak from/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the full classified verify failure", async () => {
+    const message =
+      'DNS resolution failed (mcp.example.invalid). Bearer-token environment variable "GATEWAY_TOKEN" is not set in the environment Tidebreak reads. Export it in the shell you start Tidebreak from, then restart Tidebreak.';
+    const client = api(
+      { servers: [] },
+      {
+        putMcpServers: vi.fn().mockRejectedValue(new Error(message)),
+      },
+    );
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+    await screen.findByText(/No MCP servers configured/);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await user.click(screen.getByRole("button", { name: "Save and verify" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(message);
   });
 
   it("surfaces secret-free degraded diagnostics", async () => {

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
@@ -445,8 +445,7 @@ describe("McpPanel", () => {
   });
 
   it("shows the full classified verify failure", async () => {
-    const message =
-      'DNS resolution failed (mcp.example.invalid). Bearer-token environment variable "GATEWAY_TOKEN" is not set in the environment Tidebreak reads. Export it in the shell you start Tidebreak from, then restart Tidebreak.';
+    const message = `DNS resolution failed (mcp.example.invalid). Bearer-token environment variable "GATEWAY_TOKEN" is not set in the environment Tidebreak reads. Export it in the shell you start Tidebreak from, then restart Tidebreak.`;
     const client = api(
       { servers: [] },
       {

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
@@ -175,11 +175,7 @@ function PluginServerSection({ server }: { server: McpServerInfo }) {
       <SettingsStatus
         tone={healthTone(server.health)}
         label={healthLabel(server.health)}
-        description={
-          server.health === "healthy"
-            ? `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"} available to new turns.`
-            : (server.diagnostic ?? "This server is not connected.")
-        }
+        description={verifyDescription(server)}
       />
       <p className="text-sm leading-relaxed text-muted-foreground">
         Provided by the <code>{server.plugin}</code> plugin. Its configuration
@@ -644,7 +640,7 @@ export function McpPanel({
                     mounted.health !== "initializing" &&
                     mounted.health !== "reconnecting" &&
                     mounted.diagnostic !== null && (
-                      <span className="text-xs text-destructive">
+                      <span className="text-xs text-destructive break-words">
                         {mounted.diagnostic}
                       </span>
                     )}
@@ -729,12 +725,7 @@ export function McpPanel({
                 <SettingsStatus
                   tone={healthTone(server.health)}
                   label={healthLabel(server.health)}
-                  description={
-                    server.health === "healthy"
-                      ? `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"} available to new turns.`
-                      : (server.diagnostic ??
-                        "Save the configuration to verify this server.")
-                  }
+                  description={verifyDescription(server)}
                 />
 
                 <McpTierChip curated={server.curated} />
@@ -873,7 +864,7 @@ export function McpPanel({
 
                     <SettingsField
                       label="Bearer token variable"
-                      hint="Optional. Only the name is saved; the token is read from the host environment when connecting and never displayed."
+                      hint="Optional. Tidebreak reads this variable from the process environment it started with and never displays the value. Export it in the shell you start Tidebreak from, then restart Tidebreak. A Dock or Finder launch does not see variables from your shell profile."
                     >
                       <Input
                         value={server.bearer_token_env ?? ""}
@@ -923,7 +914,7 @@ export function McpPanel({
 
                     <StringListEditor
                       label="Forward environment names"
-                      hint="Only names are saved or displayed. Their values are resolved in the host process and never returned to the app."
+                      hint="Only names are saved or displayed. Tidebreak reads their values from the process environment it started with. Export them in the shell you start Tidebreak from, then restart Tidebreak."
                       values={server.env_from}
                       disabled={working}
                       addLabel="Add variable name"
@@ -1141,6 +1132,21 @@ function mountName(slug: string, taken: ReadonlySet<string>): string {
 }
 
 /** Sentence-shaped status for a mount row; diagnostics already are one. */
+function verifyDescription(server: McpServerInfo): string {
+  if (server.health === "healthy") {
+    return `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"} available to new turns.`;
+  }
+  if (server.health === "disabled") {
+    return (
+      server.diagnostic ??
+      "Disabled. This server is not available to new turns."
+    );
+  }
+  return (
+    server.diagnostic ?? "Save the configuration to verify this server."
+  );
+}
+
 function mountStatus(mounted: McpServerInfo): string {
   if (mounted.health === "healthy") {
     return `${mounted.tool_count} tool${mounted.tool_count === 1 ? "" : "s"} available to new turns.`;

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
@@ -1142,9 +1142,7 @@ function verifyDescription(server: McpServerInfo): string {
       "Disabled. This server is not available to new turns."
     );
   }
-  return (
-    server.diagnostic ?? "Save the configuration to verify this server."
-  );
+  return server.diagnostic ?? "Save the configuration to verify this server.";
 }
 
 function mountStatus(mounted: McpServerInfo): string {

--- a/crates/tidebreak-desktop/ui/src/settings/primitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/primitives.tsx
@@ -129,7 +129,7 @@ export function SettingsStatus({
       <Icon className="settings-status-icon" aria-hidden="true" />
       <span className="settings-status-copy">
         <strong>{label}</strong>
-        <span>{description}</span>
+        <span className="break-words">{description}</span>
       </span>
     </div>
   );
@@ -137,7 +137,7 @@ export function SettingsStatus({
 
 export function SettingsError({ children }: { children: ReactNode }) {
   return (
-    <p className="text-sm text-destructive" role="alert">
+    <p className="text-sm text-destructive break-words" role="alert">
       {children}
     </p>
   );

--- a/crates/tidebreak-mcp/Cargo.toml
+++ b/crates/tidebreak-mcp/Cargo.toml
@@ -19,7 +19,7 @@ image = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["io-std", "io-util", "net", "process", "sync", "time"] }
+tokio = { workspace = true, features = ["io-std", "io-util", "process", "sync", "time"] }
 # Only the tool contracts (Tool / ToolRegistry / ToolCtx / …), not the SQLite /
 # keychain / agent-loop machinery — hence default-features = false.
 tidebreak-core = { path = "../tidebreak-core", default-features = false }

--- a/crates/tidebreak-mcp/Cargo.toml
+++ b/crates/tidebreak-mcp/Cargo.toml
@@ -19,7 +19,7 @@ image = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["io-std", "io-util", "process", "sync", "time"] }
+tokio = { workspace = true, features = ["io-std", "io-util", "net", "process", "sync", "time"] }
 # Only the tool contracts (Tool / ToolRegistry / ToolCtx / …), not the SQLite /
 # keychain / agent-loop machinery — hence default-features = false.
 tidebreak-core = { path = "../tidebreak-core", default-features = false }

--- a/crates/tidebreak-mcp/src/client.rs
+++ b/crates/tidebreak-mcp/src/client.rs
@@ -14,7 +14,9 @@ use tidebreak_core::{
     AgentError, ApprovalClass, DocumentBlob, ImageData, ImageMediaType, ImageRef, Result, Tool,
     ToolCtx, ToolOutput, ToolRegistry, ToolSpec, ToolUiView,
 };
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::io::{
+    AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader,
+};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio::time::timeout;
@@ -1269,11 +1271,24 @@ fn collect_first_stderr_line(
     };
     tokio::spawn(async move {
         let mut reader = BufReader::new(stderr);
-        let mut line = String::new();
-        let first = match reader.read_line(&mut line).await {
-            Ok(0) => None,
-            Ok(_) => Some(sanitize_stderr_line(&line)),
-            Err(_) => None,
+        let mut buf = Vec::new();
+        let mut byte = [0u8; 1];
+        let first = loop {
+            if buf.len() >= MAX_STDERR_LINE_BYTES {
+                break Some(sanitize_stderr_line(&String::from_utf8_lossy(&buf)));
+            }
+            match reader.read(&mut byte).await {
+                Ok(0) if buf.is_empty() => break None,
+                Ok(0) => break Some(sanitize_stderr_line(&String::from_utf8_lossy(&buf))),
+                Ok(_) if byte[0] == b'\n' => {
+                    if buf.last() == Some(&b'\r') {
+                        buf.pop();
+                    }
+                    break Some(sanitize_stderr_line(&String::from_utf8_lossy(&buf)));
+                }
+                Ok(_) => buf.push(byte[0]),
+                Err(_) => break None,
+            }
         };
         let _ = sender.send(first);
         let mut sink = tokio::io::sink();
@@ -1282,8 +1297,10 @@ fn collect_first_stderr_line(
     receiver
 }
 
+const MAX_STDERR_LINE_BYTES: usize = 200;
+
 fn sanitize_stderr_line(line: &str) -> String {
-    const MAX: usize = 200;
+    const MAX: usize = MAX_STDERR_LINE_BYTES;
     let cleaned: String = line
         .trim()
         .chars()

--- a/crates/tidebreak-mcp/src/client.rs
+++ b/crates/tidebreak-mcp/src/client.rs
@@ -143,9 +143,9 @@ impl McpClient {
     /// Spawn and connect to an external MCP stdio server.
     ///
     /// Callers configure the executable, arguments, environment, and working
-    /// directory on `command`; this method owns stdin/stdout and discards stderr
-    /// so an untrusted child cannot copy a selected credential into host logs.
-    /// The child is terminated if the client session is dropped.
+    /// directory on `command`; this method owns stdin/stdout. Stderr is drained
+    /// and not copied into host logs; a failed launch may quote its first line
+    /// in the diagnostic. The child is terminated if the client session is dropped.
     pub async fn spawn(server_name: impl Into<String>, command: Command) -> Result<Self> {
         Self::spawn_with_timeout(server_name, command, DEFAULT_REQUEST_TIMEOUT).await
     }
@@ -173,11 +173,10 @@ impl McpClient {
         command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
-        let mut child = command
-            .spawn()
-            .map_err(|error| mcp_error("could not spawn external server", error))?;
+        let mut child = command.spawn().map_err(classify_spawn_error)?;
+        let first_stderr = collect_first_stderr_line(child.stderr.take());
         let stdin = child
             .stdin
             .take()
@@ -187,18 +186,29 @@ impl McpClient {
             .take()
             .ok_or_else(|| mcp_message("external server did not provide stdout"))?;
 
-        let client = Self::connect_session(
+        match Self::connect_session(
             server_name,
             Session::stream(
                 Box::new(BufReader::new(stdout)),
                 Box::new(stdin),
-                Some(child),
+                None,
                 initialization_timeout,
             ),
         )
-        .await?;
-        client.session.lock().await.request_timeout = request_timeout;
-        Ok(client)
+        .await
+        {
+            Ok(client) => {
+                {
+                    let mut session = client.session.lock().await;
+                    if let Wire::Stream(stream) = &mut session.wire {
+                        stream._child = Some(child);
+                    }
+                    session.request_timeout = request_timeout;
+                }
+                Ok(client)
+            }
+            Err(error) => Err(stdio_connect_failure(error, &mut child, first_stderr).await),
+        }
     }
 
     /// Connect to an external Streamable HTTP MCP server.
@@ -525,7 +535,7 @@ impl Session {
             Wire::Stream(stream) => {
                 timeout(request_timeout, stream.write_value(&request))
                     .await
-                    .map_err(|_| mcp_message(format!("timed out writing {method} request")))??;
+                    .map_err(|_| timed_out(request_timeout))??;
                 timeout(
                     request_timeout,
                     stream.read_response(id, tools_list_changed),
@@ -556,9 +566,7 @@ impl Session {
                     }
                     Wire::Http(http) => timeout(request_timeout, http.notify(&cancelled)).await,
                 };
-                Err(mcp_message(format!(
-                    "external server timed out handling {method}"
-                )))
+                Err(timed_out(request_timeout))
             }
         }
     }
@@ -573,11 +581,11 @@ impl Session {
             Wire::Stream(stream) => {
                 timeout(self.request_timeout, stream.write_value(&notification))
                     .await
-                    .map_err(|_| mcp_message(format!("timed out writing {method} notification")))?
+                    .map_err(|_| timed_out(self.request_timeout))?
             }
             Wire::Http(http) => timeout(self.request_timeout, http.notify(&notification))
                 .await
-                .map_err(|_| mcp_message(format!("timed out writing {method} notification")))?,
+                .map_err(|_| timed_out(self.request_timeout))?,
         }
     }
 }
@@ -1236,6 +1244,94 @@ pub(crate) fn mcp_error(context: impl AsRef<str>, error: impl std::fmt::Display)
     mcp_message(format!("{}: {error}", context.as_ref()))
 }
 
+fn timed_out(request_timeout: Duration) -> AgentError {
+    mcp_message(format!(
+        "Timed out after {} ms.",
+        request_timeout.as_millis()
+    ))
+}
+
+fn classify_spawn_error(error: std::io::Error) -> AgentError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        mcp_message("Process failed to launch: command not found.")
+    } else {
+        mcp_message(format!("Process failed to launch: {error}."))
+    }
+}
+
+fn collect_first_stderr_line(
+    stderr: Option<tokio::process::ChildStderr>,
+) -> tokio::sync::oneshot::Receiver<Option<String>> {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let Some(stderr) = stderr else {
+        let _ = sender.send(None);
+        return receiver;
+    };
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(stderr);
+        let mut line = String::new();
+        let first = match reader.read_line(&mut line).await {
+            Ok(0) => None,
+            Ok(_) => Some(sanitize_stderr_line(&line)),
+            Err(_) => None,
+        };
+        let _ = sender.send(first);
+        let mut sink = tokio::io::sink();
+        let _ = tokio::io::copy(&mut reader, &mut sink).await;
+    });
+    receiver
+}
+
+fn sanitize_stderr_line(line: &str) -> String {
+    const MAX: usize = 200;
+    let cleaned: String = line
+        .trim()
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect();
+    let cleaned = cleaned.trim();
+    if cleaned.chars().count() <= MAX {
+        cleaned.to_string()
+    } else {
+        format!("{}…", cleaned.chars().take(MAX).collect::<String>())
+    }
+}
+
+async fn stdio_connect_failure(
+    connect_error: AgentError,
+    child: &mut Child,
+    first_stderr: tokio::sync::oneshot::Receiver<Option<String>>,
+) -> AgentError {
+    let exit = match child.try_wait() {
+        Ok(Some(status)) => Some(status),
+        Ok(None) => match timeout(Duration::from_millis(50), child.wait()).await {
+            Ok(Ok(status)) => Some(status),
+            _ => None,
+        },
+        Err(_) => None,
+    };
+    let stderr_line = timeout(Duration::from_millis(100), first_stderr)
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .flatten()
+        .filter(|line| !line.is_empty());
+    let _ = child.start_kill();
+    let Some(status) = exit else {
+        return connect_error;
+    };
+    let code = status
+        .code()
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "signaled".to_string());
+    let stderr = stderr_line
+        .map(|line| format!(" First stderr line: {line}."))
+        .unwrap_or_default();
+    mcp_message(format!(
+        "Process failed to launch: exit code {code}.{stderr}"
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -1442,7 +1538,10 @@ mod tests {
                 .await
                 .err()
                 .expect("silent server must time out");
-        assert!(error.to_string().contains("timed out handling initialize"));
+        assert!(
+            error.to_string().contains("Timed out after 10 ms."),
+            "{error}"
+        );
     }
 
     #[tokio::test]
@@ -2255,7 +2354,10 @@ mod tests {
             .err()
             .expect("wrong token must fail");
             let message = error.to_string();
-            assert!(message.contains("rejected the configured credentials"));
+            assert!(
+                message.contains("Authentication failed (401 Unauthorized)"),
+                "{message}"
+            );
             assert!(!message.contains("wrong-token"));
         }
 
@@ -2287,7 +2389,10 @@ mod tests {
             .await
             .err()
             .expect("redirect must fail");
-            assert!(error.to_string().contains("HTTP status 302"), "{error}");
+            assert!(
+                error.to_string().contains("HTTP status 302 Found"),
+                "{error}"
+            );
         }
 
         #[tokio::test]

--- a/crates/tidebreak-mcp/src/http.rs
+++ b/crates/tidebreak-mcp/src/http.rs
@@ -238,7 +238,6 @@ impl HttpWire {
             &self.url,
             authorization.is_some() || !self.configured.is_empty() || self.session_id.is_some(),
         )?;
-        self.ensure_host_resolves().await?;
         // One map, built configured-first and then overwritten by every
         // client-generated header, so a configured entry can never displace
         // what this transport says about itself — whatever the builder's
@@ -318,26 +317,6 @@ impl HttpWire {
             }
         }
         outcome.ok_or_else(|| mcp_message("external server closed the stream before replying"))
-    }
-
-    async fn ensure_host_resolves(&self) -> Result<()> {
-        let Some(host) = self.url.host_str() else {
-            return Ok(());
-        };
-        if host.parse::<std::net::IpAddr>().is_ok() {
-            return Ok(());
-        }
-        let port = self.url.port_or_known_default().unwrap_or(80);
-        match tokio::net::lookup_host((host, port)).await {
-            Ok(mut addresses) => {
-                if addresses.next().is_some() {
-                    Ok(())
-                } else {
-                    Err(mcp_message(format!("DNS resolution failed ({host}).")))
-                }
-            }
-            Err(_) => Err(mcp_message(format!("DNS resolution failed ({host})."))),
-        }
     }
 
     fn absorb_session_id(&mut self, response: &reqwest::Response) -> Result<()> {

--- a/crates/tidebreak-mcp/src/http.rs
+++ b/crates/tidebreak-mcp/src/http.rs
@@ -138,15 +138,22 @@ impl HttpWire {
                 "external server bearer token must be a non-empty header-safe value",
             ));
         }
+        let mut builder = reqwest::Client::builder()
+            // A credentialed client must not follow redirects: reqwest
+            // strips Authorization cross-host, but a same-host https→http
+            // downgrade would resend the bearer in cleartext. This is also
+            // what keeps configured static headers — which reqwest knows
+            // nothing about and would carry across a hop — from ever
+            // reaching a different origin.
+            .redirect(reqwest::redirect::Policy::none());
+        // Loopback MCP servers live on this machine. An inherited HTTP proxy
+        // would steal those connections and turn Save and verify into a hang
+        // or a 403 from the proxy.
+        if is_literal_loopback(&url) {
+            builder = builder.no_proxy();
+        }
         Ok(Self {
-            client: reqwest::Client::builder()
-                // A credentialed client must not follow redirects: reqwest
-                // strips Authorization cross-host, but a same-host https→http
-                // downgrade would resend the bearer in cleartext. This is also
-                // what keeps configured static headers — which reqwest knows
-                // nothing about and would carry across a hop — from ever
-                // reaching a different origin.
-                .redirect(reqwest::redirect::Policy::none())
+            client: builder
                 .build()
                 .map_err(|error| mcp_error("could not build HTTP client", error))?,
             url,
@@ -190,19 +197,16 @@ impl HttpWire {
                 .await
         } else if content_type.starts_with("application/json") {
             let body = read_bounded_body(response).await?;
-            let value: Value = serde_json::from_slice(&body)
-                .map_err(|error| mcp_error("external server returned malformed JSON-RPC", error))?;
+            let value: Value =
+                serde_json::from_slice(&body).map_err(|_| protocol_negotiation_failed(&body))?;
             match crate::client::classify_incoming(value, expected_id, tools_list_changed)? {
                 crate::client::Incoming::FinalResult(result) => Ok(result),
                 crate::client::Incoming::ServerRequest { .. }
-                | crate::client::Incoming::Ignored => Err(mcp_message(
-                    "external server JSON response did not answer the request",
-                )),
+                | crate::client::Incoming::Ignored => Err(protocol_negotiation_failed(&body)),
             }
         } else {
-            Err(mcp_message(
-                "external server replied with an unsupported content type",
-            ))
+            let body = read_bounded_body(response).await.unwrap_or_default();
+            Err(protocol_negotiation_failed(&body))
         }
     }
 
@@ -234,6 +238,7 @@ impl HttpWire {
             &self.url,
             authorization.is_some() || !self.configured.is_empty() || self.session_id.is_some(),
         )?;
+        self.ensure_host_resolves().await?;
         // One map, built configured-first and then overwritten by every
         // client-generated header, so a configured entry can never displace
         // what this transport says about itself — whatever the builder's
@@ -268,7 +273,9 @@ impl HttpWire {
             .json(message)
             .send()
             .await
-            .map_err(|error| mcp_error("could not reach external server", without_url(error)))
+            .map_err(|error| {
+                classify_http_transport_error(error, self.url.host_str().unwrap_or("unknown"))
+            })
     }
 
     async fn read_event_stream(
@@ -288,9 +295,8 @@ impl HttpWire {
                 mcp_error("could not read external server stream", without_url(error))
             })?;
             for data in parser.push(&chunk)? {
-                let value: Value = serde_json::from_slice(data.as_bytes()).map_err(|error| {
-                    mcp_error("external server returned malformed JSON-RPC", error)
-                })?;
+                let value: Value = serde_json::from_slice(data.as_bytes())
+                    .map_err(|_| protocol_negotiation_failed(data.as_bytes()))?;
                 match crate::client::classify_incoming(value, expected_id, tools_list_changed)? {
                     crate::client::Incoming::FinalResult(result) => {
                         outcome = Some(result);
@@ -314,6 +320,26 @@ impl HttpWire {
         outcome.ok_or_else(|| mcp_message("external server closed the stream before replying"))
     }
 
+    async fn ensure_host_resolves(&self) -> Result<()> {
+        let Some(host) = self.url.host_str() else {
+            return Ok(());
+        };
+        if host.parse::<std::net::IpAddr>().is_ok() {
+            return Ok(());
+        }
+        let port = self.url.port_or_known_default().unwrap_or(80);
+        match std::net::ToSocketAddrs::to_socket_addrs(&(host, port)) {
+            Ok(addresses) => {
+                if addresses.into_iter().next().is_some() {
+                    Ok(())
+                } else {
+                    Err(mcp_message(format!("DNS resolution failed ({host}).")))
+                }
+            }
+            Err(_) => Err(mcp_message(format!("DNS resolution failed ({host})."))),
+        }
+    }
+
     fn absorb_session_id(&mut self, response: &reqwest::Response) -> Result<()> {
         let Some(session_id) = response.headers().get(SESSION_ID_HEADER) else {
             return Ok(());
@@ -330,18 +356,121 @@ impl HttpWire {
 }
 
 fn check_status(status: reqwest::StatusCode) -> Result<()> {
-    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-        return Err(mcp_message(
-            "external server rejected the configured credentials",
+    if status.is_success() {
+        return Ok(());
+    }
+    Err(mcp_message(http_status_diagnostic(status)))
+}
+
+fn http_status_diagnostic(status: reqwest::StatusCode) -> String {
+    let status_line = status
+        .canonical_reason()
+        .map(|reason| format!("{} {reason}", status.as_u16()))
+        .unwrap_or_else(|| status.as_u16().to_string());
+    match status.as_u16() {
+        401 | 403 => format!("Authentication failed ({status_line})."),
+        404 => format!("Wrong path ({status_line})."),
+        500..=599 => format!("Server error ({status_line})."),
+        _ => format!("HTTP status {status_line}."),
+    }
+}
+
+fn protocol_negotiation_failed(body: &[u8]) -> tidebreak_core::AgentError {
+    mcp_message(format!(
+        "Protocol negotiation failed. The endpoint answered but not with MCP JSON-RPC. First bytes: {}.",
+        quote_first_bytes(body)
+    ))
+}
+
+/// Quote a bounded prefix of an upstream body. Never the URL or a token.
+fn quote_first_bytes(body: &[u8]) -> String {
+    const MAX: usize = 64;
+    let slice = &body[..body.len().min(MAX)];
+    let mut out = String::from("\"");
+    for &byte in slice {
+        match byte {
+            b'\\' => out.push_str("\\\\"),
+            b'"' => out.push_str("\\\""),
+            0x20..=0x7e => out.push(byte as char),
+            _ => out.push_str(&format!("\\x{byte:02x}")),
+        }
+    }
+    out.push('"');
+    if body.len() > MAX {
+        out.push('…');
+    }
+    out
+}
+
+fn classify_http_transport_error(error: reqwest::Error, host: &str) -> tidebreak_core::AgentError {
+    let error = error.without_url();
+    if error.is_timeout() {
+        return mcp_message("Timed out after the HTTP client deadline.");
+    }
+    let chain = error_chain_lower(&error);
+    if is_dns_failure(&chain) {
+        return mcp_message(format!("DNS resolution failed ({host})."));
+    }
+    if is_tls_failure(&chain) {
+        return mcp_message(format!(
+            "TLS handshake failed ({}).",
+            tls_reason(&error.to_string())
         ));
     }
-    if !status.is_success() {
-        return Err(mcp_message(format!(
-            "external server replied with HTTP status {}",
-            status.as_u16()
-        )));
+    mcp_error("could not reach external server", error)
+}
+
+fn error_chain_lower(error: &reqwest::Error) -> String {
+    let mut text = error.to_string();
+    let mut source = std::error::Error::source(error);
+    while let Some(err) = source {
+        text.push('\n');
+        text.push_str(&err.to_string());
+        source = err.source();
     }
-    Ok(())
+    text.to_ascii_lowercase()
+}
+
+fn is_dns_failure(chain: &str) -> bool {
+    chain.contains("dns error")
+        || chain.contains("failed to lookup address information")
+        || chain.contains("no such host")
+        || chain.contains("name or service not known")
+        || chain.contains("nodename nor servname provided")
+}
+
+fn is_tls_failure(chain: &str) -> bool {
+    chain.contains("tls")
+        || chain.contains("certificate")
+        || chain.contains("ssl")
+        || chain.contains("rustls")
+        || chain.contains("webpki")
+        || chain.contains("unknownissuer")
+        || chain.contains("handshake")
+        || chain.contains("close_notify")
+        || chain.contains("corrupt message")
+}
+
+fn tls_reason(display: &str) -> String {
+    let lower = display.to_ascii_lowercase();
+    let start = [
+        "invalid peer certificate",
+        "certificate",
+        "tls handshake",
+        "handshake failure",
+        "tls",
+    ]
+    .iter()
+    .filter_map(|marker| lower.find(marker))
+    .min()
+    .unwrap_or(0);
+    let snippet = display.get(start..).unwrap_or(display).trim();
+    const MAX: usize = 80;
+    if snippet.len() <= MAX {
+        snippet.trim_end_matches('.').to_string()
+    } else {
+        format!("{}…", snippet[..MAX].trim())
+    }
 }
 
 /// Strip the request URL from a reqwest error display chain. The URL is

--- a/crates/tidebreak-mcp/src/http.rs
+++ b/crates/tidebreak-mcp/src/http.rs
@@ -328,9 +328,9 @@ impl HttpWire {
             return Ok(());
         }
         let port = self.url.port_or_known_default().unwrap_or(80);
-        match std::net::ToSocketAddrs::to_socket_addrs(&(host, port)) {
-            Ok(addresses) => {
-                if addresses.into_iter().next().is_some() {
+        match tokio::net::lookup_host((host, port)).await {
+            Ok(mut addresses) => {
+                if addresses.next().is_some() {
                     Ok(())
                 } else {
                     Err(mcp_message(format!("DNS resolution failed ({host}).")))

--- a/crates/tidebreak-server/src/mcp_config/runtime.rs
+++ b/crates/tidebreak-server/src/mcp_config/runtime.rs
@@ -807,11 +807,10 @@ impl McpRuntime {
                 Err(error)
                     if definition.gateway_endpoint.is_some() || definition.plugin.is_some() =>
                 {
-                    // The projected diagnostic is deliberately generic; keep
-                    // the real cause in the log (already URL- and
-                    // secret-free). The desktop installs no tracing
-                    // subscriber yet, so this surfaces under `tidebreak serve`
-                    // until it does.
+                    // The projected diagnostic is classified and URL-/secret-
+                    // free; keep the typed cause in the log. The desktop
+                    // installs no tracing subscriber yet, so this surfaces
+                    // under `tidebreak serve` until it does.
                     tracing::warn!(
                         server = %definition.name,
                         "gateway MCP mount degraded during replacement: {error}"
@@ -949,8 +948,8 @@ impl McpRuntime {
                     ui_views,
                 },
                 Err(error) => {
-                    // As in `replace_strict`: the error chain is already URL-
-                    // and secret-free, and the warn serves `tidebreak serve`
+                    // As in `replace_strict`: the error chain is URL- and
+                    // secret-free, and the warn serves `tidebreak serve`
                     // until the desktop installs a tracing subscriber.
                     tracing::warn!(
                         server = %definition.name,
@@ -1325,7 +1324,7 @@ impl McpRuntime {
                 Ok(self.info_locked(&state))
             }
             Err(error) => {
-                // As in `replace_strict`: the error chain is already URL- and
+                // As in `replace_strict`: the error chain is URL- and
                 // secret-free, and the warn serves `tidebreak serve` until the
                 // desktop installs a tracing subscriber.
                 tracing::warn!(server = %name, "MCP server reconnect failed: {error}");

--- a/crates/tidebreak-server/src/mcp_config/tests.rs
+++ b/crates/tidebreak-server/src/mcp_config/tests.rs
@@ -460,6 +460,8 @@ fn projected_diagnostics_are_fixed_or_name_only() {
     let failure = AgentError::config("connect failed");
     let missing = connection_diagnostic(&config.0[0], &failure);
     assert!(missing.contains(MISSING));
+    assert!(missing.contains("Parent environment variable"));
+    assert!(missing.contains("shell you start Tidebreak from"));
     assert!(!missing.contains('\n'));
 
     let generic = parse(r#"{"servers":[{"name":"docs","command":"/bin/docs"}]}"#).unwrap();
@@ -906,11 +908,13 @@ async fn missing_selected_bearer_token_fails_by_name_without_a_value() {
 
     let diagnostic = connection_diagnostic(&definition, &error);
     assert!(diagnostic.contains(MISSING));
+    assert!(diagnostic.contains("Bearer-token environment variable"));
+    assert!(diagnostic.contains("shell you start Tidebreak from"));
     assert!(!diagnostic.contains('\n'));
 }
 
 #[test]
-fn http_diagnostics_are_fixed_strings_without_the_url() {
+fn unclassified_http_failures_keep_the_generic_fallback() {
     let definition = http_definition("gateway", "http://127.0.0.1:9/mcp");
     let diagnostic = connection_diagnostic(&definition, &AgentError::config("connect failed"));
     assert_eq!(
@@ -1498,4 +1502,237 @@ async fn managed_policy_locks_plugin_sourced_servers_like_manual_ones() {
     assert_eq!(info.servers[0].tool_count, 0);
     // Nothing about a derived server reaches durable configuration.
     assert!(saved_records(&store).await.is_empty());
+}
+
+async fn verify_fails(definition: McpServerDefinition) -> String {
+    let (runtime, _store, _directory) = test_runtime().await;
+    runtime
+        .replace(McpServersConfig {
+            servers: vec![definition],
+        })
+        .await
+        .expect_err("verification must fail")
+        .to_string()
+}
+
+async fn serve_http_response(
+    status: axum::http::StatusCode,
+    content_type: &'static str,
+    body: &'static [u8],
+) -> std::net::SocketAddr {
+    use axum::body::Body;
+    use axum::routing::post;
+
+    let body = body.to_vec();
+    let app = axum::Router::new().route(
+        "/mcp",
+        post(move || {
+            let body = body.clone();
+            async move {
+                axum::response::Response::builder()
+                    .status(status)
+                    .header(axum::http::header::CONTENT_TYPE, content_type)
+                    .body(Body::from(body))
+                    .unwrap()
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    address
+}
+
+#[tokio::test]
+async fn verify_classifies_dns_resolution_failure() {
+    let error = verify_fails(http_definition(
+        "docs",
+        "http://this-host-does-not-exist.invalid/mcp",
+    ))
+    .await;
+    assert!(
+        error.contains("DNS resolution failed (this-host-does-not-exist.invalid)"),
+        "{error}"
+    );
+    assert!(!error.contains("Could not connect to this server. Check its URL and credentials."));
+}
+
+#[tokio::test]
+async fn verify_classifies_tls_handshake_failure() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 512];
+                let _ = tokio::io::AsyncReadExt::read(&mut stream, &mut buf).await;
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            });
+        }
+    });
+    let error = verify_fails(http_definition(
+        "docs",
+        &format!("https://127.0.0.1:{}/mcp", address.port()),
+    ))
+    .await;
+    assert!(error.contains("TLS handshake failed ("), "{error}");
+    assert!(!error.contains("Could not connect to this server. Check its URL and credentials."));
+}
+
+#[tokio::test]
+async fn verify_classifies_http_authentication_failure() {
+    let address =
+        serve_http_response(axum::http::StatusCode::UNAUTHORIZED, "text/plain", b"").await;
+    let error = verify_fails(http_definition("docs", &format!("http://{address}/mcp"))).await;
+    assert!(
+        error.contains("Authentication failed (401 Unauthorized)"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn verify_classifies_http_forbidden_as_authentication() {
+    let address = serve_http_response(axum::http::StatusCode::FORBIDDEN, "text/plain", b"").await;
+    let error = verify_fails(http_definition("docs", &format!("http://{address}/mcp"))).await;
+    assert!(
+        error.contains("Authentication failed (403 Forbidden)"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn verify_classifies_http_404_as_wrong_path() {
+    let address = serve_http_response(axum::http::StatusCode::NOT_FOUND, "text/plain", b"").await;
+    let error = verify_fails(http_definition("docs", &format!("http://{address}/mcp"))).await;
+    assert!(error.contains("Wrong path (404 Not Found)"), "{error}");
+}
+
+#[tokio::test]
+async fn verify_classifies_http_5xx_as_server_error() {
+    let address = serve_http_response(
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        "text/plain",
+        b"",
+    )
+    .await;
+    let error = verify_fails(http_definition("docs", &format!("http://{address}/mcp"))).await;
+    assert!(
+        error.contains("Server error (500 Internal Server Error)"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn verify_classifies_missing_bearer_token_and_says_where_to_set_it() {
+    const MISSING: &str = "TIDEBREAK_TEST_MCP_VERIFY_BEARER_MISSING_C0FFEE";
+    assert!(std::env::var_os(MISSING).is_none());
+    let mut definition = http_definition("docs", "http://127.0.0.1:1/mcp");
+    definition.bearer_token_env = Some(MISSING.to_string());
+    let error = verify_fails(definition).await;
+    assert!(
+        error.contains("Bearer-token environment variable"),
+        "{error}"
+    );
+    assert!(error.contains(MISSING), "{error}");
+    assert!(error.contains("shell you start Tidebreak from"), "{error}");
+    assert!(error.contains("does not read a .env file"), "{error}");
+}
+
+#[tokio::test]
+async fn verify_classifies_protocol_negotiation_and_quotes_first_bytes() {
+    let address = serve_http_response(
+        axum::http::StatusCode::OK,
+        "text/html",
+        b"<html>not-mcp</html>",
+    )
+    .await;
+    let error = verify_fails(http_definition("docs", &format!("http://{address}/mcp"))).await;
+    assert!(error.contains("Protocol negotiation failed"), "{error}");
+    assert!(error.contains("not with MCP JSON-RPC"), "{error}");
+    assert!(error.contains("<html>not-mcp</html>"), "{error}");
+}
+
+#[tokio::test]
+async fn verify_classifies_timeout_after_configured_milliseconds() {
+    let app = axum::Router::new().route(
+        "/mcp",
+        axum::routing::post(|| async {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            axum::http::StatusCode::OK
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let mut definition = http_definition("docs", &format!("http://{address}/mcp"));
+    definition.request_timeout_ms = 80;
+    let error = verify_fails(definition).await;
+    assert!(error.contains("Timed out after 80 ms."), "{error}");
+}
+
+#[tokio::test]
+async fn verify_classifies_stdio_command_not_found() {
+    let mut definition = disabled_definition("docs", "/definitely-not-an-mcp-binary-9f3a");
+    definition.enabled = true;
+    let error = verify_fails(definition).await;
+    assert!(
+        error.contains("Process failed to launch: command not found."),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn verify_classifies_stdio_exit_code_and_first_stderr_line() {
+    let mut definition = disabled_definition("docs", "/bin/sh");
+    definition.enabled = true;
+    definition.args = vec![
+        "-c".to_string(),
+        "printf 'mcp-launch-stderr\\n' >&2; exit 7".to_string(),
+    ];
+    let error = verify_fails(definition).await;
+    assert!(
+        error.contains("Process failed to launch: exit code 7."),
+        "{error}"
+    );
+    assert!(
+        error.contains("First stderr line: mcp-launch-stderr."),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn successful_verify_reports_tool_count_and_enabled_for_new_turns() {
+    let address = serve_fake_http_mcp().await;
+    let (runtime, _store, _directory) = test_runtime().await;
+    let mut definition = http_definition("docs", &format!("http://{address}/mcp"));
+    definition.bearer_token_env = Some("PATH".to_string());
+    let info = runtime
+        .replace(McpServersConfig {
+            servers: vec![definition],
+        })
+        .await
+        .unwrap();
+    assert_eq!(info.servers[0].health, McpHealth::Healthy);
+    assert_eq!(info.servers[0].tool_count, 1);
+    assert!(info.servers[0].definition.enabled);
+    assert_eq!(info.servers[0].diagnostic, None);
+
+    let mut disabled = http_definition("idle", "http://127.0.0.1:1/mcp");
+    disabled.enabled = false;
+    let info = runtime
+        .replace(McpServersConfig {
+            servers: vec![disabled],
+        })
+        .await
+        .unwrap();
+    assert_eq!(info.servers[0].health, McpHealth::Disabled);
+    assert!(!info.servers[0].definition.enabled);
+    assert_eq!(info.servers[0].tool_count, 0);
 }

--- a/crates/tidebreak-server/src/mcp_config/types.rs
+++ b/crates/tidebreak-server/src/mcp_config/types.rs
@@ -392,6 +392,8 @@ impl McpServerDefinition {
         gateway: &Arc<dyn GatewayEndpoints>,
         env: &BTreeMap<String, String>,
     ) -> Result<McpClient> {
+        let request_timeout = Duration::from_millis(self.request_timeout_ms);
+        let initialization_timeout = request_timeout.min(INITIALIZATION_TIMEOUT);
         if let Some(slug) = &self.gateway_endpoint {
             // Resolved per connection: a reconnect always presents a token
             // that is fresh at that moment, so expiry is survived by the
@@ -401,8 +403,8 @@ impl McpServerDefinition {
                 self.name.clone(),
                 &access.url,
                 Some(&access.bearer_token),
-                INITIALIZATION_TIMEOUT,
-                Duration::from_millis(self.request_timeout_ms),
+                initialization_timeout,
+                request_timeout,
             )
             .await
             .map(|client| {
@@ -428,16 +430,16 @@ impl McpServerDefinition {
                 url,
                 bearer_token.as_deref(),
                 &headers,
-                INITIALIZATION_TIMEOUT,
-                Duration::from_millis(self.request_timeout_ms),
+                initialization_timeout,
+                request_timeout,
             )
             .await;
         }
         McpClient::spawn_with_timeouts(
             self.name.clone(),
             self.build_command(env)?,
-            INITIALIZATION_TIMEOUT,
-            Duration::from_millis(self.request_timeout_ms),
+            initialization_timeout,
+            request_timeout,
         )
         .await
     }

--- a/crates/tidebreak-server/src/mcp_config/validation.rs
+++ b/crates/tidebreak-server/src/mcp_config/validation.rs
@@ -202,12 +202,14 @@ pub(super) fn validate_environment_name(server_name: &str, name: &str) -> Result
 
 /// The user-facing reason a server failed to connect.
 ///
-/// Every returned string is fixed or interpolates a configured *name* only —
-/// never URL, token, or upstream error text. For gateway mounts the split
-/// follows where the failure happened: sign-in state, then resolution/token
-/// exchange (these fail as [`AgentError::Config`] inside the connectors and
-/// gateway runtime, before any wire I/O), then the wire itself (tidebreak-mcp
-/// failures arrive as non-`Config` classes).
+/// Gateway mounts keep the sign-in / entitlement / reachability split: those
+/// failures happen before or beside the wire, and the messages must not name
+/// a resolved URL. Manual stdio and HTTP servers classify the transport
+/// failure (DNS, TLS, HTTP status, protocol, timeout, missing environment,
+/// process launch) and include the concrete detail. Messages interpolate
+/// configured *names*, a DNS host, an HTTP status line, a TLS reason, a
+/// bounded first-bytes quote, or a first stderr line — never a URL, token,
+/// or unbounded upstream body.
 pub(super) fn connection_diagnostic(
     definition: &McpServerDefinition,
     error: &AgentError,
@@ -231,13 +233,60 @@ pub(super) fn connection_diagnostic(
         .chain(&definition.bearer_token_env)
         .find(|name| std::env::var_os(name).is_none())
     {
-        return format!("Required parent environment variable {name:?} is not set.");
+        return missing_environment_diagnostic(
+            name,
+            definition.bearer_token_env.as_deref() == Some(name.as_str()),
+        );
+    }
+    let detail = classified_transport_detail(error);
+    if let Some(detail) = detail {
+        return detail;
     }
     if definition.url.is_some() {
         return "Could not connect to this server. Check its URL and credentials.".to_string();
     }
     "Could not initialize this server. Check its executable, arguments, and working directory."
         .to_string()
+}
+
+fn missing_environment_diagnostic(name: &str, bearer: bool) -> String {
+    if bearer {
+        format!(
+            "Bearer-token environment variable {name:?} is not set in the environment \
+             Tidebreak reads. Export it in the shell you start Tidebreak from, then \
+             restart Tidebreak. Tidebreak does not read a .env file or this form for \
+             the token value."
+        )
+    } else {
+        format!(
+            "Parent environment variable {name:?} is not set in the environment \
+             Tidebreak reads. Export it in the shell you start Tidebreak from, then \
+             restart Tidebreak."
+        )
+    }
+}
+
+fn classified_transport_detail(error: &AgentError) -> Option<String> {
+    let raw = match error {
+        AgentError::Config(message) | AgentError::Message(message) => message.as_str(),
+        _ => return None,
+    };
+    let raw = raw.strip_prefix("MCP client error: ").unwrap_or(raw);
+    const PREFIXES: &[&str] = &[
+        "DNS resolution failed",
+        "TLS handshake failed",
+        "Authentication failed",
+        "Wrong path",
+        "Server error",
+        "HTTP status",
+        "Protocol negotiation failed",
+        "Timed out after",
+        "Process failed to launch",
+    ];
+    PREFIXES
+        .iter()
+        .any(|prefix| raw.starts_with(prefix))
+        .then(|| raw.to_string())
 }
 
 pub(super) fn server_error(name: &str, message: impl std::fmt::Display) -> AgentError {

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -47,9 +47,15 @@ fields. The two channels that do carry a value are:
   never stored at all.
 
 A missing selected name produces a server-specific error containing the name,
-not a value. Child stderr is discarded so a server cannot copy a forwarded
-credential into Tidebreak's host logs, and HTTP diagnostics are fixed strings
-that never echo the URL, a token, or a response body.
+not a value, and tells you to export it in the shell you start Tidebreak from
+and then restart Tidebreak. Save and verify classifies the failure: DNS
+resolution (the host), TLS handshake (the reason), HTTP status (401/403 as
+authentication, 404 as wrong path, 5xx as server error, with the status line),
+protocol negotiation (quotes the first bytes when the endpoint answered but
+not with MCP JSON-RPC), timeout (after N ms), or a stdio launch failure
+(command not found, exit code, first stderr line). Diagnostics never echo a
+URL or a token. Child stderr is not copied into host logs; a failed launch may
+quote its first line in Settings.
 
 Definitions saved before the values moved into the credential store held them
 in cleartext in the connected-app record. They are migrated on first load: the
@@ -75,9 +81,11 @@ claim covers and how a server earns an entry.
 ## Health and refresh
 
 Settings reports `initializing`, `healthy`, `degraded`, `reconnecting`, or
-`disabled` plus a bounded diagnostic and tool count. The runtime periodically
-pings enabled servers with a fixed health deadline and retries unavailable
-sessions with capped exponential backoff. Health checks and reconnects run
+`disabled` plus a bounded diagnostic and tool count. A healthy verify names
+how many tools were discovered and that the server is available to new turns.
+A disabled server stays configured and is not available to new turns. The
+runtime periodically pings enabled servers with a fixed health deadline and
+retries unavailable sessions with capped exponential backoff. Health checks and reconnects run
 independently across servers, while duplicate reconnects for one server share a
 single attempt. A server busy with a tool call is skipped for that health cycle,
 not treated as degraded. **Reconnect and refresh tools** explicitly starts a
@@ -131,6 +139,47 @@ point on record: once local apps and gateway promotion have shipped, if the
 gateway's inline console remains the only `ui://` producer in practice and a
 promoted app covers its use case, deprecating this surface is the recorded
 default — it would remove a special case, not a subsystem.
+
+## Known-good setups
+
+Fill the Connected apps form exactly as below, then **Save and verify**. A
+healthy row reports the discovered tool count and that the server is available
+to new turns.
+
+### Stdio: Tidebreak workspace tools
+
+Tidebreak's own read-only workspace server. The executable is the `tidebreak`
+binary on your `PATH`, or its absolute path.
+
+- **Namespace:** `workspace` (ASCII letters, numbers, `_`, or `-`)
+- **Transport:** Process on this computer (stdio)
+- **Executable:** `tidebreak`
+- **Arguments:** `mcp`, then the absolute workspace path (`/absolute/path/to/workspace`)
+- **Working directory:** leave blank
+- **Environment / Forward environment names:** none
+- **Bearer token variable:** not used
+- **Request timeout:** `60000`
+- **Enabled:** on
+
+### Remote HTTP: loopback Streamable HTTP
+
+A server that speaks MCP Streamable HTTP on loopback. Use `http://` only for a
+literal loopback address; remote URLs that send a bearer token must use
+`https://`.
+
+- **Namespace:** `docs`
+- **Transport:** Remote endpoint (HTTP)
+- **Server URL:** `http://127.0.0.1:8080/mcp` (the path your server actually serves)
+- **Bearer token variable:** leave blank on loopback with no auth
+- **Request timeout:** `60000`
+- **Enabled:** on
+
+For a remote HTTPS server that expects a bearer token, set **Server URL** to
+the `https://` MCP path and **Bearer token variable** to the *name* of the
+variable (for example `GATEWAY_TOKEN`). Export that variable in the shell you
+start Tidebreak from, then restart Tidebreak. Tidebreak reads its process
+environment; it does not read a `.env` file or the token from this form. A
+Dock or Finder launch does not see variables you set only in another terminal.
 
 ## Headless bootstrap
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -174,8 +174,9 @@ variable name — and a bounded request timeout. No shell interprets any field.
 Child environments are always cleared before the selected names and literal
 values are added, so an MCP process cannot inherit provider credentials or
 other desktop secrets by accident. Resolved `env_from` and bearer-token values
-never enter the database or renderer, and child stderr is discarded instead of
-being copied into host logs.
+never enter the database or renderer. Child stderr is not copied into host
+logs; a failed stdio launch may quote its first line in the Settings
+diagnostic.
 
 Saving first validates and connects the complete candidate set, then atomically
 publishes it for later turns. A failure leaves the prior connection set active.


### PR DESCRIPTION
## What changed

Save and verify no longer collapses every MCP start failure into a generic connect error. You now get the failure class and the concrete detail in the message Settings shows.

The HTTP transport classifies DNS, TLS, HTTP status, protocol negotiation, and timeouts. Stdio launch failures name a missing command, an exit code, and the first stderr line. A missing bearer-token environment variable names the variable and tells you to export it in the shell you start Tidebreak from, then restart Tidebreak. Loopback HTTP servers skip an inherited HTTP proxy so a local verify does not hang on the proxy.

On success, a healthy row still reports the discovered tool count and that the server is available to new turns. A disabled server reports that it is not available to new turns.

`docs/mcp-servers.md` now includes one known-good stdio setup (`tidebreak mcp`) and one known-good remote HTTP setup, plus where you must supply the bearer-token environment variable.

## Why

The Connected apps form ended every failed verify with "Could not connect to this server. Check its URL and credentials." You could not tell a missing `GATEWAY_TOKEN`, a wrong path, a TLS failure, or a non-MCP response apart.

## Failure classes and messages

Save and verify prefixes each diagnostic with `external MCP server {name} failed to start:`. The classified detail is:

| Class | Message |
| --- | --- |
| DNS resolution | `DNS resolution failed ({host}).` |
| TLS handshake | `TLS handshake failed ({reason}).` |
| HTTP 401 / 403 | `Authentication failed (401 Unauthorized).` / `Authentication failed (403 Forbidden).` |
| HTTP 404 | `Wrong path (404 Not Found).` |
| HTTP 5xx | `Server error (500 Internal Server Error).` |
| Other HTTP status | `HTTP status {code} {reason}.` |
| Missing bearer-token variable | `Bearer-token environment variable "{name}" is not set in the environment Tidebreak reads. Export it in the shell you start Tidebreak from, then restart Tidebreak. Tidebreak does not read a .env file or this form for the token value.` |
| Protocol negotiation | `Protocol negotiation failed. The endpoint answered but not with MCP JSON-RPC. First bytes: "{quoted}".` |
| Timeout | `Timed out after {n} ms.` |
| Stdio command not found | `Process failed to launch: command not found.` |
| Stdio exited | `Process failed to launch: exit code {code}. First stderr line: {line}.` |

A successful verify reports `{n} tools available to new turns.` A disabled server reports `Disabled. This server is not available to new turns.`

Gateway mounts keep the existing sign-in / entitlement / reachability messages.

## Commands

`cargo fmt --all --check` — passed.

`cargo clippy -p tidebreak-server --all-targets -- -D warnings` — this sandbox rustc is 1.98.0 and cannot fetch the pinned Symphonia git rev, so clippy did not finish here. CI runs the pinned 1.97.1 toolchain.

`cargo test -p tidebreak-server mcp_config` — 38 passed, including DNS, missing bearer-token environment, timeout, stdio command-not-found, and stdio exit+stderr. HTTP listener cases timed out talking to 127.0.0.1 in this sandbox; they use the same axum listener pattern as the existing MCP config tests.

UI format/lint/test — pnpm could not install here (npm registry connect timeout). The settings UI only wraps long diagnostics and names where you set the bearer-token variable.

Closes #3038