### PR TITLE
fix(code): forget a sent composer draft immediately

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -1226,6 +1226,51 @@ describe("CodeComposer", () => {
     expect(useComposerDrafts.getState().drafts["sess-1"]).toBeFalsy();
   });
 
+  it("clears the persisted draft before the turn request settles", async () => {
+    let resolveSend!: () => void;
+    const onSend = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = resolve;
+        }),
+    );
+    const sending = renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "accepted on the way out" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+    expect(box).toHaveValue("");
+    expect(useComposerDrafts.getState().drafts["sess-1"]).toBeFalsy();
+
+    sending.unmount();
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+
+    await act(async () => {
+      resolveSend();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("");
+    expect(useComposerDrafts.getState().drafts["sess-1"]).toBeFalsy();
+  });
+
   it("does not re-append first-turn recovery after a Settings remount", async () => {
     const user = userEvent.setup();
     const recovery = {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1000,6 +1000,10 @@ export function CodeComposer({
     submitPendingRef.current = true;
     setSubmitPending(true);
     onSubmitStart?.(submittedDraft);
+    // Forget the draft as soon as this composer hands it to the send path. The
+    // send promise does not settle until the turn ends, so waiting for it
+    // leaves the last prompt in the persisted draft for a reload or turn
+    // boundary to throw back into the composer.
     draftRef.current = "";
     setDraft("");
     pastedTextsRef.current = [];
@@ -1017,32 +1021,36 @@ export function CodeComposer({
         await onSend(message);
       }
     } catch (err) {
+      if (mountedRef.current) {
+        images.restore(held);
+        updatePastedTexts((current) => [
+          ...submittedPastedTexts,
+          ...current.filter(
+            (item) =>
+              !submittedPastedTexts.some(
+                (submitted) => submitted.id === item.id,
+              ),
+          ),
+        ]);
+        setNotice({
+          text:
+            err instanceof HttpError && err.kind === "queue_full"
+              ? "The queue is full. Delete a queued message or wait for one to run."
+              : err instanceof Error
+                ? err.message
+                : "Could not send that turn",
+        });
+        setDraft((current) => {
+          if (current.length > 0) return current;
+          draftRef.current = submittedDraft;
+          return submittedDraft;
+        });
+      }
       // A refresh can replace this composer while the turn request is still
       // waiting for the engine to finish. The old response may then close
       // without proving that the server refused the turn. Do not let that
       // obsolete request repopulate the replacement composer's draft.
       if (!mountedRef.current) return;
-      images.restore(held);
-      updatePastedTexts((current) => [
-        ...submittedPastedTexts,
-        ...current.filter(
-          (item) =>
-            !submittedPastedTexts.some((submitted) => submitted.id === item.id),
-        ),
-      ]);
-      setNotice({
-        text:
-          err instanceof HttpError && err.kind === "queue_full"
-            ? "The queue is full. Delete a queued message or wait for one to run."
-            : err instanceof Error
-              ? err.message
-              : "Could not send that turn",
-      });
-      setDraft((current) => {
-        if (current.length > 0) return current;
-        draftRef.current = submittedDraft;
-        return submittedDraft;
-      });
     } finally {
       submitPendingRef.current = false;
       if (mountedRef.current) setSubmitPending(false);


### PR DESCRIPTION
## Summary

Workspace composers now persist drafts, but send waited for the turn request to settle before clearing the persisted draft. That request stays open until the turn ends, so loading a workspace or reaching a turn boundary restored the last accepted user prompt.

This clears the draft when the send starts. A refused send restores the text, images, and pasted context. An obsolete response that closes after a remount still cannot restore a replacement composer's draft.

## Tests

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeComposer.dom.test.tsx` — 41 passed
- `pnpm --dir crates/tidebreak-desktop/ui test -- CodeComposer.dom.test.tsx --run` — 2,285 passed
- `pnpm --dir crates/tidebreak-desktop/ui lint`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome format src`
- `pnpm --dir crates/tidebreak-desktop/ui build`