### PR TITLE
fix(openai): stop routing revoked ChatGPT sessions

### DIFF
--- a/crates/tidebreak-router/src/openai.rs
+++ b/crates/tidebreak-router/src/openai.rs
@@ -250,18 +250,24 @@ impl ModelProvider for OpenAiProvider {
             .send()
             .await
             .map_err(|_| AgentError::Provider(format!("{provider_label} request failed")))?;
-        drop(authorization);
 
         let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            if let Some(source) = &self.token_source {
+                source.authentication_rejected(api_key).await;
+            }
+        }
+        drop(authorization);
         if !status.is_success() {
             let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
-            return Err(if provider_label == wire_provider {
+            let error = if provider_label == wire_provider {
                 self.profile
                     .classify_http_error(status.as_u16(), &body, retry_after)
             } else {
                 classify_provider_error(provider_label, status.as_u16(), &body, retry_after)
-            });
+            };
+            return Err(error);
         }
 
         let ceiling = crate::http::timeouts().total_stream;
@@ -1928,6 +1934,58 @@ mod tests {
             error.to_string(),
             "invalid provider request: openai returned 400: The requested model is not available for this account."
         );
+    }
+
+    #[tokio::test]
+    async fn a_rejected_dynamic_bearer_notifies_its_source() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        use axum::http::StatusCode;
+        use axum::routing::post;
+        use axum::Router;
+
+        use crate::BearerTokenSource;
+
+        struct RecordingSource(Arc<AtomicBool>);
+
+        #[async_trait]
+        impl BearerTokenSource for RecordingSource {
+            async fn bearer_token(&self) -> Result<String> {
+                Ok("revoked-token".into())
+            }
+
+            async fn authentication_rejected(&self, _bearer: &str) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        async fn reject() -> (StatusCode, &'static str) {
+            (
+                StatusCode::UNAUTHORIZED,
+                r#"{"error":{"code":"token_revoked","message":"token revoked"}}"#,
+            )
+        }
+
+        let app = Router::new().route("/v1/responses", post(reject));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let rejected = Arc::new(AtomicBool::new(false));
+        let provider = OpenAiProvider::new("")
+            .with_base_url(format!("http://{address}/v1"))
+            .with_token_source(Arc::new(RecordingSource(rejected.clone())));
+        let result = provider
+            .stream(ChatRequest {
+                model: "gpt-5.6-sol".into(),
+                messages: vec![ChatMessage::text(Role::User, "test")],
+                ..Default::default()
+            })
+            .await;
+
+        assert!(matches!(result, Err(AgentError::Authentication(_))));
+        assert!(rejected.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-router/src/router.rs
+++ b/crates/tidebreak-router/src/router.rs
@@ -92,6 +92,12 @@ pub trait BearerTokenSource: Send + Sync {
         let _ = conversation;
         self.bearer_token().await
     }
+
+    /// Record that the provider rejected this source's bearer as
+    /// authentication. Static and short-lived gateway sources need no local
+    /// action. A stored OAuth session can override this to stop later requests
+    /// from routing through a credential that now requires reconnection.
+    async fn authentication_rejected(&self, _bearer: &str) {}
 }
 
 /// A live claim that one host execution selector still maps to one wire model.

--- a/crates/tidebreak-server/src/chatgpt_runtime.rs
+++ b/crates/tidebreak-server/src/chatgpt_runtime.rs
@@ -19,6 +19,8 @@ use crate::error::ServerError;
 use crate::providers::{self, ProviderCredential, ProviderKind};
 
 const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(300);
+const RECONNECT_REQUIRED_MESSAGE: &str =
+    "Your ChatGPT session is no longer valid. Sign in with ChatGPT again.";
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 enum SignInProgress {
@@ -43,6 +45,7 @@ pub struct ChatGptRuntime {
     connection: Arc<ChatGptConnection>,
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
+    credential_motion: Arc<Mutex<()>>,
     sign_in: Mutex<SignInState>,
     sign_in_generation: AtomicU64,
 }
@@ -55,6 +58,7 @@ impl ChatGptRuntime {
             connection: Arc::new(ChatGptConnection::new(auth, vault)),
             store,
             secrets,
+            credential_motion: Arc::new(Mutex::new(())),
             sign_in: Mutex::new(SignInState::default()),
             sign_in_generation: AtomicU64::new(0),
         })
@@ -69,9 +73,20 @@ impl ChatGptRuntime {
     /// refresh token at OpenAI or resurrect a session that sign-out just
     /// cleared.
     pub async fn route_auth(&self) -> Option<(Arc<dyn BearerTokenSource>, String)> {
+        match providers::chatgpt_reconnect_required(&*self.store).await {
+            Ok(false) => {}
+            Ok(true) => return None,
+            Err(error) => {
+                tracing::warn!(%error, "could not read ChatGPT credential health");
+                return None;
+            }
+        }
         let account_id = self.connection.account_id().await.ok().flatten()?;
-        let source: Arc<dyn BearerTokenSource> =
-            Arc::new(ChatGptTokenSource(self.connection.clone()));
+        let source: Arc<dyn BearerTokenSource> = Arc::new(ChatGptTokenSource {
+            connection: self.connection.clone(),
+            store: self.store.clone(),
+            credential_motion: self.credential_motion.clone(),
+        });
         Some((source, account_id))
     }
 
@@ -136,6 +151,7 @@ impl ChatGptRuntime {
         &self,
         session: &crate::connectors::ChatGptAuthorizedSession,
     ) -> Result<(), ServerError> {
+        let _guard = self.credential_motion.lock().await;
         self.connection
             .store_session(session)
             .await
@@ -160,12 +176,14 @@ impl ChatGptRuntime {
         let mut config = providers::read_config(&*self.store, ProviderKind::Openai).await?;
         config.enabled = true;
         providers::write_config(&*self.store, ProviderKind::Openai, &config).await?;
+        providers::clear_chatgpt_reconnect_required(&*self.store).await?;
         Ok(())
     }
 
     /// Revoke best-effort, clear vault and Oauth marker.
     pub async fn sign_out(&self) -> Result<(), ServerError> {
         self.cancel_pending().await;
+        let _guard = self.credential_motion.lock().await;
         self.connection
             .sign_out()
             .await
@@ -176,12 +194,20 @@ impl ChatGptRuntime {
         ) {
             providers::delete_credential(&*self.secrets, ProviderKind::Openai).await?;
         }
+        providers::clear_chatgpt_reconnect_required(&*self.store).await?;
         Ok(())
     }
 
     /// Pending / failed status for the OpenAI Providers row.
     pub async fn status(&self) -> ChatGptSignInStatus {
         let progress = self.sign_in.lock().await.progress.clone();
+        let reconnect_required = match providers::chatgpt_reconnect_required(&*self.store).await {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::warn!(%error, "could not read ChatGPT credential health");
+                true
+            }
+        };
         // Same bar as routing: vault tokens alone are not a usable session.
         let signed_in = matches!(
             providers::read_credential(&*self.secrets, ProviderKind::Openai)
@@ -190,7 +216,8 @@ impl ChatGptRuntime {
                 .flatten(),
             Some(ProviderCredential::Oauth {})
         ) && crate::connectors::has_stored_chatgpt_credentials(&*self.secrets)
-            .await;
+            .await
+            && !reconnect_required;
         match progress {
             SignInProgress::Pending { authorization_url } => ChatGptSignInStatus {
                 signed_in,
@@ -205,7 +232,7 @@ impl ChatGptRuntime {
             SignInProgress::Idle => ChatGptSignInStatus {
                 signed_in,
                 pending_authorization_url: None,
-                error: None,
+                error: reconnect_required.then(|| RECONNECT_REQUIRED_MESSAGE.to_owned()),
             },
         }
     }
@@ -222,11 +249,186 @@ pub struct ChatGptSignInStatus {
     pub error: Option<String>,
 }
 
-struct ChatGptTokenSource(Arc<ChatGptConnection>);
+struct ChatGptTokenSource {
+    connection: Arc<ChatGptConnection>,
+    store: Arc<dyn Store>,
+    credential_motion: Arc<Mutex<()>>,
+}
 
 #[async_trait::async_trait]
 impl BearerTokenSource for ChatGptTokenSource {
     async fn bearer_token(&self) -> tidebreak_core::Result<String> {
-        self.0.access_token().await
+        let _guard = self.credential_motion.lock().await;
+        if providers::chatgpt_reconnect_required(&*self.store).await? {
+            return Err(tidebreak_core::AgentError::SignInRequired(
+                RECONNECT_REQUIRED_MESSAGE.to_owned(),
+            ));
+        }
+        self.connection.access_token().await
+    }
+
+    async fn authentication_rejected(&self, bearer: &str) {
+        let _guard = self.credential_motion.lock().await;
+        match self.connection.stored_access_token_matches(bearer).await {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(error) => {
+                tracing::warn!(%error, "could not compare the rejected ChatGPT credential");
+                return;
+            }
+        }
+        if let Err(error) = providers::mark_chatgpt_reconnect_required(&*self.store).await {
+            tracing::warn!(%error, "could not mark the ChatGPT credential for reconnection");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    use tidebreak_core::{DbStore, SecretProvider};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestSecrets(StdMutex<HashMap<String, String>>);
+
+    #[async_trait::async_trait]
+    impl SecretProvider for TestSecrets {
+        async fn get_secret(&self, key: &str) -> tidebreak_core::Result<Option<String>> {
+            Ok(self.0.lock().unwrap().get(key).cloned())
+        }
+
+        async fn set_secret(&self, key: &str, value: &str) -> tidebreak_core::Result<()> {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(key.to_owned(), value.to_owned());
+            Ok(())
+        }
+
+        async fn delete_secret(&self, key: &str) -> tidebreak_core::Result<()> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn a_provider_rejection_requires_reconnect_without_deleting_the_session() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("chatgpt-health.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets = Arc::new(TestSecrets::default());
+        providers::write_credential(
+            &*secrets,
+            ProviderKind::Openai,
+            &ProviderCredential::Oauth {},
+        )
+        .await
+        .unwrap();
+        secrets
+            .set_secret(
+                crate::connectors::CHATGPT_SECRET_KEY,
+                &serde_json::json!({
+                    "access_token": "access",
+                    "refresh_token": "refresh",
+                    "account_id": "acct-test",
+                    "expires_at_unix": 4_102_444_800_u64,
+                })
+                .to_string(),
+            )
+            .await
+            .unwrap();
+        providers::write_config(
+            &*store,
+            ProviderKind::Openai,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: None,
+                models: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        let runtime = ChatGptRuntime::new(store.clone(), secrets.clone()).unwrap();
+        let (source, _) = runtime
+            .route_auth()
+            .await
+            .expect("the session routes first");
+
+        source.authentication_rejected("access").await;
+
+        assert!(runtime.route_auth().await.is_none());
+        let status = runtime.status().await;
+        assert!(!status.signed_in);
+        assert_eq!(status.error.as_deref(), Some(RECONNECT_REQUIRED_MESSAGE));
+        assert!(crate::connectors::has_stored_chatgpt_credentials(&*secrets).await);
+        assert!(matches!(
+            providers::read_credential(&*secrets, ProviderKind::Openai)
+                .await
+                .unwrap(),
+            Some(ProviderCredential::Oauth {})
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_stale_rejection_cannot_disable_a_replacement_session() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("chatgpt-stale-health.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets = Arc::new(TestSecrets::default());
+        providers::write_credential(
+            &*secrets,
+            ProviderKind::Openai,
+            &ProviderCredential::Oauth {},
+        )
+        .await
+        .unwrap();
+        let credentials = |access_token: &str| {
+            serde_json::json!({
+                "access_token": access_token,
+                "refresh_token": "refresh",
+                "account_id": "acct-test",
+                "expires_at_unix": 4_102_444_800_u64,
+            })
+            .to_string()
+        };
+        secrets
+            .set_secret(
+                crate::connectors::CHATGPT_SECRET_KEY,
+                &credentials("old-access"),
+            )
+            .await
+            .unwrap();
+        let runtime = ChatGptRuntime::new(store.clone(), secrets.clone()).unwrap();
+        let (source, _) = runtime.route_auth().await.expect("the old session routes");
+        secrets
+            .set_secret(
+                crate::connectors::CHATGPT_SECRET_KEY,
+                &credentials("new-access"),
+            )
+            .await
+            .unwrap();
+
+        source.authentication_rejected("old-access").await;
+
+        assert!(!providers::chatgpt_reconnect_required(&*store)
+            .await
+            .unwrap());
+        assert!(runtime.route_auth().await.is_some());
     }
 }

--- a/crates/tidebreak-server/src/connectors/chatgpt.rs
+++ b/crates/tidebreak-server/src/connectors/chatgpt.rs
@@ -551,6 +551,19 @@ impl ChatGptConnection {
         self.vault.load().await
     }
 
+    /// Whether `candidate` is still the stored access token.
+    ///
+    /// A provider rejection can arrive after a completed sign-in replaced the
+    /// credential that sent the request. Callers compare before recording a
+    /// reconnect need so that a stale response cannot disable the new session.
+    pub async fn stored_access_token_matches(&self, candidate: &str) -> Result<bool> {
+        Ok(self
+            .vault
+            .load()
+            .await?
+            .is_some_and(|credentials| credentials.access_token == candidate))
+    }
+
     /// A currently valid access token, refreshing near expiry.
     pub async fn access_token(&self) -> Result<String> {
         let _guard = self.token_motion.lock().await;

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -806,6 +806,37 @@ pub struct ProviderConfig {
     pub models: Vec<CustomModelConfig>,
 }
 
+/// Non-secret runtime health for a stored ChatGPT OAuth session.
+///
+/// The OAuth credential remains in the OS vault so reconnect and explicit
+/// sign-out retain their normal ownership. This store marker only prevents a
+/// provider rejection from being advertised and routed again.
+const CHATGPT_RECONNECT_REQUIRED_SETTING: &str = "provider.openai.chatgpt_reconnect_required";
+
+pub(crate) async fn chatgpt_reconnect_required(store: &dyn Store) -> Result<bool> {
+    Ok(matches!(
+        store
+            .get_setting(CHATGPT_RECONNECT_REQUIRED_SETTING)
+            .await?,
+        Some(serde_json::Value::Bool(true))
+    ))
+}
+
+pub(crate) async fn mark_chatgpt_reconnect_required(store: &dyn Store) -> Result<()> {
+    store
+        .set_setting(
+            CHATGPT_RECONNECT_REQUIRED_SETTING,
+            &serde_json::Value::Bool(true),
+        )
+        .await
+}
+
+pub(crate) async fn clear_chatgpt_reconnect_required(store: &dyn Store) -> Result<()> {
+    store
+        .delete_setting(CHATGPT_RECONNECT_REQUIRED_SETTING)
+        .await
+}
+
 impl ProviderConfig {
     /// Default config when nothing is stored: disabled, no base URL.
     pub fn disabled() -> Self {
@@ -1705,12 +1736,22 @@ pub async fn list_providers(
             continue;
         }
         let config = read_config(store, kind).await?;
+        let auth_mode = auth_mode_for(secrets, kind).await;
+        let has_credential = has_credential(secrets, kind).await;
+        let has_credential = if kind == ProviderKind::Openai
+            && auth_mode == Some(ProviderAuthMode::Chatgpt)
+            && chatgpt_reconnect_required(store).await?
+        {
+            false
+        } else {
+            has_credential
+        };
         out.push(ProviderInfo {
             kind,
             enabled: config.enabled,
             base_url: kind.effective_base_url(config.base_url.as_deref()),
-            has_credential: has_credential(secrets, kind).await,
-            auth_mode: auth_mode_for(secrets, kind).await,
+            has_credential,
+            auth_mode,
             models: config.models,
         });
     }
@@ -1836,6 +1877,9 @@ pub async fn update_provider(
     }
 
     write_config(store, kind, &config).await?;
+    if kind == ProviderKind::Openai && credential_changed {
+        clear_chatgpt_reconnect_required(store).await?;
+    }
 
     Ok(ProviderInfo {
         kind,
@@ -2443,6 +2487,15 @@ pub async fn provider_is_usable(
         return Ok(false);
     }
     if kind.requires_credential() && !has_credential(secrets, kind).await {
+        return Ok(false);
+    }
+    if kind == ProviderKind::Openai
+        && matches!(
+            auth_mode_for(secrets, kind).await,
+            Some(ProviderAuthMode::Chatgpt)
+        )
+        && chatgpt_reconnect_required(store).await?
+    {
         return Ok(false);
     }
     if !matches!(kind, ProviderKind::Gemini | ProviderKind::Xai) {

--- a/crates/tidebreak-server/src/providers/tests.rs
+++ b/crates/tidebreak-server/src/providers/tests.rs
@@ -228,6 +228,80 @@ async fn upgrade_enables_missing_provider_rows_for_existing_authentication() {
 }
 
 #[tokio::test]
+async fn a_rejected_chatgpt_session_stays_stored_but_is_not_routable() {
+    let (store, _directory) = provider_test_store().await;
+    let secrets = TestSecrets::default();
+    store_chatgpt_session(&secrets).await;
+    write_config(
+        &store,
+        ProviderKind::Openai,
+        &ProviderConfig {
+            enabled: true,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    mark_chatgpt_reconnect_required(&store).await.unwrap();
+    let policy = crate::managed_policy::resolve(
+        &*crate::managed_policy::MemoryProvisionedPolicy::new(),
+        &crate::managed_policy::NoOsPolicy,
+    )
+    .unwrap();
+
+    assert!(has_credential(&secrets, ProviderKind::Openai).await);
+    assert!(
+        !provider_is_usable(&store, &secrets, ProviderKind::Openai, &policy, None)
+            .await
+            .unwrap()
+    );
+    let openai = list_providers(&store, &secrets, &policy, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|provider| provider.kind == ProviderKind::Openai)
+        .unwrap();
+    assert!(!openai.has_credential);
+    assert_eq!(openai.auth_mode, Some(ProviderAuthMode::Chatgpt));
+    assert!(catalog_models(&store, &secrets, &policy, None)
+        .await
+        .unwrap()
+        .iter()
+        .filter(|model| model.policy.provider == ProviderKind::Openai)
+        .all(|model| !model.available));
+}
+
+#[tokio::test]
+async fn replacing_a_rejected_chatgpt_session_with_an_api_key_restores_routing() {
+    let (store, _directory) = provider_test_store().await;
+    let secrets = TestSecrets::default();
+    store_chatgpt_session(&secrets).await;
+    mark_chatgpt_reconnect_required(&store).await.unwrap();
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+
+    let info = update_provider(
+        &store,
+        &secrets,
+        ProviderKind::Openai,
+        ProviderUpdate {
+            enabled: None,
+            base_url: None,
+            credential: Some(ProviderCredential::api_key("replacement")),
+            models: None,
+        },
+        &*provisioned,
+        &crate::managed_policy::NoOsPolicy,
+    )
+    .await
+    .unwrap();
+
+    assert!(info.has_credential);
+    assert_eq!(info.auth_mode, Some(ProviderAuthMode::ApiKey));
+    assert!(!chatgpt_reconnect_required(&store).await.unwrap());
+}
+
+#[tokio::test]
 async fn upgrade_preserves_an_explicitly_disabled_openai_provider() {
     let (store, _directory) = provider_test_store().await;
     let secrets = TestSecrets::default();

--- a/crates/tidebreak-server/src/routes/providers_models.rs
+++ b/crates/tidebreak-server/src/routes/providers_models.rs
@@ -447,6 +447,9 @@ pub async fn delete_provider_credential(
         state.chatgpt.sign_out().await?;
     }
     providers::delete_credential(&*state.secrets, kind).await?;
+    if kind == ProviderKind::Openai {
+        providers::clear_chatgpt_reconnect_required(&*state.store).await?;
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -1669,6 +1669,104 @@ async fn chatgpt_auth_marks_api_only_openai_models_unavailable() {
 }
 
 #[tokio::test]
+async fn a_rejected_chatgpt_session_is_unavailable_across_configuration_routes() {
+    let (router, token, state, store, _dir) = test_app_with_state().await;
+    let bearer = format!("Bearer {token}");
+    providers::write_credential(
+        &*state.secrets,
+        providers::ProviderKind::Openai,
+        &providers::ProviderCredential::Oauth {},
+    )
+    .await
+    .unwrap();
+    state
+        .secrets
+        .set_secret(
+            crate::connectors::CHATGPT_SECRET_KEY,
+            &serde_json::json!({
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "account_id": "acct-test",
+                "expires_at_unix": 4_102_444_800_u64,
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Openai,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    providers::mark_chatgpt_reconnect_required(&*store)
+        .await
+        .unwrap();
+
+    let providers_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/providers")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let providers_body: serde_json::Value = json_body(providers_response).await;
+    let openai = providers_body["providers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|provider| provider["kind"] == "openai")
+        .unwrap();
+    assert_eq!(openai["auth_mode"], "chatgpt");
+    assert_eq!(openai["has_credential"], false);
+
+    let models_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/models")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let models_body: serde_json::Value = json_body(models_response).await;
+    assert!(models_body["models"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|model| model["provider"] == "openai")
+        .all(|model| model["available"] == false));
+
+    let status_response = router
+        .oneshot(
+            Request::builder()
+                .uri("/providers/openai/chatgpt/status")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status: serde_json::Value = json_body(status_response).await;
+    assert_eq!(status["signed_in"], false);
+    assert_eq!(
+        status["error"],
+        "Your ChatGPT session is no longer valid. Sign in with ChatGPT again."
+    );
+}
+
+#[tokio::test]
 async fn xai_settings_publish_curated_and_explicit_model_capabilities() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");


### PR DESCRIPTION
OpenAI can return HTTP 401 after a stored ChatGPT OAuth session is revoked. Tidebreak kept advertising and routing that session, so every later turn retried a credential that required reconnection.

This change records a non-secret reconnect marker when OpenAI rejects the active bearer. Provider and model projections stop advertising the session, cached routers fail locally, and the ChatGPT status endpoint tells you to sign in again. A later sign-in, API-key replacement, sign-out, or credential deletion clears the marker. The credential stays stored until you reconnect or sign out.

Tests cover rejection notification, cached routing, stale 401 responses after credential replacement, provider and model availability, and the public configuration routes.

Validated with:

- `cargo check -p tidebreak-router -p tidebreak-server`
- Focused router, provider, ChatGPT runtime, and configuration-route tests
- `cargo fmt --all -- --check`
- `git diff --check`