### PR TITLE
fix(server): give the hosted machine a writable home so harnesses install

### DIFF
--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -984,6 +984,10 @@ async fn serve() -> Result<()> {
     // Tracing events land in `logs/tidebreak.log` under the profile data dir
     // (plus stderr in debug builds); see `tidebreak_server::logging`.
     tidebreak_server::logging::init_logging(&config.data_dir);
+    if profile == Profile::SelfHost {
+        // The container may run as a uid with no home; see the function.
+        tidebreak_server::ensure_home_dir();
+    }
     let server = tidebreak_server::bind_configured(config).await?;
     // The daemon is the trusted client for its own connected-folder tool calls:
     // it holds this machine's broker state, so a turn that reads a folder an

--- a/crates/tidebreak-harness/src/pin.rs
+++ b/crates/tidebreak-harness/src/pin.rs
@@ -227,26 +227,22 @@ fn is_plausible_version(candidate: &str) -> bool {
 /// network round trip, and the doctor's Check for updates and a deliberate
 /// install are the only callers.
 pub async fn latest_published_version(
+    data_dir: &Path,
     kind: HarnessKind,
     managed_node_root: Option<&Path>,
 ) -> Result<String, String> {
     let node_root = verified_managed_node_root(managed_node_root)
         .ok_or_else(|| "install the managed Node runtime before checking for updates".to_owned())?;
     let pin = pin_for(kind).ok_or_else(|| format!("{kind} has no pin"))?;
-    let mut command = Command::new(managed_npm_executable(node_root));
-    command
-        .args([
-            "view",
-            "--no-fund",
-            "--no-audit",
-            "--no-update-notifier",
-            pin.package,
-            "dist-tags.latest",
-        ])
-        .env("PATH", prepend_path(&managed_node_path_dir(node_root)))
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    let mut command = npm_command(data_dir, node_root);
+    command.args([
+        "view",
+        "--no-fund",
+        "--no-audit",
+        "--no-update-notifier",
+        pin.package,
+        "dist-tags.latest",
+    ]);
     let child = spawn_process_tree(&mut command)
         .map_err(|err| format!("npm view {}: {err}", pin.package))?;
     let output = timeout(LOOKUP_TIMEOUT, child.wait_with_output())
@@ -343,7 +339,7 @@ pub async fn ensure_installed_version(
         .await
         .map_err(|err| format!("could not create harness install dir: {err}"))?;
     let spec = format!("{}@{}", pin.package, version);
-    let mut command = Command::new(managed_npm_executable(node_root));
+    let mut command = npm_command(data_dir, node_root);
     command
         .args([
             "install",
@@ -353,11 +349,7 @@ pub async fn ensure_installed_version(
             "--no-progress",
             &spec,
         ])
-        .current_dir(&dir)
-        .env("PATH", prepend_path(&managed_node_path_dir(node_root)))
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .current_dir(&dir);
     let child =
         spawn_process_tree(&mut command).map_err(|err| format!("npm install {spec}: {err}"))?;
     let output = timeout(INSTALL_TIMEOUT, child.wait_with_output())
@@ -400,6 +392,31 @@ fn verified_managed_node_root(managed_node_root: Option<&Path>) -> Option<&Path>
     (is_absolute_executable(&managed_node_executable(root))
         && is_absolute_executable(&managed_npm_executable(root)))
     .then_some(root)
+}
+
+/// Where npm keeps its cache and logs for every command this crate runs.
+///
+/// npm defaults both to `$HOME/.npm`, and a self-host container may run as a
+/// uid with no home at all: Kubernetes hands an unmapped uid `HOME=/`, and
+/// the first thing npm does is fail to create `/.npm/_logs`, so every install
+/// died before a byte was fetched. The cache lives beside the installs so it
+/// depends on nothing but the data directory.
+pub fn npm_cache_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join("tools").join("npm-cache")
+}
+
+/// The managed runtime's npm with the environment every command needs: the
+/// runtime first on PATH, and its cache under the data directory rather than
+/// wherever `$HOME` points.
+fn npm_command(data_dir: &Path, node_root: &Path) -> Command {
+    let mut command = Command::new(managed_npm_executable(node_root));
+    command
+        .env("PATH", prepend_path(&managed_node_path_dir(node_root)))
+        .env("npm_config_cache", npm_cache_dir(data_dir))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command
 }
 
 fn prepend_path(bin: &Path) -> std::ffi::OsString {
@@ -546,6 +563,31 @@ mod tests {
         assert_eq!(path.file_name().unwrap(), "claude.cmd");
         #[cfg(not(windows))]
         assert_eq!(path.file_name().unwrap(), "claude");
+    }
+
+    /// A container may run as a uid that owns no home directory. npm must
+    /// never learn where `$HOME` points: its cache and logs go under the data
+    /// directory for every command, install and registry lookup alike.
+    #[test]
+    fn npm_keeps_its_cache_under_the_data_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        let node_root = tmp.path().join("node");
+        let command = npm_command(&data_dir, &node_root);
+        let std_command = command.as_std();
+        let cache = std_command
+            .get_envs()
+            .find(|(key, _)| *key == "npm_config_cache")
+            .and_then(|(_, value)| value)
+            .expect("npm is told where its cache lives");
+        assert_eq!(
+            std::path::Path::new(cache),
+            data_dir.join("tools").join("npm-cache")
+        );
+        assert!(
+            std_command.get_envs().all(|(key, _)| key != "HOME"),
+            "npm's cache placement does not depend on HOME"
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/harness_release.rs
+++ b/crates/tidebreak-server/src/code/harness_release.rs
@@ -166,7 +166,9 @@ impl CodeRuntime {
     /// A registry that cannot be reached is a warning here, not an error: the
     /// caller has an installed version or the pin to fall back on.
     async fn lookup_latest(&self, kind: HarnessKind, node_root: &Path) -> Option<String> {
-        match tidebreak_harness::latest_published_version(kind, Some(node_root)).await {
+        match tidebreak_harness::latest_published_version(&self.data_dir, kind, Some(node_root))
+            .await
+        {
             Ok(version) => {
                 self.harness_releases.record(kind, version.clone());
                 Some(version)
@@ -245,10 +247,16 @@ impl CodeRuntime {
             .filter(|kind| tidebreak_harness::pin_for(*kind).is_some())
             .map(|kind| {
                 let node_root = node_root.clone();
+                let data_dir = self.data_dir.clone();
                 async move {
                     (
                         kind,
-                        tidebreak_harness::latest_published_version(kind, Some(&node_root)).await,
+                        tidebreak_harness::latest_published_version(
+                            &data_dir,
+                            kind,
+                            Some(&node_root),
+                        )
+                        .await,
                     )
                 }
             });

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -125,7 +125,7 @@ mod workspace_config;
 
 use std::fs::{OpenOptions, TryLockError};
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::extract::{DefaultBodyLimit, Request};
@@ -1565,6 +1565,41 @@ const DEFAULT_MODEL: &str = "gpt-5.6-sol";
 ///
 /// This generic embedding does not expose durable root-attachment mutations,
 /// because it has no restart-stable native executor identity.
+/// Make `$HOME` usable before anything spawns npm or a coding harness.
+///
+/// The self-host image points HOME under the data directory because a hosting
+/// plane may run the container as a uid with no passwd entry, and such a uid
+/// is handed `HOME=/`, which nothing can write. Create the directory so a
+/// fresh volume has it, and say so at boot when it is unusable: the failure
+/// otherwise surfaces later as every harness install dying inside npm.
+pub fn ensure_home_dir() {
+    let Some(home) = std::env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+    else {
+        tracing::warn!(
+            "HOME is unset; harness installs and the coding engines need a writable home"
+        );
+        return;
+    };
+    if let Err(error) = ensure_home_dir_at(&home) {
+        tracing::warn!(
+            home = %home.display(),
+            error,
+            "HOME is not writable; harness installs will fail until it is"
+        );
+    }
+}
+
+/// Create `home` if it is missing and prove it takes a file.
+fn ensure_home_dir_at(home: &Path) -> std::result::Result<(), String> {
+    std::fs::create_dir_all(home).map_err(|error| format!("could not create it: {error}"))?;
+    let probe = home.join(".tidebreak-write-probe");
+    std::fs::write(&probe, b"").map_err(|error| format!("could not write to it: {error}"))?;
+    let _ = std::fs::remove_file(&probe);
+    Ok(())
+}
+
 pub async fn bind(config: Config) -> Result<Server> {
     bind_inner(
         config,
@@ -3105,3 +3140,24 @@ pub(crate) fn desktop_connect_options(url: &str) -> sea_orm::ConnectOptions {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod home_dir_tests {
+    use super::ensure_home_dir_at;
+
+    /// A fresh data volume has no home directory yet; boot makes one. A home
+    /// that cannot take a file is reported, not silently accepted, because
+    /// npm would be the first thing to find out.
+    #[test]
+    fn boot_creates_a_missing_home_and_names_an_unusable_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("data").join("home");
+        ensure_home_dir_at(&home).expect("a missing home is created");
+        assert!(home.is_dir());
+
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, b"not a directory").unwrap();
+        let error = ensure_home_dir_at(&blocker.join("home")).unwrap_err();
+        assert!(error.contains("could not create it"), "{error}");
+    }
+}

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -193,6 +193,12 @@ ENV TIDEBREAK_PROFILE=self_host
 # only if you want the logs to outlive the container. The durable state is in
 # PostgreSQL.
 ENV TIDEBREAK_DATA_DIR=/var/lib/tidebreak
+# A writable home, on the data volume. The image's own user is below, but a
+# hosting plane may run the container as any non-root uid (Model Gateway
+# uses 65532), and a uid with no passwd entry is handed `HOME=/`, which
+# nothing can write: npm then fails before it fetches a byte, and every
+# harness install with it. The server creates this directory at boot.
+ENV HOME=/var/lib/tidebreak/home
 # All interfaces *of this container* — which is what makes it reachable at a
 # known port from outside its own network namespace. Exposure beyond the
 # container is the host's decision: docker-compose.yml publishes this to

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -269,6 +269,7 @@ aspirational.
 | `TIDEBREAK_VAULT_PATH` | no | `tidebreak` | Deployment-specific path below the mount. Tidebreak appends one encoded credential key. |
 | `TIDEBREAK_VAULT_NAMESPACE` | no | unset | Vault Enterprise or HCP namespace sent as `X-Vault-Namespace`. |
 | `TIDEBREAK_DATA_DIR` | no | `./.tidebreak` | Instance lock, logs, per-turn scratch. Durable state lives in PostgreSQL, not here. |
+| `HOME` | no | `/var/lib/tidebreak/home` in the image | Writable home for npm and the coding harnesses. The image keeps it on the data volume because a hosting plane may run the container as a uid with no passwd entry, which is otherwise handed `HOME=/`. The server creates it at boot. |
 | `TIDEBREAK_LOG` | no | built-in policy | `tracing` filter directives, e.g. `debug` or `warn,tidebreak_server=trace`. An invalid spec falls back to the default. |
 | `TIDEBREAK_DIAGNOSTICS_LOG` | no | `off,tidebreak_diagnostics=info` | `tracing` filter directives for the bounded structured JSONL log. See [Diagnostics](diagnostics.md). |
 | `TIDEBREAK_MODEL` | no | built-in default | Default model name; also settable at runtime through settings or per chat. |


### PR DESCRIPTION
## What changed

On the hosted machine every harness install failed, and the install directories under `tools/harnesses` were left empty. The image creates its user as uid 10001 with a home directory, but a hosting plane may run the container as any non-root uid (Model Gateway runs add-ons as 65532), and a uid with no passwd entry is handed `HOME=/`. npm's first act is to create `$HOME/.npm/_logs`, which fails there, so `npm install` exited before fetching a byte: "Log files were not written due to an error writing to the directory: /.npm/_logs". The coding engines would have hit the same wall next, since they write under `$HOME` too.

Three changes, each standing on its own:

- The self-host image sets `HOME=/var/lib/tidebreak/home`, on the data volume, so harness state survives a restart and the value does not depend on the uid the container runs as.
- `tidebreak serve` on the self-host profile creates that directory at boot and warns when it cannot take a file, so an unusable home is named once at startup instead of surfacing as every install failing.
- npm no longer learns where `$HOME` points: every npm command this crate runs, install and registry lookup alike, keeps its cache and logs under `{data_dir}/tools/npm-cache`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tidebreak-harness --lib npm_keeps_its_cache_under_the_data_dir`: the command's environment carries `npm_config_cache` under the data directory and never sets `HOME`.
- `cargo test -p tidebreak-server --lib home_dir_tests`: boot creates a missing home and names one it cannot create.
- `cargo check -p tidebreak-cli --features tidebreak-server/postgres --locked`, the self-host binary build.
- `cargo clippy -p tidebreak-harness -p tidebreak-server -p tidebreak-cli --all-targets --locked -- -D warnings`
- Reproduced in the hosted pod by hand: the same `npm install` fails with `HOME=/` and succeeds with a writable home.

## Compatibility and risk

No wire or persisted format changes. Desktop installs move npm's cache from `~/.npm` to the data directory; the old cache is left where it was and npm rebuilds the new one on first use. A self-host operator who sets `HOME` themselves keeps their value; the image default only applies when nothing else set it.
