### PR TITLE
ci: attest the published server image

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -57,6 +57,16 @@ run-name: >-
 # whole point of that lane. Consumers that need an immutable reference pin the
 # digest, which every run prints in its step summary.
 #
+# Every pushed manifest — each per-architecture image and the multi-arch
+# index — carries a GitHub build-provenance attestation (docs/decisions/0084).
+# A consumer verifies a digest offline against the Sigstore trust root and
+# reads the signing identity from the certificate:
+#
+#   https://github.com/<owner>/tidebreak/.github/workflows/publish-server-image.yml@<ref>
+#
+# so this file's path is a public contract; moving it changes the identity of
+# every image published afterwards.
+#
 # Publishing uses the workflow's own GITHUB_TOKEN; no repository secret is
 # consumed. First-time note: a package created by this workflow is private by
 # default — making it publicly pullable (and linking it to the repository) is a
@@ -222,6 +232,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Attestation: the OIDC token signs, and the bundle is stored under
+      # this repository.
+      id-token: write
+      attestations: write
     env:
       BUILD_SHA: ${{ needs.resolve.outputs.build_sha }}
       IMMUTABLE: ${{ needs.resolve.outputs.immutable }}
@@ -286,6 +300,27 @@ jobs:
       - name: Push the per-architecture tag
         run: docker push "$SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}"
 
+      # The digest is read back from the registry rather than from the local
+      # image: the attestation must name exactly the manifest consumers pull.
+      - name: Read the pushed manifest digest
+        id: pushed
+        run: |
+          digest="$(docker buildx imagetools inspect \
+            "$SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "unexpected digest for $SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}: $digest" >&2
+            exit 1
+          }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Attest the per-architecture manifest
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.SERVER_REPOSITORY }}
+          subject-digest: ${{ steps.pushed.outputs.digest }}
+          push-to-registry: true
+
   manifest:
     # Assembles the user-facing tags only after every architecture has built
     # and pushed.
@@ -296,6 +331,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     env:
       VERSION: ${{ needs.resolve.outputs.version }}
     steps:
@@ -324,6 +361,7 @@ jobs:
       # The digest is the reference deployments pin, so print it where a human
       # and a copy-paste can both reach it.
       - name: Record the published digest
+        id: published
         env:
           PUBLISH_LATEST: ${{ needs.resolve.outputs.publish_latest }}
         run: |
@@ -334,6 +372,7 @@ jobs:
             echo "unexpected digest for $SERVER_REPOSITORY:$VERSION: $digest" >&2
             exit 1
           }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
           echo "Published $SERVER_REPOSITORY:$VERSION at $digest"
           {
             echo "## Published server image"
@@ -349,3 +388,13 @@ jobs:
             echo "$SERVER_REPOSITORY@$digest"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # The index is what a version tag resolves to, so this is the
+      # attestation a consumer that pins the tag's digest verifies. `latest`
+      # is assembled from the same manifests and resolves to the same index.
+      - name: Attest the multi-arch index
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.SERVER_REPOSITORY }}
+          subject-digest: ${{ steps.published.outputs.digest }}
+          push-to-registry: true

