### PR TITLE
fix(server): build the internal-engine tests against the leg driver

### DIFF
--- a/crates/tidebreak-server/src/tests/code_internal.rs
+++ b/crates/tidebreak-server/src/tests/code_internal.rs
@@ -204,7 +204,7 @@ async fn internal_engine_app_capturing(
 }
 
 fn spawn_turn_worker_with_blobs(state: &AppState) {
-    let worker = crate::turn_worker::TurnWorker::new(
+    let worker = crate::engine::internal::leg::LegDriver::new(
         state.store.clone(),
         state.resolver.clone(),
         state.secrets.clone(),
@@ -219,7 +219,7 @@ fn spawn_turn_worker_with_blobs(state: &AppState) {
         state.queued_turn_wake.clone(),
         state.agent_config.clone(),
         None,
-        crate::turn_worker::TurnWorkerConfig::default(),
+        crate::engine::internal::leg::LegDriverConfig::default(),
     )
     .with_blobs(state.blobs.clone());
     tokio::spawn(worker.run());


### PR DESCRIPTION
The chat turn worker moved under the internal engine as `LegDriver` in #3054 while #3050 added a test helper that still spawned `crate::turn_worker::TurnWorker`. Both merged green on their own bases, so `main` no longer compiles its server tests (`cargo test -p tidebreak-server` fails with `cannot find turn_worker in crate`).

This points the helper at the leg driver, matching `spawn_turn_worker_with_config` in `tests.rs`.

Verified locally: `cargo check -p tidebreak-server --tests` and `cargo test -p tidebreak-server code_internal` pass.