### PR TITLE
ci: compile macOS release slices in parallel and stop staging's second build

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -44,17 +44,23 @@ jobs:
           cargo fetch --locked --target x86_64-apple-darwin
 
   warm:
-    name: macOS cache · universal
+    name: macOS cache · ${{ matrix.target }}
     needs: cargo-downloads
     runs-on: macos-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+          - target: x86_64-apple-darwin
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
       # GitHub throttles sccache's many small writes. Retain its existing
-      # object cache as a read-only fallback and persist build outputs below
-      # with one cache archive containing both universal slices.
+      # object cache as a read-only fallback and persist each architecture's
+      # build outputs in one archive that the matching release prepare restores.
       SCCACHE_GHA_RW_MODE: READ_ONLY
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -62,43 +68,27 @@ jobs:
       - name: Install Rust target
         run: |
           rustup show
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+          rustup target add "${{ matrix.target }}"
 
       - name: Restore unsigned Rust build cache
         id: rust-build-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/aarch64-apple-darwin/release/.cargo-lock
-            target/aarch64-apple-darwin/release/.fingerprint
-            target/aarch64-apple-darwin/release/build
-            target/aarch64-apple-darwin/release/deps
-            target/aarch64-apple-darwin/release/tidebreak-desktop
-            target/aarch64-apple-darwin/release/tidebreak-host-broker
-            target/aarch64-apple-darwin/release/tidebreak
-            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
-            target/x86_64-apple-darwin/release/.cargo-lock
-            target/x86_64-apple-darwin/release/.fingerprint
-            target/x86_64-apple-darwin/release/build
-            target/x86_64-apple-darwin/release/deps
-            target/x86_64-apple-darwin/release/tidebreak-desktop
-            target/x86_64-apple-darwin/release/tidebreak-host-broker
-            target/x86_64-apple-darwin/release/tidebreak
-            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
-          key: macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/tidebreak
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}
+          key: macos-release-target-v5-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
           restore-keys: |
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v5-universal-
+            macos-release-target-v5-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v5-${{ matrix.target }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -133,22 +123,19 @@ jobs:
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/tidebreak-desktop
-          args: --target universal-apple-darwin --no-bundle --ci
+          args: --target ${{ matrix.target }} --no-bundle --ci
 
       - name: Report unsigned Rust build cache size
         if: ${{ !cancelled() }}
         run: |
           du -ch \
-            target/release/{.cargo-lock,.fingerprint,build,deps} \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/{.cargo-lock,.fingerprint,build,deps} \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak-desktop \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak-host-broker \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/libtidebreak_desktop_lib.* \
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-{aarch64-apple-darwin,x86_64-apple-darwin} \
-            crates/tidebreak-desktop/binaries/tidebreak-{aarch64-apple-darwin,x86_64-apple-darwin} \
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin \
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin \
+            target/${{ matrix.target }}/release/{.cargo-lock,.fingerprint,build,deps} \
+            target/${{ matrix.target }}/release/tidebreak-desktop \
+            target/${{ matrix.target }}/release/tidebreak-host-broker \
+            target/${{ matrix.target }}/release/tidebreak \
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.* \
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }} \
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }} \
             2>/dev/null | tail -1 || true
 
       - name: Save unsigned Rust build cache
@@ -156,32 +143,16 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/aarch64-apple-darwin/release/.cargo-lock
-            target/aarch64-apple-darwin/release/.fingerprint
-            target/aarch64-apple-darwin/release/build
-            target/aarch64-apple-darwin/release/deps
-            target/aarch64-apple-darwin/release/tidebreak-desktop
-            target/aarch64-apple-darwin/release/tidebreak-host-broker
-            target/aarch64-apple-darwin/release/tidebreak
-            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
-            target/x86_64-apple-darwin/release/.cargo-lock
-            target/x86_64-apple-darwin/release/.fingerprint
-            target/x86_64-apple-darwin/release/build
-            target/x86_64-apple-darwin/release/deps
-            target/x86_64-apple-darwin/release/tidebreak-desktop
-            target/x86_64-apple-darwin/release/tidebreak-host-broker
-            target/x86_64-apple-darwin/release/tidebreak
-            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/tidebreak
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}
           key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
 
       - name: Require a successful cache-warm compilation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -580,18 +580,32 @@ jobs:
           echo "Validated the complete immutable release for $RELEASE_TAG."
           echo "exists=true" >> "$GITHUB_OUTPUT"
 
