### PR TITLE
feat(agent): park durable turn waits

### DIFF
--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -243,6 +243,17 @@ impl DbStore {
         ops::turn::take_lease_on_turn(self, id, lease_token, now, lease_expires_at).await
     }
 
+    /// Claim one exact resuming turn under a fresh lease.
+    pub async fn take_lease_on_resuming_turn(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        lease_expires_at: chrono::DateTime<Utc>,
+    ) -> Result<Option<()>> {
+        ops::turn::take_lease_on_resuming_turn(self, id, lease_token, now, lease_expires_at).await
+    }
+
     /// Claim an inserted turn and add its user transcript row in one write.
     pub async fn take_lease_on_turn_with_input_message(
         &self,

--- a/crates/tidebreak-core/src/db/ops/code/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/code/turn.rs
@@ -10,12 +10,12 @@ use crate::error::{AgentError, Result};
 use crate::image::ImageMediaType;
 use crate::image::ImageRef;
 use crate::model::{TurnAgentRunWaitStatus, TurnClientWaitStatus, MAX_MESSAGE_ATTACHMENTS};
-use crate::{AgentRunId, CallId, ChatId, OwnerId};
+use crate::{AgentRunId, CallId, OwnerId};
 
 use super::super::super::{entities, store_err, DbStore};
 use super::super::blob as blob_ops;
 use super::super::{
-    acquire_advisory_lock, acquire_chat_write_lock, acquire_turn_write_lock, AdvisoryLockName,
+    acquire_advisory_lock, acquire_session_write_lock, acquire_turn_write_lock, AdvisoryLockName,
 };
 
 /// The fields analytics needs from one turn.
@@ -451,7 +451,7 @@ pub async fn store_turn_park(
     if matches!(wait, TurnParkWait::AgentRuns { .. }) {
         acquire_advisory_lock(&transaction, AdvisoryLockName::TurnAgentRunWait).await?;
     }
-    if !acquire_chat_write_lock(&transaction, ChatId(scope.session_id)).await?
+    if !acquire_session_write_lock(&transaction, scope.session_id).await?
         || !acquire_turn_write_lock(&transaction, crate::TurnId(id.0)).await?
     {
         transaction.commit().await.map_err(store_err)?;
@@ -581,7 +581,7 @@ pub async fn clear_turn_park(
         return Ok(None);
     };
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    if !acquire_chat_write_lock(&transaction, ChatId(scope.session_id)).await?
+    if !acquire_session_write_lock(&transaction, scope.session_id).await?
         || !acquire_turn_write_lock(&transaction, crate::TurnId(id.0)).await?
     {
         transaction.commit().await.map_err(store_err)?;

--- a/crates/tidebreak-core/src/db/ops/code/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/code/turn.rs
@@ -15,7 +15,8 @@ use crate::{AgentRunId, CallId, OwnerId};
 use super::super::super::{entities, store_err, DbStore};
 use super::super::blob as blob_ops;
 use super::super::{
-    acquire_advisory_lock, acquire_session_write_lock, acquire_turn_write_lock, AdvisoryLockName,
+    acquire_advisory_lock, acquire_code_turn_write_lock, acquire_session_write_lock,
+    AdvisoryLockName,
 };
 
 /// The fields analytics needs from one turn.
@@ -452,7 +453,7 @@ pub async fn store_turn_park(
         acquire_advisory_lock(&transaction, AdvisoryLockName::TurnAgentRunWait).await?;
     }
     if !acquire_session_write_lock(&transaction, scope.session_id).await?
-        || !acquire_turn_write_lock(&transaction, crate::TurnId(id.0)).await?
+        || !acquire_code_turn_write_lock(&transaction, id).await?
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
@@ -582,7 +583,7 @@ pub async fn clear_turn_park(
     };
     let transaction = store.conn.begin().await.map_err(store_err)?;
     if !acquire_session_write_lock(&transaction, scope.session_id).await?
-        || !acquire_turn_write_lock(&transaction, crate::TurnId(id.0)).await?
+        || !acquire_code_turn_write_lock(&transaction, id).await?
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
@@ -699,14 +700,14 @@ where
         TurnParkWait::AgentRuns { .. } => {
             return Err(AgentError::Store(format!(
                 "turn {} client park has an agent-run wait",
-                crate::TurnId(turn.id)
+                CodeTurnId(turn.id)
             )));
         }
     };
     let call_id = call_id.parse::<CallId>().map_err(|_| {
         AgentError::Store(format!(
             "turn {} client park has an invalid call id",
-            crate::TurnId(turn.id)
+            CodeTurnId(turn.id)
         ))
     })?;
     let receipt = entities::turn_client_wait::Entity::find_by_id(call_id.0)
@@ -716,7 +717,7 @@ where
         .ok_or_else(|| {
             AgentError::Store(format!(
                 "turn {} client park is missing wait {call_id}",
-                crate::TurnId(turn.id)
+                CodeTurnId(turn.id)
             ))
         })?;
     if receipt.turn_id != turn.id
@@ -727,7 +728,7 @@ where
     {
         return Err(AgentError::Store(format!(
             "turn {} client park has a mismatched wait {call_id}",
-            crate::TurnId(turn.id)
+            CodeTurnId(turn.id)
         )));
     }
     Ok(())
@@ -746,13 +747,13 @@ where
     let TurnParkWait::AgentRuns { run_ids } = wait else {
         return Err(AgentError::Store(format!(
             "turn {} agent-run park has a different wait kind",
-            crate::TurnId(turn.id)
+            CodeTurnId(turn.id)
         )));
     };
     let wait_id = park_ref.parse::<CallId>().map_err(|_| {
         AgentError::Store(format!(
             "turn {} agent-run park has an invalid wait id",
-            crate::TurnId(turn.id)
+            CodeTurnId(turn.id)
         ))
     })?;
     let expected_runs = run_ids
@@ -761,7 +762,7 @@ where
             id.parse::<AgentRunId>().map_err(|_| {
                 AgentError::Store(format!(
                     "turn {} agent-run park has an invalid run id",
-                    crate::TurnId(turn.id)
+                    CodeTurnId(turn.id)
                 ))
             })
         })
@@ -773,7 +774,7 @@ where
         .ok_or_else(|| {
             AgentError::Store(format!(
                 "turn {} agent-run park is missing wait {wait_id}",
-                crate::TurnId(turn.id)
+                CodeTurnId(turn.id)
             ))
         })?;
     let members = entities::turn_agent_run_wait_member::Entity::find()
@@ -795,7 +796,7 @@ where
     {
         return Err(AgentError::Store(format!(
             "turn {} agent-run park has a mismatched wait {wait_id}",
-            crate::TurnId(turn.id)
+            CodeTurnId(turn.id)
         )));
     }
     Ok(())

--- a/crates/tidebreak-core/src/db/ops/code/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/code/turn.rs
@@ -3,15 +3,20 @@ use sea_orm::{
     QueryOrder, QuerySelect, Set, TransactionTrait,
 };
 
-use crate::code::{CodeSessionId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeUsage, Diffstat};
+use crate::code::{
+    CodeSessionId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeUsage, Diffstat, TurnParkWait,
+};
 use crate::error::{AgentError, Result};
 use crate::image::ImageMediaType;
 use crate::image::ImageRef;
-use crate::model::MAX_MESSAGE_ATTACHMENTS;
-use crate::OwnerId;
+use crate::model::{TurnAgentRunWaitStatus, TurnClientWaitStatus, MAX_MESSAGE_ATTACHMENTS};
+use crate::{AgentRunId, CallId, ChatId, OwnerId};
 
 use super::super::super::{entities, store_err, DbStore};
 use super::super::blob as blob_ops;
+use super::super::{
+    acquire_advisory_lock, acquire_chat_write_lock, acquire_turn_write_lock, AdvisoryLockName,
+};
 
 /// The fields analytics needs from one turn.
 ///
@@ -417,6 +422,383 @@ pub async fn save_turn(store: &DbStore, owner: &OwnerId, turn: &CodeTurn) -> Res
         .await
         .map_err(store_err)?;
     Ok(result.rows_affected == 1)
+}
+
+/// Attach one durable adapter park without overwriting a resolution that won
+/// after the engine released its turn lease.
+///
+/// Internal-engine client and agent-run waits first checkpoint through the
+/// turn store, which leaves the row in a legacy wait status. The adapter then
+/// records its opaque resume ref and changes that status to `waiting`. If the
+/// dependency resolves between those two writes, the row is already
+/// `resuming`; this operation keeps that status and only attaches the park.
+pub async fn store_turn_park(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeTurnId,
+    park_ref: &str,
+    wait: &TurnParkWait,
+) -> Result<Option<CodeTurnStatus>> {
+    let Some(scope) = entities::code_turn::Entity::find_by_id(id.0)
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if matches!(wait, TurnParkWait::AgentRuns { .. }) {
+        acquire_advisory_lock(&transaction, AdvisoryLockName::TurnAgentRunWait).await?;
+    }
+    if !acquire_chat_write_lock(&transaction, ChatId(scope.session_id)).await?
+        || !acquire_turn_write_lock(&transaction, crate::TurnId(id.0)).await?
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(turn) = entities::code_turn::Entity::find_by_id(id.0)
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let status = CodeTurnStatus::from_str(&turn.status).ok_or_else(|| {
+        AgentError::Store(format!("turn {} has unknown status {}", id, turn.status))
+    })?;
+    let raw_wait = serde_json::to_value(wait)?;
+    match (turn.park_ref.as_deref(), turn.park_wait.as_ref()) {
+        (Some(stored_ref), Some(stored_wait))
+            if stored_ref == park_ref && stored_wait == &raw_wait =>
+        {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(status));
+        }
+        (None, None) => {}
+        _ => {
+            return Err(AgentError::Store(format!(
+                "turn {id} already carries a different durable park"
+            )));
+        }
+    }
+
+    let next_status = match status {
+        CodeTurnStatus::Running => CodeTurnStatus::Waiting,
+        CodeTurnStatus::WaitingForClient
+            if matches!(
+                wait,
+                TurnParkWait::Approval { .. } | TurnParkWait::ClientToolCall { .. }
+            ) =>
+        {
+            require_client_park_receipt(&transaction, &turn, wait, TurnClientWaitStatus::Waiting)
+                .await?;
+            CodeTurnStatus::Waiting
+        }
+        CodeTurnStatus::WaitingForAgentRun if matches!(wait, TurnParkWait::AgentRuns { .. }) => {
+            require_agent_run_park_receipt(
+                &transaction,
+                &turn,
+                park_ref,
+                wait,
+                TurnAgentRunWaitStatus::Waiting,
+            )
+            .await?;
+            CodeTurnStatus::Waiting
+        }
+        CodeTurnStatus::Resuming => {
+            require_resolved_park_receipt(&transaction, &turn, park_ref, wait).await?;
+            CodeTurnStatus::Resuming
+        }
+        CodeTurnStatus::CancellingClient
+            if matches!(
+                wait,
+                TurnParkWait::Approval { .. } | TurnParkWait::ClientToolCall { .. }
+            ) =>
+        {
+            require_client_park_receipt(&transaction, &turn, wait, TurnClientWaitStatus::Waiting)
+                .await?;
+            CodeTurnStatus::CancellingClient
+        }
+        CodeTurnStatus::Interrupted => {
+            require_cancelled_park_receipt(&transaction, &turn, park_ref, wait).await?;
+            CodeTurnStatus::Interrupted
+        }
+        _ => {
+            return Err(AgentError::Store(format!(
+                "turn {id} cannot store a durable park from status {}",
+                status.as_str()
+            )));
+        }
+    };
+    let updated = entities::code_turn::Entity::update_many()
+        .col_expr(
+            entities::code_turn::Column::Status,
+            sea_orm::sea_query::Expr::value(next_status.as_str()),
+        )
+        .col_expr(
+            entities::code_turn::Column::ParkRef,
+            sea_orm::sea_query::Expr::value(Some(park_ref.to_owned())),
+        )
+        .col_expr(
+            entities::code_turn::Column::ParkWait,
+            sea_orm::sea_query::Expr::value(Some(raw_wait)),
+        )
+        .filter(entities::code_turn::Column::Id.eq(turn.id))
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_turn::Column::Status.eq(&turn.status))
+        .filter(entities::code_turn::Column::AttemptCount.eq(turn.attempt_count))
+        .filter(entities::code_turn::Column::ClaimCount.eq(turn.claim_count))
+        .filter(entities::code_turn::Column::ParkRef.is_null())
+        .filter(entities::code_turn::Column::ParkWait.is_null())
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(next_status))
+}
+
+/// Clear one exact durable adapter park without writing any other turn field.
+pub async fn clear_turn_park(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeTurnId,
+    park_ref: &str,
+    wait: &TurnParkWait,
+) -> Result<Option<CodeTurnStatus>> {
+    let Some(scope) = entities::code_turn::Entity::find_by_id(id.0)
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, ChatId(scope.session_id)).await?
+        || !acquire_turn_write_lock(&transaction, crate::TurnId(id.0)).await?
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(turn) = entities::code_turn::Entity::find_by_id(id.0)
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let status = CodeTurnStatus::from_str(&turn.status).ok_or_else(|| {
+        AgentError::Store(format!("turn {} has unknown status {}", id, turn.status))
+    })?;
+    let raw_wait = serde_json::to_value(wait)?;
+    if turn.park_ref.is_none() && turn.park_wait.is_none() {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(status));
+    }
+    if turn.park_ref.as_deref() != Some(park_ref) || turn.park_wait.as_ref() != Some(&raw_wait) {
+        return Err(AgentError::Store(format!(
+            "turn {id} carries a different durable park"
+        )));
+    }
+    let updated = entities::code_turn::Entity::update_many()
+        .col_expr(
+            entities::code_turn::Column::ParkRef,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::code_turn::Column::ParkWait,
+            sea_orm::sea_query::Expr::value(Option::<serde_json::Value>::None),
+        )
+        .filter(entities::code_turn::Column::Id.eq(turn.id))
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_turn::Column::ParkRef.eq(park_ref))
+        .filter(entities::code_turn::Column::ParkWait.eq(raw_wait))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(status))
+}
+
+async fn require_resolved_park_receipt<C>(
+    conn: &C,
+    turn: &entities::code_turn::Model,
+    park_ref: &str,
+    wait: &TurnParkWait,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    match wait {
+        TurnParkWait::Approval { .. } | TurnParkWait::ClientToolCall { .. } => {
+            require_client_park_receipt(conn, turn, wait, TurnClientWaitStatus::Resumed).await
+        }
+        TurnParkWait::AgentRuns { .. } => {
+            require_agent_run_park_receipt(
+                conn,
+                turn,
+                park_ref,
+                wait,
+                TurnAgentRunWaitStatus::Resumed,
+            )
+            .await
+        }
+    }
+}
+
+async fn require_cancelled_park_receipt<C>(
+    conn: &C,
+    turn: &entities::code_turn::Model,
+    park_ref: &str,
+    wait: &TurnParkWait,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    match wait {
+        TurnParkWait::Approval { .. } | TurnParkWait::ClientToolCall { .. } => {
+            require_client_park_receipt(conn, turn, wait, TurnClientWaitStatus::Cancelled).await
+        }
+        TurnParkWait::AgentRuns { .. } => {
+            require_agent_run_park_receipt(
+                conn,
+                turn,
+                park_ref,
+                wait,
+                TurnAgentRunWaitStatus::Cancelled,
+            )
+            .await
+        }
+    }
+}
+
+async fn require_client_park_receipt<C>(
+    conn: &C,
+    turn: &entities::code_turn::Model,
+    wait: &TurnParkWait,
+    expected_status: TurnClientWaitStatus,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let call_id = match wait {
+        TurnParkWait::Approval { call_id } | TurnParkWait::ClientToolCall { call_id } => call_id,
+        TurnParkWait::AgentRuns { .. } => {
+            return Err(AgentError::Store(format!(
+                "turn {} client park has an agent-run wait",
+                crate::TurnId(turn.id)
+            )));
+        }
+    };
+    let call_id = call_id.parse::<CallId>().map_err(|_| {
+        AgentError::Store(format!(
+            "turn {} client park has an invalid call id",
+            crate::TurnId(turn.id)
+        ))
+    })?;
+    let receipt = entities::turn_client_wait::Entity::find_by_id(call_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "turn {} client park is missing wait {call_id}",
+                crate::TurnId(turn.id)
+            ))
+        })?;
+    if receipt.turn_id != turn.id
+        || receipt.session_id != turn.session_id
+        || receipt.attempt_count != turn.attempt_count
+        || receipt.claim_count != turn.claim_count
+        || receipt.status != expected_status.as_str()
+    {
+        return Err(AgentError::Store(format!(
+            "turn {} client park has a mismatched wait {call_id}",
+            crate::TurnId(turn.id)
+        )));
+    }
+    Ok(())
+}
+
+async fn require_agent_run_park_receipt<C>(
+    conn: &C,
+    turn: &entities::code_turn::Model,
+    park_ref: &str,
+    wait: &TurnParkWait,
+    expected_status: TurnAgentRunWaitStatus,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let TurnParkWait::AgentRuns { run_ids } = wait else {
+        return Err(AgentError::Store(format!(
+            "turn {} agent-run park has a different wait kind",
+            crate::TurnId(turn.id)
+        )));
+    };
+    let wait_id = park_ref.parse::<CallId>().map_err(|_| {
+        AgentError::Store(format!(
+            "turn {} agent-run park has an invalid wait id",
+            crate::TurnId(turn.id)
+        ))
+    })?;
+    let expected_runs = run_ids
+        .iter()
+        .map(|id| {
+            id.parse::<AgentRunId>().map_err(|_| {
+                AgentError::Store(format!(
+                    "turn {} agent-run park has an invalid run id",
+                    crate::TurnId(turn.id)
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let receipt = entities::turn_agent_run_wait_set::Entity::find_by_id(wait_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "turn {} agent-run park is missing wait {wait_id}",
+                crate::TurnId(turn.id)
+            ))
+        })?;
+    let members = entities::turn_agent_run_wait_member::Entity::find()
+        .filter(entities::turn_agent_run_wait_member::Column::WaitId.eq(wait_id.0))
+        .order_by_asc(entities::turn_agent_run_wait_member::Column::Position)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    let stored_runs = members
+        .iter()
+        .map(|member| AgentRunId(member.child_run_id))
+        .collect::<Vec<_>>();
+    if receipt.turn_id != turn.id
+        || receipt.session_id != turn.session_id
+        || receipt.attempt_count != turn.attempt_count
+        || receipt.claim_count != turn.claim_count
+        || receipt.status != expected_status.as_str()
+        || stored_runs != expected_runs
+    {
+        return Err(AgentError::Store(format!(
+            "turn {} agent-run park has a mismatched wait {wait_id}",
+            crate::TurnId(turn.id)
+        )));
+    }
+    Ok(())
 }
 
 /// Store one turn's derived narrative, touching no other column.

--- a/crates/tidebreak-core/src/db/ops/mod.rs
+++ b/crates/tidebreak-core/src/db/ops/mod.rs
@@ -1,5 +1,6 @@
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder};
 
+use crate::code::CodeTurnId;
 use crate::error::{AgentError, Result};
 use crate::id::{CallId, ChatId, ProjectId, TurnId};
 
@@ -241,4 +242,15 @@ where
         .await
         .map_err(store_err)?;
     Ok(locked.rows_affected == 1)
+}
+
+/// Acquire the same durable-turn lock using the code-mode turn identifier.
+pub(in crate::db) async fn acquire_code_turn_write_lock<C>(
+    conn: &C,
+    turn_id: CodeTurnId,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    acquire_turn_write_lock(conn, TurnId(turn_id.0)).await
 }

--- a/crates/tidebreak-core/src/db/ops/mod.rs
+++ b/crates/tidebreak-core/src/db/ops/mod.rs
@@ -105,12 +105,23 @@ pub(in crate::db) async fn acquire_chat_write_lock<C>(conn: &C, chat_id: ChatId)
 where
     C: ConnectionTrait,
 {
+    acquire_session_write_lock(conn, chat_id.0).await
+}
+
+/// Acquire the shared cross-backend write lock for one universal session row.
+pub(in crate::db) async fn acquire_session_write_lock<C>(
+    conn: &C,
+    session_id: uuid::Uuid,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
     let locked = entities::code_session::Entity::update_many()
         .col_expr(
             entities::code_session::Column::Title,
             sea_orm::sea_query::Expr::col(entities::code_session::Column::Title),
         )
-        .filter(entities::code_session::Column::Id.eq(chat_id.0))
+        .filter(entities::code_session::Column::Id.eq(session_id))
         .exec(conn)
         .await
         .map_err(store_err)?;

--- a/crates/tidebreak-core/src/db/ops/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/turn.rs
@@ -16,6 +16,7 @@ use crate::provider::Usage;
 use crate::storage::{
     AcceptTurnOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome, ReservedTurnAcceptanceOutcome,
 };
+use crate::CodeTurnStatus;
 
 use super::super::{entities, store_err, DbStore};
 use super::chat_image_publication as chat_image_publication_ops;
@@ -39,8 +40,9 @@ mod sandbox_spawn;
 pub(in crate::db) mod steer;
 
 pub(in crate::db) use client_wait::{
-    advance_turn_after_client_resolution_on, approval_park_call_id, park_turn_for_client_tool_call,
-    recover_turn_after_client_resolution_on, resumed_client_vendor_web_search,
+    adapter_client_park_call_id, adapter_park_wait, advance_turn_after_client_resolution_on,
+    approval_park_call_id, park_turn_for_client_tool_call, recover_turn_after_client_resolution_on,
+    resumed_client_vendor_web_search,
 };
 #[cfg(test)]
 pub(in crate::db) use multi_agent_run_wait::ready_agent_run_wait_set_candidates_sql;
@@ -133,7 +135,11 @@ async fn take_lease_on_turn_inner(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
-    let next_attempt = std::cmp::Ord::max(existing.attempt_count.saturating_add(1), 1);
+    let next_attempt = if existing.status == TurnRunStatus::Resuming.as_str() {
+        std::cmp::Ord::max(existing.attempt_count, 1)
+    } else {
+        std::cmp::Ord::max(existing.attempt_count.saturating_add(1), 1)
+    };
     let next_claim = std::cmp::Ord::max(existing.claim_count.saturating_add(1), 1);
     let inserted =
         entities::code_turn_claim::Entity::insert(entities::code_turn_claim::ActiveModel {
@@ -1531,6 +1537,7 @@ where
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
             TurnRunStatus::Cancelling.as_str(),
+            CodeTurnStatus::Waiting.as_str(),
             TurnRunStatus::WaitingForClient.as_str(),
             TurnRunStatus::WaitingForAgentRun.as_str(),
             TurnRunStatus::CancellingClient.as_str(),

--- a/crates/tidebreak-core/src/db/ops/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/turn.rs
@@ -70,7 +70,27 @@ pub(in crate::db) async fn take_lease_on_turn(
     now: chrono::DateTime<Utc>,
     lease_expires_at: chrono::DateTime<Utc>,
 ) -> Result<Option<()>> {
-    take_lease_on_turn_inner(store, id, lease_token, now, lease_expires_at, None).await
+    take_lease_on_turn_inner(store, id, lease_token, now, lease_expires_at, None, None).await
+}
+
+/// Take a fresh lease only while one exact turn is ready to resume.
+pub(in crate::db) async fn take_lease_on_resuming_turn(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    lease_expires_at: chrono::DateTime<Utc>,
+) -> Result<Option<()>> {
+    take_lease_on_turn_inner(
+        store,
+        id,
+        lease_token,
+        now,
+        lease_expires_at,
+        None,
+        Some(TurnRunStatus::Resuming),
+    )
+    .await
 }
 
 /// Claim one inserted turn and add its missing user transcript row atomically.
@@ -82,7 +102,16 @@ pub(in crate::db) async fn take_lease_on_turn_with_input_message(
     lease_expires_at: chrono::DateTime<Utc>,
     content: &str,
 ) -> Result<Option<()>> {
-    take_lease_on_turn_inner(store, id, lease_token, now, lease_expires_at, Some(content)).await
+    take_lease_on_turn_inner(
+        store,
+        id,
+        lease_token,
+        now,
+        lease_expires_at,
+        Some(content),
+        None,
+    )
+    .await
 }
 
 async fn take_lease_on_turn_inner(
@@ -92,6 +121,7 @@ async fn take_lease_on_turn_inner(
     now: chrono::DateTime<Utc>,
     lease_expires_at: chrono::DateTime<Utc>,
     input: Option<&str>,
+    required_status: Option<TurnRunStatus>,
 ) -> Result<Option<()>> {
     let now = canonical_db_timestamp(now)?;
     let lease_expires_at = canonical_db_timestamp(lease_expires_at)?;
@@ -126,6 +156,10 @@ async fn take_lease_on_turn_inner(
         transaction.rollback().await.map_err(store_err)?;
         return Ok(None);
     };
+    if required_status.is_some_and(|required| existing.status != required.as_str()) {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
     if existing.lease_token.is_some()
         && existing.status == TurnRunStatus::Running.as_str()
         && existing

--- a/crates/tidebreak-core/src/db/ops/turn/client_wait.rs
+++ b/crates/tidebreak-core/src/db/ops/turn/client_wait.rs
@@ -24,14 +24,14 @@ pub(in crate::db) struct ClientWaitTurnTransition {
     pub terminal_event: Option<SequencedEvent>,
 }
 
-/// Return the approval call wrapped by a code-session durable park.
-pub(in crate::db) fn approval_park_call_id(
+/// Return the dependency wrapped by a code-session durable park.
+pub(in crate::db) fn adapter_park_wait(
     turn: &entities::code_turn::Model,
-) -> Result<Option<CallId>> {
+) -> Result<Option<TurnParkWait>> {
     if turn.status != CodeTurnStatus::Waiting.as_str() {
         return Ok(None);
     }
-    let (Some(park_ref), Some(raw_wait)) = (turn.park_ref.as_deref(), turn.park_wait.as_ref())
+    let (Some(_park_ref), Some(raw_wait)) = (turn.park_ref.as_deref(), turn.park_wait.as_ref())
     else {
         return Ok(None);
     };
@@ -41,15 +41,38 @@ pub(in crate::db) fn approval_park_call_id(
             turn.id
         ))
     })?;
+    Ok(Some(wait))
+}
+
+/// Return the client-call dependency wrapped by a durable adapter park.
+pub(in crate::db) fn adapter_client_park_call_id(
+    turn: &entities::code_turn::Model,
+) -> Result<Option<CallId>> {
+    let Some(wait) = adapter_park_wait(turn)? else {
+        return Ok(None);
+    };
+    let call_id = match wait {
+        TurnParkWait::Approval { call_id } | TurnParkWait::ClientToolCall { call_id } => call_id,
+        TurnParkWait::AgentRuns { .. } => return Ok(None),
+    };
+    call_id.parse::<CallId>().map(Some).map_err(|_| {
+        AgentError::Store(format!(
+            "turn {} client park has an invalid call id",
+            turn.id
+        ))
+    })
+}
+
+/// Return the approval call wrapped by a code-session durable park.
+pub(in crate::db) fn approval_park_call_id(
+    turn: &entities::code_turn::Model,
+) -> Result<Option<CallId>> {
+    let Some(wait) = adapter_park_wait(turn)? else {
+        return Ok(None);
+    };
     let TurnParkWait::Approval { call_id } = wait else {
         return Ok(None);
     };
-    if call_id != park_ref {
-        return Err(AgentError::Store(format!(
-            "turn {} approval park has mismatched call ids",
-            turn.id
-        )));
-    }
     call_id.parse::<CallId>().map(Some).map_err(|_| {
         AgentError::Store(format!(
             "turn {} approval park has an invalid call id",
@@ -577,12 +600,12 @@ where
         .await
         .map_err(store_err)?
         .expect("locked client-wait turn exists");
-    let adapter_approval_call = approval_park_call_id(&turn)?;
+    let adapter_client_call = adapter_client_park_call_id(&turn)?;
     if turn.session_id != wait.session_id
         || (!matches!(
             turn.status.as_str(),
             "waiting_for_client" | "cancelling_client"
-        ) && adapter_approval_call != Some(CallId(call.id)))
+        ) && adapter_client_call != Some(CallId(call.id)))
         || turn.attempt_count != wait.attempt_count
         || turn.claim_count != wait.claim_count
         || turn.lease_token.is_some()

--- a/crates/tidebreak-core/src/db/ops/turn/client_wait.rs
+++ b/crates/tidebreak-core/src/db/ops/turn/client_wait.rs
@@ -31,7 +31,7 @@ pub(in crate::db) fn adapter_park_wait(
     if turn.status != CodeTurnStatus::Waiting.as_str() {
         return Ok(None);
     }
-    let (Some(_park_ref), Some(raw_wait)) = (turn.park_ref.as_deref(), turn.park_wait.as_ref())
+    let (Some(park_ref), Some(raw_wait)) = (turn.park_ref.as_deref(), turn.park_wait.as_ref())
     else {
         return Ok(None);
     };
@@ -41,6 +41,14 @@ pub(in crate::db) fn adapter_park_wait(
             turn.id
         ))
     })?;
+    if let TurnParkWait::Approval { call_id } = &wait {
+        if call_id != park_ref {
+            return Err(AgentError::Store(format!(
+                "turn {} approval park has mismatched call ids",
+                turn.id
+            )));
+        }
+    }
     Ok(Some(wait))
 }
 

--- a/crates/tidebreak-core/src/db/ops/turn/multi_agent_run_wait.rs
+++ b/crates/tidebreak-core/src/db/ops/turn/multi_agent_run_wait.rs
@@ -86,7 +86,7 @@ WHERE w.status = 'waiting' AND w.condition = 'all'
   AND w.claim_count >= w.attempt_count AND w.model_steps > 0
   AND w.input_tokens >= 0 AND w.output_tokens >= 0
   AND w.cache_read_input_tokens >= 0 AND w.cache_creation_input_tokens >= 0
-  AND t.status = 'waiting_for_agent_run'
+  AND t.status IN ('waiting_for_agent_run', 'waiting')
   AND t.attempt_count = w.attempt_count AND t.claim_count = w.claim_count
   AND t.lease_token IS NULL AND t.lease_expires_at IS NULL
   AND t.steer_revision = w.expected_steer_revision AND t.updated_at >= w.parked_at
@@ -624,8 +624,9 @@ pub(in crate::db) async fn resume_turn_for_agent_run_wait_set(
         transaction.commit().await.map_err(store_err)?;
         return Ok(Some(outcome));
     }
+    let adapter_park = adapter_agent_run_park_matches(&turn, &stored, &members)?;
     if stored.status != TurnAgentRunWaitStatus::Waiting.as_str()
-        || turn.status != TurnRunStatus::WaitingForAgentRun.as_str()
+        || (turn.status != TurnRunStatus::WaitingForAgentRun.as_str() && !adapter_park)
         || turn.parent_shape_mismatch(&stored)
     {
         transaction.commit().await.map_err(store_err)?;
@@ -812,7 +813,10 @@ pub(in crate::db) async fn resume_turn_for_agent_run_wait_set(
             sea_orm::sea_query::Expr::value(transition_at),
         )
         .filter(entities::code_turn::Column::Id.eq(turn.id))
-        .filter(entities::code_turn::Column::Status.eq(TurnRunStatus::WaitingForAgentRun.as_str()))
+        .filter(entities::code_turn::Column::Status.is_in([
+            TurnRunStatus::WaitingForAgentRun.as_str(),
+            crate::CodeTurnStatus::Waiting.as_str(),
+        ]))
         .filter(entities::code_turn::Column::AttemptCount.eq(stored.attempt_count))
         .filter(entities::code_turn::Column::ClaimCount.eq(stored.claim_count))
         .exec(&transaction)
@@ -1057,6 +1061,29 @@ where
 
 trait TurnShape {
     fn parent_shape_mismatch(&self, wait: &entities::turn_agent_run_wait_set::Model) -> bool;
+}
+
+fn adapter_agent_run_park_matches(
+    turn: &entities::code_turn::Model,
+    wait: &entities::turn_agent_run_wait_set::Model,
+    members: &[entities::turn_agent_run_wait_member::Model],
+) -> Result<bool> {
+    let Some(crate::TurnParkWait::AgentRuns { run_ids }) =
+        super::client_wait::adapter_park_wait(turn)?
+    else {
+        return Ok(false);
+    };
+    let Some(park_ref) = turn.park_ref.as_deref() else {
+        return Ok(false);
+    };
+    let Ok(park_wait_id) = park_ref.parse::<CallId>() else {
+        return Ok(false);
+    };
+    let parsed_runs = run_ids
+        .iter()
+        .map(|id| id.parse::<AgentRunId>())
+        .collect::<std::result::Result<Vec<_>, _>>();
+    Ok(park_wait_id.0 == wait.id && parsed_runs.is_ok_and(|runs| runs == member_ids(members)))
 }
 
 impl TurnShape for entities::code_turn::Model {

--- a/crates/tidebreak-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/tidebreak-core/src/db/ops/turn/resolution/cancellation.rs
@@ -68,11 +68,13 @@ async fn request_turn_cancellation_inner(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     };
-    let adapter_approval_call = super::super::approval_park_call_id(&turn)?;
-    let status = if adapter_approval_call.is_some() {
-        TurnRunStatus::WaitingForClient
-    } else {
-        turn_run_status_from_db(&turn.status)?
+    let adapter_wait = super::super::adapter_park_wait(&turn)?;
+    let adapter_client_call = super::super::adapter_client_park_call_id(&turn)?;
+    let status = match adapter_wait {
+        Some(crate::TurnParkWait::Approval { .. })
+        | Some(crate::TurnParkWait::ClientToolCall { .. }) => TurnRunStatus::WaitingForClient,
+        Some(crate::TurnParkWait::AgentRuns { .. }) => TurnRunStatus::WaitingForAgentRun,
+        None => turn_run_status_from_db(&turn.status)?,
     };
     match status {
         TurnRunStatus::Cancelling | TurnRunStatus::CancellingClient | TurnRunStatus::Cancelled => {
@@ -145,7 +147,7 @@ async fn request_turn_cancellation_inner(
         if wait.session_id != turn.session_id
             || wait.attempt_count != turn.attempt_count
             || wait.claim_count != turn.claim_count
-            || adapter_approval_call.is_some_and(|call_id| call_id.0 != wait.call_id)
+            || adapter_client_call.is_some_and(|call_id| call_id.0 != wait.call_id)
         {
             return Err(AgentError::Store(format!(
                 "waiting turn {id} has a mismatched client receipt"

--- a/crates/tidebreak-core/src/db/tests/client_wait.rs
+++ b/crates/tidebreak-core/src/db/tests/client_wait.rs
@@ -1,5 +1,232 @@
 use super::*;
 
+async fn parked_client_call_for_adapter_test(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> (TurnId, crate::model::ClientToolCallRequest) {
+    let turn_id = TurnId::new();
+    assert!(matches!(
+        store
+            .accept_turn(turn_id, chat_id, "gpt-5", "connect a folder")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::Accepted(_)
+    ));
+    let claimed_at = Utc::now();
+    let turn_lease = uuid::Uuid::new_v4();
+    let claimed = store
+        .claim_turn(
+            turn_lease,
+            claimed_at,
+            claimed_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(claimed.id, turn_id);
+    let request = crate::model::ClientToolCallRequest {
+        id: CallId::new(),
+        chat_id,
+        turn_id,
+        provider_id: "native".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({"suggested_name": "Documents"}),
+    };
+    assert!(matches!(
+        store
+            .park_turn_for_client_tool_call(
+                turn_id,
+                turn_lease,
+                0,
+                test_checkpoint_progress(),
+                Utc::now(),
+                &request,
+            )
+            .await
+            .unwrap(),
+        Some(ParkTurnForClientCallOutcome::Parked { .. })
+    ));
+    (turn_id, request)
+}
+
+async fn resolve_adapter_client_call(store: &DbStore, chat_id: ChatId, call_id: CallId) {
+    let claimed_at = Utc::now();
+    let client_lease = uuid::Uuid::new_v4();
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                call_id,
+                chat_id,
+                uuid::Uuid::new_v4(),
+                client_lease,
+                claimed_at,
+                claimed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Claimed(_)
+    ));
+    let resolved_at = claimed_at + chrono::Duration::seconds(1);
+    assert_eq!(
+        store
+            .resolve_client_tool_call_and_append_event(
+                call_id,
+                chat_id,
+                client_lease,
+                resolved_at,
+                &ToolCallResolution::Completed {
+                    result: "root-1".into(),
+                },
+                resolved_at,
+            )
+            .await
+            .unwrap()
+            .outcome,
+        ResolveToolCallOutcome::Resolved
+    );
+}
+
+#[tokio::test]
+async fn adapter_client_wait_resolves_from_the_generic_park() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn_id, request) = parked_client_call_for_adapter_test(&store, chat.id).await;
+    let park_ref = request.id.to_string();
+    let wait = crate::TurnParkWait::ClientToolCall {
+        call_id: park_ref.clone(),
+    };
+    assert_eq!(
+        crate::db::code::store_turn_park(
+            &store,
+            &OwnerId::local(),
+            crate::CodeTurnId(turn_id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Waiting)
+    );
+
+    resolve_adapter_client_call(&store, chat.id, request.id).await;
+
+    let turn = crate::db::code::get_turn(&store, &OwnerId::local(), crate::CodeTurnId(turn_id.0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(turn.status, crate::CodeTurnStatus::Resuming);
+    assert_eq!(turn.park_ref.as_deref(), Some(park_ref.as_str()));
+    assert_eq!(turn.park_wait, Some(wait));
+}
+
+#[tokio::test]
+async fn adapter_client_park_preserves_a_resolution_that_won_first() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn_id, request) = parked_client_call_for_adapter_test(&store, chat.id).await;
+    resolve_adapter_client_call(&store, chat.id, request.id).await;
+    let park_ref = request.id.to_string();
+    let wait = crate::TurnParkWait::ClientToolCall {
+        call_id: park_ref.clone(),
+    };
+
+    assert_eq!(
+        crate::db::code::store_turn_park(
+            &store,
+            &OwnerId::local(),
+            crate::CodeTurnId(turn_id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Resuming)
+    );
+    assert_eq!(
+        crate::db::code::clear_turn_park(
+            &store,
+            &OwnerId::local(),
+            crate::CodeTurnId(turn_id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Resuming)
+    );
+    let turn = crate::db::code::get_turn(&store, &OwnerId::local(), crate::CodeTurnId(turn_id.0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(turn.status, crate::CodeTurnStatus::Resuming);
+    assert_eq!(turn.park_ref, None);
+    assert_eq!(turn.park_wait, None);
+}
+
+#[tokio::test]
+async fn adapter_client_park_cancels_with_its_client_receipt() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn_id, request) = parked_client_call_for_adapter_test(&store, chat.id).await;
+    let park_ref = request.id.to_string();
+    let wait = crate::TurnParkWait::ClientToolCall {
+        call_id: park_ref.clone(),
+    };
+    assert_eq!(
+        crate::db::code::store_turn_park(
+            &store,
+            &OwnerId::local(),
+            crate::CodeTurnId(turn_id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Waiting)
+    );
+
+    assert!(matches!(
+        store
+            .request_turn_cancellation(turn_id, Utc::now())
+            .await
+            .unwrap(),
+        Some(RequestTurnCancellationOutcome::Cancelled(turn))
+            if turn.status == TurnRunStatus::Cancelled
+    ));
+    let turn = crate::db::code::get_turn(&store, &OwnerId::local(), crate::CodeTurnId(turn_id.0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(turn.status, crate::CodeTurnStatus::Interrupted);
+    assert_eq!(turn.park_ref.as_deref(), Some(park_ref.as_str()));
+    assert_eq!(turn.park_wait, Some(wait));
+    let call = store
+        .list_tool_calls(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|call| call.id == request.id)
+        .unwrap();
+    assert_eq!(call.status, ToolCallStatus::Cancelled);
+    assert_eq!(
+        call.result.as_deref(),
+        Some("cancelled before client execution")
+    );
+    let receipt = entities::turn_client_wait::Entity::find_by_id(request.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        receipt.status,
+        crate::model::TurnClientWaitStatus::Cancelled.as_str()
+    );
+}
+
 #[tokio::test]
 async fn client_wait_parks_resolves_and_recovers_exactly() {
     let (_dir, store) = temp_store().await;

--- a/crates/tidebreak-core/src/db/tests/client_wait.rs
+++ b/crates/tidebreak-core/src/db/tests/client_wait.rs
@@ -167,6 +167,88 @@ async fn adapter_client_park_preserves_a_resolution_that_won_first() {
 }
 
 #[tokio::test]
+async fn an_approval_park_rejects_mismatched_call_ids() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn_id, request) = parked_client_call_for_adapter_test(&store, chat.id).await;
+    let park_ref = CallId::new().to_string();
+    let wait = crate::TurnParkWait::Approval {
+        call_id: request.id.to_string(),
+    };
+    assert_eq!(
+        crate::db::code::store_turn_park(
+            &store,
+            &OwnerId::local(),
+            crate::CodeTurnId(turn_id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Waiting)
+    );
+    let turn = entities::code_turn::Entity::find_by_id(turn_id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    let error = crate::db::ops::turn::approval_park_call_id(&turn).unwrap_err();
+    assert!(error.to_string().contains("mismatched call ids"), "{error}");
+}
+
+#[tokio::test]
+async fn cancelling_a_resuming_adapter_park_keeps_the_resolved_receipt() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn_id, request) = parked_client_call_for_adapter_test(&store, chat.id).await;
+    let park_ref = request.id.to_string();
+    let wait = crate::TurnParkWait::ClientToolCall {
+        call_id: park_ref.clone(),
+    };
+    assert_eq!(
+        crate::db::code::store_turn_park(
+            &store,
+            &OwnerId::local(),
+            crate::CodeTurnId(turn_id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Waiting)
+    );
+    resolve_adapter_client_call(&store, chat.id, request.id).await;
+
+    assert!(matches!(
+        store
+            .request_turn_cancellation(turn_id, Utc::now() + chrono::Duration::seconds(2))
+            .await
+            .unwrap(),
+        Some(RequestTurnCancellationOutcome::Cancelled(turn))
+            if turn.status == TurnRunStatus::Cancelled
+    ));
+    let receipt = entities::turn_client_wait::Entity::find_by_id(request.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        receipt.status,
+        crate::model::TurnClientWaitStatus::Resumed.as_str()
+    );
+    let call = store
+        .list_tool_calls(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|call| call.id == request.id)
+        .unwrap();
+    assert_eq!(call.status, ToolCallStatus::Completed);
+}
+
+#[tokio::test]
 async fn adapter_client_park_cancels_with_its_client_receipt() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -125,6 +125,75 @@ async fn an_internal_turn_claim_backfills_its_input_message_once() {
 }
 
 #[tokio::test]
+async fn an_internal_resume_keeps_the_failure_attempt() {
+    let (_dir, store, _session_id, code_turn_id) = seeded_session().await;
+    let turn_id = TurnId(code_turn_id.0);
+    let claimed_at = now();
+    let first_token = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .take_lease_on_turn_with_input_message(
+                turn_id,
+                first_token,
+                claimed_at,
+                claimed_at + chrono::Duration::minutes(1),
+                "hello",
+            )
+            .await
+            .unwrap(),
+        Some(())
+    );
+    let resumed_at = claimed_at + chrono::Duration::seconds(1);
+    entities::code_turn::Entity::update_many()
+        .col_expr(
+            entities::code_turn::Column::Status,
+            sea_orm::sea_query::Expr::value(crate::TurnRunStatus::Resuming.as_str()),
+        )
+        .col_expr(
+            entities::code_turn::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::code_turn::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::code_turn::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(resumed_at),
+        )
+        .col_expr(
+            entities::code_turn::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(resumed_at),
+        )
+        .filter(entities::code_turn::Column::Id.eq(code_turn_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let second_token = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .take_lease_on_turn(
+                turn_id,
+                second_token,
+                resumed_at,
+                resumed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        Some(())
+    );
+    let resumed = entities::code_turn::Entity::find_by_id(code_turn_id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(resumed.attempt_count, 1);
+    assert_eq!(resumed.claim_count, 2);
+    assert_eq!(resumed.lease_token, Some(second_token));
+}
+
+#[tokio::test]
 async fn repository_transcript_search_survives_workspace_release() {
     let (_dir, store, session_id, turn_id) = seeded_session().await;
     let owner = OwnerId::local();

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -173,7 +173,7 @@ async fn an_internal_resume_keeps_the_failure_attempt() {
     let second_token = uuid::Uuid::new_v4();
     assert_eq!(
         store
-            .take_lease_on_turn(
+            .take_lease_on_resuming_turn(
                 turn_id,
                 second_token,
                 resumed_at,
@@ -191,6 +191,19 @@ async fn an_internal_resume_keeps_the_failure_attempt() {
     assert_eq!(resumed.attempt_count, 1);
     assert_eq!(resumed.claim_count, 2);
     assert_eq!(resumed.lease_token, Some(second_token));
+    assert_eq!(
+        store
+            .take_lease_on_resuming_turn(
+                turn_id,
+                uuid::Uuid::new_v4(),
+                resumed_at,
+                resumed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        None,
+        "a live resumed segment cannot be claimed again"
+    );
 }
 
 #[tokio::test]

--- a/crates/tidebreak-core/src/db/tests/multi_agent_wait.rs
+++ b/crates/tidebreak-core/src/db/tests/multi_agent_wait.rs
@@ -70,6 +70,220 @@ async fn park_wait_set_for_test(
         .await
 }
 
+#[tokio::test]
+async fn adapter_agent_wait_resolves_from_the_generic_park() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (running, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let child = admit_sandbox_call_for_test(&store, chat.id, CallId::new(), "child").await;
+    let wait_id = CallId::new();
+    park_wait_set_for_test(
+        &store,
+        wait_id,
+        running.id,
+        &[child.id],
+        AgentRunWaitCondition::All,
+        lease,
+        running.steer_revision,
+        test_checkpoint_progress(),
+        Utc::now(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let park_ref = wait_id.to_string();
+    let wait = crate::TurnParkWait::AgentRuns {
+        run_ids: vec![child.id.to_string()],
+    };
+    assert_eq!(
+        crate::db::code::store_turn_park(
+            &store,
+            &crate::OwnerId::local(),
+            crate::CodeTurnId(running.id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Waiting)
+    );
+    assert_eq!(complete_next_child(&store, "done").await, child.id);
+    assert_eq!(
+        store
+            .list_ready_agent_run_wait_set_candidates(8)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|candidate| candidate.wait_id)
+            .collect::<Vec<_>>(),
+        vec![wait_id]
+    );
+
+    let resumed = store
+        .resume_turn_for_agent_run_wait_set(wait_id, uuid::Uuid::new_v4())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        resumed,
+        ResumeTurnForAgentRunWaitSetOutcome::Resumed { .. }
+    ));
+    let turn = crate::db::code::get_turn(
+        &store,
+        &crate::OwnerId::local(),
+        crate::CodeTurnId(running.id.0),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(turn.status, crate::CodeTurnStatus::Resuming);
+    assert_eq!(turn.park_ref.as_deref(), Some(park_ref.as_str()));
+    assert_eq!(turn.park_wait, Some(wait));
+}
+
+#[tokio::test]
+async fn adapter_agent_park_preserves_a_resolution_that_won_first() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (running, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let child = admit_sandbox_call_for_test(&store, chat.id, CallId::new(), "child").await;
+    let wait_id = CallId::new();
+    park_wait_set_for_test(
+        &store,
+        wait_id,
+        running.id,
+        &[child.id],
+        AgentRunWaitCondition::All,
+        lease,
+        running.steer_revision,
+        test_checkpoint_progress(),
+        Utc::now(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(complete_next_child(&store, "done").await, child.id);
+    assert!(matches!(
+        store
+            .resume_turn_for_agent_run_wait_set(wait_id, uuid::Uuid::new_v4())
+            .await
+            .unwrap(),
+        Some(ResumeTurnForAgentRunWaitSetOutcome::Resumed { .. })
+    ));
+    let park_ref = wait_id.to_string();
+    let wait = crate::TurnParkWait::AgentRuns {
+        run_ids: vec![child.id.to_string()],
+    };
+
+    assert_eq!(
+        crate::db::code::store_turn_park(
+            &store,
+            &crate::OwnerId::local(),
+            crate::CodeTurnId(running.id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Resuming)
+    );
+    assert_eq!(
+        crate::db::code::clear_turn_park(
+            &store,
+            &crate::OwnerId::local(),
+            crate::CodeTurnId(running.id.0),
+            &park_ref,
+            &wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Resuming)
+    );
+    let turn = crate::db::code::get_turn(
+        &store,
+        &crate::OwnerId::local(),
+        crate::CodeTurnId(running.id.0),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(turn.status, crate::CodeTurnStatus::Resuming);
+    assert_eq!(turn.park_ref, None);
+    assert_eq!(turn.park_wait, None);
+}
+
+#[tokio::test]
+async fn adapter_agent_park_cancels_with_its_wait_receipt() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (running, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let child = admit_sandbox_call_for_test(&store, chat.id, CallId::new(), "child").await;
+    let wait_id = CallId::new();
+    park_wait_set_for_test(
+        &store,
+        wait_id,
+        running.id,
+        &[child.id],
+        AgentRunWaitCondition::All,
+        lease,
+        running.steer_revision,
+        test_checkpoint_progress(),
+        Utc::now(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let park_ref = wait_id.to_string();
+    let park_wait = crate::TurnParkWait::AgentRuns {
+        run_ids: vec![child.id.to_string()],
+    };
+    assert_eq!(
+        crate::db::code::store_turn_park(
+            &store,
+            &crate::OwnerId::local(),
+            crate::CodeTurnId(running.id.0),
+            &park_ref,
+            &park_wait,
+        )
+        .await
+        .unwrap(),
+        Some(crate::CodeTurnStatus::Waiting)
+    );
+
+    assert!(matches!(
+        store
+            .request_turn_cancellation(running.id, Utc::now())
+            .await
+            .unwrap(),
+        Some(RequestTurnCancellationOutcome::Cancelled(turn))
+            if turn.status == TurnRunStatus::Cancelled
+    ));
+    let turn = crate::db::code::get_turn(
+        &store,
+        &crate::OwnerId::local(),
+        crate::CodeTurnId(running.id.0),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(turn.status, crate::CodeTurnStatus::Interrupted);
+    assert_eq!(turn.park_ref.as_deref(), Some(park_ref.as_str()));
+    assert_eq!(turn.park_wait, Some(park_wait));
+    assert_cancelled_wait_shape(
+        &store,
+        wait_id,
+        crate::agent_tools::WAIT_CANCELLED_WITH_TURN_RESULT,
+    )
+    .await;
+    assert_eq!(
+        store.get_agent_run(child.id).await.unwrap().unwrap().status,
+        AgentRunStatus::Cancelled
+    );
+}
+
 async fn assert_cancelled_wait_shape(
     store: &crate::DbStore,
     wait_id: CallId,

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -1360,11 +1360,13 @@ async fn clear_persisted_turn_park(
     park_ref: &str,
     wait: &tidebreak_core::TurnParkWait,
 ) -> Result<(), String> {
-    let status = clear_turn_park(db, &session.owner, turn.id, park_ref, wait)
+    clear_turn_park(db, &session.owner, turn.id, park_ref, wait)
         .await
         .map_err(|err| format!("clearing the parked turn failed: {err}"))?
         .ok_or_else(|| format!("clearing the parked turn {} lost its row", turn.id))?;
-    turn.status = status;
+    // The worker is about to start the resumed leg. Do not restore the
+    // transient `waiting` or `resuming` database status in its live snapshot.
+    turn.status = CodeTurnStatus::Running;
     turn.park_ref = None;
     turn.park_wait = None;
     Ok(())
@@ -1632,10 +1634,9 @@ async fn durable_park_state(
     ) {
         Ok(DurableParkState::Pending)
     } else {
-        Err(WorkerError::Failed(format!(
-            "turn {turn_id} has status {} while its durable park is unresolved",
-            turn.status.as_str()
-        )))
+        // A legacy or damaged wait cannot resume safely. Close it through the
+        // normal turn path so one bad row cannot keep the session worker live.
+        Ok(DurableParkState::Closed)
     }
 }
 

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -24,13 +24,13 @@ use tracing::{warn, Instrument as _};
 
 use tidebreak_core::db::code::{
     accept_trigger_turn_delivery, append_event, append_event_with_notification,
-    begin_permission_mode_change, bump_spawn_epoch, cancel_permission_mode_change,
+    begin_permission_mode_change, bump_spawn_epoch, cancel_permission_mode_change, clear_turn_park,
     confirm_permission_mode_change, delete_queued_turn, get_open_turn, get_session,
     get_session_all_owners, get_workspace, insert_approval_for_worker, insert_turn, list_approvals,
     next_turn_ordinal, promote_queued_turn, queue_paused, queued_turn_head,
     rebind_pending_approvals_to_worker, save_session, save_turn, set_queue_paused,
     set_session_harness_resume_ref, set_session_subagents, settle_engine_observed_approval,
-    CodeJournalError, CodeSessionExecutionSettings,
+    store_turn_park, CodeJournalError, CodeSessionExecutionSettings,
 };
 use tidebreak_core::{
     bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
@@ -866,8 +866,10 @@ async fn run_worker(
     }
 
     if let Ok(Some(open)) = get_open_turn(&sink.db, &session.owner, session.id).await {
-        if open.status == CodeTurnStatus::Waiting
-            && open.park_ref.is_some()
+        if matches!(
+            open.status,
+            CodeTurnStatus::Waiting | CodeTurnStatus::Resuming
+        ) && open.park_ref.is_some()
             && open.park_wait.is_some()
         {
             if let Err(error) = continue_parked_turn(
@@ -1341,13 +1343,31 @@ async fn persist_turn_park(
             }
         }
     };
-    turn.status = CodeTurnStatus::Waiting;
+    let status = store_turn_park(db, &session.owner, turn.id, park_ref, &wait)
+        .await
+        .map_err(|err| format!("persisting the parked turn failed: {err}"))?
+        .ok_or_else(|| format!("persisting the parked turn {} lost its row", turn.id))?;
+    turn.status = status;
     turn.park_ref = Some(park_ref.to_owned());
     turn.park_wait = Some(wait.clone());
-    save_turn(db, &session.owner, turn)
-        .await
-        .map_err(|err| format!("persisting the parked turn failed: {err}"))?;
     Ok(wait)
+}
+
+async fn clear_persisted_turn_park(
+    db: &DbStore,
+    session: &CodeSession,
+    turn: &mut CodeTurn,
+    park_ref: &str,
+    wait: &tidebreak_core::TurnParkWait,
+) -> Result<(), String> {
+    let status = clear_turn_park(db, &session.owner, turn.id, park_ref, wait)
+        .await
+        .map_err(|err| format!("clearing the parked turn failed: {err}"))?
+        .ok_or_else(|| format!("clearing the parked turn {} lost its row", turn.id))?;
+    turn.status = status;
+    turn.park_ref = None;
+    turn.park_wait = None;
+    Ok(())
 }
 
 /// Hold a parked turn until its wait resolves, the worker is interrupted, or
@@ -1478,6 +1498,12 @@ struct ParkResolution {
     delivered_here: bool,
 }
 
+enum DurableParkState {
+    Pending,
+    Resolved(ParkResolution),
+    Closed,
+}
+
 /// The engine-channel decision a settled row's resolution carries.
 fn resume_decision(decision: tidebreak_core::ApprovalDecisionKind) -> ApprovalDecision {
     use tidebreak_core::ApprovalDecisionKind as Kind;
@@ -1506,18 +1532,21 @@ async fn resume_from_settled_row(
     owner: &OwnerId,
     session_id: CodeSessionId,
     call_id: &str,
-) -> Option<tidebreak_harness::ResumeInput> {
+) -> Result<Option<tidebreak_harness::ResumeInput>, WorkerError> {
     let approval = list_approvals(db, owner, None, Some(session_id))
         .await
-        .ok()?
+        .map_err(|error| WorkerError::Failed(error.to_string()))?
         .into_iter()
-        .find(|approval| approval.native_call_id.as_deref() == Some(call_id))?;
+        .find(|approval| approval.native_call_id.as_deref() == Some(call_id));
+    let Some(approval) = approval else {
+        return Ok(None);
+    };
     if approval.state.is_pending() {
-        return None;
+        return Ok(None);
     }
     let journaled = tidebreak_core::db::code::list_recent_events(db, owner, session_id, 256)
         .await
-        .ok()?
+        .map_err(|error| WorkerError::Failed(error.to_string()))?
         .into_iter()
         .find_map(|row| match row.event {
             CodeEvent::ApprovalResolved {
@@ -1538,10 +1567,76 @@ async fn resume_from_settled_row(
             }
         },
     };
-    Some(tidebreak_harness::ResumeInput::ApprovalDecided {
+    Ok(Some(tidebreak_harness::ResumeInput::ApprovalDecided {
         call_id: call_id.to_owned(),
         decision: resume_decision(decision),
-    })
+    }))
+}
+
+async fn durable_park_state(
+    db: &DbStore,
+    session: &CodeSession,
+    park_ref: &str,
+    wait: &tidebreak_core::TurnParkWait,
+    turn_id: CodeTurnId,
+    delivered: &DeliveredDecisions,
+) -> Result<DurableParkState, WorkerError> {
+    if let Some(input) = resume_if_already_delivered(wait, delivered) {
+        return Ok(DurableParkState::Resolved(ParkResolution {
+            input,
+            delivered_here: true,
+        }));
+    }
+    let turn = tidebreak_core::db::code::get_turn(db, &session.owner, turn_id)
+        .await
+        .map_err(|error| WorkerError::Failed(error.to_string()))?
+        .ok_or_else(|| WorkerError::Failed(format!("parked turn {turn_id} disappeared")))?;
+    if !turn.status.is_open() {
+        return Ok(DurableParkState::Closed);
+    }
+    if turn.park_ref.as_deref() != Some(park_ref) || turn.park_wait.as_ref() != Some(wait) {
+        return Err(WorkerError::Failed(format!(
+            "turn {turn_id} changed its durable park while the worker waited"
+        )));
+    }
+    let input = match wait {
+        tidebreak_core::TurnParkWait::Approval { call_id } => {
+            resume_from_settled_row(db, &session.owner, session.id, call_id).await?
+        }
+        tidebreak_core::TurnParkWait::ClientToolCall { call_id }
+            if turn.status == CodeTurnStatus::Resuming =>
+        {
+            Some(tidebreak_harness::ResumeInput::ClientToolCompleted {
+                call_id: call_id.clone(),
+            })
+        }
+        tidebreak_core::TurnParkWait::AgentRuns { run_ids }
+            if turn.status == CodeTurnStatus::Resuming =>
+        {
+            Some(tidebreak_harness::ResumeInput::AgentRunsSettled {
+                run_ids: run_ids.clone(),
+            })
+        }
+        tidebreak_core::TurnParkWait::ClientToolCall { .. }
+        | tidebreak_core::TurnParkWait::AgentRuns { .. } => None,
+    };
+    if let Some(input) = input {
+        return Ok(DurableParkState::Resolved(ParkResolution {
+            input,
+            delivered_here: false,
+        }));
+    }
+    if matches!(
+        turn.status,
+        CodeTurnStatus::Waiting | CodeTurnStatus::CancellingClient
+    ) {
+        Ok(DurableParkState::Pending)
+    } else {
+        Err(WorkerError::Failed(format!(
+            "turn {turn_id} has status {} while its durable park is unresolved",
+            turn.status.as_str()
+        )))
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1554,76 +1649,57 @@ async fn await_park_resolution<'a>(
     controls: &mut FuturesUnordered<BoxFuture<'a, ControlFlow>>,
     interrupted: &mut bool,
     commands_closed: &mut bool,
+    park_ref: &str,
     wait: &tidebreak_core::TurnParkWait,
     turn_id: CodeTurnId,
     delivered: &DeliveredDecisions,
-) -> Option<ParkResolution> {
-    if let Some(input) = resume_if_already_delivered(wait, delivered) {
-        return Some(ParkResolution {
-            input,
-            delivered_here: true,
-        });
-    }
+) -> Result<Option<ParkResolution>, WorkerError> {
     // Subscribe before the read below, so a settlement between the two
     // cannot slip past both.
     let (mut live, _tail) = bus.attach(session.id);
-    let waited_call = match wait {
-        tidebreak_core::TurnParkWait::Approval { call_id } => Some(call_id.clone()),
-        _ => None,
-    };
-    if let Some(call_id) = waited_call.as_deref() {
-        if let Some(input) = resume_from_settled_row(db, &session.owner, session.id, call_id).await
-        {
-            return Some(ParkResolution {
-                input,
-                delivered_here: false,
-            });
-        }
+    match durable_park_state(db, session, park_ref, wait, turn_id, delivered).await? {
+        DurableParkState::Pending => {}
+        DurableParkState::Resolved(resolution) => return Ok(Some(resolution)),
+        DurableParkState::Closed => return Ok(None),
     }
+    let mut durable_poll = tokio::time::interval(Duration::from_millis(100));
+    durable_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    durable_poll.tick().await;
     loop {
         tokio::select! {
             biased;
             Some(flow) = controls.next(), if !controls.is_empty() => {
                 if flow == ControlFlow::Shutdown {
                     *interrupted = true;
-                    return None;
+                    return Ok(None);
                 }
-                // The opening leg may still be delivering the awaited
-                // decision when the engine parks. That future lives in
-                // `controls`; once it finishes, resume from the record.
-                if let Some(input) = resume_if_already_delivered(wait, delivered) {
-                    return Some(ParkResolution {
-                        input,
-                        delivered_here: true,
-                    });
+                match durable_park_state(db, session, park_ref, wait, turn_id, delivered).await? {
+                    DurableParkState::Pending => {}
+                    DurableParkState::Resolved(resolution) => return Ok(Some(resolution)),
+                    DurableParkState::Closed => return Ok(None),
                 }
             }
-            published = live.recv(), if waited_call.is_some() => {
-                let call_id = waited_call.as_deref().unwrap_or_default();
-                let settled = match published {
-                    Ok(CodeLiveEvent {
-                        event: CodeEvent::ApprovalResolved { approval_id, .. },
-                        ..
-                    }) => {
-                        // The row the resolution names must be the one this
-                        // park waits on; another card's decision is not it.
-                        matches!(
-                            tidebreak_core::db::code::get_approval(db, &session.owner, approval_id).await,
-                            Ok(Some(approval)) if approval.native_call_id.as_deref() == Some(call_id)
-                        )
+            published = live.recv() => {
+                match published {
+                    Ok(CodeLiveEvent { .. })
+                    | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        return Err(WorkerError::Failed(
+                            "the live event channel closed while a turn was parked".into(),
+                        ));
                     }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => true,
-                    _ => false,
-                };
-                if settled {
-                    if let Some(input) =
-                        resume_from_settled_row(db, &session.owner, session.id, call_id).await
-                    {
-                        return Some(ParkResolution {
-                            input,
-                            delivered_here: false,
-                        });
-                    }
+                }
+                match durable_park_state(db, session, park_ref, wait, turn_id, delivered).await? {
+                    DurableParkState::Pending => {}
+                    DurableParkState::Resolved(resolution) => return Ok(Some(resolution)),
+                    DurableParkState::Closed => return Ok(None),
+                }
+            }
+            _ = durable_poll.tick() => {
+                match durable_park_state(db, session, park_ref, wait, turn_id, delivered).await? {
+                    DurableParkState::Pending => {}
+                    DurableParkState::Resolved(resolution) => return Ok(Some(resolution)),
+                    DurableParkState::Closed => return Ok(None),
                 }
             }
             command = commands.recv(), if !*commands_closed => match command {
@@ -1640,13 +1716,13 @@ async fn await_park_resolution<'a>(
                             if *waited == call_id
                     );
                     if delivered && awaited {
-                        return Some(ParkResolution {
+                        return Ok(Some(ParkResolution {
                             input: tidebreak_harness::ResumeInput::ApprovalDecided {
                                 call_id,
                                 decision: decided,
                             },
                             delivered_here: true,
-                        });
+                        }));
                     }
                 }
                 Some(WorkerCommand::Interrupt { reply }) => {
@@ -1656,11 +1732,11 @@ async fn await_park_resolution<'a>(
                         .await
                         .map_err(|err| WorkerError::Failed(err.to_string()));
                     let _ = reply.send(result);
-                    return None;
+                    return Ok(None);
                 }
                 Some(WorkerCommand::Shutdown) => {
                     *interrupted = true;
-                    return None;
+                    return Ok(None);
                 }
                 Some(other) => {
                     controls.push(Box::pin(apply_control(
@@ -1673,7 +1749,7 @@ async fn await_park_resolution<'a>(
                 None => {
                     *commands_closed = true;
                     *interrupted = true;
-                    return None;
+                    return Ok(None);
                 }
             },
         }
@@ -2020,25 +2096,26 @@ async fn continue_parked_turn(
         &mut controls,
         &mut interrupted,
         &mut commands_closed,
+        &park_ref,
         &wait,
         turn.id,
         &delivered,
     )
     .await
     {
-        Some(ParkResolution {
+        Ok(Some(ParkResolution {
             input,
             delivered_here,
-        }) => {
+        })) => {
             if delivered_here {
                 apply_accepted_plan_mode(db, bus, session, engine, &input).await;
             }
-            turn.park_ref = None;
-            turn.park_wait = None;
-            let _ = save_turn(db, &session.owner, &turn).await;
+            clear_persisted_turn_park(db, session, &mut turn, &park_ref, &wait)
+                .await
+                .map_err(WorkerError::Failed)?;
             next_resume = Some((park_ref, input));
         }
-        None => {
+        Ok(None) => {
             while controls.next().await.is_some() {}
             return close_open_turn(
                 session,
@@ -2051,6 +2128,7 @@ async fn continue_parked_turn(
             )
             .await;
         }
+        Err(error) => return Err(error),
     }
 
     let run = 'legs: loop {
@@ -2117,25 +2195,29 @@ async fn continue_parked_turn(
             &mut controls,
             &mut interrupted,
             &mut commands_closed,
+            &park_ref,
             &wait,
             turn.id,
             &delivered,
         )
         .await
         {
-            Some(ParkResolution {
+            Ok(Some(ParkResolution {
                 input,
                 delivered_here,
-            }) => {
+            })) => {
                 if delivered_here {
                     apply_accepted_plan_mode(db, bus, session, engine, &input).await;
                 }
-                turn.park_ref = None;
-                turn.park_wait = None;
-                let _ = save_turn(db, &session.owner, &turn).await;
+                if let Err(error) =
+                    clear_persisted_turn_park(db, session, &mut turn, &park_ref, &wait).await
+                {
+                    break 'legs Err(HarnessError::Other(error));
+                }
                 next_resume = Some((park_ref, input));
             }
-            None => break 'legs Ok(TurnOutcome::Clean),
+            Ok(None) => break 'legs Ok(TurnOutcome::Clean),
+            Err(error) => break 'legs Err(HarnessError::Other(error.to_string())),
         }
     };
     while controls.next().await.is_some() {}
@@ -2888,16 +2970,17 @@ async fn drive_turn_inner(
             &mut controls,
             &mut interrupted,
             &mut commands_closed,
+            &park_ref,
             &wait,
             turn.id,
             &delivered,
         )
         .await
         {
-            Some(ParkResolution {
+            Ok(Some(ParkResolution {
                 input,
                 delivered_here,
-            }) => {
+            })) => {
                 // An accepted plan re-postures the session before the turn
                 // continues: the decision itself never changes the mode, the
                 // engine's own channel does, and the row must say so too. A
@@ -2905,14 +2988,17 @@ async fn drive_turn_inner(
                 if delivered_here {
                     apply_accepted_plan_mode(db, bus, session, engine, &input).await;
                 }
-                turn.park_ref = None;
-                turn.park_wait = None;
-                let _ = save_turn(db, &session.owner, &turn).await;
+                if let Err(error) =
+                    clear_persisted_turn_park(db, session, &mut turn, &park_ref, &wait).await
+                {
+                    break 'legs Err(HarnessError::Other(error));
+                }
                 next_resume = Some((park_ref, input));
             }
             // Interrupted or shut down while parked: fall through to the
             // shared closing code, which closes an open turn as interrupted.
-            None => break 'legs Ok(TurnOutcome::Clean),
+            Ok(None) => break 'legs Ok(TurnOutcome::Clean),
+            Err(error) => break 'legs Err(HarnessError::Other(error.to_string())),
         }
     };
     // A control command still in flight has a caller waiting on its reply.

--- a/crates/tidebreak-server/src/code/session_worker/tests.rs
+++ b/crates/tidebreak-server/src/code/session_worker/tests.rs
@@ -595,6 +595,196 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
 }
 
 #[tokio::test]
+async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
+    let client_call = tidebreak_core::CallId::new().to_string();
+    let agent_wait = tidebreak_core::CallId::new().to_string();
+    let run_ids = vec![
+        tidebreak_core::AgentRunId::new().to_string(),
+        tidebreak_core::AgentRunId::new().to_string(),
+    ];
+    let cases = vec![
+        (
+            client_call.clone(),
+            tidebreak_harness::ParkWait::ClientToolCall {
+                call_id: client_call.clone(),
+            },
+            tidebreak_harness::ResumeInput::ClientToolCompleted {
+                call_id: client_call,
+            },
+        ),
+        (
+            agent_wait.clone(),
+            tidebreak_harness::ParkWait::AgentRuns {
+                run_ids: run_ids.clone(),
+            },
+            tidebreak_harness::ResumeInput::AgentRunsSettled { run_ids },
+        ),
+    ];
+
+    for (park_ref, waiting_on, expected_resume) in cases {
+        let (directory, store, sink, session_id) = seeded_sink().await;
+        let owner = OwnerId::local();
+        let mut session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        session.lifecycle = CodeSessionLifecycle::Idle;
+        assert!(save_session(&store, &session).await.unwrap());
+
+        let worktree = directory.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let private = directory.path().join("private");
+        std::fs::create_dir(&private).unwrap();
+        let adapter = ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantMessage {
+                text: "resumed after the restart".into(),
+                parent_call_id: None,
+            },
+            HarnessEvent::TurnCompleted {
+                usage: CodeUsage::default(),
+            },
+        ])
+        .with_parked_turn(1, park_ref.clone(), waiting_on.clone());
+        let first_engine = adapter
+            .launch(SessionSpec {
+                owner: owner.clone(),
+                session_id,
+                worktree: worktree.clone(),
+                allowed_read_roots: Vec::new(),
+                permission_mode: session.permission_mode,
+                model: session.model.clone(),
+                reasoning_effort: session.reasoning_effort,
+                fast_mode: session.fast_mode,
+                resume_ref: None,
+                extra_argv: Vec::new(),
+                extra_env: Vec::new(),
+                relay_key_env: None,
+                env: Vec::new(),
+                approval: None,
+                binary: Some(std::path::PathBuf::from("/scripted/engine")),
+                sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+                browser: None,
+            })
+            .await
+            .unwrap();
+        let first_private_root =
+            super::super::scratch::ScratchRoot::open_for_test(&private).expect("scratch root");
+        let first = spawn_session_worker(
+            session.clone(),
+            first_engine,
+            sink.clone(),
+            AttachmentStore {
+                blobs: None,
+                private_root: first_private_root,
+                engine_reads_images: false,
+            },
+            Arc::new(tokio::sync::Mutex::new(())),
+            tokio::sync::watch::channel(false).1,
+        );
+        let (turn_reply, _turn_response) = oneshot::channel();
+        first
+            .commands
+            .send(WorkerCommand::RunTurn {
+                message: "park across a restart".into(),
+                attachments: Vec::new(),
+                trigger_delivery: None,
+                reply: turn_reply,
+            })
+            .await
+            .unwrap();
+        let parked = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(turn) = get_open_turn(&store, &owner, session_id).await.unwrap() {
+                    if turn.status == CodeTurnStatus::Waiting {
+                        break turn;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("the first worker stores the park");
+        assert_eq!(parked.park_ref.as_deref(), Some(park_ref.as_str()));
+        first.abort.abort();
+        tokio::time::timeout(Duration::from_secs(5), first.commands.closed())
+            .await
+            .expect("the crashed worker releases its command channel");
+
+        session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let second_engine = adapter
+            .launch(SessionSpec {
+                owner: owner.clone(),
+                session_id,
+                worktree,
+                allowed_read_roots: Vec::new(),
+                permission_mode: session.permission_mode,
+                model: session.model.clone(),
+                reasoning_effort: session.reasoning_effort,
+                fast_mode: session.fast_mode,
+                resume_ref: None,
+                extra_argv: Vec::new(),
+                extra_env: Vec::new(),
+                relay_key_env: None,
+                env: Vec::new(),
+                approval: None,
+                binary: Some(std::path::PathBuf::from("/scripted/engine")),
+                sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+                browser: None,
+            })
+            .await
+            .unwrap();
+        let second_private_root =
+            super::super::scratch::ScratchRoot::open_for_test(&private).expect("scratch root");
+        let second = spawn_session_worker(
+            session,
+            second_engine,
+            sink,
+            AttachmentStore {
+                blobs: None,
+                private_root: second_private_root,
+                engine_reads_images: false,
+            },
+            Arc::new(tokio::sync::Mutex::new(())),
+            tokio::sync::watch::channel(false).1,
+        );
+
+        let mut resolved = tidebreak_core::db::code::get_turn(&store, &owner, parked.id)
+            .await
+            .unwrap()
+            .unwrap();
+        resolved.status = CodeTurnStatus::Resuming;
+        assert!(save_turn(&store, &owner, &resolved).await.unwrap());
+
+        let completed = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let turn = tidebreak_core::db::code::get_turn(&store, &owner, parked.id)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                if turn.status == CodeTurnStatus::Completed {
+                    break turn;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("the relaunched worker resumes the park");
+        assert_eq!(completed.park_ref, None);
+        assert_eq!(completed.park_wait, None);
+        assert_eq!(
+            adapter.resumes(),
+            vec![(park_ref, expected_resume)],
+            "the recovered park resumes once with its exact dependency"
+        );
+        let _ = second.commands.send(WorkerCommand::Shutdown).await;
+    }
+}
+
+#[tokio::test]
 async fn a_decision_on_the_running_leg_resumes_the_park() {
     let (directory, store, sink, session_id) = seeded_sink().await;
     let owner = OwnerId::local();

--- a/crates/tidebreak-server/src/engine/internal/leg.rs
+++ b/crates/tidebreak-server/src/engine/internal/leg.rs
@@ -15,8 +15,8 @@ use chrono::Utc;
 use futures::channel::mpsc::{unbounded, TryRecvError, UnboundedReceiver};
 use futures::StreamExt;
 use tidebreak_core::{
-    Agent, AgentConfig, AgentError, AgentEvent, AgentRunExecutionLocation, AgentRunWaitCondition,
-    AgentRunWaitSetCheckpointRequest, AgentTurnOutcome, BlobStore, CallId,
+    Agent, AgentConfig, AgentError, AgentEvent, AgentRunExecutionLocation, AgentRunId,
+    AgentRunWaitCondition, AgentRunWaitSetCheckpointRequest, AgentTurnOutcome, BlobStore, CallId,
     CheckpointSandboxSpawnOutcome, ClaimedAgentEvent, CompleteTurnRunOutcome,
     ForegroundAgentWaitRequest, MessageId, ParkTurnForAgentRunWaitSetOutcome,
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, Result, SandboxAgentSpawnRequest,
@@ -88,12 +88,22 @@ impl Default for LegDriverConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum LegDriverOutcome {
     Completed(TurnId),
-    WaitingForApproval { turn_id: TurnId, call_id: CallId },
-    WaitingForClient(TurnId),
-    WaitingForAgentRun(TurnId),
+    WaitingForApproval {
+        turn_id: TurnId,
+        call_id: CallId,
+    },
+    WaitingForClient {
+        turn_id: TurnId,
+        call_id: CallId,
+    },
+    WaitingForAgentRun {
+        turn_id: TurnId,
+        call_id: CallId,
+        run_ids: Vec<AgentRunId>,
+    },
     Resuming(TurnId),
     Cancelled(TurnId),
     Failed(TurnId),
@@ -2217,7 +2227,10 @@ impl LegDriver {
                                         call_id: request.id,
                                     });
                                 }
-                                return Ok(LegDriverOutcome::WaitingForClient(turn.id));
+                                return Ok(LegDriverOutcome::WaitingForClient {
+                                    turn_id: turn.id,
+                                    call_id: request.id,
+                                });
                             }
                             Ok(Some(ParkTurnForClientCallOutcome::SteerPending(_)))
                             | Ok(Some(ParkTurnForClientCallOutcome::OutputSuperseded(_))) => {
@@ -2714,7 +2727,11 @@ impl LegDriver {
                                 // This also drives the durable ready-set scan
                                 // when every child completed before the park.
                                 self.sandbox_agent_wake.notify_one();
-                                return Ok(LegDriverOutcome::WaitingForAgentRun(turn.id));
+                                return Ok(LegDriverOutcome::WaitingForAgentRun {
+                                    turn_id: turn.id,
+                                    call_id: checkpoint.call_id,
+                                    run_ids: checkpoint.child_run_ids.clone(),
+                                });
                             }
                             Ok(Some(ParkTurnForAgentRunWaitSetOutcome::SteerPending(_)))
                             | Ok(Some(ParkTurnForAgentRunWaitSetOutcome::OutputSuperseded(_))) => {
@@ -3563,8 +3580,8 @@ fn turn_worker_outcome_label(outcome: &Result<LegDriverOutcome>) -> &'static str
     match outcome {
         Ok(LegDriverOutcome::Completed(_)) => "completed",
         Ok(LegDriverOutcome::WaitingForApproval { .. }) => "waiting_for_approval",
-        Ok(LegDriverOutcome::WaitingForClient(_)) => "waiting_for_client",
-        Ok(LegDriverOutcome::WaitingForAgentRun(_)) => "waiting_for_agent_run",
+        Ok(LegDriverOutcome::WaitingForClient { .. }) => "waiting_for_client",
+        Ok(LegDriverOutcome::WaitingForAgentRun { .. }) => "waiting_for_agent_run",
         Ok(LegDriverOutcome::Resuming(_)) => "resuming",
         Ok(LegDriverOutcome::Cancelled(_)) => "cancelled",
         Ok(LegDriverOutcome::Failed(_)) => "failed",

--- a/crates/tidebreak-server/src/engine/internal/session.rs
+++ b/crates/tidebreak-server/src/engine/internal/session.rs
@@ -2,8 +2,8 @@
 //! turn lease.
 //!
 //! `run_turn` drives [`LegDriver::run_turn`] for the row the session worker
-//! already inserted and claimed. Client waits still end the leg and drop the
-//! lease so the claim scan can pick the turn up again.
+//! already inserted and claimed. Every durable wait returns through the
+//! adapter park contract, so the session worker stays attached until resume.
 
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -18,7 +18,7 @@ use tidebreak_core::{
     chat_journal, AcceptTurnSteerOutcome, AnswerUserQuestions, AnswerUserQuestionsOutcome,
     AnswerUserQuestionsRequest, CallId, ChatId, CodeApprovalKind, CodeSessionId, CodeTurnStatus,
     DecidePlanRequest, OwnerId, PermissionMode, PlanDecision, PlanDecisionChoice,
-    ToolApprovalStatus, TurnId, TurnSteerId, DEFAULT_ACCEPTED_PLAN_MODE,
+    ToolApprovalStatus, TurnId, TurnParkWait, TurnSteerId, DEFAULT_ACCEPTED_PLAN_MODE,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessSession, ParkWait, ResumeInput,
@@ -40,9 +40,21 @@ pub(super) struct InternalSession {
     #[allow(dead_code)]
     session_id: CodeSessionId,
     chat_id: ChatId,
-    active: Mutex<Option<TurnId>>,
+    active: Mutex<Option<ActiveTurn>>,
     /// Tool approvals acknowledged through [`HarnessSession::decide`].
     decided: Mutex<HashSet<CallId>>,
+}
+
+#[derive(Clone)]
+struct ActiveTurn {
+    turn_id: TurnId,
+    park: Option<ActivePark>,
+}
+
+#[derive(Clone)]
+struct ActivePark {
+    park_ref: String,
+    waiting_on: ParkWait,
 }
 
 fn store_error(error: tidebreak_core::AgentError) -> HarnessError {
@@ -128,27 +140,61 @@ impl InternalSession {
         else {
             return Ok(());
         };
-        if turn.park_ref.is_none()
-            || !matches!(
-                turn.status,
-                CodeTurnStatus::Waiting | CodeTurnStatus::Resuming
-            )
-        {
+        if !matches!(
+            turn.status,
+            CodeTurnStatus::Waiting | CodeTurnStatus::Resuming
+        ) {
             return Ok(());
         }
-        *self.active.lock().expect("active turn") = Some(TurnId(turn.id.0));
+        let (Some(park_ref), Some(wait)) = (turn.park_ref, turn.park_wait) else {
+            return Ok(());
+        };
+        let waiting_on = match wait {
+            TurnParkWait::Approval { call_id } => ParkWait::Approval { call_id },
+            TurnParkWait::ClientToolCall { call_id } => ParkWait::ClientToolCall { call_id },
+            TurnParkWait::AgentRuns { run_ids } => ParkWait::AgentRuns { run_ids },
+        };
+        *self.active.lock().expect("active turn") = Some(ActiveTurn {
+            turn_id: TurnId(turn.id.0),
+            park: Some(ActivePark {
+                park_ref,
+                waiting_on,
+            }),
+        });
         Ok(())
     }
 
     fn active_turn(&self) -> Option<TurnId> {
-        *self.active.lock().expect("active turn")
+        self.active
+            .lock()
+            .expect("active turn")
+            .as_ref()
+            .map(|active| active.turn_id)
+    }
+
+    fn active_park(&self) -> Option<ActivePark> {
+        self.active
+            .lock()
+            .expect("active turn")
+            .as_ref()
+            .and_then(|active| active.park.clone())
     }
 
     fn map_and_release(&self, turn_id: TurnId, outcome: LegDriverOutcome) -> TurnOutcome {
         let mapped = Self::map_leg_outcome(turn_id, outcome);
-        if !matches!(mapped, TurnOutcome::Parked { .. }) {
-            *self.active.lock().expect("active turn") = None;
-        }
+        *self.active.lock().expect("active turn") = match &mapped {
+            TurnOutcome::Parked {
+                park_ref,
+                waiting_on,
+            } => Some(ActiveTurn {
+                turn_id,
+                park: Some(ActivePark {
+                    park_ref: park_ref.clone(),
+                    waiting_on: waiting_on.clone(),
+                }),
+            }),
+            TurnOutcome::Clean | TurnOutcome::Incomplete { .. } => None,
+        };
         mapped
     }
 
@@ -162,12 +208,21 @@ impl InternalSession {
                     waiting_on: ParkWait::Approval { call_id },
                 }
             }
-            LegDriverOutcome::WaitingForClient(_) | LegDriverOutcome::WaitingForAgentRun(_) => {
-                // Client waits keep the lease-release shape until D4b: the
-                // leg ends, the lease drops, and the turn returns to the
-                // claim scan. Do not pin the worker on the wait.
-                TurnOutcome::Clean
+            LegDriverOutcome::WaitingForClient { call_id, .. } => {
+                let call_id = call_id.to_string();
+                TurnOutcome::Parked {
+                    park_ref: call_id.clone(),
+                    waiting_on: ParkWait::ClientToolCall { call_id },
+                }
             }
+            LegDriverOutcome::WaitingForAgentRun {
+                call_id, run_ids, ..
+            } => TurnOutcome::Parked {
+                park_ref: call_id.to_string(),
+                waiting_on: ParkWait::AgentRuns {
+                    run_ids: run_ids.into_iter().map(|id| id.to_string()).collect(),
+                },
+            },
             LegDriverOutcome::Resuming(_) => TurnOutcome::Clean,
             LegDriverOutcome::Failed(_) | LegDriverOutcome::LeaseLost(_) => {
                 TurnOutcome::Incomplete {
@@ -374,6 +429,139 @@ impl InternalSession {
             HarnessError::ApprovalBindingMismatch(format!("{raw} is not an engine call id"))
         })
     }
+
+    fn validate_resume(
+        park: &ActivePark,
+        park_ref: &str,
+        input: &ResumeInput,
+    ) -> Result<(), HarnessError> {
+        if park.park_ref != park_ref {
+            return Err(HarnessError::Other(format!(
+                "park {park_ref} does not match the active park {}",
+                park.park_ref
+            )));
+        }
+        match (&park.waiting_on, input) {
+            (
+                ParkWait::Approval { call_id: waiting },
+                ResumeInput::ApprovalDecided {
+                    call_id: decided, ..
+                },
+            ) if waiting == decided => Ok(()),
+            (
+                ParkWait::ClientToolCall { call_id: waiting },
+                ResumeInput::ClientToolCompleted { call_id: completed },
+            ) if waiting == completed => Ok(()),
+            (
+                ParkWait::AgentRuns { run_ids: waiting },
+                ResumeInput::AgentRunsSettled { run_ids: settled },
+            ) if waiting == settled => Ok(()),
+            (ParkWait::Approval { call_id }, _) => Err(HarnessError::ApprovalBindingMismatch(
+                format!("park {park_ref} waited on approval {call_id}"),
+            )),
+            (ParkWait::ClientToolCall { call_id }, _) => Err(HarnessError::Other(format!(
+                "park {park_ref} waited on client tool call {call_id}"
+            ))),
+            (ParkWait::AgentRuns { run_ids }, _) => Err(HarnessError::Other(format!(
+                "park {park_ref} waited on agent runs {}",
+                run_ids.join(", ")
+            ))),
+        }
+    }
+
+    async fn claim_resuming_turn(
+        &self,
+        turn_id: TurnId,
+    ) -> Result<(tidebreak_core::TurnRun, uuid::Uuid), HarnessError> {
+        // The checkpoint drops the lease before it returns. Yield so its
+        // transaction releases SQLite's write lock before this claim starts.
+        tokio::task::yield_now().await;
+        let mut claimed = None;
+        let mut lease_token = uuid::Uuid::nil();
+        for _ in 0..40 {
+            lease_token = uuid::Uuid::new_v4();
+            let now = Utc::now();
+            match self
+                .db
+                .take_lease_on_turn(
+                    turn_id,
+                    lease_token,
+                    now,
+                    now + chrono::Duration::seconds(60),
+                )
+                .await
+            {
+                Ok(value) => {
+                    claimed = Some(value);
+                    break;
+                }
+                Err(error) if error.to_string().contains("database is locked") => {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                Err(error) => return Err(store_error(error)),
+            }
+        }
+        let Some(Some(())) = claimed else {
+            return Err(HarnessError::Other(format!(
+                "could not claim a lease on turn {turn_id} before resume"
+            )));
+        };
+        let mut turn = None;
+        for _ in 0..40 {
+            match self.state.store.get_turn(turn_id).await {
+                Ok(Some(loaded)) => {
+                    turn = Some(loaded);
+                    break;
+                }
+                Ok(None) => {
+                    return Err(HarnessError::Other(format!(
+                        "turn {turn_id} was not claimed before the resume"
+                    )));
+                }
+                Err(error) if error.to_string().contains("database is locked") => {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                Err(error) => return Err(store_error(error)),
+            }
+        }
+        let Some(turn) = turn else {
+            return Err(HarnessError::Other(format!(
+                "turn {turn_id} was not readable after the resume claim"
+            )));
+        };
+        if turn.lease_token != Some(lease_token) {
+            return Err(HarnessError::Other(format!(
+                "turn {turn_id} reclaimed a different lease"
+            )));
+        }
+        Ok((turn, lease_token))
+    }
+
+    async fn drive_claimed_turn(
+        &self,
+        turn_id: TurnId,
+        mut turn: tidebreak_core::TurnRun,
+        mut lease_token: uuid::Uuid,
+    ) -> Result<LegDriverOutcome, HarnessError> {
+        loop {
+            let outcome = self
+                .driver
+                .run_turn(turn, lease_token)
+                .await
+                .map_err(|error| HarnessError::Other(error.to_string()))?;
+            match outcome {
+                LegDriverOutcome::Resuming(resuming_id) if resuming_id == turn_id => {
+                    (turn, lease_token) = self.claim_resuming_turn(turn_id).await?;
+                }
+                LegDriverOutcome::Resuming(resuming_id) => {
+                    return Err(HarnessError::Other(format!(
+                        "turn {turn_id} returned a resume for {resuming_id}"
+                    )));
+                }
+                outcome => return Ok(outcome),
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -418,12 +606,11 @@ impl HarnessSession for InternalSession {
         let Some(lease_token) = turn.lease_token else {
             return Err(HarnessError::Other(format!("turn {turn_id} has no lease")));
         };
-        *self.active.lock().expect("active turn") = Some(turn_id);
-        let outcome = self
-            .driver
-            .run_turn(turn, lease_token)
-            .await
-            .map_err(|error| HarnessError::Other(error.to_string()))?;
+        *self.active.lock().expect("active turn") = Some(ActiveTurn {
+            turn_id,
+            park: None,
+        });
+        let outcome = self.drive_claimed_turn(turn_id, turn, lease_token).await?;
         Ok(self.map_and_release(turn_id, outcome))
     }
 
@@ -440,78 +627,17 @@ impl HarnessSession for InternalSession {
                 "no parked turn to resume for {park_ref}"
             )));
         };
-        let _call_id = Self::parse_call_id(&park_ref)?;
-        let ResumeInput::ApprovalDecided {
-            call_id: decided, ..
-        } = input
-        else {
-            return Err(HarnessError::ParkResumeUnsupported);
-        };
-        if decided != park_ref {
-            return Err(HarnessError::ApprovalBindingMismatch(format!(
-                "park {park_ref} did not wait on {decided}"
-            )));
-        }
-        // The chat route or `decide` already settled the row. Client-wait
-        // parks drop the lease; a live running claim is reused. Yield so the
-        // settling request can drop its SQLite write lock before we claim.
-        tokio::task::yield_now().await;
-        let mut lease_token = None;
-        let mut turn = None;
-        for _ in 0..40 {
-            let token = uuid::Uuid::new_v4();
-            let now = Utc::now();
-            let claimed = match self
-                .db
-                .take_lease_on_turn(turn_id, token, now, now + chrono::Duration::seconds(60))
-                .await
-            {
-                Ok(value) => value,
-                Err(error) if error.to_string().contains("database is locked") => {
-                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                    continue;
-                }
-                Err(error) => return Err(store_error(error)),
-            };
-            let loaded = match self.state.store.get_turn(turn_id).await {
-                Ok(value) => value,
-                Err(error) if error.to_string().contains("database is locked") => {
-                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                    continue;
-                }
-                Err(error) => return Err(store_error(error)),
-            };
-            let Some(loaded) = loaded else {
-                return Err(HarnessError::Other(format!(
-                    "turn {turn_id} was not claimed before the resume"
-                )));
-            };
-            match (claimed, loaded.lease_token) {
-                (Some(()), _) => {
-                    lease_token = Some(token);
-                    turn = Some(loaded);
-                    break;
-                }
-                (None, Some(existing)) => {
-                    lease_token = Some(existing);
-                    turn = Some(loaded);
-                    break;
-                }
-                (None, None) => {
-                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                }
-            }
-        }
-        let (Some(lease_token), Some(turn)) = (lease_token, turn) else {
+        let Some(active_park) = self.active_park() else {
             return Err(HarnessError::Other(format!(
-                "could not claim a lease on turn {turn_id} before resume"
+                "turn {turn_id} has no active park for {park_ref}"
             )));
         };
-        let outcome = self
-            .driver
-            .run_turn(turn, lease_token)
-            .await
-            .map_err(|error| HarnessError::Other(error.to_string()))?;
+        let _call_id = Self::parse_call_id(&park_ref)?;
+        Self::validate_resume(&active_park, &park_ref, &input)?;
+        // The dependency settled the row and dropped the lease. This worker
+        // takes a fresh claim before it resumes the internal lane.
+        let (turn, lease_token) = self.claim_resuming_turn(turn_id).await?;
+        let outcome = self.drive_claimed_turn(turn_id, turn, lease_token).await?;
         Ok(self.map_and_release(turn_id, outcome))
     }
 
@@ -632,5 +758,115 @@ impl HarnessSession for InternalSession {
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidebreak_core::AgentRunId;
+
+    #[test]
+    fn client_and_agent_waits_map_to_adapter_parks() {
+        let turn_id = TurnId::new();
+        let client_call = CallId::new();
+        assert_eq!(
+            InternalSession::map_leg_outcome(
+                turn_id,
+                LegDriverOutcome::WaitingForClient {
+                    turn_id,
+                    call_id: client_call,
+                },
+            ),
+            TurnOutcome::Parked {
+                park_ref: client_call.to_string(),
+                waiting_on: ParkWait::ClientToolCall {
+                    call_id: client_call.to_string(),
+                },
+            }
+        );
+
+        let wait_call = CallId::new();
+        let run_a = AgentRunId::new();
+        let run_b = AgentRunId::new();
+        assert_eq!(
+            InternalSession::map_leg_outcome(
+                turn_id,
+                LegDriverOutcome::WaitingForAgentRun {
+                    turn_id,
+                    call_id: wait_call,
+                    run_ids: vec![run_a, run_b],
+                },
+            ),
+            TurnOutcome::Parked {
+                park_ref: wait_call.to_string(),
+                waiting_on: ParkWait::AgentRuns {
+                    run_ids: vec![run_a.to_string(), run_b.to_string()],
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn resume_input_must_match_the_active_park() {
+        let call_id = CallId::new().to_string();
+        let client = ActivePark {
+            park_ref: call_id.clone(),
+            waiting_on: ParkWait::ClientToolCall {
+                call_id: call_id.clone(),
+            },
+        };
+        assert!(InternalSession::validate_resume(
+            &client,
+            &call_id,
+            &ResumeInput::ClientToolCompleted {
+                call_id: call_id.clone(),
+            },
+        )
+        .is_ok());
+        assert!(InternalSession::validate_resume(
+            &client,
+            &call_id,
+            &ResumeInput::ClientToolCompleted {
+                call_id: CallId::new().to_string(),
+            },
+        )
+        .is_err());
+
+        let run_a = AgentRunId::new().to_string();
+        let run_b = AgentRunId::new().to_string();
+        let agents = ActivePark {
+            park_ref: CallId::new().to_string(),
+            waiting_on: ParkWait::AgentRuns {
+                run_ids: vec![run_a.clone(), run_b.clone()],
+            },
+        };
+        assert!(InternalSession::validate_resume(
+            &agents,
+            &agents.park_ref,
+            &ResumeInput::AgentRunsSettled {
+                run_ids: vec![run_a.clone(), run_b.clone()],
+            },
+        )
+        .is_ok());
+        assert!(InternalSession::validate_resume(
+            &agents,
+            &agents.park_ref,
+            &ResumeInput::AgentRunsSettled {
+                run_ids: vec![run_b, run_a],
+            },
+        )
+        .is_err());
+        assert!(InternalSession::validate_resume(
+            &agents,
+            &call_id,
+            &ResumeInput::AgentRunsSettled {
+                run_ids: match agents.waiting_on.clone() {
+                    ParkWait::AgentRuns { run_ids } => run_ids,
+                    _ => unreachable!(),
+                },
+            },
+        )
+        .is_err());
     }
 }

--- a/crates/tidebreak-server/src/engine/internal/session.rs
+++ b/crates/tidebreak-server/src/engine/internal/session.rs
@@ -483,7 +483,7 @@ impl InternalSession {
             let now = Utc::now();
             match self
                 .db
-                .take_lease_on_turn(
+                .take_lease_on_resuming_turn(
                     turn_id,
                     lease_token,
                     now,

--- a/crates/tidebreak-server/src/tests/code_internal.rs
+++ b/crates/tidebreak-server/src/tests/code_internal.rs
@@ -17,8 +17,10 @@ use axum::http::{header, Request, StatusCode};
 use tower::ServiceExt;
 
 use tidebreak_core::{
-    ApprovalClass, ChatRequest, CodeSessionId, ContentBlock, DbStore, ModelProvider, ProviderEvent,
-    ProviderId, StopReason, Tool, ToolCtx, ToolOutput, ToolRegistry, ToolSpec,
+    ApprovalClass, ChatRequest, CodeSessionId, CodeTurnStatus, ContentBlock, DbStore,
+    ModelProvider, OwnerId, ProviderEvent, ProviderId, StopReason, Store,
+    SubmitAgentRunResultOutcome, Tool, ToolCtx, ToolOutput, ToolRegistry, ToolSpec, TurnId,
+    TurnParkWait, TurnRunStatus,
 };
 use tidebreak_harness::AdapterRegistry;
 
@@ -31,6 +33,7 @@ enum Step {
         name: &'static str,
         input: serde_json::Value,
     },
+    WaitForSpawnedAgent,
     Text(&'static str),
 }
 
@@ -51,6 +54,7 @@ impl ModelProvider for ScriptedProvider {
         &self,
         request: ChatRequest,
     ) -> tidebreak_core::Result<BoxStream<'static, ProviderEvent>> {
+        let request_for_step = request.clone();
         self.requests.lock().unwrap().push(request);
         let call = self.calls.fetch_add(1, Ordering::SeqCst);
         let step = {
@@ -76,6 +80,36 @@ impl ModelProvider for ScriptedProvider {
                     reason: StopReason::ToolUse,
                 },
             ],
+            Some(Step::WaitForSpawnedAgent) => {
+                let agent_id = request_for_step
+                    .messages
+                    .iter()
+                    .rev()
+                    .flat_map(|message| message.content.iter().rev())
+                    .find_map(|block| match block {
+                        ContentBlock::ToolResult { content, .. } => {
+                            serde_json::from_str::<serde_json::Value>(content)
+                                .ok()
+                                .and_then(|value| value["agent_id"].as_str().map(str::to_owned))
+                        }
+                        _ => None,
+                    })
+                    .expect("the spawn result names its child");
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: format!("scripted_{call}"),
+                        name: tidebreak_core::WAIT_FOR_AGENTS_TOOL.to_owned(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: serde_json::json!({ "agent_ids": [agent_id] }).to_string(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            }
             Some(Step::Text(text)) => vec![
                 ProviderEvent::TextDelta {
                     text: text.to_owned(),
@@ -138,7 +172,8 @@ async fn internal_engine_app(
     Arc<AtomicUsize>,
     tempfile::TempDir,
 ) {
-    let (router, token, runtime, ran, dir, _provider) = internal_engine_app_capturing(steps).await;
+    let (router, token, runtime, ran, dir, _provider, _state) =
+        internal_engine_app_capturing(steps).await;
     let addr = super::code::serve(router).await;
     (addr, token, runtime, ran, dir)
 }
@@ -152,6 +187,7 @@ async fn internal_engine_app_capturing(
     Arc<AtomicUsize>,
     tempfile::TempDir,
     Arc<ScriptedProvider>,
+    AppState,
 ) {
     let (dir, store) = temp_db_store("internal.db").await;
     let db = Arc::new(store);
@@ -168,6 +204,15 @@ async fn internal_engine_app_capturing(
         tidebreak_core::exit_plan_mode_tool_spec(),
         ApprovalClass::ReadOnly,
         tidebreak_core::validate_exit_plan_mode_arguments,
+    );
+    tools.register_validated_foreground_client(
+        ToolSpec {
+            name: "connect_folder".into(),
+            description: "Connect one folder through the trusted client".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        },
+        ApprovalClass::ReadOnly,
+        serde_json::Value::is_object,
     );
     tools.register_foreground_agent_orchestration();
     let provider = Arc::new(ScriptedProvider {
@@ -200,7 +245,15 @@ async fn internal_engine_app_capturing(
     let runtime = Arc::new(runtime);
     state.code = Some(runtime.clone());
     let token = state.token.clone();
-    (app(state), token, runtime, ran, dir, provider)
+    (
+        app(state.clone()),
+        token,
+        runtime,
+        ran,
+        dir,
+        provider,
+        state,
+    )
 }
 
 fn spawn_turn_worker_with_blobs(state: &AppState) {
@@ -342,6 +395,107 @@ fn position(types: &[String], wanted: &str, after: usize) -> usize {
         .find(|(_, kind)| kind.as_str() == wanted)
         .map(|(index, _)| index)
         .unwrap_or_else(|| panic!("{wanted} after {after} in {types:?}"))
+}
+
+async fn create_internal_session(
+    router: &axum::Router,
+    bearer: &str,
+    permission_mode: &str,
+) -> CodeSessionId {
+    let created = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/code/sessions")
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "permission_mode": permission_mode }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let session: serde_json::Value = super::json_body(created).await;
+    session["id"].as_str().unwrap().parse().unwrap()
+}
+
+fn submit_internal_turn(
+    router: &axum::Router,
+    bearer: &str,
+    session_id: CodeSessionId,
+    message: &str,
+) -> tokio::task::JoinHandle<axum::response::Response> {
+    let router = router.clone();
+    let bearer = bearer.to_owned();
+    let message = message.to_owned();
+    tokio::spawn(async move {
+        router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/code/sessions/{session_id}/turns"))
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "message": message }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    })
+}
+
+async fn wait_for_durable_park(
+    runtime: &CodeRuntime,
+    session_id: CodeSessionId,
+) -> tidebreak_core::CodeTurn {
+    let parked = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(turn) =
+                tidebreak_core::db::code::get_open_turn(&runtime.db, &OwnerId::local(), session_id)
+                    .await
+                    .unwrap()
+            {
+                if turn.status == CodeTurnStatus::Waiting
+                    && turn.park_ref.is_some()
+                    && turn.park_wait.is_some()
+                {
+                    break turn;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    match parked {
+        Ok(turn) => turn,
+        Err(_) => {
+            let turns =
+                tidebreak_core::db::code::list_turns(&runtime.db, &OwnerId::local(), session_id)
+                    .await
+                    .unwrap();
+            let runs = runtime
+                .db
+                .list_agent_runs(tidebreak_core::ChatId(session_id.0))
+                .await
+                .unwrap();
+            let events = tidebreak_core::db::code::list_recent_events(
+                &runtime.db,
+                &OwnerId::local(),
+                session_id,
+                32,
+            )
+            .await
+            .unwrap();
+            panic!(
+                "the internal turn did not store its adapter park; turns={turns:?} runs={runs:?} events={events:?}"
+            );
+        }
+    }
 }
 
 /// The whole chat interaction model, reached only through `/code/*`: a plan
@@ -861,6 +1015,281 @@ async fn a_plan_accepted_from_the_chat_route_resumes_the_session() {
     }
 }
 
+#[tokio::test]
+async fn an_internal_client_wait_resumes_through_one_adapter_park() {
+    let (router, token, runtime, _ran, _dir, provider, _state) =
+        internal_engine_app_capturing(vec![
+            Step::Tool {
+                name: "connect_folder",
+                input: serde_json::json!({ "suggested_name": "Documents" }),
+            },
+            Step::Text("folder connected"),
+        ])
+        .await;
+    let bearer = format!("Bearer {token}");
+    let session_id = create_internal_session(&router, &bearer, "ask").await;
+    let response = submit_internal_turn(&router, &bearer, session_id, "connect documents");
+
+    let parked = wait_for_durable_park(&runtime, session_id).await;
+    let call_id = match parked.park_wait.as_ref().unwrap() {
+        TurnParkWait::ClientToolCall { call_id } => call_id.clone(),
+        other => panic!("the turn parked on the wrong dependency: {other:?}"),
+    };
+    assert_eq!(parked.park_ref.as_deref(), Some(call_id.as_str()));
+    let call_id: tidebreak_core::CallId = call_id.parse().unwrap();
+    let pending = runtime
+        .db
+        .list_pending_client_tool_calls(tidebreak_core::ChatId(session_id.0))
+        .await
+        .unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].id, call_id);
+    assert_eq!(pending[0].name, "connect_folder");
+    let before_resume = runtime
+        .db
+        .get_turn(TurnId(parked.id.0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        (before_resume.attempt_count, before_resume.claim_count),
+        (1, 1)
+    );
+
+    let lease_token = uuid::Uuid::new_v4();
+    let claim = super::lifecycle::post_native_json(
+        &router,
+        &bearer,
+        &format!("/chats/{session_id}/client-executions/{call_id}/claim"),
+        serde_json::json!({
+            "executor_id": uuid::Uuid::new_v4(),
+            "lease_token": lease_token,
+        }),
+    )
+    .await;
+    assert_eq!(claim.status(), StatusCode::OK);
+    let resolved = super::lifecycle::post_native_json(
+        &router,
+        &bearer,
+        &format!("/chats/{session_id}/client-executions/{call_id}/resolve"),
+        serde_json::json!({
+            "lease_token": lease_token,
+            "resolution": {
+                "status": "completed",
+                "result": "connected-root",
+            },
+        }),
+    )
+    .await;
+    assert_eq!(resolved.status(), StatusCode::OK);
+
+    let response = match tokio::time::timeout(Duration::from_secs(20), response).await {
+        Ok(response) => response.unwrap(),
+        Err(_) => {
+            let code_turn =
+                tidebreak_core::db::code::get_turn(&runtime.db, &OwnerId::local(), parked.id)
+                    .await
+                    .unwrap();
+            let run = runtime.db.get_turn(TurnId(parked.id.0)).await.unwrap();
+            let events = tidebreak_core::db::code::list_recent_events(
+                &runtime.db,
+                &OwnerId::local(),
+                session_id,
+                32,
+            )
+            .await
+            .unwrap();
+            let requests = provider.requests.lock().unwrap().len();
+            panic!(
+                "the client result did not resume the turn; code_turn={code_turn:?} run={run:?} requests={requests} events={events:?}"
+            );
+        }
+    };
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let completed = tidebreak_core::db::code::get_turn(&runtime.db, &OwnerId::local(), parked.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(completed.status, CodeTurnStatus::Completed);
+    assert_eq!(completed.park_ref, None);
+    assert_eq!(completed.park_wait, None);
+    let after_resume = runtime
+        .db
+        .get_turn(TurnId(parked.id.0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(after_resume.status, TurnRunStatus::Completed);
+    assert_eq!(
+        (after_resume.attempt_count, after_resume.claim_count),
+        (1, 2)
+    );
+    let requests = provider.requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(requests[1].messages.iter().any(|message| {
+        message.content.iter().any(|block| {
+            matches!(
+                block,
+                ContentBlock::ToolResult { content, .. } if content == "connected-root"
+            )
+        })
+    }));
+}
+
+#[tokio::test]
+async fn an_internal_agent_wait_resumes_through_one_adapter_park() {
+    let (router, token, runtime, _ran, _dir, _provider, state) =
+        internal_engine_app_capturing(vec![
+            Step::Tool {
+                name: tidebreak_core::SPAWN_SANDBOX_AGENT_TOOL,
+                input: serde_json::json!({ "task": "research the answer" }),
+            },
+            Step::WaitForSpawnedAgent,
+            Step::Text("child result received"),
+        ])
+        .await;
+    let bearer = format!("Bearer {token}");
+    let session_id = create_internal_session(&router, &bearer, "allow").await;
+    let response = submit_internal_turn(&router, &bearer, session_id, "delegate this");
+
+    let parked = wait_for_durable_park(&runtime, session_id).await;
+    let run_ids = match parked.park_wait.as_ref().unwrap() {
+        TurnParkWait::AgentRuns { run_ids } => run_ids.clone(),
+        other => panic!("the turn parked on the wrong dependency: {other:?}"),
+    };
+    assert_eq!(run_ids.len(), 1);
+    let child_id: tidebreak_core::AgentRunId = run_ids[0].parse().unwrap();
+    let children = runtime
+        .db
+        .list_agent_runs(tidebreak_core::ChatId(session_id.0))
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|run| run.parent_id.is_some())
+        .collect::<Vec<_>>();
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].id, child_id);
+    let before_resume = runtime
+        .db
+        .get_turn(TurnId(parked.id.0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        (before_resume.attempt_count, before_resume.claim_count),
+        (1, 2)
+    );
+
+    let child_lease = uuid::Uuid::new_v4();
+    let claimed = runtime
+        .db
+        .claim_agent_run(child_lease, chrono::Duration::minutes(5), 4, 4)
+        .await
+        .unwrap()
+        .expect("the sandbox child is claimable");
+    assert_eq!(claimed.id, child_id);
+    assert!(matches!(
+        runtime
+            .db
+            .submit_agent_run_result(child_id, child_lease, "research complete")
+            .await
+            .unwrap(),
+        Some(SubmitAgentRunResultOutcome::Completed(_))
+    ));
+    let wait_id: tidebreak_core::CallId = parked.park_ref.as_deref().unwrap().parse().unwrap();
+    let resumed = runtime
+        .db
+        .resume_turn_for_agent_run_wait_set(wait_id, uuid::Uuid::new_v4())
+        .await
+        .unwrap()
+        .unwrap();
+    let event = match resumed {
+        tidebreak_core::ResumeTurnForAgentRunWaitSetOutcome::Resumed { event, .. } => event,
+        other => panic!("the ready wait did not resume: {other:?}"),
+    };
+    let _ = state
+        .events
+        .sender(tidebreak_core::ChatId(session_id.0))
+        .send(event);
+    state.turn_job_wake.notify_one();
+
+    let response = tokio::time::timeout(Duration::from_secs(20), response)
+        .await
+        .expect("the child result resumes the turn")
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let completed = tidebreak_core::db::code::get_turn(&runtime.db, &OwnerId::local(), parked.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(completed.status, CodeTurnStatus::Completed);
+    assert_eq!(completed.park_ref, None);
+    assert_eq!(completed.park_wait, None);
+    let after_resume = runtime
+        .db
+        .get_turn(TurnId(parked.id.0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(after_resume.status, TurnRunStatus::Completed);
+    assert_eq!(
+        (after_resume.attempt_count, after_resume.claim_count),
+        (1, 3)
+    );
+}
+
+#[tokio::test]
+async fn interrupting_an_internal_client_park_closes_the_turn() {
+    let (router, token, runtime, _ran, _dir, _provider, _state) =
+        internal_engine_app_capturing(vec![Step::Tool {
+            name: "connect_folder",
+            input: serde_json::json!({ "suggested_name": "Documents" }),
+        }])
+        .await;
+    let bearer = format!("Bearer {token}");
+    let session_id = create_internal_session(&router, &bearer, "ask").await;
+    let response = submit_internal_turn(&router, &bearer, session_id, "connect documents");
+    let parked = wait_for_durable_park(&runtime, session_id).await;
+    let call_id = match parked.park_wait.as_ref().unwrap() {
+        TurnParkWait::ClientToolCall { call_id } => call_id.clone(),
+        other => panic!("the turn parked on the wrong dependency: {other:?}"),
+    };
+
+    let interrupted = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/code/sessions/{session_id}/interrupt"))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(interrupted.status(), StatusCode::ACCEPTED);
+    let response = tokio::time::timeout(Duration::from_secs(20), response)
+        .await
+        .expect("the interrupt closes the parked turn")
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let closed = tidebreak_core::db::code::get_turn(&runtime.db, &OwnerId::local(), parked.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(closed.status, CodeTurnStatus::Interrupted);
+    let call_id: tidebreak_core::CallId = call_id.parse().unwrap();
+    let call = runtime
+        .db
+        .list_tool_calls(tidebreak_core::ChatId(session_id.0))
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|call| call.id == call_id)
+        .unwrap();
+    assert_eq!(call.status, tidebreak_core::ToolCallStatus::Cancelled);
+}
+
 /// The plainest turn on the internal engine — one answer, no tools — is in
 /// the journal once: the lane's rows, and nothing the worker wrote beside
 /// them.
@@ -1059,7 +1488,7 @@ async fn the_internal_engine_is_only_reachable_without_a_workspace() {
 /// model, and the lane's existing resolution puts them on the request.
 #[tokio::test]
 async fn an_internal_turn_with_an_image_reaches_the_model_with_the_bytes() {
-    let (router, token, _runtime, _ran, _dir, provider) =
+    let (router, token, _runtime, _ran, _dir, provider, _state) =
         internal_engine_app_capturing(vec![Step::Text("i see it")]).await;
     let bearer = format!("Bearer {token}");
     let created = router


### PR DESCRIPTION
Part of #2313. Follows the merged D4a turn-lane work in #3074.

## Summary

- Store client-tool and agent-run waits as durable turn parks.
- Resume parked turns from their persisted dependency after a worker restart.
- Route internal-engine waits through the same adapter park contract.
- Close or cancel parked turns with the matching durable receipt.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tidebreak-core -p tidebreak-server`
- `adapter_client_wait_resolves_from_the_generic_park`
- `adapter_agent_wait_resolves_from_the_generic_park`
- `client_and_agent_run_parks_resume_after_a_worker_restart`
- `an_internal_client_wait_resumes_through_one_adapter_park`
- `an_internal_agent_wait_resumes_through_one_adapter_park`