### PR TITLE
fix(terminal): keep PTY size and keystrokes aligned with the pane

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.dom.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@xterm/xterm", () => ({
     }
     loadAddon() {}
     open() {}
+    focus() {}
     dispose() {}
     onData() {
       return { dispose() {} };

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -107,6 +107,7 @@ vi.mock("@xterm/xterm", () => ({
     }
     loadAddon() {}
     open() {}
+    focus() {}
     dispose() {}
     onData() {
       return { dispose() {} };

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
@@ -39,6 +39,7 @@ vi.mock("@xterm/xterm", () => ({
     }
     loadAddon() {}
     open() {}
+    focus() {}
     dispose() {
       this.disposed = true;
     }
@@ -228,6 +229,24 @@ describe("TerminalPane", () => {
     );
   });
 
+  it("resizes the PTY to the renderer once the shell is attached", async () => {
+    const client = clientWith();
+    render(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-1" />,
+    );
+    await expectReady();
+    expect(client.resizeCodeTerminal).toHaveBeenCalledTimes(1);
+    expect(client.resizeCodeTerminal).toHaveBeenCalledWith(
+      "ws-1",
+      "term-1",
+      80,
+      24,
+    );
+
+    fireEvent(window, new Event("resize"));
+    expect(client.resizeCodeTerminal).toHaveBeenCalledTimes(1);
+  });
+
   it("serializes writes while an earlier request is delayed", async () => {
     const first = deferred<void>();
     const writeCodeTerminal = vi
@@ -280,7 +299,6 @@ describe("TerminalPane", () => {
       "aria-disabled",
       "true",
     );
-    expect(terminals.at(-1)?.options.disableStdin).toBe(true);
 
     emitData("ignored");
     expect(writeCodeTerminal).toHaveBeenCalledTimes(1);

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -263,6 +263,7 @@ export function TerminalPane({
   const rafRef = useRef<number | null>(null);
   const lastFlushRef = useRef(Date.now());
   const inputPausedRef = useRef(true);
+  const sentSizeRef = useRef<{ cols: number; rows: number } | null>(null);
   const stalledRef = useRef(false);
   const [generation, setGeneration] = useState(0);
   const [ended, setEnded] = useState(false);
@@ -287,7 +288,6 @@ export function TerminalPane({
       convertEol: true,
       fontSize: 13,
       cursorBlink: true,
-      disableStdin: true,
       theme: readXtermTheme(),
     });
     const fit = new FitAddon();
@@ -335,11 +335,7 @@ export function TerminalPane({
       const active = activeTerminalRef.current;
       const tid =
         active?.epoch === identityEpoch ? active.writer.terminalId : null;
-      const dims =
-        term.cols && term.rows ? { cols: term.cols, rows: term.rows } : null;
-      if (tid && dims) {
-        void client.resizeCodeTerminal(workspaceId, tid, dims.cols, dims.rows);
-      }
+      if (tid) syncPtySize(tid);
     };
     window.addEventListener("resize", onResize);
     const observer =
@@ -387,6 +383,7 @@ export function TerminalPane({
     pendingRef.current = "";
     cursorRef.current = 0;
     tidRef.current = null;
+    sentSizeRef.current = null;
     activeTerminalRef.current = null;
 
     async function pull(): Promise<boolean> {
@@ -467,6 +464,10 @@ export function TerminalPane({
         cursorRef.current = 0;
         const writer = writerFor(snap.id);
         activeTerminalRef.current = { epoch: identityEpoch, writer };
+        // Fit often reports before this id exists, and a tab that re-attaches
+        // to a live shell never goes through create. Push the renderer size
+        // now so the PTY and xterm agree on columns.
+        syncPtySize(snap.id);
         if (writer.failed) {
           surfaceWriteFailure(writer);
         } else {
@@ -671,11 +672,30 @@ export function TerminalPane({
     });
   }
 
+  function syncPtySize(terminalId: string) {
+    const term = termRef.current;
+    const cols = term?.cols;
+    const rows = term?.rows;
+    if (!cols || !rows) return;
+    const sent = sentSizeRef.current;
+    if (sent && sent.cols === cols && sent.rows === rows) return;
+    sentSizeRef.current = { cols, rows };
+    void client.resizeCodeTerminal(workspaceId, terminalId, cols, rows);
+  }
+
   function setInputPausedForCurrent(paused: boolean) {
+    const wasPaused = inputPausedRef.current;
     inputPausedRef.current = paused;
     setInputPaused(paused);
-    const term = termRef.current;
-    if (term?.options) term.options.disableStdin = paused;
+    // Do not toggle xterm `disableStdin`. That sets the helper textarea
+    // `readOnly`, and WKWebView then drops keys on the still-focused field.
+    // onData already ignores input while paused.
+    if (wasPaused && !paused) {
+      const host = hostRef.current;
+      if (host && host.contains(document.activeElement)) {
+        termRef.current?.focus();
+      }
+    }
   }
 
   function retryTerminal() {
@@ -859,7 +879,7 @@ export function TerminalPane({
       <div className="relative min-h-0 flex-1">
         <div
           ref={hostRef}
-          className="h-full"
+          className="terminal-host h-full overflow-hidden"
           data-testid="terminal-host"
           // xterm builds its own tree inside this host; the host itself is a
           // plain div, so it needs a role that takes a name before the label

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -2130,6 +2130,24 @@ body {
   }
 } /* @layer components */
 
+/* xterm.css is unlayered, so these have to be too. WKWebView does not deliver
+   keys to a helper textarea parked at -9999em, and a fitted pane with a
+   forced viewport scrollbar makes the PTY and renderer disagree on columns. */
+.terminal-host .xterm {
+  width: 100%;
+  height: 100%;
+}
+
+.terminal-host .xterm .xterm-helper-textarea {
+  left: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.terminal-host .xterm .xterm-viewport {
+  overflow-y: auto;
+}
+
 /* Scrollbar styling. The thumb rests dim and brightens on hover; scoping the
    color to scrollable containers keeps it from painting on every element.
    These rules must stay unlayered to override Tailwind v4's unlayered


### PR DESCRIPTION
Typing in a workspace terminal wrapped at 80 columns and dropped keys after the first pause.

The tab creates the shell at 80×24, then xterm fits the pane later and never told the PTY. Pausing input also set xterm `disableStdin`, which marks the helper textarea `readOnly`; WKWebView then stops delivering keys to that field.

This resizes the PTY as soon as the pane attaches, keeps stdin enabled (the write path already ignores paused input), and keeps the helper textarea inside the pane.

## Test plan

- Open a workspace terminal and type, backspace, and use arrow keys across the full width of the pane.
- Pause input (ended shell or a failed write), then recover. Typing should work again without clicking away.
- Resize the window and confirm wrapping follows the pane.