### PR TITLE
fix(agent): preserve vendor search across tool steps

### DIFF
--- a/crates/tidebreak-core/src/agent/mod.rs
+++ b/crates/tidebreak-core/src/agent/mod.rs
@@ -84,6 +84,12 @@ pub(crate) struct StreamAttempt {
     /// reported them. Argument deltas stay in this sequence for live event
     /// ordering while [`PendingCall`] keeps the accumulated argument string.
     items: Vec<StreamItem>,
+    /// Whether the provider reported running its web search, including a
+    /// malformed receipt that Tidebreak could not admit into the transcript.
+    vendor_web_search_seen: bool,
+    /// Whether the provider sent a terminal stop or refusal before the stream
+    /// closed. A stream that disappears without one has an uncertain outcome.
+    completion_seen: bool,
     reasoning: Vec<Value>,
     stop_reason: StopReason,
     refusal_details: Option<RefusalDetails>,

--- a/crates/tidebreak-core/src/agent/tests/compaction.rs
+++ b/crates/tidebreak-core/src/agent/tests/compaction.rs
@@ -288,15 +288,9 @@ async fn creates_projects_and_deduplicates_a_structured_semantic_checkpoint() {
         .iter()
         .filter(|request| !is_checkpoint_request(request))
         .collect::<Vec<_>>();
-    assert_eq!(
-        foreground.first().unwrap().vendor_web_search,
-        Some(vendor_search),
-        "the first foreground request receives the turn's search allowance"
-    );
     assert!(foreground
         .iter()
-        .skip(1)
-        .all(|request| request.vendor_web_search.is_none()));
+        .all(|request| request.vendor_web_search == Some(vendor_search)));
     assert!(foreground.iter().all(|request| request.messages.iter().any(
             |message| message.content.iter().any(
                 |block| matches!(block, ContentBlock::Text { text } if text.contains(CHECKPOINT_CONTEXT_PREFIX)),

--- a/crates/tidebreak-core/src/agent/tests/provider_search.rs
+++ b/crates/tidebreak-core/src/agent/tests/provider_search.rs
@@ -247,6 +247,13 @@ struct MultiStepVendorSearchBudgetProvider {
     seen: Arc<Mutex<Vec<ChatRequest>>>,
 }
 
+/// Runs one host tool without using the offered vendor search, then answers
+/// from the tool result on the next model step.
+struct HostToolWithoutVendorSearchProvider {
+    calls: AtomicUsize,
+    seen: Arc<Mutex<Vec<ChatRequest>>>,
+}
+
 /// Reports provider-native browsing actions through the shared search name.
 /// None of these inputs can be represented by Tidebreak's canonical
 /// `web_search` arguments, so they must remain transient provider state.
@@ -331,6 +338,43 @@ impl ModelProvider for MultiStepVendorSearchBudgetProvider {
                     is_error: false,
                     replay: None,
                 },
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "checkpoint_noop_1".into(),
+                    name: "checkpoint_noop".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ]
+        } else {
+            vec![
+                ProviderEvent::TextDelta {
+                    text: "done after the host-tool follow-up".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ]
+        };
+        Ok(stream::iter(events).boxed())
+    }
+}
+
+#[async_trait]
+impl ModelProvider for HostToolWithoutVendorSearchProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("host-tool-without-vendor-search")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        self.seen.lock().unwrap().push(req);
+        let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            vec![
                 ProviderEvent::ToolCallStarted {
                     index: 0,
                     id: "checkpoint_noop_1".into(),
@@ -621,6 +665,68 @@ async fn foreground_vendor_search_budget_is_offered_to_only_one_model_request() 
     assert_eq!(
         requests[1].vendor_web_search, None,
         "a later request cannot reopen any part of the per-turn allowance"
+    );
+}
+
+#[tokio::test]
+async fn unused_vendor_search_stays_offered_across_a_host_tool_follow_up() {
+    let db = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            db.path().join("unused-vendor-search.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: None,
+        model: None,
+        reasoning_effort: None,
+        permission_mode: None,
+        network_policy: Default::default(),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        memory_incognito: false,
+        created_at: Utc::now(),
+    };
+    store.create_chat(&chat).await.unwrap();
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let budget = VendorWebSearch { max_uses: 3 };
+    let agent = Agent::new(
+        Arc::new(HostToolWithoutVendorSearchProvider {
+            calls: AtomicUsize::new(0),
+            seen: seen.clone(),
+        }),
+        Arc::new(ToolRegistry::new().with(Box::new(CheckpointNoopTool))),
+        store,
+        AgentConfig {
+            model: "fake".into(),
+            web_search: TurnWebSearch::Vendor(budget),
+            ..Default::default()
+        },
+    );
+
+    let (tx, _rx) = unbounded();
+    agent
+        .run_turn(&chat, "read the host tool, then answer", &tx)
+        .await
+        .unwrap();
+
+    let requests = seen.lock().unwrap();
+    assert_eq!(requests.len(), 2, "expected one host-tool follow-up");
+    assert_eq!(requests[0].vendor_web_search, Some(budget));
+    assert_eq!(
+        requests[1].vendor_web_search,
+        Some(budget),
+        "a completed step that did not search must keep the vendor tool in the cached request prefix"
+    );
+    assert_eq!(
+        requests[1].tools, requests[0].tools,
+        "a host-tool continuation must keep the advertised tool prefix stable"
     );
 }
 

--- a/crates/tidebreak-core/src/agent/turn.rs
+++ b/crates/tidebreak-core/src/agent/turn.rs
@@ -363,10 +363,12 @@ impl Agent {
         }
         let mut total_usage = Usage::default();
         // Provider adapters enforce vendor-search limits per request, while
-        // Tidebreak's contract is per turn. Offer the allowance to at most one
-        // foreground request: once an egress attempt receives the full cap,
-        // Tidebreak cannot prove how much it spent after a failed or partial
-        // stream, so every retry and later model step must fail closed to none.
+        // Tidebreak's contract is per turn. Keep offering the allowance across
+        // completed host-tool steps that report no provider execution. This
+        // preserves the request's tool prefix and its prompt cache. Once a
+        // provider reports executing a server tool, or an attempt ends with an
+        // error, cancellation, steer, or incomplete stream, Tidebreak cannot
+        // prove how much of the allowance remains and fails closed to none.
         let mut remaining_vendor_web_search = match self.config.web_search {
             super::types::TurnWebSearch::Vendor(vendor) if vendor.max_uses > 0 => Some(vendor),
             _ => None,
@@ -431,16 +433,21 @@ impl Agent {
             // step with tighter budgets on prompt-too-long errors. A provider
             // may report the overflow before returning a stream or after
             // streaming a partial candidate; both rejoin this attempt loop.
-            let StreamAttempt {
-                end: stream_end,
-                text,
-                mut calls,
-                items,
-                mut reasoning,
-                stop_reason,
-                refusal_details,
-            } = 'step_attempt: loop {
-                let stream = loop {
+            let (
+                StreamAttempt {
+                    end: stream_end,
+                    text,
+                    mut calls,
+                    items,
+                    vendor_web_search_seen,
+                    completion_seen,
+                    mut reasoning,
+                    stop_reason,
+                    refusal_details,
+                },
+                offered_vendor_web_search,
+            ) = 'step_attempt: loop {
+                let (stream, offered_vendor_web_search) = loop {
                     let mut prefix = self
                         .build_request_prefix(
                             chat,
@@ -577,7 +584,7 @@ impl Agent {
                                     fitted_tokens: fitted_tokens as u32,
                                 });
                             }
-                            break stream;
+                            break (stream, vendor_web_search);
                         }
                         Err(AgentError::PromptTooLong(_))
                             if reduction_level < context::MAX_REDUCTION_LEVEL =>
@@ -609,11 +616,14 @@ impl Agent {
                 // the left arm of the nested select). Also catch a cancel that raced
                 // the final stream event.
                 reduction_level = 0;
-                break 'step_attempt attempt;
+                break 'step_attempt (attempt, offered_vendor_web_search);
             };
             let has_provider_executed = items
                 .iter()
                 .any(|item| matches!(item, StreamItem::ProviderExecuted { .. }));
+            if matches!(stream_end, StreamEnd::Done) && completion_seen && !vendor_web_search_seen {
+                remaining_vendor_web_search = offered_vendor_web_search;
+            }
             if matches!(stream_end, StreamEnd::Cancelled) || self.cancel.is_cancelled() {
                 // Calls that started before the cancel were already journaled,
                 // so terminalizing silently would leave replay and live clients
@@ -1650,6 +1660,8 @@ impl Agent {
         let mut reasoning = Vec::new();
         let mut by_index = HashMap::new();
         let mut provider_seen = false;
+        let mut vendor_web_search_seen = false;
+        let mut completion_seen = false;
         let mut stop_reason = StopReason::EndTurn;
         let mut refusal_details = None;
         let mut streamed_events = AssistantStreamEventFilter::new(events);
@@ -1727,6 +1739,7 @@ impl Agent {
                     is_error,
                     replay,
                 } => {
+                    vendor_web_search_seen |= name == crate::WEB_SEARCH_TOOL;
                     let block = ContentBlock::ProviderExecutedToolCall {
                         name,
                         input,
@@ -1742,8 +1755,12 @@ impl Agent {
                         provider_seen = true;
                     }
                 }
-                ProviderEvent::Stop { reason } => stop_reason = reason,
+                ProviderEvent::Stop { reason } => {
+                    completion_seen = true;
+                    stop_reason = reason;
+                }
                 ProviderEvent::Refusal { details } => {
+                    completion_seen = true;
                     stop_reason = StopReason::Refusal;
                     refusal_details = Some(details);
                 }
@@ -1763,6 +1780,8 @@ impl Agent {
             text,
             calls,
             items,
+            vendor_web_search_seen,
+            completion_seen,
             reasoning,
             stop_reason,
             refusal_details,


### PR DESCRIPTION
## Summary

- Keep an unused vendor web-search allowance on completed host-tool steps.
- Consume the allowance after reported vendor search activity or an uncertain stream outcome.
- Keep compaction maintenance calls search-free while preserving the foreground request surface.

## Why

An Anthropic turn in automatic search mode offered vendor search on its first request, then removed it after a read_document call that never searched. That changed the tool prefix on the follow-up request and caused 50,061 cache-creation tokens with no cache read.

## Tests

- cargo test -p tidebreak-core agent::tests --lib (99 passed)
- cargo clippy -p tidebreak-core --tests -- -D warnings
- cargo fmt --all -- --check
- git diff --check
