### PR TITLE
ci: run Windows native tests and test partitions in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types:
-      [opened, reopened, synchronize, edited, labeled, unlabeled, ready_for_review]
-  # Speculative merge groups from the main merge queue. Required checks must
-  # report here or the queue never drains. Scope detection diffs the group
-  # against its base the same way a pull request diffs against main.
-  merge_group:
+    types: [opened, reopened, synchronize, ready_for_review]
   # Backstop the deliberately scoped post-merge capability lanes even during a
   # week with no relevant merge. The non-PR full-validation path below makes a
   # scheduled run exercise every lane.
@@ -43,53 +38,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  pr-title:
-    name: semantic PR title
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      # A merge group has no pull-request title payload. The same check name
-      # is required on the queue, and the title was already judged when the
-      # pull request entered it.
-      - name: Accept titles already checked on the pull request
-        if: ${{ github.event_name == 'merge_group' }}
-        run: echo "Merge groups reuse the pull request title check."
-      # The title and labels come from the event payload, so this job never
-      # needs the pull request's own code — only the trusted base-branch copy
-      # of the policy it is judged by.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 1
-      - name: Validate Conventional Commit title
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          CANONICAL_REPOSITORY: brightwave-inc/tidebreak
-          GH_TOKEN: ${{ github.token }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          node scripts/check-pr-title.mjs "$PR_TITLE"
-          expected_labels="$(node scripts/release-label.mjs --labels "$PR_TITLE" |
-            jq -r 'sort | join(",")')"
-          actual_labels=""
-          for _ in {1..10}; do
-            actual_labels="$(gh api "repos/$CANONICAL_REPOSITORY/pulls/$PR_NUMBER" \
-              --jq '[.labels[].name | select(startswith("semver:") or startswith("release-note:"))] | sort | join(",")')"
-            [[ "$actual_labels" = "$expected_labels" ]] && break
-            sleep 2
-          done
-          test "$actual_labels" = "$expected_labels" || {
-            echo "Expected managed release labels $expected_labels; found: ${actual_labels:-none}." >&2
-            echo "The trusted Release draft workflow may still be synchronizing it." >&2
-            exit 1
-          }
-
   release-policy:
     name: release policy
     runs-on: ubuntu-latest
@@ -130,6 +78,7 @@ jobs:
       notices: ${{ steps.scope.outputs.notices }}
       rust: ${{ steps.scope.outputs.rust }}
       ui: ${{ steps.scope.outputs.ui }}
+      windows_native: ${{ steps.scope.outputs.windows_native }}
       workspace: ${{ steps.scope.outputs.workspace }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -141,8 +90,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
-          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           PUSH_BASE_SHA: ${{ github.event.before }}
           PUSH_HEAD_SHA: ${{ github.event.after }}
         run: |
@@ -153,6 +100,7 @@ jobs:
               echo "notices=true"
               echo "rust=true"
               echo "ui=true"
+              echo "windows_native=true"
               echo "workspace=true"
             } >> "$GITHUB_OUTPUT"
           }
@@ -161,11 +109,6 @@ jobs:
             pull_request)
               base_sha="$PR_BASE_SHA"
               head_sha="$PR_HEAD_SHA"
-              diff_range="$base_sha...$head_sha"
-              ;;
-            merge_group)
-              base_sha="$MERGE_GROUP_BASE_SHA"
-              head_sha="$MERGE_GROUP_HEAD_SHA"
               diff_range="$base_sha...$head_sha"
               ;;
             push)
@@ -202,6 +145,7 @@ jobs:
           notices=false
           rust=false
           ui=false
+          windows_native=false
           workspace=false
           git diff --no-renames --name-only -z "$diff_range" \
             > "$RUNNER_TEMP/changed-files"
@@ -222,6 +166,7 @@ jobs:
                 notices=true
                 rust=true
                 ui=true
+                windows_native=true
                 workspace=true
                 ;;
               # Generated from Rust definitions, and a Rust test is what checks
@@ -249,6 +194,20 @@ jobs:
                 notices=true; rust=true; workspace=true ;;
               *) rust=true; workspace=true ;;
             esac
