### PR TITLE
fix(agent): restore SQLite turn claim indexes

### DIFF
--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -80,6 +80,7 @@ impl MigratorTrait for Migrator {
             Box::new(one_turn_lane::OneTurnLane),
             Box::new(ReadyAgentRunWaitIndex),
             Box::new(ClientWaitVendorWebSearch),
+            Box::new(RestoreTurnClaimIndexes),
         ]
     }
 }
@@ -4559,6 +4560,38 @@ impl MigrationTrait for ClientWaitVendorWebSearch {
     async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
         // A downgrade keeps the checkpoint state so it cannot accidentally
         // reopen a provider search allowance after the migration runs again.
+        Ok(())
+    }
+}
+
+/// Restore the claim indexes lost when SQLite rebuilt `code_turn`.
+struct RestoreTurnClaimIndexes;
+
+impl MigrationName for RestoreTurnClaimIndexes {
+    fn name(&self) -> &str {
+        "m20260903_000004_restore_turn_claim_indexes"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for RestoreTurnClaimIndexes {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"CREATE INDEX IF NOT EXISTS "idx_code_turn_due"
+                       ON "code_turn" ("status", "available_at", "started_at");
+                   CREATE INDEX IF NOT EXISTS "idx_code_turn_stale_lease"
+                       ON "code_turn" ("status", "lease_expires_at")"#,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // PostgreSQL already owns these indexes through the one-turn-lane
+        // migration. A rollback must not remove required claim-path indexes
+        // from either backend.
         Ok(())
     }
 }

--- a/crates/tidebreak-core/src/db/migration/tests.rs
+++ b/crates/tidebreak-core/src/db/migration/tests.rs
@@ -84,6 +84,7 @@ async fn a_fresh_database_records_the_whole_chain() {
             "m20260903_000001_one_turn_lane",
             "m20260903_000002_ready_agent_run_wait_index",
             "m20260903_000003_client_wait_vendor_web_search",
+            "m20260903_000004_restore_turn_claim_indexes",
         ]
     );
     assert!(db
@@ -94,6 +95,67 @@ async fn a_fresh_database_records_the_whole_chain() {
         .await
         .unwrap()
         .is_none());
+}
+
+#[tokio::test]
+async fn turn_claim_indexes_reach_existing_sqlite_databases() {
+    let db = Database::connect("sqlite::memory:").await.unwrap();
+    Migrator::up(
+        &db,
+        Some(steps_before("m20260903_000004_restore_turn_claim_indexes")),
+    )
+    .await
+    .unwrap();
+
+    for index in ["idx_code_turn_due", "idx_code_turn_stale_lease"] {
+        let missing = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                format!(
+                    "SELECT 1 AS present FROM sqlite_master \
+                     WHERE type = 'index' AND name = '{index}'"
+                ),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            missing.is_none(),
+            "the pre-repair schema already has {index}"
+        );
+    }
+
+    Migrator::up(&db, None).await.unwrap();
+
+    for (index, query) in [
+        (
+            "idx_code_turn_due",
+            "SELECT id FROM code_turn \
+             WHERE status = 'queued' AND available_at <= '2026-09-03T00:00:00Z' \
+             ORDER BY available_at, started_at LIMIT 1",
+        ),
+        (
+            "idx_code_turn_stale_lease",
+            "SELECT id FROM code_turn \
+             WHERE status = 'running' AND lease_expires_at <= '2026-09-03T00:00:00Z' \
+             ORDER BY lease_expires_at, started_at LIMIT 1",
+        ),
+    ] {
+        let plan = db
+            .query_all_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("EXPLAIN QUERY PLAN {query}"),
+            ))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| row.try_get::<String>("", "detail").unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            plan.contains(index),
+            "the turn claim scan must use {index}:\n{plan}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Restore the `code_turn` due-work and stale-lease indexes that the SQLite one-turn-lane table rebuild omitted. The appended migration reaches existing development profiles without changing the recorded historical migration.

## Tests

- `TIDEBREAK_DEV_SIGNING_IDENTITY= cargo test -p tidebreak-core db::migration::tests::turn_claim_indexes_reach_existing_sqlite_databases -- --exact --nocapture`
- `TIDEBREAK_DEV_SIGNING_IDENTITY= cargo test -p tidebreak-core db::migration::tests::a_fresh_database_records_the_whole_chain -- --exact --nocapture`
- `TIDEBREAK_DEV_SIGNING_IDENTITY= cargo test -p tidebreak-core db::migration::tests::a_stepwise_upgrade_lands_on_the_fresh_schema -- --exact --nocapture`