### PR TITLE
fix(cli): the server dials itself over loopback when bound to an unspecified address

### DIFF
--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -103,8 +103,13 @@ struct DurableTerminalTurn {
 
 impl Client {
     /// A client for a server bound in this process.
+    ///
+    /// A server that listens on an unspecified address (`0.0.0.0` or `::`,
+    /// the self-host image's `TIDEBREAK_LISTEN_ADDR`) is reached from this
+    /// process over loopback: the unspecified address is not a host to dial,
+    /// and the plain-http rule (#2917) admits only a loopback host.
     pub fn new(addr: SocketAddr, token: &str) -> Result<Self> {
-        Self::attach(format!("http://{addr}"), token)
+        Self::attach(format!("http://{}", local_dial_addr(addr)), token)
     }
 
     /// A client for a server running somewhere else, named by its base URL.
@@ -1253,6 +1258,21 @@ fn server_url_is_loopback(base: &str) -> bool {
     reqwest::Url::parse(base).is_ok_and(|url| url_host_is_loopback(&url))
 }
 
+/// The address this process dials to reach a server it bound itself: the
+/// bound address, unless that is unspecified, in which case the loopback
+/// address of the same family and port.
+pub(crate) fn local_dial_addr(bound: SocketAddr) -> SocketAddr {
+    match bound {
+        SocketAddr::V4(v4) if v4.ip().is_unspecified() => {
+            SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, v4.port()))
+        }
+        SocketAddr::V6(v6) if v6.ip().is_unspecified() => {
+            SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, v6.port()))
+        }
+        other => other,
+    }
+}
+
 fn url_host_is_loopback(url: &reqwest::Url) -> bool {
     url.host_str().is_some_and(|host| {
         host.eq_ignore_ascii_case("localhost")
@@ -1336,6 +1356,20 @@ fn durable_turn_from_transcript(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn the_self_client_dials_loopback_for_an_unspecified_listen_address() {
+        use std::net::SocketAddr;
+        let v4: SocketAddr = "0.0.0.0:8080".parse().unwrap();
+        assert_eq!(super::local_dial_addr(v4).to_string(), "127.0.0.1:8080");
+        let v6: SocketAddr = "[::]:8080".parse().unwrap();
+        assert_eq!(super::local_dial_addr(v6).to_string(), "[::1]:8080");
+        let bound: SocketAddr = "127.0.0.1:4321".parse().unwrap();
+        assert_eq!(super::local_dial_addr(bound), bound);
+        // The whole point: the self-host image binds 0.0.0.0, and the server's
+        // own client must pass the plain-http loopback rule.
+        assert!(super::Client::new(v4, "token").is_ok());
+    }
+
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
     use super::*;


### PR DESCRIPTION
## What

`Client::new(addr, token)`, which `serve` uses to talk to the server it just bound, maps an unspecified bound address (`0.0.0.0`, `::`) to the loopback address of the same family and port before building the base URL.

## Why

#2917 made a plain-http server URL valid only for a loopback host. The self-host image binds `TIDEBREAK_LISTEN_ADDR=0.0.0.0:8080`, so since that change every self-host server exits at startup:

```
tidebreak: configuration error: server URL must use https unless it names a loopback host
```

The gateway-hosted devops machine hit this tonight when it adopted v0.85.0 (the older image it ran predated #2917). `0.0.0.0` is not a host to dial in any case; loopback is where a process reaches its own listener.

## Checks

- `cargo fmt --all --check`
- `cargo test -p tidebreak-cli --bin tidebreak the_self_client_dials_loopback` (new; covers v4, v6, a specific bind, and that `Client::new` on `0.0.0.0:8080` now succeeds)
- `cargo clippy -p tidebreak-cli --all-targets -- -D warnings` (the only error is a pre-existing `too_many_arguments` in `tidebreak-code-execution` on `main`)