### PR TITLE
fix(server): let a dead store owner's lock lapse within seconds

### DIFF
--- a/crates/tidebreak-server/src/store_ownership.rs
+++ b/crates/tidebreak-server/src/store_ownership.rs
@@ -21,8 +21,22 @@ use sea_orm::sqlx::{Connection, Either, PgConnection};
 const POSTGRES_OWNERSHIP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 #[cfg(feature = "postgres")]
 const POSTGRES_OWNERSHIP_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+/// How long each monitor sleep on the owner connection lasts. Short on
+/// purpose: a backend blocked in `pg_sleep` never reads its socket, so when
+/// this process dies without a Terminate message (a pod stop is a signal, not
+/// a handshake) the backend only notices the dead client on its next reply.
+/// A single 68-year sleep left the lock held until TCP keepalive gave up,
+/// hours later, and every replacement refused to boot meanwhile.
 #[cfg(feature = "postgres")]
-const POSTGRES_OWNERSHIP_MONITOR_SLEEP_SECONDS: f64 = 2_147_483_647.0;
+const POSTGRES_OWNERSHIP_MONITOR_SLEEP_SECONDS: f64 = 5.0;
+/// How long a booting process waits for a previous owner's backend to let go
+/// before calling the store owned. Covers one monitor sleep plus the reply
+/// that surfaces the closed socket, so a `Recreate` rollout's replacement
+/// boots instead of crash-looping behind its predecessor.
+#[cfg(feature = "postgres")]
+const POSTGRES_OWNERSHIP_ACQUIRE_WAIT: std::time::Duration = std::time::Duration::from_secs(20);
+#[cfg(feature = "postgres")]
+const POSTGRES_OWNERSHIP_ACQUIRE_RETRY: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Stable across Tidebreak and SQLx versions so a rolling deploy cannot make
 /// two server versions choose different ownership keys.
@@ -97,19 +111,24 @@ impl PostgresStoreOwnership {
         })?;
 
         let lock = PgAdvisoryLock::with_key(PgAdvisoryLockKey::BigInt(POSTGRES_OWNERSHIP_LOCK_KEY));
