### PR TITLE
ci(release): add improvement PR classification

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,10 @@ categories:
     exclusive: true
     when:
       label: "release-note:feature"
+  - title: "🌟 Improvements"
+    exclusive: true
+    when:
+      label: "release-note:improvement"
   - title: "🐛 Bug Fixes"
     exclusive: true
     when:
@@ -27,7 +31,7 @@ categories:
     exclusive: true
     when:
       label: "release-note:revert"
-  # Maintenance changes carry no user-facing feature or fix, but they are not
+  # Maintenance changes carry no user-facing release note, but they are not
   # invisible: a refactor can rebuild the local database or change build
   # requirements. Every merged PR is accounted for in the notes — nothing is
   # pre-excluded — with maintenance listed after the user-facing sections.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,6 +8,9 @@ changelog:
     - title: "✨ New Features"
       labels:
         - "release-note:feature"
+    - title: "🌟 Improvements"
+      labels:
+        - "release-note:improvement"
     - title: "🐛 Bug Fixes"
       labels:
         - "release-note:fix"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,13 +126,15 @@ dev`, or run the React UI in a browser against `tidebreak serve` via
   [Conventional Commits](https://www.conventionalcommits.org/) header. CI checks
   the title because squash merge makes it the release commit on `main`:
   `type(optional-scope)[!]: description`.
-- Allowed types are `feat`, `fix`, `perf`, `deps`, `revert`, `docs`, `refactor`,
-  `chore`, `build`, `ci`, and `test`. Use `!` only with a release-driving type
-  (`feat`, `fix`, `perf`, `deps`, or `revert`) and only for an intentionally
-  breaking product, API, data, or configuration change.
-- `feat` drives a minor release; `fix`, `perf`, shipped `deps`, and `revert`
-  changes drive a patch; maintenance-only types do not release. Before 1.0,
-  breaking changes drive a minor release. See the
+- Allowed types are `feat`, `improve`, `fix`, `perf`, `deps`, `revert`, `docs`,
+  `refactor`, `chore`, `build`, `ci`, and `test`. Use `improve` for user-visible
+  polish or behavior changes that add no capability and correct no defect. Use
+  `!` only with a release-driving type (`feat`, `improve`, `fix`, `perf`, `deps`,
+  or `revert`) and only for an intentionally breaking product, API, data, or
+  configuration change.
+- `feat` drives a minor release; `improve`, `fix`, `perf`, shipped `deps`, and
+  `revert` changes drive a patch; maintenance-only types do not release. Before
+  1.0, breaking changes drive a minor release. See the
   [release guide](docs/releases.md) for the full policy and the deliberate
   `1.0.0` procedure.
 - Individual commits on a PR may use the same convention, but only the PR title

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,17 +24,19 @@ Scopes are optional and descriptive; common examples are `core`, `server`,
 | Title type                                          | Use for                                              | Release effect |
 | --------------------------------------------------- | ---------------------------------------------------- | -------------- |
 | `feat`                                              | New user-visible capability                          | Minor          |
+| `improve`                                           | User-visible polish or behavior improvement          | Patch          |
 | `fix`                                               | User-visible defect correction                       | Patch          |
 | `perf`                                              | User-visible performance improvement                 | Patch          |
 | `deps`                                              | Shipped runtime dependency update                    | Patch          |
 | `revert`                                            | Reversal of a previously shipped change              | Patch          |
 | `docs`, `refactor`, `test`, `build`, `ci`, `chore`  | Non-user-facing maintenance                          | None           |
-| `feat`, `fix`, `perf`, `deps`, or `revert` with `!` | Breaking product, API, data, or configuration change | Breaking       |
+| `feat`, `improve`, `fix`, `perf`, `deps`, or `revert` with `!` | Breaking product, API, data, or configuration change | Breaking       |
 
 Examples:
 
 ```text
 feat(desktop): add document search
+improve(desktop): simplify settings navigation
 fix(core): prevent duplicate turn completion
 deps(cargo): update the database stack
 revert: restore the previous storage behavior
