### PR TITLE
ci: restore staging desktop publishes

### DIFF
--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -425,11 +425,28 @@ jobs:
             --key "$APPLE_API_KEY_PATH" \
             --key-id "$APPLE_API_KEY_ID" \
             --issuer "$APPLE_API_ISSUER" \
-            --wait \
-            --timeout 30m \
             --output-format json)"
           printf '%s\n' "$submission_output"
           submission_id="$(jq -er .id <<<"$submission_output")"
+
+          submission_output=""
+          for attempt in 1 2 3; do
+            if submission_output="$(xcrun notarytool wait "$submission_id" \
+              --key "$APPLE_API_KEY_PATH" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER" \
+              --timeout 20m \
+              --output-format json)"; then
+              break
+            fi
+            if (( attempt == 3 )); then
+              echo "Notary status checks failed three times for $submission_id." >&2
+              exit 1
+            fi
+            echo "Notary status check failed; retrying in 15 seconds." >&2
+            sleep 15
+          done
+          printf '%s\n' "$submission_output"
           submission_status="$(jq -er .status <<<"$submission_output")"
           if [[ "$submission_status" != Accepted ]]; then
             echo "DMG notarization failed with status: $submission_status" >&2

--- a/scripts/smoke-packaged-gh-discovery.sh
+++ b/scripts/smoke-packaged-gh-discovery.sh
@@ -32,7 +32,7 @@ profile_home="$smoke_root/home"
 profile_data="$profile_home/Library/Application Support/$identifier"
 shell_config="$smoke_root/zsh"
 fake_bin="$smoke_root/login-bin"
-fake_log="$smoke_root/gh-invocations.log"
+fake_log="$smoke_root/gh-config/invocations.log"
 app_log="$smoke_root/app.log"
 response="$smoke_root/repositories.json"
 app_pid=""
@@ -60,14 +60,19 @@ trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-mkdir -p "$profile_home" "$shell_config" "$fake_bin" "$smoke_root/tmp"
+mkdir -p \
+  "$profile_home" \
+  "$shell_config" \
+  "$fake_bin" \
+  "$smoke_root/gh-config" \
+  "$smoke_root/tmp"
 
 cat > "$fake_bin/gh" <<'FAKE_GH'
 #!/bin/sh
 set -eu
 
-: "${GH_SMOKE_LOG:?}"
-printf '%s\n' "$*" >> "$GH_SMOKE_LOG"
+: "${GH_CONFIG_DIR:?}"
+printf '%s\n' "$*" >> "$GH_CONFIG_DIR/invocations.log"
 
 if [ "$#" -eq 4 ] \
   && [ "$1" = auth ] \
@@ -98,7 +103,6 @@ ZSHRC
   TMPDIR="$smoke_root/tmp" \
   GH_CONFIG_DIR="$smoke_root/gh-config" \
   GH_SMOKE_LOGIN_BIN="$fake_bin" \
-  GH_SMOKE_LOG="$fake_log" \
   "$app_executable" > "$app_log" 2>&1 &
 app_pid=$!
 
@@ -131,8 +135,18 @@ token="$(jq -er .token "$listen_path")"
   --header "Authorization: Bearer $token" \
   "$base_url/code/delivery/repositories" > "$response"
 
-jq -e '.capability.found == true' "$response" >/dev/null
-jq -e '.capability.authenticated == false' "$response" >/dev/null
+if ! jq -e '.capability.found == true' "$response" >/dev/null; then
+  echo "The packaged app did not discover gh through the login shell." >&2
+  jq '.capability' "$response" >&2 || cat "$response" >&2
+  sed -n '1,200p' "$app_log" >&2
+  exit 1
+fi
+if ! jq -e '.capability.authenticated == false' "$response" >/dev/null; then
+  echo "The packaged app did not report the fake gh account as signed out." >&2
+  jq '.capability' "$response" >&2 || cat "$response" >&2
+  sed -n '1,200p' "$app_log" >&2
+  exit 1
+fi
 
 [[ -s "$fake_log" ]] || {
   echo "The packaged app reported gh without invoking the login-shell binary." >&2

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1909,6 +1909,16 @@ test("macOS notarization happens after bundling and before artifact verification
         assert.ok(sKey <= sNotarize, "staging: the notary key must load before notarization");
       }
     }
+    const stagingNotarytoolIdx = staging.indexOf("notarytool submit");
+    const stagingStepStart = staging.lastIndexOf("- name:", stagingNotarytoolIdx);
+    const stagingStepEnd = staging.indexOf("\n      - name:", stagingNotarytoolIdx);
+    const stagingNotarizeStep = staging.slice(
+      stagingStepStart,
+      stagingStepEnd !== -1 ? stagingStepEnd : undefined,
+    );
+    assert.match(stagingNotarizeStep, /notarytool wait/);
+    assert.match(stagingNotarizeStep, /for attempt in 1 2 3/);
+    assert.match(stagingNotarizeStep, /Notary status check failed; retrying/);
   }
 });
 
@@ -2347,6 +2357,15 @@ test("staging smoke-tests packaged GitHub CLI discovery before upload", () => {
     packagedGhDiscoverySmoke,
     /export PATH="\$GH_SMOKE_LOGIN_BIN:\$PATH"/,
   );
+  assert.match(
+    packagedGhDiscoverySmoke,
+    /fake_log="\$smoke_root\/gh-config\/invocations\.log"/,
+  );
+  assert.match(
+    packagedGhDiscoverySmoke,
+    />> "\$GH_CONFIG_DIR\/invocations\.log"/,
+  );
+  assert.doesNotMatch(packagedGhDiscoverySmoke, /GH_SMOKE_LOG=/);
   assert.match(packagedGhDiscoverySmoke, /listen_path="\$profile_data\/listen\.json"/);
   assert.match(packagedGhDiscoverySmoke, /\/code\/delivery\/repositories/);
   assert.match(packagedGhDiscoverySmoke, /\.capability\.found == true/);


### PR DESCRIPTION
Staging desktop publishes fail for two independent reasons. The packaged GitHub CLI smoke test writes through an environment variable that the child allowlist now removes, and Apple notarization status polling sometimes loses its network route.\n\nThis change stores the smoke-test log under the allowed `GH_CONFIG_DIR`, prints the returned capability when an assertion fails, submits each notarization once, and retries status polling without uploading the DMG again.\n\nValidation:\n\n- Ran the packaged smoke test against the exact binary from failed staging run 607.\n- Ran `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs`: 91 passed.\n- Ran `actionlint .github/workflows/staging-publish.yml`.\n- Ran `bash -n scripts/smoke-packaged-gh-discovery.sh`.\n- Ran `git diff --check`.