### PR TITLE
fix(desktop): keep SQLite connections warm

### DIFF
--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -86,7 +86,7 @@ impl SchemaMarker {
 
 pub(super) async fn connect(config: &Config) -> Result<DbStore> {
     connect_with(config, |database_url| async move {
-        DbStore::connect_with_options(crate::host_connect_options(&database_url)).await
+        DbStore::connect_with_options(crate::desktop_connect_options(&database_url)).await
     })
     .await
 }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -3078,15 +3078,28 @@ const HOST_MAX_CONNECTIONS: u32 = 8;
 /// dialog that never resolves.
 const HOST_ACQUIRE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Build the connect options every host store opens with.
+/// Build the connect options a self-host store opens with.
 pub(crate) fn host_connect_options(url: &str) -> sea_orm::ConnectOptions {
     let mut options = sea_orm::ConnectOptions::new(url.to_owned());
     options
         .max_connections(HOST_MAX_CONNECTIONS)
-        // Keep one connection warm so an idle profile does not pay reconnect
-        // latency on the first interactive request.
+        // Keep one connection warm without forcing every self-host database
+        // to reserve the desktop pool's full capacity.
         .min_connections(1)
         .acquire_timeout(HOST_ACQUIRE_TIMEOUT);
+    options
+}
+
+/// Build the connect options for the desktop profile's local SQLite store.
+pub(crate) fn desktop_connect_options(url: &str) -> sea_orm::ConnectOptions {
+    let mut options = host_connect_options(url);
+    options
+        // New SQLite connections apply per-connection PRAGMAs. Opening them
+        // lazily during active writes can block every waiter behind that work,
+        // so create the full fixed pool at startup and keep it warm.
+        .min_connections(HOST_MAX_CONNECTIONS)
+        .idle_timeout(None)
+        .max_lifetime(None);
     options
 }
 

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -144,6 +144,34 @@ async fn temp_db_store(database_name: &str) -> (tempfile::TempDir, DbStore) {
 }
 
 #[test]
+fn desktop_pool_stays_full_and_does_not_reap_connections() {
+    let options = crate::desktop_connect_options("sqlite::memory:");
+
+    assert_eq!(options.get_max_connections(), Some(8));
+    assert_eq!(options.get_min_connections(), Some(8));
+    assert_eq!(
+        options.get_acquire_timeout(),
+        Some(std::time::Duration::from_secs(30))
+    );
+    assert_eq!(options.get_idle_timeout(), Some(None));
+    assert_eq!(options.get_max_lifetime(), Some(None));
+}
+
+#[test]
+fn self_host_pool_keeps_database_lifetime_defaults() {
+    let options = crate::host_connect_options("postgres://localhost/tidebreak");
+
+    assert_eq!(options.get_max_connections(), Some(8));
+    assert_eq!(options.get_min_connections(), Some(1));
+    assert_eq!(
+        options.get_acquire_timeout(),
+        Some(std::time::Duration::from_secs(30))
+    );
+    assert_eq!(options.get_idle_timeout(), None);
+    assert_eq!(options.get_max_lifetime(), None);
+}
+
+#[test]
 fn transcript_citation_json_is_closed_and_renderer_bounded() {
     let message_id = MessageId::new();
     let snapshot = crate::routes::ChatMessageSnapshot {


### PR DESCRIPTION
## Summary

- Open the full eight-connection SQLite pool when the desktop starts.
- Disable idle and lifetime reaping for the local pool so active work does not trigger connection PRAGMAs.
- Keep the self-host pool at one warm connection with the existing SQLx lifetime defaults.

## Why

Desktop-dev logs recorded 9,694 slow pool acquisitions. Of those, 1,163 took at least 10 seconds, and the longest took 345 seconds. Reconnect bursts also ran the SQLite connection PRAGMAs for as long as 52 seconds while turns were active.

## Tests

- `cargo test -p tidebreak-server pool_ --lib` (2 passed)
- `cargo check -p tidebreak-server --features postgres`
- `cargo fmt --all -- --check`
- `git diff --check`
