### PR TITLE
build: unify shared Cargo features across build selections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,13 @@ debug = "line-tables-only"
 debug-assertions = true
 overflow-checks = true
 
+# The scripted test seams (`tidebreak-server`'s `scripted_provider` and
+# `scripted_harness`) compile under `cfg(debug_assertions)`. This is Cargo's
+# default for release, but the guarantee that released binaries never contain
+# them rests on it, so it stays pinned rather than implied.
+[profile.release]
+debug-assertions = false
+
 # Shared dependency versions. Crates opt in with `dep.workspace = true` so the
 # whole workspace resolves one version of each.
 [workspace.dependencies]
@@ -39,7 +46,9 @@ brush-parser = "=0.4.0"
 # backreferences and cannot express them.
 fancy-regex = "=0.19.0"
 serde = { version = "=1.0.229", features = ["derive"] }
-serde_json = "=1.0.151"
+# `unbounded_depth` matches what tauri-build already enables in the desktop
+# graph, so every build selection resolves one serde_json instead of two.
+serde_json = { version = "=1.0.151", features = ["unbounded_depth"] }
 # Parses the same `$CODEX_HOME/config.toml` the Codex engine parses, so
 # auth-override detection and the engine child-env filter agree with the
 # engine (and each other) about what the config declares. A substring scan
@@ -74,7 +83,29 @@ ts-rs = { version = "=12.0.1", features = ["chrono-impl", "uuid-impl", "no-serde
 windows-sys = "=0.61.2"
 sea-orm = { version = "=2.0.2", default-features = false, features = ["macros", "runtime-tokio-rustls", "with-uuid", "with-chrono", "with-json"] }
 sea-orm-migration = { version = "=2.0.2", default-features = false, features = ["runtime-tokio-rustls"] }
-tokio = { version = "=1.53.1", features = ["rt", "macros", "fs"] }
+# One unified feature set for every build selection, so `-p` builds, the
+# `--workspace` lanes, and the release sidecar/desktop builds all share the
+# same compiled tokio (and everything above it) instead of resolving
+# per-crate subsets that force rebuilds. This is the union every crate needs:
+# `signal` is the CLI's ctrl-c handling, `rt-multi-thread` backs the server's
+# `block_in_place` bridge, `io-std` is the MCP stdio transport. `test-util`
+# is only paused-clock test plumbing, but it is behavior-neutral unless
+# `pause()` is called, and carrying it here keeps `cargo build` and
+# `cargo test` on one tokio artifact.
+tokio = { version = "=1.53.1", features = [
+    "fs",
+    "io-std",
+    "io-util",
+    "macros",
+    "net",
+    "process",
+    "rt",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "test-util",
+    "time",
+] }
 tokio-util = { version = "=0.7.19", features = ["io-util"] }
 # rustls-tls-webpki-roots (never native-tls) matches the reqwest stack; the
 # loopback chat socket itself is plain ws://.
@@ -101,7 +132,9 @@ zip = { version = "=8.6.0", default-features = false, features = ["deflate-flate
 # not cut a release. Drop this patch for a plain version bump once 0.6.1 ships.
 
 tracing = "=0.1.44"
-url = "=2.5.8"
+# `serde` matches what the tauri plugins already enable in the desktop graph,
+# so every build selection resolves one url instead of two.
+url = { version = "=2.5.8", features = ["serde"] }
 # Image header/decode allowlist codecs shared by server, mcp, code-execution.
 image = { version = "=0.25.10", default-features = false, features = ["png", "jpeg", "webp", "gif"] }
 dom_smoothie = "=0.18.0"

--- a/crates/tidebreak-cli/Cargo.toml
+++ b/crates/tidebreak-cli/Cargo.toml
@@ -44,7 +44,7 @@ serde = { workspace = true }
 # never enters model-facing text or log data.
 image = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time"] }
+tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
 # The connected-folder executor's diagnostics belong in the profile's log file:
 # it polls, so stderr would flood a print run.
@@ -53,9 +53,5 @@ url = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-# The scripted model provider and scripted code-mode engine the end-to-end
-# tests drive. Enabling them here compiles them into the `tidebreak` binary
-# the tests spawn, and only when the tests are built.
-tidebreak-server = { path = "../tidebreak-server", features = ["scripted-provider", "scripted-harness"] }
 tempfile = { workspace = true }
 jsonschema = { workspace = true }

--- a/crates/tidebreak-cli/tests/agent_mcp_code.rs
+++ b/crates/tidebreak-cli/tests/agent_mcp_code.rs
@@ -1,5 +1,5 @@
 //! End-to-end tests of `tidebreak agent-mcp` code-mode tools over a real
-//! `tidebreak serve` with the feature-gated scripted harness.
+//! `tidebreak serve` with the debug-only scripted harness.
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;

--- a/crates/tidebreak-code-execution/Cargo.toml
+++ b/crates/tidebreak-code-execution/Cargo.toml
@@ -26,7 +26,7 @@ ts-rs = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "net", "process", "rt", "sync", "time"] }
+tokio = { workspace = true }
 tracing = { workspace = true }
 trash = { workspace = true }
 url = { workspace = true }
@@ -38,4 +38,3 @@ libc = { workspace = true }
 [dev-dependencies]
 axum = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt-multi-thread"] }

--- a/crates/tidebreak-core/Cargo.toml
+++ b/crates/tidebreak-core/Cargo.toml
@@ -61,7 +61,7 @@ chrono = { workspace = true }
 ts-rs = { workspace = true }
 sea-orm = { workspace = true, optional = true }
 sea-orm-migration = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, features = ["io-util", "sync"] }
+tokio = { workspace = true, optional = true }
 
 # Keychain backends are per-OS: Security framework (macOS), Credential Manager
 # (Windows), and the Secret Service on Linux. The Linux backend uses

--- a/crates/tidebreak-desktop/Cargo.toml
+++ b/crates/tidebreak-desktop/Cargo.toml
@@ -57,7 +57,7 @@ tauri-plugin-updater = "=2.10.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "process", "rt-multi-thread", "macros", "sync", "time"] }
+tokio = { workspace = true }
 tokio-util = { workspace = true }
 unicode-general-category = { workspace = true }
 url = { workspace = true }

--- a/crates/tidebreak-harness/Cargo.toml
+++ b/crates/tidebreak-harness/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tidebreak-core = { path = "../tidebreak-core", default-features = false }
 tidebreak-managed-node = { path = "../tidebreak-managed-node" }
-tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync", "time"] }
+tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
@@ -36,9 +36,6 @@ libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
-
-[dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }
 
 [[bin]]
 name = "tidebreak-harness-capture"

--- a/crates/tidebreak-mcp/Cargo.toml
+++ b/crates/tidebreak-mcp/Cargo.toml
@@ -19,7 +19,7 @@ image = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["io-std", "io-util", "process", "sync", "time"] }
+tokio = { workspace = true }
 # Only the tool contracts (Tool / ToolRegistry / ToolCtx / …), not the SQLite /
 # keychain / agent-loop machinery — hence default-features = false.
 tidebreak-core = { path = "../tidebreak-core", default-features = false }
