### PR TITLE
fix(agent): index ready agent wait recovery

### DIFF
--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -78,6 +78,7 @@ impl MigratorTrait for Migrator {
             Box::new(MemorySweepState),
             Box::new(ChatMemoryIncognito),
             Box::new(one_turn_lane::OneTurnLane),
+            Box::new(ReadyAgentRunWaitIndex),
         ]
     }
 }
@@ -4487,6 +4488,40 @@ impl MigrationTrait for ChatMemoryIncognito {
         // `Baseline::down` drops that table outright. The frozen baseline
         // does not declare this column, so a rolled-back database gets it
         // again from this migration's `up` on the way back.
+        Ok(())
+    }
+}
+
+/// Start the background-agent wait resolver from its small open-wait set.
+struct ReadyAgentRunWaitIndex;
+
+impl MigrationName for ReadyAgentRunWaitIndex {
+    fn name(&self) -> &str {
+        "m20260903_000002_ready_agent_run_wait_index"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for ReadyAgentRunWaitIndex {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"CREATE INDEX IF NOT EXISTS "idx_turn_agent_run_wait_set_ready"
+                   ON "turn_agent_run_wait_set" ("status", "condition", "turn_id", "id")
+                   WHERE "closed_at" IS NULL
+                     AND "resume_token" IS NULL
+                     AND "event_seq" IS NULL"#,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(r#"DROP INDEX IF EXISTS "idx_turn_agent_run_wait_set_ready""#)
+            .await?;
         Ok(())
     }
 }

--- a/crates/tidebreak-core/src/db/migration/tests.rs
+++ b/crates/tidebreak-core/src/db/migration/tests.rs
@@ -82,6 +82,7 @@ async fn a_fresh_database_records_the_whole_chain() {
             "m20260902_000005_memory_sweep_state",
             "m20260902_000006_chat_memory_incognito",
             "m20260903_000001_one_turn_lane",
+            "m20260903_000002_ready_agent_run_wait_index",
         ]
     );
     assert!(db

--- a/crates/tidebreak-core/src/db/ops/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/turn.rs
@@ -42,6 +42,8 @@ pub(in crate::db) use client_wait::{
     advance_turn_after_client_resolution_on, approval_park_call_id, park_turn_for_client_tool_call,
     recover_turn_after_client_resolution_on,
 };
+#[cfg(test)]
+pub(in crate::db) use multi_agent_run_wait::ready_agent_run_wait_set_candidates_sql;
 pub(in crate::db) use multi_agent_run_wait::{
     list_ready_agent_run_wait_set_candidates, park_turn_for_agent_run_wait_set,
     resume_turn_for_agent_run_wait_set,

--- a/crates/tidebreak-core/src/db/ops/turn/multi_agent_run_wait.rs
+++ b/crates/tidebreak-core/src/db/ops/turn/multi_agent_run_wait.rs
@@ -49,20 +49,13 @@ struct ReadyWaitSetRow {
     ready_at: chrono::DateTime<Utc>,
 }
 
-pub(in crate::db) async fn list_ready_agent_run_wait_set_candidates(
-    store: &DbStore,
-    limit: u64,
-) -> Result<Vec<AgentRunWaitSetCandidate>> {
-    if limit == 0 {
-        return Ok(Vec::new());
-    }
-    let now = database_now(&store.conn).await?;
+pub(in crate::db) fn ready_agent_run_wait_set_candidates_sql(limit: u64) -> String {
     // The joins are an intentionally strict prefilter: because the joined row
     // count must equal the complete member count, one missing, claimed, or
     // ownership-mismatched member excludes the set before LIMIT is applied.
     // This keeps the scan bounded without allowing corrupt historical rows to
     // starve a later coherent wait.
-    let sql = format!(
+    format!(
         r#"
 SELECT w.id AS wait_id, MAX(i.delivered_at) AS ready_at
 FROM turn_agent_run_wait_set w
@@ -122,7 +115,18 @@ LIMIT {limit}
 "#,
         max_children = TurnAgentRunWaitSet::MAX_CHILDREN,
         limit = limit.min(i64::MAX as u64),
-    );
+    )
+}
+
+pub(in crate::db) async fn list_ready_agent_run_wait_set_candidates(
+    store: &DbStore,
+    limit: u64,
+) -> Result<Vec<AgentRunWaitSetCandidate>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let now = database_now(&store.conn).await?;
+    let sql = ready_agent_run_wait_set_candidates_sql(limit);
     let rows = ReadyWaitSetRow::find_by_statement(Statement::from_string(
         store.conn.get_database_backend(),
         sql,

--- a/crates/tidebreak-core/src/db/tests/multi_agent_wait.rs
+++ b/crates/tidebreak-core/src/db/tests/multi_agent_wait.rs
@@ -7,7 +7,7 @@ use crate::{
     ToolCallStatus, TurnAgentRunWaitStatus, TurnRunStatus, TurnSteerId,
 };
 use chrono::{Duration, Utc};
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, Statement};
 use sea_orm_migration::MigratorTrait;
 
 #[allow(clippy::too_many_arguments)]
@@ -410,6 +410,31 @@ async fn recovery_scan_becomes_ready_only_after_the_last_ordered_child() {
         .await
         .unwrap()
         .is_empty());
+}
+
+#[tokio::test]
+async fn recovery_scan_starts_from_the_open_wait_set() {
+    let (_dir, store) = temp_store().await;
+    let plan = store
+        .conn
+        .query_all_raw(Statement::from_string(
+            DbBackend::Sqlite,
+            format!(
+                "EXPLAIN QUERY PLAN {}",
+                crate::db::ops::turn::ready_agent_run_wait_set_candidates_sql(8)
+            ),
+        ))
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| row.try_get::<String>("", "detail").unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        plan.contains("idx_turn_agent_run_wait_set_ready"),
+        "the resolver must start from the indexed open-wait set:\n{plan}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
The background-agent wait resolver ran from four scheduler lanes and started from every unleased turn. On the exercised development database, slow scans averaged 32 seconds and concurrent scans took about two minutes even when no wait sets were open.

This change adds a partial index for open, unresolved `turn_agent_run_wait_set` rows. It also adds an `EXPLAIN QUERY PLAN` regression that requires SQLite to start from that index.

Checks:
- `cargo fmt --all -- --check`
- `cargo clippy -p tidebreak-core --tests --no-deps -- -D warnings`
- `cargo test -p tidebreak-core recovery_scan -- --nocapture`
- `cargo test -p tidebreak-core a_fresh_database_records_the_whole_chain -- --nocapture`
- `git diff --check`