-        let guard = match lock.try_acquire(connection).await.map_err(|error| {
-            AgentError::config(format!(
-                "could not acquire PostgreSQL self-host ownership: {error}"
-            ))
-        })? {
-            Either::Left(guard) => guard,
-            Either::Right(_) => {
+        let deadline = tokio::time::Instant::now() + POSTGRES_OWNERSHIP_ACQUIRE_WAIT;
+        let mut connection = connection;
+        loop {
+            connection = match lock.try_acquire(connection).await.map_err(|error| {
+                AgentError::config(format!(
+                    "could not acquire PostgreSQL self-host ownership: {error}"
+                ))
+            })? {
+                Either::Left(guard) => return Ok(Self { guard }),
+                Either::Right(connection) => connection,
+            };
+            if tokio::time::Instant::now() >= deadline {
                 return Err(AgentError::config(
                     "another Tidebreak self-host process already owns this PostgreSQL database. Stop it before starting another process against the same TIDEBREAK_DATABASE_URL",
                 ));
             }
-        };
-        Ok(Self { guard })
+            tokio::time::sleep(POSTGRES_OWNERSHIP_ACQUIRE_RETRY).await;
+        }
     }
 
     pub(crate) async fn verify(&mut self) -> Result<()> {
@@ -127,12 +146,19 @@ impl PostgresStoreOwnership {
     /// Keep a query pending on the lock-holding connection. PostgreSQL ends
     /// the query as soon as that backend disappears, so `serve` can stop in
     /// the same `select!` instead of waiting for a periodic health check.
+    /// The sleep runs in short rounds so the backend, in turn, notices this
+    /// process disappearing (see [`POSTGRES_OWNERSHIP_MONITOR_SLEEP_SECONDS`]).
     pub(crate) async fn wait_until_lost(&mut self) -> AgentError {
-        let _ = sea_orm::sqlx::query("SELECT pg_sleep($1)")
-            .bind(POSTGRES_OWNERSHIP_MONITOR_SLEEP_SECONDS)
-            .execute(self.guard.as_mut())
-            .await;
-        ownership_lost_error()
+        loop {
+            if sea_orm::sqlx::query("SELECT pg_sleep($1)")
+                .bind(POSTGRES_OWNERSHIP_MONITOR_SLEEP_SECONDS)
+                .execute(self.guard.as_mut())
+                .await
+                .is_err()
+            {
+                return ownership_lost_error();
+            }
+        }
     }
 }
 

--- a/crates/tidebreak-server/tests/postgres_store_ownership.rs
+++ b/crates/tidebreak-server/tests/postgres_store_ownership.rs
@@ -43,7 +43,7 @@ fn self_host_config(data_dir: &Path) -> Config {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn postgres_store_ownership_refuses_a_second_boot_and_fails_closed_on_loss() {
+async fn postgres_store_ownership_is_exclusive_and_outlives_a_dead_owner() {
     let url = match std::env::var("TIDEBREAK_POSTGRES_TEST_URL") {
         Ok(url) => url,
         Err(_) if std::env::var_os("TIDEBREAK_REQUIRE_POSTGRES_TEST").is_some() => {
@@ -112,6 +112,49 @@ async fn postgres_store_ownership_refuses_a_second_boot_and_fails_closed_on_loss
     );
 
     drop(replacement);
+
+    // A pod stop is a signal, not a Terminate message: the owner's socket
+    // closes while its backend is asleep in the monitor query. The next boot
+    // must still get the store within the acquisition wait, not hours later
+    // when TCP keepalive finally ends that backend.
+    let silent_dir = tempfile::tempdir().expect("silent-owner data dir");
+    let silent = tidebreak_server::bind(self_host_config(silent_dir.path()))
+        .await
+        .expect("a self-host server owns the database again");
+    let serving = tokio::spawn(silent.serve());
+    let monitoring = async {
+        loop {
+            let asleep: bool = sea_orm::sqlx::query_scalar(
+                "SELECT EXISTS ( \
+                   SELECT 1 FROM pg_stat_activity \
+                   WHERE datname = current_database() \
+                     AND application_name = $1 \
+                     AND state = 'active' \
+                     AND query LIKE 'SELECT pg_sleep%')",
+            )
+            .bind(OWNERSHIP_APPLICATION_NAME)
+            .fetch_one(&mut admin)
+            .await
+            .expect("inspect the owner's monitor query");
+            if asleep {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(10), monitoring)
+        .await
+        .expect("the serving owner must be asleep in its monitor query");
+    serving.abort();
+    let _ = serving.await;
+
+    let successor_dir = tempfile::tempdir().expect("successor data dir");
+    let successor = tidebreak_server::bind(self_host_config(successor_dir.path()))
+        .await
+        .expect(
+            "a replacement takes ownership once the dead owner's backend notices the closed socket",
+        );
+    drop(successor);
 
     let secret = "store-owner-url-secret";
     std::env::set_var(


### PR DESCRIPTION
## What changed

A self-host server holds its PostgreSQL store through a session advisory lock and keeps that connection busy with one `SELECT pg_sleep(2147483647)`, so `serve` stops the moment the backend disappears. The other direction did not work. A backend blocked in `pg_sleep` never reads its socket, and sqlx only queues the unlock on drop, so when the process died without a Terminate message the backend kept the lock until TCP keepalive gave up, hours later. On a managed gateway plane every rollout stops the pod with a signal, so every rollout produced a replacement crash-looping on "another Tidebreak self-host process already owns this PostgreSQL database" until an operator terminated the stale backend by hand. Tidebreak on devops sat in that state twice on Sep 3.

The monitor now sleeps in five-second rounds. A round that ends normally starts the next one, so `serve` still stops on the first failed round when the store goes away. A backend whose client died sees the closed socket when it replies after the round and exits, releasing the lock. Booting waits up to twenty seconds for that, retrying the acquisition each second before it refuses, so a `Recreate` rollout's replacement takes the store instead of exiting behind its predecessor.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tidebreak-server --features postgres --test postgres_store_ownership` against a throwaway `postgres:16-alpine` with `TIDEBREAK_POSTGRES_TEST_URL` set. The test now also aborts a serving owner while its monitor query is asleep, without a Terminate message, and asserts a successor boots. That scenario fails on `main`: the successor is refused because the dead owner's backend still holds the lock.

## Compatibility and risk

No wire or persisted format changes. The lock key is unchanged, so an old and a new server version still contend for the same ownership. A store that disappears is noticed within the same round it was before, since the failed query returns immediately. The acquisition wait adds at most twenty seconds to a boot that would previously have been refused instantly, and only when another owner still holds the lock.