@@ -27,4 +27,3 @@ tidebreak-core = { path = "../tidebreak-core", default-features = false }
 [dev-dependencies]
 axum = { workspace = true }
 chrono = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "net"] }

--- a/crates/tidebreak-router/Cargo.toml
+++ b/crates/tidebreak-router/Cargo.toml
@@ -38,11 +38,11 @@ futures = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true, optional = true }
 async-stream = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["time"], optional = true }
+tokio = { workspace = true, optional = true }
 url = { workspace = true }
 uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 axum = { workspace = true }
 tidebreak-core = { path = "../tidebreak-core", default-features = false, features = ["tools"] }
-tokio = { workspace = true, features = ["net", "rt-multi-thread", "test-util"] }
+tokio = { workspace = true }

--- a/crates/tidebreak-sandbox-agent/Cargo.toml
+++ b/crates/tidebreak-sandbox-agent/Cargo.toml
@@ -23,7 +23,7 @@ tidebreak-core = { path = "../tidebreak-core", default-features = false }
 # Destination hygiene for the egress-proxy mode: dependency-free by charter, so
 # it costs the container image nothing.
 tidebreak-egress = { path = "../tidebreak-egress" }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "process", "time"] }
+tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -36,7 +36,6 @@ thiserror = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time", "test-util"] }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/tidebreak-sandbox-protocol/Cargo.toml
+++ b/crates/tidebreak-sandbox-protocol/Cargo.toml
@@ -22,13 +22,10 @@ uuid = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["rt", "sync", "macros", "time", "io-util"] }
+tokio = { workspace = true }
 
 [dev-dependencies]
 tidebreak-sandbox-protocol = { path = ".", features = ["conformance"] }
