### PR TITLE
ci: give the macOS cache warmer 90 minutes

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -47,7 +47,7 @@ jobs:
     name: macOS cache · universal
     needs: cargo-downloads
     runs-on: macos-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache


### PR DESCRIPTION
## Why

The macOS cache warmer (\`cache-macos.yml\`) has a 60-minute job timeout, but a cold universal release compile takes 66–70 minutes on \`macos-latest\`. The last three warm jobs each ran exactly 60 minutes and were cancelled by the timeout, so the warmer has never saved a \`macos-release-target-v5-universal\` archive and every release starts cold (four sequential release compiles, ~70 minutes).

## Change

Raise the warm job's \`timeout-minutes\` from 60 to 90. This matches \`cache-linux.yml\`, \`cache-windows.yml\`, and the macOS \`prepare\` job in \`release.yml\`.

## Not in this PR

The warmer still keys its archive by \`github.sha\`, so a saved cache only helps a release cut from that exact commit or one that matches a restore prefix. Moving to one stable key per OS is a separate change.