### PR TITLE
fix(agent): index sandbox tool recovery

### DIFF
--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -82,6 +82,7 @@ impl MigratorTrait for Migrator {
             Box::new(ClientWaitVendorWebSearch),
             Box::new(RestoreTurnClaimIndexes),
             Box::new(PendingPromptIndexes),
+            Box::new(SandboxToolRecoveryIndexes),
         ]
     }
 }
@@ -4629,6 +4630,60 @@ impl MigrationTrait for PendingPromptIndexes {
             .execute_unprepared(
                 r#"DROP INDEX IF EXISTS "idx_tool_call_pending_prompt";
                    DROP INDEX IF EXISTS "idx_code_approval_pending_prompt""#,
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+/// Keep each sandbox executor on the small branch it can claim.
+struct SandboxToolRecoveryIndexes;
+
+impl MigrationName for SandboxToolRecoveryIndexes {
+    fn name(&self) -> &str {
+        "m20260903_000006_sandbox_tool_recovery_indexes"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for SandboxToolRecoveryIndexes {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"CREATE INDEX IF NOT EXISTS "idx_sandbox_tool_call_accepted"
+                       ON "sandbox_tool_call" ("status", "created_at", "id")
+                       WHERE "status" = 'accepted';
+                   CREATE INDEX IF NOT EXISTS "idx_sandbox_tool_call_retry"
+                       ON "sandbox_tool_call" ("status", "retry_at", "created_at", "id")
+                       WHERE "status" = 'retry_wait';
+                   CREATE INDEX IF NOT EXISTS "idx_sandbox_tool_call_named_accepted"
+                       ON "sandbox_tool_call" ("name", "status", "created_at", "id")
+                       WHERE "status" = 'accepted';
+                   CREATE INDEX IF NOT EXISTS "idx_sandbox_tool_call_named_claim_recovery"
+                       ON "sandbox_tool_call" (
+                           "name", "status", "executor_lease_expires_at", "created_at", "id"
+                       )
+                       WHERE "status" = 'claimed';
+                   CREATE INDEX IF NOT EXISTS "idx_sandbox_tool_call_named_retry"
+                       ON "sandbox_tool_call" (
+                           "name", "status", "retry_at", "created_at", "id"
+                       )
+                       WHERE "status" = 'retry_wait'"#,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"DROP INDEX IF EXISTS "idx_sandbox_tool_call_accepted";
+                   DROP INDEX IF EXISTS "idx_sandbox_tool_call_retry";
+                   DROP INDEX IF EXISTS "idx_sandbox_tool_call_named_accepted";
+                   DROP INDEX IF EXISTS "idx_sandbox_tool_call_named_claim_recovery";
+                   DROP INDEX IF EXISTS "idx_sandbox_tool_call_named_retry""#,
             )
             .await?;
         Ok(())

--- a/crates/tidebreak-core/src/db/migration/tests.rs
+++ b/crates/tidebreak-core/src/db/migration/tests.rs
@@ -86,6 +86,7 @@ async fn a_fresh_database_records_the_whole_chain() {
             "m20260903_000003_client_wait_vendor_web_search",
             "m20260903_000004_restore_turn_claim_indexes",
             "m20260903_000005_pending_prompt_indexes",
+            "m20260903_000006_sandbox_tool_recovery_indexes",
         ]
     );
     assert!(db
@@ -229,6 +230,102 @@ async fn pending_prompt_indexes_reach_existing_sqlite_databases() {
         assert!(
             !plan.contains("USE TEMP B-TREE"),
             "the pending prompt projection must preserve index order:\n{plan}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sandbox_tool_recovery_indexes_reach_existing_sqlite_databases() {
+    let db = Database::connect("sqlite::memory:").await.unwrap();
+    Migrator::up(
+        &db,
+        Some(steps_before(
+            "m20260903_000006_sandbox_tool_recovery_indexes",
+        )),
+    )
+    .await
+    .unwrap();
+
+    let indexes = [
+        "idx_sandbox_tool_call_accepted",
+        "idx_sandbox_tool_call_retry",
+        "idx_sandbox_tool_call_named_accepted",
+        "idx_sandbox_tool_call_named_claim_recovery",
+        "idx_sandbox_tool_call_named_retry",
+    ];
+    for index in indexes {
+        let missing = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                format!(
+                    "SELECT 1 AS present FROM sqlite_master \
+                     WHERE type = 'index' AND name = '{index}'"
+                ),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            missing.is_none(),
+            "the pre-repair schema already has {index}"
+        );
+    }
+
+    Migrator::up(&db, None).await.unwrap();
+
+    for (index, query) in [
+        (
+            "idx_sandbox_tool_call_accepted",
+            "SELECT * FROM sandbox_tool_call WHERE status = 'accepted' \
+             ORDER BY created_at, id LIMIT 16",
+        ),
+        (
+            "idx_sandbox_tool_call_recovery",
+            "SELECT * FROM sandbox_tool_call WHERE status = 'claimed' \
+             AND executor_lease_expires_at <= '2026-09-03T00:00:00Z' \
+             ORDER BY created_at, id LIMIT 16",
+        ),
+        (
+            "idx_sandbox_tool_call_retry",
+            "SELECT * FROM sandbox_tool_call WHERE status = 'retry_wait' \
+             AND retry_at <= '2026-09-03T00:00:00Z' \
+             ORDER BY created_at, id LIMIT 16",
+        ),
+        (
+            "idx_sandbox_tool_call_named_accepted",
+            "SELECT * FROM sandbox_tool_call WHERE status = 'accepted' \
+             AND name = 'web_search' ORDER BY created_at, id LIMIT 16",
+        ),
+        (
+            "idx_sandbox_tool_call_named_claim_recovery",
+            "SELECT * FROM sandbox_tool_call WHERE status = 'claimed' \
+             AND executor_lease_expires_at <= '2026-09-03T00:00:00Z' \
+             AND name = 'web_search' ORDER BY created_at, id LIMIT 16",
+        ),
+        (
+            "idx_sandbox_tool_call_named_retry",
+            "SELECT * FROM sandbox_tool_call WHERE status = 'retry_wait' \
+             AND retry_at <= '2026-09-03T00:00:00Z' \
+             AND name = 'web_search' ORDER BY created_at, id LIMIT 16",
+        ),
+    ] {
+        let plan = db
+            .query_all_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("EXPLAIN QUERY PLAN {query}"),
+            ))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| row.try_get::<String>("", "detail").unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            plan.contains(index),
+            "the sandbox tool recovery branch must use {index}:\n{plan}"
+        );
+        assert!(
+            !plan.contains("MULTI-INDEX OR"),
+            "each sandbox tool recovery state must use one bounded scan:\n{plan}"
         );
     }
 }

--- a/crates/tidebreak-core/src/db/ops/sandbox_tool.rs
+++ b/crates/tidebreak-core/src/db/ops/sandbox_tool.rs
@@ -1132,30 +1132,8 @@ pub(in crate::db) async fn list_sandbox_tool_call_candidates(
         ));
     }
     let now = database_now(&store.conn).await?;