-# `test-util` pauses the clock so the handshake deadline can be exercised without
-# the suite waiting on it.
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros", "time", "io-util", "net", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -16,20 +16,20 @@ workspace = true
 # `TIDEBREAK_DATABASE_URL` names. Off by default: the desktop profile is
 # SQLite-only and the driver is a heavy build-time dependency.
 postgres = ["tidebreak-core/postgres", "sea-orm/sqlx-postgres", "tidebreak-core/blob-object"]
-# Compile the scripted model provider in, so a test in another crate can drive
-# a real turn through the binary. Off by default and never enabled by a release
-# build: see `src/scripted_provider.rs`.
-scripted-provider = []
-# Compile the scripted external-engine adapter in, so a test in another crate
-# can drive a real code-mode turn through the binary. Off by default.
-scripted-harness = []
 
 [dependencies]
 tidebreak-shell-policy = { path = "../tidebreak-shell-policy" }
 tidebreak-code-execution = { path = "../tidebreak-code-execution" }
 tidebreak-harness = { path = "../tidebreak-harness" }
 tidebreak-managed-node = { path = "../tidebreak-managed-node" }
-tidebreak-core = { path = "../tidebreak-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
+# Default features on purpose: the server wants exactly core's default set
+# (`sqlite`, `tools`, `keychain`, `blob-fs`), and asking for the parts with
+# `default-features = false` would drop the `default` pseudo-feature that a
+# `--workspace` build (where core is its own build root) turns on — producing
+# a second, byte-identical core rlib. Leaner dependents still say
+# `default-features = false`; feature unification ORs `default` back in
+# whenever the server is in the graph.
+tidebreak-core = { path = "../tidebreak-core" }
 tidebreak-egress = { path = "../tidebreak-egress" }
 tidebreak-mcp = { path = "../tidebreak-mcp" }
 tidebreak-router = { path = "../tidebreak-router" }
@@ -38,9 +38,7 @@ axum = { workspace = true }
 # Pool sizing for the store this host opens (`host_connect_options`); the
 # driver features come from `tidebreak-core`.
 sea-orm = { workspace = true }
-# `rt-multi-thread` backs the durable operation log's synchronous `OperationStore`
-# bridge (`tokio::task::block_in_place`); the host runs on a multi-thread runtime.
-tokio = { workspace = true, features = ["net", "process", "rt", "rt-multi-thread", "sync", "macros", "time"] }
+tokio = { workspace = true }
 tower-http = { version = "=0.7.0", features = ["cors", "fs", "limit"] }
 futures = { workspace = true }
 async-trait = { workspace = true }
@@ -117,7 +115,5 @@ winreg = "=0.56.0"
 # so the sandbox-resident driver tests can drive the actual sandbox side over a
 # loopback socket, with only Docker and the host model mocked.
 tidebreak-sandbox-agent = { path = "../tidebreak-sandbox-agent" }
-# `test-util` provides the paused Tokio clock used by the HostGate tests.
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync", "test-util"] }
 tower = { version = "=0.5.3", features = ["util"] }
 tokio-tungstenite = { workspace = true }

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -83,11 +83,11 @@ impl CodeRuntime {
             // Skip when a CLI e2e has replaced this kind with the scripted
             // engine: that binary has no pin and must not try to download one.
             let skip_pin = {
-                #[cfg(feature = "scripted-harness")]
+                #[cfg(debug_assertions)]
                 {
                     crate::scripted_harness::env_is_set()
                 }
-                #[cfg(not(feature = "scripted-harness"))]
+                #[cfg(not(debug_assertions))]
                 {
                     false
                 }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -100,9 +100,9 @@ mod sandbox_web_search_worker;
 mod scoped_memory;
 mod scoped_model_token;
 mod scoped_store;
-#[cfg(any(test, feature = "scripted-harness"))]
+#[cfg(any(test, debug_assertions))]
 mod scripted_harness;
-#[cfg(feature = "scripted-provider")]
+#[cfg(debug_assertions)]
 mod scripted_provider;
 /// Rewriting stored credentials so the running binary owns their keychain items.
 pub mod secret_rehome;
@@ -2119,11 +2119,12 @@ async fn bind_inner(
         )
         .with_on_behalf_of_gateway(on_behalf_of_gateway.clone()),
     );
-    // Under the `scripted-provider` feature only — absent from every released
-    // binary — a scripted provider stands in for configured routing so a test
-    // in another crate can drive a real turn. See [`scripted_provider`].
+    // In debug builds only — release profiles compile with `debug_assertions`
+    // off, so this is absent from every released binary — a scripted provider
+    // stands in for configured routing so a test in another crate can drive a
+    // real turn. See [`scripted_provider`].
     let resolver: Arc<dyn resolver::ProviderResolver> = resolver;
-    #[cfg(feature = "scripted-provider")]
+    #[cfg(debug_assertions)]
     let resolver = scripted_provider::resolver_from_env()?.unwrap_or(resolver);
     let blobs = configured_blob_store(&config).await?;
     // The same lock root `AppState` uses. `BlobWriteGuard` rendezvouses through
@@ -2309,7 +2310,7 @@ async fn bind_inner(
     // A chat is a session on the one journal: every event the lane
     // publishes reaches the session's channel too.
     state.events.mirror_into(runtime.bus.clone());
-    #[cfg(feature = "scripted-harness")]
+    #[cfg(debug_assertions)]
     scripted_harness::install_from_env(&mut runtime.adapters)?;
     // Remote sessions need both halves: the configured runtime endpoint and
     // a gateway to mint owner-scoped tokens through. Half a configuration is

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -1,9 +1,9 @@
 //! A [`HarnessAdapter`] / [`HarnessSession`] driven by a script of events.
 //!
-//! Compiled only under the `scripted-harness` feature or in this crate's
-//! tests, matching [`scripted_provider`]: a released binary never contains it.
-//! Test-only builders are gated with `#[cfg(test)]` so a feature-enabled
-//! binary does not carry them.
+//! Compiled only under `cfg(debug_assertions)` or in this crate's tests,
+//! matching [`scripted_provider`]: a released binary never contains it.
+//! Test-only builders are gated with `#[cfg(test)]` so a debug binary does not
+//! carry them.
 
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/crates/tidebreak-server/src/scripted_provider.rs
+++ b/crates/tidebreak-server/src/scripted_provider.rs
@@ -7,10 +7,13 @@
 //! This module is the one seam that does, and it stays deliberately small — a
 //! list of steps in, provider events out.
 //!
-//! It is compiled only under the `scripted-provider` feature, which
-//! `tidebreak-cli` enables from its dev-dependencies. A released binary never
-//! contains it, so the environment variable below cannot divert a real
-//! installation's model traffic.
+//! It is compiled only under `cfg(debug_assertions)`, which the release
+//! profile pins off (see the root manifest's `[profile.release]`). A released
+//! binary never contains it, so the environment variable below cannot divert a
+//! real installation's model traffic. The debug gate — rather than a cargo
+//! feature `tidebreak-cli` turns on from its dev-dependencies — keeps every
+//! dev-profile build of this crate on one feature set, so `-p` builds and
+//! `--workspace` builds share the same compiled rlib.
 //!
 //! `TIDEBREAK_SCRIPTED_PROVIDER` holds the script as a JSON array, one entry per
 //! model step:

--- a/crates/tidebreak-supervised-agent/Cargo.toml
+++ b/crates/tidebreak-supervised-agent/Cargo.toml
@@ -21,12 +21,11 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tidebreak-core = { path = "../tidebreak-core", default-features = false }
 tidebreak-harness = { path = "../tidebreak-harness" }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "sync", "time"] }
+tokio = { workspace = true }
 
 [dev-dependencies]
 axum = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "process", "sync", "time", "test-util"] }
 
 [lints]
 workspace = true

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -109,7 +109,7 @@ crates/tidebreak-server/src/routes/code/      repos, workspaces, sessions,
                                               session_events, updates, approvals,
                                               git, terminals, harnesses, triggers,
                                               delivery, analytics, usage, browser, llm
