### PR TITLE
fix(agent): distinguish blocked turn outcomes

### DIFF
--- a/crates/tidebreak-core/fixtures/code-journal-events.json
+++ b/crates/tidebreak-core/fixtures/code-journal-events.json
@@ -136,9 +136,10 @@
     },
     "refusal": {
       "details": {
-        "category": "cyber"
+        "category": "blocked"
       },
-      "partial_output": true
+      "partial_output": true,
+      "source": "report_blocked"
     }
   },
   {

--- a/crates/tidebreak-core/fixtures/journal-events.json
+++ b/crates/tidebreak-core/fixtures/journal-events.json
@@ -108,9 +108,10 @@
     },
     "refusal": {
       "details": {
-        "category": "cyber"
+        "category": "blocked"
       },
-      "partial_output": true
+      "partial_output": true,
+      "source": "report_blocked"
     }
   },
   {

--- a/crates/tidebreak-core/src/agent/turn.rs
+++ b/crates/tidebreak-core/src/agent/turn.rs
@@ -23,7 +23,7 @@ use crate::model::{
 use crate::preview::ToolResultPreview;
 use crate::provider::{
     ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
-    ReasoningOrigin, RefusalDetails, RefusalOutcome, StopReason, Usage,
+    ReasoningOrigin, RefusalOutcome, StopReason, Usage,
 };
 use crate::steer::SteerInbox;
 use crate::storage::{
@@ -893,10 +893,7 @@ impl Agent {
                     citations: Vec::new(),
                     usage: total_usage,
                     stop_reason: StopReason::Refusal,
-                    refusal: Some(RefusalOutcome::new(
-                        RefusalDetails::from_category(Some("blocked")),
-                        true,
-                    )),
+                    refusal: Some(RefusalOutcome::report_blocked()),
                     steer_revision: Some(steer_revision),
                     model_steps: steps_used,
                 });

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -773,10 +773,7 @@ mod tests {
                     context_tokens: 0,
                     first_call_context_tokens: None,
                 },
-                refusal: RefusalOutcome::new(
-                    crate::provider::RefusalDetails::from_category(Some("cyber")),
-                    true,
-                ),
+                refusal: RefusalOutcome::report_blocked(),
             },
             CodeEvent::StreamInterrupted,
             CodeEvent::ToolArgsDelta {

--- a/crates/tidebreak-core/src/db/ops/turn/resolution.rs
+++ b/crates/tidebreak-core/src/db/ops/turn/resolution.rs
@@ -1061,13 +1061,7 @@ where
         event,
     )
     .await?;
-    let notification_kind = match event {
-        AgentEvent::TurnCompleted { .. } | AgentEvent::TurnRefused { .. } => {
-            Some(crate::NotificationKind::AgentCompleted)
-        }
-        AgentEvent::TurnFailed { .. } => Some(crate::NotificationKind::AgentFailed),
-        _ => None,
-    };
+    let notification_kind = terminal_notification_kind(event);
     if let Some(kind) = notification_kind {
         super::super::notification::record_work_turn_notification_on(conn, chat_id, id, kind)
             .await?;
@@ -1106,13 +1100,7 @@ where
             "turn {id} has a different terminal event"
         )));
     }
-    let notification_kind = match &event {
-        AgentEvent::TurnCompleted { .. } | AgentEvent::TurnRefused { .. } => {
-            Some(crate::NotificationKind::AgentCompleted)
-        }
-        AgentEvent::TurnFailed { .. } => Some(crate::NotificationKind::AgentFailed),
-        _ => None,
-    };
+    let notification_kind = terminal_notification_kind(&event);
     if let Some(kind) = notification_kind {
         super::super::notification::record_work_turn_notification_on(
             conn,
@@ -1126,6 +1114,18 @@ where
         seq: stored.seq,
         event,
     }))
