### PR TITLE
fix(code): start sessions from the repository's real default branch

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -757,6 +757,8 @@ pub struct CodeRepo {
     /// Display name.
     pub display_name: String,
     /// Default base ref for new workspaces.
+    ///
+    /// Resolved from the repository when you do not set one.
     pub default_base_ref: String,
     /// Prefix applied to workspace branch names.
     pub branch_prefix: String,

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -813,6 +813,9 @@ fn map_worktree(err: WorktreeError) -> ServerError {
                 ServerError::bad_request_kind("worktree", message)
             }
         }
+        missing @ WorktreeError::MissingBaseRef { .. } => {
+            ServerError::bad_request_kind("missing_base_ref", missing.to_string())
+        }
         WorktreeError::Internal(message) => ServerError::internal(message),
         WorktreeError::ArchiveUncertain(message) => {
             ServerError::conflict_kind("archive_inspection_uncertain", message)

--- a/crates/tidebreak-server/src/code/runtime/repos.rs
+++ b/crates/tidebreak-server/src/code/runtime/repos.rs
@@ -53,14 +53,27 @@ impl CodeRuntime {
                     .unwrap_or_else(|| "repo".into())
             });
         let default_branch_prefix = self.default_branch_prefix(owner).await;
+        let configured_base = default_base_ref
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty());
+        let default_base_ref = match worktree::resolve_default_base_ref(
+            &validated.toplevel,
+            configured_base.as_deref(),
+        )
+        .await
+        {
+            Ok(resolved) => resolved,
+            Err(WorktreeError::MissingBaseRef { .. }) => {
+                configured_base.unwrap_or_else(|| "main".into())
+            }
+            Err(other) => return Err(map_worktree(other)),
+        };
         let repo = CodeRepo {
             id: RepoId::new(),
             owner: owner.clone(),
             root_path: toplevel,
             display_name: name,
-            default_base_ref: default_base_ref
-                .filter(|value| !value.trim().is_empty())
-                .unwrap_or_else(|| "main".into()),
+            default_base_ref,
             branch_prefix: branch_prefix
                 .filter(|value| !value.trim().is_empty())
                 .unwrap_or(default_branch_prefix),

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -62,12 +62,18 @@ impl CodeRuntime {
             .clone()
             .unwrap_or_else(|| repo.default_base_ref.clone());
         let repo_root = std::path::Path::new(&repo.root_path);
-        let base = worktree::resolve_default_base_ref(repo_root, Some(&requested))
-            .await
-            .map_err(map_worktree)?;
         let requested_repo_default = explicit_base
             .as_deref()
             .is_none_or(|value| value == repo.default_base_ref);
+        let base = if requested_repo_default {
+            worktree::resolve_default_base_ref(repo_root, Some(&requested))
+                .await
+                .map_err(map_worktree)?
+        } else {
+            worktree::resolve_named_base_ref(repo_root, &requested)
+                .await
+                .map_err(map_worktree)?
+        };
         if requested_repo_default && repo.default_base_ref != base {
             let mut repo = repo.clone();
             repo.default_base_ref = base.clone();

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -55,9 +55,24 @@ impl CodeRuntime {
         } else {
             title
         };
-        let base = base_ref
-            .filter(|value| !value.trim().is_empty())
+        let explicit_base = base_ref
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty());
+        let requested = explicit_base
+            .clone()
             .unwrap_or_else(|| repo.default_base_ref.clone());
+        let repo_root = std::path::Path::new(&repo.root_path);
+        let base = worktree::resolve_default_base_ref(repo_root, Some(&requested))
+            .await
+            .map_err(map_worktree)?;
+        let requested_repo_default = explicit_base
+            .as_deref()
+            .is_none_or(|value| value == repo.default_base_ref);
+        if requested_repo_default && repo.default_base_ref != base {
+            let mut repo = repo.clone();
+            repo.default_base_ref = base.clone();
+            self.save_repo(&repo).await?;
+        }
         let mut workspace = CodeWorkspace {
             id,
             owner: owner.clone(),

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -566,6 +566,31 @@ pub(crate) async fn resolve_default_base_ref(
     Err(WorktreeError::missing_base_ref(looked_for, &tried))
 }
 
+/// Resolve one requested ref, including `origin/<name>` when the local branch
+/// is missing. Does not walk sibling default names.
+pub(crate) async fn resolve_named_base_ref(
+    repo_root: &Path,
+    reference: &str,
+) -> Result<String, WorktreeError> {
+    let reference = reference.trim();
+    if reference.is_empty() {
+        return Err(WorktreeError::user(
+            "You cannot start from an empty base ref.",
+        ));
+    }
+    let mut tried = Vec::new();
+    for candidate in base_ref_candidates(reference) {
+        if tried.contains(&candidate) {
+            continue;
+        }
+        tried.push(candidate.clone());
+        if verify_commit(repo_root, &candidate).await?.is_some() {
+            return Ok(candidate);
+        }
+    }
+    Err(WorktreeError::missing_base_ref(reference, &tried))
+}
+
 /// Create a worktree and branch under the Tidebreak data directory.
 pub(crate) async fn create_worktree(
     repo_root: &Path,
@@ -2429,6 +2454,25 @@ mod tests {
 
         let resolved = resolve_default_base_ref(&repo, Some("main")).await.unwrap();
         assert_eq!(resolved, "origin/trunk");
+    }
+
+    #[tokio::test]
+    async fn named_base_ref_does_not_fall_through_to_the_current_branch() {
+        let (_dir, repo) = init_named_repo("trunk", true);
+        let err = resolve_named_base_ref(&repo, "feature-x")
+            .await
+            .unwrap_err();
+        match &err {
+            WorktreeError::MissingBaseRef { looked_for, tried } => {
+                assert_eq!(looked_for, "feature-x");
+                assert!(tried.contains("feature-x"), "{tried}");
+                assert!(
+                    !tried.contains("trunk"),
+                    "an explicit miss must not walk sibling defaults: {tried}"
+                );
+            }
+            other => panic!("expected MissingBaseRef, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -157,6 +157,8 @@ impl ArchiveBlock {
 pub(crate) enum WorktreeError {
     #[error("{0}")]
     User(String),
+    #[error("You cannot start from `{looked_for}`. None of these resolve: {tried}. Choose a reachable base ref and try again.")]
+    MissingBaseRef { looked_for: String, tried: String },
     #[error("{0}")]
     Internal(String),
     #[error("{0}")]
@@ -168,6 +170,16 @@ pub(crate) enum WorktreeError {
 impl WorktreeError {
     pub(crate) fn user(message: impl Into<String>) -> Self {
         Self::User(message.into())
+    }
+
+    fn missing_base_ref(looked_for: impl Into<String>, candidates: &[String]) -> Self {
+        let looked_for = looked_for.into();
+        let tried = if candidates.is_empty() {
+            looked_for.clone()
+        } else {
+            candidates.join(", ")
+        };
+        Self::MissingBaseRef { looked_for, tried }
     }
 
     fn internal(message: impl Into<String>) -> Self {
@@ -507,6 +519,51 @@ pub(crate) async fn validate_repo_path(path: &Path) -> Result<ValidatedRepo, Wor
         ))
     })?;
     Ok(ValidatedRepo { toplevel })
+}
+
+/// Resolve the default base ref from the repository instead of assuming `main`.
+///
+/// Tries the configured ref, then the target of `refs/remotes/origin/HEAD`,
+/// then `main`, then `master`, then the current branch. A remote-only
+/// `origin/<name>` is accepted when the local branch does not exist.
+pub(crate) async fn resolve_default_base_ref(
+    repo_root: &Path,
+    configured: Option<&str>,
+) -> Result<String, WorktreeError> {
+    let configured = configured.map(str::trim).filter(|value| !value.is_empty());
+
+    let mut logical = Vec::new();
+    if let Some(configured) = configured {
+        push_unique(&mut logical, configured.to_owned());
+    }
+    if let Some(origin_default) = origin_head_branch(repo_root).await {
+        push_unique(&mut logical, origin_default);
+    }
+    push_unique(&mut logical, "main".into());
+    push_unique(&mut logical, "master".into());
+    if let Some(current) = current_branch_name(repo_root).await {
+        push_unique(&mut logical, current);
+    }
+
+    let looked_for = configured
+        .map(str::to_owned)
+        .or_else(|| logical.first().cloned())
+        .unwrap_or_else(|| "main".into());
+
+    let mut tried = Vec::new();
+    for name in &logical {
+        for candidate in base_ref_candidates(name) {
+            if tried.contains(&candidate) {
+                continue;
+            }
+            tried.push(candidate.clone());
+            if verify_commit(repo_root, &candidate).await?.is_some() {
+                return Ok(candidate);
+            }
+        }
+    }
+
+    Err(WorktreeError::missing_base_ref(looked_for, &tried))
 }
 
 /// Create a worktree and branch under the Tidebreak data directory.
@@ -1011,14 +1068,96 @@ fn worktree_operation_marker_path(worktree_path: &Path) -> Result<PathBuf, Workt
 }
 
 async fn resolve_ref(repo_root: &Path, reference: &str) -> Result<String, WorktreeError> {
-    git_stdout(
+    let reference = reference.trim();
+    for candidate in base_ref_candidates(reference) {
+        if let Some(commit) = verify_commit(repo_root, &candidate).await? {
+            return Ok(commit);
+        }
+    }
+    Err(WorktreeError::user(format!(
+        "You cannot resolve `{reference}` because that ref is missing."
+    )))
+}
+
+fn base_ref_candidates(reference: &str) -> Vec<String> {
+    let reference = reference.trim();
+    if reference.is_empty() {
+        return Vec::new();
+    }
+    let mut candidates = vec![reference.to_owned()];
+    if reference != "HEAD" && !reference.starts_with("refs/") && !reference.starts_with("origin/") {
+        candidates.push(format!("origin/{reference}"));
+    }
+    candidates
+}
+
+fn push_unique(names: &mut Vec<String>, name: String) {
+    if !name.is_empty() && !names.contains(&name) {
+        names.push(name);
+    }
+}
+
+fn short_branch_name(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let stripped = value
+        .strip_prefix("refs/remotes/origin/")
+        .or_else(|| value.strip_prefix("refs/heads/"))
+        .or_else(|| value.strip_prefix("origin/"))
+        .unwrap_or(value);
+    if stripped.is_empty() || stripped == "HEAD" {
+        None
+    } else {
+        Some(stripped.to_owned())
+    }
+}
+
+async fn origin_head_branch(repo_root: &Path) -> Option<String> {
+    let value = git_stdout(
         Some(repo_root),
-        &["rev-parse", &format!("{reference}^{{commit}}")],
+        &["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
         GIT_TIMEOUT,
     )
     .await
-    .map(|tip| tip.trim().to_owned())
-    .map_err(|error| WorktreeError::user(format!("could not resolve {reference}: {error}")))
+    .ok()?;
+    short_branch_name(&value)
+}
+
+async fn current_branch_name(repo_root: &Path) -> Option<String> {
+    let value = git_stdout(
+        Some(repo_root),
+        &["symbolic-ref", "--quiet", "--short", "HEAD"],
+        GIT_TIMEOUT,
+    )
+    .await
+    .ok()?;
+    short_branch_name(&value)
+}
+
+async fn verify_commit(repo_root: &Path, reference: &str) -> Result<Option<String>, WorktreeError> {
+    let revision = format!("{reference}^{{commit}}");
+    match git_stdout(
+        Some(repo_root),
+        &["rev-parse", "--verify", "--quiet", &revision],
+        GIT_TIMEOUT,
+    )
+    .await
+    {
+        Ok(commit) => {
+            let commit = commit.trim();
+            if commit.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(commit.to_owned()))
+            }
+        }
+        Err(error) if error.is_empty() => Ok(None),
+        Err(error) => Err(WorktreeError::internal(format!(
+            "could not resolve {reference}: {error}"
+        ))),
+    }
 }
 
 async fn create_branch_at(
@@ -2237,6 +2376,107 @@ mod tests {
         assert!(
             !listed.contains("ghost"),
             "stale worktree left behind: {listed}"
+        );
+    }
+
+    fn init_named_repo(branch: &str, commit: bool) -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path().join("origin");
+        std::fs::create_dir_all(&repo).unwrap();
+        run(&repo, &["git", "init", "-b", branch]);
+        run(&repo, &["git", "config", "user.email", "dev@example.com"]);
+        run(&repo, &["git", "config", "user.name", "Dev"]);
+        if commit {
+            std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+            run(&repo, &["git", "add", "README.md"]);
+            run(&repo, &["git", "commit", "-m", "init"]);
+        }
+        (dir, repo)
+    }
+
+    #[tokio::test]
+    async fn default_base_ref_uses_trunk_when_main_is_missing() {
+        let (_dir, repo) = init_named_repo("trunk", true);
+        let resolved = resolve_default_base_ref(&repo, Some("main")).await.unwrap();
+        assert_eq!(resolved, "trunk");
+        let data = TempDir::new().unwrap();
+        let path = scratch_worktree(data.path(), "from-trunk");
+        create_ready(&repo, &path, "tidebreak/from-trunk", &resolved).await;
+        assert!(path.join("README.md").is_file());
+    }
+
+    #[tokio::test]
+    async fn default_base_ref_uses_origin_when_the_local_branch_is_missing() {
+        let (_dir, repo) = init_named_repo("trunk", true);
+        let tip = git_stdout(Some(&repo), &["rev-parse", "HEAD"], GIT_TIMEOUT)
+            .await
+            .unwrap();
+        run(
+            &repo,
+            &["git", "update-ref", "refs/remotes/origin/trunk", &tip],
+        );
+        run(
+            &repo,
+            &[
+                "git",
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/trunk",
+            ],
+        );
+        run(&repo, &["git", "checkout", "--detach", "HEAD"]);
+        run(&repo, &["git", "branch", "-D", "trunk"]);
+
+        let resolved = resolve_default_base_ref(&repo, Some("main")).await.unwrap();
+        assert_eq!(resolved, "origin/trunk");
+    }
+
+    #[tokio::test]
+    async fn default_base_ref_prefers_origin_head_over_main() {
+        let (_dir, repo) = init_named_repo("trunk", true);
+        run(&repo, &["git", "branch", "main"]);
+        let tip = git_stdout(Some(&repo), &["rev-parse", "HEAD"], GIT_TIMEOUT)
+            .await
+            .unwrap();
+        run(
+            &repo,
+            &["git", "update-ref", "refs/remotes/origin/trunk", &tip],
+        );
+        run(
+            &repo,
+            &["git", "update-ref", "refs/remotes/origin/main", &tip],
+        );
+        run(
+            &repo,
+            &[
+                "git",
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/trunk",
+            ],
+        );
+
+        let resolved = resolve_default_base_ref(&repo, None).await.unwrap();
+        assert_eq!(resolved, "trunk");
+    }
+
+    #[tokio::test]
+    async fn default_base_ref_names_the_missing_ref_when_nothing_resolves() {
+        let (_dir, repo) = init_named_repo("trunk", false);
+        let err = resolve_default_base_ref(&repo, Some("main"))
+            .await
+            .unwrap_err();
+        match &err {
+            WorktreeError::MissingBaseRef { looked_for, tried } => {
+                assert_eq!(looked_for, "main");
+                assert!(tried.contains("main"), "{tried}");
+                assert!(tried.contains("trunk"), "{tried}");
+            }
+            other => panic!("expected MissingBaseRef, got {other:?}"),
+        }
+        assert!(
+            err.to_string().contains("`main`"),
+            "error must name the missing ref: {err}"
         );
     }
 

--- a/crates/tidebreak-server/src/tests/code_create.rs
+++ b/crates/tidebreak-server/src/tests/code_create.rs
@@ -823,3 +823,168 @@ async fn a_signed_out_relay_covered_engine_still_creates_on_a_hosted_machine() {
         .unwrap();
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
 }
+
+fn init_git_repo_on_branch(
+    dir: &std::path::Path,
+    branch: &str,
+    commit: bool,
+) -> std::path::PathBuf {
+    let repo = dir.join("origin");
+    std::fs::create_dir_all(&repo).unwrap();
+    for args in [
+        ["git", "init", "-b", branch].as_slice(),
+        ["git", "config", "user.email", "dev@example.com"].as_slice(),
+        ["git", "config", "user.name", "Dev"].as_slice(),
+        ["git", "config", "core.autocrlf", "false"].as_slice(),
+    ] {
+        assert!(std::process::Command::new(args[0])
+            .args(&args[1..])
+            .current_dir(&repo)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .status()
+            .unwrap()
+            .success());
+    }
+    if commit {
+        std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+        assert!(std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&repo)
+            .status()
+            .unwrap()
+            .success());
+        assert!(std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&repo)
+            .status()
+            .unwrap()
+            .success());
+    }
+    repo
+}
+
+#[tokio::test]
+async fn first_turn_starts_when_the_repository_has_no_main_ref() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo_on_branch(dir.path(), "trunk", true);
+
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    assert_eq!(repo_body["default_base_ref"], "trunk");
+
+    let patched = client
+        .patch(format!("http://{addr}/code/repos/{}", json_id(&repo_body)))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "default_base_ref": "main" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(patched.status(), reqwest::StatusCode::OK);
+
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "first change",
+            "base_ref": "main",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(workspace["base_ref"], "trunk");
+
+    let persisted = client
+        .get(format!("http://{addr}/code/repos/{}", json_id(&repo_body)))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(persisted["default_base_ref"], "trunk");
+
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(session.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = session.json().await.unwrap();
+
+    let turn = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "hello" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+    let turn: serde_json::Value = turn.json().await.unwrap();
+    assert_eq!(turn["status"], "completed");
+}
+
+#[tokio::test]
+async fn workspace_create_names_the_missing_base_ref_when_nothing_resolves() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo_on_branch(dir.path(), "trunk", false);
+
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "first change",
+            "base_ref": "main",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(body["kind"], "missing_base_ref");
+    let message = body["message"].as_str().unwrap_or("");
+    assert!(
+        message.contains("`main`"),
+        "error must name the missing ref: {message}"
+    );
+    assert!(
+        message.contains("trunk"),
+        "error must name the candidates you tried: {message}"
+    );
+}

--- a/crates/tidebreak-server/src/tests/code_create.rs
+++ b/crates/tidebreak-server/src/tests/code_create.rs
@@ -988,3 +988,46 @@ async fn workspace_create_names_the_missing_base_ref_when_nothing_resolves() {
         "error must name the candidates you tried: {message}"
     );
 }
+
+#[tokio::test]
+async fn workspace_create_does_not_fall_through_an_explicit_missing_ref() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo_on_branch(dir.path(), "trunk", true);
+
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    assert_eq!(repo_body["default_base_ref"], "trunk");
+
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "first change",
+            "base_ref": "feature-x",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(body["kind"], "missing_base_ref");
+    let message = body["message"].as_str().unwrap_or("");
+    assert!(
+        message.contains("`feature-x`"),
+        "error must name the missing ref: {message}"
+    );
+    assert!(
+        !message.contains("trunk"),
+        "an explicit miss must not walk sibling defaults: {message}"
+    );
+}


