### PR TITLE
fix(code): resolve workspace session UI issues

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -1144,6 +1144,51 @@ describe("CodeComposer", () => {
     expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
   });
 
+  it("does not restore a submitted prompt after the composer remounts", async () => {
+    let rejectSend!: (error: Error) => void;
+    const onSend = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSend = reject;
+        }),
+    );
+    const first = renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "already accepted" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+    expect(box).toHaveValue("");
+
+    first.unmount();
+    renderComposer(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+
+    await act(async () => {
+      rejectSend(new Error("the old response closed"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+    expect(useComposerDrafts.getState().drafts["sess-1"]).toBeFalsy();
+  });
+
   it("does not re-append first-turn recovery after a Settings remount", async () => {
     const user = userEvent.setup();
     const recovery = {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1017,6 +1017,11 @@ export function CodeComposer({
         await onSend(message);
       }
     } catch (err) {
+      // A refresh can replace this composer while the turn request is still
+      // waiting for the engine to finish. The old response may then close
+      // without proving that the server refused the turn. Do not let that
+      // obsolete request repopulate the replacement composer's draft.
+      if (!mountedRef.current) return;
       images.restore(held);
       updatePastedTexts((current) => [
         ...submittedPastedTexts,

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -413,6 +413,24 @@ describe("CodeTranscript", () => {
     ).toHaveAttribute("datetime", "2026-08-15T12:00:00.000Z");
   });
 
+  it("hides internal trigger-fire notices", () => {
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "notice",
+            id: "trigger-fire",
+            level: "info",
+            message:
+              "trigger d655b722-50c4-4560-b09b-991a56182771 fired: changes requested on #3105",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText(/trigger d655b722/)).not.toBeInTheDocument();
+  });
+
   it("closes a completed turn with its duration, diffstat, and usage", () => {
     render(<CodeTranscript items={items} />);
     const seam = screen.getByRole("group", { name: "Turn finished" });

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -275,6 +275,13 @@ export function codeTranscriptPresentationItems(
 ): CodeTranscriptItem[] {
   return items.filter((item, index) => {
     if (
+      item.kind === "notice" &&
+      item.level === "info" &&
+      /^trigger [0-9a-f-]+ fired: /.test(item.message)
+    ) {
+      return false;
+    }
+    if (
       item.kind !== "notice" ||
       item.level !== "error" ||
       !hasTurnRecovery(item.message)

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -35,6 +35,8 @@ afterEach(cleanup);
 function renderCard(overrides?: {
   workspace?: Partial<CodeWorkspaceSnapshot>;
   pr?: PullRequestDigest;
+  digest?: CodeSessionDigest;
+  session?: CodeSessionSnapshot;
   density?: "compact" | "detailed";
   visibleMeta?: { repoChip: boolean; branch: boolean };
   detailDefaultOpen?: boolean;
@@ -55,8 +57,8 @@ function renderCard(overrides?: {
   render(
     <WorkspaceCard
       workspace={merged}
-      digest={undefined}
-      session={undefined}
+      digest={overrides?.digest}
+      session={overrides?.session}
       repoName="app"
       active={overrides?.active ?? false}
       selected={overrides?.selected}
@@ -300,6 +302,46 @@ describe("WorkspaceCard", () => {
     expect(screen.queryByText("Idle")).not.toBeInTheDocument();
     expect(screen.queryByText("Done")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Claude Code")).not.toBeInTheDocument();
+  });
+
+  it("keeps a silent running command out of needs-you", () => {
+    const digest: CodeSessionDigest = {
+      workspace: workspace.id,
+      session: "sess-1",
+      kind: "interactive",
+      harness_kind: "claude_code",
+      lifecycle: "running",
+      attention: {
+        state: { type: "stalled", idle_secs: 1_140 },
+        source: "heuristic",
+      },
+      title: workspace.title,
+      turn_count: 3,
+      activity: "shell",
+      activity_detail: "git commit -m release-notes",
+    };
+    renderCard({
+      digest,
+      session: {
+        id: "sess-1",
+        workspace_id: workspace.id,
+        kind: "interactive",
+        harness_kind: "claude_code",
+        permission_mode: "plan",
+        fast_mode: false,
+        lifecycle: "running",
+        attention: digest.attention,
+        unrecognized_event_count: 0,
+        created_at: "2026-08-15T00:00:00.000Z",
+      },
+    });
+
+    expect(screen.getByLabelText("Running")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Needs you")).not.toBeInTheDocument();
+    expect(screen.getByText("git commit -m release-notes")).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-state-glyph="stalled"]'),
+    ).toBeInTheDocument();
   });
 
   it("does not open on a modifier click so the rail can select", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -326,7 +326,24 @@ describe("workspaceStatusRank", () => {
     ).toBe("running");
   });
 
-  it("ranks stalled and fenced with needs-you", () => {
+  it("keeps a silent running command with live work", () => {
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app"),
+        digest("ws-a", {
+          lifecycle: "running",
+          attention: {
+            state: { type: "stalled", idle_secs: 90 },
+            source: "heuristic",
+          },
+          activity: "shell",
+          activity_detail: "cargo test -p tidebreak-server",
+        }),
+      ),
+    ).toBe("running");
+  });
+
+  it("ranks a stale stall and a fenced session with needs-you", () => {
     expect(
       workspaceStatusRank(
         workspace("ws-a", "app"),

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -186,14 +186,16 @@ export function readyToMergeNotice(
 }
 
 /**
- * Rank a workspace for the by-status rail. Needs-you wins, then a running
+ * Rank a workspace for the by-status rail. A direct need wins, then a running
  * engine, then an open PR, then done-unreviewed, then a workspace whose setup
  * script failed, then idle. Archived is last. A digest may change the rank;
  * viewing or selecting never does.
  *
- * Stalled and fenced join needs-you so the card mark and the group agree.
- * Ready-to-merge does not: notify and watch store it as needs-you, but it is
- * a successful pull-request state, and a merged or closed pull request makes
+ * A stalled state is only a silence heuristic. While the lifecycle still says
+ * running, the workspace stays with live work and the session row carries the
+ * warning. A stale stalled state and a fenced session join needs-you. Ready to
+ * merge does not: notify and watch store it as needs-you, but it is a
+ * successful pull-request state, and a merged or closed pull request makes
  * that prompt stale. Idle or ended sessions with turns join Done, matching
  * `attentionMarkForDigest`. A failed setup ranks below live work because the
  * checkout survives — but above idle, because nothing else on the card says
@@ -209,12 +211,12 @@ export function workspaceStatusRank(
   if (
     (attentionType === "needs_you" &&
       !isReadyToMergeAttention(digest?.attention)) ||
-    attentionType === "stalled" ||
     attentionType === "fenced"
   ) {
     return "needs_you";
   }
   if (digest?.lifecycle === "running") return "running";
+  if (attentionType === "stalled") return "needs_you";
   if (pr) {
     const lifecycle = pullRequestLifecycle(pr);
     if (lifecycle === "open" || lifecycle === "draft") return "pr_open";

--- a/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 import { CodeTranscript } from "@/code/CodeTranscript";
 import type { CodeTranscriptItem } from "@/code/CodeSessionReducer";
 
@@ -102,6 +102,53 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const ProgressUpdates: Story = {};
+
+/** Internal trigger delivery stays out of the transcript after the turn runs. */
+export const TriggerFireNoticeHidden: Story = {
+  args: {
+    items: [
+      {
+        kind: "assistant",
+        id: "assistant-trigger-result",
+        turnId: "turn-trigger",
+        parentCallId: null,
+        text: "I addressed the requested changes and reran the focused tests.",
+        streaming: false,
+      },
+      {
+        kind: "notice",
+        id: "trigger-fire",
+        level: "info",
+        message:
+          "trigger d655b722-50c4-4560-b09b-991a56182771 fired: changes requested on #3105",
+      },
+      {
+        kind: "turn_boundary",
+        id: "boundary-trigger",
+        turnId: "turn-trigger",
+        status: "completed",
+        durationMs: 130_000,
+        usage: null,
+        error: null,
+        diffstat: {
+          files: 1,
+          insertions: 5,
+          deletions: 5,
+          truncated: false,
+        },
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/addressed the requested changes/),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByText(/trigger d655b722/),
+    ).not.toBeInTheDocument();
+  },
+};
 
 /** A fallback recap stays quiet beneath the turn seam. */
 export const SessionRecap: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -1,6 +1,6 @@
 import { useState, type ComponentProps, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 import { toast } from "sonner";
 
 import { setEditorPreference } from "@/code/editorPreference";
@@ -33,6 +33,7 @@ import {
   queuedPrDigest,
   runningDigest,
   shellDigest,
+  attentionStalled,
   stalledDigest,
   settledSubagentsDigest,
   subagentsDigest,
@@ -603,6 +604,51 @@ export const Stalled: Story = {
       archived: false,
       hasSession: true,
     }),
+  },
+};
+
+/** A long-running command stays with Running while its row shows the warning. */
+export const SilentRunningCommand: Story = {
+  render: (args) => (
+    <StatusGroup rank="running" count={1}>
+      <WorkspaceCard
+        {...args}
+        workspace={{
+          ...codeWorkspace,
+          id: "ws-silent-command",
+          title: "Uneff: hidden-thicket",
+        }}
+        digest={{
+          ...shellDigest,
+          workspace: "ws-silent-command",
+          title: "Uneff: hidden-thicket",
+          attention: attentionStalled,
+          activity_detail: "git commit -m \"$(cat <<'EOF'\"",
+        }}
+        session={{
+          ...codeSession,
+          workspace_id: "ws-silent-command",
+          attention: attentionStalled,
+          created_at: new Date(Date.now() - 19 * 60_000).toISOString(),
+        }}
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          hasSession: true,
+        })}
+      />
+    </StatusGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Running · 1")).toBeVisible();
+    await expect(canvas.queryByText("Needs you · 1")).not.toBeInTheDocument();
+    await expect(
+      canvas.getByText("git commit -m \"$(cat <<'EOF'\""),
+    ).toBeVisible();
+    await expect(
+      canvasElement.querySelector('[data-state-glyph="stalled"]'),
+    ).not.toBeNull();
   },
 };
 

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -48,7 +48,7 @@ impl CodeRuntime {
             .filter(|value| !value.is_empty())
             .unwrap_or_default();
         let id = WorkspaceId::new();
-        let branch = branch_name(&repo.branch_prefix, &title, id.0.as_u128());
+        let branch = branch_name(&repo.branch_prefix, &title, id.as_uuid());
         let existing = list_workspaces(&self.db, owner, Some(repo.id)).await?;
         if existing
             .iter()

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -17,7 +17,7 @@ impl CodeRuntime {
             .filter(|value| !value.is_empty())
             .unwrap_or_default();
         let id = WorkspaceId::new();
-        let branch = branch_name(&repo.branch_prefix, &title, id.0.as_u128());
+        let branch = branch_name(&repo.branch_prefix, &title, id.as_uuid());
         let existing = list_workspaces(&self.db, owner, Some(repo_id)).await?;
         if existing
             .iter()
@@ -242,11 +242,11 @@ impl CodeRuntime {
             return Ok(false);
         }
         let repo = self.get_repo(owner, workspace.repo_id).await?;
-        let expected = branch_name(&repo.branch_prefix, "", id.0.as_u128());
+        let expected = branch_name(&repo.branch_prefix, "", id.as_uuid());
         if workspace.branch_name != expected {
             return Ok(false);
         }
-        let next = branch_name(&repo.branch_prefix, title, id.0.as_u128());
+        let next = branch_name(&repo.branch_prefix, title, id.as_uuid());
         if next == expected {
             return Ok(false);
         }

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -1741,8 +1741,10 @@ pub(crate) fn slugify(value: &str) -> String {
     slug
 }
 
-/// Branch name: repo prefix plus a slug of the title, or a two-word fallback.
-pub(crate) fn branch_name(prefix: &str, title: &str, seed: u128) -> String {
+/// Branch name: repo prefix plus a title slug, or a generated name that also
+/// carries the workspace id. The id keeps the 400 readable word pairs from
+/// colliding with an older workspace or a concurrent create.
+pub(crate) fn branch_name(prefix: &str, title: &str, id: &uuid::Uuid) -> String {
     let prefix = if prefix.is_empty() {
         String::new()
     } else if prefix.ends_with('/') {
@@ -1752,7 +1754,7 @@ pub(crate) fn branch_name(prefix: &str, title: &str, seed: u128) -> String {
     };
     let slug = slugify(title);
     let slug = if slug.is_empty() {
-        two_word_name(seed)
+        format!("{}-{}", two_word_name(id.as_u128()), short_id(id))
     } else {
         slug
     };
@@ -2871,12 +2873,28 @@ mod tests {
     }
 
     #[test]
-    fn untitled_workspaces_get_two_word_branch_names() {
-        let name = branch_name("tidebreak/", "", 42);
+    fn untitled_workspace_branches_keep_the_readable_name_and_add_the_id() {
+        let id = uuid::Uuid::from_u128(42);
+        let name = branch_name("tidebreak/", "", &id);
         assert!(name.starts_with("tidebreak/"));
         let slug = name.strip_prefix("tidebreak/").unwrap();
         assert!(slug.contains('-'), "{slug}");
+        assert_eq!(slug, format!("{}-{}", two_word_name(42), short_id(&id)));
         assert_eq!(slugify("Hello, World!"), "hello-world");
+    }
+
+    #[test]
+    fn untitled_workspace_branches_stay_unique_when_word_pairs_repeat() {
+        let first = uuid::Uuid::from_u128(42);
+        let second = uuid::Uuid::from_u128(42 + (400_u128 << 96));
+        assert_eq!(
+            two_word_name(first.as_u128()),
+            two_word_name(second.as_u128())
+        );
+        assert_ne!(
+            branch_name("tidebreak/", "", &first),
+            branch_name("tidebreak/", "", &second)
+        );
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/tests/code_workspace.rs
+++ b/crates/tidebreak-server/src/tests/code_workspace.rs
@@ -26,6 +26,33 @@ async fn two_repos_with_the_same_name_get_distinct_worktrees() {
     assert!(std::path::Path::new(path_b).join("README.md").is_file());
 }
 
+#[tokio::test]
+async fn untitled_workspace_branch_includes_the_workspace_id() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo_root = init_git_repo(dir.path());
+    let (repo, _first) = register_and_workspace(&client, addr, &token, &repo_root).await;
+
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "repo_id": json_id(&repo) }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let title = workspace["title"].as_str().unwrap();
+    let branch = workspace["branch_name"].as_str().unwrap();
+
+    assert_eq!(
+        branch,
+        format!("tidebreak/{title}-{}", &json_id(&workspace)[..8])
+    );
+    assert!(branch_exists_in(&repo_root, branch));
+}
+
 /// The worktree root is a setting, and moving it moves only what comes next.
 ///
 /// The two halves are one test because the second is meaningless without the


### PR DESCRIPTION
Summary

- Keep heuristic stalls under Running while retaining the stalled command warning.
- Add the workspace ID to generated branch names to prevent collisions.
- Stop obsolete send requests from restoring submitted prompts after a composer remount.
- Hide internal trigger-fire notices from the transcript.

Tests

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeComposer.dom.test.tsx src/code/CodeTranscript.dom.test.tsx src/code/WorkspaceCard.dom.test.tsx src/code/workspaceCards.test.ts`
- `cargo test -p tidebreak-server untitled_workspace_branch --lib`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check ...`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`