### PR TITLE
feat(server): serve the desktop renderer from the hosted machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,6 +2832,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7988,11 +7994,19 @@ checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
 ]

--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -269,6 +269,16 @@ pub struct Config {
     /// way the stored setting wins once an operator sets one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code_worktree_root_default: Option<PathBuf>,
+    /// A built renderer bundle to serve to browsers, so the machine has a
+    /// page of its own to land on.
+    ///
+    /// The directory is the desktop UI's `dist` output — the same bundle the
+    /// packaged app loads from its own protocol — and its `index.html` is the
+    /// answer for any page navigation the API does not own. The self-host
+    /// image sets `TIDEBREAK_UI_DIST` to the copy it carries; absent, the
+    /// server serves no pages at all and an unknown path stays a `404`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ui_dist: Option<PathBuf>,
 }
 
 /// The bind every profile uses when no address is configured: loopback, and
@@ -365,6 +375,7 @@ impl Config {
             runtime_session_spend_ceiling_microusd: default_runtime_session_spend_ceiling_microusd(
             ),
             code_worktree_root_default: None,
+            ui_dist: None,
         }
     }
 
@@ -388,7 +399,8 @@ impl Config {
     /// `TIDEBREAK_RUNTIME_PROFILE` together to enable remote sessions. Remote
     /// deployments can also set `TIDEBREAK_RUNTIME_CONCURRENCY_CAP`,
     /// `TIDEBREAK_RUNTIME_SPAWN_SPEND_CEILING_MICROUSD`, and
-    /// `TIDEBREAK_RUNTIME_SESSION_SPEND_CEILING_MICROUSD`.
+    /// `TIDEBREAK_RUNTIME_SESSION_SPEND_CEILING_MICROUSD`. Optional
+    /// `TIDEBREAK_UI_DIST` names a built renderer bundle to serve to browsers.
     pub fn from_env() -> Result<Self> {
         let vault_secrets = VaultSecretConfig::from_vars(
             std::env::var("TIDEBREAK_VAULT_ADDR").ok(),
@@ -417,6 +429,18 @@ impl Config {
             std::env::var("TIDEBREAK_RUNTIME_SPAWN_SPEND_CEILING_MICROUSD").ok(),
             std::env::var("TIDEBREAK_RUNTIME_SESSION_SPEND_CEILING_MICROUSD").ok(),
         )
+        .map(|config| config.with_ui_dist_var(std::env::var_os("TIDEBREAK_UI_DIST")))
+    }
+
+    /// Apply `TIDEBREAK_UI_DIST`. Split from [`Config::from_env`] like the
+    /// runtime limits, so the empty-means-unset rule is testable without
+    /// touching the process environment. Whether the directory actually holds
+    /// a bundle is checked where the server binds, so the refusal names the
+    /// path and happens before anything listens.
+    #[must_use]
+    pub fn with_ui_dist_var(mut self, ui_dist: Option<OsString>) -> Self {
+        self.ui_dist = ui_dist.filter(|value| !value.is_empty()).map(PathBuf::from);
+        self
     }
 
     /// Resolve a config from raw variable values. Split out from [`from_env`] so
@@ -530,6 +554,7 @@ impl Config {
             runtime_session_spend_ceiling_microusd: default_runtime_session_spend_ceiling_microusd(
             ),
             code_worktree_root_default: None,
+            ui_dist: None,
         })
     }
 
@@ -732,6 +757,26 @@ mod tests {
         let expected = std::env::current_dir().unwrap().join(".tidebreak");
         assert_eq!(config.data_dir, expected);
         assert_eq!(config.profile, Profile::Desktop);
+    }
+
+    #[test]
+    fn an_empty_ui_dist_var_means_no_bundle() {
+        let config = Config::desktop("/data");
+        assert_eq!(
+            config
+                .clone()
+                .with_ui_dist_var(Some(OsString::new()))
+                .ui_dist,
+            None
+        );
+        assert_eq!(config.clone().with_ui_dist_var(None).ui_dist, None);
+        assert_eq!(
+            config
+                .with_ui_dist_var(Some(OsString::from("/opt/tidebreak/ui")))
+                .ui_dist
+                .as_deref(),
+            Some(std::path::Path::new("/opt/tidebreak/ui"))
+        );
     }
 
     #[test]

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -191,7 +191,12 @@ const disconnectRemoteMachine = vi.hoisted(() =>
   vi.fn(async () => ({ attachment: "local" as const, baseUrl: null })),
 );
 
-vi.mock("./boot", () => ({ resolveServerInfo }));
+// Partial: boot's hosted branch also exports the error class the shell
+// branches on, and a mock without it would turn that check into a crash.
+vi.mock("./boot", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./boot")>()),
+  resolveServerInfo,
+}));
 
 // Partial: the shell reaches for three of this module's functions and the
 // settings panel for the rest, so replacing the whole module would break

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -21,7 +21,8 @@ import {
 } from "./api";
 import { AppContextProvider, type AppContextValue } from "./AppContext";
 