+            # Native Windows tests cover contracts that a cross-target check
+            # cannot prove: NTFS path behavior, Windows process APIs, SQLite
+            # profile migration, and the Credential Manager backend.
+            case "$file" in
+              .github/workflows/ci.yml) windows_native=true ;;
+              crates/tidebreak-code-execution/*|crates/tidebreak-harness/*|crates/tidebreak-host-broker/*)
+                windows_native=true ;;
+              crates/tidebreak-server/src/code/*|crates/tidebreak-server/src/tests/code*)
+                windows_native=true ;;
+              crates/tidebreak-server/src/desktop_schema.rs|crates/tidebreak-core/src/keychain.rs)
+                windows_native=true ;;
+              crates/tidebreak-desktop/scripts/prepare-sidecar.mjs)
+                windows_native=true ;;
+            esac
           done < "$RUNNER_TEMP/changed-files"
 
           # Keep narrower scopes honest here, before conditional jobs consume
@@ -258,6 +217,10 @@ jobs:
             echo "workspace scope without Rust scope; the detector is wrong." >&2
             exit 1
           fi
+          if [[ "$windows_native" == true && "$rust" != true ]]; then
+            echo "native Windows scope without Rust scope; the detector is wrong." >&2
+            exit 1
+          fi
 
           {
             echo "docs_site=$docs_site"
@@ -265,6 +228,7 @@ jobs:
             echo "notices=$notices"
             echo "rust=$rust"
             echo "ui=$ui"
+            echo "windows_native=$windows_native"
             echo "workspace=$workspace"
           } >> "$GITHUB_OUTPUT"
 
@@ -521,14 +485,15 @@ jobs:
     # A native runner keeps the Windows SDK and MSVC available for native
     # dependencies such as ring and SQLite. `cargo check` is rust-scoped like
     # clippy: a Windows compile break on main blocks the desktop release, so
-    # every Rust-scoped pull request has to catch it. The check covers the
-    # installer graph only. Native Windows tests are not a merge gate.
+    # every Rust-scoped pull request has to catch it. Native Windows runtime
+    # tests run independently below so they no longer extend this required
+    # lane's wall time.
     if: ${{ needs.changes.outputs.rust == 'true' }}
     # Prefer an 8 vCPU / 32 GB Windows larger runner. Standard windows-latest
     # is 4 cores and spends most of this lane in rustc; 16 cores is not worth
     # the extra cost for cargo check. Set CI_WINDOWS_RUNNER to the provisioned
     # label. If the variable is unset, the job uses windows-latest so a missing
-    # larger runner cannot stall the merge queue.
+    # larger runner cannot stall merges.
     runs-on: ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
     timeout-minutes: 20
     env:
@@ -600,13 +565,93 @@ jobs:
         if: ${{ steps.tip.outputs.superseded != 'true' }}
         run: >-
           cargo check --target x86_64-pc-windows-msvc
+          -p tidebreak-core
+          -p tidebreak-code-execution
           -p tidebreak-cli
           -p tidebreak-host-broker
+          -p tidebreak-server
           -p tidebreak-desktop
           --locked
 
+  windows-native:
+    name: Windows native tests
+    needs: changes
+    if: ${{ needs.changes.outputs.windows_native == 'true' }}
+    runs-on: ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
+    timeout-minutes: 30
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_WRITE
+      RUSTC_WRAPPER: sccache
+      # link.exe dominates Windows test-binary time on four cores. rust-lld
+      # ships with the toolchain and is the MSVC analogue of mold on Linux.
+      RUSTFLAGS: -C linker=rust-lld
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: windows-check-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+      # The host broker suite covers real NTFS containment and the stdio
+      # sidecar boundary: state placement, ownership, restart persistence, and
+      # exit when the desktop pipe closes.
+      - name: Host broker Windows tests
+        run: cargo test --target x86_64-pc-windows-msvc -p tidebreak-host-broker --locked
+      # Code mode crosses Windows-native executable, environment, PowerShell,
+      # path-identity, and process-tree boundaries. Retry each suite to absorb
+      # the known PowerShell startup race on loaded hosted runners.
+      - name: Code mode Windows lifecycle tests
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          $PSNativeCommandUseErrorActionPreference = $false
+          $attempts = 3
+          $suites = @(
+            @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-code-execution", "--locked"),
+            @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-harness", "--locked"),
+            @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-server", "--lib", "code::", "--locked")
+          )
+          foreach ($suite in $suites) {
+            $passed = $false
+            for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+              & cargo @suite
+              if ($LASTEXITCODE -eq 0) {
+                $passed = $true
+                break
+              }
+              Write-Host "cargo $($suite -join ' ') failed on attempt $attempt/$attempts"
+            }
+            if (-not $passed) {
+              exit 1
+            }
+          }
+      - name: SQLite profile open and migrations
+        run: >-
+          cargo test --target x86_64-pc-windows-msvc
+          -p tidebreak-server --lib desktop_schema --locked
+      # `-- --ignored` runs the native round trip alone, so the process-global
+      # in-memory keyring mock never activates and the test reaches the hosted
+      # runner's real Credential Manager.
+      - name: Credential Manager round trip
+        run: >-
+          cargo test --target x86_64-pc-windows-msvc
+          -p tidebreak-core --lib keychain --locked -- --ignored
+
   test:
-    name: test
+    name: test partition ${{ matrix.part }}/3
     needs: changes
     if: ${{ needs.changes.outputs.workspace == 'true' }}
     # Prefer an 8 vCPU larger runner: this lane splits roughly evenly between
@@ -615,6 +660,10 @@ jobs:
     # job uses ubuntu-latest so a missing larger runner cannot stall merges.
     runs-on: ${{ vars.CI_TEST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        part: [1, 2, 3]
     env:
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_DEV_DEBUG: 0
@@ -646,12 +695,12 @@ jobs:
           add-rust-environment-hash-key: "false"
           cache-bin: false
           cache-targets: false
-          # This is the single Cargo-download writer. sccache remains the
-          # compiler-output cache used independently by every Rust lane.
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Partition one is the single Cargo-download writer. sccache remains
+          # the compiler-output cache used independently by every Rust lane.
+          save-if: ${{ github.ref == 'refs/heads/main' && matrix.part == 1 }}
           cache-on-failure: true
       - name: Fetch the complete workspace lockfile
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && matrix.part == 1 }}
         run: cargo fetch --locked
       # nextest schedules tests from every binary in parallel, so the few
       # long-running suites overlap instead of queuing behind each other, and
@@ -663,7 +712,33 @@ jobs:
       - name: headless tests
         run: >-
           cargo nextest run --workspace --exclude tidebreak-desktop
-          --locked --retries 2
+          --locked --retries 2 --partition count:${{ matrix.part }}/3
+
+  test-aggregate:
+    name: test
+    needs: [changes, test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every scoped test partition
+        env:
+          CHANGE_SCOPE_RESULT: ${{ needs.changes.result }}
+          PARTITION_RESULT: ${{ needs.test.result }}
+          WORKSPACE_SCOPE: ${{ needs.changes.outputs.workspace }}
+        run: |
+          if [[ "$CHANGE_SCOPE_RESULT" != success ]]; then
+            echo "Change scope detection ended with $CHANGE_SCOPE_RESULT." >&2
+            exit 1
+          fi
+          if [[ "$WORKSPACE_SCOPE" == true ]]; then
+            if [[ "$PARTITION_RESULT" != success ]]; then
+              echo "A required test partition ended with $PARTITION_RESULT." >&2
+              exit 1
+            fi
+          elif [[ "$PARTITION_RESULT" != skipped ]]; then
+            echo "Unscoped test partitions unexpectedly ended with $PARTITION_RESULT." >&2
+            exit 1
+          fi
 
   postgres:
     name: postgres state machine
@@ -710,22 +785,14 @@ jobs:
           cache-bin: false
           cache-targets: false
           save-if: false
-      - name: Exercise durable turn state on PostgreSQL
+      - name: Exercise core state machines on PostgreSQL
         run: >-
           cargo test -p tidebreak-core --no-default-features --features postgres
-          --test postgres_turn_state --locked
-      - name: Exercise document and blob lifecycle on PostgreSQL
-        run: >-
-          cargo test -p tidebreak-core --no-default-features --features postgres
-          --test postgres_document_blob --locked
-      - name: Exercise code-mode owner scoping on PostgreSQL
-        run: >-
-          cargo test -p tidebreak-core --no-default-features --features postgres
-          --test postgres_code_owner --locked
-      - name: Exercise released schema upgrades on PostgreSQL
-        run: >-
-          cargo test -p tidebreak-core --no-default-features --features postgres
-          --test postgres_release_upgrade --locked
+          --test postgres_turn_state
+          --test postgres_document_blob
+          --test postgres_code_owner
+          --test postgres_release_upgrade
+          --locked
       - name: Exercise self-host store ownership on PostgreSQL
         run: >-
           cargo test -p tidebreak-server --features postgres

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -420,13 +420,24 @@ test("PR lanes are scope-gated, never label-gated", () => {
   const e2bCli = workflowJob(ci, "e2b-cli");
   const fmt = workflowJob(ci, "fmt");
   const postgres = workflowJob(ci, "postgres");
-  const testJob = workflowJob(ci, "test");
+  const testPartitions = workflowJob(ci, "test");
+  const testAggregate = workflowJob(ci, "test-aggregate");
 
   assert.match(
     ci,
     /^on:\n  push:\n    branches: \[main\]\n  pull_request:/m,
   );
+  const ciTrigger =
+    /^  pull_request:\n\s+types:\s*\[([^\]]*)\]/m.exec(ci);
+  assert.ok(ciTrigger, "ci.yml must list its pull request event types");
+  assert.deepEqual(
+    ciTrigger[1].split(",").map((event) => event.trim()),
+    ["opened", "reopened", "synchronize", "ready_for_review"],
+  );
+  assert.doesNotMatch(ci, /^  merge_group:/m);
+  assert.doesNotMatch(workflowJob(ci, "changes"), /MERGE_GROUP_|merge_group\)/);
   const title = semanticTitleCheck();
+  assert.equal(title.file, "release-draft.yml");
   const titleTrigger =
     /^  pull_request(?:_target)?:\n\s+types:\s*\[([^\]]*)\]/m.exec(title.source);
   assert.ok(
@@ -502,7 +513,8 @@ test("PR lanes are scope-gated, never label-gated", () => {
     [workflowJob(ci, "lint"), "rust"],
     [workflowJob(ci, "desktop"), "rust"],
     [workflowJob(ci, "windows-check"), "rust"],
-    [testJob, "workspace"],
+    [workflowJob(ci, "windows-native"), "windows_native"],
+    [testPartitions, "workspace"],
     [postgres, "workspace"],
     [workflowJob(ci, "ui"), "ui"],
     [docsSite, "docs_site"],
@@ -519,7 +531,7 @@ test("PR lanes are scope-gated, never label-gated", () => {
   for (const job of [
     workflowJob(ci, "lint"),
     workflowJob(ci, "desktop"),
-    testJob,
+    testPartitions,
     postgres,
   ]) {
     assert.match(
@@ -532,14 +544,25 @@ test("PR lanes are scope-gated, never label-gated", () => {
   // The registry cache has one writer, and only on main. A lane may narrow
   // that further (one matrix leg, say) but never widen it.
   assert.match(
-    testJob,
+    testPartitions,
     /save-if: \$\{\{ github\.ref == 'refs\/heads\/main'(?: && [^|}]*)? \}\}/,
   );
-  assert.match(testJob, /cache-on-failure: true/);
+  assert.match(testPartitions, /cache-on-failure: true/);
   assert.match(
-    testJob,
-    /cargo nextest run --workspace --exclude tidebreak-desktop\n\s+--locked --retries 2/,
+    testPartitions,
+    /strategy:\n\s+fail-fast: false\n\s+matrix:\n\s+part: \[1, 2, 3\]/,
   );
+  assert.match(
+    testPartitions,
+    /cargo nextest run --workspace --exclude tidebreak-desktop\n\s+--locked --retries 2 --partition count:\$\{\{ matrix\.part \}\}\/3/,
+  );
+  assert.match(testAggregate, /name: test\n/);
+  assert.match(testAggregate, /needs: \[changes, test\]/);
+  assert.match(testAggregate, /if: \$\{\{ always\(\) \}\}/);
+  assert.match(testAggregate, /CHANGE_SCOPE_RESULT: \$\{\{ needs\.changes\.result \}\}/);
+  assert.match(testAggregate, /PARTITION_RESULT: \$\{\{ needs\.test\.result \}\}/);
+  assert.match(testAggregate, /WORKSPACE_SCOPE: \$\{\{ needs\.changes\.outputs\.workspace \}\}/);
+  assert.match(testAggregate, /"\$PARTITION_RESULT" != success/);
   assert.doesNotMatch(ci, /^  parsers:$/m);
   assert.doesNotMatch(ci, /outputs\.parsers|echo "parsers=/);
   assert.match(changes, /\*\.md\|docs\/\*\|assets\/\*\|\.githooks\/\*/);
