### PR TITLE
fix(desktop): paint ready-to-merge as success, not needs-you

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -344,6 +344,108 @@ describe("WorkspaceCard", () => {
     expect(menu).not.toHaveTextContent("New session");
   });
 
+  it("paints a ready-to-merge notice as success, not needs-you", () => {
+    const digest: CodeSessionDigest = {
+      workspace: workspace.id,
+      session: "sess-1",
+      kind: "interactive",
+      lifecycle: "idle",
+      attention: {
+        state: {
+          type: "needs_you",
+          prompt: "#184 is ready to merge",
+          source: "structured",
+        },
+        source: "structured",
+      },
+      title: workspace.title,
+      turn_count: 4,
+      pr_state: pr,
+    };
+    render(
+      <WorkspaceCard
+        workspace={{ ...workspace, pr }}
+        digest={digest}
+        session={undefined}
+        repoName="app"
+        active={false}
+        terminalOpen={false}
+        density="detailed"
+        visibleMeta={{ repoChip: true, branch: false }}
+        commands={workspaceCommands({
+          hasPr: true,
+          archived: false,
+          hasSession: true,
+        })}
+        onOpen={vi.fn()}
+        onCommand={vi.fn()}
+      />,
+    );
+
+    const line = screen.getByText("#184 is ready to merge");
+    expect(line).toHaveClass("text-success-foreground");
+    expect(line).not.toHaveClass("text-critical-foreground");
+    expect(screen.queryByLabelText("Needs you")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("PR open")).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-state-glyph="ready_to_merge"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("does not keep a ready-to-merge notice after the pull request merges", () => {
+    const merged: PullRequestDigest = {
+      ...pr,
+      state: "merged",
+      merged: true,
+    };
+    const digest: CodeSessionDigest = {
+      workspace: workspace.id,
+      session: "sess-1",
+      kind: "interactive",
+      lifecycle: "idle",
+      attention: {
+        state: {
+          type: "needs_you",
+          prompt: "#184 is ready to merge",
+          source: "structured",
+        },
+        source: "structured",
+      },
+      title: workspace.title,
+      turn_count: 4,
+      recap: "Folded the backoff into refresh.",
+      pr_state: merged,
+    };
+    render(
+      <WorkspaceCard
+        workspace={{ ...workspace, pr: merged }}
+        digest={digest}
+        session={undefined}
+        repoName="app"
+        active={false}
+        terminalOpen={false}
+        density="detailed"
+        visibleMeta={{ repoChip: true, branch: false }}
+        commands={workspaceCommands({
+          hasPr: true,
+          archived: false,
+          hasSession: true,
+        })}
+        onOpen={vi.fn()}
+        onCommand={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/ready to merge/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Needs you")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Folded the backoff into refresh."),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-pr-state="merged"]'),
+    ).toBeInTheDocument();
+  });
+
   it("keeps a parked agent visible as a completed turn", () => {
     const digest: CodeSessionDigest = {
       workspace: workspace.id,

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -78,6 +78,7 @@ import {
   isSessionRowWorthy,
   isPutAway,
   middleTruncate,
+  readyToMergeNotice,
   repoAccentClass,
   sessionActivityLineLabel,
   watchRowLabel,
@@ -553,7 +554,7 @@ function WorkspaceDetailPanel({
   onCommand: (command: WorkspaceCommand["id"]) => void;
   onWorkflowAction?: (action: WorkspaceWorkflowAction) => void;
 }) {
-  const activity = workspaceActivitySummary(digest, session, terminalOpen);
+  const activity = workspaceActivitySummary(digest, session, terminalOpen, pr);
   const matchingSession =
     !digest || session?.id === digest.session ? session : undefined;
   const stamp = archived
@@ -855,7 +856,12 @@ function WorkspaceActivityLine({
   const railDigest = digest && isSessionRowWorthy(digest) ? digest : undefined;
   if (!railDigest) return null;
 
-  const activity = workspaceActivitySummary(railDigest, session, false);
+  const activity = workspaceActivitySummary(
+    railDigest,
+    session,
+    false,
+    workspace.pr,
+  );
   const matchingSession =
     session?.id === railDigest.session ? session : undefined;
   const harnessKind = railDigest.harness_kind ?? matchingSession?.harness_kind;
@@ -871,13 +877,14 @@ function WorkspaceActivityLine({
       {activity.terminalOnly ? (
         <SquareTerminal className="size-3 shrink-0" aria-hidden />
       ) : (
-        <SessionStateGlyph digest={railDigest} />
+        <SessionStateGlyph digest={railDigest} pr={workspace.pr} />
       )}
       <span
         className={cn(
           "min-w-0 flex-1 truncate",
           activity.needsYou && STATUS_TEXT.critical,
           running && STATUS_TEXT.running,
+          activity.tone === "ready" && STATUS_TEXT.ready,
         )}
         title={activity.label}
       >
@@ -909,10 +916,29 @@ function WorkspaceActivityLine({
  * that is alive but parked on something else: a bot for subagents and a
  * radar for a monitor, both in the live tone with the live pulse.
  */
-function SessionStateGlyph({ digest }: { digest: CodeSessionDigest }) {
+function SessionStateGlyph({
+  digest,
+  pr,
+}: {
+  digest: CodeSessionDigest;
+  pr?: PullRequestDigest;
+}) {
   const className = "size-3 shrink-0";
   const attention = digest.attention.state.type;
-  if (attention === "needs_you") {
+  const mergeNotice = readyToMergeNotice(
+    digest.attention,
+    digest.pr_state ?? pr,
+  );
+  if (attention === "needs_you" && mergeNotice !== "stale") {
+    if (mergeNotice === "ready") {
+      return (
+        <CircleCheck
+          className={cn(className, STATUS_MARK.ready)}
+          data-state-glyph="ready_to_merge"
+          aria-hidden
+        />
+      );
+    }
     return (
       <CircleAlert
         className={cn(className, STATUS_MARK.critical)}
@@ -1033,19 +1059,26 @@ function workspaceActivitySummary(
   digest: CodeSessionDigest | undefined,
   session: CodeSessionSnapshot | undefined,
   terminalOpen: boolean,
+  pr?: PullRequestDigest,
 ): {
   label: string;
   tone: StatusTone;
   needsYou: boolean;
   terminalOnly: boolean;
 } | null {
-  const needsYou =
-    digest?.attention.state.type === "needs_you"
-      ? digest.attention.state.prompt || "Needs you"
-      : null;
-  if (needsYou) {
+  const pullRequest = digest?.pr_state ?? pr;
+  const mergeNotice = readyToMergeNotice(digest?.attention, pullRequest);
+  if (digest?.attention.state.type === "needs_you" && mergeNotice !== "stale") {
+    if (mergeNotice === "ready") {
+      return {
+        label: digest.attention.state.prompt || "Ready to merge",
+        tone: "ready",
+        needsYou: false,
+        terminalOnly: false,
+      };
+    }
     return {
-      label: needsYou,
+      label: digest.attention.state.prompt || "Needs you",
       tone: "critical",
       needsYou: true,
       terminalOnly: false,
@@ -1055,7 +1088,7 @@ function workspaceActivitySummary(
   const worthyDigest =
     digest && isSessionRowWorthy(digest) ? digest : undefined;
   const statusLabel = worthyDigest
-    ? sessionActivityLineLabel(worthyDigest)
+    ? sessionActivityLineLabel(worthyDigest, pullRequest)
     : digest
       ? LIFECYCLE_LABELS[digest.lifecycle]
       : session
@@ -1066,7 +1099,7 @@ function workspaceActivitySummary(
 
   return {
     label: statusLabel || "Terminal open",
-    tone: digestStatusTone(digest),
+    tone: mergeNotice === "stale" ? "neutral" : digestStatusTone(digest),
     needsYou: false,
     terminalOnly,
   };

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -16,6 +16,7 @@ import {
   sessionActivityLabel,
   sessionActivityLineLabel,
   sessionRowLabel,
+  readyToMergeNotice,
   workspaceCardLabel,
   workspaceCardStatus,
   workspacePrChipSummary,
@@ -367,6 +368,114 @@ describe("workspaceStatusRank", () => {
       "idle",
     );
   });
+
+  it("ranks a ready-to-merge notice with the open pull request, not needs-you", () => {
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app"),
+        digest("ws-a", {
+          attention: {
+            state: {
+              type: "needs_you",
+              prompt: "#3081 is ready to merge",
+              source: "structured",
+            },
+            source: "structured",
+          },
+          pr_state: { number: 3081, state: "open" },
+        }),
+      ),
+    ).toBe("pr_open");
+  });
+
+  it("does not keep a ready-to-merge notice after the pull request merges", () => {
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app"),
+        digest("ws-a", {
+          attention: {
+            state: {
+              type: "needs_you",
+              prompt: "#3081 is ready to merge",
+              source: "structured",
+            },
+            source: "structured",
+          },
+          pr_state: { number: 3081, state: "merged", merged: true },
+          turn_count: 4,
+        }),
+      ),
+    ).toBe("done_unreviewed");
+  });
+
+  it("still ranks a real blocker as needs-you when a pull request is open", () => {
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app"),
+        digest("ws-a", {
+          attention: {
+            state: {
+              type: "needs_you",
+              prompt: "an approval is waiting",
+              source: "structured",
+            },
+            source: "structured",
+          },
+          pr_state: { number: 12, state: "open" },
+        }),
+      ),
+    ).toBe("needs_you");
+  });
+});
+
+describe("readyToMergeNotice", () => {
+  const ready = {
+    state: {
+      type: "needs_you" as const,
+      prompt: "#3081 is ready to merge",
+      source: "structured" as const,
+    },
+    source: "structured" as const,
+  };
+
+  it("treats the watch and notify prompts as ready while the pull request is open", () => {
+    expect(readyToMergeNotice(ready, { state: "open" })).toBe("ready");
+    expect(
+      readyToMergeNotice(
+        {
+          ...ready,
+          state: {
+            ...ready.state,
+            prompt: "the pull request is ready to merge",
+          },
+        },
+        { state: "open" },
+      ),
+    ).toBe("ready");
+  });
+
+  it("is stale once the pull request has merged or closed", () => {
+    expect(readyToMergeNotice(ready, { state: "merged", merged: true })).toBe(
+      "stale",
+    );
+    expect(readyToMergeNotice(ready, { state: "closed" })).toBe("stale");
+  });
+
+  it("ignores other needs-you prompts", () => {
+    expect(
+      readyToMergeNotice(
+        {
+          state: {
+            type: "needs_you",
+            prompt: "an approval is waiting",
+            source: "structured",
+          },
+          source: "structured",
+        },
+        { state: "open" },
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("workspaceCardStatus", () => {
@@ -501,6 +610,45 @@ describe("sessionActivityLineLabel", () => {
       "Done",
     );
   });
+
+  it("keeps a ready-to-merge notice while the pull request is open", () => {
+    expect(
+      sessionActivityLineLabel(
+        digest("ws-a", {
+          attention: {
+            state: {
+              type: "needs_you",
+              prompt: "#3081 is ready to merge",
+              source: "structured",
+            },
+            source: "structured",
+          },
+          pr_state: { number: 3081, state: "open" },
+          turn_count: 4,
+        }),
+      ),
+    ).toBe("#3081 is ready to merge");
+  });
+
+  it("drops a ready-to-merge notice after the pull request merges", () => {
+    expect(
+      sessionActivityLineLabel(
+        digest("ws-a", {
+          attention: {
+            state: {
+              type: "needs_you",
+              prompt: "#3081 is ready to merge",
+              source: "structured",
+            },
+            source: "structured",
+          },
+          pr_state: { number: 3081, state: "merged", merged: true },
+          recap: "Opened the page as soon as the session existed.",
+          turn_count: 4,
+        }),
+      ),
+    ).toBe("Opened the page as soon as the session existed.");
+  });
 });
 
 describe("sessionActivityLabel", () => {
@@ -628,6 +776,25 @@ describe("workspaceCardLabel", () => {
         pr: { number: 12, state: "open", in_merge_queue: true },
       }),
     ).toContain("Pull request #12 In merge queue");
+  });
+
+  it("does not announce ready-to-merge after the pull request has merged", () => {
+    expect(
+      workspaceCardLabel({
+        title: "Fix login",
+        repoName: "app",
+        branchName: "tidebreak/fix-login",
+        attention: {
+          state: {
+            type: "needs_you",
+            prompt: "#12 is ready to merge",
+            source: "structured",
+          },
+          source: "structured",
+        },
+        pr: { number: 12, state: "merged", merged: true },
+      }),
+    ).toBe("Fix login · Pull request #12 Merged · app · tidebreak/fix-login");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -6,7 +6,11 @@ import type {
   CodeWorkspaceStatus,
 } from "../api/types";
 import { attentionLabel, LIFECYCLE_LABELS } from "./labels";
-import { prCompactStatusLabel, pullRequestLifecycle } from "./prState";
+import {
+  prCompactStatusLabel,
+  pullRequestLifecycle,
+  type PrStateInput,
+} from "./prState";
 import type { StatusTone } from "./statusTone";
 
 /**
@@ -147,13 +151,50 @@ export function isWorkspaceStatusRank(
 }
 
 /**
+ * Watch and notify write "ready to merge" as needs-you so it reaches the
+ * rail. The prompt is the only discriminator: merging is optional good news,
+ * not a blocker, and the same string is leftover after the pull request
+ * settles.
+ */
+const READY_TO_MERGE_PROMPT = /^(?:the pull request|#\d+) is ready to merge$/i;
+
+export function isReadyToMergeAttention(
+  attention: Attention | undefined,
+): boolean {
+  return (
+    attention?.state.type === "needs_you" &&
+    READY_TO_MERGE_PROMPT.test(attention.state.prompt)
+  );
+}
+
+/**
+ * How a ready-to-merge notice should read against the current pull request.
+ *
+ * `ready` while the pull request is still open. `stale` once it has merged or
+ * closed, so the card does not keep saying ready next to a merged glyph.
+ */
+export function readyToMergeNotice(
+  attention: Attention | undefined,
+  pr: PrStateInput | undefined,
+): "ready" | "stale" | null {
+  if (!isReadyToMergeAttention(attention)) return null;
+  if (pr) {
+    const lifecycle = pullRequestLifecycle(pr);
+    if (lifecycle === "merged" || lifecycle === "closed") return "stale";
+  }
+  return "ready";
+}
+
+/**
  * Rank a workspace for the by-status rail. Needs-you wins, then a running
  * engine, then an open PR, then done-unreviewed, then a workspace whose setup
  * script failed, then idle. Archived is last. A digest may change the rank;
  * viewing or selecting never does.
  *
  * Stalled and fenced join needs-you so the card mark and the group agree.
- * Idle or ended sessions with turns join Done, matching
+ * Ready-to-merge does not: notify and watch store it as needs-you, but it is
+ * a successful pull-request state, and a merged or closed pull request makes
+ * that prompt stale. Idle or ended sessions with turns join Done, matching
  * `attentionMarkForDigest`. A failed setup ranks below live work because the
  * checkout survives — but above idle, because nothing else on the card says
  * the script never finished.
@@ -164,15 +205,16 @@ export function workspaceStatusRank(
 ): WorkspaceStatusRank {
   if (isPutAway(workspace)) return "archived";
   const attentionType = digest?.attention.state.type;
+  const pr = digest?.pr_state ?? workspace.pr;
   if (
-    attentionType === "needs_you" ||
+    (attentionType === "needs_you" &&
+      !isReadyToMergeAttention(digest?.attention)) ||
     attentionType === "stalled" ||
     attentionType === "fenced"
   ) {
     return "needs_you";
   }
   if (digest?.lifecycle === "running") return "running";
-  const pr = digest?.pr_state ?? workspace.pr;
   if (pr) {
     const lifecycle = pullRequestLifecycle(pr);
     if (lifecycle === "open" || lifecycle === "draft") return "pr_open";
@@ -349,7 +391,13 @@ export function isSessionRowWorthy(
 
 /** Short lifecycle word for the nested session row. */
 export function sessionRowLabel(digest: CodeSessionDigest): string {
-  if (digest.attention.state.type === "needs_you") return "Needs you";
+  if (digest.attention.state.type === "needs_you") {
+    const notice = readyToMergeNotice(digest.attention, digest.pr_state);
+    if (notice === "ready") {
+      return digest.attention.state.prompt || "Ready to merge";
+    }
+    if (notice !== "stale") return "Needs you";
+  }
   if (digest.lifecycle === "running") return sessionActivityLabel(digest);
   switch (digest.attention.state.type) {
     case "stalled":
@@ -381,9 +429,15 @@ export function sessionRowLabel(digest: CodeSessionDigest): string {
  * the agent is still visible. No tallies: how many turns have run is not
  * what a reader scanning the rail wants to know.
  */
-export function sessionActivityLineLabel(digest: CodeSessionDigest): string {
+export function sessionActivityLineLabel(
+  digest: CodeSessionDigest,
+  pr: PrStateInput | undefined = digest.pr_state,
+): string {
   if (digest.attention.state.type === "needs_you") {
-    return digest.attention.state.prompt || "Needs you";
+    const notice = readyToMergeNotice(digest.attention, pr);
+    if (notice !== "stale") {
+      return digest.attention.state.prompt || "Needs you";
+    }
   }
   if (digest.lifecycle === "running") {
     // Subagents keep their count: the child rows name them. Everything else
@@ -480,6 +534,7 @@ export function workspaceCardLabel(input: {
     number: number;
     state: string;
     draft?: boolean;
+    merged?: boolean | null;
     in_merge_queue?: boolean;
   };
   terminalOpen?: boolean;
@@ -488,10 +543,12 @@ export function workspaceCardLabel(input: {
   const parts = [input.title];
   if (input.workspaceStatus === "creating") parts.push("Creating workspace");
   if (input.workspaceStatus === "setup_failed") parts.push("Setup failed");
+  const mergeNotice = readyToMergeNotice(input.attention, input.pr);
   if (
     input.attention &&
     input.attention.state.type !== "working" &&
-    input.attention.state.type !== "idle"
+    input.attention.state.type !== "idle" &&
+    mergeNotice !== "stale"
   ) {
     parts.push(attentionLabel(input.attention));
   }

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -36,6 +36,7 @@ import {
   monitorDigest,
   needsYouDigest,
   openPrDigest,
+  readyToMergeDigest,
   queuedPrDigest,
   runningDigest,
   shellDigest,
@@ -356,6 +357,58 @@ export const NeedsYouInline: Story = {
   },
 };
 
+/**
+ * Ready to merge is success, not a blocker. The notice stays on the row in
+ * the ready tone, and the card sits with open pull requests rather than
+ * Needs you.
+ */
+export const ReadyToMergeNotice: Story = {
+  args: {
+    workspace: {
+      ...codeWorkspace,
+      pr: readyToMergeDigest.pr_state ?? openPrDigest,
+    },
+    digest: readyToMergeDigest,
+    session: idleSession,
+    commands: workspaceCommands({
+      hasPr: true,
+      archived: false,
+      hasSession: true,
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("#184 is ready to merge")).toBeVisible();
+    await expect(canvas.queryByLabelText("Needs you")).not.toBeInTheDocument();
+    await expect(canvas.getByLabelText("PR open")).toBeVisible();
+  },
+};
+
+/**
+ * After the pull request merges, a leftover ready-to-merge notice must not
+ * keep saying ready next to the merged glyph.
+ */
+export const ReadyToMergeAfterMerge: Story = {
+  args: {
+    workspace: { ...codeWorkspace, pr: mergedPrDigest },
+    digest: { ...readyToMergeDigest, pr_state: mergedPrDigest },
+    session: idleSession,
+    commands: workspaceCommands({
+      hasPr: true,
+      archived: false,
+      hasSession: true,
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText(/ready to merge/i)).not.toBeInTheDocument();
+    await expect(canvas.queryByLabelText("Needs you")).not.toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-pr-state="merged"]'),
+    ).not.toBeNull();
+  },
+};
+
 /** How the card reads inside a by-repo group: no repo chip, title leads. */
 export const InRepoGroup: Story = {
   args: { visibleMeta: { repoChip: false, branch: false } },
@@ -649,9 +702,10 @@ export const PullRequestTones: Story = {
 /**
  * The status ramp on one screen, which is the only way to catch a tone drawn
  * at the wrong strength. Read down the glyph rail: working moves, needs-you is
- * the one red, stalled joins needs-you, done is quiet, an empty workspace
- * still has an outline circle, and merged is purple rather than a second
- * shade of green. Check this in both themes.
+ * the one red, ready-to-merge is green rather than a second needs-you, stalled
+ * joins needs-you, done is quiet, an empty workspace still has an outline
+ * circle, and merged is purple rather than a second shade of green. Check this
+ * in both themes.
  */
 export const StatusTones: Story = {
   render: (args) => (
@@ -660,6 +714,7 @@ export const StatusTones: Story = {
         [
           ["Working", runningDigest, codeSession, undefined],
           ["Needs you", needsYouDigest, codeSession, undefined],
+          ["Ready to merge", readyToMergeDigest, idleSession, openPrDigest],
           ["Stalled", stalledDigest, codeSession, undefined],
           ["Done, unreviewed", doneDigest, idleSession, undefined],
           ["Parked, complete", idleCompleteDigest, grokIdleSession, undefined],

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -911,6 +911,27 @@ export const closedPrDigest: PullRequestDigest = {
   state: "closed",
 };
 
+/** Trigger/watch wrote that the pull request is mergeable. */
+export const readyToMergeDigest: CodeSessionDigest = codeDigest({
+  lifecycle: "idle",
+  attention: {
+    state: {
+      type: "needs_you",
+      prompt: "#184 is ready to merge",
+      source: "structured",
+    },
+    source: "structured",
+  },
+  turn_count: 4,
+  recap: "Opened the page as soon as the session existed.",
+  pr_state: {
+    ...openPrDigest,
+    mergeable: "mergeable",
+    merge_state_status: "clean",
+    review_decision: "approved",
+  },
+});
+
 /** A remote-style put-away workspace: no host worktree, history kept. */
 export const archivedWorkspace: CodeWorkspaceSnapshot = {
   ...codeWorkspace,


### PR DESCRIPTION
## What

Workspace cards treated a ready-to-merge watch/notify prompt as Needs you, so mergeable work painted red. After the pull request merged, that leftover prompt still sat next to the purple merged glyph.

The rail now treats that notice as an open-PR success state. Once the pull request has merged or closed, the notice drops.

## Why

Ready to merge is optional good news, not a blocker. Saying both "ready to merge" and "merged" is a lie.

## How to test

1. Open Storybook → Code/Workspace card → Ready to merge notice. The row is green, grouped with open pull requests, not Needs you.
2. Open Ready to merge after merge. The leftover prompt is gone; only the purple merged glyph remains.
3. Open Needs you inline and confirm approvals are still red.