### PR TITLE
fix(agent): preserve vendor search across client tools

### DIFF
--- a/crates/tidebreak-core/src/agent/tests/client_tools.rs
+++ b/crates/tidebreak-core/src/agent/tests/client_tools.rs
@@ -53,6 +53,7 @@ async fn claimed_agent_returns_a_client_tool_checkpoint_without_executing_it() {
     );
     assert!(registry.get("connect_folder").is_none());
     assert_eq!(registry.specs(), vec![client_spec]);
+    let registry = Arc::new(registry);
     let agent = Agent::new(
         Arc::new(ClientToolProvider {
             assistant_text: false,
@@ -60,10 +61,11 @@ async fn claimed_agent_returns_a_client_tool_checkpoint_without_executing_it() {
             name: "connect_folder",
             arguments: r#"{"hint":"Documents"}"#,
         }),
-        Arc::new(registry),
+        registry.clone(),
         store.clone(),
         AgentConfig {
             model: "fake".into(),
+            web_search: TurnWebSearch::Vendor(VendorWebSearch { max_uses: 3 }),
             ..AgentConfig::default()
         },
     )
@@ -78,6 +80,7 @@ async fn claimed_agent_returns_a_client_tool_checkpoint_without_executing_it() {
     let events = emitted_events(rx.collect().await);
     let AgentTurnOutcome::ClientToolCall {
         request,
+        remaining_vendor_web_search,
         usage,
         steer_revision,
         model_steps,
@@ -90,6 +93,10 @@ async fn claimed_agent_returns_a_client_tool_checkpoint_without_executing_it() {
     assert_eq!(request.provider_id, "native_1");
     assert_eq!(request.name, "connect_folder");
     assert_eq!(request.arguments, serde_json::json!({"hint": "Documents"}));
+    assert_eq!(
+        remaining_vendor_web_search,
+        Some(VendorWebSearch { max_uses: 3 })
+    );
     assert_eq!(usage.input_tokens, 5);
     assert_eq!(usage.output_tokens, 2);
     assert_eq!(steer_revision, 0);

--- a/crates/tidebreak-core/src/agent/turn.rs
+++ b/crates/tidebreak-core/src/agent/turn.rs
@@ -1401,6 +1401,7 @@ impl Agent {
                                         Ok((request, steer_revision)) => {
                                             return Ok(AgentTurnOutcome::ClientToolCall {
                                                 request,
+                                                remaining_vendor_web_search,
                                                 usage: total_usage,
                                                 steer_revision,
                                                 model_steps: steps_used,

--- a/crates/tidebreak-core/src/agent/types.rs
+++ b/crates/tidebreak-core/src/agent/types.rs
@@ -10,7 +10,7 @@ use crate::citation::AssistantCitationInput;
 use crate::compaction::CompactionPolicy;
 use crate::id::{AgentRunId, CallId};
 use crate::model::{Message, ToolCallRecord};
-use crate::provider::{RefusalOutcome, StopReason, Usage};
+use crate::provider::{RefusalOutcome, StopReason, Usage, VendorWebSearch};
 use crate::tool::ToolScratch;
 
 /// Default cap on a single tool result fed back to the model: 64 KiB (~16k
@@ -251,6 +251,8 @@ pub enum AgentTurnOutcome {
     ClientToolCall {
         /// Immutable call identity and canonical arguments to checkpoint.
         request: crate::model::ClientToolCallRequest,
+        /// Vendor search allowance that remains after the producing step.
+        remaining_vendor_web_search: Option<VendorWebSearch>,
         /// Provider usage incurred in this agent invocation.
         usage: Usage,
         /// Durable steering epoch captured before the producing model call.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -868,6 +868,7 @@ pub mod turn_client_wait {
         pub output_tokens: i64,
         pub cache_read_input_tokens: i64,
         pub cache_creation_input_tokens: i64,
+        pub vendor_web_search_max_uses: Option<i64>,
         pub status: String,
         pub parked_at: DateTimeUtc,
         pub closed_at: Option<DateTimeUtc>,

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -79,6 +79,7 @@ impl MigratorTrait for Migrator {
             Box::new(ChatMemoryIncognito),
             Box::new(one_turn_lane::OneTurnLane),
             Box::new(ReadyAgentRunWaitIndex),
+            Box::new(ClientWaitVendorWebSearch),
         ]
     }
 }
@@ -4522,6 +4523,42 @@ impl MigrationTrait for ReadyAgentRunWaitIndex {
             .get_connection()
             .execute_unprepared(r#"DROP INDEX IF EXISTS "idx_turn_agent_run_wait_set_ready""#)
             .await?;
+        Ok(())
+    }
+}
+
+/// Preserve an unused provider search allowance across a client-tool wait.
+struct ClientWaitVendorWebSearch;
+
+impl MigrationName for ClientWaitVendorWebSearch {
+    fn name(&self) -> &str {
+        "m20260903_000003_client_wait_vendor_web_search"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for ClientWaitVendorWebSearch {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if !manager
+            .has_column("turn_client_wait", "vendor_web_search_max_uses")
+            .await?
+        {
+            manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"ALTER TABLE "turn_client_wait"
+                       ADD COLUMN "vendor_web_search_max_uses" bigint
+                       CHECK ("vendor_web_search_max_uses" IS NULL OR
+                              "vendor_web_search_max_uses" BETWEEN 1 AND 4294967295)"#,
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // A downgrade keeps the checkpoint state so it cannot accidentally
+        // reopen a provider search allowance after the migration runs again.
         Ok(())
     }
 }

--- a/crates/tidebreak-core/src/db/migration/tests.rs
+++ b/crates/tidebreak-core/src/db/migration/tests.rs
@@ -83,6 +83,7 @@ async fn a_fresh_database_records_the_whole_chain() {
             "m20260902_000006_chat_memory_incognito",
             "m20260903_000001_one_turn_lane",
             "m20260903_000002_ready_agent_run_wait_index",
+            "m20260903_000003_client_wait_vendor_web_search",
         ]
     );
     assert!(db

--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -45,7 +45,7 @@ use crate::model::{
 };
 #[cfg(test)]
 use crate::model::{AgentRunStatus, TurnRunStatus, TurnSteerStatus};
-use crate::provider::{StopReason, Usage};
+use crate::provider::{StopReason, Usage, VendorWebSearch};
 use crate::semantic_checkpoint::{ContextCheckpoint, SaveContextCheckpointOutcome};
 use crate::storage::{
     AcceptAgentRunOutcome, AcceptClaimedToolCallOutcome, AcceptToolCallOutcome, AcceptTurnOutcome,
@@ -2184,12 +2184,14 @@ impl Store for DbStore {
         .await
     }
 
-    async fn park_turn_for_client_tool_call(
+    #[allow(clippy::too_many_arguments)]
+    async fn park_turn_for_client_tool_call_with_search_state(
         &self,
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         expected_steer_revision: i64,
         progress: TurnCheckpointProgress,
+        remaining_vendor_web_search: Option<VendorWebSearch>,
         now: chrono::DateTime<Utc>,
         call: &crate::model::ClientToolCallRequest,
     ) -> Result<Option<ParkTurnForClientCallOutcome>> {
@@ -2199,10 +2201,20 @@ impl Store for DbStore {
             lease_token,
             expected_steer_revision,
             progress,
+            remaining_vendor_web_search,
             now,
             call,
         )
         .await
+    }
+
+    async fn resumed_client_vendor_web_search(
+        &self,
+        turn_id: TurnId,
+        attempt_count: i32,
+        claim_count: i32,
+    ) -> Result<Option<VendorWebSearch>> {
+        ops::turn::resumed_client_vendor_web_search(self, turn_id, attempt_count, claim_count).await
     }
 
     async fn park_turn_for_agent_run_wait_set(

--- a/crates/tidebreak-core/src/db/ops/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/turn.rs
@@ -40,7 +40,7 @@ pub(in crate::db) mod steer;
 
 pub(in crate::db) use client_wait::{
     advance_turn_after_client_resolution_on, approval_park_call_id, park_turn_for_client_tool_call,
-    recover_turn_after_client_resolution_on,
+    recover_turn_after_client_resolution_on, resumed_client_vendor_web_search,
 };
 #[cfg(test)]
 pub(in crate::db) use multi_agent_run_wait::ready_agent_run_wait_set_candidates_sql;

--- a/crates/tidebreak-core/src/db/ops/turn/client_wait.rs
+++ b/crates/tidebreak-core/src/db/ops/turn/client_wait.rs
@@ -9,6 +9,7 @@ use crate::model::{
     ClientToolCallRequest, ToolCallExecution, ToolCallStatus, TurnCheckpointProgress,
     TurnClientWait, TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus,
 };
+use crate::provider::VendorWebSearch;
 use crate::storage::ParkTurnForClientCallOutcome;
 use crate::{
     AgentEvent, CallId, ChatId, CodeTurnStatus, SequencedEvent, TurnId, TurnParkWait, TurnRun,
@@ -57,16 +58,24 @@ pub(in crate::db) fn approval_park_call_id(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::db) async fn park_turn_for_client_tool_call(
     store: &DbStore,
     turn_id: crate::TurnId,
     lease_token: uuid::Uuid,
     expected_steer_revision: i64,
     progress: TurnCheckpointProgress,
+    remaining_vendor_web_search: Option<VendorWebSearch>,
     now: chrono::DateTime<Utc>,
     call: &ClientToolCallRequest,
 ) -> Result<Option<ParkTurnForClientCallOutcome>> {
-    validate_request(turn_id, lease_token, progress, call)?;
+    validate_request(
+        turn_id,
+        lease_token,
+        progress,
+        remaining_vendor_web_search,
+        call,
+    )?;
     let now = canonical_db_timestamp(now)?;
     let Some(scope) = entities::code_turn::Entity::find_by_id(turn_id.0)
         .one(&store.conn)
@@ -109,6 +118,7 @@ pub(in crate::db) async fn park_turn_for_client_tool_call(
             && wait.session_id == call.chat_id.0
             && wait.park_lease_token == lease_token
             && progress_from_wait_model(&wait)? == progress
+            && vendor_web_search_from_wait_model(&wait)? == remaining_vendor_web_search
             && exact_call_request(&existing_call, call);
         let outcome = if exact {
             let renderer_event =
@@ -224,6 +234,9 @@ pub(in crate::db) async fn park_turn_for_client_tool_call(
         output_tokens: Set(i64::from(progress.usage.output_tokens)),
         cache_read_input_tokens: Set(i64::from(progress.usage.cache_read_input_tokens)),
         cache_creation_input_tokens: Set(i64::from(progress.usage.cache_creation_input_tokens)),
+        vendor_web_search_max_uses: Set(
+            remaining_vendor_web_search.map(|search| i64::from(search.max_uses))
+        ),
         status: Set(TurnClientWaitStatus::Waiting.as_str().into()),
         parked_at: Set(now),
         closed_at: Set(None),
@@ -314,12 +327,14 @@ fn validate_request(
     turn_id: crate::TurnId,
     lease_token: uuid::Uuid,
     progress: TurnCheckpointProgress,
+    remaining_vendor_web_search: Option<VendorWebSearch>,
     call: &ClientToolCallRequest,
 ) -> Result<()> {
     if turn_id.0.is_nil()
         || lease_token.is_nil()
         || call.turn_id != turn_id
         || progress.model_steps <= 0
+        || remaining_vendor_web_search.is_some_and(|search| search.max_uses == 0)
         || !call.is_well_formed()
     {
         return Err(AgentError::Store(
@@ -372,10 +387,63 @@ pub(super) fn wait_from_model(model: entities::turn_client_wait::Model) -> Resul
         attempt_count: model.attempt_count,
         claim_count: model.claim_count,
         progress: progress_from_wait_model(&model)?,
+        remaining_vendor_web_search: vendor_web_search_from_wait_model(&model)?,
         status,
         parked_at: model.parked_at,
         closed_at: model.closed_at,
     })
+}
+
+fn vendor_web_search_from_wait_model(
+    model: &entities::turn_client_wait::Model,
+) -> Result<Option<VendorWebSearch>> {
+    let Some(max_uses) = model.vendor_web_search_max_uses else {
+        return Ok(None);
+    };
+    let max_uses = u32::try_from(max_uses).map_err(|_| {
+        AgentError::Store(format!(
+            "client wait {} has an invalid vendor web-search allowance",
+            crate::CallId(model.call_id)
+        ))
+    })?;
+    if max_uses == 0 {
+        return Err(AgentError::Store(format!(
+            "client wait {} has an invalid vendor web-search allowance",
+            crate::CallId(model.call_id)
+        )));
+    }
+    Ok(Some(VendorWebSearch { max_uses }))
+}
+
+pub(in crate::db) async fn resumed_client_vendor_web_search(
+    store: &DbStore,
+    turn_id: crate::TurnId,
+    attempt_count: i32,
+    claim_count: i32,
+) -> Result<Option<VendorWebSearch>> {
+    let Some(previous_claim_count) = claim_count.checked_sub(1) else {
+        return Ok(None);
+    };
+    let waits = entities::turn_client_wait::Entity::find()
+        .filter(entities::turn_client_wait::Column::TurnId.eq(turn_id.0))
+        .filter(entities::turn_client_wait::Column::AttemptCount.eq(attempt_count))
+        .filter(entities::turn_client_wait::Column::ClaimCount.eq(previous_claim_count))
+        .filter(
+            entities::turn_client_wait::Column::Status.eq(TurnClientWaitStatus::Resumed.as_str()),
+        )
+        .filter(entities::turn_client_wait::Column::ClosedAt.is_not_null())
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    let [wait] = waits.as_slice() else {
+        if waits.is_empty() {
+            return Ok(None);
+        }
+        return Err(AgentError::Store(format!(
+            "turn {turn_id} has multiple client waits for claim {previous_claim_count}"
+        )));
+    };
+    vendor_web_search_from_wait_model(wait)
 }
 
 fn progress_from_wait_model(

--- a/crates/tidebreak-core/src/db/tests/client_wait.rs
+++ b/crates/tidebreak-core/src/db/tests/client_wait.rs
@@ -43,6 +43,7 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
             cache_creation_input_tokens: 2,
         },
     };
+    let remaining_vendor_web_search = Some(crate::provider::VendorWebSearch { max_uses: 3 });
     assert!(store
         .park_turn_for_client_tool_call(
             turn_id,
@@ -174,7 +175,15 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
     );
     assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
     let (parked_turn, parked_call, parked_wait) = match store
-        .park_turn_for_client_tool_call(turn_id, turn_lease, 2, progress, parked_at, &request)
+        .park_turn_for_client_tool_call_with_search_state(
+            turn_id,
+            turn_lease,
+            2,
+            progress,
+            remaining_vendor_web_search,
+            parked_at,
+            &request,
+        )
         .await
         .unwrap()
         .unwrap()
@@ -195,6 +204,10 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
     );
     assert_eq!((parked_wait.attempt_count, parked_wait.claim_count), (1, 1));
     assert_eq!(parked_wait.progress, progress);
+    assert_eq!(
+        parked_wait.remaining_vendor_web_search,
+        remaining_vendor_web_search
+    );
     let conflicting_progress = crate::model::TurnCheckpointProgress {
         model_steps: progress.model_steps + 1,
         ..progress
@@ -339,6 +352,15 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
         .exec(&store.conn)
         .await
         .is_err());
+    assert!(entities::turn_client_wait::Entity::update_many()
+        .col_expr(
+            entities::turn_client_wait::Column::VendorWebSearchMaxUses,
+            sea_orm::sea_query::Expr::value(0),
+        )
+        .filter(entities::turn_client_wait::Column::CallId.eq(request.id.0))
+        .exec(&store.conn)
+        .await
+        .is_err());
     assert_eq!(
         wait.status,
         crate::model::TurnClientWaitStatus::Resumed.as_str()
@@ -347,11 +369,12 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
 
     assert!(matches!(
         store
-            .park_turn_for_client_tool_call(
+            .park_turn_for_client_tool_call_with_search_state(
                 turn_id,
                 turn_lease,
                 2,
                 progress,
+                remaining_vendor_web_search,
                 Utc::now(),
                 &request,
             )
@@ -376,6 +399,17 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
     assert_eq!((resumed.attempt_count, resumed.claim_count), (1, 2));
     assert_eq!(resumed.model_steps, progress.model_steps);
     assert_eq!(resumed.usage, progress.usage);
+    assert_eq!(
+        store
+            .resumed_client_vendor_web_search(
+                resumed.id,
+                resumed.attempt_count,
+                resumed.claim_count,
+            )
+            .await
+            .unwrap(),
+        remaining_vendor_web_search
+    );
     let regressing_output = Message {
         id: MessageId::new(),
         chat_id: chat.id,
@@ -1264,6 +1298,7 @@ async fn client_wait_schema_rejects_invalid_scope_claim_and_lifecycle() {
         output_tokens: Set(0),
         cache_read_input_tokens: Set(0),
         cache_creation_input_tokens: Set(0),
+        vendor_web_search_max_uses: Set(None),
         status: Set(crate::model::TurnClientWaitStatus::Waiting.as_str().into()),
         parked_at: Set(second_call.created_at),
         closed_at: Set(None),

--- a/crates/tidebreak-core/src/model/turns.rs
+++ b/crates/tidebreak-core/src/model/turns.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::id::{AgentRunId, CallId, ChatId, MessageId, TurnId};
-use crate::provider::Usage;
+use crate::provider::{Usage, VendorWebSearch};
 
 use super::is_false;
 use super::messages::ToolCallRecord;
@@ -406,6 +406,9 @@ pub struct TurnClientWait {
     pub claim_count: i32,
     /// Exact progress delta committed by this checkpoint.
     pub progress: TurnCheckpointProgress,
+    /// Vendor search allowance left after the model produced this checkpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remaining_vendor_web_search: Option<VendorWebSearch>,
     /// Durable wait lifecycle.
     pub status: TurnClientWaitStatus,
     /// Store-owned time when parking committed.

--- a/crates/tidebreak-core/src/storage/store.rs
+++ b/crates/tidebreak-core/src/storage/store.rs
@@ -24,7 +24,7 @@ use crate::model::{
     RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution,
     TurnAdmissionLease, TurnCheckpointProgress, TurnFailureRetry, TurnRun, TurnSteer,
 };
-use crate::provider::{RefusalOutcome, StopReason, Usage};
+use crate::provider::{RefusalOutcome, StopReason, Usage, VendorWebSearch};
 use crate::semantic_checkpoint::{ContextCheckpoint, SaveContextCheckpointOutcome};
 use crate::PermissionMode;
 use crate::{AnswerUserQuestionsRequest, PendingUserQuestions};
@@ -2464,14 +2464,50 @@ pub trait Store: Send + Sync {
     /// worker can apply that instruction first.
     async fn park_turn_for_client_tool_call(
         &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        progress: TurnCheckpointProgress,
+        now: chrono::DateTime<chrono::Utc>,
+        call: &ClientToolCallRequest,
+    ) -> Result<Option<ParkTurnForClientCallOutcome>> {
+        self.park_turn_for_client_tool_call_with_search_state(
+            turn_id,
+            lease_token,
+            expected_steer_revision,
+            progress,
+            None,
+            now,
+            call,
+        )
+        .await
+    }
+
+    /// Park a client tool call with the provider search allowance that remains
+    /// after its producing model step.
+    #[allow(clippy::too_many_arguments)]
+    async fn park_turn_for_client_tool_call_with_search_state(
+        &self,
         _turn_id: TurnId,
         _lease_token: uuid::Uuid,
         _expected_steer_revision: i64,
         _progress: TurnCheckpointProgress,
+        _remaining_vendor_web_search: Option<VendorWebSearch>,
         _now: chrono::DateTime<chrono::Utc>,
         _call: &ClientToolCallRequest,
     ) -> Result<Option<ParkTurnForClientCallOutcome>> {
         turn_storage_unavailable()
+    }
+
+    /// Return the provider search allowance recorded by the client wait that
+    /// immediately preceded this claimed segment.
+    async fn resumed_client_vendor_web_search(
+        &self,
+        _turn_id: TurnId,
+        _attempt_count: i32,
+        _claim_count: i32,
+    ) -> Result<Option<VendorWebSearch>> {
+        Ok(None)
     }
 
     /// Persist an ordered, unique, bounded child set and release a claimed

--- a/crates/tidebreak-server/src/engine/internal/leg.rs
+++ b/crates/tidebreak-server/src/engine/internal/leg.rs
@@ -1233,6 +1233,13 @@ impl LegDriver {
             .await?;
         let mut pending_sandbox_spawn_steer_revision =
             (!pending_sandbox_spawns.is_empty()).then_some(turn.steer_revision);
+        let mut resumed_client_vendor_web_search = if total_model_steps > 0 {
+            self.store
+                .resumed_client_vendor_web_search(turn.id, turn.attempt_count, turn.claim_count)
+                .await?
+        } else {
+            None
+        };
         // A segment arriving with zero remaining steps is not refused: the
         // budget was spent by earlier segments — a checkpoint parked on the
         // last budgeted step, or a wrap-up whose provider call failed
@@ -1523,13 +1530,15 @@ impl LegDriver {
             config.prompt_cache_retention =
                 crate::routes::read_prompt_cache_retention(&*self.store).await?;
             config.max_steps = remaining_steps;
-            // A parked segment belongs to the same Tidebreak turn. The first
-            // segment may already have offered the provider its complete
-            // request-scoped search allowance, so a resumed segment must not
-            // recreate it even when no accepted search receipt was durable.
-            if total_model_steps > 0 {
-                config.web_search = tidebreak_core::TurnWebSearch::Off;
-            }
+            // A parked segment belongs to the same Tidebreak turn. Restore an
+            // unused allowance only from the exact client wait that preceded
+            // this claim. Every later loop or retry fails closed to no vendor
+            // search because its prior provider outcome is not durable here.
+            config.web_search = claimed_segment_web_search(
+                config.web_search,
+                total_model_steps,
+                &mut resumed_client_vendor_web_search,
+            );
             config.tool_scratch = self.private_scratch_root.as_deref().and_then(|root| {
                 match private_chat_scratch(root, chat.id) {
                     Ok(scratch) => Some(self.with_scratch_write_journal(
@@ -2073,6 +2082,7 @@ impl LegDriver {
                 }
                 Ok(AgentTurnOutcome::ClientToolCall {
                     request,
+                    remaining_vendor_web_search,
                     usage,
                     steer_revision,
                     model_steps,
@@ -2158,11 +2168,12 @@ impl LegDriver {
                     ));
                     loop {
                         let park_result = tokio::select! {
-                            result = self.store.park_turn_for_client_tool_call(
+                            result = self.store.park_turn_for_client_tool_call_with_search_state(
                                 turn.id,
                                 lease_token,
                                 steer_revision,
                                 progress,
+                                remaining_vendor_web_search,
                                 Utc::now(),
                                 &request,
                             ) => result,
@@ -3438,6 +3449,21 @@ fn checked_usage_sum(
         .ok_or_else(|| AgentError::msg("provider usage exceeded the supported turn total"))
 }
 
+fn claimed_segment_web_search(
+    configured: tidebreak_core::TurnWebSearch,
+    total_model_steps: i32,
+    resumed_client_vendor_web_search: &mut Option<tidebreak_core::VendorWebSearch>,
+) -> tidebreak_core::TurnWebSearch {
+    if total_model_steps == 0 {
+        return configured;
+    }
+    resumed_client_vendor_web_search
+        .take()
+        .map_or(tidebreak_core::TurnWebSearch::Off, |search| {
+            tidebreak_core::TurnWebSearch::Vendor(search)
+        })
+}
+
 fn cancellation_race_accounting(
     turn_id: TurnId,
     drive_result: &Result<AgentTurnOutcome>,
@@ -3554,6 +3580,24 @@ fn turn_worker_outcome_is_error(outcome: &Result<LegDriverOutcome>) -> bool {
 #[cfg(test)]
 mod committed_event_drain_tests {
     use super::*;
+
+    #[test]
+    fn resumed_client_wait_restores_vendor_search_once() {
+        let search = tidebreak_core::VendorWebSearch { max_uses: 3 };
+        let mut resumed = Some(search);
+        assert_eq!(
+            claimed_segment_web_search(tidebreak_core::TurnWebSearch::Off, 1, &mut resumed,),
+            tidebreak_core::TurnWebSearch::Vendor(search)
+        );
+        assert_eq!(
+            claimed_segment_web_search(
+                tidebreak_core::TurnWebSearch::Vendor(search),
+                1,
+                &mut resumed,
+            ),
+            tidebreak_core::TurnWebSearch::Off
+        );
+    }
 
     #[test]
     fn chat_only_surface_freezes_matching_empty_tools_and_prompt() {

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -1366,22 +1366,25 @@ impl Store for PauseTerminalStore {
         }
         Ok(outcome)
     }
-    async fn park_turn_for_client_tool_call(
+    #[allow(clippy::too_many_arguments)]
+    async fn park_turn_for_client_tool_call_with_search_state(
         &self,
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         expected_steer_revision: i64,
         progress: TurnCheckpointProgress,
+        remaining_vendor_web_search: Option<tidebreak_core::VendorWebSearch>,
         now: chrono::DateTime<chrono::Utc>,
         call: &ClientToolCallRequest,
     ) -> Result<Option<ParkTurnForClientCallOutcome>> {
         let outcome = self
             .inner
-            .park_turn_for_client_tool_call(
+            .park_turn_for_client_tool_call_with_search_state(
                 turn_id,
                 lease_token,
                 expected_steer_revision,
                 progress,
+                remaining_vendor_web_search,
                 now,
                 call,
             )
@@ -1392,6 +1395,16 @@ impl Store for PauseTerminalStore {
             ));
         }
         Ok(outcome)
+    }
+    async fn resumed_client_vendor_web_search(
+        &self,
+        turn_id: TurnId,
+        attempt_count: i32,
+        claim_count: i32,
+    ) -> Result<Option<tidebreak_core::VendorWebSearch>> {
+        self.inner
+            .resumed_client_vendor_web_search(turn_id, attempt_count, claim_count)
+            .await
     }
     async fn checkpoint_sandbox_spawn(
         &self,


### PR DESCRIPTION
PR #3122 keeps an unused Anthropic vendor-search allowance across host-tool steps. Client-mediated tools still split the Tidebreak turn into a new worker segment, where the server forced search off and changed the cached tool prefix.

This change records the exact remaining vendor-search budget in the durable client-wait receipt. The immediately resumed claim restores that budget once. A used allowance, a retry, or any later loop remains search-free.

Checks:
- `cargo fmt --all -- --check`
- `cargo clippy -p tidebreak-core -p tidebreak-server --tests --no-deps -- -D warnings`
- `cargo test -p tidebreak-core claimed_agent_returns_a_client_tool_checkpoint_without_executing_it -- --nocapture`
- `cargo test -p tidebreak-core client_wait_parks_resolves_and_recovers_exactly -- --nocapture`
- `cargo test -p tidebreak-core a_fresh_database_records_the_whole_chain -- --nocapture`
- `cargo test -p tidebreak-core a_stepwise_upgrade_lands_on_the_fresh_schema -- --nocapture`
- `cargo test -p tidebreak-server resumed_client_wait_restores_vendor_search_once -- --nocapture`
- `cargo test -p tidebreak-server worker_checkpoints_a_client_tool_and_resumes_after_its_result -- --nocapture`
- `git diff --check`