+  notices:
+    name: third-party notices
+    needs: validate
+    if: ${{ needs.validate.outputs.draft == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/third-party-notices.yml
+    with:
+      sha: ${{ needs.validate.outputs.sha }}
+
   prepare_macos:
-    name: prepare unsigned macOS · universal
-    needs: [validate, inspect_hosted]
+    name: prepare unsigned macOS · ${{ matrix.target }}
+    needs: [validate, inspect_hosted, notices]
     if: >-
       ${{
         needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.outputs.exists != 'true'
       }}
-    # Set PRODUCTION_MACOS_RUNNER to a provisioned ARM64 larger-runner label
-    # when release compile time matters more than the additional runner cost.
-    runs-on: ${{ vars.PRODUCTION_MACOS_RUNNER || 'macos-latest' }}
+    runs-on: macos-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+          - target: x86_64-apple-darwin
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
@@ -624,45 +638,29 @@ jobs:
       - name: Install Rust target
         run: |
           rustup show
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+          rustup target add "${{ matrix.target }}"
 
       - name: Restore unsigned Rust build cache
         id: rust-build-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/aarch64-apple-darwin/release/.cargo-lock
-            target/aarch64-apple-darwin/release/.fingerprint
-            target/aarch64-apple-darwin/release/build
-            target/aarch64-apple-darwin/release/deps
-            target/aarch64-apple-darwin/release/tidebreak-desktop
-            target/aarch64-apple-darwin/release/tidebreak-host-broker
-            target/aarch64-apple-darwin/release/tidebreak
-            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
-            target/x86_64-apple-darwin/release/.cargo-lock
-            target/x86_64-apple-darwin/release/.fingerprint
-            target/x86_64-apple-darwin/release/build
-            target/x86_64-apple-darwin/release/deps
-            target/x86_64-apple-darwin/release/tidebreak-desktop
-            target/x86_64-apple-darwin/release/tidebreak-host-broker
-            target/x86_64-apple-darwin/release/tidebreak
-            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
-          key: macos-release-prepared-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/tidebreak
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}
+          key: macos-release-target-v5-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            macos-release-prepared-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v5-universal-
+            macos-release-target-v5-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            macos-release-target-v5-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+            macos-release-target-v5-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v5-${{ matrix.target }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -691,13 +689,6 @@ jobs:
         working-directory: crates/tidebreak-desktop/ui
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      # The signed bundle ships legal/THIRD-PARTY-NOTICES.md as a resource, so
-      # the released tag must not carry a stale copy. Both dependency graphs are
-      # already resolved on this runner, and this job gates the signed build, so
-      # drift fails here, before any signing material is loaded.
-      - name: Verify the third-party notices match the released graph
-        run: node scripts/generate-third-party-notices.mjs --check
-
       - name: Compile without production credentials or bundles
         id: compile
         continue-on-error: true
@@ -705,7 +696,7 @@ jobs:
         with:
           projectPath: crates/tidebreak-desktop
           args: >-
-            --target universal-apple-darwin
+            --target ${{ matrix.target }}
             --config ${{ runner.temp }}/tidebreak-release.json
             --no-bundle
             --ci
@@ -715,32 +706,16 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/aarch64-apple-darwin/release/.cargo-lock
-            target/aarch64-apple-darwin/release/.fingerprint
-            target/aarch64-apple-darwin/release/build
-            target/aarch64-apple-darwin/release/deps
-            target/aarch64-apple-darwin/release/tidebreak-desktop
-            target/aarch64-apple-darwin/release/tidebreak-host-broker
-            target/aarch64-apple-darwin/release/tidebreak
-            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
-            target/x86_64-apple-darwin/release/.cargo-lock
-            target/x86_64-apple-darwin/release/.fingerprint
-            target/x86_64-apple-darwin/release/build
-            target/x86_64-apple-darwin/release/deps
-            target/x86_64-apple-darwin/release/tidebreak-desktop
-            target/x86_64-apple-darwin/release/tidebreak-host-broker
-            target/x86_64-apple-darwin/release/tidebreak
-            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/tidebreak
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}
           key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
 
       - name: Require a successful unsigned compilation
@@ -749,9 +724,9 @@ jobs:
 
       - name: Archive prepared macOS inputs
         env:
-          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-macos
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-macos-${{ matrix.target }}
           RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
-          RELEASE_TARGET: universal-apple-darwin
+          RELEASE_TARGET: ${{ matrix.target }}
         run: |
           app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop"
           broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
@@ -788,7 +763,7 @@ jobs:
               "$broker_sidecar" \
               "$cli_sidecar" \
               > SHA256SUMS
-            tar -cf "$GITHUB_WORKSPACE/prepared-macos.tar" \
+            tar -cf "$GITHUB_WORKSPACE/prepared-macos-$RELEASE_TARGET.tar" \
               SHA256SUMS \
               release-config.json \
               target \
@@ -796,10 +771,138 @@ jobs:
           )
           (
             cd "$GITHUB_WORKSPACE"
-            shasum -a 256 prepared-macos.tar > prepared-macos.tar.sha256
+            shasum -a 256 \
+              "prepared-macos-$RELEASE_TARGET.tar" \
+              > "prepared-macos-$RELEASE_TARGET.tar.sha256"
           )
 
       - name: Upload prepared macOS inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-prepared-macos-${{ matrix.target }}-${{ github.run_id }}
+          path: |
+            prepared-macos-${{ matrix.target }}.tar
+            prepared-macos-${{ matrix.target }}.tar.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+  combine_macos:
+    name: combine unsigned macOS · universal
+    needs: [validate, inspect_hosted, prepare_macos]
+    if: >-
+      ${{
+        always()
+        && needs.validate.result == 'success'
+        && needs.validate.outputs.draft == 'true'
+        && needs.inspect_hosted.result == 'success'
+        && needs.inspect_hosted.outputs.exists != 'true'
+        && needs.prepare_macos.result == 'success'
+      }}
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - name: Download prepared aarch64 macOS inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-prepared-macos-aarch64-apple-darwin-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-macos-aarch64-apple-darwin-download
+
+      - name: Download prepared x86_64 macOS inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-prepared-macos-x86_64-apple-darwin-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-macos-x86_64-apple-darwin-download
+
+      - name: Verify and combine prepared macOS slices
+        env:
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-macos-universal
+        run: |
+          for target in aarch64-apple-darwin x86_64-apple-darwin; do
+            download="$RUNNER_TEMP/prepared-macos-$target-download"
+            slice_root="$RUNNER_TEMP/tidebreak-prepared-macos-$target"
+            (
+              cd "$download"
+              shasum -a 256 --check "prepared-macos-$target.tar.sha256"
+            )
+            rm -rf "$slice_root"
+            install -d "$slice_root"
+            tar -xf "$download/prepared-macos-$target.tar" -C "$slice_root"
+            (
+              cd "$slice_root"
+              shasum -a 256 --check SHA256SUMS
+              expected_files="$(printf '%s\n' \
+                "./SHA256SUMS" \
+                "./crates/tidebreak-desktop/binaries/tidebreak-host-broker-$target" \
+                "./crates/tidebreak-desktop/binaries/tidebreak-$target" \
+                "./release-config.json" \
+                "./target/$target/release/tidebreak-desktop" \
+                | LC_ALL=C sort)"
+              actual_files="$(find . -type f -print | LC_ALL=C sort)"
+              [[ "$actual_files" = "$expected_files" ]] || {
+                echo "Prepared $target archive contains an unexpected file set" >&2
+                printf '%s\n' "$actual_files" >&2
+                exit 1
+              }
+            )
+          done
+
+          arm_root="$RUNNER_TEMP/tidebreak-prepared-macos-aarch64-apple-darwin"
+          x86_root="$RUNNER_TEMP/tidebreak-prepared-macos-x86_64-apple-darwin"
+          cmp "$arm_root/release-config.json" "$x86_root/release-config.json"
+
+          app_binary="target/universal-apple-darwin/release/tidebreak-desktop"
+          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin"
+          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin"
+          rm -rf "$PREPARED_ROOT"
+          install -d \
+            "$PREPARED_ROOT/target/universal-apple-darwin/release" \
+            "$PREPARED_ROOT/crates/tidebreak-desktop/binaries"
+          install -m 644 "$arm_root/release-config.json" "$PREPARED_ROOT/release-config.json"
+
+          lipo -create \
+            "$arm_root/target/aarch64-apple-darwin/release/tidebreak-desktop" \
+            "$x86_root/target/x86_64-apple-darwin/release/tidebreak-desktop" \
+            -output "$PREPARED_ROOT/$app_binary"
+          lipo -create \
+            "$arm_root/crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin" \
+            "$x86_root/crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin" \
+            -output "$PREPARED_ROOT/$broker_sidecar"
+          lipo -create \
+            "$arm_root/crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin" \
+            "$x86_root/crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin" \
+            -output "$PREPARED_ROOT/$cli_sidecar"
+          chmod 755 \
+            "$PREPARED_ROOT/$app_binary" \
+            "$PREPARED_ROOT/$broker_sidecar" \
+            "$PREPARED_ROOT/$cli_sidecar"
+
+          for file in "$app_binary" "$broker_sidecar" "$cli_sidecar"; do
+            arches="$(lipo -archs "$PREPARED_ROOT/$file")"
+            [[ "$arches" = *arm64* && "$arches" = *x86_64* ]] || {
+              echo "Combined macOS input is not universal: $file ($arches)" >&2
+              exit 1
+            }
+          done
+
+          (
+            cd "$PREPARED_ROOT"
+            shasum -a 256 \
+              release-config.json \
+              "$app_binary" \
+              "$broker_sidecar" \
+              "$cli_sidecar" \
+              > SHA256SUMS
+            tar -cf "$GITHUB_WORKSPACE/prepared-macos.tar" \
+              SHA256SUMS \
+              release-config.json \
+              target \
+              crates
+          )
+          shasum -a 256 prepared-macos.tar > prepared-macos.tar.sha256
+
+      - name: Upload prepared universal macOS inputs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: tidebreak-prepared-macos-universal-${{ github.run_id }}
@@ -813,7 +916,7 @@ jobs:
 
   build_macos:
     name: macOS · universal
