### PR TITLE
fix(code): open the workspace conversation as soon as the session exists

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -942,6 +942,57 @@ describe("NewWorkspaceDialog", () => {
     );
   });
 
+  it("drops the handoff once the session exists, before the first turn finishes", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const turn = deferred<CodeTurnSubmission>();
+    const submitCodeTurn = vi.fn(() => turn.promise);
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace: vi.fn(async () =>
+            workspace("ws-live", "repo-new", "2026-08-20T00:00:00.000Z"),
+          ),
+          createCodeSession: vi.fn(async () =>
+            session("ws-live", "claude_code", "2026-08-20T00:00:00.000Z"),
+          ),
+          submitCodeTurn,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "First message" }), {
+      target: { value: "list the files" },
+    });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-live"),
+    );
+    await waitFor(() => expect(submitCodeTurn).toHaveBeenCalled());
+    expect(
+      useCodeUiStore.getState().workspaceStartups["ws-live"],
+    ).toBeUndefined();
+    expect(
+      useCodeCatalogStore.getState().sessionsByWorkspace["ws-live"]?.id,
+    ).toBe("sess-ws-live");
+    turn.resolve({ kind: "turn" } as unknown as CodeTurnSubmission);
+    await turn.promise;
+  });
+
   it("attaches a pasted image instead of inserting its clipboard path", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({

--- a/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
@@ -72,7 +72,11 @@ export async function resolveSessionModel(input: {
  * by the workspace, so `reveal` runs first: the page the reader lands on is
  * the one carrying the steps. A failed session leaves the text with the
  * workspace composer, and a failed first turn does the same, so typed words
- * and pasted images are never dropped. The handoff clears on every exit.
+ * and pasted images are never dropped.
+ *
+ * The handoff clears as soon as the session exists. `POST /turns` waits for
+ * the worker to finish the turn, so leaving the overlay up until submit
+ * returns would cover the conversation for the whole first reply.
  */
 export async function startFirstSession(input: {
   client: ApiClient;
@@ -148,14 +152,11 @@ export async function startFirstSession(input: {
       ...(settings.fastMode ? { fast_mode: true } : {}),
     });
     useCodeCatalogStore.getState().rememberSession(session);
-    if (prompt) {
-      setWorkspaceStartup(workspace.id, {
-        ...base,
-        hasFirstMessage: true,
-        phase: "sending_message",
-      });
-    }
     input.onSessionCreated?.(session, posted);
+    // Drop the steps before posting the first turn so the workspace page can
+    // open the session socket and stream. The route does not return until
+    // the turn ends.
+    setWorkspaceStartup(workspace.id, null);
     if (prompt) {
       try {
         const attachments = await publishFirstTurnImages(

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.test.ts
@@ -63,10 +63,46 @@ function searchOf(call: unknown): Record<string, unknown> {
   return { ...args.search({ tabs: "kept" }), replace: args.replace };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => useCodeCatalogStore.getState().reset());
 afterEach(cleanup);
 
 describe("useWorkspaceSessions", () => {
+  it("picks up a session remembered after mount, before the list returns", () => {
+    const list = deferred<CodeSessionSnapshot[]>();
+    const client = {
+      getCodeWorkspace: vi.fn(async () => codeWorkspace),
+      listCodeWorkspaceSessions: vi.fn(() => list.promise),
+      getCodeRepo: vi.fn(async () => deliveryCodeRepo),
+    };
+    const { result } = renderHook(() =>
+      useWorkspaceSessions({
+        workspaceId: codeWorkspace.id,
+        client: client as never,
+        models: [],
+        defaultModelKey: null,
+        taskParam: undefined,
+        navigate: vi.fn() as never,
+        focusConversationPane: vi.fn(),
+      }),
+    );
+
+    expect(result.current.session).toBeNull();
+    act(() => {
+      useCodeCatalogStore.getState().rememberSession(main);
+    });
+    expect(result.current.session?.id).toBe("sess-main");
+    expect(result.current.startingNewAgent).toBe(false);
+    list.resolve([main]);
+  });
+
   it("shows the first live agent when nothing is named", async () => {
     const { result } = setup([main, sibling]);
     await waitFor(() => expect(result.current.session?.id).toBe("sess-main"));

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
@@ -139,15 +139,32 @@ export function useWorkspaceSessions({
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const [starting, setStarting] = useState(false);
-  const conversations = useMemo(() => liveCodeSessions(sessions), [sessions]);
-  const session = useMemo(
-    () => sessions.find((entry) => entry.id === activeSessionId) ?? null,
-    [activeSessionId, sessions],
-  );
-  const conversationDigests = useConversationDigests(workspaceId);
   const rememberedSession = useCodeCatalogStore(
     (state) => state.sessionsByWorkspace[workspaceId] ?? null,
   );
+  // A create remembers the session before this page's list returns, and
+  // before the merge effect below runs. Fold it in during render so dropping
+  // the startup overlay does not flash the empty start prompt for a frame.
+  const listedSessions = useMemo(() => {
+    if (!rememberedSession) return sessions;
+    if (sessions.some((entry) => entry.id === rememberedSession.id)) {
+      return sessions;
+    }
+    return [rememberedSession, ...sessions];
+  }, [rememberedSession, sessions]);
+  const conversations = useMemo(
+    () => liveCodeSessions(listedSessions),
+    [listedSessions],
+  );
+  const session = useMemo(() => {
+    const selected = listedSessions.find(
+      (entry) => entry.id === activeSessionId,
+    );
+    if (selected) return selected;
+    if (draftAgent || activeSessionId) return null;
+    return conversations[0] ?? null;
+  }, [activeSessionId, conversations, draftAgent, listedSessions]);
+  const conversationDigests = useConversationDigests(workspaceId);
 
   useEffect(() => {
     startRequestRef.current += 1;


### PR DESCRIPTION
## What

Creating a workspace with a first message left the starting steps on screen until you refreshed, even after the agent had begun answering.

`POST /turns` waits until that first turn finishes. The create handoff waited for the same response, so the workspace page never opened the session socket while the turn ran.

The overlay now clears as soon as the session exists. The page also reads a remembered session during render, so dropping the overlay does not flash the empty start prompt.

## Why

A refresh should not be required to watch the first reply.

## Test plan

- [ ] Create a workspace with a first message. The conversation appears while the agent is still working.
- [ ] Create a workspace with no first message. The start composer still appears after the session exists.
- [ ] If the first turn fails to send, the prompt returns to the workspace composer.

Focused checks: `biome check` on the four touched files; `vitest run` for `NewWorkspaceDialog.dom.test.tsx`, `useWorkspaceSessions.test.ts`, and `CodeWorkspacePage.dom.test.tsx` (113 passed).