### PR TITLE
fix: let headless executor sweep shared chats

### DIFF
--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -1028,6 +1028,13 @@ pub struct PendingClientCall {
     pub client_executor_id: Option<uuid::Uuid>,
 }
 
+/// One parked call plus the conversation that owns it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NativePendingClientExecution {
+    pub chat_id: ChatId,
+    pub call: PendingClientCall,
+}
+
 /// The canonical call one claim installed, plus the receipt needed to operate
 /// it.
 ///
@@ -1103,6 +1110,25 @@ impl std::fmt::Display for ClientExecutionError {
 type ExecutionResult<T> = std::result::Result<T, ClientExecutionError>;
 
 impl Client {
+    /// Every client-owned tool call parked across this server.
+    pub async fn all_pending_client_executions(
+        &self,
+        executor_token: &str,
+    ) -> ExecutionResult<Vec<NativePendingClientExecution>> {
+        let response = self
+            .http
+            .get(format!("{}/native/client-executions/pending", self.base))
+            .header(CLIENT_EXECUTOR_HEADER, executor_token)
+            .send()
+            .await
+            .map_err(|error| ClientExecutionError::Failed(request_error(error)))?;
+        Self::expect_execution_success(response)
+            .await?
+            .json::<Vec<NativePendingClientExecution>>()
+            .await
+            .map_err(|error| ClientExecutionError::Failed(request_error(error)))
+    }
+
     /// Every client-owned tool call currently parked on this chat.
     pub async fn pending_client_executions(
         &self,

--- a/crates/tidebreak-cli/src/folder_executor.rs
+++ b/crates/tidebreak-cli/src/folder_executor.rs
@@ -195,31 +195,26 @@ impl FolderExecutor {
     }
 
     /// One pass: finish what an earlier run left behind, then take up new work.
-    ///
-    /// One conversation's failure never hides another's: the daemon walks every
-    /// chat it can see, and a chat that cannot be read this pass is reported and
-    /// retried on the next.
     async fn sweep(&self, scope: &Scope) -> Result<()> {
         let recovered = self.recover().await?;
-        for chat in self.chats(scope).await? {
-            if let Err(error) = self.discover(chat, &recovered).await {
-                tracing::warn!(%error, "connected-folder work deferred");
+        match scope {
+            Scope::Chat(chat) => self.discover(*chat, &recovered).await?,
+            Scope::AllChats => {
+                for pending in self
+                    .client
+                    .all_pending_client_executions(&self.executor_token)
+                    .await?
+                {
+                    if let Err(error) = self
+                        .discover_call(pending.chat_id, pending.call, &recovered)
+                        .await
+                    {
+                        tracing::warn!(%error, "connected-folder work deferred");
+                    }
+                }
             }
         }
         Ok(())
-    }
-
-    async fn chats(&self, scope: &Scope) -> Result<Vec<ChatId>> {
-        match scope {
-            Scope::Chat(chat) => Ok(vec![*chat]),
-            Scope::AllChats => Ok(self
-                .client
-                .list_chats()
-                .await?
-                .into_iter()
-                .map(|chat| chat.id)
-                .collect()),
-        }
     }
 
     /// Drive every persisted receipt to a terminal result, and report which
@@ -242,21 +237,30 @@ impl FolderExecutor {
             .pending_client_executions(&self.executor_token, chat)
             .await?;
         for call in pending {
-            if covered.contains(&call.id) || !handles(&call.name) {
-                continue;
-            }
-            // Never race another executor. The server hands a claimed call to
-            // nobody else, so a call already owned is either being run by its
-            // owner or is that owner's to recover from its own receipt.
-            if call.client_executor_id.is_some() {
-                continue;
-            }
-            let receipt =
-                Receipt::new(chat, call.id, self.executor_id, recovery_policy(&call.name));
-            self.receipts.save(&receipt)?;
-            if let Err(error) = self.execute(receipt).await {
-                tracing::warn!(%error, "connected-folder execution deferred");
-            }
+            self.discover_call(chat, call, covered).await?;
+        }
+        Ok(())
+    }
+
+    async fn discover_call(
+        &self,
+        chat: ChatId,
+        call: crate::api::client::PendingClientCall,
+        covered: &HashSet<CallId>,
+    ) -> Result<()> {
+        if covered.contains(&call.id) || !handles(&call.name) {
+            return Ok(());
+        }
+        // Never race another executor. The server hands a claimed call to
+        // nobody else, so a call already owned is either being run by its
+        // owner or is that owner's to recover from its own receipt.
+        if call.client_executor_id.is_some() {
+            return Ok(());
+        }
+        let receipt = Receipt::new(chat, call.id, self.executor_id, recovery_policy(&call.name));
+        self.receipts.save(&receipt)?;
+        if let Err(error) = self.execute(receipt).await {
+            tracing::warn!(%error, "connected-folder execution deferred");
         }
         Ok(())
     }

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -72,7 +72,7 @@ use futures::StreamExt as _;
 use tidebreak_core::{AgentError, Profile, Result};
 
 use crate::error::ServerError;
-use crate::principal::{AuthContext, Principal, Role, UserId};
+use crate::principal::{AuthContext, ClientExecutor, Principal, Role, UserId};
 use crate::state::AppState;
 
 /// Handshake subprotocol the server selects when the client offered it.
@@ -849,10 +849,10 @@ pub async fn require_admin(request: Request, next: Next) -> Response {
 
 /// Require the second credential held only by the trusted native host.
 ///
-/// The credential is a capability, not a principal: it marks the bit on the
-/// [`AuthContext`] the bearer middleware already attached, and fails closed if
-/// no context is present — the native credential alone names nobody and must
-/// never admit a request by itself.
+/// The credential is a machine capability, not a principal. It admits only
+/// routes mounted on the native executor surface. When bearer authentication
+/// already attached an [`AuthContext`], it also marks that context so native
+/// configuration routes can distinguish the host from the renderer.
 pub async fn require_client_executor_token(
     State(state): State<AppState>,
     mut request: Request,
@@ -866,13 +866,13 @@ pub async fn require_client_executor_token(
         Some(token)
             if constant_time_eq(token.as_bytes(), state.client_executor_token.as_bytes()) =>
         {
-            let Some(auth) = request.extensions().get::<AuthContext>().cloned() else {
-                return StatusCode::UNAUTHORIZED.into_response();
-            };
-            request.extensions_mut().insert(AuthContext {
-                client_executor: true,
-                ..auth
-            });
+            request.extensions_mut().insert(ClientExecutor);
+            if let Some(auth) = request.extensions().get::<AuthContext>().cloned() {
+                request.extensions_mut().insert(AuthContext {
+                    client_executor: true,
+                    ..auth
+                });
+            }
             next.run(request).await
         }
         _ => StatusCode::UNAUTHORIZED.into_response(),

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -322,6 +322,33 @@ pub fn app(state: AppState) -> Router {
                 .layer(DefaultBodyLimit::max(routes::MAX_IMAGE_ATTACHMENT_BYTES)),
         );
 
+    let machine_client_executor_api = Router::new()
+        .route(
+            "/native/client-executions/pending",
+            get(routes::list_all_pending_client_executions),
+        )
+        .route(
+            "/chats/{id}/client-executions/pending/raw",
+            get(routes::list_pending_client_executions_raw),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/claim",
+            post(routes::claim_client_execution),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/heartbeat",
+            post(routes::heartbeat_client_execution),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/resolve",
+            post(routes::resolve_client_execution),
+        )
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_client_executor_token,
+        ))
+        .with_state(state.clone());
+
     let client_executor_api = Router::new()
         .route(
             "/native/mcp/servers",
@@ -343,22 +370,6 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/sandbox-file-reads/{call_id}/resolve",
             post(routes::resolve_delegated_file_read),
-        )
-        .route(
-            "/chats/{id}/client-executions/pending/raw",
-            get(routes::list_pending_client_executions_raw),
-        )
-        .route(
-            "/chats/{id}/client-executions/{call_id}/claim",
-            post(routes::claim_client_execution),
-        )
-        .route(
-            "/chats/{id}/client-executions/{call_id}/heartbeat",
-            post(routes::heartbeat_client_execution),
-        )
-        .route(
-            "/chats/{id}/client-executions/{call_id}/resolve",
-            post(routes::resolve_client_execution),
         );
     // The reader's half of the document surface. `ChatDocumentDetail` omits the
     // catalog's `uri` and index bookkeeping, so unlike the full-fidelity routes
@@ -1357,6 +1368,7 @@ pub fn app(state: AppState) -> Router {
     let root = Router::new()
         .merge(view_frames)
         .merge(auth_discovery)
+        .merge(machine_client_executor_api)
         .merge(api);
     // The renderer bundle, when this machine carries one, answers what no
     // route claimed. It sits with the API inside the origin and CORS layers

--- a/crates/tidebreak-server/src/principal.rs
+++ b/crates/tidebreak-server/src/principal.rs
@@ -12,9 +12,8 @@
 //!   is an extractor that fails closed: a handler that asks for it on a route
 //!   the auth layer does not cover gets `401`, never a defaulted identity.
 //! - **The client-executor credential is a capability, not a principal.** It
-//!   marks a bit on an existing context; it cannot conjure an identity on its
-//!   own. [`ClientExecutor`] types that requirement into handler signatures so
-//!   it survives router refactors.
+//!   admits only the machine routes that use [`ClientExecutor`]. It never
+//!   creates an [`AuthContext`] or grants access to owner-scoped routes.
 //!
 //! A principal also carries a [`Role`]: the split between the member plane
 //! (owner-scoped data and capability discovery) and the deployment plane
@@ -208,26 +207,24 @@ impl<S: Send + Sync> FromRequestParts<S> for AuthContext {
     }
 }
 
-/// Proof the request presented the native client-executor credential on top of
-/// an authenticated principal.
+/// Proof that the request presented the native client-executor credential.
 ///
 /// Handlers on the native-only surface take this so the requirement is part of
 /// the handler's type, not only of which router it happens to be mounted on.
-/// When owner-scoped queries land, this grows the principal the capability was
-/// granted on; until a consumer exists it stays a bare proof token.
+/// This proof grants machine authority only. It never supplies a principal for
+/// owner-scoped routes.
 #[derive(Debug, Clone, Copy)]
 pub struct ClientExecutor;
 
 impl<S: Send + Sync> FromRequestParts<S> for ClientExecutor {
     type Rejection = StatusCode;
 
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let auth = AuthContext::from_request_parts(parts, state).await?;
-        if auth.client_executor {
-            Ok(Self)
-        } else {
-            Err(StatusCode::UNAUTHORIZED)
-        }
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<ClientExecutor>()
+            .copied()
+            .ok_or(StatusCode::UNAUTHORIZED)
     }
 }
 

--- a/crates/tidebreak-server/src/routes/client_execution.rs
+++ b/crates/tidebreak-server/src/routes/client_execution.rs
@@ -22,7 +22,6 @@ use tidebreak_core::{
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::principal::ClientExecutor;
-use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 const CLIENT_EXECUTION_LEASE: Duration = Duration::seconds(60);
@@ -191,13 +190,23 @@ pub struct PendingOutputWritebackRequest {
     pub claimed: bool,
 }
 
+/// One pending call plus the conversation that owns it.
+///
+/// The trusted machine executor uses this unscoped projection to sweep a
+/// shared self-host without impersonating one of its named users.
+#[derive(Serialize)]
+pub struct NativePendingClientExecution {
+    pub chat_id: ChatId,
+    pub call: ToolCallRecord,
+}
+
 /// `GET /chats/{id}/client-executions/pending` — renderer-safe consent prompts.
 ///
 /// Unknown, malformed, or non-folder-access client calls are omitted rather
 /// than exposing their canonical records across the renderer boundary.
 pub async fn list_pending_folder_access_requests(
     State(state): State<AppState>,
-    store: ScopedStore,
+    store: crate::scoped_store::ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<PendingFolderAccessRequest>>, ServerError> {
     store.require_chat(id).await?;
@@ -218,7 +227,7 @@ pub async fn list_pending_folder_access_requests(
 /// takes it automatically and it is intentionally omitted from the renderer.
 pub async fn list_pending_output_writebacks(
     State(state): State<AppState>,
-    store: ScopedStore,
+    store: crate::scoped_store::ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<PendingOutputWritebackRequest>>, ServerError> {
     let chat = store.require_chat(id).await?;
@@ -232,15 +241,15 @@ pub async fn list_pending_output_writebacks(
     Ok(Json(requests))
 }
 
-/// Native-only authoritative pending work used by the trusted executor.
+/// Native-only authoritative pending work for one conversation.
 pub async fn list_pending_client_executions_raw(
     State(state): State<AppState>,
-    store: ScopedStore,
     _executor: ClientExecutor,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<ToolCallRecord>>, ServerError> {
-    store.require_chat(id).await?;
-    let calls = store
+    require_native_chat(&state, id).await?;
+    let calls = state
+        .store
         .list_pending_client_tool_calls(id)
         .await?
         .into_iter()
@@ -248,6 +257,30 @@ pub async fn list_pending_client_executions_raw(
         .collect();
     state.turn_job_wake.notify_one();
     Ok(Json(calls))
+}
+
+/// Native-only authoritative pending work across every conversation.
+pub async fn list_all_pending_client_executions(
+    State(state): State<AppState>,
+    _executor: ClientExecutor,
+) -> Result<Json<Vec<NativePendingClientExecution>>, ServerError> {
+    let mut pending = Vec::new();
+    for chat in state.store.list_chats().await? {
+        pending.extend(
+            state
+                .store
+                .list_pending_client_tool_calls(chat.id)
+                .await?
+                .into_iter()
+                .filter(|call| call.name != tidebreak_core::ASK_USER_QUESTIONS_TOOL)
+                .map(|call| NativePendingClientExecution {
+                    chat_id: chat.id,
+                    call,
+                }),
+        );
+    }
+    state.turn_job_wake.notify_one();
+    Ok(Json(pending))
 }
 
 fn renderer_folder_access_request(call: ToolCallRecord) -> Option<PendingFolderAccessRequest> {
@@ -296,22 +329,22 @@ fn renderer_output_writeback_request(
 /// `POST .../{call_id}/claim` — atomically acquire or recover one exact claim.
 pub async fn claim_client_execution(
     State(state): State<AppState>,
-    store: ScopedStore,
     _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<ClaimClientExecution>,
 ) -> Result<Json<ClaimedClientExecution>, ServerError> {
-    store.require_chat(id).await?;
+    require_native_chat(&state, id).await?;
     ensure_non_nil(body.executor_id, "executor_id")?;
     ensure_non_nil(body.lease_token, "lease_token")?;
     // Polling is also the recovery watchdog after a server restart: sweep a
     // prior executor's expired claim before deciding whether this call can be
     // claimed. The store performs the failure, event append, wait closure, and
     // turn transition atomically.
-    store.list_pending_client_tool_calls(id).await?;
+    state.store.list_pending_client_tool_calls(id).await?;
     state.turn_job_wake.notify_one();
     let now = Utc::now();
-    let outcome = store
+    let outcome = state
+        .store
         .claim_client_tool_call(
             call_id,
             id,
@@ -341,15 +374,16 @@ pub async fn claim_client_execution(
 /// Heartbeats are monotonic liveness updates rather than exact commands: a
 /// repeated request can extend the lease again from its new server receive time.
 pub async fn heartbeat_client_execution(
-    store: ScopedStore,
+    State(state): State<AppState>,
     _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<HeartbeatClientExecution>,
 ) -> Result<Json<ClientExecutionHeartbeat>, ServerError> {
-    store.require_chat(id).await?;
+    require_native_chat(&state, id).await?;
     ensure_non_nil(body.lease_token, "lease_token")?;
     let now = Utc::now();
-    let disposition = match store
+    let disposition = match state
+        .store
         .heartbeat_client_tool_call(
             call_id,
             id,
@@ -377,19 +411,19 @@ pub async fn heartbeat_client_execution(
 /// with the first committed result.
 pub async fn resolve_client_execution(
     State(state): State<AppState>,
-    store: ScopedStore,
     _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<ResolveClientExecution>,
 ) -> Result<Json<ResolvedClientExecution>, ServerError> {
-    store.require_chat(id).await?;
+    require_native_chat(&state, id).await?;
     ensure_non_nil(body.lease_token, "lease_token")?;
     let rows = body.resolution.rows().cloned();
     let images = body.resolution.images().map(<[_]>::to_vec);
     let resolution = body.resolution.into_core();
     validate_resolution(&resolution)?;
     let now = Utc::now();
-    let mut resolution_receipt = store
+    let mut resolution_receipt = state
+        .store
         .resolve_client_tool_call_and_append_event_with_rows(
             call_id,
             id,
@@ -402,7 +436,8 @@ pub async fn resolve_client_execution(
         )
         .await?;
     if resolution_receipt.outcome == ResolveToolCallOutcome::LeaseLost {
-        resolution_receipt = store
+        resolution_receipt = state
+            .store
             .resolve_expired_client_tool_call_and_append_event_with_rows(
                 call_id,
                 id,
@@ -446,6 +481,14 @@ pub async fn resolve_client_execution(
         state.turn_job_wake.notify_one();
     }
     Ok(Json(ResolvedClientExecution { disposition }))
+}
+
+async fn require_native_chat(state: &AppState, id: ChatId) -> Result<(), ServerError> {
+    if state.store.get_chat(id).await?.is_some() {
+        Ok(())
+    } else {
+        Err(ServerError::not_found(format!("chat {id} not found")))
+    }
 }
 
 fn ensure_non_nil(value: uuid::Uuid, field: &str) -> Result<(), ServerError> {

--- a/crates/tidebreak-server/src/scoped_store.rs
+++ b/crates/tidebreak-server/src/scoped_store.rs
@@ -1,11 +1,12 @@
 //! The request-facing store view, bound to one authenticated principal.
 //!
-//! Route handlers do not touch [`Store`] directly. They extract a
-//! [`ScopedStore`] — the durable store bound to the requesting principal's
-//! [`OwnerId`] — and every root-aggregate query on it (chats, projects,
-//! documents) is the trait's owner-scoped variant. The unscoped root surface
-//! simply does not exist on this type, and the inner handle never escapes it,
-//! so route code cannot express a query that crosses owners (#853).
+//! Principal-facing route handlers do not touch [`Store`] directly. They
+//! extract a [`ScopedStore`] — the durable store bound to the requesting
+//! principal's [`OwnerId`] — and every root-aggregate query on it (chats,
+//! projects, documents) is the trait's owner-scoped variant. The unscoped root
+//! surface simply does not exist on this type, and the inner handle never
+//! escapes it, so principal-facing route code cannot express a query that
+//! crosses owners (#853).
 //!
 //! Non-root operations (turns, agent runs, events, approvals) hang off a
 //! root by id and pass through unchanged; the handler authorizes the root
@@ -14,7 +15,8 @@
 //! chat or project their level points at. System paths that act on
 //! already-authorized ids — turn workers, retirement scans, post-commit
 //! signalling — are not requests and keep the separate unscoped handle on
-//! [`AppState`].
+//! [`AppState`]. The native executor capability also uses that handle on its
+//! isolated machine routes because it serves every owner without becoming one.
 //!
 //! The extractor fails closed like [`AuthContext`] itself: on a route the
 //! auth middleware does not cover it answers `401`, never a defaulted owner.
@@ -31,15 +33,14 @@ use tidebreak_core::local_app::{AppGrant, AppRecord, AppRevision};
 use tidebreak_core::storage::DecidePlanOutcome;
 use tidebreak_core::{
     AcceptTurnSteerOutcome, AgentRun, AgentRunId, AgentRunResult, AnswerUserQuestionsOutcome,
-    AnswerUserQuestionsRequest, CallId, Chat, ChatId, ChatTranscriptSnapshot,
-    ClaimClientToolCallOutcome, DecidePlanRequest, DeleteChatOutcome, DeleteProjectOutcome,
-    DocumentId, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceUpsert,
-    DocumentSummaryRecord, HeartbeatClientToolCallOutcome, ImageRef,
-    JournaledClientToolCallOutcome, JournaledTurnOutcome, MessageAttachment, MoveChatOutcome,
-    NetworkPolicy, OwnerId, PendingPlanApproval, PendingUserQuestions, PermissionMode, Project,
-    ProjectId, ReasoningEffort, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
-    Result, SandboxAgentAdmission, SandboxToolCall, SandboxToolCallReceipt, SequencedEvent, Store,
-    TaskPlan, ToolApproval, ToolCallRecord, ToolCallResolution, TurnId, TurnRun, TurnSteerId,
+    AnswerUserQuestionsRequest, CallId, Chat, ChatId, ChatTranscriptSnapshot, DecidePlanRequest,
+    DeleteChatOutcome, DeleteProjectOutcome, DocumentId, DocumentListCursor, DocumentRecord,
+    DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, ImageRef, JournaledTurnOutcome,
+    MessageAttachment, MoveChatOutcome, NetworkPolicy, OwnerId, PendingPlanApproval,
+    PendingUserQuestions, PermissionMode, Project, ProjectId, ReasoningEffort,
+    RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Result,
+    SandboxAgentAdmission, SandboxToolCall, SandboxToolCallReceipt, SequencedEvent, Store,
+    TaskPlan, ToolApproval, ToolCallRecord, TurnId, TurnRun, TurnSteerId,
 };
 
 use crate::error::ServerError;
@@ -577,89 +578,6 @@ impl ScopedStore {
     /// [`Store::list_tool_calls`].
     pub async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
         self.store.list_tool_calls(chat_id).await
-    }
-
-    /// [`Store::claim_client_tool_call`].
-    pub async fn claim_client_tool_call(
-        &self,
-        id: CallId,
-        chat_id: ChatId,
-        executor_id: uuid::Uuid,
-        lease_token: uuid::Uuid,
-        now: chrono::DateTime<chrono::Utc>,
-        lease_expires_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<ClaimClientToolCallOutcome> {
-        self.store
-            .claim_client_tool_call(id, chat_id, executor_id, lease_token, now, lease_expires_at)
-            .await
-    }
-
-    /// [`Store::heartbeat_client_tool_call`].
-    pub async fn heartbeat_client_tool_call(
-        &self,
-        id: CallId,
-        chat_id: ChatId,
-        lease_token: uuid::Uuid,
-        now: chrono::DateTime<chrono::Utc>,
-        lease_expires_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<HeartbeatClientToolCallOutcome> {
-        self.store
-            .heartbeat_client_tool_call(id, chat_id, lease_token, now, lease_expires_at)
-            .await
-    }
-
-    /// [`Store::resolve_client_tool_call_and_append_event_with_rows`].
-    #[allow(clippy::too_many_arguments)]
-    pub async fn resolve_client_tool_call_and_append_event_with_rows(
-        &self,
-        id: CallId,
-        chat_id: ChatId,
-        lease_token: uuid::Uuid,
-        now: chrono::DateTime<chrono::Utc>,
-        resolution: &ToolCallResolution,
-        resolved_at: chrono::DateTime<chrono::Utc>,
-        rows: Option<&serde_json::Value>,
-        images: Option<&[tidebreak_core::ImageRef]>,
-    ) -> Result<JournaledClientToolCallOutcome> {
-        self.store
-            .resolve_client_tool_call_and_append_event_with_rows(
-                id,
-                chat_id,
-                lease_token,
-                now,
-                resolution,
-                resolved_at,
-                rows,
-                images,
-            )
-            .await
-    }
-
-    /// [`Store::resolve_expired_client_tool_call_and_append_event_with_rows`].
-    #[allow(clippy::too_many_arguments)]
-    pub async fn resolve_expired_client_tool_call_and_append_event_with_rows(
-        &self,
-        id: CallId,
-        chat_id: ChatId,
-        lease_token: uuid::Uuid,
-        now: chrono::DateTime<chrono::Utc>,
-        resolution: &ToolCallResolution,
-        resolved_at: chrono::DateTime<chrono::Utc>,
-        rows: Option<&serde_json::Value>,
-        images: Option<&[tidebreak_core::ImageRef]>,
-    ) -> Result<JournaledClientToolCallOutcome> {
-        self.store
-            .resolve_expired_client_tool_call_and_append_event_with_rows(
-                id,
-                chat_id,
-                lease_token,
-                now,
-                resolution,
-                resolved_at,
-                rows,
-                images,
-            )
-            .await
     }
 }
 

--- a/crates/tidebreak-server/src/tests/lifecycle.rs
+++ b/crates/tidebreak-server/src/tests/lifecycle.rs
@@ -1068,6 +1068,30 @@ pub(super) async fn post_native_json(
         .unwrap()
 }
 
+/// POST a JSON body with only the machine executor capability.
+async fn post_executor_json(
+    router: &Router,
+    uri: &str,
+    body: serde_json::Value,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header(
+                    crate::auth::CLIENT_EXECUTOR_HEADER,
+                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+                )
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
 /// Park a turn on a client tool call without running the agent loop.
 ///
 /// This and the other `park_*_for_route_test` helpers accept a turn and then
@@ -1465,7 +1489,6 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         .oneshot(
             Request::builder()
                 .uri(format!("/chats/{}/client-executions/pending/raw", chat.id))
-                .header(header::AUTHORIZATION, &bearer)
                 .header(
                     crate::auth::CLIENT_EXECUTOR_HEADER,
                     crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
@@ -1501,7 +1524,7 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         .unwrap();
     assert_eq!(renderer_only.status(), StatusCode::UNAUTHORIZED);
 
-    let first = post_native_json(&router, &bearer, &claim_uri, claim_body.clone()).await;
+    let first = post_executor_json(&router, &claim_uri, claim_body.clone()).await;
     assert_eq!(first.status(), StatusCode::OK);
     let first: serde_json::Value = json_body(first).await;
     assert_eq!(first["disposition"], "claimed");
@@ -1510,15 +1533,14 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
 
     // A lost response can be retried with the stable secret token even though
     // the server calculates a fresh proposed expiry for the second request.
-    let retry = post_native_json(&router, &bearer, &claim_uri, claim_body).await;
+    let retry = post_executor_json(&router, &claim_uri, claim_body).await;
     assert_eq!(retry.status(), StatusCode::OK);
     let retry: serde_json::Value = json_body(retry).await;
     assert_eq!(retry["disposition"], "existing");
     assert_eq!(retry["lease_token"], lease_token.to_string());
 
-    let stolen = post_native_json(
+    let stolen = post_executor_json(
         &router,
-        &bearer,
         &claim_uri,
         serde_json::json!({
             "executor_id": executor_id,
@@ -1545,9 +1567,8 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         "authoritative polling must never disclose the secret lease token"
     );
 
-    let wrong_chat_heartbeat = post_native_json(
+    let wrong_chat_heartbeat = post_executor_json(
         &router,
-        &bearer,
         &format!(
             "/chats/{}/client-executions/{}/heartbeat",
             other_chat.id, call.id
@@ -1558,9 +1579,8 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
     assert_eq!(wrong_chat_heartbeat.status(), StatusCode::CONFLICT);
 
     tokio::time::sleep(Duration::from_millis(2)).await;
-    let heartbeat = post_native_json(
+    let heartbeat = post_executor_json(
         &router,
-        &bearer,
         &format!("/chats/{}/client-executions/{}/heartbeat", chat.id, call.id),
         serde_json::json!({"lease_token": lease_token}),
     )
@@ -1574,9 +1594,8 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         "lease_token": lease_token,
         "resolution": {"status": "completed", "result": "folder connected"},
     });
-    let wrong_chat_resolve = post_native_json(
+    let wrong_chat_resolve = post_executor_json(
         &router,
-        &bearer,
         &format!(
             "/chats/{}/client-executions/{}/resolve",
             other_chat.id, call.id
@@ -1585,9 +1604,8 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
     )
     .await;
     assert_eq!(wrong_chat_resolve.status(), StatusCode::CONFLICT);
-    let wrong_token = post_native_json(
+    let wrong_token = post_executor_json(
         &router,
-        &bearer,
         &resolve_uri,
         serde_json::json!({
             "lease_token": uuid::Uuid::new_v4(),
@@ -1597,7 +1615,7 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
     .await;
     assert_eq!(wrong_token.status(), StatusCode::CONFLICT);
 
-    let resolved = post_native_json(&router, &bearer, &resolve_uri, resolution.clone()).await;
+    let resolved = post_executor_json(&router, &resolve_uri, resolution.clone()).await;
     assert_eq!(resolved.status(), StatusCode::OK);
     let resolved: serde_json::Value = json_body(resolved).await;
     assert_eq!(resolved["disposition"], "resolved");
@@ -1605,14 +1623,13 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
     // Resolution time is server-owned metadata, not part of the stable command
     // identity, so an ambiguous retry converges on token + terminal payload.
     tokio::time::sleep(Duration::from_millis(2)).await;
-    let retry = post_native_json(&router, &bearer, &resolve_uri, resolution).await;
+    let retry = post_executor_json(&router, &resolve_uri, resolution).await;
     assert_eq!(retry.status(), StatusCode::OK);
     let retry: serde_json::Value = json_body(retry).await;
     assert_eq!(retry["disposition"], "existing");
 
-    let conflicting = post_native_json(
+    let conflicting = post_executor_json(
         &router,
-        &bearer,
         &resolve_uri,
         serde_json::json!({
             "lease_token": lease_token,
@@ -3074,34 +3091,90 @@ async fn client_execution_api_validates_scope_identity_and_terminal_payloads() {
     assert_eq!(oversized.status(), StatusCode::BAD_REQUEST);
 }
 
-/// The native-only surface requires a principal, not just the capability:
-/// presenting only the client-executor credential names nobody and is
-/// rejected before any handler runs.
+/// The machine executor sweeps named owners without impersonating one.
 #[tokio::test]
-async fn client_executor_credential_alone_is_rejected() {
-    let (router, _token, _store, _dir) = test_app().await;
+async fn client_executor_capability_reaches_only_its_machine_surface() {
+    let (dir, store) = temp_db_store("self-host-executor.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let tokens_file = dir.path().join("tokens");
+    std::fs::write(&tokens_file, format!("alice {ALICE_TOKEN} admin\n")).unwrap();
+    let mut config = Config::desktop(dir.path());
+    config.profile = tidebreak_core::Profile::SelfHost;
+    config.auth_tokens_file = Some(tokens_file);
+    let state = AppState::new(
+        config,
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let router = app(state);
+    let alice = format!("Bearer {ALICE_TOKEN}");
+    let chat = make_chat(&router, &alice).await;
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "native".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({}),
+        raw_arguments: None,
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        result_preview: None,
+        provider_replay: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    store.accept_tool_call(&call).await.unwrap();
+
+    let capability_request = |uri: &str| {
+        Request::builder()
+            .uri(uri)
+            .header(
+                crate::auth::CLIENT_EXECUTOR_HEADER,
+                crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+            )
+            .body(Body::empty())
+            .unwrap()
+    };
 
     let response = router
-        .oneshot(
-            Request::builder()
-                .uri("/sandbox-file-reads/pending")
-                .header(
-                    crate::auth::CLIENT_EXECUTOR_HEADER,
-                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
-                )
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .clone()
+        .oneshot(capability_request("/native/client-executions/pending"))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let pending: serde_json::Value = json_body(response).await;
+    assert_eq!(pending[0]["chat_id"], chat.id.to_string());
+    assert_eq!(pending[0]["call"]["id"], call.id.to_string());
+
+    let response = router
+        .clone()
+        .oneshot(capability_request("/chats"))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = router
+        .oneshot(capability_request("/sandbox-file-reads/pending"))
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
-/// The auth middleware is the one place a principal is minted: the bearer
-/// resolves to the local owner without the executor capability, the native
-/// credential upgrades the capability bit on that principal, and the
-/// capability alone cannot reach a handler. Probes the real middlewares in
-/// the production layering (bearer outermost).
+/// The bearer middleware creates the principal. The executor middleware adds
+/// its independent machine proof and marks an existing context for routes that
+/// deliberately require both credentials.
 #[tokio::test]
 async fn auth_middleware_resolves_principal_and_capability() {
     use crate::principal::{AuthContext, Principal};


### PR DESCRIPTION
Fixes the headless connected-folder executor on gateway-authenticated self-hosts.

The server now exposes client-execution polling and lifecycle routes through the machine executor capability without inventing a user principal. Normal chat routes remain owner-scoped. The daemon polls one native endpoint for pending work across named owners.

Tests cover capability-only polling, claim, heartbeat, and resolution. They also verify that the capability cannot reach normal chat or delegated-file routes.

Closes #3146

Validation:
- `cargo test -p tidebreak-server tests::lifecycle::client_executor_capability_reaches_only_its_machine_surface -- --exact --nocapture`
- `cargo test -p tidebreak-server tests::lifecycle::client_execution_api_polls_claims_heartbeats_and_resolves_idempotently -- --exact --nocapture`
- `cargo test -p tidebreak-cli folder_executor::tests -- --nocapture`
- `cargo check -p tidebreak-cli`
- `cargo clippy -p tidebreak-server -p tidebreak-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`