### PR TITLE
test(desktop): isolate the node vitest project

### DIFF
--- a/crates/tidebreak-desktop/ui/vite.config.ts
+++ b/crates/tidebreak-desktop/ui/vite.config.ts
@@ -171,7 +171,12 @@ export default defineConfig(async () => ({
         test: {
           name: "node",
           environment: "node",
-          isolate: false,
+          // Files in this project use `vi.mock` for shared modules such as
+          // `@tauri-apps/api/core`; without isolation one file's mock and
+          // module cache leak into the next, and codeWorktreeHost.test.ts
+          // failed on an unrelated PR with a leaked mock and a
+          // `window is not defined` from a cached module.
+          isolate: true,
           pool: "threads",
           include: nodeTestFiles,
         },


### PR DESCRIPTION
## Why

#3100 split vitest into a `node` project (`isolate: false`, threads) and a `dom` project (jsdom, forks). Files in the node project mock shared modules with `vi.mock` (for example `@tauri-apps/api/core` in `src/code/codeWorktreeHost.test.ts`). Without isolation, one file's mock and module cache leak into the next file in the same worker. On #3111, which touches no UI code, `codeWorktreeHost.test.ts` failed with a leaked `invoke` mock (`code_worktree_open_failed`) and `ReferenceError: window is not defined` from a cached module, while the same suite passed on main; the failure depends on file order.

## Change

`isolate: true` for the node project. The dom project already runs isolated in forks. The node project's own wall time is small (its 155 files ran in about 26 s before the split), so the cost is a few seconds.

## Verified

`pnpm exec vitest run --project node` locally, biome clean on `vite.config.ts`.