### PR TITLE
improve(desktop): widen and center the default launch window

### DIFF
--- a/crates/tidebreak-desktop/tauri.conf.json
+++ b/crates/tidebreak-desktop/tauri.conf.json
@@ -20,10 +20,11 @@
       {
         "label": "main",
         "title": "Tidebreak",
-        "width": 1100,
-        "height": 760,
+        "width": 1280,
+        "height": 800,
         "minWidth": 720,
         "minHeight": 480,
+        "center": true,
         "dragDropEnabled": true
       }
     ],

--- a/crates/tidebreak-desktop/tauri.macos.conf.json
+++ b/crates/tidebreak-desktop/tauri.macos.conf.json
@@ -5,10 +5,11 @@
       {
         "label": "main",
         "title": "Tidebreak",
-        "width": 1100,
-        "height": 760,
+        "width": 1280,
+        "height": 800,
         "minWidth": 720,
         "minHeight": 480,
+        "center": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "dragDropEnabled": true,


### PR DESCRIPTION
## Summary

The desktop app’s main window now opens at **1280×800** instead of **1100×760**, and is **centered on launch** via Tauri’s `center` config field, in both the default `tauri.conf.json` and the macOS override `tauri.macos.conf.json`.

Unchanged: `minWidth` 720, `minHeight` 480, `dragDropEnabled`, macOS overlay fields (`titleBarStyle`, `hiddenTitle`, `trafficLightPosition`), DMG `windowSize`, React UI, and runtime window behavior.

## Checks run

- `python3 -m json.tool crates/tidebreak-desktop/tauri.conf.json` — JSON valid
- `python3 -m json.tool crates/tidebreak-desktop/tauri.macos.conf.json` — JSON valid
- `git diff origin/main` — only `crates/tidebreak-desktop/tauri.conf.json` and `crates/tidebreak-desktop/tauri.macos.conf.json` (width, height, `center`)
- Full workspace test suite **not** run (JSON-only Tauri configuration change)

This PR does not claim CI or Shipright results.