@@ -42,12 +44,13 @@ feat(core)!: replace the persisted conversation format
 docs: explain local model configuration
 ```
 
-Choose the type based on user impact, not the files changed. A refactor that
-fixes observable behavior is `fix`; a build change that adds a shipped
-capability is `feat`. A breaking refactor is normally `feat!` or `fix!`, based
-on its user impact. CI rejects `!` on maintenance-only types. If the PR body has
-a `BREAKING CHANGE:` footer, its title must also carry `!` so the impact is
-visible during review.
+Choose the type based on user impact, not the files changed. Use `improve` when
+the product works but the change makes an existing experience better. A
+refactor that fixes observable behavior is `fix`; a build change that adds a
+shipped capability is `feat`. Classify a breaking refactor as `feat!`,
+`improve!`, or `fix!` based on its user impact. CI rejects `!` on
+maintenance-only types. If the PR body has a `BREAKING CHANGE:` footer, its
+title must also carry `!` so the impact is visible during review.
 
 GitHub Actions dependency updates remain `ci(deps)` and do not release the
 product. Cargo Dependabot updates use `deps` because those dependencies ship in
@@ -60,6 +63,7 @@ without asking authors to classify a PR twice:
 | Title type | Release-notes section          |
 | ---------- | ------------------------------ |
 | `feat`     | ✨ New Features                |
+| `improve`  | 🌟 Improvements                |
 | `fix`      | 🐛 Bug Fixes                   |
 | `perf`     | ⚡ Performance Improvements    |
 | `deps`     | 📦 Dependency Updates          |
@@ -615,13 +619,13 @@ see exactly what a change to either lockfile adds to the product's obligations.
 
 ## Before 1.0
 
-While the latest published version is below `1.0.0`, fixes increment patch,
-features increment minor, and breaking changes also increment minor. The
-`semver:breaking` version-resolver entry in `.github/release-drafter.yml`
-encodes that pre-1.0 behavior.
+While the latest published version is below `1.0.0`, improvements and fixes
+increment patch, features increment minor, and breaking changes also increment
+minor. The `semver:breaking` version-resolver entry in
+`.github/release-drafter.yml` encodes that pre-1.0 behavior.
 
-For example, `0.3.2` becomes `0.3.3` for a fix and `0.4.0` for either a feature
-or a breaking pre-1.0 change.
+For example, `0.3.2` becomes `0.3.3` for an improvement or fix and `0.4.0` for
+either a feature or a breaking pre-1.0 change.
 
 Desktop upgrades from **v0.61.0** onward keep local data. Schema changes after
 that pin are appended migrations
@@ -667,8 +671,8 @@ its local profile until this checklist is complete:
    upgrade behavior, and every reported application/protocol version.
 
 After `1.0.0`, breaking changes increment major, features increment minor, and
-fixes increment patch. Add supported release branches only if the project later
-commits to maintaining multiple release lines.
+improvements and fixes increment patch. Add supported release branches only if
+the project later commits to maintaining multiple release lines.
 
 ## Required repository settings
 

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 
 export const ALLOWED_TYPES = [
   "feat",
+  "improve",
   "fix",
   "perf",
   "deps",
@@ -16,7 +17,14 @@ export const ALLOWED_TYPES = [
   "test",
 ];
 
-const RELEASING_TYPES = new Set(["feat", "fix", "perf", "deps", "revert"]);
+const RELEASING_TYPES = new Set([
+  "feat",
+  "improve",
+  "fix",
+  "perf",
+  "deps",
+  "revert",
+]);
 
 const TITLE_PATTERN = new RegExp(
   `^(${ALLOWED_TYPES.join("|")})(?:\\(([a-z0-9]+(?:[._/-][a-z0-9]+)*)\\))?(!)?: (\\S.*)$`,
@@ -45,7 +53,7 @@ export function validatePrTitle(title, body = "") {
       `invalid pull request title: ${JSON.stringify(title)}`,
       "expected: type(optional-scope)[!]: description",
       `allowed types: ${ALLOWED_TYPES.join(", ")}`,
-      "examples: feat(desktop): add search, fix(core): prevent a race, feat(core)!: replace the storage format",
+      "examples: feat(desktop): add search, improve(desktop): simplify navigation, fix(core): prevent a race",
     ].join("\n");
   }
 
@@ -53,8 +61,8 @@ export function validatePrTitle(title, body = "") {
   if (breaking && !RELEASING_TYPES.has(type)) {
     return [
       `invalid breaking pull request title: ${JSON.stringify(title)}`,
-      "the ! marker must use a release-driving type: feat, fix, perf, deps, or revert",
-      "classify a breaking refactor or build change by its user impact, usually feat! or fix!",
+      "the ! marker must use a release-driving type: feat, improve, fix, perf, deps, or revert",
+      "classify a breaking refactor or build change by its user impact, usually feat!, improve!, or fix!",
     ].join("\n");
   }
 

--- a/scripts/check-pr-title.test.mjs
+++ b/scripts/check-pr-title.test.mjs
@@ -5,6 +5,7 @@ import { parsePrTitle, validatePrTitle } from "./check-pr-title.mjs";
 
 for (const title of [
   "feat: add document search",
+  "improve(desktop): simplify settings navigation",
   "fix(core): prevent duplicate turns",
   "feat(core)!: replace the storage format",
   "deps(cargo): update database dependencies",
@@ -39,11 +40,11 @@ test("rejects a hidden breaking-change footer", () => {
 });
 
 test("parses the release-relevant parts of a title", () => {
-  assert.deepEqual(parsePrTitle("feat(core)!: replace the API"), {
-    type: "feat",
-    scope: "core",
+  assert.deepEqual(parsePrTitle("improve(desktop)!: replace navigation"), {
+    type: "improve",
+    scope: "desktop",
     breaking: true,
-    description: "replace the API",
+    description: "replace navigation",
   });
 });
 

--- a/scripts/create-release-label-plan.test.mjs
+++ b/scripts/create-release-label-plan.test.mjs
@@ -41,9 +41,27 @@ test("leaves already-correct labels unchanged", () => {
   assert.deepEqual(plan.updates, []);
 });
 
+test("plans improvement release labels", () => {
+  const plan = createReleaseLabelPlan([
+    {
+      number: 14,
+      title: "improve(desktop): simplify navigation",
+      labels: ["release-note:feature", "semver:minor"],
+    },
+  ]);
+
+  assert.deepEqual(plan.updates[0], {
+    number: 14,
+    title: "improve(desktop): simplify navigation",
+    desired_labels: ["release-note:improvement", "semver:patch"],
+    add_labels: ["release-note:improvement", "semver:patch"],
+    remove_labels: ["release-note:feature", "semver:minor"],
+  });
+});
+
 test("skips ambiguous historical titles instead of guessing", () => {
   const plan = createReleaseLabelPlan([
-    { number: 14, title: "Add search", labels: [] },
+    { number: 15, title: "Add search", labels: [] },
   ]);
 
   assert.equal(plan.summary.skipped, 1);

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -22,6 +22,11 @@ const CATEGORIES = [
     scoped: true,
   },
   {
+    key: "Improvements",
+    title: "🌟 Improvements",
+    scoped: true,
+  },
+  {
     key: "Bug Fixes",
     title: "🐛 Bug Fixes",
     scoped: true,

--- a/scripts/format-release-notes.test.mjs
+++ b/scripts/format-release-notes.test.mjs
@@ -58,6 +58,21 @@ test("keeps unscoped release entries in their category without a subheading", ()
   );
 });
 
+test("formats improvements as their own release category", () => {
+  const notes = `### Improvements
+- improve(desktop): simplify settings navigation ([#18](https://example.com/18)) by @octo
+`;
+
+  assert.equal(
+    formatReleaseNotes(notes),
+    `${THANK_YOU}
+
+## 🌟 Improvements
+- **Desktop:** simplify settings navigation ([#18](https://example.com/18)) by @octo
+`,
+  );
+});
+
 test("uses readable acronyms in singleton scope prefixes", () => {
   const notes = `### Breaking Changes
 - feat(mcp)!: replace the protocol ([#18](https://example.com/18)) by @octo

--- a/scripts/release-label.mjs
+++ b/scripts/release-label.mjs
@@ -10,15 +10,17 @@ export const MANAGED_RELEASE_LABELS = [
   "semver:patch",
   "semver:none",
   "release-note:feature",
+  "release-note:improvement",
   "release-note:fix",
   "release-note:performance",
   "release-note:dependencies",
   "release-note:revert",
 ];
 
-const PATCH_TYPES = new Set(["fix", "perf", "deps", "revert"]);
+const PATCH_TYPES = new Set(["improve", "fix", "perf", "deps", "revert"]);
 const RELEASE_NOTE_LABELS = new Map([
   ["feat", "release-note:feature"],
+  ["improve", "release-note:improvement"],
   ["fix", "release-note:fix"],
   ["perf", "release-note:performance"],
   ["deps", "release-note:dependencies"],

--- a/scripts/release-label.test.mjs
+++ b/scripts/release-label.test.mjs
@@ -10,6 +10,7 @@ import {
 
 for (const [title, label] of [
   ["feat: add search", "semver:minor"],
+  ["improve(desktop): simplify navigation", "semver:patch"],
   ["fix(core): prevent a race", "semver:patch"],
   ["perf: reduce startup time", "semver:patch"],
   ["deps(cargo): update sqlite", "semver:patch"],
@@ -29,6 +30,7 @@ test("rejects an invalid title instead of guessing its impact", () => {
 
 for (const [title, label] of [
   ["feat: add search", "release-note:feature"],
+  ["improve(desktop): simplify navigation", "release-note:improvement"],
   ["fix(core): prevent a race", "release-note:fix"],
   ["perf: reduce startup time", "release-note:performance"],
   ["deps(cargo): update sqlite", "release-note:dependencies"],
@@ -45,6 +47,10 @@ test("returns the exact managed labels expected on a pull request", () => {
   assert.deepEqual(releaseLabels("feat: add search"), [
     "semver:minor",
     "release-note:feature",
+  ]);
+  assert.deepEqual(releaseLabels("improve: simplify navigation"), [
+    "semver:patch",
+    "release-note:improvement",
   ]);
   assert.deepEqual(releaseLabels("fix(core)!: replace the API"), [
     "semver:breaking",


### PR DESCRIPTION
## What changed

Add `improve` as a semantic pull request type for user-visible changes that add no capability and correct no defect. Map it to a patch release and a dedicated `🌟 Improvements` release-note section.

## Validation

- `git diff --check`
- `node --test scripts/*.test.mjs` — 216 tests passed

## Compatibility and risk

Existing title types and release labels keep their behavior. The `release-note:improvement` repository label already exists.