-    needs: [validate, inspect_hosted, prepare_macos]
+    needs: [validate, inspect_hosted, notices, combine_macos]
     if: >-
       ${{
         always()
@@ -821,7 +924,8 @@ jobs:
         && needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.result == 'success'
         && needs.inspect_hosted.outputs.exists != 'true'
-        && needs.prepare_macos.result == 'success'
+        && needs.notices.result == 'success'
+        && needs.combine_macos.result == 'success'
       }}
     runs-on: macos-latest
     timeout-minutes: 90
@@ -1180,7 +1284,7 @@ jobs:
 
   prepare_windows:
     name: prepare unsigned Windows · ${{ matrix.arch }}
-    needs: [validate, inspect_hosted]
+    needs: [validate, inspect_hosted, notices]
     if: >-
       ${{
         needs.validate.outputs.draft == 'true'
@@ -1305,9 +1409,6 @@ jobs:
         working-directory: crates/tidebreak-desktop/ui
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Verify the third-party notices match the released graph
-        run: node scripts/generate-third-party-notices.mjs --check
-
       - name: Compile without production credentials or bundles
         id: compile
         continue-on-error: true
@@ -1408,7 +1509,7 @@ jobs:
 
   build_windows:
     name: Windows · ${{ matrix.arch }}
-    needs: [validate, inspect_hosted, prepare_windows]
+    needs: [validate, inspect_hosted, notices, prepare_windows]
     if: >-
       ${{
         always()
@@ -1416,6 +1517,7 @@ jobs:
         && needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.result == 'success'
         && needs.inspect_hosted.outputs.exists != 'true'
+        && needs.notices.result == 'success'
         && needs.prepare_windows.result == 'success'
       }}
     runs-on: ${{ matrix.runner }}
@@ -1605,7 +1707,7 @@ jobs:
 
   build_linux:
     name: Linux · ${{ matrix.arch }}
-    needs: [validate, inspect_hosted]
+    needs: [validate, inspect_hosted, notices]
     if: >-
       ${{
         needs.validate.outputs.draft == 'true'
@@ -1717,9 +1819,6 @@ jobs:
       - name: Install UI dependencies
         working-directory: crates/tidebreak-desktop/ui
         run: pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Verify the third-party notices match the released graph
-        run: node scripts/generate-third-party-notices.mjs --check
 
       - name: Install Rust target
         run: |

--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -62,9 +62,19 @@ jobs:
             echo "sha=$STAGING_SHA"
           } >> "$GITHUB_OUTPUT"
 
+  notices:
+    name: third-party notices
+    needs: validate_staging
+    if: ${{ inputs.channel == 'staging' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/third-party-notices.yml
+    with:
+      sha: ${{ needs.validate_staging.outputs.sha }}
+
   prepare_macos_staging:
     name: prepare unsigned staging macOS · universal
-    needs: validate_staging
+    needs: [validate_staging, notices]
     if: ${{ inputs.channel == 'staging' }}
     runs-on: macos-latest
     timeout-minutes: 60
@@ -84,43 +94,6 @@ jobs:
         run: |
           rustup show
           rustup target add aarch64-apple-darwin x86_64-apple-darwin
-
-      - name: Restore unsigned Rust build cache
-        id: rust-build-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/aarch64-apple-darwin/release/.cargo-lock
-            target/aarch64-apple-darwin/release/.fingerprint
-            target/aarch64-apple-darwin/release/build
-            target/aarch64-apple-darwin/release/deps
-            target/aarch64-apple-darwin/release/tidebreak-desktop
-            target/aarch64-apple-darwin/release/tidebreak-host-broker
-            target/aarch64-apple-darwin/release/tidebreak
-            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
-            target/x86_64-apple-darwin/release/.cargo-lock
-            target/x86_64-apple-darwin/release/.fingerprint
-            target/x86_64-apple-darwin/release/build
-            target/x86_64-apple-darwin/release/deps
-            target/x86_64-apple-darwin/release/tidebreak-desktop
-            target/x86_64-apple-darwin/release/tidebreak-host-broker
-            target/x86_64-apple-darwin/release/tidebreak
-            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
-          key: macos-staging-prepared-v2-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-${{ needs.validate_staging.outputs.version }}
-          restore-keys: |
-            macos-staging-prepared-v2-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -149,8 +122,24 @@ jobs:
         working-directory: crates/tidebreak-desktop/ui
         run: pnpm install --frozen-lockfile
 
-      - name: Verify the third-party notices match the released graph
-        run: node scripts/generate-third-party-notices.mjs --check
+      - name: Write staging Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-staging.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const overlay = JSON.parse(fs.readFileSync(
+              "crates/tidebreak-desktop/tauri.staging.conf.json",
+              "utf8",
+            ));
+            overlay.version = process.env.TIDEBREAK_VERSION;
+            overlay.bundle = overlay.bundle || {};
+            overlay.bundle.targets = ["app", "dmg"];
+            if (overlay.identifier !== "io.brightwave.tidebreak.staging") {
+              throw new Error("staging overlay lost its identifier");
+            }
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify(overlay));
+          '
 
       - name: Compile without staging credentials or bundles
         id: compile
@@ -158,48 +147,74 @@ jobs:
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/tidebreak-desktop
-          args: --target universal-apple-darwin --no-bundle --ci
-
-      - name: Save staging-specific unsigned Rust build cache
-        if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/aarch64-apple-darwin/release/.cargo-lock
-            target/aarch64-apple-darwin/release/.fingerprint
-            target/aarch64-apple-darwin/release/build
-            target/aarch64-apple-darwin/release/deps
-            target/aarch64-apple-darwin/release/tidebreak-desktop
-            target/aarch64-apple-darwin/release/tidebreak-host-broker
-            target/aarch64-apple-darwin/release/tidebreak
-            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
-            target/x86_64-apple-darwin/release/.cargo-lock
-            target/x86_64-apple-darwin/release/.fingerprint
-            target/x86_64-apple-darwin/release/build
-            target/x86_64-apple-darwin/release/deps
-            target/x86_64-apple-darwin/release/tidebreak-desktop
-            target/x86_64-apple-darwin/release/tidebreak-host-broker
-            target/x86_64-apple-darwin/release/tidebreak
-            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
-          key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
+          args: >-
+            --target universal-apple-darwin
+            --config ${{ runner.temp }}/tidebreak-staging.json
+            --no-bundle
+            --ci
 
       - name: Require a successful unsigned compilation
         if: ${{ steps.compile.outcome != 'success' }}
         run: exit 1
 
+      - name: Archive prepared staging macOS inputs
+        env:
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-staging-macos
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-staging.json
+          RELEASE_TARGET: universal-apple-darwin
+        run: |
+          app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop"
+          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
+          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET"
+          for file in "$app_binary" "$broker_sidecar" "$cli_sidecar" "$RELEASE_CONFIG"; do
+            [[ -s "$file" ]] || {
+              echo "Prepared staging macOS input is missing or empty: $file" >&2
+              exit 1
+            }
+          done
+
+          rm -rf "$PREPARED_ROOT"
+          install -d \
+            "$PREPARED_ROOT/target/$RELEASE_TARGET/release" \
+            "$PREPARED_ROOT/crates/tidebreak-desktop/binaries"
+          install -m 755 "$app_binary" "$PREPARED_ROOT/$app_binary"
+          install -m 755 "$broker_sidecar" "$PREPARED_ROOT/$broker_sidecar"
+          install -m 755 "$cli_sidecar" "$PREPARED_ROOT/$cli_sidecar"
+          install -m 644 "$RELEASE_CONFIG" "$PREPARED_ROOT/staging-config.json"
+
+          (
+            cd "$PREPARED_ROOT"
+            shasum -a 256 \
+              staging-config.json \
+              "$app_binary" \
+              "$broker_sidecar" \
+              "$cli_sidecar" \
+              > SHA256SUMS
+            tar -cf "$GITHUB_WORKSPACE/prepared-staging-macos.tar" \
+              SHA256SUMS \
+              staging-config.json \
+              target \
+              crates
+          )
+          shasum -a 256 \
+            prepared-staging-macos.tar \
+            > prepared-staging-macos.tar.sha256
+
+      - name: Upload prepared staging macOS inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-prepared-staging-macos-universal-${{ github.run_id }}
+          path: |
+            prepared-staging-macos.tar
+            prepared-staging-macos.tar.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
   build_macos_staging:
     name: staging macOS · universal
-    needs: [validate_staging, prepare_macos_staging]
+    needs: [validate_staging, notices, prepare_macos_staging]
     if: ${{ inputs.channel == 'staging' }}
     runs-on: macos-latest
     timeout-minutes: 90
@@ -207,10 +222,6 @@ jobs:
       name: desktop-staging
       url: https://downloads.brightwave.io/tidebreak/staging/manifest.json
     env:
-      CARGO_INCREMENTAL: 0
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: READ_ONLY
       TIDEBREAK_CHANNEL: staging
       TIDEBREAK_VERSION: ${{ needs.validate_staging.outputs.version }}
       APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER }}
@@ -221,70 +232,52 @@ jobs:
         with:
           ref: ${{ needs.validate_staging.outputs.sha }}
 
-      - name: Restore unsigned Rust build cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download prepared staging macOS inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/aarch64-apple-darwin/release/.cargo-lock
-            target/aarch64-apple-darwin/release/.fingerprint
-            target/aarch64-apple-darwin/release/build
-            target/aarch64-apple-darwin/release/deps
-            target/aarch64-apple-darwin/release/tidebreak-desktop
-            target/aarch64-apple-darwin/release/tidebreak-host-broker
-            target/aarch64-apple-darwin/release/tidebreak
-            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
-            target/x86_64-apple-darwin/release/.cargo-lock
-            target/x86_64-apple-darwin/release/.fingerprint
-            target/x86_64-apple-darwin/release/build
-            target/x86_64-apple-darwin/release/deps
-            target/x86_64-apple-darwin/release/tidebreak-desktop
-            target/x86_64-apple-darwin/release/tidebreak-host-broker
-            target/x86_64-apple-darwin/release/tidebreak
-            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
-          key: macos-staging-prepared-v2-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-${{ needs.validate_staging.outputs.version }}
-          restore-keys: |
-            macos-staging-prepared-v2-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}-
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate_staging.outputs.sha }}
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+          name: tidebreak-prepared-staging-macos-universal-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-staging-macos-download
 