--- a/docs/decisions/0084-the-server-image-carries-github-build-provenance.md
+++ b/docs/decisions/0084-the-server-image-carries-github-build-provenance.md
@@ -1,0 +1,96 @@
+# 84. The server image carries GitHub build provenance
+
+- Status: Accepted
+- Date: 2026-09-02
+- Owners: server
+- Related: [`0047-gateway-linked-hosting.md`](0047-gateway-linked-hosting.md),
+  [`0082-the-hosted-machine-serves-the-renderer.md`](0082-the-hosted-machine-serves-the-renderer.md),
+  [`../self-hosting.md`](../self-hosting.md),
+  [`.github/workflows/publish-server-image.yml`](../../.github/workflows/publish-server-image.yml)
+- Supersedes: none
+
+## Context
+
+`publish-server-image.yml` builds `ghcr.io/brightwave-inc/tidebreak-server`
+on every release, on a weekly schedule that flushes base-image patches into
+the same version tag, and on manual dispatch. A consumer that pins the image
+pins a digest, and nothing on the registry says where that digest came from:
+a digest pushed by a package-write token looks exactly like one the workflow
+built.
+
+Model Gateway hosts Tidebreak as a managed add-on and admits images against
+a trust policy. Today that policy enumerates digests, so every Tidebreak
+release needs a deployment change to admit the new digest, and a weekly
+rebuild that moves a version tag onto patched bases needs one too. The
+gateway wants to replace the enumerated list with a rule: admit any digest
+that this repository's publish workflow provably built. That rule needs a
+signed statement it can verify without trusting the registry or the network
+path to it.
+
+GitHub artifact attestations provide one. `actions/attest-build-provenance`
+signs an in-toto statement carrying a SLSA v1 provenance predicate with a
+Sigstore certificate issued to the workflow's OIDC identity, records it in
+the public transparency log, and stores the bundle under the repository. A
+verifier checks the bundle offline against the public Sigstore trust root
+and reads the signing identity from the certificate, not from the
+statement.
+
+## Decision
+
+1. **Every published server image is attested.** The per-architecture
+   manifests that the build job pushes and the multi-architecture index the
+   manifest job assembles each get a build-provenance attestation. All three
+   publish lanes attest, the weekly rebuild included, because a rebuilt
+   digest is exactly the digest a consumer next adopts.
+2. **Attestations are stored with the repository and pushed to the
+   registry.** The bundle lands in GitHub's attestation store for
+   `brightwave-inc/tidebreak` and is also attached to the image as an OCI
+   referrer, so `gh attestation verify` and `cosign` both find it.
+3. **The workflow path is a public contract.** A verifier identifies the
+   image by the signing certificate's identity:
+   `https://github.com/brightwave-inc/tidebreak/.github/workflows/publish-server-image.yml`
+   followed by the ref the run used. Renaming or moving that file changes
+   the identity of every image published afterwards and must be treated as
+   a breaking change to consumers that verify provenance.
+4. **The action is pinned by commit and moved by Dependabot**, like every
+   other action in the file.
+
+Deliberately excluded: signing with a repository-held key, attesting the
+desktop bundles, and any change to how the image is built.
+
+## Alternatives Considered
+
+- **Do nothing; consumers keep enumerating digests.** Every release and
+  every weekly rebuild then costs a deployment change somewhere else, and
+  the list says nothing about where a digest came from.
+- **Cosign keyless signing from the workflow.** Equivalent trust, but a
+  second signing tool with its own pinning and its own storage convention,
+  while the attestation action is first-party and its bundles are readable
+  through the GitHub API without registry credentials.
+- **Attest only the index digest.** Enough for the gateway, which resolves
+  a tag to the index. The per-architecture attestations cost one step each
+  and let an operator who pins a single-platform manifest verify it too.
+
+## Consequences
+
+- The build and manifest jobs gain `id-token: write` and
+  `attestations: write`. Neither grants anything beyond signing with the
+  workflow's own identity and writing bundles under this repository.
+- A package-write token can still push to GHCR, but what it pushes carries
+  no attestation and a provenance-verifying consumer refuses it. That is
+  the point.
+- The workflow file name is now load-bearing outside this repository.
+- Revisit if GitHub changes the attestation storage or Sigstore trust
+  domain for public repositories, or if a consumer needs a predicate the
+  build-provenance action does not emit.
+
+## Validation
+
+- `gh attestation verify oci://ghcr.io/brightwave-inc/tidebreak-server:<version> -R brightwave-inc/tidebreak`
+  succeeds for the first release published after this record merges, and
+  the printed signer identity names `publish-server-image.yml`.
+- The same command against a digest pushed outside the workflow reports no
+  attestation, which is the refusal a consumer must produce.
+- A wrong implementation that attested only the per-architecture manifests
+  would still pass a per-platform verify; the check above runs against the
+  version tag, which resolves to the index.

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -92,3 +92,4 @@
 0081  0081-uneff-me-works-without-a-tidebreak-checkout.md
 0082  0082-the-hosted-machine-serves-the-renderer.md
 0083  0083-portable-workspace-configuration-export.md
+0084  0084-the-server-image-carries-github-build-provenance.md


### PR DESCRIPTION
Every pushed server manifest, each per-architecture image and the multi-arch index, now carries a GitHub build-provenance attestation (`actions/attest-build-provenance`, pinned by commit). The bundle is stored under this repository and pushed to GHCR as an OCI referrer.

Why: Model Gateway hosts Tidebreak as a managed add-on and admits images against a trust policy that enumerates digests today, so every release and every weekly rebuild needs a deployment change to admit the new digest. With provenance, the gateway can admit any digest that this repository's publish workflow provably built, verified offline against the Sigstore trust root.

Decision record 84 states the contract: the workflow file path is now the image's public identity, so moving it is a breaking change for verifying consumers.

Verify on the next publish:

```
gh attestation verify oci://ghcr.io/brightwave-inc/tidebreak-server:<version> -R brightwave-inc/tidebreak
```

`actionlint` passes on the workflow. No image build changes.