### PR TITLE
feat(connected-apps): make REST API and OpenAPI discovery practical

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client/apps.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/apps.ts
@@ -22,6 +22,7 @@ import {
   type PromptBody,
   type RestCredentialUpdate,
   type SkillInstructions,
+  type SpecDiscoveryInfo,
   type SpecPreviewInfo,
 } from "../types";
 import { attachedRemotely } from "../../host";
@@ -71,6 +72,15 @@ export function withAppsApi<TBase extends Constructor<HttpCore>>(Base: TBase) {
         method: "POST",
         headers: this.headers(true),
         body: JSON.stringify({ source }),
+      });
+    }
+
+    /** Probe well-known OpenAPI locations for one https origin or base URL. */
+    discoverRestSpec(origin: string): Promise<SpecDiscoveryInfo> {
+      return this.json("/connected-apps/rest/spec-discovery", {
+        method: "POST",
+        headers: this.headers(true),
+        body: JSON.stringify({ origin }),
       });
     }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -28,6 +28,8 @@ import {
   type RestCredentialStatus as WireRestCredentialStatus,
   type SpecPreviewInfo as WireSpecPreviewInfo,
   type SpecPreviewOperation as WireSpecPreviewOperation,
+  type SpecDiscoveryInfo as WireSpecDiscoveryInfo,
+  type SpecDiscoveryCandidate as WireSpecDiscoveryCandidate,
   type ExecCredentialReadiness as WireExecCredentialReadiness,
   type ExecProviderKind as WireExecProviderKind,
   type CodeDeliveryActionResult as WireCodeDeliveryActionResult,
@@ -552,6 +554,8 @@ export type ConnectedAppInfo = WireConnectedAppInfo;
 export type RestCredentialStatus = WireRestCredentialStatus;
 export type SpecPreviewInfo = WireSpecPreviewInfo;
 export type SpecPreviewOperation = WireSpecPreviewOperation;
+export type SpecDiscoveryInfo = WireSpecDiscoveryInfo;
+export type SpecDiscoveryCandidate = WireSpecDiscoveryCandidate;
 /** Where a stored REST credential is injected: `"bearer"` or a named header. */
 export type CredentialPlacement = WireCredentialPlacement;
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -5031,6 +5031,32 @@ instructions: string, };
 export type SkillOrigin = "builtin" | "user";
 
 /**
+ * One well-known location that returned a document.
+ */
+export type SpecDiscoveryCandidate = { url: string,
+/**
+ * Selectable operations when the document enumerates as OpenAPI 3 JSON.
+ */
+operation_count: number | null,
+/**
+ * Why the document cannot be used, when it cannot.
+ */
+unsupported_reason: string | null, };
+
+/**
+ * What probing one origin found.
+ */
+export type SpecDiscoveryInfo = {
+/**
+ * Candidate documents that answered, usable or not.
+ */
+candidates: Array<SpecDiscoveryCandidate>,
+/**
+ * Every location that was considered, in probe order.
+ */
+tried: Array<string>, };
+
+/**
  * What a document declares, for the configuration form's operation picker.
  * Renderer-safe: ids, methods, paths, and truncated summaries only.
  */

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -384,6 +384,102 @@ describe("ConnectedAppsPanel", () => {
     );
   });
 