-      - name: Discard restored product binaries
+      - name: Verify prepared staging macOS inputs
+        env:
+          PREPARED_DOWNLOAD: ${{ runner.temp }}/prepared-staging-macos-download
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-staging-macos
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-staging.json
+          RELEASE_TARGET: universal-apple-darwin
         run: |
-          rm -rf \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin,universal-apple-darwin}/release/tidebreak-desktop \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak-host-broker \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/libtidebreak_desktop_lib.* \
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-{aarch64-apple-darwin,x86_64-apple-darwin} \
-            crates/tidebreak-desktop/binaries/tidebreak-{aarch64-apple-darwin,x86_64-apple-darwin} \
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin \
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
+          (
+            cd "$PREPARED_DOWNLOAD"
+            shasum -a 256 --check prepared-staging-macos.tar.sha256
+          )
+          rm -rf "$PREPARED_ROOT"
+          install -d "$PREPARED_ROOT"
+          tar -xf "$PREPARED_DOWNLOAD/prepared-staging-macos.tar" -C "$PREPARED_ROOT"
+          (
+            cd "$PREPARED_ROOT"
+            shasum -a 256 --check SHA256SUMS
+            expected_files="$(printf '%s\n' \
+              "./SHA256SUMS" \
+              "./crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET" \
+              "./crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET" \
+              "./staging-config.json" \
+              "./target/$RELEASE_TARGET/release/tidebreak-desktop" \
+              | LC_ALL=C sort)"
+            actual_files="$(find . -type f -print | LC_ALL=C sort)"
+            [[ "$actual_files" = "$expected_files" ]] || {
+              echo "Prepared staging macOS archive contains an unexpected file set" >&2
+              printf '%s\n' "$actual_files" >&2
+              exit 1
+            }
+          )
 