-crates/tidebreak-server/src/scripted_harness.rs   feature-gated fake adapter
+crates/tidebreak-server/src/scripted_harness.rs   debug-only fake adapter
                                               (the scripted_provider.rs pattern)
 
 crates/tidebreak-desktop/ui/src/code/         the UI family (below)


### PR DESCRIPTION
## Why

Cargo feature unification is selected across the entire resolved graph, but several shared dependencies previously acquired extra features only when particular workspace roots, dev-dependencies, or Tauri build dependencies were selected. That made `-p`, `--workspace`, CI, and release-sidecar invocations produce different crate hashes and recompile Tokio and everything above it.

This change makes every applicable build selection resolve one feature set for the shared dependency graph, so Cargo can reuse artifacts.

## Root causes and fixes

1. **Tokio features were split across crate manifests.** The root workspace dependency now carries the union used by non-desktop binaries: `fs`, `io-std`, `io-util`, `macros`, `net`, `process`, `rt`, `rt-multi-thread`, `signal`, `sync`, `time`, plus `test-util`. Per-crate Tokio feature lists and duplicate dev-dependencies are removed.
2. **Desktop-only Tauri paths added shared serialization features.** The workspace entries now enable `serde_json/unbounded_depth` and `url/serde`, matching the Tauri graph in every selection.
3. **`tidebreak-core` had two equivalent feature identities.** `tidebreak-server` now depends on core with its default features instead of spelling out the same set behind `default-features = false`, so the `default` pseudo-feature is present whether core is a workspace root or a transitive dependency. Leaner core dependents remain `default-features = false`; the normalized proof below confirms no third server graph appears.
4. **CLI dev-dependencies changed `tidebreak-server` features only in workspace/test graphs.** The `scripted-provider` and `scripted-harness` Cargo features are removed. Their test seams compile under `cfg(debug_assertions)` instead, giving all dev/test graphs the same server feature set. `[profile.release]` explicitly pins `debug-assertions = false`; the release sidecar and Tauri builds use that profile, so released binaries cannot compile or consult the scripted environment-variable paths.
5. **Tokio `test-util` appeared only in five dev-dependency graphs.** It is now part of the workspace Tokio union. Trade-off: dev and release Tokio artifacts include the paused-clock plumbing, but it is behavior-neutral unless a caller invokes test-time clock controls; in return, build and test selections share the same Tokio artifact.

