### PR TITLE
feat(code): name workspace folders before creation

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client/code-workspaces.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/code-workspaces.ts
@@ -1,4 +1,4 @@
-import type { CodeWorkspaceSnapshot } from "../types";
+import type { CodeWorkspaceSnapshot, WorkspaceTitleProposal } from "../types";
 import { parseCodeWorkspace } from "../../code/parsers";
 import { type Constructor, HttpCore, parseList, requireParsed } from "./http";
 
@@ -20,6 +20,7 @@ export function withCodeWorkspacesApi<TBase extends Constructor<HttpCore>>(
     async createCodeWorkspace(body: {
       repo_id: string;
       title?: string;
+      suggested_title?: string;
       base_ref?: string;
     }): Promise<CodeWorkspaceSnapshot> {
       return requireParsed(
@@ -32,6 +33,21 @@ export function withCodeWorkspacesApi<TBase extends Constructor<HttpCore>>(
         ),
         "code workspace",
       );
+    }
+
+    async proposeCodeWorkspaceTitle(message: string): Promise<string | null> {
+      const body = await this.json<WorkspaceTitleProposal>(
+        "/code/workspace-title",
+        {
+          method: "POST",
+          headers: this.headers(true),
+          body: JSON.stringify({ message }),
+        },
+      );
+      if (!body || !(body.title === null || typeof body.title === "string")) {
+        throw new Error("invalid workspace title proposal");
+      }
+      return body.title;
     }
 
     async getCodeWorkspace(

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -228,6 +228,7 @@ import {
   type CodeTerminalRead as WireCodeTerminalRead,
   type CodeTerminalSnapshot as WireCodeTerminalSnapshot,
   type CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
+  type WorkspaceTitleProposal as WireWorkspaceTitleProposal,
   type CodeGrantSnapshot as WireCodeGrantSnapshot,
   type CodeConnectPage as WireCodeConnectPage,
   type Diffstat as WireDiffstat,
@@ -1268,6 +1269,7 @@ export type MemorySweepStatus = WireMemorySweepStatus;
 
 /** One isolated worktree + branch on a repo. */
 export type CodeWorkspaceSnapshot = WireCodeWorkspaceSnapshot;
+export type WorkspaceTitleProposal = WireWorkspaceTitleProposal;
 export type WorkspaceId = WireWorkspaceId;
 export type CodeWorkspaceStatus = WireCodeWorkspaceStatus;
 /** One durable conversation with an external coding engine. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -107,6 +107,21 @@ type CodeCatalogStore = CodeCatalogState & {
 
 export const OPTIMISTIC_WORKSPACE_ID_PREFIX = "optimistic-workspace:";
 
+export type WorkspaceCreationPhase = "naming" | "creating";
+
+export type OptimisticCodeWorkspaceSnapshot = CodeWorkspaceSnapshot & {
+  optimistic_creation_phase?: WorkspaceCreationPhase;
+};
+
+export function workspaceCreationPhase(
+  workspace: CodeWorkspaceSnapshot,
+): WorkspaceCreationPhase {
+  return (
+    (workspace as OptimisticCodeWorkspaceSnapshot).optimistic_creation_phase ??
+    "creating"
+  );
+}
+
 export function isOptimisticWorkspace(workspace: CodeWorkspaceSnapshot) {
   return workspace.id.startsWith(OPTIMISTIC_WORKSPACE_ID_PREFIX);
 }

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -183,7 +183,10 @@ function claudeModels() {
 
 function app(client: Partial<AppContextValue["client"]>): AppContextValue {
   return {
-    client: client as never,
+    client: {
+      proposeCodeWorkspaceTitle: vi.fn(async () => null),
+      ...client,
+    } as never,
     models: [],
     defaultModelKey: null,
     providers: [],
@@ -306,6 +309,7 @@ describe("NewWorkspaceDialog", () => {
         id: expect.stringMatching(`^${OPTIMISTIC_WORKSPACE_ID_PREFIX}`),
         status: "creating",
         title: "New workspace",
+        optimistic_creation_phase: "creating",
       }),
     ]);
 
@@ -314,6 +318,113 @@ describe("NewWorkspaceDialog", () => {
       expect(router.state.location.pathname).toBe("/code/w/ws-created"),
     );
     expect(useCodeCatalogStore.getState().workspaces).toEqual([created]);
+  });
+
+  it("updates the pending card when precreation naming finishes", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const proposal = deferred<string | null>();
+    const creation = deferred<CodeWorkspaceSnapshot>();
+    const createCodeWorkspace = vi.fn(() => creation.promise);
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          proposeCodeWorkspaceTitle: vi.fn(() => proposal.promise),
+          createCodeWorkspace,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "First message" }), {
+      target: { value: "Fix the flaky auth retry test" },
+    });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(useCodeCatalogStore.getState().workspaces).toEqual([
+      expect.objectContaining({
+        title: "New workspace",
+        optimistic_creation_phase: "naming",
+      }),
+    ]);
+    expect(createCodeWorkspace).not.toHaveBeenCalled();
+
+    proposal.resolve("Fix the flaky auth retry test");
+    await waitFor(() =>
+      expect(useCodeCatalogStore.getState().workspaces).toEqual([
+        expect.objectContaining({
+          title: "Fix the flaky auth retry test",
+          optimistic_creation_phase: "creating",
+        }),
+      ]),
+    );
+    expect(createCodeWorkspace).toHaveBeenCalledWith({
+      repo_id: "repo-new",
+      title: undefined,
+      suggested_title: "Fix the flaky auth retry test",
+      base_ref: "main",
+    });
+  });
+
+  it("falls back to creation when precreation naming is unavailable", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const creation = deferred<CodeWorkspaceSnapshot>();
+    const createCodeWorkspace = vi.fn(() => creation.promise);
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          proposeCodeWorkspaceTitle: vi.fn(async () => {
+            throw new Error("utility model unavailable");
+          }),
+          createCodeWorkspace,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "First message" }), {
+      target: { value: "Fix the flaky auth retry test" },
+    });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(createCodeWorkspace).toHaveBeenCalledWith({
+        repo_id: "repo-new",
+        title: undefined,
+        base_ref: "main",
+      }),
+    );
+    expect(useCodeCatalogStore.getState().workspaces).toEqual([
+      expect.objectContaining({
+        title: "New workspace",
+        optimistic_creation_phase: "creating",
+      }),
+    ]);
   });
 
   it("opens the workspace as soon as it exists, before the session starts", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -60,6 +60,7 @@ import { useManagedPolicy } from "../managedPolicy";
 import { usesCommandModifier } from "@/ShellShortcuts";
 import {
   OPTIMISTIC_WORKSPACE_ID_PREFIX,
+  type OptimisticCodeWorkspaceSnapshot,
   useCodeCatalogStore,
 } from "./CodeCatalogStore";
 import { EMPTY_NEW_WORKSPACE_DRAFT, useCodeUiStore } from "./CodeUiStore";
@@ -113,9 +114,11 @@ const NO_ENGINE_EFFORTS: ReasoningEffort[] = [];
  * settings. A create that is not "Create more" opens the workspace as soon
  * as it exists, so the reader is already on it while the first session starts.
  *
- * The title is optional: left blank, the server generates a two-word name and
- * later replaces it with one derived from the first turn, the same way chats
- * are named. Permission mode defaults to the most autonomous posture the
+ * The title is optional. When the composer has a first message, Tidebreak
+ * derives the title before it creates the branch and worktree folder. The
+ * optimistic rail card shows both phases and changes title in place. Without
+ * a first message, the server uses a stable two-word name. Permission mode
+ * defaults to the most autonomous posture the
  * engine honors (decision 0039, amended). The engine menu lists every doctor
  * entry — ready rows are selectable; unusable ones stay visible, dimmed, with
  * the reason.
@@ -189,6 +192,8 @@ type CreateAttempt = {
   fastModeByHarness: Partial<Record<HarnessKind, boolean>>;
   createMore: boolean;
   images: readonly File[];
+  suggestedTitle?: string;
+  namingComplete: boolean;
 };
 
 type HeldWorkspaceImage = {
@@ -623,6 +628,7 @@ export function NewWorkspaceDialog({
       fastModeByHarness: { ...fastByHarness },
       createMore,
       images: heldImagesRef.current.map((image) => image.file),
+      namingComplete: Boolean(title.trim()) || !startingPrompt.trim(),
     };
     useCodeUiStore.getState().setNewWorkspaceDraft(EMPTY_NEW_WORKSPACE_DRAFT);
     clearImages();
@@ -669,15 +675,17 @@ export function NewWorkspaceDialog({
       toast.error("Could not create the workspace because its repo is gone");
       return;
     }
-    const pending: CodeWorkspaceSnapshot = {
+    const naming = !attempt.namingComplete;
+    const pending: OptimisticCodeWorkspaceSnapshot = {
       id: `${OPTIMISTIC_WORKSPACE_ID_PREFIX}${crypto.randomUUID()}`,
       repo_id: attempt.repoId,
-      title: attempt.title.trim() || "New workspace",
+      title: attempt.title.trim() || attempt.suggestedTitle || "New workspace",
       worktree_path: "",
       branch_name: "",
       base_ref: attempt.baseRef.trim() || repo.default_base_ref,
       status: "creating",
       created_at: new Date().toISOString(),
+      optimistic_creation_phase: naming ? "naming" : "creating",
     };
     upsertWorkspace(pending);
     void finishCreate(attempt, pending);
@@ -713,13 +721,32 @@ export function NewWorkspaceDialog({
 
   async function finishCreate(
     attempt: CreateAttempt,
-    pending: CodeWorkspaceSnapshot,
+    pending: OptimisticCodeWorkspaceSnapshot,
   ) {
+    if (!attempt.namingComplete) {
+      attempt.namingComplete = true;
+      try {
+        attempt.suggestedTitle =
+          (await client.proposeCodeWorkspaceTitle(attempt.startingPrompt)) ??
+          undefined;
+      } catch {
+        attempt.suggestedTitle = undefined;
+      }
+      const creatingPending: OptimisticCodeWorkspaceSnapshot = {
+        ...pending,
+        title: attempt.suggestedTitle ?? pending.title,
+        optimistic_creation_phase: "creating",
+      };
+      upsertWorkspace(creatingPending);
+    }
     let workspace: CodeWorkspaceSnapshot;
     try {
       workspace = await client.createCodeWorkspace({
         repo_id: attempt.repoId,
         title: attempt.title.trim() || undefined,
+        ...(attempt.suggestedTitle
+          ? { suggested_title: attempt.suggestedTitle }
+          : {}),
         base_ref: attempt.baseRef.trim() || undefined,
       });
     } catch (error) {
@@ -1039,7 +1066,8 @@ export function NewWorkspaceDialog({
                   }}
                 />
                 <p className="text-muted-foreground text-xs">
-                  Left blank, the first turn names it.
+                  With a first message, Tidebreak names the workspace, branch,
+                  and folder before creation.
                 </p>
               </PopoverContent>
             </Popover>

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -11,6 +11,7 @@ import type {
   CodeWorkspaceSnapshot,
   PullRequestDigest,
 } from "../api/types";
+import type { OptimisticCodeWorkspaceSnapshot } from "./CodeCatalogStore";
 
 const workspace: CodeWorkspaceSnapshot = {
   id: "ws-1",
@@ -33,7 +34,7 @@ const pr: PullRequestDigest = {
 afterEach(cleanup);
 
 function renderCard(overrides?: {
-  workspace?: Partial<CodeWorkspaceSnapshot>;
+  workspace?: Partial<OptimisticCodeWorkspaceSnapshot>;
   pr?: PullRequestDigest;
   digest?: CodeSessionDigest;
   session?: CodeSessionSnapshot;
@@ -107,13 +108,13 @@ describe("WorkspaceCard", () => {
     });
 
     const row = screen.getByRole("button", {
-      name: "Fix login · Creating workspace · app",
+      name: "Fix login · Creating branch and folder · app",
     });
     const progress = screen.getByRole("status", {
-      name: "Creating workspace",
+      name: "Creating branch and folder",
     });
     expect(row).toBeDisabled();
-    expect(progress).toHaveTextContent("Creating workspace");
+    expect(progress).toHaveTextContent("Creating branch and folder");
     expect(progress.querySelector(".live-label-shimmer")).not.toBeNull();
     expect(
       progress.querySelector(".workspace-creation-progress"),
@@ -133,8 +134,28 @@ describe("WorkspaceCard", () => {
     });
 
     expect(
-      screen.getByRole("status", { name: "Creating workspace" }),
+      screen.getByRole("status", { name: "Creating branch and folder" }),
     ).toBeInTheDocument();
+  });
+
+  it("shows naming before the derived title lands", () => {
+    renderCard({
+      workspace: {
+        status: "creating",
+        branch_name: "",
+        worktree_path: "",
+        optimistic_creation_phase: "naming",
+      },
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Fix login · Naming workspace · app",
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("status", { name: "Naming workspace" }),
+    ).toHaveTextContent("Naming workspace");
   });
 
   it("keeps one menu: right-click carries every command", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -58,6 +58,11 @@ import {
 } from "./labels";
 import type { WorkspaceCommand } from "./workspaceActions";
 import {
+  workspaceCreationPhase,
+  type OptimisticCodeWorkspaceSnapshot,
+  type WorkspaceCreationPhase,
+} from "./CodeCatalogStore";
+import {
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
   type WorkspaceWorkflowAction,
@@ -176,7 +181,7 @@ export function WorkspaceCard({
   onOpenStackParent,
   onWorkflowAction,
 }: {
-  workspace: CodeWorkspaceSnapshot;
+  workspace: OptimisticCodeWorkspaceSnapshot;
   digest: CodeSessionDigest | undefined;
   session: CodeSessionSnapshot | undefined;
   repoName: string;
@@ -210,6 +215,8 @@ export function WorkspaceCard({
   const pr = digest?.pr_state ?? workspace.pr;
   const archived = isPutAway(workspace);
   const creating = workspace.status === "creating";
+  const creationPhase = workspaceCreationPhase(workspace);
+  const creationLabel = workspaceCreationLabel(creationPhase);
   const cardStatus = workspaceCardStatus(workspace, digest);
   const attentionMark = attentionMarkForDigest(digest);
   const [detailOpen, setDetailOpen] = useState(detailDefaultOpen);
@@ -265,6 +272,7 @@ export function WorkspaceCard({
                   pr,
                   terminalOpen,
                   workspaceStatus: workspace.status,
+                  creationLabel,
                 })}
                 aria-current={active ? "page" : undefined}
                 aria-selected={selected || undefined}
@@ -372,7 +380,7 @@ export function WorkspaceCard({
       </ContextMenu>
 
       {creating ? (
-        <WorkspaceCreationProgress />
+        <WorkspaceCreationProgress phase={creationPhase} />
       ) : (
         density === "detailed" && (
           <WorkspaceActivityLine
@@ -1036,16 +1044,25 @@ function runningParkedOn(
   return null;
 }
 
-function WorkspaceCreationProgress() {
+function workspaceCreationLabel(phase: WorkspaceCreationPhase): string {
+  return phase === "naming" ? "Naming workspace" : "Creating branch and folder";
+}
+
+function WorkspaceCreationProgress({
+  phase,
+}: {
+  phase: WorkspaceCreationPhase;
+}) {
+  const label = workspaceCreationLabel(phase);
   return (
     <div
       className="px-2.5 pb-2 pl-7"
       role="status"
-      aria-label="Creating workspace"
+      aria-label={label}
       data-testid="workspace-creation-progress"
     >
       <LiveLabel live className="block truncate text-xs">
-        Creating workspace
+        {label}
       </LiveLabel>
       <span
         className="workspace-creation-progress mt-1.5 block h-0.5 overflow-hidden rounded-full bg-live-border/20"

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -541,9 +541,12 @@ export function workspaceCardLabel(input: {
   };
   terminalOpen?: boolean;
   workspaceStatus?: CodeWorkspaceStatus;
+  creationLabel?: string;
 }): string {
   const parts = [input.title];
-  if (input.workspaceStatus === "creating") parts.push("Creating workspace");
+  if (input.workspaceStatus === "creating") {
+    parts.push(input.creationLabel ?? "Creating workspace");
+  }
   if (input.workspaceStatus === "setup_failed") parts.push("Setup failed");
   const mergeNotice = readyToMergeNotice(input.attention, input.pr);
   if (

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -5690,6 +5690,11 @@ export type WorkspaceConfigSections = { code_repositories: Array<ExportedCodeRep
 export type WorkspaceId = string;
 
 /**
+ * Suggested display title for a workspace that has not been created yet.
+ */
+export type WorkspaceTitleProposal = { title: string | null, };
+
+/**
  * Every tool name the renderer will accept, at runtime.
  *
  * An allowlist, not a display transformation. Tool events come from

--- a/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.dom.test.tsx
@@ -72,7 +72,7 @@ describe("GitSourceControlPanel", () => {
 
     await user.click(
       await screen.findByRole("switch", {
-        name: "Rename generated branches automatically",
+        name: "Name generated branches and folders automatically",
       }),
     );
     expect(putSettings).toHaveBeenCalledWith({
@@ -109,7 +109,7 @@ describe("GitSourceControlPanel", () => {
     );
 
     const toggle = await screen.findByRole("switch", {
-      name: "Rename generated branches automatically",
+      name: "Name generated branches and folders automatically",
     });
     await user.click(toggle);
 

--- a/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.tsx
@@ -139,7 +139,7 @@ export function GitSourceControlPanel({
   return (
     <SettingsPanel
       title="Git & source control"
-      description="Choose how Tidebreak names branches for new code workspaces."
+      description="Choose how Tidebreak names branches and worktree folders for new code workspaces."
       busy={loading || saving}
     >
       {error && <SettingsError>{error}</SettingsError>}
@@ -152,8 +152,8 @@ export function GitSourceControlPanel({
             description="These defaults apply when you add a repository. Existing repositories keep their own branch prefix."
           >
             <SettingsField
-              label="Rename generated branches automatically"
-              hint="After Tidebreak names an untitled workspace, it updates the generated local branch. Pushed, remote, user-renamed, and pull request branches stay unchanged."
+              label="Name generated branches and folders automatically"
+              hint="When a new workspace starts with a message, Tidebreak names its local branch and worktree folder before creating them. Existing paths never move."
             >
               <Switch
                 checked={settings.auto_rename_branches}
@@ -163,7 +163,7 @@ export function GitSourceControlPanel({
                   setSettings({ ...settings, auto_rename_branches: enabled });
                   void save({ auto_rename_branches: enabled }, rollback);
                 }}
-                aria-label="Rename generated branches automatically"
+                aria-label="Name generated branches and folders automatically"
               />
             </SettingsField>
             <SettingsField

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -83,8 +83,8 @@ export const SelectedAndActive: Story = {
   args: { selected: true, active: true },
 };
 
-/** The rail hands off from the composer while the server creates the worktree. */
-export const Creating: Story = {
+/** The first message is being turned into the branch and folder name. */
+export const Naming: Story = {
   args: {
     workspace: {
       ...codeWorkspace,
@@ -94,6 +94,25 @@ export const Creating: Story = {
       worktree_path: "",
       status: "creating",
       created_at: "2026-08-24T12:00:00.000Z",
+      optimistic_creation_phase: "naming",
+    },
+    visibleMeta: { repoChip: true, branch: false },
+    commands: [],
+  },
+};
+
+/** The derived title lands before Git creates the branch and folder. */
+export const Creating: Story = {
+  args: {
+    workspace: {
+      ...codeWorkspace,
+      id: "optimistic-workspace:storybook",
+      title: "Apply workspace names before creation",
+      branch_name: "",
+      worktree_path: "",
+      status: "creating",
+      created_at: "2026-08-24T12:00:00.000Z",
+      optimistic_creation_phase: "creating",
     },
     visibleMeta: { repoChip: true, branch: false },
     commands: [],

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -38,9 +38,9 @@ use tidebreak_core::db::code::{
     list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
     list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head,
     replace_session_execution_settings, save_repo, save_workspace,
-    set_active_workspace_pull_request, set_workspace_branch_if, settle_approval_claim,
-    update_trigger_enabled, ClaimedApprovalSettlement, CodeSessionExecutionSettings,
-    PermissionModeChangeIntent, MAX_REPLAY_EVENTS,
+    set_active_workspace_pull_request, settle_approval_claim, update_trigger_enabled,
+    ClaimedApprovalSettlement, CodeSessionExecutionSettings, PermissionModeChangeIntent,
+    MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
@@ -78,8 +78,8 @@ use super::session_worker::{
 #[cfg(windows)]
 use super::worktree::repo_paths_equivalent;
 use super::worktree::{
-    self, archive_blockers, branch_name, create_worktree, prune_worktrees, remove_worktree,
-    rename_local_only_branch, run_archive_script, run_setup_script, slugify, validate_repo_path,
+    self, archive_blockers, branch_name, branch_name_from_slug, create_worktree, prune_worktrees,
+    remove_worktree, run_archive_script, run_setup_script, slugify, validate_repo_path,
     worktree_dir, WorktreeError,
 };
 use crate::error::ServerError;
@@ -206,6 +206,8 @@ pub(crate) struct CodeRuntime {
     update_quiesce: watch::Sender<bool>,
     /// Serializes writer admission with workspace lifecycle transitions.
     workspace_lifecycles: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
+    /// Serializes branch and folder allocation per repository.
+    workspace_creations: Mutex<HashMap<RepoId, Arc<tokio::sync::Mutex<()>>>>,
     /// One turn at a time per worktree, shared by every session in it.
     ///
     /// Sessions in a workspace share one checkout, so their turns cannot
@@ -438,6 +440,7 @@ impl CodeRuntime {
             deferred_resyncs: Mutex::new(HashSet::new()),
             update_quiesce: watch::channel(false).0,
             workspace_lifecycles: Mutex::new(HashMap::new()),
+            workspace_creations: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: super::pr_refresh::HotPullRequests::default(),
             delivery_nudges: DeliveryNudgeDebounce::default(),
@@ -596,6 +599,7 @@ impl CodeRuntime {
             deferred_resyncs: Mutex::new(HashSet::new()),
             update_quiesce: watch::channel(false).0,
             workspace_lifecycles: Mutex::new(HashMap::new()),
+            workspace_creations: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: super::pr_refresh::HotPullRequests::default(),
             delivery_nudges: DeliveryNudgeDebounce::default(),

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -2,32 +2,58 @@
 
 use super::*;
 
+fn collision_resolved_slug(base: &str, index: u64) -> String {
+    if index <= 1 {
+        return base.to_owned();
+    }
+    let suffix = format!("-{index}");
+    let keep = 40_usize.saturating_sub(suffix.len());
+    let mut stem = base[..base.len().min(keep)]
+        .trim_end_matches('-')
+        .to_owned();
+    if stem.is_empty() {
+        stem.push_str("workspace");
+    }
+    stem.push_str(&suffix);
+    stem
+}
+
 impl CodeRuntime {
     pub(crate) async fn create_workspace(
         &self,
         owner: &OwnerId,
         repo_id: RepoId,
         title: Option<String>,
+        suggested_title: Option<String>,
         base_ref: Option<String>,
     ) -> Result<CodeWorkspace, ServerError> {
         let repo = self.get_repo(owner, repo_id).await?;
         Self::refuse_removed_repo(&repo)?;
-        let title = title
+        let explicit_title = title
             .map(|value| value.trim().to_owned())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_default();
+            .filter(|value| !value.is_empty());
+        let suggested_title = suggested_title
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty());
         let id = WorkspaceId::new();
-        let branch = branch_name(&repo.branch_prefix, &title, id.as_uuid());
-        let existing = list_workspaces(&self.db, owner, Some(repo_id)).await?;
-        if existing
-            .iter()
-            .any(|workspace| workspace.branch_name == branch)
-        {
-            return Err(ServerError::conflict_kind(
-                "branch_collision",
-                format!("branch {branch} already exists on this repository"),
-            ));
-        }
+        let fallback_name = worktree::two_word_name(id.as_uuid().as_u128());
+        let fallback_branch_slug = format!("{fallback_name}-{}", worktree::short_id(id.as_uuid()));
+        let display_title = explicit_title
+            .clone()
+            .or_else(|| suggested_title.clone())
+            .unwrap_or_else(|| fallback_name.clone());
+        let use_suggested_checkout_name = explicit_title.is_none()
+            && suggested_title.is_some()
+            && naming_settings::auto_rename_branches(&*self.db, owner).await?;
+        let named_checkout = explicit_title
+            .as_deref()
+            .or_else(|| use_suggested_checkout_name.then_some(display_title.as_str()))
+            .map(slugify)
+            .filter(|slug| !slug.is_empty());
+        let checkout_slug = named_checkout
+            .clone()
+            .unwrap_or_else(|| fallback_name.clone());
+        let branch_slug_base = named_checkout.unwrap_or(fallback_branch_slug);
         let repo_slug = {
             let from_name = slugify(&repo.display_name);
             if from_name.is_empty() {
@@ -36,25 +62,11 @@ impl CodeRuntime {
                 from_name
             }
         };
-        let workspace_slug = {
-            let from_title = slugify(&title);
-            if from_title.is_empty() {
-                worktree::two_word_name(id.0.as_u128())
-            } else {
-                from_title
-            }
-        };
         // Resolved per creation, not cached: the root is a setting an operator
         // can change while the process runs, and it decides only where the
         // *next* worktree lands. Existing workspaces keep the absolute path on
         // their row (`crate::code::worktree_root`).
         let root = self.owner_worktree_root(owner).await?;
-        let path = worktree_dir(&root, id, &repo_slug, &workspace_slug);
-        let display_title = if title.is_empty() {
-            workspace_slug.clone()
-        } else {
-            title
-        };
         let explicit_base = base_ref
             .map(|value| value.trim().to_owned())
             .filter(|value| !value.is_empty());
@@ -79,33 +91,66 @@ impl CodeRuntime {
             repo.default_base_ref = base.clone();
             self.save_repo(&repo).await?;
         }
-        let mut workspace = CodeWorkspace {
-            id,
-            owner: owner.clone(),
-            repo_id,
-            title: display_title,
-            worktree_path: path.display().to_string(),
-            branch_name: branch.clone(),
-            base_ref: base.clone(),
-            status: CodeWorkspaceStatus::Creating,
-            pr: None,
-            created_at: Utc::now(),
-            archived_at: None,
-            released_at: None,
-            released_tip: None,
-            bundle_bytes: None,
-        };
-        insert_workspace(&self.db, &workspace).await?;
-        let operation =
-            match create_worktree(std::path::Path::new(&repo.root_path), &path, &branch, &base)
-                .await
+        let repo_root = std::path::Path::new(&repo.root_path);
+        let creation = self.workspace_creation_lock(repo_id);
+        let creation_guard = creation.lock().await;
+        let mut existing = list_workspaces(&self.db, owner, Some(repo_id))
+            .await?
+            .into_iter()
+            .map(|workspace| workspace.branch_name)
+            .collect::<HashSet<_>>();
+        let mut collision_index = 1_u64;
+        let (mut workspace, path, operation) = loop {
+            let workspace_slug = collision_resolved_slug(&checkout_slug, collision_index);
+            let resolved_branch_slug = collision_resolved_slug(&branch_slug_base, collision_index);
+            let branch = branch_name_from_slug(&repo.branch_prefix, &resolved_branch_slug);
+            if existing.contains(&branch)
+                || worktree::branch_exists(repo_root, &branch)
+                    .await
+                    .map_err(map_worktree)?
             {
-                Ok(operation) => operation,
+                collision_index = collision_index.checked_add(1).ok_or_else(|| {
+                    ServerError::internal("workspace name collision limit exhausted")
+                })?;
+                continue;
+            }
+            let path = worktree_dir(&root, id, &repo_slug, &workspace_slug);
+            let workspace = CodeWorkspace {
+                id,
+                owner: owner.clone(),
+                repo_id,
+                title: display_title.clone(),
+                worktree_path: path.display().to_string(),
+                branch_name: branch.clone(),
+                base_ref: base.clone(),
+                status: CodeWorkspaceStatus::Creating,
+                pr: None,
+                created_at: Utc::now(),
+                archived_at: None,
+                released_at: None,
+                released_tip: None,
+                bundle_bytes: None,
+            };
+            insert_workspace(&self.db, &workspace).await?;
+            match create_worktree(repo_root, &path, &branch, &base).await {
+                Ok(operation) => break (workspace, path, operation),
+                Err(WorktreeError::Conflict {
+                    kind: "branch_collision",
+                    ..
+                }) => {
+                    let _ = delete_workspace(&self.db, owner, id).await;
+                    existing.insert(branch);
+                    collision_index = collision_index.checked_add(1).ok_or_else(|| {
+                        ServerError::internal("workspace name collision limit exhausted")
+                    })?;
+                }
                 Err(err) => {
                     let _ = delete_workspace(&self.db, owner, id).await;
                     return Err(map_worktree(err));
                 }
-            };
+            }
+        };
+        drop(creation_guard);
         // Before the setup script, which may itself commit: from here on,
         // anything this workspace commits should already carry the right
         // name.
@@ -216,59 +261,6 @@ impl CodeRuntime {
         )
         .await;
         Ok(())
-    }
-
-    /// Rename the untouched placeholder branch after background titling names
-    /// the workspace. Every guard fails closed and leaves the original branch.
-    pub(crate) async fn rename_generated_workspace_branch(
-        &self,
-        owner: &OwnerId,
-        id: WorkspaceId,
-        title: &str,
-    ) -> Result<bool, ServerError> {
-        if !naming_settings::auto_rename_branches(&*self.db, owner).await? {
-            return Ok(false);
-        }
-        let turn = self.worktree_turn_lock(id);
-        let _turn_guard = turn.lock().await;
-        let lifecycle = self.workspace_lifecycle_lock(id);
-        let _lifecycle_guard = lifecycle.lock().await;
-        let workspace = self.get_workspace(owner, id).await?;
-        if workspace.is_remote()
-            || workspace.status != CodeWorkspaceStatus::Active
-            || workspace.pr.is_some()
-            || workspace.title != title
-        {
-            return Ok(false);
-        }
-        let repo = self.get_repo(owner, workspace.repo_id).await?;
-        let expected = branch_name(&repo.branch_prefix, "", id.as_uuid());
-        if workspace.branch_name != expected {
-            return Ok(false);
-        }
-        let next = branch_name(&repo.branch_prefix, title, id.as_uuid());
-        if next == expected {
-            return Ok(false);
-        }
-        let path = std::path::Path::new(&workspace.worktree_path);
-        if !rename_local_only_branch(path, &expected, &next)
-            .await
-            .map_err(map_worktree)?
-        {
-            return Ok(false);
-        }
-        if !set_workspace_branch_if(&self.db, owner, id, title, &expected, &next).await? {
-            if let Err(error) = rename_local_only_branch(path, &next, &expected).await {
-                tracing::error!(
-                    workspace = %id,
-                    error = %error,
-                    "could not restore a branch after its workspace update lost the race"
-                );
-            }
-            return Ok(false);
-        }
-        crate::code::attention::emit_workspace_digests(&self.db, &self.bus, owner, id).await;
-        Ok(true)
     }
 
     pub(crate) async fn archive_workspace(
@@ -606,6 +598,15 @@ impl CodeRuntime {
             .lock()
             .expect("worktree turn locks")
             .remove(&workspace_id);
+    }
+
+    fn workspace_creation_lock(&self, repo_id: RepoId) -> Arc<tokio::sync::Mutex<()>> {
+        self.workspace_creations
+            .lock()
+            .expect("workspace creation locks")
+            .entry(repo_id)
+            .or_default()
+            .clone()
     }
 
     /// Restore a saved workspace. A local archive records the exact tip,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -283,10 +283,11 @@ impl ScopedCode {
         &self,
         repo_id: RepoId,
         title: Option<String>,
+        suggested_title: Option<String>,
         base_ref: Option<String>,
     ) -> Result<CodeWorkspace, ServerError> {
         self.runtime
-            .create_workspace(&self.owner, repo_id, title, base_ref)
+            .create_workspace(&self.owner, repo_id, title, suggested_title, base_ref)
             .await
     }
 

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -1,11 +1,11 @@
 //! Naming a workspace the user has not named.
 //!
-//! A workspace created without a title gets a generated two-word placeholder
-//! (`worktree::two_word_name`) so it always has something to show and slug.
-//! This derives a real name from the first thing the user asked the engine to
-//! do, the same way chats are named ([`crate::chat_titling`]): off to the side
-//! of a turn, on the utility model, with every failure leaving the placeholder
-//! in place so the next turn can try again.
+//! The desktop asks for a title before it creates a workspace whose composer
+//! already has a first message. That lets the branch and worktree folder start
+//! with the same name without moving a live checkout. A workspace created
+//! without a first message still gets a generated two-word placeholder
+//! (`worktree::two_word_name`). Its first later turn can update the display
+//! title, but the branch and path stay fixed.
 //!
 //! The write is a compare-and-swap against the placeholder, which is
 //! deterministic from the workspace id. A rename — through `PATCH
@@ -14,9 +14,7 @@
 //! one, no matter when it lands. The placeholder never changes for the life of
 //! the workspace, so the swap stays valid on retries.
 //!
-//! The worktree path keeps its two-word slug. When the user's Git settings
-//! allow it, the generated local branch follows the derived title only while
-//! it is still local-only and untouched.
+//! The worktree path and branch never change after creation.
 
 use std::sync::Arc;
 
@@ -56,6 +54,24 @@ enum Outcome {
     Declined,
     /// Nothing to do — already named, already running, or no model to run on.
     NotApplicable,
+}
+
+enum ProposalOutcome {
+    Proposed(String),
+    Declined,
+    NotApplicable,
+}
+
+/// Derive the name that a new workspace should use before checkout creation.
+pub(crate) async fn propose_for_creation(
+    state: &AppState,
+    owner: &OwnerId,
+    message: &str,
+) -> Result<Option<String>> {
+    Ok(match propose_from_message(state, owner, message).await? {
+        ProposalOutcome::Proposed(title) => Some(title),
+        ProposalOutcome::Declined | ProposalOutcome::NotApplicable => None,
+    })
 }
 
 /// Derive a title for the workspace behind `session_id` in the background,
@@ -120,18 +136,40 @@ async fn derive_workspace_title(
     let Some(workspace) = get_workspace(&code.db, owner, workspace_id).await? else {
         return Ok(Outcome::NotApplicable);
     };
-    let placeholder = worktree::two_word_name(workspace.id.0.as_u128());
+    let placeholder = worktree::two_word_name(workspace.id.as_uuid().as_u128());
     if workspace.title != placeholder || workspace.status != CodeWorkspaceStatus::Active {
         return Ok(Outcome::NotApplicable);
     }
-    let material = head(message.trim(), MAX_TITLE_SOURCE_MESSAGE_BYTES);
-    if material.is_empty() {
+    let title = match propose_from_message(state, owner, message).await? {
+        ProposalOutcome::Proposed(title) => title,
+        ProposalOutcome::Declined => return Ok(Outcome::Declined),
+        ProposalOutcome::NotApplicable => return Ok(Outcome::NotApplicable),
+    };
+    if !set_workspace_title_if(&code.db, owner, workspace.id, &placeholder, &title).await? {
+        // Renamed while the call ran; the chosen name has the floor.
         return Ok(Outcome::NotApplicable);
     }
+    // Announced only once the write applied, on the digest channel every list
+    // surface already watches.
+    super::attention::emit_workspace_digests(&code.db, &code.bus, owner, workspace.id).await;
+    Ok(Outcome::Named(title))
+}
+
+async fn propose_from_message(
+    state: &AppState,
+    owner: &OwnerId,
+    message: &str,
+) -> Result<ProposalOutcome> {
+    if !state.resolver.enforces_model_registry() {
+        return Ok(ProposalOutcome::NotApplicable);
+    }
+    let material = head(message.trim(), MAX_TITLE_SOURCE_MESSAGE_BYTES);
+    if material.is_empty() {
+        return Ok(ProposalOutcome::NotApplicable);
+    }
     // Resolved per call, like every consumer of the utility role: `None` means
-    // this install has no model for background work, and the placeholder stays.
-    // On a hosted machine both the role and the provider resolve as the
-    // workspace's owner (decision 62).
+    // this install has no model for background work. On a hosted machine both
+    // the role and the provider resolve as the workspace's owner (decision 62).
     let caller_gateway = state.caller_gateway_snapshot(owner).await.ok().flatten();
     let Some(utility) = crate::model_roles::resolve_utility_model(
         &*state.store,
@@ -142,7 +180,7 @@ async fn derive_workspace_title(
     )
     .await?
     else {
-        return Ok(Outcome::NotApplicable);
+        return Ok(ProposalOutcome::NotApplicable);
     };
     let provider = state.resolver.resolve_for(Some(owner)).await;
     let title = derive_text_with_retries::<TitleProposal>(
@@ -151,26 +189,13 @@ async fn derive_workspace_title(
         &system_prompt(),
         WORKSPACE_TITLE_SCHEMA_NAME,
         material,
-        &format!("workspace {}", workspace.id),
+        "new workspace",
     )
     .await?;
-    let Some(title) = title else {
-        return Ok(Outcome::Declined);
-    };
-    if !set_workspace_title_if(&code.db, owner, workspace.id, &placeholder, &title).await? {
-        // Renamed while the call ran; the chosen name has the floor.
-        return Ok(Outcome::NotApplicable);
-    }
-    if let Err(error) = code
-        .rename_generated_workspace_branch(owner, workspace.id, &title)
-        .await
-    {
-        tracing::debug!(workspace = %workspace.id, error = ?error, "the generated branch was not renamed");
-    }
-    // Announced only once the write applied, on the digest channel every list
-    // surface already watches.
-    super::attention::emit_workspace_digests(&code.db, &code.bus, owner, workspace.id).await;
-    Ok(Outcome::Named(title))
+    Ok(match title {
+        Some(title) => ProposalOutcome::Proposed(title),
+        None => ProposalOutcome::Declined,
+    })
 }
 
 /// A workspace's place in [`CodeRuntime::titling_in_flight`], released on drop.

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -1661,56 +1661,6 @@ pub(crate) async fn delete_branch(repo_root: &Path, branch: &str) -> Result<(), 
         .map_err(|err| WorktreeError::internal(format!("git branch -D {branch} failed: {err}")))
 }
 
-/// Rename the branch checked out in one worktree after proving it is still
-/// local-only. A branch with an upstream or an origin tracking ref has already
-/// crossed the boundary where a background rename is safe.
-pub(crate) async fn rename_local_only_branch(
-    worktree: &Path,
-    expected: &str,
-    next: &str,
-) -> Result<bool, WorktreeError> {
-    let current = git_stdout(
-        Some(worktree),
-        &["symbolic-ref", "--quiet", "--short", "HEAD"],
-        GIT_TIMEOUT,
-    )
-    .await
-    .map_err(|error| {
-        WorktreeError::internal(format!("could not read workspace branch: {error}"))
-    })?;
-    if current.trim() != expected {
-        return Ok(false);
-    }
-    if git_stdout(
-        Some(worktree),
-        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
-        GIT_TIMEOUT,
-    )
-    .await
-    .is_ok()
-    {
-        return Ok(false);
-    }
-    let tracking_ref = format!("refs/remotes/origin/{expected}");
-    if git_stdout(
-        Some(worktree),
-        &["rev-parse", "--verify", "--quiet", &tracking_ref],
-        GIT_TIMEOUT,
-    )
-    .await
-    .is_ok()
-    {
-        return Ok(false);
-    }
-    if branch_exists(worktree, next).await? {
-        return Ok(false);
-    }
-    git(Some(worktree), &["branch", "-m", next], GIT_TIMEOUT)
-        .await
-        .map_err(|error| WorktreeError::internal(format!("could not rename branch: {error}")))?;
-    Ok(true)
-}
-
 /// Drop stale worktree registrations from the repo.
 pub(crate) async fn prune_worktrees(repo_root: &Path) -> Result<(), WorktreeError> {
     git(Some(repo_root), &["worktree", "prune"], GIT_TIMEOUT)
@@ -1745,18 +1695,23 @@ pub(crate) fn slugify(value: &str) -> String {
 /// carries the workspace id. The id keeps the 400 readable word pairs from
 /// colliding with an older workspace or a concurrent create.
 pub(crate) fn branch_name(prefix: &str, title: &str, id: &uuid::Uuid) -> String {
+    let slug = slugify(title);
+    let slug = if slug.is_empty() {
+        format!("{}-{}", two_word_name(id.as_u128()), short_id(id))
+    } else {
+        slug
+    };
+    branch_name_from_slug(prefix, &slug)
+}
+
+/// Branch name from a slug that the workspace allocator already resolved.
+pub(crate) fn branch_name_from_slug(prefix: &str, slug: &str) -> String {
     let prefix = if prefix.is_empty() {
         String::new()
     } else if prefix.ends_with('/') {
         prefix.to_owned()
     } else {
         format!("{prefix}/")
-    };
-    let slug = slugify(title);
-    let slug = if slug.is_empty() {
-        format!("{}-{}", two_word_name(id.as_u128()), short_id(id))
-    } else {
-        slug
     };
     format!("{prefix}{slug}")
 }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1017,6 +1017,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::create_workspace).get(routes::code::list_workspaces),
         )
         .route(
+            "/code/workspace-title",
+            post(routes::code::propose_workspace_title),
+        )
+        .route(
             "/code/remote/workspaces",
             post(routes::code::create_remote_workspace),
         )

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -102,7 +102,7 @@ pub(crate) use types::{
     CodeWorkspacePullRequests, CodeWorkspaceSearch, CodeWorkspaceSnapshot, CodeWorkspaceTree,
     CreateCodeTriggerBody, HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
     ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame, SetCodeWorktreeRootBody,
-    UpdateCodeTriggerBody,
+    UpdateCodeTriggerBody, WorkspaceTitleProposal,
 };
 pub(crate) use types::{
     CodeCloneDefaults, CodeCloneJobSnapshot, CodeGithubRepositories, CodeGithubRepository,
@@ -113,8 +113,8 @@ pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_remote_workspace, create_workspace, get_workspace,
     get_workspace_blob, get_workspace_diff, get_worktree_root, list_workspace_files,
-    list_workspace_tree, list_workspaces, patch_workspace, restore_workspace,
-    retry_workspace_setup, search_workspace, set_worktree_root,
+    list_workspace_tree, list_workspaces, patch_workspace, propose_workspace_title,
+    restore_workspace, retry_workspace_setup, search_workspace, set_worktree_root,
 };
 
 // App-token handlers do not reach `AppState.code` directly. They extract a

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -847,8 +847,25 @@ pub struct CreateWorkspaceBody {
     pub repo_id: RepoId,
     #[serde(default)]
     pub title: Option<String>,
+    /// A utility-model title proposed from the first message before creation.
+    #[serde(default)]
+    pub suggested_title: Option<String>,
     #[serde(default)]
     pub base_ref: Option<String>,
+}
+
+/// Body of `POST /code/workspace-title`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceTitleBody {
+    pub message: String,
+}
+
+/// Suggested display title for a workspace that has not been created yet.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceTitleProposal {
+    pub title: Option<String>,
 }
 
 /// Body of `POST /code/remote/workspaces`.

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -13,9 +15,14 @@ use super::types::{
     CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot,
     CreateRemoteWorkspaceBody, CreateWorkspaceBody, ListWorkspacesQuery, PatchWorkspaceBody,
     SetCodeWorktreeRootBody, WorkspaceBlobQuery, WorkspaceDiffQuery, WorkspaceFilesQuery,
-    WorkspaceSearchQuery, WorkspaceTreeQuery,
+    WorkspaceSearchQuery, WorkspaceTitleBody, WorkspaceTitleProposal, WorkspaceTreeQuery,
 };
 use tidebreak_core::WorkspaceId;
+
+/// Naming improves the checkout but must never hold workspace creation behind
+/// a slow provider stream. A later first turn can still update the display
+/// title when this foreground attempt falls back.
+const WORKSPACE_TITLE_DEADLINE: Duration = Duration::from_secs(10);
 
 /// `GET /code/worktree-root`: where the next workspace's worktree lands.
 pub async fn get_worktree_root(code: ScopedCode) -> Result<Json<CodeWorktreeRoot>, ServerError> {
@@ -39,12 +46,42 @@ pub async fn create_workspace(
     Json(body): Json<CreateWorkspaceBody>,
 ) -> Result<impl IntoResponse, ServerError> {
     let workspace = code
-        .create_workspace(body.repo_id, body.title, body.base_ref)
+        .create_workspace(
+            body.repo_id,
+            body.title,
+            body.suggested_title,
+            body.base_ref,
+        )
         .await?;
     Ok((
         StatusCode::CREATED,
         Json(CodeWorkspaceSnapshot::from(workspace)),
     ))
+}
+
+/// `POST /code/workspace-title` — name a workspace before its checkout exists.
+pub async fn propose_workspace_title(
+    State(state): State<AppState>,
+    code: ScopedCode,
+    Json(body): Json<WorkspaceTitleBody>,
+) -> Result<Json<WorkspaceTitleProposal>, ServerError> {
+    let title = match tokio::time::timeout(
+        WORKSPACE_TITLE_DEADLINE,
+        crate::code::titling::propose_for_creation(&state, code.owner(), &body.message),
+    )
+    .await
+    {
+        Ok(Ok(title)) => title,
+        Ok(Err(error)) => {
+            tracing::warn!(?error, "could not name workspace before creation");
+            None
+        }
+        Err(_) => {
+            tracing::warn!("workspace naming timed out before creation");
+            None
+        }
+    };
+    Ok(Json(WorkspaceTitleProposal { title }))
 }
 
 /// `POST /code/remote/workspaces` — create a workspace whose checkout lives

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -313,6 +313,7 @@ pub(super) fn init_git_repo_named(dir: &std::path::Path, name: &str) -> std::pat
         ["git", "init", "-b", "main"].as_slice(),
         ["git", "config", "user.email", "dev@example.com"].as_slice(),
         ["git", "config", "user.name", "Dev"].as_slice(),
+        ["git", "config", "commit.gpgsign", "false"].as_slice(),
         // Windows runners default to autocrlf=true; pin LF so file-content
         // assertions stay identical across platforms.
         ["git", "config", "core.autocrlf", "false"].as_slice(),

--- a/crates/tidebreak-server/src/tests/code_owner_scope.rs
+++ b/crates/tidebreak-server/src/tests/code_owner_scope.rs
@@ -304,6 +304,7 @@ async fn legacy_managed_repo_and_worktree_paths_remain_accessible() {
             repo.id,
             Some("New owner namespace".to_owned()),
             None,
+            None,
         )
         .await
         .unwrap();

--- a/crates/tidebreak-server/src/tests/code_titling.rs
+++ b/crates/tidebreak-server/src/tests/code_titling.rs
@@ -142,6 +142,7 @@ fn init_git_repo(dir: &std::path::Path) -> std::path::PathBuf {
         ["git", "init", "-b", "main"].as_slice(),
         ["git", "config", "user.email", "dev@example.com"].as_slice(),
         ["git", "config", "user.name", "Dev"].as_slice(),
+        ["git", "config", "commit.gpgsign", "false"].as_slice(),
     ] {
         assert!(std::process::Command::new(args[0])
             .args(&args[1..])
@@ -175,12 +176,85 @@ async fn serve(router: Router) -> std::net::SocketAddr {
     addr
 }
 
-/// The whole feature over the wire: a workspace created without a title gets
-/// the generated two-word placeholder, and the first turn replaces it with a
-/// name derived from what the user asked for, on the utility model, announced
-/// on the digest channel — without the turn waiting for any of it.
+/// A first message names the display title, branch, and folder before Git
+/// creates the checkout.
 #[tokio::test(flavor = "multi_thread")]
-async fn a_first_turn_names_an_untitled_workspace() {
+async fn a_precreation_title_names_the_branch_and_worktree_folder() {
+    let (router, token, stub, _runtime, dir) = code_titling_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+
+    let proposed = client
+        .post(format!("http://{addr}/code/workspace-title"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "message": "Fix the flaky retry test in the auth crate"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(proposed.status(), reqwest::StatusCode::OK);
+    let proposed: serde_json::Value = proposed.json().await.unwrap();
+    assert_eq!(proposed["title"], DERIVED_TITLE);
+
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": repo_body["id"],
+            "suggested_title": proposed["title"],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let id = workspace["id"].as_str().unwrap();
+    assert_eq!(workspace["title"], DERIVED_TITLE);
+    assert_eq!(
+        workspace["branch_name"],
+        "tidebreak/fix-the-flaky-auth-retry-test"
+    );
+    assert!(workspace["worktree_path"]
+        .as_str()
+        .unwrap()
+        .ends_with(&format!("fix-the-flaky-auth-retry-test-{}", &id[..8])));
+
+    let checked_out = std::process::Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(workspace["worktree_path"].as_str().unwrap())
+        .output()
+        .unwrap();
+    assert!(checked_out.status.success());
+    assert_eq!(
+        String::from_utf8(checked_out.stdout).unwrap().trim(),
+        "tidebreak/fix-the-flaky-auth-retry-test"
+    );
+
+    let requests = stub.requests.lock().unwrap().clone();
+    assert_eq!(
+        requests.len(),
+        1,
+        "precreation naming makes one utility call"
+    );
+    assert_eq!(requests[0]["model"], UTILITY_MODEL);
+}
+
+/// A workspace created without a first message can still gain a display title
+/// later. Its branch and worktree path stay fixed.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_first_turn_names_an_untitled_workspace_without_moving_it() {
     let (router, token, stub, runtime, dir) = code_titling_app().await;
     let addr = serve(router).await;
     let client = reqwest::Client::new();
@@ -208,6 +282,7 @@ async fn a_first_turn_names_an_untitled_workspace() {
     let workspace: serde_json::Value = created.json().await.unwrap();
     let workspace_id = workspace["id"].as_str().unwrap().to_owned();
     let original_branch = workspace["branch_name"].as_str().unwrap().to_owned();
+    let original_path = workspace["worktree_path"].as_str().unwrap().to_owned();
     let placeholder = crate::code::worktree::two_word_name(
         uuid::Uuid::parse_str(&workspace_id).unwrap().as_u128(),
     );
@@ -249,7 +324,7 @@ async fn a_first_turn_names_an_untitled_workspace() {
     // The derived name lands in the store.
     let mut title = String::new();
     let mut branch = original_branch.clone();
-    let mut worktree_path = String::new();
+    let mut worktree_path = original_path.clone();
     for _ in 0..300 {
         let current: serde_json::Value = client
             .get(format!("http://{addr}/code/workspaces/{workspace_id}"))
@@ -263,13 +338,14 @@ async fn a_first_turn_names_an_untitled_workspace() {
         title = current["title"].as_str().unwrap().to_owned();
         branch = current["branch_name"].as_str().unwrap().to_owned();
         worktree_path = current["worktree_path"].as_str().unwrap().to_owned();
-        if title != placeholder && branch != original_branch {
+        if title != placeholder {
             break;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     assert_eq!(title, DERIVED_TITLE);
-    assert_eq!(branch, "tidebreak/fix-the-flaky-auth-retry-test");
+    assert_eq!(branch, original_branch);
+    assert_eq!(worktree_path, original_path);
     let checked_out = std::process::Command::new("git")
         .args(["branch", "--show-current"])
         .current_dir(worktree_path)
@@ -291,7 +367,7 @@ async fn a_first_turn_names_an_untitled_workspace() {
         "the naming call reads the submitted turn: {input}"
     );
 
-    // The rename was announced on the digest channel every list surface
+    // The display title was announced on the digest channel every list surface
     // watches, so an open sidebar re-labels without a refresh.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
     loop {

--- a/crates/tidebreak-server/src/tests/code_workspace.rs
+++ b/crates/tidebreak-server/src/tests/code_workspace.rs
@@ -53,6 +53,98 @@ async fn untitled_workspace_branch_includes_the_workspace_id() {
     assert!(branch_exists_in(&repo_root, branch));
 }
 
+#[tokio::test]
+async fn duplicate_workspace_names_resolve_one_slug_for_branch_and_folder() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let registered: serde_json::Value = registered.json().await.unwrap();
+
+    let mut created = Vec::new();
+    for _ in 0..2 {
+        let response = client
+            .post(format!("http://{addr}/code/workspaces"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "repo_id": registered["id"],
+                "title": "Fix login",
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+        created.push(response.json::<serde_json::Value>().await.unwrap());
+    }
+
+    assert_eq!(created[0]["branch_name"], "tidebreak/fix-login");
+    assert_eq!(created[1]["branch_name"], "tidebreak/fix-login-2");
+    for (workspace, slug) in created.iter().zip(["fix-login", "fix-login-2"]) {
+        let id = workspace["id"].as_str().unwrap();
+        assert!(workspace["worktree_path"]
+            .as_str()
+            .unwrap()
+            .ends_with(&format!("{slug}-{}", &id[..8])));
+    }
+}
+
+#[tokio::test]
+async fn suggested_names_leave_checkout_names_generated_when_automatic_naming_is_off() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    crate::code::naming_settings::write_auto_rename_branches(
+        &*runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        false,
+    )
+    .await
+    .unwrap();
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let registered: serde_json::Value = registered.json().await.unwrap();
+
+    let response = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": registered["id"],
+            "suggested_title": "Fix login",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = response.json().await.unwrap();
+    let id = workspace["id"].as_str().unwrap();
+    let fallback =
+        crate::code::worktree::two_word_name(uuid::Uuid::parse_str(id).unwrap().as_u128());
+    assert_eq!(workspace["title"], "Fix login");
+    assert_eq!(
+        workspace["branch_name"],
+        format!("tidebreak/{fallback}-{}", &id[..8])
+    );
+    assert!(workspace["worktree_path"]
+        .as_str()
+        .unwrap()
+        .ends_with(&format!("{fallback}-{}", &id[..8])));
+}
+
 /// The worktree root is a setting, and moving it moves only what comes next.
 ///
 /// The two halves are one test because the second is meaningless without the

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -464,6 +464,7 @@ mod tests {
         );
         generate::collect_from::<crate::routes::code::CodeRepoSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeWorkspaceSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::WorkspaceTitleProposal>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeConnectPage>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeGrantSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeSessionSnapshot>(&cfg, &mut out);

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -5690,6 +5690,11 @@ export type WorkspaceConfigSections = { code_repositories: Array<ExportedCodeRep
 export type WorkspaceId = string;
 
 /**
+ * Suggested display title for a workspace that has not been created yet.
+ */
+export type WorkspaceTitleProposal = { title: string | null, };
+
+/**
  * Every tool name the renderer will accept, at runtime.
  *
  * An allowlist, not a display transformation. Tool events come from


### PR DESCRIPTION
## What changed

Tidebreak names a new code workspace before it creates the checkout. With automatic branch naming enabled, the first-message title sets the display title, Git branch, and worktree folder. With automatic naming disabled, Tidebreak still updates the display title and keeps the generated checkout names.

The server allocates collision-safe names per repository, retries Git collisions, and falls back after a 10-second naming deadline. Existing worktrees never move. The sidebar updates live through the `Naming workspace` and `Creating branch and folder` states.

## Validation

- `cargo check -p tidebreak-server`
- `cargo test -p tidebreak-server code_titling:: -- --nocapture`
- Three focused server workspace-naming tests
- Wire binding generation and currentness test
- UI TypeScript check
- Biome lint and format check
- Four focused UI test files: 76 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`

A browser surface was unavailable, so Storybook screenshots could not be captured or inspected.

## Compatibility and risk

This change does not require a persisted-data migration. It adds workspace-creation progress fields to the generated wire types. Existing worktrees keep their paths. Slow or failed title generation uses the existing generated-name fallback, and duplicate names receive a numeric suffix.