+}
+
+fn terminal_notification_kind(event: &AgentEvent) -> Option<crate::NotificationKind> {
+    match event {
+        AgentEvent::TurnCompleted { .. } => Some(crate::NotificationKind::AgentCompleted),
+        AgentEvent::TurnRefused { refusal, .. } if refusal.category() == Some("blocked") => {
+            Some(crate::NotificationKind::AgentFailed)
+        }
+        AgentEvent::TurnRefused { .. } => Some(crate::NotificationKind::AgentCompleted),
+        AgentEvent::TurnFailed { .. } => Some(crate::NotificationKind::AgentFailed),
+        _ => None,
+    }
 }
 
 async fn exact_failure_terminal_event_on<C>(

--- a/crates/tidebreak-core/src/db/ops/turn/resolution.rs
+++ b/crates/tidebreak-core/src/db/ops/turn/resolution.rs
@@ -1119,7 +1119,9 @@ where
 fn terminal_notification_kind(event: &AgentEvent) -> Option<crate::NotificationKind> {
     match event {
         AgentEvent::TurnCompleted { .. } => Some(crate::NotificationKind::AgentCompleted),
-        AgentEvent::TurnRefused { refusal, .. } if refusal.category() == Some("blocked") => {
+        AgentEvent::TurnRefused { refusal, .. }
+            if refusal.source() == Some(crate::RefusalSource::ReportBlocked) =>
+        {
             Some(crate::NotificationKind::AgentFailed)
         }
         AgentEvent::TurnRefused { .. } => Some(crate::NotificationKind::AgentCompleted),

--- a/crates/tidebreak-core/src/db/tests/turn_terminal_usage.rs
+++ b/crates/tidebreak-core/src/db/tests/turn_terminal_usage.rs
@@ -228,7 +228,7 @@ async fn refused_terminal_event_replaces_checkpoint_with_authoritative_totals() 
 }
 
 #[tokio::test]
-async fn blocked_refusal_mints_a_failed_notification() {
+async fn report_blocked_refusal_mints_a_failed_notification() {
     let (_dir, store) = temp_store().await;
     let (chat, turn_id, lease_token, claimed_at) =
         claimed_turn(&store, "report an operational blocker").await;
@@ -253,7 +253,7 @@ async fn blocked_refusal_mints_a_failed_notification() {
         &[],
         1,
         Usage::default(),
-        RefusalOutcome::new(RefusalDetails::from_category(Some("blocked")), true),
+        RefusalOutcome::report_blocked(),
     )
     .await
     .unwrap()
@@ -266,4 +266,45 @@ async fn blocked_refusal_mints_a_failed_notification() {
     assert_eq!(notifications.len(), 1);
     assert_eq!(notifications[0].kind, NotificationKind::AgentFailed);
     assert_eq!(notifications[0].title, "hello failed");
+}
+
+#[tokio::test]
+async fn provider_blocked_refusal_remains_a_completed_notification() {
+    let (_dir, store) = temp_store().await;
+    let (chat, turn_id, lease_token, claimed_at) =
+        claimed_turn(&store, "persist a provider refusal").await;
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        reasoning: Default::default(),
+        content: "Provider refusal".into(),
+        llm_content: None,
+        created_at: claimed_at + Duration::seconds(1),
+    };
+
+    super::super::ops::turn::complete_refused_turn_with_citations_and_append_event(
+        &store,
+        turn_id,
+        lease_token,
+        0,
+        output.created_at,
+        &output,
+        &[],
+        1,
+        Usage::default(),
+        RefusalOutcome::new(RefusalDetails::from_category(Some("blocked")), true),
+    )
+    .await
+    .unwrap()
+    .expect("live provider refusal completion");
+
+    let notifications = store
+        .list_notifications_scoped(&OwnerId::local(), None, 50)
+        .await
+        .unwrap();
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].kind, NotificationKind::AgentCompleted);
+    assert_eq!(notifications[0].title, "hello finished");
 }

--- a/crates/tidebreak-core/src/db/tests/turn_terminal_usage.rs
+++ b/crates/tidebreak-core/src/db/tests/turn_terminal_usage.rs
@@ -219,4 +219,51 @@ async fn refused_terminal_event_replaces_checkpoint_with_authoritative_totals() 
     let stored = store.get_turn(turn_id).await.unwrap().unwrap();
     assert_eq!((stored.model_steps, stored.usage), (4, total));
     assert_ne!(stored.usage, checkpoint);
+    let notifications = store
+        .list_notifications_scoped(&OwnerId::local(), None, 50)
+        .await
+        .unwrap();
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].kind, NotificationKind::AgentCompleted);
+}
+
+#[tokio::test]
+async fn blocked_refusal_mints_a_failed_notification() {
+    let (_dir, store) = temp_store().await;
+    let (chat, turn_id, lease_token, claimed_at) =
+        claimed_turn(&store, "report an operational blocker").await;
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        reasoning: Default::default(),
+        content: "Docker is unavailable, so I could not run the required script.".into(),
+        llm_content: None,
+        created_at: claimed_at + Duration::seconds(1),
+    };
+
+    super::super::ops::turn::complete_refused_turn_with_citations_and_append_event(
+        &store,
+        turn_id,
+        lease_token,
+        0,
+        output.created_at,
+        &output,
+        &[],
+        1,
+        Usage::default(),
+        RefusalOutcome::new(RefusalDetails::from_category(Some("blocked")), true),
+    )
+    .await
+    .unwrap()
+    .expect("live blocked completion");
+
+    let notifications = store
+        .list_notifications_scoped(&OwnerId::local(), None, 50)
+        .await
+        .unwrap();
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].kind, NotificationKind::AgentFailed);
+    assert_eq!(notifications[0].title, "hello failed");
 }

