### PR TITLE
ci: compile Windows native tests once and link with rust-lld

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,6 +560,11 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: READ_WRITE
       RUSTC_WRAPPER: sccache
+      # link.exe dominates Windows test-binary time on 4 cores. rust-lld ships
+      # with the toolchain and is the MSVC analogue of mold on the Linux lanes.
+      # `cargo check` clears this so a linker mismatch cannot fail the
+      # rust-scoped compile gate.
+      RUSTFLAGS: -C linker=rust-lld
     steps:
       # A newer main commit contains this one, so its own Windows run proves
       # everything this run would. Bailing out with success is what keeps that
@@ -621,6 +626,8 @@ jobs:
           [System.IO.File]::WriteAllBytes($cli, $mz)
       - name: Check Windows-gated crates
         if: ${{ steps.tip.outputs.superseded != 'true' }}
+        env:
+          RUSTFLAGS: ""
         run: >-
           cargo check --target x86_64-pc-windows-msvc
           -p tidebreak-core
@@ -650,6 +657,28 @@ jobs:
           elif [[ "$WINDOWS_CI_GATE" == true ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
+      # `cargo check` does not build test binaries, and `--lib` is workspace-wide,
+      # so host-broker's sidecar integration test cannot share an invocation with
+      # server and core. Two `--no-run` graphs compile everything the later run
+      # steps need; rustc can then keep those binaries instead of rebuilding
+      # them four times in sequence.
+      - name: Compile native Windows test binaries
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
+        env:
+          NATIVE_RUN: ${{ steps.native.outputs.run }}
+        shell: bash
+        run: |
+          if [[ "$NATIVE_RUN" != "true" ]]; then
+            echo "Skipping native Windows test compile."
+            exit 0
+          fi
+          cargo test --target x86_64-pc-windows-msvc --locked --no-run --lib \
+            -p tidebreak-server \
+            -p tidebreak-core
+          cargo test --target x86_64-pc-windows-msvc --locked --no-run \
+            -p tidebreak-host-broker \
+            -p tidebreak-code-execution \
+            -p tidebreak-harness
       # The host broker suite covers both real NTFS containment and the stdio
       # sidecar boundary: private state/audit placement, exclusive ownership of
       # the state directory, restart persistence, and exit when the desktop pipe

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -701,7 +701,12 @@ break on `main` blocks the desktop release. Native Windows tests inside that
 job still wait for the `windows` scope, the `windows-ci` label, or a
 main/scheduled/manual run: those suites need NTFS and the Windows process
 APIs, and they retry a PowerShell startup race that should not gate unrelated
-Rust changes.
+Rust changes. After `cargo check`, a windows-scoped run compiles the native
+test binaries in two `cargo test --no-run` graphs: server and core `--lib`
+together, then host-broker, code-execution, and harness together. Those graphs
+link with `rust-lld`. The later run steps then reuse the binaries instead of
+rebuilding them one crate at a time with `link.exe`. `cargo check` keeps the
+MSVC linker.
 
 To run that job on an 8-core Windows larger runner (8 vCPU, 32 GB), set the
 repository variable `CI_WINDOWS_RUNNER` to the provisioned x64 label. If you

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -617,9 +617,15 @@ test("native Windows CI is scope-triggered, label-overridable, with a main backs
   const windows = workflowJob(ci, "windows-check");
   const changes = workflowJob(ci, "changes");
   const nativeTests = windows.match(
-    /- name: Record native Windows test gate[\s\S]*?(?=\n {6}- name: Host broker Windows tests)/,
+    /- name: Record native Windows test gate[\s\S]*?(?=\n {6}- name: Compile native Windows test binaries)/,
   )?.[0];
   assert.ok(nativeTests, "missing native Windows test gate step");
+  const check = windows.match(
+    /- name: Check Windows-gated crates[\s\S]*?(?=\n {6}- name: Record native Windows test gate)/,
+  )?.[0];
+  assert.ok(check, "missing Windows cargo check step");
+  assert.match(check, /RUSTFLAGS: ""/);
+  assert.doesNotMatch(check, /linker=rust-lld/);
   assert.match(
     nativeTests,
     /github\.event_name != 'pull_request' \|\| contains\(github\.event\.pull_request\.labels\.\*\.name, 'windows-ci'\) \|\| needs\.changes\.outputs\.windows == 'true'/,
@@ -671,9 +677,19 @@ test("native Windows CI is scope-triggered, label-overridable, with a main backs
   assert.match(windows, /SCCACHE_GHA_ENABLED: "true"/);
   assert.match(windows, /SCCACHE_GHA_RW_MODE: READ_WRITE/);
   assert.match(windows, /RUSTC_WRAPPER: sccache/);
+  assert.match(windows, /RUSTFLAGS: -C linker=rust-lld/);
   assert.match(
     windows,
     /uses: mozilla-actions\/sccache-action@[0-9a-f]{40}/,
+  );
+  assert.match(windows, /Compile native Windows test binaries/);
+  assert.match(
+    windows,
+    /cargo test --target x86_64-pc-windows-msvc --locked --no-run --lib/,
+  );
+  assert.match(
+    windows,
+    /cargo test --target x86_64-pc-windows-msvc --locked --no-run \\\n\s+-p tidebreak-host-broker/,
   );
   assert.match(windows, /\$attempts = 3/);
   assert.match(windows, /tidebreak-server", "--lib", "code::"/);


### PR DESCRIPTION
## What changed

Windows-scoped CI rebuilt four test crates in sequence under `link.exe`, which is what made the required `Windows cargo check` job take ~20 minutes. After `cargo check`, that job now compiles the native test binaries in two `cargo test --no-run` graphs and links them with `rust-lld`. The later run steps reuse those binaries. `cargo check` still uses the MSVC linker so a linker mismatch cannot fail the rust-scoped compile gate.

A rust-only change still pays only `cargo check`. This does not switch the job onto a larger runner.

## Validation

- `node --test scripts/workflow-security.test.mjs`

Could not time the Windows job locally. The first windows-scoped CI run on this PR is the measurement.

## Compatibility and risk

Windows CI linker for native test binaries only. `cargo check` and non-Windows lanes are unchanged.