### PR TITLE
fix(code): attach first-session pasted text before send

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -123,6 +123,43 @@ describe("CodeComposer", () => {
     expect(screen.queryByText("Pasted text")).toBeNull();
   });
 
+  it("attaches a long first-session paste before sending it", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    const box = screen.getByRole("textbox", { name: "Message" });
+    const pasted = `{
+  "message": "<pasted_text>\\ninner paste\\n</pasted_text>",
+  "payload": "${"x".repeat(1_000)}"
+}`;
+    const event = createEvent.paste(box, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => (type === "text/plain" ? pasted : ""),
+      },
+    });
+
+    fireEvent(box, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(box).toHaveValue("");
+    expect(screen.getByText("Pasted text")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(onSend).toHaveBeenCalledWith(
+        `<pasted_text>\n${pasted}\n</pasted_text>`,
+      ),
+    );
+  });
+
   it("inserts a pending inspector prompt into the draft", async () => {
     useCodeUiStore
       .getState()

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1216,22 +1216,18 @@ export function CodeComposer({
               }
             : undefined
         }
-        pastedTexts={
-          sessionId
-            ? {
-                items: pastedTexts,
-                onPaste: (text) =>
-                  updatePastedTexts((current) => [
-                    ...current,
-                    { id: crypto.randomUUID(), text },
-                  ]),
-                onRemove: (id) =>
-                  updatePastedTexts((current) =>
-                    current.filter((item) => item.id !== id),
-                  ),
-              }
-            : undefined
-        }
+        pastedTexts={{
+          items: pastedTexts,
+          onPaste: (text) =>
+            updatePastedTexts((current) => [
+              ...current,
+              { id: crypto.randomUUID(), text },
+            ]),
+          onRemove: (id) =>
+            updatePastedTexts((current) =>
+              current.filter((item) => item.id !== id),
+            ),
+        }}
         workspaceFiles={workspaceFiles}
         onDraftChange={(value) => {
           draftRef.current = value;

--- a/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
@@ -1,6 +1,6 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -135,18 +135,40 @@ function StartSession({
   starting = false,
   fork,
   permissionModeCeiling,
+  pastedText,
 }: {
   harnesses: typeof harnessDoctor.harnesses;
   starting?: boolean;
   fork?: CodeForkTranscript;
   permissionModeCeiling?: PermissionMode;
+  pastedText?: string;
 }) {
+  const pastedTextApplied = useRef(false);
   // A fork seeds the framing lines the same way the workspace page does, so
   // the story shows the state the reader actually lands in.
   useEffect(() => {
     if (!fork) return;
     useCodeUiStore.getState().offerComposerPrompt("ws-1", forkFraming(fork));
   }, [fork]);
+  useEffect(() => {
+    if (!pastedText || pastedTextApplied.current) return;
+    const frame = window.requestAnimationFrame(() => {
+      const composer = document.querySelector<HTMLTextAreaElement>(
+        "[data-composer-input]",
+      );
+      if (!composer) return;
+      const event = new Event("paste", { bubbles: true, cancelable: true });
+      Object.defineProperty(event, "clipboardData", {
+        value: {
+          files: [],
+          getData: (type: string) => (type === "text/plain" ? pastedText : ""),
+        },
+      });
+      composer.dispatchEvent(event);
+      pastedTextApplied.current = true;
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [pastedText]);
   const policy: ManagedPolicy = {
     managed: Boolean(permissionModeCeiling),
     source: permissionModeCeiling ? "os" : "unmanaged",
@@ -193,6 +215,18 @@ type Story = StoryObj<typeof meta>;
 
 /** Four engines, each with its honest mode list. */
 export const AllEngines: Story = {};
+
+export const PastedTextBeforeSession: Story = {
+  args: {
+    pastedText: `Session report\n${"x".repeat(1_000)}`,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const composer = await canvas.findByRole("textbox", { name: "Message" });
+    await expect(composer).toHaveValue("");
+    await expect(await canvas.findByText("Pasted text")).toBeVisible();
+  },
+};
 
 export const Starting: Story = {
   args: { starting: true },


### PR DESCRIPTION
## Summary

Long text pasted into the first Code workspace prompt now enters the composer attachment state immediately. Sending the first message no longer reconstructs the wrapper after session creation or folds nested `<pasted_text>` content incorrectly.

The Start session Storybook story covers the pre-session attachment state.

## Tests

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeComposer.dom.test.tsx src/PastedText.test.ts` (45 passed)
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/code/CodeComposer.tsx src/code/CodeComposer.dom.test.tsx src/stories/StartSession.stories.tsx`
- `git diff --check`