### PR DESCRIPTION
## Why

Code session startup assumed a `main` ref. When a repository uses another default branch, the first turn fails with HTTP 400 while git tries `main^{commit}`, and Try again repeats the same failure with the prompt still sitting there.

## What changed

Startup now resolves the base ref from the checkout.

`crates/tidebreak-server/src/code/worktree.rs` owns the resolver. `crates/tidebreak-server/src/code/runtime/repos.rs` and `crates/tidebreak-server/src/code/runtime/workspaces.rs` persist the ref you actually used. `crates/tidebreak-server/src/code/runtime/mod.rs` maps a miss to the typed `missing_base_ref` error. `crates/tidebreak-core/src/code/mod.rs` documents that the stored default comes from the repository when you do not set one. `crates/tidebreak-server/src/tests/code_create.rs` pins the HTTP path.

Candidates, in this order:

1. The explicitly configured base ref
2. The target of `refs/remotes/origin/HEAD` (`git symbolic-ref`)
3. `main`
4. `master`
5. The current branch

Each candidate is checked with `git rev-parse --verify --quiet <ref>^{commit}`. If the local branch is missing, `origin/<name>` is accepted. The workspace records that resolved ref, and the repo default is updated when you asked for the stored default.

When nothing resolves, you get `missing_base_ref` naming the ref you looked for and the candidates that were tried. That is distinct from a prompt or model failure. Workspace create still fails before a session starts, so the composer keeps the prompt and Try again works once the base is reachable.

## Tests

- `git init -b trunk` with one commit: register, create, and first turn start from `trunk` even when the stored default is `main`
- Empty `git init -b trunk` with no commit: workspace create returns `missing_base_ref` and names `main`
- Unit tests for origin-only refs, origin/HEAD over `main`, and the missing-ref error

## Commands

`cargo fmt --all --check` is clean.

`cargo test -p tidebreak-server --lib default_base_ref`: 4 passed.

`cargo test -p tidebreak-server --lib code::worktree::`: 29 passed.

`cargo clippy -p tidebreak-server -p tidebreak-core --all-targets -- -D warnings` compiles this change. This sandbox rustc is 1.98.0; CI pins 1.97.1. On 1.98 two existing lints fire in files this PR does not touch (`clippy::result_large_err` in `harness_llm.rs`, `clippy::chunks_exact_to_as_chunks` in `exec_write_snapshot.rs`). Allowing those two sandbox-only lints, clippy finishes clean.

`cargo test -p tidebreak-server code_create` cannot connect to `127.0.0.1` in this sandbox (`tcp connect error`, timed out). Existing `code_create` tests fail the same way. The new HTTP tests share that fixture; the worktree unit tests cover the resolver and the missing-ref error.

Closes #3040
