### PR TITLE
fix(harness): pass the SSH agent socket to harness children

### DIFF
--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -1216,6 +1216,21 @@ mod tests {
             .any(|(key, value)| { key == "HOME" && value == "/home/probe" }));
     }
 
+    /// A signing-key passphrase prompt in a headless child never returns, so
+    /// the agent socket must reach the child or every signed `git commit`
+    /// hangs until the tool times out.
+    #[test]
+    fn filter_child_env_keeps_the_ssh_agent_socket() {
+        let snapshot = vec![(
+            std::ffi::OsString::from("SSH_AUTH_SOCK"),
+            std::ffi::OsString::from("/run/user/1000/agent.sock"),
+        )];
+        let env = filter_child_env(snapshot);
+        assert!(env.iter().any(|(key, value)| {
+            key == "SSH_AUTH_SOCK" && value == "/run/user/1000/agent.sock"
+        }));
+    }
+
     #[test]
     fn no_adapter_declares_image_input_without_an_image_fixture() {
         use tidebreak_core::CapLevel;

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -612,6 +612,13 @@ const CHILD_ENV_ALLOWED_NAMES: &[&str] = &[
     "CURL_CA_BUNDLE",
     "GIT_SSL_CAINFO",
     "NODE_EXTRA_CA_CERTS",
+    // The user's SSH agent socket: a path, not a secret. `git commit` with
+    // `commit.gpgsign` and `gpg.format = ssh` signs through the agent, and
+    // `git push` over SSH authenticates through it. Without the socket,
+    // `ssh-keygen -Y sign` falls back to the on-disk key and, when that key
+    // has a passphrase, blocks reading it from a stdin that never answers,
+    // so the child's commit hangs until the tool times out.
+    "SSH_AUTH_SOCK",
     // Windows children cannot start, resolve commands, or write temp files
     // without these; on Unix they are simply absent.
     "SYSTEMROOT",


### PR DESCRIPTION
## Problem

A `git commit` run by a coding session hung until the harness tool timed out, and every retry hung the same way. It looked like a slow pre-commit hook, but the repository's hook path was not configured in the worktree, so no hook ran.

The stuck process was `ssh-keygen -Y sign`, spawned by git because the user's global config signs commits with an SSH key (`commit.gpgsign = true`, `gpg.format = ssh`). The harness child environment is built from an allowlist, and that allowlist dropped `SSH_AUTH_SOCK`. Without the agent, ssh-keygen fell back to the on-disk key, which has a passphrase, and blocked reading the passphrase from a stdin that never answers.

The desktop process itself carries `SSH_AUTH_SOCK` from launchd, and the agent holds the key, so the only missing piece was the pass-through.

## Fix

Add `SSH_AUTH_SOCK` to the child environment allowlist. It is a socket path, not a secret, and the same variable lets `git push` over SSH authenticate. Hosted clones keep their own `env_clear` isolation and are unaffected.

A test pins that the socket survives `filter_child_env`; it fails without the allowlist entry.

## Verification

```
cargo test -p tidebreak-harness --lib -- filter_child_env
test tests::filter_child_env_keeps_the_ssh_agent_socket ... ok
test tests::filter_child_env_strips_tidebreak_keys ... ok
```