### PR TITLE
feat(desktop): use comet loaders for live status

### DIFF
--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -245,9 +245,11 @@ markers, not as decorative advertising.
 - Do not place an icon in a colored or gray container on high-density
   surfaces. `EmptyMedia variant="icon"` draws no container at all, and it is
   the only icon treatment allowed on an empty surface.
-- Indeterminate progress uses `Spinner`. A busy refresh control swaps to that
-  glyph. Do not put `animate-spin` on `RefreshCw` or `RotateCw`: Lucide's ink
-  box is not the viewBox center, so the glyph orbits.
+- Live agent, workspace, tool, and plan status uses the `Loader` comet variant
+  in the `live` tone. Indeterminate action progress uses `Spinner`; a busy
+  refresh control swaps to that glyph. Do not put `animate-spin` on `RefreshCw`
+  or `RotateCw`: Lucide's ink box is not the viewBox center, so the glyph
+  orbits.
 
 ### Destructive actions
 

--- a/crates/tidebreak-desktop/ui/components.json
+++ b/crates/tidebreak-desktop/ui/components.json
@@ -16,5 +16,8 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide"
+  "iconLibrary": "lucide",
+  "registries": {
+    "@beui": "https://beui.dev/r/{name}.json"
+  }
 }

--- a/crates/tidebreak-desktop/ui/package.json
+++ b/crates/tidebreak-desktop/ui/package.json
@@ -82,6 +82,7 @@
     "lucide-react": "1.37.0",
     "mdast-util-from-markdown": "2.0.3",
     "monaco-editor": "0.56.0",
+    "motion": "13.1.1",
     "pdf-lib": "1.17.1",
     "plotly.js-dist-min": "4.0.0",
     "react": "19.2.8",

--- a/crates/tidebreak-desktop/ui/pnpm-lock.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       monaco-editor:
         specifier: 0.56.0
         version: 0.56.0
+      motion:
+        specifier: 13.1.1
+        version: 13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pdf-lib:
         specifier: 1.17.1
         version: 1.17.1