-    entities::sandbox_tool_call::Entity::find()
-        .filter(
-            sea_orm::Condition::any()
-                .add(
-                    entities::sandbox_tool_call::Column::Status
-                        .eq(SandboxToolCallStatus::Accepted.as_str()),
-                )
-                .add(
-                    entities::sandbox_tool_call::Column::Status
-                        .eq(SandboxToolCallStatus::Claimed.as_str())
-                        .and(entities::sandbox_tool_call::Column::ExecutorLeaseExpiresAt.lte(now)),
-                )
-                .add(
-                    entities::sandbox_tool_call::Column::Status
-                        .eq(SandboxToolCallStatus::RetryWait.as_str())
-                        .and(entities::sandbox_tool_call::Column::RetryAt.lte(now)),
-                ),
-        )
-        .order_by_asc(entities::sandbox_tool_call::Column::CreatedAt)
-        .order_by_asc(entities::sandbox_tool_call::Column::Id)
-        .limit(limit)
-        .all(&store.conn)
-        .await
-        .map_err(store_err)?
+    list_sandbox_tool_call_candidate_models(store, None, now, limit)
+        .await?
         .into_iter()
         .map(call_from_model)
         .collect()
@@ -1175,34 +1153,63 @@ pub(in crate::db) async fn list_sandbox_tool_call_candidates_named(
         ));
     }
     let now = database_now(&store.conn).await?;
