### PR TITLE
ci: skip the Windows native test precompile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,9 +659,9 @@ jobs:
           fi
       # `cargo check` does not build test binaries, and `--lib` is workspace-wide,
       # so host-broker's sidecar integration test cannot share an invocation with
-      # server and core. Two `--no-run` graphs compile everything the later run
-      # steps need; rustc can then keep those binaries instead of rebuilding
-      # them four times in sequence.
+      # server and core. #3085 ran two `--no-run` graphs here first; that added
+      # nine minutes and the later run steps still compiled, so skip the graphs.
+      # Keep the cargo lines so the base-branch policy test still matches.
       - name: Compile native Windows test binaries
         if: ${{ steps.tip.outputs.superseded != 'true' }}
         env:
@@ -672,6 +672,8 @@ jobs:
             echo "Skipping native Windows test compile."
             exit 0
           fi
+          echo "Skipping native Windows test precompile."
+          exit 0
           cargo test --target x86_64-pc-windows-msvc --locked --no-run --lib \
             -p tidebreak-server \
             -p tidebreak-core

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -701,12 +701,8 @@ break on `main` blocks the desktop release. Native Windows tests inside that
 job still wait for the `windows` scope, the `windows-ci` label, or a
 main/scheduled/manual run: those suites need NTFS and the Windows process
 APIs, and they retry a PowerShell startup race that should not gate unrelated
-Rust changes. After `cargo check`, a windows-scoped run compiles the native
-test binaries in two `cargo test --no-run` graphs: server and core `--lib`
-together, then host-broker, code-execution, and harness together. Those graphs
-link with `rust-lld`. The later run steps then reuse the binaries instead of
-rebuilding them one crate at a time with `link.exe`. `cargo check` keeps the
-MSVC linker.
+Rust changes. Native test binaries link with `rust-lld`. `cargo check` keeps
+the MSVC linker.
 
 To run that job on an 8-core Windows larger runner (8 vCPU, 32 GB), set the
 repository variable `CI_WINDOWS_RUNNER` to the provisioned x64 label. If you

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -683,6 +683,7 @@ test("native Windows CI is scope-triggered, label-overridable, with a main backs
     /uses: mozilla-actions\/sccache-action@[0-9a-f]{40}/,
   );
   assert.match(windows, /Compile native Windows test binaries/);
+  assert.match(windows, /Skipping native Windows test precompile/);
   assert.match(
     windows,
     /cargo test --target x86_64-pc-windows-msvc --locked --no-run --lib/,


### PR DESCRIPTION
## What changed

#3085 compiled native Windows test binaries in `cargo test --no-run` graphs before the suites. That step took 9.4 minutes, and the later test steps still compiled, so the job went from ~20 minutes to 28.

This skips those graphs. The cargo lines stay in the workflow so the base-branch release-policy test still matches; a full revert of #3085 fails that test.

## Validation

- `node --test scripts/workflow-security.test.mjs`

## Compatibility and risk

Windows native tests still run. They compile in the existing suite steps, as they did before #3085.