### PR TITLE
fix(code): avoid duplicate Claude recaps

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -1043,7 +1043,7 @@ describe("CodeTranscript", () => {
       screen.getByText("Now check what identity we store for the child."),
     ).toBeInTheDocument();
   });
-  it("shows the session recap on the newest turn boundary only", () => {
+  it("shows the session recap in the newest closing message only", () => {
     const boundary = (id: string, turnId: string): CodeTranscriptItem => ({
       kind: "turn_boundary",
       id,
@@ -1054,17 +1054,107 @@ describe("CodeTranscript", () => {
       error: null,
       diffstat: null,
     });
+    const closing = (
+      id: string,
+      turnId: string,
+      text: string,
+    ): CodeTranscriptItem => ({
+      kind: "assistant",
+      id,
+      turnId,
+      parentCallId: null,
+      text,
+      streaming: false,
+    });
     const recap = "Retry test passes. Next: fold the backoff into refresh.";
     render(
       <CodeTranscript
-        items={[boundary("b1", "t1"), boundary("b2", "t2")]}
+        items={[
+          closing("a1", "t1", "The first turn finished."),
+          boundary("b1", "t1"),
+          closing("a2", "t2", "The second turn finished."),
+          boundary("b2", "t2"),
+        ]}
         recap={recap}
       />,
     );
 
-    // One copy, not one per turn: the line describes where the session stands,
-    // so an older boundary carrying it would be stale the moment it rendered.
     expect(screen.getAllByText(recap)).toHaveLength(1);
+    expect(screen.getAllByText("Recap")).toHaveLength(1);
+    expect(
+      within(screen.getAllByLabelText("Assistant")[1]!).getByText(recap),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getAllByRole("group", { name: "Turn finished" })[1]!,
+      ).queryByText(recap),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the stored closing recap instead of a second session recap", () => {
+    const original = "Workspace switching now reuses recent transcript stores.";
+    const closingRecap =
+      "Workspace switching reuses recent transcript stores. It reconnects from the last event sequence.";
+    const sessionRecap =
+      "Recent transcript stores now survive workspace switches.";
+    render(
+      <CodeTranscript
+        recap={sessionRecap}
+        items={[
+          {
+            kind: "assistant",
+            id: "a-final",
+            turnId: "t1",
+            parentCallId: null,
+            text: original,
+            streaming: false,
+            rewrite: closingRecap,
+            rewriteState: "rewritten",
+          },
+          {
+            kind: "turn_boundary",
+            id: "b1",
+            turnId: "t1",
+            status: "completed",
+            durationMs: 4_000,
+            usage: USAGE,
+            error: null,
+            diffstat: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(closingRecap)).toBeInTheDocument();
+    expect(screen.queryByText(sessionRecap)).not.toBeInTheDocument();
+    expect(screen.getAllByText("Recap")).toHaveLength(1);
+  });
+
+  it("shows a standalone recap when the turn has no closing message", () => {
+    const recap = "The interrupted turn left the retry test unchanged.";
+    render(
+      <CodeTranscript
+        recap={recap}
+        items={[
+          {
+            kind: "turn_boundary",
+            id: "b1",
+            turnId: "t1",
+            status: "interrupted",
+            durationMs: 4_000,
+            usage: USAGE,
+            error: null,
+            diffstat: null,
+          },
+        ]}
+      />,
+    );
+
+    const standalone = screen.getByLabelText("Recap");
+    expect(within(standalone).getByText(recap)).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Turn interrupted" }),
+    ).not.toHaveTextContent(recap);
   });
 
   it("keeps the original closing message and shows the recap beside it", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -119,11 +119,11 @@ export function CodeTranscript({
   contentRef?: RefCallback<HTMLDivElement>;
   onScroll?: () => void;
   /**
-   * Where the session stands, shown on the newest turn boundary.
+   * Where the session stands, shown in the newest turn's recap block.
    *
    * Derived after a turn completes rather than streamed with it, so it appears
-   * a moment later than the boundary it lands on — which is the point: it is
-   * written for the reader who left and came back, not the one watching.
+   * a moment later than the closing message it joins. It is written for the
+   * reader who left and came back, not the one watching.
    */
   recap?: string;
 }) {
@@ -166,13 +166,30 @@ export function CodeTranscript({
     );
   }
   const presentationItems = codeTranscriptPresentationItems(items);
-  // The recap belongs to the session, so only its newest boundary carries one.
+  // The recap belongs to the newest settled turn. Put it on that turn's final
+  // assistant row, which is where captured Claude recaps already live.
   let newestBoundaryId: string | undefined;
+  let newestBoundaryTurnId: string | undefined;
   for (let index = presentationItems.length - 1; index >= 0; index -= 1) {
     const item = presentationItems[index];
     if (item?.kind === "turn_boundary") {
       newestBoundaryId = item.id;
+      newestBoundaryTurnId = item.turnId ?? undefined;
       break;
+    }
+  }
+  let recapOwnerId: string | undefined;
+  if (newestBoundaryTurnId) {
+    for (let index = presentationItems.length - 1; index >= 0; index -= 1) {
+      const item = presentationItems[index];
+      if (
+        item?.kind === "assistant" &&
+        item.turnId === newestBoundaryTurnId &&
+        item.parentCallId === null
+      ) {
+        recapOwnerId = item.id;
+        break;
+      }
     }
   }
   const copyOwnerIds = assistantCopyOwnerIds(items, busy);
@@ -224,7 +241,12 @@ export function CodeTranscript({
                   onFileIssue={onFileIssue}
                   sessionId={sessionId}
                   onReveal={onReveal}
-                  recap={row.item.id === newestBoundaryId ? recap : undefined}
+                  recap={
+                    row.item.id === recapOwnerId ||
+                    (!recapOwnerId && row.item.id === newestBoundaryId)
+                      ? recap
+                      : undefined
+                  }
                 />,
               ),
         )}
@@ -575,11 +597,10 @@ const TranscriptItem = memo(function TranscriptItem({
   sessionId?: string;
   onReveal?: () => void;
   /**
-   * Where the session stands, on the newest turn boundary only.
+   * Where the session stands, on the newest turn's recap row only.
    *
-   * Passed to exactly one row: the recap describes the session, not the turn,
-   * so repeating it at every boundary would fill a long transcript with stale
-   * copies of a line that is only true at the bottom.
+   * Passed to exactly one row. The closing assistant message owns the recap
+   * when one exists; the turn boundary owns a standalone fallback otherwise.
    */
   recap?: string;
 }) {
@@ -620,6 +641,7 @@ const TranscriptItem = memo(function TranscriptItem({
           item={item}
           animateStreaming={animateStreaming}
           ownsCopyAction={ownsCopyAction}
+          recap={recap}
         />
       );
     case "reasoning":
@@ -687,17 +709,15 @@ const TranscriptItem = memo(function TranscriptItem({
     }
     case "turn_boundary":
       return (
-        <TurnReviewCard
-          turn={item}
-          onOpenTurnDiff={onOpenTurnDiff}
-          onForkFromTurn={onForkFromTurn}
-          onFileIssue={onFileIssue}
-          narrative={
-            recap ? (
-              <span className="text-muted-foreground">{recap}</span>
-            ) : undefined
-          }
-        />
+        <>
+          {recap && <StandaloneRecap text={recap} />}
+          <TurnReviewCard
+            turn={item}
+            onOpenTurnDiff={onOpenTurnDiff}
+            onForkFromTurn={onForkFromTurn}
+            onFileIssue={onFileIssue}
+          />
+        </>
       );
   }
 });
@@ -706,20 +726,24 @@ function AssistantRewriteMessage({
   item,
   animateStreaming,
   ownsCopyAction,
+  recap,
 }: {
   item: Extract<CodeTranscriptItem, { kind: "assistant" }>;
   animateStreaming: boolean;
   ownsCopyAction?: boolean;
+  /** Fallback recap for engines that do not supply a captured closing recap. */
+  recap?: string;
 }) {
   const rewritten = item.rewriteState === "rewritten" && Boolean(item.rewrite);
+  const displayedRecap = rewritten && item.rewrite ? item.rewrite : recap;
   return (
     <article className="message message-assistant" aria-label="Assistant">
-      {item.rewriteState === "rewriting" && (
+      {item.rewriteState === "rewriting" && !displayedRecap && (
         <p className="text-muted-foreground mb-2 text-xs" role="status">
           Writing a recap…
         </p>
       )}
-      {item.rewriteState === "failed" && (
+      {item.rewriteState === "failed" && !displayedRecap && (
         <p className="text-muted-foreground mb-2 text-xs" role="status">
           Couldn't write a recap. The original stands.
         </p>
@@ -728,14 +752,7 @@ function AssistantRewriteMessage({
         text={item.text}
         streaming={item.streaming && animateStreaming}
       />
-      {rewritten && item.rewrite && (
-        <div className="mt-3 border-t border-border-subtle pt-3">
-          <p className="text-muted-foreground mb-1 text-2xs font-medium tracking-wide uppercase">
-            Recap
-          </p>
-          <AssistantMessageBody text={item.rewrite} streaming={false} />
-        </div>
-      )}
+      {displayedRecap && <RecapBlock text={displayedRecap} separated />}
       <MessageFooter
         role="assistant"
         text={item.text}
@@ -743,6 +760,31 @@ function AssistantRewriteMessage({
         sequenceEnd={ownsCopyAction}
       />
     </article>
+  );
+}
+
+function StandaloneRecap({ text }: { text: string }) {
+  return (
+    <article className="message message-assistant" aria-label="Recap">
+      <RecapBlock text={text} />
+    </article>
+  );
+}
+
+function RecapBlock({
+  text,
+  separated = false,
+}: {
+  text: string;
+  separated?: boolean;
+}) {
+  return (
+    <div className={cn(separated && "mt-3 border-t border-border-subtle pt-3")}>
+      <p className="text-muted-foreground mb-1 text-2xs font-medium tracking-wide uppercase">
+        Recap
+      </p>
+      <AssistantMessageBody text={text} streaming={false} />
+    </div>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -74,22 +74,11 @@ export function harnessVersionRequirement(error: string | null): string | null {
 
 export function TurnReviewCard({
   turn,
-  narrative,
   onOpenTurnDiff,
   onForkFromTurn,
   onFileIssue,
 }: {
   turn: TurnBoundary;
-  /**
-   * Where the session stands, on the newest boundary only.
-   *
-   * Not the engine's own account of the turn — no engine event carries one,
-   * and that stays a documented gap. This is Tidebreak's recap, derived on the
-   * utility model after the turn completes and written for a reader who left
-   * and came back, which is why it sits at the bottom of the transcript rather
-   * than against every turn.
-   */
-  narrative?: ReactNode;
   /** Scope the review sidebar to this turn's changes. */
   onOpenTurnDiff?: (turnId: string) => void;
   /** Hand everything up to this turn to a fresh agent, in a new tab. */
@@ -131,7 +120,6 @@ export function TurnReviewCard({
         ) : (
           <p>{turn.error ?? "The engine stopped without saying why."}</p>
         )}
-        {narrative}
         {(diffstat || actions || onFileIssue) && (
           <div className="flex items-center gap-2">
             {diffstat}
@@ -149,7 +137,6 @@ export function TurnReviewCard({
         <CircleSlash size={13} aria-hidden="true" />
         <span>Turn interrupted</span>
         {duration && <span className="tabular-nums">· {duration}</span>}
-        {narrative}
         {diffstat}
         {actions}
       </SeamRow>
@@ -161,7 +148,6 @@ export function TurnReviewCard({
       <Check size={13} aria-hidden="true" />
       <span>Turn finished</span>
       {duration && <span className="tabular-nums">· {duration}</span>}
-      {narrative}
       {diffstat}
       {actions}
     </SeamRow>

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -88,7 +88,7 @@ describe("AgentsPanel", () => {
     );
   });
 
-  it("turns off future code turn recaps", async () => {
+  it("turns off future fallback recaps", async () => {
     const settings: RuntimeSettings = {
       model: null,
       has_api_key: false,
@@ -131,7 +131,7 @@ describe("AgentsPanel", () => {
 
     render(<AgentsPanel client={client} />);
     const toggle = await screen.findByRole("switch", {
-      name: "Write turn recaps",
+      name: "Write fallback recaps",
     });
     expect(toggle).toBeChecked();
 

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
@@ -176,17 +176,17 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
       </SettingsSection>
       <SettingsSection
         title="Turn recaps"
-        description="After a coding turn finishes, Tidebreak can add a one-line update beside the turn result."
+        description="Tidebreak keeps Claude Code's captured recap. For other engines, it can add a one-line fallback after the turn finishes."
       >
         <SettingsField
-          label="Write turn recaps"
-          hint="Uses the utility model after each completed coding turn. Turning this off affects future turns; existing recaps stay in the transcript."
+          label="Write fallback recaps"
+          hint="Uses the utility model when the engine does not supply a recap. Turning this off stops future fallback recaps; existing recaps stay in the transcript."
         >
           <Switch
             checked={turnRecapsEnabled}
             disabled={loading || savingTurnRecaps}
             onCheckedChange={(enabled) => void saveTurnRecaps(enabled)}
-            aria-label="Write turn recaps"
+            aria-label="Write fallback recaps"
           />
         </SettingsField>
       </SettingsSection>

--- a/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
@@ -111,6 +111,53 @@ export const ProgressUpdates: Story = {
   },
 };
 
+/** A fallback recap uses the same block as a captured closing recap. */
+export const SessionRecap: Story = {
+  args: {
+    items,
+    recap:
+      "Workspace switching reuses recent transcript stores. Next: verify the reconnect path under rapid workspace changes.",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Recap")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("group", { name: "Turn finished" }),
+    ).not.toHaveTextContent(
+      "Workspace switching reuses recent transcript stores",
+    );
+  },
+};
+
+/** A turn with no closing message keeps the fallback recap above its boundary. */
+export const SessionRecapWithoutClosingMessage: Story = {
+  args: {
+    items: [
+      items[0],
+      {
+        kind: "turn_boundary",
+        id: "boundary-interrupted",
+        turnId: "turn-1",
+        status: "interrupted",
+        durationMs: 18_000,
+        usage: null,
+        error: null,
+        diffstat: null,
+      },
+    ],
+    recap: "The interrupted turn left the transcript store unchanged.",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText("Recap")).toHaveTextContent(
+      "The interrupted turn left the transcript store unchanged.",
+    );
+    await expect(
+      canvas.getByRole("group", { name: "Turn interrupted" }),
+    ).not.toHaveTextContent("transcript store unchanged");
+  },
+};
+
 const rewrittenItems: CodeTranscriptItem[] = items.map((item) =>
   item.kind === "assistant" && item.id === "assistant-final"
     ? {

--- a/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
@@ -61,21 +61,6 @@ export const CompletedWithTurnActions: Story = {
   args: { onForkFromTurn: fn() },
 };
 
-/**
- * The newest boundary carries the session recap, so a reader who left and came
- * back reads where the work stands instead of the last twenty tool calls.
- */
-export const CompletedWithRecap: Story = {
-  args: {
-    narrative: (
-      <span className="text-muted-foreground">
-        Auth middleware is wired up and its tests pass. Next: hook the refresh
-        path into the session store.
-      </span>
-    ),
-  },
-};
-
 /** A turn that changed nothing still says it finished, without a zero-stat chip. */
 export const CompletedNoChanges: Story = {
   args: {

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -452,7 +452,13 @@ async fn build_digest(
     // The newest recapped turn speaks for the session: a turn the model
     // declined to recap, or one whose call is still in flight, leaves the
     // previous line standing rather than blanking the row mid-work.
-    let recap = turns.into_iter().rev().find_map(|turn| turn.narrative);
+    // Claude Code supplies its own closing recap. Do not carry an older
+    // Tidebreak fallback forward after a Claude turn finishes.
+    let recap = if session.harness_kind == tidebreak_core::HarnessKind::ClaudeCode {
+        None
+    } else {
+        turns.into_iter().rev().find_map(|turn| turn.narrative)
+    };
     // A session with no workspace is titled by its conversation, which
     // nothing names yet; the client falls back to its own label.
     let (title, pr_state) = match workspace {

--- a/crates/tidebreak-server/src/code/recap.rs
+++ b/crates/tidebreak-server/src/code/recap.rs
@@ -5,13 +5,10 @@
 //! calls" — it is "where is this, and what happens next". This answers that in
 //! a sentence, derived once per turn and stored on the turn it describes.
 //!
-//! Claude Code has the same feature and calls it `awaySummary`, but we cannot
-//! reuse it: it reaches its reader through the TUI's own Ink hook or through
-//! `notifyMetadataChanged({recap})` on the Remote Control channel, and we drive
-//! engines headlessly over stream-json, which carries neither. `/recap` is a
-//! TUI-local command rather than a turn we can send. Codex, OpenCode, and Grok
-//! have no equivalent at all. Deriving it ourselves is what makes it the same
-//! feature on all four engines instead of a Claude Code detail.
+//! Claude Code already closes a successful turn with a captured assistant
+//! recap. Running this derivation too repeats the same outcome and spends a
+//! second model call. Claude sessions therefore keep the captured recap, while
+//! the other engines use this fallback when the setting is enabled.
 //!
 //! It is not asked of the harness. A recap asked there would be a real turn: it
 //! would append to the engine's own history, land in the transcript, and
@@ -52,7 +49,7 @@ use tidebreak_core::db::code::{
     get_session, get_turn, list_recent_events, list_turns, set_turn_narrative,
 };
 use tidebreak_core::{
-    CodeEvent, CodeSessionId, CodeTurnId, CodeTurnStatus, DbStore, OwnerId, Result,
+    CodeEvent, CodeSessionId, CodeTurnId, CodeTurnStatus, DbStore, HarnessKind, OwnerId, Result,
 };
 
 use crate::chat_titling::{derive_text_with_retries, head, Proposal};
@@ -60,8 +57,8 @@ use crate::resolver::ProviderResolver;
 
 use super::bus::CodeEventBus;
 
-/// Store key. Default on: completed code turns receive a one-line recap unless
-/// the reader turns the feature off in agent settings.
+/// Store key. Default on: completed turns that need a fallback receive a
+/// one-line recap unless the reader turns the feature off in agent settings.
 pub(crate) const TURN_RECAPS_SETTING: &str = "code.turn_recaps";
 
 /// Longest recap stored, and the bound the schema states.
@@ -133,9 +130,9 @@ pub(crate) enum Outcome {
     Recapped(String),
     /// The model declined: the turn is not worth a line.
     Declined,
-    /// Nothing to do — recaps are off, the turn is missing, unfinished,
-    /// already recapped, has nothing to describe, or this machine has no
-    /// utility model.
+    /// Nothing to do — recaps are off, Claude already supplied one, the turn
+    /// is missing, unfinished, already recapped, has nothing to describe, or
+    /// this machine has no utility model.
     NotApplicable,
 }
 
@@ -243,6 +240,12 @@ impl TurnRecapper {
         let Some(session) = get_session(&self.db, owner, session_id).await? else {
             return Ok(Outcome::NotApplicable);
         };
+        // Claude Code's final top-level assistant message is already captured
+        // in the transcript and presented as the turn recap. A second utility
+        // call would restate it in another UI slot.
+        if session.harness_kind == HarnessKind::ClaudeCode {
+            return Ok(Outcome::NotApplicable);
+        }
         let material = self.material(owner, session_id, &turn).await?;
         if material.is_empty() {
             // A turn with no request and no journaled work says nothing worth

--- a/crates/tidebreak-server/src/tests/code_recap.rs
+++ b/crates/tidebreak-server/src/tests/code_recap.rs
@@ -10,7 +10,7 @@ use super::*;
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use axum::Router;
-use tidebreak_harness::AdapterRegistry;
+use tidebreak_harness::{AdapterRegistry, HarnessEvent};
 use tokio::net::TcpListener;
 
 /// The model an OpenAI-only install resolves the `utility` role to.
@@ -52,7 +52,9 @@ async fn answer_as_stub(
 /// An app whose code mode runs the scripted engine, whose only credentialed
 /// provider is the stub endpoint, and whose runtime has the recap hook
 /// installed the way `lib.rs` installs it in a real process.
-async fn code_recap_app() -> (
+async fn code_recap_app(
+    harness_kind: tidebreak_core::HarnessKind,
+) -> (
     Router,
     String,
     Arc<RecapStub>,
@@ -102,8 +104,18 @@ async fn code_recap_app() -> (
     )
     .await
     .unwrap();
+    let mut script = plain_text_script();
+    if let Some(HarnessEvent::SessionStarted {
+        harness_kind: started,
+        ..
+    }) = script.first_mut()
+    {
+        *started = harness_kind;
+    }
     let mut registry = AdapterRegistry::new();
-    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    registry.register(Arc::new(
+        ScriptedAdapter::new(script).with_kind(harness_kind),
+    ));
     let runtime = Arc::new(CodeRuntime::with_registry(
         db,
         dir.path().to_path_buf(),
@@ -192,20 +204,17 @@ async fn serve(router: Router) -> std::net::SocketAddr {
     addr
 }
 
-/// The whole feature over the wire: a completed turn is recapped on the
-/// utility model, the line is stored on the turn it describes, and it reaches
-/// every list surface on the digest channel — without the turn waiting for any
-/// of it.
-#[tokio::test(flavor = "multi_thread")]
-async fn a_completed_turn_is_recapped_onto_the_digest() {
-    let (router, token, stub, runtime, dir) = code_recap_app().await;
-    let addr = serve(router).await;
-    let client = reqwest::Client::new();
-    let repo = init_git_repo(dir.path());
-
+async fn start_turn(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    dir: &std::path::Path,
+    harness_kind: tidebreak_core::HarnessKind,
+) -> tidebreak_core::CodeSessionId {
+    let repo = init_git_repo(dir);
     let registered = client
         .post(format!("http://{addr}/code/repos"))
-        .bearer_auth(&token)
+        .bearer_auth(token)
         .json(&serde_json::json!({ "path": repo }))
         .send()
         .await
@@ -215,26 +224,22 @@ async fn a_completed_turn_is_recapped_onto_the_digest() {
 
     let created = client
         .post(format!("http://{addr}/code/workspaces"))
-        .bearer_auth(&token)
+        .bearer_auth(token)
         .json(&serde_json::json!({ "repo_id": repo_body["id"] }))
         .send()
         .await
         .unwrap();
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let workspace: serde_json::Value = created.json().await.unwrap();
-    let workspace_id = workspace["id"].as_str().unwrap().to_owned();
-
-    let mut updates = runtime
-        .bus
-        .subscribe_updates(&tidebreak_core::OwnerId::local());
 
     let session = client
         .post(format!(
-            "http://{addr}/code/workspaces/{workspace_id}/sessions"
+            "http://{addr}/code/workspaces/{}/sessions",
+            workspace["id"].as_str().unwrap()
         ))
-        .bearer_auth(&token)
+        .bearer_auth(token)
         .json(&serde_json::json!({
-            "harness": "claude_code",
+            "harness": harness_kind.as_str(),
             "permission_mode": "plan",
         }))
         .send()
@@ -242,11 +247,13 @@ async fn a_completed_turn_is_recapped_onto_the_digest() {
         .unwrap();
     assert_eq!(session.status(), reqwest::StatusCode::CREATED);
     let session: serde_json::Value = session.json().await.unwrap();
-    let session_id = session["id"].as_str().unwrap().to_owned();
+    let session_id = tidebreak_core::CodeSessionId(
+        uuid::Uuid::parse_str(session["id"].as_str().unwrap()).unwrap(),
+    );
 
     let turn = client
         .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
-        .bearer_auth(&token)
+        .bearer_auth(token)
         .json(&serde_json::json!({
             "message": "Fix the flaky retry test in the auth crate"
         }))
@@ -254,6 +261,56 @@ async fn a_completed_turn_is_recapped_onto_the_digest() {
         .await
         .unwrap();
     assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+    session_id
+}
+
+async fn wait_for_completed_turn(
+    runtime: &CodeRuntime,
+    session_id: tidebreak_core::CodeSessionId,
+) -> tidebreak_core::CodeTurn {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let turns = tidebreak_core::db::code::list_turns(
+            &runtime.db,
+            &tidebreak_core::OwnerId::local(),
+            session_id,
+        )
+        .await
+        .unwrap();
+        if let Some(turn) = turns
+            .last()
+            .filter(|turn| turn.status == tidebreak_core::CodeTurnStatus::Completed)
+        {
+            return turn.clone();
+        }
+        tokio::time::timeout_at(deadline, tokio::time::sleep(Duration::from_millis(20)))
+            .await
+            .expect("the scripted turn completes before the deadline");
+    }
+}
+
+/// The whole feature over the wire: a completed turn is recapped on the
+/// utility model, the line is stored on the turn it describes, and it reaches
+/// every list surface on the digest channel — without the turn waiting for any
+/// of it.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_completed_turn_is_recapped_onto_the_digest() {
+    let (router, token, stub, runtime, dir) =
+        code_recap_app(tidebreak_core::HarnessKind::Codex).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+
+    let mut updates = runtime
+        .bus
+        .subscribe_updates(&tidebreak_core::OwnerId::local());
+    let session_id = start_turn(
+        &client,
+        addr,
+        &token,
+        dir.path(),
+        tidebreak_core::HarnessKind::Codex,
+    )
+    .await;
 
     // The recap reaches the digest channel every list surface watches, so a
     // rail row can say where the session stands without a refresh.
@@ -274,7 +331,7 @@ async fn a_completed_turn_is_recapped_onto_the_digest() {
     let turns = tidebreak_core::db::code::list_turns(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
-        tidebreak_core::CodeSessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
+        session_id,
     )
     .await
     .unwrap();
@@ -299,10 +356,62 @@ async fn a_completed_turn_is_recapped_onto_the_digest() {
     );
 }
 
+/// Claude Code already supplies the closing recap that the transcript keeps.
+/// A second utility-model call would duplicate that line and its cost.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_claude_turn_skips_the_fallback_recap() {
+    let (router, token, stub, runtime, dir) =
+        code_recap_app(tidebreak_core::HarnessKind::ClaudeCode).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let session_id = start_turn(
+        &client,
+        addr,
+        &token,
+        dir.path(),
+        tidebreak_core::HarnessKind::ClaudeCode,
+    )
+    .await;
+
+    wait_for_completed_turn(&runtime, session_id).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let turn = wait_for_completed_turn(&runtime, session_id).await;
+
+    assert!(turn.narrative.is_none());
+    let recap_calls = stub
+        .requests
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|request| request.to_string().contains("session_recap"))
+        .count();
+    assert_eq!(recap_calls, 0);
+
+    // Older builds may have stored a fallback on a Claude turn. The digest
+    // must not carry that text forward and attach it to a newer closing recap.
+    tidebreak_core::db::code::set_turn_narrative(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        turn.id,
+        "A stale Tidebreak fallback.",
+    )
+    .await
+    .unwrap();
+    let digest =
+        crate::code::attention::list_digests(&runtime.db, &tidebreak_core::OwnerId::local())
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|digest| digest.session == session_id)
+            .expect("the Claude session stays listed");
+    assert!(digest.recap.is_none());
+}
+
 /// Turning recaps off prevents the utility-model call for later turns.
 #[tokio::test(flavor = "multi_thread")]
 async fn a_disabled_recap_setting_skips_the_model_call() {
-    let (router, token, stub, runtime, dir) = code_recap_app().await;
+    let (router, token, stub, runtime, dir) =
+        code_recap_app(tidebreak_core::HarnessKind::Codex).await;
     runtime
         .db
         .set_setting(
@@ -311,83 +420,18 @@ async fn a_disabled_recap_setting_skips_the_model_call() {
         )
         .await
         .unwrap();
-    let addr = serve(router.clone()).await;
+    let addr = serve(router).await;
     let client = reqwest::Client::new();
-    let repo = init_git_repo(dir.path());
-
-    let registered = client
-        .post(format!("http://{addr}/code/repos"))
-        .bearer_auth(&token)
-        .json(&serde_json::json!({ "path": repo }))
-        .send()
-        .await
-        .unwrap();
-    let repo_body: serde_json::Value = registered.json().await.unwrap();
-    let created = client
-        .post(format!("http://{addr}/code/workspaces"))
-        .bearer_auth(&token)
-        .json(&serde_json::json!({ "repo_id": repo_body["id"] }))
-        .send()
-        .await
-        .unwrap();
-    let workspace: serde_json::Value = created.json().await.unwrap();
-    let session = client
-        .post(format!(
-            "http://{addr}/code/workspaces/{}/sessions",
-            workspace["id"].as_str().unwrap()
-        ))
-        .bearer_auth(&token)
-        .json(&serde_json::json!({
-            "harness": "claude_code",
-            "permission_mode": "plan",
-        }))
-        .send()
-        .await
-        .unwrap();
-    let session: serde_json::Value = session.json().await.unwrap();
-    let session_id = tidebreak_core::CodeSessionId(
-        uuid::Uuid::parse_str(session["id"].as_str().unwrap()).unwrap(),
-    );
-
-    let turn = router
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri(format!("/code/sessions/{session_id}/turns"))
-                .header("authorization", format!("Bearer {token}"))
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(
-                    serde_json::json!({ "message": "Fix the retry test" }).to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(turn.status(), StatusCode::ACCEPTED);
-
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-    loop {
-        let turns = tidebreak_core::db::code::list_turns(
-            &runtime.db,
-            &tidebreak_core::OwnerId::local(),
-            session_id,
-        )
-        .await
-        .unwrap();
-        if turns
-            .last()
-            .is_some_and(|turn| turn.status == tidebreak_core::CodeTurnStatus::Completed)
-        {
-            assert!(turns
-                .last()
-                .and_then(|turn| turn.narrative.as_ref())
-                .is_none());
-            break;
-        }
-        tokio::time::timeout_at(deadline, tokio::time::sleep(Duration::from_millis(20)))
-            .await
-            .expect("the scripted turn completes before the deadline");
-    }
+    let session_id = start_turn(
+        &client,
+        addr,
+        &token,
+        dir.path(),
+        tidebreak_core::HarnessKind::Codex,
+    )
+    .await;
+    let turn = wait_for_completed_turn(&runtime, session_id).await;
+    assert!(turn.narrative.is_none());
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let recap_calls = stub


### PR DESCRIPTION
## Summary

- Skip Tidebreak's fallback recap model call for Claude Code sessions.
- Keep fallback recaps in the existing closing-message recap block, with the captured closing recap taking precedence.
- Suppress stale fallback digests for Claude and update the recap setting copy.
- Cover closing-message, standalone, duplicate, and engine-specific recap behavior in tests and Storybook.

## Validation

- `cargo test -p tidebreak-server code_recap -- --nocapture`
- `vitest run src/code/CodeTranscript.dom.test.tsx src/code/TurnReviewCard.dom.test.tsx src/settings/AgentsPanel.dom.test.tsx src/stylesContract.test.ts`
- `tsc --noEmit`
- Biome on changed UI files
- `cargo fmt --check`
- `git diff --check`
- Storybook production build
- Storybook screenshots at 1000px and 390px in light, dark, high-contrast light, and high-contrast dark