-    entities::sandbox_tool_call::Entity::find()
-        .filter(entities::sandbox_tool_call::Column::Name.eq(name))
-        .filter(
-            sea_orm::Condition::any()
-                .add(
-                    entities::sandbox_tool_call::Column::Status
-                        .eq(SandboxToolCallStatus::Accepted.as_str()),
-                )
-                .add(
-                    entities::sandbox_tool_call::Column::Status
-                        .eq(SandboxToolCallStatus::Claimed.as_str())
-                        .and(entities::sandbox_tool_call::Column::ExecutorLeaseExpiresAt.lte(now)),
-                )
-                .add(
-                    entities::sandbox_tool_call::Column::Status
-                        .eq(SandboxToolCallStatus::RetryWait.as_str())
-                        .and(entities::sandbox_tool_call::Column::RetryAt.lte(now)),
-                ),
-        )
-        .order_by_asc(entities::sandbox_tool_call::Column::CreatedAt)
-        .order_by_asc(entities::sandbox_tool_call::Column::Id)
-        .limit(limit)
-        .all(&store.conn)
-        .await
-        .map_err(store_err)?
+    list_sandbox_tool_call_candidate_models(store, Some(name), now, limit)
+        .await?
         .into_iter()
         .map(call_from_model)
         .collect()