-      # sccache, rust-cache, and the UI install run before any Apple or Tauri
-      # material is on disk. pnpm is pinned; lifecycle scripts stay off.
-      - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
-        with:
-          shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
-          cache-bin: false
-          cache-targets: false
-          save-if: false
+          app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop"
+          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
+          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET"
+          install -d "$(dirname "$app_binary")" "$(dirname "$broker_sidecar")"
+          install -m 755 "$PREPARED_ROOT/$app_binary" "$app_binary"
+          install -m 755 "$PREPARED_ROOT/$broker_sidecar" "$broker_sidecar"
+          install -m 755 "$PREPARED_ROOT/$cli_sidecar" "$cli_sidecar"
+          install -m 644 "$PREPARED_ROOT/staging-config.json" "$RELEASE_CONFIG"
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
@@ -293,10 +286,11 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
-      - name: Install UI dependencies
-        working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile --ignore-scripts
+          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
+      - name: Install pinned Tauri bundler
+        run: |
+          pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts
+          echo "$GITHUB_WORKSPACE/.github/tauri-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Validate staging signing configuration
         env:
@@ -363,47 +357,39 @@ jobs:
             echo "APPLE_SIGNING_KEYCHAIN=$keychain_path"
           } >> "$GITHUB_ENV"
 
-      - name: Install Rust target
-        run: |
-          rustup show
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
-
-      - name: Write staging Tauri configuration
+      - name: Add the macOS signing identity to the prepared configuration
         env:
-          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-staging.json
+          PREPARED_CONFIG: ${{ runner.temp }}/tidebreak-staging.json
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-staging-signing.json
         run: |
           node -e '
             const fs = require("node:fs");
-            const overlay = JSON.parse(fs.readFileSync(
-              "crates/tidebreak-desktop/tauri.staging.conf.json",
-              "utf8",
-            ));
-            overlay.version = process.env.TIDEBREAK_VERSION;
-            overlay.bundle = overlay.bundle || {};
-            overlay.bundle.targets = ["app", "dmg"];
-            overlay.bundle.macOS = {
-              ...(overlay.bundle.macOS || {}),
-              signingIdentity: process.env.APPLE_SIGNING_IDENTITY,
-            };
-            if (overlay.identifier !== "io.brightwave.tidebreak.staging") {
+            const config = JSON.parse(fs.readFileSync(process.env.PREPARED_CONFIG, "utf8"));
+            if (config.version !== process.env.TIDEBREAK_VERSION) {
+              throw new Error("Prepared version " + config.version + " does not match " + process.env.TIDEBREAK_VERSION);
+            }
+            if (config.identifier !== "io.brightwave.tidebreak.staging") {
               throw new Error("staging overlay lost its identifier");
             }
-            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify(overlay));
+            config.bundle.macOS = {
+              ...(config.bundle.macOS || {}),
+              signingIdentity: process.env.APPLE_SIGNING_IDENTITY,
+            };
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify(config));
           '
 
       # The App Store Connect key is deliberately not in the environment yet:
       # without notary credentials, Tauri signs the app and DMG but skips its
       # own notarization submission. One submission of the DMG below covers
       # the nested app too, halving the Apple round trips.
-      - name: Build and sign the staging app
-        id: tauri
-        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
-        with:
-          projectPath: crates/tidebreak-desktop
-          args: >-
-            --target universal-apple-darwin
-            --config ${{ runner.temp }}/tidebreak-staging.json
-            --bundles app,dmg
+      - name: Bundle and sign the prepared staging app
+        working-directory: crates/tidebreak-desktop
+        run: |
+          tauri bundle \
+            --target universal-apple-darwin \
+            --config "$RUNNER_TEMP/tidebreak-staging-signing.json" \
+            --bundles app,dmg \
+            --ci
 
       - name: Prepare App Store Connect key
         env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -89,6 +89,7 @@ jobs:
             .github/workflows/release.yml \
             .github/workflows/staging-publish.yml \
             .github/workflows/staging.yml \
+            .github/workflows/third-party-notices.yml \
             Cargo.lock \
             Cargo.toml \
             crates \

--- a/.github/workflows/third-party-notices.yml
+++ b/.github/workflows/third-party-notices.yml
@@ -1,0 +1,44 @@
+name: Check released third-party notices
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        description: Full source commit whose released dependency graphs to check
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: third-party notices
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.sha }}
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: notices-cargo-registry-v2-${{ hashFiles('Cargo.lock', 'crates/tidebreak-whisper/Cargo.lock') }}
+          cache-targets: false
+          cache-bin: false
+      - name: Fetch both released Cargo graphs
+        run: |
+          cargo fetch --locked
+          cargo fetch --locked --manifest-path crates/tidebreak-whisper/Cargo.toml
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Check the third-party notices
+        run: node scripts/generate-third-party-notices.mjs --check

