### PR TITLE
fix(desktop): keep turn recaps below the seam

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -1043,7 +1043,7 @@ describe("CodeTranscript", () => {
       screen.getByText("Now check what identity we store for the child."),
     ).toBeInTheDocument();
   });
-  it("shows the session recap in the newest closing message only", () => {
+  it("shows the session recap under the newest turn boundary only", () => {
     const boundary = (id: string, turnId: string): CodeTranscriptItem => ({
       kind: "turn_boundary",
       id,
@@ -1080,14 +1080,13 @@ describe("CodeTranscript", () => {
     );
 
     expect(screen.getAllByText(recap)).toHaveLength(1);
-    expect(screen.getAllByText("Recap")).toHaveLength(1);
-    expect(
-      within(screen.getAllByLabelText("Assistant")[1]!).getByText(recap),
-    ).toBeInTheDocument();
     expect(
       within(
         screen.getAllByRole("group", { name: "Turn finished" })[1]!,
-      ).queryByText(recap),
+      ).getByText(recap),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getAllByLabelText("Assistant")[1]!).queryByText(recap),
     ).not.toBeInTheDocument();
   });
 
@@ -1127,10 +1126,14 @@ describe("CodeTranscript", () => {
 
     expect(screen.getByText(closingRecap)).toBeInTheDocument();
     expect(screen.queryByText(sessionRecap)).not.toBeInTheDocument();
-    expect(screen.getAllByText("Recap")).toHaveLength(1);
+    expect(
+      within(screen.getByRole("group", { name: "Turn finished" })).getByText(
+        closingRecap,
+      ),
+    ).toBeInTheDocument();
   });
 
-  it("shows a standalone recap when the turn has no closing message", () => {
+  it("shows the fallback recap under the boundary without a closing message", () => {
     const recap = "The interrupted turn left the retry test unchanged.";
     render(
       <CodeTranscript
@@ -1150,14 +1153,14 @@ describe("CodeTranscript", () => {
       />,
     );
 
-    const standalone = screen.getByLabelText("Recap");
-    expect(within(standalone).getByText(recap)).toBeInTheDocument();
     expect(
-      screen.getByRole("group", { name: "Turn interrupted" }),
-    ).not.toHaveTextContent(recap);
+      within(screen.getByRole("group", { name: "Turn interrupted" })).getByText(
+        recap,
+      ),
+    ).toBeInTheDocument();
   });
 
-  it("keeps the original closing message and shows the recap beside it", () => {
+  it("keeps the original closing message and shows the recap under the boundary", () => {
     const original = "Workspace switching now reuses recent transcript stores.";
     const rewrite =
       "Workspace switching reuses recent transcript stores. It reconnects from the last event sequence.";
@@ -1174,12 +1177,27 @@ describe("CodeTranscript", () => {
             rewrite,
             rewriteState: "rewritten",
           },
+          {
+            kind: "turn_boundary",
+            id: "b1",
+            turnId: "t1",
+            status: "completed",
+            durationMs: 4_000,
+            usage: USAGE,
+            error: null,
+            diffstat: null,
+          },
         ]}
       />,
     );
 
     expect(screen.getByText(original)).toBeInTheDocument();
     expect(screen.getByText(rewrite)).toBeInTheDocument();
-    expect(screen.getByText("Recap")).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("group", { name: "Turn finished" })).getByText(
+        rewrite,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Recap")).not.toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -166,31 +166,40 @@ export function CodeTranscript({
     );
   }
   const presentationItems = codeTranscriptPresentationItems(items);
-  // The recap belongs to the newest settled turn. Put it on that turn's final
-  // assistant row, which is where captured Claude recaps already live.
+  // Captured and fallback recaps share the quiet turn seam. Stored recaps live
+  // on the closing assistant row, while the session digest supplies only the
+  // newest fallback, so project both sources onto their boundary here.
   let newestBoundaryId: string | undefined;
-  let newestBoundaryTurnId: string | undefined;
   for (let index = presentationItems.length - 1; index >= 0; index -= 1) {
     const item = presentationItems[index];
     if (item?.kind === "turn_boundary") {
       newestBoundaryId = item.id;
-      newestBoundaryTurnId = item.turnId ?? undefined;
       break;
     }
   }
-  let recapOwnerId: string | undefined;
-  if (newestBoundaryTurnId) {
-    for (let index = presentationItems.length - 1; index >= 0; index -= 1) {
-      const item = presentationItems[index];
-      if (
-        item?.kind === "assistant" &&
-        item.turnId === newestBoundaryTurnId &&
-        item.parentCallId === null
-      ) {
-        recapOwnerId = item.id;
-        break;
-      }
+
+  const storedRecapsByTurn = new Map<string, string>();
+  for (const item of presentationItems) {
+    if (
+      item.kind === "assistant" &&
+      item.turnId &&
+      item.parentCallId === null &&
+      item.rewriteState === "rewritten" &&
+      item.rewrite?.trim()
+    ) {
+      storedRecapsByTurn.set(item.turnId, item.rewrite.trim());
     }
+  }
+
+  const recapByBoundary = new Map<string, string>();
+  for (const item of presentationItems) {
+    if (item.kind !== "turn_boundary") continue;
+    const stored = item.turnId
+      ? storedRecapsByTurn.get(item.turnId)
+      : undefined;
+    const fallback = item.id === newestBoundaryId ? recap?.trim() : undefined;
+    const displayed = stored ?? fallback;
+    if (displayed) recapByBoundary.set(item.id, displayed);
   }
   const copyOwnerIds = assistantCopyOwnerIds(items, busy);
   return (
@@ -241,12 +250,7 @@ export function CodeTranscript({
                   onFileIssue={onFileIssue}
                   sessionId={sessionId}
                   onReveal={onReveal}
-                  recap={
-                    row.item.id === recapOwnerId ||
-                    (!recapOwnerId && row.item.id === newestBoundaryId)
-                      ? recap
-                      : undefined
-                  }
+                  recap={recapByBoundary.get(row.item.id)}
                 />,
               ),
         )}
@@ -597,10 +601,9 @@ const TranscriptItem = memo(function TranscriptItem({
   sessionId?: string;
   onReveal?: () => void;
   /**
-   * Where the session stands, on the newest turn's recap row only.
+   * Where the turn stands, on its boundary row only.
    *
-   * Passed to exactly one row. The closing assistant message owns the recap
-   * when one exists; the turn boundary owns a standalone fallback otherwise.
+   * Captured and fallback recaps both use the boundary's quiet presentation.
    */
   recap?: string;
 }) {
@@ -641,7 +644,6 @@ const TranscriptItem = memo(function TranscriptItem({
           item={item}
           animateStreaming={animateStreaming}
           ownsCopyAction={ownsCopyAction}
-          recap={recap}
         />
       );
     case "reasoning":
@@ -709,15 +711,13 @@ const TranscriptItem = memo(function TranscriptItem({
     }
     case "turn_boundary":
       return (
-        <>
-          {recap && <StandaloneRecap text={recap} />}
-          <TurnReviewCard
-            turn={item}
-            onOpenTurnDiff={onOpenTurnDiff}
-            onForkFromTurn={onForkFromTurn}
-            onFileIssue={onFileIssue}
-          />
-        </>
+        <TurnReviewCard
+          turn={item}
+          recap={recap}
+          onOpenTurnDiff={onOpenTurnDiff}
+          onForkFromTurn={onForkFromTurn}
+          onFileIssue={onFileIssue}
+        />
       );
   }
 });
@@ -726,24 +726,19 @@ function AssistantRewriteMessage({
   item,
   animateStreaming,
   ownsCopyAction,
-  recap,
 }: {
   item: Extract<CodeTranscriptItem, { kind: "assistant" }>;
   animateStreaming: boolean;
   ownsCopyAction?: boolean;
-  /** Fallback recap for engines that do not supply a captured closing recap. */
-  recap?: string;
 }) {
-  const rewritten = item.rewriteState === "rewritten" && Boolean(item.rewrite);
-  const displayedRecap = rewritten && item.rewrite ? item.rewrite : recap;
   return (
     <article className="message message-assistant" aria-label="Assistant">
-      {item.rewriteState === "rewriting" && !displayedRecap && (
+      {item.rewriteState === "rewriting" && (
         <p className="text-muted-foreground mb-2 text-xs" role="status">
           Writing a recap…
         </p>
       )}
-      {item.rewriteState === "failed" && !displayedRecap && (
+      {item.rewriteState === "failed" && (
         <p className="text-muted-foreground mb-2 text-xs" role="status">
           Couldn't write a recap. The original stands.
         </p>
@@ -752,7 +747,6 @@ function AssistantRewriteMessage({
         text={item.text}
         streaming={item.streaming && animateStreaming}
       />
-      {displayedRecap && <RecapBlock text={displayedRecap} separated />}
       <MessageFooter
         role="assistant"
         text={item.text}
@@ -760,31 +754,6 @@ function AssistantRewriteMessage({
         sequenceEnd={ownsCopyAction}
       />
     </article>
-  );
-}
-
-function StandaloneRecap({ text }: { text: string }) {
-  return (
-    <article className="message message-assistant" aria-label="Recap">
-      <RecapBlock text={text} />
-    </article>
-  );
-}
-
-function RecapBlock({
-  text,
-  separated = false,
-}: {
-  text: string;
-  separated?: boolean;
-}) {
-  return (
-    <div className={cn(separated && "mt-3 border-t border-border-subtle pt-3")}>
-      <p className="text-muted-foreground mb-1 text-2xs font-medium tracking-wide uppercase">
-        Recap
-      </p>
-      <AssistantMessageBody text={text} streaming={false} />
-    </div>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 
 import type { Diffstat } from "../api/types";
+import { AssistantMessageBody } from "@/AssistantMessageBody";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -74,11 +75,14 @@ export function harnessVersionRequirement(error: string | null): string | null {
 
 export function TurnReviewCard({
   turn,
+  recap,
   onOpenTurnDiff,
   onForkFromTurn,
   onFileIssue,
 }: {
   turn: TurnBoundary;
+  /** A quiet reading of what the completed turn accomplished. */
+  recap?: string;
   /** Scope the review sidebar to this turn's changes. */
   onOpenTurnDiff?: (turnId: string) => void;
   /** Hand everything up to this turn to a fresh agent, in a new tab. */
@@ -120,6 +124,7 @@ export function TurnReviewCard({
         ) : (
           <p>{turn.error ?? "The engine stopped without saying why."}</p>
         )}
+        {recap && <TurnRecap text={recap} tone="critical" />}
         {(diffstat || actions || onFileIssue) && (
           <div className="flex items-center gap-2">
             {diffstat}
@@ -133,7 +138,7 @@ export function TurnReviewCard({
 
   if (turn.status === "interrupted") {
     return (
-      <SeamRow label="Turn interrupted" tone="warning">
+      <SeamRow label="Turn interrupted" tone="warning" recap={recap}>
         <CircleSlash size={13} aria-hidden="true" />
         <span>Turn interrupted</span>
         {duration && <span className="tabular-nums">· {duration}</span>}
@@ -144,7 +149,7 @@ export function TurnReviewCard({
   }
 
   return (
-    <SeamRow label="Turn finished" tone="quiet">
+    <SeamRow label="Turn finished" tone="quiet" recap={recap}>
       <Check size={13} aria-hidden="true" />
       <span>Turn finished</span>
       {duration && <span className="tabular-nums">· {duration}</span>}
@@ -251,10 +256,12 @@ function CodingHarnessesLink({ children }: { children: ReactNode }) {
 function SeamRow({
   label,
   tone,
+  recap,
   children,
 }: {
   label: string;
   tone: "quiet" | "warning";
+  recap?: string;
   children: ReactNode;
 }) {
   return (
@@ -262,13 +269,36 @@ function SeamRow({
       role="group"
       aria-label={label}
       className={cn(
-        "flex flex-wrap items-center gap-1.5 border-t pt-2 text-xs",
+        "border-t pt-2 text-xs",
         tone === "warning"
           ? "text-warning-foreground"
           : "text-muted-foreground",
       )}
     >
-      {children}
+      <div className="flex flex-wrap items-center gap-1.5">{children}</div>
+      {recap && <TurnRecap text={recap} />}
+    </div>
+  );
+}
+
+/** The recap stays subordinate to the turn outcome and keeps markdown links. */
+function TurnRecap({
+  text,
+  tone = "quiet",
+}: {
+  text: string;
+  tone?: "quiet" | "critical";
+}) {
+  return (
+    <div
+      className={cn(
+        "mt-1.5 [&_.message-markdown]:text-xs",
+        tone === "critical"
+          ? "text-critical-foreground-muted"
+          : "text-muted-foreground",
+      )}
+    >
+      <AssistantMessageBody text={text} streaming={false} />
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
@@ -103,7 +103,7 @@ type Story = StoryObj<typeof meta>;
 
 export const ProgressUpdates: Story = {};
 
-/** A fallback recap uses the same block as a captured closing recap. */
+/** A fallback recap stays quiet beneath the turn seam. */
 export const SessionRecap: Story = {
   args: {
     items,
@@ -112,7 +112,7 @@ export const SessionRecap: Story = {
   },
 };
 
-/** A turn with no closing message keeps the fallback recap above its boundary. */
+/** A turn with no closing message keeps the same quiet boundary recap. */
 export const SessionRecapWithoutClosingMessage: Story = {
   args: {
     items: [
@@ -159,7 +159,7 @@ export const RewriteRewriting: Story = {
   },
 };
 
-/** Rewritten: original stays, recap sits under it. */
+/** Rewritten: original stays, and the recap moves to the quiet turn seam. */
 export const RewriteRewritten: Story = {
   args: { items: rewrittenItems },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
@@ -52,6 +52,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Completed: Story = {};
 
+/** A recap is quiet supporting text beneath the completed-turn row. */
+export const CompletedWithRecap: Story = {
+  args: {
+    recap:
+      "Auth middleware is wired up and its tests pass. Next: hook the refresh path into the session store.",
+  },
+};
+
 /**
  * With a fork handler, the seam carries a quiet actions menu: "Fork from
  * here" hands everything up to this turn to a fresh agent in a new tab.


### PR DESCRIPTION
## Summary

- Render captured and fallback recaps through the quiet turn-boundary treatment.
- Keep recap markdown while removing the large assistant-message recap block and heading.
- Cover completed, interrupted, and stored recap states in tests and Storybook.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeTranscript.dom.test.tsx src/code/TurnReviewCard.dom.test.tsx src/stylesContract.test.ts`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/code/CodeTranscript.tsx src/code/TurnReviewCard.tsx src/code/CodeTranscript.dom.test.tsx src/stories/CodeTranscript.stories.tsx src/stories/TurnReviewCard.stories.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- `git diff --check`
- Storybook visual review at 1000px in dark mode