### PR TITLE
build(self-host): admit vendored crates into the image build context

### DIFF
--- a/deploy/self-host/Dockerfile.dockerignore
+++ b/deploy/self-host/Dockerfile.dockerignore
@@ -21,6 +21,17 @@
 !crates/tidebreak-code-execution/baseline_python_deps.txt
 !crates/tidebreak-sandbox-agent/documents-requirements.txt
 
+# Vendored crates named by `[patch.crates-io]` in the workspace manifest.
+# Cargo resolves the patch by path, so a missing manifest fails the build
+# before it compiles a line. The same shape as `crates/`: manifests and
+# source trees only, never the crate's docs, lock, or hidden files.
+!vendor/
+!vendor/*/
+!vendor/*/Cargo.toml
+!vendor/*/build.rs
+!vendor/*/src/
+!vendor/*/src/**
+
 # The desktop renderer, which the image builds and the server serves to
 # browsers. The whole package directory, because Vite's inputs are its
 # manifests, `index.html`, `public/`, and `src/` together. The deny rules
@@ -93,3 +104,4 @@
 # the context. This wins because it is last; every non-source file the block
 # above denies stays denied.
 !crates/*/src/**/*.rs
+!vendor/*/src/**/*.rs

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1074,6 +1074,11 @@ test("the self-host Docker context is allowlisted and denies hidden credentials"
     "!skills/*/SKILL.md",
     "!plugins/*/PLUGIN.md",
     "!crates/*/src/**/*.rs",
+    // Crates named by `[patch.crates-io]` resolve by path; a missing manifest
+    // fails the build before it compiles a line (v0.87.1's image did).
+    "!vendor/*/Cargo.toml",
+    "!vendor/*/src/**",
+    "!vendor/*/src/**/*.rs",
   ]) {
     assert.ok(dockerIgnore.includes(`${required}\n`), `missing allow rule ${required}`);
   }
@@ -1156,6 +1161,12 @@ test(
       "crates/tidebreak-sandbox-agent/documents-requirements.txt",
       "skills/demo/SKILL.md",
       "plugins/demo/PLUGIN.md",
+      // A vendored crate the workspace patches in by path: its manifest and
+      // sources, like any workspace member.
+      "vendor/demo/Cargo.toml",
+      "vendor/demo/build.rs",
+      "vendor/demo/src/lib.rs",
+      "vendor/demo/src/web/credentials.rs",
       // The renderer the image builds: manifests, the page, and sources.
       "crates/tidebreak-desktop/ui/package.json",
       "crates/tidebreak-desktop/ui/pnpm-lock.yaml",
@@ -1181,6 +1192,9 @@ test(
       "skills/demo/.draft",
       "plugins/demo/credentials.json",
       "crates/demo/src/credentials.json",
+      // Hidden files beside a vendored crate stay denied, as under crates/.
+      "vendor/demo/.cargo/credentials",
+      "vendor/demo/src/.netrc",
       "outside/secret.txt",
     ];
 


### PR DESCRIPTION
## What changed

The v0.87.1 server image failed to build: `cargo build` in the container stopped at "failed to read /src/vendor/symphonia-format-mkv/Cargo.toml". #3143 moved the Symphonia WebM fix into `vendor/` and named it in `[patch.crates-io]`, and the self-host image's deny-by-default `Dockerfile.dockerignore` never admits that directory, so BuildKit uploaded a workspace whose manifest points at a crate that is not there. The CI build lane passed because it compiles from the checkout, not from the Docker context.

The ignore file now admits vendored crates the same way it admits workspace members: the directory, its manifest and build script, and its source tree, with the hidden-file denials still winning. The context tests gain the matching probes: a vendored manifest and sources are in, hidden files beside them stay out, and the static allow-list check names the new rules.

## Validation

- `node --test scripts/workflow-security.test.mjs` for the self-host context tests, against Docker BuildKit locally. The BuildKit probe fails on the original ignore file with "missing vendor/demo/Cargo.toml" and passes on this one.

## Compatibility and risk

Build context only. A vendored crate's README, lock, and patch notes land in the context the way a workspace crate's do today; nothing hidden does.
