### PR TITLE
fix(server): detect OpenAPI spec indexes and probe child documents

### DIFF
--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -5098,7 +5098,12 @@ operation_count: number | null,
 /**
  * Why the document cannot be used, when it cannot.
  */
-unsupported_reason: string | null, };
+unsupported_reason: string | null,
+/**
+ * Resolved child document URLs when the response was a specification
+ * index rather than a single OpenAPI document.
+ */
+child_urls?: Array<string>, };
 
 /**
  * What probing one origin found.

--- a/crates/tidebreak-desktop/ui/src/settings/OpenApiDiscovery.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/OpenApiDiscovery.tsx
@@ -34,6 +34,9 @@ export function ingestErrorGuidance(message: string): string {
   if (lower.includes("html")) {
     return `${message} That URL is a documentation page. Find a link to the OpenAPI JSON, or paste the JSON itself.`;
   }
+  if (lower.includes("specification index")) {
+    return message;
+  }
   if (lower.includes("yaml")) {
     return `${message} Convert it to JSON, or point at a .json URL.`;
   }
@@ -106,8 +109,14 @@ export function DiscoveryResults({
   const usable = discovery.candidates.filter(
     (candidate) => candidate.operation_count != null,
   );
+  const indexes = discovery.candidates.filter(
+    (candidate) =>
+      candidate.child_urls != null && candidate.child_urls.length > 0,
+  );
   const unsupported = discovery.candidates.filter(
-    (candidate) => candidate.unsupported_reason != null,
+    (candidate) =>
+      candidate.unsupported_reason != null &&
+      (candidate.child_urls == null || candidate.child_urls.length === 0),
   );
   if (discovery.candidates.length === 0) {
     return (
@@ -141,6 +150,29 @@ export function DiscoveryResults({
           ))}
         </ul>
       )}
+      {indexes.map((candidate) => (
+        <div key={candidate.url} className="flex flex-col gap-1.5">
+          <p className="text-sm text-muted-foreground">
+            <span className="font-mono text-xs">{candidate.url}</span> is a spec
+            index. Pick a document:
+          </p>
+          <ul className="flex flex-col gap-1" aria-label="Child documents">
+            {candidate.child_urls?.map((childUrl) => (
+              <li key={childUrl} className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onChoose(childUrl)}
+                >
+                  Use this document
+                </Button>
+                <span className="font-mono text-xs">{childUrl}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
       {unsupported.map((candidate) => (
         <p key={candidate.url} className="text-sm text-muted-foreground">
           <span className="font-mono text-xs">{candidate.url}</span>

--- a/crates/tidebreak-desktop/ui/src/stories/OpenApiDiscovery.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/OpenApiDiscovery.stories.tsx
@@ -47,6 +47,78 @@ export const FoundCandidates: Story = {
   ),
 };
 
+export const SpecIndex: Story = {
+  render: () => (
+    <DiscoveryResults
+      discovering={false}
+      onChoose={fn()}
+      discovery={{
+        candidates: [
+          {
+            url: "https://developers.beehiiv.com/openapi.json",
+            operation_count: null,
+            unsupported_reason:
+              "this URL is a specification index pointing to 3 child documents; use one of the child documents instead",
+            child_urls: [
+              "https://developers.beehiiv.com/openapi/webhooks.json",
+              "https://developers.beehiiv.com/openapi/oauth2.json",
+              "https://developers.beehiiv.com/openapi/api-reference.json",
+            ],
+          },
+        ],
+        tried: [
+          "https://developers.beehiiv.com/openapi.json",
+          "https://developers.beehiiv.com/openapi.yaml",
+          "https://developers.beehiiv.com/swagger.json",
+        ],
+      }}
+    />
+  ),
+};
+
+export const SpecIndexWithResolvedChildren: Story = {
+  render: () => (
+    <DiscoveryResults
+      discovering={false}
+      onChoose={fn()}
+      discovery={{
+        candidates: [
+          {
+            url: "https://developers.beehiiv.com/openapi.json",
+            operation_count: null,
+            unsupported_reason:
+              "this URL is a specification index pointing to 3 child documents; use one of the child documents instead",
+            child_urls: [
+              "https://developers.beehiiv.com/openapi/webhooks.json",
+              "https://developers.beehiiv.com/openapi/oauth2.json",
+              "https://developers.beehiiv.com/openapi/api-reference.json",
+            ],
+          },
+          {
+            url: "https://developers.beehiiv.com/openapi/webhooks.json",
+            operation_count: 4,
+            unsupported_reason: null,
+          },
+          {
+            url: "https://developers.beehiiv.com/openapi/oauth2.json",
+            operation_count: 6,
+            unsupported_reason: null,
+          },
+          {
+            url: "https://developers.beehiiv.com/openapi/api-reference.json",
+            operation_count: 42,
+            unsupported_reason: null,
+          },
+        ],
+        tried: [
+          "https://developers.beehiiv.com/openapi.json",
+          "https://developers.beehiiv.com/openapi.yaml",
+        ],
+      }}
+    />
+  ),
+};
+
 export const NothingFound: Story = {
   render: () => (
     <DiscoveryResults

--- a/crates/tidebreak-server/src/openapi_catalog.rs
+++ b/crates/tidebreak-server/src/openapi_catalog.rs
@@ -51,6 +51,10 @@ pub const MAX_SCHEMA_SUBTREE_BYTES: usize = 16 * 1024;
 /// Deepest `$ref` chain followed during resolution. Caps work on cyclic or
 /// adversarially nested reference graphs.
 pub const MAX_REF_RESOLUTION_DEPTH: usize = 8;
+/// Most entries a specification index may carry. A Fern-style index
+/// typically lists 2–5 child documents; the bound prevents an
+/// adversarial array from minting unbounded output.
+pub const MAX_SPEC_INDEX_ENTRIES: usize = 32;
 
 /// HTTP methods an operation may declare — the standard OpenAPI path-item set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -167,6 +171,16 @@ pub struct OperationCatalog {
     pub operations: BTreeMap<String, CatalogOperation>,
 }
 
+/// One entry extracted from a specification index — a top-level JSON array
+/// whose elements point to individual OpenAPI documents.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecIndexEntry {
+    /// Relative or absolute path to the child document.
+    pub path: String,
+    /// Display title when the index carries one.
+    pub title: Option<String>,
+}
+
 /// Why an OpenAPI document was refused.
 ///
 /// The enum is closed and never echoes unbounded document text: an
@@ -194,6 +208,8 @@ pub enum OpenApiIngestError {
         "only JSON OpenAPI documents are supported; the document is a JSON {found}, not an object"
     )]
     NotAnObject { found: &'static str },
+    #[error("this URL is a specification index pointing to {} child document{}; use one of the child documents instead", entries.len(), if entries.len() == 1 { "" } else { "s" })]
+    SpecIndex { entries: Vec<SpecIndexEntry> },
     #[error(
         "only JSON OpenAPI documents are supported; the first non-whitespace byte is not '{{' or '[' (YAML and other formats are not accepted)"
     )]
@@ -486,6 +502,12 @@ fn parse_openapi_root(document: &[u8]) -> Result<Value, OpenApiIngestError> {
         .find(|byte| !byte.is_ascii_whitespace());
     match first {
         Some(b'{') => {}
+        Some(b'[') => {
+            return match try_parse_spec_index(without_bom) {
+                Some(entries) => Err(OpenApiIngestError::SpecIndex { entries }),
+                None => Err(OpenApiIngestError::NotAnObject { found: "array" }),
+            };
+        }
         Some(byte) => return Err(leading_byte_refusal(byte)),
         None => return Err(OpenApiIngestError::NotJsonDocument),
     }
@@ -518,7 +540,6 @@ fn strip_utf8_bom(bytes: &[u8]) -> &[u8] {
 
 fn leading_byte_refusal(byte: u8) -> OpenApiIngestError {
     let found = match byte {
-        b'[' => "array",
         b'"' => "string",
         b't' | b'f' => "boolean",
         b'n' => "null",
@@ -528,6 +549,54 @@ fn leading_byte_refusal(byte: u8) -> OpenApiIngestError {
         }
     };
     OpenApiIngestError::NotAnObject { found }
+}
+
+/// Try to interpret a JSON array as a specification index — a top-level
+/// array of objects where each element points to an individual OpenAPI
+/// document. Returns `None` when the array does not look like an index,
+/// letting the caller fall through to the generic `NotAnObject` refusal.
+fn try_parse_spec_index(bytes: &[u8]) -> Option<Vec<SpecIndexEntry>> {
+    let array: Vec<Value> = serde_json::from_slice(bytes).ok()?;
+    if array.is_empty() || array.len() > MAX_SPEC_INDEX_ENTRIES {
+        return None;
+    }
+    let mut entries = Vec::with_capacity(array.len());
+    for element in &array {
+        let object = element.as_object()?;
+        let path = extract_document_path(object)?;
+        if path.is_empty() || path.len() > MAX_PATH_TEMPLATE_BYTES {
+            return None;
+        }
+        let title = object
+            .get("title")
+            .or_else(|| object.get("name"))
+            .or_else(|| object.get("description"))
+            .and_then(Value::as_str)
+            .map(truncate_to_display_prefix);
+        entries.push(SpecIndexEntry { path, title });
+    }
+    Some(entries)
+}
+
+const SPEC_INDEX_PATH_KEYS: &[&str] = &["path", "url", "href", "source"];
+
+fn extract_document_path(object: &Map<String, Value>) -> Option<String> {
+    for key in SPEC_INDEX_PATH_KEYS {
+        if let Some(value) = object.get(*key).and_then(Value::as_str) {
+            if looks_like_document_path(value) {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn looks_like_document_path(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.ends_with(".json")
+        || lower.ends_with(".yaml")
+        || lower.ends_with(".yml")
+        || value.contains('/')
 }
 
 fn json_value_kind(value: &Value) -> &'static str {
@@ -1348,6 +1417,66 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("array"));
+    }
+
+    #[test]
+    fn a_spec_index_array_returns_spec_index_error() {
+        let index = serde_json::to_vec(&serde_json::json!([
+            { "path": "openapi/webhooks.json", "title": "Webhooks" },
+            { "path": "openapi/api-reference.json", "title": "API Reference" },
+        ]))
+        .unwrap();
+        let err = parse_openapi_root(&index).unwrap_err();
+        match &err {
+            OpenApiIngestError::SpecIndex { entries } => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].path, "openapi/webhooks.json");
+                assert_eq!(entries[0].title.as_deref(), Some("Webhooks"));
+                assert_eq!(entries[1].path, "openapi/api-reference.json");
+                assert_eq!(entries[1].title.as_deref(), Some("API Reference"));
+            }
+            other => panic!("expected SpecIndex, got {other:?}"),
+        }
+        let text = err.to_string();
+        assert!(text.contains("2 child documents"), "{text}");
+        assert!(text.contains("specification index"), "{text}");
+    }
+
+    #[test]
+    fn a_spec_index_uses_url_key_and_name_fallback() {
+        let index = serde_json::to_vec(&serde_json::json!([
+            { "url": "/specs/v1.json", "name": "V1" },
+        ]))
+        .unwrap();
+        match parse_openapi_root(&index).unwrap_err() {
+            OpenApiIngestError::SpecIndex { entries } => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].path, "/specs/v1.json");
+                assert_eq!(entries[0].title.as_deref(), Some("V1"));
+            }
+            other => panic!("expected SpecIndex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_plain_json_array_is_not_a_spec_index() {
+        assert_eq!(
+            parse_openapi_root(b"[1, 2, 3]").unwrap_err(),
+            OpenApiIngestError::NotAnObject { found: "array" }
+        );
+        let strings = serde_json::to_vec(&serde_json::json!(["a", "b"])).unwrap();
+        assert_eq!(
+            parse_openapi_root(&strings).unwrap_err(),
+            OpenApiIngestError::NotAnObject { found: "array" }
+        );
+        let no_path = serde_json::to_vec(&serde_json::json!([
+            { "name": "test" },
+        ]))
+        .unwrap();
+        assert_eq!(
+            parse_openapi_root(&no_path).unwrap_err(),
+            OpenApiIngestError::NotAnObject { found: "array" }
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/openapi_discovery.rs
+++ b/crates/tidebreak-server/src/openapi_discovery.rs
@@ -58,6 +58,10 @@ pub struct SpecDiscoveryCandidate {
     pub operation_count: Option<usize>,
     /// Why the document cannot be used, when it cannot.
     pub unsupported_reason: Option<String>,
+    /// Resolved child document URLs when the response was a specification
+    /// index rather than a single OpenAPI document.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub child_urls: Vec<String>,
 }
 
 /// Why discovery refused the origin before probing.
@@ -136,6 +140,8 @@ fn admit_discovery_origin(origin: &str) -> Result<Url, SpecDiscoveryError> {
 /// Probe well-known locations. Hits that enumerate as OpenAPI 3 JSON are
 /// usable; YAML, HTML, and Swagger 2.0 are reported as found-but-unsupported.
 /// The first usable document cancels probes that have not started yet.
+/// When a probed URL turns out to be a specification index, its child
+/// document URLs are probed automatically within the same deadline.
 pub async fn discover_openapi_documents(
     origin: &str,
 ) -> Result<SpecDiscoveryInfo, SpecDiscoveryError> {
@@ -175,6 +181,30 @@ pub async fn discover_openapi_documents(
                 candidates.push(candidate);
             }
         }
+
+        // Second pass: probe child URLs from any spec-index candidates.
+        let child_urls: Vec<String> = candidates
+            .iter()
+            .flat_map(|c| c.child_urls.iter().cloned())
+            .collect();
+        if !child_urls.is_empty() {
+            let mut child_tasks = Vec::new();
+            for url in child_urls {
+                let permit = Arc::clone(&permit);
+                child_tasks.push(tokio::spawn(async move {
+                    let Ok(_guard) = permit.acquire().await else {
+                        return None;
+                    };
+                    probe_location(&url).await
+                }));
+            }
+            for task in child_tasks {
+                if let Ok(Some(candidate)) = task.await {
+                    candidates.push(candidate);
+                }
+            }
+        }
+
         candidates
     };
     let candidates = tokio::time::timeout(DISCOVERY_DEADLINE, collect)
@@ -201,16 +231,19 @@ async fn probe_location(url: &str) -> Option<SpecDiscoveryCandidate> {
             url: url.to_owned(),
             operation_count: None,
             unsupported_reason: Some(format!("document URL is inadmissible: {reason}")),
+            child_urls: Vec::new(),
         }),
         Err(SpecFetchError::DeniedAddress) => Some(SpecDiscoveryCandidate {
             url: url.to_owned(),
             operation_count: None,
             unsupported_reason: Some("document URL resolves into a denied network range".into()),
+            child_urls: Vec::new(),
         }),
         Err(SpecFetchError::DocumentTooLarge) => Some(SpecDiscoveryCandidate {
             url: url.to_owned(),
             operation_count: None,
             unsupported_reason: Some(SpecFetchError::DocumentTooLarge.to_string()),
+            child_urls: Vec::new(),
         }),
     }
 }
@@ -224,38 +257,80 @@ fn classify_document(url: &str, content_type: Option<&str>, body: &[u8]) -> Spec
             unsupported_reason: Some(
                 "this URL returned an HTML page, not a JSON OpenAPI document".into(),
             ),
+            child_urls: Vec::new(),
         };
     }
-    let path_yaml = url.rsplit('/').next().is_some_and(|name| {
-        let lower = name.to_ascii_lowercase();
-        lower.ends_with(".yaml") || lower.ends_with(".yml")
-    });
-    if path_yaml || media.contains("yaml") || looks_like_yaml(body) {
-        return SpecDiscoveryCandidate {
-            url: url.to_owned(),
-            operation_count: None,
-            unsupported_reason: Some(
-                "YAML OpenAPI documents are not supported; convert to JSON".into(),
-            ),
-        };
+    // Inspect the actual content before considering the URL suffix: a
+    // `.yaml` URL that serves JSON should classify by content.
+    let first_byte = body.iter().copied().find(|b| !b.is_ascii_whitespace());
+    let body_is_json = matches!(first_byte, Some(b'{') | Some(b'['));
+    if !body_is_json {
+        if media.contains("yaml") || looks_like_yaml(body) || path_looks_yaml(url) {
+            return SpecDiscoveryCandidate {
+                url: url.to_owned(),
+                operation_count: None,
+                unsupported_reason: Some(
+                    "YAML OpenAPI documents are not supported; convert to JSON".into(),
+                ),
+                child_urls: Vec::new(),
+            };
+        }
     }
     match enumerate_openapi_operations(body) {
         Ok(inventory) => SpecDiscoveryCandidate {
             url: url.to_owned(),
             operation_count: Some(inventory.operations.len()),
             unsupported_reason: None,
+            child_urls: Vec::new(),
         },
+        Err(OpenApiIngestError::SpecIndex { entries }) => {
+            let child_urls = resolve_index_children(url, &entries);
+            SpecDiscoveryCandidate {
+                url: url.to_owned(),
+                operation_count: None,
+                unsupported_reason: Some(format!(
+                    "this URL is a specification index pointing to {} child document{}; \
+                     use one of the child documents instead",
+                    entries.len(),
+                    if entries.len() == 1 { "" } else { "s" },
+                )),
+                child_urls,
+            }
+        }
         Err(OpenApiIngestError::SwaggerNotSupported) => SpecDiscoveryCandidate {
             url: url.to_owned(),
             operation_count: None,
             unsupported_reason: Some(OpenApiIngestError::SwaggerNotSupported.to_string()),
+            child_urls: Vec::new(),
         },
         Err(error) => SpecDiscoveryCandidate {
             url: url.to_owned(),
             operation_count: None,
             unsupported_reason: Some(error.to_string()),
+            child_urls: Vec::new(),
         },
     }
+}
+
+fn path_looks_yaml(url: &str) -> bool {
+    url.rsplit('/').next().is_some_and(|name| {
+        let lower = name.to_ascii_lowercase();
+        lower.ends_with(".yaml") || lower.ends_with(".yml")
+    })
+}
+
+fn resolve_index_children(
+    parent_url: &str,
+    entries: &[crate::openapi_catalog::SpecIndexEntry],
+) -> Vec<String> {
+    let Ok(base) = Url::parse(parent_url) else {
+        return Vec::new();
+    };
+    entries
+        .iter()
+        .filter_map(|entry| base.join(&entry.path).ok())
+        .map(|url| url.to_string())
+        .collect()
 }
 
 fn looks_like_yaml(body: &[u8]) -> bool {
@@ -282,5 +357,74 @@ mod tests {
         assert!(bare
             .iter()
             .all(|url| url.starts_with("https://api.example.com/")));
+    }
+
+    #[test]
+    fn classify_document_detects_spec_index_and_resolves_children() {
+        let index = serde_json::to_vec(&serde_json::json!([
+            { "path": "openapi/webhooks.json", "title": "Webhooks" },
+            { "path": "openapi/api-reference.json", "title": "API Reference" },
+        ]))
+        .unwrap();
+        let candidate = classify_document(
+            "https://developers.beehiiv.com/openapi.json",
+            Some("application/json"),
+            &index,
+        );
+        assert!(candidate.unsupported_reason.is_some());
+        assert!(candidate
+            .unsupported_reason
+            .as_ref()
+            .unwrap()
+            .contains("specification index"));
+        assert_eq!(candidate.child_urls.len(), 2);
+        assert_eq!(
+            candidate.child_urls[0],
+            "https://developers.beehiiv.com/openapi/webhooks.json"
+        );
+        assert_eq!(
+            candidate.child_urls[1],
+            "https://developers.beehiiv.com/openapi/api-reference.json"
+        );
+        assert!(candidate.operation_count.is_none());
+    }
+
+    #[test]
+    fn classify_document_yaml_url_serving_json_classifies_by_content() {
+        let spec = serde_json::to_vec(&serde_json::json!({
+            "openapi": "3.0.3",
+            "info": { "title": "Test", "version": "1" },
+            "paths": {
+                "/items": { "get": { "operationId": "listItems" } }
+            }
+        }))
+        .unwrap();
+        let candidate = classify_document(
+            "https://api.example.com/openapi.yaml",
+            Some("application/json"),
+            &spec,
+        );
+        assert!(
+            candidate.operation_count.is_some(),
+            "should classify by content, not extension"
+        );
+        assert_eq!(candidate.operation_count, Some(1));
+        assert!(candidate.unsupported_reason.is_none());
+    }
+
+    #[test]
+    fn classify_document_actual_yaml_body_with_yaml_url_reports_yaml() {
+        let yaml_body = b"openapi: '3.0.3'\ninfo:\n  title: T\n  version: '1'\npaths: {}";
+        let candidate = classify_document(
+            "https://api.example.com/openapi.yaml",
+            Some("text/yaml"),
+            yaml_body,
+        );
+        assert!(candidate.unsupported_reason.is_some());
+        assert!(candidate
+            .unsupported_reason
+            .as_ref()
+            .unwrap()
+            .contains("YAML"));
     }
 }

--- a/crates/tidebreak-server/src/openapi_discovery.rs
+++ b/crates/tidebreak-server/src/openapi_discovery.rs
@@ -264,17 +264,17 @@ fn classify_document(url: &str, content_type: Option<&str>, body: &[u8]) -> Spec
     // `.yaml` URL that serves JSON should classify by content.
     let first_byte = body.iter().copied().find(|b| !b.is_ascii_whitespace());
     let body_is_json = matches!(first_byte, Some(b'{') | Some(b'['));
-    if !body_is_json {
-        if media.contains("yaml") || looks_like_yaml(body) || path_looks_yaml(url) {
-            return SpecDiscoveryCandidate {
-                url: url.to_owned(),
-                operation_count: None,
-                unsupported_reason: Some(
-                    "YAML OpenAPI documents are not supported; convert to JSON".into(),
-                ),
-                child_urls: Vec::new(),
-            };
-        }
+    if !body_is_json
+        && (media.contains("yaml") || looks_like_yaml(body) || path_looks_yaml(url))
+    {
+        return SpecDiscoveryCandidate {
+            url: url.to_owned(),
+            operation_count: None,
+            unsupported_reason: Some(
+                "YAML OpenAPI documents are not supported; convert to JSON".into(),
+            ),
+            child_urls: Vec::new(),
+        };
     }
     match enumerate_openapi_operations(body) {
         Ok(inventory) => SpecDiscoveryCandidate {

--- a/crates/tidebreak-server/src/openapi_discovery.rs
+++ b/crates/tidebreak-server/src/openapi_discovery.rs
@@ -264,9 +264,7 @@ fn classify_document(url: &str, content_type: Option<&str>, body: &[u8]) -> Spec
     // `.yaml` URL that serves JSON should classify by content.
     let first_byte = body.iter().copied().find(|b| !b.is_ascii_whitespace());
     let body_is_json = matches!(first_byte, Some(b'{') | Some(b'['));
-    if !body_is_json
-        && (media.contains("yaml") || looks_like_yaml(body) || path_looks_yaml(url))
-    {
+    if !body_is_json && (media.contains("yaml") || looks_like_yaml(body) || path_looks_yaml(url)) {
         return SpecDiscoveryCandidate {
             url: url.to_owned(),
             operation_count: None,

--- a/crates/tidebreak-server/src/tests/connected_apps.rs
+++ b/crates/tidebreak-server/src/tests/connected_apps.rs
@@ -766,6 +766,99 @@ async fn spec_discovery_refuses_a_denied_address() {
     );
 }
 
+#[tokio::test]
+async fn spec_discovery_detects_spec_index_and_probes_children() {
+    let _guard = discovery_mock_lock().await;
+    let index = json!([
+        { "path": "openapi/webhooks.json", "title": "Webhooks" },
+        { "path": "openapi/api-reference.json", "title": "API Reference" },
+    ])
+    .to_string();
+    let child_spec = json!({
+        "openapi": "3.0.3",
+        "info": { "title": "API Reference", "version": "1" },
+        "paths": {
+            "/items": { "get": { "operationId": "listItems" } }
+        }
+    })
+    .to_string();
+    let child_bytes = child_spec.into_bytes();
+    let index_bytes = index.into_bytes();
+    crate::rest_executor::spec_fetch_mock::install(std::sync::Arc::new(move |url: &str| {
+        let path = reqwest::Url::parse(url)
+            .ok()
+            .map(|parsed| parsed.path().to_owned())
+            .unwrap_or_default();
+        if path == "/openapi.json" {
+            Ok(crate::rest_executor::FetchedSpecDocument {
+                body: index_bytes.clone(),
+                content_type: Some("application/json".to_owned()),
+            })
+        } else if path == "/openapi/api-reference.json" {
+            Ok(crate::rest_executor::FetchedSpecDocument {
+                body: child_bytes.clone(),
+                content_type: Some("application/json".to_owned()),
+            })
+        } else {
+            Err(crate::rest_executor::SpecFetchError::HttpStatus { status: 404 })
+        }
+    }));
+    let (router, bearer, _state, _dir) = connected_apps_test_app().await;
+    let response = post_discovery(&router, &bearer, "https://api.example.com").await;
+    crate::rest_executor::spec_fetch_mock::clear();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&raw_body(response).await).unwrap();
+    let candidates = body["candidates"].as_array().expect("candidates");
+    let index_hit = candidates
+        .iter()
+        .find(|c| c["url"].as_str().unwrap().ends_with("/openapi.json"))
+        .expect("index candidate");
+    assert!(
+        index_hit["unsupported_reason"]
+            .as_str()
+            .unwrap()
+            .contains("specification index"),
+        "{index_hit}"
+    );
+    let child_urls = index_hit["child_urls"].as_array().expect("child_urls");
+    assert_eq!(child_urls.len(), 2);
+    let child_hit = candidates
+        .iter()
+        .find(|c| {
+            c["url"]
+                .as_str()
+                .unwrap()
+                .ends_with("/openapi/api-reference.json")
+        })
+        .expect("child candidate should be probed");
+    assert_eq!(child_hit["operation_count"], json!(1));
+    assert!(child_hit["unsupported_reason"].is_null());
+}
+
+#[tokio::test]
+async fn spec_discovery_yaml_url_serving_json_classifies_by_content() {
+    let _guard = discovery_mock_lock().await;
+    let spec = issues_spec();
+    install_mock_origin("/openapi.yaml", spec.into_bytes(), "application/json");
+    let (router, bearer, _state, _dir) = connected_apps_test_app().await;
+    let response = post_discovery(&router, &bearer, "https://api.example.com").await;
+    crate::rest_executor::spec_fetch_mock::clear();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&raw_body(response).await).unwrap();
+    let hit = body["candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["url"].as_str().unwrap().ends_with("/openapi.yaml"))
+        .expect("yaml url candidate");
+    assert_eq!(
+        hit["operation_count"],
+        json!(2),
+        "should classify by JSON content, not .yaml extension"
+    );
+    assert!(hit["unsupported_reason"].is_null(), "{hit}");
+}
+
 /// A local app with one `rest_api` binding, created straight through the
 /// store so grant tests don't route through the authoring surface.
 fn bound_app(name: &str, connected: ConnectedAppId) -> CreateApp {

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -5098,7 +5098,12 @@ operation_count: number | null,
 /**
  * Why the document cannot be used, when it cannot.
  */