-import { resolveServerInfo } from "./boot";
+import { HostedSignInRequired, resolveServerInfo } from "./boot";
+import { HostedSignIn } from "./HostedSignIn";
 import {
   BootFailure,
   type BootAttachment,
@@ -239,6 +240,11 @@ export function AppShell() {
   const [bootAttachment, setBootAttachment] = useState<BootAttachment | null>(
     null,
   );
+  // A hosted browser tab that holds no session. Not a failure: the machine
+  // answered, and the page knows which console can sign it in.
+  const [hostedSignIn, setHostedSignIn] = useState<{
+    gatewayUrl: string | null;
+  } | null>(null);
   const [appVersion, setAppVersion] = useState<string | null>(null);
   const [info, setInfo] = useState<ServerInfo | null>(null);
   const [client, setClient] = useState<ApiClient | null>(null);
@@ -506,7 +512,12 @@ export function AppShell() {
         connectOutputs(server.baseUrl, server.token);
         setStatus(`connected ${server.baseUrl}`);
       } catch (err) {
-        if (!cancelled) setBootFailure({ stage: "connect", error: err });
+        if (cancelled) return;
+        if (err instanceof HostedSignInRequired) {
+          setHostedSignIn({ gatewayUrl: err.gatewayUrl });
+          return;
+        }
+        setBootFailure({ stage: "connect", error: err });
       }
     })();
     return () => {
@@ -515,7 +526,11 @@ export function AppShell() {
   }, [bootAttempt]);
 
   useEffect(() => {
-    if (!client || !info?.gatewayAuth) return;
+    // The shell mints a fresh bearer from the gateway session it holds. A
+    // browser tab holds no such session: its bearer arrived once from the
+    // console and lasts its hour, after which the reader re-enters from
+    // there. Nothing here to refresh from, so nothing to schedule.
+    if (!client || !info?.gatewayAuth || !hasNativeHost()) return;
     let cancelled = false;
     const refresh = async () => {
       try {
@@ -952,6 +967,7 @@ export function AppShell() {
    */
   function retryBoot() {
     setBootFailure(null);
+    setHostedSignIn(null);
     setClient(null);
     setInfo(null);
     setStatus("starting…");
@@ -1064,6 +1080,17 @@ export function AppShell() {
       stableActions,
     ],
   );
+
+  if (hostedSignIn) {
+    return (
+      <HostedSignIn
+        reason="no_session"
+        machineUrl={window.location.origin}
+        gatewayUrl={hostedSignIn.gatewayUrl}
+        onRetry={retryBoot}
+      />
+    );
+  }
 
   if (bootFailure) {
     return (

--- a/crates/tidebreak-desktop/ui/src/HostedSignIn.tsx
+++ b/crates/tidebreak-desktop/ui/src/HostedSignIn.tsx
@@ -1,0 +1,103 @@
+import { ExternalLink, RotateCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Logomark } from "./Logomark";
+import { WindowDragStrip } from "./WindowDragStrip";
+
+/**
+ * Why a hosted browser tab has no session to show the app with.
+ *
+ * `no_session`: the page opened without a bearer — someone typed the
+ * machine's address, or reloaded a tab. `session_ended`: the bearer the page
+ * held stopped being accepted, which after an hour is simply its lifetime.
+ */
+export type HostedSignInReason = "no_session" | "session_ended";
+
+export type HostedSignInProps = {
+  reason: HostedSignInReason;
+  /** The machine this page is served by. */
+  machineUrl: string;
+  /**
+   * The console that can sign the reader in here. `null` when the machine
+   * has no gateway, in which case the page can only say where to go instead.
+   */
+  gatewayUrl: string | null;
+  onRetry?: () => void;
+};
+
+/**
+ * The screen a hosted browser tab shows until it holds a session.
+ *
+ * A browser tab cannot start the sign-in itself: the bearer it needs is
+ * minted by the reader's Model Gateway console, which hands it to this page
+ * once. So the screen names the console and sends the reader there; the
+ * console's Manage Tidebreak action is what brings them back signed in.
+ */
+export function HostedSignIn({
+  reason,
+  machineUrl,
+  gatewayUrl,
+  onRetry = () => window.location.reload(),
+}: HostedSignInProps) {
+  const ended = reason === "session_ended";
+  return (
+    <div className="boot" aria-label="Sign in required">
+      <WindowDragStrip />
+      <div className="boot-brand">
+        <Logomark />
+        <h1>Tidebreak</h1>
+      </div>
+      <div className="welcome-copy">
+        {ended ? (
+          <>
+            <h2>Your session on this machine ended</h2>
+            <p>
+              Browser sessions last an hour. Work on this machine keeps running,
+              and nothing you did here is lost.
+            </p>
+          </>
+        ) : (
+          <>
+            <h2>Sign in through your Model Gateway console</h2>
+            <p>
+              This machine runs Tidebreak for your organization. Its address
+              alone does not sign you in.
+            </p>
+          </>
+        )}
+        {gatewayUrl ? (
+          <p>
+            Open the console and choose <strong>Manage Tidebreak</strong> to
+            come back here signed in.
+          </p>
+        ) : (
+          <p>
+            This machine does not sign browsers in. Attach to it from the
+            Tidebreak desktop app instead.
+          </p>
+        )}
+      </div>
+      <p className="text-muted-foreground text-sm">
+        Machine <code className="font-medium">{machineUrl}</code>
+      </p>
+      <div className="boot-actions">
+        {gatewayUrl && (
+          <Button size="sm" asChild>
+            <a href={gatewayUrl} rel="noreferrer">
+              <ExternalLink size={16} aria-hidden />
+              Open the console
+            </a>
+          </Button>
+        )}
+        <Button
+          size="sm"
+          variant={gatewayUrl ? "outline" : "default"}
+          onClick={onRetry}
+        >
+          <RotateCw size={16} aria-hidden />
+          Try again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
@@ -3,9 +3,11 @@ import { ExternalLink, Laptop, RefreshCw } from "lucide-react";
 
 import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
 import { Button } from "@/components/ui/button";
+import { HostedSignIn } from "./HostedSignIn";
 import { Logomark } from "./Logomark";
 import { ManagedPolicyContext } from "./managedPolicy";
-import { onPairingChanged } from "./host";
+import { hasNativeHost, onPairingChanged } from "./host";
+import { hostedSession } from "./hostedSession";
 import { openInBrowser } from "./openInBrowser";
 import { disconnectRemoteMachine, remoteMachineState } from "./remoteMachine";
 import { useVisibilityGatedPoll } from "./useVisibilityGatedPoll";
@@ -29,8 +31,10 @@ type PolicyState =
   | { kind: "resolved"; policy: ManagedPolicy }
   /** The server answered, and the answer was an error: the policy exists but
    * cannot be read. A profile that claims to be managed must never quietly
-   * revert to the open experience, so this blocks instead of failing open. */
-  | { kind: "blocked" };
+   * revert to the open experience, so this blocks instead of failing open.
+   * The status is kept because one answer means something specific to a
+   * hosted browser tab: a refused bearer is a session that ended. */
+  | { kind: "blocked"; status: number };
 
 /** ApiClient throws `Error("<status>: <detail>")` for an HTTP error response;
  * everything else — a rejected fetch, the timeout — is transport-level. */
@@ -192,7 +196,7 @@ export function ManagedGate({
           return;
         }
         if (httpStatus !== null) {
-          setPolicyState({ kind: "blocked" });
+          setPolicyState({ kind: "blocked", status: httpStatus });
           return;
         }
         timer = window.setTimeout(() => {
@@ -229,8 +233,9 @@ export function ManagedGate({
         // An error *response* means the server says the policy is
         // unreadable, which fails closed exactly as it does on first read.
         // A transport failure says nothing, so the last answer stands.
-        if (httpStatusOf(err) !== null && httpStatusOf(err) !== 404) {
-          setPolicyState({ kind: "blocked" });
+        const httpStatus = httpStatusOf(err);
+        if (httpStatus !== null && httpStatus !== 404) {
+          setPolicyState({ kind: "blocked", status: httpStatus });
         }
       });
   }, [client]);
@@ -328,6 +333,24 @@ export function ManagedGate({
       (policy.managed && !policy.gateway_url));
 
   if (policyState.kind === "blocked" || policyMisconfigured) {
+    // A hosted browser tab whose bearer the machine stopped accepting. There
+    // is no shell to mint another and no local server to fall back to; the
+    // way back in is the console that signed the reader in the first time.
+    const hosted = hostedSession();
+    if (
+      hosted !== null &&
+      !hasNativeHost() &&
+      policyState.kind === "blocked" &&
+      (policyState.status === 401 || policyState.status === 403)
+    ) {
+      return (
+        <HostedSignIn
+          reason="session_ended"
+          machineUrl={hosted.baseUrl}
+          gatewayUrl={hosted.gatewayUrl}
+        />
+      );
+    }
     // Attached to a machine, and it will not answer. Naming the managed
     // policy here would be a lie — the policy on this computer is fine, and
     // the reader cannot act on the machine's copy anyway. What they can
@@ -357,29 +380,31 @@ export function ManagedGate({
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              disabled={working}
-              onClick={() =>
-                void (async () => {
-                  setWorking(true);
-                  setActionError(null);
-                  try {
-                    await disconnectRemoteMachine();
-                    // Same reason the settings panel reloads: the API client
-                    // and the event stream were built against the machine
-                    // this window opened on.
-                    window.location.reload();
-                  } catch (err) {
-                    setActionError(String(err));
-                    setWorking(false);
-                  }
-                })()
-              }
-            >
-              <Laptop size={14} />
-              Work on this computer
-            </Button>
+            {hasNativeHost() && (
+              <Button
+                type="button"
+                disabled={working}
+                onClick={() =>
+                  void (async () => {
+                    setWorking(true);
+                    setActionError(null);
+                    try {
+                      await disconnectRemoteMachine();
+                      // Same reason the settings panel reloads: the API
+                      // client and the event stream were built against the
+                      // machine this window opened on.
+                      window.location.reload();
+                    } catch (err) {
+                      setActionError(String(err));
+                      setWorking(false);
+                    }
+                  })()
+                }
+              >
+                <Laptop size={14} />
+                Work on this computer
+              </Button>
+            )}
             <Button
               type="button"
               variant="ghost"

--- a/crates/tidebreak-desktop/ui/src/boot.ts
+++ b/crates/tidebreak-desktop/ui/src/boot.ts
@@ -1,5 +1,10 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import type { RemoteMachineState, ServerInfo } from "./api";
+import {
+  handoffBearer,
+  hostedSession,
+  markHostedSession,
+} from "./hostedSession";
 
 /**
  * Resolve how the UI reaches the API it is attached to.
@@ -12,10 +17,15 @@ import type { RemoteMachineState, ServerInfo } from "./api";
  *   the same `scripts/dev.sh` process.
  * - Explicit `VITE_TIDEBREAK_URL` + `VITE_TIDEBREAK_TOKEN` still win, for
  *   pointing the same React app at `tidebreak serve`.
+ * - A production bundle served by a machine: the page's own origin is the
+ *   API, and the bearer is the one the page was handed. See
+ *   {@link hostedServerInfo}.
  *
- * Every path outside Tauri reports `local`. Host authority is a property of the
- * native shell, and a browser tab has none of it either way, so nothing is
- * gained by calling those attachments remote.
+ * The dev paths report `local`. Host authority is a property of the native
+ * shell, and a browser tab has none of it either way, so nothing is gained by
+ * calling those attachments remote. The hosted page reports `remote`, because
+ * that is what it is: the work lives on the machine, and every control that
+ * would reach this computer must know to stand down.
  */
 export async function resolveServerInfo(): Promise<ServerInfo> {
   if (isTauri()) {
@@ -28,6 +38,9 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
   const fromDesktop = await desktopListenInfo();
   if (fromDesktop) return fromDesktop;
 
+  const fromMachine = await hostedServerInfo();
+  if (fromMachine) return fromMachine;
+
   throw new Error(
     "No Tidebreak server is reachable from this browser tab. Keep " +
       "`scripts/dev.sh` running (it publishes a listen endpoint), or set " +
@@ -37,8 +50,101 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
 
 /** Which machine this client is attached to, without opening a connection. */
 export async function remoteMachineState(): Promise<RemoteMachineState> {
-  if (!isTauri()) return { attachment: "local", baseUrl: null };
+  if (!isTauri()) {
+    const hosted = hostedSession();
+    return hosted
+      ? { attachment: "remote", baseUrl: hosted.baseUrl }
+      : { attachment: "local", baseUrl: null };
+  }
   return await invoke<RemoteMachineState>("remote_machine_state");
+}
+
+/**
+ * Thrown by boot when the page is served by a machine but holds no bearer.
+ *
+ * Not a boot failure: the machine answered, and the page knows exactly what
+ * is missing. The shell shows the sign-in screen instead of the failure one.
+ */
+export class HostedSignInRequired extends Error {
+  constructor(readonly gatewayUrl: string | null) {
+    super("This machine needs a session from your Model Gateway console.");
+    this.name = "HostedSignInRequired";
+  }
+}
+
+/** What the machine's public discovery document says about signing in. */
+type AuthDiscovery =
+  | { mode: "gateway"; gateway_url: string; resource: string }
+  | { mode: "static_token" }
+  | { mode: "local" };
+
+const DISCOVERY_PATH = "/auth/discovery";
+
+/**
+ * The hosted branch: a production bundle whose origin is a Tidebreak machine.
+ *
+ * The origin is asked, not assumed. `/auth/discovery` is the one public,
+ * JSON-answering route every machine has, so a page that gets a discovery
+ * document back is served by a machine, and one that does not — a static
+ * preview of the bundle, say — is not, and boot goes on to say nothing is
+ * reachable. A page served by a machine but holding no bearer throws
+ * {@link HostedSignInRequired} with the console that can mint one.
+ */
+export async function hostedServerInfo({
+  origin = window.location.origin,
+  dev = import.meta.env.DEV,
+  fetch = globalThis.fetch,
+  bearer = handoffBearer(),
+}: {
+  origin?: string;
+  dev?: boolean;
+  fetch?: typeof globalThis.fetch;
+  bearer?: string | null;
+} = {}): Promise<ServerInfo | null> {
+  // The dev server answers every path with the page, so discovery there
+  // would parse the bundle's own HTML. Dev tabs have `listen.json`.
+  if (dev) return null;
+  const discovery = await readDiscovery(fetch, `${origin}${DISCOVERY_PATH}`);
+  if (!discovery) return null;
+  const gatewayUrl =
+    discovery.mode === "gateway"
+      ? discovery.gateway_url.replace(/\/$/, "")
+      : null;
+  markHostedSession({ baseUrl: origin, gatewayUrl });
+  if (!bearer) throw new HostedSignInRequired(gatewayUrl);
+  return {
+    baseUrl: origin,
+    token: bearer,
+    attachment: "remote",
+    gatewayAuth: discovery.mode === "gateway",
+  };
+}
+
+async function readDiscovery(
+  fetch: typeof globalThis.fetch,
+  url: string,
+): Promise<AuthDiscovery | null> {
+  try {
+    const response = await fetch(url, {
+      cache: "no-store",
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) return null;
+    const body: unknown = await response.json();
+    if (!body || typeof body !== "object") return null;
+    const record = body as { mode?: unknown; gateway_url?: unknown };
+    if (record.mode === "gateway") {
+      return typeof record.gateway_url === "string" && record.gateway_url
+        ? { mode: "gateway", gateway_url: record.gateway_url, resource: "" }
+        : null;
+    }
+    if (record.mode === "static_token" || record.mode === "local") {
+      return { mode: record.mode };
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /** Vite-dev middleware that reads the desktop's listen.json. Absent in prod. */

--- a/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { HostedSignInRequired, hostedServerInfo } from "./boot";
+import {
+  captureHandoffToken,
+  handoffBearer,
+  hostedSession,
+  resetHostedSessionForTests,
+} from "./hostedSession";
+import { remoteMachineState } from "./remoteMachine";
+
+function fakeWindow(hash: string): Window & { replaced: string[] } {
+  const replaced: string[] = [];
+  return {
+    location: { hash, pathname: "/", search: "" },
+    history: {
+      state: null,
+      replaceState: (_state: unknown, _title: string, url: string) => {
+        replaced.push(url);
+      },
+    },
+    replaced,
+  } as unknown as Window & { replaced: string[] };
+}
+
+function discovery(body: unknown, ok = true): typeof globalThis.fetch {
+  return vi.fn(async () => ({
+    ok,
+    json: async () => body,
+  })) as unknown as typeof globalThis.fetch;
+}
+
+afterEach(() => {
+  resetHostedSessionForTests();
+});
+
+describe("the handoff fragment", () => {
+  it("is taken into memory and cleared from the address before the router sees it", () => {
+    const win = fakeWindow("#handoff=mg_at_abc.DEF-123~");
+    captureHandoffToken(win);
+    expect(handoffBearer()).toBe("mg_at_abc.DEF-123~");
+    expect(win.replaced).toEqual(["/"]);
+  });
+
+  it("leaves a route fragment alone", () => {
+    const win = fakeWindow("#/settings/machine");
+    captureHandoffToken(win);
+    expect(handoffBearer()).toBeNull();
+    expect(win.replaced).toEqual([]);
+  });
+
+  it("refuses a fragment that is not a bare token", () => {
+    const win = fakeWindow("#handoff=<script>alert(1)</script>");
+    captureHandoffToken(win);
+    expect(handoffBearer()).toBeNull();
+  });
+});
+
+describe("the hosted boot branch", () => {
+  it("is off in the dev server, whose pages are the bundle itself", async () => {
+    const fetch = discovery({ mode: "gateway", gateway_url: "https://g" });
+    await expect(
+      hostedServerInfo({ origin: "http://localhost:1420", dev: true, fetch }),
+    ).resolves.toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("attaches remotely to its own origin with the bearer it was handed", async () => {
+    const fetch = discovery({
+      mode: "gateway",
+      gateway_url: "https://gateway.example.com/",
+      resource: "tidebreak:abc",
+    });
+    const info = await hostedServerInfo({
+      origin: "https://tidebreak.example.com",
+      dev: false,
+      fetch,
+      bearer: "mg_at_token",
+    });
+    expect(info).toEqual({
+      baseUrl: "https://tidebreak.example.com",
+      token: "mg_at_token",
+      attachment: "remote",
+      gatewayAuth: true,
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://tidebreak.example.com/auth/discovery",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    expect(hostedSession()).toEqual({
+      baseUrl: "https://tidebreak.example.com",
+      gatewayUrl: "https://gateway.example.com",
+    });
+    // The gate and the Machine panel read the attachment from here, and a
+    // browser tab has no shell to ask.
+    await expect(remoteMachineState()).resolves.toEqual({
+      attachment: "remote",
+      baseUrl: "https://tidebreak.example.com",
+    });
+  });
+
+  it("asks for a sign-in, naming the console, when the page holds no bearer", async () => {
+    const fetch = discovery({
+      mode: "gateway",
+      gateway_url: "https://gateway.example.com",
+    });
+    const attempt = hostedServerInfo({
+      origin: "https://tidebreak.example.com",
+      dev: false,
+      fetch,
+      bearer: null,
+    });
+    await expect(attempt).rejects.toBeInstanceOf(HostedSignInRequired);
+    await attempt.catch((error: HostedSignInRequired) => {
+      expect(error.gatewayUrl).toBe("https://gateway.example.com");
+    });
+  });
+
+  it("has no console to name for a machine on static tokens", async () => {
+    const fetch = discovery({ mode: "static_token" });
+    const attempt = hostedServerInfo({
+      origin: "https://tidebreak.example.com",
+      dev: false,
+      fetch,
+      bearer: null,
+    });
+    await expect(attempt).rejects.toMatchObject({ gatewayUrl: null });
+  });
+
+  it("is not a machine when the origin answers no discovery document", async () => {
+    await expect(
+      hostedServerInfo({
+        origin: "https://static.example.com",
+        dev: false,
+        fetch: discovery("<!doctype html>", false),
+        bearer: "mg_at_token",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      hostedServerInfo({
+        origin: "https://static.example.com",
+        dev: false,
+        fetch: vi.fn(async () => {
+          throw new TypeError("Load failed");
+        }) as unknown as typeof globalThis.fetch,
+        bearer: "mg_at_token",
+      }),
+    ).resolves.toBeNull();
+    expect(hostedSession()).toBeNull();
+    await expect(remoteMachineState()).resolves.toEqual({
+      attachment: "local",
+      baseUrl: null,
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/hostedSession.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.ts
@@ -1,0 +1,72 @@
+/**
+ * A browser tab served by the machine itself.
+ *
+ * The hosted machine serves this renderer at its own origin, so a tab there
+ * is a remote attachment with no native shell behind it: the API is
+ * `window.location.origin`, and the bearer is whatever the page was handed.
+ * Nothing here talks to the server; boot does that. This module is the one
+ * place the two facts a page holds live — the handoff token it arrived with
+ * and the machine it is attached to — so the callers that need them outside
+ * React (boot, the machine state read, the gate) agree.
+ */
+
+/** Where a page came from, once boot has confirmed the origin is a machine. */
+export type HostedSession = {
+  /** The machine's origin, which is also this page's. */
+  baseUrl: string;
+  /**
+   * The Model Gateway the machine authenticates against, from the machine's
+   * own discovery document. `null` for a machine on static tokens, which has
+   * no browser sign-in to send a reader to.
+   */
+  gatewayUrl: string | null;
+};
+
+/**
+ * The one carrier a bearer may arrive in. A fragment never reaches the
+ * server or its access log, and the page clears it before anything else can
+ * read it. Tokens are URL-safe by construction; anything else is not a token.
+ */
+const HANDOFF_FRAGMENT = /^#handoff=([A-Za-z0-9._~-]+)$/;
+
+let handoffToken: string | null = null;
+let session: HostedSession | null = null;
+
+/**
+ * Take the handoff bearer out of the page's fragment, if it arrived with one.
+ *
+ * Call this before the router exists: the router owns the fragment from then
+ * on, and would read the token as a route. The token stays in memory for
+ * this page's life — long enough for boot to retry — and nowhere else.
+ */
+export function captureHandoffToken(win: Window = window): void {
+  const match = HANDOFF_FRAGMENT.exec(win.location.hash);
+  if (!match) return;
+  handoffToken = match[1];
+  win.history.replaceState(
+    win.history.state,
+    "",
+    `${win.location.pathname}${win.location.search}`,
+  );
+}
+
+/** The bearer the page arrived with, or `null` if it opened without one. */
+export function handoffBearer(): string | null {
+  return handoffToken;
+}
+
+/** Record that this page is served by the machine at `next.baseUrl`. */
+export function markHostedSession(next: HostedSession | null): void {
+  session = next;
+}
+
+/** The machine this page is served by, or `null` outside a hosted tab. */
+export function hostedSession(): HostedSession | null {
+  return session;
+}
+
+/** Test seam: forget both facts. */
+export function resetHostedSessionForTests(): void {
+  handoffToken = null;
+  session = null;
+}

--- a/crates/tidebreak-desktop/ui/src/main.tsx
+++ b/crates/tidebreak-desktop/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { Toaster } from "@/components/ui/sonner";
 import { restoreStoredAppMode } from "./appMode";
 import { ErrorBoundary } from "./ErrorBoundary";
+import { captureHandoffToken } from "./hostedSession";
 import { refuseStrayFileDrops } from "./ImageAttachments";
 import { createAppRouter } from "./router";
 import { initTheme } from "./theme";
@@ -13,6 +14,9 @@ import "./styles.css";
 initTheme();
 restoreStoredAppMode();
 refuseStrayFileDrops(window);
+// Before the router: it owns the fragment from here on, and a handoff bearer
+// left in it would be read as a route and stay in the address bar.
+captureHandoffToken();
 const router = createAppRouter();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/crates/tidebreak-desktop/ui/src/remoteMachine.ts
+++ b/crates/tidebreak-desktop/ui/src/remoteMachine.ts
@@ -7,6 +7,7 @@ import type {
 } from "./api";
 import type { HostAuthority } from "./host";
 import { attachedRemotely, hostAuthorityRefusal } from "./host";
+import { hostedSession } from "./hostedSession";
 import { friendlyErrorMessage } from "./lib/utils";
 
 /**
@@ -22,9 +23,19 @@ import { friendlyErrorMessage } from "./lib/utils";
  * wording below is the renderer's to change without touching the shell.
  */
 
-/** Which machine this client is attached to. */
+/**
+ * Which machine this client is attached to.
+ *
+ * Outside the native shell the answer is the page's: a tab served by a
+ * machine is attached to that machine, and any other browser tab is local.
+ */
 export async function remoteMachineState(): Promise<RemoteMachineState> {
-  if (!isTauri()) return { attachment: "local", baseUrl: null };
+  if (!isTauri()) {
+    const hosted = hostedSession();
+    return hosted
+      ? { attachment: "remote", baseUrl: hosted.baseUrl }
+      : { attachment: "local", baseUrl: null };
+  }
   return await invoke<RemoteMachineState>("remote_machine_state");
 }
 

--- a/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -52,6 +52,7 @@ function machineStub(
     attachWithGateway: vi.fn().mockResolvedValue(state),
     attachWithToken: vi.fn().mockResolvedValue(state),
     detach: vi.fn().mockResolvedValue(local),
+    detachable: true,
     reattach: vi.fn(),
   };
 }

--- a/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.tsx
@@ -33,6 +33,7 @@ import {
   remoteConnectError,
   remoteMachineState,
 } from "@/remoteMachine";
+import { hasNativeHost } from "@/host";
 import { friendlyErrorMessage } from "@/lib/utils";
 import {
   SettingsError,
@@ -58,6 +59,12 @@ export type MachineControls = {
   attachWithToken: (baseUrl: string, token: string) => Promise<unknown>;
   detach: () => Promise<unknown>;
   /**
+   * Whether this window has a server of its own to return to. The desktop
+   * does; a browser tab served by the machine is only ever attached to it,
+   * and offering to disconnect would offer a place that does not exist.
+   */
+  detachable: boolean;
+  /**
    * Rebuild this window against the machine that is now current.
    *
    * A reload rather than a state update: the API client, the event stream,
@@ -72,6 +79,7 @@ const NATIVE_MACHINE: MachineControls = {
   attachWithGateway: connectGatewayRemoteMachine,
   attachWithToken: connectRemoteMachine,
   detach: disconnectRemoteMachine,
+  detachable: hasNativeHost(),
   reattach: () => window.location.reload(),
 };
 
@@ -665,20 +673,30 @@ function MachineSections({
                 <span>{state?.baseUrl}</span>
               </p>
             </SettingsField>
-            <p className="text-sm text-muted-foreground">
-              Disconnecting returns this window to the server inside this app.
-              It changes nothing on the remote machine.
-            </p>
-            <div>
-              <Button
-                variant="outline"
-                onClick={() => void detach()}
-                disabled={busy}
-              >
-                <Laptop size={16} aria-hidden />
-                Work on this computer
-              </Button>
-            </div>
+            {machine.detachable ? (
+              <>
+                <p className="text-sm text-muted-foreground">
+                  Disconnecting returns this window to the server inside this
+                  app. It changes nothing on the remote machine.
+                </p>
+                <div>
+                  <Button
+                    variant="outline"
+                    onClick={() => void detach()}
+                    disabled={busy}
+                  >
+                    <Laptop size={16} aria-hidden />
+                    Work on this computer
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                You opened this machine in your browser. Closing the tab stops
+                watching; the work here keeps running, and the Tidebreak desktop
+                app can attach to the same machine.
+              </p>
+            )}
           </>
         ) : (
           <>
@@ -761,9 +779,11 @@ function MachineSections({
       <SettingsSection
         title="What stays on this computer"
         description={
-          remote
-            ? "These reach this computer's files, screen, and input. Your conversation is not on this computer, so they are unavailable until you disconnect."
-            : "These reach this computer's files, screen, and input. Attaching to a remote machine makes them unavailable, because your conversation would not be on this computer."
+          remote && !machine.detachable
+            ? "These reach this computer's files, screen, and input. Your conversation is not on this computer, so they are unavailable in this tab."
+            : remote
+              ? "These reach this computer's files, screen, and input. Your conversation is not on this computer, so they are unavailable until you disconnect."
+              : "These reach this computer's files, screen, and input. Attaching to a remote machine makes them unavailable, because your conversation would not be on this computer."
         }
       >
         <ul className="flex flex-col gap-2 text-sm">

--- a/crates/tidebreak-desktop/ui/src/stories/GatewayPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/GatewayPanel.stories.tsx
@@ -31,12 +31,16 @@ function stubClient(status: GatewayStatus, offered?: string): ApiClient {
  * and go no further — a story that could reattach the window would take the
  * canvas with it.
  */
-function stubMachine(state: RemoteMachineState): MachineControls {
+function stubMachine(
+  state: RemoteMachineState,
+  { detachable = true }: { detachable?: boolean } = {},
+): MachineControls {
   return {
     read: async () => state,
     attachWithGateway: fn(async () => state),
     attachWithToken: fn(async () => state),
     detach: fn(async () => machineLocal),
+    detachable,
     reattach: fn(),
   };
 }
@@ -148,5 +152,22 @@ export const HostedMachine: Story = {
     gatewayUrl: null,
     hostedGatewayUrl: "https://gateway.example.com/",
     machine: stubMachine(machineAttached),
+  },
+};
+
+/**
+ * The same hosted machine, opened in a browser tab the machine served.
+ *
+ * There is no server inside a browser tab to return to, so the disconnect
+ * control is replaced by the one thing the reader can do: close the tab, or
+ * attach from the desktop app.
+ */
+export const HostedMachineInBrowser: Story = {
+  args: {
+    client: stubClient(gatewaySignedOut),
+    managed: false,
+    gatewayUrl: null,
+    hostedGatewayUrl: "https://gateway.example.com/",
+    machine: stubMachine(machineAttached, { detachable: false }),
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/HostedSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HostedSession.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { HostedSignIn } from "@/HostedSignIn";
+
+/**
+ * A browser tab served by a hosted machine, before it holds a session.
+ *
+ * The machine serves the same renderer the desktop app runs, but a tab
+ * cannot sign itself in: its bearer comes from the reader's Model Gateway
+ * console, once. These are the screens between opening the address and
+ * arriving signed in, and the one that follows an hour later.
+ */
+const meta = {
+  title: "Shell/Hosted browser session",
+  component: HostedSignIn,
+  parameters: { layout: "fullscreen" },
+  args: {
+    reason: "no_session",
+    machineUrl: "https://tidebreak.example.com",
+    gatewayUrl: "https://gateway.example.com",
+    onRetry: fn(),
+  },
+} satisfies Meta<typeof HostedSignIn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Someone opened the machine's address directly, or reloaded a tab that had
+ * a session. The page names the console that can send them back signed in.
+ */
+export const SignInRequired: Story = {};
+
+/**
+ * The bearer a tab held stopped being accepted. After an hour that is simply
+ * its lifetime, and the copy says so before it says where to go.
+ */
+export const SessionEnded: Story = {
+  args: { reason: "session_ended" },
+};
+
+/**
+ * A machine on static tokens has no console to send a browser to. The page
+ * still says what to do instead of offering a link that goes nowhere.
+ */
+export const NoBrowserSignIn: Story = {
+  args: { gatewayUrl: null },
+};

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -2034,6 +2034,10 @@ body {
   .boot {
     height: 100%;
     display: grid;
+    /* One track the width of the screen, never the width of the widest
+       line: a browser tab can be far narrower than any desktop window, and
+       an auto track would size to the copy and push it off the edge. */
+    grid-template-columns: minmax(0, 1fr);
     place-items: center;
     text-align: center;
     padding: 2rem;
@@ -2062,6 +2066,20 @@ body {
   .boot p {
     color: var(--muted-foreground);
     margin: 0;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+
+  .boot .welcome-copy {
+    max-width: min(34rem, 100%);
+  }
+
+  .boot .welcome-copy h2 {
+    text-wrap: balance;
+  }
+
+  .boot .welcome-copy p {
+    text-wrap: pretty;
   }
 
   .boot .boot-error-detail {

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -41,7 +41,7 @@ sea-orm = { workspace = true }
 # `rt-multi-thread` backs the durable operation log's synchronous `OperationStore`
 # bridge (`tokio::task::block_in_place`); the host runs on a multi-thread runtime.
 tokio = { workspace = true, features = ["net", "process", "rt", "rt-multi-thread", "sync", "macros", "time"] }
-tower-http = { version = "=0.7.0", features = ["cors", "limit"] }
+tower-http = { version = "=0.7.0", features = ["cors", "fs", "limit"] }
 futures = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -105,6 +105,7 @@ mod source_tools;
 mod state;
 mod store_ownership;
 mod task_plan_tool;
+mod ui_bundle;
 mod update_quiesce;
 mod vault_secrets;
 mod view_frames;
@@ -121,7 +122,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::extract::DefaultBodyLimit;
+use axum::extract::{DefaultBodyLimit, Request};
 use axum::http::{header, Method};
 use axum::routing::{delete, get, patch, post};
 use axum::Router;
@@ -1253,10 +1254,25 @@ pub fn app(state: AppState) -> Router {
         )
         .with_state(frame_state);
 
-    Router::new()
+    let root = Router::new()
         .merge(view_frames)
         .merge(auth_discovery)
-        .merge(api)
+        .merge(api);
+    // The renderer bundle, when this machine carries one, answers what no
+    // route claimed. It sits with the API inside the origin and CORS layers
+    // and outside `require_token`: a page has to load before it can hold a
+    // bearer. Without a bundle the fallback stays axum's own `404`.
+    let root = match state.config.ui_dist.clone() {
+        Some(dist) => {
+            let dist = Arc::new(dist);
+            root.fallback(move |request: Request| {
+                let dist = dist.clone();
+                async move { ui_bundle::serve(dist, request).await }
+            })
+        }
+        None => root,
+    };
+    root
         // Inside CORS, so a foreign preflight is answered by the CORS layer's
         // own rejection rather than by a bare 403.
         .layer(axum::middleware::from_fn_with_state(
@@ -2460,6 +2476,9 @@ async fn bind_inner(
     let data_dir = state.config.data_dir.clone();
     let mcp_runtime = state.mcp.clone();
     let gateway_runtime = state.gateway.clone();
+    if let Some(dist) = state.config.ui_dist.as_deref() {
+        ui_bundle::verify(dist)?;
+    }
     let router = app(state);
 
     let listener = TcpListener::bind(bind_addr)

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -2654,3 +2654,164 @@ pub(crate) fn dispatchable(
         resolution: None,
     }
 }
+
+/// A router over `dist`, or over no bundle at all.
+async fn ui_bundle_app(dist: Option<&std::path::Path>) -> (Router, Arc<str>, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("t.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut config = Config::desktop(dir.path());
+    config.ui_dist = dist.map(std::path::Path::to_path_buf);
+    let state = AppState::new(
+        config,
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    (app(state), token, dir)
+}
+
+fn ui_bundle_fixture() -> tempfile::TempDir {
+    let dist = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dist.path().join("index.html"),
+        "<!doctype html><title>Tidebreak</title>",
+    )
+    .unwrap();
+    std::fs::create_dir(dist.path().join("assets")).unwrap();
+    std::fs::write(dist.path().join("assets").join("app-abc123.js"), "boot()").unwrap();
+    dist
+}
+
+async fn text_body(response: axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+/// The hosted machine's page contract: a navigation lands on the bundle for
+/// any path the API does not own, a `fetch` for an unknown route still
+/// learns it is unknown, and the API keeps its own answers ahead of the
+/// bundle. Without a bundle nothing changes — an unknown path is a `404`,
+/// not a `401` and not a page.
+#[tokio::test]
+async fn a_configured_ui_bundle_answers_navigations_and_nothing_else() {
+    let dist = ui_bundle_fixture();
+    let (router, bearer, _dir) = ui_bundle_app(Some(dist.path())).await;
+    let get = |path: &str, accept: &str| {
+        Request::builder()
+            .uri(path)
+            .header(header::ACCEPT, accept)
+            .body(Body::empty())
+            .unwrap()
+    };
+    const NAVIGATION: &str = "text/html,application/xhtml+xml,*/*;q=0.8";
+
+    let root = router.clone().oneshot(get("/", NAVIGATION)).await.unwrap();
+    assert_eq!(root.status(), StatusCode::OK);
+    assert_eq!(root.headers()[header::CACHE_CONTROL], "no-cache");
+    assert!(text_body(root).await.contains("<title>Tidebreak</title>"));
+
+    // A deep link: no such file, but a navigation, so the page answers and
+    // the renderer's own router takes it from there.
+    let deep = router
+        .clone()
+        .oneshot(get("/settings/machine", NAVIGATION))
+        .await
+        .unwrap();
+    assert_eq!(deep.status(), StatusCode::OK);
+    assert!(text_body(deep).await.contains("<title>Tidebreak</title>"));
+
+    // Hashed assets are held forever; they change name when they change.
+    let asset = router
+        .clone()
+        .oneshot(get("/assets/app-abc123.js", "*/*"))
+        .await
+        .unwrap();
+    assert_eq!(asset.status(), StatusCode::OK);
+    assert_eq!(
+        asset.headers()[header::CACHE_CONTROL],
+        "public, max-age=31536000, immutable"
+    );
+    assert_eq!(text_body(asset).await, "boot()");
+
+    // A `fetch` for a route that does not exist is told so.
+    let missing = router
+        .clone()
+        .oneshot(get("/settings/machine", "application/json"))
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    let posted = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/settings/machine")
+                .header(header::ACCEPT, NAVIGATION)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(posted.status(), StatusCode::NOT_FOUND);
+
+    // The API is matched first: a navigation to an API route is the API's
+    // answer, bearer check included, never the page.
+    let api = router
+        .clone()
+        .oneshot(get("/chats", NAVIGATION))
+        .await
+        .unwrap();
+    assert_eq!(api.status(), StatusCode::UNAUTHORIZED);
+    let api = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/chats")
+                .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+                .header(header::ACCEPT, NAVIGATION)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(api.status(), StatusCode::OK);
+
+    // Escaping the bundle directory is refused, navigation or not.
+    let escape = router
+        .clone()
+        .oneshot(get("/../tidebreak.db", "*/*"))
+        .await
+        .unwrap();
+    assert_ne!(escape.status(), StatusCode::OK);
+
+    let (bare, _bearer, _dir) = ui_bundle_app(None).await;
+    let unknown = bare.clone().oneshot(get("/", NAVIGATION)).await.unwrap();
+    assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+    let unknown = bare
+        .oneshot(get("/settings/machine", NAVIGATION))
+        .await
+        .unwrap();
+    assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+}
+
+/// The bundle is checked before the server listens: an image that forgot to
+/// copy it refuses to boot, naming the path, instead of serving `404`s.
+#[test]
+fn a_ui_bundle_without_an_index_page_is_refused_at_bind() {
+    let dist = tempfile::tempdir().unwrap();
+    let refusal = ui_bundle::verify(dist.path()).unwrap_err().to_string();
+    assert!(refusal.contains("index.html"), "{refusal}");
+    assert!(
+        refusal.contains(&dist.path().display().to_string()),
+        "{refusal}"
+    );
+
+    std::fs::write(dist.path().join("index.html"), "<!doctype html>").unwrap();
+    ui_bundle::verify(dist.path()).unwrap();
+}

--- a/crates/tidebreak-server/src/ui_bundle.rs
+++ b/crates/tidebreak-server/src/ui_bundle.rs
@@ -1,0 +1,101 @@
+//! Serving the renderer bundle to browsers.
+//!
+//! A hosted machine has nowhere to land a person until it serves a page.
+//! Configured with a built desktop UI bundle (`TIDEBREAK_UI_DIST`), the
+//! server answers page navigations for any path the API does not own with
+//! that bundle, and serves its files by name. The bundle is the same `dist`
+//! the packaged desktop app loads over its own protocol, so a browser tab and
+//! the desktop run one renderer against one API.
+//!
+//! The fallback is deliberately narrow. Only `GET` and `HEAD` reach the
+//! bundle, and `index.html` stands in for an unknown path only when the
+//! request is a navigation — an `Accept` that names `text/html`. A `fetch`
+//! for a route that does not exist keeps its `404`, so a renderer newer than
+//! its server still learns that an endpoint is missing instead of parsing a
+//! page as JSON.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{header, HeaderValue, Method, StatusCode};
+use axum::response::{IntoResponse, Response};
+use tidebreak_core::AgentError;
+use tower_http::services::ServeDir;
+
+/// The renderer's compiled assets carry a content hash in their name, so a
+/// changed bundle is a changed URL and the old file can be held forever.
+const IMMUTABLE_ASSET_PREFIX: &str = "/assets/";
+const IMMUTABLE: &str = "public, max-age=31536000, immutable";
+/// Everything else — `index.html` above all — is fetched by a stable name and
+/// must be revalidated, or a tab keeps an old bundle after an image update.
+const REVALIDATE: &str = "no-cache";
+
+/// Refuse a configured directory that cannot serve a page. Checked at bind,
+/// so an image that forgot to copy its bundle fails before it listens rather
+/// than answering every navigation with a `404`.
+pub(crate) fn verify(dist: &Path) -> Result<(), AgentError> {
+    let index = dist.join("index.html");
+    if index.is_file() {
+        return Ok(());
+    }
+    Err(AgentError::config(format!(
+        "TIDEBREAK_UI_DIST names {}, which holds no index.html; point it at a built \
+         renderer bundle or unset it to serve no pages",
+        dist.display()
+    )))
+}
+
+/// The router fallback: a file from the bundle, `index.html` for a page
+/// navigation, and a `404` for everything else.
+pub(crate) async fn serve(dist: Arc<PathBuf>, request: Request) -> Response {
+    if !matches!(*request.method(), Method::GET | Method::HEAD) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let navigation = accepts_html(request.headers());
+    let path = request.uri().path().to_owned();
+    let served = ServeDir::new(dist.as_path()).try_call(request).await;
+    match served {
+        Ok(response) if response.status() != StatusCode::NOT_FOUND => {
+            with_cache_policy(response.map(Body::new), &path)
+        }
+        Ok(_) if navigation => index(&dist).await,
+        Ok(_) => StatusCode::NOT_FOUND.into_response(),
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+async fn index(dist: &Path) -> Response {
+    let request = Request::builder()
+        .uri("/index.html")
+        .body(Body::empty())
+        .expect("a literal request line is well-formed");
+    match ServeDir::new(dist).try_call(request).await {
+        Ok(response) if response.status() == StatusCode::OK => {
+            with_cache_policy(response.map(Body::new), "/index.html")
+        }
+        // Verified at bind, so this is the bundle disappearing from under a
+        // running server. Say so rather than pretend the path is unknown.
+        _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+fn accepts_html(headers: &axum::http::HeaderMap) -> bool {
+    headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|accept| accept.contains("text/html"))
+}
+
+fn with_cache_policy(mut response: Response, path: &str) -> Response {
+    let policy = if path.starts_with(IMMUTABLE_ASSET_PREFIX) {
+        IMMUTABLE
+    } else {
+        REVALIDATE
+    };
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static(policy));
+    response
+}

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -4,7 +4,9 @@
 # tidebreak-server's `postgres` feature, which is what `Profile::SelfHost`
 # needs to open the store named by `TIDEBREAK_DATABASE_URL`. The desktop crate
 # is never built: `-p tidebreak-cli` selects only that binary's dependency
-# closure.
+# closure. The desktop's renderer is: the image carries the built UI bundle
+# and the server serves it, so a browser can land on the machine
+# (decision record 82).
 #
 # Build context is the WORKSPACE ROOT, so the whole Cargo workspace and the
 # committed Cargo.lock are visible to a `--locked` build:
@@ -18,6 +20,28 @@
 # and its PostgreSQL database run inside the operator's own network, and TLS
 # termination plus network exposure belong to the operator's fronting
 # infrastructure. Nothing here terminates TLS. See docs/self-hosting.md.
+
+# ---- renderer stage --------------------------------------------------------
+# The same `pnpm build` the desktop packages as `frontendDist`, so a browser
+# tab and the desktop app run one renderer against one API. Node 22 and pnpm
+# 10 match the desktop UI lane in .github/workflows/ci.yml. Digest-pinned
+# like the stages below: this is node:22-bookworm as of 2026-09-02.
+FROM node:22-bookworm@sha256:8a34c4ab3ea2c5cd194f07e317b2a8f09461d3c8b05c4e34c8ccd56d56024c4d AS renderer
+WORKDIR /src/crates/tidebreak-desktop/ui
+
+# Manifests first, so the dependency layer survives a source-only change.
+COPY crates/tidebreak-desktop/ui/package.json \
+     crates/tidebreak-desktop/ui/pnpm-lock.yaml \
+     crates/tidebreak-desktop/ui/pnpm-workspace.yaml ./
+# `--ignore-scripts`: the lockfile's only native build (canvas) serves the
+# test environment, and a production bundle never loads it. Skipping every
+# install script also keeps the image build off the dependency tree's
+# lifecycle hooks, which is where a supply-chain compromise runs first.
+RUN npm install -g pnpm@10.34.5 \
+    && pnpm install --frozen-lockfile --ignore-scripts
+
+COPY crates/tidebreak-desktop/ui/ ./
+RUN pnpm build
 
 # ---- build stage -----------------------------------------------------------
 # The workspace toolchain channel (stable) via the bookworm image; the
@@ -147,6 +171,7 @@ RUN set -eu; \
     npm --version
 
 COPY --from=build /src/target/release/tidebreak /usr/local/bin/tidebreak
+COPY --from=renderer /src/crates/tidebreak-desktop/ui/dist /opt/tidebreak/ui
 COPY deploy/self-host/entrypoint.sh /usr/local/bin/tidebreak-entrypoint
 
 # The server runs unprivileged. The uid is fixed rather than assigned by
@@ -175,6 +200,10 @@ ENV TIDEBREAK_DATA_DIR=/var/lib/tidebreak
 # front of it. Plain HTTP by design; nothing here terminates TLS.
 ENV TIDEBREAK_LISTEN_ADDR=0.0.0.0:8080
 EXPOSE 8080
+# The renderer bundle the server serves to browsers: a page navigation to any
+# path the API does not own answers with it, and an unknown route fetched as
+# JSON stays a 404. The server refuses to start if this names no bundle.
+ENV TIDEBREAK_UI_DIST=/opt/tidebreak/ui
 
 USER tidebreak:tidebreak
 

--- a/deploy/self-host/Dockerfile.dockerignore
+++ b/deploy/self-host/Dockerfile.dockerignore
@@ -21,6 +21,16 @@
 !crates/tidebreak-code-execution/baseline_python_deps.txt
 !crates/tidebreak-sandbox-agent/documents-requirements.txt
 
+# The desktop renderer, which the image builds and the server serves to
+# browsers. The whole package directory, because Vite's inputs are its
+# manifests, `index.html`, `public/`, and `src/` together. The deny rules
+# below still win for what must never reach the daemon: `node_modules`, a
+# stale `dist`, and every hidden file — `.npmrc` and `.storybook` included,
+# neither of which the production build reads.
+!crates/tidebreak-desktop/
+!crates/tidebreak-desktop/ui/
+!crates/tidebreak-desktop/ui/**
+
 # Built-in manifests are source inputs for compile-time contract checks. Admit
 # only the reviewed manifest names, not arbitrary files beside them.
 !skills/

--- a/docs/decisions/0082-the-hosted-machine-serves-the-renderer.md
+++ b/docs/decisions/0082-the-hosted-machine-serves-the-renderer.md
@@ -1,0 +1,109 @@
+# 82. The hosted machine serves the renderer
+
+- Status: Accepted
+- Date: 2026-09-02
+- Owners: server, desktop
+- Related: [`0006-self-host-deployment-plane-authorization.md`](0006-self-host-deployment-plane-authorization.md),
+  [`0047-gateway-linked-hosting.md`](0047-gateway-linked-hosting.md),
+  [`../self-hosting.md`](../self-hosting.md)
+- Supersedes: none
+
+## Context
+
+A hosted Tidebreak machine has no page. The server mounts the API, the view
+frames, the auth discovery document, and `/healthz`; its root answers `404`.
+The only client is the desktop app, which attaches to the machine with a
+Gateway-minted bearer ([record 47](0047-gateway-linked-hosting.md)).
+[`docs/deferred.md`](../deferred.md) parks a hosted web UI as "a later
+surface on that same wire".
+
+That later surface is now the one that matters. A Model Gateway administrator
+who sets the machine up in the console has nowhere to go from there: the
+console can name the machine's URL, and the URL shows nothing. The desktop app
+is the wrong first answer for that person — they are already in a browser,
+signed in, one click from the machine.
+
+The renderer that would serve them already exists. The desktop UI is a React
+bundle the packaged app loads over Tauri's own protocol; every attachment
+state a browser tab could be in is one the app already renders, including the
+remote attachment with host authority struck through ([PR
+#2514](https://github.com/brightwave-inc/tidebreak/pull/2514) made
+`attachedRemotely` the signal for that).
+
+## Decision
+
+The self-host image builds the desktop renderer and the server serves it.
+
+1. **The image carries the bundle.** `deploy/self-host/Dockerfile` gains a
+   Node stage that runs the desktop UI's `pnpm build` and copies `dist` into
+   the runtime image at `/opt/tidebreak/ui`. Node 22 and pnpm 10 match the
+   desktop UI lane in CI; the base image is digest-pinned like the others.
+   The build installs with `--ignore-scripts`: a production bundle loads no
+   native module, and the image build should not run the dependency tree's
+   lifecycle hooks.
+
+2. **The server serves it only when told to.** `TIDEBREAK_UI_DIST` names the
+   bundle directory. Set, the server mounts it as the router's fallback:
+   files by name, and `index.html` for a `GET` or `HEAD` whose `Accept`
+   names `text/html` and whose path no route claimed. A `fetch` for an
+   unknown route keeps its `404`, and every API route is matched first, so a
+   navigation to `/chats` is still the bearer check's `401`. Unset, nothing
+   changes: an unknown path is a `404`, not a `401` and not a page. The
+   directory is verified at bind, and a configured directory without an
+   `index.html` refuses to start.
+
+3. **The bundle is the one the desktop ships.** The same `dist` Tauri
+   packages as `frontendDist`, with no hosted build flavor. Boot gains one
+   branch: outside Tauri, with no explicit URL and no dev listen endpoint, a
+   production bundle asks its own origin for `/auth/discovery`. A discovery
+   document means the page is served by a machine; the page then attaches to
+   `window.location.origin` as a remote attachment, with `gatewayAuth` set
+   when the machine authenticates through a gateway.
+
+4. **The bearer arrives in the fragment, once.** A page served by a machine
+   holds whatever bearer it was handed in `#handoff=<token>`. Boot takes it
+   out of the address before the router exists, keeps it in memory, and
+   nowhere else — no cookie, no storage. A page that opens without one shows
+   a sign-in screen that names the gateway console, because the console is
+   what can mint one. The mint and the redeem are the gateway's and a
+   follow-up route's; this record settles only what the page does with the
+   result.
+
+5. **A browser session lasts its token.** The desktop refreshes its bearer
+   from the gateway session it holds; a browser tab holds no such session,
+   so nothing refreshes. When the machine stops accepting the bearer, the
+   page says the session ended and sends the reader back through the
+   console. A refresh path for long-lived tabs is deferred until someone
+   keeps one open past an hour and minds.
+
+6. **The Machine panel knows a tab has nowhere to go.** The desktop offers to
+   disconnect from a remote machine and return to the server inside the app.
+   A browser tab has no such server, so the offer is replaced by what the
+   reader can do: close the tab, or attach from the desktop app.
+
+## Consequences
+
+- The hosted machine has a landing page, which is what the console's
+  Manage action needs to link to.
+- The server image grows by the bundle and its build time by the Node stage.
+  The Docker context now admits the desktop UI package directory; the
+  deny-by-default `Dockerfile.dockerignore` still excludes `node_modules`, a
+  stale `dist`, and every hidden file, and the context probe test pins that.
+- Origin checks do not change. The self-host profile does not check
+  `Origin` — an operator-chosen name is not knowable to the server — and a
+  same-origin page never triggers CORS. A hosted tab and the machine share
+  one origin by construction.
+- Storybook carries the hosted browser states: "Shell/Hosted browser
+  session" and the Machine panel's in-browser variant.
+
+## Alternatives considered
+
+- **A separate hosted web app.** A second renderer would drift from the
+  desktop's within a release. The desktop already renders every attachment
+  state a tab needs.
+- **A cookie session.** The server reads bearers from `Authorization` and the
+  WebSocket subprotocol only; a cookie would be the first in the codebase
+  and would need CSRF protection across every mutating route.
+- **Serving `index.html` for every unmatched path.** Swallows API `404`s: a
+  renderer newer than its server would parse a page as JSON instead of
+  learning an endpoint is missing.

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -90,3 +90,4 @@
 0079  0079-supervised-agent-declines-the-sandbox-protocol.md
 0080  0080-update-restarts-park-sessions-at-turn-boundaries.md
 0081  0081-uneff-me-works-without-a-tidebreak-checkout.md
+0082  0082-the-hosted-machine-serves-the-renderer.md

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -39,8 +39,12 @@ a remote deployment.
 The first member client is now specified:
 [decision 47](decisions/0047-gateway-linked-hosting.md) is a desktop remote
 connection mode (URL, token, TLS except on loopback) with host authority
-degrading on a remote machine. A hosted web UI remains a later surface on
-that same wire. The supervision-first mobile client is unparked as #2644.
+degrading on a remote machine. The hosted web UI is unparked:
+[decision 82](decisions/0082-the-hosted-machine-serves-the-renderer.md) has
+the machine serve the desktop renderer to browsers, with a session that lasts
+its bearer. Refreshing a browser session without re-entering through the
+gateway console stays parked until someone keeps a tab open past an hour and
+minds. The supervision-first mobile client is unparked as #2644.
 Auth beyond the static token file is sequenced there too:
 roster-provisioned tokens first, a gateway authenticator behind decision 6's
 credential-to-principal seam as the end state.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -282,6 +282,7 @@ aspirational.
 | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `GEMINI_API_KEY`, `FIREWORKS_API_KEY`, `TOGETHER_API_KEY` | no | unset | Fallback provider credentials, consulted when Vault holds no credential for that provider or Vault custody is not configured. |
 | `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `OPENAI_COMPATIBLE_BASE_URL`, `OLLAMA_BASE_URL` | no | unset | Fallback provider endpoints, consulted when no base URL is stored for that provider. Point a provider at a compatible endpoint from your chart or compose file instead of setting it after first boot. Use HTTPS; Ollama also accepts HTTP on a loopback address. An unusable value is ignored, and the provider keeps its built-in endpoint. |
 | `TIDEBREAK_LISTEN_ADDR` | no | loopback, ephemeral port | Self-host only: the address and port the API binds, e.g. `0.0.0.0:8080`. The desktop profile refuses to boot with it set — that profile's loopback binding is what its per-launch token assumes. The image sets it to `0.0.0.0:8080` so the container is reachable at a known port. |
+| `TIDEBREAK_UI_DIST` | no | unset | A built desktop renderer bundle to serve to browsers; see [Opening the machine in a browser](#opening-the-machine-in-a-browser). The image sets it to the bundle it carries. Unset, the server serves no pages and an unknown path answers `404`. The server refuses to start if the directory holds no `index.html`. |
 
 ## Compose quickstart
 
@@ -366,6 +367,30 @@ Two things the image deliberately does not decide for you:
 
 The image ships no SSH client and no known-hosts file, so clone over HTTPS.
 An SSH clone URL fails.
+
+## Opening the machine in a browser
+
+The image carries the Tidebreak desktop app's renderer, and the server serves
+it at the machine's own address: a browser tab at `TIDEBREAK_PUBLIC_URL`
+lands on the same app the desktop runs, attached to this machine. Pages are
+served for navigations only — a request for an unknown route with a JSON
+`Accept` still answers `404`, and every API route is matched ahead of the
+bundle — so the API contract does not change.
+
+A tab signs in the way the desktop does: with a short-lived Gateway bearer
+bound to this machine. The page holds that bearer in memory for the tab's
+life and never in a cookie or in storage. It arrives once, from the Model
+Gateway console's Manage action, and lasts its hour; a tab that opens the
+address directly, or outlives its bearer, shows a sign-in screen that sends
+the reader back through the console. A machine on static tokens
+(`TIDEBREAK_AUTH_TOKENS_FILE`) has no browser sign-in: the page says so, and
+the desktop app remains the client for it.
+
+Everything that reaches the reader's own computer — connected folders, tool
+calls on the local machine, saving files locally, computer use — is
+unavailable in a browser tab, as it is for any remote attachment.
+
+To run the image without pages, unset `TIDEBREAK_UI_DIST`.
 
 ## Putting it behind a reverse proxy
 

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -26,9 +26,9 @@ a stale one.
 
 ## Summary
 
-- Rust crates: 860
+- Rust crates: 861
 - Desktop UI production packages: 535
-- Distinct license texts: 591
+- Distinct license texts: 592
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -1686,6 +1686,12 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: https://github.com/hyperium/http-body
 - License text: `LICENSE` ([L-57f841bc9767](#l-57f841bc9767))
+
+### http-range-header 0.4.2
+
+- License: `MIT`
+- Repository: https://github.com/MarcusGrass/parse-range-headers
+- License text: `LICENSE` ([L-e30cd0c9491a](#l-e30cd0c9491a))
 
 ### httparse 1.10.1
 
@@ -37068,6 +37074,32 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
+
+### L-e30cd0c9491a
+
+```
+MIT License
+
+Copyright (c) 2021 MarcusGrass
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### L-e35e8f8a37b5

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1072,8 +1072,20 @@ test(
       "crates/tidebreak-sandbox-agent/documents-requirements.txt",
       "skills/demo/SKILL.md",
       "plugins/demo/PLUGIN.md",
+      // The renderer the image builds: manifests, the page, and sources.
+      "crates/tidebreak-desktop/ui/package.json",
+      "crates/tidebreak-desktop/ui/pnpm-lock.yaml",
+      "crates/tidebreak-desktop/ui/index.html",
+      "crates/tidebreak-desktop/ui/public/favicon.svg",
+      "crates/tidebreak-desktop/ui/src/main.tsx",
     ];
     const excluded = [
+      // Never a dependency tree, a stale bundle, or the hidden config
+      // beside the renderer sources.
+      "crates/tidebreak-desktop/ui/node_modules/vite/index.js",
+      "crates/tidebreak-desktop/ui/dist/index.html",
+      "crates/tidebreak-desktop/ui/.npmrc",
+      "crates/tidebreak-desktop/ui/.storybook/main.ts",
       "crates/demo/.npmrc",
       "crates/demo/src/.netrc",
       "crates/demo/src/deep/.pypirc",


### PR DESCRIPTION
## Why

A hosted Tidebreak machine has no page. The server mounts the API, the view frames, auth discovery, and `/healthz`; its root answers `404`. A Model Gateway administrator who sets the machine up in the console has nowhere to land. This is the unpark of the hosted web UI in `docs/deferred.md`, recorded as decision 82.

## What changes

**Server.** `TIDEBREAK_UI_DIST` names a built desktop UI bundle. Set, the server mounts it as the router's fallback: files by name, and `index.html` for a `GET` or `HEAD` navigation (an `Accept` naming `text/html`) on any path no route claimed. A `fetch` for an unknown route keeps its `404`, and every API route is matched first, so a navigation to `/chats` is still the bearer check's `401`. Hashed assets are `immutable`; everything else is `no-cache`. A configured directory without `index.html` refuses to bind. Unset, nothing changes: an unknown path is a `404`, not a `401` and not a page.

**Renderer.** Boot gains a hosted branch. Outside Tauri, with no explicit URL and no dev listen endpoint, a production bundle asks its own origin for `/auth/discovery`. A discovery document means the page is served by a machine; it then attaches to `window.location.origin` as a remote attachment, `gatewayAuth` set when the machine authenticates through a gateway. The bearer arrives once in the `#handoff=<token>` fragment, is taken out of the address before the router exists, and lives in memory only. A page with no bearer shows a sign-in screen that names the gateway console; a page whose bearer stops being accepted (`401`/`403` on the policy read) says the session ended. The tab skips the shell's 30 s token refresh, and the Machine panel replaces "Work on this computer" with what a tab can do.

**Image.** A digest-pinned Node 22 stage runs the desktop UI's `pnpm build` with `--ignore-scripts` and the runtime stage copies `dist` to `/opt/tidebreak/ui`, with `TIDEBREAK_UI_DIST` set. The Docker context admits `crates/tidebreak-desktop/ui/`; the deny rules still exclude `node_modules`, `dist`, and hidden files, and the context probe test pins that.

**Not changed: origin checks.** The self-host profile does not check `Origin` (an operator-chosen name is not knowable to the server), and a same-origin page never triggers CORS, so the hosted tab needs no admission there.

## Storybook

- New "Shell/Hosted browser session": `SignInRequired`, `SessionEnded`, `NoBrowserSignIn`.
- "Settings/Model Gateway": new `HostedMachineInBrowser`.
- The boot screen's grid column now sizes to the viewport, so every `.boot` screen wraps at narrow widths instead of clipping.

## Checks run

- `cargo test -p tidebreak-server --lib -- ui_bundle` (2 new tests), `cargo test -p tidebreak-core --lib`, clippy on both crates, `cargo fmt --check`.
- Desktop UI lane: biome format, lint, `tsc`, full `pnpm test` (the two failures on the first run were a mock missing the new export, fixed, and a load-only flake in `OutputsView` that passes alone), `pnpm build`, `pnpm storybook:build`.
- `node --test scripts/workflow-security.test.mjs scripts/self-host-image-pins.test.mjs` (the Docker context probe runs locally).
- `docker build --target renderer` of the new stage: builds, `dist` holds `index.html` and 283 assets.
- Screenshots of the new stories in light and dark at desktop and narrow widths.

## Follow-ups (separate PRs)

- `GET /auth/handoff?code=` on the machine, redeeming the gateway's one-time code and answering `302 /#handoff=<token>`.
- Gateway: mint and redeem endpoints, then the console's Manage action.