+  it("discovery fills the document URL from a candidate and fetches operations", async () => {
+    const preview = {
+      document_sha256: "cd".repeat(32),
+      operations: [
+        {
+          operation_id: "listOrganizations",
+          method: "get",
+          path: "/api/organizations/",
+          summary: null,
+        },
+      ],
+      unlistable: 0,
+      truncated: false,
+    };
+    const client = api({
+      discoverRestSpec: vi.fn().mockResolvedValue({
+        candidates: [
+          {
+            url: "https://api.example.com/openapi.json",
+            operation_count: 1,
+            unsupported_reason: null,
+          },
+        ],
+        tried: [
+          "https://api.example.com/openapi.json",
+          "https://api.example.com/swagger.json",
+        ],
+      }),
+      previewRestSpec: vi.fn().mockResolvedValue(preview),
+    });
+    const user = userEvent.setup();
+    render(<ConnectedAppsPanel client={client} managed={false} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /Add REST API/ }),
+    );
+    await user.type(
+      screen.getByLabelText(/Base URL/),
+      "https://api.example.com",
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Find the OpenAPI document/ }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /Use this document/ }),
+    );
+
+    await waitFor(() =>
+      expect(client.previewRestSpec).toHaveBeenCalledWith({
+        url: "https://api.example.com/openapi.json",
+      }),
+    );
+    expect(screen.getByLabelText(/Document URL/)).toHaveValue(
+      "https://api.example.com/openapi.json",
+    );
+    expect(
+      await screen.findByRole("list", { name: "Operations" }),
+    ).toBeInTheDocument();
+  });
+
+  it("discovery with no candidates lists the locations tried", async () => {
+    const client = api({
+      discoverRestSpec: vi.fn().mockResolvedValue({
+        candidates: [],
+        tried: [
+          "https://api.example.com/openapi.json",
+          "https://api.example.com/swagger.json",
+        ],
+      }),
+    });
+    const user = userEvent.setup();
+    render(<ConnectedAppsPanel client={client} managed={false} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /Add REST API/ }),
+    );
+    await user.type(
+      screen.getByLabelText(/Base URL/),
+      "https://api.example.com",
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Find the OpenAPI document/ }),
+    );
+
+    expect(
+      await screen.findByText(/No OpenAPI document turned up/),
+    ).toBeInTheDocument();
+    await user.click(screen.getByText("Locations tried"));
+    expect(
+      screen.getByText("https://api.example.com/openapi.json"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Paste this example/ }),
+    ).toBeInTheDocument();
+  });
+
   it("an edit with an untouched value keeps the stored credential", async () => {
     const client = api();
     const user = userEvent.setup();

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -15,8 +15,15 @@ import {
   type ConnectedAppInfo,
   type CredentialPlacement,
   type RestCredentialUpdate,
+  type SpecDiscoveryInfo,
   type SpecPreviewInfo,
 } from "../api";
+import {
+  DiscoveryResults,
+  ingestErrorGuidance,
+  MINIMAL_OPENAPI_EXAMPLE,
+  NoPublicDocumentGuidance,
+} from "./OpenApiDiscovery";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -57,6 +64,7 @@ type Draft = {
    * whenever the source it came from changes, so a stale selection can never
    * outlive the document it was made against. */
   preview: SpecPreviewInfo | null;
+  discovery: SpecDiscoveryInfo | null;
   /** Selected operationIds; the saved catalog is exactly this set. */
   selected: string[];
   mode: CredentialMode;
@@ -78,6 +86,7 @@ function draftFor(existing: RestEntry | null): Draft {
     documentUrl: "",
     document: "",
     preview: null,
+    discovery: null,
     selected: [],
     mode:
       placement === null
@@ -125,13 +134,14 @@ function credentialLabel(entry: RestEntry): string {
 }
 
 function errorMessage(err: unknown): string {
+  let raw = err instanceof Error ? err.message : String(err);
   if (err instanceof HttpError) {
     const prefix = `${err.status}: `;
-    if (err.message.startsWith(prefix)) {
-      return err.message.slice(prefix.length);
+    if (raw.startsWith(prefix)) {
+      raw = raw.slice(prefix.length);
     }
   }
-  return err instanceof Error ? err.message : String(err);
+  return ingestErrorGuidance(raw);
 }
 
 /** The name an app entry leads with. A gateway-backed record shows the
@@ -408,6 +418,7 @@ export function ConnectedAppsPanel({
   const [formError, setFormError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [previewing, setPreviewing] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [reconnecting, setReconnecting] = useState<string | null>(null);
 
@@ -435,6 +446,62 @@ export function ConnectedAppsPanel({
     setDraft((current) =>
       current === null ? null : { ...current, ...change },
     );
+  }
+
+  async function findOpenApiDocument() {
+    if (draft === null) return;
+    const origin = draft.baseUrl.trim();
+    if (origin === "") {
+      setFormError("Enter the base URL first, then find the OpenAPI document.");
+      return;
+    }
+    setDiscovering(true);
+    setFormError(null);
+    try {
+      const discovery = await client.discoverRestSpec(origin);
+      update({ discovery });
+      const usable = discovery.candidates.find(
+        (candidate) => candidate.operation_count != null,
+      );
+      if (usable) {
+        toast.success("Found an OpenAPI document.");
+      } else {
+        toast.message("No OpenAPI document at the usual locations.");
+      }
+    } catch (err) {
+      setFormError(errorMessage(err));
+      toast.error(errorMessage(err));
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
+  async function chooseDiscovered(url: string) {
+    update({
+      source: "url",
+      documentUrl: url,
+      preview: null,
+      selected: [],
+    });
+    setPreviewing(true);
+    setFormError(null);
+    try {
+      const preview = await client.previewRestSpec({ url });
+      update({
+        source: "url",
+        documentUrl: url,
+        preview,
+        selected: defaultSelection(preview),
+      });
+      toast.success(
+        `Found ${preview.operations.length} operation${preview.operations.length === 1 ? "" : "s"}`,
+      );
+    } catch (err) {
+      setFormError(errorMessage(err));
+      toast.error(errorMessage(err));
+    } finally {
+      setPreviewing(false);
+    }
   }
 
   /** Enumerate the draft's document (URL or pasted) into the picker. */
@@ -666,15 +733,43 @@ export function ConnectedAppsPanel({
         label="Base URL"
         hint="https only; operation paths from the document append to it."
       >
-        <Input
-          value={draft.baseUrl}
-          disabled={saving}
-          autoComplete="off"
-          spellCheck={false}
-          placeholder="https://api.example.com/v2"
-          onChange={(event) => update({ baseUrl: event.target.value })}
-        />
+        <div className="flex gap-2">
+          <Input
+            value={draft.baseUrl}
+            disabled={saving || discovering}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="https://api.example.com/v2"
+            onChange={(event) =>
+              update({ baseUrl: event.target.value, discovery: null })
+            }
+          />
+          <Button
+            type="button"
+            variant="outline"
+            disabled={saving || discovering || previewing}
+            onClick={() => void findOpenApiDocument()}
+          >
+            {discovering && <Loader2 size={14} className="animate-spin" />}
+            {discovering ? "Searching…" : "Find the OpenAPI document"}
+          </Button>
+        </div>
       </SettingsField>
+      <DiscoveryResults
+        discovery={draft.discovery}
+        discovering={discovering}
+        onChoose={(url) => void chooseDiscovered(url)}
+      />
+      <NoPublicDocumentGuidance
+        onPasteExample={() =>
+          update({
+            source: "paste",
+            document: MINIMAL_OPENAPI_EXAMPLE,
+            preview: null,
+            selected: [],
+          })
+        }
+      />
       <div className="flex flex-col gap-1.5">
         <p className="font-bold">OpenAPI document</p>
         <p className="text-sm text-muted-foreground">
@@ -693,6 +788,7 @@ export function ConnectedAppsPanel({
             update({
               source: source as DocumentSource,
               preview: null,
+              discovery: source === "url" ? draft.discovery : null,
               selected: [],
             })
           }

--- a/crates/tidebreak-desktop/ui/src/settings/OpenApiDiscovery.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/OpenApiDiscovery.tsx
@@ -165,5 +165,3 @@ function TriedList({ tried }: { tried: string[] }) {
     </details>
   );
 }
-
-

--- a/crates/tidebreak-desktop/ui/src/settings/OpenApiDiscovery.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/OpenApiDiscovery.tsx
@@ -1,0 +1,169 @@
+import { Loader2 } from "lucide-react";
+
+import type { SpecDiscoveryInfo } from "../api";
+import { Button } from "@/components/ui/button";
+
+/** A copyable OpenAPI 3 JSON document with one GET, a path parameter, and a
+ * bearer header — enough to ingest when the vendor publishes nothing. */
+export const MINIMAL_OPENAPI_EXAMPLE = `{
+  "openapi": "3.0.3",
+  "info": { "title": "Example", "version": "1" },
+  "paths": {
+    "/items/{id}": {
+      "get": {
+        "operationId": "getItem",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "security": [{ "bearer": [] }]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearer": { "type": "http", "scheme": "bearer" }
+    }
+  }
+}`;
+
+export function ingestErrorGuidance(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes("scheme must be https")) {
+    return `${message} Use an https URL.`;
+  }
+  if (lower.includes("html")) {
+    return `${message} That URL is a documentation page. Find a link to the OpenAPI JSON, or paste the JSON itself.`;
+  }
+  if (lower.includes("yaml")) {
+    return `${message} Convert it to JSON, or point at a .json URL.`;
+  }
+  if (lower.includes("swagger 2.0")) {
+    return `${message} Export or convert it to OpenAPI 3 JSON.`;
+  }
+  return message;
+}
+
+export function NoPublicDocumentGuidance({
+  onPasteExample,
+}: {
+  onPasteExample: () => void;
+}) {
+  return (
+    <details className="text-sm text-muted-foreground">
+      <summary className="cursor-pointer font-medium text-foreground">
+        No public OpenAPI document?
+      </summary>
+      <ol className="mt-2 flex list-decimal flex-col gap-2 pl-5">
+        <li>
+          Check the vendor&apos;s developer portal for an OpenAPI, Swagger, or
+          API reference download link, then paste that URL.
+        </li>
+        <li>
+          If they publish no document, author a minimal OpenAPI 3 JSON listing
+          only the operations you need.
+          <div className="mt-1.5 flex flex-col gap-1.5">
+            <pre className="overflow-x-auto rounded-md border bg-transparent p-2 font-mono text-xs text-foreground">
+              {MINIMAL_OPENAPI_EXAMPLE}
+            </pre>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="self-start"
+              onClick={onPasteExample}
+            >
+              Paste this example
+            </Button>
+          </div>
+        </li>
+        <li>
+          If they offer an MCP server instead, add it under Settings → MCP
+          servers on this page.
+        </li>
+      </ol>
+    </details>
+  );
+}
+
+export function DiscoveryResults({
+  discovery,
+  discovering,
+  onChoose,
+}: {
+  discovery: SpecDiscoveryInfo | null;
+  discovering: boolean;
+  onChoose: (url: string) => void;
+}) {
+  if (discovering) {
+    return (
+      <p className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 size={14} className="animate-spin" />
+        Searching well-known OpenAPI locations…
+      </p>
+    );
+  }
+  if (discovery === null) return null;
+  const usable = discovery.candidates.filter(
+    (candidate) => candidate.operation_count != null,
+  );
+  const unsupported = discovery.candidates.filter(
+    (candidate) => candidate.unsupported_reason != null,
+  );
+  if (discovery.candidates.length === 0) {
+    return (
+      <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+        <p>No OpenAPI document turned up at the usual locations.</p>
+        <TriedList tried={discovery.tried} />
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {usable.length > 0 && (
+        <ul className="flex flex-col gap-1" aria-label="OpenAPI candidates">
+          {usable.map((candidate) => (
+            <li key={candidate.url} className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => onChoose(candidate.url)}
+              >
+                Use this document
+              </Button>
+              <span className="font-mono text-xs">
+                {candidate.url}
+                {candidate.operation_count != null
+                  ? ` · ${candidate.operation_count} operation${candidate.operation_count === 1 ? "" : "s"}`
+                  : ""}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {unsupported.map((candidate) => (
+        <p key={candidate.url} className="text-sm text-muted-foreground">
+          <span className="font-mono text-xs">{candidate.url}</span>
+          {": "}
+          {ingestErrorGuidance(candidate.unsupported_reason ?? "")}
+        </p>
+      ))}
+      {usable.length === 0 && <TriedList tried={discovery.tried} />}
+    </div>
+  );
+}
+
+function TriedList({ tried }: { tried: string[] }) {
+  return (
+    <details>
+      <summary className="cursor-pointer text-sm">Locations tried</summary>
+      <ul className="mt-1 font-mono text-xs">
+        {tried.map((url) => (
+          <li key={url}>{url}</li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+

--- a/crates/tidebreak-desktop/ui/src/stories/OpenApiDiscovery.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/OpenApiDiscovery.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import {
+  DiscoveryResults,
+  NoPublicDocumentGuidance,
+} from "@/settings/OpenApiDiscovery";
+
+const meta = {
+  title: "Settings/OpenAPI discovery",
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Searching: Story = {
+  render: () => (
+    <DiscoveryResults
+      discovery={null}
+      discovering
+      onChoose={fn()}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByText(
+        /Searching well-known OpenAPI locations/,
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const FoundCandidates: Story = {
+  render: () => (
+    <DiscoveryResults
+      discovering={false}
+      onChoose={fn()}
+      discovery={{
+        candidates: [
+          {
+            url: "https://api.example.com/openapi.json",
+            operation_count: 12,
+            unsupported_reason: null,
+          },
+          {
+            url: "https://api.example.com/openapi.yaml",
+            operation_count: null,
+            unsupported_reason:
+              "YAML OpenAPI documents are not supported; convert to JSON",
+          },
+        ],
+        tried: [
+          "https://api.example.com/openapi.json",
+          "https://api.example.com/openapi.yaml",
+        ],
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByRole("button", {
+        name: /Use this document/,
+      }),
+    ).toBeVisible();
+  },
+};
+
+export const NothingFound: Story = {
+  render: () => (
+    <DiscoveryResults
+      discovering={false}
+      onChoose={fn()}
+      discovery={{
+        candidates: [],
+        tried: [
+          "https://api.example.com/openapi.json",
+          "https://api.example.com/swagger.json",
+          "https://api.example.com/docs/openapi.json",
+        ],
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/No OpenAPI document turned up/),
+    ).toBeVisible();
+    await userEvent.click(canvas.getByText("Locations tried"));
+    await expect(
+      canvas.getByText("https://api.example.com/openapi.json"),
+    ).toBeVisible();
+  },
+};
+
+export const NoPublicDocument: Story = {
+  render: () => <NoPublicDocumentGuidance onPasteExample={fn()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByText("No public OpenAPI document?"),
+    );
+    await expect(
+      await canvas.findByRole("button", { name: /Paste this example/ }),
+    ).toBeVisible();
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/OpenApiDiscovery.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/OpenApiDiscovery.stories.tsx
@@ -16,11 +16,7 @@ type Story = StoryObj;
 
 export const Searching: Story = {
   render: () => (
-    <DiscoveryResults
-      discovery={null}
-      discovering
-      onChoose={fn()}
-    />
+    <DiscoveryResults discovery={null} discovering onChoose={fn()} />
   ),
   play: async ({ canvasElement }) => {
     await expect(
@@ -97,9 +93,7 @@ export const NoPublicDocument: Story = {
   render: () => <NoPublicDocumentGuidance onPasteExample={fn()} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(
-      canvas.getByText("No public OpenAPI document?"),
-    );
+    await userEvent.click(canvas.getByText("No public OpenAPI document?"));
     await expect(
       await canvas.findByRole("button", { name: /Paste this example/ }),
     ).toBeVisible();

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
@@ -57,6 +57,7 @@ type SettingsClientMethods = Pick<
   | "listConnectedApps"
   | "putRestConnectedApp"
   | "previewRestSpec"
+  | "discoverRestSpec"
   | "deleteRestConnectedApp"
   | "listMcpServers"
   | "putMcpServers"
@@ -548,6 +549,14 @@ function createSettingsStoryClient(
         operations: [],
         unlistable: 0,
         truncated: false,
+      }),
+    discoverRestSpec: () =>
+      write({
+        candidates: [],
+        tried: [
+          "https://api.example.com/openapi.json",
+          "https://api.example.com/swagger.json",
+        ],
       }),
     deleteRestConnectedApp: () => write(undefined),
     listMcpServers: () => read({ servers: state === "empty" ? [] : servers }),

--- a/crates/tidebreak-desktop/ui/src/stories/routeStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/routeStoryHarness.tsx
@@ -569,6 +569,7 @@ type RouteClientMethods = Pick<
   | "listConnectedApps"
   | "putRestConnectedApp"
   | "previewRestSpec"
+  | "discoverRestSpec"
   | "deleteRestConnectedApp"
   | "listMcpServers"
   | "putMcpServers"
@@ -716,6 +717,13 @@ export function storyClient(
       operations: [],
       unlistable: 0,
       truncated: false,
+    }),
+    discoverRestSpec: async () => ({
+      candidates: [],
+      tried: [
+        "https://api.example.com/openapi.json",
+        "https://api.example.com/swagger.json",
+      ],
     }),
     deleteRestConnectedApp: async () => {},
     listMcpServers: async () => ({ servers: [routeMcpServer] }),

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -65,6 +65,8 @@ mod obo_gateway;
 /// OpenAPI ingest into the bounded operation catalog a `rest_api` connected
 /// app stores and the governed REST executor validates against.
 pub mod openapi_catalog;
+/// Probe well-known OpenAPI document locations for a REST origin.
+pub(crate) mod openapi_discovery;
 /// Reading a conversation output's immutable revision bytes out of private
 /// scratch — shared by the HTTP routes and the desktop's native save dialog.
 pub mod output_files;
@@ -491,6 +493,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::post_rest_spec_preview).layer(DefaultBodyLimit::max(
                 routes::MAX_REST_CONNECTED_APP_BODY_BYTES,
             )),
+        )
+        .route(
+            "/connected-apps/rest/spec-discovery",
+            post(routes::post_rest_spec_discovery),
         )
         .route("/gateway/sign-in", post(routes::post_gateway_sign_in))
         .route("/gateway/sign-out", post(routes::post_gateway_sign_out))

--- a/crates/tidebreak-server/src/openapi_discovery.rs
+++ b/crates/tidebreak-server/src/openapi_discovery.rs
@@ -177,10 +177,9 @@ pub async fn discover_openapi_documents(
         }
         candidates
     };
-    let candidates = match tokio::time::timeout(DISCOVERY_DEADLINE, collect).await {
-        Ok(candidates) => candidates,
-        Err(_) => Vec::new(),
-    };
+    let candidates = tokio::time::timeout(DISCOVERY_DEADLINE, collect)
+        .await
+        .unwrap_or_default();
     Ok(SpecDiscoveryInfo { candidates, tried })
 }
 

--- a/crates/tidebreak-server/src/openapi_discovery.rs
+++ b/crates/tidebreak-server/src/openapi_discovery.rs
@@ -1,0 +1,287 @@
+//! Probe a bounded list of well-known OpenAPI document locations relative to
+//! an operator-supplied https origin or base URL.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+
+use crate::openapi_catalog::{enumerate_openapi_operations, OpenApiIngestError};
+use crate::rest_executor::{
+    fetch_spec_document_detailed, SpecFetchError, SpecRedirectPolicy, UrlAdmissionRefusal,
+};
+
+/// Locations tried relative to the origin and, when present, the supplied
+/// path prefix.
+pub const WELL_KNOWN_OPENAPI_PATHS: &[&str] = &[
+    "/openapi.json",
+    "/openapi/v3.json",
+    "/openapi.yaml",
+    "/swagger.json",
+    "/swagger/v1/swagger.json",
+    "/v3/api-docs",
+    "/api-docs",
+    "/api/openapi.json",
+    "/.well-known/openapi.json",
+    "/docs/openapi.json",
+];
+
+/// Concurrent probes against one origin.
+const DISCOVERY_CONCURRENCY: usize = 4;
+/// Wall-time budget for the whole probe set.
+pub const DISCOVERY_DEADLINE: Duration = Duration::from_secs(5);
+
+/// `POST /connected-apps/rest/spec-discovery` body.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpecDiscoveryRequest {
+    /// https origin or base URL the well-known paths are joined to.
+    pub origin: String,
+}
+
+/// What probing one origin found.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct SpecDiscoveryInfo {
+    /// Candidate documents that answered, usable or not.
+    pub candidates: Vec<SpecDiscoveryCandidate>,
+    /// Every location that was considered, in probe order.
+    pub tried: Vec<String>,
+}
+
+/// One well-known location that returned a document.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct SpecDiscoveryCandidate {
+    pub url: String,
+    /// Selectable operations when the document enumerates as OpenAPI 3 JSON.
+    pub operation_count: Option<usize>,
+    /// Why the document cannot be used, when it cannot.
+    pub unsupported_reason: Option<String>,
+}
+
+/// Why discovery refused the origin before probing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpecDiscoveryError {
+    InadmissibleUrl { reason: &'static str },
+    DeniedAddress,
+}
+
+impl std::fmt::Display for SpecDiscoveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InadmissibleUrl { reason } => write!(f, "origin is inadmissible: {reason}"),
+            Self::DeniedAddress => write!(f, "origin resolves into a denied network range"),
+        }
+    }
+}
+
+/// Join well-known paths to the origin and, when the URL carries a path
+/// prefix, to that prefix as well. Duplicates (origin already has no prefix)
+/// are dropped, preserving first-seen order.
+pub fn discovery_probe_urls(origin: &Url) -> Vec<String> {
+    let mut origin_root = origin.clone();
+    origin_root.set_path("/");
+    origin_root.set_query(None);
+    origin_root.set_fragment(None);
+    let prefix = origin.path().trim_end_matches('/');
+    let prefixed = if prefix.is_empty() || prefix == "/" {
+        None
+    } else {
+        let mut prefixed = origin.clone();
+        prefixed.set_path(prefix);
+        prefixed.set_query(None);
+        prefixed.set_fragment(None);
+        Some(prefixed)
+    };
+    let mut urls = Vec::new();
+    for path in WELL_KNOWN_OPENAPI_PATHS {
+        push_unique(&mut urls, join_path(&origin_root, path));
+        if let Some(base) = &prefixed {
+            push_unique(&mut urls, join_path(base, path));
+        }
+    }
+    urls
+}
+
+fn join_path(base: &Url, path: &str) -> String {
+    let mut url = base.clone();
+    let prefix = base.path().trim_end_matches('/');
+    url.set_path(&format!("{prefix}{path}"));
+    url.to_string()
+}
+
+fn push_unique(urls: &mut Vec<String>, url: String) {
+    if !urls.iter().any(|existing| existing == &url) {
+        urls.push(url);
+    }
+}
+
+fn admit_discovery_origin(origin: &str) -> Result<Url, SpecDiscoveryError> {
+    if cfg!(test) {
+        if let Ok(parsed) = Url::parse(origin) {
+            let loopback = matches!(parsed.host_str(), Some("127.0.0.1") | Some("[::1]"));
+            if parsed.scheme() == "http" && loopback {
+                return Ok(parsed);
+            }
+        }
+    }
+    crate::rest_executor::admit_https_url(origin, crate::rest_executor::UrlQueryPolicy::Refuse)
+        .map_err(|refusal| match refusal {
+            UrlAdmissionRefusal::Reason(reason) => SpecDiscoveryError::InadmissibleUrl { reason },
+            UrlAdmissionRefusal::DeniedAddress => SpecDiscoveryError::DeniedAddress,
+        })
+}
+
+/// Probe well-known locations. Hits that enumerate as OpenAPI 3 JSON are
+/// usable; YAML, HTML, and Swagger 2.0 are reported as found-but-unsupported.
+/// The first usable document cancels probes that have not started yet.
+pub async fn discover_openapi_documents(
+    origin: &str,
+) -> Result<SpecDiscoveryInfo, SpecDiscoveryError> {
+    let admitted = admit_discovery_origin(origin)?;
+    let tried = discovery_probe_urls(&admitted);
+    let permit = Arc::new(Semaphore::new(DISCOVERY_CONCURRENCY));
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let mut tasks = Vec::new();
+    for url in tried.clone() {
+        let permit = Arc::clone(&permit);
+        let stop = Arc::clone(&stop);
+        tasks.push(tokio::spawn(async move {
+            if stop.load(std::sync::atomic::Ordering::Relaxed) {
+                return None;
+            }
+            let Ok(_guard) = permit.acquire().await else {
+                return None;
+            };
+            if stop.load(std::sync::atomic::Ordering::Relaxed) {
+                return None;
+            }
+            let candidate = probe_location(&url).await;
+            if candidate
+                .as_ref()
+                .is_some_and(|found| found.operation_count.is_some())
+            {
+                stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+            candidate
+        }));
+    }
+
+    let collect = async {
+        let mut candidates = Vec::new();
+        for task in tasks {
+            if let Ok(Some(candidate)) = task.await {
+                candidates.push(candidate);
+            }
+        }
+        candidates
+    };
+    let candidates = match tokio::time::timeout(DISCOVERY_DEADLINE, collect).await {
+        Ok(candidates) => candidates,
+        Err(_) => Vec::new(),
+    };
+    Ok(SpecDiscoveryInfo { candidates, tried })
+}
+
+async fn probe_location(url: &str) -> Option<SpecDiscoveryCandidate> {
+    match fetch_spec_document_detailed(url, SpecRedirectPolicy::SameOrigin).await {
+        Ok(fetched) => Some(classify_document(
+            url,
+            fetched.content_type.as_deref(),
+            &fetched.body,
+        )),
+        Err(SpecFetchError::HttpStatus { .. })
+        | Err(SpecFetchError::CrossOriginRedirect)
+        | Err(SpecFetchError::Timeout)
+        | Err(SpecFetchError::Transport(_))
+        | Err(SpecFetchError::UnresolvableHost)
+        | Err(SpecFetchError::MalformedRedirect)
+        | Err(SpecFetchError::TooManyRedirects) => None,
+        Err(SpecFetchError::InadmissibleUrl { reason }) => Some(SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: None,
+            unsupported_reason: Some(format!("document URL is inadmissible: {reason}")),
+        }),
+        Err(SpecFetchError::DeniedAddress) => Some(SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: None,
+            unsupported_reason: Some("document URL resolves into a denied network range".into()),
+        }),
+        Err(SpecFetchError::DocumentTooLarge) => Some(SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: None,
+            unsupported_reason: Some(SpecFetchError::DocumentTooLarge.to_string()),
+        }),
+    }
+}
+
+fn classify_document(url: &str, content_type: Option<&str>, body: &[u8]) -> SpecDiscoveryCandidate {
+    let media = content_type.unwrap_or("").to_ascii_lowercase();
+    if media.contains("html") {
+        return SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: None,
+            unsupported_reason: Some(
+                "this URL returned an HTML page, not a JSON OpenAPI document".into(),
+            ),
+        };
+    }
+    let path_yaml = url.rsplit('/').next().is_some_and(|name| {
+        let lower = name.to_ascii_lowercase();
+        lower.ends_with(".yaml") || lower.ends_with(".yml")
+    });
+    if path_yaml || media.contains("yaml") || looks_like_yaml(body) {
+        return SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: None,
+            unsupported_reason: Some(
+                "YAML OpenAPI documents are not supported; convert to JSON".into(),
+            ),
+        };
+    }
+    match enumerate_openapi_operations(body) {
+        Ok(inventory) => SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: Some(inventory.operations.len()),
+            unsupported_reason: None,
+        },
+        Err(OpenApiIngestError::SwaggerNotSupported) => SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: None,
+            unsupported_reason: Some(OpenApiIngestError::SwaggerNotSupported.to_string()),
+        },
+        Err(error) => SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: None,
+            unsupported_reason: Some(error.to_string()),
+        },
+    }
+}
+
+fn looks_like_yaml(body: &[u8]) -> bool {
+    let text = std::str::from_utf8(body).unwrap_or("");
+    let trimmed = text.trim_start();
+    trimmed.starts_with("---")
+        || (trimmed.starts_with("openapi:") && !trimmed.starts_with('{'))
+        || (trimmed.starts_with("swagger:") && !trimmed.starts_with('{'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_and_origin_are_both_probed_without_duplicates() {
+        let origin = Url::parse("https://api.example.com/v2").unwrap();
+        let urls = discovery_probe_urls(&origin);
+        assert!(urls.contains(&"https://api.example.com/openapi.json".into()));
+        assert!(urls.contains(&"https://api.example.com/v2/openapi.json".into()));
+        assert!(urls.contains(&"https://api.example.com/openapi.yaml".into()));
+        let bare = discovery_probe_urls(&Url::parse("https://api.example.com/").unwrap());
+        assert_eq!(bare.len(), WELL_KNOWN_OPENAPI_PATHS.len());
+        assert!(bare
+            .iter()
+            .all(|url| url.starts_with("https://api.example.com/")));
+    }
+}

--- a/crates/tidebreak-server/src/rest_executor.rs
+++ b/crates/tidebreak-server/src/rest_executor.rs
@@ -572,17 +572,20 @@ pub(crate) fn admit_base_url(base_url: &str) -> Result<Url, RestExecuteError> {
 /// configuration that cannot mean anything; a document URL legitimately needs
 /// one (`?format=json`, versioned exports).
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum UrlQueryPolicy {
+pub(crate) enum UrlQueryPolicy {
     Refuse,
     Allow,
 }
 
-enum UrlAdmissionRefusal {
+pub(crate) enum UrlAdmissionRefusal {
     Reason(&'static str),
     DeniedAddress,
 }
 
-fn admit_https_url(url: &str, query: UrlQueryPolicy) -> Result<Url, UrlAdmissionRefusal> {
+pub(crate) fn admit_https_url(
+    url: &str,
+    query: UrlQueryPolicy,
+) -> Result<Url, UrlAdmissionRefusal> {
     let refuse = |reason| Err(UrlAdmissionRefusal::Reason(reason));
     if url.len() > MAX_REST_BASE_URL_BYTES {
         return refuse("URL exceeds the byte limit");
@@ -992,6 +995,25 @@ pub enum SpecFetchError {
     Timeout,
     #[error("fetch transport failed: {0}")]
     Transport(String),
+    #[error("a redirect left the original origin")]
+    CrossOriginRedirect,
+}
+
+/// Body and declared media type of a fetched OpenAPI document.
+#[derive(Debug)]
+pub(crate) struct FetchedSpecDocument {
+    pub body: Vec<u8>,
+    pub content_type: Option<String>,
+}
+
+/// Whether a spec fetch may follow a redirect onto another origin.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SpecRedirectPolicy {
+    /// Follow admitted hops, including a new origin (preview / upsert).
+    FollowAdmitted,
+    /// Stay on the original origin. Discovery uses this so a well-known
+    /// path cannot be turned into a cross-origin fetch.
+    SameOrigin,
 }
 
 /// Fetch an OpenAPI document from an operator-supplied URL, at configuration
@@ -1004,14 +1026,65 @@ pub enum SpecFetchError {
 /// time, so every `Location` gets the same vetting as the original URL and no
 /// credential is ever attached to any hop.
 pub(crate) async fn fetch_spec_document(url: &str) -> Result<Vec<u8>, SpecFetchError> {
+    fetch_spec_document_detailed(url, SpecRedirectPolicy::FollowAdmitted)
+        .await
+        .map(|fetched| fetched.body)
+}
+
+/// Fetch a document the way [`fetch_spec_document`] does, keeping the
+/// declared content type so discovery can tell JSON from HTML or YAML.
+#[cfg(test)]
+pub(crate) mod spec_fetch_mock {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    type MockFn = Arc<dyn Fn(&str) -> Result<FetchedSpecDocument, SpecFetchError> + Send + Sync>;
+
+    static MOCK: OnceLock<Mutex<Option<MockFn>>> = OnceLock::new();
+
+    fn slot() -> &'static Mutex<Option<MockFn>> {
+        MOCK.get_or_init(|| Mutex::new(None))
+    }
+
+    pub(crate) fn install(mock: MockFn) {
+        *slot().lock().expect("spec fetch mock") = Some(mock);
+    }
+
+    pub(crate) fn clear() {
+        *slot().lock().expect("spec fetch mock") = None;
+    }
+
+    pub(crate) fn try_fetch(url: &str) -> Option<Result<FetchedSpecDocument, SpecFetchError>> {
+        slot()
+            .lock()
+            .expect("spec fetch mock")
+            .as_ref()
+            .map(|mock| mock(url))
+    }
+}
+
+pub(crate) async fn fetch_spec_document_detailed(
+    url: &str,
+    redirects: SpecRedirectPolicy,
+) -> Result<FetchedSpecDocument, SpecFetchError> {
     let started = std::time::Instant::now();
     let mut current = url.to_string();
+    let origin = admit_spec_fetch_url(&current)?;
+    #[cfg(test)]
+    if let Some(mocked) = spec_fetch_mock::try_fetch(&current) {
+        let _ = redirects;
+        let _ = origin;
+        return mocked;
+    }
     for _ in 0..=MAX_SPEC_FETCH_REDIRECTS {
-        let admitted =
-            admit_https_url(&current, UrlQueryPolicy::Allow).map_err(|refusal| match refusal {
-                UrlAdmissionRefusal::Reason(reason) => SpecFetchError::InadmissibleUrl { reason },
-                UrlAdmissionRefusal::DeniedAddress => SpecFetchError::DeniedAddress,
-            })?;
+        let admitted = admit_spec_fetch_url(&current)?;
+        if redirects == SpecRedirectPolicy::SameOrigin
+            && (admitted.scheme() != origin.scheme()
+                || admitted.host() != origin.host()
+                || admitted.port_or_known_default() != origin.port_or_known_default())
+        {
+            return Err(SpecFetchError::CrossOriginRedirect);
+        }
         let remaining = SPEC_FETCH_TIMEOUT
             .checked_sub(started.elapsed())
             .ok_or(SpecFetchError::Timeout)?;
@@ -1040,17 +1113,22 @@ pub(crate) async fn fetch_spec_document(url: &str) -> Result<Vec<u8>, SpecFetchE
             None => Vec::new(),
         };
 
+        let https_only = admitted.scheme() != "http";
         let mut builder = reqwest::Client::builder()
             // Load-bearing for the same reason as the operation transport: a
             // discovered proxy would dial the proxy, not the vetted address.
             .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
-            .https_only(true)
+            .https_only(https_only)
+            .http1_only()
             .user_agent(REST_EXECUTOR_USER_AGENT)
             .connect_timeout(remaining.min(Duration::from_secs(10)))
             .timeout(remaining);
         if let Some(domain) = admitted.domain() {
-            let port = admitted.port_or_known_default().unwrap_or(443);
+            let port =
+                admitted
+                    .port_or_known_default()
+                    .unwrap_or(if https_only { 443 } else { 80 });
             let pinned: Vec<std::net::SocketAddr> = addresses
                 .iter()
                 .map(|address| std::net::SocketAddr::new(*address, port))
@@ -1060,7 +1138,10 @@ pub(crate) async fn fetch_spec_document(url: &str) -> Result<Vec<u8>, SpecFetchE
         let client = builder.build().map_err(spec_transport_failure)?;
         let response = client
             .get(admitted.clone())
-            .header(reqwest::header::ACCEPT, "application/json")
+            .header(
+                reqwest::header::ACCEPT,
+                "application/json, application/yaml, text/yaml;q=0.8",
+            )
             .send()
             .await
             .map_err(spec_transport_failure)?;
@@ -1073,6 +1154,13 @@ pub(crate) async fn fetch_spec_document(url: &str) -> Result<Vec<u8>, SpecFetchE
                 .and_then(|value| value.to_str().ok())
                 .and_then(|location| admitted.join(location).ok())
                 .ok_or(SpecFetchError::MalformedRedirect)?;
+            if redirects == SpecRedirectPolicy::SameOrigin
+                && (location.scheme() != origin.scheme()
+                    || location.host() != origin.host()
+                    || location.port_or_known_default() != origin.port_or_known_default())
+            {
+                return Err(SpecFetchError::CrossOriginRedirect);
+            }
             current = location.to_string();
             continue;
         }
@@ -1081,6 +1169,12 @@ pub(crate) async fn fetch_spec_document(url: &str) -> Result<Vec<u8>, SpecFetchE
                 status: status.as_u16(),
             });
         }
+
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
 
         let cap = crate::openapi_catalog::MAX_OPENAPI_DOCUMENT_BYTES;
         if response
@@ -1099,9 +1193,27 @@ pub(crate) async fn fetch_spec_document(url: &str) -> Result<Vec<u8>, SpecFetchE
             }
             body.extend_from_slice(&chunk);
         }
-        return Ok(body);
+        return Ok(FetchedSpecDocument { body, content_type });
     }
     Err(SpecFetchError::TooManyRedirects)
+}
+
+/// Admit a document URL. Tests may fetch `http://127.0.0.1` so a local mock
+/// server can stand in for a vendor origin; production still requires https
+/// and the denied-network list.
+fn admit_spec_fetch_url(url: &str) -> Result<Url, SpecFetchError> {
+    if cfg!(test) {
+        if let Ok(parsed) = Url::parse(url) {
+            let loopback = matches!(parsed.host_str(), Some("127.0.0.1") | Some("[::1]"));
+            if parsed.scheme() == "http" && loopback {
+                return Ok(parsed);
+            }
+        }
+    }
+    admit_https_url(url, UrlQueryPolicy::Allow).map_err(|refusal| match refusal {
+        UrlAdmissionRefusal::Reason(reason) => SpecFetchError::InadmissibleUrl { reason },
+        UrlAdmissionRefusal::DeniedAddress => SpecFetchError::DeniedAddress,
+    })
 }
 
 /// Map a spec-fetch transport failure, URL-stripped, timeout told apart.

--- a/crates/tidebreak-server/src/routes/connected_apps.rs
+++ b/crates/tidebreak-server/src/routes/connected_apps.rs
@@ -26,6 +26,9 @@ use crate::mcp_curated::McpCuration;
 use crate::openapi_catalog::{
     enumerate_openapi_operations, ingest_openapi_document, sha256_hex, MAX_OPENAPI_DOCUMENT_BYTES,
 };
+use crate::openapi_discovery::{
+    discover_openapi_documents, SpecDiscoveryError, SpecDiscoveryInfo, SpecDiscoveryRequest,
+};
 use crate::principal::AuthContext;
 use crate::providers::managed_profile_refusal;
 use crate::rest_executor::{
@@ -485,6 +488,34 @@ pub async fn post_rest_spec_preview(
         unlistable: inventory.unlistable,
         truncated: inventory.truncated,
     }))
+}
+
+/// `POST /connected-apps/rest/spec-discovery` — probe well-known OpenAPI
+/// document locations relative to one https origin or base URL.
+///
+/// Refused on managed profiles like the preview: this surface exists only to
+/// configure local REST records, and it performs egress.
+pub async fn post_rest_spec_discovery(
+    State(state): State<AppState>,
+    Json(body): Json<SpecDiscoveryRequest>,
+) -> Result<Json<SpecDiscoveryInfo>, ServerError> {
+    let policy = state.managed_policy()?;
+    if policy.managed {
+        return Err(managed_profile_refusal(
+            "REST connected apps are managed by your organization's gateway",
+        ));
+    }
+    discover_openapi_documents(&body.origin)
+        .await
+        .map(Json)
+        .map_err(|error| match error {
+            SpecDiscoveryError::DeniedAddress => {
+                ServerError::bad_request_kind("spec_fetch", error.to_string())
+            }
+            SpecDiscoveryError::InadmissibleUrl { .. } => {
+                ServerError::bad_request_kind("spec_fetch", error.to_string())
+            }
+        })
 }
 
 /// Every stored `rest_api` record, in storage order.

--- a/crates/tidebreak-server/src/tests/conformance.rs
+++ b/crates/tidebreak-server/src/tests/conformance.rs
@@ -558,6 +558,7 @@ fn deployment_plane_routes() -> Vec<(&'static str, &'static str)> {
         ("PUT", "/connected-apps/rest/example"),
         ("DELETE", "/connected-apps/rest/example"),
         ("POST", "/connected-apps/rest/spec-preview"),
+        ("POST", "/connected-apps/rest/spec-discovery"),
         ("POST", "/gateway/sign-in"),
         ("POST", "/gateway/sign-out"),
         ("POST", "/gateway/models/sync"),

--- a/crates/tidebreak-server/src/tests/connected_apps.rs
+++ b/crates/tidebreak-server/src/tests/connected_apps.rs
@@ -674,11 +674,9 @@ async fn post_discovery(router: &Router, bearer: &str, origin: &str) -> axum::re
 /// Local mock origin: 200 at `ok_path`, 404 elsewhere. Hits still go through
 /// `fetch_spec_document_detailed` admission; the body is served in-process
 /// because this environment cannot accept loopback TCP.
-fn discovery_mock_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-    LOCK.get_or_init(|| std::sync::Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+async fn discovery_mock_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(())).lock().await
 }
 
 fn install_mock_origin(ok_path: &'static str, body: Vec<u8>, content_type: &'static str) {
@@ -700,7 +698,7 @@ fn install_mock_origin(ok_path: &'static str, body: Vec<u8>, content_type: &'sta
 
 #[tokio::test]
 async fn spec_discovery_finds_a_well_known_document() {
-    let _guard = discovery_mock_lock();
+    let _guard = discovery_mock_lock().await;
     let spec = issues_spec();
     install_mock_origin("/openapi.json", spec.into_bytes(), "application/json");
     let origin = "https://api.example.com";
@@ -728,9 +726,13 @@ async fn spec_discovery_finds_a_well_known_document() {
 
 #[tokio::test]
 async fn spec_discovery_reports_yaml_as_unsupported() {
-    let _guard = discovery_mock_lock();
+    let _guard = discovery_mock_lock().await;
     let yaml = "openapi: 3.0.3\ninfo:\n  title: Issues\n  version: '1'\npaths: {}\n";
-    install_mock_origin("/openapi.yaml", yaml.to_string().into_bytes(), "application/yaml");
+    install_mock_origin(
+        "/openapi.yaml",
+        yaml.to_string().into_bytes(),
+        "application/yaml",
+    );
     let (router, bearer, _state, _dir) = connected_apps_test_app().await;
     let response = post_discovery(&router, &bearer, "https://api.example.com").await;
     crate::rest_executor::spec_fetch_mock::clear();

--- a/crates/tidebreak-server/src/tests/connected_apps.rs
+++ b/crates/tidebreak-server/src/tests/connected_apps.rs
@@ -655,6 +655,113 @@ async fn managed_profiles_refuse_rest_upserts_but_allow_delete() {
     assert!(state.store.list_connected_apps().await.unwrap().is_empty());
 }
 
+async fn post_discovery(router: &Router, bearer: &str, origin: &str) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/connected-apps/rest/spec-discovery")
+                .header("authorization", bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "origin": origin }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// Local mock origin: 200 at `ok_path`, 404 elsewhere. Hits still go through
+/// `fetch_spec_document_detailed` admission; the body is served in-process
+/// because this environment cannot accept loopback TCP.
+fn discovery_mock_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn install_mock_origin(ok_path: &'static str, body: Vec<u8>, content_type: &'static str) {
+    crate::rest_executor::spec_fetch_mock::install(std::sync::Arc::new(move |url: &str| {
+        let path = reqwest::Url::parse(url)
+            .ok()
+            .map(|parsed| parsed.path().to_owned())
+            .unwrap_or_default();
+        if path == ok_path {
+            Ok(crate::rest_executor::FetchedSpecDocument {
+                body: body.clone(),
+                content_type: Some(content_type.to_owned()),
+            })
+        } else {
+            Err(crate::rest_executor::SpecFetchError::HttpStatus { status: 404 })
+        }
+    }));
+}
+
+#[tokio::test]
+async fn spec_discovery_finds_a_well_known_document() {
+    let _guard = discovery_mock_lock();
+    let spec = issues_spec();
+    install_mock_origin("/openapi.json", spec.into_bytes(), "application/json");
+    let origin = "https://api.example.com";
+    let (router, bearer, _state, _dir) = connected_apps_test_app().await;
+    let response = post_discovery(&router, &bearer, origin).await;
+    crate::rest_executor::spec_fetch_mock::clear();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&raw_body(response).await).unwrap();
+    let tried = body["tried"].as_array().expect("tried list");
+    assert!(
+        tried
+            .iter()
+            .any(|url| url.as_str().unwrap().ends_with("/openapi.json")),
+        "{tried:?}"
+    );
+    assert!(tried.len() >= crate::openapi_discovery::WELL_KNOWN_OPENAPI_PATHS.len());
+    let candidates = body["candidates"].as_array().expect("candidates");
+    let hit = candidates
+        .iter()
+        .find(|c| c["url"].as_str().unwrap().ends_with("/openapi.json"))
+        .expect("openapi.json candidate");
+    assert_eq!(hit["operation_count"], json!(2));
+    assert!(hit["unsupported_reason"].is_null());
+}
+
+#[tokio::test]
+async fn spec_discovery_reports_yaml_as_unsupported() {
+    let _guard = discovery_mock_lock();
+    let yaml = "openapi: 3.0.3\ninfo:\n  title: Issues\n  version: '1'\npaths: {}\n";
+    install_mock_origin("/openapi.yaml", yaml.to_string().into_bytes(), "application/yaml");
+    let (router, bearer, _state, _dir) = connected_apps_test_app().await;
+    let response = post_discovery(&router, &bearer, "https://api.example.com").await;
+    crate::rest_executor::spec_fetch_mock::clear();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&raw_body(response).await).unwrap();
+    let hit = body["candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["url"].as_str().unwrap().ends_with("/openapi.yaml"))
+        .expect("yaml candidate");
+    assert!(hit["operation_count"].is_null());
+    assert!(
+        hit["unsupported_reason"].as_str().unwrap().contains("YAML"),
+        "{hit}"
+    );
+}
+
+#[tokio::test]
+async fn spec_discovery_refuses_a_denied_address() {
+    let (router, bearer, _state, _dir) = connected_apps_test_app().await;
+    let response = post_discovery(&router, &bearer, "https://127.0.0.1").await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = serde_json::from_str(&raw_body(response).await).unwrap();
+    assert_eq!(body["kind"], json!("spec_fetch"));
+    assert!(
+        body["message"].as_str().unwrap().contains("denied"),
+        "{body}"
+    );
+}
+
 /// A local app with one `rest_api` binding, created straight through the
 /// store so grant tests don't route through the authoring surface.
 fn bound_app(name: &str, connected: ConnectedAppId) -> CreateApp {

--- a/crates/tidebreak-server/src/tests/connected_apps.rs
+++ b/crates/tidebreak-server/src/tests/connected_apps.rs
@@ -676,7 +676,9 @@ async fn post_discovery(router: &Router, bearer: &str, origin: &str) -> axum::re
 /// because this environment cannot accept loopback TCP.
 async fn discovery_mock_lock() -> tokio::sync::MutexGuard<'static, ()> {
     static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
-    LOCK.get_or_init(|| tokio::sync::Mutex::new(())).lock().await
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
 }
 
 fn install_mock_origin(ok_path: &'static str, body: Vec<u8>, content_type: &'static str) {

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -428,6 +428,7 @@ mod tests {
         // The spec-preview response: what a document declares, for the REST
         // form's operation picker.
         generate::collect_from::<crate::routes::SpecPreviewInfo>(&cfg, &mut out);
+        generate::collect_from::<crate::openapi_discovery::SpecDiscoveryInfo>(&cfg, &mut out);
         // Named separately because `serde(flatten)` inlines it into
         // `McpServerInfo` rather than referencing it, so the walk never reaches
         // it — and the renderer uses it on its own as the PUT body shape.

--- a/docs/connected-apps.md
+++ b/docs/connected-apps.md
@@ -31,6 +31,29 @@ Two kinds initially:
   leaves the secret store except inside the executor at request time.
   Credential-less entries (public APIs) are allowed and still governed.
 
+## Finding the OpenAPI document
+
+The REST setup form does not assume you already have the document URL.
+Enter the API's https base URL and use **Find the OpenAPI document**. The
+server probes a fixed list of well-known paths on that origin (`/openapi.json`,
+`/swagger.json`, `/v3/api-docs`, and similar), with the same https, SSRF,
+size, and time bounds as a document fetch. Choose a candidate to fill the
+document URL and list operations.
+
+If nothing turns up:
+
+1. Check the vendor's developer portal for an OpenAPI, Swagger, or API
+   reference download link, and paste that URL.
+2. If they publish no document, author a minimal OpenAPI 3 JSON listing
+   only the operations you need (one GET with a path parameter is enough
+   to ingest) and paste it.
+3. If they offer an MCP server instead, add it under Settings → MCP
+   servers.
+
+YAML, Swagger 2.0, and HTML documentation pages are reported as found but
+unusable; convert to OpenAPI 3 JSON. Discovery does not search the web or
+ask a model.
+
 The vocabulary matches the model gateway's (`connected_apps` with an
 `app_kind` including both REST and MCP kinds) deliberately: a managed
 profile's gateway-served apps and an unmanaged profile's local ones read as

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -5031,6 +5031,32 @@ instructions: string, };
 export type SkillOrigin = "builtin" | "user";
 
 /**
+ * One well-known location that returned a document.
+ */
+export type SpecDiscoveryCandidate = { url: string,
+/**
+ * Selectable operations when the document enumerates as OpenAPI 3 JSON.
+ */
+operation_count: number | null,
+/**
+ * Why the document cannot be used, when it cannot.
+ */
+unsupported_reason: string | null, };
+
+/**
+ * What probing one origin found.
+ */
+export type SpecDiscoveryInfo = {
+/**
+ * Candidate documents that answered, usable or not.
+ */
+candidates: Array<SpecDiscoveryCandidate>,
+/**
+ * Every location that was considered, in probe order.
+ */
+tried: Array<string>, };
+
+/**
  * What a document declares, for the configuration form's operation picker.
  * Renderer-safe: ids, methods, paths, and truncated summaries only.
  */


### PR DESCRIPTION
Closes #3035

## What changed

The REST connected-app form no longer assumes you already have the OpenAPI document URL.

**Server.** `POST /connected-apps/rest/spec-discovery` takes one https origin or base URL (same managed-profile refusal as spec preview). It probes a fixed list of well-known paths on the origin and, when present, the path prefix (`/openapi.json`, `/openapi/v3.json`, `/openapi.yaml`, `/swagger.json`, `/swagger/v1/swagger.json`, `/v3/api-docs`, `/api-docs`, `/api/openapi.json`, `/.well-known/openapi.json`, `/docs/openapi.json`). Each fetch uses the existing spec-document admission (https, SSRF, size, time). Probes run with concurrency 4 and a 5s overall deadline. Cross-origin redirects are not followed. The response lists candidates (operation count, or why they cannot be used: YAML, Swagger 2.0, HTML) and every location tried.

**UI.** Next to the base URL, **Find the OpenAPI document** calls that route, shows candidates, and choosing one fills the document URL and runs the existing preview. On failure it lists the probed locations. **No public OpenAPI document?** is always on the form: check the vendor portal; paste a minimal OpenAPI 3 JSON example (one GET with a path parameter and a bearer header); or add an MCP server on this page. Ingest errors for http, HTML, YAML, and Swagger 2.0 keep the server text and add a next step.

**Docs.** `docs/connected-apps.md` has a short "Finding the OpenAPI document" section.

## Follow-up (deliberately not in this slice)

- Model-assisted or web-search discovery of a company's API domain / OpenAPI URL from a product name.

## What I ran

- `cargo fmt --all`
- `cargo check -p tidebreak-server --tests`
- `cargo test -p tidebreak-server connected_apps` — discovery tests pass. `the_listing_carries_mounted_tool_names_only` fails here because this sandbox cannot accept loopback TCP (pre-existing MCP mock); it is unrelated to discovery.
- `cargo test -p tidebreak-server rest_executor` — pass
- `cargo clippy -p tidebreak-server --tests -- -D warnings` — fails on two findings in `harness_llm.rs` and `exec_write_snapshot.rs` that this change does not touch
- Desktop UI: `CI=true pnpm install --frozen-lockfile` could not finish (cdn.sheetjs.com `xlsx` fetch failed in this sandbox), so biome/lint/test/build and `pnpm storybook:build` were not run here. CI should run those lanes.

Wire types were regenerated with `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --lib the_generated_bindings_are_current` and copied to `mobile/src/generated/wire.ts`.