### PR TITLE
ci: drop native tests from Windows cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,6 @@ jobs:
       notices: ${{ steps.scope.outputs.notices }}
       rust: ${{ steps.scope.outputs.rust }}
       ui: ${{ steps.scope.outputs.ui }}
-      windows: ${{ steps.scope.outputs.windows }}
       workspace: ${{ steps.scope.outputs.workspace }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -154,7 +153,6 @@ jobs:
               echo "notices=true"
               echo "rust=true"
               echo "ui=true"
-              echo "windows=true"
               echo "workspace=true"
             } >> "$GITHUB_OUTPUT"
           }
@@ -204,7 +202,6 @@ jobs:
           notices=false
           rust=false
           ui=false
-          windows=false
           workspace=false
           git diff --no-renames --name-only -z "$diff_range" \
             > "$RUNNER_TEMP/changed-files"
@@ -249,24 +246,6 @@ jobs:
                 notices=true; rust=true; workspace=true ;;
               *) rust=true; workspace=true ;;
             esac
-            # A second, independent question about the same file: can it
-            # break on Windows in a way no Linux lane can see? These are the
-            # paths the Windows lane runs native tests for. NTFS path shapes,
-            # the Windows process APIs, and the native credential store decide
-            # those results. `cargo check` on the native runner is rust-scoped
-            # and does not prove them.
-            case "$file" in
-              # This file decides what every lane runs, including this one.
-              .github/workflows/ci.yml) windows=true ;;
-              crates/tidebreak-code-execution/*|crates/tidebreak-harness/*|crates/tidebreak-host-broker/*)
-                windows=true ;;
-              crates/tidebreak-server/src/code/*|crates/tidebreak-server/src/tests/code*)
-                windows=true ;;
-              crates/tidebreak-server/src/desktop_schema.rs|crates/tidebreak-core/src/keychain.rs)
-                windows=true ;;
-              crates/tidebreak-desktop/scripts/prepare-sidecar.mjs)
-                windows=true ;;
-            esac
           done < "$RUNNER_TEMP/changed-files"
 
           # Keep narrower scopes honest here, before conditional jobs consume
@@ -276,10 +255,6 @@ jobs:
             echo "workspace scope without Rust scope; the detector is wrong." >&2
             exit 1
           fi
-          if [[ "$windows" == true && "$rust" != true ]]; then
-            echo "Windows scope without Rust scope; the detector is wrong." >&2
-            exit 1
-          fi
 
           {
             echo "docs_site=$docs_site"
@@ -287,7 +262,6 @@ jobs:
             echo "notices=$notices"
             echo "rust=$rust"
             echo "ui=$ui"
-            echo "windows=$windows"
             echo "workspace=$workspace"
           } >> "$GITHUB_OUTPUT"
 
@@ -538,10 +512,8 @@ jobs:
     # A native runner keeps the Windows SDK and MSVC available for native
     # dependencies such as ring and SQLite. `cargo check` is rust-scoped like
     # clippy: a Windows compile break on main blocks the desktop release, so
-    # every Rust-scoped pull request has to catch it. Native tests stay behind
-    # the `windows` scope, the `windows-ci` label, or a non-PR run — they need
-    # NTFS and the Windows process APIs, and they retry a PowerShell startup
-    # race that should not gate unrelated Rust changes.
+    # every Rust-scoped pull request has to catch it. The check covers the
+    # installer graph only. Native Windows tests are not a merge gate.
     if: ${{ needs.changes.outputs.rust == 'true' }}
     # Prefer an 8 vCPU / 32 GB Windows larger runner. Standard windows-latest
     # is 4 cores and spends most of this lane in rustc; 16 cores is not worth
@@ -549,22 +521,13 @@ jobs:
     # label. If the variable is unset, the job uses windows-latest so a missing
     # larger runner cannot stall the merge queue.
     runs-on: ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
-    # The persistence steps below compile tidebreak-server's test target, which
-    # is the heaviest codegen this lane pays; leave headroom over the
-    # check-plus-broker baseline.
-    timeout-minutes: 30
+    timeout-minutes: 20
     env:
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_DEV_DEBUG: 0
-      CARGO_PROFILE_TEST_DEBUG: 0
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: READ_WRITE
       RUSTC_WRAPPER: sccache
-      # link.exe dominates Windows test-binary time on 4 cores. rust-lld ships
-      # with the toolchain and is the MSVC analogue of mold on the Linux lanes.
-      # `cargo check` clears this so a linker mismatch cannot fail the
-      # rust-scoped compile gate.
-      RUSTFLAGS: -C linker=rust-lld
     steps:
       # A newer main commit contains this one, so its own Windows run proves
       # everything this run would. Bailing out with success is what keeps that
@@ -624,149 +587,14 @@ jobs:
           $mz = [byte[]](0x4D, 0x5A)
           [System.IO.File]::WriteAllBytes($broker, $mz)
           [System.IO.File]::WriteAllBytes($cli, $mz)
-      - name: Check Windows-gated crates
+      - name: Check the Windows installer crates
         if: ${{ steps.tip.outputs.superseded != 'true' }}
-        env:
-          RUSTFLAGS: ""
         run: >-
           cargo check --target x86_64-pc-windows-msvc
-          -p tidebreak-core
-          -p tidebreak-code-execution
-          -p tidebreak-host-broker
           -p tidebreak-cli
-          -p tidebreak-server
+          -p tidebreak-host-broker
           -p tidebreak-desktop
           --locked
-      - name: Record native Windows test gate
-        id: native
-        if: ${{ steps.tip.outputs.superseded != 'true' }}
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          WINDOWS_CI_GATE: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci') || needs.changes.outputs.windows == 'true' }}
-          WINDOWS_SCOPE: ${{ needs.changes.outputs.windows }}
-        run: |
-          # Merge groups are not pull requests, so WINDOWS_CI_GATE is true for
-          # every rust-scoped group. Keep the native suites on the windows
-          # scope there so the required cargo check does not compile test
-          # binaries on unrelated Rust changes.
-          if [[ "$EVENT_NAME" == merge_group ]]; then
-            if [[ "$WINDOWS_SCOPE" == true ]]; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-            fi
-          elif [[ "$WINDOWS_CI_GATE" == true ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          fi
-      # `cargo check` does not build test binaries, and `--lib` is workspace-wide,
-      # so host-broker's sidecar integration test cannot share an invocation with
-      # server and core. #3085 ran two `--no-run` graphs here first; that added
-      # nine minutes and the later run steps still compiled, so skip the graphs.
-      # Keep the cargo lines so the base-branch policy test still matches.
-      - name: Compile native Windows test binaries
-        if: ${{ steps.tip.outputs.superseded != 'true' }}
-        env:
-          NATIVE_RUN: ${{ steps.native.outputs.run }}
-        shell: bash
-        run: |
-          if [[ "$NATIVE_RUN" != "true" ]]; then
-            echo "Skipping native Windows test compile."
-            exit 0
-          fi
-          echo "Skipping native Windows test precompile."
-          exit 0
-          cargo test --target x86_64-pc-windows-msvc --locked --no-run --lib \
-            -p tidebreak-server \
-            -p tidebreak-core
-          cargo test --target x86_64-pc-windows-msvc --locked --no-run \
-            -p tidebreak-host-broker \
-            -p tidebreak-code-execution \
-            -p tidebreak-harness
-      # The host broker suite covers both real NTFS containment and the stdio
-      # sidecar boundary: private state/audit placement, exclusive ownership of
-      # the state directory, restart persistence, and exit when the desktop pipe
-      # closes. Deliberately one crate: this lane is for checks that need the
-      # native host, not a second copy of the workspace suite.
-      - name: Host broker Windows tests
-        if: ${{ steps.tip.outputs.superseded != 'true' }}
-        env:
-          NATIVE_RUN: ${{ steps.native.outputs.run }}
-        shell: pwsh
-        run: |
-          if ($env:NATIVE_RUN -ne "true") {
-            Write-Host "Skipping native Windows tests."
-            exit 0
-          }
-          cargo test --target x86_64-pc-windows-msvc -p tidebreak-host-broker --locked
-      # Code mode crosses Windows-native executable, environment, PowerShell,
-      # path-identity, and process-tree boundaries. A cross-target check cannot
-      # prove those behaviors; run the harness suite and the server's code-mode
-      # modules on NTFS with the Windows process APIs available.
-      # Process-tree teardown races PowerShell startup on a loaded runner.
-      # Three attempts cover that without dropping the Windows contract.
-      - name: Code mode Windows lifecycle tests
-        if: ${{ steps.tip.outputs.superseded != 'true' }}
-        env:
-          NATIVE_RUN: ${{ steps.native.outputs.run }}
-        shell: pwsh
-        run: |
-          if ($env:NATIVE_RUN -ne "true") {
-            Write-Host "Skipping native Windows tests."
-            exit 0
-          }
-          $ErrorActionPreference = "Continue"
-          $PSNativeCommandUseErrorActionPreference = $false
-          $attempts = 3
-          $suites = @(
-            @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-code-execution", "--locked"),
-            @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-harness", "--locked"),
-            @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-server", "--lib", "code::", "--locked")
-          )
-          foreach ($suite in $suites) {
-            $passed = $false
-            for ($attempt = 1; $attempt -le $attempts; $attempt++) {
-              & cargo @suite
-              if ($LASTEXITCODE -eq 0) {
-                $passed = $true
-                break
-              }
-              Write-Host "cargo $($suite -join ' ') failed on attempt $attempt/$attempts"
-            }
-            if (-not $passed) {
-              exit 1
-            }
-          }
-      # Boot-critical persistence, proven on the OS that ships it: the desktop
-      # profile's SQLite open/migrate lifecycle (tidebreak-server's
-      # desktop_schema module, including the Windows MoveFileExW marker swap)
-      # and a Credential Manager set/get/delete round trip through the keyring
-      # crate's windows-native backend. Targeted filters on two crates — not a
-      # second copy of the workspace suite.
-      - name: SQLite profile open and migrations
-        if: ${{ steps.tip.outputs.superseded != 'true' }}
-        env:
-          NATIVE_RUN: ${{ steps.native.outputs.run }}
-        shell: pwsh
-        run: |
-          if ($env:NATIVE_RUN -ne "true") {
-            Write-Host "Skipping native Windows tests."
-            exit 0
-          }
-          cargo test --target x86_64-pc-windows-msvc -p tidebreak-server --lib desktop_schema --locked
-      # `-- --ignored` runs the native round trip alone, so the process-global
-      # in-memory keyring mock installed by the ordinary unit test never
-      # activates and the test reaches the real Credential Manager available
-      # under the hosted runner session.
-      - name: Credential Manager round trip
-        if: ${{ steps.tip.outputs.superseded != 'true' }}
-        env:
-          NATIVE_RUN: ${{ steps.native.outputs.run }}
-        shell: pwsh
-        run: |
-          if ($env:NATIVE_RUN -ne "true") {
-            Write-Host "Skipping native Windows tests."
-            exit 0
-          }
-          cargo test --target x86_64-pc-windows-msvc -p tidebreak-core --lib keychain --locked -- --ignored
 
   test:
     name: test

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -697,12 +697,9 @@ managed release labels match the title, so requiring the label job too would
 add nothing.
 
 `Windows cargo check` is rust-scoped like clippy because a Windows compile
-break on `main` blocks the desktop release. Native Windows tests inside that
-job still wait for the `windows` scope, the `windows-ci` label, or a
-main/scheduled/manual run: those suites need NTFS and the Windows process
-APIs, and they retry a PowerShell startup race that should not gate unrelated
-Rust changes. Native test binaries link with `rust-lld`. `cargo check` keeps
-the MSVC linker.
+break on `main` blocks the desktop release. It typechecks the installer graph
+on `x86_64-pc-windows-msvc`: `tidebreak-desktop` plus the `tidebreak-cli` and
+`tidebreak-host-broker` sidecars. It does not run native Windows tests.
 
 To run that job on an 8-core Windows larger runner (8 vCPU, 32 GB), set the
 repository variable `CI_WINDOWS_RUNNER` to the provisioned x64 label. If you

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -611,9 +611,11 @@ function skipsSupersededPush(job) {
   );
 }
 
-test("Windows cargo check typechecks the installer graph", () => {
+test("Windows cargo check is a compile-only installer gate", () => {
   const ci = workflows["ci.yml"];
   const windows = workflowJob(ci, "windows-check");
+  const changes = workflowJob(ci, "changes");
+  assert.match(windows, /Check the Windows installer crates/);
   assert.match(windows, /vars\.CI_WINDOWS_RUNNER \|\| 'windows-latest'/);
   assert.match(windows, /Stage sidecar placeholders for cargo check/);
   assert.doesNotMatch(windows, /prepare-sidecar\.mjs/);
@@ -621,6 +623,9 @@ test("Windows cargo check typechecks the installer graph", () => {
   assert.match(windows, /-p tidebreak-cli/);
   assert.match(windows, /-p tidebreak-host-broker/);
   assert.match(windows, /cargo check --target x86_64-pc-windows-msvc/);
+  assert.doesNotMatch(windows, /cargo test/);
+  assert.doesNotMatch(ci, /windows-ci/);
+  assert.doesNotMatch(changes, /echo "windows=/);
   assert.ok(
     skipsSupersededPush(windows),
     "a superseded main push must skip the Windows lane, not cancel it",


### PR DESCRIPTION
## What changed

Windows cargo check compiled and retried native suites that flake on hosted runners. Those tests are not a Windows installer gate.

The job now typechecks `tidebreak-desktop`, `tidebreak-cli`, and `tidebreak-host-broker` on `x86_64-pc-windows-msvc`. It no longer runs host-broker, code-mode lifecycle, SQLite, or Credential Manager tests.

## Validation

- `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs`

## Compatibility and risk

A Windows compile break still fails the PR and would still fail a release. Runtime Windows bugs wait for user reports.