### PR TITLE
refactor(server): extract remote code sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7189,6 +7189,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tidebreak-code-remote"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "chrono",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tidebreak-core",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tidebreak-core"
 version = "0.0.0"
 dependencies = [
@@ -7419,6 +7436,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tidebreak-code-execution",
+ "tidebreak-code-remote",
  "tidebreak-core",
  "tidebreak-egress",
  "tidebreak-harness",

--- a/crates/tidebreak-code-remote/Cargo.toml
+++ b/crates/tidebreak-code-remote/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "tidebreak-code-remote"
+description = "Remote code-session sandbox client, event ingestion, and lifecycle driver."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true
+
+[dependencies]
+tidebreak-core = { path = "../tidebreak-core" }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tidebreak-core = { path = "../tidebreak-core", features = ["test-util"] }
+axum = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -28,12 +28,13 @@ use tidebreak_core::{
     FenceReason, IncarnationAdmission, IncarnationState, OwnerId,
 };
 
-use super::super::attention::persist_session;
-use super::super::bus::CodeEventBus;
-use super::super::recovery;
 use super::ingest::{ingest_events, IngestBinding, IngestOutcome};
 use super::wire::{EventCursor, SandboxMessage, SpawnArguments};
-use super::{RemoteSandboxError, SandboxProvisioner};
+use super::{
+    apply_attention, fence_session, journal_event, persist_session, reap_session,
+    recover_dead_worker, replace_attention, RemoteReapError, RemoteSandboxError, RemoteSessionHost,
+    SandboxProvisioner,
+};
 
 /// How long an unactivated intent may sit before the sweep closes it: long
 /// enough for a slow spawn round trip, short enough that a crashed server
@@ -42,7 +43,7 @@ const STALE_INTENT_AGE: chrono::Duration = chrono::Duration::minutes(10);
 
 /// Spawn-time settings for one remote session's sandboxes.
 #[derive(Clone, Debug)]
-pub(crate) struct RemoteSpawnSettings {
+pub struct RemoteSpawnSettings {
     /// Administrator-defined profile on the runtime endpoint.
     pub profile: String,
     /// Concurrent live incarnations one owner may hold.
@@ -56,7 +57,7 @@ pub(crate) struct RemoteSpawnSettings {
 
 /// What one submitted turn became.
 #[derive(Debug)]
-pub(crate) enum RemoteTurnOutcome {
+pub enum RemoteTurnOutcome {
     /// The turn reached the live sandbox's inbox.
     Delivered {
         /// The turn row, running. Boxed: the rows dwarf the refusals.
@@ -100,11 +101,11 @@ pub(crate) enum RemoteTurnOutcome {
 /// The driver one remote session's lifecycle calls go through: the store,
 /// the live bus, the transport, and the spawn settings, borrowed together
 /// so every operation reads the same world.
-pub(crate) struct RemoteDriver<'a> {
+pub struct RemoteDriver<'a> {
     /// The store every row lives in.
     pub db: &'a Arc<DbStore>,
     /// Live-update bus the journal publishes to.
-    pub bus: &'a CodeEventBus,
+    pub bus: &'a dyn RemoteSessionHost,
     /// The environment transport.
     pub provisioner: &'a dyn SandboxProvisioner,
     /// Spawn-time settings.
@@ -114,10 +115,10 @@ pub(crate) struct RemoteDriver<'a> {
 /// Surface the sign-in need on the session's attention.
 async fn sign_in_needed(
     db: &Arc<DbStore>,
-    bus: &CodeEventBus,
+    bus: &dyn RemoteSessionHost,
     session: &CodeSession,
 ) -> Result<(), tidebreak_core::AgentError> {
-    let _ = super::super::attention::apply_attention(
+    apply_attention(
         db,
         bus,
         &session.owner,
@@ -128,7 +129,6 @@ async fn sign_in_needed(
             "sign in to the sandbox environment",
             AttentionSource::Structured,
         ),
-        false,
     )
     .await?;
     Ok(())
@@ -140,12 +140,12 @@ async fn sign_in_needed(
 /// reason in the transcript.
 async fn refusal_notice(
     db: &Arc<DbStore>,
-    bus: &CodeEventBus,
+    bus: &dyn RemoteSessionHost,
     session: &CodeSession,
     message: String,
     attention: &str,
 ) -> Result<(), tidebreak_core::AgentError> {
-    let _ = super::super::session_worker::journal_event(
+    journal_event(
         db,
         bus,
         &session.owner,
@@ -157,13 +157,12 @@ async fn refusal_notice(
         },
     )
     .await;
-    let _ = super::super::attention::apply_attention(
+    apply_attention(
         db,
         bus,
         &session.owner,
         session.id,
         Attention::needs_you(attention, AttentionSource::Lifecycle),
-        false,
     )
     .await?;
     Ok(())
@@ -215,7 +214,7 @@ fn refusal_names(error: &RemoteSandboxError, reference: &str) -> bool {
 /// project them, settle turn rows, and close the incarnation when the
 /// environment says the sandbox ended.
 #[derive(Debug, Default)]
-pub(crate) struct PumpReport {
+pub struct PumpReport {
     /// Sandbox event sequences ingested this pump.
     pub ingested: u64,
     /// Whether the incarnation was closed this pump.
@@ -302,7 +301,7 @@ impl RemoteDriver<'_> {
     /// The session row is updated (lifecycle, attention) on success; the caller
     /// persists nothing else. `session`, `workspace`, and `repo` are the current
     /// rows — the caller owns loading and authorization.
-    pub(crate) async fn submit_turn(
+    pub async fn submit_turn(
         &self,
         session: &mut CodeSession,
         workspace: &CodeWorkspace,
@@ -320,7 +319,7 @@ impl RemoteDriver<'_> {
     /// trying, and outcomes like a held flush must leave the row queued.
     /// The claim itself is the local worker's atomic promotion; see
     /// [`start_turn_row`] for what a stale claim does.
-    pub(crate) async fn submit_turn_from(
+    pub async fn submit_turn_from(
         &self,
         session: &mut CodeSession,
         workspace: &CodeWorkspace,
@@ -563,7 +562,7 @@ impl RemoteDriver<'_> {
                     // earlier checkpoint or the base instead of looping on
                     // this refusal. Then fence so a reap starts fresh.
                     forget_session_wip_ref(db, &owner, session.id, &resume_ref).await?;
-                    recovery::fence_session(
+                    fence_session(
                         db,
                         bus,
                         session,
@@ -583,7 +582,7 @@ impl RemoteDriver<'_> {
     /// Idle when no incarnation is active. The caller schedules pumps; this
     /// function is safe to call on any cadence because the cursor is durable
     /// and replays are no-ops.
-    pub(crate) async fn pump(
+    pub async fn pump(
         &self,
         session: &mut CodeSession,
         wait_seconds: u16,
@@ -660,7 +659,7 @@ impl RemoteDriver<'_> {
                     detail: format!("the environment no longer serves this sandbox: {error}"),
                 };
                 report.fenced = Some(reason.clone());
-                recovery::fence_session(db, bus, session, reason).await?;
+                fence_session(db, bus, session, reason).await?;
                 return Ok(report);
             }
         };
@@ -714,7 +713,7 @@ impl RemoteDriver<'_> {
                 .await?
                 .filter(|turn| turn.status == CodeTurnStatus::Running);
             if open.is_some() {
-                if let Some(recovered) = recovery::recover_dead_worker(db, bus, session).await? {
+                if let Some(recovered) = recover_dead_worker(db, bus, session).await? {
                     *session = recovered;
                 }
             }
@@ -740,7 +739,7 @@ impl RemoteDriver<'_> {
         }
         if let Some(reason) = outcome.fence {
             report.fenced = Some(reason.clone());
-            recovery::fence_session(db, bus, session, reason).await?;
+            fence_session(db, bus, session, reason).await?;
         }
         Ok(report)
     }
@@ -750,10 +749,7 @@ impl RemoteDriver<'_> {
     ///
     /// Unlike a local reap, nothing is relaunched — the next turn reincarnates
     /// on demand.
-    pub(crate) async fn reap(
-        &self,
-        session: CodeSession,
-    ) -> Result<CodeSession, recovery::ReapSessionError> {
+    pub async fn reap(&self, session: CodeSession) -> Result<CodeSession, RemoteReapError> {
         let (db, bus, provisioner) = (self.db, self.bus, self.provisioner);
         let owner = session.owner.clone();
         if let Ok(Some(row)) = latest_incarnation(db, &owner, session.id).await {
@@ -779,7 +775,7 @@ impl RemoteDriver<'_> {
                 let _ = mark_incarnation_terminal_events_journaled(db, &owner, row.id).await;
             }
         }
-        recovery::reap_session(db, bus, session).await
+        reap_session(db, bus, session).await
     }
 }
 
@@ -789,9 +785,9 @@ impl RemoteDriver<'_> {
 /// An intent that never activated is a crash between provision and store.
 /// The sandbox it may have spawned is unknown to this server, so it cannot
 /// be cancelled from here; the ceilings requested at spawn bound it.
-pub(crate) async fn sweep_stale_intents(
+pub async fn sweep_stale_intents(
     db: &Arc<DbStore>,
-    bus: &CodeEventBus,
+    bus: &dyn RemoteSessionHost,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<u64, tidebreak_core::AgentError> {
     let cutoff = now - STALE_INTENT_AGE;
@@ -805,7 +801,7 @@ pub(crate) async fn sweep_stale_intents(
         else {
             continue;
         };
-        recovery::fence_session(
+        fence_session(
             db,
             bus,
             &mut session,
@@ -835,7 +831,7 @@ fn repository_url(repo: &CodeRepo) -> Result<String, tidebreak_core::AgentError>
 /// Insert the running turn row and mark the session working.
 async fn start_turn_row(
     db: &Arc<DbStore>,
-    bus: &CodeEventBus,
+    bus: &dyn RemoteSessionHost,
     session: &mut CodeSession,
     ordinal: i64,
     text: &str,
@@ -894,7 +890,7 @@ async fn start_turn_row(
         None => insert_turn(db, &session.owner, &turn).await?,
     }
     session.lifecycle = CodeSessionLifecycle::Running;
-    super::super::attention::replace_attention(
+    replace_attention(
         session,
         Attention::working(AttentionSource::Lifecycle),
         false,
@@ -1414,7 +1410,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (db, bus, mut session, _workspace, _repo) = seed(dir.path()).await;
         super::super::fixtures::seeded_incarnation(&db, &session).await;
-        recovery::fence_session(
+        fence_session(
             &db,
             &bus,
             &mut session,

--- a/crates/tidebreak-code-remote/src/fixtures.rs
+++ b/crates/tidebreak-code-remote/src/fixtures.rs
@@ -1,0 +1,263 @@
+//! Shared test fixtures for the remote modules: a seeded store with a repo,
+//! workspace, session, and an activated incarnation.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tidebreak_core::db::code::{
+    activate_incarnation, append_event, clear_session_harness_resume_ref,
+    create_incarnation_intent, insert_repo, insert_session, insert_workspace, reap_fenced_session,
+    recover_interrupted_session, replace_session_attention, save_session, set_session_subagents,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, AttentionState, CapLevel, CodeEvent, CodeIncarnationId, CodeRepo,
+    CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentStatus,
+    CodeWorkspace, CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind, IncarnationAdmission,
+    OwnerId, PermissionMode, RepoId, WorkspaceId,
+};
+
+use super::{replace_attention, RemoteReapError, RemoteSessionHost};
+
+#[derive(Default)]
+pub(crate) struct TestEvents;
+
+#[async_trait::async_trait]
+impl RemoteSessionHost for TestEvents {
+    fn publish(&self, _session: CodeSessionId, _event: tidebreak_core::SequencedCodeEvent) {}
+
+    async fn persist_session(
+        &self,
+        store: &DbStore,
+        session: &CodeSession,
+    ) -> Result<bool, tidebreak_core::AgentError> {
+        let saved = save_session(store, session).await?;
+        if saved {
+            let _ = replace_session_attention(
+                store,
+                &session.owner,
+                session.id,
+                &session.attention,
+                false,
+            )
+            .await?;
+        }
+        Ok(saved)
+    }
+
+    async fn apply_attention(
+        &self,
+        store: &DbStore,
+        owner: &OwnerId,
+        session_id: CodeSessionId,
+        next: Attention,
+    ) -> Result<(), tidebreak_core::AgentError> {
+        let _ = replace_session_attention(store, owner, session_id, &next, false).await?;
+        Ok(())
+    }
+
+    async fn journal_event(
+        &self,
+        store: &DbStore,
+        owner: &OwnerId,
+        session_id: CodeSessionId,
+        spawn_epoch: i64,
+        event: CodeEvent,
+    ) {
+        let _ = append_event(store, owner, session_id, spawn_epoch, &event).await;
+    }
+
+    async fn fence_session(
+        &self,
+        store: &DbStore,
+        session: &mut CodeSession,
+        reason: FenceReason,
+    ) -> Result<(), tidebreak_core::AgentError> {
+        if matches!(reason, FenceReason::ResumeLost { .. }) {
+            session.harness_resume_ref = None;
+            if !clear_session_harness_resume_ref(
+                store,
+                &session.owner,
+                session.id,
+                session.spawn_epoch,
+            )
+            .await?
+            {
+                return Err(tidebreak_core::AgentError::Store(format!(
+                    "code session {} disappeared while clearing its rejected resume ref",
+                    session.id
+                )));
+            }
+        }
+        session.lifecycle = CodeSessionLifecycle::Fenced;
+        for subagent in &mut session.subagents {
+            if subagent.status == CodeSubagentStatus::Running {
+                subagent.status = CodeSubagentStatus::Failed;
+            }
+        }
+        session.fence_reason = Some(reason.clone());
+        replace_attention(
+            session,
+            Attention::new(
+                AttentionState::Fenced { reason },
+                AttentionSource::Lifecycle,
+            ),
+            false,
+        );
+        if !save_session(store, session).await? {
+            return Ok(());
+        }
+        let _ =
+            replace_session_attention(store, &session.owner, session.id, &session.attention, false)
+                .await?;
+        let _ =
+            set_session_subagents(store, &session.owner, session.id, &session.subagents).await?;
+        Ok(())
+    }
+
+    async fn recover_dead_worker(
+        &self,
+        store: &DbStore,
+        session: &CodeSession,
+    ) -> Result<Option<CodeSession>, tidebreak_core::AgentError> {
+        let durable_parks = if session.harness_kind.is_in_process() {
+            CapLevel::Supported
+        } else {
+            CapLevel::Unsupported
+        };
+        Ok(recover_interrupted_session(
+            store,
+            &session.owner,
+            session.id,
+            session.spawn_epoch,
+            durable_parks,
+        )
+        .await?
+        .map(|recovered| recovered.session))
+    }
+
+    async fn reap_session(
+        &self,
+        store: &DbStore,
+        session: CodeSession,
+    ) -> Result<CodeSession, RemoteReapError> {
+        let Some(recovered) = reap_fenced_session(
+            store,
+            &session.owner,
+            session.id,
+            session.spawn_epoch,
+            session.child_pid,
+            session.child_process_identity.as_deref(),
+        )
+        .await?
+        else {
+            return Err(RemoteReapError::Host(
+                "the fenced session changed while it was being reaped".to_owned(),
+            ));
+        };
+        Ok(recovered.session)
+    }
+}
+
+/// A session value with sensible remote defaults, unsaved.
+pub(crate) fn session_value() -> CodeSession {
+    CodeSession {
+        id: CodeSessionId::new(),
+        owner: OwnerId::local(),
+        workspace_id: Some(WorkspaceId::new()),
+        kind: CodeSessionKind::Interactive,
+        harness_kind: HarnessKind::ClaudeCode,
+        harness_version: None,
+        harness_resume_ref: None,
+        permission_mode: PermissionMode::Allow,
+        model: None,
+        reasoning_effort: None,
+        fast_mode: false,
+        lifecycle: CodeSessionLifecycle::Running,
+        fence_reason: None,
+        child_pid: None,
+        child_process_identity: None,
+        spawn_epoch: 1,
+        attention: Attention::working(AttentionSource::Lifecycle),
+        unrecognized_event_count: 0,
+        subagents: Vec::new(),
+        created_at: chrono::Utc::now(),
+    }
+}
+
+/// A store with one repo (origin recorded), one remote workspace (no host
+/// path), and one session, all inserted.
+pub(crate) async fn seed(
+    root: &Path,
+) -> (
+    Arc<DbStore>,
+    TestEvents,
+    CodeSession,
+    CodeWorkspace,
+    CodeRepo,
+) {
+    let db = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            root.join("code.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let owner = OwnerId::local();
+    let repo = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: root.join("repo").display().to_string(),
+        display_name: "example".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "tidebreak/".into(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: chrono::Utc::now(),
+        removed_at: None,
+        cloned_from: None,
+        origin_host: Some("github.com".into()),
+        origin_owner: Some("acme".into()),
+        origin_name: Some("tools".into()),
+    };
+    insert_repo(&db, &repo).await.unwrap();
+    let workspace = CodeWorkspace {
+        id: WorkspaceId::new(),
+        owner: owner.clone(),
+        repo_id: repo.id,
+        title: "remote".into(),
+        worktree_path: String::new(),
+        branch_name: "tidebreak/remote".into(),
+        base_ref: "main".into(),
+        status: CodeWorkspaceStatus::Active,
+        pr: None,
+        created_at: chrono::Utc::now(),
+        archived_at: None,
+        released_at: None,
+        released_tip: None,
+        bundle_bytes: None,
+    };
+    insert_workspace(&db, &workspace).await.unwrap();
+    let mut session = session_value();
+    session.workspace_id = Some(workspace.id);
+    insert_session(&db, &session).await.unwrap();
+    (db, TestEvents, session, workspace, repo)
+}
+
+/// Reserve and activate one incarnation for the session.
+pub(crate) async fn seeded_incarnation(
+    db: &Arc<DbStore>,
+    session: &CodeSession,
+) -> CodeIncarnationId {
+    let admission = create_incarnation_intent(db, &session.owner, session.id, 1, 4)
+        .await
+        .unwrap();
+    let IncarnationAdmission::Admitted(row) = admission else {
+        panic!("expected admission");
+    };
+    activate_incarnation(db, &session.owner, row.id, "sb-1")
+        .await
+        .unwrap();
+    row.id
+}

--- a/crates/tidebreak-code-remote/src/gateway.rs
+++ b/crates/tidebreak-code-remote/src/gateway.rs
@@ -27,7 +27,7 @@ const CALL_TIMEOUT: Duration = Duration::from_secs(30);
 const EVENTS_TIMEOUT_SLACK: Duration = Duration::from_secs(15);
 
 /// The provisioning client for a gateway-confined sandbox.
-pub(crate) struct GatewayProvisioner {
+pub struct GatewayProvisioner {
     base_url: reqwest::Url,
     endpoint_slug: String,
     tokens: Arc<dyn RuntimeTokenSource>,
@@ -36,7 +36,7 @@ pub(crate) struct GatewayProvisioner {
 
 impl GatewayProvisioner {
     /// Builds a client against one gateway deployment and runtime endpoint.
-    pub(crate) fn new(
+    pub fn new(
         base_url: &str,
         endpoint_slug: &str,
         tokens: Arc<dyn RuntimeTokenSource>,

--- a/crates/tidebreak-code-remote/src/ingest.rs
+++ b/crates/tidebreak-code-remote/src/ingest.rs
@@ -29,8 +29,8 @@ use tidebreak_core::{
     OwnerId, SequencedCodeEvent, MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS,
 };
 
-use super::super::bus::CodeEventBus;
 use super::wire::{SandboxEvent, SandboxEvents, SandboxState};
+use super::{apply_attention, RemoteSessionHost};
 
 /// The session-side identity one cursor read is ingested under.
 #[derive(Clone, Debug)]
@@ -240,7 +240,7 @@ fn project_event(binding: &IngestBinding, kind: &str, payload: &Value) -> Projec
 /// projection.
 pub(crate) async fn ingest_events(
     db: &Arc<DbStore>,
-    bus: &CodeEventBus,
+    bus: &dyn RemoteSessionHost,
     binding: &IngestBinding,
     read: &SandboxEvents,
 ) -> Result<IngestOutcome, tidebreak_core::AgentError> {
@@ -295,7 +295,7 @@ fn terminal_state_words(state: SandboxState) -> &'static str {
 /// Returns whether the event was ingested now (false when the cursor had it).
 async fn apply_one(
     db: &Arc<DbStore>,
-    bus: &CodeEventBus,
+    bus: &dyn RemoteSessionHost,
     binding: &IngestBinding,
     event: &SandboxEvent,
     outcome: &mut IngestOutcome,
@@ -340,15 +340,7 @@ async fn apply_one(
     // them leaves attention stale, and the replay is what corrects it.
     // Re-applying an attention the session already holds is a no-op.
     if let Some(next) = projection.attention {
-        let _ = super::super::attention::apply_attention(
-            db,
-            bus,
-            &binding.owner,
-            binding.session_id,
-            next,
-            false,
-        )
-        .await?;
+        apply_attention(db, bus, &binding.owner, binding.session_id, next).await?;
     }
     Ok(ingested.is_some())
 }

--- a/crates/tidebreak-code-remote/src/lib.rs
+++ b/crates/tidebreak-code-remote/src/lib.rs
@@ -1,0 +1,312 @@
+//! Remote session execution: the client side of the confining environment's
+//! sandbox runtime API.
+//!
+//! Decision [`0079`] split remote execution in two: the workload half is
+//! `tidebreak-supervised-agent`, polling outward to a control endpoint the
+//! environment owns; this module is the other half — the Tidebreak machine
+//! asking that environment to provision, watch, steer, and stop the sandbox
+//! a remote session's engine runs in. Tidebreak never dials into the pod.
+//!
+//! The pinned contract (`/api/v1/runtime/...` on the gateway):
+//!
+//! - `POST /api/v1/runtime/endpoints/{endpoint_slug}/sandboxes` — spawn.
+//!   Preflight refuses loudly (unknown profile, unreachable repository, a
+//!   ref the remote does not advertise, an unresolvable credential) before
+//!   anything is provisioned.
+//! - `GET /api/v1/runtime/sandboxes/{id}` — status. Cheap to poll.
+//! - `GET /api/v1/runtime/sandboxes/{id}/events` — the durable, sequenced,
+//!   gap-free event stream; `after_seq` resumes without loss, `wait_seconds`
+//!   (at most 25) holds until an event lands.
+//! - `POST /api/v1/runtime/sandboxes/{id}/messages` — append to the inbox
+//!   the agent drains. At-least-once and asynchronous: a receipt means
+//!   durable, not read.
+//! - `POST /api/v1/runtime/sandboxes/{id}/cancel` — stop, with a short
+//!   grace so the terminal WIP checkpoint can land.
+//!
+//! Every call authenticates with a short-lived `mg_at_` bearer minted for
+//! the resource `runtime:{endpoint_slug}` carrying the `runtime:execute`
+//! scope. Minting is behind [`RuntimeTokenSource`] because whose credential
+//! backs it is an owner-scoped policy question (the caller's machine-bound
+//! session, decisions 0049/0051), not a transport one.
+//!
+//! [`0079`]: ../../../docs/decisions/0079-supervised-agent-declines-the-sandbox-protocol.md
+
+pub mod driver;
+#[cfg(test)]
+mod fixtures;
+pub mod gateway;
+mod ingest;
+pub mod wire;
+
+use async_trait::async_trait;
+use tidebreak_core::{
+    Attention, CodeEvent, CodeSession, CodeSessionId, DbStore, FenceReason, OwnerId,
+    SequencedCodeEvent,
+};
+
+use wire::{
+    EventCursor, MessageReceipt, SandboxEvents, SandboxLease, SandboxMessage, SandboxStatus,
+    SpawnArguments,
+};
+
+/// Why one runtime call did not produce its result.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoteSandboxError {
+    /// The environment named a refusal; retrying the same request cannot
+    /// fix it. Carries the environment's own code and description so the
+    /// session surfaces the real reason, not a paraphrase.
+    #[error("the sandbox environment refused {operation} ({code}): {message}")]
+    Refused {
+        /// Which call was refused.
+        operation: &'static str,
+        /// Machine-readable refusal code.
+        code: String,
+        /// The environment's own description.
+        message: String,
+    },
+    /// The runtime token was rejected or cannot be minted; the owner signs
+    /// in again. Never retried onto another credential.
+    #[error("the sandbox environment rejected the runtime credential: {0}")]
+    SignInRequired(String),
+    /// A transport or server fault; retryable on the caller's cadence.
+    #[error("{operation} did not reach the sandbox environment: {detail}")]
+    Unavailable {
+        /// Which call failed.
+        operation: &'static str,
+        /// What went wrong.
+        detail: String,
+    },
+    /// This side refused the request before sending it.
+    #[error("invalid sandbox request: {0}")]
+    InvalidRequest(String),
+}
+
+impl RemoteSandboxError {
+    /// Whether retrying the same call later can succeed.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Self::Unavailable { .. })
+    }
+}
+
+/// A short-lived bearer for the runtime surface.
+///
+/// The secret is the whole value: no `Clone`, and `Debug` redacts it.
+pub struct RuntimeToken {
+    /// The `mg_at_` access token presented as the bearer.
+    pub secret: String,
+}
+
+impl std::fmt::Debug for RuntimeToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RuntimeToken")
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Mints the runtime bearer one owner's calls present.
+///
+/// Owner-scoped so spend, repository access, and policy follow the person
+/// (decision 0065's stance, applied to sandboxes): a session's sandbox is
+/// provisioned as its owner, never as a shared machine identity.
+#[async_trait]
+pub trait RuntimeTokenSource: Send + Sync {
+    /// A live token for `owner`, minted or refreshed as needed.
+    ///
+    /// # Errors
+    ///
+    /// [`RemoteSandboxError::SignInRequired`] when no credential for this
+    /// owner can mint one.
+    async fn runtime_token(&self, owner: &OwnerId) -> Result<RuntimeToken, RemoteSandboxError>;
+}
+
+/// The provisioning client a remote session drives its sandbox through.
+///
+/// One method per pinned route. Implementations are transport only: no
+/// lifecycle decisions, no retries past what a single call needs, no
+/// interpretation of event payloads — the session runtime owns all of that.
+#[async_trait]
+pub trait SandboxProvisioner: Send + Sync {
+    /// Asks the environment to provision one sandbox.
+    ///
+    /// Preflight refusals surface as [`RemoteSandboxError::Refused`] with
+    /// the environment's code; nothing was provisioned in that case.
+    async fn spawn(
+        &self,
+        owner: &OwnerId,
+        arguments: &SpawnArguments,
+    ) -> Result<SandboxLease, RemoteSandboxError>;
+
+    /// One sandbox's current lifecycle state.
+    async fn status(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+    ) -> Result<SandboxStatus, RemoteSandboxError>;
+
+    /// Reads the durable event stream after a cursor, oldest first.
+    ///
+    /// Holding `wait_seconds` under [`wire::EVENTS_MAX_WAIT_SECONDS`] keeps
+    /// the environment's clamp out of the picture.
+    async fn events(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+        cursor: EventCursor,
+    ) -> Result<SandboxEvents, RemoteSandboxError>;
+
+    /// Appends one message to the sandbox's inbox.
+    async fn send(
+        &self,
+        owner: &OwnerId,
+        sandbox_id: &str,
+        message: &SandboxMessage,
+    ) -> Result<MessageReceipt, RemoteSandboxError>;
+
+    /// Asks the environment to stop the sandbox. Idempotent server-side; a
+    /// running sandbox keeps a short grace so its terminal checkpoint lands.
+    async fn cancel(&self, owner: &OwnerId, sandbox_id: &str) -> Result<(), RemoteSandboxError>;
+}
+
+/// Supplies the session operations that stay owned by the embedding server.
+///
+/// The remote driver owns sandbox lifecycle decisions. The server still owns
+/// the shared session journal, attention, recovery, and live event bus, so the
+/// driver reaches those operations through this boundary without depending
+/// on the server crate.
+#[async_trait]
+pub trait RemoteSessionHost: Send + Sync {
+    /// Publish one event after its journal row commits.
+    fn publish(&self, session: CodeSessionId, event: SequencedCodeEvent);
+
+    /// Persist the session and publish its derived state.
+    async fn persist_session(
+        &self,
+        store: &DbStore,
+        session: &CodeSession,
+    ) -> Result<bool, tidebreak_core::AgentError>;
+
+    /// Apply one attention transition and publish its derived state.
+    async fn apply_attention(
+        &self,
+        store: &DbStore,
+        owner: &OwnerId,
+        session_id: CodeSessionId,
+        next: Attention,
+    ) -> Result<(), tidebreak_core::AgentError>;
+
+    /// Append a session event. Failures are best effort for this call site.
+    async fn journal_event(
+        &self,
+        store: &DbStore,
+        owner: &OwnerId,
+        session_id: CodeSessionId,
+        spawn_epoch: i64,
+        event: CodeEvent,
+    );
+
+    /// Fence one live session and publish the resulting state.
+    async fn fence_session(
+        &self,
+        store: &DbStore,
+        session: &mut CodeSession,
+        reason: FenceReason,
+    ) -> Result<(), tidebreak_core::AgentError>;
+
+    /// Settle a turn left open by a stopped sandbox.
+    async fn recover_dead_worker(
+        &self,
+        store: &DbStore,
+        session: &CodeSession,
+    ) -> Result<Option<CodeSession>, tidebreak_core::AgentError>;
+
+    /// Resolve a fenced remote session after its sandbox stops.
+    async fn reap_session(
+        &self,
+        store: &DbStore,
+        session: CodeSession,
+    ) -> Result<CodeSession, RemoteReapError>;
+}
+
+/// Why a fenced remote session could not be reaped.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoteReapError {
+    /// A store operation failed.
+    #[error(transparent)]
+    Store(#[from] tidebreak_core::AgentError),
+    /// The host refused to resolve the fence.
+    #[error("{0}")]
+    Host(String),
+}
+
+pub(crate) fn replace_attention(
+    session: &mut CodeSession,
+    next: Attention,
+    from_user: bool,
+) -> bool {
+    if !from_user && !tidebreak_core::should_replace(&session.attention, &next) {
+        return false;
+    }
+    if session.attention == next {
+        return false;
+    }
+    session.attention = next;
+    true
+}
+
+pub(crate) async fn persist_session(
+    store: &DbStore,
+    host: &dyn RemoteSessionHost,
+    session: &CodeSession,
+) -> Result<bool, tidebreak_core::AgentError> {
+    host.persist_session(store, session).await
+}
+
+pub(crate) async fn apply_attention(
+    store: &DbStore,
+    host: &dyn RemoteSessionHost,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    next: Attention,
+) -> Result<(), tidebreak_core::AgentError> {
+    host.apply_attention(store, owner, session_id, next).await
+}
+
+pub(crate) async fn journal_event(
+    store: &DbStore,
+    host: &dyn RemoteSessionHost,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+    event: CodeEvent,
+) {
+    host.journal_event(store, owner, session_id, spawn_epoch, event)
+        .await;
+}
+
+pub(crate) async fn fence_session(
+    store: &DbStore,
+    host: &dyn RemoteSessionHost,
+    session: &mut CodeSession,
+    reason: FenceReason,
+) -> Result<(), tidebreak_core::AgentError> {
+    host.fence_session(store, session, reason).await
+}
+
+pub(crate) async fn recover_dead_worker(
+    store: &DbStore,
+    host: &dyn RemoteSessionHost,
+    session: &CodeSession,
+) -> Result<Option<CodeSession>, tidebreak_core::AgentError> {
+    host.recover_dead_worker(store, session).await
+}
+
+pub(crate) async fn reap_session(
+    store: &DbStore,
+    host: &dyn RemoteSessionHost,
+    session: CodeSession,
+) -> Result<CodeSession, RemoteReapError> {
+    host.reap_session(store, session).await
+}

--- a/crates/tidebreak-code-remote/src/wire.rs
+++ b/crates/tidebreak-code-remote/src/wire.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 /// Longest `events` wait the environment honors, in seconds. A larger
 /// request is clamped server-side; staying at or under it keeps the clamp
 /// out of the picture.
-pub(crate) const EVENTS_MAX_WAIT_SECONDS: u32 = 25;
+pub const EVENTS_MAX_WAIT_SECONDS: u32 = 25;
 
 /// Largest message body the environment accepts, in bytes.
 const MESSAGE_MAX_BODY_BYTES: usize = 32 * 1024;
@@ -29,7 +29,7 @@ const MESSAGE_MAX_BODY_BYTES: usize = 32 * 1024;
 /// environment intersects rather than trusting these values. `max_turns` is
 /// a spawn-only opt-in — omission means no supervisor turn cap.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
-pub(crate) struct SpawnArguments {
+pub struct SpawnArguments {
     /// Administrator-defined profile name on the runtime endpoint.
     pub profile: String,
     /// Harness token the sandbox drives headless (`claude_code`, `codex`,
@@ -79,7 +79,7 @@ pub(crate) struct SpawnArguments {
 
 /// One git repository a spawn declares.
 #[derive(Clone, Debug, PartialEq, Serialize)]
-pub(crate) struct SpawnRepository {
+pub struct SpawnRepository {
     /// HTTPS URL of the repository.
     pub url: String,
     /// Branch or commit to start from. Absent means the remote's default.
@@ -91,7 +91,7 @@ pub(crate) struct SpawnRepository {
 /// the identifier and the cursor position to resume from.
 #[derive(Clone, Debug, Deserialize)]
 #[allow(dead_code)]
-pub(crate) struct SandboxLease {
+pub struct SandboxLease {
     /// Sandbox identifier every other call takes. Opaque here.
     pub sandbox_id: String,
     /// Lifecycle state at the moment the row committed.
@@ -112,7 +112,7 @@ pub(crate) struct SandboxLease {
 /// it cannot read.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum SandboxState {
+pub enum SandboxState {
     /// Recorded and preflighted; no backend object exists yet.
     Pending,
     /// A backend object has been requested and is not yet ready.
@@ -139,7 +139,7 @@ pub(crate) enum SandboxState {
 impl SandboxState {
     /// Whether the environment will run this sandbox no further.
     #[must_use]
-    pub(crate) fn is_terminal(self) -> bool {
+    pub fn is_terminal(self) -> bool {
         matches!(
             self,
             Self::Completed
@@ -154,7 +154,7 @@ impl SandboxState {
 /// Current state of one sandbox, reduced to the fields this server acts on.
 #[derive(Clone, Debug, Deserialize)]
 #[allow(dead_code)]
-pub(crate) struct SandboxStatus {
+pub struct SandboxStatus {
     /// Sandbox identifier.
     pub sandbox_id: String,
     /// Current lifecycle state.
@@ -190,7 +190,7 @@ pub(crate) struct SandboxStatus {
 
 /// Cursor into one sandbox's durable, gap-free event stream.
 #[derive(Clone, Copy, Debug, Default, Serialize)]
-pub(crate) struct EventCursor {
+pub struct EventCursor {
     /// Highest sequence already seen; omit to read from the beginning.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after_seq: Option<i64>,
@@ -205,7 +205,7 @@ pub(crate) struct EventCursor {
 
 /// A page of one sandbox's durable event stream.
 #[derive(Clone, Debug, Deserialize)]
-pub(crate) struct SandboxEvents {
+pub struct SandboxEvents {
     /// Sandbox identifier.
     #[allow(dead_code)]
     pub sandbox_id: String,
@@ -221,7 +221,7 @@ pub(crate) struct SandboxEvents {
 
 /// One durable sandbox progress event.
 #[derive(Clone, Debug, Deserialize)]
-pub(crate) struct SandboxEvent {
+pub struct SandboxEvent {
     /// Per-sandbox monotonic, gap-free sequence number.
     pub seq: i64,
     /// Event kind slug.
@@ -237,7 +237,7 @@ pub(crate) struct SandboxEvent {
 
 /// One message on its way into a running sandbox's inbox.
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct SandboxMessage {
+pub struct SandboxMessage {
     /// Ordinary input for the sandbox's next turn. The environment attaches
     /// no meaning to it.
     pub body: String,
@@ -248,7 +248,7 @@ pub(crate) struct SandboxMessage {
 
 impl SandboxMessage {
     /// Refuses a body the environment would refuse, before the request.
-    pub(crate) fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self) -> Result<(), String> {
         if self.body.trim().is_empty() {
             return Err("sandbox message body is empty".to_owned());
         }
@@ -266,7 +266,7 @@ impl SandboxMessage {
 /// delivery is at-least-once and asynchronous.
 #[derive(Clone, Copy, Debug, Deserialize)]
 #[allow(dead_code)]
-pub(crate) struct MessageReceipt {
+pub struct MessageReceipt {
     /// Per-sandbox monotonic sequence this message was recorded at.
     pub seq: i64,
     /// Whether it will preempt the turn in flight.
@@ -279,7 +279,7 @@ pub(crate) struct MessageReceipt {
 
 /// The environment's error body: `{"error", "error_description"}`.
 #[derive(Clone, Debug, Default, Deserialize)]
-pub(crate) struct RuntimeErrorBody {
+pub struct RuntimeErrorBody {
     /// Machine-readable refusal code.
     #[serde(default)]
     pub error: String,

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -23,6 +23,7 @@ postgres = ["tidebreak-core/postgres", "sea-orm/sqlx-postgres", "tidebreak-core/
 [dependencies]
 tidebreak-shell-policy = { path = "../tidebreak-shell-policy" }
 tidebreak-code-execution = { path = "../tidebreak-code-execution" }
+tidebreak-code-remote = { path = "../tidebreak-code-remote" }
 tidebreak-harness = { path = "../tidebreak-harness" }
 tidebreak-managed-node = { path = "../tidebreak-managed-node" }
 # Default features on purpose: the server wants exactly core's default set

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -382,12 +382,8 @@ async fn expire_internal_turn_lease(
     Ok(())
 }
 
-/// Settle a session whose worker died with a turn still open: interrupt the
-/// turn, journal it, set needs-you, and go Idle, all in one fenced
-/// transaction — unless the engine declares durable parks and the open turn
-/// is waiting on a park, in which case the turn stays waiting so a restarted
-/// worker can resume it. Remote sessions reuse this when the sandbox ends
-/// beneath an unsettled turn.
+/// Settle a session whose worker died with a turn still open. Remote sessions
+/// use this when a sandbox ends beneath an unsettled turn.
 pub(crate) async fn recover_dead_worker(
     store: &DbStore,
     bus: &CodeEventBus,

--- a/crates/tidebreak-server/src/code/remote/fixtures.rs
+++ b/crates/tidebreak-server/src/code/remote/fixtures.rs
@@ -1,19 +1,10 @@
 //! Shared test fixtures for the remote modules: a seeded store with a repo,
 //! workspace, session, and an activated incarnation.
 
-use std::path::Path;
-use std::sync::Arc;
-
-use tidebreak_core::db::code::{
-    activate_incarnation, create_incarnation_intent, insert_repo, insert_session, insert_workspace,
-};
 use tidebreak_core::{
-    Attention, AttentionSource, CodeIncarnationId, CodeRepo, CodeSession, CodeSessionId,
-    CodeSessionKind, CodeSessionLifecycle, CodeWorkspace, CodeWorkspaceStatus, DbStore,
-    HarnessKind, IncarnationAdmission, OwnerId, PermissionMode, RepoId, WorkspaceId,
+    Attention, AttentionSource, CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle,
+    HarnessKind, OwnerId, PermissionMode, WorkspaceId,
 };
-
-use super::super::bus::CodeEventBus;
 
 /// A session value with sensible remote defaults, unsaved.
 pub(crate) fn session_value() -> CodeSession {
@@ -39,82 +30,4 @@ pub(crate) fn session_value() -> CodeSession {
         subagents: Vec::new(),
         created_at: chrono::Utc::now(),
     }
-}
-
-/// A store with one repo (origin recorded), one remote workspace (no host
-/// path), and one session, all inserted.
-pub(crate) async fn seed(
-    root: &Path,
-) -> (
-    Arc<DbStore>,
-    CodeEventBus,
-    CodeSession,
-    CodeWorkspace,
-    CodeRepo,
-) {
-    let db = Arc::new(
-        DbStore::connect(&format!(
-            "sqlite://{}?mode=rwc",
-            root.join("code.db").display()
-        ))
-        .await
-        .unwrap(),
-    );
-    let owner = OwnerId::local();
-    let repo = CodeRepo {
-        id: RepoId::new(),
-        owner: owner.clone(),
-        root_path: root.join("repo").display().to_string(),
-        display_name: "example".into(),
-        default_base_ref: "main".into(),
-        branch_prefix: "tidebreak/".into(),
-        setup_script: None,
-        archive_script: None,
-        quick_actions: Vec::new(),
-        created_at: chrono::Utc::now(),
-        removed_at: None,
-        cloned_from: None,
-        origin_host: Some("github.com".into()),
-        origin_owner: Some("acme".into()),
-        origin_name: Some("tools".into()),
-    };
-    insert_repo(&db, &repo).await.unwrap();
-    let workspace = CodeWorkspace {
-        id: WorkspaceId::new(),
-        owner: owner.clone(),
-        repo_id: repo.id,
-        title: "remote".into(),
-        worktree_path: String::new(),
-        branch_name: "tidebreak/remote".into(),
-        base_ref: "main".into(),
-        status: CodeWorkspaceStatus::Active,
-        pr: None,
-        created_at: chrono::Utc::now(),
-        archived_at: None,
-        released_at: None,
-        released_tip: None,
-        bundle_bytes: None,
-    };
-    insert_workspace(&db, &workspace).await.unwrap();
-    let mut session = session_value();
-    session.workspace_id = Some(workspace.id);
-    insert_session(&db, &session).await.unwrap();
-    (db, CodeEventBus::default(), session, workspace, repo)
-}
-
-/// Reserve and activate one incarnation for the session.
-pub(crate) async fn seeded_incarnation(
-    db: &Arc<DbStore>,
-    session: &CodeSession,
-) -> CodeIncarnationId {
-    let admission = create_incarnation_intent(db, &session.owner, session.id, 1, 4)
-        .await
-        .unwrap();
-    let IncarnationAdmission::Admitted(row) = admission else {
-        panic!("expected admission");
-    };
-    activate_incarnation(db, &session.owner, row.id, "sb-1")
-        .await
-        .unwrap();
-    row.id
 }

--- a/crates/tidebreak-server/src/code/remote/mod.rs
+++ b/crates/tidebreak-server/src/code/remote/mod.rs
@@ -1,169 +1,92 @@
-//! Remote session execution: the client side of the confining environment's
-//! sandbox runtime API.
-//!
-//! Decision [`0079`] split remote execution in two: the workload half is
-//! `tidebreak-supervised-agent`, polling outward to a control endpoint the
-//! environment owns; this module is the other half — the Tidebreak machine
-//! asking that environment to provision, watch, steer, and stop the sandbox
-//! a remote session's engine runs in. Tidebreak never dials into the pod.
-//!
-//! The pinned contract (`/api/v1/runtime/...` on the gateway):
-//!
-//! - `POST /api/v1/runtime/endpoints/{endpoint_slug}/sandboxes` — spawn.
-//!   Preflight refuses loudly (unknown profile, unreachable repository, a
-//!   ref the remote does not advertise, an unresolvable credential) before
-//!   anything is provisioned.
-//! - `GET /api/v1/runtime/sandboxes/{id}` — status. Cheap to poll.
-//! - `GET /api/v1/runtime/sandboxes/{id}/events` — the durable, sequenced,
-//!   gap-free event stream; `after_seq` resumes without loss, `wait_seconds`
-//!   (at most 25) holds until an event lands.
-//! - `POST /api/v1/runtime/sandboxes/{id}/messages` — append to the inbox
-//!   the agent drains. At-least-once and asynchronous: a receipt means
-//!   durable, not read.
-//! - `POST /api/v1/runtime/sandboxes/{id}/cancel` — stop, with a short
-//!   grace so the terminal WIP checkpoint can land.
-//!
-//! Every call authenticates with a short-lived `mg_at_` bearer minted for
-//! the resource `runtime:{endpoint_slug}` carrying the `runtime:execute`
-//! scope. Minting is behind [`RuntimeTokenSource`] because whose credential
-//! backs it is an owner-scoped policy question (the caller's machine-bound
-//! session, decisions 0049/0051), not a transport one.
-//!
-//! [`0079`]: ../../../../../docs/decisions/0079-supervised-agent-declines-the-sandbox-protocol.md
+//! Server wiring for the remote code-session crate.
 
-pub(crate) mod driver;
 #[cfg(test)]
 pub(crate) mod fixtures;
-pub(crate) mod gateway;
-pub(crate) mod ingest;
 pub(crate) mod service;
-pub(crate) mod wire;
 
-use async_trait::async_trait;
-use tidebreak_core::OwnerId;
-
-use wire::{
-    EventCursor, MessageReceipt, SandboxEvents, SandboxLease, SandboxMessage, SandboxStatus,
-    SpawnArguments,
+pub(crate) use tidebreak_code_remote::{driver, gateway, wire};
+pub(crate) use tidebreak_code_remote::{
+    RemoteReapError, RemoteSandboxError, RuntimeToken, RuntimeTokenSource, SandboxProvisioner,
 };
 
-/// Why one runtime call did not produce its result.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum RemoteSandboxError {
-    /// The environment named a refusal; retrying the same request cannot
-    /// fix it. Carries the environment's own code and description so the
-    /// session surfaces the real reason, not a paraphrase.
-    #[error("the sandbox environment refused {operation} ({code}): {message}")]
-    Refused {
-        /// Which call was refused.
-        operation: &'static str,
-        /// Machine-readable refusal code.
-        code: String,
-        /// The environment's own description.
-        message: String,
-    },
-    /// The runtime token was rejected or cannot be minted; the owner signs
-    /// in again. Never retried onto another credential.
-    #[error("the sandbox environment rejected the runtime credential: {0}")]
-    SignInRequired(String),
-    /// A transport or server fault; retryable on the caller's cadence.
-    #[error("{operation} did not reach the sandbox environment: {detail}")]
-    Unavailable {
-        /// Which call failed.
-        operation: &'static str,
-        /// What went wrong.
-        detail: String,
-    },
-    /// This side refused the request before sending it.
-    #[error("invalid sandbox request: {0}")]
-    InvalidRequest(String),
-}
-
-impl RemoteSandboxError {
-    /// Whether retrying the same call later can succeed.
-    #[must_use]
-    pub(crate) fn is_retryable(&self) -> bool {
-        matches!(self, Self::Unavailable { .. })
+#[async_trait::async_trait]
+impl tidebreak_code_remote::RemoteSessionHost for super::bus::CodeEventBus {
+    fn publish(
+        &self,
+        session: tidebreak_core::CodeSessionId,
+        event: tidebreak_core::SequencedCodeEvent,
+    ) {
+        super::bus::CodeEventBus::publish(self, session, event);
     }
-}
 
-/// A short-lived bearer for the runtime surface.
-///
-/// The secret is the whole value: no `Clone`, and `Debug` redacts it.
-pub(crate) struct RuntimeToken {
-    /// The `mg_at_` access token presented as the bearer.
-    pub secret: String,
-}
-
-impl std::fmt::Debug for RuntimeToken {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("RuntimeToken")
-            .field("secret", &"<redacted>")
-            .finish()
+    async fn persist_session(
+        &self,
+        store: &tidebreak_core::DbStore,
+        session: &tidebreak_core::CodeSession,
+    ) -> Result<bool, tidebreak_core::AgentError> {
+        super::attention::persist_session(store, self, session).await
     }
-}
 
-/// Mints the runtime bearer one owner's calls present.
-///
-/// Owner-scoped so spend, repository access, and policy follow the person
-/// (decision 0065's stance, applied to sandboxes): a session's sandbox is
-/// provisioned as its owner, never as a shared machine identity.
-#[async_trait]
-pub(crate) trait RuntimeTokenSource: Send + Sync {
-    /// A live token for `owner`, minted or refreshed as needed.
-    ///
-    /// # Errors
-    ///
-    /// [`RemoteSandboxError::SignInRequired`] when no credential for this
-    /// owner can mint one.
-    async fn runtime_token(&self, owner: &OwnerId) -> Result<RuntimeToken, RemoteSandboxError>;
-}
-
-/// The provisioning client a remote session drives its sandbox through.
-///
-/// One method per pinned route. Implementations are transport only: no
-/// lifecycle decisions, no retries past what a single call needs, no
-/// interpretation of event payloads — the session runtime owns all of that.
-#[async_trait]
-pub(crate) trait SandboxProvisioner: Send + Sync {
-    /// Asks the environment to provision one sandbox.
-    ///
-    /// Preflight refusals surface as [`RemoteSandboxError::Refused`] with
-    /// the environment's code; nothing was provisioned in that case.
-    async fn spawn(
+    async fn apply_attention(
         &self,
-        owner: &OwnerId,
-        arguments: &SpawnArguments,
-    ) -> Result<SandboxLease, RemoteSandboxError>;
+        store: &tidebreak_core::DbStore,
+        owner: &tidebreak_core::OwnerId,
+        session_id: tidebreak_core::CodeSessionId,
+        next: tidebreak_core::Attention,
+    ) -> Result<(), tidebreak_core::AgentError> {
+        let _ =
+            super::attention::apply_attention(store, self, owner, session_id, next, false).await?;
+        Ok(())
+    }
 
-    /// One sandbox's current lifecycle state.
-    async fn status(
+    async fn journal_event(
         &self,
-        owner: &OwnerId,
-        sandbox_id: &str,
-    ) -> Result<SandboxStatus, RemoteSandboxError>;
+        store: &tidebreak_core::DbStore,
+        owner: &tidebreak_core::OwnerId,
+        session_id: tidebreak_core::CodeSessionId,
+        spawn_epoch: i64,
+        event: tidebreak_core::CodeEvent,
+    ) {
+        let _ = super::session_worker::journal_event(
+            store,
+            self,
+            owner,
+            session_id,
+            spawn_epoch,
+            event,
+        )
+        .await;
+    }
 
-    /// Reads the durable event stream after a cursor, oldest first.
-    ///
-    /// Holding `wait_seconds` under [`wire::EVENTS_MAX_WAIT_SECONDS`] keeps
-    /// the environment's clamp out of the picture.
-    async fn events(
+    async fn fence_session(
         &self,
-        owner: &OwnerId,
-        sandbox_id: &str,
-        cursor: EventCursor,
-    ) -> Result<SandboxEvents, RemoteSandboxError>;
+        store: &tidebreak_core::DbStore,
+        session: &mut tidebreak_core::CodeSession,
+        reason: tidebreak_core::FenceReason,
+    ) -> Result<(), tidebreak_core::AgentError> {
+        super::recovery::fence_session(store, self, session, reason).await
+    }
 
-    /// Appends one message to the sandbox's inbox.
-    async fn send(
+    async fn recover_dead_worker(
         &self,
-        owner: &OwnerId,
-        sandbox_id: &str,
-        message: &SandboxMessage,
-    ) -> Result<MessageReceipt, RemoteSandboxError>;
+        store: &tidebreak_core::DbStore,
+        session: &tidebreak_core::CodeSession,
+    ) -> Result<Option<tidebreak_core::CodeSession>, tidebreak_core::AgentError> {
+        super::recovery::recover_dead_worker(store, self, session).await
+    }
 
-    /// Asks the environment to stop the sandbox. Idempotent server-side; a
-    /// running sandbox keeps a short grace so its terminal checkpoint lands.
-    async fn cancel(&self, owner: &OwnerId, sandbox_id: &str) -> Result<(), RemoteSandboxError>;
+    async fn reap_session(
+        &self,
+        store: &tidebreak_core::DbStore,
+        session: tidebreak_core::CodeSession,
+    ) -> Result<tidebreak_core::CodeSession, tidebreak_code_remote::RemoteReapError> {
+        super::recovery::reap_session(store, self, session)
+            .await
+            .map_err(|error| match error {
+                super::recovery::ReapSessionError::Store(error) => {
+                    tidebreak_code_remote::RemoteReapError::Store(error)
+                }
+                other => tidebreak_code_remote::RemoteReapError::Host(other.to_string()),
+            })
+    }
 }

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -729,7 +729,7 @@ impl CodeRuntime {
             };
             let driver = remote.driver(&self.db, self.bus.as_ref());
             return driver.reap(session).await.map_err(|error| match error {
-                recovery::ReapSessionError::Store(error) => ServerError::from(error),
+                crate::code::remote::RemoteReapError::Store(error) => ServerError::from(error),
                 other => ServerError::conflict_kind("session_not_reaped", other.to_string()),
             });
         }

--- a/crates/tidebreak-server/src/logging.rs
+++ b/crates/tidebreak-server/src/logging.rs
@@ -57,7 +57,7 @@ const DIAGNOSTIC_LOG_ENV_VAR: &str = "TIDEBREAK_DIAGNOSTICS_LOG";
 
 /// `info` for the workspace's own crates, `warn` for dependencies.
 const DEFAULT_DIRECTIVES: &str = "warn,tidebreak_cli=info,tidebreak_code_execution=info,\
-    tidebreak_core=info,tidebreak_desktop=info,tidebreak_egress=info,\
+    tidebreak_code_remote=info,tidebreak_core=info,tidebreak_desktop=info,tidebreak_egress=info,\
     tidebreak_harness=info,tidebreak_host_broker=info,tidebreak_managed_node=info,\
     tidebreak_mcp=info,\
     tidebreak_router=info,tidebreak_sandbox_agent=info,tidebreak_sandbox_protocol=info,\


### PR DESCRIPTION
## Summary

- move the remote sandbox client, event ingestion, wire types, and lifecycle driver into `tidebreak-code-remote`
- keep server-owned runtime wiring behind `RemoteSessionHost`
- preserve the existing `crate::code::remote` API through re-exports

Part of #3136.

## Test plan

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `CARGO_BUILD_JOBS=2 cargo check --locked -p tidebreak-server --tests`
- `CARGO_BUILD_JOBS=2 cargo test --locked -p tidebreak-code-remote`
- `CARGO_BUILD_JOBS=2 cargo test --locked -p tidebreak-server --lib code::remote::service`
- `CARGO_BUILD_JOBS=2 cargo test --locked -p tidebreak-server --lib code_external`
- `CARGO_BUILD_JOBS=2 cargo test --locked -p tidebreak-server --lib the_generated_bindings_are_current`
- `CARGO_BUILD_JOBS=2 cargo test --locked -p tidebreak-server --lib the_code_frame_fixtures_are_current`
- `CARGO_BUILD_JOBS=2 cargo clippy --locked -p tidebreak-code-remote --all-targets -- -D warnings`