### PR TITLE
fix(code): install selected harnesses during recovery

### DIFF
--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -3,6 +3,76 @@
 use super::*;
 
 impl CodeRuntime {
+    /// Whether startup recovery must resolve the managed install before it
+    /// probes `kind`.
+    ///
+    /// A headless embedding with no data directory, an embedding-declared
+    /// binary, and the in-process engine have no managed install to prepare.
+    /// Debug end-to-end tests can also replace every adapter with the scripted
+    /// engine; preserve that declared test surface instead of downloading a
+    /// real package behind it.
+    fn recovery_uses_managed_harness(&self, kind: HarnessKind) -> bool {
+        #[cfg(debug_assertions)]
+        if crate::scripted_harness::env_is_set() {
+            return false;
+        }
+        !kind.is_in_process()
+            && self.host.data_dir.is_some()
+            && self.host.declared(kind).is_none()
+            && tidebreak_harness::pin_for(kind).is_some()
+    }
+
+    /// Install and probe each managed engine needed by recovered sessions.
+    ///
+    /// Pin bumps leave the previous version on disk. A session-create request
+    /// resolves the selected pin before probing, but startup recovery used to
+    /// probe first and strand every saved session on `harness_not_found`.
+    /// Group by kind so many saved sessions share one install and one cold
+    /// probe. Recovery already runs after bind, so these downloads do not hold
+    /// the server port closed.
+    async fn prepare_recovered_harnesses(&self, sessions: &[CodeSession]) -> HashSet<HarnessKind> {
+        let mut kinds = sessions
+            .iter()
+            .map(|session| session.harness_kind)
+            .filter(|kind| self.recovery_uses_managed_harness(*kind))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        kinds.sort_by_key(|kind| kind.as_str());
+        let prepared = futures::future::join_all(kinds.into_iter().map(|kind| async move {
+            let result = self.ensure_harness(kind, false, false).await;
+            (kind, result)
+        }))
+        .await;
+        let mut unavailable = HashSet::new();
+        for (kind, result) in prepared {
+            match result {
+                Ok(installed) => {
+                    self.record_pin_install(kind, Ok(()));
+                    self.invalidate_moved_probe(kind, &installed.binary);
+                    if let Ok(adapter) = self.adapter(kind) {
+                        self.probe(adapter.as_ref()).await;
+                    }
+                }
+                Err(error) => {
+                    self.record_pin_install(kind, Err(error.clone()));
+                    let session_count = sessions
+                        .iter()
+                        .filter(|session| session.harness_kind == kind)
+                        .count();
+                    tracing::warn!(
+                        %kind,
+                        sessions = session_count,
+                        %error,
+                        "code-mode: could not prepare the engine for recovered session workers"
+                    );
+                    unavailable.insert(kind);
+                }
+            }
+        }
+        unavailable
+    }
+
     /// Revoke the session browser token and permanently tombstone its native
     /// adapter authority. Idempotent — safe to call multiple times.
     ///
@@ -172,15 +242,225 @@ impl CodeRuntime {
                         .contains_key(&session.id)
             })
             .collect();