--- a/crates/tidebreak-core/src/event.rs
+++ b/crates/tidebreak-core/src/event.rs
@@ -407,10 +407,7 @@ mod tests {
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
                 },
-                refusal: RefusalOutcome::new(
-                    crate::provider::RefusalDetails::from_category(Some("cyber")),
-                    true,
-                ),
+                refusal: RefusalOutcome::report_blocked(),
             },
             AgentEvent::TurnFailed {
                 error: (&AgentError::config("no provider")).into(),

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -321,8 +321,8 @@ pub use preview::{
 pub use provider::{
     provider_executed_tool_call_text, ChatMessage, ChatRequest, ContentBlock, MessageReasoning,
     ModelProvider, PromptCacheMode, PromptCacheRetention, ProviderEvent, ProviderId,
-    ProviderToolReplay, ReasoningOrigin, RefusalDetails, RefusalOutcome, ResponseFormat,
-    StopReason, ToolChoice, Usage, VendorWebSearch,
+    ProviderToolReplay, ReasoningOrigin, RefusalDetails, RefusalOutcome, RefusalSource,
+    ResponseFormat, StopReason, ToolChoice, Usage, VendorWebSearch,
 };
 pub use renderer_tool::RendererToolName;
 pub use secret_bundle::{

--- a/crates/tidebreak-core/src/provider.rs
+++ b/crates/tidebreak-core/src/provider.rs
@@ -726,11 +726,26 @@ impl<'de> Deserialize<'de> for RefusalDetails {
     }
 }
 
+/// The Tidebreak-owned source of a refusal, when one exists.
+///
+/// Provider refusals leave this absent. Keeping the field optional preserves
+/// journal rows written before Tidebreak recorded its own terminal blockers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RefusalSource {
+    /// The foreground model ended the turn through `report_blocked`.
+    ReportBlocked,
+}
+
 /// Durable outcome metadata for a refused completion.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 pub struct RefusalOutcome {
     details: RefusalDetails,
     partial_output: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    source: Option<RefusalSource>,
 }
 
 impl RefusalOutcome {
@@ -740,6 +755,17 @@ impl RefusalOutcome {
         Self {
             details,
             partial_output,
+            source: None,
+        }
+    }
+
+    /// Build the terminal refusal produced by a valid `report_blocked` call.
+    #[must_use]
+    pub fn report_blocked() -> Self {
+        Self {
+            details: RefusalDetails::from_category(Some("blocked")),
+            partial_output: true,
+            source: Some(RefusalSource::ReportBlocked),
         }
     }
 
@@ -753,6 +779,13 @@ impl RefusalOutcome {
     #[must_use]
     pub fn partial_output(&self) -> bool {
         self.partial_output
+    }
+
+    /// Return the Tidebreak-owned source, if this refusal did not come from
+    /// the provider.
+    #[must_use]
+    pub fn source(&self) -> Option<RefusalSource> {
+        self.source
     }
 }
 

--- a/crates/tidebreak-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatSessionReducer.ts
@@ -482,6 +482,7 @@ export function reduceChatSessionEvent(
               role: "refusal",
               category: event.refusal.category,
               partialOutput: event.refusal.partial_output,
+              source: event.refusal.source,
             },
           ],
         },

--- a/crates/tidebreak-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -608,6 +608,9 @@ describe("terminal transcript presentation", () => {
       "The model declined this response because it matched a safety policy.",
     );
     expect(refusalCopy("blocked", true)).toBe(
+      "The response above is incomplete. The model declined this response because it matched the blocked safety category.",
+    );
+    expect(refusalCopy("blocked", true, "report_blocked")).toBe(
       "Tidebreak could not complete this task.",
     );
   });

