### PR TITLE
refactor(api): add canonical session routes

### DIFF
--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -34,7 +34,7 @@ pub use tidebreak_server::wire::{
 
 use super::client::{Client, EventSocket};
 
-/// Result of `POST /code/sessions/{id}/turns`: the turn that ran on `200`, or
+/// Result of `POST /sessions/{id}/turns`: the turn that ran on `200`, or
 /// the follow-up the server parked on `202`. The server answers with one of
 /// two snapshots rather than a tagged union, so this is the one code-mode
 /// shape the client composes itself. Both arms reject unknown keys, so a
@@ -181,7 +181,7 @@ impl Client {
         message: &str,
     ) -> Result<SubmitTurnResponse> {
         self.post_json(
-            format!("{}/code/sessions/{session}/turns", self.base_url()),
+            format!("{}/sessions/{session}/turns", self.base_url()),
             &serde_json::json!({ "message": message }),
         )
         .await
@@ -191,7 +191,7 @@ impl Client {
         &self,
         session: CodeSessionId,
     ) -> Result<Vec<CodeTurnSnapshot>> {
-        self.get_json(format!("{}/code/sessions/{session}/turns", self.base_url()))
+        self.get_json(format!("{}/sessions/{session}/turns", self.base_url()))
             .await
     }
 
@@ -199,16 +199,13 @@ impl Client {
         &self,
         session: CodeSessionId,
     ) -> Result<QueuedCodeTurnsSnapshot> {
-        self.get_json(format!(
-            "{}/code/sessions/{session}/queued",
-            self.base_url()
-        ))
-        .await
+        self.get_json(format!("{}/sessions/{session}/queued", self.base_url()))
+            .await
     }
 
     pub async fn interrupt_session(&self, session: CodeSessionId) -> Result<()> {
         self.post_ok(
-            format!("{}/code/sessions/{session}/interrupt", self.base_url()),
+            format!("{}/sessions/{session}/interrupt", self.base_url()),
             &serde_json::json!({}),
         )
         .await
@@ -216,7 +213,7 @@ impl Client {
 
     pub async fn reap_session(&self, session: CodeSessionId) -> Result<CodeSessionSnapshot> {
         self.post_json(
-            format!("{}/code/sessions/{session}/reap", self.base_url()),
+            format!("{}/sessions/{session}/reap", self.base_url()),
             &serde_json::json!({}),
         )
         .await
@@ -228,7 +225,7 @@ impl Client {
         mode: PermissionMode,
     ) -> Result<CodeSessionSnapshot> {
         self.post_json(
-            format!("{}/code/sessions/{session}/mode", self.base_url()),
+            format!("{}/sessions/{session}/mode", self.base_url()),
             &serde_json::json!({ "permission_mode": mode }),
         )
         .await
@@ -239,7 +236,7 @@ impl Client {
         session: Option<CodeSessionId>,
         pending_only: bool,
     ) -> Result<Vec<CodeApprovalSnapshot>> {
-        let mut url = format!("{}/code/approvals", self.base_url());
+        let mut url = format!("{}/approvals", self.base_url());
         let mut separator = '?';
         if pending_only {
             url.push_str("?state=pending");
@@ -266,7 +263,7 @@ impl Client {
             body["feedback"] = feedback.into();
         }
         self.post_json(
-            format!("{}/code/approvals/{id}/decision", self.base_url()),
+            format!("{}/approvals/{id}/decision", self.base_url()),
             &body,
         )
         .await
@@ -378,12 +375,12 @@ impl Client {
         session: CodeSessionId,
         after: i64,
     ) -> Result<EventSocket> {
-        self.open_ws(&format!("/code/sessions/{session}/events?after={after}"))
+        self.open_ws(&format!("/sessions/{session}/events?after={after}"))
             .await
     }
 
     pub async fn open_code_updates(&self) -> Result<EventSocket> {
-        self.open_ws("/code/updates").await
+        self.open_ws("/updates").await
     }
 }
 
@@ -452,7 +449,7 @@ pub fn decode_event_frame(text: &str) -> Result<SequencedCodeEventFrame> {
         .map_err(|error| AgentError::msg(format!("bad code event frame: {error}")))
 }
 
-/// Decode one `/code/updates` notice. An unrecognized tag becomes
+/// Decode one `/updates` notice. An unrecognized tag becomes
 /// [`CodeUpdateNotice::Unknown`] rather than failing the stream.
 pub fn decode_update_notice(text: &str) -> Result<CodeUpdateNotice> {
     serde_json::from_str(text)

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -714,7 +714,7 @@ async fn execute(client: &Client, command: Command) -> Result<i32> {
     }
 }
 
-/// There is no `GET /code/sessions/{id}`. Walk workspaces to recover the row,
+/// There is no `GET /sessions/{id}`. Walk workspaces to recover the row,
 /// then load its turns. A missing session 404s the same way a dedicated
 /// route would.
 async fn load_session(

--- a/crates/tidebreak-cli/src/event_stream.rs
+++ b/crates/tidebreak-cli/src/event_stream.rs
@@ -1,7 +1,7 @@
 //! Shared event-socket follow: subscribe, reconnect, durable fallback.
 //!
 //! Print mode and `agent-mcp` watch a chat turn over `/chats/{id}/events`.
-//! Code-mode tools watch `/code/sessions/{id}/events`. The reconnect ladder
+//! Code-mode tools watch `/sessions/{id}/events`. The reconnect ladder
 //! lives here so those surfaces stay in lockstep; each caller decides what a
 //! frame *means*.
 

--- a/crates/tidebreak-desktop/src/image_attachments.rs
+++ b/crates/tidebreak-desktop/src/image_attachments.rs
@@ -291,7 +291,7 @@ async fn publish_code_image_bytes(
 }
 
 fn code_image_attachments_path(session_id: Uuid) -> String {
-    format!("/code/sessions/{session_id}/attachments/images")
+    format!("/sessions/{session_id}/attachments/images")
 }
 
 /// Whether this file should be attached as an image rather than imported as a

--- a/crates/tidebreak-desktop/ui/src/QueueTray.tsx
+++ b/crates/tidebreak-desktop/ui/src/QueueTray.tsx
@@ -59,7 +59,7 @@ export function chatQueueApi(client: ApiClient, chatId: string): QueueTrayApi {
   };
 }
 
-/** The code-session queue (`/code/sessions/{id}/queued`), decision 69. */
+/** The code-session queue (`/sessions/{id}/queued`), decision 69. */
 export function codeQueueApi(
   client: ApiClient,
   sessionId: string,

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1069,7 +1069,7 @@ describe("active turn steering", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("http://127.0.0.1/code/sessions/session-1/steer");
+    expect(url).toBe("http://127.0.0.1/sessions/session-1/steer");
     expect(init.method).toBe("POST");
     expect(JSON.parse(String(init.body))).toEqual({
       expected_turn_id: "turn-1",
@@ -1855,7 +1855,7 @@ describe("code workspace sessions", () => {
     expect(init.method ?? "GET").toBe("GET");
   });
 
-  it("lists GET /code/sessions/{id}/turns", async () => {
+  it("lists GET /sessions/{id}/turns", async () => {
     const turn = {
       id: "turn-1",
       session_id: "sess-1",
@@ -1876,7 +1876,7 @@ describe("code workspace sessions", () => {
       turn,
     ]);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      "http://127.0.0.1/code/sessions/sess-1/turns",
+      "http://127.0.0.1/sessions/sess-1/turns",
     );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/api/client/code-events.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/code-events.ts
@@ -30,7 +30,7 @@ export function withCodeEventsApi<TBase extends Constructor<HttpCore>>(
       after: number,
       onFrame: (frame: SequencedCodeEventFrame) => void,
     ): WebSocket {
-      const url = `${this.baseUrl.replace(/^http/, "ws")}/code/sessions/${encodeURIComponent(sessionId)}/events?after=${after}`;
+      const url = `${this.baseUrl.replace(/^http/, "ws")}/sessions/${encodeURIComponent(sessionId)}/events?after=${after}`;
       const protocols = [WS_HANDSHAKE, `${WS_TOKEN_PREFIX}${this.token}`];
       const socket = new WebSocket(url, protocols);
       socket.onmessage = (msg) => {
@@ -47,7 +47,7 @@ export function withCodeEventsApi<TBase extends Constructor<HttpCore>>(
 
     /** Open the install-wide digest channel; auth via Sec-WebSocket-Protocol. */
     openCodeUpdates(onNotice: (notice: CodeUpdateNotice) => void): WebSocket {
-      const url = `${this.baseUrl.replace(/^http/, "ws")}/code/updates`;
+      const url = `${this.baseUrl.replace(/^http/, "ws")}/updates`;
       const protocols = [WS_HANDSHAKE, `${WS_TOKEN_PREFIX}${this.token}`];
       const socket = new WebSocket(url, protocols);
       socket.onmessage = (msg) => {
@@ -69,7 +69,7 @@ export function withCodeEventsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseCodeSession(
           await this.json(
-            `/code/sessions/${encodeURIComponent(sessionId)}/attention`,
+            `/sessions/${encodeURIComponent(sessionId)}/attention`,
             {
               method: "POST",
               headers: this.headers(true),
@@ -89,7 +89,7 @@ export function withCodeEventsApi<TBase extends Constructor<HttpCore>>(
       if (query?.state) params.set("state", query.state);
       if (query?.sessionId) params.set("session_id", query.sessionId);
       const suffix = params.size > 0 ? `?${params}` : "";
-      const body = await this.json<unknown>(`/code/approvals${suffix}`, {
+      const body = await this.json<unknown>(`/approvals${suffix}`, {
         headers: this.headers(),
       });
       return parseList(body, parseCodeApproval, "code approvals");
@@ -102,7 +102,7 @@ export function withCodeEventsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseCodeApproval(
           await this.json(
-            `/code/approvals/${encodeURIComponent(approvalId)}/decision`,
+            `/approvals/${encodeURIComponent(approvalId)}/decision`,
             {
               method: "POST",
               headers: this.headers(true),

--- a/crates/tidebreak-desktop/ui/src/api/client/code-repos.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/code-repos.ts
@@ -264,7 +264,7 @@ export function withCodeReposApi<TBase extends Constructor<HttpCore>>(
      * Warm the pinned install of one engine ahead of a session create.
      *
      * Answers as soon as the server knows where the install stands; the phases
-     * that follow arrive on `WS /code/updates`. Safe to call repeatedly — an
+     * that follow arrive on `WS /updates`. Safe to call repeatedly — an
      * installed pin answers `ready` and one already running is not restarted.
      */
     /**

--- a/crates/tidebreak-desktop/ui/src/api/client/code-sessions.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/code-sessions.ts
@@ -62,12 +62,9 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
     }
 
     async getCodeSessionDebug(sessionId: string): Promise<unknown> {
-      return this.json(
-        `/sessions/${encodeURIComponent(sessionId)}/debug`,
-        {
-          headers: this.headers(),
-        },
-      );
+      return this.json(`/sessions/${encodeURIComponent(sessionId)}/debug`, {
+        headers: this.headers(),
+      });
     }
 
     async listCodeSessionTurns(sessionId: string): Promise<CodeTurnSnapshot[]> {
@@ -100,23 +97,18 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
     ): Promise<CodeTurnSubmission> {
       return requireParsed(
         parseCodeTurnSubmission(
-          await this.json(
-            `/sessions/${encodeURIComponent(sessionId)}/turns`,
-            {
-              method: "POST",
-              headers: this.headers(true),
-              body: JSON.stringify({
-                message,
-                ...(model ? { model } : {}),
-                ...(reasoningEffort !== undefined
-                  ? { reasoning_effort: reasoningEffort }
-                  : {}),
-                ...(attachments && attachments.length > 0
-                  ? { attachments }
-                  : {}),
-              }),
-            },
-          ),
+          await this.json(`/sessions/${encodeURIComponent(sessionId)}/turns`, {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({
+              message,
+              ...(model ? { model } : {}),
+              ...(reasoningEffort !== undefined
+                ? { reasoning_effort: reasoningEffort }
+                : {}),
+              ...(attachments && attachments.length > 0 ? { attachments } : {}),
+            }),
+          }),
         ),
         "code turn",
       );
@@ -135,14 +127,11 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
     ): Promise<CodeSessionSnapshot> {
       return requireParsed(
         parseCodeSession(
-          await this.json(
-            `/sessions/${encodeURIComponent(sessionId)}/mode`,
-            {
-              method: "POST",
-              headers: this.headers(true),
-              body: JSON.stringify({ permission_mode: permissionMode }),
-            },
-          ),
+          await this.json(`/sessions/${encodeURIComponent(sessionId)}/mode`, {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({ permission_mode: permissionMode }),
+          }),
         ),
         "code session",
       );
@@ -155,14 +144,11 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
     ): Promise<CodeSessionSnapshot> {
       return requireParsed(
         parseCodeSession(
-          await this.json(
-            `/sessions/${encodeURIComponent(sessionId)}/effort`,
-            {
-              method: "POST",
-              headers: this.headers(true),
-              body: JSON.stringify({ reasoning_effort: reasoningEffort }),
-            },
-          ),
+          await this.json(`/sessions/${encodeURIComponent(sessionId)}/effort`, {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({ reasoning_effort: reasoningEffort }),
+          }),
         ),
         "code session",
       );
@@ -208,27 +194,21 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       expectedTurnId: string,
       guidance: string,
     ): Promise<void> {
-      return this.json(
-        `/sessions/${encodeURIComponent(sessionId)}/steer`,
-        {
-          method: "POST",
-          headers: this.headers(true),
-          body: JSON.stringify({
-            expected_turn_id: expectedTurnId,
-            guidance,
-          }),
-        },
-      );
+      return this.json(`/sessions/${encodeURIComponent(sessionId)}/steer`, {
+        method: "POST",
+        headers: this.headers(true),
+        body: JSON.stringify({
+          expected_turn_id: expectedTurnId,
+          guidance,
+        }),
+      });
     }
 
     interruptCodeSession(sessionId: string): Promise<void> {
-      return this.json(
-        `/sessions/${encodeURIComponent(sessionId)}/interrupt`,
-        {
-          method: "POST",
-          headers: this.headers(),
-        },
-      );
+      return this.json(`/sessions/${encodeURIComponent(sessionId)}/interrupt`, {
+        method: "POST",
+        headers: this.headers(),
+      });
     }
 
     /** The session's queued messages, FIFO, plus whether promotion is paused. */
@@ -317,14 +297,11 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
     ): Promise<CodeForkTranscript> {
       return requireParsed(
         parseCodeForkTranscript(
-          await this.json(
-            `/sessions/${encodeURIComponent(sessionId)}/fork`,
-            {
-              method: "POST",
-              headers: this.headers(true),
-              body: JSON.stringify(atTurnId ? { at_turn: atTurnId } : {}),
-            },
-          ),
+          await this.json(`/sessions/${encodeURIComponent(sessionId)}/fork`, {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify(atTurnId ? { at_turn: atTurnId } : {}),
+          }),
         ),
         "code fork transcript",
       );
@@ -333,13 +310,10 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
     async reapCodeSession(sessionId: string): Promise<CodeSessionSnapshot> {
       return requireParsed(
         parseCodeSession(
-          await this.json(
-            `/sessions/${encodeURIComponent(sessionId)}/reap`,
-            {
-              method: "POST",
-              headers: this.headers(),
-            },
-          ),
+          await this.json(`/sessions/${encodeURIComponent(sessionId)}/reap`, {
+            method: "POST",
+            headers: this.headers(),
+          }),
         ),
         "code session",
       );

--- a/crates/tidebreak-desktop/ui/src/api/client/code-sessions.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/code-sessions.ts
@@ -63,7 +63,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
 
     async getCodeSessionDebug(sessionId: string): Promise<unknown> {
       return this.json(
-        `/code/sessions/${encodeURIComponent(sessionId)}/debug`,
+        `/sessions/${encodeURIComponent(sessionId)}/debug`,
         {
           headers: this.headers(),
         },
@@ -72,7 +72,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
 
     async listCodeSessionTurns(sessionId: string): Promise<CodeTurnSnapshot[]> {
       const body = await this.json<unknown>(
-        `/code/sessions/${encodeURIComponent(sessionId)}/turns`,
+        `/sessions/${encodeURIComponent(sessionId)}/turns`,
         { headers: this.headers() },
       );
       return requireParsed(parseCodeTurnList(body), "code session turns");
@@ -101,7 +101,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseCodeTurnSubmission(
           await this.json(
-            `/code/sessions/${encodeURIComponent(sessionId)}/turns`,
+            `/sessions/${encodeURIComponent(sessionId)}/turns`,
             {
               method: "POST",
               headers: this.headers(true),
@@ -136,7 +136,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseCodeSession(
           await this.json(
-            `/code/sessions/${encodeURIComponent(sessionId)}/mode`,
+            `/sessions/${encodeURIComponent(sessionId)}/mode`,
             {
               method: "POST",
               headers: this.headers(true),
@@ -156,7 +156,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseCodeSession(
           await this.json(
-            `/code/sessions/${encodeURIComponent(sessionId)}/effort`,
+            `/sessions/${encodeURIComponent(sessionId)}/effort`,
             {
               method: "POST",
               headers: this.headers(true),
@@ -176,7 +176,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseCodeSession(
           await this.json(
-            `/code/sessions/${encodeURIComponent(sessionId)}/fast-mode`,
+            `/sessions/${encodeURIComponent(sessionId)}/fast-mode`,
             {
               method: "POST",
               headers: this.headers(true),
@@ -194,7 +194,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       signal?: AbortSignal,
     ): Promise<Blob> {
       return this.blob(
-        `/code/sessions/${encodeURIComponent(sessionId)}/attachments/images/${encodeURIComponent(blobId)}`,
+        `/sessions/${encodeURIComponent(sessionId)}/attachments/images/${encodeURIComponent(blobId)}`,
         signal,
       );
     }
@@ -209,7 +209,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       guidance: string,
     ): Promise<void> {
       return this.json(
-        `/code/sessions/${encodeURIComponent(sessionId)}/steer`,
+        `/sessions/${encodeURIComponent(sessionId)}/steer`,
         {
           method: "POST",
           headers: this.headers(true),
@@ -223,7 +223,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
 
     interruptCodeSession(sessionId: string): Promise<void> {
       return this.json(
-        `/code/sessions/${encodeURIComponent(sessionId)}/interrupt`,
+        `/sessions/${encodeURIComponent(sessionId)}/interrupt`,
         {
           method: "POST",
           headers: this.headers(),
@@ -236,7 +236,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       sessionId: string,
     ): Promise<{ queued: QueuedCodeTurn[]; paused: boolean }> {
       const snapshot = await this.json<{ queued: unknown[]; paused: boolean }>(
-        `/code/sessions/${encodeURIComponent(sessionId)}/queued`,
+        `/sessions/${encodeURIComponent(sessionId)}/queued`,
         { headers: this.headers() },
       );
       return {
@@ -255,7 +255,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseQueuedCodeTurn(
           await this.json(
-            `/code/sessions/${encodeURIComponent(sessionId)}/queued/${encodeURIComponent(queuedId)}`,
+            `/sessions/${encodeURIComponent(sessionId)}/queued/${encodeURIComponent(queuedId)}`,
             {
               method: "PATCH",
               headers: this.headers(true),
@@ -272,7 +272,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       queuedId: string,
     ): Promise<void> {
       await this.json<unknown>(
-        `/code/sessions/${encodeURIComponent(sessionId)}/queued/${encodeURIComponent(queuedId)}`,
+        `/sessions/${encodeURIComponent(sessionId)}/queued/${encodeURIComponent(queuedId)}`,
         { method: "DELETE", headers: this.headers() },
         204,
       );
@@ -283,7 +283,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       paused: boolean,
     ): Promise<void> {
       await this.json<unknown>(
-        `/code/sessions/${encodeURIComponent(sessionId)}/queue-paused`,
+        `/sessions/${encodeURIComponent(sessionId)}/queue-paused`,
         {
           method: "PUT",
           headers: this.headers(true),
@@ -296,7 +296,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
     /** Release a paused queue so the worker starts the head row. */
     async sendCodeQueuedNow(sessionId: string): Promise<void> {
       await this.json<unknown>(
-        `/code/sessions/${encodeURIComponent(sessionId)}/queued/send-now`,
+        `/sessions/${encodeURIComponent(sessionId)}/queued/send-now`,
         { method: "POST", headers: this.headers() },
         204,
       );
@@ -318,7 +318,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseCodeForkTranscript(
           await this.json(
-            `/code/sessions/${encodeURIComponent(sessionId)}/fork`,
+            `/sessions/${encodeURIComponent(sessionId)}/fork`,
             {
               method: "POST",
               headers: this.headers(true),
@@ -334,7 +334,7 @@ export function withCodeSessionsApi<TBase extends Constructor<HttpCore>>(
       return requireParsed(
         parseCodeSession(
           await this.json(
-            `/code/sessions/${encodeURIComponent(sessionId)}/reap`,
+            `/sessions/${encodeURIComponent(sessionId)}/reap`,
             {
               method: "POST",
               headers: this.headers(),

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -27,7 +27,7 @@ import { applyLiveTurnRewrite } from "./CodeSessionRegistry";
 import { useCodeUiStore } from "./CodeUiStore";
 
 /**
- * Install-wide digest store fed by `WS /code/updates`.
+ * Install-wide digest store fed by `WS /updates`.
  *
  * List surfaces read lifecycle, attention, and PR state from here. The
  * socket restates a full snapshot on every connect, so a dropped notice is

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -493,7 +493,7 @@ const USAGE = {
 };
 
 describe("parseCodeTurnList", () => {
-  it("accepts GET /code/sessions/{id}/turns", () => {
+  it("accepts GET /sessions/{id}/turns", () => {
     expect(parseCodeTurnList([TURN])).toEqual([TURN]);
     expect(parseCodeTurnList([])).toEqual([]);
   });
@@ -536,7 +536,7 @@ describe("parseCodeTurnList", () => {
 
 describe("parseCodeTurnSubmission", () => {
   it("tells a turn that ran from a follow-up the server queued", () => {
-    // Both arrive as 202 on POST /code/sessions/{id}/turns. Reading the
+    // Both arrive as 202 on POST /sessions/{id}/turns. Reading the
     // queue receipt as a malformed turn reports a failure for a message the
     // server is holding, and the retry it invites double-sends.
     expect(parseCodeTurnSubmission(TURN)).toEqual({ kind: "ran", turn: TURN });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2834,7 +2834,7 @@ function parseCodeTurnAttachments(
 }
 
 /**
- * What `POST /code/sessions/{id}/turns` did with the message.
+ * What `POST /sessions/{id}/turns` did with the message.
  *
  * The route answers 202 for both outcomes: a turn that ran, or a follow-up
  * parked in the session's single queue slot while the current turn finishes.
@@ -3127,7 +3127,7 @@ export function parseDiffstat(value: unknown): Diffstat | null {
   };
 }
 
-/** `GET /code/sessions/{id}/turns` — oldest first. */
+/** `GET /sessions/{id}/turns` — oldest first. */
 export function parseCodeTurnList(value: unknown): CodeTurnSnapshot[] | null {
   if (!Array.isArray(value)) return null;
   const turns: CodeTurnSnapshot[] = [];

--- a/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
@@ -211,7 +211,7 @@ async function publishFirstTurnImages(
         onProgress: () => undefined,
         signal: new AbortController().signal,
         path: (id) =>
-          `/code/sessions/${encodeURIComponent(id)}/attachments/images`,
+          `/sessions/${encodeURIComponent(id)}/attachments/images`,
       });
     }),
   );

--- a/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
@@ -210,8 +210,7 @@ async function publishFirstTurnImages(
       return uploadImageAttachment(client, sessionId, file, {
         onProgress: () => undefined,
         signal: new AbortController().signal,
-        path: (id) =>
-          `/sessions/${encodeURIComponent(id)}/attachments/images`,
+        path: (id) => `/sessions/${encodeURIComponent(id)}/attachments/images`,
       });
     }),
   );

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
@@ -374,7 +374,7 @@ export function useWorkspaceSessions({
                         onProgress: () => undefined,
                         signal: new AbortController().signal,
                         path: (id) =>
-                          `/code/sessions/${encodeURIComponent(id)}/attachments/images`,
+                          `/sessions/${encodeURIComponent(id)}/attachments/images`,
                       },
                     );
                 return {

--- a/crates/tidebreak-desktop/ui/src/stories/QueueTray.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/QueueTray.stories.tsx
@@ -9,7 +9,7 @@ import { QueueTray, type QueueTrayApi, type QueueTrayRow } from "@/QueueTray";
  * Every row is a server-owned queued turn: edit, reorder, delete, and
  * send-now are real API calls behind the adapter, and the tray only observes.
  * Chat backs it with `/chats/{id}/queued`, a code session with
- * `/code/sessions/{id}/queued`; the rows render identically, which is the
+ * `/sessions/{id}/queued`; the rows render identically, which is the
  * point — a reader who learned the queue in one mode already knows the other.
  */
 const meta = {

--- a/crates/tidebreak-desktop/ui/src/useImageAttachments.ts
+++ b/crates/tidebreak-desktop/ui/src/useImageAttachments.ts
@@ -178,8 +178,7 @@ export function useImageAttachments(
         signal,
         path:
           scope === "code"
-            ? (id) =>
-                `/sessions/${encodeURIComponent(id)}/attachments/images`
+            ? (id) => `/sessions/${encodeURIComponent(id)}/attachments/images`
             : undefined,
       });
     }

--- a/crates/tidebreak-desktop/ui/src/useImageAttachments.ts
+++ b/crates/tidebreak-desktop/ui/src/useImageAttachments.ts
@@ -179,7 +179,7 @@ export function useImageAttachments(
         path:
           scope === "code"
             ? (id) =>
-                `/code/sessions/${encodeURIComponent(id)}/attachments/images`
+                `/sessions/${encodeURIComponent(id)}/attachments/images`
             : undefined,
       });
     }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -315,6 +315,11 @@ pub fn app(state: AppState) -> Router {
             "/code/sessions/{id}/attachments/images",
             post(routes::code::publish_session_image)
                 .layer(DefaultBodyLimit::max(routes::MAX_IMAGE_ATTACHMENT_BYTES)),
+        )
+        .route(
+            "/sessions/{id}/attachments/images",
+            post(routes::code::publish_session_image)
+                .layer(DefaultBodyLimit::max(routes::MAX_IMAGE_ATTACHMENT_BYTES)),
         );
 
     let client_executor_api = Router::new()
@@ -945,6 +950,67 @@ pub fn app(state: AppState) -> Router {
             axum::routing::delete(routes::delete_standing_grant),
         )
         .route("/chats/{id}/events", get(routes::chat_events))
+        .route(
+            "/sessions",
+            post(routes::code::create_internal_session).get(routes::code::list_internal_sessions),
+        )
+        .route("/sessions/{id}", get(routes::code::get_session))
+        .route(
+            "/sessions/{id}/turns",
+            post(routes::code::submit_turn).get(routes::code::list_session_turns),
+        )
+        .route(
+            "/sessions/{id}/queued",
+            get(routes::code::list_queued_turns),
+        )
+        .route(
+            "/sessions/{id}/queued/{queued_id}",
+            axum::routing::patch(routes::code::patch_queued_turn)
+                .delete(routes::code::delete_queued_turn),
+        )
+        .route(
+            "/sessions/{id}/queue-paused",
+            axum::routing::put(routes::code::put_queue_paused),
+        )
+        .route(
+            "/sessions/{id}/queued/send-now",
+            post(routes::code::post_queue_send_now),
+        )
+        .route(
+            "/sessions/{id}/attachments/images/{blob_id}",
+            get(routes::code::get_session_image),
+        )
+        .route("/sessions/{id}/steer", post(routes::code::steer_session))
+        .route(
+            "/sessions/{id}/interrupt",
+            post(routes::code::interrupt_session),
+        )
+        .route("/sessions/{id}/reap", post(routes::code::reap_session))
+        .route(
+            "/sessions/{id}/mode",
+            post(routes::code::set_session_permission_mode),
+        )
+        .route(
+            "/sessions/{id}/effort",
+            post(routes::code::set_session_reasoning_effort),
+        )
+        .route(
+            "/sessions/{id}/fast-mode",
+            post(routes::code::set_session_fast_mode),
+        )
+        .route("/sessions/{id}/fork", post(routes::code::fork_session))
+        .route("/sessions/{id}/debug", get(routes::code::get_session_debug))
+        .route(
+            "/sessions/{id}/attention",
+            post(routes::code::set_attention),
+        )
+        .route("/sessions/{id}/events", get(routes::code::session_events))
+        .route("/updates", get(routes::code::code_updates))
+        .route("/approvals", get(routes::code::list_approvals))
+        .route(
+            "/approvals/{id}/decision",
+            post(routes::code::decide_approval),
+        )
         .route("/code/grants", get(routes::code::list_grants))
         .route("/code/grants/{id}/revoke", post(routes::code::revoke_grant))
         .route(

--- a/crates/tidebreak-server/src/tests/code_internal.rs
+++ b/crates/tidebreak-server/src/tests/code_internal.rs
@@ -4,8 +4,8 @@
 //! on the code structures: sessions, turns, the sequenced journal, and
 //! approval rows. This module is the tripwire for that: chat's plan
 //! proposals, user questions, tool approvals with grant ladders, and
-//! mid-turn steering all have to be reachable over `/code/*`, and nothing
-//! about the conversation may leak into the chat routes.
+//! mid-turn steering all have to be reachable over the shared session routes.
+//! The `/chats/*` and `/code/sessions/*` families stay as compatibility aliases.
 
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -289,7 +289,7 @@ async fn pending_approval_of_kind(
         loop {
             let approvals: Vec<serde_json::Value> = client
                 .get(format!(
-                    "http://{addr}/code/approvals?session_id={session_id}&state=pending"
+                    "http://{addr}/approvals?session_id={session_id}&state=pending"
                 ))
                 .bearer_auth(token)
                 .send()
@@ -340,7 +340,7 @@ async fn turn_statuses(
     session_id: CodeSessionId,
 ) -> Vec<String> {
     let turns: Vec<serde_json::Value> = client
-        .get(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .get(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(token)
         .send()
         .await
@@ -362,9 +362,7 @@ async fn decide(
     body: serde_json::Value,
 ) {
     let response = client
-        .post(format!(
-            "http://{addr}/code/approvals/{approval_id}/decision"
-        ))
+        .post(format!("http://{addr}/approvals/{approval_id}/decision"))
         .bearer_auth(token)
         .json(&body)
         .send()
@@ -407,7 +405,7 @@ async fn create_internal_session(
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/code/sessions")
+                .uri("/sessions")
                 .header(header::AUTHORIZATION, bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
@@ -436,7 +434,7 @@ fn submit_internal_turn(
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri(format!("/code/sessions/{session_id}/turns"))
+                    .uri(format!("/sessions/{session_id}/turns"))
                     .header(header::AUTHORIZATION, bearer)
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(
@@ -498,7 +496,76 @@ async fn wait_for_durable_park(
     }
 }
 
-/// The whole chat interaction model, reached only through `/code/*`: a plan
+#[tokio::test]
+async fn canonical_and_compatibility_routes_share_session_rows() {
+    let (addr, token, _runtime, _ran, _dir) = internal_engine_app(Vec::new()).await;
+    let client = reqwest::Client::new();
+    let created = client
+        .post(format!("http://{addr}/sessions"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "permission_mode": "ask" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = created.json().await.unwrap();
+    let session_id = session["id"].as_str().unwrap();
+
+    let canonical: serde_json::Value = client
+        .get(format!("http://{addr}/sessions/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let code_alias: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(canonical, code_alias);
+
+    let chat_alias: serde_json::Value = client
+        .get(format!("http://{addr}/chats/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(chat_alias["id"], canonical["id"]);
+
+    let canonical_approvals: serde_json::Value = client
+        .get(format!("http://{addr}/approvals?session_id={session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let code_approvals: serde_json::Value = client
+        .get(format!(
+            "http://{addr}/code/approvals?session_id={session_id}"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(canonical_approvals, code_approvals);
+}
+
+/// The whole chat interaction model, reached through the shared session routes: a plan
 /// proposal parks the turn as an approval and its acceptance re-postures
 /// the session; a questions card parks and its answers resume; a sensitive
 /// tool waits on a structured approval that offers a grant ladder; a steer
@@ -537,7 +604,7 @@ async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
     let client = reqwest::Client::new();
 
     let created = client
-        .post(format!("http://{addr}/code/sessions"))
+        .post(format!("http://{addr}/sessions"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "plan" }))
         .send()
@@ -578,7 +645,7 @@ async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
         let token = token.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "plan it, then greet" }))
                 .send()
@@ -611,7 +678,7 @@ async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
     // Accepting the plan moved the session out of plan mode before the
     // resume, so the questions could be asked at all.
     let snapshot: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session_id}"))
+        .get(format!("http://{addr}/sessions/{session_id}"))
         .bearer_auth(&token)
         .send()
         .await
@@ -621,7 +688,7 @@ async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
         .unwrap();
     assert_eq!(snapshot["permission_mode"], "auto");
     let listed: Vec<serde_json::Value> = client
-        .get(format!("http://{addr}/code/sessions"))
+        .get(format!("http://{addr}/sessions"))
         .bearer_auth(&token)
         .send()
         .await
@@ -658,7 +725,7 @@ async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
     assert_eq!(statuses, vec!["running"]);
     let turn_id = {
         let turns: Vec<serde_json::Value> = client
-            .get(format!("http://{addr}/code/sessions/{session_id}/turns"))
+            .get(format!("http://{addr}/sessions/{session_id}/turns"))
             .bearer_auth(&token)
             .send()
             .await
@@ -669,7 +736,7 @@ async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
         turns[0]["id"].as_str().unwrap().to_owned()
     };
     let steered = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .post(format!("http://{addr}/sessions/{session_id}/steer"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "expected_turn_id": turn_id,
@@ -858,7 +925,7 @@ async fn a_questions_park_answered_from_the_chat_route_resumes_the_session() {
     .await;
     let client = reqwest::Client::new();
     let created = client
-        .post(format!("http://{addr}/code/sessions"))
+        .post(format!("http://{addr}/sessions"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "ask" }))
         .send()
@@ -872,7 +939,7 @@ async fn a_questions_park_answered_from_the_chat_route_resumes_the_session() {
         let token = token.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{hosted}/turns"))
+                .post(format!("http://{addr}/sessions/{hosted}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "ask me" }))
                 .send()
@@ -938,7 +1005,7 @@ async fn a_plan_accepted_from_the_chat_route_resumes_the_session() {
         .await;
         let client = reqwest::Client::new();
         let created = client
-            .post(format!("http://{addr}/code/sessions"))
+            .post(format!("http://{addr}/sessions"))
             .bearer_auth(&token)
             .json(&serde_json::json!({ "permission_mode": "plan" }))
             .send()
@@ -952,7 +1019,7 @@ async fn a_plan_accepted_from_the_chat_route_resumes_the_session() {
             let token = token.clone();
             async move {
                 client
-                    .post(format!("http://{addr}/code/sessions/{hosted}/turns"))
+                    .post(format!("http://{addr}/sessions/{hosted}/turns"))
                     .bearer_auth(&token)
                     .json(&serde_json::json!({ "message": "plan it" }))
                     .send()
@@ -990,7 +1057,7 @@ async fn a_plan_accepted_from_the_chat_route_resumes_the_session() {
             "{chosen_mode:?}"
         );
         let snapshot: serde_json::Value = client
-            .get(format!("http://{addr}/code/sessions/{hosted}"))
+            .get(format!("http://{addr}/sessions/{hosted}"))
             .bearer_auth(&token)
             .send()
             .await
@@ -1260,7 +1327,7 @@ async fn interrupting_an_internal_client_park_closes_the_turn() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/code/sessions/{session_id}/interrupt"))
+                .uri(format!("/sessions/{session_id}/interrupt"))
                 .header(header::AUTHORIZATION, &bearer)
                 .body(Body::empty())
                 .unwrap(),
@@ -1299,7 +1366,7 @@ async fn a_plain_internal_turn_is_journaled_once() {
         internal_engine_app(vec![Step::Text("just the answer")]).await;
     let client = reqwest::Client::new();
     let created = client
-        .post(format!("http://{addr}/code/sessions"))
+        .post(format!("http://{addr}/sessions"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "ask" }))
         .send()
@@ -1311,7 +1378,7 @@ async fn a_plain_internal_turn_is_journaled_once() {
 
     let response = tokio::time::timeout(Duration::from_secs(20), async {
         client
-            .post(format!("http://{addr}/code/sessions/{hosted}/turns"))
+            .post(format!("http://{addr}/sessions/{hosted}/turns"))
             .bearer_auth(&token)
             .json(&serde_json::json!({ "message": "say it" }))
             .send()
@@ -1360,7 +1427,7 @@ async fn a_chat_is_not_a_runtime_session_until_the_runtime_drives_it() {
 
     let sessions = || async {
         client
-            .get(format!("http://{addr}/code/sessions"))
+            .get(format!("http://{addr}/sessions"))
             .bearer_auth(&token)
             .send()
             .await
@@ -1386,7 +1453,7 @@ async fn a_chat_is_not_a_runtime_session_until_the_runtime_drives_it() {
 
     // The same id still resolves on the session route: one id, one row.
     let by_id = client
-        .get(format!("http://{addr}/code/sessions/{chat_id}"))
+        .get(format!("http://{addr}/sessions/{chat_id}"))
         .bearer_auth(&token)
         .send()
         .await
@@ -1405,7 +1472,7 @@ async fn deleting_a_hosted_session_through_the_chat_route_removes_it_from_both_s
     let (addr, token, _runtime, _ran, _dir) = internal_engine_app(Vec::new()).await;
     let client = reqwest::Client::new();
     let created = client
-        .post(format!("http://{addr}/code/sessions"))
+        .post(format!("http://{addr}/sessions"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "plan" }))
         .send()
@@ -1429,7 +1496,7 @@ async fn deleting_a_hosted_session_through_the_chat_route_removes_it_from_both_s
     assert_eq!(status, reqwest::StatusCode::NO_CONTENT, "{body}");
     for (surface, route) in [
         ("chat", format!("http://{addr}/chats/{id}")),
-        ("code", format!("http://{addr}/code/sessions/{id}")),
+        ("code", format!("http://{addr}/sessions/{id}")),
     ] {
         let missing = client.get(route).bearer_auth(&token).send().await.unwrap();
         assert_eq!(
@@ -1496,7 +1563,7 @@ async fn an_internal_turn_with_an_image_reaches_the_model_with_the_bytes() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/code/sessions")
+                .uri("/sessions")
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
@@ -1516,7 +1583,7 @@ async fn an_internal_turn_with_an_image_reaches_the_model_with_the_bytes() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/code/sessions/{session_id}/attachments/images"))
+                .uri(format!("/sessions/{session_id}/attachments/images"))
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "image/png")
                 .body(Body::from(pixels.clone()))
@@ -1538,7 +1605,7 @@ async fn an_internal_turn_with_an_image_reaches_the_model_with_the_bytes() {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri(format!("/code/sessions/{session_id}/turns"))
+                    .uri(format!("/sessions/{session_id}/turns"))
                     .header(header::AUTHORIZATION, &bearer)
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(

--- a/mobile/src/lib/api.test.ts
+++ b/mobile/src/lib/api.test.ts
@@ -282,7 +282,7 @@ describe("mobile supervision API contracts", () => {
     });
     expect(requestJson).toHaveBeenNthCalledWith(
       2,
-      "/code/sessions/session-2/turns",
+      "/sessions/session-2/turns",
       {
         method: "POST",
         body: { message: "Fix the launch flow." },
@@ -301,7 +301,7 @@ describe("mobile supervision API contracts", () => {
       submitCodeTurn(running.client, "session/1", "Continue"),
     ).resolves.toMatchObject({ kind: "ran" });
     expect(running.requestJson).toHaveBeenCalledWith(
-      "/code/sessions/session%2F1/turns",
+      "/sessions/session%2F1/turns",
       {
         method: "POST",
         body: { message: "Continue" },
@@ -356,7 +356,7 @@ describe("mobile supervision API contracts", () => {
       listCodeApprovals(listed.client, "session/1"),
     ).resolves.toHaveLength(1);
     expect(listed.getJson).toHaveBeenCalledWith(
-      "/code/approvals?state=pending&session_id=session%2F1",
+      "/approvals?state=pending&session_id=session%2F1",
     );
 
     const denied = fakeClient({
@@ -372,7 +372,7 @@ describe("mobile supervision API contracts", () => {
       "  Use the focused test.  ",
     );
     expect(denied.requestJson).toHaveBeenCalledWith(
-      "/code/approvals/approval%2F1/decision",
+      "/approvals/approval%2F1/decision",
       {
         method: "POST",
         body: { decision: "deny", feedback: "Use the focused test." },
@@ -393,7 +393,7 @@ describe("mobile supervision API contracts", () => {
     });
     await decideCodeApproval(approved.client, "approval-1", "approve");
     expect(approved.requestJson).toHaveBeenCalledWith(
-      "/code/approvals/approval-1/decision",
+      "/approvals/approval-1/decision",
       {
         method: "POST",
         body: { decision: "approve" },
@@ -407,7 +407,7 @@ describe("mobile supervision API contracts", () => {
     await steerCodeSession(client.client, "session/1", "turn-1", "Try again");
     expect(client.requestJson).toHaveBeenNthCalledWith(
       1,
-      "/code/sessions/session%2F1/steer",
+      "/sessions/session%2F1/steer",
       {
         method: "POST",
         body: { expected_turn_id: "turn-1", guidance: "Try again" },
@@ -418,7 +418,7 @@ describe("mobile supervision API contracts", () => {
     await interruptCodeSession(client.client, "session/1");
     expect(client.requestJson).toHaveBeenNthCalledWith(
       2,
-      "/code/sessions/session%2F1/interrupt",
+      "/sessions/session%2F1/interrupt",
       { method: "POST", expectedStatus: 202 },
     );
   });

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -598,7 +598,7 @@ export async function listCodeApprovals(
   const params = new URLSearchParams({ state: "pending" });
   if (sessionId) params.set("session_id", sessionId);
   return parseList(
-    await client.getJson(`/code/approvals?${params.toString()}`),
+    await client.getJson(`/approvals?${params.toString()}`),
     parseCodeApproval,
     "Code approvals",
   );
@@ -621,7 +621,7 @@ export async function decideCodeApproval(
   return required(
     parseCodeApproval(
       await client.requestJson(
-        `/code/approvals/${encodeURIComponent(approvalId)}/decision`,
+        `/approvals/${encodeURIComponent(approvalId)}/decision`,
         { method: "POST", body, expectedStatus: 200 },
       ),
     ),
@@ -635,7 +635,7 @@ export async function listCodeTurns(
 ): Promise<CodeTurnSnapshot[]> {
   return parseList(
     await client.getJson(
-      `/code/sessions/${encodeURIComponent(sessionId)}/turns`,
+      `/sessions/${encodeURIComponent(sessionId)}/turns`,
     ),
     parseCodeTurn,
     "Code turns",
@@ -648,7 +648,7 @@ export async function listCodeQueuedTurns(
 ): Promise<{ queued: QueuedCodeTurn[]; paused: boolean }> {
   const snapshot = record(
     await client.getJson(
-      `/code/sessions/${encodeURIComponent(sessionId)}/queued`,
+      `/sessions/${encodeURIComponent(sessionId)}/queued`,
     ),
   );
   if (
@@ -672,7 +672,7 @@ export async function submitCodeTurn(
   return required(
     parseCodeTurnSubmission(
       await client.requestJson(
-        `/code/sessions/${encodeURIComponent(sessionId)}/turns`,
+        `/sessions/${encodeURIComponent(sessionId)}/turns`,
         { method: "POST", body: { message }, expectedStatus: 202 },
       ),
     ),
@@ -687,7 +687,7 @@ export async function steerCodeSession(
   guidance: string,
 ): Promise<void> {
   await client.requestJson(
-    `/code/sessions/${encodeURIComponent(sessionId)}/steer`,
+    `/sessions/${encodeURIComponent(sessionId)}/steer`,
     {
       method: "POST",
       body: { expected_turn_id: expectedTurnId, guidance },
@@ -701,7 +701,7 @@ export async function interruptCodeSession(
   sessionId: string,
 ): Promise<void> {
   await client.requestJson(
-    `/code/sessions/${encodeURIComponent(sessionId)}/interrupt`,
+    `/sessions/${encodeURIComponent(sessionId)}/interrupt`,
     { method: "POST", expectedStatus: 202 },
   );
 }

--- a/mobile/src/lib/cursor.ts
+++ b/mobile/src/lib/cursor.ts
@@ -1,7 +1,7 @@
 import type { SequencedCodeEventFrame } from "../generated/wire";
 
 /**
- * Resume cursor for `GET /code/sessions/{id}/events?after=`.
+ * Resume cursor for `GET /sessions/{id}/events?after=`.
  *
  * Transient frames stamp the journal position they streamed behind; applying
  * them must not advance the cursor. Resume from the last durable seq.

--- a/mobile/src/lib/machine.test.ts
+++ b/mobile/src/lib/machine.test.ts
@@ -37,11 +37,11 @@ class FakeSocket {
 
 describe("machineWsUrl", () => {
   it("maps http(s) to ws(s)", () => {
-    expect(machineWsUrl("https://machine.example/app", "/code/updates")).toBe(
-      "wss://machine.example/app/code/updates",
+    expect(machineWsUrl("https://machine.example/app", "/updates")).toBe(
+      "wss://machine.example/app/updates",
     );
-    expect(machineWsUrl("http://127.0.0.1:8080", "/code/updates")).toBe(
-      "ws://127.0.0.1:8080/code/updates",
+    expect(machineWsUrl("http://127.0.0.1:8080", "/updates")).toBe(
+      "ws://127.0.0.1:8080/updates",
     );
   });
 });
@@ -62,7 +62,7 @@ describe("MachineClient requests", () => {
     });
 
     await expect(
-      client.requestJson("/code/sessions/s-1/turns", {
+      client.requestJson("/sessions/s-1/turns", {
         method: "POST",
         body: { message: "continue" },
         expectedStatus: 202,
@@ -72,7 +72,7 @@ describe("MachineClient requests", () => {
     expect(getAccessToken).toHaveBeenCalledWith("tidebreak:attached");
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl.mock.calls[0]?.[0]).toBe(
-      "https://machine.example/code/sessions/s-1/turns",
+      "https://machine.example/sessions/s-1/turns",
     );
     expect(fetchImpl.mock.calls[0]?.[1]).toMatchObject({
       method: "POST",
@@ -101,7 +101,7 @@ describe("MachineClient requests", () => {
         ),
     });
     await expect(
-      client.requestJson("/code/sessions/s-1/steer"),
+      client.requestJson("/sessions/s-1/steer"),
     ).rejects.toMatchObject({
       status: 422,
       kind: "steering_unavailable",
@@ -115,7 +115,7 @@ describe("MachineClient requests", () => {
       fetchImpl: async () =>
         new Response("<h1>private proxy detail</h1>", { status: 502 }),
     });
-    await expect(proxyClient.getJson("/code/approvals")).rejects.toThrow(
+    await expect(proxyClient.getJson("/approvals")).rejects.toThrow(
       "Machine request failed. (HTTP 502)",
     );
   });
@@ -134,7 +134,7 @@ describe("MachineClient requests", () => {
     });
 
     await expect(
-      client.requestJson("/code/sessions/s-1/interrupt", {
+      client.requestJson("/sessions/s-1/interrupt", {
         method: "POST",
         expectedStatus: 202,
       }),
@@ -153,7 +153,7 @@ describe("connectWithBackoff", () => {
     const conn = connectWithBackoff(
       async () => {
         tokens += 1;
-        const socket = new FakeSocket("wss://example/code/updates", [
+        const socket = new FakeSocket("wss://example/updates", [
           WS_HANDSHAKE,
           `${WS_TOKEN_PREFIX}tok-${tokens}`,
         ]);
@@ -181,7 +181,7 @@ describe("connectWithBackoff", () => {
     const sockets: FakeSocket[] = [];
     const conn = connectWithBackoff(
       async () => {
-        const socket = new FakeSocket("wss://example/code/updates");
+        const socket = new FakeSocket("wss://example/updates");
         sockets.push(socket);
         return socket as unknown as WebSocket;
       },
@@ -203,7 +203,7 @@ describe("connectWithBackoff", () => {
     const sockets: FakeSocket[] = [];
     const conn = connectWithBackoff(
       async () => {
-        const socket = new FakeSocket("wss://example/code/updates");
+        const socket = new FakeSocket("wss://example/updates");
         sockets.push(socket);
         return socket as unknown as WebSocket;
       },

--- a/mobile/src/session/useSessionEvents.ts
+++ b/mobile/src/session/useSessionEvents.ts
@@ -55,7 +55,7 @@ export function useSessionEvents(
     const conn = connectWithBackoff(
       () =>
         activeClient.openSocket(
-          `/code/sessions/${encodeURIComponent(activeSessionId)}/events?after=${lastSeq}`,
+          `/sessions/${encodeURIComponent(activeSessionId)}/events?after=${lastSeq}`,
         ),
       {
         onMessage: (data) => {

--- a/mobile/src/session/useUpdatesFeed.ts
+++ b/mobile/src/session/useUpdatesFeed.ts
@@ -20,7 +20,7 @@ export function useUpdatesFeed(client: MachineClient | null): {
       return;
     }
     const conn = connectWithBackoff(
-      () => client.openSocket("/code/updates"),
+      () => client.openSocket("/updates"),
       {
         onMessage: (data) => {
           try {


### PR DESCRIPTION
Part of #2313. Follows the durable-park work in #3134.

## Summary

- Add canonical `/sessions`, `/approvals`, and `/updates` routes.
- Keep `/code/sessions/*` and `/chats/*` as compatibility routes.
- Move the CLI, desktop, and mobile clients to the canonical routes.
- Prove that canonical and compatibility routes resolve the same session rows.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tidebreak-cli -p tidebreak-server`
- `tests::code_internal::canonical_and_compatibility_routes_share_session_rows`
- Desktop API and parser tests: 2,284 passed
- Mobile API and state-machine tests: 92 passed