### PR TITLE
feat(models): curate Claude Fable 5.1 and price every first-party row

### DIFF
--- a/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
@@ -32,8 +32,8 @@ import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
 const models: Partial<Record<HarnessKind, ParsedHarnessModel[]>> = {
   claude_code: [
     {
-      id: "claude-fable-5",
-      label: "Claude Fable 5",
+      id: "claude-fable-5-1",
+      label: "Claude Fable 5.1",
       default: true,
       reasoning_efforts: [],
       fast_mode: true,

--- a/crates/tidebreak-router/src/anthropic.rs
+++ b/crates/tidebreak-router/src/anthropic.rs
@@ -27,6 +27,8 @@ use crate::sse::{
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
+/// The beta that unlocks `thinking.block_binding` — see [`fable_5_1_or_later`].
+const THINKING_BINDING_BETA: &str = "thinking-binding-controls-2026-08-01";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 
 /// Description for the synthetic tool that carries a constrained response.
@@ -108,8 +110,14 @@ impl ModelProvider for AnthropicProvider {
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let mut body = build_request_json(&req)?;
         // `build_request_json` has already rejected a format it cannot enforce.
+        // A model on the native constraint answers on the text channel with no
+        // tool to read back.
         let output_tool = match &req.response_format {
-            Some(ResponseFormat::JsonSchema { name, .. }) => Some(name.clone()),
+            Some(ResponseFormat::JsonSchema { name, .. })
+                if !fable_5_1_or_later(req.request_shaping_model()) =>
+            {
+                Some(name.clone())
+            }
             _ => None,
         };
         // Setup failures (connection, auth, 4xx/5xx) surface here as `Err` so the
@@ -294,6 +302,10 @@ impl AnthropicProvider {
         api_key: &str,
         conversation: Option<tidebreak_core::id::ChatId>,
     ) -> Result<reqwest::Response> {
+        // The binding control is a beta field, and the header that admits it
+        // is decided from the body so every leg of a paused turn agrees with
+        // the first.
+        let binds_thinking = body.pointer("/thinking/block_binding").is_some();
         let body = serde_json::to_vec(body)?;
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let url = reqwest::Url::parse(&url)
@@ -304,6 +316,9 @@ impl AnthropicProvider {
             .header("anthropic-version", ANTHROPIC_VERSION)
             .header("content-type", "application/json");
         let mut request = request.header("x-api-key", api_key);
+        if binds_thinking {
+            request = request.header("anthropic-beta", THINKING_BINDING_BETA);
+        }
         // A conversation is declared only where one is configured to be read.
         // The id is a UUID, so it satisfies the gateway's bound on the value
         // (1-256 ASCII graphic bytes) by construction.
@@ -459,18 +474,32 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
             None => body["tools"] = json!([vendor_tool]),
         }
     }
+    let shaping_model = req.request_shaping_model();
     match &req.response_format {
         Some(ResponseFormat::JsonSchema { name, schema }) => {
-            // The Messages API constrains output through a forced tool call, so
-            // the schema becomes a tool nothing above the adapter ever sees: the
-            // stream re-reads its arguments as text (see `normalize`), which is
-            // the channel every other provider delivers structured output on.
             let schema =
                 strict_json_schema(schema, OptionalProperties::AcceptNull).ok_or_else(|| {
                     AgentError::Provider(format!(
                         "response format {name} has no strict JSON Schema form"
                     ))
                 })?;
+            if fable_5_1_or_later(shaping_model) {
+                // Fable 5.1 rejects the forced call below, and it has the
+                // native constraint the forced tool stood in for: the text
+                // channel itself carries the schema-valid answer, so there is no
+                // tool to re-read and the request keeps thinking.
+                set_output_config(
+                    &mut body,
+                    "format",
+                    json!({ "type": "json_schema", "schema": schema }),
+                );
+                return finish_request(body, req, caches_prompt, retention);
+            }
+            // Elsewhere the Messages API constrains output through a forced
+            // tool call, so the schema becomes a tool nothing above the adapter
+            // ever sees: the stream re-reads its arguments as text (see
+            // `normalize`), which is the channel every other provider delivers
+            // structured output on.
             let output_tool = json!({
                 "name": name,
                 "description": STRUCTURED_OUTPUT_TOOL_DESCRIPTION,
@@ -488,6 +517,16 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         }
         None => {
             if let Some(choice) = &req.tool_choice {
+                // A forced choice is the caller's explicit ask; on a model that
+                // returns 400 for it, failing here names the cause instead of
+                // relaying the provider's rejection as a generic fault.
+                if fable_5_1_or_later(shaping_model)
+                    && matches!(choice, ToolChoice::Required | ToolChoice::Tool { .. })
+                {
+                    return Err(AgentError::Provider(format!(
+                        "{shaping_model} rejects a forced tool choice"
+                    )));
+                }
                 body["tool_choice"] = anthropic_tool_choice(choice)?;
             }
         }
@@ -500,6 +539,17 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
             )))
         }
     }
+    finish_request(body, req, caches_prompt, retention)
+}
+
+/// The tail of [`build_request_json`], after the tool array and the output
+/// constraint are settled.
+fn finish_request(
+    mut body: Value,
+    req: &ChatRequest,
+    caches_prompt: bool,
+    retention: PromptCacheRetention,
+) -> Result<Value> {
     // After the whole tool array is settled, including a structured-output tool
     // appended above.
     if caches_prompt {
@@ -539,8 +589,22 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         // replay below keep the raw blocks whole rather than filtering on
         // `type == "thinking"`.
         body["thinking"] = json!({ "type": "adaptive", "display": "summarized" });
+        if fable_5_1_or_later(req.request_shaping_model()) {
+            // Fable 5.1 signs each thinking block against the prefix that
+            // produced it and rejects a replayed block whose prefix has since
+            // changed. This host does rewrite earlier turns — compaction and
+            // image reduction both do — so the request asks for the stale
+            // blocks to be dropped rather than the 400: the turn proceeds and
+            // the model re-plans without them. The field is a beta; `send`
+            // adds the header that admits it.
+            body["thinking"]["block_binding"] = json!({ "prefix_mismatch_behavior": "drop_block" });
+        }
         if let Some(effort) = req.reasoning_effort {
-            body["output_config"] = json!({ "effort": wire_reasoning_effort(req.request_shaping_model(), effort).as_str() });
+            set_output_config(
+                &mut body,
+                "effort",
+                json!(wire_reasoning_effort(req.request_shaping_model(), effort).as_str()),
+            );
         }
         attach_reasoning_blocks(&mut body, req);
     }
@@ -743,12 +807,48 @@ fn is_cache_markable(block: &Value) -> bool {
 }
 
 /// Whether the request obliges the model to call a specific tool or any tool.
+///
+/// A response format forces the synthetic output tool everywhere except on a
+/// model with the native constraint, where nothing on the wire is forced.
 fn forces_a_tool(req: &ChatRequest) -> bool {
-    req.response_format.is_some()
+    (req.response_format.is_some() && !fable_5_1_or_later(req.request_shaping_model()))
         || matches!(
             req.tool_choice,
             Some(ToolChoice::Required | ToolChoice::Tool { .. })
         )
+}
+
+/// Set one key of the request's `output_config`, keeping the others.
+///
+/// Effort and the output format both live under it and are decided at
+/// different points of the build.
+fn set_output_config(body: &mut Value, key: &str, value: Value) {
+    match body.get_mut("output_config") {
+        Some(Value::Object(config)) => {
+            config.insert(key.to_owned(), value);
+        }
+        _ => body["output_config"] = json!({ key: value }),
+    }
+}
+
+/// Whether `model` is Claude Fable 5.1, its Mythos twin, or a later release of
+/// that line.
+///
+/// Fable 5.1 changed two things the rest of the line did not. It returns a 400
+/// for a forced `tool_choice` (`any` and `tool`), where Opus 5 and Fable 5 both
+/// think by default and still accept one — so the structured-output constraint
+/// goes on `output_config.format` instead of a forced tool. And it binds each
+/// thinking block to the conversation prefix that produced it, so a replayed
+/// block behind a rewritten turn is rejected unless the request opts into
+/// dropping it. Neither follows from the generation alone: an Opus of the same
+/// generation keeps the old contract. So this reads the family and the
+/// generation together, the way `web_search_tool_type` carves out Haiku.
+fn fable_5_1_or_later(model: &str) -> bool {
+    /// First release of the line on this contract.
+    const FIRST: (u32, u32) = (5, 1);
+    let leaf = model.rsplit('/').next().unwrap_or(model);
+    (leaf.contains("fable") || leaf.contains("mythos"))
+        && claude_generation(model).is_some_and(|generation| generation >= FIRST)
 }
 
 fn anthropic_tool_choice(choice: &ToolChoice) -> Result<Value> {
@@ -1945,6 +2045,99 @@ mod tests {
         assert_eq!(body["thinking"]["display"], "summarized");
         // Absent a per-chat override the provider's own effort default holds.
         assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn fable_5_1_constrains_output_natively_and_keeps_thinking() {
+        let mut req = reasoning_request("claude-fable-5-1", Some(ReasoningEffort::Low));
+        req.response_format = Some(ResponseFormat::JsonSchema {
+            name: "note".into(),
+            schema: json!({
+                "type": "object",
+                "properties": { "body": { "type": "string" } },
+                "required": ["body"],
+            }),
+        });
+        let body = build_request_json(&req).unwrap();
+        // No forced call, no synthetic tool: the model rejects the former, and
+        // the native constraint makes the latter redundant.
+        assert!(body.get("tool_choice").is_none());
+        assert!(body.get("tools").is_none());
+        assert_eq!(body["output_config"]["format"]["type"], "json_schema");
+        assert_eq!(
+            body["output_config"]["format"]["schema"]["additionalProperties"],
+            false
+        );
+        // Effort shares `output_config` with the format rather than replacing
+        // it, and nothing on the wire is forced, so the request still thinks.
+        assert_eq!(body["output_config"]["effort"], "low");
+        assert_eq!(body["thinking"]["type"], "adaptive");
+    }
+
+    #[test]
+    fn fable_5_1_asks_for_stale_thinking_to_be_dropped() {
+        let body = build_request_json(&reasoning_request(
+            "claude-fable-5-1",
+            Some(ReasoningEffort::High),
+        ))
+        .unwrap();
+        assert_eq!(
+            body["thinking"]["block_binding"]["prefix_mismatch_behavior"],
+            "drop_block"
+        );
+        // Opus 5 does not bind its blocks, and the field is a beta the older
+        // rows must not be sent.
+        let body = build_request_json(&reasoning_request(
+            "claude-opus-5",
+            Some(ReasoningEffort::High),
+        ))
+        .unwrap();
+        assert!(body["thinking"].get("block_binding").is_none());
+    }
+
+    #[test]
+    fn fable_5_1_refuses_a_forced_tool_choice_by_name() {
+        for choice in [
+            ToolChoice::Required,
+            ToolChoice::Tool {
+                name: "note".into(),
+            },
+        ] {
+            let mut req = reasoning_request("claude-fable-5-1", None);
+            req.tool_choice = Some(choice);
+            let err = build_request_json(&req).unwrap_err().to_string();
+            assert!(err.contains("claude-fable-5-1"), "{err}");
+            assert!(err.contains("forced tool choice"), "{err}");
+        }
+        // `auto` and `none` are unchanged on the model.
+        let mut req = reasoning_request("claude-fable-5-1", None);
+        req.tool_choice = Some(ToolChoice::None);
+        assert_eq!(
+            build_request_json(&req).unwrap()["tool_choice"],
+            json!({ "type": "none" })
+        );
+    }
+
+    #[test]
+    fn the_fable_5_1_contract_follows_family_and_generation() {
+        for id in [
+            "claude-fable-5-1",
+            "claude-mythos-5-1",
+            "claude-fable-6",
+            "us.anthropic.claude-fable-5-1",
+        ] {
+            assert!(fable_5_1_or_later(id), "{id}");
+        }
+        for id in [
+            "claude-fable-5",
+            "claude-opus-5",
+            "claude-opus-5-1",
+            "claude-sonnet-5",
+            "claude-opus-4-8",
+            "some-gateway-alias",
+        ] {
+            assert!(!fable_5_1_or_later(id), "{id}");
+        }
     }
 
     #[test]

--- a/crates/tidebreak-server/src/model_registry.rs
+++ b/crates/tidebreak-server/src/model_registry.rs
@@ -77,7 +77,8 @@ const EFFORT_NONE_TO_HIGH: &[ReasoningEffort] = &[
     ReasoningEffort::Medium,
     ReasoningEffort::High,
 ];
-/// Gemini 3.1 Pro Preview starts at `low`; it does not accept `minimal`.
+/// Gemini 3.1 Pro Preview and Gemini Flash from 3.7 on start at `low`; they
+/// reject `minimal`.
 const EFFORT_LOW_TO_HIGH: &[ReasoningEffort] = &[
     ReasoningEffort::Low,
     ReasoningEffort::Medium,
@@ -309,9 +310,13 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
     },
     // Second, not first: the built-in default is this provider's first curated
     // row, and the default stays Opus 5.
+    //
+    // Fable 5.1 is the first Claude that rejects a forced tool choice and
+    // binds its thinking blocks to the conversation prefix. The Anthropic
+    // adapter reads both from the id, so the row carries nothing for them.
     ModelSpec {
-        id: "claude-fable-5",
-        display_name: "Claude Fable 5",
+        id: "claude-fable-5-1",
+        display_name: "Claude Fable 5.1",
         provider: ProviderKind::Anthropic,
         verification: VerificationTier::Verified,
         recommended: true,
@@ -321,6 +326,19 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning: true,
         supports_vendor_web_search: true,
         // Same adaptive-thinking generation as Opus 5 and Sonnet 5.
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
+    ModelSpec {
+        id: "claude-fable-5",
+        display_name: "Claude Fable 5",
+        provider: ProviderKind::Anthropic,
+        verification: VerificationTier::Verified,
+        recommended: false,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
@@ -523,10 +541,37 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         reasoning_efforts: EFFORT_LOW_TO_XHIGH,
     },
     // Gemini rows are intentionally limited to ids currently published by
-    // Google. All four accept images, expose thinking levels through `high`,
-    // and have 1,048,576 input / 65,536 output token limits; the Flash rows
-    // start at `minimal`, while Pro Preview starts at `low`. The native adapter
-    // owns the corresponding GenerateContent wire shape.
+    // Google. All six accept images, expose thinking levels through `high`,
+    // and have 1,048,576 input / 65,536 output token limits. Flash 3.6 and
+    // earlier start at `minimal`; Flash 3.7 and later reject it and start at
+    // `low`, as Pro Preview does. The native adapter owns the corresponding
+    // GenerateContent wire shape.
+    ModelSpec {
+        id: "gemini-3.8-flash",
+        display_name: "Gemini 3.8 Flash",
+        provider: ProviderKind::Gemini,
+        verification: VerificationTier::Verified,
+        recommended: true,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH,
+    },
+    ModelSpec {
+        id: "gemini-3.7-flash",
+        display_name: "Gemini 3.7 Flash",
+        provider: ProviderKind::Gemini,
+        verification: VerificationTier::Verified,
+        recommended: false,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_HIGH,
+    },
     ModelSpec {
         id: "gemini-3.6-flash",
         display_name: "Gemini 3.6 Flash",
@@ -1189,6 +1234,7 @@ mod tests {
         // The generations that do accept `xhigh` keep advertising it.
         for id in [
             "claude-opus-5",
+            "claude-fable-5-1",
             "claude-fable-5",
             "claude-sonnet-5",
             "claude-opus-4-8",
@@ -1313,23 +1359,47 @@ mod tests {
     #[test]
     fn every_gemini_entry_has_the_native_adapter_contract() {
         let gemini: Vec<_> = models_for(ProviderKind::Gemini).collect();
-        assert_eq!(gemini.len(), 4);
+        assert_eq!(gemini.len(), 6);
         for spec in gemini {
             assert_eq!(spec.context_window, 1_048_576, "{}", spec.id);
             assert_eq!(spec.max_output_tokens, 65_536, "{}", spec.id);
             assert!(spec.supports_reasoning, "{}", spec.id);
-            if spec.id != "gemini-3.1-pro-preview" {
+            if !GEMINI_WITHOUT_MINIMAL.contains(&spec.id) {
                 assert_eq!(spec.reasoning_efforts, EFFORT_NONE_TO_HIGH, "{}", spec.id);
             }
         }
     }
 
-    #[test]
-    fn gemini_3_1_pro_excludes_minimal() {
-        let direct = find_for(ProviderKind::Gemini, "gemini-3.1-pro-preview").unwrap();
+    /// The Gemini rows whose endpoint returns an error for `minimal`.
+    const GEMINI_WITHOUT_MINIMAL: &[&str] = &[
+        "gemini-3.8-flash",
+        "gemini-3.7-flash",
+        "gemini-3.1-pro-preview",
+    ];
 
-        assert_eq!(direct.reasoning_efforts, EFFORT_LOW_TO_HIGH);
-        assert!(!direct.reasoning_efforts.contains(&ReasoningEffort::None));
+    #[test]
+    fn gemini_3_1_pro_and_flash_3_7_onward_exclude_minimal() {
+        for id in GEMINI_WITHOUT_MINIMAL {
+            let direct = find_for(ProviderKind::Gemini, id).unwrap();
+            assert_eq!(direct.reasoning_efforts, EFFORT_LOW_TO_HIGH, "{id}");
+            assert!(!direct.reasoning_efforts.contains(&ReasoningEffort::None));
+        }
+    }
+
+    #[test]
+    fn the_anthropic_default_row_stays_opus_5_ahead_of_fable() {
+        // The first curated Anthropic row is what a fresh Anthropic-only install
+        // resolves to. Fable is the demanding-work option, not the default, and
+        // the current Fable sits ahead of the one it replaced.
+        let ids: Vec<_> = models_for(ProviderKind::Anthropic)
+            .map(|spec| spec.id)
+            .collect();
+        assert_eq!(
+            &ids[..3],
+            ["claude-opus-5", "claude-fable-5-1", "claude-fable-5"]
+        );
+        assert!(find("claude-fable-5-1").unwrap().recommended);
+        assert!(!find("claude-fable-5").unwrap().recommended);
     }
 
     #[test]

--- a/crates/tidebreak-server/src/routes/code/analytics.rs
+++ b/crates/tidebreak-server/src/routes/code/analytics.rs
@@ -454,13 +454,31 @@ fn canonical_model_id(model: &str) -> Option<&'static str> {
     if model_matches(&model, "gpt-5.6-sol") || model_matches(&model, "gpt-5.6") {
         return Some("gpt-5.6-sol");
     }
+    // Longer ids first: a bare `claude-fable-5` must not claim the 5.1 row,
+    // and Flash-Lite must not read as Flash.
     [
         "gpt-5.6-terra",
         "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "grok-4.6",
+        "grok-4.5",
+        "gemini-3.8-flash",
+        "gemini-3.7-flash",
+        "gemini-3.6-flash",
+        "gemini-3.5-flash-lite",
+        "gemini-3.5-flash",
+        "gemini-3.1-pro-preview",
+        "claude-fable-5-1",
         "claude-fable-5",
         "claude-opus-5",
         "claude-sonnet-5",
         "claude-haiku-4-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
     ]
     .into_iter()
     .find(|&id| model_matches(&model, id) || model_has_dated_suffix(&model, id))
@@ -486,23 +504,94 @@ fn model_has_dated_suffix(value: &str, id: &str) -> bool {
 
 fn price_for_canonical(model: &str) -> Option<PriceRate> {
     match model {
+        // OpenAI short-context (under 272K) rates. The GPT-5.6 rows are the
+        // only OpenAI models that bill cache writes. Sol's rate is promotional,
+        // published as holding at least through 2026-11-21.
         "gpt-5.6-sol" => Some(PriceRate {
-            input: 5_000,
-            output: 30_000,
-            cache_read: 500,
-            cache_write: 0,
+            input: 4_000,
+            output: 20_000,
+            cache_read: 400,
+            cache_write: 5_000,
         }),
         "gpt-5.6-terra" => Some(PriceRate {
             input: 2_000,
             output: 12_000,
             cache_read: 200,
-            cache_write: 0,
+            cache_write: 2_500,
         }),
         "gpt-5.6-luna" => Some(PriceRate {
             input: 200,
             output: 1_200,
             cache_read: 20,
+            cache_write: 250,
+        }),
+        "gpt-5.5" => Some(PriceRate {
+            input: 5_000,
+            output: 30_000,
+            cache_read: 500,
             cache_write: 0,
+        }),
+        "gpt-5.4-mini" => Some(PriceRate {
+            input: 750,
+            output: 4_500,
+            cache_read: 75,
+            cache_write: 0,
+        }),
+        "gpt-5.4-nano" => Some(PriceRate {
+            input: 200,
+            output: 1_250,
+            cache_read: 20,
+            cache_write: 0,
+        }),
+        // xAI rates for prompts under 200K tokens; a longer prompt doubles
+        // every token in the request, which this table does not model.
+        "grok-4.6" => Some(PriceRate {
+            input: 2_000,
+            output: 6_000,
+            cache_read: 500,
+            cache_write: 0,
+        }),
+        "grok-4.5" => Some(PriceRate {
+            input: 2_000,
+            output: 6_000,
+            cache_read: 300,
+            cache_write: 0,
+        }),
+        // Gemini bills context-cache storage by the hour rather than per
+        // written token, so cache writes stay at zero. The 3.6 through 3.8
+        // Flash rates are published as doubling on 2027-01-01.
+        "gemini-3.8-flash" | "gemini-3.7-flash" | "gemini-3.6-flash" => Some(PriceRate {
+            input: 750,
+            output: 3_750,
+            cache_read: 75,
+            cache_write: 0,
+        }),
+        "gemini-3.5-flash" => Some(PriceRate {
+            input: 1_500,
+            output: 9_000,
+            cache_read: 150,
+            cache_write: 0,
+        }),
+        "gemini-3.5-flash-lite" => Some(PriceRate {
+            input: 300,
+            output: 2_500,
+            cache_read: 30,
+            cache_write: 0,
+        }),
+        // The rate for prompts up to 200K tokens; longer prompts bill higher.
+        "gemini-3.1-pro-preview" => Some(PriceRate {
+            input: 2_000,
+            output: 12_000,
+            cache_read: 200,
+            cache_write: 0,
+        }),
+        // Same tier and per-token price as Fable 5, but cache reads at a
+        // quarter of the usual tenth of input.
+        "claude-fable-5-1" => Some(PriceRate {
+            input: 10_000,
+            output: 50_000,
+            cache_read: 250,
+            cache_write: 12_500,
         }),
         "claude-fable-5" => Some(PriceRate {
             input: 10_000,
@@ -527,6 +616,18 @@ fn price_for_canonical(model: &str) -> Option<PriceRate> {
             output: 5_000,
             cache_read: 100,
             cache_write: 1_250,
+        }),
+        "claude-opus-4-8" | "claude-opus-4-7" | "claude-opus-4-6" => Some(PriceRate {
+            input: 5_000,
+            output: 25_000,
+            cache_read: 500,
+            cache_write: 6_250,
+        }),
+        "claude-sonnet-4-6" => Some(PriceRate {
+            input: 3_000,
+            output: 15_000,
+            cache_read: 300,
+            cache_write: 3_750,
         }),
         _ => None,
     }
@@ -623,6 +724,61 @@ mod tests {
         assert_eq!(
             canonical_model_id("accounts/fireworks/models/glm-5p2"),
             None
+        );
+        // The point release must not collapse into the model it replaced.
+        assert_eq!(
+            canonical_model_id("claude-fable-5-1"),
+            Some("claude-fable-5-1")
+        );
+        assert_eq!(
+            canonical_model_id("anthropic-us-claude-fable-5"),
+            Some("claude-fable-5")
+        );
+    }
+
+    #[test]
+    fn every_curated_first_party_row_has_a_price() {
+        use crate::providers::ProviderKind;
+
+        // A curated row a session can pick must land on a rate, or its turns
+        // read as free in the dashboard. Curating a model and pricing it are
+        // two edits in two files; this is what ties them together. The
+        // open-weight hosts (Fireworks, Together) price per deployment rather
+        // than per model and stay unpriced on purpose.
+        for provider in [
+            ProviderKind::Anthropic,
+            ProviderKind::Openai,
+            ProviderKind::Xai,
+            ProviderKind::Gemini,
+        ] {
+            for spec in crate::model_registry::models_for(provider) {
+                let canonical = canonical_model_id(spec.id)
+                    .unwrap_or_else(|| panic!("{} has no canonical price id", spec.id));
+                assert!(
+                    price_for_canonical(canonical).is_some(),
+                    "{} canonicalizes to {canonical}, which has no price",
+                    spec.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn provider_prefixed_ids_reach_their_own_row() {
+        // opencode and the gateway prefix the vendor; a Flash-Lite id must not
+        // fall through to the Flash row it extends.
+        assert_eq!(
+            canonical_model_id("google/gemini-3.5-flash-lite"),
+            Some("gemini-3.5-flash-lite")
+        );
+        assert_eq!(
+            canonical_model_id("google/gemini-3.5-flash"),
+            Some("gemini-3.5-flash")
+        );
+        assert_eq!(canonical_model_id("xai/grok-4.6"), Some("grok-4.6"));
+        assert_eq!(
+            canonical_model_id("model_gateway::gpt-5.4-mini"),
+            Some("gpt-5.4-mini")
         );
     }
 


### PR DESCRIPTION
## What changes

- `model_registry.rs`: Claude Fable 5.1 is the recommended Anthropic row, ahead of Fable 5. The default stays Opus 5. Gemini 3.8 Flash and 3.7 Flash are curated, 3.8 recommended, both starting the effort ladder at `low`.
- `anthropic.rs`: Fable 5.1 and Mythos 5.1 get their new contract. Structured output goes through `output_config.format` instead of a forced tool. A forced `tool_choice` fails with an error that names the model. Replayed thinking blocks opt into `drop_block` under the `thinking-binding-controls-2026-08-01` beta header. Older rows are untouched.
- `analytics.rs`: every curated Anthropic, OpenAI, xAI, and Gemini row now has a price. GPT-5.6 Sol moves to its published promotional rate, and the GPT-5.6 rows carry cache-write rates. Fireworks and Together stay unpriced on purpose, since they price per deployment.
- The StartSession story lists Fable 5.1.

## How it is guarded

- `every_curated_first_party_row_has_a_price` walks the four first-party providers, so a curated row without a price fails CI.
- `provider_prefixed_ids_reach_their_own_row` pins that a vendor-prefixed Flash-Lite id lands on its own row rather than the Flash row.
- Adapter tests cover the native output constraint, the refused forced tool choice, the block-binding field, and the family-plus-generation gate that keeps Opus 5 on the old contract.

## Checks run

rustfmt, workspace clippy, 53 router tests, 25 registry and analytics tests, biome on the story.
