### PR TITLE
feat(connected-apps): allow explicitly approved loopback HTTP APIs

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client/apps.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/apps.ts
@@ -55,6 +55,7 @@ export function withAppsApi<TBase extends Constructor<HttpCore>>(Base: TBase) {
          * the document is not judged. */
         operation_ids?: string[];
         credential: RestCredentialUpdate;
+        allow_loopback_http?: boolean;
       },
     ): Promise<ConnectedAppsInfo> {
       return this.json(`/connected-apps/rest/${encodeURIComponent(id)}`, {
@@ -67,11 +68,15 @@ export function withAppsApi<TBase extends Constructor<HttpCore>>(Base: TBase) {
     /** List what an OpenAPI document declares, for the operation picker. */
     previewRestSpec(
       source: { url: string } | { document: string },
+      options?: { allow_loopback_http?: boolean },
     ): Promise<SpecPreviewInfo> {
       return this.json("/connected-apps/rest/spec-preview", {
         method: "POST",
         headers: this.headers(true),
-        body: JSON.stringify({ source }),
+        body: JSON.stringify({
+          source,
+          allow_loopback_http: options?.allow_loopback_http ?? false,
+        }),
       });
     }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2272,7 +2272,12 @@ placement: CredentialPlacement | null, updated_at: string,
  * a count only, never app names or ids, the renderer-safety posture
  * of this surface. Grants of library-deleted apps do not count.
  */
-used_by_app_count: number, };
+used_by_app_count: number,
+/**
+ * Whether this record opted into loopback HTTP. Surfaced so the
+ * form can re-show consent on edit.
+ */
+allow_loopback_http: boolean, };
 
 /**
  * The renderer's listing of every configured connected app, across kinds.

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -76,6 +76,7 @@ const listing: ConnectedAppsInfo = {
       placement: "bearer",
       updated_at: "2026-08-03T00:00:00Z",
       used_by_app_count: 1,
+      allow_loopback_http: false,
     },
   ],
 };
@@ -298,6 +299,7 @@ describe("ConnectedAppsPanel", () => {
           base_url: "https://api.example.com/v2",
           openapi_document: '{"openapi": "3.0.3"}',
           credential: { set: { value: SECRET, placement: "bearer" } },
+          allow_loopback_http: false,
         },
       ),
     );
@@ -379,6 +381,7 @@ describe("ConnectedAppsPanel", () => {
           document_sha256: "cd".repeat(32),
           operation_ids: ["listOrganizations"],
           credential: "none",
+          allow_loopback_http: false,
         },
       ),
     );
@@ -528,5 +531,34 @@ describe("ConnectedAppsPanel", () => {
       "JSON invalid JSON syntax at line 2, column 5. Check line 2, column 5",
     );
     expect(alert).not.toHaveTextContent(/^400:/);
+  });
+
+  it("requires loopback HTTP consent before save and hints at MCP for /mcp paths", async () => {
+    const client = api();
+    const user = userEvent.setup();
+    render(<ConnectedAppsPanel client={client} managed={false} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /Add REST API/ }),
+    );
+    await user.type(screen.getByLabelText(/^Name$/), "Local");
+    await user.type(
+      screen.getByLabelText(/Base URL/),
+      "http://127.0.0.1:23373/v0/mcp",
+    );
+    expect(
+      screen.getByText(/Settings → MCP servers as a remote HTTP server/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/sends the credential in clear text to 127.0.0.1 only/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Save$/ })).toBeDisabled();
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: /Send the credential in clear text to this loopback address/,
+      }),
+    );
+    expect(screen.getByRole("button", { name: /^Save$/ })).toBeEnabled();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -187,7 +187,7 @@ function mcpUrlHint(draft: Draft): boolean {
   );
 }
 
-function mcpHintForPreview(draft: Draft, err: unknown): string | null {
+function mcpHintForPreview(draft: Draft): string | null {
   if (mcpUrlHint(draft)) {
     return "This looks like an MCP HTTP endpoint, not an OpenAPI document. Add it under Settings → MCP servers as a remote HTTP server.";
   }
@@ -580,7 +580,7 @@ export function ConnectedAppsPanel({
         `Found ${preview.operations.length} operation${preview.operations.length === 1 ? "" : "s"}`,
       );
     } catch (err) {
-      const message = mcpHintForPreview(draft, err) ?? errorMessage(err);
+      const message = mcpHintForPreview(draft) ?? errorMessage(err);
       setFormError(message);
       toast.error(message);
     } finally {

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -104,7 +104,7 @@ function draftFor(existing: RestEntry | null): Draft {
 }
 
 /** Host of a typed URL that is plain HTTP to a loopback IP literal, else null. */
-export function loopbackHttpHost(urlText: string): string | null {
+function loopbackHttpHost(urlText: string): string | null {
   try {
     const url = new URL(urlText.trim());
     if (url.protocol !== "http:") return null;
@@ -125,7 +125,7 @@ export function loopbackHttpHost(urlText: string): string | null {
 }
 
 /** REST form URLs whose path is an MCP HTTP endpoint, not an OpenAPI base. */
-export function looksLikeMcpEndpoint(urlText: string): boolean {
+function looksLikeMcpEndpoint(urlText: string): boolean {
   try {
     const path = new URL(urlText.trim()).pathname
       .replace(/\/+$/, "")

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -73,6 +73,8 @@ type Draft = {
    * edit means "keep the stored one", and nothing this panel renders ever
    * reads a value back from the server. */
   value: string;
+  /** Explicit consent to send this record as plain HTTP to a loopback IP. */
+  allowLoopbackHttp: boolean;
 };
 
 function draftFor(existing: RestEntry | null): Draft {
@@ -97,7 +99,41 @@ function draftFor(existing: RestEntry | null): Draft {
     headerName:
       placement !== null && placement !== "bearer" ? placement.header : "",
     value: "",
+    allowLoopbackHttp: existing?.allow_loopback_http ?? false,
   };
+}
+
+/** Host of a typed URL that is plain HTTP to a loopback IP literal, else null. */
+export function loopbackHttpHost(urlText: string): string | null {
+  try {
+    const url = new URL(urlText.trim());
+    if (url.protocol !== "http:") return null;
+    const host = url.hostname;
+    if (host === "::1") return "::1";
+    const parts = host.split(".");
+    if (
+      parts.length === 4 &&
+      parts[0] === "127" &&
+      parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255)
+    ) {
+      return host;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** REST form URLs whose path is an MCP HTTP endpoint, not an OpenAPI base. */
+export function looksLikeMcpEndpoint(urlText: string): boolean {
+  try {
+    const path = new URL(urlText.trim()).pathname
+      .replace(/\/+$/, "")
+      .toLowerCase();
+    return path === "/mcp" || path.endsWith("/mcp");
+  } catch {
+    return false;
+  }
 }
 
 /** The server refuses a catalog over 256 operations, so a larger preview
@@ -142,6 +178,31 @@ function errorMessage(err: unknown): string {
     }
   }
   return ingestErrorGuidance(raw);
+}
+
+function mcpUrlHint(draft: Draft): boolean {
+  return (
+    looksLikeMcpEndpoint(draft.baseUrl) ||
+    (draft.source === "url" && looksLikeMcpEndpoint(draft.documentUrl))
+  );
+}
+
+function mcpHintForPreview(draft: Draft, err: unknown): string | null {
+  if (mcpUrlHint(draft)) {
+    return "This looks like an MCP HTTP endpoint, not an OpenAPI document. Add it under Settings → MCP servers as a remote HTTP server.";
+  }
+  if (!(err instanceof HttpError) || err.kind !== "openapi_ingest") {
+    return null;
+  }
+  const text = err.message.toLowerCase();
+  if (
+    text.includes("openapi") ||
+    text.includes("not a json object") ||
+    text.includes("json")
+  ) {
+    return "The fetched document is not an OpenAPI spec. If this URL is an MCP HTTP endpoint, add it under Settings → MCP servers as a remote HTTP server.";
+  }
+  return null;
 }
 
 /** The name an app entry leads with. A gateway-backed record shows the
@@ -522,14 +583,17 @@ export function ConnectedAppsPanel({
     setPreviewing(true);
     setFormError(null);
     try {
-      const preview = await client.previewRestSpec(source);
+      const preview = await client.previewRestSpec(source, {
+        allow_loopback_http: draft.allowLoopbackHttp,
+      });
       update({ preview, selected: defaultSelection(preview) });
       toast.success(
         `Found ${preview.operations.length} operation${preview.operations.length === 1 ? "" : "s"}`,
       );
     } catch (err) {
-      setFormError(errorMessage(err));
-      toast.error(errorMessage(err));
+      const message = mcpHintForPreview(draft, err) ?? errorMessage(err);
+      setFormError(message);
+      toast.error(message);
     } finally {
       setPreviewing(false);
     }
@@ -542,6 +606,12 @@ export function ConnectedAppsPanel({
     const document = draft.document.trim();
     if (name === "" || baseUrl === "") {
       setFormError("Name and base URL are required.");
+      return;
+    }
+    if (loopbackHttpHost(baseUrl) !== null && !draft.allowLoopbackHttp) {
+      setFormError(
+        "Confirm that Tidebreak may send this credential in clear text to this computer.",
+      );
       return;
     }
     let documentFields: {
@@ -624,6 +694,7 @@ export function ConnectedAppsPanel({
         base_url: baseUrl,
         ...documentFields,
         credential,
+        allow_loopback_http: draft.allowLoopbackHttp,
       });
       setApps(result.apps);
       setDraft(null);
@@ -731,7 +802,7 @@ export function ConnectedAppsPanel({
       </SettingsField>
       <SettingsField
         label="Base URL"
-        hint="https only; operation paths from the document append to it."
+        hint="https, or http on 127.0.0.1 / [::1] with consent. Operation paths from the document append to it."
       >
         <div className="flex gap-2">
           <Input
@@ -741,7 +812,14 @@ export function ConnectedAppsPanel({
             spellCheck={false}
             placeholder="https://api.example.com/v2"
             onChange={(event) =>
-              update({ baseUrl: event.target.value, discovery: null })
+              update({
+                baseUrl: event.target.value,
+                discovery: null,
+                allowLoopbackHttp:
+                  loopbackHttpHost(event.target.value) === null
+                    ? false
+                    : draft.allowLoopbackHttp,
+              })
             }
           />
           <Button
@@ -755,6 +833,34 @@ export function ConnectedAppsPanel({
           </Button>
         </div>
       </SettingsField>
+      {mcpUrlHint(draft) && (
+        <p className="text-sm text-muted-foreground">
+          This looks like an MCP HTTP endpoint, not a REST/OpenAPI base URL.
+          Add it under Settings → MCP servers as a remote HTTP server.
+        </p>
+      )}
+      {loopbackHttpHost(draft.baseUrl) !== null && (
+        <div className="flex flex-col gap-2 rounded-xl border border-warning-border bg-warning-background px-3 py-2">
+          <p className="text-sm font-medium">
+            Allow clear-text HTTP on this computer?
+          </p>
+          <p className="text-sm text-muted-foreground">
+            This service runs on this computer without TLS. Tidebreak sends
+            the credential in clear text to {loopbackHttpHost(draft.baseUrl)}{" "}
+            only.
+          </p>
+          <Label className="flex items-start gap-2 text-sm font-normal">
+            <Checkbox
+              checked={draft.allowLoopbackHttp}
+              disabled={saving}
+              onCheckedChange={(checked) =>
+                update({ allowLoopbackHttp: checked === true })
+              }
+            />
+            Send the credential in clear text to this loopback address
+          </Label>
+        </div>
+      )}
       <DiscoveryResults
         discovery={draft.discovery}
         discovering={discovering}
@@ -812,7 +918,7 @@ export function ConnectedAppsPanel({
       {draft.source === "url" ? (
         <SettingsField
           label="Document URL"
-          hint="https only; JSON OpenAPI 3.x. The server fetches it — the document never rides the form."
+          hint="https, or loopback http with the same consent as the base URL. JSON OpenAPI 3.x. The server fetches it — the document never rides the form."
         >
           <div className="flex gap-2">
             <Input
@@ -939,7 +1045,14 @@ export function ConnectedAppsPanel({
         <SettingsError>{formError}</SettingsError>
       )}
       <div className="flex gap-2">
-        <Button disabled={saving} onClick={() => void save()}>
+        <Button
+          disabled={
+            saving ||
+            (loopbackHttpHost(draft.baseUrl) !== null &&
+              !draft.allowLoopbackHttp)
+          }
+          onClick={() => void save()}
+        >
           {saving && <Loader2 size={14} className="animate-spin" />}
           {saving ? "Saving…" : "Save"}
         </Button>

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -835,8 +835,8 @@ export function ConnectedAppsPanel({
       </SettingsField>
       {mcpUrlHint(draft) && (
         <p className="text-sm text-muted-foreground">
-          This looks like an MCP HTTP endpoint, not a REST/OpenAPI base URL.
-          Add it under Settings → MCP servers as a remote HTTP server.
+          This looks like an MCP HTTP endpoint, not a REST/OpenAPI base URL. Add
+          it under Settings → MCP servers as a remote HTTP server.
         </p>
       )}
       {loopbackHttpHost(draft.baseUrl) !== null && (
@@ -845,9 +845,8 @@ export function ConnectedAppsPanel({
             Allow clear-text HTTP on this computer?
           </p>
           <p className="text-sm text-muted-foreground">
-            This service runs on this computer without TLS. Tidebreak sends
-            the credential in clear text to {loopbackHttpHost(draft.baseUrl)}{" "}
-            only.
+            This service runs on this computer without TLS. Tidebreak sends the
+            credential in clear text to {loopbackHttpHost(draft.baseUrl)} only.
           </p>
           <Label className="flex items-start gap-2 text-sm font-normal">
             <Checkbox

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -191,17 +191,6 @@ function mcpHintForPreview(draft: Draft, err: unknown): string | null {
   if (mcpUrlHint(draft)) {
     return "This looks like an MCP HTTP endpoint, not an OpenAPI document. Add it under Settings → MCP servers as a remote HTTP server.";
   }
-  if (!(err instanceof HttpError) || err.kind !== "openapi_ingest") {
-    return null;
-  }
-  const text = err.message.toLowerCase();
-  if (
-    text.includes("openapi") ||
-    text.includes("not a json object") ||
-    text.includes("json")
-  ) {
-    return "The fetched document is not an OpenAPI spec. If this URL is an MCP HTTP endpoint, add it under Settings → MCP servers as a remote HTTP server.";
-  }
   return null;
 }
 

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsAdvanced.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsAdvanced.stories.tsx
@@ -278,6 +278,30 @@ export const ConnectedAppsManagedCompact: Story = {
   globals: { viewport: { value: "compact", isRotated: false } },
 };
 
+export const ConnectedAppsLoopbackHttpConsent: Story = {
+  args: { panel: "connected-apps", state: "empty" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: /Add REST API/ }),
+    );
+    await userEvent.type(canvas.getByLabelText(/^Name$/), "Local service");
+    await userEvent.type(
+      canvas.getByLabelText(/Base URL/),
+      "http://127.0.0.1:23373/v0/mcp",
+    );
+    await expect(
+      canvas.getByText(
+        /This service runs on this computer without TLS. Tidebreak sends the credential in clear text to 127.0.0.1 only./,
+      ),
+    ).toBeVisible();
+    await expect(canvas.getByRole("button", { name: /^Save$/ })).toBeDisabled();
+    await expect(
+      canvas.getByText(/Settings → MCP servers as a remote HTTP server/),
+    ).toBeVisible();
+  },
+};
+
 export const PermissionsConfigured: Story = {
   args: { panel: "permissions" },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
@@ -390,6 +390,7 @@ const connectedApps: ConnectedAppsInfo = {
       placement: "bearer",
       updated_at: "2026-08-20T12:00:00Z",
       used_by_app_count: 1,
+      allow_loopback_http: false,
     },
   ],
 };

--- a/crates/tidebreak-desktop/ui/src/stories/routeStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/routeStoryHarness.tsx
@@ -533,6 +533,7 @@ const routeConnectedApps = {
       placement: "bearer",
       updated_at: "2026-08-20T12:00:00Z",
       used_by_app_count: 1,
+      allow_loopback_http: false,
     },
   ],
 } satisfies ConnectedAppsInfo;

--- a/crates/tidebreak-server/src/connected_apps.rs
+++ b/crates/tidebreak-server/src/connected_apps.rs
@@ -47,6 +47,10 @@ pub(crate) struct RestApiDefinition {
     /// Stored credential reference and placement, when the API needs one.
     /// The referenced value never appears in the definition.
     pub credential: Option<RestCredential>,
+    /// Explicit consent to send this record as plain HTTP to a loopback IP
+    /// literal. Default false so existing records keep requiring https.
+    #[serde(default)]
+    pub allow_loopback_http: bool,
 }
 
 impl RestApiDefinition {
@@ -55,6 +59,7 @@ impl RestApiDefinition {
         RestApiTarget {
             base_url: self.base_url.clone(),
             credential: self.credential.clone(),
+            allow_loopback_http: self.allow_loopback_http,
         }
     }
 }
@@ -87,12 +92,13 @@ pub(crate) fn parse_rest_api_definition(
 /// fields in declaration order, and every key is always present):
 ///
 /// ```json
-/// {"v":2,
+/// {"v":3,
 ///  "kind":"rest_api",
 ///  "base_url":string,
 ///  "document_sha256":string,
 ///  "credential_reference":string|null,
-///  "placement":"bearer"|{"header":name}|null}
+///  "placement":"bearer"|{"header":name}|null,
+///  "allow_loopback_http":bool}
 /// ```
 ///
 /// `document_sha256` is the catalog's hash of the raw OpenAPI document bytes,
@@ -103,8 +109,8 @@ pub(crate) fn parse_rest_api_definition(
 /// while repointing the reference does. The value itself never enters the
 /// form, so the fingerprint can never be a value oracle. `kind` roots the
 /// form in the connected-app vocabulary so no two kinds can collide on a
-/// canonical serialization, and `v:2` aligns with the `mcp_server` form's
-/// current version.
+/// canonical serialization. `v:3` adds `allow_loopback_http` to the consent
+/// surface: toggling the flag re-prompts.
 ///
 /// **This canonical form is a compatibility surface.** Persisted grants store
 /// the digest; changing the form (or the meaning of any field in it)
@@ -120,10 +126,11 @@ pub(crate) fn rest_api_fingerprint(definition: &RestApiDefinition) -> [u8; 32] {
         document_sha256: &'a str,
         credential_reference: Option<&'a str>,
         placement: Option<&'a CredentialPlacement>,
+        allow_loopback_http: bool,
     }
 
     let canonical = CanonicalDefinition {
-        v: 2,
+        v: 3,
         kind: "rest_api",
         base_url: &definition.base_url,
         document_sha256: &definition.catalog.document_sha256,
@@ -135,6 +142,7 @@ pub(crate) fn rest_api_fingerprint(definition: &RestApiDefinition) -> [u8; 32] {
             .credential
             .as_ref()
             .map(|credential| &credential.placement),
+        allow_loopback_http: definition.allow_loopback_http,
     };
     let bytes = serde_json::to_vec(&canonical)
         .expect("a canonical definition serializes infallibly to JSON");
@@ -647,6 +655,7 @@ mod tests {
                 operations: BTreeMap::new(),
             },
             credential,
+            allow_loopback_http: false,
         }
     }
 
@@ -711,6 +720,14 @@ mod tests {
         ] {
             assert_ne!(rest_api_fingerprint(&changed), baseline, "{changed:?}");
         }
+
+        let mut loopback = definition(
+            "http://127.0.0.1:23373/v0",
+            "doc-hash-a",
+            Some(credential("sentry-token", CredentialPlacement::Bearer)),
+        );
+        loopback.allow_loopback_http = true;
+        assert_ne!(rest_api_fingerprint(&loopback), baseline);
 
         // Catalog operations enter the form only through the document hash: a
         // catalog carrying extra parsed operations under the same document

--- a/crates/tidebreak-server/src/openapi_discovery.rs
+++ b/crates/tidebreak-server/src/openapi_discovery.rs
@@ -184,7 +184,7 @@ pub async fn discover_openapi_documents(
 }
 
 async fn probe_location(url: &str) -> Option<SpecDiscoveryCandidate> {
-    match fetch_spec_document_detailed(url, SpecRedirectPolicy::SameOrigin).await {
+    match fetch_spec_document_detailed(url, SpecRedirectPolicy::SameOrigin, false).await {
         Ok(fetched) => Some(classify_document(
             url,
             fetched.content_type.as_deref(),

--- a/crates/tidebreak-server/src/rest_executor.rs
+++ b/crates/tidebreak-server/src/rest_executor.rs
@@ -1097,11 +1097,7 @@ pub(crate) async fn fetch_spec_document(
     url: &str,
     allow_loopback_http: bool,
 ) -> Result<Vec<u8>, SpecFetchError> {
-    fetch_spec_document_detailed(
-        url,
-        SpecRedirectPolicy::FollowAdmitted,
-        allow_loopback_http,
-    )
+    fetch_spec_document_detailed(url, SpecRedirectPolicy::FollowAdmitted, allow_loopback_http)
         .await
         .map(|fetched| fetched.body)
 }

--- a/crates/tidebreak-server/src/rest_executor.rs
+++ b/crates/tidebreak-server/src/rest_executor.rs
@@ -12,7 +12,8 @@
 //!   request outright. The catalog, not the caller, decides what is
 //!   executable.
 //! - Egress mirrors the native web-search fetcher's posture: the base URL is
-//!   admitted (https only, no userinfo, no fragment), the host's DNS answer is
+//!   admitted (https, or plain HTTP only to an explicit loopback IP literal
+//!   after opt-in), no userinfo, no fragment, the host's DNS answer is
 //!   resolved and vetted per request with the same denied-network list, the
 //!   connection is pinned to exactly the vetted addresses, redirects are never
 //!   followed, and request and response byte counts and wall time are capped.
@@ -87,10 +88,16 @@ pub const REST_EXECUTOR_USER_AGENT: &str =
 #[serde(deny_unknown_fields)]
 pub struct RestApiTarget {
     /// Base URL the operation path appends to. Admitted per request; https
-    /// only, no userinfo, no fragment, explicit ports allowed.
+    /// only unless [`Self::allow_loopback_http`] admits a loopback IP
+    /// literal. No userinfo, no fragment, explicit ports allowed.
     pub base_url: String,
     /// Stored credential reference and placement, when the API needs one.
     pub credential: Option<RestCredential>,
+    /// Explicit consent to send this record's traffic as plain HTTP to a
+    /// loopback IP literal (127.0.0.0/8 or `::1`). DNS names, including
+    /// `localhost`, never qualify.
+    #[serde(default)]
+    pub allow_loopback_http: bool,
 }
 
 /// A credential *reference*: the profile secret-store key and where the value
@@ -327,8 +334,9 @@ impl<T: RestTransport, R: RestHostResolver> RestExecutor<T, R> {
         let rendered = render_parameters(operation, request, placement_header.as_deref())?;
         let body_bytes = serialize_body(operation, request)?;
 
-        let base = admit_base_url(&target.base_url)?;
+        let base = admit_base_url(&target.base_url, target.allow_loopback_http)?;
         let url = assemble_url(&base, &rendered)?;
+        pin_to_admitted_origin(&base, &url)?;
 
         // Vet the destination. A domain host is resolved freshly and every
         // answer must clear the denied-network list — refusing the whole name
@@ -561,11 +569,16 @@ fn serialize_body(
 /// or a query is refused rather than stripped — a base URL is configuration,
 /// and configuration that cannot mean anything should be corrected, not
 /// silently rewritten.
-pub(crate) fn admit_base_url(base_url: &str) -> Result<Url, RestExecuteError> {
-    admit_https_url(base_url, UrlQueryPolicy::Refuse).map_err(|refusal| match refusal {
-        UrlAdmissionRefusal::Reason(reason) => RestExecuteError::InadmissibleBaseUrl { reason },
-        UrlAdmissionRefusal::DeniedAddress => RestExecuteError::DeniedAddress,
-    })
+pub(crate) fn admit_base_url(
+    base_url: &str,
+    allow_loopback_http: bool,
+) -> Result<Url, RestExecuteError> {
+    admit_connected_app_url(base_url, UrlQueryPolicy::Refuse, allow_loopback_http).map_err(
+        |refusal| match refusal {
+            UrlAdmissionRefusal::Reason(reason) => RestExecuteError::InadmissibleBaseUrl { reason },
+            UrlAdmissionRefusal::DeniedAddress => RestExecuteError::DeniedAddress,
+        },
+    )
 }
 
 /// Whether an admitted URL may carry a query. A *base* URL with a query is
@@ -586,6 +599,14 @@ pub(crate) fn admit_https_url(
     url: &str,
     query: UrlQueryPolicy,
 ) -> Result<Url, UrlAdmissionRefusal> {
+    admit_connected_app_url(url, query, false)
+}
+
+fn admit_connected_app_url(
+    url: &str,
+    query: UrlQueryPolicy,
+    allow_loopback_http: bool,
+) -> Result<Url, UrlAdmissionRefusal> {
     let refuse = |reason| Err(UrlAdmissionRefusal::Reason(reason));
     if url.len() > MAX_REST_BASE_URL_BYTES {
         return refuse("URL exceeds the byte limit");
@@ -593,9 +614,11 @@ pub(crate) fn admit_https_url(
     let Ok(parsed) = Url::parse(url) else {
         return refuse("URL is not valid");
     };
-    if parsed.scheme() != "https" {
-        return refuse("scheme must be https");
-    }
+    let http_loopback = match parsed.scheme() {
+        "https" => false,
+        "http" => true,
+        _ => return refuse("scheme must be https"),
+    };
     if !parsed.username().is_empty() || parsed.password().is_some() {
         return refuse("URL must not carry userinfo");
     }
@@ -609,25 +632,67 @@ pub(crate) fn admit_https_url(
         None | Some("") => return refuse("URL has no host"),
         Some(_) => {}
     }
+    if http_loopback {
+        // Hostname resolution must never widen this exemption: `localhost`
+        // and every other DNS name stay refused for http.
+        if parsed.domain().is_some() {
+            return refuse("http is only allowed for loopback IP literals; use 127.0.0.1 or [::1]");
+        }
+        let address = parse_ip_literal_host(&parsed)?;
+        if !is_loopback_http_literal(address) {
+            return refuse("scheme must be https");
+        }
+        if !allow_loopback_http {
+            return refuse("http on a loopback address requires allow_loopback_http");
+        }
+        return Ok(parsed);
+    }
     // An IP-literal host — in any encoding the URL parser dials as an
     // address — is vetted against the denied-network list right here; a
     // DNS-named host is vetted after resolution instead.
     if parsed.domain().is_none() {
-        let literal = parsed
-            .host_str()
-            .unwrap_or_default()
-            .trim_start_matches('[')
-            .trim_end_matches(']');
-        match literal.parse::<IpAddr>() {
-            Ok(address) => {
-                if admit_fetch_address(address).is_err() {
-                    return Err(UrlAdmissionRefusal::DeniedAddress);
-                }
-            }
-            Err(_) => return refuse("URL host is not a name or address"),
+        let address = parse_ip_literal_host(&parsed)?;
+        if admit_fetch_address(address).is_err() {
+            return Err(UrlAdmissionRefusal::DeniedAddress);
         }
     }
     Ok(parsed)
+}
+
+/// Parse an IP-literal URL host. The URL parser has already rejected a
+/// missing host; this only fails on encodings it does not treat as addresses.
+fn parse_ip_literal_host(parsed: &Url) -> Result<IpAddr, UrlAdmissionRefusal> {
+    let literal = parsed
+        .host_str()
+        .unwrap_or_default()
+        .trim_start_matches('[')
+        .trim_end_matches(']');
+    literal
+        .parse::<IpAddr>()
+        .map_err(|_| UrlAdmissionRefusal::Reason("URL host is not a name or address"))
+}
+
+/// Loopback HTTP is 127.0.0.0/8 or exactly `::1`. Mapped IPv6 (`::ffff:127.0.0.1`)
+/// is not an exemption — use the v4 literal or `[::1]`.
+fn is_loopback_http_literal(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(v4) => v4.is_loopback(),
+        IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+/// Every executed request must stay on the admitted base origin (scheme,
+/// host, port). Path and query may change; a redirect or template must not.
+fn pin_to_admitted_origin(base: &Url, url: &Url) -> Result<(), RestExecuteError> {
+    if url.scheme() != base.scheme()
+        || url.host() != base.host()
+        || url.port_or_known_default() != base.port_or_known_default()
+    {
+        return Err(RestExecuteError::InadmissibleBaseUrl {
+            reason: "assembled request left the admitted origin",
+        });
+    }
+    Ok(())
 }
 
 /// Join the admitted base URL's path prefix with the substituted operation
@@ -858,7 +923,7 @@ impl RestTransport for ReqwestRestTransport {
             // removes the address pinning.
             .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
-            .https_only(true)
+            .https_only(request.url.scheme() != "http")
             .user_agent(REST_EXECUTOR_USER_AGENT)
             .connect_timeout(request.timeout.min(Duration::from_secs(10)))
             .timeout(request.timeout);
@@ -1017,16 +1082,26 @@ pub(crate) enum SpecRedirectPolicy {
 }
 
 /// Fetch an OpenAPI document from an operator-supplied URL, at configuration
-/// time, with the executor's egress hygiene: https-only admission, fresh
-/// per-hop resolution vetted against the denied-network list, a pinned
-/// no-proxy client, and a bounded body.
+/// time, with the executor's egress hygiene: https admission (or loopback
+/// HTTP under the same opt-in as the base URL), fresh per-hop resolution
+/// vetted against the denied-network list, a pinned no-proxy client, and a
+/// bounded body.
 ///
 /// Unlike operation execution, redirects are followed — vendors move and
 /// version their published documents — but explicitly, one admitted hop at a
 /// time, so every `Location` gets the same vetting as the original URL and no
 /// credential is ever attached to any hop.
-pub(crate) async fn fetch_spec_document(url: &str) -> Result<Vec<u8>, SpecFetchError> {
-    fetch_spec_document_detailed(url, SpecRedirectPolicy::FollowAdmitted)
+/// Loopback-http documents (only reachable with `allow_loopback_http`)
+/// never follow redirects: a 302 must not walk the opt-in off that origin.
+pub(crate) async fn fetch_spec_document(
+    url: &str,
+    allow_loopback_http: bool,
+) -> Result<Vec<u8>, SpecFetchError> {
+    fetch_spec_document_detailed(
+        url,
+        SpecRedirectPolicy::FollowAdmitted,
+        allow_loopback_http,
+    )
         .await
         .map(|fetched| fetched.body)
 }
@@ -1066,10 +1141,11 @@ pub(crate) mod spec_fetch_mock {
 pub(crate) async fn fetch_spec_document_detailed(
     url: &str,
     redirects: SpecRedirectPolicy,
+    allow_loopback_http: bool,
 ) -> Result<FetchedSpecDocument, SpecFetchError> {
     let started = std::time::Instant::now();
     let mut current = url.to_string();
-    let origin = admit_spec_fetch_url(&current)?;
+    let origin = admit_spec_fetch_url(&current, allow_loopback_http)?;
     #[cfg(test)]
     if let Some(mocked) = spec_fetch_mock::try_fetch(&current) {
         let _ = redirects;
@@ -1077,7 +1153,7 @@ pub(crate) async fn fetch_spec_document_detailed(
         return mocked;
     }
     for _ in 0..=MAX_SPEC_FETCH_REDIRECTS {
-        let admitted = admit_spec_fetch_url(&current)?;
+        let admitted = admit_spec_fetch_url(&current, allow_loopback_http)?;
         if redirects == SpecRedirectPolicy::SameOrigin
             && (admitted.scheme() != origin.scheme()
                 || admitted.host() != origin.host()
@@ -1114,6 +1190,7 @@ pub(crate) async fn fetch_spec_document_detailed(
         };
 
         let https_only = admitted.scheme() != "http";
+        let loopback_http = allow_loopback_http && !https_only;
         let mut builder = reqwest::Client::builder()
             // Load-bearing for the same reason as the operation transport: a
             // discovered proxy would dial the proxy, not the vetted address.
@@ -1148,6 +1225,11 @@ pub(crate) async fn fetch_spec_document_detailed(
 
         let status = response.status();
         if status.is_redirection() {
+            if loopback_http {
+                return Err(SpecFetchError::HttpStatus {
+                    status: status.as_u16(),
+                });
+            }
             let location = response
                 .headers()
                 .get(reqwest::header::LOCATION)
@@ -1201,7 +1283,7 @@ pub(crate) async fn fetch_spec_document_detailed(
 /// Admit a document URL. Tests may fetch `http://127.0.0.1` so a local mock
 /// server can stand in for a vendor origin; production still requires https
 /// and the denied-network list.
-fn admit_spec_fetch_url(url: &str) -> Result<Url, SpecFetchError> {
+fn admit_spec_fetch_url(url: &str, allow_loopback_http: bool) -> Result<Url, SpecFetchError> {
     if cfg!(test) {
         if let Ok(parsed) = Url::parse(url) {
             let loopback = matches!(parsed.host_str(), Some("127.0.0.1") | Some("[::1]"));
@@ -1210,9 +1292,11 @@ fn admit_spec_fetch_url(url: &str) -> Result<Url, SpecFetchError> {
             }
         }
     }
-    admit_https_url(url, UrlQueryPolicy::Allow).map_err(|refusal| match refusal {
-        UrlAdmissionRefusal::Reason(reason) => SpecFetchError::InadmissibleUrl { reason },
-        UrlAdmissionRefusal::DeniedAddress => SpecFetchError::DeniedAddress,
+    admit_connected_app_url(url, UrlQueryPolicy::Allow, allow_loopback_http).map_err(|refusal| {
+        match refusal {
+            UrlAdmissionRefusal::Reason(reason) => SpecFetchError::InadmissibleUrl { reason },
+            UrlAdmissionRefusal::DeniedAddress => SpecFetchError::DeniedAddress,
+        }
     })
 }
 
@@ -1397,6 +1481,7 @@ mod tests {
         RestApiTarget {
             base_url: "https://api.example.com/v2".to_owned(),
             credential,
+            allow_loopback_http: false,
         }
     }
 
@@ -1687,7 +1772,10 @@ mod tests {
     async fn base_url_admission_allows_ports_and_refuses_the_rest() {
         let transport = FakeTransport::ok();
         for (base_url, expected) in [
-            ("http://api.example.com", "scheme must be https"),
+            (
+                "http://api.example.com",
+                "http is only allowed for loopback IP literals; use 127.0.0.1 or [::1]",
+            ),
             ("https://u:p@api.example.com", "URL must not carry userinfo"),
             (
                 "https://api.example.com/#frag",
@@ -1703,6 +1791,7 @@ mod tests {
                 &RestApiTarget {
                     base_url: base_url.to_owned(),
                     credential: None,
+                    allow_loopback_http: false,
                 },
                 &get_issue(full_parameters()),
             )
@@ -1722,6 +1811,7 @@ mod tests {
             &RestApiTarget {
                 base_url: "https://127.0.0.1:8443".to_owned(),
                 credential: None,
+                allow_loopback_http: false,
             },
             &get_issue(full_parameters()),
         )
@@ -1739,6 +1829,7 @@ mod tests {
             &RestApiTarget {
                 base_url: "https://api.example.com:8443/v2".to_owned(),
                 credential: None,
+                allow_loopback_http: false,
             },
             &get_issue(full_parameters()),
         )
@@ -1926,5 +2017,112 @@ mod tests {
         assert_eq!(requests[0].timeout, DEFAULT_REST_TIMEOUT);
         assert_eq!(requests[1].timeout, MIN_REST_TIMEOUT);
         assert_eq!(requests[2].timeout, MAX_REST_TIMEOUT);
+    }
+
+    #[test]
+    fn admit_base_url_loopback_http_requires_flag_and_ip_literal() {
+        assert!(admit_base_url("http://127.0.0.1:23373/v0", true).is_ok());
+        assert!(admit_base_url("http://127.9.9.9:1", true).is_ok());
+        assert!(admit_base_url("http://[::1]:8080/", true).is_ok());
+
+        let localhost = admit_base_url("http://localhost:23373/v0", true).unwrap_err();
+        assert_eq!(
+            localhost,
+            RestExecuteError::InadmissibleBaseUrl {
+                reason: "http is only allowed for loopback IP literals; use 127.0.0.1 or [::1]",
+            }
+        );
+
+        let private = admit_base_url("http://10.0.0.1:80", true).unwrap_err();
+        assert_eq!(
+            private,
+            RestExecuteError::InadmissibleBaseUrl {
+                reason: "scheme must be https",
+            }
+        );
+
+        let no_flag = admit_base_url("http://127.0.0.1:23373/v0", false).unwrap_err();
+        assert_eq!(
+            no_flag,
+            RestExecuteError::InadmissibleBaseUrl {
+                reason: "http on a loopback address requires allow_loopback_http",
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn loopback_http_executor_does_not_follow_redirects() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        {
+            let probe = TcpListener::bind("127.0.0.1:0").unwrap();
+            let probe_addr = probe.local_addr().unwrap();
+            std::thread::spawn(move || {
+                let _ = probe.accept();
+            });
+            if std::net::TcpStream::connect_timeout(
+                &probe_addr,
+                std::time::Duration::from_millis(300),
+            )
+            .is_err()
+            {
+                return;
+            }
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let second = TcpListener::bind("127.0.0.1:0").unwrap();
+        let second_port = second.local_addr().unwrap().port();
+        let second_hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let second_hits_clone = second_hits.clone();
+        std::thread::spawn(move || {
+            second.set_nonblocking(true).unwrap();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            while std::time::Instant::now() < deadline {
+                if let Ok((mut stream, _)) = second.accept() {
+                    second_hits_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let mut buf = [0u8; 512];
+                    let _ = stream.read(&mut buf);
+                    let _ = stream.write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}",
+                    );
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        });
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let body = format!(
+                "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{second_port}/elsewhere\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            let _ = stream.write_all(body.as_bytes());
+        });
+
+        let response = RestExecutor::new(
+            ReqwestRestTransport,
+            FakeResolver(Vec::new()),
+            FakeSecrets::empty(),
+        )
+        .execute(
+            &RestApiTarget {
+                base_url: format!("http://127.0.0.1:{}", addr.port()),
+                credential: None,
+                allow_loopback_http: true,
+            },
+            &catalog(),
+            &get_issue(full_parameters()),
+            Some(Duration::from_secs(2)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status, 302);
+        assert_eq!(
+            second_hits.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a 302 to another loopback port must not be followed"
+        );
     }
 }

--- a/crates/tidebreak-server/src/rest_executor.rs
+++ b/crates/tidebreak-server/src/rest_executor.rs
@@ -2095,6 +2095,11 @@ mod tests {
         });
         std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
+            // Drain the request before answering: closing a socket with
+            // unread bytes resets the connection and the client reports a
+            // transport error instead of the 302.
+            let mut buf = [0u8; 2048];
+            let _ = stream.read(&mut buf);
             let body = format!(
                 "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{second_port}/elsewhere\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
             );

--- a/crates/tidebreak-server/src/routes/connected_apps.rs
+++ b/crates/tidebreak-server/src/routes/connected_apps.rs
@@ -109,6 +109,9 @@ pub enum ConnectedAppInfo {
         /// a count only, never app names or ids, the renderer-safety posture
         /// of this surface. Grants of library-deleted apps do not count.
         used_by_app_count: usize,
+        /// Whether this record opted into loopback HTTP. Surfaced so the
+        /// form can re-show consent on edit.
+        allow_loopback_http: bool,
     },
 }
 
@@ -153,6 +156,11 @@ pub struct RestConnectedAppUpsert {
     #[serde(default)]
     pub operation_ids: Option<Vec<String>>,
     pub credential: RestCredentialUpdate,
+    /// Explicit consent to send this record as plain HTTP to a loopback IP
+    /// literal. Required for `http://127.0.0.1` / `http://[::1]`; ignored
+    /// (and stored) for https.
+    #[serde(default)]
+    pub allow_loopback_http: bool,
 }
 
 /// What the upsert does about the credential. Externally tagged and closed:
@@ -216,7 +224,8 @@ pub async fn put_rest_connected_app(
         ));
     }
 
-    admit_base_url(&body.base_url).map_err(|error| ServerError::bad_request(error.to_string()))?;
+    admit_base_url(&body.base_url, body.allow_loopback_http)
+        .map_err(|error| ServerError::bad_request(error.to_string()))?;
 
     let document = match (&body.openapi_document, &body.openapi_document_url) {
         (Some(_), Some(_)) => {
@@ -236,7 +245,7 @@ pub async fn put_rest_connected_app(
                     "a URL-sourced document requires document_sha256 from the preview",
                 ));
             }
-            fetch_spec_document(url)
+            fetch_spec_document(url, body.allow_loopback_http)
                 .await
                 .map_err(|error| ServerError::bad_request_kind("spec_fetch", error.to_string()))?
         }
@@ -328,6 +337,7 @@ pub async fn put_rest_connected_app(
         base_url: body.base_url,
         catalog,
         credential,
+        allow_loopback_http: body.allow_loopback_http,
     };
     let now = Utc::now();
     let record = ConnectedApp {
@@ -423,6 +433,10 @@ pub enum SpecPreviewSource {
 #[serde(deny_unknown_fields)]
 pub struct SpecPreviewRequest {
     pub source: SpecPreviewSource,
+    /// Same opt-in as the upsert: a loopback-http document URL is admitted
+    /// only when this is true.
+    #[serde(default)]
+    pub allow_loopback_http: bool,
 }
 
 /// What a document declares, for the configuration form's operation picker.
@@ -467,7 +481,7 @@ pub async fn post_rest_spec_preview(
     }
     let document = match &body.source {
         SpecPreviewSource::Document(inline) => inline.as_bytes().to_vec(),
-        SpecPreviewSource::Url(url) => fetch_spec_document(url)
+        SpecPreviewSource::Url(url) => fetch_spec_document(url, body.allow_loopback_http)
             .await
             .map_err(|error| ServerError::bad_request_kind("spec_fetch", error.to_string()))?,
     };
@@ -637,6 +651,7 @@ async fn connected_apps_info(
             placement: definition.credential.map(|credential| credential.placement),
             updated_at: record.updated_at,
             used_by_app_count: used_by.get(&record.id).copied().unwrap_or(0),
+            allow_loopback_http: definition.allow_loopback_http,
         });
     }
     Ok(ConnectedAppsInfo { apps })

--- a/crates/tidebreak-server/src/tests/connected_apps.rs
+++ b/crates/tidebreak-server/src/tests/connected_apps.rs
@@ -938,3 +938,37 @@ async fn editing_a_rest_record_invalidates_an_existing_app_grant() {
     let after: serde_json::Value = json_body(state_after).await;
     assert_eq!(after["granted"], json!(false));
 }
+
+/// Loopback HTTP is stored only with explicit consent; the same URL without
+/// `allow_loopback_http` is refused naming the flag.
+#[tokio::test]
+async fn loopback_http_rest_app_requires_explicit_consent() {
+    let (router, bearer, _state, _dir) = connected_apps_test_app().await;
+    let id = ConnectedAppId::new();
+    let refused = put_rest(
+        &router,
+        &bearer,
+        id,
+        upsert_body("http://127.0.0.1:23373/v0", json!("none")),
+    )
+    .await;
+    assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+    let refused_body = raw_body(refused).await;
+    assert!(
+        refused_body.contains("allow_loopback_http"),
+        "refusal must name the flag: {refused_body}"
+    );
+
+    let mut consented = serde_json::from_str::<serde_json::Value>(&upsert_body(
+        "http://127.0.0.1:23373/v0",
+        json!("none"),
+    ))
+    .unwrap();
+    consented["allow_loopback_http"] = json!(true);
+    let saved = put_rest(&router, &bearer, id, consented.to_string()).await;
+    assert_eq!(saved.status(), StatusCode::OK);
+    let listing: serde_json::Value = serde_json::from_str(&raw_body(saved).await).unwrap();
+    let entry = rest_entry(&listing);
+    assert_eq!(entry["base_url"], json!("http://127.0.0.1:23373/v0"));
+    assert_eq!(entry["allow_loopback_http"], json!(true));
+}

--- a/docs/connected-apps.md
+++ b/docs/connected-apps.md
@@ -72,14 +72,43 @@ app on behalf of a caller. Its guarantees, all server-side and fail-closed:
 - The credential is injected by the executor at request time. It is never
   serialized to the renderer, a frame, a model prompt, or a log.
 - Egress is bounded: DNS resolution pinned per request, private-network
-  and loopback destinations refused, redirects refused, request and
-  response byte counts capped, per-request timeout.
+  destinations refused, redirects refused, request and
+  response byte counts capped, per-request timeout. Loopback HTTP is
+  the single exception, below.
 - Response bounds are sized for interactive UIs, not model context
   windows — deliberately larger than tool-result clamps.
 
 This is the local form of the gateway's governed REST-tool contract, without
 multi-user governance — which is exactly why managed profiles do not get it
 (below).
+
+## Local services on this computer
+
+Plain HTTP is admitted only for a tightly validated loopback destination,
+never for a remote or private-network host.
+
+- The host must be an **IP literal** in `127.0.0.0/8` or exactly `::1`.
+  `localhost` and every other DNS name are refused for `http` (the message
+  tells the operator to use `127.0.0.1` or `[::1]`), so hostname resolution
+  cannot widen the exemption.
+- The record must carry `allow_loopback_http: true`. That flag is persisted
+  on the `rest_api` definition and is part of the consent fingerprint, so
+  toggling it re-prompts. Without the flag, admission names
+  `allow_loopback_http` in the refusal.
+- The exemption applies only to that record's own admitted origin (scheme,
+  host, and port). Every executed request is pinned to it. Redirects are
+  never followed — the same `reqwest` `Policy::none()` used for https — so
+  a 302 to another host or another loopback port is reported, not chased.
+- The OpenAPI document URL may be loopback HTTP under the same flag;
+  otherwise it still requires https. Loopback-http spec fetches do not
+  follow redirects.
+- Remote `http` (including `10.0.0.0/8` and other private ranges) stays
+  refused with the existing "scheme must be https" message. https keeps
+  today's denied-network list, including loopback https.
+- The Settings form shows a consent checkbox when the typed base URL is
+  loopback HTTP and keeps Save disabled until it is checked. A path ending
+  in `/mcp` is treated as an MCP HTTP endpoint and pointed at Settings →
+  MCP servers (remote HTTP server) rather than this REST form.
 
 ## Bindings key off the app
 
@@ -100,8 +129,9 @@ one live kind:
 Grants, the consent sheet, the invoke route's refusal ladder, and live
 fingerprint invalidation carry over unchanged; the `rest_api` fingerprint is
 SHA-256 over base URL + OpenAPI document hash + credential *reference* +
-placement. Rotating the credential value behind the same reference does not
-invalidate consent; repointing the reference does.
+placement + `allow_loopback_http`. Rotating the credential value behind the
+same reference does not invalidate consent; repointing the reference or
+toggling loopback HTTP does.
 
 A manifest may also bind `{ gateway_app, operation_ids[] }` — an app the
 model gateway holds, named by the gateway's own id (record 10). It is not a

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2272,7 +2272,12 @@ placement: CredentialPlacement | null, updated_at: string,
  * a count only, never app names or ids, the renderer-safety posture
  * of this surface. Grants of library-deleted apps do not count.
  */
-used_by_app_count: number, };
+used_by_app_count: number,
+/**
+ * Whether this record opted into loopback HTTP. Surfaced so the
+ * form can re-show consent on edit.
+ */
+allow_loopback_http: boolean, };
 
 /**
  * The renderer's listing of every configured connected app, across kinds.


### PR DESCRIPTION
Closes #3063

## Security model

Plain HTTP is admitted only when all of the following hold:

- The host is an **IP literal** in `127.0.0.0/8` or exactly `::1`. `localhost` and every other DNS name are refused for `http` with a message that says to use `127.0.0.1` or `[::1]`, so hostname resolution cannot widen the exemption.
- The `rest_api` record carries `allow_loopback_http: true`. Without the flag, admission names `allow_loopback_http` in the refusal. The flag is persisted on the definition and is part of the consent fingerprint (`v:3`), so toggling it re-prompts.
- The exemption applies only to that record's own admitted origin (scheme, host, port). Every executed request is pinned to it.

https keeps today's behavior, including the denied-network list for IP literals (loopback https is still refused). Remote and RFC1918 `http` (for example `http://10.0.0.1`) still fail with `scheme must be https`. Managed profiles still refuse REST connected-app upserts.

Redirects: the reqwest client already uses `Policy::none()` for operation execution (https and loopback-http alike), so a 302 is reported and never followed. Spec fetches still follow https hops with per-hop re-admission; loopback-http spec fetches do not follow redirects, so a 302 cannot walk the opt-in off that origin.

Connected-app traffic does not pass a second policy layer in `tidebreak-egress`; admission stays in `rest_executor`.

## What changed

- `admit_base_url` / spec fetch take `allow_loopback_http` and admit loopback HTTP IP literals only under that flag.
- `RestApiDefinition` and the upsert body persist the flag; listing projects it so the form can re-show consent.
- Executor and spec-fetch clients set `https_only` from the URL scheme; loopback-http still uses `no_proxy` and `Policy::none()`.
- Settings form: consent checkbox (warning surface, Save disabled until checked) when the typed base URL is loopback HTTP; MCP hint when the path ends in `/mcp` or a preview ingest looks like a non-OpenAPI document. Story: `ConnectedAppsLoopbackHttpConsent`.
- Docs: "Local services on this computer" in `docs/connected-apps.md`.

## Commands run

```
cargo fmt --all
cargo check -p tidebreak-server --tests
cargo test -p tidebreak-server rest_executor
cargo test -p tidebreak-server connected_apps
cargo clippy -p tidebreak-server --tests -- -D warnings
UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --lib wire_types
```

`cargo fmt --all` and `cargo check -p tidebreak-server --tests` succeeded (the sandbox comments the root `symphonia` git patch locally and restores `Cargo.toml` / `Cargo.lock` before every commit).

`cargo test -p tidebreak-server rest_executor` (lib): 13 passed, including admission cases for `127.0.0.1`, `127.9.9.9`, `[::1]`, `localhost`, `10.0.0.1`, and http without the flag.

`cargo test -p tidebreak-server connected_apps`: `loopback_http_rest_app_requires_explicit_consent` passed; `the_listing_carries_mounted_tool_names_only` returned 400 on `PUT /mcp/servers` for a loopback MCP URL in this environment (loopback TCP is often dropped here). Fingerprint and upsert tests passed.

`cargo clippy -p tidebreak-server --tests -- -D warnings` failed on existing lints in `harness_llm.rs` (`result_large_err`) and `exec_write_snapshot.rs` (`chunks_exact_to_as_chunks`), not on this change.

UI: `CI=true pnpm install --frozen-lockfile` failed with `ERR_PNPM_FETCH_403` from `https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz`, so biome, lint, test, build, and `pnpm storybook:build` could not run here.