@@ -631,36 +654,99 @@ function skipsSupersededPush(job) {
   );
 }
 
-test("Windows cargo check is a compile-only installer gate", () => {
+test("Windows cargo check and native tests run in parallel scoped jobs", () => {
   const ci = workflows["ci.yml"];
-  const windows = workflowJob(ci, "windows-check");
+  const windowsCheck = workflowJob(ci, "windows-check");
+  const windowsNative = workflowJob(ci, "windows-native");
   const changes = workflowJob(ci, "changes");
-  assert.match(windows, /Check the Windows installer crates/);
-  assert.match(windows, /vars\.CI_WINDOWS_RUNNER \|\| 'windows-latest'/);
-  assert.match(windows, /Stage sidecar placeholders for cargo check/);
-  assert.doesNotMatch(windows, /prepare-sidecar\.mjs/);
-  assert.match(windows, /-p tidebreak-desktop/);
-  assert.match(windows, /-p tidebreak-cli/);
-  assert.match(windows, /-p tidebreak-host-broker/);
-  assert.match(windows, /cargo check --target x86_64-pc-windows-msvc/);
-  assert.doesNotMatch(windows, /cargo test/);
+  assert.match(windowsCheck, /name: Windows cargo check/);
+  assert.match(windowsCheck, /Check the Windows installer crates/);
+  assert.match(windowsCheck, /vars\.CI_WINDOWS_RUNNER \|\| 'windows-latest'/);
+  assert.match(windowsCheck, /Stage sidecar placeholders for cargo check/);
+  assert.doesNotMatch(windowsCheck, /prepare-sidecar\.mjs/);
+  for (const crate of [
+    "tidebreak-core",
+    "tidebreak-code-execution",
+    "tidebreak-cli",
+    "tidebreak-host-broker",
+    "tidebreak-server",
+    "tidebreak-desktop",
+  ]) {
+    assert.match(windowsCheck, new RegExp(`-p ${crate}`));
+  }
+  assert.match(windowsCheck, /cargo check --target x86_64-pc-windows-msvc/);
+  assert.doesNotMatch(windowsCheck, /cargo test/);
   assert.doesNotMatch(ci, /windows-ci/);
   assert.doesNotMatch(changes, /echo "windows=/);
   assert.ok(
-    skipsSupersededPush(windows),
+    skipsSupersededPush(windowsCheck),
     "a superseded main push must skip the Windows lane, not cancel it",
   );
   assert.doesNotMatch(
-    windows,
+    windowsCheck,
     /cancel-in-progress/,
     "cancelling this lane reddens a commit whose own checks all passed",
   );
-  assert.match(windows, /SCCACHE_GHA_ENABLED: "true"/);
-  assert.match(windows, /SCCACHE_GHA_RW_MODE: READ_WRITE/);
-  assert.match(windows, /RUSTC_WRAPPER: sccache/);
+  assert.match(windowsCheck, /SCCACHE_GHA_ENABLED: "true"/);
+  assert.match(windowsCheck, /SCCACHE_GHA_RW_MODE: READ_WRITE/);
+  assert.match(windowsCheck, /RUSTC_WRAPPER: sccache/);
   assert.match(
-    windows,
+    windowsCheck,
     /uses: mozilla-actions\/sccache-action@[0-9a-f]{40}/,
+  );
+
+  assert.match(windowsNative, /name: Windows native tests/);
+  assert.match(windowsNative, /needs: changes/);
+  assert.match(
+    windowsNative,
+    /if: \$\{\{ needs\.changes\.outputs\.windows_native == 'true' \}\}/,
+  );
+  assert.match(windowsNative, /vars\.CI_WINDOWS_RUNNER \|\| 'windows-latest'/);
+  assert.match(windowsNative, /SCCACHE_GHA_ENABLED: "true"/);
+  assert.match(windowsNative, /SCCACHE_GHA_RW_MODE: READ_WRITE/);
+  assert.match(windowsNative, /RUSTC_WRAPPER: sccache/);
+  assert.match(
+    windowsNative,
+    /uses: mozilla-actions\/sccache-action@[0-9a-f]{40}/,
+  );
+  assert.match(windowsNative, /uses: Swatinem\/rust-cache@[0-9a-f]{40}/);
+  assert.match(windowsNative, /Host broker Windows tests/);
+  assert.match(windowsNative, /Code mode Windows lifecycle tests/);
+  assert.match(windowsNative, /SQLite profile open and migrations/);
+  assert.match(windowsNative, /Credential Manager round trip/);
+  assert.match(windowsNative, /\$attempts = 3/);
+  assert.match(windowsNative, /tidebreak-server", "--lib", "code::"/);
+  assert.match(
+    windowsNative,
+    /cargo test --target x86_64-pc-windows-msvc -p tidebreak-host-broker --locked/,
+  );
+  assert.match(windowsNative, /-p tidebreak-server --lib desktop_schema --locked/);
+  assert.match(windowsNative, /-p tidebreak-core --lib keychain --locked -- --ignored/);
+  assert.match(
+    changes,
+    /windows_native: \$\{\{ steps\.scope\.outputs\.windows_native \}\}/,
+  );
+  assert.match(changes, /echo "windows_native=\$windows_native"/);
+  assert.match(
+    changes,
+    /if \[\[ "\$windows_native" == true && "\$rust" != true \]\]; then/,
+  );
+});
+
+test("PostgreSQL tests share one Cargo invocation per feature graph", () => {
+  const postgres = workflowJob(workflows["ci.yml"], "postgres");
+  assert.equal(postgres.match(/cargo test/g)?.length, 2);
+  for (const target of [
+    "postgres_turn_state",
+    "postgres_document_blob",
+    "postgres_code_owner",
+    "postgres_release_upgrade",
+  ]) {
+    assert.match(postgres, new RegExp(`--test ${target}`));
+  }
+  assert.match(
+    postgres,
+    /cargo test -p tidebreak-server --features postgres\n\s+--test postgres_store_ownership --locked/,
   );
 });
 


### PR DESCRIPTION
## Why

Measured on recent PR runs, wall time was 17–20 min, set in four of five runs by `Windows cargo check` (a 5 min check followed by 7–10 min of native tests and 2–3 min of Credential Manager tests on one runner) and otherwise by `test` (3m42 compile plus 9m17 running 3,884 tests on four cores). Any edit to a PR description or label also cancelled and restarted the whole run.

## Change

- **Windows native tests** (`windows-native`) run in their own job, in parallel with the required `Windows cargo check`, gated on a new `windows_native` scope that fires for code-execution, harness, host-broker, the server's code mode and desktop schema, the keychain, and `prepare-sidecar.mjs`. The check job keeps its required name and additionally checks `tidebreak-core`, `tidebreak-code-execution`, and `tidebreak-server` for the MSVC target.
- **Test partitions**: `headless tests` becomes a three-way matrix using `cargo nextest run ... --partition count:N/3`. An aggregate job named exactly `test` (the required context) fails when the scope said the partitions should run and any of them did not succeed, and fails if they ran when they should not have. Partition one is the only Cargo-download cache writer.
- **Title check** moves to `release-draft.yml` under `pull_request_target`, checking out only the base SHA; the check name `semantic PR title` is unchanged. `ci.yml` triggers shrink to `opened, reopened, synchronize, ready_for_review`.
- **Dead `merge_group` trigger** and its scope-detector case are removed.
- **Postgres lane** runs its four `tidebreak-core` suites in one `cargo test` invocation.
- `scripts/workflow-security.test.mjs` is updated for the new shape; main's current copy of that test also passes against these workflows, so the `release policy` lane is satisfied without a preceding allow-list PR.

## Verified

`node --test scripts/*.test.mjs` (210 pass), main's trusted `workflow-security.test.mjs` against this branch (45 pass), YAML parses. The real proof is this PR's own run: the `test` aggregate and `Windows cargo check` contexts must appear and go green.

## Not in this PR

`release.yml`, `staging*.yml`, and `cache-*.yml` are changed separately.