--- a/crates/tidebreak-desktop/scripts/prepare-sidecar.mjs
+++ b/crates/tidebreak-desktop/scripts/prepare-sidecar.mjs
@@ -27,7 +27,9 @@ mkdirSync(destinationDir, { recursive: true });
 // Tauri's synthetic universal target builds the app once per real Rust target
 // and lipo-combines the app executable. Its bundler expects an already-combined
 // external binary under the synthetic target name, while the per-target Cargo
-// builds still need their own target-suffixed sidecars.
+// builds still need their own target-suffixed sidecars. Release CI can instead
+// invoke this hook once per real target on parallel runners, then lipo the two
+// staged sidecars alongside the two desktop binaries before `tauri bundle`.
 const targets =
   triple === "universal-apple-darwin"
     ? ["aarch64-apple-darwin", "x86_64-apple-darwin"]

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -390,20 +390,19 @@ has its own workflows and failure boundary, a later signing, notarization, or
 publication failure cannot prevent that main-tip cache run from finishing. If
 a shared cache is empty or has been evicted, manually run the matching warm
 workflow from `main`; the production release workflow also compiles the exact tag
-and product version in a credential-free prerequisite. That prerequisite saves
-its release-specific unsigned cache before reporting a compile failure. After a
-successful compile, it uploads the final binary, universal sidecars, and Tauri
+and product version in credential-free prerequisites. On macOS, one
+`macos-latest` runner compiles each real architecture and saves its
+release-specific unsigned cache before reporting a compile failure. A third
+credential-free job verifies both prepared slices, combines the desktop binary
+and both sidecars with `lipo`, and uploads the universal inputs and Tauri
 configuration in a one-day, run-scoped artifact. The `desktop-production` job
 verifies that artifact before it loads signing material, then packages those
 exact binaries without compiling again. Six warm archives plus the
 release-specific ones compete for the repository's shared cache budget, so an
 evicted archive costs a slower release, never a broken one.
 