--- a/crates/tidebreak-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -607,6 +607,9 @@ describe("terminal transcript presentation", () => {
     expect(refusalCopy(null, false)).toBe(
       "The model declined this response because it matched a safety policy.",
     );
+    expect(refusalCopy("blocked", true)).toBe(
+      "Tidebreak could not complete this task.",
+    );
   });
 
   it("surfaces a turn's memory proposals right after the turn that produced them", () => {

--- a/crates/tidebreak-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/tidebreak-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -148,6 +148,7 @@ export function presentChatTranscript(
             role: "refusal",
             category: entry.refusal.category,
             partialOutput: entry.refusal.partial_output,
+            source: entry.refusal.source,
           } satisfies ChatMessage,
         ];
       }

--- a/crates/tidebreak-desktop/ui/src/MessageList.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.tsx
@@ -58,7 +58,10 @@ import {
 } from "./MessageWebSources";
 import { useSourceNav } from "./panel/SourceNav";
 import { TurnFailureNotice, turnFailureOffersRetry } from "./TurnFailureNotice";
-import type { TurnFailureCategory } from "./generated/wire";
+import type {
+  RendererRefusalSource,
+  TurnFailureCategory,
+} from "./generated/wire";
 import { ChangeSummaryCard } from "./ChangeSummaryCard";
 import {
   MemoryProposalCard,
@@ -96,6 +99,7 @@ export type ChatMessage =
       role: "refusal";
       category: string | null;
       partialOutput: boolean;
+      source?: RendererRefusalSource;
     }
   | {
       id: string;
@@ -1319,7 +1323,7 @@ function MessageBubbleImpl({
   if (message.role === "refusal") {
     return (
       <div className="message-notice is-refusal" role="status">
-        {refusalCopy(message.category, message.partialOutput)}
+        {refusalCopy(message.category, message.partialOutput, message.source)}
       </div>
     );
   }
@@ -1340,8 +1344,9 @@ export const TURN_CANCELLED_NOTICE = "Response cancelled";
 export function refusalCopy(
   category: string | null,
   partialOutput: boolean,
+  source?: RendererRefusalSource,
 ): string {
-  if (category === "blocked") {
+  if (source === "report_blocked") {
     return "Tidebreak could not complete this task.";
   }
   const reason =

--- a/crates/tidebreak-desktop/ui/src/MessageList.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.tsx
@@ -1341,6 +1341,9 @@ export function refusalCopy(
   category: string | null,
   partialOutput: boolean,
 ): string {
+  if (category === "blocked") {
+    return "Tidebreak could not complete this task.";
+  }
   const reason =
     (
       {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -1113,9 +1113,19 @@ describe("parseCodeEvent", () => {
     const refused = {
       type: "turn_refused",
       usage,
-      refusal: { details: { category: "cyber" }, partial_output: true },
+      refusal: {
+        details: { category: "blocked" },
+        partial_output: true,
+        source: "report_blocked",
+      },
     };
     expect(parseCodeEvent(refused)).toEqual(refused);
+    expect(
+      parseCodeEvent({
+        ...refused,
+        refusal: { ...refused.refusal, source: "provider" },
+      }),
+    ).toBeNull();
     expect(
       parseCodeEvent({
         ...refused,

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -3749,8 +3749,16 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
           "refusal",
         ]) ||
         !isRecord(value.refusal) ||
+        !onlyKeys<Extract<WireCodeEvent, { type: "turn_refused" }>["refusal"]>(
+          value.refusal,
+          ["details", "partial_output", "source"],
+        ) ||
         !isRecord(value.refusal.details) ||
         typeof value.refusal.partial_output !== "boolean" ||
+        !(
+          value.refusal.source === undefined ||
+          value.refusal.source === "report_blocked"
+        ) ||
         !(
           value.refusal.details.category === null ||
           typeof value.refusal.details.category === "string"
@@ -3766,6 +3774,7 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
         refusal: {
           details: { category: value.refusal.details.category },
           partial_output: value.refusal.partial_output,
+          ...(value.refusal.source ? { source: value.refusal.source } : {}),
         },
       };
     }

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -4643,7 +4643,15 @@ export type RefusalDetails = { category: string | null, };
 /**
  * Durable outcome metadata for a refused completion.
  */
-export type RefusalOutcome = { details: RefusalDetails, partial_output: boolean, };
+export type RefusalOutcome = { details: RefusalDetails, partial_output: boolean, source?: RefusalSource, };
+
+/**
+ * The Tidebreak-owned source of a refusal, when one exists.
+ *
+ * Provider refusals leave this absent. Keeping the field optional preserves
+ * journal rows written before Tidebreak recorded its own terminal blockers.
+ */
+export type RefusalSource = "report_blocked";
 
 export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta", text: string, } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "plan_proposed", call_id: CallId, turn_id: TurnId, } | { "type": "task_plan_updated", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass,
 /**
@@ -4728,7 +4736,12 @@ export type RendererModelIdentity = { id: string, provider: ProviderKind, };
 /**
  * Bounded refusal metadata safe to present in the desktop transcript.
  */
-export type RendererRefusal = { category: string | null, partial_output: boolean, };
+export type RendererRefusal = { category: string | null, partial_output: boolean, source?: RendererRefusalSource, };
+
+/**
+ * The Tidebreak-owned source of a refusal, when one exists.
+ */
+export type RendererRefusalSource = "report_blocked";
 
 export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, replayed?: boolean, };
 

--- a/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
@@ -268,6 +268,7 @@ const blockedMessages: ChatMessage[] = [
     role: "refusal",
     category: "blocked",
     partialOutput: true,
+    source: "report_blocked",
   },
 ];
 

--- a/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
@@ -248,6 +248,29 @@ const failureMessages: ChatMessage[] = [
   },
 ];
 
+const blockedMessages: ChatMessage[] = [
+  {
+    id: "blocked-user",
+    role: "user",
+    text: "Run the required browser smoke check and save the results.",
+    invokedSkills: ["browser"],
+    createdAt: "2026-09-03T04:44:00.000Z",
+  },
+  {
+    id: "blocked-assistant",
+    role: "assistant",
+    text: "No browser is connected to this Tidebreak profile, so I could not run the required smoke check or save its results.",
+    sources: [],
+    createdAt: "2026-09-03T04:45:00.000Z",
+  },
+  {
+    id: "blocked-refusal",
+    role: "refusal",
+    category: "blocked",
+    partialOutput: true,
+  },
+];
+
 const denseMessages: ChatMessage[] = [
   {
     id: "dense-user-1",
@@ -396,6 +419,11 @@ export const ToolHeavySession: Story = {};
 
 export const RetryableFailure: Story = {
   args: { messages: failureMessages },
+};
+
+/** An operational blocker stays distinct from a provider safety refusal. */
+export const BlockedTurn: Story = {
+  args: { messages: blockedMessages },
 };
 
 export const DenseLongRunningSession: Story = {

--- a/crates/tidebreak-server/fixtures/chat-frames.json
+++ b/crates/tidebreak-server/fixtures/chat-frames.json
@@ -214,8 +214,9 @@
     "frame": {
       "event": {
         "refusal": {
-          "category": "safety",
-          "partial_output": true
+          "category": "blocked",
+          "partial_output": true,
+          "source": "report_blocked"
         },
         "type": "turn_refused",
         "usage": {

--- a/crates/tidebreak-server/fixtures/code-frames.json
+++ b/crates/tidebreak-server/fixtures/code-frames.json
@@ -1046,9 +1046,10 @@
       "event": {
         "refusal": {
           "details": {
-            "category": "safety"
+            "category": "blocked"
           },
-          "partial_output": true
+          "partial_output": true,
+          "source": "report_blocked"
         },
         "type": "turn_refused",
         "usage": {

--- a/crates/tidebreak-server/src/event_projection.rs
+++ b/crates/tidebreak-server/src/event_projection.rs
@@ -149,6 +149,16 @@ impl From<tidebreak_core::Usage> for RendererTurnUsage {
 pub struct RendererRefusal {
     pub category: Option<String>,
     pub partial_output: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub source: Option<RendererRefusalSource>,
+}
+
+/// The Tidebreak-owned source of a refusal, when one exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum RendererRefusalSource {
+    ReportBlocked,
 }
 
 /// Exact model route involved in a provider failure, with no diagnostics.
@@ -172,6 +182,12 @@ impl From<&tidebreak_core::RefusalOutcome> for RendererRefusal {
         Self {
             category: value.category().map(str::to_owned),
             partial_output: value.partial_output(),
+            source: match value.source() {
+                Some(tidebreak_core::RefusalSource::ReportBlocked) => {
+                    Some(RendererRefusalSource::ReportBlocked)
+                }
+                Some(_) | None => None,
+            },
         }
     }
 }
@@ -605,6 +621,7 @@ mod tests {
                     refusal: RendererRefusal {
                         category: Some("general_harms".into()),
                         partial_output: true,
+                        source: None,
                     },
                     usage: RendererTurnUsage {
                         input_tokens: 42,

--- a/crates/tidebreak-server/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server/src/wire_code_fixtures.rs
@@ -27,8 +27,8 @@ use tidebreak_core::{
     CodeWatchState, CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, GrantScope,
     HarnessCaps, HarnessCommand, HarnessKind, HarnessNoticeLevel, HarnessTier, ImageMediaType,
     ImageRef, InternalApprovalRequest, PermissionMode, PullRequestCheckCounts, PullRequestDigest,
-    QuickAction, ReasoningEffort, RefusalDetails, RefusalOutcome, RepoId, ToolApprovalKind,
-    ToolDetail, ToolOutcome, WorkspaceId,
+    QuickAction, ReasoningEffort, RefusalOutcome, RepoId, ToolApprovalKind, ToolDetail,
+    ToolOutcome, WorkspaceId,
 };
 
 /// Path of the shared code-mode fixtures, relative to this crate.
@@ -884,10 +884,7 @@ fn event_frames() -> Vec<Fixture> {
                 56,
                 CodeEvent::TurnRefused {
                     usage: usage(),
-                    refusal: RefusalOutcome::new(
-                        RefusalDetails::from_category(Some("safety")),
-                        true,
-                    ),
+                    refusal: RefusalOutcome::report_blocked(),
                 },
             ),
         ),

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -319,6 +319,7 @@ pub(crate) mod generate {
 #[cfg(test)]
 mod tests {
     use super::generate;
+    use crate::event_projection::RendererRefusalSource;
     use std::collections::BTreeMap;
 
     /// Path of the generated bindings, relative to this crate.
@@ -1201,8 +1202,9 @@ mod tests {
                     16,
                     RendererAgentEvent::TurnRefused {
                         refusal: RendererRefusal {
-                            category: Some("safety".into()),
+                            category: Some("blocked".into()),
                             partial_output: true,
+                            source: Some(RendererRefusalSource::ReportBlocked),
                         },
                         usage,
                     },

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -4643,7 +4643,15 @@ export type RefusalDetails = { category: string | null, };
 /**
  * Durable outcome metadata for a refused completion.
  */
-export type RefusalOutcome = { details: RefusalDetails, partial_output: boolean, };
+export type RefusalOutcome = { details: RefusalDetails, partial_output: boolean, source?: RefusalSource, };
+
+/**
+ * The Tidebreak-owned source of a refusal, when one exists.
+ *
+ * Provider refusals leave this absent. Keeping the field optional preserves
+ * journal rows written before Tidebreak recorded its own terminal blockers.
+ */
+export type RefusalSource = "report_blocked";
 
 export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta", text: string, } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "plan_proposed", call_id: CallId, turn_id: TurnId, } | { "type": "task_plan_updated", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass,
 /**
@@ -4728,7 +4736,12 @@ export type RendererModelIdentity = { id: string, provider: ProviderKind, };
 /**
  * Bounded refusal metadata safe to present in the desktop transcript.
  */
-export type RendererRefusal = { category: string | null, partial_output: boolean, };
+export type RendererRefusal = { category: string | null, partial_output: boolean, source?: RendererRefusalSource, };
+
+/**
+ * The Tidebreak-owned source of a refusal, when one exists.
+ */
+export type RendererRefusalSource = "report_blocked";
 
 export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, replayed?: boolean, };
 


### PR DESCRIPTION
Blocked turns now persist as agent_failed, while provider policy refusals remain successful completions. The transcript shows a neutral completion failure instead of labeling every blocked turn as a safety issue. Storybook covers the blocked-turn state.\n\nValidation:\n- focused Rust turn-terminal tests\n- full UI test suite: 2,284 tests\n- Biome and rustfmt\n- Storybook build\n- light and dark Storybook screenshots at 1440px and the 720px app minimum