## Feature-set proof

Each hash is the MD5 of the sorted, unique feature names extracted from `cargo tree --locked -e features -i <dep>` for the named root. Hashing the normalized feature list avoids differences in inverse dependency paths while directly proving the enabled set.

| Dependency | server | CLI | core | desktop | workspace |
|---|---|---|---|---|---|
| `tokio` | `ade62ffe38b283dfd6c10026c92e7028` | same | same | same | same |
| `serde_json` | `926619e9d1a44f54c77f4c4a22ba88b8` | same | same | same | same |
| `url` | `aa0c9a13d6b8d091a8e8b74f4280ef25` | same | same | same | same |
| `tidebreak-core` | `a09d8dfd6b700797bd3c3438ecb9dfe4` | same | same | same | same |
| `tidebreak-server` | `de2b14ae7499f90736fc4a92327553a5` | same | N/A (not in core-only graph) | same | same |

Normalized sets:

- Tokio: `bytes, default, fs, io-std, io-util, libc, macros, mio, net, process, rt, rt-multi-thread, signal, signal-hook-registry, socket2, sync, test-util, time, tokio-macros, tracing`
- serde_json: `alloc, default, float_roundtrip, raw_value, std, unbounded_depth`
- url: `default, serde, std`
- tidebreak-core: `blob-fs, default, keychain, sea-orm, sea-orm-migration, sqlite, tools`
- tidebreak-server: `default`

## Local verification

- `cargo fmt --all`
- All requested `cargo tree --locked -e features -i ...` roots; hashes above.
- `cargo check --locked -p tidebreak-router`
- `cargo check --locked -p tidebreak-mcp -v`: `COMPILING_COUNT=1` (`crc32fast` build script on MCP’s image-only path); `tokio v1.53.1`, `serde_json v1.0.151`, and `url v2.5.8` were all `Fresh`.
- `cargo check --locked -p tidebreak-cli --tests` (one job): passed in 3m38s, compiling the debug-only scripted seams used by the CLI end-to-end tests.
- `node --test scripts/*.test.mjs`: 207/209 passed; the two remaining workflow-security tests require `docker buildx`, and this sandbox has no `docker` executable (`spawnSync docker ENOENT`).
- `Cargo.lock` is unchanged.

Every Cargo command used one build job, disabled incremental output and dev/test debug info, and used `--locked` to stay below the sandbox’s 8 GiB limit.

## Left to CI

The memory-intensive workspace lanes and release graphs are deliberately left to the larger CI runners: `cargo clippy --workspace --all-targets`, `cargo nextest run --workspace --exclude tidebreak-desktop`, `cargo test -p tidebreak-desktop`, the two release sidecars, and the Tauri desktop release build. CodeQL Analyze is not required for this change.