@@ -3662,6 +3665,17 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@13.1.1:
+    resolution: {integrity: sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   franc-min@6.2.0:
     resolution: {integrity: sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==}
 
@@ -4301,6 +4315,23 @@ packages:
 
   monaco-editor@0.56.0:
     resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
+
+  motion-dom@13.1.1:
+    resolution: {integrity: sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA==}
+
+  motion-utils@13.0.0:
+    resolution: {integrity: sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==}
+
+  motion@13.1.1:
+    resolution: {integrity: sha512-WNZoK6xiF+kkTqkZ5K7FDDh6A8BG4i5Hc7KXtW8gtTxkpJFds+hIOrDaQGKjQj/AE/i4hJqAaUHEqp/Qo02y6Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -9231,6 +9262,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      motion-dom: 13.1.1
+      motion-utils: 13.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   franc-min@6.2.0:
     dependencies:
       trigram-utils: 2.0.1
@@ -10070,6 +10110,20 @@ snapshots:
     dependencies:
       dompurify: 3.4.14
       marked: 14.0.0
+
+  motion-dom@13.1.1:
+    dependencies:
+      motion-utils: 13.0.0
+
+  motion-utils@13.0.0: {}
+
+  motion@13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      framer-motion: 13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   ms@2.1.3: {}
 

--- a/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
@@ -7,9 +7,9 @@ import { ToolCardShell } from "./ToolCardShell";
 import { ToolIcon } from "./ToolIcon";
 import { execCommandHeadline } from "./ToolPreview";
 import { ToolStatusIcon, type ToolTone } from "./ToolStatusIcon";
+import { Loader } from "@/components/motion/loader";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 
 export type AgentActivityState = {
@@ -325,7 +325,7 @@ function ExecActivityBadge({
     case "running":
       return (
         <Badge variant="outline" className="shrink-0 gap-1">
-          <Spinner className="size-3" aria-hidden="true" />
+          <Loader variant="comet" size={12} className="text-live" decorative />
           Running…
         </Badge>
       );

--- a/crates/tidebreak-desktop/ui/src/AgentRunTaskPlan.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentRunTaskPlan.dom.test.tsx
@@ -79,7 +79,9 @@ describe("a background run's task plan", () => {
     );
     // Named twice while live: once as the step in flight, once on the row.
     expect(screen.getAllByText("Write the summary")).toHaveLength(2);
-    expect(live.container.querySelector(".animate-spin")).not.toBeNull();
+    expect(
+      live.container.querySelector("[data-loader-variant='comet']"),
+    ).not.toBeNull();
     expect(
       live.container.querySelector("[data-slot='progress']"),
     ).not.toBeNull();
@@ -96,8 +98,10 @@ describe("a background run's task plan", () => {
     expect(screen.getByText("1/2 steps")).toBeInTheDocument();
     // ...but the row stops naming a current step, because there isn't one.
     expect(screen.getAllByText("Write the summary")).toHaveLength(1);
-    // ...without a spinner or a bar still tracking work that has stopped.
-    expect(settled.container.querySelector(".animate-spin")).toBeNull();
+    // ...without a loader or a bar still tracking work that has stopped.
+    expect(
+      settled.container.querySelector("[data-loader-variant='comet']"),
+    ).toBeNull();
     expect(
       settled.container.querySelector("[data-slot='progress']"),
     ).toBeNull();

--- a/crates/tidebreak-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -35,10 +35,10 @@ import { useAgentRuns } from "./useAgentRuns";
 import { PanelBreadcrumb } from "@/components/PanelHeader";
 import { PanelFrame } from "@/panel/PanelFrame";
 import { usePanelNav } from "@/panel/usePanelNav";
+import { Loader } from "@/components/motion/loader";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Spinner } from "@/components/ui/spinner";
 
 /**
  * One background run, opened beside the conversation from its row in the
@@ -353,7 +353,7 @@ export function AgentRunStatusBadge({
     case "cancelling":
       return (
         <Badge variant="outline" size="sm">
-          <Spinner className="size-3" aria-hidden="true" />
+          <Loader variant="comet" size={12} className="text-live" decorative />
           Stopping
         </Badge>
       );
@@ -377,7 +377,7 @@ export function AgentRunStatusBadge({
     case "running":
       return (
         <Badge variant="info" size="sm">
-          <Spinner className="size-3" aria-hidden="true" />
+          <Loader variant="comet" size={12} className="text-live" decorative />
           Running
         </Badge>
       );

--- a/crates/tidebreak-desktop/ui/src/TaskPlanCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/TaskPlanCard.dom.test.tsx
@@ -23,13 +23,15 @@ describe("TaskPlanCard", () => {
       <TaskPlanCard plan={PLAN} live={true} />,
     );
 
-    // While the turn runs the plan is open and the current step spins.
+    // While the turn runs the plan is open and the current step uses a comet.
     expect(screen.getByRole("button", { name: /task plan/i })).toHaveAttribute(
       "aria-expanded",
       "true",
     );
     expect(screen.getByText("Draft the change")).toBeInTheDocument();
-    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    expect(
+      container.querySelector("[data-loader-variant='comet']"),
+    ).not.toBeNull();
 
     rerender(<TaskPlanCard plan={PLAN} live={false} />);
 
@@ -39,6 +41,6 @@ describe("TaskPlanCard", () => {
       "false",
     );
     expect(screen.getByText("1/3")).toBeInTheDocument();
-    expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(container.querySelector("[data-loader-variant='comet']")).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/TaskPlanSteps.tsx
+++ b/crates/tidebreak-desktop/ui/src/TaskPlanSteps.tsx
@@ -1,7 +1,7 @@
 import { Circle, CircleCheck, CircleDashed } from "lucide-react";
 
 import type { TaskPlanStep, TaskPlanStepStatus } from "./api";
-import { Spinner } from "@/components/ui/spinner";
+import { Loader } from "@/components/motion/loader";
 import { cn } from "@/lib/utils";
 
 /**
@@ -100,11 +100,11 @@ function StepGlyph({
     return <CircleCheck className="text-success size-4" />;
   }
   if (status === "in_progress") {
-    // A spinner on work that has stopped would animate a claim that nothing is
+    // A loader on work that has stopped would animate a claim that nothing is
     // making true. The step still reads as started rather than untouched, but
     // it reads as stopped.
     return live ? (
-      <Spinner className="text-foreground size-4" />
+      <Loader variant="comet" size={16} className="text-live" decorative />
     ) : (
       <CircleDashed className="text-muted-foreground size-4" />
     );

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
@@ -7,8 +7,8 @@ import {
   type RendererToolName,
   type ToolActionPreview,
 } from "./api";
+import { Loader } from "@/components/motion/loader";
 import { Badge } from "@/components/ui/badge";
-import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { ToolStatusIcon, type ToolTone } from "./ToolStatusIcon";
@@ -387,7 +387,12 @@ export function ToolCommandCard({
               <TabsContent value="output" className="mt-0">
                 {output === null ? (
                   <p className="text-muted-foreground flex items-center gap-1.5 py-1 text-xs">
-                    <Spinner className="size-3.5" aria-hidden="true" />
+                    <Loader
+                      variant="comet"
+                      size={14}
+                      className="text-live"
+                      decorative
+                    />
                     Waiting for output…
                   </p>
                 ) : null}
@@ -413,7 +418,12 @@ export function ToolCommandCard({
           className="text-muted-foreground flex items-start gap-1.5 text-xs"
           role="status"
         >
-          <Spinner className="mt-0.5 size-3 shrink-0" aria-hidden="true" />
+          <Loader
+            variant="comet"
+            size={12}
+            className="mt-0.5 text-live"
+            decorative
+          />
           {SANDBOX_PREPARING_NOTICE}
         </p>
       )}
@@ -459,7 +469,7 @@ function ToolStatusBadge({
   if (presentation.tone === "running") {
     return (
       <Badge variant="outline" className="shrink-0 gap-1">
-        <Spinner className="size-3" aria-hidden="true" />
+        <Loader variant="comet" size={12} className="text-live" decorative />
         {preparing ? "Preparing sandbox…" : "Running…"}
       </Badge>
     );

--- a/crates/tidebreak-desktop/ui/src/ToolStatusIcon.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolStatusIcon.tsx
@@ -1,6 +1,6 @@
 import { Ban, CircleAlert, Clock } from "lucide-react";
 
-import { Spinner } from "@/components/ui/spinner";
+import { Loader } from "@/components/motion/loader";
 import { cn } from "@/lib/utils";
 
 export type ToolTone =
@@ -28,9 +28,14 @@ export function ToolStatusIcon({
 }) {
   switch (tone) {
     case "running":
-      // Running takes the row's own colour; the other tones are deliberately
-      // muted beside it.
-      return <Spinner className={cn(className, "text-current")} />;
+      return (
+        <Loader
+          variant="comet"
+          size={14}
+          className={cn(className, "text-live")}
+          decorative
+        />
+      );
     case "waiting_approval":
       return <Clock className={cn("text-muted-foreground", className)} />;
     case "completed":

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
@@ -65,7 +65,7 @@ describe("AttentionBadge", () => {
 
   // A compact mark is often a row's only state. Working drawing as nothing here
   // made a busy agent look idle, which is the one confusion worth a test.
-  it("renders a spinner for Working when compact", () => {
+  it("renders a comet loader for Working when compact", () => {
     render(
       <AttentionBadge
         compact
@@ -74,7 +74,7 @@ describe("AttentionBadge", () => {
     );
     const mark = screen.getByLabelText("Working");
     expect(mark).toHaveAttribute("data-attention", "working");
-    expect(mark.querySelector(".animate-spin")).not.toBeNull();
+    expect(mark.querySelector("[data-loader-variant='comet']")).not.toBeNull();
   });
 
   it("renders no mark for Idle", () => {

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
@@ -1,7 +1,7 @@
 import { Ban, CircleAlert, CircleCheck, Clock, Pin } from "lucide-react";
 
+import { Loader } from "@/components/motion/loader";
 import { Badge } from "@/components/ui/badge";
-import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 
 import type { Attention } from "../api/types";
@@ -18,10 +18,10 @@ import {
  * NeedsYou is strongest. Stalled and Fenced are distinct warnings.
  * DoneUnreviewed is a quiet mark.
  *
- * Working is a spinner but not a pill. Compact surfaces use a distinct glyph
- * for each state, so the shape still carries the meaning when color is subtle
- * or unavailable. The full badge always sits beside text that names the state
- * already, so a "Working" pill there would only repeat it.
+ * Working is a comet loader but not a pill. Compact surfaces use a distinct
+ * mark for each state, so the shape still carries the meaning when color is
+ * subtle or unavailable. The full badge always sits beside text that names
+ * the state already, so a "Working" pill there would only repeat it.
  */
 
 const BADGE_VARIANTS: Record<
@@ -92,7 +92,9 @@ function CompactAttentionMark({
   const className = cn("size-3", STATUS_MARK[tone]);
   switch (attention.state.type) {
     case "working":
-      return <Spinner className={className} aria-hidden="true" />;
+      return (
+        <Loader variant="comet" size={12} className="text-live" decorative />
+      );
     case "needs_you":
       return <CircleAlert className={className} aria-hidden="true" />;
     case "stalled":

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -3,7 +3,6 @@ import {
   CircleSlash,
   FileCode,
   FileSearch,
-  Loader2,
   Search,
   SquareTerminal,
   Wrench,
@@ -36,6 +35,7 @@ import { TranscriptSkeleton } from "@/TranscriptSkeleton";
 import { UserMessage } from "@/UserMessage";
 import { useApp } from "@/AppContext";
 import { TranscriptImageAttachments } from "@/TranscriptImageAttachments";
+import { Loader } from "@/components/motion/loader";
 import { cn } from "@/lib/utils";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
@@ -1179,12 +1179,7 @@ function StatusGlyph({
   switch (status) {
     case "running":
       return (
-        // The one animation reduced motion keeps: it is the progress signal,
-        // and a frozen spinner reads as a hung call.
-        <Loader2
-          className="text-info-foreground size-3.5 animate-spin"
-          aria-hidden="true"
-        />
+        <Loader variant="comet" size={14} className="text-live" decorative />
       );
     case "succeeded":
       return (

--- a/crates/tidebreak-desktop/ui/src/code/SessionLifecycleIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionLifecycleIndicator.tsx
@@ -1,6 +1,6 @@
 import { CircleAlert } from "lucide-react";
 
-import { Spinner } from "@/components/ui/spinner";
+import { Loader } from "@/components/motion/loader";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
@@ -58,10 +58,7 @@ export function SessionLifecycleIndicator({
         )}
       >
         {lifecycle === "running" && (
-          <Spinner
-            className={cn("size-3", STATUS_MARK.running)}
-            aria-hidden="true"
-          />
+          <Loader variant="comet" size={12} className="text-live" decorative />
         )}
         <span>{label}</span>
         {unrecognizedEventCount > 0 && (

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -11,7 +11,7 @@ import type {
 } from "../api/types";
 import type { ComposerWorkspaceFiles } from "@/Composer";
 import { LiveLabel } from "@/LiveLabel";
-import { Spinner } from "@/components/ui/spinner";
+import { Loader } from "@/components/motion/loader";
 import { cn } from "@/lib/utils";
 import { clampPermissionMode } from "../PermissionModeMenu";
 import { useManagedPolicy } from "../managedPolicy";
@@ -76,7 +76,12 @@ export function WorkspaceSessionStartingState({
       <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-10">
         <div className="w-full max-w-md">
           <div className="flex items-start gap-3">
-            <Spinner className="mt-1 size-4 text-live" aria-hidden />
+            <Loader
+              variant="comet"
+              size={16}
+              className="mt-1 text-live"
+              decorative
+            />
             <div className="min-w-0">
               <h2 className="text-lg font-semibold">
                 {startup.heading ?? "Starting your session"}
@@ -170,7 +175,7 @@ function StartupStep({
         {state === "complete" ? (
           <Check className="size-3.5 text-success" aria-hidden />
         ) : state === "active" ? (
-          <Spinner className="size-3.5 text-live" aria-hidden />
+          <Loader variant="comet" size={14} className="text-live" decorative />
         ) : (
           <Circle className="size-2.5 text-border" aria-hidden />
         )}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -23,6 +23,7 @@ import {
   SquareTerminal,
 } from "lucide-react";
 
+import { Loader } from "@/components/motion/loader";
 import { Button } from "@/components/ui/button";
 import { LiveLabel } from "@/LiveLabel";
 import {
@@ -33,7 +34,6 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { Spinner } from "@/components/ui/spinner";
 import {
   HoverCard,
   HoverCardContent,
@@ -111,7 +111,7 @@ export function WorkspaceStatusMark({
   if (creating) {
     return (
       <span role="img" aria-label="Creating workspace">
-        <Spinner className={cn("size-3", STATUS_MARK.running)} aria-hidden />
+        <Loader variant="comet" size={12} className="text-live" decorative />
       </span>
     );
   }
@@ -125,7 +125,7 @@ export function WorkspaceStatusMark({
       {rank === "needs_you" ? (
         <CircleAlert className={className} aria-hidden />
       ) : rank === "running" ? (
-        <Spinner className={className} aria-hidden />
+        <Loader variant="comet" size={12} className="text-live" decorative />
       ) : rank === "pr_open" ? (
         <GitPullRequest
           className={className}
@@ -513,7 +513,12 @@ function WorkspaceSubagentRows({
             ariaLabel={`Subagent for ${title}: ${subagent.name}, ${SUBAGENT_STATUS_LABELS[subagent.status]}`}
             icon={
               subagent.status === "running" ? (
-                <Spinner className={STATUS_MARK.running} />
+                <Loader
+                  variant="comet"
+                  size={12}
+                  className="text-live"
+                  decorative
+                />
               ) : subagent.status === "failed" ? (
                 <CircleAlert className={STATUS_MARK.critical} />
               ) : (
@@ -910,7 +915,7 @@ function WorkspaceActivityLine({
  * One glyph, one meaning, on the rail row.
  *
  * The same shapes the compact attention mark draws, so the row and the badge
- * never disagree: a spinner is work in motion, a circle-alert wants the
+ * never disagree: a comet is work in motion, a circle-alert wants the
  * reader, a clock went quiet, a ban is fenced, a check is finished and
  * unread, a pin was set by hand. Two shapes are the row's own, for a turn
  * that is alive but parked on something else: a bot for subagents and a
@@ -977,10 +982,12 @@ function SessionStateGlyph({
       );
     }
     return (
-      <Spinner
-        className={cn(className, STATUS_MARK.running)}
+      <Loader
+        variant="comet"
+        size={12}
+        className={cn(className, "text-live")}
         data-state-glyph="working"
-        aria-hidden
+        decorative
       />
     );
   }

--- a/crates/tidebreak-desktop/ui/src/components/motion/loader.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/motion/loader.tsx
@@ -1,0 +1,666 @@
+"use client";
+// beui.dev/components/motion/loader
+
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useId, useState, type HTMLAttributes } from "react";
+import { EASE_IN_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export type LoaderVariant =
+  | "spinner"
+  | "dots"
+  | "bars"
+  | "dot-matrix"
+  | "dither"
+  | "ascii"
+  | "ascii-line"
+  | "ascii-braille"
+  | "ascii-blocks"
+  | "ascii-bounce"
+  | "morph"
+  | "comet"
+  | "scramble"
+  | "metaballs"
+  | "newton"
+  | "helix"
+  | "percent";
+
+// Terminal-style frame sets — the loaders CLI AI agents cycle through.
+const ASCII_SETS: Record<string, string[]> = {
+  ascii: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+  "ascii-line": ["|", "/", "-", "\\"],
+  "ascii-braille": ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"],
+  "ascii-blocks": [
+    "▁",
+    "▂",
+    "▃",
+    "▄",
+    "▅",
+    "▆",
+    "▇",
+    "█",
+    "▇",
+    "▆",
+    "▅",
+    "▄",
+    "▃",
+    "▂",
+  ],
+  "ascii-bounce": ["⠁", "⠂", "⠄", "⡀", "⢀", "⠠", "⠐", "⠈"],
+};
+
+export interface LoaderProps
+  extends Omit<HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** Which animation to render. */
+  variant?: LoaderVariant;
+  /** Base square size in px. Everything scales from this. */
+  size?: number;
+  /** Seconds per animation cycle. */
+  speed?: number;
+  /** Accessible label announced to screen readers. */
+  label?: string;
+  /** Hide the loader from assistive technology when nearby text names it. */
+  decorative?: boolean;
+  className?: string;
+}
+
+// Reduced motion keeps a calm opacity pulse and drops every transform.
+const REDUCED = {
+  animate: { opacity: [1, 0.4, 1] },
+  transition: { duration: 1.4, ease: EASE_IN_OUT, repeat: Infinity },
+};
+
+export function Loader({
+  variant = "spinner",
+  size = 32,
+  speed = 1,
+  label = "Loading",
+  decorative = false,
+  className,
+  ...props
+}: LoaderProps) {
+  const reduce = useReducedMotion() ?? false;
+
+  return (
+    <span
+      {...props}
+      role={decorative ? undefined : "status"}
+      aria-label={decorative ? undefined : label}
+      aria-hidden={decorative || undefined}
+      data-loader-variant={variant}
+      className={cn(
+        "inline-flex items-center justify-center text-foreground",
+        className,
+      )}
+    >
+      {variant === "spinner" && (
+        <Spinner size={size} speed={speed} reduce={reduce} />
+      )}
+      {variant === "dots" && <Dots size={size} speed={speed} reduce={reduce} />}
+      {variant === "bars" && <Bars size={size} speed={speed} reduce={reduce} />}
+      {variant === "dot-matrix" && (
+        <DotMatrix size={size} speed={speed} reduce={reduce} />
+      )}
+      {variant === "dither" && (
+        <Dither size={size} speed={speed} reduce={reduce} />
+      )}
+      {ASCII_SETS[variant] && (
+        <Ascii
+          frames={ASCII_SETS[variant]}
+          size={size}
+          speed={speed}
+          reduce={reduce}
+        />
+      )}
+      {variant === "morph" && (
+        <Morph size={size} speed={speed} reduce={reduce} />
+      )}
+      {variant === "comet" && (
+        <Comet size={size} speed={speed} reduce={reduce} />
+      )}
+      {variant === "scramble" && (
+        <Scramble size={size} speed={speed} reduce={reduce} />
+      )}
+      {variant === "metaballs" && (
+        <Metaballs size={size} speed={speed} reduce={reduce} />
+      )}
+      {variant === "newton" && (
+        <Newton size={size} speed={speed} reduce={reduce} />
+      )}
+      {variant === "helix" && (
+        <Helix size={size} speed={speed} reduce={reduce} />
+      )}
+      {variant === "percent" && (
+        <Percent size={size} speed={speed} reduce={reduce} />
+      )}
+    </span>
+  );
+}
+
+interface PartProps {
+  size: number;
+  speed: number;
+  reduce: boolean;
+}
+
+function Spinner({ size, speed, reduce }: PartProps) {
+  const stroke = Math.max(2, size * 0.09);
+  const r = (size - stroke) / 2;
+  return (
+    <motion.svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      animate={reduce ? REDUCED.animate : { rotate: 360 }}
+      transition={
+        reduce
+          ? REDUCED.transition
+          : { duration: speed, ease: "linear", repeat: Infinity }
+      }
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        stroke="currentColor"
+        strokeOpacity={0.2}
+        strokeWidth={stroke}
+      />
+      <path
+        d={`M ${size / 2} ${size / 2 - r} A ${r} ${r} 0 0 1 ${size / 2 + r} ${size / 2}`}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={stroke}
+        strokeLinecap="round"
+      />
+    </motion.svg>
+  );
+}
+
+function Dots({ size, speed, reduce }: PartProps) {
+  const dot = size * 0.24;
+  return (
+    <span className="flex items-center" style={{ gap: size * 0.14 }}>
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="rounded-full bg-current"
+          style={{ width: dot, height: dot }}
+          animate={
+            reduce
+              ? { opacity: [0.4, 1, 0.4] }
+              : { y: [0, -size * 0.3, 0], opacity: [0.5, 1, 0.5] }
+          }
+          transition={{
+            duration: speed,
+            ease: EASE_IN_OUT,
+            repeat: Infinity,
+            delay: i * speed * 0.16,
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function Ascii({
+  frames,
+  size,
+  speed,
+  reduce,
+}: PartProps & { frames: string[] }) {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    // Reduced motion slows the cycle rather than stopping it — it's a glyph
+    // swap, not on-screen movement.
+    const step = ((reduce ? speed * 2.5 : speed) / frames.length) * 1000;
+    const id = setInterval(
+      () => setFrame((f) => (f + 1) % frames.length),
+      step,
+    );
+    return () => clearInterval(id);
+  }, [frames.length, speed, reduce]);
+
+  return (
+    <span
+      className="font-mono leading-none tabular-nums"
+      style={{ fontSize: size, lineHeight: 1 }}
+    >
+      {frames[frame % frames.length]}
+    </span>
+  );
+}
+
+// Each shape is sampled at the same number of points and emitted as an SVG
+// path with identical command structure, so framer tweens the `d` attribute
+// point-to-point — a real morph, not a snap. (clip-path polygon strings don't
+// interpolate reliably in framer, which left the shapes broken.)
+const MORPH_POINTS = 24;
+
+function ngonRadius(ang: number, n: number, phase = 0) {
+  const seg = (2 * Math.PI) / n;
+  const a = ang - phase;
+  const local = (((a % seg) + seg) % seg) - seg / 2;
+  return Math.cos(Math.PI / n) / Math.cos(local);
+}
+
+function morphPath(radiusAt: (ang: number) => number) {
+  const parts: string[] = [];
+  for (let i = 0; i < MORPH_POINTS; i++) {
+    const ang = (i / MORPH_POINTS) * 2 * Math.PI - Math.PI / 2;
+    const r = Math.min(1.05, radiusAt(ang));
+    const x = (50 + Math.cos(ang) * 46 * r).toFixed(2);
+    const y = (50 + Math.sin(ang) * 46 * r).toFixed(2);
+    parts.push(`${i === 0 ? "M" : "L"}${x} ${y}`);
+  }
+  return `${parts.join(" ")} Z`;
+}
+
+const MORPH_PATHS = [
+  morphPath(() => 1), // circle
+  morphPath((a) => ngonRadius(a, 4, Math.PI / 4)), // square
+  morphPath((a) => ngonRadius(a, 3)), // triangle
+  morphPath((a) => ngonRadius(a, 6)), // hexagon
+  morphPath((a) => ngonRadius(a, 4)), // diamond
+];
+
+// Each shape appears twice in a row so it fully forms and HOLDS before the
+// next morph. Even keyframe spacing then alternates hold / morph segments.
+const MORPH_SEQ = [...MORPH_PATHS.flatMap((p) => [p, p]), MORPH_PATHS[0]];
+// Rotation and scale only change across the morph segments, staying put on the
+// holds, so a settled shape sits still.
+const MORPH_ROT = [0, 0, 72, 72, 144, 144, 216, 216, 288, 288, 360];
+const MORPH_SCALE = [1, 1, 0.88, 0.88, 1, 1, 0.88, 0.88, 1, 1, 1];
+
+function Morph({ size, speed, reduce }: PartProps) {
+  return (
+    <motion.svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      role="img"
+      animate={
+        reduce
+          ? { opacity: [1, 0.4, 1] }
+          : { rotate: MORPH_ROT, scale: MORPH_SCALE }
+      }
+      transition={
+        reduce
+          ? { duration: 1.4, ease: EASE_IN_OUT, repeat: Infinity }
+          : { duration: speed * 5, ease: EASE_IN_OUT, repeat: Infinity }
+      }
+    >
+      <title>Loading</title>
+      <motion.path
+        fill="currentColor"
+        d={MORPH_PATHS[0]}
+        animate={reduce ? undefined : { d: MORPH_SEQ }}
+        transition={
+          reduce
+            ? undefined
+            : { duration: speed * 5, ease: EASE_IN_OUT, repeat: Infinity }
+        }
+      />
+    </motion.svg>
+  );
+}
+
+const COMET_TRAIL = [0, 1, 2, 3, 4, 5];
+
+function Comet({ size, speed, reduce }: PartProps) {
+  const head = size * 0.2;
+  const r = size / 2 - head / 2;
+  return (
+    <span className="relative" style={{ width: size, height: size }}>
+      <motion.span
+        className="absolute inset-0"
+        animate={reduce ? REDUCED.animate : { rotate: 360 }}
+        transition={
+          reduce
+            ? REDUCED.transition
+            : { duration: speed, ease: "linear", repeat: Infinity }
+        }
+      >
+        {COMET_TRAIL.map((i) => {
+          const scale = 1 - i * 0.13;
+          const sz = head * scale;
+          return (
+            <span
+              key={i}
+              className="absolute top-1/2 left-1/2 rounded-full bg-current"
+              style={{
+                width: sz,
+                height: sz,
+                marginLeft: -sz / 2,
+                marginTop: -sz / 2,
+                opacity: 1 - i * 0.16,
+                transform: `rotate(${-i * 15}deg) translateY(${-r}px)`,
+              }}
+            />
+          );
+        })}
+      </motion.span>
+    </span>
+  );
+}
+
+const SCRAMBLE_TARGET = "LOADING";
+const SCRAMBLE_GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>/*#@";
+
+function Scramble({ size, speed, reduce }: PartProps) {
+  const [text, setText] = useState(SCRAMBLE_TARGET);
+  useEffect(() => {
+    if (reduce) {
+      setText(SCRAMBLE_TARGET);
+      return;
+    }
+    let tick = 0;
+    const total = SCRAMBLE_TARGET.length + 4;
+    const id = setInterval(
+      () => {
+        const reveal = tick % total;
+        let s = "";
+        for (let i = 0; i < SCRAMBLE_TARGET.length; i++) {
+          s +=
+            i < reveal
+              ? SCRAMBLE_TARGET[i]
+              : SCRAMBLE_GLYPHS[
+                  Math.floor(Math.random() * SCRAMBLE_GLYPHS.length)
+                ];
+        }
+        setText(s);
+        tick++;
+      },
+      (speed / SCRAMBLE_TARGET.length) * 1000 * 0.55,
+    );
+    return () => clearInterval(id);
+  }, [speed, reduce]);
+
+  return (
+    <span
+      className="font-mono font-medium tracking-[0.2em] tabular-nums"
+      style={{ fontSize: size * 0.42 }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function Metaballs({ size, speed, reduce }: PartProps) {
+  const id = useId().replace(/:/g, "");
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 100" role="img">
+      <title>Loading</title>
+      <defs>
+        <filter id={id}>
+          <feGaussianBlur in="SourceGraphic" stdDeviation="5" result="b" />
+          <feColorMatrix
+            in="b"
+            values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -8"
+          />
+        </filter>
+      </defs>
+      <g filter={`url(#${id})`} fill="currentColor">
+        <motion.circle
+          cy="50"
+          r="15"
+          animate={reduce ? { opacity: [0.4, 1, 0.4] } : { cx: [30, 70, 30] }}
+          transition={{
+            duration: speed * 1.6,
+            ease: EASE_IN_OUT,
+            repeat: Infinity,
+          }}
+          cx={reduce ? 40 : 30}
+        />
+        <motion.circle
+          cy="50"
+          r="15"
+          animate={reduce ? { opacity: [0.4, 1, 0.4] } : { cx: [70, 30, 70] }}
+          transition={{
+            duration: speed * 1.6,
+            ease: EASE_IN_OUT,
+            repeat: Infinity,
+          }}
+          cx={reduce ? 60 : 70}
+        />
+      </g>
+    </svg>
+  );
+}
+
+const NEWTON_BALLS = [0, 1, 2, 3, 4];
+
+function Newton({ size, speed, reduce }: PartProps) {
+  const d = size * 0.2;
+  const out = d * 1.1;
+  // Only the end balls move: the left slides out and back on the first half,
+  // then the right on the second half — the impact appears to jump the three
+  // still middle balls. Pure horizontal slide, no swing, no strings.
+  const moves: Record<number, { x: number[]; times: number[] }> = {
+    0: { x: [0, -out, 0, 0], times: [0, 0.28, 0.5, 1] },
+    4: { x: [0, 0, out, 0], times: [0, 0.5, 0.78, 1] },
+  };
+
+  return (
+    <span className="flex items-center justify-center" style={{ height: d }}>
+      {NEWTON_BALLS.map((i) => {
+        const move = moves[i];
+        return (
+          <motion.span
+            key={i}
+            className="rounded-full bg-current"
+            style={{ width: d, height: d }}
+            animate={reduce || !move ? undefined : { x: move.x }}
+            transition={
+              reduce || !move
+                ? undefined
+                : {
+                    duration: speed * 1.5,
+                    ease: EASE_IN_OUT,
+                    repeat: Infinity,
+                    times: move.times,
+                  }
+            }
+          />
+        );
+      })}
+    </span>
+  );
+}
+
+function Helix({ size, speed, reduce }: PartProps) {
+  const rows = 7;
+  const dot = size * 0.14;
+  const amp = size * 0.32;
+  return (
+    <span className="relative" style={{ width: size, height: size }}>
+      {Array.from({ length: rows }, (_, r) => {
+        const top = (r / (rows - 1)) * (size - dot);
+        const delay = (r / rows) * speed;
+        return (
+          <span key={`row-${top}`}>
+            <motion.span
+              className="absolute rounded-full bg-current"
+              style={{ width: dot, height: dot, left: size / 2 - dot / 2, top }}
+              animate={
+                reduce
+                  ? { opacity: [0.4, 1, 0.4] }
+                  : {
+                      x: [amp, -amp, amp],
+                      scale: [1, 0.5, 1],
+                      opacity: [1, 0.45, 1],
+                    }
+              }
+              transition={{
+                duration: speed,
+                ease: EASE_IN_OUT,
+                repeat: Infinity,
+                delay,
+              }}
+            />
+            <motion.span
+              className="absolute rounded-full bg-current"
+              style={{ width: dot, height: dot, left: size / 2 - dot / 2, top }}
+              animate={
+                reduce
+                  ? { opacity: [0.4, 1, 0.4] }
+                  : {
+                      x: [-amp, amp, -amp],
+                      scale: [0.5, 1, 0.5],
+                      opacity: [0.45, 1, 0.45],
+                    }
+              }
+              transition={{
+                duration: speed,
+                ease: EASE_IN_OUT,
+                repeat: Infinity,
+                delay,
+              }}
+            />
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+function Percent({ size, speed, reduce }: PartProps) {
+  const [p, setP] = useState(0);
+  useEffect(() => {
+    const dur = (reduce ? speed * 2 : speed) * 1000;
+    const start = { t: 0 };
+    const tickMs = 40;
+    const id = setInterval(() => {
+      start.t += tickMs;
+      const next = Math.min(100, Math.round((start.t / dur) * 100));
+      setP(next);
+      if (next >= 100) start.t = 0;
+    }, tickMs);
+    return () => clearInterval(id);
+  }, [speed, reduce]);
+
+  return (
+    <span
+      className="flex flex-col items-center"
+      style={{ gap: size * 0.14, width: size * 1.4 }}
+    >
+      <span
+        className="font-mono font-medium tabular-nums"
+        style={{ fontSize: size * 0.42, lineHeight: 1 }}
+      >
+        {p}%
+      </span>
+      <span
+        className="w-full overflow-hidden rounded-full bg-current/15"
+        style={{ height: Math.max(3, size * 0.1) }}
+      >
+        <span
+          className="block h-full rounded-full bg-current"
+          style={{ width: `${p}%` }}
+        />
+      </span>
+    </span>
+  );
+}
+
+function Bars({ size, speed, reduce }: PartProps) {
+  const bar = size * 0.16;
+  return (
+    <span
+      className="flex items-center"
+      style={{ gap: size * 0.1, height: size }}
+    >
+      {[0, 1, 2, 3].map((i) => (
+        <motion.span
+          key={i}
+          className="rounded-full bg-current"
+          style={{ width: bar, height: size, originY: 1 }}
+          animate={
+            reduce ? { opacity: [0.4, 1, 0.4] } : { scaleY: [0.3, 1, 0.3] }
+          }
+          transition={{
+            duration: speed,
+            ease: EASE_IN_OUT,
+            repeat: Infinity,
+            delay: i * speed * 0.12,
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function DotMatrix({ size, speed, reduce }: PartProps) {
+  const n = 3;
+  const gap = size * 0.14;
+  const dot = (size - gap * (n - 1)) / n;
+  const cells = Array.from({ length: n * n }, (_, idx) => idx);
+  return (
+    <span
+      className="grid"
+      style={{
+        gap,
+        gridTemplateColumns: `repeat(${n}, ${dot}px)`,
+      }}
+    >
+      {cells.map((idx) => {
+        const x = idx % n;
+        const y = Math.floor(idx / n);
+        // Diagonal wave: cells light in order of their distance from the corner.
+        const delay = ((x + y) / (2 * (n - 1))) * speed;
+        return (
+          <motion.span
+            key={idx}
+            className="rounded-full bg-current"
+            style={{ width: dot, height: dot }}
+            animate={
+              reduce
+                ? { opacity: [0.3, 1, 0.3] }
+                : { opacity: [0.2, 1, 0.2], scale: [0.7, 1, 0.7] }
+            }
+            transition={{
+              duration: speed,
+              ease: EASE_IN_OUT,
+              repeat: Infinity,
+              delay,
+            }}
+          />
+        );
+      })}
+    </span>
+  );
+}
+
+// Ordered Bayer 4x4 matrix — the classic dithering threshold pattern. Cells
+// light in this order, so the fill shimmers like a dissolving halftone.
+const BAYER_4 = [0, 8, 2, 10, 12, 4, 14, 6, 3, 11, 1, 9, 15, 7, 13, 5];
+
+function Dither({ size, speed, reduce }: PartProps) {
+  const n = 4;
+  const gap = Math.max(1, size * 0.05);
+  const cell = (size - gap * (n - 1)) / n;
+  return (
+    <span
+      className="grid"
+      style={{ gap, gridTemplateColumns: `repeat(${n}, ${cell}px)` }}
+    >
+      {BAYER_4.map((order, idx) => (
+        <motion.span
+          key={idx}
+          className="bg-current"
+          style={{ width: cell, height: cell }}
+          animate={
+            reduce ? { opacity: [0.3, 1, 0.3] } : { opacity: [0.1, 1, 0.1] }
+          }
+          transition={{
+            duration: speed,
+            ease: EASE_IN_OUT,
+            repeat: Infinity,
+            delay: (order / BAYER_4.length) * speed,
+          }}
+        />
+      ))}
+    </span>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/lib/ease.ts
+++ b/crates/tidebreak-desktop/ui/src/lib/ease.ts
@@ -1,0 +1,1 @@
+export const EASE_IN_OUT = [0.77, 0, 0.175, 1] as const;

--- a/crates/tidebreak-desktop/ui/src/stories/Loader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Loader.stories.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Loader } from "@/components/motion/loader";
+import { AttentionBadge } from "@/code/AttentionBadge";
+import { HARNESS_ICONS } from "@/code/HarnessPicker";
+import { SessionLifecycleIndicator } from "@/code/SessionLifecycleIndicator";
+import { WorkspaceStatusMark } from "@/code/WorkspaceCard";
+import { ToolStatusIcon } from "@/ToolStatusIcon";
+
+import { attentionWorking } from "./fixtures";
+
+const ClaudeIcon = HARNESS_ICONS.claude_code;
+
+const meta = {
+  title: "Foundations/Loader",
+  component: Loader,
+  args: {
+    variant: "comet",
+    className: "text-live",
+  },
+} satisfies Meta<typeof Loader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Comet: Story = {
+  args: {
+    size: 24,
+    label: "Working",
+  },
+};
+
+export const CometSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-6 text-live">
+      {[12, 14, 16, 24, 32].map((size) => (
+        <div key={size} className="flex items-center gap-2">
+          <Loader variant="comet" size={size} label={`${size}px comet`} />
+          <span className="text-xs text-muted-foreground">{size}px</span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const StatusContexts: Story = {
+  render: () => (
+    <div className="grid w-80 gap-3 rounded-xl border border-border-subtle bg-background p-4">
+      <StatusRow label="Workspace running">
+        <WorkspaceStatusMark rank="running" />
+      </StatusRow>
+      <StatusRow label="Agent working">
+        <SessionLifecycleIndicator
+          lifecycle="running"
+          harness="codex"
+          version="0.84.0"
+          unrecognizedEventCount={0}
+          runningLabel="Agent working"
+        />
+      </StatusRow>
+      <StatusRow label="Compact agent tab">
+        <span className="flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_7%,transparent),inset_0_0_0_1px_var(--border-subtle)]">
+          <ClaudeIcon className="size-3.5 shrink-0" />
+          <span>Main agent</span>
+          <AttentionBadge attention={attentionWorking} compact />
+        </span>
+      </StatusRow>
+      <StatusRow label="Tool running">
+        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <ToolStatusIcon tone="running" className="size-3.5" />
+          Running command
+        </span>
+      </StatusRow>
+    </div>
+  ),
+};
+
+function StatusRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-8 items-center justify-between gap-4 border-t border-border-subtle pt-3 first:border-t-0 first:pt-0">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/Spinner.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Spinner.stories.tsx
@@ -3,12 +3,6 @@ import { RefreshCw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { AttentionBadge } from "@/code/AttentionBadge";
-import { HARNESS_ICONS } from "@/code/HarnessPicker";
-
-import { attentionWorking } from "./fixtures";
-
-const ClaudeIcon = HARNESS_ICONS.claude_code;
 
 /**
  * Indeterminate progress. The arc is centred on the viewBox so it rotates
@@ -47,19 +41,6 @@ export const OnRefreshButton: Story = {
         <Spinner aria-hidden />
         Refresh
       </Button>
-    </div>
-  ),
-};
-
-/** The compact working mark as the Main agent tab wears it. */
-export const OnAgentTab: Story = {
-  render: () => (
-    <div className="flex h-8 w-fit items-center rounded-lg bg-background px-2.5 shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_7%,transparent),inset_0_0_0_1px_var(--border-subtle)]">
-      <span className="flex items-center gap-1.5 text-xs font-medium">
-        <ClaudeIcon className="size-3.5 shrink-0" />
-        <span>Main agent</span>
-        <AttentionBadge attention={attentionWorking} compact />
-      </span>
     </div>
   ),
 };

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -471,7 +471,7 @@ export const ParkedIdle: Story = {
   },
 };
 
-/** Spinner, activity, and the harness mark on the detailed status line. */
+/** Comet loader, activity, and the harness mark on the detailed status line. */
 export const RunningSession: Story = {
   args: {
     digest: runningDigest,

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -28,8 +28,8 @@ a stale one.
 ## Summary
 
 - Rust crates: 861
-- Desktop UI production packages: 531
-- Distinct license texts: 591
+- Desktop UI production packages: 535
+- Distinct license texts: 593
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -7246,6 +7246,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/101arrowz/fflate
 - License text: `LICENSE` ([L-0a1df3a083d0](#l-0a1df3a083d0))
 
+### framer-motion 13.1.1
+
+- License: `MIT`
+- Repository: https://github.com/motiondivision/motion/
+- License text: `LICENSE.md` ([L-aac842346e33](#l-aac842346e33))
+
 ### franc-min 6.2.0
 
 - License: `MIT`
@@ -7809,6 +7815,24 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: https://github.com/microsoft/monaco-editor
 - License text: `LICENSE` ([L-806766baa900](#l-806766baa900))
+
+### motion 13.1.1
+
+- License: `MIT`
+- Repository: https://github.com/motiondivision/motion
+- License text: `LICENSE.md` ([L-bb59eb35f694](#l-bb59eb35f694))
+
+### motion-dom 13.1.1
+
+- License: `MIT`
+- Repository: https://github.com/motiondivision/motion
+- License text: `LICENSE.md` ([L-bb59eb35f694](#l-bb59eb35f694))
+
+### motion-utils 13.0.0
+
+- License: `MIT`
+- Repository: https://github.com/motiondivision/motion
+- License text: `LICENSE.md` ([L-bb59eb35f694](#l-bb59eb35f694))
 
 ### ms 2.1.3
 
@@ -30279,6 +30303,32 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ```
 
+### L-aac842346e33
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2018 Framer B.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### L-ab72d9e790f7
 
 ```
@@ -31933,6 +31983,32 @@ THIS SOFTWARE.
 MIT License
 
 Copyright (c) 2017 Photopea
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### L-bb59eb35f694
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2024 [Motion](https://motion.dev) B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Install the BEUI motion loader through the shadcn registry and add its comet variant as Tidebreak’s live-status mark.
- Replace ambient workspace, agent, tool, transcript, and task-plan spinners while keeping action-specific spinners for refreshes, downloads, and other direct operations.
- Add reduced-motion behavior, focused DOM assertions, Storybook examples, design-system guidance, and updated third-party notices.

## Why

The comet gives ongoing agent activity a distinct status treatment without making it look like a button or document operation is waiting to finish.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/WorkspaceCard.dom.test.tsx src/code/AttentionBadge.dom.test.tsx src/TaskPlanCard.dom.test.tsx src/AgentRunTaskPlan.dom.test.tsx src/AgentActivityTimeline.dom.test.tsx src/ToolCallCard.dom.test.tsx src/ToolCallCard.test.tsx src/code/CodeTranscript.dom.test.tsx` — 108 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui lint`
- `pnpm --dir crates/tidebreak-desktop/ui build`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- `node scripts/generate-third-party-notices.mjs --check`

Visual screenshot capture was unavailable because this workspace has no connected browser or Playwright runtime. The `Foundations/Loader` stories cover the comet alone, supported sizes, and real status contexts.