-unsupported_reason: string | null, };
+unsupported_reason: string | null,
+/**
+ * Resolved child document URLs when the response was a specification
+ * index rather than a single OpenAPI document.
+ */
+child_urls?: Array<string>, };
 
 /**
  * What probing one origin found.


### PR DESCRIPTION
## Summary

- Detect Fern-style JSON array indexes at OpenAPI document URLs: any array of objects with path-like fields (`path`, `url`, `href`, `source`) is classified as a specification index.
- Resolve child document URLs against the parent and probe them automatically during discovery, so child specs appear as selectable candidates.
- Fix `.yaml` URLs serving JSON content being rejected by filename before content inspection.
- Render spec-index results in the discovery UI with a short label and child document buttons.

Closes #3106

## Test plan

- [x] Unit tests: `SpecIndex` detection, plain arrays still return `NotAnObject`, URL/name key fallback
- [x] Unit tests: `classify_document` with spec index, `.yaml` URL serving JSON, actual YAML body
- [x] Integration tests: discovery with spec-index mock probes children, `.yaml` URL returning JSON classifies by content
- [x] `cargo check -p tidebreak-server`
- [x] `cargo fmt --check`
- [x] TypeScript typecheck
- [x] Storybook build
- [x] Storybook stories: `SpecIndex`, `SpecIndexWithResolvedChildren`