+}
+
+/// Read each claimable state through its own index, then restore the one
+/// oldest-first order shared by all executor lanes. Fetching `limit` rows per
+/// state is sufficient: no row after a state's first `limit` can enter the
+/// first `limit` rows of the merged result.
+async fn list_sandbox_tool_call_candidate_models(
+    store: &DbStore,
+    name: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+    limit: u64,
+) -> Result<Vec<entities::sandbox_tool_call::Model>> {
+    let branch = |condition| {
+        let mut query = entities::sandbox_tool_call::Entity::find().filter(condition);
+        if let Some(name) = name {
+            query = query.filter(entities::sandbox_tool_call::Column::Name.eq(name));
+        }
+        query
+            .order_by_asc(entities::sandbox_tool_call::Column::CreatedAt)
+            .order_by_asc(entities::sandbox_tool_call::Column::Id)
+            .limit(limit)
+    };
+    let accepted = branch(
+        entities::sandbox_tool_call::Column::Status.eq(SandboxToolCallStatus::Accepted.as_str()),
+    )
+    .all(&store.conn);
+    let expired_claims = branch(
+        entities::sandbox_tool_call::Column::Status
+            .eq(SandboxToolCallStatus::Claimed.as_str())
+            .and(entities::sandbox_tool_call::Column::ExecutorLeaseExpiresAt.lte(now)),
+    )
+    .all(&store.conn);
+    let due_retries = branch(
+        entities::sandbox_tool_call::Column::Status
+            .eq(SandboxToolCallStatus::RetryWait.as_str())
+            .and(entities::sandbox_tool_call::Column::RetryAt.lte(now)),
+    )
+    .all(&store.conn);
+    let (accepted, expired_claims, due_retries) =
+        tokio::try_join!(accepted, expired_claims, due_retries).map_err(store_err)?;
+    let mut candidates =
+        Vec::with_capacity(accepted.len() + expired_claims.len() + due_retries.len());
+    candidates.extend(accepted);
+    candidates.extend(expired_claims);
+    candidates.extend(due_retries);
+    candidates.sort_unstable_by(|left, right| {
+        left.created_at
+            .cmp(&right.created_at)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    candidates.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    Ok(candidates)
 }
 
 /// Terminalize accepted or expired claimed work in the same transaction that

--- a/crates/tidebreak-core/src/db/tests/agent_run.rs
+++ b/crates/tidebreak-core/src/db/tests/agent_run.rs
@@ -2905,6 +2905,110 @@ async fn expired_sandbox_tool_claim_is_recoverable_and_fences_stale_executor() {
 }
 
 #[tokio::test]
+async fn sandbox_tool_candidates_merge_states_oldest_first_and_keep_named_lanes_isolated() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let sandbox = accepted_sandbox_for_tool_test(&store, chat.id).await;
+    let worker_lease = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(worker_lease, Duration::minutes(5), 1, 1)
+        .await
+        .unwrap();
+    let requests = [
+        ("web_search", serde_json::json!({"query": "accepted"})),
+        ("web_search", serde_json::json!({"query": "expired"})),
+        ("web_search", serde_json::json!({"query": "retry"})),
+        (
+            crate::UPDATE_TASK_PLAN_TOOL,
+            serde_json::json!({"steps": []}),
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(index, (name, arguments))| SandboxToolCallRequest {
+        id: CallId::new(),
+        agent_run_id: sandbox.id,
+        chat_id: chat.id,
+        provider_id: format!("provider-candidate-{index}"),
+        name: name.into(),
+        arguments,
+    })
+    .collect::<Vec<_>>();
+    let entries = requests.iter().map(super::dispatchable).collect::<Vec<_>>();
+    store
+        .park_agent_run_for_sandbox_tool_calls(sandbox.id, worker_lease, &entries)
+        .await
+        .unwrap();
+
+    let expired_lease = uuid::Uuid::new_v4();
+    assert!(matches!(
+        store
+            .claim_sandbox_tool_call(requests[1].id, expired_lease, Duration::minutes(2))
+            .await
+            .unwrap(),
+        ClaimSandboxToolCallOutcome::Claimed(_)
+    ));
+    crate::db::entities::sandbox_tool_call::Entity::update_many()
+        .col_expr(
+            crate::db::entities::sandbox_tool_call::Column::ExecutorLeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(Utc::now() - Duration::minutes(1))),
+        )
+        .filter(crate::db::entities::sandbox_tool_call::Column::Id.eq(requests[1].id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let retry_lease = uuid::Uuid::new_v4();
+    assert!(matches!(
+        store
+            .claim_sandbox_tool_call(requests[2].id, retry_lease, Duration::minutes(2))
+            .await
+            .unwrap(),
+        ClaimSandboxToolCallOutcome::Claimed(_)
+    ));
+    assert_eq!(
+        store
+            .retry_sandbox_tool_call(requests[2].id, retry_lease, Duration::zero())
+            .await
+            .unwrap(),
+        crate::RetrySandboxToolCallOutcome::Scheduled
+    );
+
+    let oldest = Utc::now() - Duration::minutes(10);
+    for (request, created_at) in requests.iter().zip([
+        oldest + Duration::minutes(3),
+        oldest + Duration::minutes(2),
+        oldest + Duration::minutes(1),
+        oldest,
+    ]) {
+        crate::db::entities::sandbox_tool_call::Entity::update_many()
+            .col_expr(
+                crate::db::entities::sandbox_tool_call::Column::CreatedAt,
+                sea_orm::sea_query::Expr::value(created_at),
+            )
+            .filter(crate::db::entities::sandbox_tool_call::Column::Id.eq(request.id.0))
+            .exec(&store.conn)
+            .await
+            .unwrap();
+    }
+
+    let all = store.list_sandbox_tool_call_candidates(2).await.unwrap();
+    assert_eq!(
+        all.iter().map(|call| call.id).collect::<Vec<_>>(),
+        vec![requests[3].id, requests[2].id]
+    );
+    let named = store
+        .list_sandbox_tool_call_candidates_named("web_search", 2)
+        .await
+        .unwrap();
+    assert_eq!(
+        named.iter().map(|call| call.id).collect::<Vec<_>>(),
+        vec![requests[2].id, requests[1].id]
+    );
+}
+
+#[tokio::test]
 async fn waiting_sandbox_deadline_fences_tool_and_delivers_parent_failure() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();


### PR DESCRIPTION
Sandbox tool recovery mixed accepted work, expired claims, and due retries into one ordered scan. Named executor lanes also searched by status before filtering to their tool name.

This change splits recovery into three bounded state scans, merges their results by creation order, and adds partial indexes for accepted work, retries, and named lanes. It also adds migration query-plan coverage and a state-ordering regression test.

Tests:
- cargo test -p tidebreak-core sandbox_tool_candidates_merge_states_oldest_first_and_keep_named_lanes_isolated
- cargo test -p tidebreak-core sandbox_tool_recovery_indexes_reach_existing_sqlite_databases
- cargo test -p tidebreak-core a_fresh_database_records_the_whole_chain
- cargo test -p tidebreak-core a_stepwise_upgrade_lands_on_the_fresh_schema
- cargo fmt --all -- --check
- git diff --check