### PR TITLE
ci(policy): let the release draft read the app private key

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -742,6 +742,7 @@ test("production secrets remain isolated to the release workflow", () => {
   const allowedSecretConsumers = new Set([
     "publish-e2b-template.yml",
     "publish-whisper-helper.yml",
+    "release-draft.yml",
     "release.yml",
     "staging-publish.yml",
   ]);
@@ -749,6 +750,27 @@ test("production secrets remain isolated to the release workflow", () => {
     assert.ok(
       allowedSecretConsumers.has(name),
       `unexpected secret consumer: ${name}`,
+    );
+  }
+
+  // The release draft may read exactly one secret: the private key of the
+  // GitHub App whose token replaces GITHUB_TOKEN for the draft job, so the
+  // release API calls stop sharing the repository's Actions rate budget. The
+  // key stays out of the label and backfill jobs: the label job runs on
+  // pull_request_target events, and neither job needs more than GITHUB_TOKEN.
+  const releaseDraftSource = workflows["release-draft.yml"];
+  for (const secret of releaseDraftSource.match(/secrets\.[A-Za-z0-9_]+/g) ?? []) {
+    assert.equal(
+      secret,
+      "secrets.RELEASE_APP_PRIVATE_KEY",
+      `release-draft.yml may read only the app private key, found ${secret}`,
+    );
+  }
+  for (const job of ["label", "backfill"]) {
+    assert.doesNotMatch(
+      workflowJob(releaseDraftSource, job),
+      /secrets\./,
+      `the ${job} job must stay on GITHUB_TOKEN`,
     );
   }
   assert.ok(secretConsumers.includes("publish-e2b-template.yml"));


### PR DESCRIPTION
## What

The workflow-security test now allows `release-draft.yml` to read secrets, restricted to exactly `secrets.RELEASE_APP_PRIVATE_KEY`, and asserts the `label` and `backfill` jobs stay on `GITHUB_TOKEN`.

## Why

#3061 moves the draft job onto a token minted for the `tidebreak-release-bot` GitHub App so release API calls stop sharing the repository's Actions rate budget. The release policy lane runs the base branch's copy of this test against the PR's workflows, so the allow-list has to land on main before #3061 can go green. This PR changes no workflow.

Verified locally: the test passes against main's workflows and against #3061's.