### PR TITLE
fix(desktop): use the shared Spinner on busy refresh controls

### DIFF
--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -245,6 +245,9 @@ markers, not as decorative advertising.
 - Do not place an icon in a colored or gray container on high-density
   surfaces. `EmptyMedia variant="icon"` draws no container at all, and it is
   the only icon treatment allowed on an empty surface.
+- Indeterminate progress uses `Spinner`. A busy refresh control swaps to that
+  glyph. Do not put `animate-spin` on `RefreshCw` or `RotateCw`: Lucide's ink
+  box is not the viewBox center, so the glyph orbits.
 
 ### Destructive actions
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeAnalyticsPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeAnalyticsPage.tsx
@@ -20,6 +20,7 @@ import type {
   HarnessKind,
 } from "@/api/types";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import {
   Empty,
   EmptyDescription,
@@ -150,7 +151,7 @@ export function CodeAnalyticsBody() {
               disabled={refreshing}
               onClick={() => void refresh()}
             >
-              <RefreshCw className={cn(refreshing && "animate-spin")} />
+              {refreshing ? <Spinner aria-hidden /> : <RefreshCw />}
               Refresh
             </Button>
           </div>
@@ -457,9 +458,11 @@ function QuotaCard({
           disabled={quota.refreshing}
           onClick={() => void quota.refresh()}
         >
-          <RefreshCw
-            className={cn("size-3.5", quota.refreshing && "animate-spin")}
-          />
+          {quota.refreshing ? (
+            <Spinner className="size-3.5" aria-hidden />
+          ) : (
+            <RefreshCw className="size-3.5" />
+          )}
         </button>
       </div>
       <div className="p-4">

--- a/crates/tidebreak-desktop/ui/src/code/CodeSubscriptionUsage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSubscriptionUsage.tsx
@@ -6,6 +6,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { ClaudeIcon, OpenAIIcon, XaiIcon } from "@/ProviderIcons";
 import { SidebarButton } from "@/sidebar/primitives";
@@ -91,9 +92,11 @@ export function CodeSubscriptionUsage() {
             disabled={refreshing}
             onClick={() => void refresh()}
           >
-            <RefreshCw
-              className={cn("size-3.5", refreshing && "animate-spin")}
-            />
+            {refreshing ? (
+              <Spinner className="size-3.5" aria-hidden />
+            ) : (
+              <RefreshCw className="size-3.5" />
+            )}
           </button>
         </div>
 

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -15,6 +15,7 @@ import type {
 } from "../api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import {
@@ -111,10 +112,11 @@ export function DoctorList({
               onClick={onRefresh}
               disabled={refreshing || checkingUpdates}
             >
-              <RotateCw
-                className={cn("size-3.5", refreshing && "animate-spin")}
-                aria-hidden="true"
-              />
+              {refreshing ? (
+                <Spinner aria-hidden="true" />
+              ) : (
+                <RotateCw className="size-3.5" aria-hidden="true" />
+              )}
               {refreshing ? "Checking…" : "Re-check"}
             </Button>
           )}

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -35,6 +35,7 @@ import type {
 } from "../api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import {
   Dialog,
   DialogOverlay,
@@ -760,11 +761,7 @@ function PrDetailHeader({
             disabled={loading}
             onClick={onRefresh}
           >
-            {loading ? (
-              <LoaderCircle className="animate-spin" />
-            ) : (
-              <RefreshCw />
-            )}
+            {loading ? <Spinner aria-hidden /> : <RefreshCw />}
             <span className="sr-only">Refresh</span>
           </Button>
           {onClose ? (

--- a/crates/tidebreak-desktop/ui/src/code/delivery/RunDetailSheet.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/RunDetailSheet.tsx
@@ -16,13 +16,8 @@ import {
   PartialErrorBanner,
   RunStateText,
 } from "./status";
-import {
-  ExternalLink,
-  GitBranch,
-  LoaderCircle,
-  RefreshCw,
-  X,
-} from "lucide-react";
+import { ExternalLink, GitBranch, RefreshCw, X } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
 import { codeDeliveryRepositoryTarget } from "../CodeDeliveryStore";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { humanize, runBucket } from "./helpers";
@@ -194,11 +189,7 @@ export function RunDetailSheet({
                     disabled={Boolean(busy)}
                     onClick={() => void rerun("all")}
                   >
-                    {busy === "all" ? (
-                      <LoaderCircle className="animate-spin" />
-                    ) : (
-                      <RefreshCw />
-                    )}
+                    {busy === "all" ? <Spinner aria-hidden /> : <RefreshCw />}
                     Rerun all
                   </Button>
                 )}
@@ -209,11 +200,7 @@ export function RunDetailSheet({
                   disabled={Boolean(busy)}
                   onClick={() => void rerun("failed")}
                 >
-                  {busy === "failed" ? (
-                    <LoaderCircle className="animate-spin" />
-                  ) : (
-                    <RefreshCw />
-                  )}
+                  {busy === "failed" ? <Spinner aria-hidden /> : <RefreshCw />}
                   Rerun failed
                 </Button>
               )}

--- a/crates/tidebreak-desktop/ui/src/code/delivery/status.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/status.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
-import { CircleAlert, GitBranch, LoaderCircle, RefreshCw } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import { CircleAlert, GitBranch, RefreshCw } from "lucide-react";
 import type {
   CodeDeliveryRunSummary,
   CodeDeliverySourceError,
@@ -50,7 +51,7 @@ export function FreshnessBar({
         disabled={loading}
         onClick={onRefresh}
       >
-        {loading ? <LoaderCircle className="animate-spin" /> : <RefreshCw />}
+        {loading ? <Spinner aria-hidden /> : <RefreshCw />}
         Refresh
       </Button>
     </div>

--- a/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { AlertTriangle, RefreshCw, RotateCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { ClipboardCopyButton } from "../ClipboardCopyButton";
 import { hasNativeHost } from "../host";
 import type { DesktopUpdateState } from "../updates";
@@ -100,7 +101,7 @@ export function UpdatesPanel({
               disabled={!state.enabled || busy}
               onClick={() => void onCheck()}
             >
-              <RefreshCw className={busy ? "animate-spin" : undefined} />
+              {busy ? <Spinner aria-hidden /> : <RefreshCw />}
               {state.status === "checking"
                 ? "Checking…"
                 : state.status === "downloading"

--- a/crates/tidebreak-desktop/ui/src/stories/Spinner.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Spinner.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RefreshCw } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { AttentionBadge } from "@/code/AttentionBadge";
 import { HARNESS_ICONS } from "@/code/HarnessPicker";
@@ -29,6 +31,22 @@ export const Sizes: Story = {
       <Spinner className="size-3.5" />
       <Spinner className="size-4" />
       <Spinner className="size-6" />
+    </div>
+  ),
+};
+
+/** A busy refresh control swaps to Spinner. Do not spin RefreshCw. */
+export const OnRefreshButton: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Button type="button" size="sm" variant="outline">
+        <RefreshCw />
+        Refresh
+      </Button>
+      <Button type="button" size="sm" variant="outline" disabled>
+        <Spinner aria-hidden />
+        Refresh
+      </Button>
     </div>
   ),
 };

--- a/crates/tidebreak-desktop/ui/src/stylesContract.test.ts
+++ b/crates/tidebreak-desktop/ui/src/stylesContract.test.ts
@@ -53,6 +53,19 @@ function offenders(pattern: RegExp, skip?: ReadonlySet<string>): string[] {
   return hits;
 }
 
+/** RefreshCw / RotateCw JSX that also carries animate-spin. */
+const SPINNING_LUCIDE_REFRESH = /<(RefreshCw|RotateCw)\b[^>]*animate-spin/;
+
+function spinningRefreshIcons(): string[] {
+  const hits: string[] = [];
+  for (const file of sourceFiles()) {
+    if (/\.test\.(ts|tsx)$/.test(file)) continue;
+    const text = readFileSync(join(SRC, file), "utf8");
+    if (SPINNING_LUCIDE_REFRESH.test(text)) hits.push(file);
+  }
+  return hits;
+}
+
 describe("styles contract (see DESIGN.md)", () => {
   it("uses the pinned type scale, not arbitrary sizes", () => {
     expect(
@@ -68,6 +81,14 @@ describe("styles contract (see DESIGN.md)", () => {
       "Color state through the status tones (statusTone.ts, Badge) and " +
         "identity through --icon-*. See DESIGN.md; allowlist a genuine " +
         "document-viewer convention here with a reason.",
+    ).toEqual([]);
+  });
+
+  it("does not spin Lucide refresh icons", () => {
+    expect(
+      spinningRefreshIcons(),
+      "Busy refresh controls swap to Spinner from components/ui/spinner.tsx. " +
+        "Lucide RefreshCw and RotateCw orbit under animate-spin. See DESIGN.md.",
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Busy refresh buttons spun Lucide `RefreshCw` or `RotateCw`. Those glyphs orbit under `animate-spin` because the ink box is not the viewBox center.

The buttons now swap to the shared `Spinner` while work is in flight. The styles contract fails if a refresh icon is spun again.

## Validation
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check` on the changed files
- `pnpm --dir crates/tidebreak-desktop/ui test src/stylesContract.test.ts`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`