-To use a larger macOS runner for production compiles, set the repository
-variable `PRODUCTION_MACOS_RUNNER` to a provisioned ARM64 organization runner
-label. If you omit the variable, the workflow uses `macos-latest`. The signing
-and notarization job stays on the standard runner because it no longer compiles
-the application.
+The signing and notarization job stays on its own standard runner because it
+receives the prepared universal inputs and does not compile the application.
 
 ### Production environment configuration
 

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -24,10 +24,11 @@ import { execFileSync } from "node:child_process";
 import {
   copyFileSync,
   existsSync,
-  mkdtempSync,
   lstatSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -797,7 +797,20 @@ function main(argv) {
   );
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Run `main` only when this file is the entry point. Compare real paths so a
+// checkout reached through a symlink (hosted runners expose the workspace
+// under one) still matches the module's own resolved location.
+function isEntryPoint() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isEntryPoint()) {
   try {
     main(process.argv.slice(2));
   } catch (error) {

--- a/scripts/third-party-notices.test.mjs
+++ b/scripts/third-party-notices.test.mjs
@@ -523,6 +523,10 @@ test("the notices ship with the desktop app and are verified against drift", () 
     repositoryFile(".github", "workflows", "release.yml"),
     "utf8",
   );
+  const noticesWorkflow = readFileSync(
+    repositoryFile(".github", "workflows", "third-party-notices.yml"),
+    "utf8",
+  );
   assert.ok(
     release.includes(`${NOTICES_RELATIVE_PATH}:${NOTICES_RELATIVE_PATH}`) &&
       release.includes('cmp "$source_file" "$bundled"') &&
@@ -530,8 +534,8 @@ test("the notices ship with the desktop app and are verified against drift", () 
     "the release lane must compare the bundled notices against the checked-in file",
   );
   assert.ok(
-    release.includes(`${REGENERATE_COMMAND} --check`),
-    "the release lane must refuse a tag whose notices are stale",
+    noticesWorkflow.includes(`${REGENERATE_COMMAND} --check`),
+    "the shared release notice gate must refuse stale notices",
   );
   const ci = readFileSync(
     repositoryFile(".github", "workflows", "ci.yml"),

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1528,6 +1528,14 @@ test("cache warming cannot access production credentials or publish", () => {
   assert.match(cache, /^  cargo-downloads:$/m);
   assert.match(cache, /^    needs: cargo-downloads$/m);
   assert.match(cache, /cargo fetch --locked --target aarch64-apple-darwin/);
+  assert.match(cache, /target: aarch64-apple-darwin/);
+  assert.match(cache, /target: x86_64-apple-darwin/);
+  assert.match(cache, /--target \$\{\{ matrix\.target \}\} --no-bundle --ci/);
+  assert.match(
+    cache,
+    /macos-release-target-v5-\$\{\{ matrix\.target \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ github\.sha \}\}/,
+  );
+  assert.doesNotMatch(cache, /macos-release-target-v5-universal/);
   assert.match(cache, /cancel-in-progress: false/);
   assert.match(cache, /--no-bundle --ci/);
   assert.match(cache, /continue-on-error: true/);
@@ -1575,7 +1583,7 @@ function stepNames(job) {
 
 test("credential-free compile jobs never load production secrets", () => {
   const release = workflows["release.yml"];
-  for (const jobName of ["prepare_macos", "prepare_windows"]) {
+  for (const jobName of ["prepare_macos", "combine_macos", "prepare_windows"]) {
     const job = workflowJob(release, jobName);
     assert.doesNotMatch(job, /^    environment:/m);
     assert.doesNotMatch(job, /secrets\./);
@@ -1857,6 +1865,7 @@ test("an existing immutable release resumes without rebuilding or overwriting", 
   const release = workflows["release.yml"];
   const inspectJob = workflowJob(release, "inspect_hosted");
   const prepareJob = workflowJob(release, "prepare_macos");
+  const combineJob = workflowJob(release, "combine_macos");
   const signedBuildJob = workflowJob(release, "build_macos");
   const publishJob = workflowJob(release, "publish");
 
@@ -1865,6 +1874,7 @@ test("an existing immutable release resumes without rebuilding or overwriting", 
   assert.match(inspectJob, /prepare-published-release\.mjs/);
   assert.match(inspectJob, /Validated the complete immutable release/);
   assert.match(prepareJob, /needs\.inspect_hosted\.outputs\.exists != 'true'/);
+  assert.match(combineJob, /needs\.inspect_hosted\.outputs\.exists != 'true'/);
   assert.match(
     signedBuildJob,
     /needs\.inspect_hosted\.outputs\.exists != 'true'/,
@@ -2054,21 +2064,8 @@ test("GitHub release assets are attached before immutable publication", () => {
   }
 });
 
-// A macOS compile job covers both slices in one of two shapes: one runner
-// compiles Tauri's synthetic universal triple, or a matrix compiles one real
-// triple per runner and a later job joins the slices with lipo. A job that
-// only bundles compiles nothing and is not a compile job. Returns the shape
-// it found, or null when the job does not compile.
-function macosCompileShape(job, label) {
-  if (!/tauri-apps\/tauri-action@/.test(job)) return null;
-  if (/--target universal-apple-darwin/.test(job)) {
-    assert.match(
-      job,
-      /rustup target add aarch64-apple-darwin x86_64-apple-darwin/,
-      `${label} must install both macOS targets`,
-    );
-    return "universal";
-  }
+function assertPerArchMacosCompile(job, label) {
+  assert.match(job, /tauri-apps\/tauri-action@/, `${label} must compile with Tauri`);
   assert.match(job, /target: aarch64-apple-darwin/, `${label} must compile aarch64`);
   assert.match(job, /target: x86_64-apple-darwin/, `${label} must compile x86_64`);
   assert.match(
@@ -2081,7 +2078,6 @@ function macosCompileShape(job, label) {
     /rustup target add "?\$\{\{ matrix\.target \}\}"?/,
     `${label} must install the matrix target`,
   );
-  return "per-arch";
 }
 
 // A per-arch compile is only universal once the workflow lipo-joins the app
@@ -2101,11 +2097,10 @@ test("universal macOS release and staging packages contain both slices", () => {
   const release = workflows["release.yml"];
   const stagingPublish = workflows["staging-publish.yml"];
   const releasePrepare = workflowJob(release, "prepare_macos");
+  const releaseCombine = workflowJob(release, "combine_macos");
   const releaseBuild = workflowJob(release, "build_macos");
   const stagingBuild = workflowJob(stagingPublish, "build_macos_staging");
-  const stagingPrepare = /^  prepare_macos_staging:$/m.test(stagingPublish)
-    ? workflowJob(stagingPublish, "prepare_macos_staging")
-    : null;
+  const stagingPrepare = workflowJob(stagingPublish, "prepare_macos_staging");
   const warm = workflows["cache-macos.yml"];
   const sidecarPreparation = readFileSync(
     repositoryFile("crates/tidebreak-desktop/scripts/prepare-sidecar.mjs"),
@@ -2122,28 +2117,45 @@ test("universal macOS release and staging packages contain both slices", () => {
     /"lipo",\s*\["-create", \.\.\.stagedSidecars, "-output", destination\]/,
   );
 
-  // The release compiles in the credential-free prepare job and the signed
-  // job only bundles the synthetic universal target it is handed.
-  const releaseShape = macosCompileShape(releasePrepare, "prepare_macos");
-  assert.ok(releaseShape, "prepare_macos must compile the macOS app");
+  // Production compiles one real target per runner, combines exactly the app
+  // and two sidecars, then gives the signed job the same universal archive
+  // contract it consumed before the split.
+  assertPerArchMacosCompile(releasePrepare, "prepare_macos");
+  assertPerArchMacosCompile(warm, "cache-macos.yml");
+  assert.equal(
+    releaseCombine.split("lipo -create").length - 1,
+    3,
+    "combine_macos must join the app binary and both sidecars",
+  );
+  assertPerArchSlicesAreJoined(releaseCombine, "combine_macos");
+  assert.match(releaseCombine, /tidebreak-prepared-macos-aarch64-apple-darwin-/);
+  assert.match(releaseCombine, /tidebreak-prepared-macos-x86_64-apple-darwin-/);
+  assert.match(releaseCombine, /tidebreak-prepared-macos-universal-/);
+  assert.match(releaseCombine, /shasum -a 256 --check/);
+  assert.match(releasePrepare, /macos-release-target-v5-\$\{\{ matrix\.target \}\}/);
+  assert.doesNotMatch(releasePrepare, /macos-release-target-v5-universal/);
   assert.match(releaseBuild, /--target universal-apple-darwin/);
+  assert.match(releaseBuild, /needs: \[validate, inspect_hosted, notices, combine_macos\]/);
+  assert.match(releaseBuild, /tauri bundle/);
+  assert.doesNotMatch(releaseBuild, /tauri-apps\/tauri-action@/);
   assert.doesNotMatch(releaseBuild, /rustup target add/);
-  if (releaseShape === "per-arch") {
-    assertPerArchSlicesAreJoined(release, "release.yml");
-  }
 
-  // Staging compiles in its prepare job when it has one, otherwise in the
-  // signed job itself; either way the bundle is universal.
-  const stagingShape =
-    (stagingPrepare && macosCompileShape(stagingPrepare, "prepare_macos_staging")) ||
-    macosCompileShape(stagingBuild, "build_macos_staging");
-  assert.ok(stagingShape, "staging must compile the macOS app");
+  // Staging still compiles the synthetic universal target once, but transfers
+  // its prepared bytes instead of rebuilding them in the signing job.
+  assert.match(stagingPrepare, /tauri-apps\/tauri-action@/);
+  assert.match(
+    stagingPrepare,
+    /rustup target add aarch64-apple-darwin x86_64-apple-darwin/,
+  );
+  assert.match(stagingPrepare, /--target universal-apple-darwin/);
+  assert.match(stagingPrepare, /Upload prepared staging macOS inputs/);
+  assert.match(stagingBuild, /Download prepared staging macOS inputs/);
+  assert.match(stagingBuild, /shasum -a 256 --check/);
   assert.match(stagingBuild, /--target universal-apple-darwin/);
-  if (stagingShape === "per-arch") {
-    assertPerArchSlicesAreJoined(stagingPublish, "staging-publish.yml");
-  }
-
-  assert.ok(macosCompileShape(warm, "cache-macos.yml"), "the warmer must compile");
+  assert.match(stagingBuild, /tauri bundle/);
+  assert.doesNotMatch(stagingBuild, /tauri-apps\/tauri-action@/);
+  assert.doesNotMatch(stagingBuild, /rustup target add/);
+  assert.doesNotMatch(stagingPublish, /actions\/cache\/(?:restore|save)@/);
 
   for (const job of [releaseBuild, stagingBuild]) {
     assert.match(job, /timeout-minutes: 90/);
@@ -2154,6 +2166,71 @@ test("universal macOS release and staging packages contain both slices", () => {
     assert.match(job, /sidecar_arches="\$\(lipo -archs "\$sidecar"\)"/);
     assert.match(job, /cli_sidecar="\$app_path\/Contents\/MacOS\/tidebreak"/);
     assert.match(job, /cli_arches="\$\(lipo -archs "\$cli_sidecar"\)"/);
+  }
+});
+
+test("release and staging share one third-party notices implementation", () => {
+  const noticesWorkflow = workflows["third-party-notices.yml"];
+  const notices = workflowJob(noticesWorkflow, "check");
+  assert.equal(
+    noticesWorkflow.split("node scripts/generate-third-party-notices.mjs --check")
+      .length - 1,
+    1,
+    "the reusable workflow must check the notices exactly once",
+  );
+  assert.match(noticesWorkflow, /^on:\n  workflow_call:\n/m);
+  assert.match(noticesWorkflow, /^permissions:\n  contents: read$/m);
+  assert.match(notices, /runs-on: ubuntu-latest/);
+  assert.match(notices, /cargo fetch --locked\n/);
+  assert.match(
+    notices,
+    /cargo fetch --locked --manifest-path crates\/tidebreak-whisper\/Cargo\.toml/,
+  );
+  assert.match(
+    notices,
+    /hashFiles\('Cargo\.lock', 'crates\/tidebreak-whisper\/Cargo\.lock'\)/,
+  );
+
+  for (const {
+    file,
+    validate,
+    platformJobs,
+  } of [
+    {
+      file: "release.yml",
+      validate: "validate",
+      platformJobs: [
+        "prepare_macos",
+        "build_macos",
+        "prepare_windows",
+        "build_windows",
+        "build_linux",
+      ],
+    },
+    {
+      file: "staging-publish.yml",
+      validate: "validate_staging",
+      platformJobs: ["prepare_macos_staging", "build_macos_staging"],
+    },
+  ]) {
+    const source = workflows[file];
+    const caller = workflowJob(source, "notices");
+    assert.match(caller, new RegExp(`needs: ${validate}`));
+    assert.match(
+      caller,
+      /uses: \.\/\.github\/workflows\/third-party-notices\.yml/,
+    );
+    assert.match(
+      caller,
+      new RegExp(`sha: \\$\\{\\{ needs\\.${validate}\\.outputs\\.sha \\}\\}`),
+    );
+    for (const jobName of platformJobs) {
+      assert.match(
+        workflowJob(source, jobName),
+        /needs: \[[^\]]*notices[^\]]*\]/,
+        `${jobName} must depend on the shared notices check`,
+      );
+    }
   }
 });
 
@@ -2219,6 +2296,7 @@ test("staging desktop publishes only under the staging prefix", () => {
   // already hosts, which is the filter the push trigger's `paths` list was.
   assert.match(staging, /staging\/manifest\.json\?poll=/);
   assert.match(staging, /git diff --name-only "\$hosted" "\$STAGING_SHA"/);
+  assert.match(staging, /\.github\/workflows\/third-party-notices\.yml/);
   assert.match(
     staging,
     /if: \$\{\{ needs\.resolve\.outputs\.changed == 'true' \}\}/,


### PR DESCRIPTION
## Why

Measured: a release is 78–81 min, of which `prepare unsigned macOS · universal` is 70–74 min (sccache 0 hits, then four sequential release compiles of 15–19 min). Staging is ~100 min plus queueing because `staging macOS · universal` runs `tauri build` after `prepare unsigned staging macOS` already compiled everything; restored `target/` fingerprints do not survive fresh-checkout mtimes. `generate-third-party-notices.mjs --check` ran six times per release (3–4 min each on Windows).

## Change

- **macOS release per architecture.** `prepare_macos` is a matrix over `aarch64-apple-darwin` and `x86_64-apple-darwin` on separate `macos-latest` runners, each compiling its sidecars and desktop and saving a per-arch cache (`macos-release-target-v5-<target>-...`). A new `combine unsigned macOS · universal` job downloads both artifacts, verifies them, runs `lipo` for the desktop binary and both sidecars, and uploads the universal inputs. The signing and notarization job is unchanged apart from its `needs`. `PRODUCTION_MACOS_RUNNER` is dropped since compiles no longer need a larger runner; `docs/releases.md` updated.
- **Staging prepared-artifact flow.** `staging-publish.yml` uploads the prepared app as a run-scoped artifact and the publish job runs `tauri bundle` on it, matching release. The `Save/Restore unsigned Rust build cache` steps are removed.
- **Notices once.** New reusable `third-party-notices.yml` (`workflow_call`, fetches both Cargo graphs including the whisper helper's, runs the check) is called once by release and once by staging; every platform prepare job `needs` it.
- **Warmer keys** in `cache-macos.yml` match the per-arch scheme so warm caches hit the new prepare jobs. `staging.yml` lists the new workflow file among its trigger paths.
- `scripts/workflow-security.test.mjs` and `scripts/third-party-notices.test.mjs` updated for the new shape. The per-arch allow-list change already landed in #3094, and main's current trusted copy of the security test passes against this branch.

## Verified

`node --test scripts/*.test.mjs` (210 pass), main's trusted `workflow-security.test.mjs` against this branch (45 pass), YAML parses. A release cannot be exercised from a PR; the first real test is the next staging run on main after merge.

## Watch after merge

Next hourly staging run: jobs `third-party notices` (~1 min), `prepare unsigned staging macOS` (~50 min, unchanged), then the publish job should take a few minutes running `tauri bundle`, not another ~50 min compile. Artifact `tidebreak-prepared-staging-macos-universal-<run_id>` should appear. Next release: two `prepare unsigned macOS · <target>` jobs in parallel, then `combine unsigned macOS · universal`, then signing; expect the macOS critical path to drop from ~74 min toward ~40.