### PR TITLE
fix(mcp): resolve stdio command names through host PATH

### DIFF
--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -3318,6 +3318,12 @@ plugin: string | null, };
  */
 export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null,
 /**
+ * Absolute path the stdio command resolved to at the last verify or
+ * launch. Absent for HTTP/gateway servers and when resolution failed.
+ * The stored definition still holds what the user typed.
+ */
+resolved_command?: string,
+/**
  * The curated-list entry this definition matches, when Tidebreak has
  * exercised the server end to end. `null` means community: mounted and
  * usable, just not something we have driven ourselves. Derived from the

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
@@ -160,7 +160,11 @@ describe("McpPanel", () => {
       />,
     );
     expect(
-      await screen.findByText("Resolved npx to /opt/homebrew/bin/npx"),
+      await screen.findByText(
+        (_, node) =>
+          node?.tagName === "P" &&
+          node.textContent === "Resolved npx to /opt/homebrew/bin/npx",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
@@ -38,6 +38,7 @@ const healthy: McpServersInfo = {
       tool_count: 2,
       diagnostic: null,
       curated: null,
+      resolved_command: "/opt/mcp/docs",
     },
   ],
 };
@@ -141,6 +142,25 @@ describe("McpPanel", () => {
       screen.getByText(
         /Tidebreak reads their values from the process environment/i,
       ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the resolved stdio executable path after verify", async () => {
+    render(
+      <McpPanel
+        client={api({
+          servers: [
+            {
+              ...healthy.servers[0],
+              command: "npx",
+              resolved_command: "/opt/homebrew/bin/npx",
+            },
+          ],
+        })}
+      />,
+    );
+    expect(
+      await screen.findByText("Resolved npx to /opt/homebrew/bin/npx"),
     ).toBeInTheDocument();
   });
 

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
@@ -160,6 +160,7 @@ function definition(server: McpServerInfo): McpServerDefinition {
     tool_count: __,
     diagnostic: ___,
     curated: ____,
+    resolved_command: _____,
     ...value
   } = server;
   return value;
@@ -842,7 +843,7 @@ export function McpPanel({
                   <>
                     <SettingsField
                       label="Executable"
-                      hint={`A path or command name on ${hostMachineLabel()}, where the process runs. Tidebreak never invokes a shell.`}
+                      hint={`A command name or absolute path on ${hostMachineLabel()}. A bare name is resolved on the process PATH extended with the login-shell PATH (and PATHEXT on Windows) without invoking a shell. Relative paths with separators are refused.`}
                     >
                       <Input
                         value={server.command ?? ""}
@@ -855,6 +856,17 @@ export function McpPanel({
                         }
                       />
                     </SettingsField>
+                    {server.resolved_command &&
+                    server.command &&
+                    server.resolved_command !== server.command ? (
+                      <p className="text-sm text-muted-foreground">
+                        Resolved{" "}
+                        <span className="font-mono">{server.command}</span> to{" "}
+                        <span className="font-mono">
+                          {server.resolved_command}
+                        </span>
+                      </p>
+                    ) : null}
 
                     <StringListEditor
                       label="Arguments"

--- a/crates/tidebreak-desktop/ui/src/stories/McpPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/McpPanel.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+
+import type { ApiClient, GatewayStatus, McpServerInfo } from "@/api";
+import { McpPanel } from "@/settings/McpPanel";
+
+const signedOut: GatewayStatus = {
+  base_url: "http://127.0.0.1:28081",
+  signed_in: false,
+  model_count: 0,
+  sign_in: { state: "idle" },
+};
+
+function stdioServer(overrides: Partial<McpServerInfo> = {}): McpServerInfo {
+  return {
+    name: "beeper",
+    command: "npx",
+    args: ["-y", "@beeper/mcp-remote"],
+    env: ["ACCESS_TOKEN"],
+    env_from: [],
+    cwd: null,
+    url: null,
+    bearer_token_env: null,
+    gateway_endpoint: null,
+    request_timeout_ms: 60_000,
+    enabled: true,
+    plugin: null,
+    health: "healthy",
+    tool_count: 2,
+    diagnostic: null,
+    curated: null,
+    resolved_command: "/opt/homebrew/bin/npx",
+    ...overrides,
+  };
+}
+
+function stubClient(servers: McpServerInfo[]): ApiClient {
+  const listing = { servers };
+  return {
+    listMcpServers: async () => listing,
+    putMcpServers: async () => listing,
+    reconnectMcpServer: async () => listing,
+    getGatewayStatus: async () => signedOut,
+    getGatewayApps: async () => ({ supported: true, apps: [] }),
+  } as unknown as ApiClient;
+}
+
+const meta = {
+  title: "Settings/MCP servers",
+  component: McpPanel,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof McpPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StdioResolvedCommand: Story = {
+  args: { client: stubClient([stdioServer()]) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/Resolved\s+npx\s+to\s+\/opt\/homebrew\/bin\/npx/),
+    ).toBeVisible();
+  },
+};
+
+export const StdioCommandNotFound: Story = {
+  args: {
+    client: stubClient([
+      stdioServer({
+        health: "degraded",
+        tool_count: 0,
+        resolved_command: undefined,
+        diagnostic:
+          'Command not found: "npx" is not on the host PATH. Searched: /usr/bin, /bin.',
+      }),
+    ]),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/Command not found: "npx"/),
+    ).toBeVisible();
+  },
+};
+
+export const StdioLaunchFailure: Story = {
+  args: {
+    client: stubClient([
+      stdioServer({
+        health: "degraded",
+        tool_count: 0,
+        resolved_command: "/opt/homebrew/bin/npx",
+        diagnostic:
+          "Process failed to launch: exit code 1. First stderr line: npx: command failed.",
+      }),
+    ]),
+  },
+};
+
+export const StdioProtocolFailure: Story = {
+  args: {
+    client: stubClient([
+      stdioServer({
+        health: "degraded",
+        tool_count: 0,
+        resolved_command: "/opt/homebrew/bin/npx",
+        diagnostic:
+          "Protocol negotiation failed (the process answered, but not with MCP JSON-RPC).",
+      }),
+    ]),
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/McpPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/McpPanel.stories.tsx
@@ -59,7 +59,9 @@ export const StdioResolvedCommand: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
-      await canvas.findByText(/Resolved\s+npx\s+to\s+\/opt\/homebrew\/bin\/npx/),
+      await canvas.findByText(
+        /Resolved\s+npx\s+to\s+\/opt\/homebrew\/bin\/npx/,
+      ),
     ).toBeVisible();
   },
 };

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -45,9 +45,10 @@ pub use launch::{
 };
 pub use pin::{ensure_installed, managed_binary, pin_for, HarnessPin, PINS};
 pub use probe::{
-    display_model_label, filter_child_env, filter_engine_child_env, infer_listed_default,
-    list_cli_models, observe_version, prefer_gateway_models, probe_shell, resolve_binary,
-    with_reasoning_efforts, DeclaredBinary, HostEnv, ListedHarnessModel, ProbeCapture, ProbeError,
+    capture_login_env, display_model_label, env_value, filter_child_env, filter_engine_child_env,
+    infer_listed_default, list_cli_models, observe_version, prefer_gateway_models, probe_shell,
+    resolve_binary, resolve_command_on_path, with_reasoning_efforts, DeclaredBinary, HostEnv,
+    ListedHarnessModel, ProbeCapture, ProbeError,
 };
 
 /// Whether some auth mode besides the vendor login a probe observes could

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -12,7 +12,7 @@
 //! or caller overrides case-insensitively, and resolves through `PATH` plus
 //! `PATHEXT` without running a shell profile script.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -175,6 +175,34 @@ pub enum ProbeError {
 /// Resolve `name` through the user's interactive login shell.
 pub async fn resolve_binary(host: &HostEnv, name: &str) -> Result<PathBuf, ProbeError> {
     Ok(probe_shell(host, name).await?.binary)
+}
+
+/// Capture the interactive login-shell environment (Unix) or the process
+/// environment (Windows). MCP stdio resolution reuses this PATH rather than
+/// probing `$SHELL` per command.
+pub async fn capture_login_env(host: &HostEnv) -> Result<Vec<(OsString, OsString)>, ProbeError> {
+    capture_shell_env(host).await
+}
+
+/// Resolve a bare command name against `PATH` (and `PATHEXT` on Windows)
+/// without invoking a shell. Directories that are not absolute are skipped.
+#[must_use]
+pub fn resolve_command_on_path(name: &str, path: &OsStr) -> Option<PathBuf> {
+    if name.is_empty() || name.contains(['/', '\\', '\0']) {
+        return None;
+    }
+    let mut env = vec![(OsString::from("PATH"), path.to_os_string())];
+    if let Some(pathext) = std::env::var_os("PATHEXT") {
+        env.push((OsString::from("PATHEXT"), pathext));
+    }
+    #[cfg(windows)]
+    {
+        resolve_windows_command(&env, name)
+    }
+    #[cfg(not(windows))]
+    {
+        resolve_unix_command(&env, name)
+    }
 }
 
 /// Resolve `name` and capture the shell's environment in one probe.
@@ -739,7 +767,10 @@ fn env_key_eq(left: &std::ffi::OsStr, right: &std::ffi::OsStr, case_insensitive:
     }
 }
 
-pub(crate) fn env_value<'a>(
+/// Look up `key` in a captured environment. Matching is case-insensitive on
+/// Windows.
+#[must_use]
+pub fn env_value<'a>(
     env: &'a [(OsString, OsString)],
     key: &std::ffi::OsStr,
 ) -> Option<&'a OsString> {

--- a/crates/tidebreak-mcp/src/client.rs
+++ b/crates/tidebreak-mcp/src/client.rs
@@ -1256,6 +1256,8 @@ fn timed_out(request_timeout: Duration) -> AgentError {
 fn classify_spawn_error(error: std::io::Error) -> AgentError {
     if error.kind() == std::io::ErrorKind::NotFound {
         mcp_message("Process failed to launch: command not found.")
+    } else if error.kind() == std::io::ErrorKind::PermissionDenied {
+        mcp_message("Permission denied: cannot execute the stdio server.")
     } else {
         mcp_message(format!("Process failed to launch: {error}."))
     }

--- a/crates/tidebreak-server/fixtures/rest-records.json
+++ b/crates/tidebreak-server/fixtures/rest-records.json
@@ -129,6 +129,7 @@
           "name": "filesystem",
           "plugin": null,
           "request_timeout_ms": 30000,
+          "resolved_command": "/usr/local/bin/npx",
           "tool_count": 11,
           "url": null
         },

--- a/crates/tidebreak-server/src/mcp_config/mod.rs
+++ b/crates/tidebreak-server/src/mcp_config/mod.rs
@@ -10,6 +10,7 @@
 //! carry names only, and values are resolved at the connection boundary.
 
 mod runtime;
+mod stdio;
 mod types;
 mod validation;
 

--- a/crates/tidebreak-server/src/mcp_config/runtime.rs
+++ b/crates/tidebreak-server/src/mcp_config/runtime.rs
@@ -22,6 +22,7 @@ pub(super) struct ManagedServer {
     client: Option<McpClient>,
     health: McpHealth,
     diagnostic: Option<String>,
+    resolved_command: Option<String>,
     reconnect_backoff: Duration,
     pub(super) epoch: u64,
     pub(super) reconnect_lock: Arc<Mutex<()>>,
@@ -486,6 +487,8 @@ impl McpRuntime {
                             .and_then(|server| server.client.as_ref())
                             .map_or(0, |client| client.tools().count()),
                         diagnostic: managed.and_then(|server| server.diagnostic.clone()),
+                        resolved_command: managed
+                            .and_then(|server| server.resolved_command.clone()),
                         curated: curation(definition),
                         definition: definition.clone(),
                     }
@@ -821,6 +824,7 @@ impl McpRuntime {
                             client: None,
                             health: McpHealth::Degraded,
                             diagnostic: Some(connection_diagnostic(definition, &error)),
+                            resolved_command: None,
                             reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                             epoch: self.fresh_epoch(),
                             reconnect_lock: Arc::new(Mutex::new(())),
@@ -844,6 +848,7 @@ impl McpRuntime {
                         client: None,
                         health: McpHealth::Disabled,
                         diagnostic: disabled_diagnostic(definition, lockdown),
+                        resolved_command: None,
                         reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                         epoch: self.fresh_epoch(),
                         reconnect_lock: Arc::new(Mutex::new(())),
@@ -858,6 +863,7 @@ impl McpRuntime {
                     client: Some(client),
                     health: McpHealth::Healthy,
                     diagnostic: None,
+                    resolved_command: super::stdio::resolved_display(definition).await,
                     reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                     epoch: self.fresh_epoch(),
                     reconnect_lock: Arc::new(Mutex::new(())),
@@ -933,6 +939,7 @@ impl McpRuntime {
                     client: None,
                     health: McpHealth::Disabled,
                     diagnostic: disabled_diagnostic(definition, lockdown),
+                    resolved_command: None,
                     reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                     epoch: self.fresh_epoch(),
                     reconnect_lock: Arc::new(Mutex::new(())),
@@ -942,6 +949,7 @@ impl McpRuntime {
                     client: Some(client),
                     health: McpHealth::Healthy,
                     diagnostic: None,
+                    resolved_command: super::stdio::resolved_display(definition).await,
                     reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                     epoch: self.fresh_epoch(),
                     reconnect_lock: Arc::new(Mutex::new(())),
@@ -959,6 +967,7 @@ impl McpRuntime {
                         client: None,
                         health: McpHealth::Degraded,
                         diagnostic: Some(connection_diagnostic(definition, &error)),
+                        resolved_command: None,
                         reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                         epoch: self.fresh_epoch(),
                         reconnect_lock: Arc::new(Mutex::new(())),
@@ -1036,6 +1045,7 @@ impl McpRuntime {
                     client: Some(client),
                     health: McpHealth::Healthy,
                     diagnostic: None,
+                    resolved_command: super::stdio::resolved_display(definition).await,
                     reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                     epoch: self.fresh_epoch(),
                     reconnect_lock: Arc::new(Mutex::new(())),
@@ -1045,6 +1055,7 @@ impl McpRuntime {
                     client: None,
                     health: McpHealth::Disabled,
                     diagnostic: disabled_diagnostic(definition, lockdown),
+                    resolved_command: None,
                     reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                     epoch: self.fresh_epoch(),
                     reconnect_lock: Arc::new(Mutex::new(())),
@@ -1060,6 +1071,7 @@ impl McpRuntime {
                         client: None,
                         health: McpHealth::Degraded,
                         diagnostic: Some(connection_diagnostic(definition, &error)),
+                        resolved_command: None,
                         reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                         epoch: self.fresh_epoch(),
                         reconnect_lock: Arc::new(Mutex::new(())),
@@ -1305,6 +1317,7 @@ impl McpRuntime {
                         client: None,
                         health: McpHealth::Initializing,
                         diagnostic: None,
+                        resolved_command: None,
                         reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                         epoch: self.fresh_epoch(),
                         reconnect_lock: Arc::new(Mutex::new(())),
@@ -1313,6 +1326,7 @@ impl McpRuntime {
                 server.client = Some(client);
                 server.health = McpHealth::Healthy;
                 server.diagnostic = None;
+                server.resolved_command = super::stdio::resolved_display(&definition).await;
                 server.ui_views = ui_views;
                 server.reconnect_backoff = INITIAL_RECONNECT_BACKOFF;
                 server.epoch = self.fresh_epoch();
@@ -1455,6 +1469,8 @@ impl McpRuntime {
                             .and_then(|server| server.client.as_ref())
                             .map_or(0, |client| client.tools().count()),
                         diagnostic: managed.and_then(|server| server.diagnostic.clone()),
+                        resolved_command: managed
+                            .and_then(|server| server.resolved_command.clone()),
                         curated: curation(definition),
                         definition: definition.clone(),
                     }

--- a/crates/tidebreak-server/src/mcp_config/stdio.rs
+++ b/crates/tidebreak-server/src/mcp_config/stdio.rs
@@ -1,0 +1,215 @@
+//! Host PATH resolution for user-configured stdio MCP commands.
+//!
+//! A GUI process on macOS inherits launchd's minimal PATH, so a bare name
+//! like `npx` is not found unless we extend the process PATH with the
+//! login-shell PATH the harness probe already captures. Resolution never
+//! invokes a shell to run the server: it scans directories and spawns the
+//! absolute path with `Command::new`.
+
+use std::collections::HashSet;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tidebreak_core::{AgentError, Result};
+use tidebreak_harness::{
+    capture_login_env, env_value, is_absolute_executable, resolve_command_on_path, HostEnv,
+};
+use tokio::sync::OnceCell;
+
+/// Directories named in a "command not found" diagnostic. Enough to show
+/// Homebrew / nvm / volta roots without dumping an unbounded PATH.
+const MAX_SEARCHED_DIRS: usize = 8;
+
+static PATH_OVERRIDE: Mutex<Option<OsString>> = Mutex::new(None);
+static LOGIN_PATH: OnceCell<Option<OsString>> = OnceCell::const_new();
+
+/// Test seam: replace the host search PATH (process + login-shell merge).
+#[cfg(test)]
+pub(super) fn override_host_path(path: Option<OsString>) {
+    *PATH_OVERRIDE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = path;
+}
+
+/// Restore the process PATH merge after a test that overrode it.
+#[cfg(test)]
+pub(super) struct HostPathGuard;
+
+#[cfg(test)]
+impl Drop for HostPathGuard {
+    fn drop(&mut self) {
+        override_host_path(None);
+    }
+}
+
+/// Why a user-typed stdio command could not be turned into an executable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum StdioResolveError {
+    Relative { command: String },
+    NotFound { command: String, searched: String },
+    NotExecutable { path: PathBuf },
+    PermissionDenied { path: PathBuf },
+}
+
+impl StdioResolveError {
+    pub(super) fn diagnostic(&self) -> String {
+        match self {
+            Self::Relative { command } => format!(
+                "Relative executable path {command:?} is not allowed. Use an absolute path \
+                 or a command name with no path separators."
+            ),
+            Self::NotFound { command, searched } => {
+                format!(
+                    "Command not found: {command:?} is not on the host PATH. Searched: {searched}."
+                )
+            }
+            Self::NotExecutable { path } => format!(
+                "Not executable: {} exists but is not executable by this user.",
+                path.display()
+            ),
+            Self::PermissionDenied { path } => {
+                format!("Permission denied: cannot execute {}.", path.display())
+            }
+        }
+    }
+
+    pub(super) fn into_error(self) -> AgentError {
+        AgentError::config(self.diagnostic())
+    }
+}
+
+/// Absolute path to show after a successful stdio verify, when the
+/// definition still stores the user-typed command.
+pub(super) async fn resolved_display(
+    definition: &super::types::McpServerDefinition,
+) -> Option<String> {
+    if definition.launch.is_some() {
+        return None;
+    }
+    let command = definition.command.as_deref()?;
+    resolve_stdio_command(command)
+        .await
+        .ok()
+        .map(|path| path.display().to_string())
+}
+
+/// Resolve a user-configured stdio `command` at verify and launch time.
+///
+/// The definition keeps what the user typed. Absolute paths are used as-is.
+/// A bare name is found on the process PATH extended with the login-shell
+/// PATH (and `PATHEXT` on Windows). A relative path with separators is
+/// refused. Plugin `./` commands do not go through this function.
+pub(super) async fn resolve_stdio_command(command: &str) -> Result<PathBuf> {
+    let path = Path::new(command);
+    if path.is_absolute() || command.contains('/') || command.contains('\\') {
+        return resolve_stdio_command_on_path(command, OsStr::new(""))
+            .map_err(StdioResolveError::into_error);
+    }
+    resolve_stdio_command_on_path(command, &host_search_path().await)
+        .map_err(StdioResolveError::into_error)
+}
+
+pub(super) fn resolve_stdio_command_on_path(
+    command: &str,
+    search_path: &OsStr,
+) -> std::result::Result<PathBuf, StdioResolveError> {
+    let path = Path::new(command);
+    if path.is_absolute() {
+        return classify_absolute(path);
+    }
+    if command.contains('/') || command.contains('\\') {
+        return Err(StdioResolveError::Relative {
+            command: command.to_string(),
+        });
+    }
+    match resolve_command_on_path(command, search_path) {
+        Some(resolved) => Ok(resolved),
+        None => Err(StdioResolveError::NotFound {
+            command: command.to_string(),
+            searched: format_searched_directories(search_path),
+        }),
+    }
+}
+
+fn classify_absolute(path: &Path) -> std::result::Result<PathBuf, StdioResolveError> {
+    match path.metadata() {
+        Ok(_) => {
+            if is_absolute_executable(path) {
+                Ok(path.to_path_buf())
+            } else {
+                Err(StdioResolveError::NotExecutable {
+                    path: path.to_path_buf(),
+                })
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            Err(StdioResolveError::PermissionDenied {
+                path: path.to_path_buf(),
+            })
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // Missing absolute paths keep the spawn-time "command not found"
+            // path so existing verify diagnostics stay stable.
+            Ok(path.to_path_buf())
+        }
+        Err(_) => Ok(path.to_path_buf()),
+    }
+}
+
+async fn host_search_path() -> OsString {
+    if let Some(overridden) = PATH_OVERRIDE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+    {
+        return overridden;
+    }
+    let process = std::env::var_os("PATH").unwrap_or_default();
+    let login = LOGIN_PATH
+        .get_or_init(|| async {
+            let env = capture_login_env(&HostEnv::from_process()).await.ok()?;
+            env_value(&env, OsStr::new("PATH")).cloned()
+        })
+        .await
+        .clone();
+    merge_search_path(&process, login.as_deref())
+}
+
+fn merge_search_path(process: &OsStr, login: Option<&OsStr>) -> OsString {
+    let mut dirs = Vec::new();
+    let mut seen = HashSet::new();
+    for source in [Some(process), login] {
+        let Some(source) = source else {
+            continue;
+        };
+        for dir in std::env::split_paths(source) {
+            if dir.as_os_str().is_empty() || !seen.insert(dir.clone()) {
+                continue;
+            }
+            dirs.push(dir);
+        }
+    }
+    std::env::join_paths(dirs).unwrap_or_else(|_| process.to_os_string())
+}
+
+fn format_searched_directories(search_path: &OsStr) -> String {
+    let searched: Vec<String> = std::env::split_paths(search_path)
+        .filter(|dir| dir.is_absolute())
+        .map(|dir| dir.display().to_string())
+        .collect();
+    if searched.is_empty() {
+        return "(no directories on the host PATH)".to_string();
+    }
+    let shown = searched
+        .iter()
+        .take(MAX_SEARCHED_DIRS)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(", ");
+    if searched.len() > MAX_SEARCHED_DIRS {
+        format!("{shown}, and {} more", searched.len() - MAX_SEARCHED_DIRS)
+    } else {
+        shown
+    }
+}

--- a/crates/tidebreak-server/src/mcp_config/tests.rs
+++ b/crates/tidebreak-server/src/mcp_config/tests.rs
@@ -322,15 +322,15 @@ fn parses_a_bounded_stdio_server_configuration() {
     assert!(server.enabled);
 }
 
-#[test]
-fn defaults_to_an_isolated_environment_and_sixty_second_timeout() {
+#[tokio::test]
+async fn defaults_to_an_isolated_environment_and_sixty_second_timeout() {
     let config = parse(r#"{"servers":[{"name":"docs","command":"/bin/docs"}]}"#).unwrap();
     let server = &config.0[0];
     assert!(server.args.is_empty());
     assert!(server.env.is_empty());
     assert!(server.env_from.is_empty());
     assert_eq!(server.request_timeout_ms, 60_000);
-    let command = server.build_command(&BTreeMap::new()).unwrap();
+    let command = server.build_command(&BTreeMap::new()).await.unwrap();
     assert!(command.as_std().get_envs().next().is_none());
 }
 
@@ -405,8 +405,8 @@ fn rejects_ambiguous_or_invalid_environment_sources() {
         .contains("invalid environment variable name"));
 }
 
-#[test]
-fn forwards_only_explicitly_selected_parent_environment_values() {
+#[tokio::test]
+async fn forwards_only_explicitly_selected_parent_environment_values() {
     let config = parse(
         r#"{"servers":[{
                 "name":"docs",
@@ -415,7 +415,7 @@ fn forwards_only_explicitly_selected_parent_environment_values() {
             }]}"#,
     )
     .unwrap();
-    let command = config.0[0].build_command(&BTreeMap::new()).unwrap();
+    let command = config.0[0].build_command(&BTreeMap::new()).await.unwrap();
     let forwarded_path = command
         .as_std()
         .get_envs()
@@ -468,6 +468,24 @@ fn projected_diagnostics_are_fixed_or_name_only() {
     assert_eq!(
         connection_diagnostic(&generic.0[0], &failure),
         "Could not initialize this server. Check its executable, arguments, and working directory."
+    );
+
+    let not_found = AgentError::config(
+        "Command not found: \"npx\" is not on the host PATH. Searched: /opt/homebrew/bin.",
+    );
+    assert_eq!(
+        connection_diagnostic(&generic.0[0], &not_found),
+        "Command not found: \"npx\" is not on the host PATH. Searched: /opt/homebrew/bin."
+    );
+    let not_exec =
+        AgentError::config("Not executable: /tmp/npx exists but is not executable by this user.");
+    assert!(connection_diagnostic(&generic.0[0], &not_exec).starts_with("Not executable:"));
+    let denied = AgentError::config("Permission denied: cannot execute /tmp/npx.");
+    assert!(connection_diagnostic(&generic.0[0], &denied).starts_with("Permission denied:"));
+    let protocol =
+        AgentError::msg("MCP client error: Protocol negotiation failed (not with MCP JSON-RPC).");
+    assert!(
+        connection_diagnostic(&generic.0[0], &protocol).starts_with("Protocol negotiation failed")
     );
 }
 
@@ -1675,6 +1693,52 @@ async fn verify_classifies_timeout_after_configured_milliseconds() {
     definition.request_timeout_ms = 80;
     let error = verify_fails(definition).await;
     assert!(error.contains("Timed out after 80 ms."), "{error}");
+}
+
+#[test]
+fn stdio_relative_path_is_refused() {
+    let error =
+        super::stdio::resolve_stdio_command_on_path("bin/npx", std::ffi::OsStr::new("/bin"))
+            .expect_err("relative paths with separators must be refused");
+    let diagnostic = error.diagnostic();
+    assert!(
+        diagnostic.contains("Relative executable path"),
+        "{diagnostic}"
+    );
+    assert!(!diagnostic.contains("-y"), "{diagnostic}");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn stdio_bare_npx_resolves_on_overridden_host_path() {
+    let directory = tempfile::tempdir().unwrap();
+    let npx = directory.path().join("npx");
+    std::fs::write(&npx, "#!/bin/sh\nexit 0\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&npx, std::fs::Permissions::from_mode(0o755)).unwrap();
+    super::stdio::override_host_path(Some(directory.path().as_os_str().to_os_string()));
+    let _guard = super::stdio::HostPathGuard;
+    let resolved = super::stdio::resolve_stdio_command("npx").await.unwrap();
+    assert_eq!(resolved, npx);
+
+    let definition = parse(r#"{"servers":[{"name":"docs","command":"npx"}]}"#)
+        .unwrap()
+        .0
+        .remove(0);
+    assert_eq!(definition.command.as_deref(), Some("npx"));
+    let command = definition.build_command(&BTreeMap::new()).await.unwrap();
+    assert_eq!(command.as_std().get_program(), npx.as_os_str());
+
+    let missing = super::stdio::resolve_stdio_command("definitely-not-npx-9f3a")
+        .await
+        .expect_err("missing name must fail");
+    let diagnostic = missing.to_string();
+    assert!(diagnostic.contains("Command not found"), "{diagnostic}");
+    assert!(
+        diagnostic.contains(&directory.path().display().to_string()),
+        "{diagnostic}"
+    );
+    assert!(!diagnostic.contains("@beeper"), "{diagnostic}");
 }
 
 #[tokio::test]

--- a/crates/tidebreak-server/src/mcp_config/types.rs
+++ b/crates/tidebreak-server/src/mcp_config/types.rs
@@ -338,7 +338,7 @@ impl McpServerDefinition {
     /// directory is re-checked for containment here rather than trusted from
     /// the textual rule the importer applied, because only a check at launch
     /// sees symlinks and edits made since.
-    pub(super) fn build_command(&self, env: &BTreeMap<String, String>) -> Result<Command> {
+    pub(super) async fn build_command(&self, env: &BTreeMap<String, String>) -> Result<Command> {
         let Some(program) = &self.command else {
             return Err(AgentError::config(
                 "MCP server definition has no command to spawn",
@@ -346,11 +346,13 @@ impl McpServerDefinition {
         };
         // A plugin's command must be `./`-relative and is resolved against
         // the package root before the child is built. User-configured servers
-        // keep the platform resolution they already had; a plugin never does.
+        // resolve a bare name through the host PATH (process PATH extended
+        // with the login-shell PATH the harness probe captures) without
+        // invoking a shell.
         let program = match &self.launch {
             Some(launch) => crate::plugin_mcp::resolve_command(program, &launch.root)
                 .map_err(AgentError::config)?,
-            None => PathBuf::from(program),
+            None => super::stdio::resolve_stdio_command(program).await?,
         };
         let mut command = Command::new(program);
         command.args(&self.args);
@@ -437,7 +439,7 @@ impl McpServerDefinition {
         }
         McpClient::spawn_with_timeouts(
             self.name.clone(),
-            self.build_command(env)?,
+            self.build_command(env).await?,
             initialization_timeout,
             request_timeout,
         )
@@ -756,6 +758,12 @@ pub struct McpServerInfo {
     pub health: McpHealth,
     pub tool_count: usize,
     pub diagnostic: Option<String>,
+    /// Absolute path the stdio command resolved to at the last verify or
+    /// launch. Absent for HTTP/gateway servers and when resolution failed.
+    /// The stored definition still holds what the user typed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub resolved_command: Option<String>,
     /// The curated-list entry this definition matches, when Tidebreak has
     /// exercised the server end to end. `null` means community: mounted and
     /// usable, just not something we have driven ourselves. Derived from the

--- a/crates/tidebreak-server/src/mcp_config/validation.rs
+++ b/crates/tidebreak-server/src/mcp_config/validation.rs
@@ -282,6 +282,10 @@ fn classified_transport_detail(error: &AgentError) -> Option<String> {
         "Protocol negotiation failed",
         "Timed out after",
         "Process failed to launch",
+        "Command not found:",
+        "Not executable:",
+        "Permission denied:",
+        "Relative executable path",
     ];
     PREFIXES
         .iter()

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -1559,6 +1559,7 @@ mod tests {
                     health: McpHealth::Healthy,
                     tool_count: 11,
                     diagnostic: None,
+                    resolved_command: Some("/usr/local/bin/npx".into()),
                     curated: Some(McpCuration {
                         display_name: "Filesystem".into(),
                         tested_on: "2026-08-01".into(),
@@ -1570,6 +1571,7 @@ mod tests {
                     health: McpHealth::Disabled,
                     tool_count: 0,
                     diagnostic: Some("turned off".into()),
+                    resolved_command: None,
                     curated: None,
                 },
             ],

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -15,10 +15,15 @@ Each server has:
 
 - a stable namespace containing ASCII letters, numbers, `_`, or `-`;
 - exactly one transport:
-  - **stdio** — an executable, zero or more individual arguments, an optional
-    working directory, optional environment variable *names* (`env`) whose
-    values are held in the OS credential store, and optional `env_from` names
-    selected from the Tidebreak host environment; or
+  - **stdio** — an executable (a bare command name or an absolute path), zero
+    or more individual arguments, an optional working directory, optional
+    environment variable *names* (`env`) whose values are held in the OS
+    credential store, and optional `env_from` names selected from the Tidebreak
+    host environment. A bare name is resolved at verify and launch time on the
+    process PATH extended with the login-shell PATH the harness probe already
+    captures (plus `PATHEXT` on Windows). Tidebreak never invokes a shell to
+    run the server. The stored definition keeps what you typed. A relative path
+    that contains separators is refused; or
   - **HTTP** — an `http`/`https` URL and an optional bearer-token variable
     name selected from the Tidebreak host environment; or
   - **gateway** — the slug of a model-gateway MCP endpoint
@@ -52,10 +57,13 @@ and then restart Tidebreak. Save and verify classifies the failure: DNS
 resolution (the host), TLS handshake (the reason), HTTP status (401/403 as
 authentication, 404 as wrong path, 5xx as server error, with the status line),
 protocol negotiation (quotes the first bytes when the endpoint answered but
-not with MCP JSON-RPC), timeout (after N ms), or a stdio launch failure
-(command not found, exit code, first stderr line). Diagnostics never echo a
-URL or a token. Child stderr is not copied into host logs; a failed launch may
-quote its first line in Settings.
+not with MCP JSON-RPC), timeout (after N ms), or a stdio failure: command not
+found (names a bounded list of directories searched), not executable or
+permission denied, launch failure before the MCP handshake (exit status and a
+bounded stderr tail), or MCP protocol failure. A successful stdio verify
+reports the resolved executable path. Diagnostics never echo a URL, token,
+argument value, or environment value. Child stderr is not copied into host
+logs; a failed launch may quote its first line in Settings.
 
 Definitions saved before the values moved into the credential store held them
 in cleartext in the connected-app record. They are migrated on first load: the

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -3318,6 +3318,12 @@ plugin: string | null, };
  */
 export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null,
 /**
+ * Absolute path the stdio command resolved to at the last verify or
+ * launch. Absent for HTTP/gateway servers and when resolution failed.
+ * The stored definition still holds what the user typed.
+ */
+resolved_command?: string,
+/**
  * The curated-list entry this definition matches, when Tidebreak has
  * exercised the server end to end. `null` means community: mounted and
  * usable, just not something we have driven ourselves. Derived from the


### PR DESCRIPTION
Closes #3064

## Root cause

Settings → MCP servers documents the Executable field as a path **or command name**, and Tidebreak never invokes a shell. The stdio child was still spawned with `Command::new(program)` using only the server process environment.

A desktop app launched from the Dock or Finder on macOS inherits launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). Bare names such as `npx` (Homebrew, nvm, fnm, volta) are therefore not found, and the failure collapsed to the generic “check its executable” diagnostic.

## What changed

- Bare command names (no path separator) are resolved at **verify and launch** on the **process PATH extended with the login-shell PATH** the harness probe already captures, plus `PATHEXT` on Windows. Resolution scans directories and then `Command::new` the absolute file; the stored definition keeps what the user typed.
- Absolute executable paths are unchanged. A relative path with separators is refused with a distinct message.
- `connection_diagnostic` classifies: command not found (bounded list of directories searched), not executable, permission denied, launch failure before the MCP handshake (exit status and bounded stderr), and MCP protocol failure. Argument and environment **values** are never interpolated; arguments stay as typed.
- Verify projections include `resolved_command`. The MCP panel shows e.g. `Resolved npx to /opt/homebrew/bin/npx`. Storybook: `Settings/MCP servers`.
- Environment variables remain names only; values are still read from the process environment / secret store.
- Regression: Unix test plants an executable `npx` in a temp dir, injects that dir via the host-PATH test seam, and asserts `command: "npx"` launches that path. A missing name lists the searched directories.

Documented in the Executable field hint and in `docs/mcp-servers.md`.

## Checks

`cargo fmt --all`

`cargo check -p tidebreak-server --tests`

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 29.73s
```

`cargo test -p tidebreak-server mcp_config` (stdio resolution and stdio launch classification passed; HTTP classify tests in this sandbox hit a proxy: DNS for `.invalid` returned `403 Forbidden`, and some loopback HTTP verifies timed out after 10000 ms)

```
test mcp_config::tests::stdio_bare_npx_resolves_on_overridden_host_path ... ok
test mcp_config::tests::stdio_relative_path_is_refused ... ok
test mcp_config::tests::verify_classifies_stdio_command_not_found ... ok
test mcp_config::tests::verify_classifies_stdio_exit_code_and_first_stderr_line ... ok
```

`cargo clippy -p tidebreak-server --tests -- -D warnings` failed on existing crate lints (`chunks_exact` in `exec_write_snapshot.rs`, large `axum` `Err`), not on the MCP PATH change.

Desktop UI lane (`CI=true pnpm install --frozen-lockfile`, biome, lint, test, build) was not run here: `pnpm` is not installed in this sandbox.

Wire types regenerated with `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --lib wire_types` and copied to `mobile/src/generated/wire.ts`.