### PR TITLE
fix(code): keep recaps off failed turns

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -1215,6 +1215,33 @@ describe("CodeTranscript", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the fallback recap off a failed turn", () => {
+    const recap = "Audit of UI refresh gaps is done and the socket moved.";
+    render(
+      <CodeTranscript
+        recap={recap}
+        items={[
+          {
+            kind: "turn_boundary",
+            id: "b1",
+            turnId: "t1",
+            status: "failed",
+            durationMs: 4_000,
+            usage: null,
+            error:
+              "Selected model is at capacity. Please try a different model.",
+            diffstat: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Selected model is at capacity.",
+    );
+    expect(screen.queryByText(recap)).not.toBeInTheDocument();
+  });
+
   it("keeps the original closing message and shows the recap under the boundary", () => {
     const original = "Workspace switching now reuses recent transcript stores.";
     const rewrite =

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -197,7 +197,10 @@ export function CodeTranscript({
     const stored = item.turnId
       ? storedRecapsByTurn.get(item.turnId)
       : undefined;
-    const fallback = item.id === newestBoundaryId ? recap?.trim() : undefined;
+    const fallback =
+      item.id === newestBoundaryId && item.status !== "failed"
+        ? recap?.trim()
+        : undefined;
     const displayed = stored ?? fallback;
     if (displayed) recapByBoundary.set(item.id, displayed);
   }


### PR DESCRIPTION
## Summary

The newest turn seam previously received the session recap fallback even when that turn failed. That made the failure read twice when the recap repeated the same error, and it buried the recap inside the critical alert.

This excludes failed turns from the fallback. Captured recaps already stored on closing messages are unchanged, and completed or interrupted turns continue to receive the fallback.

## Testing

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeTranscript.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/code/CodeTranscript.tsx src/code/CodeTranscript.dom.test.tsx`