### PR TITLE
fix(code): keep attached idle sessions inactive

### DIFF
--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -3449,11 +3449,29 @@ pub(crate) async fn attach_engine(
     session.child_process_identity = None;
     session.harness_version = version.or(session.harness_version);
     session.lifecycle = CodeSessionLifecycle::Idle;
-    super::attention::replace_attention(
-        &mut session,
-        Attention::working(AttentionSource::Lifecycle),
-        false,
-    );
+    // Attaching an engine makes it ready for a turn, not active. Restore
+    // automatic active attention left by an earlier attachment. Preserve
+    // unread work and user pins.
+    if session.attention.source.is_automatic()
+        && matches!(
+            session.attention.state,
+            tidebreak_core::AttentionState::Working
+                | tidebreak_core::AttentionState::Stalled { .. }
+        )
+    {
+        let restored = super::attention::compute_attention(
+            db,
+            bus,
+            &session,
+            super::attention::ComputeOpts {
+                reviewed: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|err| WorkerError::Failed(err.to_string()))?;
+        super::attention::replace_attention(&mut session, restored, false);
+    }
     super::attention::persist_session(db, bus, &session)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;

--- a/crates/tidebreak-server/src/code/session_worker/tests.rs
+++ b/crates/tidebreak-server/src/code/session_worker/tests.rs
@@ -3,11 +3,13 @@ use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use chrono::Utc;
 use tidebreak_core::db::code::{
     enqueue_queued_turn, get_session, insert_repo, insert_session, insert_workspace,
-    list_approvals, list_events, list_turns, replace_session_execution_settings, MAX_REPLAY_EVENTS,
+    list_approvals, list_events, list_turns, replace_session_attention,
+    replace_session_execution_settings, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
-    CodeRepo, CodeSessionKind, CodeUsage, CodeWorkspace, CodeWorkspaceStatus, HarnessKind,
-    ImageMediaType, ImageRef, PermissionMode, ReasoningEffort, RepoId, ToolDetail, WorkspaceId,
+    AttentionState, CodeRepo, CodeSessionKind, CodeUsage, CodeWorkspace, CodeWorkspaceStatus,
+    HarnessKind, ImageMediaType, ImageRef, PermissionMode, ReasoningEffort, RepoId, ToolDetail,
+    WorkspaceId,
 };
 use tidebreak_harness::{HarnessAdapter as _, SessionSpec};
 
@@ -1092,6 +1094,17 @@ async fn codex_attachment_journals_one_start_after_the_thread_is_known() {
     .unwrap();
     let owner = OwnerId::local();
     assert_eq!(attached.harness_version.as_deref(), Some("0.147.0"));
+    assert_eq!(attached.lifecycle, CodeSessionLifecycle::Idle);
+    assert_eq!(attached.attention.state, AttentionState::Idle);
+    assert_eq!(
+        get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .attention
+            .state,
+        AttentionState::Idle
+    );
 
     assert!(
         list_events(&store, &owner, session_id, 0, MAX_REPLAY_EVENTS)
@@ -1146,6 +1159,39 @@ async fn codex_attachment_journals_one_start_after_the_thread_is_known() {
             "0.147.0".into(),
             Some("thread-1".into())
         )]
+    );
+}
+
+#[tokio::test]
+async fn engine_attachment_preserves_unreviewed_work() {
+    let (_directory, store, bus, session_id) =
+        seeded_session(HarnessKind::ClaudeCode, Some("2.1.237")).await;
+    let owner = OwnerId::local();
+    let unreviewed = Attention::new(AttentionState::DoneUnreviewed, AttentionSource::Lifecycle);
+    replace_session_attention(&store, &owner, session_id, &unreviewed, false)
+        .await
+        .unwrap();
+
+    let attached = attach_engine(
+        &store,
+        &bus,
+        session_id,
+        HarnessKind::ClaudeCode,
+        Some("2.1.237".into()),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(attached.lifecycle, CodeSessionLifecycle::Idle);
+    assert_eq!(attached.attention, unreviewed);
+    assert_eq!(
+        get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .attention,
+        unreviewed
     );
 }
 

--- a/crates/tidebreak-server/src/tests/code_doctor.rs
+++ b/crates/tidebreak-server/src/tests/code_doctor.rs
@@ -107,6 +107,15 @@ async fn stall_sweep_leaves_a_monitoring_session_working() {
     tidebreak_core::db::code::save_session(&runtime.db, &row)
         .await
         .unwrap();
+    tidebreak_core::db::code::replace_session_attention(
+        &runtime.db,
+        &owner,
+        parsed,
+        &tidebreak_core::Attention::working(tidebreak_core::AttentionSource::Lifecycle),
+        false,
+    )
+    .await
+    .unwrap();
     tidebreak_core::db::code::append_event(
         &runtime.db,
         &owner,


### PR DESCRIPTION
## What changed

Attaching an external harness now keeps the session lifecycle idle and repairs stale automatic Working or Stalled attention. The repair preserves unread completed work and user-pinned attention.

## Why

Recovering a completed session attached its engine and moved the session into the Running group even though no turn was active.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tidebreak-server code::session_worker --lib`
- `cargo clippy -p tidebreak-server --tests --no-deps -- -D warnings`
- `git diff --check`