### PR TITLE
feat(server): honor the Model Gateway add-on plane's environment contract

### DIFF
--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -384,7 +384,10 @@ impl Config {
     /// `./.tidebreak` under the current directory — desktop/CLI clients should set
     /// this to the platform's app-data location),
     /// `TIDEBREAK_BLOB_STORE_URL` (required for self-host; an S3 bucket and
-    /// optional prefix),
+    /// optional prefix), with the Model Gateway add-on plane's
+    /// `GATEWAY_BASE_URL`, `DATABASE_URL`, and `ADD_ON_PUBLIC_URL` standing in
+    /// for `TIDEBREAK_AUTH_GATEWAY_URL`, `TIDEBREAK_DATABASE_URL`, and
+    /// `TIDEBREAK_PUBLIC_URL` when those are unset (decision 0085),
     /// `TIDEBREAK_CONTAINER_EXECUTION_ENABLED` (default `false`),
     /// `TIDEBREAK_CONTAINER_IMAGE` (defaulting to the server's default agent
     /// image), `TIDEBREAK_AUTH_TOKENS_FILE` or `TIDEBREAK_AUTH_GATEWAY_URL`
@@ -416,9 +419,15 @@ impl Config {
             std::env::var("TIDEBREAK_CONTAINER_EXECUTION_ENABLED").ok(),
             std::env::var("TIDEBREAK_CONTAINER_IMAGE").ok(),
             std::env::var_os("TIDEBREAK_AUTH_TOKENS_FILE"),
-            std::env::var("TIDEBREAK_AUTH_GATEWAY_URL").ok(),
+            plane_fallback(
+                std::env::var("TIDEBREAK_AUTH_GATEWAY_URL").ok(),
+                std::env::var("GATEWAY_BASE_URL").ok(),
+            ),
             std::env::var("TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL").ok(),
-            std::env::var("TIDEBREAK_PUBLIC_URL").ok(),
+            plane_fallback(
+                std::env::var("TIDEBREAK_PUBLIC_URL").ok(),
+                std::env::var("ADD_ON_PUBLIC_URL").ok(),
+            ),
             std::env::var("TIDEBREAK_LISTEN_ADDR").ok(),
             std::env::var("TIDEBREAK_RUNTIME_ENDPOINT").ok(),
             std::env::var("TIDEBREAK_RUNTIME_PROFILE").ok(),
@@ -621,11 +630,24 @@ impl Config {
                 "sqlite://{}?mode=rwc",
                 self.data_dir.join("tidebreak.db").display()
             )),
-            Profile::SelfHost => std::env::var("TIDEBREAK_DATABASE_URL").map_err(|_| {
-                AgentError::config("TIDEBREAK_DATABASE_URL is required for self-host")
-            }),
+            Profile::SelfHost => plane_fallback(
+                std::env::var("TIDEBREAK_DATABASE_URL").ok(),
+                std::env::var("DATABASE_URL").ok(),
+            )
+            .ok_or_else(|| AgentError::config("TIDEBREAK_DATABASE_URL is required for self-host")),
         }
     }
+}
+
+/// The Model Gateway add-on plane's environment contract, honored when the
+/// server's own variable is unset (decision 0085). A managed machine is
+/// handed `GATEWAY_BASE_URL`, `DATABASE_URL`, and `ADD_ON_PUBLIC_URL` by the
+/// plane; the `TIDEBREAK_*` name always wins when both are set, and an empty
+/// value counts as unset on either side, so a blank override never hides the
+/// plane's value.
+fn plane_fallback(own: Option<String>, plane: Option<String>) -> Option<String> {
+    own.filter(|value| !value.trim().is_empty())
+        .or_else(|| plane.filter(|value| !value.trim().is_empty()))
 }
 
 /// OAuth resource bound to one exact, already-canonical Tidebreak public URL.