-        futures::future::join_all(resumable.into_iter().map(|session| async move {
-            if let Err(error) = self.attach_and_spawn_worker(session).await {
-                tracing::warn!(
-                    "code-mode: could not resume a recovered session worker: {}",
-                    error.message()
-                );
-            }
+        let unavailable = self.prepare_recovered_harnesses(&resumable).await;
+        futures::future::join_all(resumable.into_iter().filter_map(|session| {
+            (!unavailable.contains(&session.harness_kind)).then_some(async move {
+                // An install can take minutes. Re-read the row and the worker
+                // map so a user ending or reaping the session during that wait
+                // does not get an obsolete second worker afterward.
+                let latest = match get_session(&self.db, &session.owner, session.id).await {
+                    Ok(Some(latest))
+                        if !matches!(
+                            latest.lifecycle,
+                            CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+                        ) && !self
+                            .workers
+                            .lock()
+                            .expect("code workers")
+                            .contains_key(&latest.id) =>
+                    {
+                        latest
+                    }
+                    Ok(_) => return,
+                    Err(error) => {
+                        tracing::warn!(
+                            session = %session.id,
+                            %error,
+                            "code-mode: could not re-read a recovered session before attaching its worker"
+                        );
+                        return;
+                    }
+                };
+                if let Err(error) = self.attach_and_spawn_worker(latest).await {
+                    tracing::warn!(
+                        "code-mode: could not resume a recovered session worker: {}",
+                        error.message()
+                    );
+                }
+            })
         }))
         .await;
         Ok(actions)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::sync::atomic::AtomicUsize;
+
+    use async_trait::async_trait;
+    use tidebreak_code_execution::{HostDep, HostToolBroker, HostToolStatus};
+    use tidebreak_core::HarnessCaps;
+    use tidebreak_harness::HarnessSession;
+
+    use super::*;
+    use crate::code::harness_release::test_support::write_install;
+    use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+
+    struct AvailableNodeBroker {
+        ensure_calls: AtomicUsize,
+        root: PathBuf,
+    }
+
+    #[async_trait]
+    impl HostToolBroker for AvailableNodeBroker {
+        fn ensure(&self, tool: HostDep) {
+            assert_eq!(tool, HostDep::Node);
+            self.ensure_calls.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn retry(&self, tool: HostDep) {
+            assert_eq!(tool, HostDep::Node);
+        }
+
+        async fn status(&self, tool: HostDep) -> HostToolStatus {
+            assert_eq!(tool, HostDep::Node);
+            HostToolStatus::Available
+        }
+
+        async fn managed_root(&self, tool: HostDep) -> Option<PathBuf> {
+            assert_eq!(tool, HostDep::Node);
+            Some(self.root.clone())
+        }
+    }
+
+    /// The scripted engine reports missing until recovery has installed the
+    /// selected managed pin. This makes worker attachment prove the ordering,
+    /// without launching the real external engine in a unit test.
+    struct PinCheckingAdapter {
+        inner: ScriptedAdapter,
+        expected_pin: PathBuf,
+    }
+
+    #[async_trait]
+    impl HarnessAdapter for PinCheckingAdapter {
+        fn kind(&self) -> HarnessKind {
+            self.inner.kind()
+        }
+
+        async fn probe(&self, host: &HostEnv) -> HarnessProbe {
+            if !self.expected_pin.is_file() {
+                return HarnessProbe {
+                    found: false,
+                    binary_path: None,
+                    version: None,
+                    authenticated: None,
+                    stderr: "the selected pin is missing".into(),
+                    env: Vec::new(),
+                    commands: Vec::new(),
+                };
+            }
+            self.inner.probe(host).await
+        }
+
+        fn capabilities(&self, probe: &HarnessProbe) -> HarnessCaps {
+            self.inner.capabilities(probe)
+        }
+
+        async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
+            assert!(
+                self.expected_pin.is_file(),
+                "recovery must install the selected pin before launch"
+            );
+            self.inner.launch(spec).await
+        }
+    }
+
+    fn write_executable(path: &Path, contents: &[u8]) {
+        std::fs::create_dir_all(path.parent().expect("executable parent")).unwrap();
+        std::fs::write(path, contents).unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    fn saved_session(owner: &OwnerId, kind: HarnessKind) -> CodeSession {
+        CodeSession {
+            id: CodeSessionId::new(),
+            owner: owner.clone(),
+            workspace_id: None,
+            kind: CodeSessionKind::Interactive,
+            harness_kind: kind,
+            harness_version: Some("0.147.0".into()),
+            harness_resume_ref: Some("saved-session".into()),
+            permission_mode: PermissionMode::Plan,
+            model: None,
+            reasoning_effort: None,
+            fast_mode: false,
+            lifecycle: CodeSessionLifecycle::Idle,
+            fence_reason: None,
+            child_pid: None,
+            child_process_identity: None,
+            spawn_epoch: 1,
+            attention: Attention::new(
+                tidebreak_core::AttentionState::Idle,
+                AttentionSource::Lifecycle,
+            ),
+            unrecognized_event_count: 0,
+            subagents: Vec::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn recovery_installs_one_selected_pin_before_attaching_same_kind_sessions() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let node_root = data_dir.path().join("fake-node");
+        write_executable(
+            &tidebreak_managed_node::managed_node_executable(&node_root),
+            b"#!/bin/sh\nexit 0\n",
+        );
+        write_executable(
+            &tidebreak_managed_node::managed_npm_executable(&node_root),
+            b"#!/bin/sh\nset -eu\nmkdir -p node_modules/.bin\nprintf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/codex\nchmod +x node_modules/.bin/codex\n",
+        );
+
+        let kind = HarnessKind::Codex;
+        let pin = tidebreak_harness::pin_for(kind).unwrap();
+        let old_binary = write_install(data_dir.path(), kind, "0.147.0");
+        let expected_pin = tidebreak_harness::pin::install_dir(data_dir.path(), pin)
+            .join("node_modules")
+            .join(".bin")
+            .join(pin.bin);
+        assert!(old_binary.is_file());
+        assert!(!expected_pin.exists());
+
+        let db = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                data_dir.path().join("code.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let mut registry = AdapterRegistry::new();
+        registry.register(Arc::new(PinCheckingAdapter {
+            inner: ScriptedAdapter::new(plain_text_script()).with_kind(kind),
+            expected_pin: expected_pin.clone(),
+        }));
+        let mut runtime =
+            CodeRuntime::with_registry(Arc::clone(&db), data_dir.path().to_path_buf(), registry);
+        runtime.host.data_dir = Some(data_dir.path().to_path_buf());
+        let broker = Arc::new(AvailableNodeBroker {
+            ensure_calls: AtomicUsize::new(0),
+            root: node_root,
+        });
+        runtime.host_tool_broker = Some(broker.clone());
+
+        let owner = OwnerId::new("alice").unwrap();
+        let first = saved_session(&owner, kind);
+        let second = saved_session(&owner, kind);
+        insert_session(&db, &first).await.unwrap();
+        insert_session(&db, &second).await.unwrap();
+
+        runtime.recover().await.unwrap();
+
+        assert!(expected_pin.is_file());
+        assert_eq!(
+            broker.ensure_calls.load(Ordering::Relaxed),
+            1,
+            "sessions of one kind share one recovery install"
+        );
+        assert!(runtime.has_worker(first.id));
+        assert!(runtime.has_worker(second.id));
     }
 }


### PR DESCRIPTION
## What changed

- Resolve and install each selected managed harness once before startup recovery attaches saved sessions.
- Warm one probe per harness kind, then attach every recoverable session that still needs a worker.
- Re-read session state after installation so an end or reap during the wait cannot attach a stale worker.

## Why

A harness pin bump leaves the prior version on disk. Session creation installs the selected pin before probing, but startup recovery probed first and left saved Codex and Grok sessions without workers.

## Validation

- `cargo test -p tidebreak-server code::runtime::recover --lib`
- `cargo clippy -p tidebreak-server --tests --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`