### PR TITLE
fix(code): hide internal engine from workspace flows

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
@@ -201,6 +201,32 @@ describe("CodeHome", () => {
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
+  it("does not count the workspace-less internal engine as a coding engine", async () => {
+    const external = {
+      ...READY_DOCTOR.harnesses[0],
+      authenticated: false,
+    } as HarnessDoctorEntry;
+    const internal = {
+      ...READY_DOCTOR.harnesses[0],
+      kind: "internal",
+      installable: false,
+    } as HarnessDoctorEntry;
+    await renderHome(
+      app({
+        getHarnessDoctor: vi.fn(async () => ({
+          harnesses: [internal, external],
+        })),
+      }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Set up a coding engine" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Start with a repository" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("leaves the loading empty when the doctor request fails", async () => {
     await renderHome(
       app({

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -21,7 +21,7 @@ import { useCodeUiStore } from "./CodeUiStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { DoctorList } from "./DoctorList";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
-import { harnessUnusableReason } from "./labels";
+import { harnessUnusableReason, workspaceHarnesses } from "./labels";
 import { middleTruncate } from "./workspaceCards";
 
 /**
@@ -64,8 +64,9 @@ function CodeHomeBody() {
 
   // Startable now, or one download away. Either way the reader can get to
   // work from here, so the register form is what the page owes them.
-  const usable =
-    doctor?.harnesses.some((entry) => !harnessUnusableReason(entry)) ?? false;
+  const usable = workspaceHarnesses(doctor?.harnesses ?? []).some(
+    (entry) => !harnessUnusableReason(entry),
+  );
   const showRepos = loaded && repos.length > 0;
   const showEmpty = loaded && repos.length === 0 && usable;
   const showDoctor = Boolean(doctor && !usable);

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
@@ -298,6 +298,35 @@ describe("DoctorList", () => {
     );
     expect(onCheckUpdates).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the workspace-less internal engine out of the coding doctor", () => {
+    render(
+      <DoctorList
+        report={{
+          harnesses: [
+            {
+              ...notDownloaded,
+              kind: "internal",
+              found: true,
+              installable: false,
+              authenticated: true,
+              tier: "reference",
+            },
+            {
+              ...notDownloaded,
+              kind: "claude_code",
+              found: true,
+              authenticated: true,
+              tier: "reference",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Tidebreak")).not.toBeInTheDocument();
+    expect(screen.getByText("1 of 1 engine ready.")).toBeInTheDocument();
+  });
 });
 
 const notDownloaded: HarnessDoctorEntry = {

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -23,6 +23,7 @@ import {
   HARNESS_TIER_LABELS,
   harnessNeedsDownload,
   isHarnessReady,
+  workspaceHarnesses,
 } from "./labels";
 
 /**
@@ -68,8 +69,9 @@ export function DoctorList({
   onCheckUpdates?: () => void;
   checkingUpdates?: boolean;
 }) {
-  const ready = report.harnesses.filter(isHarnessReady).length;
-  const total = report.harnesses.length;
+  const harnesses = workspaceHarnesses(report.harnesses);
+  const ready = harnesses.filter(isHarnessReady).length;
+  const total = harnesses.length;
   const onLatest = report.update_channel === "latest";
   return (
     <section className="flex flex-col gap-3">
@@ -81,7 +83,7 @@ export function DoctorList({
             // know "can I start work" does not walk every row to find out.
             <p className="text-muted-foreground text-sm">
               {ready === 0
-                ? report.harnesses.every((entry) => entry.found)
+                ? harnesses.every((entry) => entry.found)
                   ? "No engine is ready yet. Sign in to one below, then re-check."
                   : "No engine is ready yet. Download one, or pick it when you start a workspace."
                 : `${ready} of ${total} ${total === 1 ? "engine" : "engines"} ready.`}
@@ -123,7 +125,7 @@ export function DoctorList({
         </div>
       </div>
       <div className="divide-subtle overflow-hidden rounded-lg border divide-y">
-        {report.harnesses.map((entry) => (
+        {harnesses.map((entry) => (
           <DoctorRow
             key={entry.kind}
             entry={entry}

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -160,4 +160,31 @@ describe("HarnessPicker", () => {
       screen.queryByRole("button", { name: "Coding harnesses" }),
     ).not.toBeInTheDocument();
   });
+
+  it("does not show the internal engine even when a caller passes it as selected", async () => {
+    await renderWithRouter(
+      <HarnessPicker
+        harnesses={[
+          entry({
+            kind: "internal",
+            installable: false,
+            authenticated: true,
+          }),
+          entry({ kind: "claude_code", authenticated: true }),
+        ]}
+        value="internal"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Harness" });
+    expect(trigger).not.toHaveTextContent("Tidebreak");
+    await userEvent.setup().click(trigger);
+    expect(
+      screen.queryByRole("option", { name: "Tidebreak" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Claude Code" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
@@ -20,6 +20,7 @@ import {
   HARNESS_LABELS,
   harnessNeedsDownload,
   harnessUnusableReason,
+  workspaceHarnesses,
 } from "./labels";
 
 /** What picking a not-yet-downloaded engine does. */
@@ -63,9 +64,10 @@ export function HarnessPicker({
 }) {
   const navigate = useNavigate();
   const harnessesPath: string = "/settings/coding-harnesses";
-  const selected = harnesses.find((entry) => entry.kind === value);
+  const choices = workspaceHarnesses(harnesses);
+  const selected = choices.find((entry) => entry.kind === value);
   const SelectedIcon = selected ? HARNESS_ICONS[selected.kind] : null;
-  const anyUnusable = harnesses.some((entry) => harnessUnusableReason(entry));
+  const anyUnusable = choices.some((entry) => harnessUnusableReason(entry));
 
   return (
     <div
@@ -76,9 +78,9 @@ export function HarnessPicker({
       }
     >
       <Select
-        value={value ?? undefined}
+        value={selected?.kind}
         onValueChange={(next) => onChange(next as HarnessKind)}
-        disabled={disabled || harnesses.length === 0}
+        disabled={disabled || choices.length === 0}
       >
         <SelectTrigger
           aria-label="Harness"
@@ -100,10 +102,7 @@ export function HarnessPicker({
           </SelectValue>
         </SelectTrigger>
         <SelectContent scrollButtons={false}>
-          {harnesses.map((entry) => {
-            // The in-process engine hosts conversations without a
-            // workspace; it is never a pick for a repo-bound session.
-            if (entry.kind === "internal") return null;
+          {choices.map((entry) => {
             const reason = harnessUnusableReason(entry);
             const note =
               reason ?? (harnessNeedsDownload(entry) ? DOWNLOAD_NOTE : null);

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -820,6 +820,42 @@ describe("NewWorkspaceDialog", () => {
     expect(createCodeWorkspace).not.toHaveBeenCalled();
   });
 
+  it("does not offer the workspace-less internal engine", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    const signedOut = { ...harness("claude_code"), authenticated: false };
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("internal"), signedOut],
+      } as never,
+    });
+    const createCodeWorkspace = vi.fn();
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Harness: Claude Code" }),
+    );
+    expect(screen.queryByText("Tidebreak")).not.toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("button", { name: /Create/ })).toBeDisabled();
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+    expect(createCodeWorkspace).not.toHaveBeenCalled();
+  });
+
   it("creates on Enter in the message; Shift+Enter stays a newline", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -85,6 +85,7 @@ import {
   preferredCodeModels,
   CREATE_PERMISSION_MODE_FIXED,
   HARNESS_LABELS,
+  workspaceHarnesses,
   type CodeModelOption,
 } from "./labels";
 
@@ -272,7 +273,7 @@ export function NewWorkspaceDialog({
     [addedRepo, repos],
   );
 
-  const allHarnesses = doctor?.harnesses ?? [];
+  const allHarnesses = workspaceHarnesses(doctor?.harnesses ?? []);
   const selectableHarnesses = allHarnesses.filter(
     (entry) => !harnessUnusableReason(entry),
   );

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -107,6 +107,27 @@ function entry(
 }
 
 describe("StartSessionPrompt", () => {
+  it("does not offer the workspace-less internal engine", async () => {
+    const onStart = vi.fn();
+    await renderWithRouter(
+      wrap(
+        <StartSessionPrompt
+          workspaceId="workspace-1"
+          harnesses={[entry("internal", {})]}
+          starting={false}
+          selectedMode={null}
+          onSelectMode={vi.fn()}
+          onStart={onStart}
+        />,
+      ),
+    );
+
+    expect(screen.queryByText("Tidebreak")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Harness" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
   it("does not offer attachments before a real session exists", async () => {
     await renderWithRouter(
       wrap(

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -35,6 +35,7 @@ import {
   harnessUnusableReason,
   preferredCodeModels,
   PERMISSION_MODE_POLICY_BLOCKED,
+  workspaceHarnesses,
   type CodeModelOption,
 } from "./labels";
 
@@ -264,9 +265,10 @@ export function StartSessionPrompt({
   const ensureHarnessModels = useCodeCatalogStore(
     (state) => state.ensureHarnessModels,
   );
-  const selectable = harnesses.filter((entry) => !harnessUnusableReason(entry));
+  const choices = workspaceHarnesses(harnesses);
+  const selectable = choices.filter((entry) => !harnessUnusableReason(entry));
   const selected =
-    harnesses.find(
+    choices.find(
       (entry) => entry.kind === picked && !harnessUnusableReason(entry),
     ) ??
     selectable.find((entry) => harnessCanStartNow(entry)) ??
@@ -410,7 +412,7 @@ export function StartSessionPrompt({
           fastMode={postedFastMode}
           harnessMenu={
             <HarnessPicker
-              harnesses={harnesses}
+              harnesses={choices}
               value={selected?.kind ?? null}
               disabled={starting}
               variant="composer"

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -16,6 +16,7 @@ import {
   preferredCodeModels,
   sessionLifecycleTooltip,
   sessionPermissionModeTooltip,
+  workspaceHarnesses,
 } from "./labels";
 
 function caps(
@@ -256,6 +257,17 @@ describe("harnessUnusableReason", () => {
     expect(
       harnessCanStartNow({ ...entry, found: true, authenticated: true }),
     ).toBe(true);
+  });
+});
+
+describe("workspaceHarnesses", () => {
+  it("keeps the internal engine out of repo-backed create surfaces", () => {
+    expect(
+      workspaceHarnesses([
+        { kind: "internal", marker: "chat" },
+        { kind: "claude_code", marker: "workspace" },
+      ] as const),
+    ).toEqual([{ kind: "claude_code", marker: "workspace" }]);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -232,6 +232,19 @@ export function harnessCanStartNow(entry: {
 }
 
 /**
+ * Engines a repo-backed workspace may start.
+ *
+ * The internal engine hosts conversations without a workspace. The server
+ * lists it in the shared engine doctor, but every Code workspace create path
+ * must keep it out of its readiness checks and pickers.
+ */
+export function workspaceHarnesses<T extends { kind: HarnessKind }>(
+  entries: readonly T[],
+): T[] {
+  return entries.filter((entry) => entry.kind !== "internal");
+}
+
+/**
  * Create default: the most autonomous posture the engine honors, walking
  * Allow → Auto → Ask → Plan (decision 0039, amended 2026-08-18). Approving
  * every step of a fresh session cost more than it caught, so create starts

--- a/crates/tidebreak-desktop/ui/src/code/uneffMe.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/uneffMe.test.ts
@@ -251,6 +251,15 @@ describe("uneff me session settings", () => {
     ).toBeNull();
     expect(
       uneffSessionSettings({
+        doctor: {
+          harnesses: [{ ...CLAUDE, kind: "internal", installable: false }],
+        },
+        lastCreate: null,
+        ceiling: null,
+      }),
+    ).toBeNull();
+    expect(
+      uneffSessionSettings({
         doctor: { harnesses: [CLAUDE] },
         lastCreate: null,
         ceiling: "plan",

--- a/crates/tidebreak-desktop/ui/src/code/uneffMe.ts
+++ b/crates/tidebreak-desktop/ui/src/code/uneffMe.ts
@@ -12,6 +12,7 @@ import {
   createPermissionModes,
   defaultCreatePermissionMode,
   harnessCanStartNow,
+  workspaceHarnesses,
 } from "./labels";
 import type { FirstSessionSettings } from "./startWorkspaceSession";
 
@@ -180,7 +181,9 @@ export function uneffSessionSettings(input: {
   lastCreate: CodeCreateDefaults | null;
   ceiling: PermissionMode | null | undefined;
 }): FirstSessionSettings | null {
-  const ready = (input.doctor?.harnesses ?? []).filter(harnessCanStartNow);
+  const ready = workspaceHarnesses(input.doctor?.harnesses ?? []).filter(
+    harnessCanStartNow,
+  );
   const entry =
     ready.find((candidate) => candidate.kind === input.sourceHarness) ??
     ready.find((candidate) => candidate.kind === input.lastCreate?.harness) ??

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -548,6 +548,16 @@ export const harnessDoctor: HarnessDoctorReport = {
         structured_approvals: "unsupported",
       },
     }),
+    doctorEntry({
+      kind: "internal",
+      installable: false,
+      version: "0.1.0",
+      caps: {
+        ...fullCaps,
+        slash_commands: "unsupported",
+        native_file_change_events: "unsupported",
+      },
+    }),
   ],
 };
 


### PR DESCRIPTION
The shared engine registry includes Tidebreak's internal, workspace-less engine. Code mode was treating that row as a repo-backed workspace option and as evidence that workspace setup was ready.

This change filters the internal engine from Code workspace readiness, setup, session start, recovery, pickers, and the coding doctor. The server registry stays unchanged for workspace-less conversations.

Validation:
- 102 focused UI tests
- desktop UI production build
- Storybook production build
- Biome check and `git diff --check`
- visual review in light, dark, high-contrast light, and high-contrast dark