@@ -716,6 +738,26 @@ fn parse_spend_ceiling(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn the_plane_contract_stands_in_only_when_the_own_variable_is_unset() {
+        // Decision 0085: the plane's name fills an unset or blank own
+        // variable and never overrides a set one.
+        assert_eq!(
+            super::plane_fallback(None, Some("https://gateway.example".into())),
+            Some("https://gateway.example".into())
+        );
+        assert_eq!(
+            super::plane_fallback(Some("  ".into()), Some("postgres://plane".into())),
+            Some("postgres://plane".into())
+        );
+        assert_eq!(
+            super::plane_fallback(Some("https://own".into()), Some("https://plane".into())),
+            Some("https://own".into())
+        );
+        assert_eq!(super::plane_fallback(None, Some(String::new())), None);
+        assert_eq!(super::plane_fallback(None, None), None);
+    }
+
     use super::*;
 
     #[test]

--- a/docs/decisions/0085-the-server-honors-the-model-gateway-add-on-plane-s-environment-contract.md
+++ b/docs/decisions/0085-the-server-honors-the-model-gateway-add-on-plane-s-environment-contract.md
@@ -1,0 +1,78 @@
+# 85. The server honors the Model Gateway add-on plane's environment contract
+
+- Status: Accepted
+- Date: 2026-09-03
+- Owners: thet
+- Related: [0047](0047-gateway-linked-hosting.md); Model Gateway ADR 0095 (managed add-on hosting) and ADR 0108 (release tracking)
+- Supersedes: none
+
+## Context
+
+A gateway-hosted Tidebreak machine is a managed add-on of the Model Gateway
+add-on plane. The plane hands every managed workload one environment
+contract: `GATEWAY_BASE_URL`, `GATEWAY_CLIENT_ID`, `GATEWAY_CLIENT_SECRET`,
+`ADD_ON_PUBLIC_URL`, and, when the row declares a database, `DATABASE_URL`.
+The server reads only its own names: `TIDEBREAK_AUTH_GATEWAY_URL`,
+`TIDEBREAK_PUBLIC_URL`, `TIDEBREAK_DATABASE_URL`.
+
+The devops machine has run since 2026-08-27 only because those three
+`TIDEBREAK_*` variables were patched onto its Deployment by hand with
+kubectl. Server-side apply preserves another manager's fields, so the patch
+survived every rollout, but a remove and reinstall of the row would drop it
+and the machine would boot without a database URL or a gateway to
+authenticate against. The plane now tracks Tidebreak's own releases and
+adopts each one on its own (Model Gateway ADR 0108), so the machine is
+rolled far more often than a person looks at it.
+
+## Decision
+
+In `Config::from_env`, and in `database_url` for the self-host profile, the
+plane's name stands in when the server's own name is unset or blank:
+
+| Server variable | Plane variable |
+| --- | --- |
+| `TIDEBREAK_AUTH_GATEWAY_URL` | `GATEWAY_BASE_URL` |
+| `TIDEBREAK_PUBLIC_URL` | `ADD_ON_PUBLIC_URL` |
+| `TIDEBREAK_DATABASE_URL` | `DATABASE_URL` |
+
+The `TIDEBREAK_*` name always wins when both are set. Nothing else from the
+contract is read: `GATEWAY_CLIENT_ID` and `GATEWAY_CLIENT_SECRET` are the
+plane's credential for the add-on registration, which the server does not
+use, and the blob store, listen address, and profile keep their own names
+and their documented defaults (the image sets `TIDEBREAK_PROFILE`,
+`TIDEBREAK_LISTEN_ADDR`, and `TIDEBREAK_UI_DIST`).
+
+`ADD_ON_PUBLIC_URL` carries a trailing slash, byte-identical to the plane's
+machine-binding canonical; `canonical_public_url` already trims it, so the
+OAuth resource derived from it is the one the patched value produced.
+
+## Alternatives Considered
+
+- **Keep the kubectl patch.** It is invisible to the plane, to the console,
+  and to anyone reading the row, and it dies with the first reinstall.
+- **Have the plane emit `TIDEBREAK_*` names.** The plane is add-on-agnostic
+  by design (Model Gateway ADR 0095 decision 5); a per-add-on rename in the
+  plane would be the first, and every add-on after Tidebreak would want its
+  own.
+- **Write the three names through the row's environment write.** Works for
+  the URLs, but `DATABASE_URL` is a plane-minted Secret reference the
+  environment write cannot express, and it repeats what the plane already
+  states.
+
+## Consequences
+
+A machine the plane installs from its preset boots with no environment
+write at all. The hand patch on devops can be removed once a server image
+carrying this decision runs there. A self-host operator who runs Tidebreak
+outside the plane sees no change: none of the plane names are set in their
+environment. The decision is revisited if the plane's contract renames a
+variable, or if the server ever needs the plane's client credential.
+
+## Validation
+
+- `plane_fallback` is a pure function with a unit test covering unset,
+  blank, and both-set inputs; a wrong implementation that let the plane's
+  value override a set `TIDEBREAK_*` fails the both-set case.
+- On devops, after the image carrying this ships: strip the kubectl patch
+  from the Deployment and confirm the pod still authenticates against the
+  gateway and opens its store.

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -93,3 +93,4 @@
 0082  0082-the-hosted-machine-serves-the-renderer.md
 0083  0083-portable-workspace-configuration-export.md
 0084  0084-the-server-image-carries-github-build-provenance.md
+0085  0085-the-server-honors-the-model-gateway-add-on-plane-s-environment-contract.md

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -255,10 +255,11 @@ aspirational.
 | Variable | Required | Default | What it does |
 | --- | --- | --- | --- |
 | `TIDEBREAK_PROFILE` | yes | `desktop` | `self_host` (or `selfhost`) selects this profile. Anything else is desktop or a config error. |
-| `TIDEBREAK_DATABASE_URL` | yes (self-host) | — | PostgreSQL connection string for the shared store. |
+| `TIDEBREAK_DATABASE_URL` | yes (self-host) | `DATABASE_URL` | PostgreSQL connection string for the shared store. On a Model Gateway managed machine the plane's `DATABASE_URL` stands in when this is unset. |
 | `TIDEBREAK_BLOB_STORE_URL` | yes (self-host) | — | S3 bucket and optional prefix, for example `s3://company-tidebreak/production`. Credentials, region, and an optional compatible endpoint come from standard `AWS_*` variables. |
 | `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_ENDPOINT_URL_S3`, `AWS_ALLOW_HTTP` | depends on provider | AWS defaults | Configure AWS S3 or an S3-compatible endpoint. Keep `AWS_ALLOW_HTTP=false` outside isolated development networks. Role, web-identity, and container credential variables are also accepted. |
-| `TIDEBREAK_AUTH_GATEWAY_URL` | one auth mode required | — | Public Model Gateway identity URL exposed to clients and, by default, used for live validation. HTTPS required except for loopback development. |
+| `TIDEBREAK_AUTH_GATEWAY_URL` | one auth mode required | `GATEWAY_BASE_URL` | Public Model Gateway identity URL exposed to clients and, by default, used for live validation. HTTPS required except for loopback development. |
+| `TIDEBREAK_PUBLIC_URL` | with Gateway auth | `ADD_ON_PUBLIC_URL` | The machine's own public URL, which user credentials are bound to. On a Model Gateway managed machine the plane's `ADD_ON_PUBLIC_URL` stands in when this is unset (decision 0085). |
 | `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` | no | `TIDEBREAK_AUTH_GATEWAY_URL` | Optional server-to-server Gateway URL for principal validation when the public origin is not cluster-routable. Requires Gateway auth. |
 | `TIDEBREAK_AUTH_TOKENS_FILE` | one auth mode required | — | Standalone compatibility: path to the static token file above. Mutually exclusive with Gateway auth. |
 | `TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS` | no | unset | Comma-separated service bearers allowed to start an external channel connect handshake. Each value must be 32–512 header-safe characters. Leave unset to disable connect start. To rotate without downtime, add the new value, move the adapter, then remove the old value. |


### PR DESCRIPTION
## What

`Config::from_env` and the self-host `database_url` now accept the Model Gateway add-on plane's variables when the server's own are unset or blank:

| Server | Plane |
| --- | --- |
| `TIDEBREAK_AUTH_GATEWAY_URL` | `GATEWAY_BASE_URL` |
| `TIDEBREAK_PUBLIC_URL` | `ADD_ON_PUBLIC_URL` |
| `TIDEBREAK_DATABASE_URL` | `DATABASE_URL` |

The `TIDEBREAK_*` name always wins when both are set. Decision 0085 records the choice and the alternatives; `docs/self-hosting.md` shows the fallback in the variable table.

## Why

The devops machine is a managed add-on of the gateway's hosting plane. It has run since Aug 27 only because those three variables were patched onto its Deployment with kubectl; server-side apply kept the patch through every rollout, but a remove and reinstall of the row drops it. The plane now adopts each Tidebreak release on its own (Model Gateway ADR 0108), so the machine will roll more often than anyone looks at it, and it should boot from the contract the plane already hands it.

## Checks

- `cargo fmt --all --check`
- `cargo clippy -p tidebreak-core --all-targets -- -D warnings`
- `cargo test -p tidebreak-core --lib config::` (24 passed, one new: unset, blank, and both-set inputs)
- `python3 scripts/adr.py check`