### PR TITLE
feat(server): land a browser on the hosted machine from a handoff code

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -23,6 +23,7 @@ import { AppContextProvider, type AppContextValue } from "./AppContext";
 
 import { HostedSignInRequired, resolveServerInfo } from "./boot";
 import { HostedSignIn } from "./HostedSignIn";
+import type { HandoffFailure } from "./hostedSession";
 import {
   BootFailure,
   type BootAttachment,
@@ -244,6 +245,7 @@ export function AppShell() {
   // answered, and the page knows which console can sign it in.
   const [hostedSignIn, setHostedSignIn] = useState<{
     gatewayUrl: string | null;
+    failure: HandoffFailure | null;
   } | null>(null);
   const [appVersion, setAppVersion] = useState<string | null>(null);
   const [info, setInfo] = useState<ServerInfo | null>(null);
@@ -514,7 +516,7 @@ export function AppShell() {
       } catch (err) {
         if (cancelled) return;
         if (err instanceof HostedSignInRequired) {
-          setHostedSignIn({ gatewayUrl: err.gatewayUrl });
+          setHostedSignIn({ gatewayUrl: err.gatewayUrl, failure: err.failure });
           return;
         }
         setBootFailure({ stage: "connect", error: err });
@@ -1084,7 +1086,8 @@ export function AppShell() {
   if (hostedSignIn) {
     return (
       <HostedSignIn
-        reason="no_session"
+        reason={hostedSignIn.failure ? "handoff_failed" : "no_session"}
+        failure={hostedSignIn.failure}
         machineUrl={window.location.origin}
         gatewayUrl={hostedSignIn.gatewayUrl}
         onRetry={retryBoot}

--- a/crates/tidebreak-desktop/ui/src/HostedSignIn.tsx
+++ b/crates/tidebreak-desktop/ui/src/HostedSignIn.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink, RotateCw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import type { HandoffFailure } from "./hostedSession";
 import { Logomark } from "./Logomark";
 import { WindowDragStrip } from "./WindowDragStrip";
 
@@ -10,11 +11,17 @@ import { WindowDragStrip } from "./WindowDragStrip";
  * `no_session`: the page opened without a bearer — someone typed the
  * machine's address, or reloaded a tab. `session_ended`: the bearer the page
  * held stopped being accepted, which after an hour is simply its lifetime.
+ * `handoff_failed`: the page came from the machine's landing route and the
+ * route could not turn the console's code into a bearer; `failure` says why.
  */
-export type HostedSignInReason = "no_session" | "session_ended";
+export type HostedSignInReason =
+  | "no_session"
+  | "session_ended"
+  | "handoff_failed";
 
 export type HostedSignInProps = {
   reason: HostedSignInReason;
+  failure?: HandoffFailure | null;
   /** The machine this page is served by. */
   machineUrl: string;
   /**
@@ -33,13 +40,41 @@ export type HostedSignInProps = {
  * once. So the screen names the console and sends the reader there; the
  * console's Manage Tidebreak action is what brings them back signed in.
  */
+function handoffFailureCopy(failure: HandoffFailure | null | undefined): {
+  title: string;
+  detail: string;
+} {
+  switch (failure) {
+    case "expired":
+      return {
+        title: "That sign-in link has expired",
+        detail:
+          "A link from the console works once, within a minute of being made.",
+      };
+    case "unavailable":
+      return {
+        title: "This machine could not reach your gateway",
+        detail:
+          "Sign-in needs the gateway to answer, and it did not. Nothing about your account has changed.",
+      };
+    default:
+      return {
+        title: "That sign-in link is not valid",
+        detail:
+          "It did not come from the console, or it was changed on the way here.",
+      };
+  }
+}
+
 export function HostedSignIn({
   reason,
+  failure = null,
   machineUrl,
   gatewayUrl,
   onRetry = () => window.location.reload(),
 }: HostedSignInProps) {
-  const ended = reason === "session_ended";
+  const failed =
+    reason === "handoff_failed" ? handoffFailureCopy(failure) : null;
   return (
     <div className="boot" aria-label="Sign in required">
       <WindowDragStrip />
@@ -48,7 +83,12 @@ export function HostedSignIn({
         <h1>Tidebreak</h1>
       </div>
       <div className="welcome-copy">
-        {ended ? (
+        {failed ? (
+          <>
+            <h2>{failed.title}</h2>
+            <p>{failed.detail}</p>
+          </>
+        ) : reason === "session_ended" ? (
           <>
             <h2>Your session on this machine ended</h2>
             <p>

--- a/crates/tidebreak-desktop/ui/src/boot.ts
+++ b/crates/tidebreak-desktop/ui/src/boot.ts
@@ -1,7 +1,9 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import type { RemoteMachineState, ServerInfo } from "./api";
 import {
+  type HandoffFailure,
   handoffBearer,
+  handoffFailure,
   hostedSession,
   markHostedSession,
 } from "./hostedSession";
@@ -66,7 +68,12 @@ export async function remoteMachineState(): Promise<RemoteMachineState> {
  * is missing. The shell shows the sign-in screen instead of the failure one.
  */
 export class HostedSignInRequired extends Error {
-  constructor(readonly gatewayUrl: string | null) {
+  constructor(
+    readonly gatewayUrl: string | null,
+    /** Set when the page came from the landing route and it could not
+     * hand over a bearer; the sign-in screen words the reason. */
+    readonly failure: HandoffFailure | null = null,
+  ) {
     super("This machine needs a session from your Model Gateway console.");
     this.name = "HostedSignInRequired";
   }
@@ -95,11 +102,13 @@ export async function hostedServerInfo({
   dev = import.meta.env.DEV,
   fetch = globalThis.fetch,
   bearer = handoffBearer(),
+  failure = handoffFailure(),
 }: {
   origin?: string;
   dev?: boolean;
   fetch?: typeof globalThis.fetch;
   bearer?: string | null;
+  failure?: HandoffFailure | null;
 } = {}): Promise<ServerInfo | null> {
   // The dev server answers every path with the page, so discovery there
   // would parse the bundle's own HTML. Dev tabs have `listen.json`.
@@ -111,7 +120,7 @@ export async function hostedServerInfo({
       ? discovery.gateway_url.replace(/\/$/, "")
       : null;
   markHostedSession({ baseUrl: origin, gatewayUrl });
-  if (!bearer) throw new HostedSignInRequired(gatewayUrl);
+  if (!bearer) throw new HostedSignInRequired(gatewayUrl, failure);
   return {
     baseUrl: origin,
     token: bearer,

--- a/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
@@ -5,6 +5,7 @@ import { HostedSignInRequired, hostedServerInfo } from "./boot";
 import {
   captureHandoffToken,
   handoffBearer,
+  handoffFailure,
   hostedSession,
   resetHostedSessionForTests,
 } from "./hostedSession";
@@ -54,6 +55,21 @@ describe("the handoff fragment", () => {
     const win = fakeWindow("#handoff=<script>alert(1)</script>");
     captureHandoffToken(win);
     expect(handoffBearer()).toBeNull();
+  });
+
+  it("keeps the landing route's failure reason and clears it from the address", () => {
+    const win = fakeWindow("#handoff-failed=expired");
+    captureHandoffToken(win);
+    expect(handoffBearer()).toBeNull();
+    expect(handoffFailure()).toBe("expired");
+    expect(win.replaced).toEqual(["/"]);
+  });
+
+  it("ignores a failure reason it has no words for", () => {
+    const win = fakeWindow("#handoff-failed=something-new");
+    captureHandoffToken(win);
+    expect(handoffFailure()).toBeNull();
+    expect(win.replaced).toEqual([]);
   });
 });
 
@@ -114,7 +130,24 @@ describe("the hosted boot branch", () => {
     await expect(attempt).rejects.toBeInstanceOf(HostedSignInRequired);
     await attempt.catch((error: HostedSignInRequired) => {
       expect(error.gatewayUrl).toBe("https://gateway.example.com");
+      expect(error.failure).toBeNull();
     });
+  });
+
+  it("carries the landing route's failure reason to the sign-in screen", async () => {
+    const fetch = discovery({
+      mode: "gateway",
+      gateway_url: "https://gateway.example.com",
+    });
+    await expect(
+      hostedServerInfo({
+        origin: "https://tidebreak.example.com",
+        dev: false,
+        fetch,
+        bearer: null,
+        failure: "unavailable",
+      }),
+    ).rejects.toMatchObject({ failure: "unavailable" });
   });
 
   it("has no console to name for a machine on static tokens", async () => {

--- a/crates/tidebreak-desktop/ui/src/hostedSession.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.ts
@@ -29,7 +29,17 @@ export type HostedSession = {
  */
 const HANDOFF_FRAGMENT = /^#handoff=([A-Za-z0-9._~-]+)$/;
 
+/**
+ * Why the machine's landing route could not hand the page a bearer. The
+ * route words nothing itself; it lands the page with one of these and the
+ * page does the talking.
+ */
+export type HandoffFailure = "expired" | "invalid" | "unavailable";
+const HANDOFF_FAILURE_FRAGMENT =
+  /^#handoff-failed=(expired|invalid|unavailable)$/;
+
 let handoffToken: string | null = null;
+let failure: HandoffFailure | null = null;
 let session: HostedSession | null = null;
 
 /**
@@ -40,9 +50,11 @@ let session: HostedSession | null = null;
  * this page's life — long enough for boot to retry — and nowhere else.
  */
 export function captureHandoffToken(win: Window = window): void {
+  const failed = HANDOFF_FAILURE_FRAGMENT.exec(win.location.hash);
   const match = HANDOFF_FRAGMENT.exec(win.location.hash);
-  if (!match) return;
-  handoffToken = match[1];
+  if (!failed && !match) return;
+  if (failed) failure = failed[1] as HandoffFailure;
+  if (match) handoffToken = match[1];
   win.history.replaceState(
     win.history.state,
     "",
@@ -53,6 +65,11 @@ export function captureHandoffToken(win: Window = window): void {
 /** The bearer the page arrived with, or `null` if it opened without one. */
 export function handoffBearer(): string | null {
   return handoffToken;
+}
+
+/** Why the page arrived without a bearer, when the landing route said. */
+export function handoffFailure(): HandoffFailure | null {
+  return failure;
 }
 
 /** Record that this page is served by the machine at `next.baseUrl`. */
@@ -68,5 +85,6 @@ export function hostedSession(): HostedSession | null {
 /** Test seam: forget both facts. */
 export function resetHostedSessionForTests(): void {
   handoffToken = null;
+  failure = null;
   session = null;
 }

--- a/crates/tidebreak-desktop/ui/src/stories/HostedSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HostedSession.stories.tsx
@@ -47,3 +47,20 @@ export const SessionEnded: Story = {
 export const NoBrowserSignIn: Story = {
   args: { gatewayUrl: null },
 };
+
+/**
+ * The console's link was followed too late, or twice. The route lands the
+ * page anyway, and the page says what a link is good for before sending the
+ * reader back for another.
+ */
+export const HandoffExpired: Story = {
+  args: { reason: "handoff_failed", failure: "expired" },
+};
+
+/**
+ * The machine could not reach the gateway to exchange the code. Nothing
+ * about the reader's account is in question, and the copy says so.
+ */
+export const HandoffUnavailable: Story = {
+  args: { reason: "handoff_failed", failure: "unavailable" },
+};

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -56,9 +56,12 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
-use axum::extract::{FromRequestParts, Request, State};
+use axum::extract::{FromRequestParts, Query, Request, State};
 use axum::http::{
-    header::{AUTHORIZATION, HOST, ORIGIN, SEC_WEBSOCKET_PROTOCOL, UPGRADE},
+    header::{
+        AUTHORIZATION, CACHE_CONTROL, HOST, LOCATION, ORIGIN, REFERRER_POLICY,
+        SEC_WEBSOCKET_PROTOCOL, UPGRADE,
+    },
     request::Parts,
     HeaderMap, HeaderName, StatusCode,
 };
@@ -217,6 +220,84 @@ pub(crate) async fn discovery(State(state): State<AppState>) -> Json<AuthDiscove
         _ => AuthDiscovery::Local,
     };
     Json(discovery)
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct HandoffQuery {
+    #[serde(default)]
+    code: String,
+}
+
+/// The URL-safe alphabet both a handoff code and a bearer are drawn from.
+fn is_token_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'~')
+}
+
+/// A handoff code is the gateway's, prefixed so a stray bearer or session id
+/// pasted here is refused before it reaches the network.
+fn handoff_code_is_well_formed(code: &str) -> bool {
+    code.starts_with("mg_ho_") && code.len() <= 256 && code.bytes().all(is_token_byte)
+}
+
+/// Where the landing page lives: the canonical public URL, so an ingress
+/// path prefix survives. Absent (it never is on a gateway-authenticated
+/// machine), the page's own root.
+fn handoff_landing(state: &AppState) -> String {
+    state
+        .config
+        .public_url
+        .as_deref()
+        .and_then(|raw| canonical_public_url(raw).ok())
+        .unwrap_or_default()
+}
+
+/// A `302` to the landing page carrying `fragment` after `#`.
+///
+/// The fragment is the one carrier a bearer may ride in: a browser never
+/// sends it to a server, so it is in no access log, and the page clears it
+/// before the router sees it. `no-store` keeps the redirect itself out of a
+/// cache that could replay it.
+fn handoff_redirect(landing: &str, fragment: &str) -> Response {
+    (
+        StatusCode::FOUND,
+        [
+            (LOCATION, format!("{landing}/#{fragment}")),
+            (CACHE_CONTROL, "no-store".to_owned()),
+            (REFERRER_POLICY, "no-referrer".to_owned()),
+        ],
+    )
+        .into_response()
+}
+
+/// Land a browser on this machine signed in.
+///
+/// The gateway console mints a one-time code and sends the reader here with
+/// it. This route exchanges the code server to server for a bearer bound to
+/// this machine and hands the bearer to the page in the URL fragment; the
+/// page keeps it in memory and presents it like any other bearer. Nothing
+/// is stored, no cookie is set, and the code is never logged.
+///
+/// A machine that does not authenticate through a gateway has no console to
+/// take codes from, so the route does not exist there. A refused or
+/// unusable exchange still lands on the page, with a reason the page can
+/// word, rather than on a bare error a reader cannot act on.
+pub(crate) async fn handoff(
+    State(state): State<AppState>,
+    Query(query): Query<HandoffQuery>,
+) -> Response {
+    let PrincipalAuthenticator::Gateway(gateway) = state.principal_authenticator.as_ref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let landing = handoff_landing(&state);
+    let code = query.code.trim();
+    if !handoff_code_is_well_formed(code) {
+        return handoff_redirect(&landing, "handoff-failed=invalid");
+    }
+    match gateway.redeem_handoff(code).await {
+        HandoffOutcome::Granted(bearer) => handoff_redirect(&landing, &format!("handoff={bearer}")),
+        HandoffOutcome::Refused => handoff_redirect(&landing, "handoff-failed=expired"),
+        HandoffOutcome::Unavailable => handoff_redirect(&landing, "handoff-failed=unavailable"),
+    }
 }
 
 /// Reject requests whose bearer token does not resolve to a principal — from
@@ -383,8 +464,26 @@ impl PrincipalAuthenticator {
 /// Live verifier for Gateway-issued `tidebreak` resource tokens.
 pub(crate) struct GatewayAuthenticator {
     principal_url: reqwest::Url,
+    /// Where a one-time handoff code becomes a bearer; see [`handoff`].
+    handoff_url: reqwest::Url,
     resource: String,
     client: reqwest::Client,
+}
+
+/// What redeeming a handoff code came to.
+pub(crate) enum HandoffOutcome {
+    /// A bearer for this machine, bound by the gateway to this resource.
+    Granted(String),
+    /// The gateway would not exchange the code: unknown, consumed, or past
+    /// its minute. The reader re-enters from the console.
+    Refused,
+    /// The gateway did not answer usably. Nothing about the code is known.
+    Unavailable,
+}
+
+#[derive(serde::Deserialize)]
+struct HandoffGrant {
+    access_token: String,
 }
 
 #[derive(serde::Deserialize)]
@@ -422,19 +521,87 @@ impl GatewayAuthenticator {
                 "the Model Gateway verifier URL must use https (http is allowed only for loopback development)",
             ));
         }
-        base.set_path("/api/v1/tidebreak/principal");
         base.set_query(None);
         base.set_fragment(None);
+        let mut principal_url = base.clone();
+        principal_url.set_path("/api/v1/tidebreak/principal");
+        let mut handoff_url = base;
+        handoff_url.set_path("/oauth/handoff/token");
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|error| AgentError::config(format!("gateway auth client: {error}")))?;
         Ok(Self {
-            principal_url: base,
+            principal_url,
+            handoff_url,
             resource,
             client,
         })
+    }
+
+    /// Exchange a console-minted one-time code for a bearer.
+    ///
+    /// The machine only relays. The gateway binds the bearer to this
+    /// machine's resource itself, and every later request re-presents that
+    /// bearer to [`GatewayAuthenticator::resolve`], so nothing the code
+    /// claims is trusted here — not even the shape of what comes back beyond
+    /// it being a bearer this verifier would accept.
+    pub(crate) async fn redeem_handoff(&self, code: &str) -> HandoffOutcome {
+        let response = match self
+            .client
+            .post(self.handoff_url.clone())
+            .json(&serde_json::json!({ "code": code }))
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::warn!(error = %error, "gateway handoff request failed");
+                return HandoffOutcome::Unavailable;
+            }
+        };
+        let status = response.status();
+        if status.is_client_error() {
+            return HandoffOutcome::Refused;
+        }
+        if !status.is_success() {
+            tracing::warn!(%status, "gateway handoff returned an error status");
+            return HandoffOutcome::Unavailable;
+        }
+        if response
+            .content_length()
+            .is_some_and(|length| length > Self::RESPONSE_LIMIT as u64)
+        {
+            tracing::warn!("gateway handoff response exceeded size limit");
+            return HandoffOutcome::Unavailable;
+        }
+        let bytes = match response.bytes().await {
+            Ok(bytes) if bytes.len() <= Self::RESPONSE_LIMIT => bytes,
+            Ok(_) => {
+                tracing::warn!("gateway handoff response exceeded size limit");
+                return HandoffOutcome::Unavailable;
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "gateway handoff response failed");
+                return HandoffOutcome::Unavailable;
+            }
+        };
+        let grant: HandoffGrant = match serde_json::from_slice(&bytes) {
+            Ok(grant) => grant,
+            Err(error) => {
+                tracing::warn!(error = %error, "gateway handoff response was invalid");
+                return HandoffOutcome::Unavailable;
+            }
+        };
+        if !grant.access_token.starts_with("mg_at_")
+            || grant.access_token.len() > 512
+            || !grant.access_token.bytes().all(is_token_byte)
+        {
+            tracing::warn!("gateway handoff granted something other than a bearer");
+            return HandoffOutcome::Unavailable;
+        }
+        HandoffOutcome::Granted(grant.access_token)
     }
 
     async fn resolve(&self, presented: &str) -> Result<Option<Principal>> {

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1212,8 +1212,12 @@ pub fn app(state: AppState) -> Router {
         .merge(harness_llm_api)
         .merge(external_adapter_api);
     let frame_state = state.clone();
+    // Public like discovery, and for the same reason: a page has to reach
+    // both before it holds a bearer. The handoff route answers only on a
+    // gateway-authenticated machine.
     let auth_discovery = Router::new()
         .route("/auth/discovery", get(auth::discovery))
+        .route("/auth/handoff", get(auth::handoff))
         .with_state(state.clone());
 
     // Loopback-only + bearer token is the real gate. CORS names the origins

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -2815,3 +2815,148 @@ fn a_ui_bundle_without_an_index_page_is_refused_at_bind() {
     std::fs::write(dist.path().join("index.html"), "<!doctype html>").unwrap();
     ui_bundle::verify(dist.path()).unwrap();
 }
+
+/// A gateway-authenticated self-host router whose gateway is `gateway_url`.
+async fn handoff_app(gateway_url: &str) -> (Router, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("t.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut config = Config::desktop(dir.path());
+    config.profile = Profile::SelfHost;
+    config.auth_gateway_url = Some(gateway_url.to_owned());
+    config.public_url = Some("https://machine.example.com/tidebreak/".to_owned());
+    let state = AppState::new(
+        config,
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    (app(state), dir)
+}
+
+fn handoff_request(query: &str) -> Request<Body> {
+    Request::builder()
+        .uri(format!("/auth/handoff{query}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// The landing route relays a one-time code to the gateway and hands the
+/// bearer to the page in the fragment — the one carrier that reaches no
+/// server and no log. Every failure still lands on the page with a reason,
+/// the code never reaches the gateway unless it looks like one, and a
+/// machine without a gateway has no such route.
+#[tokio::test]
+async fn the_handoff_route_lands_the_page_with_the_bearer_in_the_fragment() {
+    use axum::routing::post as axum_post;
+
+    let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let fake_gateway = {
+        let seen = seen.clone();
+        move |body: String| {
+            let seen = seen.clone();
+            async move {
+                let request: serde_json::Value = serde_json::from_str(&body).unwrap();
+                let code = request["code"].as_str().unwrap_or_default().to_owned();
+                seen.lock().unwrap().push(code.clone());
+                match code.as_str() {
+                    "mg_ho_good" => (
+                        StatusCode::OK,
+                        [("content-type", "application/json")],
+                        r#"{"access_token":"mg_at_minted","expires_in":3600}"#.to_owned(),
+                    ),
+                    "mg_ho_odd" => (
+                        StatusCode::OK,
+                        [("content-type", "application/json")],
+                        r#"{"access_token":"not a bearer"}"#.to_owned(),
+                    ),
+                    "mg_ho_down" => (
+                        StatusCode::BAD_GATEWAY,
+                        [("content-type", "application/json")],
+                        "{}".to_owned(),
+                    ),
+                    _ => (
+                        StatusCode::BAD_REQUEST,
+                        [("content-type", "application/json")],
+                        r#"{"error":"invalid_grant"}"#.to_owned(),
+                    ),
+                }
+            }
+        }
+    };
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let gateway_url = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            Router::new().route("/oauth/handoff/token", axum_post(fake_gateway)),
+        )
+        .await
+        .unwrap();
+    });
+
+    let (router, _dir) = handoff_app(&gateway_url).await;
+    let landed = |query: &str| {
+        let router = router.clone();
+        let query = query.to_owned();
+        async move {
+            let response = router.oneshot(handoff_request(&query)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::FOUND, "{query}");
+            assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+            response.headers()[header::LOCATION]
+                .to_str()
+                .unwrap()
+                .to_owned()
+        }
+    };
+
+    // The public URL's path prefix is kept, so the page lands where it is
+    // served from; the trailing slash is normalized away first.
+    assert_eq!(
+        landed("?code=mg_ho_good").await,
+        "https://machine.example.com/tidebreak/#handoff=mg_at_minted"
+    );
+    assert_eq!(
+        landed("?code=mg_ho_stale").await,
+        "https://machine.example.com/tidebreak/#handoff-failed=expired"
+    );
+    assert_eq!(
+        landed("?code=mg_ho_down").await,
+        "https://machine.example.com/tidebreak/#handoff-failed=unavailable"
+    );
+    // A grant that is not a bearer this machine would accept is treated as
+    // the gateway being unusable, never handed to the page.
+    assert_eq!(
+        landed("?code=mg_ho_odd").await,
+        "https://machine.example.com/tidebreak/#handoff-failed=unavailable"
+    );
+    // Not a code: refused here, without a round trip.
+    assert_eq!(
+        landed("").await,
+        "https://machine.example.com/tidebreak/#handoff-failed=invalid"
+    );
+    assert_eq!(
+        landed("?code=mg_at_a_bearer").await,
+        "https://machine.example.com/tidebreak/#handoff-failed=invalid"
+    );
+    assert_eq!(
+        landed("?code=mg_ho_%3Cscript%3E").await,
+        "https://machine.example.com/tidebreak/#handoff-failed=invalid"
+    );
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec!["mg_ho_good", "mg_ho_stale", "mg_ho_down", "mg_ho_odd"]
+    );
+
+    // No gateway, no route.
+    let (desktop, _bearer, _dir) = ui_bundle_app(None).await;
+    let missing = desktop
+        .oneshot(handoff_request("?code=mg_ho_good"))
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+}

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -380,9 +380,13 @@ bundle — so the API contract does not change.
 A tab signs in the way the desktop does: with a short-lived Gateway bearer
 bound to this machine. The page holds that bearer in memory for the tab's
 life and never in a cookie or in storage. It arrives once, from the Model
-Gateway console's Manage action, and lasts its hour; a tab that opens the
-address directly, or outlives its bearer, shows a sign-in screen that sends
-the reader back through the console. A machine on static tokens
+Gateway console's Manage action: the console sends the browser to the
+machine's `/auth/handoff` route with a one-time code, the machine exchanges
+the code with the gateway server to server, and the page receives the bearer
+in the URL fragment, which no server or access log sees. The bearer lasts
+its hour; a tab that opens the address directly, outlives its bearer, or
+arrives with a code that has already been used, shows a sign-in screen that
+sends the reader back through the console. A machine on static tokens
 (`TIDEBREAK_AUTH_TOKENS_FILE`) has no browser sign-in: the page says so, and
 the desktop app remains the client for it.
 


### PR DESCRIPTION
Stacked on #3068 (base is that PR's branch; retarget to `main` once it merges).

## Why

#3068 gives the hosted machine a page and a boot branch that reads a bearer from `#handoff=<token>`. This is the route that puts the bearer there. The gateway console will mint a one-time code and send the reader to `GET /auth/handoff?code=`; this route turns the code into a session.

## What changes

**Route.** `GET /auth/handoff?code=` is mounted beside `/auth/discovery`, outside `require_token`, and only answers on a gateway-authenticated machine (`404` otherwise). It POSTs `{ "code" }` to `<gateway>/oauth/handoff/token` with the verifier client `GatewayAuthenticator` already holds (https unless loopback, 5 s timeout, no redirects, 16 KiB response cap), and answers `302` to `<TIDEBREAK_PUBLIC_URL>/#handoff=<access_token>` with `Cache-Control: no-store` and `Referrer-Policy: no-referrer`. The public URL's path prefix survives.

**Trust.** The machine only relays. The gateway binds the bearer to this machine's resource, and every later request re-presents the bearer to the principal check; the route accepts a grant only if it is shaped like a bearer that check would take (`mg_at_`, URL-safe, ≤ 512 bytes). A code is refused before any round trip unless it is `mg_ho_`-prefixed, URL-safe, and ≤ 256 bytes. Nothing is stored, no cookie is set, and neither the code nor the bearer is logged.

**Failures land on the page.** A refused exchange (any 4xx) lands `#handoff-failed=expired`; an unreachable gateway, a 5xx, or a malformed grant lands `#handoff-failed=unavailable`; a malformed code lands `#handoff-failed=invalid`. The page captures the reason with the fragment, clears it from the address, and shows the hosted sign-in screen with copy for each.

## Storybook

"Shell/Hosted browser session" gains `HandoffExpired` and `HandoffUnavailable`.

## Checks run

- `cargo test -p tidebreak-server --lib -- handoff_route` (new test with a loopback fake gateway covering the granted, refused, unavailable, malformed-grant, malformed-code, and no-gateway paths), clippy, `cargo fmt --check`.
- Desktop UI: biome format, lint, `tsc`, `vitest` for `hostedSession`, `AppShell.dom`, and the styles contract.
- Screenshots of the two new stories.

## Follow-ups

- Gateway: `POST /api/v1/add-ons/tidebreak/machine-session` (mint) and `POST /oauth/handoff/token` (redeem) with the `tidebreak-web` confined client, then the console's Manage action.
