### PR TITLE
refactor(server): move the chat turn worker under the internal engine

### DIFF
--- a/crates/tidebreak-server/src/engine/internal/leg.rs
+++ b/crates/tidebreak-server/src/engine/internal/leg.rs
@@ -47,7 +47,7 @@ use crate::retry::{LaneBackoff, RetryAttempt, RetrySchedule};
 use crate::state::{BlobWriteGuard, TurnGuard};
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct TurnWorkerConfig {
+pub(crate) struct LegDriverConfig {
     pub(crate) lease: Duration,
     pub(crate) heartbeat: Duration,
     pub(crate) steer_poll: Duration,
@@ -64,7 +64,7 @@ pub(crate) struct TurnWorkerConfig {
     pub(crate) sandbox_spawn_execution_location: AgentRunExecutionLocation,
 }
 
-impl Default for TurnWorkerConfig {
+impl Default for LegDriverConfig {
     fn default() -> Self {
         Self {
             lease: Duration::from_secs(60),
@@ -89,7 +89,7 @@ impl Default for TurnWorkerConfig {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TurnWorkerOutcome {
+pub(crate) enum LegDriverOutcome {
     Completed(TurnId),
     WaitingForClient(TurnId),
     WaitingForAgentRun(TurnId),
@@ -100,7 +100,7 @@ pub(crate) enum TurnWorkerOutcome {
 }
 
 #[derive(Clone)]
-pub(crate) struct TurnWorker {
+pub(crate) struct LegDriver {
     /// Per-caller gateway capabilities on a hosted machine (decisions 51 and
     /// 62): the turn's model resolution and utility role read the owner's
     /// own entitlement snapshot through this. `None` everywhere else.
@@ -132,7 +132,7 @@ pub(crate) struct TurnWorker {
     exec_folder_context: Option<Arc<crate::code_execution::ConfiguredExecProvider>>,
     private_scratch_root: Option<PathBuf>,
     diagnostics: Arc<crate::diagnostics::Diagnostics>,
-    config: TurnWorkerConfig,
+    config: LegDriverConfig,
     /// Update-quiesce channel pair, when this worker serves a process that
     /// can restart to update. `None` in tests that install none.
     quiesce: Option<crate::update_quiesce::ChatQuiesceWorker>,
@@ -574,7 +574,7 @@ impl<T> AbortOnDrop<T> {
     }
 }
 
-impl TurnWorker {
+impl LegDriver {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         store: Arc<dyn Store>,
@@ -591,7 +591,7 @@ impl TurnWorker {
         queued_turn_wake: Arc<Notify>,
         agent_config: AgentConfig,
         private_scratch_root: Option<PathBuf>,
-        config: TurnWorkerConfig,
+        config: LegDriverConfig,
     ) -> Self {
         assert!(!config.lease.is_zero());
         assert!(!config.heartbeat.is_zero());
@@ -867,7 +867,7 @@ impl TurnWorker {
     /// transcript and re-runs only the model call that was in flight — so the
     /// drain never refuses; the grace only saves re-running that call for
     /// turns that were about to finish anyway.
-    async fn drain_for_update(&self, turns: &mut tokio::task::JoinSet<Result<TurnWorkerOutcome>>) {
+    async fn drain_for_update(&self, turns: &mut tokio::task::JoinSet<Result<LegDriverOutcome>>) {
         let grace = tokio::time::sleep(CHAT_QUIESCE_TURN_GRACE);
         tokio::pin!(grace);
         while !turns.is_empty() {
@@ -934,7 +934,7 @@ impl TurnWorker {
     /// end of the turn is the only place that can apply them. Every way the run
     /// below returns has to pass through here, which is why the run itself is a
     /// separate function rather than an early return in this one.
-    async fn process(&self, turn: TurnRun, lease_token: uuid::Uuid) -> Result<TurnWorkerOutcome> {
+    async fn process(&self, turn: TurnRun, lease_token: uuid::Uuid) -> Result<LegDriverOutcome> {
         let chat_id = turn.chat_id;
         let turn_id = turn.id;
         let attempt_count = turn.attempt_count;
@@ -992,9 +992,9 @@ impl TurnWorker {
         });
         if matches!(
             outcome,
-            Ok(TurnWorkerOutcome::Completed(_)
-                | TurnWorkerOutcome::Cancelled(_)
-                | TurnWorkerOutcome::Failed(_))
+            Ok(LegDriverOutcome::Completed(_)
+                | LegDriverOutcome::Cancelled(_)
+                | LegDriverOutcome::Failed(_))
         ) {
             // The chat's live slot is free; its oldest queued message may now
             // be promotable. Errored and lease-lost segments terminalize later
@@ -1004,7 +1004,7 @@ impl TurnWorker {
         outcome
     }
 
-    async fn run_turn(&self, turn: TurnRun, lease_token: uuid::Uuid) -> Result<TurnWorkerOutcome> {
+    async fn run_turn(&self, turn: TurnRun, lease_token: uuid::Uuid) -> Result<LegDriverOutcome> {
         if turn.status != TurnRunStatus::Running || turn.lease_token != Some(lease_token) {
             return Err(AgentError::msg(format!(
                 "claimed turn {} has an invalid execution identity",
@@ -1289,7 +1289,7 @@ impl TurnWorker {
                                 .await;
                         }
                         LeaseState::Lost => {
-                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                            return Ok(LegDriverOutcome::LeaseLost(turn.id));
                         }
                     }
                 }
@@ -1304,7 +1304,7 @@ impl TurnWorker {
                     .acknowledge_cancellation(&turn, lease_token, total_model_steps, total_usage)
                     .await;
             }
-            LeaseState::Lost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
+            LeaseState::Lost => return Ok(LegDriverOutcome::LeaseLost(turn.id)),
         }
         let started = AgentEvent::TurnStarted { turn_id: turn.id };
         match self.append_event(&turn, lease_token, 1, &started).await? {
@@ -1315,7 +1315,7 @@ impl TurnWorker {
                     .acknowledge_cancellation(&turn, lease_token, total_model_steps, total_usage)
                     .await;
             }
-            EventAppend::LeaseLost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
+            EventAppend::LeaseLost => return Ok(LegDriverOutcome::LeaseLost(turn.id)),
         }
 
         let mut ordinal = 2_i32;
@@ -1431,7 +1431,7 @@ impl TurnWorker {
                                             &mut events_rx,
                                         )
                                         .await;
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -1478,7 +1478,7 @@ impl TurnWorker {
                                     &mut events_rx,
                                 )
                                 .await;
-                                return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                return Ok(LegDriverOutcome::LeaseLost(turn.id));
                             }
                         }
                     }
@@ -1562,7 +1562,7 @@ impl TurnWorker {
                         )
                         .await;
                 }
-                LeaseState::Lost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
+                LeaseState::Lost => return Ok(LegDriverOutcome::LeaseLost(turn.id)),
             }
 
             match drive_result {
@@ -1750,7 +1750,7 @@ impl TurnWorker {
                                         total_usage.cache_read_input_tokens,
                                         total_usage.cache_creation_input_tokens,
                                     );
-                                    return Ok(TurnWorkerOutcome::Completed(turn.id));
+                                    return Ok(LegDriverOutcome::Completed(turn.id));
                                 }
                                 CompleteTurnRunOutcome::SteerPending(_)
                                 | CompleteTurnRunOutcome::OutputSuperseded(_) => {
@@ -1780,7 +1780,7 @@ impl TurnWorker {
                                     LiveTurnState::Running => tokio::task::yield_now().await,
                                     LiveTurnState::Cancelling => break false,
                                     LiveTurnState::Lost => {
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -1801,11 +1801,11 @@ impl TurnWorker {
                                     ResolutionState::Retry => {}
                                     ResolutionState::Resolved(event) => {
                                         self.publish(turn.chat_id, *event);
-                                        return Ok(TurnWorkerOutcome::Completed(turn.id));
+                                        return Ok(LegDriverOutcome::Completed(turn.id));
                                     }
                                     ResolutionState::Cancelling => break false,
                                     ResolutionState::Lost => {
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -1864,7 +1864,7 @@ impl TurnWorker {
                                     .await;
                             }
                             EventAppend::LeaseLost => {
-                                return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                return Ok(LegDriverOutcome::LeaseLost(turn.id));
                             }
                         }
                         continuation_heartbeat.abort_and_wait().await;
@@ -1989,7 +1989,7 @@ impl TurnWorker {
                                             .await;
                                     }
                                     Ok(HeartbeatOutcome::LeaseLost) | Err(_) => {
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -2007,7 +2007,7 @@ impl TurnWorker {
                                     self.publish(turn.chat_id, event);
                                 }
                                 checkpoint_heartbeat.abort_and_wait().await;
-                                return Ok(TurnWorkerOutcome::WaitingForClient(turn.id));
+                                return Ok(LegDriverOutcome::WaitingForClient(turn.id));
                             }
                             Ok(Some(ParkTurnForClientCallOutcome::SteerPending(_)))
                             | Ok(Some(ParkTurnForClientCallOutcome::OutputSuperseded(_))) => {
@@ -2043,7 +2043,7 @@ impl TurnWorker {
                                     }
                                     LiveTurnState::Lost => {
                                         checkpoint_heartbeat.abort_and_wait().await;
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -2092,7 +2092,7 @@ impl TurnWorker {
                                 .await;
                         }
                         EventAppend::LeaseLost => {
-                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                            return Ok(LegDriverOutcome::LeaseLost(turn.id));
                         }
                     }
                     continuation_heartbeat.abort_and_wait().await;
@@ -2216,7 +2216,7 @@ impl TurnWorker {
                                             .await;
                                     }
                                     Ok(HeartbeatOutcome::LeaseLost) | Err(_) => {
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -2229,7 +2229,7 @@ impl TurnWorker {
                                 self.publish(turn.chat_id, event);
                                 self.sandbox_agent_wake.notify_one();
                                 self.wake.notify_one();
-                                return Ok(TurnWorkerOutcome::Resuming(turn.id));
+                                return Ok(LegDriverOutcome::Resuming(turn.id));
                             }
                             Ok(Some(CheckpointSandboxSpawnOutcome::Existing { event, .. })) => {
                                 checkpoint_heartbeat.abort_and_wait().await;
@@ -2240,7 +2240,7 @@ impl TurnWorker {
                                 self.publish(turn.chat_id, event);
                                 self.sandbox_agent_wake.notify_one();
                                 self.wake.notify_one();
-                                return Ok(TurnWorkerOutcome::Resuming(turn.id));
+                                return Ok(LegDriverOutcome::Resuming(turn.id));
                             }
                             Ok(Some(CheckpointSandboxSpawnOutcome::SteerPending(_)))
                             | Ok(Some(CheckpointSandboxSpawnOutcome::OutputSuperseded(_))) => {
@@ -2306,7 +2306,7 @@ impl TurnWorker {
                                     }
                                     LiveTurnState::Lost => {
                                         checkpoint_heartbeat.abort_and_wait().await;
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -2327,7 +2327,7 @@ impl TurnWorker {
                                     }
                                     LiveTurnState::Lost => {
                                         checkpoint_heartbeat.abort_and_wait().await;
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -2377,7 +2377,7 @@ impl TurnWorker {
                                 .await;
                         }
                         EventAppend::LeaseLost => {
-                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                            return Ok(LegDriverOutcome::LeaseLost(turn.id));
                         }
                     }
                     continuation_heartbeat.abort_and_wait().await;
@@ -2492,7 +2492,7 @@ impl TurnWorker {
                                             .await;
                                     }
                                     Ok(HeartbeatOutcome::LeaseLost) | Err(_) => {
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -2504,7 +2504,7 @@ impl TurnWorker {
                                 // This also drives the durable ready-set scan
                                 // when every child completed before the park.
                                 self.sandbox_agent_wake.notify_one();
-                                return Ok(TurnWorkerOutcome::WaitingForAgentRun(turn.id));
+                                return Ok(LegDriverOutcome::WaitingForAgentRun(turn.id));
                             }
                             Ok(Some(ParkTurnForAgentRunWaitSetOutcome::SteerPending(_)))
                             | Ok(Some(ParkTurnForAgentRunWaitSetOutcome::OutputSuperseded(_))) => {
@@ -2534,7 +2534,7 @@ impl TurnWorker {
                                     }
                                     LiveTurnState::Lost => {
                                         checkpoint_heartbeat.abort_and_wait().await;
-                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                        return Ok(LegDriverOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
@@ -2575,7 +2575,7 @@ impl TurnWorker {
                                 .await;
                         }
                         EventAppend::LeaseLost => {
-                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                            return Ok(LegDriverOutcome::LeaseLost(turn.id));
                         }
                     }
                     continuation_heartbeat.abort_and_wait().await;
@@ -2927,7 +2927,7 @@ impl TurnWorker {
         lease_token: uuid::Uuid,
         model_steps: i32,
         usage: tidebreak_core::Usage,
-    ) -> Result<TurnWorkerOutcome> {
+    ) -> Result<LegDriverOutcome> {
         self.acknowledge_cancellation_with_output(turn, lease_token, model_steps, usage, None)
             .await
     }
@@ -2944,7 +2944,7 @@ impl TurnWorker {
             tidebreak_core::Message,
             Vec<tidebreak_core::AssistantCitationInput>,
         )>,
-    ) -> Result<TurnWorkerOutcome> {
+    ) -> Result<LegDriverOutcome> {
         let terminal_event = AgentEvent::TurnCancelled { usage };
         loop {
             match self
@@ -2967,9 +2967,9 @@ impl TurnWorker {
                     if let Some(event) = resolution.terminal_event {
                         self.publish(turn.chat_id, event);
                     }
-                    return Ok(TurnWorkerOutcome::Cancelled(turn.id));
+                    return Ok(LegDriverOutcome::Cancelled(turn.id));
                 }
-                Ok(None) => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
+                Ok(None) => return Ok(LegDriverOutcome::LeaseLost(turn.id)),
                 Err(error) => {
                     self.retry_after("cancellation acknowledgement", turn.id, &error)
                         .await;
@@ -2986,10 +2986,10 @@ impl TurnWorker {
                         ResolutionState::Retry | ResolutionState::Cancelling => {}
                         ResolutionState::Resolved(event) => {
                             self.publish(turn.chat_id, *event);
-                            return Ok(TurnWorkerOutcome::Cancelled(turn.id));
+                            return Ok(LegDriverOutcome::Cancelled(turn.id));
                         }
                         ResolutionState::Lost => {
-                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                            return Ok(LegDriverOutcome::LeaseLost(turn.id));
                         }
                     }
                 }
@@ -3005,7 +3005,7 @@ impl TurnWorker {
         usage: tidebreak_core::Usage,
         code: &str,
         detail: &str,
-    ) -> Result<TurnWorkerOutcome> {
+    ) -> Result<LegDriverOutcome> {
         self.record_failure_with_retry(
             turn,
             lease_token,
@@ -3028,7 +3028,7 @@ impl TurnWorker {
         code: &str,
         detail: &str,
         retry_after: Option<Duration>,
-    ) -> Result<TurnWorkerOutcome> {
+    ) -> Result<LegDriverOutcome> {
         let retry = crate::event_projection::TurnFailureCategory::from_kind(code)
             .retries_may_succeed()
             .then(|| {
@@ -3052,7 +3052,7 @@ impl TurnWorker {
         code: &str,
         detail: &str,
         retry: TurnFailureRetry,
-    ) -> Result<TurnWorkerOutcome> {
+    ) -> Result<LegDriverOutcome> {
         let mut detail: String = detail
             .chars()
             .map(|character| {
@@ -3095,7 +3095,7 @@ impl TurnWorker {
                     return Ok(match resolution.outcome {
                         RecordTurnFailureOutcome::Recorded(_)
                         | RecordTurnFailureOutcome::Existing(_) => {
-                            TurnWorkerOutcome::Failed(turn.id)
+                            LegDriverOutcome::Failed(turn.id)
                         }
                     });
                 }
@@ -3106,7 +3106,7 @@ impl TurnWorker {
                             .acknowledge_cancellation(turn, lease_token, model_steps, usage)
                             .await;
                     }
-                    LiveTurnState::Lost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
+                    LiveTurnState::Lost => return Ok(LegDriverOutcome::LeaseLost(turn.id)),
                 },
                 Err(error) => {
                     self.retry_after("failure resolution", turn.id, &error)
@@ -3132,7 +3132,7 @@ impl TurnWorker {
                         ResolutionState::Retry => {}
                         ResolutionState::Resolved(event) => {
                             self.publish(turn.chat_id, *event);
-                            return Ok(TurnWorkerOutcome::Failed(turn.id));
+                            return Ok(LegDriverOutcome::Failed(turn.id));
                         }
                         ResolutionState::Cancelling => {
                             return self
@@ -3140,7 +3140,7 @@ impl TurnWorker {
                                 .await;
                         }
                         ResolutionState::Lost => {
-                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                            return Ok(LegDriverOutcome::LeaseLost(turn.id));
                         }
                     }
                 }
@@ -3326,7 +3326,7 @@ fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
         .map_err(|error| AgentError::msg(format!("invalid turn-worker duration: {error}")))
 }
 
-fn log_turn_result(result: std::result::Result<Result<TurnWorkerOutcome>, tokio::task::JoinError>) {
+fn log_turn_result(result: std::result::Result<Result<LegDriverOutcome>, tokio::task::JoinError>) {
     match result {
         Ok(Ok(_)) => {}
         Ok(Err(error)) => tracing::error!("tidebreak: turn worker execution failed: {error}"),
@@ -3334,21 +3334,21 @@ fn log_turn_result(result: std::result::Result<Result<TurnWorkerOutcome>, tokio:
     }
 }
 
-fn turn_worker_outcome_label(outcome: &Result<TurnWorkerOutcome>) -> &'static str {
+fn turn_worker_outcome_label(outcome: &Result<LegDriverOutcome>) -> &'static str {
     match outcome {
-        Ok(TurnWorkerOutcome::Completed(_)) => "completed",
-        Ok(TurnWorkerOutcome::WaitingForClient(_)) => "waiting_for_client",
-        Ok(TurnWorkerOutcome::WaitingForAgentRun(_)) => "waiting_for_agent_run",
-        Ok(TurnWorkerOutcome::Resuming(_)) => "resuming",
-        Ok(TurnWorkerOutcome::Cancelled(_)) => "cancelled",
-        Ok(TurnWorkerOutcome::Failed(_)) => "failed",
-        Ok(TurnWorkerOutcome::LeaseLost(_)) => "lease_lost",
+        Ok(LegDriverOutcome::Completed(_)) => "completed",
+        Ok(LegDriverOutcome::WaitingForClient(_)) => "waiting_for_client",
+        Ok(LegDriverOutcome::WaitingForAgentRun(_)) => "waiting_for_agent_run",
+        Ok(LegDriverOutcome::Resuming(_)) => "resuming",
+        Ok(LegDriverOutcome::Cancelled(_)) => "cancelled",
+        Ok(LegDriverOutcome::Failed(_)) => "failed",
+        Ok(LegDriverOutcome::LeaseLost(_)) => "lease_lost",
         Err(_) => "error",
     }
 }
 
-fn turn_worker_outcome_is_error(outcome: &Result<TurnWorkerOutcome>) -> bool {
-    matches!(outcome, Ok(TurnWorkerOutcome::Failed(_)) | Err(_))
+fn turn_worker_outcome_is_error(outcome: &Result<LegDriverOutcome>) -> bool {
+    matches!(outcome, Ok(LegDriverOutcome::Failed(_)) | Err(_))
 }
 
 #[cfg(test)]

--- a/crates/tidebreak-server/src/engine/internal/mod.rs
+++ b/crates/tidebreak-server/src/engine/internal/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! The engine drives [`tidebreak_core::agent::Agent`] through the chat turn
 //! lane that already runs it — the durable `turn_run` queue and the
-//! [`crate::turn_worker::TurnWorker`]. The lane journals the turn straight
+//! [`crate::engine::internal::leg::LegDriver`]. The lane journals the turn straight
 //! into the session's code journal (decision 0048 step 5), the one journal
 //! every engine writes, so the engine has nothing to translate: it admits
 //! the turn, follows that journal, and hands the session worker only the
@@ -15,6 +15,7 @@
 //! decision resumes it through [`tidebreak_harness::HarnessSession::resume_turn`].
 
 mod adapter;
+pub(crate) mod leg;
 mod session;
 
 pub(crate) use adapter::InternalAdapter;

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -104,7 +104,6 @@ mod source_tools;
 mod state;
 mod store_ownership;
 mod task_plan_tool;
-mod turn_worker;
 mod update_quiesce;
 mod vault_secrets;
 mod view_frames;
@@ -2335,7 +2334,7 @@ async fn bind_inner(
         blob_orphan_auditor::BlobOrphanAuditorConfig::default(),
     );
     let (chat_quiesce_worker, chat_quiesce_control) = update_quiesce::chat_quiesce_pair();
-    let turn_worker = turn_worker::TurnWorker::new(
+    let turn_worker = engine::internal::leg::LegDriver::new(
         state.store.clone(),
         state.resolver.clone(),
         state.secrets.clone(),
@@ -2350,9 +2349,9 @@ async fn bind_inner(
         state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         Some(state.config.data_dir.join("scratch")),
-        turn_worker::TurnWorkerConfig {
+        engine::internal::leg::LegDriverConfig {
             sandbox_spawn_execution_location,
-            ..turn_worker::TurnWorkerConfig::default()
+            ..engine::internal::leg::LegDriverConfig::default()
         },
     )
     .with_on_behalf_of_gateway(state.on_behalf_of_gateway.clone())

--- a/crates/tidebreak-server/src/routes/projects_chats.rs
+++ b/crates/tidebreak-server/src/routes/projects_chats.rs
@@ -799,7 +799,7 @@ pub async fn list_chat_messages(
         &*state.store,
         &*state.blobs,
         id,
-        Some(&crate::turn_worker::private_chat_scratch_path(
+        Some(&crate::engine::internal::leg::private_chat_scratch_path(
             &state.config.data_dir.join("scratch"),
             id,
         )),

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -1757,7 +1757,7 @@ async fn test_app_with(
 ///
 /// A test that drives a turn by hand — accepting it and then claiming its
 /// lease straight from the store — has to be that turn's only claimant. A live
-/// `TurnWorker` scans the same queue every few hundred milliseconds, so under
+/// `LegDriver` scans the same queue every few hundred milliseconds, so under
 /// load it can take the queued turn between the accept and the claim, and the
 /// test's claim then finds nothing due. Routes that never run a turn should
 /// use this instead of `test_app`.
@@ -1788,7 +1788,7 @@ fn test_app_from_parts(
         provider,
         store,
         dir,
-        turn_worker::TurnWorkerConfig::default(),
+        engine::internal::leg::LegDriverConfig::default(),
     )
 }
 
@@ -1796,7 +1796,7 @@ fn test_app_from_parts_with_worker_config(
     provider: Arc<dyn ModelProvider>,
     store: Arc<dyn Store>,
     dir: tempfile::TempDir,
-    worker_config: turn_worker::TurnWorkerConfig,
+    worker_config: engine::internal::leg::LegDriverConfig,
 ) -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
     let state = AppState::new(
         Config::desktop(dir.path()),
@@ -1842,9 +1842,9 @@ async fn test_app_with_scanner_resolution_race(
     let token = state.token.clone();
     spawn_turn_worker_with_config(
         &state,
-        turn_worker::TurnWorkerConfig {
+        engine::internal::leg::LegDriverConfig {
             max_concurrency: 1,
-            ..turn_worker::TurnWorkerConfig::default()
+            ..engine::internal::leg::LegDriverConfig::default()
         },
     );
     (app(state), token, store, dir)
@@ -1861,11 +1861,11 @@ fn fast_retry_schedule() -> crate::retry::RetrySchedule {
 }
 
 fn spawn_turn_worker(state: &AppState) {
-    spawn_turn_worker_with_config(state, turn_worker::TurnWorkerConfig::default());
+    spawn_turn_worker_with_config(state, engine::internal::leg::LegDriverConfig::default());
 }
 
-fn spawn_turn_worker_with_config(state: &AppState, config: turn_worker::TurnWorkerConfig) {
-    let worker = turn_worker::TurnWorker::new(
+fn spawn_turn_worker_with_config(state: &AppState, config: engine::internal::leg::LegDriverConfig) {
+    let worker = engine::internal::leg::LegDriver::new(
         state.store.clone(),
         state.resolver.clone(),
         state.secrets.clone(),

--- a/crates/tidebreak-server/src/tests/documents.rs
+++ b/crates/tidebreak-server/src/tests/documents.rs
@@ -1628,7 +1628,7 @@ async fn agent_deps_registers_computer_use_tools_only_when_enabled() {
             "{name} must not register when computer use is disabled"
         );
     }
-    let surface = crate::turn_worker::freeze_foreground_turn_surface(Arc::new(tools), &{
+    let surface = crate::engine::internal::leg::freeze_foreground_turn_surface(Arc::new(tools), &{
         AgentConfig::default()
     });
     let prompt = surface.agent_config.system_prompt.as_deref().unwrap();
@@ -1722,7 +1722,7 @@ async fn agent_deps_registers_computer_use_tools_only_when_enabled() {
 
     // The operating prompt teaches the consent posture only when the tools
     // exist on the surface.
-    let surface = crate::turn_worker::freeze_foreground_turn_surface(
+    let surface = crate::engine::internal::leg::freeze_foreground_turn_surface(
         Arc::new(tools),
         &AgentConfig::default(),
     );
@@ -1758,7 +1758,8 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_capabilities() 
         },
         tidebreak_core::ApprovalClass::Sensitive,
     );
-    let surface = crate::turn_worker::freeze_foreground_turn_surface(Arc::new(tools), &config);
+    let surface =
+        crate::engine::internal::leg::freeze_foreground_turn_surface(Arc::new(tools), &config);
     let system_prompt = surface
         .agent_config
         .system_prompt
@@ -2071,7 +2072,7 @@ async fn foreground_browser_tools_absent_by_default() {
             "{name} must not execute when foreground_browser is false"
         );
     }
-    let surface = crate::turn_worker::freeze_foreground_turn_surface(Arc::new(tools), &{
+    let surface = crate::engine::internal::leg::freeze_foreground_turn_surface(Arc::new(tools), &{
         AgentConfig::default()
     });
     let prompt = surface.agent_config.system_prompt.as_deref().unwrap();

--- a/crates/tidebreak-server/src/tests/image_attachment.rs
+++ b/crates/tidebreak-server/src/tests/image_attachment.rs
@@ -130,7 +130,7 @@ fn one_pixel_jpeg() -> Vec<u8> {
 }
 
 fn spawn_turn_worker_with_image_blobs(state: &AppState) {
-    let worker = crate::turn_worker::TurnWorker::new(
+    let worker = crate::engine::internal::leg::LegDriver::new(
         state.store.clone(),
         state.resolver.clone(),
         state.secrets.clone(),
@@ -145,7 +145,7 @@ fn spawn_turn_worker_with_image_blobs(state: &AppState) {
         state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
-        crate::turn_worker::TurnWorkerConfig::default(),
+        crate::engine::internal::leg::LegDriverConfig::default(),
     )
     .with_blobs(state.blobs.clone());
     tokio::spawn(worker.run());

--- a/crates/tidebreak-server/src/tests/lifecycle.rs
+++ b/crates/tidebreak-server/src/tests/lifecycle.rs
@@ -99,9 +99,9 @@ async fn cancellation_drains_buffered_preassigned_event_ordinals() {
     let token = state.token.clone();
     spawn_turn_worker_with_config(
         &state,
-        turn_worker::TurnWorkerConfig {
+        engine::internal::leg::LegDriverConfig {
             max_concurrency: 1,
-            ..turn_worker::TurnWorkerConfig::default()
+            ..engine::internal::leg::LegDriverConfig::default()
         },
     );
     let router = app(state);
@@ -873,7 +873,7 @@ async fn committed_steer_event_recovers_when_cancellation_wins_ambiguous_respons
     let token = state.token.clone();
     spawn_turn_worker_with_config(
         &state,
-        turn_worker::TurnWorkerConfig {
+        engine::internal::leg::LegDriverConfig {
             lease: Duration::from_millis(500),
             heartbeat: Duration::from_millis(20),
             steer_poll: Duration::from_millis(5),

--- a/crates/tidebreak-server/src/tests/workers.rs
+++ b/crates/tidebreak-server/src/tests/workers.rs
@@ -1248,9 +1248,9 @@ async fn sandbox_container_routing_preserves_in_process_task_and_deadline_shape(
     let token = state.token.clone();
     spawn_turn_worker_with_config(
         &state,
-        turn_worker::TurnWorkerConfig {
+        engine::internal::leg::LegDriverConfig {
             sandbox_spawn_execution_location: tidebreak_core::AgentRunExecutionLocation::Container,
-            ..turn_worker::TurnWorkerConfig::default()
+            ..engine::internal::leg::LegDriverConfig::default()
         },
     );
     let router = app(state);
@@ -1369,7 +1369,7 @@ async fn worker_recovers_ambiguous_claim_and_completion_with_exact_receipts() {
         Arc::new(FakeProvider),
         store,
         dir,
-        turn_worker::TurnWorkerConfig {
+        engine::internal::leg::LegDriverConfig {
             // Keep this failure-injection test inside the committed claim's
             // lease even when a loaded test host delays the retry task.
             lease: Duration::from_secs(5 * 60),
@@ -1377,7 +1377,7 @@ async fn worker_recovers_ambiguous_claim_and_completion_with_exact_receipts() {
             failure_delay_cap: Duration::from_millis(40),
             retry: fast_retry_schedule(),
             max_concurrency: 1,
-            ..turn_worker::TurnWorkerConfig::default()
+            ..engine::internal::leg::LegDriverConfig::default()
         },
     );
     let bearer = format!("Bearer {token}");
@@ -1760,7 +1760,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
             ..AgentConfig::default()
         },
     );
-    let worker = turn_worker::TurnWorker::new(
+    let worker = engine::internal::leg::LegDriver::new(
         state.store.clone(),
         state.resolver.clone(),
         state.secrets.clone(),
@@ -1775,7 +1775,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
         state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
-        turn_worker::TurnWorkerConfig {
+        engine::internal::leg::LegDriverConfig {
             lease: Duration::from_millis(600),
             heartbeat: Duration::from_millis(200),
             steer_poll: Duration::from_millis(10),
@@ -1857,7 +1857,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
             ..AgentConfig::default()
         },
     );
-    let worker = turn_worker::TurnWorker::new(
+    let worker = engine::internal::leg::LegDriver::new(
         state.store.clone(),
         state.resolver.clone(),
         state.secrets.clone(),
@@ -1872,7 +1872,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
         state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
-        turn_worker::TurnWorkerConfig {
+        engine::internal::leg::LegDriverConfig {
             lease: Duration::from_millis(250),
             heartbeat: Duration::from_millis(50),
             steer_poll: Duration::from_millis(10),
@@ -2176,7 +2176,7 @@ async fn cancellation_after_drive_result_persists_the_completed_model_step() {
     );
     let drive_returned = Arc::new(Notify::new());
     let release_outcome = Arc::new(Notify::new());
-    let worker = turn_worker::TurnWorker::new(
+    let worker = engine::internal::leg::LegDriver::new(
         state.store.clone(),
         state.resolver.clone(),
         state.secrets.clone(),
@@ -2191,7 +2191,7 @@ async fn cancellation_after_drive_result_persists_the_completed_model_step() {
         state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
-        turn_worker::TurnWorkerConfig::default(),
+        engine::internal::leg::LegDriverConfig::default(),
     )
     .with_post_drive_pause(drive_returned.clone(), release_outcome.clone());
     let token = state.token.clone();

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -867,7 +867,7 @@ token is no longer printed at startup, because it authenticates nobody there.
 | Operational database | `crates/tidebreak-core/src/db/` | Schema plus transactional SQLite/Postgres state transitions |
 | Model providers | `crates/tidebreak-router/src/` | Anthropic/OpenAI adapters and model-to-provider routing |
 | Local API | `crates/tidebreak-server/src/lib.rs`, `routes.rs`, `routes/client_execution.rs` | Authentication, API assembly, chat, turn, and leased client-execution routes |
-| Turn execution | `crates/tidebreak-server/src/turn_worker.rs` | Claiming, heartbeats, event journaling, terminal resolution |
+| Turn execution | `crates/tidebreak-server/src/engine/internal/leg.rs` | Claiming, heartbeats, event journaling, terminal resolution |
 | Documents | `crates/tidebreak-server/src/routes/document.rs` | Synchronous upload, canonical decoding, and source-file access |
 | Document decoding | `crates/tidebreak-server/src/document_decode.rs` | Media-type-routed UTF-8 decoding with a binary fallback |
 | Desktop | `crates/tidebreak-desktop/src/`, `crates/tidebreak-desktop/ui/src/` | Tauri host and current React shell |


### PR DESCRIPTION
The chat turn worker lives under the internal engine. Slice D4a0 of #2313 (decision 48 step 5); follows D3 (#3042). No behavior change.

## What changed

`crates/tidebreak-server/src/turn_worker.rs` is now `crates/tidebreak-server/src/engine/internal/leg.rs`. The type is `LegDriver` (config and outcome follow). Bind, tests, and `docs/how-tidebreak-works.md` point at the new path. The process-wide claim loop, leases, and quiesce path are the same.

This exists so D4a's retarget is a reviewable diff instead of a 3,900-line move hiding inside the turn-row merge.

## Checks

- `cargo fmt --all --check`
- `cargo check -p tidebreak-server --all-targets`
- `cargo clippy -p tidebreak-server --all-targets -- -D warnings` (the only hit is the pre-existing `too_many_arguments` in `tidebreak-code-execution`, which CI allows)

Part of #2313 / epic #2311.