### PR TITLE
refactor(server): adopt shared conversation nouns

### DIFF
--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -23,9 +23,9 @@ use tidebreak_core::db::code::{
     session_spend_microusd, stale_incarnation_intents_all_owners, stop_incarnation,
 };
 use tidebreak_core::{
-    Attention, AttentionSource, CodeRepo, CodeSession, CodeSessionId, CodeSessionIncarnation,
-    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, DbStore,
-    FenceReason, IncarnationAdmission, IncarnationState, OwnerId,
+    Attention, AttentionSource, CodeRepo, CodeSessionIncarnation, CodeWorkspace, DbStore,
+    FenceReason, IncarnationAdmission, IncarnationState, OwnerId, Session, SessionId,
+    SessionLifecycle, Turn, TurnId, TurnStatus,
 };
 
 use super::ingest::{ingest_events, IngestBinding, IngestOutcome};
@@ -61,12 +61,12 @@ pub enum RemoteTurnOutcome {
     /// The turn reached the live sandbox's inbox.
     Delivered {
         /// The turn row, running. Boxed: the rows dwarf the refusals.
-        turn: Box<CodeTurn>,
+        turn: Box<Turn>,
     },
     /// No sandbox was live; one was provisioned to carry this turn.
     Reincarnated {
         /// The turn row, running.
-        turn: Box<CodeTurn>,
+        turn: Box<Turn>,
         /// The incarnation now active.
         #[cfg_attr(not(test), allow(dead_code))]
         incarnation: Box<CodeSessionIncarnation>,
@@ -74,7 +74,7 @@ pub enum RemoteTurnOutcome {
     /// The owner's concurrency cap refused, naming what runs.
     CapExhausted {
         /// Sessions holding the live incarnations.
-        running: Vec<CodeSessionId>,
+        running: Vec<SessionId>,
     },
     /// The predecessor stopped but its terminal events are not journaled
     /// yet. Retry after a pump; resuming now would miss its last output.
@@ -116,7 +116,7 @@ pub struct RemoteDriver<'a> {
 async fn sign_in_needed(
     db: &Arc<DbStore>,
     bus: &dyn RemoteSessionHost,
-    session: &CodeSession,
+    session: &Session,
 ) -> Result<(), tidebreak_core::AgentError> {
     apply_attention(
         db,
@@ -141,7 +141,7 @@ async fn sign_in_needed(
 async fn refusal_notice(
     db: &Arc<DbStore>,
     bus: &dyn RemoteSessionHost,
-    session: &CodeSession,
+    session: &Session,
     message: String,
     attention: &str,
 ) -> Result<(), tidebreak_core::AgentError> {
@@ -151,7 +151,7 @@ async fn refusal_notice(
         &session.owner,
         session.id,
         session.spawn_epoch,
-        tidebreak_core::CodeEvent::HarnessNotice {
+        tidebreak_core::Event::HarnessNotice {
             level: tidebreak_core::HarnessNoticeLevel::Warning,
             message,
         },
@@ -172,11 +172,7 @@ async fn refusal_notice(
 /// workspace titles. The owner knows workspaces, not session ids; a title
 /// that is empty falls back to the branch, and a row that vanished mid-read
 /// falls back to the id rather than failing the refusal.
-async fn occupying_names(
-    db: &Arc<DbStore>,
-    owner: &OwnerId,
-    running: &[CodeSessionId],
-) -> Vec<String> {
+async fn occupying_names(db: &Arc<DbStore>, owner: &OwnerId, running: &[SessionId]) -> Vec<String> {
     let mut names = Vec::new();
     for id in running {
         let name = match tidebreak_core::db::code::get_session(db, owner, *id).await {
@@ -256,7 +252,7 @@ async fn settle_turn_rows(
     db: &Arc<DbStore>,
     owner: &OwnerId,
     starting_turn: i32,
-    running_turn: Option<CodeTurn>,
+    running_turn: Option<Turn>,
     events: &[super::wire::SandboxEvent],
 ) -> Result<bool, tidebreak_core::AgentError> {
     let Some(mut turn) = running_turn else {
@@ -271,12 +267,12 @@ async fn settle_turn_rows(
                     .and_then(serde_json::Value::as_i64)
                     == Some(0);
                 if success {
-                    CodeTurnStatus::Completed
+                    TurnStatus::Completed
                 } else {
-                    CodeTurnStatus::Failed
+                    TurnStatus::Failed
                 }
             }
-            "turn_interrupted" => CodeTurnStatus::Interrupted,
+            "turn_interrupted" => TurnStatus::Interrupted,
             _ => continue,
         };
         let mapped_ordinal = event
@@ -303,7 +299,7 @@ impl RemoteDriver<'_> {
     /// rows — the caller owns loading and authorization.
     pub async fn submit_turn(
         &self,
-        session: &mut CodeSession,
+        session: &mut Session,
         workspace: &CodeWorkspace,
         repo: &CodeRepo,
         text: &str,
@@ -321,18 +317,18 @@ impl RemoteDriver<'_> {
     /// [`start_turn_row`] for what a stale claim does.
     pub async fn submit_turn_from(
         &self,
-        session: &mut CodeSession,
+        session: &mut Session,
         workspace: &CodeWorkspace,
         repo: &CodeRepo,
         text: &str,
-        promoted: Option<&tidebreak_core::CodeQueuedTurn>,
+        promoted: Option<&tidebreak_core::code::QueuedTurn>,
     ) -> Result<RemoteTurnOutcome, tidebreak_core::AgentError> {
         let (db, bus, provisioner, settings) = (self.db, self.bus, self.provisioner, self.settings);
         let owner = session.owner.clone();
         let last = latest_turn(db, &owner, session.id).await?;
         if last
             .as_ref()
-            .is_some_and(|turn| turn.status == CodeTurnStatus::Running)
+            .is_some_and(|turn| turn.status == TurnStatus::Running)
         {
             return Ok(RemoteTurnOutcome::TurnInFlight);
         }
@@ -584,7 +580,7 @@ impl RemoteDriver<'_> {
     /// and replays are no-ops.
     pub async fn pump(
         &self,
-        session: &mut CodeSession,
+        session: &mut Session,
         wait_seconds: u16,
     ) -> Result<PumpReport, tidebreak_core::AgentError> {
         let (db, bus, provisioner) = (self.db, self.bus, self.provisioner);
@@ -675,7 +671,7 @@ impl RemoteDriver<'_> {
 
         let running_turn = latest_turn(db, &owner, session.id)
             .await?
-            .filter(|turn| turn.status == CodeTurnStatus::Running);
+            .filter(|turn| turn.status == TurnStatus::Running);
         let binding = IngestBinding {
             owner: owner.clone(),
             session_id: session.id,
@@ -711,7 +707,7 @@ impl RemoteDriver<'_> {
             // while this read was in flight.
             let open = latest_turn(db, &owner, session.id)
                 .await?
-                .filter(|turn| turn.status == CodeTurnStatus::Running);
+                .filter(|turn| turn.status == TurnStatus::Running);
             if open.is_some() {
                 if let Some(recovered) = recover_dead_worker(db, bus, session).await? {
                     *session = recovered;
@@ -723,7 +719,7 @@ impl RemoteDriver<'_> {
         // sandbox stays live, and leaving the session Running would let the
         // stall sweep overwrite the turn's done verdict with a stall.
         if (turn_settled || read.state.is_terminal())
-            && session.lifecycle == CodeSessionLifecycle::Running
+            && session.lifecycle == SessionLifecycle::Running
         {
             // The ingest just wrote this turn's verdict (DoneUnreviewed,
             // needs-you) onto the stored row. Refresh this snapshot
@@ -734,7 +730,7 @@ impl RemoteDriver<'_> {
             {
                 *session = stored;
             }
-            session.lifecycle = CodeSessionLifecycle::Idle;
+            session.lifecycle = SessionLifecycle::Idle;
             let _ = persist_session(db, bus, session).await?;
         }
         if let Some(reason) = outcome.fence {
@@ -749,7 +745,7 @@ impl RemoteDriver<'_> {
     ///
     /// Unlike a local reap, nothing is relaunched — the next turn reincarnates
     /// on demand.
-    pub async fn reap(&self, session: CodeSession) -> Result<CodeSession, RemoteReapError> {
+    pub async fn reap(&self, session: Session) -> Result<Session, RemoteReapError> {
         let (db, bus, provisioner) = (self.db, self.bus, self.provisioner);
         let owner = session.owner.clone();
         if let Ok(Some(row)) = latest_incarnation(db, &owner, session.id).await {
@@ -832,16 +828,16 @@ fn repository_url(repo: &CodeRepo) -> Result<String, tidebreak_core::AgentError>
 async fn start_turn_row(
     db: &Arc<DbStore>,
     bus: &dyn RemoteSessionHost,
-    session: &mut CodeSession,
+    session: &mut Session,
     ordinal: i64,
     text: &str,
-    promoted: Option<&tidebreak_core::CodeQueuedTurn>,
-) -> Result<CodeTurn, tidebreak_core::AgentError> {
-    let mut turn = CodeTurn {
-        id: promoted.map_or_else(CodeTurnId::new, |row| row.id),
+    promoted: Option<&tidebreak_core::code::QueuedTurn>,
+) -> Result<Turn, tidebreak_core::AgentError> {
+    let mut turn = Turn {
+        id: promoted.map_or_else(TurnId::new, |row| row.id),
         session_id: session.id,
         ordinal,
-        status: CodeTurnStatus::Running,
+        status: TurnStatus::Running,
         model: session.model.clone(),
         fast_mode: session.fast_mode,
         user_input: text.to_owned(),
@@ -883,13 +879,13 @@ async fn start_turn_row(
                     session = %session.id,
                     "a queued message changed under its promotion; recording the delivered turn separately"
                 );
-                turn.id = CodeTurnId::new();
+                turn.id = TurnId::new();
                 insert_turn(db, &session.owner, &turn).await?;
             }
         }
         None => insert_turn(db, &session.owner, &turn).await?,
     }
-    session.lifecycle = CodeSessionLifecycle::Running;
+    session.lifecycle = SessionLifecycle::Running;
     replace_attention(
         session,
         Attention::working(AttentionSource::Lifecycle),
@@ -1088,7 +1084,7 @@ mod tests {
             panic!("expected a reincarnation");
         };
         assert_eq!(turn.ordinal, 1);
-        assert_eq!(turn.status, CodeTurnStatus::Running);
+        assert_eq!(turn.status, TurnStatus::Running);
         assert_eq!(incarnation.incarnation, 1);
         assert_eq!(incarnation.state, IncarnationState::Active);
         assert_eq!(incarnation.sandbox_id.as_deref(), Some("sb-next"));
@@ -1103,7 +1099,7 @@ mod tests {
         assert_eq!(spawns[0].task, "build it");
         assert_eq!(spawns[0].mode.as_deref(), Some("turn"));
         assert_eq!(spawns[0].spend_ceiling_microusd, Some(5_000_000));
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Running);
+        assert_eq!(session.lifecycle, SessionLifecycle::Running);
     }
 
     /// A turn while the sandbox lives is an inbox message, not a spawn.
@@ -1149,7 +1145,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(live.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(live.lifecycle, SessionLifecycle::Idle);
         assert_eq!(
             live.attention.state,
             tidebreak_core::AttentionState::DoneUnreviewed
@@ -1197,12 +1193,12 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(turn.status, CodeTurnStatus::Interrupted);
+        assert_eq!(turn.status, TurnStatus::Interrupted);
         let live = get_session(&db, &session.owner, session.id)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(live.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(live.lifecycle, SessionLifecycle::Idle);
         // The interrupt surfaces: the session must not keep showing work in
         // progress for a message the dead incarnation never ran.
         assert!(matches!(
@@ -1255,7 +1251,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(turn.status, CodeTurnStatus::Completed);
+        assert_eq!(turn.status, TurnStatus::Completed);
         // The persist after the sandbox stop must not write the snapshot's
         // stale Working back over the verdict the ingest just journaled.
         let live = tidebreak_core::db::code::get_session(&db, &session.owner, session.id)
@@ -1266,7 +1262,7 @@ mod tests {
             live.attention.state,
             tidebreak_core::AttentionState::DoneUnreviewed
         );
-        assert_eq!(live.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(live.lifecycle, SessionLifecycle::Idle);
 
         // Turn 2 reincarnates from the pushed ref, starting at turn 2.
         let outcome = driver
@@ -1304,14 +1300,14 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(settled.ordinal, 2);
-        assert_eq!(settled.status, CodeTurnStatus::Completed);
+        assert_eq!(settled.status, TurnStatus::Completed);
         // The settlement ends the Running lifecycle even though the
         // successor sandbox stays live.
         let after = get_session(&db, &session.owner, session.id)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(after.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(after.lifecycle, SessionLifecycle::Idle);
     }
 
     /// A stopped predecessor whose terminal events are not journaled yet
@@ -1376,7 +1372,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(live.lifecycle, CodeSessionLifecycle::Fenced);
+        assert_eq!(live.lifecycle, SessionLifecycle::Fenced);
         assert!(matches!(
             live.fence_reason,
             Some(FenceReason::ResumeLost { .. })
@@ -1425,7 +1421,7 @@ mod tests {
         let driver = driver!(&db, &bus, &fake, &settings);
 
         let recovered = driver.reap(session.clone()).await.unwrap();
-        assert_eq!(recovered.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(recovered.lifecycle, SessionLifecycle::Idle);
         assert!(recovered.fence_reason.is_none());
         assert_eq!(
             fake.cancels.lock().unwrap().as_slice(),
@@ -1486,7 +1482,7 @@ mod tests {
         let notice = events
             .iter()
             .find_map(|row| match &row.event {
-                tidebreak_core::CodeEvent::HarnessNotice { message, .. } => Some(message.clone()),
+                tidebreak_core::Event::HarnessNotice { message, .. } => Some(message.clone()),
                 _ => None,
             })
             .expect("expected a refusal notice");
@@ -1549,7 +1545,7 @@ mod tests {
         let notice = events
             .iter()
             .find_map(|row| match &row.event {
-                tidebreak_core::CodeEvent::HarnessNotice { message, .. } => Some(message.clone()),
+                tidebreak_core::Event::HarnessNotice { message, .. } => Some(message.clone()),
                 _ => None,
             })
             .expect("expected a refusal notice");
@@ -1722,11 +1718,11 @@ mod tests {
     async fn an_earlier_turns_ending_does_not_settle_the_running_turn() {
         let dir = tempfile::tempdir().unwrap();
         let (db, _bus, session, _workspace, _repo) = seed(dir.path()).await;
-        let running = CodeTurn {
-            id: CodeTurnId::new(),
+        let running = Turn {
+            id: TurnId::new(),
             session_id: session.id,
             ordinal: 2,
-            status: CodeTurnStatus::Running,
+            status: TurnStatus::Running,
             model: None,
             fast_mode: false,
             user_input: "second".to_owned(),
@@ -1756,7 +1752,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(row.status, CodeTurnStatus::Running);
+        assert_eq!(row.status, TurnStatus::Running);
 
         let own = [event(
             10,
@@ -1770,7 +1766,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(row.status, CodeTurnStatus::Completed);
+        assert_eq!(row.status, TurnStatus::Completed);
     }
 
     /// A lease whose activation loses to the protocol is cancelled, not

--- a/crates/tidebreak-code-remote/src/fixtures.rs
+++ b/crates/tidebreak-code-remote/src/fixtures.rs
@@ -10,10 +10,10 @@ use tidebreak_core::db::code::{
     recover_interrupted_session, replace_session_attention, save_session, set_session_subagents,
 };
 use tidebreak_core::{
-    Attention, AttentionSource, AttentionState, CapLevel, CodeEvent, CodeIncarnationId, CodeRepo,
-    CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentStatus,
-    CodeWorkspace, CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind, IncarnationAdmission,
-    OwnerId, PermissionMode, RepoId, WorkspaceId,
+    Attention, AttentionSource, AttentionState, CapLevel, CodeIncarnationId, CodeRepo,
+    CodeSubagentStatus, CodeWorkspace, CodeWorkspaceStatus, DbStore, Event, FenceReason,
+    HarnessKind, IncarnationAdmission, OwnerId, PermissionMode, RepoId, Session, SessionId,
+    SessionKind, SessionLifecycle, WorkspaceId,
 };
 
 use super::{replace_attention, RemoteReapError, RemoteSessionHost};
@@ -23,12 +23,12 @@ pub(crate) struct TestEvents;
 
 #[async_trait::async_trait]
 impl RemoteSessionHost for TestEvents {
-    fn publish(&self, _session: CodeSessionId, _event: tidebreak_core::SequencedCodeEvent) {}
+    fn publish(&self, _session: SessionId, _event: tidebreak_core::code::SequencedEvent) {}
 
     async fn persist_session(
         &self,
         store: &DbStore,
-        session: &CodeSession,
+        session: &Session,
     ) -> Result<bool, tidebreak_core::AgentError> {
         let saved = save_session(store, session).await?;
         if saved {
@@ -48,7 +48,7 @@ impl RemoteSessionHost for TestEvents {
         &self,
         store: &DbStore,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         next: Attention,
     ) -> Result<(), tidebreak_core::AgentError> {
         let _ = replace_session_attention(store, owner, session_id, &next, false).await?;
@@ -59,9 +59,9 @@ impl RemoteSessionHost for TestEvents {
         &self,
         store: &DbStore,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         spawn_epoch: i64,
-        event: CodeEvent,
+        event: Event,
     ) {
         let _ = append_event(store, owner, session_id, spawn_epoch, &event).await;
     }
@@ -69,7 +69,7 @@ impl RemoteSessionHost for TestEvents {
     async fn fence_session(
         &self,
         store: &DbStore,
-        session: &mut CodeSession,
+        session: &mut Session,
         reason: FenceReason,
     ) -> Result<(), tidebreak_core::AgentError> {
         if matches!(reason, FenceReason::ResumeLost { .. }) {
@@ -88,7 +88,7 @@ impl RemoteSessionHost for TestEvents {
                 )));
             }
         }
-        session.lifecycle = CodeSessionLifecycle::Fenced;
+        session.lifecycle = SessionLifecycle::Fenced;
         for subagent in &mut session.subagents {
             if subagent.status == CodeSubagentStatus::Running {
                 subagent.status = CodeSubagentStatus::Failed;
@@ -117,8 +117,8 @@ impl RemoteSessionHost for TestEvents {
     async fn recover_dead_worker(
         &self,
         store: &DbStore,
-        session: &CodeSession,
-    ) -> Result<Option<CodeSession>, tidebreak_core::AgentError> {
+        session: &Session,
+    ) -> Result<Option<Session>, tidebreak_core::AgentError> {
         let durable_parks = if session.harness_kind.is_in_process() {
             CapLevel::Supported
         } else {
@@ -138,8 +138,8 @@ impl RemoteSessionHost for TestEvents {
     async fn reap_session(
         &self,
         store: &DbStore,
-        session: CodeSession,
-    ) -> Result<CodeSession, RemoteReapError> {
+        session: Session,
+    ) -> Result<Session, RemoteReapError> {
         let Some(recovered) = reap_fenced_session(
             store,
             &session.owner,
@@ -159,12 +159,12 @@ impl RemoteSessionHost for TestEvents {
 }
 
 /// A session value with sensible remote defaults, unsaved.
-pub(crate) fn session_value() -> CodeSession {
-    CodeSession {
-        id: CodeSessionId::new(),
+pub(crate) fn session_value() -> Session {
+    Session {
+        id: SessionId::new(),
         owner: OwnerId::local(),
         workspace_id: Some(WorkspaceId::new()),
-        kind: CodeSessionKind::Interactive,
+        kind: SessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: None,
         harness_resume_ref: None,
@@ -172,7 +172,7 @@ pub(crate) fn session_value() -> CodeSession {
         model: None,
         reasoning_effort: None,
         fast_mode: false,
-        lifecycle: CodeSessionLifecycle::Running,
+        lifecycle: SessionLifecycle::Running,
         fence_reason: None,
         child_pid: None,
         child_process_identity: None,
@@ -188,13 +188,7 @@ pub(crate) fn session_value() -> CodeSession {
 /// path), and one session, all inserted.
 pub(crate) async fn seed(
     root: &Path,
-) -> (
-    Arc<DbStore>,
-    TestEvents,
-    CodeSession,
-    CodeWorkspace,
-    CodeRepo,
-) {
+) -> (Arc<DbStore>, TestEvents, Session, CodeWorkspace, CodeRepo) {
     let db = Arc::new(
         DbStore::connect(&format!(
             "sqlite://{}?mode=rwc",
@@ -246,10 +240,7 @@ pub(crate) async fn seed(
 }
 
 /// Reserve and activate one incarnation for the session.
-pub(crate) async fn seeded_incarnation(
-    db: &Arc<DbStore>,
-    session: &CodeSession,
-) -> CodeIncarnationId {
+pub(crate) async fn seeded_incarnation(db: &Arc<DbStore>, session: &Session) -> CodeIncarnationId {
     let admission = create_incarnation_intent(db, &session.owner, session.id, 1, 4)
         .await
         .unwrap();

--- a/crates/tidebreak-code-remote/src/ingest.rs
+++ b/crates/tidebreak-code-remote/src/ingest.rs
@@ -20,13 +20,14 @@ use std::sync::Arc;
 use serde_json::Value;
 use tracing::warn;
 
+use tidebreak_core::code::SequencedEvent;
 use tidebreak_core::db::code::{
     ingest_incarnation_event, latest_incarnation, IncarnationSideEffects,
 };
 use tidebreak_core::{
-    Attention, AttentionSource, AttentionState, BoundedError, CodeEvent, CodeIncarnationId,
-    CodeSessionId, CodeTurnId, CodeUsage, DbStore, FenceReason, HarnessKind, HarnessNoticeLevel,
-    OwnerId, SequencedCodeEvent, MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS,
+    Attention, AttentionSource, AttentionState, BoundedError, CodeIncarnationId, DbStore, Event,
+    FenceReason, HarnessKind, HarnessNoticeLevel, OwnerId, SessionId, TurnId, TurnUsage,
+    MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS,
 };
 
 use super::wire::{SandboxEvent, SandboxEvents, SandboxState};
@@ -38,7 +39,7 @@ pub(crate) struct IngestBinding {
     /// Owner of the session and the incarnation.
     pub owner: OwnerId,
     /// The remote session being projected into.
-    pub session_id: CodeSessionId,
+    pub session_id: SessionId,
     /// The session's spawn epoch, fencing a superseded worker's writes.
     pub spawn_epoch: i64,
     /// The incarnation whose sandbox produced this stream.
@@ -46,14 +47,14 @@ pub(crate) struct IngestBinding {
     /// The session's engine, for the started marker.
     pub harness_kind: HarnessKind,
     /// The turn the driver is servicing, when one is running.
-    pub turn_id: Option<CodeTurnId>,
+    pub turn_id: Option<TurnId>,
 }
 
 /// What one sandbox event becomes on the session.
 #[derive(Debug, Default, PartialEq)]
 struct Projection {
     /// Journal rows to append, in order.
-    pub journal: Vec<CodeEvent>,
+    pub journal: Vec<Event>,
     /// Attention to apply after the journal commit.
     pub attention: Option<Attention>,
     /// The terminal deliverable to retain on the incarnation.
@@ -90,8 +91,8 @@ fn bound(text: &str, max_chars: usize) -> String {
     text.chars().take(max_chars).collect()
 }
 
-fn notice(level: HarnessNoticeLevel, message: String) -> CodeEvent {
-    CodeEvent::HarnessNotice {
+fn notice(level: HarnessNoticeLevel, message: String) -> Event {
+    Event::HarnessNotice {
         level,
         message: bound(&message, MAX_NOTICE_CHARS),
     }
@@ -112,7 +113,7 @@ fn project_event(binding: &IngestBinding, kind: &str, payload: &Value) -> Projec
     let mut out = Projection::default();
     match kind {
         "supervisor_started" => {
-            out.journal.push(CodeEvent::SessionStarted {
+            out.journal.push(Event::SessionStarted {
                 harness_kind: binding.harness_kind,
                 harness_version: payload_str(payload, "agent").unwrap_or("remote").to_owned(),
                 resume_ref: None,
@@ -120,14 +121,14 @@ fn project_event(binding: &IngestBinding, kind: &str, payload: &Value) -> Projec
         }
         "turn_started" => {
             if let Some(turn_id) = binding.turn_id {
-                out.journal.push(CodeEvent::TurnStarted { turn_id });
+                out.journal.push(Event::TurnStarted { turn_id });
             }
             out.attention = Some(Attention::working(AttentionSource::Lifecycle));
         }
         "assistant_record" => {
             let body = payload_str(payload, "body").unwrap_or_default();
             if !body.is_empty() {
-                out.journal.push(CodeEvent::AssistantMessage {
+                out.journal.push(Event::AssistantMessage {
                     text: bound(body, MAX_EVENT_TEXT_CHARS),
                     parent_call_id: None,
                 });
@@ -144,8 +145,8 @@ fn project_event(binding: &IngestBinding, kind: &str, payload: &Value) -> Projec
         "turn_completed" => {
             let success = payload.get("exit_code").and_then(Value::as_i64) == Some(0);
             if success {
-                out.journal.push(CodeEvent::TurnCompleted {
-                    usage: CodeUsage::default(),
+                out.journal.push(Event::TurnCompleted {
+                    usage: TurnUsage::default(),
                     checkpoint: None,
                     stop_reason: None,
                 });
@@ -154,7 +155,7 @@ fn project_event(binding: &IngestBinding, kind: &str, payload: &Value) -> Projec
                     AttentionSource::Lifecycle,
                 ));
             } else {
-                out.journal.push(CodeEvent::TurnFailed {
+                out.journal.push(Event::TurnFailed {
                     error: BoundedError {
                         message: "the engine turn failed".to_owned(),
                     },
@@ -167,7 +168,7 @@ fn project_event(binding: &IngestBinding, kind: &str, payload: &Value) -> Projec
             }
         }
         "turn_interrupted" => {
-            out.journal.push(CodeEvent::TurnInterrupted { usage: None });
+            out.journal.push(Event::TurnInterrupted { usage: None });
             out.attention = Some(Attention::needs_you(
                 "the turn was interrupted",
                 AttentionSource::Lifecycle,
@@ -328,7 +329,7 @@ async fn apply_one(
         for (seq, journal_event) in seqs.iter().zip(&projection.journal) {
             bus.publish(
                 binding.session_id,
-                SequencedCodeEvent {
+                SequencedEvent {
                     seq: *seq,
                     event: journal_event.clone(),
                 },
@@ -353,19 +354,19 @@ mod tests {
     use tidebreak_core::db::code::{
         get_session, latest_incarnation, list_events, replace_session_attention,
     };
-    use tidebreak_core::CodeSession;
+    use tidebreak_core::Session;
 
     use super::super::fixtures::{seed, seeded_incarnation, session_value};
     use super::*;
 
-    fn binding(session: &CodeSession, incarnation: CodeIncarnationId) -> IngestBinding {
+    fn binding(session: &Session, incarnation: CodeIncarnationId) -> IngestBinding {
         IngestBinding {
             owner: session.owner.clone(),
             session_id: session.id,
             spawn_epoch: session.spawn_epoch,
             incarnation,
             harness_kind: session.harness_kind,
-            turn_id: Some(CodeTurnId::new()),
+            turn_id: Some(TurnId::new()),
         }
     }
 
@@ -393,7 +394,7 @@ mod tests {
         let b = binding(&session, CodeIncarnationId::new());
 
         let started = project_event(&b, "turn_started", &json!({ "turn": 3 }));
-        assert!(matches!(started.journal[0], CodeEvent::TurnStarted { .. }));
+        assert!(matches!(started.journal[0], Event::TurnStarted { .. }));
         assert_eq!(
             started.attention,
             Some(Attention::working(AttentionSource::Lifecycle))
@@ -406,18 +407,18 @@ mod tests {
         );
         assert!(matches!(
             &record.journal[0],
-            CodeEvent::AssistantMessage { text, parent_call_id: None } if text == "the answer"
+            Event::AssistantMessage { text, parent_call_id: None } if text == "the answer"
         ));
         assert!(matches!(
             &record.journal[1],
-            CodeEvent::HarnessNotice {
+            Event::HarnessNotice {
                 level: HarnessNoticeLevel::Warning,
                 ..
             }
         ));
 
         let failed = project_event(&b, "turn_completed", &json!({ "turn": 3, "exit_code": 1 }));
-        assert!(matches!(&failed.journal[0], CodeEvent::TurnFailed { .. }));
+        assert!(matches!(&failed.journal[0], Event::TurnFailed { .. }));
         assert!(matches!(
             failed.attention,
             Some(Attention {
@@ -497,11 +498,11 @@ mod tests {
             .events
             .iter()
             .map(|row| match &row.event {
-                CodeEvent::SessionStarted { .. } => "session_started",
-                CodeEvent::TurnStarted { .. } => "turn_started",
-                CodeEvent::AssistantMessage { .. } => "assistant_message",
-                CodeEvent::TurnCompleted { .. } => "turn_completed",
-                CodeEvent::HarnessNotice { .. } => "notice",
+                Event::SessionStarted { .. } => "session_started",
+                Event::TurnStarted { .. } => "turn_started",
+                Event::AssistantMessage { .. } => "assistant_message",
+                Event::TurnCompleted { .. } => "turn_completed",
+                Event::HarnessNotice { .. } => "notice",
                 other => panic!("unexpected journal row {other:?}"),
             })
             .collect();

--- a/crates/tidebreak-code-remote/src/lib.rs
+++ b/crates/tidebreak-code-remote/src/lib.rs
@@ -39,10 +39,8 @@ mod ingest;
 pub mod wire;
 
 use async_trait::async_trait;
-use tidebreak_core::{
-    Attention, CodeEvent, CodeSession, CodeSessionId, DbStore, FenceReason, OwnerId,
-    SequencedCodeEvent,
-};
+use tidebreak_core::code::SequencedEvent;
+use tidebreak_core::{Attention, DbStore, Event, FenceReason, OwnerId, Session, SessionId};
 
 use wire::{
     EventCursor, MessageReceipt, SandboxEvents, SandboxLease, SandboxMessage, SandboxStatus,
@@ -179,13 +177,13 @@ pub trait SandboxProvisioner: Send + Sync {
 #[async_trait]
 pub trait RemoteSessionHost: Send + Sync {
     /// Publish one event after its journal row commits.
-    fn publish(&self, session: CodeSessionId, event: SequencedCodeEvent);
+    fn publish(&self, session: SessionId, event: SequencedEvent);
 
     /// Persist the session and publish its derived state.
     async fn persist_session(
         &self,
         store: &DbStore,
-        session: &CodeSession,
+        session: &Session,
     ) -> Result<bool, tidebreak_core::AgentError>;
 
     /// Apply one attention transition and publish its derived state.
@@ -193,7 +191,7 @@ pub trait RemoteSessionHost: Send + Sync {
         &self,
         store: &DbStore,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         next: Attention,
     ) -> Result<(), tidebreak_core::AgentError>;
 
@@ -202,16 +200,16 @@ pub trait RemoteSessionHost: Send + Sync {
         &self,
         store: &DbStore,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         spawn_epoch: i64,
-        event: CodeEvent,
+        event: Event,
     );
 
     /// Fence one live session and publish the resulting state.
     async fn fence_session(
         &self,
         store: &DbStore,
-        session: &mut CodeSession,
+        session: &mut Session,
         reason: FenceReason,
     ) -> Result<(), tidebreak_core::AgentError>;
 
@@ -219,15 +217,15 @@ pub trait RemoteSessionHost: Send + Sync {
     async fn recover_dead_worker(
         &self,
         store: &DbStore,
-        session: &CodeSession,
-    ) -> Result<Option<CodeSession>, tidebreak_core::AgentError>;
+        session: &Session,
+    ) -> Result<Option<Session>, tidebreak_core::AgentError>;
 
     /// Resolve a fenced remote session after its sandbox stops.
     async fn reap_session(
         &self,
         store: &DbStore,
-        session: CodeSession,
-    ) -> Result<CodeSession, RemoteReapError>;
+        session: Session,
+    ) -> Result<Session, RemoteReapError>;
 }
 
 /// Why a fenced remote session could not be reaped.
@@ -241,11 +239,7 @@ pub enum RemoteReapError {
     Host(String),
 }
 
-pub(crate) fn replace_attention(
-    session: &mut CodeSession,
-    next: Attention,
-    from_user: bool,
-) -> bool {
+pub(crate) fn replace_attention(session: &mut Session, next: Attention, from_user: bool) -> bool {
     if !from_user && !tidebreak_core::should_replace(&session.attention, &next) {
         return false;
     }
@@ -259,7 +253,7 @@ pub(crate) fn replace_attention(
 pub(crate) async fn persist_session(
     store: &DbStore,
     host: &dyn RemoteSessionHost,
-    session: &CodeSession,
+    session: &Session,
 ) -> Result<bool, tidebreak_core::AgentError> {
     host.persist_session(store, session).await
 }
@@ -268,7 +262,7 @@ pub(crate) async fn apply_attention(
     store: &DbStore,
     host: &dyn RemoteSessionHost,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     next: Attention,
 ) -> Result<(), tidebreak_core::AgentError> {
     host.apply_attention(store, owner, session_id, next).await
@@ -278,9 +272,9 @@ pub(crate) async fn journal_event(
     store: &DbStore,
     host: &dyn RemoteSessionHost,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
-    event: CodeEvent,
+    event: Event,
 ) {
     host.journal_event(store, owner, session_id, spawn_epoch, event)
         .await;
@@ -289,7 +283,7 @@ pub(crate) async fn journal_event(
 pub(crate) async fn fence_session(
     store: &DbStore,
     host: &dyn RemoteSessionHost,
-    session: &mut CodeSession,
+    session: &mut Session,
     reason: FenceReason,
 ) -> Result<(), tidebreak_core::AgentError> {
     host.fence_session(store, session, reason).await
@@ -298,15 +292,15 @@ pub(crate) async fn fence_session(
 pub(crate) async fn recover_dead_worker(
     store: &DbStore,
     host: &dyn RemoteSessionHost,
-    session: &CodeSession,
-) -> Result<Option<CodeSession>, tidebreak_core::AgentError> {
+    session: &Session,
+) -> Result<Option<Session>, tidebreak_core::AgentError> {
     host.recover_dead_worker(store, session).await
 }
 
 pub(crate) async fn reap_session(
     store: &DbStore,
     host: &dyn RemoteSessionHost,
-    session: CodeSession,
-) -> Result<CodeSession, RemoteReapError> {
+    session: Session,
+) -> Result<Session, RemoteReapError> {
     host.reap_session(store, session).await
 }

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -506,6 +506,33 @@ export type AppViewSession = { frame_path: string, };
 export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 
 /**
+ * The decision on one approval.
+ *
+ * The richer variants are capability-gated: the server refuses them for an
+ * engine whose capability vector does not declare the channel, and a grant
+ * is named by its index into the rungs the approval's own kind offered —
+ * a client can pick a rung the card showed, never invent a scope.
+ */
+export type ApprovalDecision = "approve" | "deny" | { "approve_with_grant": {
+/**
+ * Index into the approval kind's `offered_grants`, narrowest first.
+ */
+grant_index: number, } } | { "answers": {
+/**
+ * Answers to a questions approval, validated server-side.
+ */
+answers: Array<UserQuestionAnswer>, } } | { "plan_decision": {
+/**
+ * Whether the proposed plan is accepted.
+ */
+approve: boolean, } };
+
+/**
+ * Body of `POST /approvals/{id}/decision`.
+ */
+export type ApprovalDecisionBody = { decision: ApprovalDecision, feedback?: string, };
+
+/**
  * Outcome recorded on [`Event::ApprovalResolved`].
  */
 export type ApprovalDecisionKind = { "type": "approve" } | { "type": "deny",
@@ -586,6 +613,15 @@ questions: Array<UserQuestion>, } | { "type": "plan",
  * accepted.
  */
 proposed_mode: PermissionMode, };
+
+/**
+ * One parked or decided engine approval.
+ */
+export type ApprovalSnapshot = { id: ApprovalId, session_id: SessionId, turn_id: TurnId, kind: ApprovalKind,
+/**
+ * Exact JSON the engine sent, already size-capped. The card renders this.
+ */
+harness_raw_json: string, state: ApprovalState, feedback?: string, requested_at: string, decided_at?: string, };
 
 /**
  * State of a persisted approval.
@@ -945,42 +981,6 @@ export type CodeAnalyticsSnapshot = { range: CodeAnalyticsRange, from?: string, 
 export type CodeAnalyticsTotals = { sessions: number, turns: number, completed_turns: number, failed_turns: number, interrupted_turns: number, running_turns: number, input_tokens: number, output_tokens: number, cache_read_tokens: number, cache_write_tokens: number, total_tokens: number, estimated_cost_microusd: number, pull_requests_opened: number, pull_requests_merged: number, };
 
 /**
- * The decision on one approval.
- *
- * The richer variants are capability-gated: the server refuses them for an
- * engine whose capability vector does not declare the channel, and a grant
- * is named by its index into the rungs the approval's own kind offered —
- * a client can pick a rung the card showed, never invent a scope.
- */
-export type CodeApprovalDecision = "approve" | "deny" | { "approve_with_grant": {
-/**
- * Index into the approval kind's `offered_grants`, narrowest first.
- */
-grant_index: number, } } | { "answers": {
-/**
- * Answers to a questions approval, validated server-side.
- */
-answers: Array<UserQuestionAnswer>, } } | { "plan_decision": {
-/**
- * Whether the proposed plan is accepted.
- */
-approve: boolean, } };
-
-/**
- * Body of `POST /code/approvals/{id}/decision`.
- */
-export type CodeApprovalDecisionBody = { decision: CodeApprovalDecision, feedback?: string, };
-
-/**
- * One parked or decided engine approval.
- */
-export type CodeApprovalSnapshot = { id: ApprovalId, session_id: SessionId, turn_id: TurnId, kind: ApprovalKind,
-/**
- * Exact JSON the engine sent, already size-capped. The card renders this.
- */
-harness_raw_json: string, state: ApprovalState, feedback?: string, requested_at: string, decided_at?: string, };
-
-/**
  * One failing check's downloaded job log:
  * `POST /code/workspaces/{id}/pr/check-logs`.
  *
@@ -1278,7 +1278,7 @@ relation?: CodePullRequestRelation, };
 export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: number, deletions: number, previous_path?: string, };
 
 /**
- * Body of `POST /code/sessions/{id}/fork`. An absent body forks at the
+ * Body of `POST /sessions/{id}/fork`. An absent body forks at the
  * newest turn.
  */
 export type CodeForkBody = {
@@ -1288,7 +1288,7 @@ export type CodeForkBody = {
 at_turn?: TurnId, };
 
 /**
- * A written fork handoff: `POST /code/sessions/{id}/fork`.
+ * A written fork handoff: `POST /sessions/{id}/fork`.
  *
  * `path` is the condensed transcript, absolute under private storage so a
  * child agent of any engine can read it without Git ever indexing it. `dir`
@@ -1477,99 +1477,6 @@ export type CodeRepoSource = { kind: string, available: boolean, remediation?: s
 export type CodeRepoSources = { sources: Array<CodeRepoSource>, chooses_destination: boolean, };
 
 /**
- * Cheap per-session digest on `/code/updates`.
- */
-export type CodeSessionDigest = {
-/**
- * `None` for a session that binds no workspace.
- */
-workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
-/**
- * Engine identity for list surfaces that collapse several sessions into
- * one workspace row. Optional on the wire so a desktop can still read a
- * digest from an older server during an update.
- */
-harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
-/**
- * Timestamp trigger delivery uses to rank candidate sessions: the newest
- * turn start, or session creation before the first turn. Optional so a
- * desktop can still read a digest from an older server during an update.
- */
-trigger_target_at?: string,
-/**
- * What the live turn is occupied with, while running.
- */
-activity?: SessionActivity,
-/**
- * The subject of the tool the live turn is waiting on: the command,
- * path, query, or task description. Present only while `activity`
- * names a tool, and bounded to one line.
- */
-activity_detail?: string, pr_state?: PullRequestDigest,
-/**
- * How many pull requests hold a durable attribution to this workspace
- * (decision 77). Absent when none do.
- */
-pr_count?: number,
-/**
- * Watch progress, present only on `kind: watch` digests.
- */
-watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
-/**
- * Harness subagents on this session, present only when any were
- * observed (decision 52).
- */
-subagents?: Array<CodeSubagentSummary>,
-/**
- * Where this session stands, in a sentence, derived from the newest turn
- * that carries one. Absent until a turn has been recapped, and on
- * machines with no utility model to derive one.
- */
-recap?: string,
-/**
- * Pending memory proposals that originated in this session.
- */
-memory_proposal_count?: number, };
-
-/**
- * Where an externally created session came from. The desktop renders it
- * as the provenance banner; a session the desktop created carries none.
- */
-export type CodeSessionExternalOrigin = {
-/**
- * The channel family, for example `slack`.
- */
-channel_kind: string,
-/**
- * The channel's durable conversation identity, opaque to the server.
- * For Slack this is `workspace/channel/thread_ts`, which the desktop
- * turns into a thread permalink.
- */
-external_key: string, };
-
-/**
- * One durable conversation with an external agent engine.
- */
-export type CodeSessionSnapshot = { id: SessionId,
-/**
- * `None` for a session that binds no workspace: the in-process
- * engine's (decision 0048 step 5).
- */
-workspace_id: WorkspaceId | null, kind: SessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
-/**
- * Absent means the engine's own default, which is not any level.
- */
-reasoning_effort?: ReasoningEffort,
-/**
- * Whether this session runs its turns in the engine's fast mode.
- */
-fast_mode: boolean, lifecycle: SessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string,
-/**
- * Present when an external channel created the session.
- */
-external_origin?: CodeSessionExternalOrigin, };
-
-/**
  * Status of a harness subagent, derived from its spanning `Task` call
  * (decision 52): the call's start is the subagent's start, its result is
  * the end and outcome.
@@ -1594,6 +1501,13 @@ name: string,
  * Status derived from the spanning call.
  */
 status: CodeSubagentStatus, };
+
+/**
+ * Unsequenced activity notice published on the updates channel.
+ *
+ * Never journaled. A client that missed one just pulls from its last cursor.
+ */
+export type CodeTerminalActivityNotice = { workspace_id: WorkspaceId, terminal_id: CodeTerminalId, };
 
 /**
  * Identifies one auxiliary terminal attached to a workspace.
@@ -1640,76 +1554,6 @@ export type CodeTriggerId = string;
  * One armed trigger, as the interface reads it.
  */
 export type CodeTriggerSnapshot = { id: CodeTriggerId, repo_id: RepoId, condition: CodeTriggerCondition, action: CodeTriggerAction, enabled: boolean, created_at: string, updated_at: string, };
-
-/**
- * Where one closing-message rewrite stands.
- */
-export type CodeTurnRewriteState = "rewriting" | "rewritten" | "failed";
-
-/**
- * One user→engine turn.
- */
-export type CodeTurnSnapshot = { id: TurnId, session_id: SessionId, ordinal: number, status: TurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: TurnUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string,
-/**
- * Lucid rewrite of the closing message. The journal keeps the original.
- */
-rewrite?: string, };
-
-/**
- * One unsequenced notice on `WS /code/updates`.
- *
- * A connect is restated as [`Self::Snapshot`]; later notices are live only.
- */
-export type CodeUpdateNotice = { "type": "snapshot",
-/**
- * One row per live session.
- */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
-/**
- * Engine identity for the session represented by this digest.
- */
-harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
-/**
- * Timestamp trigger delivery uses to rank candidate sessions.
- */
-trigger_target_at?: string,
-/**
- * What the live turn is occupied with, while running.
- */
-activity?: SessionActivity,
-/**
- * The subject of the tool the live turn is waiting on, while
- * `activity` names one.
- */
-activity_detail?: string,
-/**
- * Boxed to keep the notice enum's variants near one size; the wire
- * shape is unchanged.
- */
-pr_state?: PullRequestDigest,
-/**
- * How many pull requests hold a durable attribution to this
- * workspace (decision 77). Absent when none do.
- */
-pr_count?: number,
-/**
- * Watch progress, present only on `kind: watch` digests.
- */
-watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
-/**
- * Harness subagents on this session, present only when any were
- * observed (decision 52).
- */
-subagents?: Array<CodeSubagentSummary>,
-/**
- * Where this session stands, in a sentence, derived from the newest
- * turn that carries one.
- */
-recap?: string,
-/**
- * Pending memory proposals that originated in this session.
- */
-memory_proposal_count?: number, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, } | { "type": "harness_install", kind: HarnessKind, version?: string, phase: string, done: boolean, error?: string, } | { "type": "delivery" } | { "type": "turn_rewrite", session: SessionId, turn_id: TurnId, state: CodeTurnRewriteState, rewrite?: string, };
 
 /**
  * Identifies one durable watch task on a workspace's pull request.
@@ -3047,16 +2891,12 @@ byte_len: number, };
 
 /**
  * Which conversation an entry belongs to.
- *
- * Tagged because chat ids and code session ids are still separate spaces
- * (the repository check `chat_and_code_entities_do_not_cross_reference`
- * enforces it). When step 5 merges the entities this collapses to one id.
  */
-export type InboxConversation = { "surface": "chat", chat_id: SessionId, } | { "surface": "code", session_id: SessionId,
+export type InboxConversation = { session_id: SessionId,
 /**
- * `None` for a session with no workspace: the in-process engine's.
+ * Present when the conversation belongs to a repo-backed workspace.
  */
-workspace_id: WorkspaceId | null, };
+workspace_id?: WorkspaceId, };
 
 /**
  * One conversation that wants the reader, and why.
@@ -4840,7 +4680,7 @@ export type RootAttachmentOrigin = "project_default" | "conversation";
 /**
  * One event on the per-session WebSocket.
  */
-export type SequencedCodeEventFrame = {
+export type SequencedEventFrame = {
 /**
  * Journal position. On a `transient` frame this is the cursor the event
  * streamed behind, not a position the frame occupies — resume from it
@@ -4875,6 +4715,77 @@ truncated?: boolean, };
 export type SessionActivity = "agent" | "shell" | "monitor" | "subagents" | "file" | "search" | "tool";
 
 /**
+ * Cheap per-session digest on `/updates`.
+ */
+export type SessionDigest = {
+/**
+ * `None` for a session that binds no workspace.
+ */
+workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
+/**
+ * Engine identity for list surfaces that collapse several sessions into
+ * one workspace row. Optional on the wire so a desktop can still read a
+ * digest from an older server during an update.
+ */
+harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
+/**
+ * Timestamp trigger delivery uses to rank candidate sessions: the newest
+ * turn start, or session creation before the first turn. Optional so a
+ * desktop can still read a digest from an older server during an update.
+ */
+trigger_target_at?: string,
+/**
+ * What the live turn is occupied with, while running.
+ */
+activity?: SessionActivity,
+/**
+ * The subject of the tool the live turn is waiting on: the command,
+ * path, query, or task description. Present only while `activity`
+ * names a tool, and bounded to one line.
+ */
+activity_detail?: string, pr_state?: PullRequestDigest,
+/**
+ * How many pull requests hold a durable attribution to this workspace
+ * (decision 77). Absent when none do.
+ */
+pr_count?: number,
+/**
+ * Watch progress, present only on `kind: watch` digests.
+ */
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
+/**
+ * Harness subagents on this session, present only when any were
+ * observed (decision 52).
+ */
+subagents?: Array<CodeSubagentSummary>,
+/**
+ * Where this session stands, in a sentence, derived from the newest turn
+ * that carries one. Absent until a turn has been recapped, and on
+ * machines with no utility model to derive one.
+ */
+recap?: string,
+/**
+ * Pending memory proposals that originated in this session.
+ */
+memory_proposal_count?: number, };
+
+/**
+ * Where an externally created session came from. The desktop renders it
+ * as the provenance banner; a session the desktop created carries none.
+ */
+export type SessionExternalOrigin = {
+/**
+ * The channel family, for example `slack`.
+ */
+channel_kind: string,
+/**
+ * The channel's durable conversation identity, opaque to the server.
+ * For Slack this is `workspace/channel/thread_ts`, which the desktop
+ * turns into a thread permalink.
+ */
+external_key: string, };
+
+/**
  * Identifies a persistent conversation.
  */
 export type SessionId = string;
@@ -4888,6 +4799,28 @@ export type SessionKind = "interactive" | "watch";
  * Lifecycle of a persisted code session.
  */
 export type SessionLifecycle = "created" | "idle" | "running" | "fenced" | "ended";
+
+/**
+ * One durable conversation with an external agent engine.
+ */
+export type SessionSnapshot = { id: SessionId,
+/**
+ * `None` for a session that binds no workspace: the in-process
+ * engine's (decision 0048 step 5).
+ */
+workspace_id: WorkspaceId | null, kind: SessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
+/**
+ * Absent means the engine's own default, which is not any level.
+ */
+reasoning_effort?: ReasoningEffort,
+/**
+ * Whether this session runs its turns in the engine's fast mode.
+ */
+fast_mode: boolean, lifecycle: SessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string,
+/**
+ * Present when an external channel created the session.
+ */
+external_origin?: SessionExternalOrigin, };
 
 /**
  * Body of `PUT /code/worktree-root`. A null or blank root clears the setting.
@@ -5508,6 +5441,20 @@ export type TurnFailureCategory = "rate_limited" | "auth" | "provider_access" | 
 export type TurnId = string;
 
 /**
+ * Where one closing-message rewrite stands.
+ */
+export type TurnRewriteState = "rewriting" | "rewritten" | "failed";
+
+/**
+ * One user→engine turn.
+ */
+export type TurnSnapshot = { id: TurnId, session_id: SessionId, ordinal: number, status: TurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: TurnUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string,
+/**
+ * Lucid rewrite of the closing message. The journal keeps the original.
+ */
+rewrite?: string, };
+
+/**
  * Status of one user→engine turn.
  *
  * Absorbs [`crate::model::TurnRunStatus`] one-for-one. Chat's `cancelled`
@@ -5588,6 +5535,62 @@ export type UpdateCodeTriggerBody = { enabled: boolean, };
  * Body of `PATCH /memory/records/{id}`.
  */
 export type UpdateMemoryRecordBody = { expected_revision: number, kind: MemoryKind, title: string, body: string, author: MemoryAuthor, origin: MemoryOrigin, evidence: Array<MemoryEvidence>, links: Array<MemoryLink>, expires_at: string | null, observation_count: number, };
+
+/**
+ * One unsequenced notice on `WS /updates`.
+ *
+ * A connect is restated as [`Self::Snapshot`]; later notices are live only.
+ */
+export type UpdateNotice = { "type": "snapshot",
+/**
+ * One row per live session.
+ */
+sessions: Array<SessionDigest>, } | { "type": "digest", workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
+/**
+ * Engine identity for the session represented by this digest.
+ */
+harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
+/**
+ * Timestamp trigger delivery uses to rank candidate sessions.
+ */
+trigger_target_at?: string,
+/**
+ * What the live turn is occupied with, while running.
+ */
+activity?: SessionActivity,
+/**
+ * The subject of the tool the live turn is waiting on, while
+ * `activity` names one.
+ */
+activity_detail?: string,
+/**
+ * Boxed to keep the notice enum's variants near one size; the wire
+ * shape is unchanged.
+ */
+pr_state?: PullRequestDigest,
+/**
+ * How many pull requests hold a durable attribution to this
+ * workspace (decision 77). Absent when none do.
+ */
+pr_count?: number,
+/**
+ * Watch progress, present only on `kind: watch` digests.
+ */
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
+/**
+ * Harness subagents on this session, present only when any were
+ * observed (decision 52).
+ */
+subagents?: Array<CodeSubagentSummary>,
+/**
+ * Where this session stands, in a sentence, derived from the newest
+ * turn that carries one.
+ */
+recap?: string,
+/**
+ * Pending memory proposals that originated in this session.
+ */
+memory_proposal_count?: number, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, } | { "type": "harness_install", kind: HarnessKind, version?: string, phase: string, done: boolean, error?: string, } | { "type": "delivery" } | { "type": "turn_rewrite", session: SessionId, turn_id: TurnId, state: TurnRewriteState, rewrite?: string, };
 
 /**
  * One bounded question shown to the user.
@@ -5768,15 +5771,25 @@ export const MAX_WIRE_CURSOR_CHARS = 256;
 
 // Compatibility aliases for clients that still use the earlier conversation names.
 export type ChatId = SessionId;
+export type CodeApprovalDecision = ApprovalDecision;
+export type CodeApprovalDecisionBody = ApprovalDecisionBody;
 export type CodeApprovalId = ApprovalId;
 export type CodeApprovalKind = ApprovalKind;
+export type CodeApprovalSnapshot = ApprovalSnapshot;
 export type CodeApprovalState = ApprovalState;
 export type CodeEvent = Event;
 export type CodeSessionActivity = SessionActivity;
+export type CodeSessionDigest = SessionDigest;
+export type CodeSessionExternalOrigin = SessionExternalOrigin;
 export type CodeSessionId = SessionId;
 export type CodeSessionKind = SessionKind;
 export type CodeSessionLifecycle = SessionLifecycle;
+export type CodeSessionSnapshot = SessionSnapshot;
 export type CodeTurnId = TurnId;
+export type CodeTurnRewriteState = TurnRewriteState;
+export type CodeTurnSnapshot = TurnSnapshot;
 export type CodeTurnStatus = TurnStatus;
+export type CodeUpdateNotice = UpdateNotice;
 export type CodeUsage = TurnUsage;
 export type QueuedTurn = QueuedAgentTurn;
+export type SequencedCodeEventFrame = SequencedEventFrame;

--- a/crates/tidebreak-server/src/agent_run_scratch_reaper.rs
+++ b/crates/tidebreak-server/src/agent_run_scratch_reaper.rs
@@ -409,7 +409,7 @@ mod tests {
 
     use async_trait::async_trait;
     use tidebreak_core::{
-        AdmitSandboxAgentRunOutcome, AgentError, CallId, Chat, ChatId, DbStore, SecretProvider,
+        AdmitSandboxAgentRunOutcome, AgentError, CallId, Chat, DbStore, SecretProvider, SessionId,
         TurnId,
     };
 
@@ -479,7 +479,7 @@ mod tests {
     /// run that finished normally would settle. Returns the run id.
     async fn completed_run(store: &Arc<DbStore>) -> AgentRunId {
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("scratch reaper".into()),
             model: Some("model".into()),
@@ -577,7 +577,7 @@ mod tests {
 
         // Still running: never touched, no matter how old its directory looks.
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: None,
             model: None,

--- a/crates/tidebreak-server/src/approvals.rs
+++ b/crates/tidebreak-server/src/approvals.rs
@@ -11,11 +11,12 @@ use std::time::Duration;
 use chrono::Utc;
 use tokio::sync::Notify;
 
+use tidebreak_core::code::SequencedEvent;
 use tidebreak_core::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
-    ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, CallId, ChatId,
+    ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, CallId,
     DecideToolApprovalOutcome, GrantLevel, GrantScope, JudgeVerdictOutcome,
-    RequestToolApprovalOutcome, Result, SequencedCodeEvent, StandingGrant, StandingGrants, Store,
+    RequestToolApprovalOutcome, Result, SessionId, StandingGrant, StandingGrants, Store,
 };
 
 /// Coordinates durable approval state with local low-latency waiters.
@@ -51,7 +52,7 @@ impl ApprovalBroker {
 
     /// Deliver a journaled decision live. The durable write already
     /// happened; a chat nobody is watching streams to no one.
-    fn publish(&self, chat_id: ChatId, resolution: SequencedCodeEvent) {
+    fn publish(&self, chat_id: SessionId, resolution: SequencedEvent) {
         if let Some(events) = self.events.get() {
             let _ = events.sender(chat_id).send_row(resolution);
         }
@@ -67,7 +68,7 @@ impl ApprovalBroker {
     /// an opposite decision is a conflict.
     pub async fn resolve(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         call_id: CallId,
         decision: ApprovalDecision,
     ) -> Result<ResolveApprovalOutcome> {
@@ -79,7 +80,7 @@ impl ApprovalBroker {
     /// matching calls in the same chat.
     pub async fn resolve_with_grant(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         call_id: CallId,
         decision: ApprovalDecision,
         rung: Option<crate::routes::ApprovalGrantRung>,
@@ -175,12 +176,78 @@ impl ApprovalBroker {
 }
 
 impl ApprovalBroker {
+    /// Land the Auto-mode judge's verdict on one parked call.
+    ///
+    /// Approve a parked call and mint a standing grant at an exact scope the
+    /// call already offered.
+    ///
+    /// The in-process engine's path: the adapter contract carries the chosen
+    /// [`GrantScope`] itself rather than a rung name, because the route layer
+    /// picked it from the ladder the approval published.
+    pub async fn resolve_with_scope(
+        &self,
+        chat_id: SessionId,
+        call_id: CallId,
+        scope: GrantScope,
+    ) -> Result<ResolveApprovalOutcome> {
+        let Some(current) = self.store.get_tool_call_approval(call_id).await? else {
+            return Ok(ResolveApprovalOutcome::NotPending);
+        };
+        if current.chat_id != chat_id {
+            return Ok(ResolveApprovalOutcome::WrongChat);
+        }
+        if !current.kind.is_approvable() {
+            return Ok(ResolveApprovalOutcome::NotApprovable);
+        }
+        let chat_project_id = self
+            .store
+            .get_chat(chat_id)
+            .await?
+            .and_then(|chat| chat.project_id);
+        let Some(grant) = StandingGrant::scoped(
+            GrantLevel::for_chat(current.chat_id, chat_project_id),
+            current.tool_name.clone(),
+            current.kind,
+            scope,
+            Utc::now(),
+        ) else {
+            return Ok(ResolveApprovalOutcome::GrantNotAvailable);
+        };
+        let outcome = self
+            .store
+            .decide_tool_call_approval_with_grant(
+                chat_id,
+                call_id,
+                &ApprovalDecision::Approve,
+                &grant,
+                Utc::now(),
+            )
+            .await?;
+        match outcome {
+            DecideToolApprovalOutcome::Decided { resolution, .. } => {
+                self.standing_grants.record(grant);
+                self.publish(chat_id, *resolution);
+                self.wake.notify_waiters();
+                Ok(ResolveApprovalOutcome::Resolved)
+            }
+            DecideToolApprovalOutcome::Existing(_) => {
+                self.standing_grants.record(grant);
+                self.wake.notify_waiters();
+                Ok(ResolveApprovalOutcome::Resolved)
+            }
+            DecideToolApprovalOutcome::DecisionConflict => {
+                Ok(ResolveApprovalOutcome::DecisionConflict)
+            }
+            DecideToolApprovalOutcome::Unavailable => Ok(ResolveApprovalOutcome::NotPending),
+        }
+    }
+
     /// A pure compare-and-set against durable state: a human decision that
     /// already landed wins, and `false` reports the judge no longer owned the
     /// call. An approval wakes the parked waiter exactly like a human click.
     pub async fn resolve_from_judge(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         call_id: CallId,
         approved: bool,
     ) -> Result<bool> {
@@ -463,7 +530,7 @@ mod tests {
         // its open connection after this setup.
         std::mem::forget(db);
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("Approval test".into()),
             model: None,
@@ -522,7 +589,7 @@ mod tests {
 
     async fn request_for(
         store: &Arc<dyn Store>,
-        chat_id: ChatId,
+        chat_id: SessionId,
         tool_name: &str,
         arguments: serde_json::Value,
     ) -> ApprovalRequest {
@@ -669,7 +736,7 @@ mod tests {
         };
         store.create_project(&project).await.unwrap();
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: Some(project.id),
             title: Some("First".into()),
             model: None,
@@ -715,7 +782,7 @@ mod tests {
 
         // A different chat in the same project is covered without asking.
         let sibling = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: Some(project_id),
             title: Some("Second".into()),
             model: None,
@@ -739,7 +806,7 @@ mod tests {
         // A chat outside the project is not. A project grant must widen to
         // its project and no further.
         let outsider = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("Loose".into()),
             model: None,
@@ -1055,7 +1122,7 @@ mod tests {
         );
 
         let other_chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("Other approval test".into()),
             model: None,
@@ -1545,7 +1612,7 @@ mod tests {
             .unwrap(),
         );
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("Approval journal test".into()),
             model: None,

--- a/crates/tidebreak-server/src/blob_orphan_auditor.rs
+++ b/crates/tidebreak-server/src/blob_orphan_auditor.rs
@@ -350,7 +350,7 @@ mod tests {
         let root = dir.path().join("blobs");
         let store = store(&dir).await;
         let chat = tidebreak_core::Chat {
-            id: tidebreak_core::ChatId::new(),
+            id: tidebreak_core::SessionId::new(),
             project_id: None,
             title: None,
             model: None,

--- a/crates/tidebreak-server/src/bus.rs
+++ b/crates/tidebreak-server/src/bus.rs
@@ -17,9 +17,8 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use tokio::sync::broadcast;
 
-use tidebreak_core::{
-    chat_journal, ChatId, CodeSessionId, SequencedCodeEvent, SequencedEvent, TurnId,
-};
+use tidebreak_core::code::SequencedEvent;
+use tidebreak_core::{chat_journal, SequencedAgentEvent, SessionId, TurnId};
 
 use crate::code::bus::CodeEventBus;
 
@@ -38,7 +37,7 @@ const METADATA_BUFFER: usize = 8;
 
 /// Chat state that changed without being turn history.
 ///
-/// These are deliberately not [`SequencedEvent`]s. The journal records what
+/// These are deliberately not [`SequencedAgentEvent`]s. The journal records what
 /// happened inside a turn, in an order a client resumes from; a conversation's
 /// name is neither — it is written beside a turn, sometimes after it ends, by
 /// work that holds no lease. Carrying it here keeps chat metadata out of the
@@ -66,8 +65,8 @@ pub enum ChatMetadataNotice {
 /// Per-chat broadcast channels for live turn events and metadata notices.
 #[derive(Default)]
 pub struct EventBus {
-    channels: Mutex<HashMap<ChatId, broadcast::Sender<SequencedEvent>>>,
-    metadata: Mutex<HashMap<ChatId, broadcast::Sender<ChatMetadataNotice>>>,
+    channels: Mutex<HashMap<SessionId, broadcast::Sender<SequencedAgentEvent>>>,
+    metadata: Mutex<HashMap<SessionId, broadcast::Sender<ChatMetadataNotice>>>,
     /// The session-keyed bus every journaled chat event is mirrored onto.
     /// Installed once the code runtime exists; absent in tests that assemble
     /// state without one, where nothing follows the session channel.
@@ -79,8 +78,8 @@ pub struct EventBus {
 /// Sends the journaled event to the chat's subscribers and mirrors it, as the
 /// code journal row it was stored as, onto the session's channel.
 pub struct ChatEventSender {
-    chat: ChatId,
-    sender: broadcast::Sender<SequencedEvent>,
+    chat: SessionId,
+    sender: broadcast::Sender<SequencedAgentEvent>,
     mirror: Option<Arc<CodeEventBus>>,
 }
 
@@ -88,11 +87,11 @@ impl ChatEventSender {
     /// Publish one journaled event and say how many chat subscribers took
     /// it. Zero is not an error: the durable write already happened, and a
     /// chat nobody is watching streams to no one.
-    pub fn send(&self, event: SequencedEvent) -> usize {
+    pub fn send(&self, event: SequencedAgentEvent) -> usize {
         if let Some(mirror) = &self.mirror {
             mirror.publish(
-                CodeSessionId(self.chat.0),
-                SequencedCodeEvent {
+                SessionId(self.chat.0),
+                SequencedEvent {
                     seq: event.seq,
                     event: chat_journal::journal_row(&event.event),
                 },
@@ -106,16 +105,16 @@ impl ChatEventSender {
     /// one — to the chat's subscribers. An approval settlement carries more
     /// than its chat reading (a grant scope, denial feedback), so it is
     /// mirrored as stored rather than re-derived.
-    pub fn send_row(&self, row: SequencedCodeEvent) -> usize {
+    pub fn send_row(&self, row: SequencedEvent) -> usize {
         let chat_event = chat_journal::chat_event(row.event.clone())
             .ok()
             .flatten()
-            .map(|event| SequencedEvent {
+            .map(|event| SequencedAgentEvent {
                 seq: row.seq,
                 event,
             });
         if let Some(mirror) = &self.mirror {
-            mirror.publish(CodeSessionId(self.chat.0), row);
+            mirror.publish(SessionId(self.chat.0), row);
         }
         chat_event
             .map(|event| self.sender.send(event).unwrap_or(0))
@@ -124,7 +123,7 @@ impl ChatEventSender {
 
     /// Publish to the chat's subscribers only, for a row the session
     /// channel already carried.
-    pub fn send_unmirrored(&self, event: SequencedEvent) -> usize {
+    pub fn send_unmirrored(&self, event: SequencedAgentEvent) -> usize {
         self.sender.send(event).unwrap_or(0)
     }
 }
@@ -139,7 +138,7 @@ impl EventBus {
     /// The publisher for a chat's live channel, created on first use. The
     /// channel is kept in the map so it outlives any individual turn or
     /// subscriber.
-    pub fn sender(&self, chat: ChatId) -> ChatEventSender {
+    pub fn sender(&self, chat: SessionId) -> ChatEventSender {
         ChatEventSender {
             chat,
             sender: self.channel(chat),
@@ -147,7 +146,7 @@ impl EventBus {
         }
     }
 
-    fn channel(&self, chat: ChatId) -> broadcast::Sender<SequencedEvent> {
+    fn channel(&self, chat: SessionId) -> broadcast::Sender<SequencedAgentEvent> {
         self.channels
             .lock()
             .unwrap()
@@ -158,12 +157,12 @@ impl EventBus {
 
     /// Subscribe to a chat's live events. Events published after this call are
     /// delivered; a client pairs this with a journal replay to cover the past.
-    pub fn subscribe(&self, chat: ChatId) -> broadcast::Receiver<SequencedEvent> {
+    pub fn subscribe(&self, chat: SessionId) -> broadcast::Receiver<SequencedAgentEvent> {
         self.channel(chat).subscribe()
     }
 
     /// Subscribe to a chat's metadata notices.
-    pub fn subscribe_metadata(&self, chat: ChatId) -> broadcast::Receiver<ChatMetadataNotice> {
+    pub fn subscribe_metadata(&self, chat: SessionId) -> broadcast::Receiver<ChatMetadataNotice> {
         self.metadata_sender(chat).subscribe()
     }
 
@@ -172,11 +171,11 @@ impl EventBus {
     /// Nothing is retained for a client that connects later, and no caller checks
     /// the result: the durable write already happened, and this is only how an
     /// open window learns about it without asking.
-    pub fn publish_metadata(&self, chat: ChatId, notice: ChatMetadataNotice) {
+    pub fn publish_metadata(&self, chat: SessionId, notice: ChatMetadataNotice) {
         let _ = self.metadata_sender(chat).send(notice);
     }
 
-    fn metadata_sender(&self, chat: ChatId) -> broadcast::Sender<ChatMetadataNotice> {
+    fn metadata_sender(&self, chat: SessionId) -> broadcast::Sender<ChatMetadataNotice> {
         self.metadata
             .lock()
             .unwrap()

--- a/crates/tidebreak-server/src/chat_titling.rs
+++ b/crates/tidebreak-server/src/chat_titling.rs
@@ -42,9 +42,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use tidebreak_core::{
-    input_schema_for, strip_json_fence, AgentError, ChatId, ChatMessage, ChatRequest, Message,
-    ModelProvider, PromptCacheMode, ProviderEvent, ResponseFormat, Result, Role, StopReason, Store,
-    UtilityModel,
+    input_schema_for, strip_json_fence, AgentError, ChatMessage, ChatRequest, Message,
+    ModelProvider, PromptCacheMode, ProviderEvent, ResponseFormat, Result, Role, SessionId,
+    StopReason, Store, UtilityModel,
 };
 
 use crate::bus::{ChatMetadataNotice, EventBus};
@@ -170,7 +170,7 @@ pub(crate) struct ChatTitler {
     /// Every turn on an untitled chat would otherwise start another call: a
     /// conversation that stays untitled — because it is still small talk, or
     /// because the calls keep failing — would pay for one on every message.
-    in_flight: Mutex<HashMap<ChatId, Option<UtilityModel>>>,
+    in_flight: Mutex<HashMap<SessionId, Option<UtilityModel>>>,
 }
 
 impl ChatTitler {
@@ -194,7 +194,7 @@ impl ChatTitler {
     /// Returns immediately. Nothing waits on the result and nothing fails when
     /// it does not arrive, which is what lets this be called from the front of a
     /// turn rather than bolted onto each of its completion paths.
-    pub(crate) fn spawn(self: &Arc<Self>, chat_id: ChatId, utility: UtilityModel) {
+    pub(crate) fn spawn(self: &Arc<Self>, chat_id: SessionId, utility: UtilityModel) {
         let Some((mut claim, mut utility)) = TitlingClaim::acquire(self, chat_id, utility) else {
             return;
         };
@@ -245,7 +245,7 @@ impl ChatTitler {
     /// it has nothing to name yet, or another writer named it first.
     pub(crate) async fn derive_title(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         utility: &UtilityModel,
     ) -> Result<Option<String>> {
         // Re-read rather than trust the caller's snapshot: a turn can sit queued
@@ -293,7 +293,7 @@ impl ChatTitler {
 /// A conversation's place in [`ChatTitler::in_flight`], released on drop.
 struct TitlingClaim {
     titler: Arc<ChatTitler>,
-    chat_id: ChatId,
+    chat_id: SessionId,
     released: bool,
 }
 
@@ -301,7 +301,7 @@ impl TitlingClaim {
     /// Claim `chat_id`, or coalesce this trigger behind its running call.
     fn acquire(
         titler: &Arc<ChatTitler>,
-        chat_id: ChatId,
+        chat_id: SessionId,
         utility: UtilityModel,
     ) -> Option<(Self, UtilityModel)> {
         let mut in_flight = titler

--- a/crates/tidebreak-server/src/code/approval_bridge.rs
+++ b/crates/tidebreak-server/src/code/approval_bridge.rs
@@ -20,7 +20,7 @@ use sha2::{Digest as _, Sha256};
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
-use tidebreak_core::{CodeApprovalId, CodeSessionId, CodeSessionLifecycle, CodeTurnId, OwnerId};
+use tidebreak_core::{ApprovalId, OwnerId, SessionId, SessionLifecycle, TurnId};
 use tidebreak_harness::claude::approvals::{
     PermissionPromptRequest, PermissionPromptResponse, APPROVAL_MCP_TOOL,
 };
@@ -37,7 +37,7 @@ const APPROVAL_WAIT_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct NativeCallKey {
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
     call_id: String,
 }
@@ -45,12 +45,12 @@ struct NativeCallKey {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ApprovalTokenSubject {
     owner: OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
 }
 
 struct ParkedApproval {
-    session_id: CodeSessionId,
+    session_id: SessionId,
     approval: HarnessApprovalRef,
     sender: oneshot::Sender<ApprovalResolution>,
 }
@@ -70,7 +70,7 @@ struct ApprovalParks {
 #[derive(Default)]
 pub(crate) struct ApprovalBridge {
     tokens: Mutex<HashMap<String, ApprovalTokenSubject>>,
-    by_session: Mutex<HashMap<CodeSessionId, String>>,
+    by_session: Mutex<HashMap<SessionId, String>>,
     parked: Mutex<ApprovalParks>,
 }
 
@@ -83,7 +83,7 @@ impl ApprovalBridge {
     pub(crate) fn issue_token(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         spawn_epoch: i64,
     ) -> String {
         let token = format!("cma_{}", Uuid::new_v4());
@@ -112,7 +112,7 @@ impl ApprovalBridge {
     }
 
     /// Revoke one worker's bearer and close every native call it parked.
-    pub(crate) fn revoke_session(&self, session_id: CodeSessionId) {
+    pub(crate) fn revoke_session(&self, session_id: SessionId) {
         let mut by_session = self.by_session.lock().expect("approval tokens");
         let mut tokens = self.tokens.lock().expect("approval tokens");
         let mut parked = self.parked.lock().expect("approval park");
@@ -120,10 +120,10 @@ impl ApprovalBridge {
     }
 
     fn revoke_session_locked(
-        by_session: &mut HashMap<CodeSessionId, String>,
+        by_session: &mut HashMap<SessionId, String>,
         tokens: &mut HashMap<String, ApprovalTokenSubject>,
         parked: &mut ApprovalParks,
-        session_id: CodeSessionId,
+        session_id: SessionId,
     ) {
         by_session.remove(&session_id);
         tokens.retain(|_, subject| subject.session_id != session_id);
@@ -271,10 +271,10 @@ impl ApprovalCompleter for ApprovalBridge {
 
 fn approval_ref(
     owner: &OwnerId,
-    session_id: CodeSessionId,
-    turn_id: CodeTurnId,
+    session_id: SessionId,
+    turn_id: TurnId,
     spawn_epoch: i64,
-    approval_id: CodeApprovalId,
+    approval_id: ApprovalId,
     request: &PermissionPromptRequest,
 ) -> Result<HarnessApprovalRef, ServerError> {
     let bytes = serde_json::to_vec(request)
@@ -324,8 +324,8 @@ fn deny_parked(
 
 async fn await_decision(
     runtime: &crate::code::CodeRuntime,
-    session_id: CodeSessionId,
-    approval_id: CodeApprovalId,
+    session_id: SessionId,
+    approval_id: ApprovalId,
     approval: &HarnessApprovalRef,
     receiver: oneshot::Receiver<ApprovalResolution>,
 ) -> ApprovalDecision {
@@ -493,7 +493,7 @@ async fn handle_tools_call(
             "the worker that issued this approval token is no longer attached",
         ));
     }
-    if session.lifecycle == CodeSessionLifecycle::Ended {
+    if session.lifecycle == SessionLifecycle::Ended {
         return Err(ServerError::conflict_kind(
             "session_ended",
             "session has ended",
@@ -514,7 +514,7 @@ async fn handle_tools_call(
                     "the session has no running turn for this approval",
                 )
             })?;
-    let approval_id = CodeApprovalId::new();
+    let approval_id = ApprovalId::new();
     let harness_ref = approval_ref(
         &session.owner,
         subject.session_id,
@@ -708,7 +708,7 @@ async fn handle_memory_tool(
                         workspace_id: session.workspace_id,
                         ..Default::default()
                     },
-                    evidence: vec![MemoryEvidence::CodeEvent {
+                    evidence: vec![MemoryEvidence::Event {
                         session_id: subject.session_id,
                         seq: evidence_seq,
                     }],
@@ -782,10 +782,10 @@ mod tests {
 
     fn approval(
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
+        session_id: SessionId,
+        turn_id: TurnId,
         spawn_epoch: i64,
-        approval_id: CodeApprovalId,
+        approval_id: ApprovalId,
         call_id: &str,
         token: &str,
     ) -> HarnessApprovalRef {
@@ -807,8 +807,8 @@ mod tests {
     async fn the_same_native_call_id_is_isolated_between_sessions() {
         let bridge = ApprovalBridge::new();
         let owner = OwnerId::local();
-        let first_session = CodeSessionId::new();
-        let second_session = CodeSessionId::new();
+        let first_session = SessionId::new();
+        let second_session = SessionId::new();
         let first_bearer = bridge.issue_token(&owner, first_session, 1);
         let second_bearer = bridge.issue_token(&owner, second_session, 1);
         let first_subject = bridge.subject_for_token(&first_bearer).unwrap();
@@ -816,18 +816,18 @@ mod tests {
         let first = approval(
             &owner,
             first_session,
-            CodeTurnId::new(),
+            TurnId::new(),
             1,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_same",
             "cap-first",
         );
         let second = approval(
             &owner,
             second_session,
-            CodeTurnId::new(),
+            TurnId::new(),
             1,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_same",
             "cap-second",
         );
@@ -861,24 +861,24 @@ mod tests {
     fn a_duplicate_native_call_id_is_rejected_within_one_worker() {
         let bridge = ApprovalBridge::new();
         let owner = OwnerId::local();
-        let session_id = CodeSessionId::new();
+        let session_id = SessionId::new();
         let bearer = bridge.issue_token(&owner, session_id, 4);
         let subject = bridge.subject_for_token(&bearer).unwrap();
         let first = approval(
             &owner,
             session_id,
-            CodeTurnId::new(),
+            TurnId::new(),
             4,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_duplicate",
             "cap-first",
         );
         let second = approval(
             &owner,
             session_id,
-            CodeTurnId::new(),
+            TurnId::new(),
             4,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_duplicate",
             "cap-second",
         );
@@ -897,10 +897,10 @@ mod tests {
         let owner = OwnerId::local();
         let approval = approval(
             &owner,
-            CodeSessionId::new(),
-            CodeTurnId::new(),
+            SessionId::new(),
+            TurnId::new(),
             1,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_missing",
             "cap-missing",
         );
@@ -915,15 +915,15 @@ mod tests {
     async fn completing_a_closed_waiter_fails() {
         let bridge = ApprovalBridge::new();
         let owner = OwnerId::local();
-        let session_id = CodeSessionId::new();
+        let session_id = SessionId::new();
         let bearer = bridge.issue_token(&owner, session_id, 2);
         let subject = bridge.subject_for_token(&bearer).unwrap();
         let approval = approval(
             &owner,
             session_id,
-            CodeTurnId::new(),
+            TurnId::new(),
             2,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_closed",
             "cap-closed",
         );
@@ -940,15 +940,15 @@ mod tests {
     async fn completion_waits_until_the_handler_accepts_the_decision() {
         let bridge = ApprovalBridge::new();
         let owner = OwnerId::local();
-        let session_id = CodeSessionId::new();
+        let session_id = SessionId::new();
         let bearer = bridge.issue_token(&owner, session_id, 2);
         let subject = bridge.subject_for_token(&bearer).unwrap();
         let approval = approval(
             &owner,
             session_id,
-            CodeTurnId::new(),
+            TurnId::new(),
             2,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_ack",
             "cap-ack",
         );
@@ -971,15 +971,15 @@ mod tests {
     async fn losing_acknowledgement_after_delivery_is_ambiguous() {
         let bridge = ApprovalBridge::new();
         let owner = OwnerId::local();
-        let session_id = CodeSessionId::new();
+        let session_id = SessionId::new();
         let bearer = bridge.issue_token(&owner, session_id, 2);
         let subject = bridge.subject_for_token(&bearer).unwrap();
         let approval = approval(
             &owner,
             session_id,
-            CodeTurnId::new(),
+            TurnId::new(),
             2,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_lost_ack",
             "cap-lost-ack",
         );
@@ -1002,8 +1002,8 @@ mod tests {
     async fn token_rotation_closes_only_the_replaced_workers_calls() {
         let bridge = ApprovalBridge::new();
         let owner = OwnerId::local();
-        let replaced_session = CodeSessionId::new();
-        let other_session = CodeSessionId::new();
+        let replaced_session = SessionId::new();
+        let other_session = SessionId::new();
         let replaced_bearer = bridge.issue_token(&owner, replaced_session, 8);
         let other_bearer = bridge.issue_token(&owner, other_session, 3);
         let replaced_subject = bridge.subject_for_token(&replaced_bearer).unwrap();
@@ -1011,18 +1011,18 @@ mod tests {
         let replaced = approval(
             &owner,
             replaced_session,
-            CodeTurnId::new(),
+            TurnId::new(),
             8,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_replaced",
             "cap-replaced",
         );
         let other = approval(
             &owner,
             other_session,
-            CodeTurnId::new(),
+            TurnId::new(),
             3,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_other",
             "cap-other",
         );
@@ -1056,15 +1056,15 @@ mod tests {
     fn a_token_revoked_after_lookup_cannot_park() {
         let bridge = ApprovalBridge::new();
         let owner = OwnerId::local();
-        let session_id = CodeSessionId::new();
+        let session_id = SessionId::new();
         let stale_bearer = bridge.issue_token(&owner, session_id, 1);
         let stale_subject = bridge.subject_for_token(&stale_bearer).unwrap();
         let stale_approval = approval(
             &owner,
             session_id,
-            CodeTurnId::new(),
+            TurnId::new(),
             1,
-            CodeApprovalId::new(),
+            ApprovalId::new(),
             "toolu_stale",
             "cap-stale",
         );

--- a/crates/tidebreak-server/src/code/approval_sweep.rs
+++ b/crates/tidebreak-server/src/code/approval_sweep.rs
@@ -1,14 +1,14 @@
 //! Reconcile approvals whose tool call resolved before anyone decided.
 //!
 //! An approval is parked on the engine's `tool_use_id`, and the same id comes
-//! back on [`tidebreak_core::CodeEvent::ToolCompleted`]. When a completion arrives for a call
+//! back on [`tidebreak_core::Event::ToolCompleted`]. When a completion arrives for a call
 //! that still has a pending approval, nobody's decision can reach the engine
 //! any more: the engine timed the call out, denied it itself, or ran it under
 //! a rule of its own. Leaving the row `Pending` would list a request that can
 //! never be acted on, and would let a later `code approve` report success for
 //! a command the engine already failed.
 //!
-//! So the row moves to [`CodeApprovalState::Abandoned`] and the session
+//! So the row moves to [`ApprovalState::Abandoned`] and the session
 //! journals an `ApprovalResolved` carrying
 //! [`tidebreak_core::ApprovalDecisionKind::Abandoned`]. The turn and session boundaries sweep
 //! the same way, because a tool call that never reports completion must not
@@ -18,7 +18,7 @@ use tidebreak_core::db::code::{
     abandon_pending_approval, abandon_pending_approvals_for_stopped_session, get_session,
     list_approvals, list_turns,
 };
-use tidebreak_core::{CodeApproval, CodeApprovalState, CodeSessionId, DbStore, OwnerId};
+use tidebreak_core::{Approval, ApprovalState, DbStore, OwnerId, SessionId};
 
 use super::bus::CodeEventBus;
 
@@ -27,7 +27,7 @@ use super::bus::CodeEventBus;
 /// Written as a sibling of the capped payload, so an oversized request still
 /// carries it — the same field [`super::runtime::CodeRuntime::decide_approval`]
 /// reads.
-fn call_id_of(approval: &CodeApproval) -> Option<&str> {
+fn call_id_of(approval: &Approval) -> Option<&str> {
     approval.native_call_id.as_deref().or_else(|| {
         approval
             .harness_raw
@@ -42,14 +42,14 @@ pub(crate) async fn abandon_for_call(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
     call_id: &str,
 ) {
     if call_id.is_empty() {
         return;
     }
-    let doomed: Vec<CodeApproval> = pending_for_epoch(db, owner, session_id, spawn_epoch)
+    let doomed: Vec<Approval> = pending_for_epoch(db, owner, session_id, spawn_epoch)
         .await
         .into_iter()
         .filter(|approval| call_id_of(approval) == Some(call_id))
@@ -64,7 +64,7 @@ pub(crate) async fn abandon_for_settled_turns(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
 ) {
     let waiting = pending_for_epoch(db, owner, session_id, spawn_epoch).await;
@@ -79,7 +79,7 @@ pub(crate) async fn abandon_for_settled_turns(
         .filter(|turn| !turn.status.is_open())
         .map(|turn| turn.id)
         .collect();
-    let doomed: Vec<CodeApproval> = waiting
+    let doomed: Vec<Approval> = waiting
         .into_iter()
         .filter(|approval| settled.contains(&approval.turn_id))
         .collect();
@@ -96,7 +96,7 @@ pub(crate) async fn abandon_for_ended_session(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
 ) {
     if parks_are_durable(db, owner, session_id).await {
@@ -113,7 +113,7 @@ pub(crate) async fn abandon_for_restart(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
 ) {
     if parks_are_durable(db, owner, session_id).await {
@@ -132,30 +132,25 @@ pub(crate) async fn abandon_for_restart(
 
 /// Whether the session's engine holds its pending cards in the store rather
 /// than in a live process (decision 0048 step 5: `durable_parks`).
-async fn parks_are_durable(db: &DbStore, owner: &OwnerId, session_id: CodeSessionId) -> bool {
+async fn parks_are_durable(db: &DbStore, owner: &OwnerId, session_id: SessionId) -> bool {
     matches!(
         get_session(db, owner, session_id).await,
         Ok(Some(session)) if session.harness_kind == tidebreak_core::HarnessKind::Internal
     )
 }
 
-async fn pending(db: &DbStore, owner: &OwnerId, session_id: CodeSessionId) -> Vec<CodeApproval> {
-    list_approvals(
-        db,
-        owner,
-        Some(CodeApprovalState::Pending),
-        Some(session_id),
-    )
-    .await
-    .unwrap_or_default()
+async fn pending(db: &DbStore, owner: &OwnerId, session_id: SessionId) -> Vec<Approval> {
+    list_approvals(db, owner, Some(ApprovalState::Pending), Some(session_id))
+        .await
+        .unwrap_or_default()
 }
 
 async fn pending_for_epoch(
     db: &DbStore,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
-) -> Vec<CodeApproval> {
+) -> Vec<Approval> {
     pending(db, owner, session_id)
         .await
         .into_iter()
@@ -172,9 +167,9 @@ async fn abandon(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
-    doomed: Vec<CodeApproval>,
+    doomed: Vec<Approval>,
 ) {
     if doomed.is_empty() {
         return;
@@ -198,7 +193,7 @@ async fn refresh_attention_if_clear(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
 ) {
     if !pending(db, owner, session_id).await.is_empty() {
         return;

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -16,10 +16,9 @@ use tidebreak_core::db::code::{
     list_sessions_for_workspace, list_turns, replace_session_attention, save_session,
 };
 use tidebreak_core::{
-    preview_formatting_character, Attention, AttentionSource, AttentionState, CodeApprovalState,
-    CodeEvent, CodeSession, CodeSessionActivity, CodeSessionId, CodeSessionKind,
-    CodeSessionLifecycle, CodeSubagentStatus, CodeTurnStatus, DbStore, OwnerId, ToolDetail,
-    WorkspaceId,
+    preview_formatting_character, ApprovalState, Attention, AttentionSource, AttentionState,
+    CodeSubagentStatus, DbStore, Event, OwnerId, Session, SessionActivity, SessionId, SessionKind,
+    SessionLifecycle, ToolDetail, TurnStatus, WorkspaceId,
 };
 
 use super::bus::{CodeEventBus, CodeLiveUpdate, SessionDigest};
@@ -42,11 +41,7 @@ pub(crate) const ACTIVITY_DETAIL_MAX_CHARS: usize = 120;
 /// `from_user` is the explicit pin/clear path: it may replace anything,
 /// including [`AttentionState::Manual`]. Automatic writes still go through
 /// [`tidebreak_core::should_replace`].
-pub(crate) fn replace_attention(
-    session: &mut CodeSession,
-    next: Attention,
-    from_user: bool,
-) -> bool {
+pub(crate) fn replace_attention(session: &mut Session, next: Attention, from_user: bool) -> bool {
     if !from_user && !tidebreak_core::should_replace(&session.attention, &next) {
         return false;
     }
@@ -62,7 +57,7 @@ pub(crate) fn replace_attention(
 pub(crate) async fn persist_session(
     db: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
+    session: &Session,
 ) -> Result<bool, tidebreak_core::AgentError> {
     let ok = save_session(db, session).await?;
     if ok {
@@ -87,7 +82,7 @@ pub(crate) async fn apply_attention(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     next: Attention,
     from_user: bool,
 ) -> Result<Option<Attention>, tidebreak_core::AgentError> {
@@ -111,7 +106,7 @@ pub(crate) async fn apply_trigger_attention(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     delivery_id: tidebreak_core::CodeTriggerDeliveryId,
     lease_token: uuid::Uuid,
     next: Attention,
@@ -161,10 +156,10 @@ impl Default for ComputeOpts {
 pub(crate) async fn compute_attention(
     db: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
+    session: &Session,
     opts: ComputeOpts,
 ) -> Result<Attention, tidebreak_core::AgentError> {
-    if session.lifecycle == CodeSessionLifecycle::Fenced {
+    if session.lifecycle == SessionLifecycle::Fenced {
         if let Some(reason) = session.fence_reason.clone() {
             return Ok(Attention::new(
                 AttentionState::Fenced { reason },
@@ -175,7 +170,7 @@ pub(crate) async fn compute_attention(
     let pending = list_approvals(
         db,
         &session.owner,
-        Some(CodeApprovalState::Pending),
+        Some(ApprovalState::Pending),
         Some(session.id),
     )
     .await?;
@@ -185,7 +180,7 @@ pub(crate) async fn compute_attention(
             AttentionSource::Structured,
         ));
     }
-    if session.lifecycle == CodeSessionLifecycle::Running {
+    if session.lifecycle == SessionLifecycle::Running {
         let last = last_activity_at(db, bus, session).await?;
         let idle = opts.now.signed_duration_since(last).num_seconds().max(0) as u32;
         if idle >= opts.stall_idle_secs && !parked_on_background(db, session).await? {
@@ -197,17 +192,18 @@ pub(crate) async fn compute_attention(
         return Ok(Attention::working(AttentionSource::Lifecycle));
     }
     match latest_turn(db, &session.owner, session.id).await? {
-        Some(turn) if turn.status == CodeTurnStatus::Failed => Ok(Attention::needs_you(
+        Some(turn) if turn.status == TurnStatus::Failed => Ok(Attention::needs_you(
             "the engine turn failed",
             AttentionSource::Lifecycle,
         )),
-        Some(turn) if turn.status == CodeTurnStatus::Interrupted => Ok(Attention::needs_you(
+        Some(turn) if turn.status == TurnStatus::Interrupted => Ok(Attention::needs_you(
             "the turn was interrupted",
             AttentionSource::Lifecycle,
         )),
-        Some(turn) if turn.status == CodeTurnStatus::Completed && !opts.reviewed => Ok(
-            Attention::new(AttentionState::DoneUnreviewed, AttentionSource::Lifecycle),
-        ),
+        Some(turn) if turn.status == TurnStatus::Completed && !opts.reviewed => Ok(Attention::new(
+            AttentionState::DoneUnreviewed,
+            AttentionSource::Lifecycle,
+        )),
         // Nothing running, nothing waiting, nothing unreviewed. Reporting
         // `Working` here — as this arm used to — claims an engine is busy
         // when none is, and a session with no turns yet has never been busy
@@ -225,7 +221,7 @@ pub(crate) async fn mark_viewed(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
 ) -> Result<(), tidebreak_core::AgentError> {
     let Some(session) = get_session(db, owner, session_id).await? else {
         return Ok(());
@@ -255,10 +251,10 @@ pub(crate) async fn user_set_attention(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     clear: bool,
     note: Option<String>,
-) -> Result<CodeSession, tidebreak_core::AgentError> {
+) -> Result<Session, tidebreak_core::AgentError> {
     let Some(session) = get_session(db, owner, session_id).await? else {
         return Err(tidebreak_core::AgentError::Store(format!(
             "session {session_id} not found"
@@ -291,7 +287,7 @@ pub(crate) async fn sweep_stalled(
     idle_secs: u32,
 ) -> Result<(), tidebreak_core::AgentError> {
     let now = Utc::now();
-    let running = list_sessions_by_lifecycle_all_owners(db, CodeSessionLifecycle::Running).await?;
+    let running = list_sessions_by_lifecycle_all_owners(db, SessionLifecycle::Running).await?;
     for session in running {
         let last = last_activity_at(db, bus, &session).await?;
         let idle = now.signed_duration_since(last).num_seconds().max(0) as u32;
@@ -324,7 +320,7 @@ pub(crate) async fn note_activity(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
 ) -> Result<(), tidebreak_core::AgentError> {
     if !bus.maybe_stalled(session_id) {
         return Ok(());
@@ -334,7 +330,7 @@ pub(crate) async fn note_activity(
     };
     let stalled = matches!(session.attention.state, AttentionState::Stalled { .. });
     bus.set_maybe_stalled(session_id, stalled);
-    if session.lifecycle != CodeSessionLifecycle::Running {
+    if session.lifecycle != SessionLifecycle::Running {
         return Ok(());
     }
     if !stalled {
@@ -352,7 +348,7 @@ pub(crate) async fn note_activity(
     Ok(())
 }
 
-pub(crate) async fn emit_digest(db: &DbStore, bus: &CodeEventBus, session: &CodeSession) {
+pub(crate) async fn emit_digest(db: &DbStore, bus: &CodeEventBus, session: &Session) {
     match build_digest(db, session).await {
         Ok(digest) => {
             bus.publish_update(&session.owner, CodeLiveUpdate::Digest(Box::new(digest)));
@@ -385,8 +381,8 @@ pub(crate) async fn emit_workspace_digests(
     }
 }
 
-/// The owner's live session digests, restated on every `/code/updates`
-/// connect. Scoped: a subscriber never learns that another owner's session
+/// The owner's live session digests, restated on every `/updates`
+/// connection. Scoped: a subscriber never learns that another owner's session
 /// exists.
 pub(crate) async fn list_digests(
     db: &DbStore,
@@ -394,7 +390,7 @@ pub(crate) async fn list_digests(
 ) -> Result<Vec<SessionDigest>, tidebreak_core::AgentError> {
     let mut out = Vec::new();
     for session in list_sessions(db, owner).await? {
-        if session.lifecycle == CodeSessionLifecycle::Ended {
+        if session.lifecycle == SessionLifecycle::Ended {
             continue;
         }
         out.push(build_digest(db, &session).await?);
@@ -404,7 +400,7 @@ pub(crate) async fn list_digests(
 
 async fn build_digest(
     db: &DbStore,
-    session: &CodeSession,
+    session: &Session,
 ) -> Result<SessionDigest, tidebreak_core::AgentError> {
     let workspace = match session.workspace_id {
         Some(workspace_id) => Some(
@@ -423,12 +419,12 @@ async fn build_digest(
     // A watch session's lifecycle undersells it ("running" for hours), so its
     // digest carries the watch's own state. The row is small and local — this
     // never reaches the host the way the PR snapshot does.
-    let watch = if session.kind == CodeSessionKind::Watch {
+    let watch = if session.kind == SessionKind::Watch {
         latest_watch_for_session(db, &session.owner, session.id).await?
     } else {
         None
     };
-    let (activity, activity_detail) = if session.lifecycle == CodeSessionLifecycle::Running {
+    let (activity, activity_detail) = if session.lifecycle == SessionLifecycle::Running {
         let events =
             list_recent_events(db, &session.owner, session.id, ACTIVITY_EVENT_WINDOW).await?;
         let (activity, detail) = session_activity(session, &events);
@@ -492,7 +488,7 @@ async fn build_digest(
     })
 }
 
-async fn memory_proposal_count(db: &DbStore, session: &CodeSession) -> Option<u64> {
+async fn memory_proposal_count(db: &DbStore, session: &Session) -> Option<u64> {
     use tidebreak_core::{MemoryBackend, MemoryEvidence, MemoryListFilter, MemoryStatus};
     let records = db
         .list(
@@ -515,7 +511,7 @@ async fn memory_proposal_count(db: &DbStore, session: &CodeSession) -> Option<u6
                 && record.provenance.evidence.iter().any(|evidence| {
                     matches!(
                         evidence,
-                        MemoryEvidence::CodeEvent { session_id, .. } if *session_id == session.id
+                        MemoryEvidence::Event { session_id, .. } if *session_id == session.id
                     )
                 })
         })
@@ -527,40 +523,40 @@ async fn memory_proposal_count(db: &DbStore, session: &CodeSession) -> Option<u6
 /// monitor tool, or one or more harness subagents.
 async fn parked_on_background(
     db: &DbStore,
-    session: &CodeSession,
+    session: &Session,
 ) -> Result<bool, tidebreak_core::AgentError> {
     let events = list_recent_events(db, &session.owner, session.id, ACTIVITY_EVENT_WINDOW).await?;
     Ok(matches!(
         session_activity(session, &events).0,
-        CodeSessionActivity::Monitor | CodeSessionActivity::Subagents
+        SessionActivity::Monitor | SessionActivity::Subagents
     ))
 }
 
 /// What the live turn is occupied with, and the subject of the tool it is
 /// waiting on when that tool named one.
 fn session_activity(
-    session: &CodeSession,
-    events: &[tidebreak_core::SequencedCodeEvent],
-) -> (CodeSessionActivity, Option<String>) {
+    session: &Session,
+    events: &[tidebreak_core::code::SequencedEvent],
+) -> (SessionActivity, Option<String>) {
     if session
         .subagents
         .iter()
         .any(|entry| entry.status == CodeSubagentStatus::Running)
     {
-        return (CodeSessionActivity::Subagents, None);
+        return (SessionActivity::Subagents, None);
     }
 
     let mut completed = HashSet::new();
     for sequenced in events {
         match &sequenced.event {
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id,
                 parent_call_id: None,
                 ..
             } => {
                 completed.insert(call_id.as_str());
             }
-            CodeEvent::ToolStarted {
+            Event::ToolStarted {
                 call_id,
                 name,
                 detail,
@@ -568,15 +564,15 @@ fn session_activity(
             } if !completed.contains(call_id.as_str()) => {
                 return (classify_activity(name, detail), activity_detail(detail));
             }
-            CodeEvent::TurnStarted { .. }
-            | CodeEvent::TurnCompleted { .. }
-            | CodeEvent::TurnRefused { .. }
-            | CodeEvent::TurnFailed { .. }
-            | CodeEvent::TurnInterrupted { .. } => break,
+            Event::TurnStarted { .. }
+            | Event::TurnCompleted { .. }
+            | Event::TurnRefused { .. }
+            | Event::TurnFailed { .. }
+            | Event::TurnInterrupted { .. } => break,
             _ => {}
         }
     }
-    (CodeSessionActivity::Agent, None)
+    (SessionActivity::Agent, None)
 }
 
 /// One line naming what the tool is doing, or nothing when the detail has no
@@ -609,22 +605,22 @@ fn activity_detail(detail: &ToolDetail) -> Option<String> {
     })
 }
 
-fn classify_activity(name: &str, detail: &ToolDetail) -> CodeSessionActivity {
+fn classify_activity(name: &str, detail: &ToolDetail) -> SessionActivity {
     let normalized = name.to_ascii_lowercase().replace(['_', '-'], "");
     if normalized == "task" {
-        return CodeSessionActivity::Subagents;
+        return SessionActivity::Subagents;
     }
     if normalized.contains("output")
         || normalized.contains("monitor")
         || normalized.starts_with("wait")
     {
-        return CodeSessionActivity::Monitor;
+        return SessionActivity::Monitor;
     }
     match detail {
-        ToolDetail::Command { .. } => CodeSessionActivity::Shell,
-        ToolDetail::FileEdit { .. } | ToolDetail::FileRead { .. } => CodeSessionActivity::File,
-        ToolDetail::Search { .. } => CodeSessionActivity::Search,
-        ToolDetail::Other { .. } => CodeSessionActivity::Tool,
+        ToolDetail::Command { .. } => SessionActivity::Shell,
+        ToolDetail::FileEdit { .. } | ToolDetail::FileRead { .. } => SessionActivity::File,
+        ToolDetail::Search { .. } => SessionActivity::Search,
+        ToolDetail::Other { .. } => SessionActivity::Tool,
     }
 }
 
@@ -637,7 +633,7 @@ fn classify_activity(name: &str, detail: &ToolDetail) -> CodeSessionActivity {
 async fn last_activity_at(
     db: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
+    session: &Session,
 ) -> Result<DateTime<Utc>, tidebreak_core::AgentError> {
     let journaled = match latest_event_created_at(db, &session.owner, session.id).await? {
         Some(at) => at,
@@ -682,9 +678,9 @@ impl Drop for StallSweepGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tidebreak_core::code::SequencedEvent;
     use tidebreak_core::{
-        should_replace, CodeSessionKind, CodeSubagentSummary, FenceReason, SequencedCodeEvent,
-        ToolOutcome, WorkspaceId,
+        should_replace, CodeSubagentSummary, FenceReason, SessionKind, ToolOutcome, WorkspaceId,
     };
 
     fn auto_working() -> Attention {
@@ -702,12 +698,12 @@ mod tests {
         )
     }
 
-    fn session_with(attention: Attention) -> CodeSession {
-        CodeSession {
-            id: CodeSessionId::new(),
+    fn session_with(attention: Attention) -> Session {
+        Session {
+            id: SessionId::new(),
             owner: tidebreak_core::OwnerId::local(),
             workspace_id: Some(WorkspaceId::new()),
-            kind: CodeSessionKind::Interactive,
+            kind: SessionKind::Interactive,
             harness_kind: tidebreak_core::HarnessKind::ClaudeCode,
             harness_version: None,
             harness_resume_ref: None,
@@ -715,7 +711,7 @@ mod tests {
             model: None,
             reasoning_effort: None,
             fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Idle,
+            lifecycle: SessionLifecycle::Idle,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,
@@ -727,12 +723,12 @@ mod tests {
         }
     }
 
-    fn sequenced(seq: i64, event: CodeEvent) -> SequencedCodeEvent {
-        SequencedCodeEvent { seq, event }
+    fn sequenced(seq: i64, event: Event) -> SequencedEvent {
+        SequencedEvent { seq, event }
     }
 
-    fn started(name: &str, detail: ToolDetail) -> CodeEvent {
-        CodeEvent::ToolStarted {
+    fn started(name: &str, detail: ToolDetail) -> Event {
+        Event::ToolStarted {
             call_id: "tool-1".into(),
             name: name.into(),
             detail,
@@ -829,7 +825,7 @@ mod tests {
 
         assert_eq!(
             session_activity(&session, &events),
-            (CodeSessionActivity::Shell, Some("cargo test".to_owned()))
+            (SessionActivity::Shell, Some("cargo test".to_owned()))
         );
     }
 
@@ -890,7 +886,7 @@ mod tests {
         assert_eq!(
             session_activity(&session, &events),
             (
-                CodeSessionActivity::Monitor,
+                SessionActivity::Monitor,
                 Some("waiting for a background command".to_owned())
             )
         );
@@ -907,7 +903,7 @@ mod tests {
 
         assert_eq!(
             session_activity(&session, &[]),
-            (CodeSessionActivity::Subagents, None)
+            (SessionActivity::Subagents, None)
         );
     }
 
@@ -917,7 +913,7 @@ mod tests {
         let events = [
             sequenced(
                 3,
-                CodeEvent::ToolCompleted {
+                Event::ToolCompleted {
                     call_id: "tool-1".into(),
                     outcome: ToolOutcome::Succeeded,
                     preview: "done".into(),
@@ -942,7 +938,7 @@ mod tests {
 
         assert_eq!(
             session_activity(&session, &events),
-            (CodeSessionActivity::Agent, None)
+            (SessionActivity::Agent, None)
         );
     }
 }

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -27,7 +27,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use tidebreak_core::{CodeSessionId, OwnerId, WorkspaceId};
+use tidebreak_core::{OwnerId, SessionId, WorkspaceId};
 use tidebreak_harness::BrowserChannelSpec;
 
 /// Capfile format version. Increment when the schema changes in a backward-
@@ -47,7 +47,7 @@ const CAPFILE_SUBDIR: &str = "browser-caps";
 pub(crate) struct BrowserSubject {
     pub owner: OwnerId,
     pub workspace: WorkspaceId,
-    pub session: CodeSessionId,
+    pub session: SessionId,
 }
 
 /// Per-session state held in the registry.
@@ -63,7 +63,7 @@ struct SessionEntry {
 /// into inconsistent state.
 struct RegistryState {
     tokens: HashMap<String, BrowserSubject>,
-    by_session: HashMap<CodeSessionId, SessionEntry>,
+    by_session: HashMap<SessionId, SessionEntry>,
 }
 
 // ── registry ────────────────────────────────────────────────────────────────
@@ -257,7 +257,7 @@ impl BrowserTokenRegistry {
     /// Returns the [`BrowserSubject`] that was mapped to the revoked
     /// session so the caller can derive an adapter scope, or `None` if
     /// the session was not found (idempotent).
-    pub(crate) fn revoke(&self, session_id: CodeSessionId) -> Option<BrowserSubject> {
+    pub(crate) fn revoke(&self, session_id: SessionId) -> Option<BrowserSubject> {
         let mut state = self.state.lock().expect("browser registry");
         match state.by_session.remove(&session_id) {
             Some(entry) => {
@@ -478,7 +478,7 @@ mod tests {
         BrowserSubject {
             owner: OwnerId::local(),
             workspace: WorkspaceId::new(),
-            session: CodeSessionId::new(),
+            session: SessionId::new(),
         }
     }
 
@@ -608,7 +608,7 @@ mod tests {
     fn revoke_nonexistent_session_is_noop() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
-        let nonexistent = CodeSessionId::new();
+        let nonexistent = SessionId::new();
         reg.revoke(nonexistent);
     }
 

--- a/crates/tidebreak-server/src/code/browser_runtime.rs
+++ b/crates/tidebreak-server/src/code/browser_runtime.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use tidebreak_core::{
     BrowserActArgs, BrowserActResult, BrowserListResult, BrowserNavigateArgs,
     BrowserNavigateResult, BrowserPageSnapshot, BrowserScreenshotArgs, BrowserScreenshotResult,
-    BrowserSnapshotArgs, BrowserWaitArgs, BrowserWaitResult, CodeSessionId, OwnerId, WorkspaceId,
+    BrowserSnapshotArgs, BrowserWaitArgs, BrowserWaitResult, OwnerId, SessionId, WorkspaceId,
 };
 
 // ── BrowserRuntimeScope ─────────────────────────────────────────────────────
@@ -32,7 +32,7 @@ use tidebreak_core::{
 pub struct BrowserRuntimeScope {
     pub owner: OwnerId,
     pub workspace: WorkspaceId,
-    pub session: CodeSessionId,
+    pub session: SessionId,
 }
 
 impl From<crate::code::browser_channel::BrowserSubject> for BrowserRuntimeScope {

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -12,7 +12,7 @@
 //! the text streamed so far so a reader who connects mid-answer is not shown
 //! a sentence that starts in the middle.
 //!
-//! `/code/updates` is unsequenced: a dropped notice costs nothing because the
+//! The `/updates` stream is unsequenced: a dropped notice costs nothing because the
 //! full digest is restated on every connect.
 //!
 //! Updates are keyed by owner rather than filtered on the way out. There is
@@ -27,27 +27,28 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
+use tidebreak_core::code::SequencedEvent;
 use tidebreak_core::{
-    Attention, CodeEvent, CodeSessionActivity, CodeSessionId, CodeSessionKind,
-    CodeSessionLifecycle, CodeSubagentSummary, CodeTurnId, CodeWatchState, HarnessKind, OwnerId,
-    PullRequestDigest, RepoId, SequencedCodeEvent, WorkspaceId, MAX_EVENT_TEXT_CHARS,
+    Attention, CodeSubagentSummary, CodeWatchState, Event, HarnessKind, OwnerId, PullRequestDigest,
+    RepoId, SessionActivity, SessionId, SessionKind, SessionLifecycle, TurnId, WorkspaceId,
+    MAX_EVENT_TEXT_CHARS,
 };
 use tokio::sync::{broadcast, Notify};
 
 const LIVE_BUFFER: usize = 256;
 const UPDATES_BUFFER: usize = 256;
 
-/// Cheap per-session digest published on `/code/updates`.
+/// Cheap per-session digest published on `/updates`.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SessionDigest {
     /// `None` for a session that binds no workspace.
     pub workspace: Option<WorkspaceId>,
-    pub session: CodeSessionId,
-    pub kind: CodeSessionKind,
+    pub session: SessionId,
+    pub kind: SessionKind,
     /// Engine identity for list surfaces that collapse several sessions into
     /// one workspace row.
     pub harness_kind: HarnessKind,
-    pub lifecycle: CodeSessionLifecycle,
+    pub lifecycle: SessionLifecycle,
     pub attention: Attention,
     pub title: String,
     pub turn_count: i64,
@@ -56,7 +57,7 @@ pub(crate) struct SessionDigest {
     pub trigger_target_at: DateTime<Utc>,
     /// What the live turn is occupied with. Set only while lifecycle is
     /// running; older clients safely fall back to a generic running label.
-    pub activity: Option<CodeSessionActivity>,
+    pub activity: Option<SessionActivity>,
     /// The subject of the tool the live turn is waiting on: the command,
     /// path, query, or task description. Set only while `activity` names a
     /// tool; bounded so a digest never carries a whole script.
@@ -125,8 +126,8 @@ pub(crate) enum CodeLiveUpdate {
 /// Progress of one background rewrite of a completed turn's closing message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TurnRewriteNotice {
-    pub session: CodeSessionId,
-    pub turn_id: CodeTurnId,
+    pub session: SessionId,
+    pub turn_id: TurnId,
     pub state: TurnRewriteState,
     pub rewrite: Option<String>,
 }
@@ -142,9 +143,9 @@ pub(crate) enum TurnRewriteState {
 /// Per-session broadcast channels for live journal events, plus one digest
 /// channel per owner.
 pub(crate) struct CodeEventBus {
-    channels: Mutex<HashMap<CodeSessionId, LiveSession>>,
+    channels: Mutex<HashMap<SessionId, LiveSession>>,
     updates: Mutex<HashMap<OwnerId, broadcast::Sender<CodeLiveUpdate>>>,
-    /// Fires when a `/code/updates` socket subscribes, so background work
+    /// Fires when a client subscribes to `/updates`, so background work
     /// that slows down while nobody is looking can speed back up at once.
     updates_attached: Notify,
 }
@@ -199,7 +200,7 @@ pub(crate) struct CodeLiveEvent {
     /// the turn's end) restates or discards this text, and a reader whose
     /// replay already read that far must not be handed the fragment as well.
     pub cursor: i64,
-    pub event: CodeEvent,
+    pub event: Event,
 }
 
 /// What a freshly attached reader needs to catch up on the live tail.
@@ -222,11 +223,7 @@ impl Default for CodeEventBus {
 }
 
 impl CodeEventBus {
-    fn with_session<T>(
-        &self,
-        session: CodeSessionId,
-        act: impl FnOnce(&mut LiveSession) -> T,
-    ) -> T {
+    fn with_session<T>(&self, session: SessionId, act: impl FnOnce(&mut LiveSession) -> T) -> T {
         let mut channels = self.channels.lock().expect("code event bus lock");
         act(channels.entry(session).or_default())
     }
@@ -239,7 +236,7 @@ impl CodeEventBus {
     /// same lock, so nothing lands between these two lines.
     pub(crate) fn attach(
         &self,
-        session: CodeSessionId,
+        session: SessionId,
     ) -> (broadcast::Receiver<CodeLiveEvent>, LiveTail) {
         self.with_session(session, |live| {
             (
@@ -257,7 +254,7 @@ impl CodeEventBus {
     /// Journaled events are what the tail is measured against: an event that
     /// finishes the assistant's turn of speech retires the buffered text
     /// rather than leaving a stale copy for the next reconnect to replay.
-    pub(crate) fn publish(&self, session: CodeSessionId, event: SequencedCodeEvent) {
+    pub(crate) fn publish(&self, session: SessionId, event: SequencedEvent) {
         self.with_session(session, |live| {
             live.cursor = live.cursor.max(event.seq);
             live.last_activity = Utc::now();
@@ -278,10 +275,10 @@ impl CodeEventBus {
     /// reader watches an answer arrive, and the `assistant_message` that
     /// follows carries the same bytes, so the durable copy would say nothing
     /// new (record 57).
-    pub(crate) fn publish_transient(&self, session: CodeSessionId, event: CodeEvent) {
+    pub(crate) fn publish_transient(&self, session: SessionId, event: Event) {
         self.with_session(session, |live| {
             live.last_activity = Utc::now();
-            if let CodeEvent::AssistantDelta { text } = &event {
+            if let Event::AssistantDelta { text } = &event {
                 append_bounded(&mut live.assistant, text);
             }
             let _ = live.sender.send(CodeLiveEvent {
@@ -296,7 +293,7 @@ impl CodeEventBus {
     ///
     /// Empty once the message lands. Taking it clears it, which is what the
     /// journal path wants: it is about to write the text down.
-    pub(crate) fn take_assistant_tail(&self, session: CodeSessionId) -> String {
+    pub(crate) fn take_assistant_tail(&self, session: SessionId) -> String {
         self.with_session(session, |live| std::mem::take(&mut live.assistant))
     }
 
@@ -305,7 +302,7 @@ impl CodeEventBus {
     /// The stall sweep reads it. Without it a session streaming a long answer
     /// and nothing else would look silent, because the deltas carrying that
     /// answer no longer touch a row's `created_at`.
-    pub(crate) fn last_activity(&self, session: CodeSessionId) -> Option<DateTime<Utc>> {
+    pub(crate) fn last_activity(&self, session: SessionId) -> Option<DateTime<Utc>> {
         self.channels
             .lock()
             .expect("code event bus lock")
@@ -318,7 +315,7 @@ impl CodeEventBus {
     /// A hint, not an answer: it starts pessimistic and is corrected by the
     /// first caller that reads the row. Its job is to spare the common path —
     /// a running session that is not stalled — a `get_session` per event.
-    pub(crate) fn maybe_stalled(&self, session: CodeSessionId) -> bool {
+    pub(crate) fn maybe_stalled(&self, session: SessionId) -> bool {
         self.channels
             .lock()
             .expect("code event bus lock")
@@ -328,7 +325,7 @@ impl CodeEventBus {
 
     /// Record what the session row actually says, so the next event can skip
     /// the read.
-    pub(crate) fn set_maybe_stalled(&self, session: CodeSessionId, stalled: bool) {
+    pub(crate) fn set_maybe_stalled(&self, session: SessionId, stalled: bool) {
         self.with_session(session, |live| live.maybe_stalled = stalled);
     }
 
@@ -342,19 +339,19 @@ impl CodeEventBus {
     }
 
     /// Subscribe to one owner's updates. The receiver is the only view of the
-    /// channel a `/code/updates` socket gets, and it carries nothing else.
+    /// channel available to an `/updates` socket, and it carries nothing else.
     ///
     /// Subscribing also wakes [`Self::updates_attached`] waiters. A
-    /// `/code/updates` socket is how a client says it is looking, and sweeps
-    /// that back off while nobody is use that moment to return to their fast
-    /// cadence.
+    /// A client says it is looking by opening an `/updates` socket. Sweeps
+    /// that back off while nobody is looking use that moment to return to
+    /// their fast cadence.
     pub(crate) fn subscribe_updates(&self, owner: &OwnerId) -> broadcast::Receiver<CodeLiveUpdate> {
         let receiver = self.updates_sender(owner).subscribe();
         self.updates_attached.notify_one();
         receiver
     }
 
-    /// Whether any client currently holds a `/code/updates` subscription.
+    /// Whether any client currently holds an `/updates` subscription.
     ///
     /// This is the server's "someone is looking" signal for code mode: the
     /// desktop keeps that socket open for as long as it runs, and the CLI
@@ -368,7 +365,7 @@ impl CodeEventBus {
             .any(|sender| sender.receiver_count() > 0)
     }
 
-    /// Resolve the next time a `/code/updates` socket subscribes.
+    /// Resolve when a client next subscribes to `/updates`.
     ///
     /// One pending wake is retained if nobody is waiting when a subscription
     /// lands, so a caller that checks [`Self::has_updates_subscribers`] and
@@ -392,21 +389,21 @@ impl CodeEventBus {
 /// a turn boundary closes it the same way the renderer's reducer does. Child
 /// (subagent) messages and calls are excluded: they never owned the parent's
 /// buffer.
-fn ends_assistant_text(event: &CodeEvent) -> bool {
+fn ends_assistant_text(event: &Event) -> bool {
     matches!(
         event,
-        CodeEvent::AssistantMessage {
+        Event::AssistantMessage {
             parent_call_id: None,
             ..
-        } | CodeEvent::ToolStarted {
+        } | Event::ToolStarted {
             parent_call_id: None,
             ..
-        } | CodeEvent::TurnStarted { .. }
-            | CodeEvent::TurnResumed { .. }
-            | CodeEvent::TurnCompleted { .. }
-            | CodeEvent::TurnRefused { .. }
-            | CodeEvent::TurnFailed { .. }
-            | CodeEvent::TurnInterrupted { .. }
+        } | Event::TurnStarted { .. }
+            | Event::TurnResumed { .. }
+            | Event::TurnCompleted { .. }
+            | Event::TurnRefused { .. }
+            | Event::TurnFailed { .. }
+            | Event::TurnInterrupted { .. }
     )
 }
 

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -40,12 +40,13 @@ use tokio::process::Command;
 use tokio::time::{timeout, timeout_at, Instant};
 use tracing::warn;
 
+use tidebreak_core::code::SequencedEvent;
 use tidebreak_core::db::code::{
     append_event, get_session, get_turn, get_workspace, list_turns, save_turn,
 };
 use tidebreak_core::{
-    CodeEvent, CodeSession, CodeSessionId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace,
-    DbStore, Diffstat, FileChangeKind, HarnessNoticeLevel, SequencedCodeEvent, WorkspaceId,
+    CodeWorkspace, DbStore, Diffstat, Event, FileChangeKind, HarnessNoticeLevel, Session,
+    SessionId, Turn, TurnId, TurnStatus, WorkspaceId,
 };
 
 use super::bus::CodeEventBus;
@@ -263,14 +264,14 @@ impl SnapshotGit for ProcessSnapshotGit {
 /// [`delete_workspace_refs`] can match every session by prefix.
 pub(crate) fn checkpoint_ref(
     workspace_id: WorkspaceId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     ordinal: i64,
 ) -> String {
     format!("{REF_PREFIX}/{workspace_id}/{session_id}/{ordinal}")
 }
 
 /// Hidden ref for where one session started.
-pub(crate) fn session_baseline_ref(workspace_id: WorkspaceId, session_id: CodeSessionId) -> String {
+pub(crate) fn session_baseline_ref(workspace_id: WorkspaceId, session_id: SessionId) -> String {
     checkpoint_ref(workspace_id, session_id, BASELINE_ORDINAL)
 }
 
@@ -288,7 +289,7 @@ pub(crate) fn session_baseline_ref(workspace_id: WorkspaceId, session_id: CodeSe
 pub(crate) async fn record_session_baseline(
     worktree: &Path,
     workspace_id: WorkspaceId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
 ) -> Result<String, CheckpointError> {
     let r#ref = session_baseline_ref(workspace_id, session_id);
     write_snapshot_ref(worktree, &r#ref, None, "session baseline").await?;
@@ -304,17 +305,17 @@ pub(crate) async fn record_session_baseline(
 /// `Running` turn is skipped — the worktree is still moving — and a turn that
 /// already holds a ref is left alone.
 ///
-/// Checkpoint failure does not fail the turn: a [`CodeEvent::HarnessNotice`]
+/// Checkpoint failure does not fail the turn: a [`Event::HarnessNotice`]
 /// is journaled and the already-recorded work stands.
 pub(crate) async fn after_turn_ended(
     db: &Arc<DbStore>,
     bus: &Arc<CodeEventBus>,
-    session: &CodeSession,
-    turn: &mut CodeTurn,
+    session: &Session,
+    turn: &mut Turn,
 ) {
     let terminal = matches!(
         turn.status,
-        CodeTurnStatus::Completed | CodeTurnStatus::Failed | CodeTurnStatus::Interrupted
+        TurnStatus::Completed | TurnStatus::Failed | TurnStatus::Interrupted
     );
     if !terminal || turn.checkpoint_ref.is_some() {
         return;
@@ -339,7 +340,7 @@ pub(crate) async fn after_turn_ended(
                 db,
                 bus,
                 session,
-                CodeEvent::CheckpointRecorded {
+                Event::CheckpointRecorded {
                     turn_id: turn.id,
                     diffstat: recorded.diffstat,
                 },
@@ -358,7 +359,7 @@ pub(crate) async fn after_turn_ended(
                 db,
                 bus,
                 session,
-                CodeEvent::HarnessNotice {
+                Event::HarnessNotice {
                     level: HarnessNoticeLevel::Warning,
                     message,
                 },
@@ -370,8 +371,8 @@ pub(crate) async fn after_turn_ended(
 
 async fn record_for_turn(
     db: &DbStore,
-    session: &CodeSession,
-    turn: &CodeTurn,
+    session: &Session,
+    turn: &Turn,
 ) -> Result<RecordedCheckpoint, CheckpointError> {
     let workspace_id = session
         .workspace_id
@@ -401,9 +402,9 @@ async fn record_for_turn(
 pub(crate) async fn record_checkpoint(
     worktree: &Path,
     workspace_id: WorkspaceId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     ordinal: i64,
-    status: CodeTurnStatus,
+    status: TurnStatus,
     previous_oid: Option<&str>,
     base_ref: &str,
 ) -> Result<RecordedCheckpoint, CheckpointError> {
@@ -909,8 +910,8 @@ pub(crate) async fn list_checkpoint_refs(repo_root: &Path) -> Result<Vec<String>
 pub(crate) async fn resolve_diff_range(
     db: &DbStore,
     workspace: &CodeWorkspace,
-    turn_id: Option<CodeTurnId>,
-) -> Result<(PathBuf, String, String, Option<CodeTurnId>), CheckpointError> {
+    turn_id: Option<TurnId>,
+) -> Result<(PathBuf, String, String, Option<TurnId>), CheckpointError> {
     let worktree = PathBuf::from(&workspace.worktree_path);
     if !worktree.exists() {
         return Err(CheckpointError::user("workspace worktree is gone"));
@@ -973,7 +974,7 @@ async fn previous_checkpoint_oid(
     worktree: &Path,
     workspace: &CodeWorkspace,
     db: &DbStore,
-    turn: &CodeTurn,
+    turn: &Turn,
 ) -> Result<Option<String>, CheckpointError> {
     if turn.ordinal <= BASELINE_ORDINAL {
         return Ok(None);
@@ -1229,11 +1230,11 @@ async fn delete_ref(repo_root: &Path, r#ref: &str) -> Result<(), CheckpointError
 async fn journal(
     db: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
-    event: CodeEvent,
-) -> Result<(), tidebreak_core::db::code::CodeJournalError> {
+    session: &Session,
+    event: Event,
+) -> Result<(), tidebreak_core::db::code::JournalError> {
     let seq = append_event(db, &session.owner, session.id, session.spawn_epoch, &event).await?;
-    bus.publish(session.id, SequencedCodeEvent { seq, event });
+    bus.publish(session.id, SequencedEvent { seq, event });
     Ok(())
 }
 
@@ -1515,8 +1516,8 @@ mod tests {
         insert_repo, insert_session, insert_turn, insert_workspace, list_events, MAX_REPLAY_EVENTS,
     };
     use tidebreak_core::{
-        Attention, AttentionSource, CodeRepo, CodeSessionKind, CodeSessionLifecycle, CodeTurnId,
-        CodeWorkspaceStatus, HarnessKind, OwnerId, PermissionMode, RepoId,
+        Attention, AttentionSource, CodeRepo, CodeWorkspaceStatus, HarnessKind, OwnerId,
+        PermissionMode, RepoId, SessionKind, SessionLifecycle, TurnId,
     };
     use tokio::sync::Notify;
 
@@ -1644,8 +1645,8 @@ mod tests {
         WorkspaceId::new()
     }
 
-    fn sess() -> CodeSessionId {
-        CodeSessionId::new()
+    fn sess() -> SessionId {
+        SessionId::new()
     }
 
     #[tokio::test]
@@ -1662,17 +1663,10 @@ mod tests {
         std::fs::set_permissions(tree.join("README.md"), perms).unwrap();
 
         let before = user_git_fingerprint(&tree).await.unwrap();
-        let recorded = record_checkpoint(
-            &tree,
-            ws(),
-            sess(),
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
+        let recorded =
+            record_checkpoint(&tree, ws(), sess(), 1, TurnStatus::Completed, None, "main")
+                .await
+                .unwrap();
         let after = user_git_fingerprint(&tree).await.unwrap();
         assert_eq!(before, after, "user index and HEAD must be byte-identical");
         assert!(recorded.checkpoint_ref.starts_with(REF_PREFIX));
@@ -1758,17 +1752,10 @@ mod tests {
         std::fs::write(tree.join("src/beta.rs"), format!("{body}line 13\n")).unwrap();
         std::fs::write(tree.join("café.txt"), "un\ndeux\n").unwrap();
 
-        let recorded = record_checkpoint(
-            &tree,
-            ws(),
-            sess(),
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
+        let recorded =
+            record_checkpoint(&tree, ws(), sess(), 1, TurnStatus::Completed, None, "main")
+                .await
+                .unwrap();
         let from = merge_base(&tree, "main").await.unwrap();
         let files = list_changed_files(
             &tree,
@@ -1872,17 +1859,10 @@ mod tests {
         )
         .unwrap();
 
-        let recorded = record_checkpoint(
-            &tree,
-            ws(),
-            sess(),
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
+        let recorded =
+            record_checkpoint(&tree, ws(), sess(), 1, TurnStatus::Completed, None, "main")
+                .await
+                .unwrap();
         let from = merge_base(&tree, "main").await.unwrap();
         let files = list_changed_files(
             &tree,
@@ -1961,17 +1941,10 @@ mod tests {
         std::fs::write(tree.join(literal), "literal magic\n").unwrap();
         std::fs::write(tree.join("victim.txt"), "must stay out\n").unwrap();
 
-        let recorded = record_checkpoint(
-            &tree,
-            ws(),
-            sess(),
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
+        let recorded =
+            record_checkpoint(&tree, ws(), sess(), 1, TurnStatus::Completed, None, "main")
+                .await
+                .unwrap();
         let from = merge_base(&tree, "main").await.unwrap();
         let diff = produce_diff(
             &tree,
@@ -1999,17 +1972,10 @@ mod tests {
         std::fs::write(tree.join("b-second.txt"), "second\n").unwrap();
         std::fs::write(tree.join("z-selected.txt"), "one\ntwo\n").unwrap();
 
-        let recorded = record_checkpoint(
-            &tree,
-            ws(),
-            sess(),
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
+        let recorded =
+            record_checkpoint(&tree, ws(), sess(), 1, TurnStatus::Completed, None, "main")
+                .await
+                .unwrap();
         let from = merge_base(&tree, "main").await.unwrap();
         let bounds = DiffBounds {
             max_bytes: MAX_DIFF_BYTES,
@@ -2048,17 +2014,9 @@ mod tests {
         let id = ws();
         let session = sess();
         std::fs::write(tree.join("a.txt"), "one\n").unwrap();
-        let first = record_checkpoint(
-            &tree,
-            id,
-            session,
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
+        let first = record_checkpoint(&tree, id, session, 1, TurnStatus::Completed, None, "main")
+            .await
+            .unwrap();
         std::fs::write(tree.join("b.txt"), "two\n").unwrap();
         let first_oid = git_text(&tree, &["rev-parse", &first.checkpoint_ref], GIT_TIMEOUT)
             .await
@@ -2068,7 +2026,7 @@ mod tests {
             id,
             session,
             2,
-            CodeTurnStatus::Completed,
+            TurnStatus::Completed,
             Some(&first_oid),
             "main",
         )
@@ -2115,17 +2073,10 @@ mod tests {
             )
             .unwrap();
         }
-        let recorded = record_checkpoint(
-            &tree,
-            ws(),
-            sess(),
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
+        let recorded =
+            record_checkpoint(&tree, ws(), sess(), 1, TurnStatus::Completed, None, "main")
+                .await
+                .unwrap();
         let from = merge_base(&tree, "main").await.unwrap();
         let tight = DiffBounds {
             max_bytes: 40,
@@ -2191,28 +2142,12 @@ mod tests {
         let live = ws();
         let dead = ws();
         std::fs::write(tree.join("x.txt"), "x\n").unwrap();
-        record_checkpoint(
-            &tree,
-            live,
-            sess(),
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
-        record_checkpoint(
-            &tree,
-            dead,
-            sess(),
-            1,
-            CodeTurnStatus::Completed,
-            None,
-            "main",
-        )
-        .await
-        .unwrap();
+        record_checkpoint(&tree, live, sess(), 1, TurnStatus::Completed, None, "main")
+            .await
+            .unwrap();
+        record_checkpoint(&tree, dead, sess(), 1, TurnStatus::Completed, None, "main")
+            .await
+            .unwrap();
         let listed = list_checkpoint_refs(&repo).await.unwrap();
         assert_eq!(listed.len(), 2, "{listed:?}");
 
@@ -2248,7 +2183,7 @@ mod tests {
             workspace,
             first_session,
             1,
-            CodeTurnStatus::Completed,
+            TurnStatus::Completed,
             None,
             "main",
         )
@@ -2260,7 +2195,7 @@ mod tests {
             workspace,
             second_session,
             1,
-            CodeTurnStatus::Completed,
+            TurnStatus::Completed,
             None,
             "main",
         )
@@ -2509,7 +2444,7 @@ mod tests {
     async fn seed_session(
         repo: &Path,
         worktree: &Path,
-    ) -> (Arc<DbStore>, Arc<CodeEventBus>, CodeSession) {
+    ) -> (Arc<DbStore>, Arc<CodeEventBus>, Session) {
         let db = Arc::new(
             DbStore::connect(&format!(
                 "sqlite://{}?mode=rwc",
@@ -2564,11 +2499,11 @@ mod tests {
         )
         .await
         .unwrap();
-        let session = CodeSession {
-            id: CodeSessionId::new(),
+        let session = Session {
+            id: SessionId::new(),
             owner,
             workspace_id: Some(workspace_id),
-            kind: CodeSessionKind::Interactive,
+            kind: SessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: None,
             harness_resume_ref: None,
@@ -2576,7 +2511,7 @@ mod tests {
             model: None,
             reasoning_effort: None,
             fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Running,
+            lifecycle: SessionLifecycle::Running,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,
@@ -2592,12 +2527,12 @@ mod tests {
 
     async fn seed_turn(
         db: &Arc<DbStore>,
-        session: &CodeSession,
+        session: &Session,
         ordinal: i64,
-        status: CodeTurnStatus,
-    ) -> CodeTurn {
-        let turn = CodeTurn {
-            id: CodeTurnId::new(),
+        status: TurnStatus,
+    ) -> Turn {
+        let turn = Turn {
+            id: TurnId::new(),
             session_id: session.id,
             ordinal,
             status,
@@ -2620,7 +2555,7 @@ mod tests {
         turn
     }
 
-    async fn recorded_events(db: &Arc<DbStore>, session: &CodeSession) -> Vec<CodeEvent> {
+    async fn recorded_events(db: &Arc<DbStore>, session: &Session) -> Vec<Event> {
         list_events(db, &session.owner, session.id, 0, MAX_REPLAY_EVENTS)
             .await
             .unwrap()
@@ -2639,7 +2574,7 @@ mod tests {
         let tree = add_worktree(&repo, "interrupted");
         std::fs::write(tree.join("half-done.txt"), "written before the stop\n").unwrap();
         let (db, bus, session) = seed_session(&repo, &tree).await;
-        let mut turn = seed_turn(&db, &session, 1, CodeTurnStatus::Interrupted).await;
+        let mut turn = seed_turn(&db, &session, 1, TurnStatus::Interrupted).await;
 
         after_turn_ended(&db, &bus, &session, &mut turn).await;
 
@@ -2662,7 +2597,7 @@ mod tests {
             recorded_events(&db, &session)
                 .await
                 .iter()
-                .any(|event| matches!(event, CodeEvent::CheckpointRecorded { .. })),
+                .any(|event| matches!(event, Event::CheckpointRecorded { .. })),
             "an interrupted turn must journal its checkpoint"
         );
 
@@ -2679,7 +2614,7 @@ mod tests {
         let tree = add_worktree(&repo, "failed");
         std::fs::write(tree.join("README.md"), "rewritten before the failure\n").unwrap();
         let (db, bus, session) = seed_session(&repo, &tree).await;
-        let mut turn = seed_turn(&db, &session, 1, CodeTurnStatus::Failed).await;
+        let mut turn = seed_turn(&db, &session, 1, TurnStatus::Failed).await;
 
         after_turn_ended(&db, &bus, &session, &mut turn).await;
 
@@ -2705,7 +2640,7 @@ mod tests {
             recorded_events(&db, &session)
                 .await
                 .iter()
-                .any(|event| matches!(event, CodeEvent::CheckpointRecorded { .. })),
+                .any(|event| matches!(event, Event::CheckpointRecorded { .. })),
             "a failed turn must journal its checkpoint"
         );
     }
@@ -2717,7 +2652,7 @@ mod tests {
         let tree = add_worktree(&repo, "running");
         std::fs::write(tree.join("in-flight.txt"), "mid-edit\n").unwrap();
         let (db, bus, session) = seed_session(&repo, &tree).await;
-        let mut turn = seed_turn(&db, &session, 1, CodeTurnStatus::Running).await;
+        let mut turn = seed_turn(&db, &session, 1, TurnStatus::Running).await;
 
         after_turn_ended(&db, &bus, &session, &mut turn).await;
 
@@ -2741,19 +2676,19 @@ mod tests {
         std::fs::remove_dir_all(&tree).unwrap();
         std::fs::create_dir_all(&tree).unwrap();
         std::fs::write(tree.join("orphan.txt"), "still here\n").unwrap();
-        let mut turn = seed_turn(&db, &session, 1, CodeTurnStatus::Failed).await;
+        let mut turn = seed_turn(&db, &session, 1, TurnStatus::Failed).await;
 
         after_turn_ended(&db, &bus, &session, &mut turn).await;
 
         assert!(turn.checkpoint_ref.is_none());
-        assert_eq!(turn.status, CodeTurnStatus::Failed);
+        assert_eq!(turn.status, TurnStatus::Failed);
         assert!(
             recorded_events(&db, &session)
                 .await
                 .iter()
                 .any(|event| matches!(
                     event,
-                    CodeEvent::HarnessNotice {
+                    Event::HarnessNotice {
                         level: HarnessNoticeLevel::Warning,
                         ..
                     }
@@ -2771,12 +2706,12 @@ mod tests {
         let (db, bus, session) = seed_session(&repo, &tree).await;
 
         std::fs::write(tree.join("from-failed.txt"), "one\n").unwrap();
-        let mut failed = seed_turn(&db, &session, 1, CodeTurnStatus::Failed).await;
+        let mut failed = seed_turn(&db, &session, 1, TurnStatus::Failed).await;
         after_turn_ended(&db, &bus, &session, &mut failed).await;
         let first = failed.checkpoint_ref.clone().unwrap();
 
         std::fs::write(tree.join("from-completed.txt"), "two\n").unwrap();
-        let mut completed = seed_turn(&db, &session, 2, CodeTurnStatus::Completed).await;
+        let mut completed = seed_turn(&db, &session, 2, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &session, &mut completed).await;
         let second = completed.checkpoint_ref.clone().unwrap();
 
@@ -2801,9 +2736,9 @@ mod tests {
     }
 
     /// A second session over the same worktree, the shape record 55 allows.
-    async fn seed_sibling_session(db: &Arc<DbStore>, sibling: &CodeSession) -> CodeSession {
-        let session = CodeSession {
-            id: CodeSessionId::new(),
+    async fn seed_sibling_session(db: &Arc<DbStore>, sibling: &Session) -> Session {
+        let session = Session {
+            id: SessionId::new(),
             harness_kind: HarnessKind::Codex,
             created_at: chrono::Utc::now(),
             ..sibling.clone()
@@ -2847,7 +2782,7 @@ mod tests {
             "from .parser import parse\n",
         )
         .unwrap();
-        let mut theirs = seed_turn(&db, &earlier, 1, CodeTurnStatus::Completed).await;
+        let mut theirs = seed_turn(&db, &earlier, 1, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &earlier, &mut theirs).await;
 
         // A second session starts on the worktree the first one has edited.
@@ -2863,7 +2798,7 @@ mod tests {
             format!("def parse(line):\n{body}"),
         )
         .unwrap();
-        let mut mine = seed_turn(&db, &later, 1, CodeTurnStatus::Completed).await;
+        let mut mine = seed_turn(&db, &later, 1, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &later, &mut mine).await;
 
         let stat = mine.diffstat.clone().expect("turn 1 records a diffstat");
@@ -2910,7 +2845,7 @@ mod tests {
 
         std::fs::write(tree.join("README.md"), "hello world\n").unwrap();
         std::fs::write(tree.join("new.txt"), "untracked\n").unwrap();
-        let mut turn = seed_turn(&db, &session, 1, CodeTurnStatus::Completed).await;
+        let mut turn = seed_turn(&db, &session, 1, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &session, &mut turn).await;
 
         let stat = turn.diffstat.clone().unwrap();
@@ -2935,7 +2870,7 @@ mod tests {
         let (db, bus, session) = seed_session(&repo, &tree).await;
 
         std::fs::write(tree.join("a.txt"), "one\n").unwrap();
-        let mut turn = seed_turn(&db, &session, 1, CodeTurnStatus::Completed).await;
+        let mut turn = seed_turn(&db, &session, 1, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &session, &mut turn).await;
 
         let r#ref = turn.checkpoint_ref.clone().expect("turn 1 keeps its ref");
@@ -2967,12 +2902,12 @@ mod tests {
                 .unwrap();
 
         std::fs::write(tree.join("one.txt"), "one\n").unwrap();
-        let mut first = seed_turn(&db, &session, 1, CodeTurnStatus::Completed).await;
+        let mut first = seed_turn(&db, &session, 1, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &session, &mut first).await;
         let first_ref = first.checkpoint_ref.clone().unwrap();
 
         std::fs::write(tree.join("two.txt"), "two\n").unwrap();
-        let mut second = seed_turn(&db, &session, 2, CodeTurnStatus::Completed).await;
+        let mut second = seed_turn(&db, &session, 2, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &session, &mut second).await;
         let second_ref = second.checkpoint_ref.clone().unwrap();
 
@@ -3009,13 +2944,13 @@ mod tests {
                 .unwrap();
 
         std::fs::write(tree.join("one.txt"), "one\n").unwrap();
-        let mut first = seed_turn(&db, &session, 1, CodeTurnStatus::Completed).await;
+        let mut first = seed_turn(&db, &session, 1, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &session, &mut first).await;
         let first_ref = first.checkpoint_ref.clone().unwrap();
         delete_ref(&repo, &first_ref).await.unwrap();
 
         std::fs::write(tree.join("two.txt"), "two\n").unwrap();
-        let mut second = seed_turn(&db, &session, 2, CodeTurnStatus::Completed).await;
+        let mut second = seed_turn(&db, &session, 2, TurnStatus::Completed).await;
         after_turn_ended(&db, &bus, &session, &mut second).await;
         let second_ref = second
             .checkpoint_ref
@@ -3038,7 +2973,7 @@ mod tests {
                 .iter()
                 .all(|event| !matches!(
                     event,
-                    CodeEvent::HarnessNotice {
+                    Event::HarnessNotice {
                         level: HarnessNoticeLevel::Warning,
                         ..
                     }
@@ -3057,7 +2992,7 @@ mod tests {
             ws(),
             sess(),
             1,
-            CodeTurnStatus::Completed,
+            TurnStatus::Completed,
             None,
             "main",
         )

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -23,9 +23,10 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 
+use tidebreak_core::code::SequencedEvent;
 use tidebreak_core::{
-    BlobStore, CodeEvent, CodeSession, CodeTurn, CodeTurnId, CodeTurnStatus, DocumentBlob,
-    HarnessKind, HarnessNoticeLevel, SequencedCodeEvent, ToolDetail, ToolOutcome,
+    BlobStore, DocumentBlob, Event, HarnessKind, HarnessNoticeLevel, Session, ToolDetail,
+    ToolOutcome, Turn, TurnId, TurnStatus,
 };
 
 /// Directory holding fork transcripts below the workspace's private root.
@@ -59,10 +60,7 @@ const MAX_RECORD_TOTAL_BYTES: usize = 8 * 1024 * 1024;
 const MAX_FORK_ATTACHMENT_BYTES: u64 = 20 * 1024 * 1024;
 
 type ForkLockRegistry = Mutex<
-    std::collections::HashMap<
-        (PathBuf, tidebreak_core::CodeSessionId),
-        Weak<tokio::sync::Mutex<()>>,
-    >,
+    std::collections::HashMap<(PathBuf, tidebreak_core::SessionId), Weak<tokio::sync::Mutex<()>>>,
 >;
 
 fn fork_lock_registry() -> &'static ForkLockRegistry {
@@ -72,7 +70,7 @@ fn fork_lock_registry() -> &'static ForkLockRegistry {
 
 fn fork_lock(
     private_root: &Path,
-    session_id: tidebreak_core::CodeSessionId,
+    session_id: tidebreak_core::SessionId,
 ) -> Arc<tokio::sync::Mutex<()>> {
     let key = (private_root.to_path_buf(), session_id);
     let mut registry = fork_lock_registry().lock().expect("fork write registry");
@@ -88,7 +86,7 @@ fn fork_lock(
 /// A session's turns sliced at a fork point.
 pub(crate) struct ForkCut<'a> {
     /// The turns the fork covers, oldest first, ending at the fork point.
-    pub(crate) turns: &'a [CodeTurn],
+    pub(crate) turns: &'a [Turn],
     /// Turns of the session that ran after the fork point.
     pub(crate) excluded: usize,
 }
@@ -150,7 +148,7 @@ impl ForkBoundaryError {
 /// `None` forks at the newest turn. Returns `None` when `at_turn` names a
 /// turn that is not part of this session, which the route reports rather
 /// than silently forking the whole conversation.
-pub(crate) fn cut_at(turns: &[CodeTurn], at_turn: Option<CodeTurnId>) -> Option<ForkCut<'_>> {
+pub(crate) fn cut_at(turns: &[Turn], at_turn: Option<TurnId>) -> Option<ForkCut<'_>> {
     let Some(at) = at_turn else {
         return Some(ForkCut { turns, excluded: 0 });
     };
@@ -167,11 +165,11 @@ pub(crate) fn cut_at(turns: &[CodeTurn], at_turn: Option<CodeTurnId>) -> Option<
 /// follow-up blocks it. An explicit turn fork may leave later running or
 /// queued work behind because the reader selected that earlier seam.
 pub(crate) fn cut_at_settled_boundary<'a>(
-    turns: &'a [CodeTurn],
-    boundary_status: Option<CodeTurnStatus>,
-    pending_approval_turns: &HashSet<CodeTurnId>,
+    turns: &'a [Turn],
+    boundary_status: Option<TurnStatus>,
+    pending_approval_turns: &HashSet<TurnId>,
     has_queued_follow_up: bool,
-    at_turn: Option<CodeTurnId>,
+    at_turn: Option<TurnId>,
 ) -> Result<ForkCut<'a>, ForkBoundaryError> {
     let Some(cut) = cut_at(turns, at_turn) else {
         return Err(ForkBoundaryError::UnknownTurn);
@@ -179,7 +177,7 @@ pub(crate) fn cut_at_settled_boundary<'a>(
     let Some(boundary) = cut.turns.last() else {
         return Err(ForkBoundaryError::NoTurns);
     };
-    if boundary.status == CodeTurnStatus::Running {
+    if boundary.status == TurnStatus::Running {
         return Err(ForkBoundaryError::Running {
             ordinal: boundary.ordinal,
         });
@@ -239,10 +237,10 @@ pub(crate) struct WrittenTranscript {
 pub(crate) async fn write_transcript(
     private_root: &super::scratch::ScratchRoot,
     blobs: &dyn BlobStore,
-    session: &CodeSession,
+    session: &Session,
     cut: ForkCut<'_>,
-    events: &[SequencedCodeEvent],
-    complete_turns: &HashSet<CodeTurnId>,
+    events: &[SequencedEvent],
+    complete_turns: &HashSet<TurnId>,
 ) -> std::io::Result<WrittenTranscript> {
     let private_path = private_root.path();
     let write_lock = fork_lock(private_path, session.id);
@@ -333,14 +331,14 @@ struct RenderedTranscript {
 #[allow(clippy::too_many_arguments)]
 fn render_transcript_with_generation(
     private_root: &Path,
-    session: &CodeSession,
-    turns: &[CodeTurn],
+    session: &Session,
+    turns: &[Turn],
     excluded: usize,
-    events: &[SequencedCodeEvent],
+    events: &[SequencedEvent],
     generation: uuid::Uuid,
     record_ordinals: &HashSet<i64>,
-    retained_images: &HashSet<CodeTurnId>,
-    complete_turns: &HashSet<CodeTurnId>,
+    retained_images: &HashSet<TurnId>,
+    complete_turns: &HashSet<TurnId>,
 ) -> RenderedTranscript {
     let engine = harness_label(session.harness_kind);
     let mut sections: Vec<String> = Vec::with_capacity(turns.len());
@@ -453,7 +451,7 @@ fn render_transcript_with_generation(
 /// never names half of what a message attached. The first turn that would
 /// overflow the budget stops retention: everything older is dropped with it,
 /// and the transcript says so per turn.
-fn plan_attachment_retention(turns: &[CodeTurn]) -> HashSet<CodeTurnId> {
+fn plan_attachment_retention(turns: &[Turn]) -> HashSet<TurnId> {
     let mut retained = HashSet::new();
     let mut total: u64 = 0;
     for turn in turns.iter().rev() {
@@ -480,8 +478,8 @@ fn plan_attachment_retention(turns: &[CodeTurn]) -> HashSet<CodeTurnId> {
 async fn materialize_attachments(
     scope: &super::scratch::ScratchScope,
     blobs: &dyn BlobStore,
-    turns: &[CodeTurn],
-    retained: &HashSet<CodeTurnId>,
+    turns: &[Turn],
+    retained: &HashSet<TurnId>,
 ) -> std::io::Result<()> {
     for turn in turns {
         if !retained.contains(&turn.id) {
@@ -516,11 +514,7 @@ async fn materialize_attachments(
     Ok(())
 }
 
-fn fork_attachment_name(
-    turn: &CodeTurn,
-    ordinal: usize,
-    image: &tidebreak_core::ImageRef,
-) -> String {
+fn fork_attachment_name(turn: &Turn, ordinal: usize, image: &tidebreak_core::ImageRef) -> String {
     format!(
         "turn-{}-{}-{}.{}",
         turn.ordinal,
@@ -532,9 +526,9 @@ fn fork_attachment_name(
 
 fn fork_attachment_path(
     private_root: &Path,
-    session_id: tidebreak_core::CodeSessionId,
+    session_id: tidebreak_core::SessionId,
     generation: uuid::Uuid,
-    turn: &CodeTurn,
+    turn: &Turn,
     ordinal: usize,
     image: &tidebreak_core::ImageRef,
 ) -> String {
@@ -550,13 +544,13 @@ fn fork_attachment_path(
 /// The file's opening: where the transcript came from, what it condenses,
 /// and where the full records are.
 fn header(
-    session: &CodeSession,
-    turns: &[CodeTurn],
+    session: &Session,
+    turns: &[Turn],
     excluded: usize,
     reduced: usize,
     record_ordinals: &HashSet<i64>,
     engine: &str,
-    complete_turns: &HashSet<CodeTurnId>,
+    complete_turns: &HashSet<TurnId>,
 ) -> String {
     let total = turns.len();
     let mut out = String::new();
@@ -655,7 +649,7 @@ fn clip(section: &mut String, budget: usize) {
 ///
 /// The heading deliberately differs from a full section's `— you`, so the
 /// child can tell a stub from a turn it can read here.
-fn render_stub(turn: &CodeTurn, has_record: bool, events_complete: bool) -> String {
+fn render_stub(turn: &Turn, has_record: bool, events_complete: bool) -> String {
     let asked = turn.user_input.trim();
     let asked = if asked.is_empty() {
         "_(empty)_".to_owned()
@@ -686,9 +680,9 @@ fn render_stub(turn: &CodeTurn, has_record: bool, events_complete: bool) -> Stri
 #[allow(clippy::too_many_arguments)]
 fn render_turn(
     private_root: &Path,
-    session_id: tidebreak_core::CodeSessionId,
-    turn: &CodeTurn,
-    events: &[SequencedCodeEvent],
+    session_id: tidebreak_core::SessionId,
+    turn: &Turn,
+    events: &[SequencedEvent],
     engine: &str,
     generation: uuid::Uuid,
     images_retained: bool,
@@ -734,8 +728,8 @@ fn render_turn(
 fn render_attachment_list(
     out: &mut String,
     private_root: &Path,
-    session_id: tidebreak_core::CodeSessionId,
-    turn: &CodeTurn,
+    session_id: tidebreak_core::SessionId,
+    turn: &Turn,
     generation: uuid::Uuid,
     images_retained: bool,
 ) {
@@ -770,7 +764,7 @@ fn render_attachment_list(
 ///
 /// Scoped by walking from this turn's `TurnStarted` to the next one: a turn
 /// id appears on the boundary events, not on every event inside it.
-fn turn_lines(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<String> {
+fn turn_lines(turn_id: TurnId, events: &[SequencedEvent]) -> Vec<String> {
     let mut lines: Vec<String> = Vec::new();
     let mut inside = false;
     // A tool call opens and closes on separate events, and the closing one
@@ -780,14 +774,14 @@ fn turn_lines(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<String>
 
     for entry in events {
         match &entry.event {
-            CodeEvent::TurnStarted { turn_id: started } => {
+            Event::TurnStarted { turn_id: started } => {
                 if inside {
                     break;
                 }
                 inside = *started == turn_id;
             }
             _ if !inside => {}
-            CodeEvent::AssistantMessage {
+            Event::AssistantMessage {
                 text,
                 parent_call_id,
             } => {
@@ -795,12 +789,12 @@ fn turn_lines(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<String>
                     lines.push(text.trim().to_owned());
                 }
             }
-            CodeEvent::UserSteered { text, .. } => {
+            Event::UserSteered { text, .. } => {
                 if !text.trim().is_empty() {
                     lines.push(format!("**You, mid-turn:** {}", text.trim()));
                 }
             }
-            CodeEvent::ToolStarted {
+            Event::ToolStarted {
                 call_id,
                 name,
                 detail,
@@ -812,7 +806,7 @@ fn turn_lines(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<String>
                 open.push((call_id.clone(), lines.len(), name.clone(), detail.clone()));
                 lines.push(tool_line(name, detail, None));
             }
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id,
                 outcome,
                 detail,
@@ -835,16 +829,14 @@ fn turn_lines(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<String>
                     outcome_suffix(outcome)
                 );
             }
-            CodeEvent::TurnFailed { error, .. } => {
+            Event::TurnFailed { error, .. } => {
                 lines.push(format!("**The turn failed:** {}", error.message.trim()));
             }
-            CodeEvent::TurnInterrupted { .. } => {
-                lines.push("**The turn was interrupted.**".to_owned())
-            }
-            CodeEvent::TurnResumed { .. } => {
+            Event::TurnInterrupted { .. } => lines.push("**The turn was interrupted.**".to_owned()),
+            Event::TurnResumed { .. } => {
                 lines.push("**The turn resumed after the worker restarted.**".to_owned())
             }
-            CodeEvent::TurnRefused { .. } => {
+            Event::TurnRefused { .. } => {
                 lines.push("**The model declined to continue.**".to_owned())
             }
             _ => {}
@@ -866,13 +858,13 @@ struct RenderedRecords {
 #[allow(clippy::too_many_arguments)]
 fn render_turn_records(
     private_root: &Path,
-    session: &CodeSession,
-    turns: &[CodeTurn],
-    events: &[SequencedCodeEvent],
+    session: &Session,
+    turns: &[Turn],
+    events: &[SequencedEvent],
     engine: &str,
     generation: uuid::Uuid,
-    retained_images: &HashSet<CodeTurnId>,
-    complete_turns: &HashSet<CodeTurnId>,
+    retained_images: &HashSet<TurnId>,
+    complete_turns: &HashSet<TurnId>,
 ) -> RenderedRecords {
     let mut files: Vec<(i64, String)> = Vec::with_capacity(turns.len());
     let mut total = 0usize;
@@ -905,9 +897,9 @@ fn render_turn_records(
 #[allow(clippy::too_many_arguments)]
 fn render_turn_record(
     private_root: &Path,
-    session: &CodeSession,
-    turn: &CodeTurn,
-    events: &[SequencedCodeEvent],
+    session: &Session,
+    turn: &Turn,
+    events: &[SequencedEvent],
     engine: &str,
     generation: uuid::Uuid,
     images_retained: bool,
@@ -959,7 +951,7 @@ fn render_turn_record(
 /// Unlike [`turn_lines`], subagent events stay — indented under their `Task`
 /// call — tool previews ride their call, and reasoning runs are kept as
 /// quoted blocks.
-fn record_blocks(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<String> {
+fn record_blocks(turn_id: TurnId, events: &[SequencedEvent]) -> Vec<String> {
     let mut blocks: Vec<String> = Vec::new();
     let mut inside = false;
     let mut reasoning: Vec<&str> = Vec::new();
@@ -985,7 +977,7 @@ fn record_blocks(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<Stri
     }
 
     for entry in events {
-        if let CodeEvent::TurnStarted { turn_id: started } = &entry.event {
+        if let Event::TurnStarted { turn_id: started } = &entry.event {
             if inside {
                 break;
             }
@@ -995,13 +987,13 @@ fn record_blocks(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<Stri
         if !inside {
             continue;
         }
-        if let CodeEvent::ReasoningDelta { text } = &entry.event {
+        if let Event::ReasoningDelta { text } = &entry.event {
             reasoning.push(text);
             continue;
         }
         flush_reasoning(&mut blocks, &mut reasoning);
         match &entry.event {
-            CodeEvent::AssistantMessage {
+            Event::AssistantMessage {
                 text,
                 parent_call_id,
             } => {
@@ -1017,12 +1009,12 @@ fn record_blocks(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<Stri
                     ));
                 }
             }
-            CodeEvent::UserSteered { text, .. } => {
+            Event::UserSteered { text, .. } => {
                 if !text.trim().is_empty() {
                     blocks.push(format!("**You, mid-turn:** {}", text.trim()));
                 }
             }
-            CodeEvent::ToolStarted {
+            Event::ToolStarted {
                 call_id,
                 name,
                 detail,
@@ -1039,7 +1031,7 @@ fn record_blocks(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<Stri
                 let line = tool_line(name, detail, None);
                 blocks.push(if nested { format!("  {line}") } else { line });
             }
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id,
                 outcome,
                 preview,
@@ -1065,23 +1057,23 @@ fn record_blocks(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<Stri
                 }
                 *block = line;
             }
-            CodeEvent::HarnessNotice { level, message } => {
+            Event::HarnessNotice { level, message } => {
                 blocks.push(format!(
                     "**Engine notice ({}):** {}",
                     notice_level(*level),
                     message.trim()
                 ));
             }
-            CodeEvent::TurnFailed { error, .. } => {
+            Event::TurnFailed { error, .. } => {
                 blocks.push(format!("**The turn failed:** {}", error.message.trim()));
             }
-            CodeEvent::TurnInterrupted { .. } => {
+            Event::TurnInterrupted { .. } => {
                 blocks.push("**The turn was interrupted.**".to_owned());
             }
-            CodeEvent::TurnResumed { .. } => {
+            Event::TurnResumed { .. } => {
                 blocks.push("**The turn resumed after the worker restarted.**".to_owned());
             }
-            CodeEvent::TurnRefused { .. } => {
+            Event::TurnRefused { .. } => {
                 blocks.push("**The model declined to continue.**".to_owned());
             }
             _ => {}
@@ -1178,17 +1170,16 @@ fn harness_label(kind: HarnessKind) -> &'static str {
 mod tests {
     use super::*;
     use tidebreak_core::{
-        Attention, AttentionSource, BoundedError, CodeSessionId, CodeSessionKind,
-        CodeSessionLifecycle, CodeTurnStatus, FsBlobStore, ImageMediaType, ImageRef, OwnerId,
-        PermissionMode, WorkspaceId,
+        Attention, AttentionSource, BoundedError, FsBlobStore, ImageMediaType, ImageRef, OwnerId,
+        PermissionMode, SessionId, SessionKind, SessionLifecycle, TurnStatus, WorkspaceId,
     };
 
-    fn session() -> CodeSession {
-        CodeSession {
-            id: CodeSessionId::new(),
+    fn session() -> Session {
+        Session {
+            id: SessionId::new(),
             owner: OwnerId::local(),
             workspace_id: Some(WorkspaceId::new()),
-            kind: CodeSessionKind::Interactive,
+            kind: SessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: None,
             harness_resume_ref: None,
@@ -1196,7 +1187,7 @@ mod tests {
             model: None,
             reasoning_effort: None,
             fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Idle,
+            lifecycle: SessionLifecycle::Idle,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,
@@ -1208,12 +1199,12 @@ mod tests {
         }
     }
 
-    fn turn(session_id: CodeSessionId, ordinal: i64, asked: &str) -> CodeTurn {
-        CodeTurn {
-            id: CodeTurnId::new(),
+    fn turn(session_id: SessionId, ordinal: i64, asked: &str) -> Turn {
+        Turn {
+            id: TurnId::new(),
             session_id,
             ordinal,
-            status: CodeTurnStatus::Completed,
+            status: TurnStatus::Completed,
             model: None,
             fast_mode: false,
             user_input: asked.to_owned(),
@@ -1231,18 +1222,18 @@ mod tests {
         }
     }
 
-    fn seq(events: Vec<CodeEvent>) -> Vec<SequencedCodeEvent> {
+    fn seq(events: Vec<Event>) -> Vec<SequencedEvent> {
         events
             .into_iter()
             .enumerate()
-            .map(|(at, event)| SequencedCodeEvent {
+            .map(|(at, event)| SequencedEvent {
                 seq: at as i64 + 1,
                 event,
             })
             .collect()
     }
 
-    fn all_turn_ids(turns: &[CodeTurn]) -> HashSet<CodeTurnId> {
+    fn all_turn_ids(turns: &[Turn]) -> HashSet<TurnId> {
         turns.iter().map(|turn| turn.id).collect()
     }
 
@@ -1253,12 +1244,12 @@ mod tests {
     /// Render the condensed transcript as if every turn had a record file and
     /// every image was retained, which is what most summary tests care about.
     fn render_transcript(
-        session: &CodeSession,
-        turns: &[CodeTurn],
-        events: &[SequencedCodeEvent],
+        session: &Session,
+        turns: &[Turn],
+        events: &[SequencedEvent],
     ) -> RenderedTranscript {
         let records: HashSet<i64> = turns.iter().map(|turn| turn.ordinal).collect();
-        let retained: HashSet<CodeTurnId> = turns.iter().map(|turn| turn.id).collect();
+        let retained: HashSet<TurnId> = turns.iter().map(|turn| turn.id).collect();
         render_transcript_with_generation(
             Path::new("/private"),
             session,
@@ -1281,12 +1272,12 @@ mod tests {
         let first = turn(session.id, 1, "fix the failing auth test");
         let second = turn(session.id, 2, "now push it");
         let events = seq(vec![
-            CodeEvent::TurnStarted { turn_id: first.id },
-            CodeEvent::AssistantMessage {
+            Event::TurnStarted { turn_id: first.id },
+            Event::AssistantMessage {
                 text: "Looking at the test now.".to_owned(),
                 parent_call_id: None,
             },
-            CodeEvent::ToolStarted {
+            Event::ToolStarted {
                 call_id: "call-1".to_owned(),
                 name: "Bash".to_owned(),
                 detail: ToolDetail::Other {
@@ -1294,7 +1285,7 @@ mod tests {
                 },
                 parent_call_id: None,
             },
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id: "call-1".to_owned(),
                 outcome: ToolOutcome::Failed,
                 preview: "1 failed".to_owned(),
@@ -1307,8 +1298,8 @@ mod tests {
                 }),
                 parent_call_id: None,
             },
-            CodeEvent::TurnStarted { turn_id: second.id },
-            CodeEvent::AssistantMessage {
+            Event::TurnStarted { turn_id: second.id },
+            Event::AssistantMessage {
                 text: "Pushed.".to_owned(),
                 parent_call_id: None,
             },
@@ -1339,8 +1330,8 @@ mod tests {
         let session = session();
         let only = turn(session.id, 1, "audit the crate");
         let events = seq(vec![
-            CodeEvent::TurnStarted { turn_id: only.id },
-            CodeEvent::ToolStarted {
+            Event::TurnStarted { turn_id: only.id },
+            Event::ToolStarted {
                 call_id: "task-1".to_owned(),
                 name: "Task".to_owned(),
                 detail: ToolDetail::Other {
@@ -1348,11 +1339,11 @@ mod tests {
                 },
                 parent_call_id: None,
             },
-            CodeEvent::AssistantMessage {
+            Event::AssistantMessage {
                 text: "subagent thinking out loud".to_owned(),
                 parent_call_id: Some("task-1".to_owned()),
             },
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id: "task-1".to_owned(),
                 outcome: ToolOutcome::Succeeded,
                 preview: "done".to_owned(),
@@ -1376,8 +1367,8 @@ mod tests {
         let session = session();
         let only = turn(session.id, 1, "deploy it");
         let events = seq(vec![
-            CodeEvent::TurnStarted { turn_id: only.id },
-            CodeEvent::TurnFailed {
+            Event::TurnStarted { turn_id: only.id },
+            Event::TurnFailed {
                 error: BoundedError {
                     message: "the engine exited".to_owned(),
                 },
@@ -1394,7 +1385,7 @@ mod tests {
     #[test]
     fn cuts_at_a_turn_and_counts_the_excluded_tail() {
         let session = session();
-        let turns: Vec<CodeTurn> = (1..=5)
+        let turns: Vec<Turn> = (1..=5)
             .map(|ordinal| turn(session.id, ordinal, "work"))
             .collect();
 
@@ -1406,7 +1397,7 @@ mod tests {
         assert_eq!(whole.turns.len(), 5);
         assert_eq!(whole.excluded, 0);
 
-        assert!(cut_at(&turns, Some(CodeTurnId::new())).is_none());
+        assert!(cut_at(&turns, Some(TurnId::new())).is_none());
     }
 
     /// A session-level fork must not turn the partial journal prefix of the
@@ -1416,7 +1407,7 @@ mod tests {
         let session = session();
         let completed = turn(session.id, 1, "first");
         let mut running = turn(session.id, 2, "keep working");
-        running.status = CodeTurnStatus::Running;
+        running.status = TurnStatus::Running;
         let turns = [completed.clone(), running];
 
         let result = cut_at_settled_boundary(&turns, None, &HashSet::new(), false, None);
@@ -1428,7 +1419,7 @@ mod tests {
 
         let earlier = cut_at_settled_boundary(
             &turns,
-            Some(CodeTurnStatus::Completed),
+            Some(TurnStatus::Completed),
             &HashSet::new(),
             false,
             Some(completed.id),
@@ -1447,13 +1438,8 @@ mod tests {
         let pending = HashSet::from([completed.id]);
         let turns = [completed];
 
-        let result = cut_at_settled_boundary(
-            &turns,
-            Some(CodeTurnStatus::Completed),
-            &pending,
-            false,
-            None,
-        );
+        let result =
+            cut_at_settled_boundary(&turns, Some(TurnStatus::Completed), &pending, false, None);
 
         assert!(matches!(
             result,
@@ -1470,7 +1456,7 @@ mod tests {
         let completed = turn(session.id, 1, "first");
         let ordinary = cut_at_settled_boundary(
             std::slice::from_ref(&completed),
-            Some(CodeTurnStatus::Completed),
+            Some(TurnStatus::Completed),
             &HashSet::new(),
             true,
             None,
@@ -1479,7 +1465,7 @@ mod tests {
 
         let explicit = cut_at_settled_boundary(
             std::slice::from_ref(&completed),
-            Some(CodeTurnStatus::Completed),
+            Some(TurnStatus::Completed),
             &HashSet::new(),
             true,
             Some(completed.id),
@@ -1495,10 +1481,10 @@ mod tests {
     fn retries_after_a_turn_finishes_during_preparation() {
         let session = session();
         let mut stale = turn(session.id, 1, "finish while forking");
-        stale.status = CodeTurnStatus::Running;
+        stale.status = TurnStatus::Running;
         let mixed = cut_at_settled_boundary(
             std::slice::from_ref(&stale),
-            Some(CodeTurnStatus::Completed),
+            Some(TurnStatus::Completed),
             &HashSet::new(),
             false,
             None,
@@ -1509,7 +1495,7 @@ mod tests {
         ));
 
         let mut settled = stale;
-        settled.status = CodeTurnStatus::Completed;
+        settled.status = TurnStatus::Completed;
         let settled_turns = [settled];
         let row_ahead = cut_at_settled_boundary(&settled_turns, None, &HashSet::new(), false, None);
         assert!(matches!(
@@ -1519,7 +1505,7 @@ mod tests {
 
         let retry = cut_at_settled_boundary(
             &settled_turns,
-            Some(CodeTurnStatus::Completed),
+            Some(TurnStatus::Completed),
             &HashSet::new(),
             false,
             None,
@@ -1534,7 +1520,7 @@ mod tests {
     #[test]
     fn says_when_the_conversation_continued_past_the_fork_point() {
         let session = session();
-        let turns: Vec<CodeTurn> = (1..=2)
+        let turns: Vec<Turn> = (1..=2)
             .map(|ordinal| turn(session.id, ordinal, "work"))
             .collect();
         let records: HashSet<i64> = turns.iter().map(|turn| turn.ordinal).collect();
@@ -1565,7 +1551,7 @@ mod tests {
     fn reduces_the_oldest_turns_to_stubs_and_says_so() {
         let session = session();
         let bulk = "x".repeat(200 * 1024);
-        let turns: Vec<CodeTurn> = (1..=5)
+        let turns: Vec<Turn> = (1..=5)
             .map(|ordinal| turn(session.id, ordinal, &bulk))
             .collect();
 
@@ -1586,7 +1572,7 @@ mod tests {
     fn a_stub_says_when_its_record_was_dropped() {
         let session = session();
         let bulk = "x".repeat(300 * 1024);
-        let turns: Vec<CodeTurn> = (1..=3)
+        let turns: Vec<Turn> = (1..=3)
             .map(|ordinal| turn(session.id, ordinal, &bulk))
             .collect();
         let records: HashSet<i64> = [3].into_iter().collect();
@@ -1617,7 +1603,7 @@ mod tests {
     fn counts_the_header_against_the_cap() {
         let session = session();
         let bulk = "x".repeat(MAX_TRANSCRIPT_BYTES / 2 - 40);
-        let turns: Vec<CodeTurn> = (1..=2)
+        let turns: Vec<Turn> = (1..=2)
             .map(|ordinal| turn(session.id, ordinal, &bulk))
             .collect();
 
@@ -1679,14 +1665,14 @@ mod tests {
         let session = session();
         let only = turn(session.id, 1, "audit the crate");
         let events = seq(vec![
-            CodeEvent::TurnStarted { turn_id: only.id },
-            CodeEvent::ReasoningDelta {
+            Event::TurnStarted { turn_id: only.id },
+            Event::ReasoningDelta {
                 text: "the tests look".to_owned(),
             },
-            CodeEvent::ReasoningDelta {
+            Event::ReasoningDelta {
                 text: " flaky".to_owned(),
             },
-            CodeEvent::ToolStarted {
+            Event::ToolStarted {
                 call_id: "task-1".to_owned(),
                 name: "Task".to_owned(),
                 detail: ToolDetail::Other {
@@ -1694,7 +1680,7 @@ mod tests {
                 },
                 parent_call_id: None,
             },
-            CodeEvent::ToolStarted {
+            Event::ToolStarted {
                 call_id: "sub-1".to_owned(),
                 name: "Bash".to_owned(),
                 detail: ToolDetail::Command {
@@ -1703,7 +1689,7 @@ mod tests {
                 },
                 parent_call_id: Some("task-1".to_owned()),
             },
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id: "sub-1".to_owned(),
                 outcome: ToolOutcome::Succeeded,
                 preview: "tidebreak-core v0.1.0".to_owned(),
@@ -1713,11 +1699,11 @@ mod tests {
                 detail: None,
                 parent_call_id: Some("task-1".to_owned()),
             },
-            CodeEvent::AssistantMessage {
+            Event::AssistantMessage {
                 text: "two crates look unused".to_owned(),
                 parent_call_id: Some("task-1".to_owned()),
             },
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id: "task-1".to_owned(),
                 outcome: ToolOutcome::Succeeded,
                 preview: "audit done".to_owned(),
@@ -1727,7 +1713,7 @@ mod tests {
                 detail: None,
                 parent_call_id: None,
             },
-            CodeEvent::UserSteered {
+            Event::UserSteered {
                 text: "skip the benches".to_owned(),
                 message_id: None,
             },
@@ -1760,8 +1746,8 @@ mod tests {
         let session = session();
         let only = turn(session.id, 1, "show me");
         let events = seq(vec![
-            CodeEvent::TurnStarted { turn_id: only.id },
-            CodeEvent::ToolStarted {
+            Event::TurnStarted { turn_id: only.id },
+            Event::ToolStarted {
                 call_id: "call-1".to_owned(),
                 name: "Read".to_owned(),
                 detail: ToolDetail::Other {
@@ -1769,7 +1755,7 @@ mod tests {
                 },
                 parent_call_id: None,
             },
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id: "call-1".to_owned(),
                 outcome: ToolOutcome::Succeeded,
                 preview: "````\nfour ticks\n````".to_owned(),
@@ -1854,7 +1840,7 @@ mod tests {
     fn drops_the_oldest_records_over_the_total_budget() {
         let session = session();
         let bulk = "x".repeat(MAX_RECORD_FILE_BYTES * 2);
-        let turns: Vec<CodeTurn> = (1..=40)
+        let turns: Vec<Turn> = (1..=40)
             .map(|ordinal| turn(session.id, ordinal, &bulk))
             .collect();
         let complete = all_turn_ids(&turns);
@@ -1931,7 +1917,7 @@ mod tests {
         let blob_root = tempfile::tempdir().expect("blob tempdir");
         let blobs = FsBlobStore::new(blob_root.path());
         let session = session();
-        let turns: Vec<CodeTurn> = (1..=3)
+        let turns: Vec<Turn> = (1..=3)
             .map(|ordinal| turn(session.id, ordinal, "work"))
             .collect();
         let cut = cut_at(&turns, Some(turns[0].id)).expect("known turn");
@@ -2014,7 +2000,7 @@ mod tests {
         let blob_root = tempfile::tempdir().unwrap();
         let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(blob_root.path()));
         let mut session = session();
-        session.lifecycle = CodeSessionLifecycle::Ended;
+        session.lifecycle = SessionLifecycle::Ended;
         let mut only = turn(session.id, 1, "compare these screenshots");
         let first_bytes = b"\x89PNG\r\n\x1a\nfirst".to_vec();
         let second_bytes = b"GIF89asecond".to_vec();

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -36,7 +36,7 @@ use axum::http::header::AUTHORIZATION;
 use axum::http::{HeaderMap, HeaderName, StatusCode};
 use axum::response::Response;
 
-use tidebreak_core::{AgentError, CodeSessionId, HarnessKind, OwnerId};
+use tidebreak_core::{AgentError, HarnessKind, OwnerId, SessionId};
 
 use crate::obo_gateway::{GatewayCompatModel, OboGateway};
 
@@ -44,7 +44,7 @@ use crate::obo_gateway::{GatewayCompatModel, OboGateway};
 #[derive(Clone)]
 pub(crate) struct HarnessLlmSubject {
     pub(crate) owner: OwnerId,
-    pub(crate) session: CodeSessionId,
+    pub(crate) session: SessionId,
 }
 
 /// The gateway compat endpoint one relay route forwards to.
@@ -97,7 +97,7 @@ pub(crate) struct HarnessLlmRelay {
 
 #[derive(Default)]
 struct RelayState {
-    by_session: HashMap<CodeSessionId, String>,
+    by_session: HashMap<SessionId, String>,
     keys: HashMap<String, HarnessLlmSubject>,
 }
 
@@ -154,7 +154,7 @@ impl HarnessLlmRelay {
     }
 
     /// Revoke the key for `session_id`. Idempotent.
-    pub(crate) fn revoke(&self, session_id: CodeSessionId) {
+    pub(crate) fn revoke(&self, session_id: SessionId) {
         let mut state = self.state.lock().expect("harness llm registry");
         if let Some(key) = state.by_session.remove(&session_id) {
             state.keys.remove(&key);
@@ -501,7 +501,7 @@ mod tests {
     fn subject_for(name: &str) -> HarnessLlmSubject {
         HarnessLlmSubject {
             owner: owner(name),
-            session: CodeSessionId::new(),
+            session: SessionId::new(),
         }
     }
 

--- a/crates/tidebreak-server/src/code/memory_capture.rs
+++ b/crates/tidebreak-server/src/code/memory_capture.rs
@@ -9,10 +9,10 @@ use serde::{Deserialize, Serialize};
 
 use tidebreak_core::db::code::{get_session, get_turn, get_workspace, list_recent_events};
 use tidebreak_core::{
-    AgentError, CodeEvent, CodeSessionId, CodeTurnId, CodeTurnStatus, DbStore, HarnessNoticeLevel,
-    MemoryAuthor, MemoryBackend, MemoryEvidence, MemoryKind, MemoryOrigin, MemoryProvenance,
-    MemoryRecord, MemoryRecordId, MemoryScope, MemoryStatus, OwnerId, Result,
-    MAX_MEMORY_BODY_BYTES, MAX_MEMORY_TITLE_CHARS,
+    AgentError, DbStore, Event, HarnessNoticeLevel, MemoryAuthor, MemoryBackend, MemoryEvidence,
+    MemoryKind, MemoryOrigin, MemoryProvenance, MemoryRecord, MemoryRecordId, MemoryScope,
+    MemoryStatus, OwnerId, Result, SessionId, TurnId, TurnStatus, MAX_MEMORY_BODY_BYTES,
+    MAX_MEMORY_TITLE_CHARS,
 };
 
 use crate::chat_titling::{derive_text_with_retries, Proposal};
@@ -70,7 +70,7 @@ Answer {{"kind":null,"title":null,"body":null}} when the turn has no durable fac
 
 /// Starts memory capture for a turn that just completed.
 pub(crate) trait TurnMemoryCapture: Send + Sync {
-    fn spawn(&self, owner: OwnerId, session_id: CodeSessionId, turn_id: CodeTurnId);
+    fn spawn(&self, owner: OwnerId, session_id: SessionId, turn_id: TurnId);
 }
 
 #[derive(Clone)]
@@ -104,13 +104,13 @@ impl TurnMemoryCapturer {
     pub(crate) async fn derive(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
+        session_id: SessionId,
+        turn_id: TurnId,
     ) -> Result<()> {
         let Some(turn) = get_turn(&self.db, owner, turn_id).await? else {
             return Ok(());
         };
-        if turn.status != CodeTurnStatus::Completed {
+        if turn.status != TurnStatus::Completed {
             return Ok(());
         }
         let Some(session) = get_session(&self.db, owner, session_id).await? else {
@@ -184,7 +184,7 @@ impl TurnMemoryCapturer {
             evidence = events
                 .iter()
                 .take(1)
-                .map(|sequenced| MemoryEvidence::CodeEvent {
+                .map(|sequenced| MemoryEvidence::Event {
                     session_id,
                     seq: sequenced.seq,
                 })
@@ -235,7 +235,7 @@ impl TurnMemoryCapturer {
 
     /// Journals a capture failure so the person sees it in the session,
     /// instead of the proposal vanishing into a log line.
-    async fn report_failure(&self, owner: &OwnerId, session_id: CodeSessionId, error: &AgentError) {
+    async fn report_failure(&self, owner: &OwnerId, session_id: SessionId, error: &AgentError) {
         let Ok(Some(session)) = get_session(&self.db, owner, session_id).await else {
             return;
         };
@@ -245,7 +245,7 @@ impl TurnMemoryCapturer {
             owner,
             session_id,
             session.spawn_epoch,
-            CodeEvent::HarnessNotice {
+            Event::HarnessNotice {
                 level: HarnessNoticeLevel::Warning,
                 message: format!("Memory capture for this turn did not complete: {error}"),
             },
@@ -261,7 +261,7 @@ impl TurnMemoryCapturer {
 }
 
 impl TurnMemoryCapture for TurnMemoryCapturer {
-    fn spawn(&self, owner: OwnerId, session_id: CodeSessionId, turn_id: CodeTurnId) {
+    fn spawn(&self, owner: OwnerId, session_id: SessionId, turn_id: TurnId) {
         let capturer = self.clone();
         tokio::spawn(async move {
             if let Err(error) = capturer.derive(&owner, session_id, turn_id).await {
@@ -277,15 +277,15 @@ impl TurnMemoryCapture for TurnMemoryCapturer {
 async fn context_file_hint(
     db: &DbStore,
     owner: &OwnerId,
-    session_id: CodeSessionId,
-    turn_id: CodeTurnId,
+    session_id: SessionId,
+    turn_id: TurnId,
 ) -> Result<String> {
     let events = list_recent_events(db, owner, session_id, 400).await?;
     let mut paths = Vec::new();
     for sequenced in &events {
         match &sequenced.event {
-            CodeEvent::TurnStarted { turn_id: started } if *started == turn_id => break,
-            CodeEvent::FileChanged { path, .. }
+            Event::TurnStarted { turn_id: started } if *started == turn_id => break,
+            Event::FileChanged { path, .. }
                 if is_agent_context_file(path) && !paths.contains(path) =>
             {
                 paths.push(path.clone());
@@ -307,8 +307,8 @@ async fn context_file_hint(
 async fn context_file_diff(
     db: &DbStore,
     owner: &OwnerId,
-    session_id: CodeSessionId,
-    turn_id: CodeTurnId,
+    session_id: SessionId,
+    turn_id: TurnId,
     paths: &[String],
 ) -> Result<Option<String>> {
     let Some(session) = get_session(db, owner, session_id).await? else {
@@ -397,9 +397,9 @@ mod tests {
         append_event, insert_repo, insert_session, insert_turn, insert_workspace, save_turn,
     };
     use tidebreak_core::{
-        Attention, AttentionSource, AttentionState, CodeRepo, CodeSession, CodeSessionKind,
-        CodeSessionLifecycle, CodeTurn, CodeWorkspace, CodeWorkspaceStatus, Diffstat,
-        FileChangeKind, HarnessKind, PermissionMode, RepoId, WorkspaceId,
+        Attention, AttentionSource, AttentionState, CodeRepo, CodeWorkspace, CodeWorkspaceStatus,
+        Diffstat, Event, FileChangeKind, HarnessKind, PermissionMode, RepoId, Session, SessionId,
+        SessionKind, SessionLifecycle, Turn, TurnId, TurnStatus, WorkspaceId,
     };
 
     fn git(repo: &Path, args: &[&str]) {
@@ -489,14 +489,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let session_id = CodeSessionId::new();
+        let session_id = SessionId::new();
         insert_session(
             &db,
-            &CodeSession {
+            &Session {
                 id: session_id,
                 owner: owner.clone(),
                 workspace_id: Some(workspace_id),
-                kind: CodeSessionKind::Interactive,
+                kind: SessionKind::Interactive,
                 harness_kind: HarnessKind::ClaudeCode,
                 harness_version: None,
                 harness_resume_ref: None,
@@ -504,7 +504,7 @@ mod tests {
                 model: None,
                 reasoning_effort: None,
                 fast_mode: false,
-                lifecycle: CodeSessionLifecycle::Idle,
+                lifecycle: SessionLifecycle::Idle,
                 fence_reason: None,
                 child_pid: None,
                 child_process_identity: None,
@@ -521,12 +521,12 @@ mod tests {
             .await
             .unwrap();
 
-        let turn_id = CodeTurnId::new();
-        let mut turn = CodeTurn {
+        let turn_id = TurnId::new();
+        let mut turn = Turn {
             id: turn_id,
             session_id,
             ordinal: 1,
-            status: CodeTurnStatus::Completed,
+            status: TurnStatus::Completed,
             model: None,
             fast_mode: false,
             user_input: "Update the instructions.".into(),
@@ -543,22 +543,16 @@ mod tests {
             park_wait: None,
         };
         insert_turn(&db, &owner, &turn).await.unwrap();
-        append_event(
-            &db,
-            &owner,
-            session_id,
-            1,
-            &CodeEvent::TurnStarted { turn_id },
-        )
-        .await
-        .unwrap();
+        append_event(&db, &owner, session_id, 1, &Event::TurnStarted { turn_id })
+            .await
+            .unwrap();
         std::fs::write(repo.join("CLAUDE.md"), "Keep the new rule.\n").unwrap();
         append_event(
             &db,
             &owner,
             session_id,
             1,
-            &CodeEvent::FileChanged {
+            &Event::FileChanged {
                 path: "CLAUDE.md".into(),
                 kind: FileChangeKind::Modified,
                 diffstat: Diffstat {
@@ -576,7 +570,7 @@ mod tests {
             workspace_id,
             session_id,
             1,
-            CodeTurnStatus::Completed,
+            TurnStatus::Completed,
             None,
             "main",
         )

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -66,7 +66,7 @@ pub(crate) fn trigger_target_at(
 /// skip the work instead of failing the session.
 pub(crate) async fn session_workspace(
     db: &tidebreak_core::db::DbStore,
-    session: &tidebreak_core::CodeSession,
+    session: &tidebreak_core::Session,
 ) -> Result<Option<tidebreak_core::CodeWorkspace>, tidebreak_core::AgentError> {
     match session.workspace_id {
         Some(workspace_id) => {

--- a/crates/tidebreak-server/src/code/pr_facts.rs
+++ b/crates/tidebreak-server/src/code/pr_facts.rs
@@ -24,9 +24,9 @@ use tidebreak_core::db::code::{
     promote_attribution_to_authored, save_pull_request_fact,
 };
 use tidebreak_core::{
-    CodeEvent, CodePullRequestAttribution, CodePullRequestDiscovery, CodePullRequestFact,
-    CodePullRequestId, CodePullRequestRelation, CodePullRequestState, CodeSession, CodeSessionId,
-    CodeTurnId, DbStore, OwnerId, ToolDetail, ToolOutcome, WorkspaceId,
+    CodePullRequestAttribution, CodePullRequestDiscovery, CodePullRequestFact, CodePullRequestId,
+    CodePullRequestRelation, CodePullRequestState, DbStore, Event, OwnerId, Session, SessionId,
+    ToolDetail, ToolOutcome, TurnId, WorkspaceId,
 };
 use tidebreak_shell_policy::simple_command_argvs;
 
@@ -83,8 +83,8 @@ struct PushAct {
 /// its own fix turn a repeat, and parks the watch.
 pub(crate) async fn sweep_turn_for_pull_request_acts(
     db: &DbStore,
-    session: &CodeSession,
-    turn_id: CodeTurnId,
+    session: &Session,
+    turn_id: TurnId,
     gh_search_path: Option<&str>,
     hot: Option<&super::pr_refresh::HotPullRequests>,
 ) {
@@ -105,8 +105,8 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
     let mut commands: HashMap<String, RecordedCommand> = HashMap::new();
     for sequenced in &events {
         match &sequenced.event {
-            CodeEvent::TurnStarted { turn_id: started } if *started == turn_id => break,
-            CodeEvent::ToolCompleted {
+            Event::TurnStarted { turn_id: started } if *started == turn_id => break,
+            Event::ToolCompleted {
                 call_id,
                 outcome,
                 preview,
@@ -130,7 +130,7 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
                     });
                 }
             }
-            CodeEvent::ToolStarted {
+            Event::ToolStarted {
                 call_id,
                 detail: ToolDetail::Command { cmd, cwd },
                 parent_call_id,
@@ -258,8 +258,8 @@ pub(crate) async fn sweep_turn_for_pull_request_acts(
 /// Reports whether a fact landed, so the caller can mark the workspace hot.
 async fn confirm_changed_checkout(
     db: &DbStore,
-    session: &CodeSession,
-    turn_id: CodeTurnId,
+    session: &Session,
+    turn_id: TurnId,
     gh_search_path: Option<&str>,
 ) -> bool {
     let turn = match get_turn(db, &session.owner, turn_id).await {
@@ -375,7 +375,7 @@ async fn confirm_changed_checkout(
 /// Reports whether a fact landed, so the caller can mark the workspace hot.
 async fn confirm_create(
     db: &DbStore,
-    session: &CodeSession,
+    session: &Session,
     command: &RecordedCommand,
     create: &CreateAct,
     preview: Option<&str>,
@@ -455,7 +455,7 @@ async fn confirm_create(
 /// Reports whether a fact landed, so the caller can mark the workspace hot.
 async fn confirm_push(
     db: &DbStore,
-    session: &CodeSession,
+    session: &Session,
     command: &RecordedCommand,
     push: &PushAct,
     gh_search_path: Option<&str>,
@@ -543,7 +543,7 @@ pub(crate) async fn record_confirmed_fact(
     db: &DbStore,
     owner: &OwnerId,
     workspace_id: WorkspaceId,
-    session_id: Option<CodeSessionId>,
+    session_id: Option<SessionId>,
     parent_call_id: Option<String>,
     target: &CodeGitHubRepositoryTarget,
     value: &Value,

--- a/crates/tidebreak-server/src/code/recap.rs
+++ b/crates/tidebreak-server/src/code/recap.rs
@@ -48,9 +48,7 @@ use serde::{Deserialize, Serialize};
 use tidebreak_core::db::code::{
     get_session, get_turn, list_recent_events, list_turns, set_turn_narrative,
 };
-use tidebreak_core::{
-    CodeEvent, CodeSessionId, CodeTurnId, CodeTurnStatus, DbStore, HarnessKind, OwnerId, Result,
-};
+use tidebreak_core::{DbStore, Event, HarnessKind, OwnerId, Result, SessionId, TurnId, TurnStatus};
 
 use crate::chat_titling::{derive_text_with_retries, head, Proposal};
 use crate::resolver::ProviderResolver;
@@ -145,7 +143,7 @@ pub(crate) enum Outcome {
 pub(crate) trait TurnRecap: Send + Sync {
     /// Derive and store the recap for `turn_id`. Returns immediately; nothing
     /// waits on the result and a lost recap costs nothing.
-    fn spawn(&self, owner: OwnerId, session_id: CodeSessionId, turn_id: CodeTurnId);
+    fn spawn(&self, owner: OwnerId, session_id: SessionId, turn_id: TurnId);
 }
 
 /// Derives recaps on the utility role, one at a time per session.
@@ -180,7 +178,7 @@ pub(crate) struct TurnRecapper {
     /// Only the newest queued turn is kept. One it replaces was superseded
     /// before its recap was ever written, and the newer turn's line describes
     /// the session that turn left behind.
-    in_flight: Arc<Mutex<HashMap<CodeSessionId, Option<CodeTurnId>>>>,
+    in_flight: Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
 }
 
 impl TurnRecapper {
@@ -221,8 +219,8 @@ impl TurnRecapper {
     pub(crate) async fn derive(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
+        session_id: SessionId,
+        turn_id: TurnId,
     ) -> Result<Outcome> {
         if !turn_recaps_enabled(&*self.store).await? {
             return Ok(Outcome::NotApplicable);
@@ -234,7 +232,7 @@ impl TurnRecapper {
         // already carries a line is not re-derived: the sink fires once per
         // completion, and a retry would spend a second call to say the same
         // thing.
-        if turn.status != CodeTurnStatus::Completed || turn.narrative.is_some() {
+        if turn.status != TurnStatus::Completed || turn.narrative.is_some() {
             return Ok(Outcome::NotApplicable);
         }
         let Some(session) = get_session(&self.db, owner, session_id).await? else {
@@ -285,7 +283,7 @@ impl TurnRecapper {
             return Ok(Outcome::Declined);
         };
         // A targeted column write, never a whole-row save. The checkpoint task
-        // is writing this same row from a `CodeTurn` it read before the turn
+        // is writing this same row from a `Turn` it read before the turn
         // ended, so a whole-row save from either side blanks the other's work:
         // ours would drop the checkpoint ref, and theirs would drop this line
         // — silently, and only sometimes, depending on which finished last.
@@ -308,8 +306,8 @@ impl TurnRecapper {
     pub(crate) async fn turn_material(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn: &tidebreak_core::CodeTurn,
+        session_id: SessionId,
+        turn: &tidebreak_core::Turn,
     ) -> Result<String> {
         self.material(owner, session_id, turn).await
     }
@@ -317,8 +315,8 @@ impl TurnRecapper {
     async fn material(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn: &tidebreak_core::CodeTurn,
+        session_id: SessionId,
+        turn: &tidebreak_core::Turn,
     ) -> Result<String> {
         let mut material = String::new();
         // The session's first request is its goal. On turn one that is this
@@ -365,8 +363,8 @@ impl TurnRecapper {
     async fn turn_record(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
+        session_id: SessionId,
+        turn_id: TurnId,
     ) -> Result<(Option<String>, Vec<String>)> {
         let events = list_recent_events(&self.db, owner, session_id, RECAP_EVENT_WINDOW).await?;
         let mut closing = None;
@@ -375,12 +373,12 @@ impl TurnRecapper {
         // and the walk can stop the moment it reaches this turn's start.
         for sequenced in &events {
             match &sequenced.event {
-                CodeEvent::TurnStarted { turn_id: started } if *started == turn_id => break,
-                CodeEvent::AssistantMessage {
+                Event::TurnStarted { turn_id: started } if *started == turn_id => break,
+                Event::AssistantMessage {
                     text,
                     parent_call_id: None,
                 } if closing.is_none() => closing = Some(text.clone()),
-                CodeEvent::ToolCompleted {
+                Event::ToolCompleted {
                     call_id: _,
                     outcome,
                     detail: Some(detail),
@@ -393,7 +391,7 @@ impl TurnRecapper {
                         activity.push(format!("{outcome:?}: {subject}"));
                     }
                 }
-                CodeEvent::FileChanged { path, kind, .. }
+                Event::FileChanged { path, kind, .. }
                     if activity.len() < MAX_RECAP_ACTIVITY_LINES =>
                 {
                     activity.push(format!("{kind:?} {path}"));
@@ -407,7 +405,7 @@ impl TurnRecapper {
 }
 
 impl TurnRecap for TurnRecapper {
-    fn spawn(&self, owner: OwnerId, session_id: CodeSessionId, turn_id: CodeTurnId) {
+    fn spawn(&self, owner: OwnerId, session_id: SessionId, turn_id: TurnId) {
         let Some((mut claim, mut turn_id)) =
             RecapClaim::acquire(&self.in_flight, session_id, turn_id)
         else {
@@ -462,8 +460,8 @@ pub(crate) async fn turn_recaps_enabled(
 
 /// A session's place in [`TurnRecapper::in_flight`], released on drop.
 struct RecapClaim {
-    in_flight: Arc<Mutex<HashMap<CodeSessionId, Option<CodeTurnId>>>>,
-    session_id: CodeSessionId,
+    in_flight: Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
+    session_id: SessionId,
     released: bool,
 }
 
@@ -476,10 +474,10 @@ impl RecapClaim {
     /// database, a provider, and a policy source to assert something none of
     /// them take part in.
     fn acquire(
-        in_flight: &Arc<Mutex<HashMap<CodeSessionId, Option<CodeTurnId>>>>,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
-    ) -> Option<(Self, CodeTurnId)> {
+        in_flight: &Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
+        session_id: SessionId,
+        turn_id: TurnId,
+    ) -> Option<(Self, TurnId)> {
         let in_flight = in_flight.clone();
         let mut guard = in_flight
             .lock()
@@ -507,7 +505,7 @@ impl RecapClaim {
     /// Take the one turn that completed while this call ran. With none queued,
     /// release atomically so a concurrent next turn either queues here or
     /// starts a fresh task; there is no gap in which its trigger can be lost.
-    fn take_pending_or_release(&mut self) -> Option<CodeTurnId> {
+    fn take_pending_or_release(&mut self) -> Option<TurnId> {
         let mut in_flight = self
             .in_flight
             .lock()
@@ -536,16 +534,16 @@ impl Drop for RecapClaim {
 mod tests {
     use super::*;
 
-    fn claims() -> Arc<Mutex<HashMap<CodeSessionId, Option<CodeTurnId>>>> {
+    fn claims() -> Arc<Mutex<HashMap<SessionId, Option<TurnId>>>> {
         Arc::new(Mutex::new(HashMap::new()))
     }
 
-    fn session() -> CodeSessionId {
-        CodeSessionId(uuid::Uuid::new_v4())
+    fn session() -> SessionId {
+        SessionId(uuid::Uuid::new_v4())
     }
 
-    fn turn() -> CodeTurnId {
-        CodeTurnId(uuid::Uuid::new_v4())
+    fn turn() -> TurnId {
+        TurnId(uuid::Uuid::new_v4())
     }
 
     /// A turn that finishes while an earlier recap is still running is queued,

--- a/crates/tidebreak-server/src/code/reconcile.rs
+++ b/crates/tidebreak-server/src/code/reconcile.rs
@@ -28,7 +28,7 @@ use crate::routes::code::types::{
 
 /// Coprime with the 47s watch and 53s trigger sweeps, so three GitHub-reading
 /// sweeps never land on the same tick. This is the cadence while a client
-/// holds a `/code/updates` socket, meaning someone can see the result.
+/// holds an `/updates` socket, meaning someone can see the result.
 pub(crate) const RECONCILE_SWEEP_INTERVAL: Duration = Duration::from_secs(61);
 
 /// The cadence while no client is attached.
@@ -36,7 +36,7 @@ pub(crate) const RECONCILE_SWEEP_INTERVAL: Duration = Duration::from_secs(61);
 /// Idle sweeps are mostly conditional 304s, but any repository that moved
 /// pays real per-pull-request reads, and with nobody looking the answer only
 /// has to be current by the time a window opens again. Subscribing to
-/// `/code/updates` wakes the sweep, so reopening the app does not wait this
+/// `/updates` wakes the sweep, so reopening the app does not wait this
 /// long. Prime, like the others, so the idle sweep does not fall into step
 /// with the watch and trigger sweeps.
 pub(crate) const RECONCILE_DETACHED_INTERVAL: Duration = Duration::from_secs(421);

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -18,8 +18,8 @@ use tidebreak_core::db::code::{
     set_session_subagents,
 };
 use tidebreak_core::{
-    Attention, AttentionSource, AttentionState, CapLevel, CodeSession, CodeSessionLifecycle,
-    CodeSubagentStatus, DbStore, FenceReason, HarnessKind, Store,
+    Attention, AttentionSource, AttentionState, CapLevel, CodeSubagentStatus, DbStore, FenceReason,
+    HarnessKind, Session, SessionLifecycle, Store,
 };
 
 use super::attention::{emit_digest, replace_attention};
@@ -83,11 +83,10 @@ pub(crate) async fn recover_running_sessions_with_caps(
     store: &DbStore,
     bus: &CodeEventBus,
     probe: impl Fn(i64, Option<&str>) -> PidLiveness,
-    durable_parks: impl Fn(&CodeSession) -> CapLevel,
+    durable_parks: impl Fn(&Session) -> CapLevel,
 ) -> Result<Vec<RecoveryAction>, tidebreak_core::AgentError> {
-    let running =
-        list_sessions_by_lifecycle_all_owners(store, CodeSessionLifecycle::Running).await?;
-    let fenced = list_sessions_by_lifecycle_all_owners(store, CodeSessionLifecycle::Fenced).await?;
+    let running = list_sessions_by_lifecycle_all_owners(store, SessionLifecycle::Running).await?;
+    let fenced = list_sessions_by_lifecycle_all_owners(store, SessionLifecycle::Fenced).await?;
     let mut actions = Vec::new();
     for session in running {
         // A remote session's engine lives in a sandbox, not a local child:
@@ -150,7 +149,7 @@ pub(crate) async fn recover_running_sessions_with_caps(
 pub(crate) async fn fence_session(
     store: &DbStore,
     bus: &CodeEventBus,
-    session: &mut CodeSession,
+    session: &mut Session,
     reason: FenceReason,
 ) -> Result<(), tidebreak_core::AgentError> {
     if matches!(reason, FenceReason::ResumeLost { .. }) {
@@ -164,7 +163,7 @@ pub(crate) async fn fence_session(
             )));
         }
     }
-    session.lifecycle = CodeSessionLifecycle::Fenced;
+    session.lifecycle = SessionLifecycle::Fenced;
     settle_running_subagents(&mut session.subagents, CodeSubagentStatus::Failed);
     session.fence_reason = Some(reason.clone());
     replace_attention(
@@ -187,7 +186,7 @@ pub(crate) async fn fence_session(
 async fn persist_recovery_session(
     store: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
+    session: &Session,
 ) -> Result<bool, tidebreak_core::AgentError> {
     if !save_session(store, session).await? {
         return Ok(false);
@@ -254,8 +253,8 @@ impl ProcessReaper for SystemProcessReaper {
 pub(crate) async fn reap_session(
     store: &DbStore,
     bus: &CodeEventBus,
-    session: CodeSession,
-) -> Result<CodeSession, ReapSessionError> {
+    session: Session,
+) -> Result<Session, ReapSessionError> {
     reap_session_with(
         store,
         bus,
@@ -269,10 +268,10 @@ pub(crate) async fn reap_session(
 async fn reap_session_with(
     store: &DbStore,
     bus: &CodeEventBus,
-    session: CodeSession,
+    session: Session,
     reaper: &(impl ProcessReaper + Sync),
     timeout: std::time::Duration,
-) -> Result<CodeSession, ReapSessionError> {
+) -> Result<Session, ReapSessionError> {
     match (session.child_pid, session.child_process_identity.as_deref()) {
         (Some(pid), Some(identity)) => match reaper.terminate(pid, identity, timeout).await {
             Ok(tidebreak_harness::RecordedProcessReap::Exited) => {}
@@ -322,7 +321,7 @@ async fn reap_session_with(
 async fn recover_one(
     store: &DbStore,
     bus: &CodeEventBus,
-    mut session: CodeSession,
+    mut session: Session,
     probe: &impl Fn(i64, Option<&str>) -> PidLiveness,
     durable_parks: CapLevel,
 ) -> Result<Option<RecoveryAction>, tidebreak_core::AgentError> {
@@ -343,7 +342,7 @@ async fn recover_one(
         PidLiveness::Dead => dead_worker_action(store, bus, &session, durable_parks).await,
         PidLiveness::Alive => {
             settle_running_subagents(&mut session.subagents, CodeSubagentStatus::Failed);
-            session.lifecycle = CodeSessionLifecycle::Fenced;
+            session.lifecycle = SessionLifecycle::Fenced;
             session.fence_reason = Some(FenceReason::OrphanAlive);
             replace_attention(
                 &mut session,
@@ -365,7 +364,7 @@ async fn recover_one(
 
 async fn expire_internal_turn_lease(
     store: &DbStore,
-    session: &CodeSession,
+    session: &Session,
 ) -> Result<(), tidebreak_core::AgentError> {
     let Some(open) = get_open_turn(store, &session.owner, session.id).await? else {
         return Ok(());
@@ -387,17 +386,17 @@ async fn expire_internal_turn_lease(
 pub(crate) async fn recover_dead_worker(
     store: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
-) -> Result<Option<CodeSession>, tidebreak_core::AgentError> {
+    session: &Session,
+) -> Result<Option<Session>, tidebreak_core::AgentError> {
     recover_dead_worker_with(store, bus, session, durable_parks_for(session.harness_kind)).await
 }
 
 pub(crate) async fn recover_dead_worker_with(
     store: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
+    session: &Session,
     durable_parks: CapLevel,
-) -> Result<Option<CodeSession>, tidebreak_core::AgentError> {
+) -> Result<Option<Session>, tidebreak_core::AgentError> {
     let Some(recovered) = recover_interrupted_session(
         store,
         &session.owner,
@@ -419,7 +418,7 @@ pub(crate) async fn recover_dead_worker_with(
 async fn dead_worker_action(
     store: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
+    session: &Session,
     durable_parks: CapLevel,
 ) -> Result<Option<RecoveryAction>, tidebreak_core::AgentError> {
     let Some(recovered) = recover_dead_worker_with(store, bus, session, durable_parks).await?
@@ -428,7 +427,7 @@ async fn dead_worker_action(
     };
     let action =
         match tidebreak_core::db::code::get_open_turn(store, &session.owner, session.id).await? {
-            Some(turn) if turn.status == tidebreak_core::CodeTurnStatus::Waiting => {
+            Some(turn) if turn.status == tidebreak_core::TurnStatus::Waiting => {
                 RecoveryAction::ReattachedPark {
                     session: recovered.id.to_string(),
                 }
@@ -553,10 +552,10 @@ mod tests {
         MAX_REPLAY_EVENTS,
     };
     use tidebreak_core::{
-        ApprovalDecisionKind, Attention, CodeApproval, CodeApprovalId, CodeApprovalKind,
-        CodeApprovalState, CodeEvent, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
-        CodeSubagentSummary, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace,
-        CodeWorkspaceStatus, HarnessKind, PermissionMode, RepoId, TurnParkWait, WorkspaceId,
+        Approval, ApprovalDecisionKind, ApprovalId, ApprovalKind, ApprovalState, Attention,
+        CodeRepo, CodeSubagentSummary, CodeWorkspace, CodeWorkspaceStatus, Event, HarnessKind,
+        PermissionMode, RepoId, Session, SessionId, SessionKind, Turn, TurnId, TurnParkWait,
+        TurnStatus, WorkspaceId,
     };
     use tidebreak_harness::HarnessAdapter;
 
@@ -564,7 +563,7 @@ mod tests {
         Utc::now()
     }
 
-    async fn seed_running_subagent(store: &DbStore, session_id: CodeSessionId) {
+    async fn seed_running_subagent(store: &DbStore, session_id: SessionId) {
         set_session_subagents(
             store,
             &tidebreak_core::OwnerId::local(),
@@ -579,7 +578,7 @@ mod tests {
         .unwrap();
     }
 
-    async fn assert_subagent_failed(store: &DbStore, session_id: CodeSessionId) {
+    async fn assert_subagent_failed(store: &DbStore, session_id: SessionId) {
         let session = get_session(store, &tidebreak_core::OwnerId::local(), session_id)
             .await
             .unwrap()
@@ -589,18 +588,18 @@ mod tests {
 
     async fn seed_pending_approval(
         store: &DbStore,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
-    ) -> CodeApprovalId {
-        let approval_id = CodeApprovalId::new();
+        session_id: SessionId,
+        turn_id: TurnId,
+    ) -> ApprovalId {
+        let approval_id = ApprovalId::new();
         insert_approval(
             store,
             &tidebreak_core::OwnerId::local(),
-            &CodeApproval {
+            &Approval {
                 id: approval_id,
                 session_id,
                 turn_id,
-                kind: CodeApprovalKind::Other {
+                kind: ApprovalKind::Other {
                     summary: "run command".into(),
                 },
                 harness_raw: serde_json::json!({"call_id":"toolu_recovery"}),
@@ -610,7 +609,7 @@ mod tests {
                 worker_epoch: Some(1),
                 decision_claim: Some(uuid::Uuid::new_v4()),
                 claimed_at: Some(now()),
-                state: CodeApprovalState::Pending,
+                state: ApprovalState::Pending,
                 feedback: None,
                 requested_at: now(),
                 decided_at: None,
@@ -669,20 +668,17 @@ mod tests {
         }
     }
 
-    async fn seeded_running(
-        pid: Option<i64>,
-    ) -> (tempfile::TempDir, DbStore, CodeSessionId, CodeTurnId) {
-        let (directory, store, session_id) =
-            seeded_session(pid, CodeSessionLifecycle::Running).await;
-        let turn_id = CodeTurnId::new();
+    async fn seeded_running(pid: Option<i64>) -> (tempfile::TempDir, DbStore, SessionId, TurnId) {
+        let (directory, store, session_id) = seeded_session(pid, SessionLifecycle::Running).await;
+        let turn_id = TurnId::new();
         insert_turn(
             &store,
             &tidebreak_core::OwnerId::local(),
-            &CodeTurn {
+            &Turn {
                 id: turn_id,
                 session_id,
                 ordinal: 1,
-                status: CodeTurnStatus::Running,
+                status: TurnStatus::Running,
                 model: None,
                 fast_mode: false,
                 user_input: "hello".into(),
@@ -706,8 +702,8 @@ mod tests {
 
     async fn seeded_session(
         pid: Option<i64>,
-        lifecycle: CodeSessionLifecycle,
-    ) -> (tempfile::TempDir, DbStore, CodeSessionId) {
+        lifecycle: SessionLifecycle,
+    ) -> (tempfile::TempDir, DbStore, SessionId) {
         let directory = tempfile::tempdir().unwrap();
         let store = DbStore::connect(&format!(
             "sqlite://{}?mode=rwc",
@@ -760,14 +756,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let session_id = CodeSessionId::new();
+        let session_id = SessionId::new();
         insert_session(
             &store,
-            &CodeSession {
+            &Session {
                 id: session_id,
                 owner: tidebreak_core::OwnerId::local(),
                 workspace_id: Some(workspace_id),
-                kind: CodeSessionKind::Interactive,
+                kind: SessionKind::Interactive,
                 harness_kind: HarnessKind::ClaudeCode,
                 harness_version: Some("2.1.233".into()),
                 harness_resume_ref: None,
@@ -824,7 +820,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(untouched.lifecycle, CodeSessionLifecycle::Running);
+        assert_eq!(untouched.lifecycle, SessionLifecycle::Running);
     }
 
     async fn seeded_fenced_orphan(
@@ -833,9 +829,9 @@ mod tests {
         tempfile::TempDir,
         DbStore,
         crate::code::bus::CodeEventBus,
-        CodeSession,
-        CodeTurnId,
-        CodeApprovalId,
+        Session,
+        TurnId,
+        ApprovalId,
     ) {
         let (directory, store, session_id, turn_id) = seeded_running(Some(pid)).await;
         let approval_id = seed_pending_approval(&store, session_id, turn_id).await;
@@ -859,17 +855,17 @@ mod tests {
         pid: i64,
         identity: &str,
         epoch: i64,
-        turn_id: CodeTurnId,
-        approval_id: CodeApprovalId,
+        turn_id: TurnId,
+        approval_id: ApprovalId,
     ) {
         let owner = tidebreak_core::OwnerId::local();
         let turn = get_turn(store, &owner, turn_id).await.unwrap().unwrap();
-        assert_eq!(turn.status, CodeTurnStatus::Running);
+        assert_eq!(turn.status, TurnStatus::Running);
         let session = get_session(store, &owner, turn.session_id)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
+        assert_eq!(session.lifecycle, SessionLifecycle::Fenced);
         assert_eq!(session.fence_reason, Some(FenceReason::OrphanAlive));
         assert_eq!(session.child_pid, Some(pid));
         assert_eq!(session.child_process_identity.as_deref(), Some(identity));
@@ -880,7 +876,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .state,
-            CodeApprovalState::Pending
+            ApprovalState::Pending
         );
     }
 
@@ -901,7 +897,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(session.lifecycle, SessionLifecycle::Idle);
         assert!(matches!(
             session.attention.state,
             AttentionState::NeedsYou {
@@ -913,12 +909,12 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(turn.status, CodeTurnStatus::Interrupted);
+        assert_eq!(turn.status, TurnStatus::Interrupted);
         let approval = get_approval(&store, &tidebreak_core::OwnerId::local(), approval_id)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(approval.state, CodeApprovalState::Abandoned);
+        assert_eq!(approval.state, ApprovalState::Abandoned);
         assert!(approval.decision_claim.is_none());
         assert!(approval.decided_at.is_some());
         let events = list_events(
@@ -931,13 +927,10 @@ mod tests {
         .await
         .unwrap()
         .events;
-        assert!(matches!(
-            &events[0].event,
-            CodeEvent::TurnInterrupted { .. }
-        ));
+        assert!(matches!(&events[0].event, Event::TurnInterrupted { .. }));
         assert!(matches!(
             &events[1].event,
-            CodeEvent::ApprovalResolved {
+            Event::ApprovalResolved {
                 approval_id: resolved,
                 decision: ApprovalDecisionKind::Abandoned,
             } if *resolved == approval_id
@@ -965,7 +958,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .status,
-            CodeTurnStatus::Interrupted
+            TurnStatus::Interrupted
         );
         assert_subagent_failed(&store, session_id).await;
     }
@@ -1001,7 +994,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
+        assert_eq!(session.lifecycle, SessionLifecycle::Fenced);
         assert_eq!(session.fence_reason, Some(FenceReason::OrphanAlive));
         assert!(matches!(
             session.attention.state,
@@ -1013,7 +1006,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(turn.status, CodeTurnStatus::Running);
+        assert_eq!(turn.status, TurnStatus::Running);
         assert_subagent_failed(&store, session_id).await;
         assert!(
             decoy.try_wait().ok().flatten().is_none(),
@@ -1047,7 +1040,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(recovered.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(recovered.lifecycle, SessionLifecycle::Idle);
         assert_eq!(recovered.child_pid, None);
         assert_eq!(recovered.child_process_identity, None);
         assert_eq!(recovered.fence_reason, None);
@@ -1057,7 +1050,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .status,
-            CodeTurnStatus::Interrupted
+            TurnStatus::Interrupted
         );
         assert_eq!(
             get_approval(&store, &tidebreak_core::OwnerId::local(), approval_id)
@@ -1065,7 +1058,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .state,
-            CodeApprovalState::Abandoned
+            ApprovalState::Abandoned
         );
     }
 
@@ -1088,7 +1081,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(reaper.calls.load(Ordering::SeqCst), 1);
-        assert_eq!(reaped.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(reaped.lifecycle, SessionLifecycle::Idle);
         assert_eq!(reaped.spawn_epoch, old_epoch + 1);
         assert_eq!(reaped.child_pid, None);
         assert_eq!(reaped.child_process_identity, None);
@@ -1099,7 +1092,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .status,
-            CodeTurnStatus::Interrupted
+            TurnStatus::Interrupted
         );
         assert_eq!(
             get_approval(&store, &tidebreak_core::OwnerId::local(), approval_id)
@@ -1107,7 +1100,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .state,
-            CodeApprovalState::Abandoned
+            ApprovalState::Abandoned
         );
     }
 
@@ -1196,7 +1189,7 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_fence_settles_running_subagents_as_failed() {
-        let (_dir, store, session_id) = seeded_session(None, CodeSessionLifecycle::Running).await;
+        let (_dir, store, session_id) = seeded_session(None, SessionLifecycle::Running).await;
         seed_running_subagent(&store, session_id).await;
         let mut session = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
             .await
@@ -1232,7 +1225,7 @@ mod tests {
         // one child per turn have no pid to report at turn boundaries, so this
         // drives a real worker turn and reads back what the worker itself
         // wrote — seeding a pid here would test nothing.
-        let (_dir, store, session_id) = seeded_session(None, CodeSessionLifecycle::Idle).await;
+        let (_dir, store, session_id) = seeded_session(None, SessionLifecycle::Idle).await;
         let store = Arc::new(store);
         let bus = Arc::new(crate::code::bus::CodeEventBus::default());
         let session = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
@@ -1272,7 +1265,7 @@ mod tests {
         .with_delay(std::time::Duration::from_secs(30))
         .launch(tidebreak_harness::SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree: _dir.path().join("wt"),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Plan,
@@ -1380,7 +1373,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
+        assert_eq!(session.lifecycle, SessionLifecycle::Fenced);
         assert!(
             matches!(session.attention.state, AttentionState::Manual { .. }),
             "Fenced recovery must go through should_replace: {:?}",
@@ -1403,7 +1396,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
+        assert_eq!(session.lifecycle, SessionLifecycle::Fenced);
     }
 
     #[tokio::test]
@@ -1416,14 +1409,14 @@ mod tests {
         .await
         .unwrap();
         let owner = tidebreak_core::OwnerId::local();
-        let session_id = CodeSessionId::new();
+        let session_id = SessionId::new();
         insert_session(
             &store,
-            &CodeSession {
+            &Session {
                 id: session_id,
                 owner: owner.clone(),
                 workspace_id: None,
-                kind: CodeSessionKind::Interactive,
+                kind: SessionKind::Interactive,
                 harness_kind: HarnessKind::Internal,
                 harness_version: Some("internal".into()),
                 harness_resume_ref: None,
@@ -1431,7 +1424,7 @@ mod tests {
                 model: Some("test".into()),
                 reasoning_effort: None,
                 fast_mode: false,
-                lifecycle: CodeSessionLifecycle::Running,
+                lifecycle: SessionLifecycle::Running,
                 fence_reason: None,
                 child_pid: None,
                 child_process_identity: None,
@@ -1444,15 +1437,15 @@ mod tests {
         )
         .await
         .unwrap();
-        let turn_id = CodeTurnId::new();
+        let turn_id = TurnId::new();
         insert_turn(
             &store,
             &owner,
-            &CodeTurn {
+            &Turn {
                 id: turn_id,
                 session_id,
                 ordinal: 1,
-                status: CodeTurnStatus::Running,
+                status: TurnStatus::Running,
                 model: Some("test".into()),
                 fast_mode: false,
                 user_input: "hello".into(),
@@ -1484,9 +1477,9 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Running);
+        assert_eq!(session.lifecycle, SessionLifecycle::Running);
         let turn = get_turn(&store, &owner, turn_id).await.unwrap().unwrap();
-        assert_eq!(turn.status, CodeTurnStatus::Running);
+        assert_eq!(turn.status, TurnStatus::Running);
     }
 
     #[test]
@@ -1498,10 +1491,10 @@ mod tests {
         assert_eq!(probe_recorded_pid(0), PidLiveness::Dead);
     }
 
-    async fn park_waiting_turn(store: &DbStore, turn_id: CodeTurnId) {
+    async fn park_waiting_turn(store: &DbStore, turn_id: TurnId) {
         let owner = tidebreak_core::OwnerId::local();
         let mut turn = get_turn(store, &owner, turn_id).await.unwrap().unwrap();
-        turn.status = CodeTurnStatus::Waiting;
+        turn.status = TurnStatus::Waiting;
         turn.park_ref = Some("cp-1".into());
         turn.park_wait = Some(TurnParkWait::Approval {
             call_id: "call-1".into(),
@@ -1525,7 +1518,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(turn.status, CodeTurnStatus::Interrupted);
+        assert_eq!(turn.status, TurnStatus::Interrupted);
         let events = list_events(
             &store,
             &tidebreak_core::OwnerId::local(),
@@ -1536,10 +1529,7 @@ mod tests {
         .await
         .unwrap()
         .events;
-        assert!(matches!(
-            &events[0].event,
-            CodeEvent::TurnInterrupted { .. }
-        ));
+        assert!(matches!(&events[0].event, Event::TurnInterrupted { .. }));
     }
 
     #[tokio::test]
@@ -1562,7 +1552,7 @@ mod tests {
         ));
         let owner = tidebreak_core::OwnerId::local();
         let turn = get_turn(&store, &owner, turn_id).await.unwrap().unwrap();
-        assert_eq!(turn.status, CodeTurnStatus::Waiting);
+        assert_eq!(turn.status, TurnStatus::Waiting);
         assert_eq!(turn.park_ref.as_deref(), Some("cp-1"));
         assert_eq!(
             get_approval(&store, &owner, approval_id)
@@ -1570,7 +1560,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .state,
-            CodeApprovalState::Pending
+            ApprovalState::Pending
         );
         let events = list_events(&store, &owner, session_id, 0, MAX_REPLAY_EVENTS)
             .await
@@ -1579,7 +1569,7 @@ mod tests {
         assert!(
             events
                 .iter()
-                .all(|event| !matches!(event.event, CodeEvent::TurnInterrupted { .. })),
+                .all(|event| !matches!(event.event, Event::TurnInterrupted { .. })),
             "a durable park must not journal an interrupt"
         );
 
@@ -1623,7 +1613,7 @@ mod tests {
                 parent_call_id: None,
             },
             tidebreak_harness::HarnessEvent::TurnCompleted {
-                usage: tidebreak_core::CodeUsage::default(),
+                usage: tidebreak_core::TurnUsage::default(),
             },
         ])
         .with_unattended_approvals()
@@ -1637,7 +1627,7 @@ mod tests {
         let engine = adapter
             .launch(tidebreak_harness::SessionSpec {
                 owner: tidebreak_core::OwnerId::local(),
-                session_id: tidebreak_core::CodeSessionId::new(),
+                session_id: tidebreak_core::SessionId::new(),
                 worktree,
                 allowed_read_roots: Vec::new(),
                 permission_mode: session.permission_mode,
@@ -1675,7 +1665,7 @@ mod tests {
                     .await
                     .unwrap()
                     .unwrap();
-                if current.lifecycle == CodeSessionLifecycle::Running {
+                if current.lifecycle == SessionLifecycle::Running {
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
@@ -1699,7 +1689,7 @@ mod tests {
         let completed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
                 let turn = get_turn(&store, &owner, turn_id).await.unwrap().unwrap();
-                if turn.status == CodeTurnStatus::Completed {
+                if turn.status == TurnStatus::Completed {
                     break turn;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
@@ -1720,7 +1710,7 @@ mod tests {
         assert!(
             events
                 .iter()
-                .any(|event| matches!(event.event, CodeEvent::TurnResumed { .. })),
+                .any(|event| matches!(event.event, Event::TurnResumed { .. })),
             "the journal records the resume"
         );
         let _ = handle

--- a/crates/tidebreak-server/src/code/remote/fixtures.rs
+++ b/crates/tidebreak-server/src/code/remote/fixtures.rs
@@ -2,17 +2,17 @@
 //! workspace, session, and an activated incarnation.
 
 use tidebreak_core::{
-    Attention, AttentionSource, CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle,
-    HarnessKind, OwnerId, PermissionMode, WorkspaceId,
+    Attention, AttentionSource, HarnessKind, OwnerId, PermissionMode, Session, SessionId,
+    SessionKind, SessionLifecycle, WorkspaceId,
 };
 
 /// A session value with sensible remote defaults, unsaved.
-pub(crate) fn session_value() -> CodeSession {
-    CodeSession {
-        id: CodeSessionId::new(),
+pub(crate) fn session_value() -> Session {
+    Session {
+        id: SessionId::new(),
         owner: OwnerId::local(),
         workspace_id: Some(WorkspaceId::new()),
-        kind: CodeSessionKind::Interactive,
+        kind: SessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: None,
         harness_resume_ref: None,
@@ -20,7 +20,7 @@ pub(crate) fn session_value() -> CodeSession {
         model: None,
         reasoning_effort: None,
         fast_mode: false,
-        lifecycle: CodeSessionLifecycle::Running,
+        lifecycle: SessionLifecycle::Running,
         fence_reason: None,
         child_pid: None,
         child_process_identity: None,

--- a/crates/tidebreak-server/src/code/remote/mod.rs
+++ b/crates/tidebreak-server/src/code/remote/mod.rs
@@ -13,8 +13,8 @@ pub(crate) use tidebreak_code_remote::{
 impl tidebreak_code_remote::RemoteSessionHost for super::bus::CodeEventBus {
     fn publish(
         &self,
-        session: tidebreak_core::CodeSessionId,
-        event: tidebreak_core::SequencedCodeEvent,
+        session: tidebreak_core::SessionId,
+        event: tidebreak_core::code::SequencedEvent,
     ) {
         super::bus::CodeEventBus::publish(self, session, event);
     }
@@ -22,7 +22,7 @@ impl tidebreak_code_remote::RemoteSessionHost for super::bus::CodeEventBus {
     async fn persist_session(
         &self,
         store: &tidebreak_core::DbStore,
-        session: &tidebreak_core::CodeSession,
+        session: &tidebreak_core::Session,
     ) -> Result<bool, tidebreak_core::AgentError> {
         super::attention::persist_session(store, self, session).await
     }
@@ -31,7 +31,7 @@ impl tidebreak_code_remote::RemoteSessionHost for super::bus::CodeEventBus {
         &self,
         store: &tidebreak_core::DbStore,
         owner: &tidebreak_core::OwnerId,
-        session_id: tidebreak_core::CodeSessionId,
+        session_id: tidebreak_core::SessionId,
         next: tidebreak_core::Attention,
     ) -> Result<(), tidebreak_core::AgentError> {
         let _ =
@@ -43,9 +43,9 @@ impl tidebreak_code_remote::RemoteSessionHost for super::bus::CodeEventBus {
         &self,
         store: &tidebreak_core::DbStore,
         owner: &tidebreak_core::OwnerId,
-        session_id: tidebreak_core::CodeSessionId,
+        session_id: tidebreak_core::SessionId,
         spawn_epoch: i64,
-        event: tidebreak_core::CodeEvent,
+        event: tidebreak_core::Event,
     ) {
         let _ = super::session_worker::journal_event(
             store,
@@ -61,7 +61,7 @@ impl tidebreak_code_remote::RemoteSessionHost for super::bus::CodeEventBus {
     async fn fence_session(
         &self,
         store: &tidebreak_core::DbStore,
-        session: &mut tidebreak_core::CodeSession,
+        session: &mut tidebreak_core::Session,
         reason: tidebreak_core::FenceReason,
     ) -> Result<(), tidebreak_core::AgentError> {
         super::recovery::fence_session(store, self, session, reason).await
@@ -70,16 +70,16 @@ impl tidebreak_code_remote::RemoteSessionHost for super::bus::CodeEventBus {
     async fn recover_dead_worker(
         &self,
         store: &tidebreak_core::DbStore,
-        session: &tidebreak_core::CodeSession,
-    ) -> Result<Option<tidebreak_core::CodeSession>, tidebreak_core::AgentError> {
+        session: &tidebreak_core::Session,
+    ) -> Result<Option<tidebreak_core::Session>, tidebreak_core::AgentError> {
         super::recovery::recover_dead_worker(store, self, session).await
     }
 
     async fn reap_session(
         &self,
         store: &tidebreak_core::DbStore,
-        session: tidebreak_core::CodeSession,
-    ) -> Result<tidebreak_core::CodeSession, tidebreak_code_remote::RemoteReapError> {
+        session: tidebreak_core::Session,
+    ) -> Result<tidebreak_core::Session, tidebreak_code_remote::RemoteReapError> {
         super::recovery::reap_session(store, self, session)
             .await
             .map_err(|error| match error {

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -20,7 +20,7 @@ use tokio::sync::Notify;
 use tracing::{debug, warn};
 
 use tidebreak_core::db::code::{get_session, latest_incarnations_of_live_sessions_all_owners};
-use tidebreak_core::{CodeSessionId, CodeSessionLifecycle, DbStore, IncarnationState, OwnerId};
+use tidebreak_core::{DbStore, IncarnationState, OwnerId, SessionId, SessionLifecycle};
 
 use super::super::runtime::CodeRuntime;
 use super::driver::{sweep_stale_intents, RemoteDriver, RemoteSpawnSettings};
@@ -79,11 +79,11 @@ pub(crate) struct RemoteSessions {
     /// Live pump tasks by session. The sweep prunes finished entries and
     /// spawns missing ones; a pump task removes its own entry on the way out
     /// so the pass it wakes sees the slot free.
-    pumps: Mutex<HashMap<CodeSessionId, tokio::task::JoinHandle<()>>>,
+    pumps: Mutex<HashMap<SessionId, tokio::task::JoinHandle<()>>>,
     /// Sessions whose queue promotion is on hold until the given instant,
     /// after a machine-side refusal. In-memory on purpose: a restart retries
     /// once and re-arms the hold from the fresh refusal.
-    promotion_holds: Mutex<HashMap<CodeSessionId, std::time::Instant>>,
+    promotion_holds: Mutex<HashMap<SessionId, std::time::Instant>>,
     /// Wakes the sweep for an immediate pass. A wake with no waiter is kept
     /// until the sweep next listens, so none is lost between passes.
     sweep_wake: Notify,
@@ -123,7 +123,7 @@ impl RemoteSessions {
     }
 
     /// Whether promotion for `session` is inside a refusal hold.
-    pub(crate) fn promotion_held(&self, session: CodeSessionId) -> bool {
+    pub(crate) fn promotion_held(&self, session: SessionId) -> bool {
         let mut holds = self.promotion_holds.lock().expect("promotion holds");
         match holds.get(&session) {
             Some(until) if *until > std::time::Instant::now() => true,
@@ -136,7 +136,7 @@ impl RemoteSessions {
     }
 
     /// Hold promotion for `session` for [`PROMOTION_RETRY_HOLD`].
-    pub(crate) fn hold_promotion(&self, session: CodeSessionId) {
+    pub(crate) fn hold_promotion(&self, session: SessionId) {
         self.promotion_holds
             .lock()
             .expect("promotion holds")
@@ -144,7 +144,7 @@ impl RemoteSessions {
     }
 
     /// Clear a hold after a promotion that went through.
-    pub(crate) fn clear_promotion_hold(&self, session: CodeSessionId) {
+    pub(crate) fn clear_promotion_hold(&self, session: SessionId) {
         self.promotion_holds
             .lock()
             .expect("promotion holds")
@@ -156,7 +156,7 @@ impl RemoteSessions {
         self: &Arc<Self>,
         runtime: &Arc<CodeRuntime>,
         owner: OwnerId,
-        session: CodeSessionId,
+        session: SessionId,
     ) {
         let mut pumps = self.pumps.lock().expect("remote pumps");
         pumps.retain(|_, handle| !handle.is_finished());
@@ -208,7 +208,7 @@ async fn pump_session(
     runtime: Weak<CodeRuntime>,
     remote: Arc<RemoteSessions>,
     owner: OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     mut backoff: LaneBackoff,
 ) -> bool {
     loop {
@@ -220,7 +220,7 @@ async fn pump_session(
         };
         if matches!(
             session.lifecycle,
-            CodeSessionLifecycle::Fenced | CodeSessionLifecycle::Ended
+            SessionLifecycle::Fenced | SessionLifecycle::Ended
         ) {
             return false;
         }
@@ -359,8 +359,8 @@ mod tests {
 
     use tidebreak_core::db::code::{insert_repo, latest_turn};
     use tidebreak_core::{
-        CodeRepo, CodeSessionLifecycle, CodeTurnStatus, CodeWorkspaceStatus, FenceReason,
-        HarnessKind, OwnerId, PermissionMode, RepoId,
+        CodeRepo, CodeWorkspaceStatus, FenceReason, HarnessKind, OwnerId, PermissionMode, RepoId,
+        SessionLifecycle, TurnStatus,
     };
 
     use super::super::super::runtime::{
@@ -578,7 +578,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(session.lifecycle, SessionLifecycle::Idle);
 
         let outcome = runtime
             .submit_turn(&owner, session.id, "start".into(), None, None, Vec::new())
@@ -638,7 +638,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(turn.ordinal, 2);
-        assert_eq!(turn.status, CodeTurnStatus::Running);
+        assert_eq!(turn.status, TurnStatus::Running);
         assert_eq!(
             fake.sends.lock().unwrap().as_slice(),
             &["and then".to_owned()]
@@ -868,8 +868,8 @@ mod tests {
         tidebreak_core::db::code::enqueue_queued_turn(
             &runtime.db,
             &owner,
-            &tidebreak_core::CodeQueuedTurn {
-                id: tidebreak_core::CodeTurnId::new(),
+            &tidebreak_core::code::QueuedTurn {
+                id: tidebreak_core::TurnId::new(),
                 session_id: blocked.id,
                 message: "waiting".into(),
                 attachments: Vec::new(),
@@ -883,10 +883,10 @@ mod tests {
 
         runtime.promote_remote_queue_heads().await.unwrap();
         assert!(remote.promotion_held(blocked.id));
-        let notices = |events: &[tidebreak_core::SequencedCodeEvent]| {
+        let notices = |events: &[tidebreak_core::code::SequencedEvent]| {
             events
                 .iter()
-                .filter(|row| matches!(row.event, tidebreak_core::CodeEvent::HarnessNotice { .. }))
+                .filter(|row| matches!(row.event, tidebreak_core::Event::HarnessNotice { .. }))
                 .count()
         };
         let events = tidebreak_core::db::code::list_events(&runtime.db, &owner, blocked.id, 0, 50)
@@ -974,8 +974,8 @@ mod tests {
         tidebreak_core::db::code::enqueue_queued_turn(
             &runtime.db,
             &owner,
-            &tidebreak_core::CodeQueuedTurn {
-                id: tidebreak_core::CodeTurnId::new(),
+            &tidebreak_core::code::QueuedTurn {
+                id: tidebreak_core::TurnId::new(),
                 session_id: session.id,
                 message: "one more".into(),
                 attachments: Vec::new(),
@@ -1093,7 +1093,7 @@ mod tests {
         .unwrap();
 
         let reaped = runtime.reap(&owner, session.id).await.unwrap();
-        assert_eq!(reaped.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(reaped.lifecycle, SessionLifecycle::Idle);
         assert!(reaped.fence_reason.is_none());
         assert_eq!(
             fake.cancels.lock().unwrap().as_slice(),
@@ -1305,7 +1305,7 @@ mod tests {
             .get_session(&owner, binding.session_id)
             .await
             .unwrap();
-        assert_eq!(session.lifecycle, CodeSessionLifecycle::Idle);
+        assert_eq!(session.lifecycle, SessionLifecycle::Idle);
         let workspace = runtime
             .get_workspace(&owner, session.workspace_id.expect("workspace"))
             .await
@@ -1355,7 +1355,7 @@ mod tests {
             .get_session(&owner, binding.session_id)
             .await
             .unwrap();
-        stored.lifecycle = CodeSessionLifecycle::Ended;
+        stored.lifecycle = SessionLifecycle::Ended;
         assert!(tidebreak_core::db::code::save_session(&runtime.db, &stored)
             .await
             .unwrap());
@@ -1489,7 +1489,7 @@ mod tests {
 
         // An ended session refuses instead of queueing into the void.
         let mut stored = runtime.get_session(&owner, session_id).await.unwrap();
-        stored.lifecycle = CodeSessionLifecycle::Ended;
+        stored.lifecycle = SessionLifecycle::Ended;
         assert!(tidebreak_core::db::code::save_session(&runtime.db, &stored)
             .await
             .unwrap());

--- a/crates/tidebreak-server/src/code/rewrite.rs
+++ b/crates/tidebreak-server/src/code/rewrite.rs
@@ -17,9 +17,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use tidebreak_core::db::code::{get_turn, list_recent_events, set_turn_rewrite};
-use tidebreak_core::{
-    CodeEvent, CodeSessionId, CodeTurnId, CodeTurnStatus, DbStore, OwnerId, Result,
-};
+use tidebreak_core::{DbStore, Event, OwnerId, Result, SessionId, TurnId, TurnStatus};
 
 use crate::chat_titling::{derive_text_with_retries, head, Proposal};
 use crate::resolver::ProviderResolver;
@@ -100,7 +98,7 @@ pub(crate) enum Outcome {
 pub(crate) trait TurnRewrite: Send + Sync {
     /// Derive and store the rewrite for `turn_id`. Returns immediately; nothing
     /// waits on the result and a lost rewrite costs nothing.
-    fn spawn(&self, owner: OwnerId, session_id: CodeSessionId, turn_id: CodeTurnId);
+    fn spawn(&self, owner: OwnerId, session_id: SessionId, turn_id: TurnId);
 }
 
 /// Derives rewrites on the utility role, one at a time per session.
@@ -118,7 +116,7 @@ pub(crate) struct TurnRewriter {
     os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     /// Sessions with a rewrite call in flight, and at most one turn queued by
     /// a completion that landed while that call was running.
-    in_flight: Arc<Mutex<HashMap<CodeSessionId, Option<CodeTurnId>>>>,
+    in_flight: Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
 }
 
 impl TurnRewriter {
@@ -159,13 +157,13 @@ impl TurnRewriter {
     pub(crate) async fn derive(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
+        session_id: SessionId,
+        turn_id: TurnId,
     ) -> Result<Outcome> {
         let Some(turn) = get_turn(&self.db, owner, turn_id).await? else {
             return Ok(Outcome::NotApplicable);
         };
-        if turn.status != CodeTurnStatus::Completed || turn.rewrite.is_some() {
+        if turn.status != TurnStatus::Completed || turn.rewrite.is_some() {
             return Ok(Outcome::NotApplicable);
         }
         if !rewrite_closing_enabled(&*self.store).await? {
@@ -259,15 +257,15 @@ impl TurnRewriter {
     async fn closing_message(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
+        session_id: SessionId,
+        turn_id: TurnId,
     ) -> Result<Option<String>> {
         let events = list_recent_events(&self.db, owner, session_id, REWRITE_EVENT_WINDOW).await?;
         let mut closing = None;
         for sequenced in &events {
             match &sequenced.event {
-                CodeEvent::TurnStarted { turn_id: started } if *started == turn_id => break,
-                CodeEvent::AssistantMessage {
+                Event::TurnStarted { turn_id: started } if *started == turn_id => break,
+                Event::AssistantMessage {
                     text,
                     parent_call_id: None,
                 } if closing.is_none() => closing = Some(text.clone()),
@@ -280,8 +278,8 @@ impl TurnRewriter {
     fn announce(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
+        session_id: SessionId,
+        turn_id: TurnId,
         state: TurnRewriteState,
         rewrite: Option<String>,
     ) {
@@ -298,7 +296,7 @@ impl TurnRewriter {
 }
 
 impl TurnRewrite for TurnRewriter {
-    fn spawn(&self, owner: OwnerId, session_id: CodeSessionId, turn_id: CodeTurnId) {
+    fn spawn(&self, owner: OwnerId, session_id: SessionId, turn_id: TurnId) {
         let Some((mut claim, mut turn_id)) =
             RewriteClaim::acquire(&self.in_flight, session_id, turn_id)
         else {
@@ -343,17 +341,17 @@ pub(crate) async fn rewrite_closing_enabled(
 
 /// A session's place in [`TurnRewriter::in_flight`], released on drop.
 struct RewriteClaim {
-    in_flight: Arc<Mutex<HashMap<CodeSessionId, Option<CodeTurnId>>>>,
-    session_id: CodeSessionId,
+    in_flight: Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
+    session_id: SessionId,
     released: bool,
 }
 
 impl RewriteClaim {
     fn acquire(
-        in_flight: &Arc<Mutex<HashMap<CodeSessionId, Option<CodeTurnId>>>>,
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
-    ) -> Option<(Self, CodeTurnId)> {
+        in_flight: &Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
+        session_id: SessionId,
+        turn_id: TurnId,
+    ) -> Option<(Self, TurnId)> {
         let in_flight = in_flight.clone();
         let mut guard = in_flight
             .lock()
@@ -378,7 +376,7 @@ impl RewriteClaim {
         }
     }
 
-    fn take_pending_or_release(&mut self) -> Option<CodeTurnId> {
+    fn take_pending_or_release(&mut self) -> Option<TurnId> {
         let mut in_flight = self
             .in_flight
             .lock()
@@ -407,16 +405,16 @@ impl Drop for RewriteClaim {
 mod tests {
     use super::*;
 
-    fn claims() -> Arc<Mutex<HashMap<CodeSessionId, Option<CodeTurnId>>>> {
+    fn claims() -> Arc<Mutex<HashMap<SessionId, Option<TurnId>>>> {
         Arc::new(Mutex::new(HashMap::new()))
     }
 
-    fn session() -> CodeSessionId {
-        CodeSessionId(uuid::Uuid::new_v4())
+    fn session() -> SessionId {
+        SessionId(uuid::Uuid::new_v4())
     }
 
-    fn turn() -> CodeTurnId {
-        CodeTurnId(uuid::Uuid::new_v4())
+    fn turn() -> TurnId {
+        TurnId(uuid::Uuid::new_v4())
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/runtime/approvals.rs
+++ b/crates/tidebreak-server/src/code/runtime/approvals.rs
@@ -6,11 +6,11 @@ use super::*;
 /// anything the approval's kind or the engine's capability vector cannot
 /// carry. One approval surface, capability-gated decisions (decision 0048).
 pub(super) fn resolve_decision_request(
-    approval: &CodeApproval,
+    approval: &Approval,
     caps: &tidebreak_core::HarnessCaps,
     request: ApprovalDecisionRequest,
 ) -> Result<ApprovalDecision, ServerError> {
-    use tidebreak_core::CodeApprovalKind as Kind;
+    use tidebreak_core::ApprovalKind as Kind;
     let structured_mismatch = |wanted: &str| {
         ServerError::unprocessable_kind(
             "approval_decision_mismatch",
@@ -89,7 +89,7 @@ impl CodeRuntime {
     pub(super) fn approval_channel(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         spawn_epoch: i64,
         mode: PermissionMode,
     ) -> Option<ApprovalChannelSpec> {
@@ -109,17 +109,17 @@ impl CodeRuntime {
     pub(crate) async fn list_approvals(
         &self,
         owner: &OwnerId,
-        state: Option<CodeApprovalState>,
-        session_id: Option<CodeSessionId>,
-    ) -> Result<Vec<CodeApproval>, ServerError> {
+        state: Option<ApprovalState>,
+        session_id: Option<SessionId>,
+    ) -> Result<Vec<Approval>, ServerError> {
         Ok(list_approvals(&self.db, owner, state, session_id).await?)
     }
 
     pub(crate) async fn get_approval(
         &self,
         owner: &OwnerId,
-        id: CodeApprovalId,
-    ) -> Result<CodeApproval, ServerError> {
+        id: ApprovalId,
+    ) -> Result<Approval, ServerError> {
         get_approval(&self.db, owner, id)
             .await?
             .ok_or_else(|| ServerError::not_found(format!("approval {id} not found")))
@@ -127,11 +127,11 @@ impl CodeRuntime {
 
     pub(crate) async fn record_external_approval(
         &self,
-        session_id: CodeSessionId,
-        approval_id: CodeApprovalId,
+        session_id: SessionId,
+        approval_id: ApprovalId,
         approval: &HarnessApprovalRef,
         raw: &serde_json::Value,
-    ) -> Result<CodeApproval, ServerError> {
+    ) -> Result<Approval, ServerError> {
         let capability = approval.capability.as_ref().ok_or_else(|| {
             ServerError::internal("external approval is missing its server capability")
         })?;
@@ -151,8 +151,8 @@ impl CodeRuntime {
 
     pub(crate) async fn abandon_external_approval(
         &self,
-        session_id: CodeSessionId,
-        approval_id: CodeApprovalId,
+        session_id: SessionId,
+        approval_id: ApprovalId,
     ) -> Result<(), ServerError> {
         let session = tidebreak_core::db::code::get_session_all_owners(&self.db, session_id)
             .await?
@@ -187,11 +187,7 @@ impl CodeRuntime {
         Ok(())
     }
 
-    pub(super) async fn refresh_approval_attention(
-        &self,
-        owner: &OwnerId,
-        session_id: CodeSessionId,
-    ) {
+    pub(super) async fn refresh_approval_attention(&self, owner: &OwnerId, session_id: SessionId) {
         let Ok(Some(session)) = get_session(&self.db, owner, session_id).await else {
             return;
         };
@@ -213,7 +209,7 @@ impl CodeRuntime {
 
     pub(super) fn native_approval_ref(
         owner: &OwnerId,
-        approval: &CodeApproval,
+        approval: &Approval,
     ) -> Result<HarnessApprovalRef, ServerError> {
         let call_id = approval.native_call_id.clone().ok_or_else(|| {
             ServerError::internal(format!("approval {} has no native call ID", approval.id))
@@ -261,8 +257,8 @@ impl CodeRuntime {
     pub(super) async fn abandon_claim_after_delivery_failure(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        approval_id: CodeApprovalId,
+        session_id: SessionId,
+        approval_id: ApprovalId,
         worker_epoch: i64,
         claim: uuid::Uuid,
     ) -> Result<(), ServerError> {
@@ -289,9 +285,9 @@ impl CodeRuntime {
     pub(crate) async fn decide_approval(
         &self,
         owner: &OwnerId,
-        id: CodeApprovalId,
+        id: ApprovalId,
         request: ApprovalDecisionRequest,
-    ) -> Result<CodeApproval, ServerError> {
+    ) -> Result<Approval, ServerError> {
         let initial = self.get_approval(owner, id).await?;
         if !initial.state.is_pending() {
             return Err(ServerError::conflict_kind(
@@ -332,7 +328,7 @@ impl CodeRuntime {
             .worker_epoch
             .ok_or_else(|| ServerError::internal(format!("approval {id} has no worker epoch")))?;
         let session = self.get_session(owner, approval.session_id).await?;
-        if session.lifecycle != CodeSessionLifecycle::Running {
+        if session.lifecycle != SessionLifecycle::Running {
             return Err(ServerError::conflict_kind(
                 "approval_worker_inactive",
                 format!(

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -27,6 +27,7 @@ use chrono::Utc;
 use tokio::sync::{oneshot, watch};
 use tokio::time::Instant as TokioInstant;
 
+use tidebreak_core::code::QueuedTurn;
 use tidebreak_core::db::code::{
     abandon_pending_approval, arm_trigger, begin_permission_mode_change,
     cancel_permission_mode_change, claim_approval, compare_and_set_workspace_status,
@@ -39,16 +40,15 @@ use tidebreak_core::db::code::{
     list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head,
     replace_session_execution_settings, save_repo, save_workspace,
     set_active_workspace_pull_request, settle_approval_claim, update_trigger_enabled,
-    ClaimedApprovalSettlement, CodeSessionExecutionSettings, PermissionModeChangeIntent,
+    ClaimedApprovalSettlement, PermissionModeChangeIntent, SessionExecutionSettings,
     MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
-    ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
-    CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeRepo, CodeSession, CodeSessionId,
-    CodeSessionKind, CodeSessionLifecycle, CodeTrigger, CodeTriggerAction, CodeTriggerCondition,
-    CodeTriggerId, CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore, Diffstat,
-    FenceReason, HarnessKind, OwnerId, PermissionMode, PullRequestDigest, QuickAction,
-    ReasoningEffort, RepoId, WorkspaceId,
+    Approval, ApprovalDecisionKind, ApprovalId, ApprovalState, Attention, AttentionSource,
+    CapLevel, CodeRepo, CodeTrigger, CodeTriggerAction, CodeTriggerCondition, CodeTriggerId,
+    CodeWorkspace, CodeWorkspaceStatus, DbStore, Diffstat, Event, FenceReason, HarnessKind,
+    OwnerId, PermissionMode, PullRequestDigest, QuickAction, ReasoningEffort, RepoId, Session,
+    SessionId, SessionKind, SessionLifecycle, Turn, TurnId, WorkspaceId,
 };
 use tidebreak_harness::{
     builtin_registry, AdapterRegistry, ApprovalChannelSpec, ApprovalDecision, HarnessAdapter,
@@ -117,13 +117,13 @@ pub(crate) struct RepoRegistration {
     pub quick_actions: Vec<QuickAction>,
 }
 
-/// Result of `POST /code/sessions/{id}/turns`.
+/// Result of `POST /sessions/{id}/turns`.
 pub(crate) enum SubmitTurnOutcome {
     /// The session was idle; the turn ran to a terminal event.
-    Ran(Box<CodeTurn>),
+    Ran(Box<Turn>),
     /// The session or its workspace was busy; the message parked as a
     /// durable queue row (decision 69).
-    Queued(Box<CodeQueuedTurn>),
+    Queued(Box<QueuedTurn>),
     /// The durable trigger delivery behind this submit was already accepted
     /// by an earlier attempt; nothing new was written.
     AlreadyDelivered,
@@ -135,9 +135,9 @@ pub(crate) enum SubmitTurnOutcome {
 #[derive(Debug)]
 pub(crate) enum ExternalMessageOutcome {
     /// The message became a running turn.
-    NewTurn(Box<CodeTurn>),
+    NewTurn(Box<Turn>),
     /// The session was busy; the message sits as a durable queue row.
-    Queued(Box<CodeQueuedTurn>),
+    Queued(Box<QueuedTurn>),
     /// The row the first delivery caused was retracted before it could
     /// run; the replay has nothing to point at.
     Dropped,
@@ -195,10 +195,10 @@ pub(crate) struct CodeRuntime {
     probes: Mutex<HashMap<HarnessKind, HarnessProbe>>,
     /// Last pin-install failure per kind. Cleared on a successful install.
     pin_install_errors: Mutex<HashMap<HarnessKind, String>>,
-    workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
+    workers: Mutex<HashMap<SessionId, WorkerHandle>>,
     /// Sessions whose worker must move to the selected engine binary once
     /// their turn in flight ends. See `resync_workers_to_selected_binaries`.
-    deferred_resyncs: Mutex<HashSet<CodeSessionId>>,
+    deferred_resyncs: Mutex<HashSet<SessionId>>,
     /// Flips true while the process quiesces for a restart-to-update. Every
     /// session worker subscribes: the flag holds queue drains, refuses new
     /// turn starts at the worktree boundary, and parks idle engine children

--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -30,7 +30,7 @@ impl CodeRuntime {
     /// Group by kind so many saved sessions share one install and one cold
     /// probe. Recovery already runs after bind, so these downloads do not hold
     /// the server port closed.
-    async fn prepare_recovered_harnesses(&self, sessions: &[CodeSession]) -> HashSet<HarnessKind> {
+    async fn prepare_recovered_harnesses(&self, sessions: &[Session]) -> HashSet<HarnessKind> {
         let mut kinds = sessions
             .iter()
             .map(|session| session.harness_kind)
@@ -79,7 +79,7 @@ impl CodeRuntime {
     /// Terminal paths pass the database-backed session scope explicitly so
     /// the adapter is still tombstoned when a prior launch failure already
     /// removed the transient bearer token and capfile.
-    pub(super) fn revoke_browser_session(&self, session: &CodeSession) {
+    pub(super) fn revoke_browser_session(&self, session: &Session) {
         self.browser_tokens.revoke(session.id);
         self.approvals.revoke_session(session.id);
         if let Some(relay) = &self.harness_llm {
@@ -102,7 +102,7 @@ impl CodeRuntime {
     /// stays live and can be reused by the fresh channel. Only terminal end
     /// paths call [`Self::revoke_browser_session`] and plant the adapter's
     /// enduring tombstone.
-    pub(super) fn revoke_worker_channels(&self, session_id: CodeSessionId) {
+    pub(super) fn revoke_worker_channels(&self, session_id: SessionId) {
         self.browser_tokens.revoke(session_id);
         self.approvals.revoke_session(session_id);
         if let Some(relay) = &self.harness_llm {
@@ -156,7 +156,7 @@ impl CodeRuntime {
             if sessions.iter().any(|session| {
                 matches!(
                     session.lifecycle,
-                    CodeSessionLifecycle::Running | CodeSessionLifecycle::Fenced
+                    SessionLifecycle::Running | SessionLifecycle::Fenced
                 )
             }) {
                 tracing::warn!(
@@ -228,12 +228,12 @@ impl CodeRuntime {
                 }
             }
         }
-        let resumable: Vec<CodeSession> = recovered_sessions
+        let resumable: Vec<Session> = recovered_sessions
             .into_iter()
             .filter(|session| {
                 !matches!(
                     session.lifecycle,
-                    CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+                    SessionLifecycle::Ended | SessionLifecycle::Fenced
                 ) && !remote_workspaces.contains(&session.workspace_id)
                     && !self
                         .workers
@@ -252,7 +252,7 @@ impl CodeRuntime {
                     Ok(Some(latest))
                         if !matches!(
                             latest.lifecycle,
-                            CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+                            SessionLifecycle::Ended | SessionLifecycle::Fenced
                         ) && !self
                             .workers
                             .lock()
@@ -373,12 +373,12 @@ mod tests {
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
-    fn saved_session(owner: &OwnerId, kind: HarnessKind) -> CodeSession {
-        CodeSession {
-            id: CodeSessionId::new(),
+    fn saved_session(owner: &OwnerId, kind: HarnessKind) -> Session {
+        Session {
+            id: SessionId::new(),
             owner: owner.clone(),
             workspace_id: None,
-            kind: CodeSessionKind::Interactive,
+            kind: SessionKind::Interactive,
             harness_kind: kind,
             harness_version: Some("0.147.0".into()),
             harness_resume_ref: Some("saved-session".into()),
@@ -386,7 +386,7 @@ mod tests {
             model: None,
             reasoning_effort: None,
             fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Idle,
+            lifecycle: SessionLifecycle::Idle,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -83,12 +83,12 @@ impl CodeRuntime {
         workspace_id: WorkspaceId,
         harness: HarnessKind,
         settings: NewSessionSettings,
-    ) -> CodeSession {
-        CodeSession {
-            id: CodeSessionId::new(),
+    ) -> Session {
+        Session {
+            id: SessionId::new(),
             owner: owner.clone(),
             workspace_id: Some(workspace_id),
-            kind: CodeSessionKind::Interactive,
+            kind: SessionKind::Interactive,
             harness_kind: harness,
             harness_version: None,
             harness_resume_ref: None,
@@ -96,7 +96,7 @@ impl CodeRuntime {
             model: normalize_model(settings.model),
             reasoning_effort: settings.reasoning_effort,
             fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Idle,
+            lifecycle: SessionLifecycle::Idle,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,
@@ -154,7 +154,7 @@ impl CodeRuntime {
                 return Ok(tidebreak_core::ExternalSessionResolution::GrantMismatch);
             }
             let session = self.get_session(owner, binding.session_id).await?;
-            if session.lifecycle == CodeSessionLifecycle::Ended {
+            if session.lifecycle == SessionLifecycle::Ended {
                 return Ok(tidebreak_core::ExternalSessionResolution::Ended {
                     session_id: binding.session_id,
                 });
@@ -197,7 +197,7 @@ impl CodeRuntime {
         workspace_id: WorkspaceId,
         harness: HarnessKind,
         settings: NewSessionSettings,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         if self.remote.is_none() {
             return Err(ServerError::conflict_kind(
                 "remote_disabled",
@@ -229,7 +229,7 @@ impl CodeRuntime {
     pub(super) async fn submit_remote_turn(
         &self,
         owner: &OwnerId,
-        mut session: CodeSession,
+        mut session: Session,
         workspace: &CodeWorkspace,
         message: String,
         model: Option<String>,
@@ -265,14 +265,14 @@ impl CodeRuntime {
         // Settings stick without local capability validation: the sandbox
         // engine reads them off the spawn, and no local harness answers for
         // a remote one.
-        let mut next = CodeSessionExecutionSettings::from(&session);
+        let mut next = SessionExecutionSettings::from(&session);
         if let Some(model) = normalize_model(model) {
             next.model = Some(model);
         }
         if let Some(effort) = reasoning_effort {
             next.reasoning_effort = effort;
         }
-        if next != CodeSessionExecutionSettings::from(&session) {
+        if next != SessionExecutionSettings::from(&session) {
             session = replace_session_execution_settings(&self.db, owner, &session, &next)
                 .await?
                 .ok_or_else(|| {
@@ -284,7 +284,7 @@ impl CodeRuntime {
         }
         // Queue-default, exactly as the local path: a busy session parks the
         // send as a durable row the remote sweep promotes at the next idle.
-        let in_flight = session.lifecycle == CodeSessionLifecycle::Running
+        let in_flight = session.lifecycle == SessionLifecycle::Running
             || get_open_turn(&self.db, owner, session.id).await?.is_some();
         let backlog = !tidebreak_core::db::code::list_queued_turns(&self.db, owner, session.id)
             .await?
@@ -315,7 +315,7 @@ impl CodeRuntime {
     pub(super) async fn relay_remote_outcome(
         &self,
         owner: &OwnerId,
-        session: &CodeSession,
+        session: &Session,
         outcome: crate::code::remote::driver::RemoteTurnOutcome,
         message: String,
         queue_if_busy: bool,
@@ -362,18 +362,18 @@ impl CodeRuntime {
     pub(super) async fn park_remote_follow_up(
         &self,
         owner: &OwnerId,
-        session: &CodeSession,
+        session: &Session,
         message: String,
     ) -> Result<SubmitTurnOutcome, ServerError> {
         let queued = tidebreak_core::db::code::list_queued_turns(&self.db, owner, session.id)
             .await
             .map_err(ServerError::from)?;
-        if queued.len() >= CodeQueuedTurn::MAX_PER_SESSION {
+        if queued.len() >= QueuedTurn::MAX_PER_SESSION {
             return Err(ServerError::conflict_kind(
                 "queue_full",
                 format!(
                     "this session may queue at most {} messages",
-                    CodeQueuedTurn::MAX_PER_SESSION
+                    QueuedTurn::MAX_PER_SESSION
                 ),
             ));
         }
@@ -381,8 +381,8 @@ impl CodeRuntime {
         let row = tidebreak_core::db::code::enqueue_queued_turn(
             &self.db,
             owner,
-            &CodeQueuedTurn {
-                id: CodeTurnId::new(),
+            &QueuedTurn {
+                id: TurnId::new(),
                 session_id: session.id,
                 message,
                 attachments: Vec::new(),
@@ -425,12 +425,12 @@ impl CodeRuntime {
     /// rather than waiting out a sweep tick.
     pub(super) async fn try_promote_remote_head(
         &self,
-        mut session: CodeSession,
+        mut session: Session,
     ) -> Result<(), ServerError> {
         let Some(remote) = self.remote_sessions() else {
             return Ok(());
         };
-        if session.lifecycle != CodeSessionLifecycle::Idle {
+        if session.lifecycle != SessionLifecycle::Idle {
             return Ok(());
         }
         let Ok(Some(workspace)) = self.session_workspace(&session).await else {
@@ -511,7 +511,7 @@ impl CodeRuntime {
         &self,
         owner: &OwnerId,
         grant_id: tidebreak_core::CodeGrantId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         message: String,
         event_id: &str,
         channel_ts: &str,
@@ -532,13 +532,13 @@ impl CodeRuntime {
         }
         let session = self.get_session(owner, session_id).await?;
         match session.lifecycle {
-            CodeSessionLifecycle::Ended => {
+            SessionLifecycle::Ended => {
                 return Err(ServerError::conflict_kind(
                     "session_ended",
                     "the bound session has ended; the conversation is closed",
                 ));
             }
-            CodeSessionLifecycle::Fenced => {
+            SessionLifecycle::Fenced => {
                 return Err(ServerError::conflict_kind(
                     "session_fenced",
                     "the bound session is fenced pending a reap",
@@ -579,7 +579,7 @@ impl CodeRuntime {
         Ok(ExternalMessageOutcome::Dropped)
     }
 
-    pub(super) async fn interrupt_remote(&self, session: &CodeSession) -> Result<(), ServerError> {
+    pub(super) async fn interrupt_remote(&self, session: &Session) -> Result<(), ServerError> {
         let Some(remote) = self.remote_sessions() else {
             return Err(ServerError::conflict_kind(
                 "remote_disabled",
@@ -629,7 +629,7 @@ impl CodeRuntime {
 
     /// Best-effort stop of a remote session's sandbox. Used when the session
     /// row is ending, so the environment does not keep spending.
-    pub(super) async fn cancel_remote_sandbox(&self, session: &CodeSession) {
+    pub(super) async fn cancel_remote_sandbox(&self, session: &Session) {
         let Some(remote) = self.remote_sessions() else {
             return;
         };

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -9,11 +9,11 @@ impl CodeRuntime {
         workspace_id: WorkspaceId,
         harness: HarnessKind,
         settings: NewSessionSettings,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         self.create_session_of_kind(
             owner,
             workspace_id,
-            CodeSessionKind::Interactive,
+            SessionKind::Interactive,
             harness,
             settings,
         )
@@ -30,7 +30,7 @@ impl CodeRuntime {
         &self,
         owner: &OwnerId,
         workspace_id: WorkspaceId,
-        kind: CodeSessionKind,
+        kind: SessionKind,
         harness: HarnessKind,
         NewSessionSettings {
             permission_mode,
@@ -39,7 +39,7 @@ impl CodeRuntime {
             fast_mode,
             permission_mode_ceiling,
         }: NewSessionSettings,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         if harness.is_in_process() {
             return Err(ServerError::conflict_kind(
                 "harness_needs_no_workspace",
@@ -61,11 +61,10 @@ impl CodeRuntime {
                 "this workspace's engine runs in a remote sandbox; create a remote session on it",
             ));
         }
-        if kind == CodeSessionKind::Watch {
+        if kind == SessionKind::Watch {
             let existing = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
             if existing.iter().any(|session| {
-                session.lifecycle != CodeSessionLifecycle::Ended
-                    && session.kind == CodeSessionKind::Watch
+                session.lifecycle != SessionLifecycle::Ended && session.kind == SessionKind::Watch
             }) {
                 return Err(ServerError::conflict_kind(
                     "session_exists",
@@ -144,7 +143,7 @@ impl CodeRuntime {
             ));
         }
         self.refuse_signed_out_harness(harness, &probe)?;
-        let execution_settings = CodeSessionExecutionSettings {
+        let execution_settings = SessionExecutionSettings {
             model: normalize_model(model),
             reasoning_effort,
             fast_mode,
@@ -160,8 +159,8 @@ impl CodeRuntime {
                 .await;
             Self::validate_execution_settings(harness, &execution_settings, &selected)?;
         }
-        let session = CodeSession {
-            id: CodeSessionId::new(),
+        let session = Session {
+            id: SessionId::new(),
             owner: owner.clone(),
             workspace_id: Some(workspace_id),
             kind,
@@ -172,7 +171,7 @@ impl CodeRuntime {
             model: execution_settings.model,
             reasoning_effort: execution_settings.reasoning_effort,
             fast_mode: execution_settings.fast_mode,
-            lifecycle: CodeSessionLifecycle::Created,
+            lifecycle: SessionLifecycle::Created,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,
@@ -220,7 +219,7 @@ impl CodeRuntime {
             fast_mode,
             permission_mode_ceiling,
         }: NewSessionSettings,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         let harness = HarnessKind::Internal;
         let adapter = self.adapter(harness)?;
         let probe = self.probe_for_session_create(adapter.as_ref()).await;
@@ -239,7 +238,7 @@ impl CodeRuntime {
             }
         }
         refuse_unhonored_mode(harness, permission_mode, &caps)?;
-        let execution_settings = CodeSessionExecutionSettings {
+        let execution_settings = SessionExecutionSettings {
             model: normalize_model(model),
             reasoning_effort,
             fast_mode,
@@ -250,11 +249,11 @@ impl CodeRuntime {
                 "the internal engine has no fast mode",
             ));
         }
-        let session = CodeSession {
-            id: CodeSessionId::new(),
+        let session = Session {
+            id: SessionId::new(),
             owner: owner.clone(),
             workspace_id: None,
-            kind: CodeSessionKind::Interactive,
+            kind: SessionKind::Interactive,
             harness_kind: harness,
             harness_version: probe.version.clone(),
             harness_resume_ref: None,
@@ -262,7 +261,7 @@ impl CodeRuntime {
             model: execution_settings.model,
             reasoning_effort: execution_settings.reasoning_effort,
             fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Created,
+            lifecycle: SessionLifecycle::Created,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,
@@ -279,8 +278,8 @@ impl CodeRuntime {
     pub(crate) async fn get_session(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
-    ) -> Result<CodeSession, ServerError> {
+        id: SessionId,
+    ) -> Result<Session, ServerError> {
         get_session(&self.db, owner, id)
             .await?
             .ok_or_else(|| ServerError::not_found(format!("session {id} not found")))
@@ -294,7 +293,7 @@ impl CodeRuntime {
     pub(crate) async fn resolve_turn_attachments(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         requested: &[(uuid::Uuid, String)],
     ) -> Result<Vec<tidebreak_core::ImageRef>, ServerError> {
         if requested.len() > tidebreak_core::context::MAX_HYDRATED_IMAGES {
@@ -368,10 +367,10 @@ impl CodeRuntime {
     pub(crate) async fn set_attention(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
         clear: bool,
         note: Option<String>,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         let _ = self.get_session(owner, id).await?;
         crate::code::attention::user_set_attention(&self.db, &self.bus, owner, id, clear, note)
             .await
@@ -381,7 +380,7 @@ impl CodeRuntime {
     pub(crate) async fn mark_session_viewed(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
     ) -> Result<(), ServerError> {
         crate::code::attention::mark_viewed(&self.db, &self.bus, owner, id)
             .await
@@ -396,12 +395,12 @@ impl CodeRuntime {
     pub(in crate::code) async fn end_session_row(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
     ) -> Result<(), ServerError> {
         let Some(mut session) = get_session(&self.db, owner, session_id).await? else {
             return Ok(());
         };
-        if session.lifecycle == CodeSessionLifecycle::Ended {
+        if session.lifecycle == SessionLifecycle::Ended {
             return Ok(());
         }
         if let Ok(Some(workspace)) = self.session_workspace(&session).await {
@@ -422,7 +421,7 @@ impl CodeRuntime {
             None => None,
         };
         self.revoke_browser_session(&session);
-        session.lifecycle = CodeSessionLifecycle::Ended;
+        session.lifecycle = SessionLifecycle::Ended;
         session.child_pid = None;
         session.child_process_identity = None;
         session.fence_reason = None;
@@ -432,7 +431,7 @@ impl CodeRuntime {
             None => true,
         };
         let mut current = self.get_session(owner, session.id).await?;
-        current.lifecycle = CodeSessionLifecycle::Ended;
+        current.lifecycle = SessionLifecycle::Ended;
         current.child_pid = None;
         current.child_process_identity = None;
         current.fence_reason = None;
@@ -475,10 +474,7 @@ impl CodeRuntime {
         Ok(())
     }
 
-    pub(crate) async fn list_sessions(
-        &self,
-        owner: &OwnerId,
-    ) -> Result<Vec<CodeSession>, ServerError> {
+    pub(crate) async fn list_sessions(&self, owner: &OwnerId) -> Result<Vec<Session>, ServerError> {
         Ok(list_sessions(&self.db, owner).await?)
     }
 
@@ -486,7 +482,7 @@ impl CodeRuntime {
         &self,
         owner: &OwnerId,
         workspace_id: WorkspaceId,
-    ) -> Result<Vec<CodeSession>, ServerError> {
+    ) -> Result<Vec<Session>, ServerError> {
         let _ = self.get_workspace(owner, workspace_id).await?;
         Ok(list_sessions_for_workspace(&self.db, owner, workspace_id).await?)
     }
@@ -495,7 +491,7 @@ impl CodeRuntime {
     pub(crate) async fn list_internal_sessions(
         &self,
         owner: &OwnerId,
-    ) -> Result<Vec<CodeSession>, ServerError> {
+    ) -> Result<Vec<Session>, ServerError> {
         Ok(tidebreak_core::db::code::list_sessions(&self.db, owner)
             .await?
             .into_iter()
@@ -508,7 +504,7 @@ impl CodeRuntime {
     pub(crate) async fn external_bindings_for_sessions(
         &self,
         owner: &OwnerId,
-        session_ids: &[CodeSessionId],
+        session_ids: &[SessionId],
     ) -> Result<Vec<tidebreak_core::CodeExternalBinding>, ServerError> {
         Ok(
             tidebreak_core::db::code::list_external_bindings_for_sessions(
@@ -523,8 +519,8 @@ impl CodeRuntime {
     pub(crate) async fn list_session_turns(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-    ) -> Result<Vec<CodeTurn>, ServerError> {
+        session_id: SessionId,
+    ) -> Result<Vec<Turn>, ServerError> {
         let _ = self.get_session(owner, session_id).await?;
         Ok(list_turns(&self.db, owner, session_id).await?)
     }
@@ -532,7 +528,7 @@ impl CodeRuntime {
     pub(crate) async fn list_turn_metrics(
         &self,
         owner: &OwnerId,
-    ) -> Result<Vec<tidebreak_core::db::code::CodeTurnMetric>, ServerError> {
+    ) -> Result<Vec<tidebreak_core::db::code::TurnMetric>, ServerError> {
         Ok(tidebreak_core::db::code::list_turn_metrics(&self.db, owner).await?)
     }
 
@@ -553,12 +549,12 @@ impl CodeRuntime {
     pub(crate) async fn session_debug(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
+        session_id: SessionId,
     ) -> Result<
         (
-            CodeSession,
-            Vec<CodeTurn>,
-            Vec<tidebreak_core::SequencedCodeEvent>,
+            Session,
+            Vec<Turn>,
+            Vec<tidebreak_core::code::SequencedEvent>,
         ),
         ServerError,
     > {
@@ -577,8 +573,8 @@ impl CodeRuntime {
     pub(crate) async fn fork_transcript(
         &self,
         owner: &OwnerId,
-        session_id: CodeSessionId,
-        at_turn: Option<tidebreak_core::CodeTurnId>,
+        session_id: SessionId,
+        at_turn: Option<tidebreak_core::TurnId>,
     ) -> Result<fork::WrittenTranscript, ServerError> {
         let session = self.get_session(owner, session_id).await?;
         let workspace = self
@@ -610,10 +606,10 @@ impl CodeRuntime {
             .transpose()?;
 
         let turns = list_turns(&self.db, owner, session_id).await?;
-        let pending_approval_turns: HashSet<CodeTurnId> = list_approvals(
+        let pending_approval_turns: HashSet<TurnId> = list_approvals(
             &self.db,
             owner,
-            Some(CodeApprovalState::Pending),
+            Some(ApprovalState::Pending),
             Some(session_id),
         )
         .await?

--- a/crates/tidebreak-server/src/code/runtime/settings.rs
+++ b/crates/tidebreak-server/src/code/runtime/settings.rs
@@ -27,7 +27,7 @@ impl SelectedModelCapabilities {
         self.reasoning_efforts.contains(&effort)
     }
 
-    pub(super) fn deactivate_unsupported(&self, settings: &mut CodeSessionExecutionSettings) {
+    pub(super) fn deactivate_unsupported(&self, settings: &mut SessionExecutionSettings) {
         if self.reasoning_known
             && settings
                 .reasoning_effort
@@ -150,21 +150,21 @@ impl CodeRuntime {
     pub(crate) async fn set_permission_mode(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
         mode: PermissionMode,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         let session = self.get_session(owner, id).await?;
         if session.permission_mode == mode {
             return Ok(session);
         }
         match session.lifecycle {
-            CodeSessionLifecycle::Running => {
+            SessionLifecycle::Running => {
                 return Err(ServerError::conflict_kind(
                     "turn_running",
                     "finish or interrupt the running turn before changing the permission mode",
                 ));
             }
-            CodeSessionLifecycle::Ended => {
+            SessionLifecycle::Ended => {
                 return Err(ServerError::conflict_kind(
                     "session_ended",
                     "this session has ended; start a new one to pick a different mode",
@@ -364,7 +364,7 @@ impl CodeRuntime {
     /// Ask the live engine to take a mode, then hold its worker for settlement.
     pub(super) async fn repostured_in_place(
         &self,
-        id: CodeSessionId,
+        id: SessionId,
         expected_spawn_epoch: i64,
         mode: PermissionMode,
     ) -> Result<LivePermissionModeOutcome, ServerError> {
@@ -406,7 +406,7 @@ impl CodeRuntime {
         owner: &OwnerId,
         intent: &PermissionModeChangeIntent,
         change: LivePermissionModeChange,
-    ) -> Result<Option<CodeSession>, ServerError> {
+    ) -> Result<Option<Session>, ServerError> {
         let LivePermissionModeChange { settlement, handle } = change;
         let _ = settlement.send(PermissionModeSettlement::Abort);
         let handle = if let Some(registered) =
@@ -440,11 +440,11 @@ impl CodeRuntime {
 
     pub(super) async fn commit_execution_settings(
         &self,
-        expected: &CodeSession,
-        next: &CodeSessionExecutionSettings,
+        expected: &Session,
+        next: &SessionExecutionSettings,
         action: &'static str,
-    ) -> Result<CodeSession, ServerError> {
-        let applies_to_future_turn = expected.lifecycle == CodeSessionLifecycle::Running
+    ) -> Result<Session, ServerError> {
+        let applies_to_future_turn = expected.lifecycle == SessionLifecycle::Running
             || get_open_turn(&self.db, &expected.owner, expected.id)
                 .await?
                 .is_some();
@@ -524,7 +524,7 @@ impl CodeRuntime {
 
     pub(super) fn take_worker_for_epoch(
         &self,
-        id: CodeSessionId,
+        id: SessionId,
         spawn_epoch: i64,
     ) -> Option<WorkerHandle> {
         let mut workers = self.workers.lock().expect("code workers");
@@ -538,7 +538,7 @@ impl CodeRuntime {
     pub(super) async fn note_permission_mode(
         &self,
         owner: &OwnerId,
-        session: &CodeSession,
+        session: &Session,
         previous: PermissionMode,
         mode: PermissionMode,
         revision: i64,
@@ -549,7 +549,7 @@ impl CodeRuntime {
             owner,
             session.id,
             session.spawn_epoch,
-            CodeEvent::HarnessNotice {
+            Event::HarnessNotice {
                 level: tidebreak_core::HarnessNoticeLevel::Info,
                 message: format!(
                     "permission mode changed from {previous} to {mode} at revision {revision}"
@@ -569,18 +569,18 @@ impl CodeRuntime {
     pub(crate) async fn set_reasoning_effort(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
         effort: Option<ReasoningEffort>,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         let session = self.get_session(owner, id).await?;
         match session.lifecycle {
-            CodeSessionLifecycle::Running => {
+            SessionLifecycle::Running => {
                 return Err(ServerError::conflict_kind(
                     "turn_running",
                     "finish or interrupt the running turn before changing the reasoning effort",
                 ));
             }
-            CodeSessionLifecycle::Ended => {
+            SessionLifecycle::Ended => {
                 return Err(ServerError::conflict_kind(
                     "session_ended",
                     "this session has ended; start a new one to pick a different effort",
@@ -604,11 +604,11 @@ impl CodeRuntime {
                 session.model.as_deref(),
             )
             .await;
-        let mut next = CodeSessionExecutionSettings::from(&session);
+        let mut next = SessionExecutionSettings::from(&session);
         selected.deactivate_unsupported(&mut next);
         next.reasoning_effort = effort;
         Self::validate_execution_settings(session.harness_kind, &next, &selected)?;
-        if next == CodeSessionExecutionSettings::from(&session) {
+        if next == SessionExecutionSettings::from(&session) {
             return Ok(session);
         }
         self.commit_execution_settings(&session, &next, "the reasoning effort could be saved")
@@ -624,18 +624,18 @@ impl CodeRuntime {
     pub(crate) async fn set_fast_mode(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
         fast_mode: bool,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         let session = self.get_session(owner, id).await?;
         match session.lifecycle {
-            CodeSessionLifecycle::Running => {
+            SessionLifecycle::Running => {
                 return Err(ServerError::conflict_kind(
                     "turn_running",
                     "finish or interrupt the running turn before changing fast mode",
                 ));
             }
-            CodeSessionLifecycle::Ended => {
+            SessionLifecycle::Ended => {
                 return Err(ServerError::conflict_kind(
                     "session_ended",
                     "this session has ended; start a new one to run it in fast mode",
@@ -659,11 +659,11 @@ impl CodeRuntime {
                 session.model.as_deref(),
             )
             .await;
-        let mut next = CodeSessionExecutionSettings::from(&session);
+        let mut next = SessionExecutionSettings::from(&session);
         selected.deactivate_unsupported(&mut next);
         next.fast_mode = fast_mode;
         Self::validate_execution_settings(session.harness_kind, &next, &selected)?;
-        if next == CodeSessionExecutionSettings::from(&session) {
+        if next == SessionExecutionSettings::from(&session) {
             return Ok(session);
         }
         self.commit_execution_settings(&session, &next, "fast mode could be saved")
@@ -755,7 +755,7 @@ impl CodeRuntime {
 
     pub(super) fn validate_execution_settings(
         harness: HarnessKind,
-        settings: &CodeSessionExecutionSettings,
+        settings: &SessionExecutionSettings,
         selected: &SelectedModelCapabilities,
     ) -> Result<(), ServerError> {
         let model = settings.model.as_deref().unwrap_or("the default model");
@@ -921,7 +921,7 @@ mod selected_model_capabilities_tests {
         };
         let capabilities =
             CodeRuntime::selected_model_capabilities(&adapter, &probe, Some("configured")).await;
-        let mut settings = CodeSessionExecutionSettings {
+        let mut settings = SessionExecutionSettings {
             model: Some("configured".into()),
             reasoning_effort: Some(ReasoningEffort::High),
             fast_mode: true,
@@ -1028,7 +1028,7 @@ mod selected_model_capabilities_tests {
             fast_mode: false,
             fast_mode_known: true,
         };
-        let mut settings = CodeSessionExecutionSettings {
+        let mut settings = SessionExecutionSettings {
             model: Some("steady".into()),
             reasoning_effort: Some(ReasoningEffort::High),
             fast_mode: true,

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -62,7 +62,7 @@ impl CodeRuntime {
         // Past every turn boundary; now wait for the workers to park their
         // engine children and for the stored rows to agree.
         loop {
-            let ids: Vec<CodeSessionId> = self
+            let ids: Vec<SessionId> = self
                 .workers
                 .lock()
                 .expect("code workers")
@@ -73,7 +73,7 @@ impl CodeRuntime {
             for id in ids {
                 match tidebreak_core::db::code::get_session_all_owners(&self.db, id).await {
                     Ok(Some(session)) => {
-                        if session.lifecycle == CodeSessionLifecycle::Running
+                        if session.lifecycle == SessionLifecycle::Running
                             || session.child_pid.is_some()
                         {
                             busy += 1;
@@ -109,7 +109,7 @@ impl CodeRuntime {
     pub(crate) async fn submit_turn(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
         message: String,
         model: Option<String>,
         reasoning_effort: Option<Option<ReasoningEffort>>,
@@ -132,7 +132,7 @@ impl CodeRuntime {
     pub(super) async fn submit_turn_inner(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
         message: String,
         model: Option<String>,
         reasoning_effort: Option<Option<ReasoningEffort>>,
@@ -161,13 +161,13 @@ impl CodeRuntime {
                 ));
             }
         }
-        if session.lifecycle == CodeSessionLifecycle::Fenced {
+        if session.lifecycle == SessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
                 "session_fenced",
                 "session is fenced until it is reaped",
             ));
         }
-        if session.lifecycle == CodeSessionLifecycle::Ended {
+        if session.lifecycle == SessionLifecycle::Ended {
             return Err(ServerError::conflict_kind(
                 "session_ended",
                 "session has ended",
@@ -204,7 +204,7 @@ impl CodeRuntime {
             .as_deref()
             .is_some_and(|model| session.model.as_deref() != Some(model));
         let requested_effort = reasoning_effort;
-        let mut next = CodeSessionExecutionSettings::from(&session);
+        let mut next = SessionExecutionSettings::from(&session);
         if let Some(model) = requested_model {
             next.model = Some(model);
         }
@@ -227,7 +227,7 @@ impl CodeRuntime {
                 )
                 .await;
             if requested_effort.is_some() {
-                let requested = CodeSessionExecutionSettings {
+                let requested = SessionExecutionSettings {
                     model: next.model.clone(),
                     reasoning_effort: next.reasoning_effort,
                     fast_mode: false,
@@ -236,7 +236,7 @@ impl CodeRuntime {
             }
             selected.deactivate_unsupported(&mut next);
         }
-        if next != CodeSessionExecutionSettings::from(&session) {
+        if next != SessionExecutionSettings::from(&session) {
             session = self
                 .commit_execution_settings(&session, &next, "the turn could reserve them")
                 .await?;
@@ -263,7 +263,7 @@ impl CodeRuntime {
         // send even with no open turn: rows ahead of this message must run
         // first (FIFO), and the worker may already be holding the head while
         // it waits on a sibling's worktree turn.
-        let in_flight = session.lifecycle == CodeSessionLifecycle::Running
+        let in_flight = session.lifecycle == SessionLifecycle::Running
             || get_open_turn(&self.db, owner, id).await?.is_some();
         let backlog = !tidebreak_core::db::code::list_queued_turns(&self.db, owner, id)
             .await?
@@ -340,7 +340,7 @@ impl CodeRuntime {
     pub(crate) async fn submit_trigger_turn(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
         message: String,
         delivery_id: tidebreak_core::CodeTriggerDeliveryId,
         lease_token: uuid::Uuid,
@@ -371,19 +371,19 @@ impl CodeRuntime {
         &self,
         owner: &OwnerId,
         handle: &WorkerHandle,
-        session: &CodeSession,
+        session: &Session,
         message: String,
         attachments: Vec<tidebreak_core::ImageRef>,
     ) -> Result<SubmitTurnOutcome, ServerError> {
         let queued = tidebreak_core::db::code::list_queued_turns(&self.db, owner, session.id)
             .await
             .map_err(ServerError::from)?;
-        if queued.len() >= CodeQueuedTurn::MAX_PER_SESSION {
+        if queued.len() >= QueuedTurn::MAX_PER_SESSION {
             return Err(ServerError::conflict_kind(
                 "queue_full",
                 format!(
                     "this session may queue at most {} messages",
-                    CodeQueuedTurn::MAX_PER_SESSION
+                    QueuedTurn::MAX_PER_SESSION
                 ),
             ));
         }
@@ -391,8 +391,8 @@ impl CodeRuntime {
         let row = tidebreak_core::db::code::enqueue_queued_turn(
             &self.db,
             owner,
-            &CodeQueuedTurn {
-                id: CodeTurnId::new(),
+            &QueuedTurn {
+                id: TurnId::new(),
                 session_id: session.id,
                 message,
                 attachments,
@@ -411,8 +411,8 @@ impl CodeRuntime {
     pub(crate) async fn list_queued_turns(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
-    ) -> Result<(Vec<CodeQueuedTurn>, bool), ServerError> {
+        id: SessionId,
+    ) -> Result<(Vec<QueuedTurn>, bool), ServerError> {
         let _ = self.get_session(owner, id).await?;
         let queued = tidebreak_core::db::code::list_queued_turns(&self.db, owner, id).await?;
         let paused = tidebreak_core::db::code::queue_paused(&self.db, owner, id).await?;
@@ -423,11 +423,11 @@ impl CodeRuntime {
     pub(crate) async fn update_queued_turn(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
-        queued_id: CodeTurnId,
+        id: SessionId,
+        queued_id: TurnId,
         message: Option<&str>,
         position: Option<i32>,
-    ) -> Result<Option<CodeQueuedTurn>, ServerError> {
+    ) -> Result<Option<QueuedTurn>, ServerError> {
         let _ = self.get_session(owner, id).await?;
         Ok(tidebreak_core::db::code::update_queued_turn(
             &self.db, owner, id, queued_id, message, position,
@@ -435,7 +435,7 @@ impl CodeRuntime {
         .await?)
     }
 
-    pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
+    pub(crate) async fn interrupt(&self, id: SessionId) -> Result<(), ServerError> {
         // Interrupt stops only the active turn. The worker and logical code
         // session continue, so its browser capfile and native capability must
         // remain live for later turns.
@@ -474,8 +474,8 @@ impl CodeRuntime {
     pub(crate) async fn delete_queued_turn(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
-        queued_id: CodeTurnId,
+        id: SessionId,
+        queued_id: TurnId,
     ) -> Result<bool, ServerError> {
         let _ = self.get_session(owner, id).await?;
         Ok(tidebreak_core::db::code::delete_queued_turn(&self.db, owner, id, queued_id).await?)
@@ -486,7 +486,7 @@ impl CodeRuntime {
     pub(crate) async fn set_queue_paused(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
         paused: bool,
     ) -> Result<(), ServerError> {
         let _ = self.get_session(owner, id).await?;
@@ -503,7 +503,7 @@ impl CodeRuntime {
     pub(crate) async fn send_queued_now(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
+        id: SessionId,
     ) -> Result<(), ServerError> {
         let _ = self.get_session(owner, id).await?;
         tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, false).await?;
@@ -513,7 +513,7 @@ impl CodeRuntime {
 
     /// Nudge a live worker to re-read its queue. A session with no worker has
     /// nothing to wake; its next spawn drains the queue first thing.
-    pub(super) fn wake_session_queue(&self, id: CodeSessionId) {
+    pub(super) fn wake_session_queue(&self, id: SessionId) {
         if let Ok(handle) = self.require_worker(id) {
             wake_queue(&handle);
         }
@@ -530,7 +530,7 @@ impl CodeRuntime {
     pub(super) async fn workspace_fence_reason(
         &self,
         owner: &OwnerId,
-        session: &CodeSession,
+        session: &Session,
     ) -> Result<Option<String>, ServerError> {
         let Some(workspace_id) = session.workspace_id else {
             return Ok(None);
@@ -540,7 +540,7 @@ impl CodeRuntime {
             .iter()
             .find(|other| {
                 other.id != session.id
-                    && other.lifecycle == CodeSessionLifecycle::Fenced
+                    && other.lifecycle == SessionLifecycle::Fenced
                     // Only a fence that implies an unaccounted engine process
                     // stops the workspace. A sibling fenced for repeated turn
                     // failures answered every time; its worktree is not at
@@ -561,8 +561,8 @@ impl CodeRuntime {
     pub(crate) async fn steer(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
-        expected_turn_id: CodeTurnId,
+        id: SessionId,
+        expected_turn_id: TurnId,
         message: String,
     ) -> Result<(), ServerError> {
         self.steer_inner(owner, id, expected_turn_id, message, None)
@@ -572,8 +572,8 @@ impl CodeRuntime {
     pub(super) async fn steer_inner(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
-        expected_turn_id: CodeTurnId,
+        id: SessionId,
+        expected_turn_id: TurnId,
         message: String,
         trigger_delivery: Option<TriggerDeliveryClaim>,
     ) -> Result<(), ServerError> {
@@ -589,7 +589,7 @@ impl CodeRuntime {
             }
         }
         let session = self.get_session(owner, id).await?;
-        if session.lifecycle != CodeSessionLifecycle::Running {
+        if session.lifecycle != SessionLifecycle::Running {
             return Err(ServerError::conflict_kind(
                 "no_active_turn",
                 "there is no active turn to steer; the message was not queued",
@@ -681,8 +681,8 @@ impl CodeRuntime {
     pub(crate) async fn steer_trigger(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
-        expected_turn_id: CodeTurnId,
+        id: SessionId,
+        expected_turn_id: TurnId,
         message: String,
         delivery_id: tidebreak_core::CodeTriggerDeliveryId,
         lease_token: uuid::Uuid,
@@ -703,10 +703,10 @@ impl CodeRuntime {
     pub(crate) async fn reap(
         &self,
         owner: &OwnerId,
-        id: CodeSessionId,
-    ) -> Result<CodeSession, ServerError> {
+        id: SessionId,
+    ) -> Result<Session, ServerError> {
         let session = self.get_session(owner, id).await?;
-        if session.lifecycle != CodeSessionLifecycle::Fenced {
+        if session.lifecycle != SessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
                 "not_fenced",
                 "only a fenced session can be reaped",

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -25,7 +25,7 @@ impl CodeRuntime {
     /// to the caller: a worker that outlived its grace still holds this
     /// workspace's turn lock, so anything keyed on "the checkout is now
     /// unowned" has to stay put.
-    pub(super) async fn shut_down_worker(id: CodeSessionId, handle: WorkerHandle) -> bool {
+    pub(super) async fn shut_down_worker(id: SessionId, handle: WorkerHandle) -> bool {
         const GRACE: std::time::Duration = std::time::Duration::from_secs(5);
         let commands = handle.commands.clone();
         drop(handle);
@@ -49,8 +49,8 @@ impl CodeRuntime {
 
     pub(crate) async fn attach_and_spawn_worker(
         &self,
-        session: CodeSession,
-    ) -> Result<CodeSession, ServerError> {
+        session: Session,
+    ) -> Result<Session, ServerError> {
         let mut session = session;
         let workspace = self.session_workspace(&session).await?;
         let adapter = self.adapter(session.harness_kind)?;
@@ -72,9 +72,9 @@ impl CodeRuntime {
                     session.model.as_deref(),
                 )
                 .await;
-            let mut next = CodeSessionExecutionSettings::from(&session);
+            let mut next = SessionExecutionSettings::from(&session);
             selected.deactivate_unsupported(&mut next);
-            if next != CodeSessionExecutionSettings::from(&session) {
+            if next != SessionExecutionSettings::from(&session) {
                 session =
                     replace_session_execution_settings(&self.db, &session.owner, &session, &next)
                         .await?
@@ -295,7 +295,7 @@ impl CodeRuntime {
         let pending = list_approvals(
             &self.db,
             &attached.owner,
-            Some(CodeApprovalState::Pending),
+            Some(ApprovalState::Pending),
             Some(attached.id),
         )
         .await?;
@@ -311,7 +311,7 @@ impl CodeRuntime {
     }
 
     /// Whether a worker is attached to the session right now.
-    pub(crate) fn has_worker(&self, id: CodeSessionId) -> bool {
+    pub(crate) fn has_worker(&self, id: SessionId) -> bool {
         self.workers.lock().expect("code workers").contains_key(&id)
     }
 
@@ -333,7 +333,7 @@ impl CodeRuntime {
     pub(crate) async fn resync_workers_to_selected_binaries(
         self: &Arc<Self>,
         kinds: &[HarnessKind],
-    ) -> Vec<CodeSessionId> {
+    ) -> Vec<SessionId> {
         let mut moved = Vec::new();
         for kind in kinds {
             // A declared binary never moves, and a host with no data
@@ -347,7 +347,7 @@ impl CodeRuntime {
             let Some(selected) = self.selected_harness(*kind).await else {
                 continue;
             };
-            let stale: Vec<(CodeSessionId, i64, OwnerId)> = self
+            let stale: Vec<(SessionId, i64, OwnerId)> = self
                 .workers
                 .lock()
                 .expect("code workers")
@@ -367,7 +367,7 @@ impl CodeRuntime {
                 if session.harness_kind != *kind || session.spawn_epoch != spawn_epoch {
                     continue;
                 }
-                if session.lifecycle == CodeSessionLifecycle::Running {
+                if session.lifecycle == SessionLifecycle::Running {
                     self.defer_worker_resync(*kind, id, owner);
                     continue;
                 }
@@ -402,7 +402,7 @@ impl CodeRuntime {
     /// the moment it is no longer running. One watcher per session: a second
     /// install or channel flip while one is pending changes what the resync
     /// will select, not whether it runs.
-    fn defer_worker_resync(self: &Arc<Self>, kind: HarnessKind, id: CodeSessionId, owner: OwnerId) {
+    fn defer_worker_resync(self: &Arc<Self>, kind: HarnessKind, id: SessionId, owner: OwnerId) {
         if !self
             .deferred_resyncs
             .lock()
@@ -422,7 +422,7 @@ impl CodeRuntime {
             let outcome = loop {
                 tokio::time::sleep(DEFERRED_RESYNC_POLL).await;
                 match runtime.get_session(&owner, id).await {
-                    Ok(session) if session.lifecycle != CodeSessionLifecycle::Running => {
+                    Ok(session) if session.lifecycle != SessionLifecycle::Running => {
                         break Ok(());
                     }
                     Ok(_) if TokioInstant::now() < deadline => continue,
@@ -449,7 +449,7 @@ impl CodeRuntime {
         });
     }
 
-    pub(super) fn require_worker(&self, id: CodeSessionId) -> Result<WorkerHandle, ServerError> {
+    pub(super) fn require_worker(&self, id: SessionId) -> Result<WorkerHandle, ServerError> {
         self.workers
             .lock()
             .expect("code workers")
@@ -496,12 +496,12 @@ mod tests {
         runtime
     }
 
-    fn workspaceless_session(owner: &OwnerId, harness: HarnessKind) -> CodeSession {
-        CodeSession {
-            id: CodeSessionId::new(),
+    fn workspaceless_session(owner: &OwnerId, harness: HarnessKind) -> Session {
+        Session {
+            id: SessionId::new(),
             owner: owner.clone(),
             workspace_id: None,
-            kind: CodeSessionKind::Interactive,
+            kind: SessionKind::Interactive,
             harness_kind: harness,
             harness_version: None,
             harness_resume_ref: None,
@@ -509,7 +509,7 @@ mod tests {
             model: None,
             reasoning_effort: None,
             fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Created,
+            lifecycle: SessionLifecycle::Created,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,
@@ -547,7 +547,7 @@ mod tests {
         assert!(runtime.require_worker(attached.id).is_ok());
 
         let mut running = session.clone();
-        running.lifecycle = CodeSessionLifecycle::Running;
+        running.lifecycle = SessionLifecycle::Running;
         crate::code::attention::persist_session(&runtime.db, &runtime.bus, &running)
             .await
             .unwrap();
@@ -566,7 +566,7 @@ mod tests {
 
         // Once the turn ends, the deferred pass makes the swap on its own.
         let mut idle = running.clone();
-        idle.lifecycle = CodeSessionLifecycle::Idle;
+        idle.lifecycle = SessionLifecycle::Idle;
         crate::code::attention::persist_session(&runtime.db, &runtime.bus, &idle)
             .await
             .unwrap();

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -280,7 +280,7 @@ impl CodeRuntime {
             if sessions.iter().any(|session| {
                 matches!(
                     session.lifecycle,
-                    CodeSessionLifecycle::Running | CodeSessionLifecycle::Fenced
+                    SessionLifecycle::Running | SessionLifecycle::Fenced
                 )
             }) {
                 return Err(ServerError::conflict_kind(
@@ -899,8 +899,8 @@ impl CodeRuntime {
         &self,
         owner: &OwnerId,
         workspace_id: WorkspaceId,
-        turn_id: Option<CodeTurnId>,
-    ) -> Result<(Vec<ChangedFile>, bool, Diffstat, Option<CodeTurnId>), ServerError> {
+        turn_id: Option<TurnId>,
+    ) -> Result<(Vec<ChangedFile>, bool, Diffstat, Option<TurnId>), ServerError> {
         let workspace = self.get_workspace(owner, workspace_id).await?;
         if workspace.is_remote() {
             return Err(ServerError::conflict_kind(
@@ -933,9 +933,9 @@ impl CodeRuntime {
         &self,
         owner: &OwnerId,
         workspace_id: WorkspaceId,
-        turn_id: Option<CodeTurnId>,
+        turn_id: Option<TurnId>,
         file: Option<&str>,
-    ) -> Result<(String, bool, Diffstat, Option<CodeTurnId>), ServerError> {
+    ) -> Result<(String, bool, Diffstat, Option<TurnId>), ServerError> {
         let workspace = self.get_workspace(owner, workspace_id).await?;
         if workspace.is_remote() {
             return Err(ServerError::conflict_kind(
@@ -964,7 +964,7 @@ impl CodeRuntime {
         let sessions = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         if sessions
             .iter()
-            .any(|session| session.lifecycle == CodeSessionLifecycle::Running)
+            .any(|session| session.lifecycle == SessionLifecycle::Running)
         {
             return Err(ServerError::conflict_kind(
                 "session_running",
@@ -987,7 +987,7 @@ impl CodeRuntime {
         let mut all_stopped = true;
         let sessions = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         for mut session in sessions {
-            if session.lifecycle == CodeSessionLifecycle::Ended {
+            if session.lifecycle == SessionLifecycle::Ended {
                 continue;
             }
             let handle = self
@@ -1007,7 +1007,7 @@ impl CodeRuntime {
             // interrupted mid-turn re-reads the row on its way round the loop
             // and leaves on its own when it finds the session ended, so one
             // `Shutdown` is enough however busy it was.
-            session.lifecycle = CodeSessionLifecycle::Ended;
+            session.lifecycle = SessionLifecycle::Ended;
             session.child_pid = None;
             session.child_process_identity = None;
             session.fence_reason = None;
@@ -1020,7 +1020,7 @@ impl CodeRuntime {
             // The outgoing worker still holds this epoch, so a persist during
             // the wait can overwrite Ended. Re-assert from a fresh load.
             let mut current = self.get_session(owner, session.id).await?;
-            current.lifecycle = CodeSessionLifecycle::Ended;
+            current.lifecycle = SessionLifecycle::Ended;
             current.child_pid = None;
             current.child_process_identity = None;
             current.fence_reason = None;
@@ -1056,7 +1056,7 @@ impl CodeRuntime {
     /// The workspace a session binds, when it binds one.
     pub(crate) async fn session_workspace(
         &self,
-        session: &CodeSession,
+        session: &Session,
     ) -> Result<Option<CodeWorkspace>, ServerError> {
         match session.workspace_id {
             Some(workspace_id) => self
@@ -1069,7 +1069,7 @@ impl CodeRuntime {
 
     /// The workspace id a checkout-bound operation needs, or the conflict a
     /// session without one answers.
-    pub(crate) fn require_workspace_id(session: &CodeSession) -> Result<WorkspaceId, ServerError> {
+    pub(crate) fn require_workspace_id(session: &Session) -> Result<WorkspaceId, ServerError> {
         session.workspace_id.ok_or_else(|| {
             ServerError::conflict_kind(
                 "session_has_no_workspace",

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -21,11 +21,11 @@ use std::sync::Arc;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 
+use tidebreak_core::code::{QueuedTurn, SequencedEvent};
 use tidebreak_core::{
-    CodeApproval, CodeApprovalId, CodeApprovalState, CodeRepo, CodeSession, CodeSessionId,
-    CodeTrigger, CodeTriggerAction, CodeTriggerCondition, CodeTriggerId, CodeTurn, CodeTurnId,
-    CodeWorkspace, Diffstat, HarnessKind, OwnerId, PermissionMode, ReasoningEffort, RepoId,
-    SequencedCodeEvent, WorkspaceId,
+    Approval, ApprovalId, ApprovalState, CodeRepo, CodeTrigger, CodeTriggerAction,
+    CodeTriggerCondition, CodeTriggerId, CodeWorkspace, Diffstat, HarnessKind, OwnerId,
+    PermissionMode, ReasoningEffort, RepoId, Session, SessionId, Turn, TurnId, WorkspaceId,
 };
 
 use super::checkpoint::ChangedFile;
@@ -412,17 +412,17 @@ impl ScopedCode {
     pub(crate) async fn workspace_files(
         &self,
         id: WorkspaceId,
-        turn_id: Option<CodeTurnId>,
-    ) -> Result<(Vec<ChangedFile>, bool, Diffstat, Option<CodeTurnId>), ServerError> {
+        turn_id: Option<TurnId>,
+    ) -> Result<(Vec<ChangedFile>, bool, Diffstat, Option<TurnId>), ServerError> {
         self.runtime.workspace_files(&self.owner, id, turn_id).await
     }
 
     pub(crate) async fn workspace_diff(
         &self,
         id: WorkspaceId,
-        turn_id: Option<CodeTurnId>,
+        turn_id: Option<TurnId>,
         file: Option<&str>,
-    ) -> Result<(String, bool, Diffstat, Option<CodeTurnId>), ServerError> {
+    ) -> Result<(String, bool, Diffstat, Option<TurnId>), ServerError> {
         self.runtime
             .workspace_diff(&self.owner, id, turn_id, file)
             .await
@@ -598,7 +598,7 @@ impl ScopedCode {
         workspace_id: WorkspaceId,
         harness: HarnessKind,
         settings: NewSessionSettings,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         self.runtime
             .create_session(&self.owner, workspace_id, harness, settings)
             .await
@@ -607,7 +607,7 @@ impl ScopedCode {
     pub(crate) async fn create_internal_session(
         &self,
         settings: NewSessionSettings,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         self.runtime
             .create_internal_session(&self.owner, settings)
             .await
@@ -618,24 +618,24 @@ impl ScopedCode {
         workspace_id: WorkspaceId,
         harness: HarnessKind,
         settings: NewSessionSettings,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         self.runtime
             .create_remote_session(&self.owner, workspace_id, harness, settings)
             .await
     }
 
-    pub(crate) async fn get_session(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
+    pub(crate) async fn get_session(&self, id: SessionId) -> Result<Session, ServerError> {
         self.runtime.get_session(&self.owner, id).await
     }
 
-    pub(crate) async fn list_internal_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
+    pub(crate) async fn list_internal_sessions(&self) -> Result<Vec<Session>, ServerError> {
         self.runtime.list_internal_sessions(&self.owner).await
     }
 
     pub(crate) async fn list_workspace_sessions(
         &self,
         workspace_id: WorkspaceId,
-    ) -> Result<Vec<CodeSession>, ServerError> {
+    ) -> Result<Vec<Session>, ServerError> {
         self.runtime
             .list_workspace_sessions(&self.owner, workspace_id)
             .await
@@ -643,23 +643,20 @@ impl ScopedCode {
 
     pub(crate) async fn external_bindings_for_sessions(
         &self,
-        session_ids: &[CodeSessionId],
+        session_ids: &[SessionId],
     ) -> Result<Vec<tidebreak_core::CodeExternalBinding>, ServerError> {
         self.runtime
             .external_bindings_for_sessions(&self.owner, session_ids)
             .await
     }
 
-    pub(crate) async fn list_session_turns(
-        &self,
-        id: CodeSessionId,
-    ) -> Result<Vec<CodeTurn>, ServerError> {
+    pub(crate) async fn list_session_turns(&self, id: SessionId) -> Result<Vec<Turn>, ServerError> {
         self.runtime.list_session_turns(&self.owner, id).await
     }
 
     pub(crate) async fn list_turn_metrics(
         &self,
-    ) -> Result<Vec<tidebreak_core::db::code::CodeTurnMetric>, ServerError> {
+    ) -> Result<Vec<tidebreak_core::db::code::TurnMetric>, ServerError> {
         self.runtime.list_turn_metrics(&self.owner).await
     }
 
@@ -679,22 +676,22 @@ impl ScopedCode {
 
     pub(crate) async fn fork_transcript(
         &self,
-        id: CodeSessionId,
-        at_turn: Option<tidebreak_core::CodeTurnId>,
+        id: SessionId,
+        at_turn: Option<tidebreak_core::TurnId>,
     ) -> Result<super::fork::WrittenTranscript, ServerError> {
         self.runtime.fork_transcript(&self.owner, id, at_turn).await
     }
 
     pub(crate) async fn session_debug(
         &self,
-        id: CodeSessionId,
-    ) -> Result<(CodeSession, Vec<CodeTurn>, Vec<SequencedCodeEvent>), ServerError> {
+        id: SessionId,
+    ) -> Result<(Session, Vec<Turn>, Vec<SequencedEvent>), ServerError> {
         self.runtime.session_debug(&self.owner, id).await
     }
 
     pub(crate) async fn resolve_turn_attachments(
         &self,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         requested: &[(uuid::Uuid, String)],
     ) -> Result<Vec<tidebreak_core::ImageRef>, ServerError> {
         self.runtime
@@ -704,7 +701,7 @@ impl ScopedCode {
 
     pub(crate) async fn submit_turn(
         &self,
-        id: CodeSessionId,
+        id: SessionId,
         message: String,
         model: Option<String>,
         reasoning_effort: Option<Option<ReasoningEffort>>,
@@ -724,18 +721,18 @@ impl ScopedCode {
 
     pub(crate) async fn list_queued_turns(
         &self,
-        id: CodeSessionId,
-    ) -> Result<(Vec<tidebreak_core::CodeQueuedTurn>, bool), ServerError> {
+        id: SessionId,
+    ) -> Result<(Vec<QueuedTurn>, bool), ServerError> {
         self.runtime.list_queued_turns(&self.owner, id).await
     }
 
     pub(crate) async fn update_queued_turn(
         &self,
-        id: CodeSessionId,
-        queued_id: CodeTurnId,
+        id: SessionId,
+        queued_id: TurnId,
         message: Option<&str>,
         position: Option<i32>,
-    ) -> Result<Option<tidebreak_core::CodeQueuedTurn>, ServerError> {
+    ) -> Result<Option<QueuedTurn>, ServerError> {
         self.runtime
             .update_queued_turn(&self.owner, id, queued_id, message, position)
             .await
@@ -743,8 +740,8 @@ impl ScopedCode {
 
     pub(crate) async fn delete_queued_turn(
         &self,
-        id: CodeSessionId,
-        queued_id: CodeTurnId,
+        id: SessionId,
+        queued_id: TurnId,
     ) -> Result<bool, ServerError> {
         self.runtime
             .delete_queued_turn(&self.owner, id, queued_id)
@@ -753,21 +750,21 @@ impl ScopedCode {
 
     pub(crate) async fn set_queue_paused(
         &self,
-        id: CodeSessionId,
+        id: SessionId,
         paused: bool,
     ) -> Result<(), ServerError> {
         self.runtime.set_queue_paused(&self.owner, id, paused).await
     }
 
-    pub(crate) async fn send_queued_now(&self, id: CodeSessionId) -> Result<(), ServerError> {
+    pub(crate) async fn send_queued_now(&self, id: SessionId) -> Result<(), ServerError> {
         self.runtime.send_queued_now(&self.owner, id).await
     }
 
     pub(crate) async fn set_reasoning_effort(
         &self,
-        id: CodeSessionId,
+        id: SessionId,
         effort: Option<ReasoningEffort>,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         self.runtime
             .set_reasoning_effort(&self.owner, id, effort)
             .await
@@ -775,13 +772,13 @@ impl ScopedCode {
 
     pub(crate) async fn set_fast_mode(
         &self,
-        id: CodeSessionId,
+        id: SessionId,
         fast_mode: bool,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         self.runtime.set_fast_mode(&self.owner, id, fast_mode).await
     }
 
-    pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
+    pub(crate) async fn interrupt(&self, id: SessionId) -> Result<(), ServerError> {
         // Authorize the session first: without this the worker registry would
         // answer for a session id whatever owner holds it.
         let _ = self.get_session(id).await?;
@@ -790,8 +787,8 @@ impl ScopedCode {
 
     pub(crate) async fn steer(
         &self,
-        id: CodeSessionId,
-        expected_turn_id: CodeTurnId,
+        id: SessionId,
+        expected_turn_id: TurnId,
         message: String,
     ) -> Result<(), ServerError> {
         self.runtime
@@ -799,7 +796,7 @@ impl ScopedCode {
             .await
     }
 
-    pub(crate) async fn reap(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
+    pub(crate) async fn reap(&self, id: SessionId) -> Result<Session, ServerError> {
         self.runtime.reap(&self.owner, id).await
     }
 
@@ -861,9 +858,9 @@ impl ScopedCode {
 
     pub(crate) async fn set_permission_mode(
         &self,
-        id: CodeSessionId,
+        id: SessionId,
         mode: PermissionMode,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         self.runtime
             .set_permission_mode(&self.owner, id, mode)
             .await
@@ -871,10 +868,10 @@ impl ScopedCode {
 
     pub(crate) async fn set_attention(
         &self,
-        id: CodeSessionId,
+        id: SessionId,
         clear: bool,
         note: Option<String>,
-    ) -> Result<CodeSession, ServerError> {
+    ) -> Result<Session, ServerError> {
         self.runtime
             .set_attention(&self.owner, id, clear, note)
             .await
@@ -886,9 +883,9 @@ impl ScopedCode {
 
     pub(crate) async fn list_approvals(
         &self,
-        state: Option<CodeApprovalState>,
-        session_id: Option<CodeSessionId>,
-    ) -> Result<Vec<CodeApproval>, ServerError> {
+        state: Option<ApprovalState>,
+        session_id: Option<SessionId>,
+    ) -> Result<Vec<Approval>, ServerError> {
         self.runtime
             .list_approvals(&self.owner, state, session_id)
             .await
@@ -896,9 +893,9 @@ impl ScopedCode {
 
     pub(crate) async fn decide_approval(
         &self,
-        id: CodeApprovalId,
+        id: ApprovalId,
         decision: super::runtime::ApprovalDecisionRequest,
-    ) -> Result<CodeApproval, ServerError> {
+    ) -> Result<Approval, ServerError> {
         self.runtime
             .decide_approval(&self.owner, id, decision)
             .await
@@ -914,7 +911,7 @@ impl ScopedCode {
     /// Reserve a validated image for one of the principal's sessions.
     pub(crate) async fn publish_session_image(
         &self,
-        session_id: CodeSessionId,
+        session_id: SessionId,
         image: &tidebreak_core::ImageRef,
     ) -> Result<bool, ServerError> {
         Ok(tidebreak_core::db::code::publish_session_image(
@@ -927,7 +924,7 @@ impl ScopedCode {
         .await?)
     }
 
-    pub(crate) async fn list_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
+    pub(crate) async fn list_sessions(&self) -> Result<Vec<Session>, ServerError> {
         self.runtime.list_sessions(&self.owner).await
     }
 
@@ -980,7 +977,7 @@ impl ScopedCode {
     /// Warm the pinned install of one engine. See
     /// [`CodeRuntime::start_harness_install`].
     ///
-    /// Progress reaches this principal's `/code/updates` socket; the binary it
+    /// Progress reaches this principal's `/updates` socket; the binary it
     /// writes belongs to the machine, which is why the route sits on the
     /// deployment plane beside the doctor's refresh.
     pub(crate) async fn start_harness_install(

--- a/crates/tidebreak-server/src/code/scratch.rs
+++ b/crates/tidebreak-server/src/code/scratch.rs
@@ -152,7 +152,7 @@ pub(crate) fn workspace_root(
 /// and no other session shares it.
 pub(crate) fn session_root(
     data_dir: &Path,
-    session_id: tidebreak_core::CodeSessionId,
+    session_id: tidebreak_core::SessionId,
 ) -> io::Result<ScratchRoot> {
     let data_dir = absolute_path(data_dir)?;
     let root = open_root(&data_dir)?;

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -22,6 +22,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot, watch, Notify};
 use tracing::{warn, Instrument as _};
 
+use tidebreak_core::code::QueuedTurn;
 use tidebreak_core::db::code::{
     accept_trigger_turn_delivery, append_event, append_event_with_notification,
     begin_permission_mode_change, bump_spawn_epoch, cancel_permission_mode_change, clear_turn_park,
@@ -30,14 +31,13 @@ use tidebreak_core::db::code::{
     next_turn_ordinal, promote_queued_turn, queue_paused, queued_turn_head,
     rebind_pending_approvals_to_worker, save_session, save_turn, set_queue_paused,
     set_session_harness_resume_ref, set_session_subagents, settle_engine_observed_approval,
-    store_turn_park, CodeJournalError, CodeSessionExecutionSettings,
+    store_turn_park, JournalError, SessionExecutionSettings,
 };
 use tidebreak_core::{
-    bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
-    CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeSession,
-    CodeSessionId, CodeSessionLifecycle, CodeSubagentStatus, CodeSubagentSummary, CodeTurn,
-    CodeTurnId, CodeTurnStatus, CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind,
-    HarnessNoticeLevel, OwnerId, PermissionMode, Store, ToolOutcome,
+    bound_subagents, Approval, ApprovalId, ApprovalKind, ApprovalState, Attention, AttentionSource,
+    BlobStore, BoundedError, CodeSubagentStatus, CodeSubagentSummary, CodeWorkspaceStatus, DbStore,
+    Event, FenceReason, HarnessKind, HarnessNoticeLevel, OwnerId, PermissionMode, Session,
+    SessionId, SessionLifecycle, Store, ToolOutcome, Turn, TurnId, TurnStatus,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
@@ -51,7 +51,7 @@ pub(crate) enum WorkerCommand {
         message: String,
         attachments: Vec<tidebreak_core::ImageRef>,
         trigger_delivery: Option<TriggerDeliveryClaim>,
-        reply: oneshot::Sender<Result<CodeTurn, WorkerError>>,
+        reply: oneshot::Sender<Result<Turn, WorkerError>>,
     },
     SetPermissionMode {
         mode: PermissionMode,
@@ -59,7 +59,7 @@ pub(crate) enum WorkerCommand {
         reply: oneshot::Sender<Result<(), WorkerError>>,
     },
     SetExecutionSettings {
-        settings: CodeSessionExecutionSettings,
+        settings: SessionExecutionSettings,
         settlement: oneshot::Receiver<ExecutionSettingsSettlement>,
         reply: oneshot::Sender<Result<(), WorkerError>>,
     },
@@ -74,7 +74,7 @@ pub(crate) enum WorkerCommand {
         reply: oneshot::Sender<Result<(), WorkerError>>,
     },
     Steer {
-        expected_turn_id: CodeTurnId,
+        expected_turn_id: TurnId,
         message: String,
         reply: oneshot::Sender<Result<(), WorkerError>>,
     },
@@ -241,7 +241,7 @@ pub(crate) struct QueuedFollowUp {
     /// The durable queue row this turn promotes, when the message came from
     /// the queue rather than a live send. The turn is inserted under the
     /// row's id, in the transaction that deletes the row.
-    pub queued_row: Option<Box<CodeQueuedTurn>>,
+    pub queued_row: Option<Box<QueuedTurn>>,
 }
 
 pub(crate) struct LiveSink {
@@ -250,7 +250,7 @@ pub(crate) struct LiveSink {
     /// Owner of the session this sink writes for. Carried explicitly so every
     /// journal and approval write the worker makes stays inside one owner.
     owner: OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
     /// Which engine this session runs, for copy that names it.
     harness: HarnessKind,
@@ -270,7 +270,7 @@ pub(crate) struct LiveSink {
     /// (decision 71). The relay's refusals are already legible and name the
     /// gateway, so [`LiveSink::legible_turn_error`] leaves them untouched.
     relay_wired: bool,
-    turn_id: std::sync::Mutex<Option<CodeTurnId>>,
+    turn_id: std::sync::Mutex<Option<TurnId>>,
     /// Resume ref reported during engine startup but not yet proven durable.
     ///
     /// Codex creates a thread before it writes that thread to disk. The first
@@ -311,7 +311,7 @@ impl LiveSink {
         &self.owner
     }
 
-    pub(crate) fn set_turn(&self, turn_id: CodeTurnId) {
+    pub(crate) fn set_turn(&self, turn_id: TurnId) {
         *self.turn_id.lock().expect("code sink turn") = Some(turn_id);
     }
 
@@ -393,9 +393,9 @@ impl LiveSink {
     /// whose own completion was lost, so the rail never claims work survived a
     /// turn that has already ended. Boundaries are rare, so each one persists
     /// the list through the targeted write and restates the session's digest.
-    async fn note_subagent_boundary(&self, event: &CodeEvent) {
+    async fn note_subagent_boundary(&self, event: &Event) {
         let changed = match event {
-            CodeEvent::ToolStarted {
+            Event::ToolStarted {
                 call_id,
                 name,
                 detail,
@@ -416,7 +416,7 @@ impl LiveSink {
                 bound_subagents(&mut subagents);
                 Some(subagents.clone())
             }
-            CodeEvent::ToolCompleted {
+            Event::ToolCompleted {
                 call_id,
                 outcome,
                 detail,
@@ -444,12 +444,12 @@ impl LiveSink {
                     Some(_) | None => None,
                 }
             }
-            CodeEvent::TurnCompleted { .. } | CodeEvent::TurnRefused { .. } => {
+            Event::TurnCompleted { .. } | Event::TurnRefused { .. } => {
                 let mut subagents = self.subagents.lock().expect("code sink subagents");
                 settle_running_subagents(&mut subagents, CodeSubagentStatus::Done)
                     .then(|| subagents.clone())
             }
-            CodeEvent::TurnFailed { .. } | CodeEvent::TurnInterrupted { .. } => {
+            Event::TurnFailed { .. } | Event::TurnInterrupted { .. } => {
                 let mut subagents = self.subagents.lock().expect("code sink subagents");
                 settle_running_subagents(&mut subagents, CodeSubagentStatus::Failed)
                     .then(|| subagents.clone())
@@ -467,10 +467,10 @@ impl LiveSink {
 
     pub(crate) async fn record_external_approval(
         &self,
-        approval_id: CodeApprovalId,
+        approval_id: ApprovalId,
         harness_ref: &tidebreak_harness::HarnessApprovalRef,
         raw: &serde_json::Value,
-    ) -> Result<CodeApproval, WorkerError> {
+    ) -> Result<Approval, WorkerError> {
         let Some(capability) = harness_ref.capability.as_ref() else {
             return Err(WorkerError::Failed(
                 "external approval is missing its server capability".into(),
@@ -525,11 +525,11 @@ impl LiveSink {
 
     async fn record_approval(
         &self,
-        approval_id: CodeApprovalId,
+        approval_id: ApprovalId,
         harness_ref: &tidebreak_harness::HarnessApprovalRef,
         raw: &serde_json::Value,
-        kind: Option<&tidebreak_core::CodeApprovalKind>,
-    ) -> Result<CodeApproval, WorkerError> {
+        kind: Option<&tidebreak_core::ApprovalKind>,
+    ) -> Result<Approval, WorkerError> {
         let existing = *self.turn_id.lock().expect("code sink turn");
         let turn_id = match existing {
             Some(id) => id,
@@ -552,7 +552,7 @@ impl LiveSink {
             }
         }
         let capability = harness_ref.capability.as_ref();
-        let approval = CodeApproval {
+        let approval = Approval {
             id: approval_id,
             session_id: self.session_id,
             turn_id,
@@ -566,7 +566,7 @@ impl LiveSink {
             worker_epoch: Some(self.spawn_epoch),
             decision_claim: None,
             claimed_at: None,
-            state: CodeApprovalState::Pending,
+            state: ApprovalState::Pending,
             feedback: None,
             requested_at: Utc::now(),
             decided_at: None,
@@ -653,7 +653,7 @@ impl HarnessEventSink for LiveSink {
         } = &event
         {
             if let Err(error) = self
-                .record_approval(CodeApprovalId::new(), harness_ref, raw, kind.as_ref())
+                .record_approval(ApprovalId::new(), harness_ref, raw, kind.as_ref())
                 .await
             {
                 warn!(
@@ -684,14 +684,14 @@ impl HarnessEventSink for LiveSink {
             return;
         }
         let turn_id = *self.turn_id.lock().unwrap();
-        let Some(code_event) = map_event(event, turn_id) else {
+        let Some(session_event) = map_event(event, turn_id) else {
             return;
         };
         // An engine that fails a turn can pass the provider's raw 401 body
         // straight through. Swap it for the legible sentence before the
         // journal keeps it.
-        let code_event = match code_event {
-            CodeEvent::TurnFailed { error, .. } => CodeEvent::TurnFailed {
+        let session_event = match session_event {
+            Event::TurnFailed { error, .. } => Event::TurnFailed {
                 error: self.legible_turn_error(error.message),
                 detail: None,
             },
@@ -700,34 +700,34 @@ impl HarnessEventSink for LiveSink {
         // Assistant deltas stream and are gone. The `assistant_message` that
         // closes the run repeats them exactly, so a row here would store the
         // same words a second time (record 57).
-        if matches!(code_event, CodeEvent::AssistantDelta { .. }) {
+        if matches!(session_event, Event::AssistantDelta { .. }) {
             if self.native_journal {
                 return;
             }
-            self.bus.publish_transient(self.session_id, code_event);
+            self.bus.publish_transient(self.session_id, session_event);
             let _ =
                 super::attention::note_activity(&self.db, &self.bus, &self.owner, self.session_id)
                     .await;
             return;
         }
-        self.note_subagent_boundary(&code_event).await;
+        self.note_subagent_boundary(&session_event).await;
         // An approval is parked on the call this completion names. Reconcile
         // it after the completion lands, so the journal reads in the order it
         // happened. See `approval_sweep`.
-        let completed_call = match &code_event {
-            CodeEvent::ToolCompleted { call_id, .. } => Some(call_id.clone()),
+        let completed_call = match &session_event {
+            Event::ToolCompleted { call_id, .. } => Some(call_id.clone()),
             _ => None,
         };
         // A completed turn is the moment its recap has everything it needs and
         // the reader has most likely stopped watching. Started below rather
         // than here, so a journal write that was dropped never produces a line
         // describing a turn the database does not agree finished.
-        let completed_turn = matches!(code_event, CodeEvent::TurnCompleted { .. })
+        let completed_turn = matches!(session_event, Event::TurnCompleted { .. })
             .then_some(turn_id)
             .flatten();
         let notification_turn = matches!(
-            &code_event,
-            CodeEvent::TurnCompleted { .. } | CodeEvent::TurnFailed { .. }
+            &session_event,
+            Event::TurnCompleted { .. } | Event::TurnFailed { .. }
         )
         .then_some(turn_id)
         .flatten();
@@ -739,7 +739,7 @@ impl HarnessEventSink for LiveSink {
                 self.session_id,
                 self.spawn_epoch,
                 turn_id,
-                code_event,
+                session_event,
                 self.native_journal,
             )
             .await
@@ -750,14 +750,14 @@ impl HarnessEventSink for LiveSink {
                 &self.owner,
                 self.session_id,
                 self.spawn_epoch,
-                code_event,
+                session_event,
                 self.native_journal,
             )
             .await
         };
         let journaled = match write {
             Ok(()) => !self.native_journal,
-            Err(CodeJournalError::StaleSpawnEpoch { .. }) => {
+            Err(JournalError::StaleSpawnEpoch { .. }) => {
                 warn!(
                     session = %self.session_id,
                     "dropping event from a superseded code-session worker"
@@ -804,7 +804,7 @@ impl HarnessEventSink for LiveSink {
 /// turn, which is what keeps two agents from editing one worktree at once;
 /// see record 55.
 pub(crate) fn spawn_session_worker(
-    session: CodeSession,
+    session: Session,
     engine: Box<dyn HarnessSession>,
     sink: Arc<LiveSink>,
     attachments: AttachmentStore,
@@ -834,7 +834,7 @@ pub(crate) fn spawn_session_worker(
     }
 }
 
-fn record_child_process(session: &mut CodeSession, pid: Option<i64>) {
+fn record_child_process(session: &mut Session, pid: Option<i64>) {
     session.child_pid = pid;
     session.child_process_identity = pid.and_then(|pid| {
         tidebreak_harness::spawned_process_identity(pid).or_else(|| {
@@ -853,7 +853,7 @@ pub(crate) fn wake_queue(handle: &WorkerHandle) {
 }
 
 async fn run_worker(
-    mut session: CodeSession,
+    mut session: Session,
     engine: Box<dyn HarnessSession>,
     sink: Arc<LiveSink>,
     queue: TurnQueue,
@@ -866,10 +866,8 @@ async fn run_worker(
     }
 
     if let Ok(Some(open)) = get_open_turn(&sink.db, &session.owner, session.id).await {
-        if matches!(
-            open.status,
-            CodeTurnStatus::Waiting | CodeTurnStatus::Resuming
-        ) && open.park_ref.is_some()
+        if matches!(open.status, TurnStatus::Waiting | TurnStatus::Resuming)
+            && open.park_ref.is_some()
             && open.park_wait.is_some()
         {
             if let Err(error) = continue_parked_turn(
@@ -889,7 +887,7 @@ async fn run_worker(
                 );
             }
         } else if session.harness_kind == HarnessKind::Internal
-            && open.status == CodeTurnStatus::Running
+            && open.status == TurnStatus::Running
         {
             let lease_token = uuid::Uuid::new_v4();
             let now = Utc::now();
@@ -1139,7 +1137,7 @@ const QUIESCE_PARK_RETRY: Duration = Duration::from_millis(50);
 /// nothing reads the dead process as live. The next turn respawns and
 /// resumes. A park that fails keeps the child and simply retries on the next
 /// idle window.
-async fn park_idle_engine(session: &mut CodeSession, engine: &dyn HarnessSession, sink: &LiveSink) {
+async fn park_idle_engine(session: &mut Session, engine: &dyn HarnessSession, sink: &LiveSink) {
     if let Err(error) = engine.park().await {
         warn!(
             session = %session.id,
@@ -1193,7 +1191,7 @@ enum WorktreeWait<'a> {
 }
 
 async fn await_worktree_turn<'a>(
-    session: &mut CodeSession,
+    session: &mut Session,
     engine: &dyn HarnessSession,
     worktree_turn: &'a tokio::sync::Mutex<()>,
     commands: &mut mpsc::Receiver<WorkerCommand>,
@@ -1240,8 +1238,8 @@ async fn await_worktree_turn<'a>(
 /// wait, or the live route cannot use the same reserve-commit-release boundary
 /// that protects ordinary idle updates.
 async fn reserve_execution_settings(
-    session: &mut CodeSession,
-    settings: CodeSessionExecutionSettings,
+    session: &mut Session,
+    settings: SessionExecutionSettings,
     settlement: oneshot::Receiver<ExecutionSettingsSettlement>,
     reply: oneshot::Sender<Result<(), WorkerError>>,
 ) -> bool {
@@ -1321,8 +1319,8 @@ async fn deliver_decision(
 /// awaited dependency, mapped into the durable park-wait shape.
 async fn persist_turn_park(
     db: &DbStore,
-    session: &CodeSession,
-    turn: &mut CodeTurn,
+    session: &Session,
+    turn: &mut Turn,
     park_ref: &str,
     waiting_on: &tidebreak_harness::ParkWait,
 ) -> Result<tidebreak_core::TurnParkWait, String> {
@@ -1355,8 +1353,8 @@ async fn persist_turn_park(
 
 async fn clear_persisted_turn_park(
     db: &DbStore,
-    session: &CodeSession,
-    turn: &mut CodeTurn,
+    session: &Session,
+    turn: &mut Turn,
     park_ref: &str,
     wait: &tidebreak_core::TurnParkWait,
 ) -> Result<(), String> {
@@ -1366,7 +1364,7 @@ async fn clear_persisted_turn_park(
         .ok_or_else(|| format!("clearing the parked turn {} lost its row", turn.id))?;
     // The worker is about to start the resumed leg. Do not restore the
     // transient `waiting` or `resuming` database status in its live snapshot.
-    turn.status = CodeTurnStatus::Running;
+    turn.status = TurnStatus::Running;
     turn.park_ref = None;
     turn.park_wait = None;
     Ok(())
@@ -1390,7 +1388,7 @@ async fn clear_persisted_turn_park(
 async fn apply_accepted_plan_mode(
     db: &DbStore,
     bus: &CodeEventBus,
-    session: &mut CodeSession,
+    session: &mut Session,
     engine: &dyn HarnessSession,
     input: &tidebreak_harness::ResumeInput,
 ) {
@@ -1404,7 +1402,7 @@ async fn apply_accepted_plan_mode(
     let proposed = match list_approvals(db, &session.owner, None, Some(session.id)).await {
         Ok(approvals) => approvals.into_iter().find_map(|approval| {
             match (&approval.native_call_id, &approval.kind) {
-                (Some(native), CodeApprovalKind::Plan { proposed_mode }) if native == call_id => {
+                (Some(native), ApprovalKind::Plan { proposed_mode }) if native == call_id => {
                     Some(*proposed_mode)
                 }
                 _ => None,
@@ -1456,7 +1454,7 @@ async fn apply_accepted_plan_mode(
                 &session.owner,
                 session.id,
                 session.spawn_epoch,
-                CodeEvent::HarnessNotice {
+                Event::HarnessNotice {
                     level: HarnessNoticeLevel::Info,
                     message: format!(
                         "Plan accepted; the session continues in {} mode.",
@@ -1475,7 +1473,7 @@ async fn apply_accepted_plan_mode(
                 &session.owner,
                 session.id,
                 session.spawn_epoch,
-                CodeEvent::HarnessNotice {
+                Event::HarnessNotice {
                     level: HarnessNoticeLevel::Warning,
                     message: format!(
                         "Plan accepted, but the engine kept its {} posture: {error}",
@@ -1532,7 +1530,7 @@ fn resume_decision(decision: tidebreak_core::ApprovalDecisionKind) -> ApprovalDe
 async fn resume_from_settled_row(
     db: &DbStore,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     call_id: &str,
 ) -> Result<Option<tidebreak_harness::ResumeInput>, WorkerError> {
     let approval = list_approvals(db, owner, None, Some(session_id))
@@ -1551,7 +1549,7 @@ async fn resume_from_settled_row(
         .map_err(|error| WorkerError::Failed(error.to_string()))?
         .into_iter()
         .find_map(|row| match row.event {
-            CodeEvent::ApprovalResolved {
+            Event::ApprovalResolved {
                 approval_id,
                 decision,
             } if approval_id == approval.id => Some(decision),
@@ -1560,11 +1558,11 @@ async fn resume_from_settled_row(
     let decision = match journaled {
         Some(decision) => decision,
         None => match approval.state {
-            CodeApprovalState::Approved => tidebreak_core::ApprovalDecisionKind::Approve,
-            CodeApprovalState::Denied => tidebreak_core::ApprovalDecisionKind::Deny {
+            ApprovalState::Approved => tidebreak_core::ApprovalDecisionKind::Approve,
+            ApprovalState::Denied => tidebreak_core::ApprovalDecisionKind::Deny {
                 feedback: approval.feedback,
             },
-            CodeApprovalState::Abandoned | CodeApprovalState::Pending => {
+            ApprovalState::Abandoned | ApprovalState::Pending => {
                 tidebreak_core::ApprovalDecisionKind::Abandoned
             }
         },
@@ -1577,10 +1575,10 @@ async fn resume_from_settled_row(
 
 async fn durable_park_state(
     db: &DbStore,
-    session: &CodeSession,
+    session: &Session,
     park_ref: &str,
     wait: &tidebreak_core::TurnParkWait,
-    turn_id: CodeTurnId,
+    turn_id: TurnId,
     delivered: &DeliveredDecisions,
 ) -> Result<DurableParkState, WorkerError> {
     if let Some(input) = resume_if_already_delivered(wait, delivered) {
@@ -1606,14 +1604,14 @@ async fn durable_park_state(
             resume_from_settled_row(db, &session.owner, session.id, call_id).await?
         }
         tidebreak_core::TurnParkWait::ClientToolCall { call_id }
-            if turn.status == CodeTurnStatus::Resuming =>
+            if turn.status == TurnStatus::Resuming =>
         {
             Some(tidebreak_harness::ResumeInput::ClientToolCompleted {
                 call_id: call_id.clone(),
             })
         }
         tidebreak_core::TurnParkWait::AgentRuns { run_ids }
-            if turn.status == CodeTurnStatus::Resuming =>
+            if turn.status == TurnStatus::Resuming =>
         {
             Some(tidebreak_harness::ResumeInput::AgentRunsSettled {
                 run_ids: run_ids.clone(),
@@ -1630,7 +1628,7 @@ async fn durable_park_state(
     }
     if matches!(
         turn.status,
-        CodeTurnStatus::Waiting | CodeTurnStatus::CancellingClient
+        TurnStatus::Waiting | TurnStatus::CancellingClient
     ) {
         Ok(DurableParkState::Pending)
     } else {
@@ -1645,14 +1643,14 @@ async fn await_park_resolution<'a>(
     engine: &'a dyn HarnessSession,
     db: &DbStore,
     bus: &CodeEventBus,
-    session: &CodeSession,
+    session: &Session,
     commands: &mut mpsc::Receiver<WorkerCommand>,
     controls: &mut FuturesUnordered<BoxFuture<'a, ControlFlow>>,
     interrupted: &mut bool,
     commands_closed: &mut bool,
     park_ref: &str,
     wait: &tidebreak_core::TurnParkWait,
-    turn_id: CodeTurnId,
+    turn_id: TurnId,
     delivered: &DeliveredDecisions,
 ) -> Result<Option<ParkResolution>, WorkerError> {
     // Subscribe before the read below, so a settlement between the two
@@ -1760,7 +1758,7 @@ async fn await_park_resolution<'a>(
 async fn apply_control(
     engine: &dyn HarnessSession,
     command: WorkerCommand,
-    active_turn_id: Option<CodeTurnId>,
+    active_turn_id: Option<TurnId>,
     delivered: Option<DeliveredDecisions>,
 ) -> ControlFlow {
     match command {
@@ -1877,7 +1875,7 @@ async fn set_permission_mode(
 /// queue. A pause holds the whole drain; the resume, the next enqueue, or
 /// send-now wakes the worker again.
 async fn drain_queued(
-    session: &mut CodeSession,
+    session: &mut Session,
     engine: &dyn HarnessSession,
     sink: &LiveSink,
     queue: &TurnQueue,
@@ -1986,14 +1984,14 @@ async fn drain_queued(
                     &session.owner,
                     session.id,
                     session.spawn_epoch,
-                    CodeEvent::HarnessNotice {
+                    Event::HarnessNotice {
                         level: HarnessNoticeLevel::Error,
                         message: format!("The queued turn could not start: {detail}"),
                     },
                     false,
                 )
                 .await;
-                if session.lifecycle != CodeSessionLifecycle::Fenced {
+                if session.lifecycle != SessionLifecycle::Fenced {
                     super::attention::replace_attention(
                         session,
                         Attention::needs_you(
@@ -2016,13 +2014,13 @@ async fn drain_queued(
 /// Pick a waiting turn back up after a worker restart and drive the same
 /// `resume_turn` path a live park resolution uses.
 async fn continue_parked_turn(
-    session: &mut CodeSession,
+    session: &mut Session,
     engine: &dyn HarnessSession,
     sink: &LiveSink,
     commands: &mut mpsc::Receiver<WorkerCommand>,
     queue: &TurnQueue,
-    mut turn: CodeTurn,
-) -> Result<CodeTurn, WorkerError> {
+    mut turn: Turn,
+) -> Result<Turn, WorkerError> {
     let db = &sink.db;
     let bus = &sink.bus;
     let Some(park_ref) = turn.park_ref.clone() else {
@@ -2050,7 +2048,7 @@ async fn continue_parked_turn(
         return Err(WorkerError::Conflict("session has ended".into()));
     }
 
-    session.lifecycle = CodeSessionLifecycle::Running;
+    session.lifecycle = SessionLifecycle::Running;
     super::attention::replace_attention(
         session,
         Attention::working(AttentionSource::Lifecycle),
@@ -2075,7 +2073,7 @@ async fn continue_parked_turn(
         &session.owner,
         session.id,
         session.spawn_epoch,
-        CodeEvent::TurnResumed { turn_id: turn.id },
+        Event::TurnResumed { turn_id: turn.id },
         false,
     )
     .await
@@ -2227,14 +2225,14 @@ async fn continue_parked_turn(
 
 #[allow(clippy::too_many_arguments)]
 async fn close_open_turn(
-    session: &mut CodeSession,
+    session: &mut Session,
     engine: &dyn HarnessSession,
     sink: &LiveSink,
-    mut turn: CodeTurn,
+    mut turn: Turn,
     run: Result<TurnOutcome, HarnessError>,
     interrupted: bool,
     attachment_cleanup_error: Option<String>,
-) -> Result<CodeTurn, WorkerError> {
+) -> Result<Turn, WorkerError> {
     let db = &sink.db;
     let bus = &sink.bus;
     record_child_process(session, engine.child_pid());
@@ -2271,7 +2269,7 @@ async fn close_open_turn(
                     &session.owner,
                     session.id,
                     session.spawn_epoch,
-                    CodeEvent::HarnessNotice {
+                    Event::HarnessNotice {
                         level: HarnessNoticeLevel::Error,
                         message: detail.clone(),
                     },
@@ -2282,21 +2280,21 @@ async fn close_open_turn(
             if turn.status.is_open() {
                 let (status, event) = if interrupted {
                     (
-                        CodeTurnStatus::Interrupted,
-                        CodeEvent::TurnInterrupted { usage: None },
+                        TurnStatus::Interrupted,
+                        Event::TurnInterrupted { usage: None },
                     )
                 } else if let Some(detail) = detail {
                     (
-                        CodeTurnStatus::Failed,
-                        CodeEvent::TurnFailed {
+                        TurnStatus::Failed,
+                        Event::TurnFailed {
                             error: sink.legible_turn_error(detail),
                             detail: None,
                         },
                     )
                 } else {
                     (
-                        CodeTurnStatus::Completed,
-                        CodeEvent::TurnCompleted {
+                        TurnStatus::Completed,
+                        Event::TurnCompleted {
                             usage: turn.usage.clone().unwrap_or_default(),
                             checkpoint: None,
                             stop_reason: None,
@@ -2307,7 +2305,7 @@ async fn close_open_turn(
                 turn.ended_at = Some(Utc::now());
                 let _ = save_turn(db, &session.owner, &turn).await;
                 sink.note_subagent_boundary(&event).await;
-                let write = if matches!(event, CodeEvent::TurnInterrupted { .. }) {
+                let write = if matches!(event, Event::TurnInterrupted { .. }) {
                     persist_and_publish(
                         db,
                         bus,
@@ -2336,10 +2334,10 @@ async fn close_open_turn(
         }
         Err(err) => {
             if turn.status.is_open() {
-                turn.status = CodeTurnStatus::Failed;
+                turn.status = TurnStatus::Failed;
                 turn.ended_at = Some(Utc::now());
                 let _ = save_turn(db, &session.owner, &turn).await;
-                let event = CodeEvent::TurnFailed {
+                let event = Event::TurnFailed {
                     error: sink.legible_turn_error(err.to_string()),
                     detail: None,
                 };
@@ -2390,7 +2388,7 @@ async fn close_open_turn(
                     .await;
                     return Err(WorkerError::Failed(err.to_string()));
                 }
-                session.lifecycle = CodeSessionLifecycle::Idle;
+                session.lifecycle = SessionLifecycle::Idle;
                 super::attention::replace_attention(
                     session,
                     Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle),
@@ -2430,13 +2428,13 @@ async fn close_open_turn(
     if session_was_ended(db, session).await {
         return Ok(turn);
     }
-    if turn.status == CodeTurnStatus::Interrupted {
+    if turn.status == TurnStatus::Interrupted {
         super::attention::replace_attention(
             session,
             Attention::needs_you("the turn was interrupted", AttentionSource::Lifecycle),
             false,
         );
-    } else if turn.status == CodeTurnStatus::Failed {
+    } else if turn.status == TurnStatus::Failed {
         if let Some(reason) = repeated_failure_fence(db, session, &turn).await {
             let _ = super::recovery::fence_session(db, bus, session, reason).await;
             return Ok(turn);
@@ -2456,20 +2454,20 @@ async fn close_open_turn(
             false,
         );
     }
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     let _ = super::attention::persist_session(db, bus, session).await;
     Ok(turn)
 }
 
 async fn drive_turn(
-    session: &mut CodeSession,
+    session: &mut Session,
     engine: &dyn HarnessSession,
     sink: &LiveSink,
     store: &AttachmentStore,
     commands: &mut mpsc::Receiver<WorkerCommand>,
     worktree: WorktreeTurn<'_>,
     follow_up: QueuedFollowUp,
-) -> Result<CodeTurn, WorkerError> {
+) -> Result<Turn, WorkerError> {
     let session_id = session.id;
     let wait = match worktree.wait {
         TurnWait::Send => "send",
@@ -2477,8 +2475,8 @@ async fn drive_turn(
     };
     let span = tracing::info_span!(
         target: crate::diagnostics::EVENT_TARGET,
-        "tidebreak.code_turn",
-        otel.name = "tidebreak.code_turn",
+        "tidebreak.turn",
+        otel.name = "tidebreak.turn",
         otel.kind = "internal",
         otel.status_code = tracing::field::Empty,
         tidebreak.code.session_id = %session_id,
@@ -2505,17 +2503,17 @@ async fn drive_turn(
     span.in_scope(|| {
         tracing::info!(
             target: crate::diagnostics::EVENT_TARGET,
-            event_name = "tidebreak.code_turn.completed",
+            event_name = "tidebreak.turn.completed",
             outcome,
             duration_ms,
-            "code turn completed"
+            "turn completed"
         );
     });
     result
 }
 
 async fn drive_turn_inner(
-    session: &mut CodeSession,
+    session: &mut Session,
     engine: &dyn HarnessSession,
     sink: &LiveSink,
     store: &AttachmentStore,
@@ -2527,20 +2525,20 @@ async fn drive_turn_inner(
         trigger_delivery,
         queued_row,
     }: QueuedFollowUp,
-) -> Result<CodeTurn, WorkerError> {
+) -> Result<Turn, WorkerError> {
     let db = &sink.db;
     let bus = &sink.bus;
-    if session.lifecycle == CodeSessionLifecycle::Running {
+    if session.lifecycle == SessionLifecycle::Running {
         return Err(WorkerError::Conflict(
             "a turn is already running on this session".into(),
         ));
     }
-    if session.lifecycle == CodeSessionLifecycle::Fenced {
+    if session.lifecycle == SessionLifecycle::Fenced {
         return Err(WorkerError::Conflict(
             "session is fenced until it is reaped".into(),
         ));
     }
-    if session.lifecycle == CodeSessionLifecycle::Ended {
+    if session.lifecycle == SessionLifecycle::Ended {
         return Err(WorkerError::Conflict("session has ended".into()));
     }
     // Bytes first, before the worktree lock: a blob read and a decode should
@@ -2639,7 +2637,7 @@ async fn drive_turn_inner(
     // engine. A queued row uses the worker copy initialized before the wait and
     // updated by every confirmed reservation accepted during that wait.
     let turn_settings = match worktree.wait {
-        TurnWait::Queued => CodeSessionExecutionSettings::from(&*session),
+        TurnWait::Queued => SessionExecutionSettings::from(&*session),
         TurnWait::Send => {
             let current = get_session(db, &session.owner, session.id)
                 .await
@@ -2653,23 +2651,21 @@ async fn drive_turn_inner(
             session.model = current.model;
             session.reasoning_effort = current.reasoning_effort;
             session.fast_mode = current.fast_mode;
-            CodeSessionExecutionSettings::from(&*session)
+            SessionExecutionSettings::from(&*session)
         }
     };
 
     let ordinal = next_turn_ordinal(db, &session.owner, session.id)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;
-    let mut turn = CodeTurn {
+    let mut turn = Turn {
         // A promoted queue row already carries the turn's id: inserting under
         // it is what lets the row deletion and the turn insertion commit as
         // one write (decision 69).
-        id: queued_row
-            .as_ref()
-            .map_or_else(CodeTurnId::new, |row| row.id),
+        id: queued_row.as_ref().map_or_else(TurnId::new, |row| row.id),
         session_id: session.id,
         ordinal,
-        status: CodeTurnStatus::Running,
+        status: TurnStatus::Running,
         model: turn_settings.model.clone(),
         fast_mode: turn_settings.fast_mode,
         user_input: message.clone(),
@@ -2769,7 +2765,7 @@ async fn drive_turn_inner(
         None
     };
 
-    session.lifecycle = CodeSessionLifecycle::Running;
+    session.lifecycle = SessionLifecycle::Running;
     super::attention::replace_attention(
         session,
         Attention::working(AttentionSource::Lifecycle),
@@ -2786,7 +2782,7 @@ async fn drive_turn_inner(
         &session.owner,
         session.id,
         session.spawn_epoch,
-        CodeEvent::TurnStarted { turn_id: turn.id },
+        Event::TurnStarted { turn_id: turn.id },
         sink.native_journal,
     )
     .await
@@ -3075,7 +3071,7 @@ async fn drive_turn_inner(
                     &session.owner,
                     session.id,
                     session.spawn_epoch,
-                    CodeEvent::HarnessNotice {
+                    Event::HarnessNotice {
                         level: HarnessNoticeLevel::Error,
                         message: detail.clone(),
                     },
@@ -3083,33 +3079,28 @@ async fn drive_turn_inner(
                 )
                 .await;
             }
-            if turn.status.is_open()
-                && !matches!(
-                    turn.status,
-                    CodeTurnStatus::WaitingForClient | CodeTurnStatus::WaitingForAgentRun
-                )
-            {
+            if turn.status.is_open() {
                 // The stream ended without closing the turn. Only the worker
-                // knows whether that was asked for. Client and agent-run
-                // waits keep the lease-release shape until D4b. An approval
-                // park stays on the worker, so an interrupt must close it.
+                // knows whether that was asked for. Durable parks return to
+                // the leg loop before this point, so every remaining open
+                // state needs a terminal result.
                 let (status, event) = if interrupted {
                     (
-                        CodeTurnStatus::Interrupted,
-                        CodeEvent::TurnInterrupted { usage: None },
+                        TurnStatus::Interrupted,
+                        Event::TurnInterrupted { usage: None },
                     )
                 } else if let Some(detail) = detail {
                     (
-                        CodeTurnStatus::Failed,
-                        CodeEvent::TurnFailed {
+                        TurnStatus::Failed,
+                        Event::TurnFailed {
                             error: sink.legible_turn_error(detail),
                             detail: None,
                         },
                     )
                 } else {
                     (
-                        CodeTurnStatus::Completed,
-                        CodeEvent::TurnCompleted {
+                        TurnStatus::Completed,
+                        Event::TurnCompleted {
                             usage: turn.usage.clone().unwrap_or_default(),
                             checkpoint: None,
                             stop_reason: None,
@@ -3120,7 +3111,7 @@ async fn drive_turn_inner(
                 turn.ended_at = Some(Utc::now());
                 let _ = save_turn(db, &session.owner, &turn).await;
                 sink.note_subagent_boundary(&event).await;
-                let write = if matches!(event, CodeEvent::TurnInterrupted { .. }) {
+                let write = if matches!(event, Event::TurnInterrupted { .. }) {
                     persist_and_publish(
                         db,
                         bus,
@@ -3149,10 +3140,10 @@ async fn drive_turn_inner(
         }
         Err(err) => {
             if turn.status.is_open() {
-                turn.status = CodeTurnStatus::Failed;
+                turn.status = TurnStatus::Failed;
                 turn.ended_at = Some(Utc::now());
                 let _ = save_turn(db, &session.owner, &turn).await;
-                let event = CodeEvent::TurnFailed {
+                let event = Event::TurnFailed {
                     error: sink.legible_turn_error(err.to_string()),
                     detail: None,
                 };
@@ -3209,7 +3200,7 @@ async fn drive_turn_inner(
                     .await;
                     return Err(WorkerError::Failed(err.to_string()));
                 }
-                session.lifecycle = CodeSessionLifecycle::Idle;
+                session.lifecycle = SessionLifecycle::Idle;
                 super::attention::replace_attention(
                     session,
                     Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle),
@@ -3249,13 +3240,13 @@ async fn drive_turn_inner(
     if session_was_ended(db, session).await {
         return Ok(turn);
     }
-    if turn.status == CodeTurnStatus::Interrupted {
+    if turn.status == TurnStatus::Interrupted {
         super::attention::replace_attention(
             session,
             Attention::needs_you("the turn was interrupted", AttentionSource::Lifecycle),
             false,
         );
-    } else if turn.status == CodeTurnStatus::Failed {
+    } else if turn.status == TurnStatus::Failed {
         // Whatever broke may not be about this prompt. An expired credential
         // or an unreachable provider fails every turn identically, and a
         // session that keeps saying "idle" invites the user to retry into it
@@ -3280,7 +3271,7 @@ async fn drive_turn_inner(
             false,
         );
     }
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     let _ = super::attention::persist_session(db, bus, session).await;
     Ok(turn)
 }
@@ -3292,7 +3283,7 @@ async fn drive_turn_inner(
 async fn sweep_attachment_leftovers_or_fence(
     db: &DbStore,
     bus: &CodeEventBus,
-    session: &mut CodeSession,
+    session: &mut Session,
     private_root: &super::scratch::ScratchRoot,
 ) -> Result<(), WorkerError> {
     let Err(error) = super::scratch::sweep_scopes(private_root, ATTACHMENTS_DIR) else {
@@ -3316,7 +3307,7 @@ async fn sweep_attachment_leftovers_or_fence(
     Err(WorkerError::Failed(detail))
 }
 
-fn code_turn_outcome(result: &Result<CodeTurn, WorkerError>) -> &'static str {
+fn code_turn_outcome(result: &Result<Turn, WorkerError>) -> &'static str {
     match result {
         Ok(turn) => turn.status.as_str(),
         Err(WorkerError::Conflict(_)) => "conflict",
@@ -3336,11 +3327,11 @@ fn code_turn_outcome(result: &Result<CodeTurn, WorkerError>) -> &'static str {
     }
 }
 
-fn code_turn_is_error(result: &Result<CodeTurn, WorkerError>) -> bool {
+fn code_turn_is_error(result: &Result<Turn, WorkerError>) -> bool {
     matches!(
         result,
-        Ok(CodeTurn {
-            status: CodeTurnStatus::Failed,
+        Ok(Turn {
+            status: TurnStatus::Failed,
             ..
         }) | Err(WorkerError::Failed(_))
     )
@@ -3361,8 +3352,8 @@ struct StagedTurnAttachments {
 /// from this one. The returned scope removes the directory on every exit.
 async fn write_turn_attachments(
     private_root: &super::scratch::ScratchRoot,
-    session_id: CodeSessionId,
-    turn_id: CodeTurnId,
+    session_id: SessionId,
+    turn_id: TurnId,
     attachments: &[tidebreak_core::ImageRef],
     images: &[TurnImage],
 ) -> std::io::Result<StagedTurnAttachments> {
@@ -3462,8 +3453,8 @@ const REPEATED_FAILURE_FENCE: u32 = 3;
 /// did not fail, so a session that recovers starts the count over.
 async fn repeated_failure_fence(
     db: &DbStore,
-    session: &CodeSession,
-    turn: &CodeTurn,
+    session: &Session,
+    turn: &Turn,
 ) -> Option<FenceReason> {
     let turns = tidebreak_core::db::code::list_turns(db, &session.owner, session.id)
         .await
@@ -3471,10 +3462,10 @@ async fn repeated_failure_fence(
     let mut count = 0u32;
     for candidate in turns.iter().rev() {
         match candidate.status {
-            CodeTurnStatus::Failed => count += 1,
+            TurnStatus::Failed => count += 1,
             // A turn still running is the one we are closing out; anything
             // else ends the streak.
-            CodeTurnStatus::Running if candidate.id == turn.id => count += 1,
+            TurnStatus::Running if candidate.id == turn.id => count += 1,
             _ => break,
         }
     }
@@ -3489,19 +3480,19 @@ async fn repeated_failure_fence(
 ///
 /// The turn row keeps no error column, so the journal is the only place the
 /// reason survives. Without it the fence would say only that turns failed.
-async fn last_failure_detail(db: &DbStore, session: &CodeSession) -> Option<String> {
+async fn last_failure_detail(db: &DbStore, session: &Session) -> Option<String> {
     let events = tidebreak_core::db::code::list_recent_events(db, &session.owner, session.id, 64)
         .await
         .ok()?;
     events.into_iter().find_map(|item| match item.event {
-        CodeEvent::TurnFailed { error, .. } => Some(error.message),
+        Event::TurnFailed { error, .. } => Some(error.message),
         _ => None,
     })
 }
 
-async fn session_was_ended(db: &DbStore, session: &mut CodeSession) -> bool {
+async fn session_was_ended(db: &DbStore, session: &mut Session) -> bool {
     match get_session(db, &session.owner, session.id).await {
-        Ok(Some(current)) if current.lifecycle == CodeSessionLifecycle::Ended => {
+        Ok(Some(current)) if current.lifecycle == SessionLifecycle::Ended => {
             *session = current;
             true
         }
@@ -3519,11 +3510,11 @@ async fn session_was_ended(db: &DbStore, session: &mut CodeSession) -> bool {
 pub(crate) async fn attach_engine(
     db: &DbStore,
     bus: &CodeEventBus,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     kind: tidebreak_core::HarnessKind,
     version: Option<String>,
     child_pid: Option<i64>,
-) -> Result<CodeSession, WorkerError> {
+) -> Result<Session, WorkerError> {
     let epoch = bump_spawn_epoch(db, session_id, child_pid)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;
@@ -3535,7 +3526,7 @@ pub(crate) async fn attach_engine(
     session.child_pid = child_pid;
     session.child_process_identity = None;
     session.harness_version = version.or(session.harness_version);
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     // Attaching an engine makes it ready for a turn, not active. Restore
     // automatic active attention left by an earlier attachment. Preserve
     // unread work and user pins.
@@ -3569,7 +3560,7 @@ pub(crate) async fn attach_engine(
             &session.owner,
             session_id,
             epoch,
-            CodeEvent::SessionStarted {
+            Event::SessionStarted {
                 harness_kind: kind,
                 harness_version: session
                     .harness_version
@@ -3612,11 +3603,11 @@ pub(crate) fn sink_for(
     db: Arc<DbStore>,
     bus: Arc<CodeEventBus>,
     owner: OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
     harness: HarnessKind,
     relay_wired: bool,
-    turn_id: Option<CodeTurnId>,
+    turn_id: Option<TurnId>,
     subagents: Vec<CodeSubagentSummary>,
     gh_search_path: Option<String>,
     recap: Option<Arc<dyn super::recap::TurnRecap>>,
@@ -3649,10 +3640,10 @@ pub(crate) async fn journal_event(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
-    event: CodeEvent,
-) -> Result<(), CodeJournalError> {
+    event: Event,
+) -> Result<(), JournalError> {
     persist_and_publish(db, bus, owner, session_id, spawn_epoch, event, false).await
 }
 
@@ -3664,11 +3655,11 @@ pub(crate) async fn persist_and_publish(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
-    event: CodeEvent,
+    event: Event,
     native_journal: bool,
-) -> Result<(), CodeJournalError> {
+) -> Result<(), JournalError> {
     persist_and_publish_inner(
         db,
         bus,
@@ -3687,12 +3678,12 @@ async fn persist_turn_and_publish(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
-    turn_id: CodeTurnId,
-    event: CodeEvent,
+    turn_id: TurnId,
+    event: Event,
     native_journal: bool,
-) -> Result<(), CodeJournalError> {
+) -> Result<(), JournalError> {
     persist_and_publish_inner(
         db,
         bus,
@@ -3711,12 +3702,12 @@ async fn persist_and_publish_inner(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
-    notification_turn_id: Option<CodeTurnId>,
-    event: CodeEvent,
+    notification_turn_id: Option<TurnId>,
+    event: Event,
     native_journal: bool,
-) -> Result<(), CodeJournalError> {
+) -> Result<(), JournalError> {
     if native_journal {
         // The row is already in the journal and on the bus; only the
         // worker's bookkeeping is left: the turn row closes with the usage
@@ -3724,10 +3715,10 @@ async fn persist_and_publish_inner(
         apply_side_effects(db, owner, session_id, spawn_epoch, &event).await?;
         if matches!(
             &event,
-            CodeEvent::TurnCompleted { .. }
-                | CodeEvent::TurnRefused { .. }
-                | CodeEvent::TurnFailed { .. }
-                | CodeEvent::TurnInterrupted { .. }
+            Event::TurnCompleted { .. }
+                | Event::TurnRefused { .. }
+                | Event::TurnFailed { .. }
+                | Event::TurnInterrupted { .. }
         ) {
             super::approval_sweep::abandon_for_settled_turns(
                 db,
@@ -3743,10 +3734,10 @@ async fn persist_and_publish_inner(
     settle_streamed_text(db, bus, owner, session_id, spawn_epoch, &event).await;
     let activity_boundary = matches!(
         &event,
-        CodeEvent::ToolStarted {
+        Event::ToolStarted {
             parent_call_id: None,
             ..
-        } | CodeEvent::ToolCompleted {
+        } | Event::ToolCompleted {
             parent_call_id: None,
             ..
         }
@@ -3768,14 +3759,14 @@ async fn persist_and_publish_inner(
     // journals keeps its later sequence number on the live stream too.
     let closes_turn = matches!(
         &event,
-        CodeEvent::TurnCompleted { .. }
-            | CodeEvent::TurnRefused { .. }
-            | CodeEvent::TurnFailed { .. }
-            | CodeEvent::TurnInterrupted { .. }
+        Event::TurnCompleted { .. }
+            | Event::TurnRefused { .. }
+            | Event::TurnFailed { .. }
+            | Event::TurnInterrupted { .. }
     );
     bus.publish(
         session_id,
-        tidebreak_core::SequencedCodeEvent { seq, event },
+        tidebreak_core::code::SequencedEvent { seq, event },
     );
     if closes_turn {
         super::approval_sweep::abandon_for_settled_turns(db, bus, owner, session_id, spawn_epoch)
@@ -3809,16 +3800,16 @@ async fn settle_streamed_text(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     spawn_epoch: i64,
-    event: &CodeEvent,
+    event: &Event,
 ) {
     if !matches!(
         event,
-        CodeEvent::TurnCompleted { .. }
-            | CodeEvent::TurnRefused { .. }
-            | CodeEvent::TurnFailed { .. }
-            | CodeEvent::TurnInterrupted { .. }
+        Event::TurnCompleted { .. }
+            | Event::TurnRefused { .. }
+            | Event::TurnFailed { .. }
+            | Event::TurnInterrupted { .. }
     ) {
         return;
     }
@@ -3826,14 +3817,14 @@ async fn settle_streamed_text(
     if streamed.is_empty() {
         return;
     }
-    let recovered = CodeEvent::AssistantMessage {
+    let recovered = Event::AssistantMessage {
         text: streamed,
         parent_call_id: None,
     };
     match append_event(db, owner, session_id, spawn_epoch, &recovered).await {
         Ok(seq) => bus.publish(
             session_id,
-            tidebreak_core::SequencedCodeEvent {
+            tidebreak_core::code::SequencedEvent {
                 seq,
                 event: recovered,
             },
@@ -3846,32 +3837,32 @@ async fn settle_streamed_text(
     }
 }
 
-fn is_activity(event: &CodeEvent) -> bool {
+fn is_activity(event: &Event) -> bool {
     matches!(
         event,
-        CodeEvent::AssistantMessage { .. }
-            | CodeEvent::ReasoningDelta { .. }
-            | CodeEvent::ToolStarted { .. }
-            | CodeEvent::ToolCompleted { .. }
-            | CodeEvent::FileChanged { .. }
-            | CodeEvent::ApprovalRequested { .. }
-            | CodeEvent::UserSteered { .. }
+        Event::AssistantMessage { .. }
+            | Event::ReasoningDelta { .. }
+            | Event::ToolStarted { .. }
+            | Event::ToolCompleted { .. }
+            | Event::FileChanged { .. }
+            | Event::ApprovalRequested { .. }
+            | Event::UserSteered { .. }
     )
 }
 
 async fn apply_side_effects(
     db: &DbStore,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     _spawn_epoch: i64,
-    event: &CodeEvent,
-) -> Result<(), CodeJournalError> {
+    event: &Event,
+) -> Result<(), JournalError> {
     match event {
-        CodeEvent::TurnCompleted {
+        Event::TurnCompleted {
             usage, checkpoint, ..
         } => {
             if let Ok(Some(mut turn)) = get_open_turn(db, owner, session_id).await {
-                turn.status = CodeTurnStatus::Completed;
+                turn.status = TurnStatus::Completed;
                 turn.ended_at = Some(Utc::now());
                 turn.usage = Some(usage.clone());
                 if let Some(hint) = checkpoint {
@@ -3883,24 +3874,24 @@ async fn apply_side_effects(
         }
         // A refusal ends the turn the way a completion does: the model
         // answered, and its answer was to decline.
-        CodeEvent::TurnRefused { usage, .. } => {
+        Event::TurnRefused { usage, .. } => {
             if let Ok(Some(mut turn)) = get_open_turn(db, owner, session_id).await {
-                turn.status = CodeTurnStatus::Completed;
+                turn.status = TurnStatus::Completed;
                 turn.ended_at = Some(Utc::now());
                 turn.usage = Some(usage.clone());
                 let _ = save_turn(db, owner, &turn).await;
             }
         }
-        CodeEvent::TurnFailed { .. } => {
+        Event::TurnFailed { .. } => {
             if let Ok(Some(mut turn)) = get_open_turn(db, owner, session_id).await {
-                turn.status = CodeTurnStatus::Failed;
+                turn.status = TurnStatus::Failed;
                 turn.ended_at = Some(Utc::now());
                 let _ = save_turn(db, owner, &turn).await;
             }
         }
-        CodeEvent::TurnInterrupted { .. } => {
+        Event::TurnInterrupted { .. } => {
             if let Ok(Some(mut turn)) = get_open_turn(db, owner, session_id).await {
-                turn.status = CodeTurnStatus::Interrupted;
+                turn.status = TurnStatus::Interrupted;
                 turn.ended_at = Some(Utc::now());
                 let _ = save_turn(db, owner, &turn).await;
             }
@@ -3940,7 +3931,7 @@ fn cap_raw(raw: &serde_json::Value) -> serde_json::Value {
     serde_json::json!({ "truncated": true, "preview": &rendered[..end] })
 }
 
-fn kind_from_raw(raw: &serde_json::Value) -> CodeApprovalKind {
+fn kind_from_raw(raw: &serde_json::Value) -> ApprovalKind {
     let input = raw
         .get("input")
         .or_else(|| raw.get("metadata"))
@@ -3952,7 +3943,7 @@ fn kind_from_raw(raw: &serde_json::Value) -> CodeApprovalKind {
         .and_then(serde_json::Value::as_str)
         .filter(|cmd| !cmd.is_empty())
     {
-        return CodeApprovalKind::Command {
+        return ApprovalKind::Command {
             cmd: cmd.to_owned(),
             cwd: raw
                 .get("cwd")
@@ -3965,7 +3956,7 @@ fn kind_from_raw(raw: &serde_json::Value) -> CodeApprovalKind {
         .and_then(serde_json::Value::as_str)
         .filter(|cmd| !cmd.is_empty())
     {
-        return CodeApprovalKind::Command {
+        return ApprovalKind::Command {
             cmd: cmd.to_owned(),
             cwd: input
                 .get("cwd")
@@ -3982,21 +3973,19 @@ fn kind_from_raw(raw: &serde_json::Value) -> CodeApprovalKind {
     let paths = approval_file_paths(raw, &input);
     let path = paths.first().map(String::as_str).unwrap_or("");
     match tool {
-        "Write" | "Edit" | "NotebookEdit" | "write" | "edit" => {
-            CodeApprovalKind::FileWrite { paths }
-        }
-        "Bash" | "bash" => CodeApprovalKind::Command {
+        "Write" | "Edit" | "NotebookEdit" | "write" | "edit" => ApprovalKind::FileWrite { paths },
+        "Bash" | "bash" => ApprovalKind::Command {
             cmd: String::new(),
             cwd: input
                 .get("cwd")
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_owned),
         },
-        "WebFetch" | "WebSearch" | "webfetch" | "websearch" => CodeApprovalKind::Network {
+        "WebFetch" | "WebSearch" | "webfetch" | "websearch" => ApprovalKind::Network {
             summary: tool.to_owned(),
         },
         "Read" | "read" | "Grep" | "grep" | "Glob" | "glob" | "NotebookRead" => {
-            CodeApprovalKind::Other {
+            ApprovalKind::Other {
                 summary: if path.is_empty() {
                     tool.to_owned()
                 } else {
@@ -4004,10 +3993,10 @@ fn kind_from_raw(raw: &serde_json::Value) -> CodeApprovalKind {
                 },
             }
         }
-        "" | "unknown" => CodeApprovalKind::Other {
+        "" | "unknown" => ApprovalKind::Other {
             summary: "The engine needs approval".to_owned(),
         },
-        other => CodeApprovalKind::Other {
+        other => ApprovalKind::Other {
             summary: other.to_owned(),
         },
     }
@@ -4066,33 +4055,33 @@ fn normalize_approval_path(path: &str, cwd: Option<&str>) -> String {
     render(path)
 }
 
-fn map_event(event: HarnessEvent, turn_id: Option<CodeTurnId>) -> Option<CodeEvent> {
+fn map_event(event: HarnessEvent, turn_id: Option<TurnId>) -> Option<Event> {
     Some(match event {
         HarnessEvent::SessionStarted {
             harness_kind,
             harness_version,
             resume_ref,
-        } => CodeEvent::SessionStarted {
+        } => Event::SessionStarted {
             harness_kind,
             harness_version,
             resume_ref,
         },
-        HarnessEvent::TurnStarted => CodeEvent::TurnStarted { turn_id: turn_id? },
-        HarnessEvent::AssistantDelta { text } => CodeEvent::AssistantDelta { text },
+        HarnessEvent::TurnStarted => Event::TurnStarted { turn_id: turn_id? },
+        HarnessEvent::AssistantDelta { text } => Event::AssistantDelta { text },
         HarnessEvent::AssistantMessage {
             text,
             parent_call_id,
-        } => CodeEvent::AssistantMessage {
+        } => Event::AssistantMessage {
             text,
             parent_call_id,
         },
-        HarnessEvent::ReasoningDelta { text } => CodeEvent::ReasoningDelta { text },
+        HarnessEvent::ReasoningDelta { text } => Event::ReasoningDelta { text },
         HarnessEvent::ToolStarted {
             call_id,
             name,
             detail,
             parent_call_id,
-        } => CodeEvent::ToolStarted {
+        } => Event::ToolStarted {
             call_id,
             name,
             detail,
@@ -4104,7 +4093,7 @@ fn map_event(event: HarnessEvent, turn_id: Option<CodeTurnId>) -> Option<CodeEve
             preview,
             detail,
             parent_call_id,
-        } => CodeEvent::ToolCompleted {
+        } => Event::ToolCompleted {
             call_id,
             outcome,
             preview,
@@ -4118,7 +4107,7 @@ fn map_event(event: HarnessEvent, turn_id: Option<CodeTurnId>) -> Option<CodeEve
             path,
             kind,
             diffstat,
-        } => CodeEvent::FileChanged {
+        } => Event::FileChanged {
             path,
             kind,
             diffstat,
@@ -4126,27 +4115,25 @@ fn map_event(event: HarnessEvent, turn_id: Option<CodeTurnId>) -> Option<CodeEve
         HarnessEvent::ApprovalRequested { .. } => {
             return None;
         }
-        HarnessEvent::ApprovalResolved { decision, .. } => CodeEvent::ApprovalResolved {
-            approval_id: CodeApprovalId::new(),
+        HarnessEvent::ApprovalResolved { decision, .. } => Event::ApprovalResolved {
+            approval_id: ApprovalId::new(),
             decision: decision.into(),
         },
-        HarnessEvent::UserSteered { text } => CodeEvent::UserSteered {
+        HarnessEvent::UserSteered { text } => Event::UserSteered {
             text,
             message_id: None,
         },
-        HarnessEvent::TurnCompleted { usage } => CodeEvent::TurnCompleted {
+        HarnessEvent::TurnCompleted { usage } => Event::TurnCompleted {
             usage,
             checkpoint: None,
             stop_reason: None,
         },
-        HarnessEvent::TurnFailed { error } => CodeEvent::TurnFailed {
+        HarnessEvent::TurnFailed { error } => Event::TurnFailed {
             error,
             detail: None,
         },
-        HarnessEvent::TurnInterrupted => CodeEvent::TurnInterrupted { usage: None },
-        HarnessEvent::HarnessNotice { level, message } => {
-            CodeEvent::HarnessNotice { level, message }
-        }
+        HarnessEvent::TurnInterrupted => Event::TurnInterrupted { usage: None },
+        HarnessEvent::HarnessNotice { level, message } => Event::HarnessNotice { level, message },
     })
 }
 

--- a/crates/tidebreak-server/src/code/session_worker/tests.rs
+++ b/crates/tidebreak-server/src/code/session_worker/tests.rs
@@ -7,8 +7,8 @@ use tidebreak_core::db::code::{
     replace_session_execution_settings, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
-    AttentionState, CodeRepo, CodeSessionKind, CodeUsage, CodeWorkspace, CodeWorkspaceStatus,
-    HarnessKind, ImageMediaType, ImageRef, PermissionMode, ReasoningEffort, RepoId, ToolDetail,
+    AttentionState, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, HarnessKind, ImageMediaType,
+    ImageRef, PermissionMode, ReasoningEffort, RepoId, SessionKind, ToolDetail, TurnUsage,
     WorkspaceId,
 };
 use tidebreak_harness::{HarnessAdapter as _, SessionSpec};
@@ -83,7 +83,7 @@ async fn seeded_session(
     tempfile::TempDir,
     Arc<DbStore>,
     Arc<CodeEventBus>,
-    CodeSessionId,
+    SessionId,
 ) {
     let directory = tempfile::tempdir().unwrap();
     let store = Arc::new(
@@ -140,14 +140,14 @@ async fn seeded_session(
     )
     .await
     .unwrap();
-    let session_id = CodeSessionId::new();
+    let session_id = SessionId::new();
     insert_session(
         &store,
-        &CodeSession {
+        &Session {
             id: session_id,
             owner: owner.clone(),
             workspace_id: Some(workspace_id),
-            kind: CodeSessionKind::Interactive,
+            kind: SessionKind::Interactive,
             harness_kind,
             harness_version: harness_version.map(str::to_owned),
             harness_resume_ref: None,
@@ -155,7 +155,7 @@ async fn seeded_session(
             model: None,
             reasoning_effort: None,
             fast_mode: false,
-            lifecycle: CodeSessionLifecycle::Running,
+            lifecycle: SessionLifecycle::Running,
             fence_reason: None,
             child_pid: None,
             child_process_identity: None,
@@ -176,12 +176,7 @@ async fn seeded_session(
     )
 }
 
-async fn seeded_sink() -> (
-    tempfile::TempDir,
-    Arc<DbStore>,
-    Arc<LiveSink>,
-    CodeSessionId,
-) {
+async fn seeded_sink() -> (tempfile::TempDir, Arc<DbStore>, Arc<LiveSink>, SessionId) {
     let (directory, store, bus, session_id) =
         seeded_session(HarnessKind::ClaudeCode, Some("2.1.237")).await;
     let sink = sink_for(
@@ -214,7 +209,7 @@ async fn an_engine_observed_decision_settles_its_own_approval_row() {
         .await
         .unwrap()
         .unwrap();
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     assert!(save_session(&store, &session).await.unwrap());
 
     let worktree = directory.path().join("wt");
@@ -228,7 +223,7 @@ async fn an_engine_observed_decision_settles_its_own_approval_row() {
         HarnessEvent::ApprovalRequested {
             harness_ref: tidebreak_harness::HarnessApprovalRef::engine("call-1"),
             raw: serde_json::Value::Null,
-            kind: Some(tidebreak_core::CodeApprovalKind::Other {
+            kind: Some(tidebreak_core::ApprovalKind::Other {
                 summary: "exec".into(),
             }),
         },
@@ -241,14 +236,14 @@ async fn an_engine_observed_decision_settles_its_own_approval_row() {
             parent_call_id: None,
         },
         HarnessEvent::TurnCompleted {
-            usage: CodeUsage::default(),
+            usage: TurnUsage::default(),
         },
     ];
     let adapter = ScriptedAdapter::new(script).with_unattended_approvals();
     let engine = adapter
         .launch(SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree,
             allowed_read_roots: Vec::new(),
             permission_mode: session.permission_mode,
@@ -296,13 +291,13 @@ async fn an_engine_observed_decision_settles_its_own_approval_row() {
         .expect("the turn completes")
         .unwrap()
         .unwrap();
-    assert_eq!(turn.status, CodeTurnStatus::Completed);
+    assert_eq!(turn.status, TurnStatus::Completed);
 
     let approvals = list_approvals(&store, &owner, None, Some(session_id))
         .await
         .unwrap();
     assert_eq!(approvals.len(), 1);
-    assert_eq!(approvals[0].state, CodeApprovalState::Approved);
+    assert_eq!(approvals[0].state, ApprovalState::Approved);
     assert_eq!(approvals[0].native_call_id.as_deref(), Some("call-1"));
     let events = list_events(&store, &owner, session_id, 0, MAX_REPLAY_EVENTS)
         .await
@@ -310,7 +305,7 @@ async fn an_engine_observed_decision_settles_its_own_approval_row() {
     assert!(
         events.events.iter().any(|event| matches!(
             &event.event,
-            CodeEvent::ApprovalResolved {
+            Event::ApprovalResolved {
                 approval_id,
                 decision: tidebreak_core::ApprovalDecisionKind::Approve,
             } if *approval_id == approvals[0].id
@@ -348,13 +343,13 @@ async fn a_send_over_an_internal_turn_waiting_on_a_client_is_refused() {
         .await
         .unwrap()
         .unwrap();
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     assert!(save_session(&store, &session).await.unwrap());
-    let waiting = CodeTurn {
-        id: CodeTurnId::new(),
+    let waiting = Turn {
+        id: TurnId::new(),
         session_id,
         ordinal: 1,
-        status: CodeTurnStatus::WaitingForClient,
+        status: TurnStatus::WaitingForClient,
         model: None,
         fast_mode: false,
         user_input: "needs the client".into(),
@@ -381,7 +376,7 @@ async fn a_send_over_an_internal_turn_waiting_on_a_client_is_refused() {
     let adapter = ScriptedAdapter::new(vec![
         HarnessEvent::TurnStarted,
         HarnessEvent::TurnCompleted {
-            usage: CodeUsage::default(),
+            usage: TurnUsage::default(),
         },
     ]);
     let engine = adapter
@@ -447,7 +442,7 @@ async fn a_send_over_an_internal_turn_waiting_on_a_client_is_refused() {
     }
     let turns = list_turns(&store, &owner, session_id).await.unwrap();
     assert_eq!(turns.len(), 1, "no second row was inserted: {turns:?}");
-    assert_eq!(turns[0].status, CodeTurnStatus::WaitingForClient);
+    assert_eq!(turns[0].status, TurnStatus::WaitingForClient);
     let _ = handle.commands.send(WorkerCommand::Shutdown).await;
 }
 
@@ -459,7 +454,7 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
         .await
         .unwrap()
         .unwrap();
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     assert!(save_session(&store, &session).await.unwrap());
 
     let worktree = directory.path().join("wt");
@@ -480,7 +475,7 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
             parent_call_id: None,
         },
         HarnessEvent::TurnCompleted {
-            usage: CodeUsage::default(),
+            usage: TurnUsage::default(),
         },
     ];
     // The engine checkpoints after the request instead of blocking on it.
@@ -496,7 +491,7 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
     let engine = adapter
         .launch(SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree,
             allowed_read_roots: Vec::new(),
             permission_mode: session.permission_mode,
@@ -544,7 +539,7 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
     let parked = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let turns = list_turns(&store, &owner, session_id).await.unwrap();
-            if let Some(turn) = turns.iter().find(|t| t.status == CodeTurnStatus::Waiting) {
+            if let Some(turn) = turns.iter().find(|t| t.status == TurnStatus::Waiting) {
                 break turn.clone();
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
@@ -577,7 +572,7 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
         .expect("the turn completes after the resume")
         .unwrap()
         .unwrap();
-    assert_eq!(turn.status, CodeTurnStatus::Completed);
+    assert_eq!(turn.status, TurnStatus::Completed);
     assert_eq!(turn.park_ref, None, "the resume clears the park");
     assert_eq!(turn.park_wait, None);
     assert_eq!(adapter.resumes().len(), 1, "one resume for one park");
@@ -588,7 +583,7 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
         events
             .events
             .iter()
-            .any(|event| matches!(event.event, CodeEvent::TurnCompleted { .. })),
+            .any(|event| matches!(event.event, Event::TurnCompleted { .. })),
         "the resumed leg reaches the journal"
     );
     let _ = handle.commands.send(WorkerCommand::Shutdown).await;
@@ -628,7 +623,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
             .await
             .unwrap()
             .unwrap();
-        session.lifecycle = CodeSessionLifecycle::Idle;
+        session.lifecycle = SessionLifecycle::Idle;
         assert!(save_session(&store, &session).await.unwrap());
 
         let worktree = directory.path().join("wt");
@@ -642,7 +637,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
                 parent_call_id: None,
             },
             HarnessEvent::TurnCompleted {
-                usage: CodeUsage::default(),
+                usage: TurnUsage::default(),
             },
         ])
         .with_parked_turn(1, park_ref.clone(), waiting_on.clone());
@@ -696,7 +691,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
         let parked = tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 if let Some(turn) = get_open_turn(&store, &owner, session_id).await.unwrap() {
-                    if turn.status == CodeTurnStatus::Waiting {
+                    if turn.status == TurnStatus::Waiting {
                         break turn;
                     }
                 }
@@ -756,7 +751,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
             .await
             .unwrap()
             .unwrap();
-        resolved.status = CodeTurnStatus::Resuming;
+        resolved.status = TurnStatus::Resuming;
         assert!(save_turn(&store, &owner, &resolved).await.unwrap());
 
         let completed = tokio::time::timeout(Duration::from_secs(5), async {
@@ -765,7 +760,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
                     .await
                     .unwrap()
                     .unwrap();
-                if turn.status == CodeTurnStatus::Completed {
+                if turn.status == TurnStatus::Completed {
                     break turn;
                 }
                 tokio::time::sleep(Duration::from_millis(20)).await;
@@ -792,7 +787,7 @@ async fn a_decision_on_the_running_leg_resumes_the_park() {
         .await
         .unwrap()
         .unwrap();
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     assert!(save_session(&store, &session).await.unwrap());
 
     let worktree = directory.path().join("wt");
@@ -818,7 +813,7 @@ async fn a_decision_on_the_running_leg_resumes_the_park() {
             parent_call_id: None,
         },
         HarnessEvent::TurnCompleted {
-            usage: CodeUsage::default(),
+            usage: TurnUsage::default(),
         },
     ];
     let adapter = ScriptedAdapter::new(script)
@@ -835,7 +830,7 @@ async fn a_decision_on_the_running_leg_resumes_the_park() {
     let engine = adapter
         .launch(SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree,
             allowed_read_roots: Vec::new(),
             permission_mode: session.permission_mode,
@@ -884,7 +879,7 @@ async fn a_decision_on_the_running_leg_resumes_the_park() {
             let pending = list_approvals(
                 &store,
                 &owner,
-                Some(CodeApprovalState::Pending),
+                Some(ApprovalState::Pending),
                 Some(session_id),
             )
             .await
@@ -899,9 +894,7 @@ async fn a_decision_on_the_running_leg_resumes_the_park() {
     .expect("the approval is published");
     let turns = list_turns(&store, &owner, session_id).await.unwrap();
     assert!(
-        turns
-            .iter()
-            .any(|turn| turn.status == CodeTurnStatus::Running),
+        turns.iter().any(|turn| turn.status == TurnStatus::Running),
         "Decide must reach the opening leg while the turn is still running"
     );
 
@@ -922,7 +915,7 @@ async fn a_decision_on_the_running_leg_resumes_the_park() {
         .expect("the turn completes from the already-delivered decision")
         .unwrap()
         .unwrap();
-    assert_eq!(turn.status, CodeTurnStatus::Completed);
+    assert_eq!(turn.status, TurnStatus::Completed);
     assert_eq!(turn.park_ref, None, "the resume clears the park");
     assert_eq!(turn.park_wait, None);
     assert_eq!(adapter.resumes().len(), 1, "one resume for one park");
@@ -937,7 +930,7 @@ async fn an_interrupt_closes_a_parked_turn() {
         .await
         .unwrap()
         .unwrap();
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     assert!(save_session(&store, &session).await.unwrap());
     let worktree = directory.path().join("wt");
     std::fs::create_dir_all(&worktree).unwrap();
@@ -955,7 +948,7 @@ async fn an_interrupt_closes_a_parked_turn() {
     let engine = adapter
         .launch(SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree,
             allowed_read_roots: Vec::new(),
             permission_mode: session.permission_mode,
@@ -1000,7 +993,7 @@ async fn an_interrupt_closes_a_parked_turn() {
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             if let Some(turn) = get_open_turn(&store, &owner, session_id).await.unwrap() {
-                if turn.status == CodeTurnStatus::Waiting {
+                if turn.status == TurnStatus::Waiting {
                     break;
                 }
             }
@@ -1021,7 +1014,7 @@ async fn an_interrupt_closes_a_parked_turn() {
         .expect("the parked turn closes")
         .unwrap()
         .unwrap();
-    assert_eq!(turn.status, CodeTurnStatus::Interrupted);
+    assert_eq!(turn.status, TurnStatus::Interrupted);
     let _ = handle.commands.send(WorkerCommand::Shutdown).await;
 }
 
@@ -1033,9 +1026,9 @@ async fn a_confirmed_setting_reservation_wins_over_an_already_queued_idle_turn()
         .await
         .unwrap()
         .unwrap();
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     assert!(save_session(&store, &session).await.unwrap());
-    let stale = CodeSessionExecutionSettings {
+    let stale = SessionExecutionSettings {
         model: Some("stale".into()),
         reasoning_effort: Some(ReasoningEffort::High),
         fast_mode: true,
@@ -1055,7 +1048,7 @@ async fn a_confirmed_setting_reservation_wins_over_an_already_queued_idle_turn()
     let engine = adapter
         .launch(SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree,
             allowed_read_roots: Vec::new(),
             permission_mode: session.permission_mode,
@@ -1087,7 +1080,7 @@ async fn a_confirmed_setting_reservation_wins_over_an_already_queued_idle_turn()
         tokio::sync::watch::channel(false).1,
     );
 
-    let committed = CodeSessionExecutionSettings {
+    let committed = SessionExecutionSettings {
         model: Some("committed".into()),
         reasoning_effort: None,
         fast_mode: false,
@@ -1147,9 +1140,9 @@ async fn a_queued_turn_uses_a_later_setting_committed_before_promotion() {
         .await
         .unwrap()
         .unwrap();
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     assert!(save_session(&store, &session).await.unwrap());
-    let held = CodeSessionExecutionSettings {
+    let held = SessionExecutionSettings {
         model: Some("held".into()),
         reasoning_effort: Some(ReasoningEffort::High),
         fast_mode: true,
@@ -1169,7 +1162,7 @@ async fn a_queued_turn_uses_a_later_setting_committed_before_promotion() {
     let engine = adapter
         .launch(SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree,
             allowed_read_roots: Vec::new(),
             permission_mode: session.permission_mode,
@@ -1192,8 +1185,8 @@ async fn a_queued_turn_uses_a_later_setting_committed_before_promotion() {
     enqueue_queued_turn(
         &store,
         &owner,
-        &CodeQueuedTurn {
-            id: CodeTurnId::new(),
+        &QueuedTurn {
+            id: TurnId::new(),
             session_id,
             message: "use the held settings".into(),
             attachments: Vec::new(),
@@ -1219,7 +1212,7 @@ async fn a_queued_turn_uses_a_later_setting_committed_before_promotion() {
         tokio::sync::watch::channel(false).1,
     );
 
-    let later = CodeSessionExecutionSettings {
+    let later = SessionExecutionSettings {
         model: Some("later".into()),
         reasoning_effort: None,
         fast_mode: false,
@@ -1250,7 +1243,7 @@ async fn a_queued_turn_uses_a_later_setting_committed_before_promotion() {
             let turns = list_turns(&store, &owner, session_id).await.unwrap();
             if let Some(turn) = turns
                 .into_iter()
-                .find(|turn| turn.status != CodeTurnStatus::Running && !turn.user_input.is_empty())
+                .find(|turn| turn.status != TurnStatus::Running && !turn.user_input.is_empty())
             {
                 return turn;
             }
@@ -1284,7 +1277,7 @@ async fn codex_attachment_journals_one_start_after_the_thread_is_known() {
     .unwrap();
     let owner = OwnerId::local();
     assert_eq!(attached.harness_version.as_deref(), Some("0.147.0"));
-    assert_eq!(attached.lifecycle, CodeSessionLifecycle::Idle);
+    assert_eq!(attached.lifecycle, SessionLifecycle::Idle);
     assert_eq!(attached.attention.state, AttentionState::Idle);
     assert_eq!(
         get_session(&store, &owner, session_id)
@@ -1302,7 +1295,7 @@ async fn codex_attachment_journals_one_start_after_the_thread_is_known() {
             .unwrap()
             .events
             .iter()
-            .all(|event| !matches!(&event.event, CodeEvent::SessionStarted { .. }))
+            .all(|event| !matches!(&event.event, Event::SessionStarted { .. }))
     );
 
     let sink = sink_for(
@@ -1334,7 +1327,7 @@ async fn codex_attachment_journals_one_start_after_the_thread_is_known() {
         .events
         .into_iter()
         .filter_map(|event| match event.event {
-            CodeEvent::SessionStarted {
+            Event::SessionStarted {
                 harness_kind,
                 harness_version,
                 resume_ref,
@@ -1373,7 +1366,7 @@ async fn engine_attachment_preserves_unreviewed_work() {
     .await
     .unwrap();
 
-    assert_eq!(attached.lifecycle, CodeSessionLifecycle::Idle);
+    assert_eq!(attached.lifecycle, SessionLifecycle::Idle);
     assert_eq!(attached.attention, unreviewed);
     assert_eq!(
         get_session(&store, &owner, session_id)
@@ -1408,7 +1401,7 @@ async fn non_codex_attachment_keeps_the_eager_session_start() {
     assert_eq!(
         events
             .iter()
-            .filter(|event| matches!(&event.event, CodeEvent::SessionStarted { .. }))
+            .filter(|event| matches!(&event.event, Event::SessionStarted { .. }))
             .count(),
         1
     );
@@ -1421,7 +1414,7 @@ async fn sink_settles_unclosed_tasks_at_each_terminal_parent_boundary() {
         (
             "completed",
             HarnessEvent::TurnCompleted {
-                usage: CodeUsage::default(),
+                usage: TurnUsage::default(),
             },
             CodeSubagentStatus::Done,
         ),
@@ -1576,7 +1569,7 @@ async fn a_failed_pre_turn_attachment_sweep_fences_the_session() {
     let private_root =
         super::super::scratch::ScratchRoot::open_for_test(&private_path).expect("scratch root");
     let attachment_root = private_root.path().join(ATTACHMENTS_DIR);
-    let leftover = attachment_root.join(CodeSessionId::new().to_string());
+    let leftover = attachment_root.join(SessionId::new().to_string());
     std::fs::create_dir_all(&leftover).unwrap();
     std::fs::write(leftover.join("private.png"), b"private").unwrap();
     std::fs::set_permissions(&attachment_root, std::fs::Permissions::from_mode(0o500)).unwrap();
@@ -1594,7 +1587,7 @@ async fn a_failed_pre_turn_attachment_sweep_fences_the_session() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(stored.lifecycle, CodeSessionLifecycle::Fenced);
+    assert_eq!(stored.lifecycle, SessionLifecycle::Fenced);
     assert!(matches!(
         stored.fence_reason,
         Some(FenceReason::ProbeAmbiguous { ref detail })
@@ -1639,7 +1632,7 @@ fn kind_from_raw_reads_codex_and_opencode_payloads() {
             "command": "/bin/zsh -lc rg foo",
             "cwd": "/workspace",
         })),
-        CodeApprovalKind::Command {
+        ApprovalKind::Command {
             cmd: "/bin/zsh -lc rg foo".into(),
             cwd: Some("/workspace".into()),
         }
@@ -1649,7 +1642,7 @@ fn kind_from_raw_reads_codex_and_opencode_payloads() {
             "permission": "bash",
             "metadata": { "command": "rg foo" },
         })),
-        CodeApprovalKind::Command {
+        ApprovalKind::Command {
             cmd: "rg foo".into(),
             cwd: None,
         }
@@ -1663,7 +1656,7 @@ fn kind_from_raw_reads_codex_and_opencode_payloads() {
             },
             "patterns": ["docs/approval.md", "*.md"]
         })),
-        CodeApprovalKind::FileWrite {
+        ApprovalKind::FileWrite {
             paths: vec!["/worktree/docs/approval.md".into()],
         }
     );
@@ -1673,7 +1666,7 @@ fn kind_from_raw_reads_codex_and_opencode_payloads() {
             "cwd": "/worktree",
             "patterns": ["docs/fallback.md", "*"]
         })),
-        CodeApprovalKind::FileWrite {
+        ApprovalKind::FileWrite {
             paths: vec!["/worktree/docs/fallback.md".into()],
         }
     );
@@ -1682,20 +1675,20 @@ fn kind_from_raw_reads_codex_and_opencode_payloads() {
             "permission": "edit",
             "patterns": ["*"]
         })),
-        CodeApprovalKind::FileWrite { paths: Vec::new() }
+        ApprovalKind::FileWrite { paths: Vec::new() }
     );
     assert_eq!(
         kind_from_raw(&serde_json::json!({
             "tool_name": "Read",
             "input": { "file_path": "/workspace/README.md" },
         })),
-        CodeApprovalKind::Other {
+        ApprovalKind::Other {
             summary: "Read /workspace/README.md".into(),
         }
     );
     assert_eq!(
         kind_from_raw(&serde_json::Value::Null),
-        CodeApprovalKind::Other {
+        ApprovalKind::Other {
             summary: "The engine needs approval".into(),
         }
     );
@@ -1706,8 +1699,8 @@ async fn fallback_images_live_only_in_the_session_turn_scope() {
     let private = tempfile::tempdir().unwrap();
     let private_root =
         super::super::scratch::ScratchRoot::open_for_test(private.path()).expect("scratch root");
-    let session_id = CodeSessionId::new();
-    let turn_id = CodeTurnId::new();
+    let session_id = SessionId::new();
+    let turn_id = TurnId::new();
     let attachment = ImageRef {
         blob_id: uuid::Uuid::new_v4(),
         media_type: ImageMediaType::Png,
@@ -1829,7 +1822,7 @@ async fn an_update_quiesce_refuses_new_turns_until_resumed() {
         .await
         .unwrap()
         .unwrap();
-    session.lifecycle = CodeSessionLifecycle::Idle;
+    session.lifecycle = SessionLifecycle::Idle;
     assert!(save_session(&store, &session).await.unwrap());
 
     let worktree = directory.path().join("wt");
@@ -1842,7 +1835,7 @@ async fn an_update_quiesce_refuses_new_turns_until_resumed() {
     let engine = adapter
         .launch(SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree,
             allowed_read_roots: Vec::new(),
             permission_mode: session.permission_mode,

--- a/crates/tidebreak-server/src/code/terminal.rs
+++ b/crates/tidebreak-server/src/code/terminal.rs
@@ -47,7 +47,7 @@ const TERMINAL_EXIT_GRACE: Duration = Duration::from_secs(5);
 pub(crate) struct TerminalHub {
     inner: Mutex<HubInner>,
     /// One notice channel per owner. Terminal activity rides
-    /// `/code/updates`, so it is partitioned the same way the digests are:
+    /// `/updates`, so it is partitioned the same way the digests are:
     /// a subscriber's receiver only ever carries its own owner's notices.
     notices: Mutex<HashMap<OwnerId, broadcast::Sender<TerminalNotice>>>,
 }

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -19,7 +19,7 @@
 use std::sync::Arc;
 
 use tidebreak_core::db::code::{get_session, get_workspace, set_workspace_title_if};
-use tidebreak_core::{CodeSessionId, CodeWorkspaceStatus, OwnerId, Result, WorkspaceId};
+use tidebreak_core::{CodeWorkspaceStatus, OwnerId, Result, SessionId, WorkspaceId};
 
 use crate::chat_titling::{
     derive_text_with_retries, head, TitleProposal, MAX_TITLE_SOURCE_MESSAGE_BYTES,
@@ -83,7 +83,7 @@ pub(crate) async fn propose_for_creation(
 pub(crate) fn spawn_for_turn(
     state: &AppState,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     message: String,
 ) {
     let Some(code) = state.code.clone() else {
@@ -119,7 +119,7 @@ async fn derive_workspace_title(
     state: &AppState,
     code: &Arc<CodeRuntime>,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     message: &str,
 ) -> Result<Outcome> {
     let Some(session) = get_session(&code.db, owner, session_id).await? else {

--- a/crates/tidebreak-server/src/code/trigger.rs
+++ b/crates/tidebreak-server/src/code/trigger.rs
@@ -25,12 +25,11 @@ use tidebreak_core::db::code::{
     reschedule_trigger_fire_delivery_failure, trigger_delivery_accepted, trigger_fire_heads_for_pr,
 };
 use tidebreak_core::{
-    classify_trigger_condition, Attention, AttentionSource, CapLevel, CodeEvent,
-    CodePullRequestFact, CodePullRequestId, CodeSession, CodeSessionId, CodeSessionKind,
-    CodeSessionLifecycle, CodeTrigger, CodeTriggerAction, CodeTriggerCondition,
-    CodeTriggerDeliveryId, CodeTriggerFire, CodeTriggerFireIdentity, CodeTriggerFirePayload,
-    CodeTurnId, CodeWorkspaceStatus, HarnessNoticeLevel, OwnerId, PullRequestDigest, RepoId,
-    WorkspaceId,
+    classify_trigger_condition, Attention, AttentionSource, CapLevel, CodePullRequestFact,
+    CodePullRequestId, CodeTrigger, CodeTriggerAction, CodeTriggerCondition, CodeTriggerDeliveryId,
+    CodeTriggerFire, CodeTriggerFireIdentity, CodeTriggerFirePayload, CodeWorkspaceStatus, Event,
+    HarnessNoticeLevel, OwnerId, PullRequestDigest, RepoId, Session, SessionId, SessionKind,
+    SessionLifecycle, TurnId, WorkspaceId,
 };
 use tracing::{debug, warn};
 
@@ -707,17 +706,17 @@ async fn claim_fires(
 enum Delivery {
     /// Interrupt the turn already running. Only where the harness declares it.
     Steer {
-        session_id: CodeSessionId,
-        turn_id: CodeTurnId,
+        session_id: SessionId,
+        turn_id: TurnId,
     },
     /// Submit a turn. The workspace is quiet, so nothing is contended.
-    Turn { session_id: CodeSessionId },
+    Turn { session_id: SessionId },
     /// Raise attention and leave the session alone.
-    Notify { session_id: CodeSessionId },
+    Notify { session_id: SessionId },
 }
 
 impl Delivery {
-    fn session_id(self) -> CodeSessionId {
+    fn session_id(self) -> SessionId {
         match self {
             Self::Steer { session_id, .. }
             | Self::Turn { session_id }
@@ -970,7 +969,7 @@ async fn plan_delivery(
     // outbox pending so a later lease delivers it.
     let busy = sessions
         .iter()
-        .any(|session| session.lifecycle == CodeSessionLifecycle::Running);
+        .any(|session| session.lifecycle == SessionLifecycle::Running);
     if !busy {
         return Ok(Some(Delivery::Turn {
             session_id: target.id,
@@ -978,7 +977,7 @@ async fn plan_delivery(
     }
 
     // Busy: steering is the only way in, and only where the engine takes it.
-    if target.lifecycle != CodeSessionLifecycle::Running {
+    if target.lifecycle != SessionLifecycle::Running {
         return Ok(None);
     }
     let adapter = runtime.adapter(target.harness_kind)?;
@@ -1004,16 +1003,16 @@ async fn plan_delivery(
 async fn most_recently_active(
     runtime: &Arc<CodeRuntime>,
     owner: &OwnerId,
-    sessions: &[CodeSession],
-) -> Result<Option<CodeSession>, ServerError> {
-    let mut best: Option<(chrono::DateTime<chrono::Utc>, CodeSession)> = None;
+    sessions: &[Session],
+) -> Result<Option<Session>, ServerError> {
+    let mut best: Option<(chrono::DateTime<chrono::Utc>, Session)> = None;
     for session in sessions {
-        if session.kind != CodeSessionKind::Interactive {
+        if session.kind != SessionKind::Interactive {
             continue;
         }
         if matches!(
             session.lifecycle,
-            CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+            SessionLifecycle::Ended | SessionLifecycle::Fenced
         ) {
             continue;
         }
@@ -1106,7 +1105,7 @@ fn describe_condition(condition: CodeTriggerCondition, number: u64) -> String {
 async fn note_fire(
     runtime: &Arc<CodeRuntime>,
     owner: &OwnerId,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     identity: &CodeTriggerFireIdentity,
     condition: CodeTriggerCondition,
 ) {
@@ -1119,7 +1118,7 @@ async fn note_fire(
         owner,
         session_id,
         session.spawn_epoch,
-        CodeEvent::HarnessNotice {
+        Event::HarnessNotice {
             level: HarnessNoticeLevel::Info,
             message: format!(
                 "trigger {} fired: {}",

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -1,7 +1,7 @@
 //! Durable watch tasks: a server-side loop that keeps one workspace's pull
 //! request moving until it merges or genuinely needs the user.
 //!
-//! The watch owns a dedicated [`CodeSessionKind::Watch`] session in the same
+//! The watch owns a dedicated [`SessionKind::Watch`] session in the same
 //! worktree as the conversation it forked from. Each sweep reads the PR
 //! digest through the normal `workspace_pr` path (so the updates channel sees
 //! every read), classifies it, and either waits, submits one bounded fix
@@ -26,9 +26,9 @@ use tidebreak_core::db::code::{
     release_watch_submission, reserve_watch_submission, save_watch, WatchSubmissionClaim,
 };
 use tidebreak_core::{
-    Attention, AttentionSource, AttentionState, CodeSession, CodeSessionKind, CodeSessionLifecycle,
-    CodeWatch, CodeWatchId, CodeWatchState, CodeWorkspaceStatus, HarnessKind, OwnerId,
-    PermissionMode, PullRequestDigest, WorkspaceId,
+    Attention, AttentionSource, AttentionState, CodeWatch, CodeWatchId, CodeWatchState,
+    CodeWorkspaceStatus, HarnessKind, OwnerId, PermissionMode, PullRequestDigest, Session,
+    SessionKind, SessionLifecycle, WorkspaceId,
 };
 
 use super::attention::{apply_attention, emit_workspace_digests};
@@ -258,12 +258,12 @@ pub(crate) fn fix_turn_instruction(reason: WatchReason, pr: &PullRequestDigest) 
 }
 
 fn watch_session_settings(
-    sessions: &[CodeSession],
+    sessions: &[Session],
     permission_mode_ceiling: Option<PermissionMode>,
 ) -> Result<(HarnessKind, NewSessionSettings), ServerError> {
     let (harness, model, permission_mode) = sessions
         .iter()
-        .find(|session| session.kind == CodeSessionKind::Interactive)
+        .find(|session| session.kind == SessionKind::Interactive)
         .map(|session| {
             (
                 session.harness_kind,
@@ -348,13 +348,7 @@ impl CodeRuntime {
             _ => {}
         }
         let session = self
-            .create_session_of_kind(
-                owner,
-                workspace_id,
-                CodeSessionKind::Watch,
-                harness,
-                settings,
-            )
+            .create_session_of_kind(owner, workspace_id, SessionKind::Watch, harness, settings)
             .await?;
         let now = Utc::now();
         let watch = CodeWatch {
@@ -446,7 +440,7 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
         .await;
     };
     match session.lifecycle {
-        CodeSessionLifecycle::Ended => {
+        SessionLifecycle::Ended => {
             return finish_watch(
                 runtime.as_ref(),
                 watch,
@@ -455,7 +449,7 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
             )
             .await;
         }
-        CodeSessionLifecycle::Fenced => {
+        SessionLifecycle::Fenced => {
             return finish_watch(
                 runtime.as_ref(),
                 watch,
@@ -467,9 +461,7 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
         // A running fix turn no longer skips the sweep: the state read below
         // still happens, and only the transitions that need an idle worktree
         // hold (decision 66).
-        CodeSessionLifecycle::Running
-        | CodeSessionLifecycle::Created
-        | CodeSessionLifecycle::Idle => {}
+        SessionLifecycle::Running | SessionLifecycle::Created | SessionLifecycle::Idle => {}
     }
     if reconcile_watch_submission(runtime, watch, &session).await? {
         return Ok(());
@@ -504,7 +496,7 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
     let sessions = list_sessions_for_workspace(&runtime.db, &owner, watch.workspace_id).await?;
     let turn_in_flight = sessions
         .iter()
-        .any(|other| other.lifecycle == CodeSessionLifecycle::Running);
+        .any(|other| other.lifecycle == SessionLifecycle::Running);
     // The store answers first (decision 66): the reconcile sweep's one list
     // read per repository keeps the live tier fresh, and write-through keeps
     // the workspace column equal to it. Only a missing or stale tier pays a
@@ -758,12 +750,12 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
 async fn reconcile_watch_submission(
     runtime: &CodeRuntime,
     watch: &mut CodeWatch,
-    session: &tidebreak_core::CodeSession,
+    session: &tidebreak_core::Session,
 ) -> Result<bool, ServerError> {
     let Some(reservation) = watch_submission_reservation(watch) else {
         return Ok(false);
     };
-    let accepted = session.lifecycle == CodeSessionLifecycle::Running
+    let accepted = session.lifecycle == SessionLifecycle::Running
         || watch_submission_was_accepted(runtime, &watch.owner, watch.session_id, watch.updated_at)
             .await?;
     let reservation_detail = watch.detail.clone().unwrap_or_default();
@@ -815,7 +807,7 @@ async fn reconcile_watch_submission(
 async fn watch_submission_was_accepted(
     runtime: &CodeRuntime,
     owner: &OwnerId,
-    session_id: tidebreak_core::CodeSessionId,
+    session_id: tidebreak_core::SessionId,
     reserved_at: chrono::DateTime<Utc>,
 ) -> Result<bool, ServerError> {
     if list_queued_turns(&runtime.db, owner, session_id)
@@ -997,7 +989,7 @@ mod tests {
     #[test]
     fn watch_inherits_the_newest_interactive_session_settings() {
         let mut watch = crate::code::remote::fixtures::session_value();
-        watch.kind = CodeSessionKind::Watch;
+        watch.kind = SessionKind::Watch;
         watch.harness_kind = HarnessKind::Grok;
         watch.permission_mode = PermissionMode::Plan;
         watch.model = Some("watch-model".to_owned());
@@ -1027,7 +1019,7 @@ mod tests {
     #[test]
     fn watch_without_an_interactive_session_uses_auto() {
         let mut watch = crate::code::remote::fixtures::session_value();
-        watch.kind = CodeSessionKind::Watch;
+        watch.kind = SessionKind::Watch;
 
         let (harness, settings) =
             watch_session_settings(&[watch], Some(PermissionMode::Auto)).unwrap();
@@ -1182,7 +1174,7 @@ mod tests {
             id: CodeWatchId::new(),
             owner: OwnerId::local(),
             workspace_id: WorkspaceId::new(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             pr_number: 12,
             state: CodeWatchState::Blocked,
             detail: Some(reason.to_owned()),
@@ -1306,7 +1298,7 @@ mod tests {
             id: CodeWatchId::new(),
             owner: OwnerId::local(),
             workspace_id: WorkspaceId::new(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             pr_number: 12,
             state: CodeWatchState::Fixing,
             detail: Some(watch_submission_detail(
@@ -1344,7 +1336,7 @@ mod tests {
             id: CodeWatchId::new(),
             owner: OwnerId::local(),
             workspace_id: WorkspaceId::new(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             pr_number: 12,
             state: CodeWatchState::Fixing,
             detail: Some(watch_submission_detail(

--- a/crates/tidebreak-server/src/code_execution/config.rs
+++ b/crates/tidebreak-server/src/code_execution/config.rs
@@ -13,7 +13,9 @@ use tidebreak_code_execution::{
     LocalExecutionProvider, RemoteSessionPool, DAYTONA_CREDENTIAL_KEY, E2B_CREDENTIAL_KEY,
     PACKAGE_MANAGER_DOMAINS,
 };
-use tidebreak_core::{ChatId, HostRootId, NetworkPolicy, ProjectId, Result, SecretProvider, Store};
+use tidebreak_core::{
+    HostRootId, NetworkPolicy, ProjectId, Result, SecretProvider, SessionId, Store,
+};
 use tidebreak_egress::{
     CidrBlock, DomainPattern, EgressAllowlist, EgressEnforcement, EgressError, EgressPolicy,
 };
@@ -116,7 +118,7 @@ pub(super) fn network_egress_config(policy: &NetworkPolicy) -> EgressConfig {
 /// Exact product attachment projection sent to the trusted desktop host.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecFolderGrantQuery {
-    pub chat_id: ChatId,
+    pub chat_id: SessionId,
     pub project_id: Option<ProjectId>,
     pub root_ids: Vec<HostRootId>,
 }

--- a/crates/tidebreak-server/src/code_execution/provider.rs
+++ b/crates/tidebreak-server/src/code_execution/provider.rs
@@ -16,8 +16,8 @@ use tidebreak_code_execution::{
     WorkspaceLifecycle, WorkspaceListing, WriteOverlay, WriteSnapshotSink, PACKAGE_CACHE_DIR,
 };
 use tidebreak_core::{
-    BlobStore, CallId, Chat, ChatId, ExecFileRejectionReason, ExecFileRejectionRecord, HostRootId,
-    NetworkPolicy, RevisionProducer, SecretProvider, Store, TurnId,
+    BlobStore, CallId, Chat, ExecFileRejectionReason, ExecFileRejectionRecord, HostRootId,
+    NetworkPolicy, RevisionProducer, SecretProvider, SessionId, Store, TurnId,
 };
 
 use crate::exec_write_snapshot::TurnSnapshotSink;
@@ -85,7 +85,7 @@ pub struct ConfiguredExecProvider {
     /// A turn opens one entry when it resolves its folder grants and closes it
     /// when the turn ends; every `exec` in between finds it here and points the
     /// sandbox at the staged copy instead of the user's folder.
-    write_overlays: Mutex<HashMap<ChatId, StagedTurn>>,
+    write_overlays: Mutex<HashMap<SessionId, StagedTurn>>,
     /// The supported Python runtime selected for local execution and package
     /// caching once per process. `None` leaves the system interpreter in place
     /// and disables the shared cache.
@@ -110,7 +110,7 @@ pub struct ConfiguredExecProvider {
     /// built per execution — so without this the same warning would land on
     /// every card that recreates a sandbox. Warning once per chat is what a
     /// reader needs: the second card says nothing new.
-    degradation_reported: Mutex<HashSet<ChatId>>,
+    degradation_reported: Mutex<HashSet<SessionId>>,
 }
 
 /// Publishes a provider's first-run image preparation to the chat that is
@@ -123,7 +123,7 @@ impl tidebreak_code_execution::SandboxPreparationSink for SandboxPreparationNoti
     fn report(&self, workspace_id: &str, stage: tidebreak_code_execution::SandboxPreparation) {
         // The workspace identity is the chat's; a workspace that does not name
         // one has no window to tell, and the execution itself proceeds.
-        let Ok(chat) = workspace_id.parse::<ChatId>() else {
+        let Ok(chat) = workspace_id.parse::<SessionId>() else {
             return;
         };
         self.events.publish_metadata(
@@ -137,7 +137,7 @@ impl tidebreak_code_execution::SandboxPreparationSink for SandboxPreparationNoti
 
 #[async_trait]
 impl StagedFolders for ConfiguredExecProvider {
-    fn staged_root(&self, chat: ChatId, root_id: HostRootId) -> Option<PathBuf> {
+    fn staged_root(&self, chat: SessionId, root_id: HostRootId) -> Option<PathBuf> {
         self.write_overlays
             .lock()
             .expect("write overlay registry is not poisoned")
@@ -149,7 +149,7 @@ impl StagedFolders for ConfiguredExecProvider {
 
     async fn materialize_connected_file(
         &self,
-        chat: ChatId,
+        chat: SessionId,
         turn: TurnId,
         root_id: HostRootId,
         relative: &str,
@@ -191,7 +191,7 @@ impl StagedFolders for ConfiguredExecProvider {
 
     async fn connected_file_matches(
         &self,
-        chat: ChatId,
+        chat: SessionId,
         root_id: HostRootId,
         relative: &str,
         byte_len: u64,
@@ -640,7 +640,7 @@ impl ConfiguredExecProvider {
     /// on purpose — prompt enrichment is not an authority boundary, and
     /// `execute` re-prepares (with the provider-correct mirroring flag)
     /// before any command runs.
-    pub(crate) async fn stage_turn_workspace(&self, chat_id: ChatId) {
+    pub(crate) async fn stage_turn_workspace(&self, chat_id: SessionId) {
         // A configuration with no skills at all — a headless embedding — has
         // no workspace to prepare. An install that has *disabled* every skill
         // is a different case: a workspace may already hold staged copies, and
@@ -985,7 +985,7 @@ impl ConfiguredExecProvider {
     /// the largest or most unusual folders.
     pub(super) async fn open_write_overlay(
         &self,
-        chat: ChatId,
+        chat: SessionId,
         turn: TurnId,
         grants: &mut [ResolvedExecFolderGrant],
     ) {
@@ -1042,7 +1042,7 @@ impl ConfiguredExecProvider {
     /// to do. A turn that is abandoned rather than finished never reaches here,
     /// and its staged writes are discarded when the next turn sweeps them:
     /// applying them later would write a folder that has since moved on.
-    pub(crate) async fn close_write_overlay(&self, chat: ChatId) -> Option<TurnId> {
+    pub(crate) async fn close_write_overlay(&self, chat: SessionId) -> Option<TurnId> {
         let staged = self
             .write_overlays
             .lock()
@@ -1136,7 +1136,7 @@ impl ConfiguredExecProvider {
     /// registry for exactly the length of the turn, so nothing an in-flight
     /// execution holds can keep it alive past the point where its writes are
     /// applied.
-    fn staged_folders(&self, chat: ChatId) -> HashMap<PathBuf, PathBuf> {
+    fn staged_folders(&self, chat: SessionId) -> HashMap<PathBuf, PathBuf> {
         self.write_overlays
             .lock()
             .expect("write overlay registry is not poisoned")
@@ -1154,7 +1154,7 @@ impl ConfiguredExecProvider {
 
     fn overlay_inspector(
         &self,
-        chat: ChatId,
+        chat: SessionId,
     ) -> Option<tidebreak_code_execution::OverlayInspector> {
         self.write_overlays
             .lock()
@@ -1219,7 +1219,7 @@ impl ConfiguredExecProvider {
 
     async fn writable_connected_root(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         root_id: HostRootId,
     ) -> std::result::Result<PathBuf, RejectedChangeReason> {
         let chat = self
@@ -1361,7 +1361,7 @@ impl ConfiguredExecProvider {
     /// network policy — because the user chose that policy for this work.
     pub async fn execute_for_agent_run(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         request: ExecRequest,
     ) -> std::result::Result<ExecResponse, ExecError> {
         if !request.folder_grants.is_empty() {
@@ -1397,8 +1397,8 @@ impl ConfiguredExecProvider {
         kind: ExecProviderKind,
         provider: Box<dyn ExecProvider>,
         request: ExecRequest,
-        chat: Option<ChatId>,
-        degradation_chat: ChatId,
+        chat: Option<SessionId>,
+        degradation_chat: SessionId,
     ) -> std::result::Result<ExecResponse, ExecError> {
         let host_dir = self.scratch_root.join(request.workspace_id.as_str());
         let skills = self.current_skills().await;
@@ -1509,7 +1509,7 @@ impl ConfiguredExecProvider {
     pub async fn collect_agent_run_outputs(
         &self,
         workspace: &ExecutionWorkspaceId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         call_id: CallId,
         run_id: tidebreak_core::AgentRunId,
     ) -> std::result::Result<OutputArtifactScan, ExecError> {
@@ -1544,7 +1544,7 @@ impl ConfiguredExecProvider {
     async fn publish_output_directory(
         &self,
         workspace: &ExecutionWorkspaceId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         call_id: CallId,
         producer: RevisionProducer,
     ) -> std::result::Result<OutputArtifactScan, ExecError> {
@@ -1854,7 +1854,7 @@ impl ExecProvider for ConfiguredExecProvider {
         let chat_id = request
             .workspace_id
             .as_str()
-            .parse::<ChatId>()
+            .parse::<SessionId>()
             .map_err(|_| {
                 ExecError::InvalidRequest(
                     "execution workspace does not identify a conversation".into(),
@@ -1917,7 +1917,7 @@ impl ExecProvider for ConfiguredExecProvider {
         workspace: &ExecutionWorkspaceId,
         execution: &ExecutionId,
     ) -> std::result::Result<OutputArtifactScan, ExecError> {
-        let chat_id = workspace.as_str().parse::<ChatId>().map_err(|_| {
+        let chat_id = workspace.as_str().parse::<SessionId>().map_err(|_| {
             ExecError::InvalidRequest("execution workspace does not identify a conversation".into())
         })?;
         let call_id = execution.as_str().parse::<CallId>().map_err(|_| {

--- a/crates/tidebreak-server/src/code_execution/staging.rs
+++ b/crates/tidebreak-server/src/code_execution/staging.rs
@@ -10,7 +10,7 @@ use tidebreak_code_execution::{
     DOCUMENT_SCRIPT_FILES,
 };
 use tidebreak_core::{
-    exec_attachment_file_name, BlobStore, ChatId, HostRootId, MessageDocumentAttachment, Store,
+    exec_attachment_file_name, BlobStore, HostRootId, MessageDocumentAttachment, SessionId, Store,
     TurnId, MAX_EXEC_WORKSPACE_FILE_BYTES,
 };
 
@@ -47,13 +47,13 @@ pub trait StagedFolders: Send + Sync {
     /// stages that folder. `None` covers every case where the user's folder is
     /// still the only view — no turn in flight, a read-only grant, or a folder
     /// the overlay could not stage.
-    fn staged_root(&self, chat: ChatId, root_id: HostRootId) -> Option<PathBuf>;
+    fn staged_root(&self, chat: SessionId, root_id: HostRootId) -> Option<PathBuf>;
 
     /// Publish one trusted file through the same conditional materializer and
     /// turn journal as an overlay write.
     async fn materialize_connected_file(
         &self,
-        chat: ChatId,
+        chat: SessionId,
         turn: TurnId,
         root_id: HostRootId,
         relative: &str,
@@ -64,7 +64,7 @@ pub trait StagedFolders: Send + Sync {
     /// Reconcile an interrupted publication against its exact content.
     async fn connected_file_matches(
         &self,
-        chat: ChatId,
+        chat: SessionId,
         root_id: HostRootId,
         relative: &str,
         byte_len: u64,
@@ -122,7 +122,7 @@ pub(super) fn staged_set_note(files: &[WorkspaceFilePath]) -> String {
 pub(super) async fn materialize_chat_attachments(
     store: &dyn Store,
     blobs: &dyn BlobStore,
-    chat_id: ChatId,
+    chat_id: SessionId,
     host_dir: &std::path::Path,
 ) -> std::result::Result<(), ExecError> {
     let attachments = store

--- a/crates/tidebreak-server/src/code_execution/tests.rs
+++ b/crates/tidebreak-server/src/code_execution/tests.rs
@@ -12,8 +12,8 @@ use tidebreak_code_execution::{
     PACKAGE_MANAGER_DOMAINS,
 };
 use tidebreak_core::{
-    exec_attachment_file_name, BlobStore, Chat, ChatId, HostRootId, NetworkPolicy, Result,
-    SecretProvider, Store, TurnId, MAX_EXEC_WORKSPACE_FILE_BYTES,
+    exec_attachment_file_name, BlobStore, Chat, HostRootId, NetworkPolicy, Result, SecretProvider,
+    SessionId, Store, TurnId, MAX_EXEC_WORKSPACE_FILE_BYTES,
 };
 use tidebreak_egress::EgressPolicy;
 
@@ -184,7 +184,7 @@ async fn folder_resolution_is_fenced_to_the_chat_projection() {
     )
     .with_folder_grant_resolver(Some(resolver.clone()));
     let chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: None,
         model: None,
@@ -251,7 +251,7 @@ async fn a_folder_that_cannot_be_staged_fails_closed_and_stays_visible() {
     }];
 
     provider
-        .open_write_overlay(ChatId::new(), TurnId::new(), &mut grants)
+        .open_write_overlay(SessionId::new(), TurnId::new(), &mut grants)
         .await;
 
     assert!(!grants[0].writable);
@@ -274,7 +274,7 @@ async fn output_files_publish_as_turn_attributed_outputs() {
     let store = Arc::new(store);
     let scratch_root = tempfile::tempdir().unwrap();
     let chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: None,
         model: None,
@@ -395,7 +395,7 @@ async fn attached_documents_backfill_lazily_with_collision_and_size_limits() {
     let (store, database) = test_store().await;
     let blobs = FsBlobStore::new(database.path().join("blobs"));
     let chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: None,
         model: None,
@@ -637,7 +637,7 @@ async fn turn_start_staging_makes_skills_readable_before_any_exec() {
         ConfiguredExecProvider::new(store.clone(), Arc::new(NoSecrets), scratch_root.path())
             .with_skills(Some(source.path().to_owned()))
             .with_user_skills(Some(scratch_root.path().join("user-skills")));
-    let chat_id = ChatId::new();
+    let chat_id = SessionId::new();
 
     provider.stage_turn_workspace(chat_id).await;
 
@@ -706,7 +706,7 @@ async fn turn_start_staging_makes_skills_readable_before_any_exec() {
 
     // A skill-less configuration (headless embeddings) stages nothing.
     let bare = ConfiguredExecProvider::new(store, Arc::new(NoSecrets), scratch_root.path());
-    let bare_chat = ChatId::new();
+    let bare_chat = SessionId::new();
     bare.stage_turn_workspace(bare_chat).await;
     assert!(!scratch_root.path().join(bare_chat.to_string()).exists());
 }
@@ -744,7 +744,7 @@ async fn disabling_drops_a_component_from_staging_and_the_catalog() {
         ConfiguredExecProvider::new(store.clone(), Arc::new(NoSecrets), scratch_root.path())
             .with_skills(Some(skills_dir.path().to_owned()))
             .with_plugins(Some(plugins_dir.path().to_owned()));
-    let chat_id = ChatId::new();
+    let chat_id = SessionId::new();
     let staged = |name: &str| {
         scratch_root
             .path()
@@ -853,7 +853,7 @@ async fn staged_skills_warm_their_host_tools_and_gate_the_capability_lines() {
             .with_skills(Some(source.path().to_owned()))
             .with_host_tool_broker(Some(broker.clone()));
 
-    provider.stage_turn_workspace(ChatId::new()).await;
+    provider.stage_turn_workspace(SessionId::new()).await;
     assert_eq!(
         *broker.ensured.lock().expect("ensured tools"),
         [

--- a/crates/tidebreak-server/src/consent.rs
+++ b/crates/tidebreak-server/src/consent.rs
@@ -131,7 +131,7 @@ pub enum ConsentMethodSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidebreak_core::{ChatId, ProjectId};
+    use tidebreak_core::{ProjectId, SessionId};
     use uuid::Uuid;
 
     /// Both halves of the union serialize to the tagged JSON the renderer's
@@ -148,7 +148,7 @@ mod tests {
                 call_id: CallId(call_id),
             },
             level: GrantLevel::Chat {
-                chat_id: ChatId::from(chat_id),
+                chat_id: SessionId::from(chat_id),
             },
             level_title: Some("Quarterly filings".into()),
             verb: ConsentVerb::Tool {

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -391,7 +391,7 @@ fn write_current_marker_inner(data_dir: &Path, failure: MarkerWriteFailure) -> R
 mod tests {
     use chrono::Utc;
     use tidebreak_core::{
-        db, Chat, ChatId, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId, RepoId, Store,
+        db, Chat, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId, RepoId, SessionId, Store,
         WorkspaceId,
     };
 
@@ -400,7 +400,7 @@ mod tests {
 
     fn chat() -> Chat {
         Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("preservation probe".to_owned()),
             model: None,

--- a/crates/tidebreak-server/src/engine/internal/leg.rs
+++ b/crates/tidebreak-server/src/engine/internal/leg.rs
@@ -20,7 +20,7 @@ use tidebreak_core::{
     CheckpointSandboxSpawnOutcome, ClaimedAgentEvent, CompleteTurnRunOutcome,
     ForegroundAgentWaitRequest, MessageId, ParkTurnForAgentRunWaitSetOutcome,
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, Result, SandboxAgentSpawnRequest,
-    SandboxSpawnCheckpointRequest, SecretProvider, SequencedEvent, Store, ToolRegistry,
+    SandboxSpawnCheckpointRequest, SecretProvider, SequencedAgentEvent, Store, ToolRegistry,
     ToolScratch, TurnCheckpointProgress, TurnEventAppend, TurnFailureRetry, TurnId, TurnRun,
     TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
 };
@@ -156,7 +156,7 @@ pub(crate) struct LegDriver {
     /// per turn would invalidate the conversation's prompt cache on every
     /// accepted record.
     pinned_memory_digests: Arc<
-        std::sync::Mutex<std::collections::HashMap<tidebreak_core::ChatId, PinnedMemoryDigest>>,
+        std::sync::Mutex<std::collections::HashMap<tidebreak_core::SessionId, PinnedMemoryDigest>>,
     >,
     diagnostics: Arc<crate::diagnostics::Diagnostics>,
     config: LegDriverConfig,
@@ -478,7 +478,7 @@ fn freeze_foreground_turn_surface_with_folders(
 /// the channel closes after its already-buffered emissions are consumed.
 async fn drain_committed_events(
     events: &EventBus,
-    chat_id: tidebreak_core::ChatId,
+    chat_id: tidebreak_core::SessionId,
     emissions: &mut EmissionBatcher,
 ) {
     // Pending events the batcher collected but never journaled are discarded
@@ -524,7 +524,7 @@ fn expect_ordinal_run(turn_id: TurnId, ordinal: i32, batch: &[TurnEventAppend]) 
 
 fn client_checkpoint_is_valid(
     tools: &ToolRegistry,
-    chat_id: tidebreak_core::ChatId,
+    chat_id: tidebreak_core::SessionId,
     turn_id: TurnId,
     request: &tidebreak_core::ClientToolCallRequest,
 ) -> bool {
@@ -577,7 +577,7 @@ enum ResolutionState {
     Retry,
     /// Boxed: an event carrying a tool's projected command output dwarfs the
     /// other variants, and this enum is returned on every resolution poll.
-    Resolved(Box<SequencedEvent>),
+    Resolved(Box<SequencedAgentEvent>),
     Cancelling,
     Lost,
 }
@@ -751,7 +751,7 @@ impl LegDriver {
         &self,
         scratch: ToolScratch,
         folder: PathBuf,
-        chat_id: tidebreak_core::ChatId,
+        chat_id: tidebreak_core::SessionId,
         turn_id: TurnId,
     ) -> ToolScratch {
         let Some((blobs, blob_writes)) = self.blobs.clone().zip(self.blob_writes.clone()) else {
@@ -2946,7 +2946,7 @@ impl LegDriver {
                     for (entry, seq) in events.iter().zip(seqs) {
                         self.publish(
                             turn.chat_id,
-                            SequencedEvent {
+                            SequencedAgentEvent {
                                 seq,
                                 event: entry.event.clone(),
                             },
@@ -3382,7 +3382,7 @@ impl LegDriver {
         tokio::time::sleep(self.config.failure_delay).await;
     }
 
-    fn publish(&self, chat_id: tidebreak_core::ChatId, event: SequencedEvent) {
+    fn publish(&self, chat_id: tidebreak_core::SessionId, event: SequencedAgentEvent) {
         let _ = self.events.sender(chat_id).send(event);
     }
 }
@@ -3392,7 +3392,10 @@ impl LegDriver {
 /// The path is derived rather than stored, so the turn worker that journals a
 /// scratch write and the transcript that labels it later agree without either
 /// one persisting a host path.
-pub(crate) fn private_chat_scratch_path(root: &Path, chat_id: tidebreak_core::ChatId) -> PathBuf {
+pub(crate) fn private_chat_scratch_path(
+    root: &Path,
+    chat_id: tidebreak_core::SessionId,
+) -> PathBuf {
     root.join(chat_id.to_string())
 }
 
@@ -3400,7 +3403,7 @@ pub(crate) fn private_chat_scratch_path(root: &Path, chat_id: tidebreak_core::Ch
 /// data directory. Product records and API responses never receive this path.
 fn private_chat_scratch(
     root: &Path,
-    chat_id: tidebreak_core::ChatId,
+    chat_id: tidebreak_core::SessionId,
 ) -> std::io::Result<ToolScratch> {
     let mut root_builder = fs::DirBuilder::new();
     root_builder.recursive(true);
@@ -3839,8 +3842,8 @@ mod committed_event_drain_tests {
     #[test]
     fn private_scratch_is_isolated_per_chat() {
         let root = tempfile::tempdir().unwrap();
-        let first_chat = tidebreak_core::ChatId::new();
-        let second_chat = tidebreak_core::ChatId::new();
+        let first_chat = tidebreak_core::SessionId::new();
+        let second_chat = tidebreak_core::SessionId::new();
 
         let _first = private_chat_scratch(root.path(), first_chat).unwrap();
         let _second = private_chat_scratch(root.path(), second_chat).unwrap();
@@ -3872,7 +3875,7 @@ mod committed_event_drain_tests {
 
         let root = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
-        let chat_id = tidebreak_core::ChatId::new();
+        let chat_id = tidebreak_core::SessionId::new();
         symlink(outside.path(), root.path().join(chat_id.to_string())).unwrap();
 
         let error = private_chat_scratch(root.path(), chat_id).unwrap_err();
@@ -3890,7 +3893,7 @@ mod committed_event_drain_tests {
         let root = parent.path().join("scratch");
         symlink(outside.path(), &root).unwrap();
 
-        let error = private_chat_scratch(&root, tidebreak_core::ChatId::new()).unwrap_err();
+        let error = private_chat_scratch(&root, tidebreak_core::SessionId::new()).unwrap_err();
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
     }
@@ -3903,7 +3906,7 @@ mod committed_event_drain_tests {
 
         let root = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
-        let chat_id = tidebreak_core::ChatId::new();
+        let chat_id = tidebreak_core::SessionId::new();
         let original = root.path().join(chat_id.to_string());
         let moved = root.path().join("pinned");
         let scratch = private_chat_scratch(root.path(), chat_id).unwrap();
@@ -3930,7 +3933,7 @@ mod committed_event_drain_tests {
     #[tokio::test]
     async fn lease_loss_drain_discards_pending_and_publishes_committed_events() {
         let events = EventBus::default();
-        let chat_id = tidebreak_core::ChatId::new();
+        let chat_id = tidebreak_core::SessionId::new();
         let mut live = events.subscribe(chat_id);
         let (sender, receiver) = unbounded();
         sender
@@ -3941,7 +3944,7 @@ mod committed_event_drain_tests {
                 },
             })
             .unwrap();
-        let committed = SequencedEvent {
+        let committed = SequencedAgentEvent {
             seq: 7,
             event: AgentEvent::UserSteered {
                 message_id: MessageId::new(),
@@ -4006,7 +4009,7 @@ mod committed_event_drain_tests {
         for (ordinal, text) in [(2, "Hel"), (3, "lo"), (4, ", ")] {
             sender.unbounded_send(pending_delta(ordinal, text)).unwrap();
         }
-        let committed = SequencedEvent {
+        let committed = SequencedAgentEvent {
             seq: 9,
             event: AgentEvent::UserSteered {
                 message_id: MessageId::new(),
@@ -4196,7 +4199,7 @@ mod committed_event_drain_tests {
             tidebreak_core::ApprovalClass::ReadOnly,
             tidebreak_core::validate_request_folder_access_arguments,
         );
-        let chat_id = tidebreak_core::ChatId::new();
+        let chat_id = tidebreak_core::SessionId::new();
         let turn_id = TurnId::new();
         let mut request = tidebreak_core::ClientToolCallRequest {
             id: tidebreak_core::CallId::new(),

--- a/crates/tidebreak-server/src/engine/internal/session.rs
+++ b/crates/tidebreak-server/src/engine/internal/session.rs
@@ -16,9 +16,9 @@ use tidebreak_core::db::DbStore;
 use tidebreak_core::storage::DecidePlanOutcome;
 use tidebreak_core::{
     chat_journal, AcceptTurnSteerOutcome, AnswerUserQuestions, AnswerUserQuestionsOutcome,
-    AnswerUserQuestionsRequest, CallId, ChatId, CodeApprovalKind, CodeSessionId, CodeTurnStatus,
-    DecidePlanRequest, OwnerId, PermissionMode, PlanDecision, PlanDecisionChoice,
-    ToolApprovalStatus, TurnId, TurnParkWait, TurnSteerId, DEFAULT_ACCEPTED_PLAN_MODE,
+    AnswerUserQuestionsRequest, ApprovalKind, CallId, DecidePlanRequest, OwnerId, PermissionMode,
+    PlanDecision, PlanDecisionChoice, SessionId, ToolApprovalStatus, TurnId, TurnParkWait,
+    TurnStatus, TurnSteerId, DEFAULT_ACCEPTED_PLAN_MODE,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessSession, ParkWait, ResumeInput,
@@ -38,8 +38,8 @@ pub(super) struct InternalSession {
     driver: LegDriver,
     owner: OwnerId,
     #[allow(dead_code)]
-    session_id: CodeSessionId,
-    chat_id: ChatId,
+    session_id: SessionId,
+    chat_id: SessionId,
     active: Mutex<Option<ActiveTurn>>,
     /// Tool approvals acknowledged through [`HarnessSession::decide`].
     decided: Mutex<HashSet<CallId>>,
@@ -73,7 +73,7 @@ impl InternalSession {
         // The session row is the conversation row (decision 0048 step 5):
         // the runtime created it, and the engine follows the spec's posture
         // and model on every launch.
-        let chat_id = ChatId(spec.session_id.0);
+        let chat_id = SessionId(spec.session_id.0);
         if state
             .store
             .get_chat(chat_id)
@@ -140,10 +140,7 @@ impl InternalSession {
         else {
             return Ok(());
         };
-        if !matches!(
-            turn.status,
-            CodeTurnStatus::Waiting | CodeTurnStatus::Resuming
-        ) {
+        if !matches!(turn.status, TurnStatus::Waiting | TurnStatus::Resuming) {
             return Ok(());
         }
         let (Some(park_ref), Some(wait)) = (turn.park_ref, turn.park_wait) else {
@@ -404,7 +401,7 @@ impl InternalSession {
                 .await
                 .map_err(store_error)?
                 .map(|approval| match approval.kind {
-                    CodeApprovalKind::ToolUse { offered_grants, .. } => offered_grants,
+                    ApprovalKind::ToolUse { offered_grants, .. } => offered_grants,
                     _ => Vec::new(),
                 })
                 .unwrap_or_default();

--- a/crates/tidebreak-server/src/event_projection.rs
+++ b/crates/tidebreak-server/src/event_projection.rs
@@ -27,7 +27,7 @@
 
 use serde::{Deserialize, Serialize};
 use tidebreak_core::{
-    AgentEvent, ApprovalClass, CallId, MessageId, RendererToolName, SequencedEvent,
+    AgentEvent, ApprovalClass, CallId, MessageId, RendererToolName, SequencedAgentEvent,
     ToolActionPreview, ToolApprovalKind, ToolResultPreview, TurnId,
 };
 use ts_rs::TS;
@@ -435,8 +435,8 @@ pub enum RendererToolFailureReason {
     ProviderUnavailable,
 }
 
-impl From<&SequencedEvent> for RendererSequencedEvent {
-    fn from(value: &SequencedEvent) -> Self {
+impl From<&SequencedAgentEvent> for RendererSequencedEvent {
+    fn from(value: &SequencedAgentEvent) -> Self {
         let event = match &value.event {
             AgentEvent::TurnStarted { turn_id } => {
                 RendererAgentEvent::TurnStarted { turn_id: *turn_id }
@@ -598,7 +598,7 @@ mod tests {
 
     #[test]
     fn refusal_projection_exposes_only_bounded_presentation_metadata() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 12,
             event: AgentEvent::TurnRefused {
                 usage: Usage {
@@ -652,7 +652,8 @@ mod tests {
             cache_read_input_tokens: 33_000,
             cache_creation_input_tokens: 4_400,
         };
-        let project = |event| RendererSequencedEvent::from(&SequencedEvent { seq: 1, event }).event;
+        let project =
+            |event| RendererSequencedEvent::from(&SequencedAgentEvent { seq: 1, event }).event;
 
         assert_eq!(
             project(AgentEvent::TurnCompleted {
@@ -679,7 +680,8 @@ mod tests {
 
     #[test]
     fn compaction_events_project_to_the_renderer() {
-        let project = |event| RendererSequencedEvent::from(&SequencedEvent { seq: 1, event }).event;
+        let project =
+            |event| RendererSequencedEvent::from(&SequencedAgentEvent { seq: 1, event }).event;
         assert_eq!(
             project(AgentEvent::CompactionStarted),
             RendererAgentEvent::CompactionStarted
@@ -697,7 +699,7 @@ mod tests {
     #[test]
     fn unavailable_exec_projects_a_bounded_failure_reason() {
         let call_id = CallId::new();
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 1,
             event: AgentEvent::ToolCallCompleted {
                 call_id,
@@ -778,7 +780,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(index, event)| {
-                serde_json::to_string(&RendererSequencedEvent::from(&SequencedEvent {
+                serde_json::to_string(&RendererSequencedEvent::from(&SequencedAgentEvent {
                     seq: index as i64 + 1,
                     event: event.clone(),
                 }))
@@ -815,7 +817,7 @@ mod tests {
     /// a unit variant would silently empty it.
     #[test]
     fn reasoning_summary_crosses_to_the_renderer() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 7,
             event: AgentEvent::ReasoningDelta {
                 text: "weighing two approaches".into(),
@@ -867,7 +869,7 @@ mod tests {
         ];
 
         for (error, expected, exposes_detail) in cases {
-            let projected = RendererSequencedEvent::from(&SequencedEvent {
+            let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
                 seq: 1,
                 event: AgentEvent::TurnFailed {
                     error: (&error).into(),
@@ -895,7 +897,7 @@ mod tests {
     fn question_event_is_only_a_bounded_refresh_hint() {
         let call_id = CallId::new();
         let turn_id = TurnId::new();
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 7,
             event: AgentEvent::UserQuestionsAsked { call_id, turn_id },
         });
@@ -910,7 +912,7 @@ mod tests {
 
     #[test]
     fn exec_approval_projects_the_command_under_review() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 10,
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
@@ -946,7 +948,7 @@ mod tests {
 
     #[test]
     fn interpreter_approval_projects_no_remembered_grant_choices() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 11,
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
@@ -976,7 +978,7 @@ mod tests {
 
     #[test]
     fn exec_completion_projects_what_ran_and_what_it_produced() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 12,
             event: AgentEvent::ToolCallCompleted {
                 call_id: CallId::new(),
@@ -1024,7 +1026,7 @@ mod tests {
                 server: "gateway".into(),
                 resource_uri: "ui://gateway/app.html".into(),
             });
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 14,
             event: AgentEvent::ToolCallCompleted {
                 call_id: CallId::new(),
@@ -1054,7 +1056,7 @@ mod tests {
 
     #[test]
     fn completions_without_a_projection_stay_closed() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 13,
             event: AgentEvent::ToolCallCompleted {
                 call_id: CallId::new(),
@@ -1083,7 +1085,7 @@ mod tests {
 
     #[test]
     fn approvals_without_a_preview_stay_closed() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 11,
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
@@ -1111,7 +1113,7 @@ mod tests {
     /// does — it is not part of the projection at all.
     #[test]
     fn a_workspace_write_approval_carries_the_path_and_not_the_content() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 11,
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
@@ -1137,7 +1139,7 @@ mod tests {
     /// not.
     #[test]
     fn a_web_search_approval_carries_the_query_being_shared() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 11,
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
@@ -1204,7 +1206,7 @@ mod tests {
                 RendererToolName::BrowserAct,
             ),
         ] {
-            let projected = RendererSequencedEvent::from(&SequencedEvent {
+            let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
                 seq: 1,
                 event: AgentEvent::ToolCallStarted {
                     call_id: CallId::new(),
@@ -1226,14 +1228,14 @@ mod tests {
         let first_id = MessageId::new();
         let second_id = MessageId::new();
         let projected = [
-            SequencedEvent {
+            SequencedAgentEvent {
                 seq: 41,
                 event: AgentEvent::UserSteered {
                     message_id: first_id,
                     content: "first".into(),
                 },
             },
-            SequencedEvent {
+            SequencedAgentEvent {
                 seq: 42,
                 event: AgentEvent::UserSteered {
                     message_id: second_id,
@@ -1270,7 +1272,7 @@ mod tests {
 
     #[test]
     fn search_approval_projects_frozen_egress_kind_without_private_payload() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 7,
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
@@ -1290,7 +1292,7 @@ mod tests {
 
     #[test]
     fn web_search_approval_projects_narrow_query_egress_kind() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 8,
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
@@ -1311,7 +1313,7 @@ mod tests {
 
     #[test]
     fn mcp_approval_projects_one_generic_action_without_remote_metadata() {
-        let projected = RendererSequencedEvent::from(&SequencedEvent {
+        let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
             seq: 9,
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
@@ -1345,7 +1347,7 @@ mod tests {
                 r#""name":"ask_user_questions""#,
             ),
         ] {
-            let projected = RendererSequencedEvent::from(&SequencedEvent {
+            let projected = RendererSequencedEvent::from(&SequencedAgentEvent {
                 seq: 1,
                 event: AgentEvent::ToolCallStarted {
                     call_id: CallId::new(),

--- a/crates/tidebreak-server/src/exec_write_snapshot.rs
+++ b/crates/tidebreak-server/src/exec_write_snapshot.rs
@@ -26,9 +26,9 @@ use tidebreak_code_execution::{
     ScratchDir, StagedChange, WriteSnapshotSink,
 };
 use tidebreak_core::{
-    sha256_hex, BlobStore, ChatId, DocumentBlob, ExecFileChange, ExecFileRejectionReason,
-    ExecFileSnapshot, ExecFileSnapshotRecord, ExecUndoState, ImageMediaType, ScratchPriorContents,
-    Store, TurnId, MAX_EXEC_WORKSPACE_FILE_BYTES,
+    sha256_hex, BlobStore, DocumentBlob, ExecFileChange, ExecFileRejectionReason, ExecFileSnapshot,
+    ExecFileSnapshotRecord, ExecUndoState, ImageMediaType, ScratchPriorContents, SessionId, Store,
+    TurnId, MAX_EXEC_WORKSPACE_FILE_BYTES,
 };
 use ts_rs::TS;
 
@@ -59,7 +59,7 @@ impl TurnSnapshotSink {
     /// Commit the journal for `turn_id`, making its retained bytes live.
     pub(crate) async fn commit(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         turn_id: TurnId,
     ) -> tidebreak_core::Result<()> {
         let files = std::mem::take(
@@ -86,7 +86,7 @@ impl TurnSnapshotSink {
 pub(crate) struct TurnScratchJournal {
     sink: TurnSnapshotSink,
     folder: std::path::PathBuf,
-    chat_id: ChatId,
+    chat_id: SessionId,
     turn_id: TurnId,
 }
 
@@ -96,7 +96,7 @@ impl TurnScratchJournal {
         blobs: Arc<dyn BlobStore>,
         blob_writes: Arc<BlobWriteGuard>,
         folder: std::path::PathBuf,
-        chat_id: ChatId,
+        chat_id: SessionId,
         turn_id: TurnId,
     ) -> Self {
         Self {
@@ -223,7 +223,7 @@ impl WriteSnapshotSink for TurnSnapshotSink {
 /// Result of replaying one turn's durable file-change journal.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ExecTurnUndoOutcome {
-    pub chat_id: ChatId,
+    pub chat_id: SessionId,
     pub turn_id: TurnId,
     pub files: Vec<ExecFileUndoOutcome>,
 }
@@ -268,7 +268,7 @@ pub(crate) enum ExecFileUndoStatus {
 pub(crate) async fn undo_turn_file_changes(
     store: &dyn Store,
     blobs: &dyn BlobStore,
-    chat_id: ChatId,
+    chat_id: SessionId,
     turn_id: TurnId,
 ) -> tidebreak_core::Result<ExecTurnUndoOutcome> {
     let snapshots = store.list_exec_file_snapshots(chat_id).await?;
@@ -296,7 +296,7 @@ pub(crate) async fn undo_turn_file_changes(
 pub(crate) async fn undo_one_file_change(
     store: &dyn Store,
     blobs: &dyn BlobStore,
-    chat_id: ChatId,
+    chat_id: SessionId,
     turn_id: TurnId,
     snapshot_id: uuid::Uuid,
 ) -> tidebreak_core::Result<Option<ExecFileUndoOutcome>> {
@@ -428,7 +428,7 @@ const FILE_PREVIEW_TIMEOUT: Duration = Duration::from_secs(20);
 pub(crate) async fn list_file_change_summaries(
     store: &dyn Store,
     blobs: &dyn BlobStore,
-    chat_id: ChatId,
+    chat_id: SessionId,
     scratch_folder: Option<&Path>,
 ) -> tidebreak_core::Result<std::collections::HashMap<TurnId, Vec<ExecFileChangeSummary>>> {
     let mut by_turn = std::collections::HashMap::<TurnId, Vec<_>>::new();
@@ -668,7 +668,7 @@ pub(crate) enum ExecFilePreviewError {
 }
 
 pub(crate) struct ExecFilePreviewRequest<'a> {
-    pub chat_id: ChatId,
+    pub chat_id: SessionId,
     pub turn_id: TurnId,
     pub snapshot_id: uuid::Uuid,
     pub revision: ExecFilePreviewRevision,
@@ -1081,7 +1081,7 @@ mod tests {
 
         let store = Arc::new(DbStore::connect(&database_url).await.unwrap());
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: None,
             model: None,
@@ -1222,7 +1222,7 @@ mod tests {
         );
         let store = Arc::new(DbStore::connect(&database_url).await.unwrap());
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: None,
             model: None,
@@ -1326,7 +1326,7 @@ mod tests {
 
         let store = DbStore::connect(&database_url).await.unwrap();
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: None,
             model: None,

--- a/crates/tidebreak-server/src/gateway_runtime/apps.rs
+++ b/crates/tidebreak-server/src/gateway_runtime/apps.rs
@@ -33,7 +33,7 @@ impl crate::mcp_config::GatewayEndpoints for GatewayRuntime {
     /// carry — so an attested endpoint can match the call against the
     /// observation that inference recorded. Direct endpoints ignore the
     /// context, so every gateway mount dispatches this way.
-    async fn call_bearer(&self, slug: &str, chat: tidebreak_core::id::ChatId) -> Result<String> {
+    async fn call_bearer(&self, slug: &str, chat: tidebreak_core::id::SessionId) -> Result<String> {
         let connection = self
             .connection()
             .await?

--- a/crates/tidebreak-server/src/gateway_runtime/models.rs
+++ b/crates/tidebreak-server/src/gateway_runtime/models.rs
@@ -79,7 +79,7 @@ impl BearerTokenSource for GatewayTokenSource {
     async fn authorize_model_route(
         &self,
         route_model: &str,
-        conversation: Option<tidebreak_core::id::ChatId>,
+        conversation: Option<tidebreak_core::id::SessionId>,
     ) -> Result<(String, Option<ModelRouteLease>)> {
         let guard = self.model_sync.clone().read_owned().await;
         if self.resolve_model_route(route_model).await?.is_none() {
@@ -111,7 +111,7 @@ impl BearerTokenSource for GatewayTokenSource {
     /// the shared token: there is no chat for an observation to serve.
     async fn bearer_token_for(
         &self,
-        conversation: Option<tidebreak_core::id::ChatId>,
+        conversation: Option<tidebreak_core::id::SessionId>,
     ) -> Result<String> {
         match conversation {
             Some(chat) => {

--- a/crates/tidebreak-server/src/gateway_runtime/tests.rs
+++ b/crates/tidebreak-server/src/gateway_runtime/tests.rs
@@ -1116,7 +1116,7 @@ async fn sync_never_rewrites_durable_model_selections() {
         .await
         .unwrap();
     let pinned = tidebreak_core::Chat {
-        id: tidebreak_core::ChatId::new(),
+        id: tidebreak_core::SessionId::new(),
         project_id: None,
         title: None,
         model: Some("claude-opus-5".into()),
@@ -1638,12 +1638,12 @@ async fn the_route_token_source_mints_llm_tokens_per_rotation() {
 
     // A conversation mints inside that chat's attestation context: cached
     // per chat, distinct across chats, and never the shared token.
-    let chat = tidebreak_core::id::ChatId::new();
+    let chat = tidebreak_core::id::SessionId::new();
     let attested = source.bearer_token_for(Some(chat)).await.unwrap();
     assert_ne!(attested, token);
     assert_eq!(source.bearer_token_for(Some(chat)).await.unwrap(), attested);
     let other = source
-        .bearer_token_for(Some(tidebreak_core::id::ChatId::new()))
+        .bearer_token_for(Some(tidebreak_core::id::SessionId::new()))
         .await
         .unwrap();
     assert_ne!(other, attested);
@@ -1964,7 +1964,7 @@ async fn mounts_a_gateway_endpoint_from_the_signed_in_session() {
     // the same attestation context the chat's inference tokens carry —
     // the invariant that lets an attested endpoint match the call against
     // the observation the inference recorded.
-    let chat = tidebreak_core::id::ChatId::new();
+    let chat = tidebreak_core::id::SessionId::new();
     let snapshot = mcp.snapshot();
     let tool = snapshot.get("mcp__tools__lookup").unwrap();
     let ctx = tidebreak_core::ToolCtx::without_private_scratch(chat, None);
@@ -2143,7 +2143,7 @@ async fn assembled_state_mints_inference_and_mcp_dispatch_in_one_attestation_con
         crate::mcp_config::McpHealth::Healthy
     );
 
-    let chat = tidebreak_core::id::ChatId::new();
+    let chat = tidebreak_core::id::SessionId::new();
     let snapshot = state.mcp.snapshot();
     let tool = snapshot.get("mcp__tools__lookup").unwrap();
     let ctx = tidebreak_core::ToolCtx::without_private_scratch(chat, None);
@@ -2919,7 +2919,7 @@ async fn a_schema_epoch_reset_keeps_the_policy_and_its_session() {
     .unwrap();
     store
         .create_chat(&tidebreak_core::Chat {
-            id: tidebreak_core::ChatId::new(),
+            id: tidebreak_core::SessionId::new(),
             project_id: None,
             title: Some("lost to the reset".to_owned()),
             model: None,

--- a/crates/tidebreak-server/src/mcp_config/types.rs
+++ b/crates/tidebreak-server/src/mcp_config/types.rs
@@ -281,7 +281,7 @@ pub(crate) trait GatewayEndpoints: Send + Sync {
     /// endpoints can match the call against the observation the chat's
     /// inference recorded; the default keeps the connect-time bearer for
     /// implementations that don't distinguish.
-    async fn call_bearer(&self, slug: &str, chat: tidebreak_core::id::ChatId) -> Result<String> {
+    async fn call_bearer(&self, slug: &str, chat: tidebreak_core::id::SessionId) -> Result<String> {
         let _ = chat;
         Ok(self.endpoint(slug).await?.bearer_token)
     }
@@ -307,7 +307,7 @@ pub(super) struct GatewayCallBearer {
 
 #[async_trait::async_trait]
 impl tidebreak_mcp::CallBearerSource for GatewayCallBearer {
-    async fn call_bearer(&self, chat: tidebreak_core::id::ChatId) -> Result<Option<String>> {
+    async fn call_bearer(&self, chat: tidebreak_core::id::SessionId) -> Result<Option<String>> {
         self.gateway.call_bearer(&self.slug, chat).await.map(Some)
     }
 }

--- a/crates/tidebreak-server/src/memory_capture.rs
+++ b/crates/tidebreak-server/src/memory_capture.rs
@@ -21,9 +21,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use tidebreak_core::{
-    ChatId, MemoryAuthor, MemoryBackend, MemoryEvidence, MemoryKind, MemoryListFilter,
-    MemoryOrigin, MemoryProvenance, MemoryRecord, MemoryRecordId, MemoryRecordUpdate, MemoryScope,
-    MemoryStatus, MemoryStatusChange, OwnerId, Result, Role, Store, TurnId, MAX_MEMORY_BODY_BYTES,
+    MemoryAuthor, MemoryBackend, MemoryEvidence, MemoryKind, MemoryListFilter, MemoryOrigin,
+    MemoryProvenance, MemoryRecord, MemoryRecordId, MemoryRecordUpdate, MemoryScope, MemoryStatus,
+    MemoryStatusChange, OwnerId, Result, Role, SessionId, Store, TurnId, MAX_MEMORY_BODY_BYTES,
     MAX_MEMORY_TITLE_CHARS,
 };
 
@@ -149,7 +149,7 @@ pub(crate) struct MemoryCapture {
     /// completion that landed while that call was running. Only the newest
     /// queued turn is kept: capture judges one turn's material, and the
     /// newest completed turn is the one still worth judging.
-    in_flight: Arc<Mutex<HashMap<ChatId, Option<TurnId>>>>,
+    in_flight: Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
 }
 
 impl MemoryCapture {
@@ -189,7 +189,7 @@ impl MemoryCapture {
     /// Returns immediately. Nothing waits on the result and nothing fails
     /// when it does not arrive, which is what lets the turn worker call this
     /// from its one completion seam without touching the turn's outcome.
-    pub(crate) fn spawn(&self, chat_id: ChatId, turn_id: TurnId) {
+    pub(crate) fn spawn(&self, chat_id: SessionId, turn_id: TurnId) {
         let Some((mut claim, mut turn_id)) =
             CaptureClaim::acquire(&self.in_flight, chat_id, turn_id)
         else {
@@ -241,7 +241,7 @@ impl MemoryCapture {
     ///
     /// The awaitable form of [`MemoryCapture::spawn`], which is what a test
     /// asserts on.
-    pub(crate) async fn derive(&self, chat_id: ChatId, turn_id: TurnId) -> Result<Outcome> {
+    pub(crate) async fn derive(&self, chat_id: SessionId, turn_id: TurnId) -> Result<Outcome> {
         if !capture_enabled(&*self.store).await? {
             return Ok(Outcome::NotApplicable);
         }
@@ -310,7 +310,7 @@ impl MemoryCapture {
     pub(crate) async fn store_candidate(
         &self,
         owner: &OwnerId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         turn_id: TurnId,
         evidence: MemoryEvidence,
         candidate: MemoryCandidate,
@@ -395,7 +395,7 @@ impl MemoryCapture {
     async fn observe_hypothesis(
         &self,
         owner: &OwnerId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         turn_id: TurnId,
         evidence: MemoryEvidence,
         tracked: &MemoryRecord,
@@ -453,7 +453,7 @@ impl MemoryCapture {
     async fn material(
         &self,
         owner: &OwnerId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         turn_id: TurnId,
     ) -> Result<Option<(String, MemoryEvidence)>> {
         let messages = self.store.list_messages(chat_id).await?;
@@ -590,8 +590,8 @@ pub(crate) async fn capture_enabled(store: &dyn Store) -> Result<bool> {
 
 /// A chat's place in [`MemoryCapture::in_flight`], released on drop.
 struct CaptureClaim {
-    in_flight: Arc<Mutex<HashMap<ChatId, Option<TurnId>>>>,
-    chat_id: ChatId,
+    in_flight: Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
+    chat_id: SessionId,
     released: bool,
 }
 
@@ -599,8 +599,8 @@ impl CaptureClaim {
     /// Claim `chat_id`, or queue `turn_id` behind the call already running
     /// for it.
     fn acquire(
-        in_flight: &Arc<Mutex<HashMap<ChatId, Option<TurnId>>>>,
-        chat_id: ChatId,
+        in_flight: &Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
+        chat_id: SessionId,
         turn_id: TurnId,
     ) -> Option<(Self, TurnId)> {
         let in_flight = in_flight.clone();

--- a/crates/tidebreak-server/src/memory_sweep.rs
+++ b/crates/tidebreak-server/src/memory_sweep.rs
@@ -36,10 +36,10 @@ use tidebreak_core::db::memory_sweep::{
     record_sweep_run, save_sweep_scope_state,
 };
 use tidebreak_core::{
-    AgentError, CodeSessionLifecycle, DbStore, MemoryAuthor, MemoryBackend, MemoryEvidence,
-    MemoryKind, MemoryLink, MemoryLinkRelation, MemoryListFilter, MemoryOrigin, MemoryProvenance,
-    MemoryRecord, MemoryRecordId, MemoryScope, MemoryStatus, MemoryStatusChange,
-    MemorySweepOutcome, MemorySweepRun, MemorySweepScopeState, MemorySweepStatus, OwnerId, Result,
+    AgentError, DbStore, MemoryAuthor, MemoryBackend, MemoryEvidence, MemoryKind, MemoryLink,
+    MemoryLinkRelation, MemoryListFilter, MemoryOrigin, MemoryProvenance, MemoryRecord,
+    MemoryRecordId, MemoryScope, MemoryStatus, MemoryStatusChange, MemorySweepOutcome,
+    MemorySweepRun, MemorySweepScopeState, MemorySweepStatus, OwnerId, Result, SessionLifecycle,
     Store, UtilityModel, MAX_MEMORY_EVIDENCE, MAX_MEMORY_LINKS, MAX_MEMORY_TITLE_CHARS,
 };
 
@@ -603,7 +603,7 @@ impl MemorySweep {
         Ok(tidebreak_core::db::code::list_sessions(&self.db, owner)
             .await?
             .iter()
-            .any(|session| session.lifecycle == CodeSessionLifecycle::Running))
+            .any(|session| session.lifecycle == SessionLifecycle::Running))
     }
 
     fn backend(&self) -> &dyn MemoryBackend {

--- a/crates/tidebreak-server/src/output_files.rs
+++ b/crates/tidebreak-server/src/output_files.rs
@@ -25,8 +25,8 @@ use cap_std::fs::{Dir, DirBuilder, OpenOptions};
 use sha2::{Digest, Sha256};
 
 use tidebreak_core::{
-    revision_byte_ceiling, ChatId, OutputId, OutputRecord, OutputRevision, OutputRevisionId, Store,
-    OUTPUTS_DIRECTORY,
+    revision_byte_ceiling, OutputId, OutputRecord, OutputRevision, OutputRevisionId, SessionId,
+    Store, OUTPUTS_DIRECTORY,
 };
 
 /// The one live output plus its current revision, bound to one conversation.
@@ -36,7 +36,7 @@ use tidebreak_core::{
 /// to tell them apart from the outside.
 pub async fn require_live_output(
     store: &Arc<dyn Store>,
-    chat_id: ChatId,
+    chat_id: SessionId,
     output_id: OutputId,
 ) -> Result<(OutputRecord, OutputRevision), String> {
     let output = store
@@ -57,7 +57,7 @@ pub async fn require_live_output(
 /// One exact revision of a live output, by id.
 pub async fn require_output_revision(
     store: &Arc<dyn Store>,
-    chat_id: ChatId,
+    chat_id: SessionId,
     output_id: OutputId,
     revision_id: OutputRevisionId,
 ) -> Result<(OutputRecord, OutputRevision), String> {
@@ -81,7 +81,7 @@ pub async fn require_output_revision(
 /// immediately before it happens.
 pub async fn require_exact_revision(
     store: &Arc<dyn Store>,
-    chat_id: ChatId,
+    chat_id: SessionId,
     output_id: OutputId,
     revision_id: OutputRevisionId,
     byte_len: u64,
@@ -116,7 +116,7 @@ pub async fn require_exact_revision(
 /// Open the exact conversation's private scratch directory, refusing symlinked
 /// components. This is the directory the append-only revision writers in
 /// `tidebreak-core` publish into.
-pub fn open_chat_scratch(scratch_root: &Path, chat_id: ChatId) -> Result<Dir, String> {
+pub fn open_chat_scratch(scratch_root: &Path, chat_id: SessionId) -> Result<Dir, String> {
     let Some(root) = open_regular_directory(scratch_root)? else {
         return Err("Output content is unavailable".to_owned());
     };
@@ -133,7 +133,7 @@ pub fn open_chat_scratch(scratch_root: &Path, chat_id: ChatId) -> Result<Dir, St
 /// Native host operations use this when they publish an output before a turn
 /// has created the chat directory. Every path component is checked without
 /// following symlinks before the returned capability can write below it.
-pub fn open_or_create_chat_scratch(scratch_root: &Path, chat_id: ChatId) -> Result<Dir, String> {
+pub fn open_or_create_chat_scratch(scratch_root: &Path, chat_id: SessionId) -> Result<Dir, String> {
     match fs::symlink_metadata(scratch_root) {
         Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
         Ok(_) => return Err("Private output storage is invalid".to_owned()),
@@ -192,7 +192,7 @@ pub fn open_or_create_chat_scratch(scratch_root: &Path, chat_id: ChatId) -> Resu
 /// Blocking file I/O — call it from a blocking context.
 pub fn read_output_revision_bytes(
     scratch_root: &Path,
-    chat_id: ChatId,
+    chat_id: SessionId,
     output: &OutputRecord,
     revision: &OutputRevision,
 ) -> Result<Vec<u8>, String> {
@@ -296,7 +296,7 @@ mod tests {
     use super::*;
 
     fn output_record(
-        chat_id: ChatId,
+        chat_id: SessionId,
         filename: &str,
         content: &[u8],
     ) -> (OutputRecord, OutputRevision) {
@@ -343,7 +343,7 @@ mod tests {
     fn immutable_revision_reads_are_exactly_scoped_and_content_addressed() {
         let scratch = tempfile::tempdir().unwrap();
         let content = b"private";
-        let (output, revision) = output_record(ChatId::new(), "brief.txt", content);
+        let (output, revision) = output_record(SessionId::new(), "brief.txt", content);
         let path = revision_path(scratch.path(), &output, &revision);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, content).unwrap();
@@ -353,7 +353,8 @@ mod tests {
             content
         );
         assert!(
-            read_output_revision_bytes(scratch.path(), ChatId::new(), &output, &revision).is_err()
+            read_output_revision_bytes(scratch.path(), SessionId::new(), &output, &revision)
+                .is_err()
         );
         std::fs::write(path, b"tampered").unwrap();
         assert!(
@@ -365,7 +366,7 @@ mod tests {
     fn chat_scratch_is_created_with_private_directories() {
         let parent = tempfile::tempdir().unwrap();
         let scratch_root = parent.path().join("scratch");
-        let chat_id = ChatId::new();
+        let chat_id = SessionId::new();
 
         let _scratch = open_or_create_chat_scratch(&scratch_root, chat_id).unwrap();
 
@@ -399,11 +400,11 @@ mod tests {
         let outside = tempfile::tempdir().unwrap();
         let scratch_root = parent.path().join("scratch");
         symlink(outside.path(), &scratch_root).unwrap();
-        assert!(open_or_create_chat_scratch(&scratch_root, ChatId::new()).is_err());
+        assert!(open_or_create_chat_scratch(&scratch_root, SessionId::new()).is_err());
 
         fs::remove_file(&scratch_root).unwrap();
         fs::create_dir(&scratch_root).unwrap();
-        let chat_id = ChatId::new();
+        let chat_id = SessionId::new();
         symlink(outside.path(), scratch_root.join(chat_id.to_string())).unwrap();
         assert!(open_or_create_chat_scratch(&scratch_root, chat_id).is_err());
     }
@@ -416,7 +417,7 @@ mod tests {
         let scratch = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         let content = b"private";
-        let (output, revision) = output_record(ChatId::new(), "brief.txt", content);
+        let (output, revision) = output_record(SessionId::new(), "brief.txt", content);
         let path = revision_path(scratch.path(), &output, &revision);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         let outside_source = outside.path().join("source.txt");

--- a/crates/tidebreak-server/src/routes/agent_runs.rs
+++ b/crates/tidebreak-server/src/routes/agent_runs.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 
 use tidebreak_code_execution::ExecProviderKind;
 use tidebreak_core::{
-    AgentRun, AgentRunExecutionLocation, AgentRunStatus, AgentRunTier, CallId, ChatId,
-    RequestAgentRunCancellationOutcome, SandboxToolCall, SandboxToolCallStatus, TurnId,
+    AgentRun, AgentRunExecutionLocation, AgentRunStatus, AgentRunTier, CallId,
+    RequestAgentRunCancellationOutcome, SandboxToolCall, SandboxToolCallStatus, SessionId, TurnId,
 };
 
 use crate::agent_control_tools::SandboxCancellationAcceleration;
@@ -460,7 +460,7 @@ fn sandbox_activity_history_item(
 pub async fn list_agent_runs(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<Json<Vec<AgentRunSnapshot>>, ServerError> {
     store.require_chat(id).await?;
     let runs = store.list_agent_runs(id).await?;
@@ -538,7 +538,7 @@ pub async fn list_agent_runs(
 /// identifier exists.
 pub async fn list_agent_run_activity(
     store: ScopedStore,
-    Path((chat_id, run_id)): Path<(ChatId, tidebreak_core::AgentRunId)>,
+    Path((chat_id, run_id)): Path<(SessionId, tidebreak_core::AgentRunId)>,
 ) -> Result<Json<Vec<AgentActivityHistoryItem>>, ServerError> {
     store.require_chat(chat_id).await?;
     let run = store
@@ -598,7 +598,7 @@ pub async fn list_agent_run_activity(
 /// made a plan is not an error; it answers `null`.
 pub async fn get_agent_run_task_plan(
     store: ScopedStore,
-    Path((chat_id, run_id)): Path<(ChatId, tidebreak_core::AgentRunId)>,
+    Path((chat_id, run_id)): Path<(SessionId, tidebreak_core::AgentRunId)>,
 ) -> Result<Json<Option<tidebreak_core::AgentRunTaskPlan>>, ServerError> {
     store.require_chat(chat_id).await?;
     let run = store
@@ -667,7 +667,7 @@ pub struct AgentRunProgressQuery {
 /// exists.
 pub async fn list_agent_run_progress(
     store: ScopedStore,
-    Path((chat_id, run_id)): Path<(ChatId, tidebreak_core::AgentRunId)>,
+    Path((chat_id, run_id)): Path<(SessionId, tidebreak_core::AgentRunId)>,
     Query(query): Query<AgentRunProgressQuery>,
 ) -> Result<Json<AgentRunProgressPage>, ServerError> {
     store.require_chat(chat_id).await?;
@@ -727,7 +727,7 @@ pub enum AgentRunCancellationStatus {
 pub async fn post_agent_run_cancel(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, run_id)): Path<(ChatId, tidebreak_core::AgentRunId)>,
+    Path((chat_id, run_id)): Path<(SessionId, tidebreak_core::AgentRunId)>,
 ) -> Result<(StatusCode, Json<AgentRunCancellationSnapshot>), ServerError> {
     store.require_chat(chat_id).await?;
     let Some(run) = store.get_agent_run(run_id).await? else {
@@ -805,7 +805,7 @@ pub struct AgentRunResumeBody {
 pub async fn post_agent_run_resume(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, run_id)): Path<(ChatId, tidebreak_core::AgentRunId)>,
+    Path((chat_id, run_id)): Path<(SessionId, tidebreak_core::AgentRunId)>,
     Json(body): Json<AgentRunResumeBody>,
 ) -> Result<StatusCode, ServerError> {
     let guidance = body
@@ -858,7 +858,7 @@ pub struct AgentRunSteerBody {
 pub async fn post_agent_run_steer(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, run_id)): Path<(ChatId, tidebreak_core::AgentRunId)>,
+    Path((chat_id, run_id)): Path<(SessionId, tidebreak_core::AgentRunId)>,
     Json(body): Json<AgentRunSteerBody>,
 ) -> Result<StatusCode, ServerError> {
     let content = body.content.trim().to_owned();
@@ -919,7 +919,7 @@ pub(super) async fn signal_sandbox_run_after_commit(
 /// Signal only children durably owned by the cancelled origin turn.
 pub(super) async fn signal_origin_sandbox_runs_after_commit(
     state: &AppState,
-    chat_id: ChatId,
+    chat_id: SessionId,
     origin_turn_id: TurnId,
 ) {
     let Ok(runs) = state.store.list_agent_runs(chat_id).await else {

--- a/crates/tidebreak-server/src/routes/approvals.rs
+++ b/crates/tidebreak-server/src/routes/approvals.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use tidebreak_core::{ApprovalDecision, CallId, ChatId, ProjectId, TurnId};
+use tidebreak_core::{ApprovalDecision, CallId, ProjectId, SessionId, TurnId};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
@@ -177,7 +177,7 @@ pub(crate) fn grant_rungs_from_scopes(
 /// `GET /chats/{id}/approvals` — recover a bounded page of pending cards.
 pub(crate) async fn list_pending_approvals(
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
     Query(query): Query<PendingApprovalsQuery>,
 ) -> Result<Json<Vec<PendingApprovalSnapshot>>, ServerError> {
     if !(1..=100).contains(&query.limit) {
@@ -234,7 +234,7 @@ async fn standing_grant_snapshots(
     store: &ScopedStore,
 ) -> Result<Vec<StandingGrantSnapshot>, ServerError> {
     let grants = store.list_standing_tool_grants().await?;
-    let chat_titles: std::collections::HashMap<ChatId, Option<String>> = store
+    let chat_titles: std::collections::HashMap<SessionId, Option<String>> = store
         .list_chats()
         .await?
         .into_iter()
@@ -325,7 +325,7 @@ pub(crate) async fn delete_standing_grant(
 pub async fn post_approval(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, call_id)): Path<(ChatId, CallId)>,
+    Path((chat_id, call_id)): Path<(SessionId, CallId)>,
     Json(body): Json<ApprovalBody>,
 ) -> Result<StatusCode, ServerError> {
     // Confirm the chat exists so a typo'd id doesn't look like "not pending".

--- a/crates/tidebreak-server/src/routes/client_execution.rs
+++ b/crates/tidebreak-server/src/routes/client_execution.rs
@@ -12,10 +12,10 @@ use serde::{Deserialize, Serialize};
 
 use chrono::{Duration, Utc};
 use tidebreak_core::{
-    CallId, ChatId, ClaimClientToolCallOutcome, HeartbeatClientToolCallOutcome, OutputWriteMode,
+    CallId, ClaimClientToolCallOutcome, HeartbeatClientToolCallOutcome, OutputWriteMode,
     PermissionMode, RequestFolderAccessArgs, RequestedFolderHint, ResolveToolCallOutcome,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnId, TurnRunStatus,
-    WriteOutputToConnectedFolderArgs, REQUEST_FOLDER_ACCESS_TOOL,
+    SessionId, ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnId,
+    TurnRunStatus, WriteOutputToConnectedFolderArgs, REQUEST_FOLDER_ACCESS_TOOL,
     WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
 
@@ -196,7 +196,7 @@ pub struct PendingOutputWritebackRequest {
 /// shared self-host without impersonating one of its named users.
 #[derive(Serialize)]
 pub struct NativePendingClientExecution {
-    pub chat_id: ChatId,
+    pub chat_id: SessionId,
     pub call: ToolCallRecord,
 }
 
@@ -207,7 +207,7 @@ pub struct NativePendingClientExecution {
 pub async fn list_pending_folder_access_requests(
     State(state): State<AppState>,
     store: crate::scoped_store::ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<Json<Vec<PendingFolderAccessRequest>>, ServerError> {
     store.require_chat(id).await?;
     let requests = store
@@ -228,7 +228,7 @@ pub async fn list_pending_folder_access_requests(
 pub async fn list_pending_output_writebacks(
     State(state): State<AppState>,
     store: crate::scoped_store::ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<Json<Vec<PendingOutputWritebackRequest>>, ServerError> {
     let chat = store.require_chat(id).await?;
     let requests = store
@@ -245,7 +245,7 @@ pub async fn list_pending_output_writebacks(
 pub async fn list_pending_client_executions_raw(
     State(state): State<AppState>,
     _executor: ClientExecutor,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<Json<Vec<ToolCallRecord>>, ServerError> {
     require_native_chat(&state, id).await?;
     let calls = state
@@ -330,7 +330,7 @@ fn renderer_output_writeback_request(
 pub async fn claim_client_execution(
     State(state): State<AppState>,
     _executor: ClientExecutor,
-    Path((id, call_id)): Path<(ChatId, CallId)>,
+    Path((id, call_id)): Path<(SessionId, CallId)>,
     Json(body): Json<ClaimClientExecution>,
 ) -> Result<Json<ClaimedClientExecution>, ServerError> {
     require_native_chat(&state, id).await?;
@@ -376,7 +376,7 @@ pub async fn claim_client_execution(
 pub async fn heartbeat_client_execution(
     State(state): State<AppState>,
     _executor: ClientExecutor,
-    Path((id, call_id)): Path<(ChatId, CallId)>,
+    Path((id, call_id)): Path<(SessionId, CallId)>,
     Json(body): Json<HeartbeatClientExecution>,
 ) -> Result<Json<ClientExecutionHeartbeat>, ServerError> {
     require_native_chat(&state, id).await?;
@@ -412,7 +412,7 @@ pub async fn heartbeat_client_execution(
 pub async fn resolve_client_execution(
     State(state): State<AppState>,
     _executor: ClientExecutor,
-    Path((id, call_id)): Path<(ChatId, CallId)>,
+    Path((id, call_id)): Path<(SessionId, CallId)>,
     Json(body): Json<ResolveClientExecution>,
 ) -> Result<Json<ResolvedClientExecution>, ServerError> {
     require_native_chat(&state, id).await?;
@@ -483,7 +483,7 @@ pub async fn resolve_client_execution(
     Ok(Json(ResolvedClientExecution { disposition }))
 }
 
-async fn require_native_chat(state: &AppState, id: ChatId) -> Result<(), ServerError> {
+async fn require_native_chat(state: &AppState, id: SessionId) -> Result<(), ServerError> {
     if state.store.get_chat(id).await?.is_some() {
         Ok(())
     } else {

--- a/crates/tidebreak-server/src/routes/code/analytics.rs
+++ b/crates/tidebreak-server/src/routes/code/analytics.rs
@@ -9,7 +9,7 @@ use axum::extract::Query;
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::Deserialize;
 use tidebreak_core::{
-    CodePullRequestId, CodeSession, CodeSessionId, CodeTurnStatus, HarnessKind, RepoId, WorkspaceId,
+    CodePullRequestId, HarnessKind, RepoId, Session, SessionId, TurnStatus, WorkspaceId,
 };
 
 use crate::code::ScopedCode;
@@ -77,8 +77,8 @@ fn build_snapshot(
     repo_filter: Option<RepoId>,
     repos: Vec<tidebreak_core::CodeRepo>,
     workspaces: Vec<tidebreak_core::CodeWorkspace>,
-    sessions: Vec<CodeSession>,
-    turns: Vec<tidebreak_core::db::code::CodeTurnMetric>,
+    sessions: Vec<Session>,
+    turns: Vec<tidebreak_core::db::code::TurnMetric>,
     pull_requests: Vec<tidebreak_core::CodePullRequestFact>,
     attributions: Vec<tidebreak_core::CodePullRequestAttribution>,
 ) -> CodeAnalyticsSnapshot {
@@ -86,7 +86,7 @@ fn build_snapshot(
         .iter()
         .map(|workspace| (workspace.id, workspace.repo_id))
         .collect();
-    let session_by_id: HashMap<CodeSessionId, &CodeSession> = sessions
+    let session_by_id: HashMap<SessionId, &Session> = sessions
         .iter()
         .filter(|session| {
             session
@@ -138,22 +138,22 @@ fn build_snapshot(
 
         totals.turns = totals.turns.saturating_add(1);
         match turn.status {
-            CodeTurnStatus::Completed => {
+            TurnStatus::Completed => {
                 totals.completed_turns = totals.completed_turns.saturating_add(1)
             }
-            CodeTurnStatus::Failed => totals.failed_turns = totals.failed_turns.saturating_add(1),
-            CodeTurnStatus::Interrupted => {
+            TurnStatus::Failed => totals.failed_turns = totals.failed_turns.saturating_add(1),
+            TurnStatus::Interrupted => {
                 totals.interrupted_turns = totals.interrupted_turns.saturating_add(1)
             }
-            CodeTurnStatus::Running
-            | CodeTurnStatus::Waiting
-            | CodeTurnStatus::Queued
-            | CodeTurnStatus::Cancelling
-            | CodeTurnStatus::WaitingForClient
-            | CodeTurnStatus::WaitingForAgentRun
-            | CodeTurnStatus::CancellingClient
-            | CodeTurnStatus::Resuming
-            | CodeTurnStatus::RetryWait => {
+            TurnStatus::Running
+            | TurnStatus::Waiting
+            | TurnStatus::Queued
+            | TurnStatus::Cancelling
+            | TurnStatus::WaitingForClient
+            | TurnStatus::WaitingForAgentRun
+            | TurnStatus::CancellingClient
+            | TurnStatus::Resuming
+            | TurnStatus::RetryWait => {
                 totals.running_turns = totals.running_turns.saturating_add(1)
             }
         }
@@ -418,7 +418,7 @@ struct UsageTotals {
 }
 
 impl UsageTotals {
-    fn from_usage(usage: &tidebreak_core::CodeUsage) -> Self {
+    fn from_usage(usage: &tidebreak_core::TurnUsage) -> Self {
         let total = usage
             .input_tokens
             .saturating_add(usage.output_tokens)
@@ -643,7 +643,7 @@ fn price_for_canonical(model: &str) -> Option<PriceRate> {
 
 #[derive(Debug, Default)]
 struct DailyAccumulator {
-    sessions: HashSet<CodeSessionId>,
+    sessions: HashSet<SessionId>,
     turns: u64,
     total_tokens: u64,
     cost_millimicrousd: u128,
@@ -653,7 +653,7 @@ struct DailyAccumulator {
 
 #[derive(Debug, Default)]
 struct MetricsAccumulator {
-    sessions: HashSet<CodeSessionId>,
+    sessions: HashSet<SessionId>,
     turns: u64,
     tokens: u64,
     cost_millimicrousd: u128,
@@ -670,7 +670,7 @@ struct ModelKey {
 
 #[derive(Debug, Default)]
 struct ModelAccumulator {
-    sessions: HashSet<CodeSessionId>,
+    sessions: HashSet<SessionId>,
     turns: u64,
     tokens: u64,
     cost_millimicrousd: u128,

--- a/crates/tidebreak-server/src/routes/code/approvals.rs
+++ b/crates/tidebreak-server/src/routes/code/approvals.rs
@@ -6,44 +6,39 @@ use crate::code::runtime::ApprovalDecisionRequest;
 use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
-use tidebreak_core::CodeApprovalId;
+use tidebreak_core::ApprovalId;
 
-use super::types::{
-    CodeApprovalDecision, CodeApprovalDecisionBody, CodeApprovalSnapshot, ListApprovalsQuery,
-};
+use super::types::{ApprovalDecision, ApprovalDecisionBody, ApprovalSnapshot, ListApprovalsQuery};
 
 pub async fn list_approvals(
     code: ScopedCode,
     Query(query): Query<ListApprovalsQuery>,
-) -> Result<Json<Vec<CodeApprovalSnapshot>>, ServerError> {
+) -> Result<Json<Vec<ApprovalSnapshot>>, ServerError> {
     let approvals = code.list_approvals(query.state, query.session_id).await?;
     Ok(Json(
-        approvals
-            .into_iter()
-            .map(CodeApprovalSnapshot::from)
-            .collect(),
+        approvals.into_iter().map(ApprovalSnapshot::from).collect(),
     ))
 }
 
 pub async fn decide_approval(
     code: ScopedCode,
-    Path(id): Path<CodeApprovalId>,
-    Json(body): Json<CodeApprovalDecisionBody>,
+    Path(id): Path<ApprovalId>,
+    Json(body): Json<ApprovalDecisionBody>,
 ) -> Result<impl IntoResponse, ServerError> {
     let decision = match body.decision {
-        CodeApprovalDecision::Approve => ApprovalDecisionRequest::Approve,
-        CodeApprovalDecision::Deny => ApprovalDecisionRequest::Deny {
+        ApprovalDecision::Approve => ApprovalDecisionRequest::Approve,
+        ApprovalDecision::Deny => ApprovalDecisionRequest::Deny {
             feedback: body.feedback,
         },
-        CodeApprovalDecision::ApproveWithGrant { grant_index } => {
+        ApprovalDecision::ApproveWithGrant { grant_index } => {
             ApprovalDecisionRequest::ApproveWithGrant { grant_index }
         }
-        CodeApprovalDecision::Answers { answers } => ApprovalDecisionRequest::Answers { answers },
-        CodeApprovalDecision::PlanDecision { approve } => ApprovalDecisionRequest::PlanDecision {
+        ApprovalDecision::Answers { answers } => ApprovalDecisionRequest::Answers { answers },
+        ApprovalDecision::PlanDecision { approve } => ApprovalDecisionRequest::PlanDecision {
             approve,
             feedback: body.feedback,
         },
     };
     let approval = code.decide_approval(id, decision).await?;
-    Ok((StatusCode::OK, Json(CodeApprovalSnapshot::from(approval))))
+    Ok((StatusCode::OK, Json(ApprovalSnapshot::from(approval))))
 }

--- a/crates/tidebreak-server/src/routes/code/browser.rs
+++ b/crates/tidebreak-server/src/routes/code/browser.rs
@@ -13,8 +13,7 @@ use axum::http::HeaderMap;
 use tidebreak_core::{
     db, BrowserActArgs, BrowserActResult, BrowserListResult, BrowserNavigateArgs,
     BrowserNavigateResult, BrowserPageSnapshot, BrowserScreenshotArgs, BrowserScreenshotResult,
-    BrowserSnapshotArgs, BrowserWaitArgs, BrowserWaitResult, CodeSessionLifecycle,
-    CodeWorkspaceStatus,
+    BrowserSnapshotArgs, BrowserWaitArgs, BrowserWaitResult, CodeWorkspaceStatus, SessionLifecycle,
 };
 
 use crate::code::browser_channel::BrowserSubject;
@@ -136,7 +135,7 @@ async fn authorize(state: &AppState, headers: &HeaderMap) -> Result<BrowserSubje
         .ok_or_else(|| ServerError::forbidden("the browser session has ended"))?;
     if matches!(
         session.lifecycle,
-        CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+        SessionLifecycle::Ended | SessionLifecycle::Fenced
     ) {
         return Err(ServerError::forbidden("the browser session has ended"));
     }

--- a/crates/tidebreak-server/src/routes/code/external.rs
+++ b/crates/tidebreak-server/src/routes/code/external.rs
@@ -16,8 +16,8 @@ use axum::http::StatusCode;
 use axum::response::Response;
 
 use tidebreak_core::{
-    CodeExternalGrant, CodeSessionId, ExternalSessionResolution, GrantRotation, HarnessKind,
-    PermissionMode, RepoId,
+    CodeExternalGrant, ExternalSessionResolution, GrantRotation, HarnessKind, PermissionMode,
+    RepoId, SessionId,
 };
 
 use crate::code::runtime::{ExternalMessageOutcome, NewSessionSettings};
@@ -25,7 +25,7 @@ use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
 
-use super::types::{CodeSessionSnapshot, QueuedCodeTurn, SessionEventsQuery};
+use super::types::{QueuedTurn, SessionEventsQuery, SessionSnapshot};
 
 /// The authenticated grant behind an adapter request.
 ///
@@ -67,7 +67,7 @@ impl FromRequestParts<AppState> for ExternalGrantAuth {
 async fn require_bound(
     state: &AppState,
     grant: &CodeExternalGrant,
-    session: CodeSessionId,
+    session: SessionId,
 ) -> Result<std::sync::Arc<crate::code::runtime::CodeRuntime>, ServerError> {
     let runtime = state
         .code
@@ -102,7 +102,7 @@ pub struct ExternalSessionBody {
 pub struct ExternalSessionResponse {
     /// `created`, `existing`, or `ended`.
     pub status: &'static str,
-    pub session_id: CodeSessionId,
+    pub session_id: SessionId,
 }
 
 /// `POST /external/code/sessions` — idempotent get-or-create for one
@@ -180,9 +180,9 @@ pub struct ExternalMessageResponse {
     /// `new_turn`, `queued`, or `dropped`.
     pub outcome: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub turn_id: Option<tidebreak_core::CodeTurnId>,
+    pub turn_id: Option<tidebreak_core::TurnId>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub queued: Option<QueuedCodeTurn>,
+    pub queued: Option<QueuedTurn>,
 }
 
 /// `POST /external/code/sessions/{id}/messages` — deliver one message.
@@ -190,7 +190,7 @@ pub struct ExternalMessageResponse {
 pub async fn external_messages(
     State(state): State<AppState>,
     ExternalGrantAuth(grant): ExternalGrantAuth,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<ExternalMessageBody>,
 ) -> Result<Json<ExternalMessageResponse>, ServerError> {
     let runtime = require_bound(&state, &grant, id).await?;
@@ -213,7 +213,7 @@ pub async fn external_messages(
         ExternalMessageOutcome::Queued(row) => ExternalMessageResponse {
             outcome: "queued",
             turn_id: Some(row.id),
-            queued: Some(QueuedCodeTurn::from(*row)),
+            queued: Some(QueuedTurn::from(*row)),
         },
         ExternalMessageOutcome::Dropped => ExternalMessageResponse {
             outcome: "dropped",
@@ -230,7 +230,7 @@ pub async fn external_messages(
 pub async fn external_events(
     State(state): State<AppState>,
     ExternalGrantAuth(grant): ExternalGrantAuth,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Query(query): Query<SessionEventsQuery>,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
@@ -255,7 +255,7 @@ pub async fn external_events(
         // lifecycle and the attention snapshot arrive first, as their own
         // frame shape.
         let snapshot = serde_json::json!({
-            "snapshot": CodeSessionSnapshot::from(session),
+            "snapshot": SessionSnapshot::from(session),
         });
         if let Ok(json) = serde_json::to_string(&snapshot) {
             if socket
@@ -300,7 +300,7 @@ pub async fn external_events(
 pub async fn external_interrupt(
     State(state): State<AppState>,
     ExternalGrantAuth(grant): ExternalGrantAuth,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
 ) -> Result<StatusCode, ServerError> {
     let runtime = require_bound(&state, &grant, id).await?;
     let _ = runtime.get_session(&grant.owner, id).await?;
@@ -313,11 +313,11 @@ pub async fn external_interrupt(
 pub async fn external_reap(
     State(state): State<AppState>,
     ExternalGrantAuth(grant): ExternalGrantAuth,
-    Path(id): Path<CodeSessionId>,
-) -> Result<Json<CodeSessionSnapshot>, ServerError> {
+    Path(id): Path<SessionId>,
+) -> Result<Json<SessionSnapshot>, ServerError> {
     let runtime = require_bound(&state, &grant, id).await?;
     let session = runtime.reap(&grant.owner, id).await?;
-    Ok(Json(CodeSessionSnapshot::from(session)))
+    Ok(Json(SessionSnapshot::from(session)))
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -37,7 +37,7 @@ pub async fn refresh_harnesses(code: ScopedCode) -> Result<Json<HarnessDoctorRep
 /// Every surface that picks an engine calls this when it opens and when the
 /// engine changes. A cold pin is minutes of `npm install`; on the create path
 /// that is a silent stall, so it runs here instead and reports on
-/// `WS /code/updates`. Answers immediately in every case — already installed,
+/// `WS /updates`. Answers immediately in every case — already installed,
 /// already running, or now started — and never installs twice for one pin.
 ///
 /// `?deliberate=true` marks a reader who pressed Download rather than a picker

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -1,4 +1,4 @@
-//! `/code/*` routes: repos, workspaces, sessions, doctor, event stream.
+//! Code workspace routes plus shared session, approval, and update handlers.
 //!
 //! App-token routes here are owner-scoped through `ScopedCode`. Three route
 //! families use narrower bearer capabilities instead. The `/code/browser/*`
@@ -89,20 +89,20 @@ pub(crate) use triggers::{
 };
 #[cfg(test)]
 pub(crate) use types::{
-    CodeActionSnapshot, CodeAnalyticsSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot,
+    ApprovalDecisionBody, ApprovalSnapshot, CodeActionSnapshot, CodeAnalyticsSnapshot,
     CodeCheckLogsSnapshot, CodeCommitSnapshot, CodeConnectPage, CodeDeliveryActionResult,
     CodeDeliveryPullRequestActionBody, CodeDeliveryPullRequestDetail, CodeDeliveryPullRequestFile,
     CodeDeliveryPullRequestQuery, CodeDeliveryPullRequestTarget, CodeDeliveryPullRequestsPage,
     CodeDeliveryRepositoriesSnapshot, CodeDeliveryRunActionBody, CodeDeliveryRunDetail,
     CodeDeliveryRunQuery, CodeDeliveryRunTarget, CodeDeliveryRunsPage, CodeForkBody,
     CodeForkTranscript, CodeGrantSnapshot, CodePrCommentsSnapshot, CodePushSnapshot,
-    CodeRepoSnapshot, CodeSessionDigest, CodeSessionSnapshot, CodeTerminalRead,
-    CodeTerminalSnapshot, CodeTriggerSnapshot, CodeTurnSnapshot, CodeUpdateNotice,
-    CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspacePrSnapshot,
-    CodeWorkspacePullRequests, CodeWorkspaceSearch, CodeWorkspaceSnapshot, CodeWorkspaceTree,
-    CreateCodeTriggerBody, HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
-    ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame, SetCodeWorktreeRootBody,
-    UpdateCodeTriggerBody, WorkspaceTitleProposal,
+    CodeRepoSnapshot, CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot,
+    CodeTriggerSnapshot, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
+    CodeWorkspacePrSnapshot, CodeWorkspacePullRequests, CodeWorkspaceSearch, CodeWorkspaceSnapshot,
+    CodeWorkspaceTree, CreateCodeTriggerBody, HarnessDoctorReport, HarnessModelList,
+    MergeCodePrBody, QueuedTurn, ResolveCodeDeliveryRepositoriesBody, SequencedEventFrame,
+    SessionDigest, SessionSnapshot, SetCodeWorktreeRootBody, TurnSnapshot, UpdateCodeTriggerBody,
+    UpdateNotice, WorkspaceTitleProposal,
 };
 pub(crate) use types::{
     CodeCloneDefaults, CodeCloneJobSnapshot, CodeGithubRepositories, CodeGithubRepository,

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -1,4 +1,4 @@
-//! `WS /code/sessions/{id}/events?after=` — snapshot → replay → live.
+//! `WS /sessions/{id}/events?after=` — snapshot → replay → live.
 //!
 //! Replay is bounded (`MAX_REPLAY_EVENTS`) and says when it dropped history,
 //! so a very long session cannot make one connect read its whole life. The
@@ -13,7 +13,7 @@ use axum::Extension;
 use tokio::sync::broadcast::error::RecvError;
 
 use tidebreak_core::db::code::{list_events, MAX_REPLAY_EVENTS};
-use tidebreak_core::{CodeEvent, CodeSessionId, OwnerId};
+use tidebreak_core::{Event, OwnerId, SessionId};
 
 use crate::auth::{offered_handshake_subprotocol, GatewayAuthLease, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::code::bus::LiveTail;
@@ -23,12 +23,12 @@ use crate::extract::{Path, Query};
 use crate::routes::events::{gateway_auth_revalidation_timer, wait_for_gateway_auth_revalidation};
 use crate::state::AppState;
 
-use super::types::{SequencedCodeEventFrame, SessionEventsQuery};
+use super::types::{SequencedEventFrame, SessionEventsQuery};
 
 pub async fn session_events(
     State(state): State<AppState>,
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Query(query): Query<SessionEventsQuery>,
     headers: axum::http::HeaderMap,
     auth_lease: Option<Extension<GatewayAuthLease>>,
@@ -70,7 +70,7 @@ pub(super) async fn stream_events(
     mut socket: WebSocket,
     state: AppState,
     owner: OwnerId,
-    session: CodeSessionId,
+    session: SessionId,
     after: i64,
     auth_lease: Option<GatewayAuthLease>,
     viewer: Viewer,
@@ -127,7 +127,7 @@ pub(super) async fn stream_events(
                         }
                         if send_frame(
                             &mut socket,
-                            &SequencedCodeEventFrame {
+                            &SequencedEventFrame {
                                 seq: last_seq,
                                 event: event.event,
                                 replayed: None,
@@ -158,7 +158,7 @@ pub(super) async fn stream_events(
                     last_seq = seq;
                     if send_frame(
                         &mut socket,
-                        &SequencedCodeEventFrame {
+                        &SequencedEventFrame {
                             seq,
                             event: event.event,
                             replayed: None,
@@ -206,9 +206,9 @@ async fn send_live_tail(
     }
     send_frame(
         socket,
-        &SequencedCodeEventFrame {
+        &SequencedEventFrame {
             seq: last_seq,
-            event: CodeEvent::AssistantDelta {
+            event: Event::AssistantDelta {
                 text: tail.assistant.clone(),
             },
             replayed: None,
@@ -224,7 +224,7 @@ async fn replay_after(
     socket: &mut WebSocket,
     store: &tidebreak_core::DbStore,
     owner: &OwnerId,
-    session: CodeSessionId,
+    session: SessionId,
     last_seq: &mut i64,
 ) -> Result<(), ()> {
     let page = list_events(store, owner, session, *last_seq, MAX_REPLAY_EVENTS)
@@ -235,7 +235,7 @@ async fn replay_after(
         *last_seq = event.seq;
         send_frame(
             socket,
-            &SequencedCodeEventFrame {
+            &SequencedEventFrame {
                 seq: event.seq,
                 event: event.event,
                 replayed: Some(true),
@@ -272,7 +272,7 @@ fn transient_is_current(cursor: i64, last_seq: i64) -> bool {
 
 async fn send_frame(
     socket: &mut WebSocket,
-    frame: &SequencedCodeEventFrame,
+    frame: &SequencedEventFrame,
 ) -> Result<(), axum::Error> {
     let Ok(json) = serde_json::to_string(frame) else {
         return Ok(());

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -15,14 +15,13 @@ use axum::http::{header, request::Parts, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 
 use super::types::{
-    CodeForkTranscript, CodeSessionExternalOrigin, CodeSessionSnapshot, CodeTurnSnapshot,
-    CreateInternalSessionBody, CreateRemoteSessionBody, CreateSessionBody, QueuePausedBody,
-    QueuedCodeTurn, QueuedCodeTurnUpdate, QueuedCodeTurnsSnapshot, SequencedCodeEventFrame,
-    SetAttentionBody, SetFastModeBody, SetPermissionModeBody, SetReasoningEffortBody, SteerBody,
-    SubmitTurnBody,
+    CodeForkTranscript, CreateInternalSessionBody, CreateRemoteSessionBody, CreateSessionBody,
+    QueuePausedBody, QueuedTurn, QueuedTurnUpdate, QueuedTurnsSnapshot, SequencedEventFrame,
+    SessionExternalOrigin, SessionSnapshot, SetAttentionBody, SetFastModeBody,
+    SetPermissionModeBody, SetReasoningEffortBody, SteerBody, SubmitTurnBody, TurnSnapshot,
 };
 use crate::code::runtime::{NewSessionSettings, SubmitTurnOutcome};
-use tidebreak_core::{CodeSessionId, PermissionMode, TurnSteer, WorkspaceId};
+use tidebreak_core::{PermissionMode, SessionId, TurnSteer, WorkspaceId};
 
 /// The managed ceiling remote session creation needs, resolved before the
 /// handler receives request fields.
@@ -71,13 +70,10 @@ pub async fn create_session(
             },
         )
         .await?;
-    Ok((
-        StatusCode::CREATED,
-        Json(CodeSessionSnapshot::from(session)),
-    ))
+    Ok((StatusCode::CREATED, Json(SessionSnapshot::from(session))))
 }
 
-/// `POST /code/sessions` — create a conversation with no workspace. The
+/// `POST /sessions` — create a conversation with no workspace. The
 /// in-process engine hosts it (decision 0048 step 5).
 pub async fn create_internal_session(
     State(state): State<AppState>,
@@ -94,10 +90,7 @@ pub async fn create_internal_session(
             permission_mode_ceiling,
         })
         .await?;
-    Ok((
-        StatusCode::CREATED,
-        Json(CodeSessionSnapshot::from(session)),
-    ))
+    Ok((StatusCode::CREATED, Json(SessionSnapshot::from(session))))
 }
 
 /// `POST /code/remote/workspaces/{id}/sessions` — create a session whose
@@ -123,10 +116,7 @@ pub async fn create_remote_session(
             },
         )
         .await?;
-    Ok((
-        StatusCode::CREATED,
-        Json(CodeSessionSnapshot::from(session)),
-    ))
+    Ok((StatusCode::CREATED, Json(SessionSnapshot::from(session))))
 }
 
 /// One session as a snapshot with its external origin attached.
@@ -137,18 +127,18 @@ pub async fn create_remote_session(
 /// next reap, mode change, or attention edit.
 async fn snapshot_with_origin(
     code: &ScopedCode,
-    session: tidebreak_core::CodeSession,
-) -> Result<CodeSessionSnapshot, ServerError> {
+    session: tidebreak_core::Session,
+) -> Result<SessionSnapshot, ServerError> {
     let origin = code
         .external_bindings_for_sessions(&[session.id])
         .await?
         .into_iter()
         .next()
-        .map(|binding| CodeSessionExternalOrigin {
+        .map(|binding| SessionExternalOrigin {
             channel_kind: binding.channel_kind,
             external_key: binding.external_key,
         });
-    let mut snapshot = CodeSessionSnapshot::from(session);
+    let mut snapshot = SessionSnapshot::from(session);
     snapshot.external_origin = origin;
     Ok(snapshot)
 }
@@ -156,17 +146,17 @@ async fn snapshot_with_origin(
 pub async fn list_workspace_sessions(
     code: ScopedCode,
     Path(workspace_id): Path<WorkspaceId>,
-) -> Result<Json<Vec<CodeSessionSnapshot>>, ServerError> {
+) -> Result<Json<Vec<SessionSnapshot>>, ServerError> {
     let sessions = code.list_workspace_sessions(workspace_id).await?;
-    let ids: Vec<CodeSessionId> = sessions.iter().map(|session| session.id).collect();
-    let origins: std::collections::HashMap<CodeSessionId, CodeSessionExternalOrigin> = code
+    let ids: Vec<SessionId> = sessions.iter().map(|session| session.id).collect();
+    let origins: std::collections::HashMap<SessionId, SessionExternalOrigin> = code
         .external_bindings_for_sessions(&ids)
         .await?
         .into_iter()
         .map(|binding| {
             (
                 binding.session_id,
-                CodeSessionExternalOrigin {
+                SessionExternalOrigin {
                     channel_kind: binding.channel_kind,
                     external_key: binding.external_key,
                 },
@@ -178,7 +168,7 @@ pub async fn list_workspace_sessions(
             .into_iter()
             .map(|session| {
                 let origin = origins.get(&session.id).cloned();
-                let mut snapshot = CodeSessionSnapshot::from(session);
+                let mut snapshot = SessionSnapshot::from(session);
                 snapshot.external_origin = origin;
                 snapshot
             })
@@ -186,36 +176,33 @@ pub async fn list_workspace_sessions(
     ))
 }
 
-/// `GET /code/sessions` — the owner's conversations that bind no
+/// `GET /sessions` — the owner's conversations that bind no
 /// workspace, newest first.
 pub async fn list_internal_sessions(
     code: ScopedCode,
-) -> Result<Json<Vec<CodeSessionSnapshot>>, ServerError> {
+) -> Result<Json<Vec<SessionSnapshot>>, ServerError> {
     let sessions = code.list_internal_sessions().await?;
     Ok(Json(
-        sessions
-            .into_iter()
-            .map(CodeSessionSnapshot::from)
-            .collect(),
+        sessions.into_iter().map(SessionSnapshot::from).collect(),
     ))
 }
 
-/// `GET /code/sessions/{id}` — one session by id, whatever it binds.
+/// `GET /sessions/{id}` — one session by id, whatever it binds.
 pub async fn get_session(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
-) -> Result<Json<CodeSessionSnapshot>, ServerError> {
+    Path(id): Path<SessionId>,
+) -> Result<Json<SessionSnapshot>, ServerError> {
     let session = code.get_session(id).await?;
     let origin = code
         .external_bindings_for_sessions(&[id])
         .await?
         .into_iter()
         .next()
-        .map(|binding| CodeSessionExternalOrigin {
+        .map(|binding| SessionExternalOrigin {
             channel_kind: binding.channel_kind,
             external_key: binding.external_key,
         });
-    let mut snapshot = CodeSessionSnapshot::from(session);
+    let mut snapshot = SessionSnapshot::from(session);
     snapshot.external_origin = origin;
     Ok(Json(snapshot))
 }
@@ -223,7 +210,7 @@ pub async fn get_session(
 pub async fn submit_turn(
     State(state): State<AppState>,
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<SubmitTurnBody>,
 ) -> Result<impl IntoResponse, ServerError> {
     let message = body.message.trim().to_owned();
@@ -251,10 +238,10 @@ pub async fn submit_turn(
         .await?
     {
         SubmitTurnOutcome::Ran(turn) => {
-            Ok((StatusCode::ACCEPTED, Json(CodeTurnSnapshot::from(*turn))).into_response())
+            Ok((StatusCode::ACCEPTED, Json(TurnSnapshot::from(*turn))).into_response())
         }
         SubmitTurnOutcome::Queued(row) => {
-            Ok((StatusCode::ACCEPTED, Json(QueuedCodeTurn::from(*row))).into_response())
+            Ok((StatusCode::ACCEPTED, Json(QueuedTurn::from(*row))).into_response())
         }
         // Trigger submits never come through this route; the enum is shared
         // with the trigger sweep, which is the only caller that can see this.
@@ -264,26 +251,26 @@ pub async fn submit_turn(
     }
 }
 
-/// `GET /code/sessions/{id}/queued` — the session's queued messages, FIFO,
+/// `GET /sessions/{id}/queued` — the session's queued messages, FIFO,
 /// plus whether promotion is paused.
 pub async fn list_queued_turns(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
-) -> Result<Json<QueuedCodeTurnsSnapshot>, ServerError> {
+    Path(id): Path<SessionId>,
+) -> Result<Json<QueuedTurnsSnapshot>, ServerError> {
     let (queued, paused) = code.list_queued_turns(id).await?;
-    Ok(Json(QueuedCodeTurnsSnapshot {
-        queued: queued.into_iter().map(QueuedCodeTurn::from).collect(),
+    Ok(Json(QueuedTurnsSnapshot {
+        queued: queued.into_iter().map(QueuedTurn::from).collect(),
         paused,
     }))
 }
 
-/// `PATCH /code/sessions/{id}/queued/{queued_id}` — edit or reorder one
+/// `PATCH /sessions/{id}/queued/{queued_id}` — edit or reorder one
 /// queued message.
 pub async fn patch_queued_turn(
     code: ScopedCode,
-    Path((id, queued_id)): Path<(CodeSessionId, tidebreak_core::CodeTurnId)>,
-    Json(body): Json<QueuedCodeTurnUpdate>,
-) -> Result<Json<QueuedCodeTurn>, ServerError> {
+    Path((id, queued_id)): Path<(SessionId, tidebreak_core::TurnId)>,
+    Json(body): Json<QueuedTurnUpdate>,
+) -> Result<Json<QueuedTurn>, ServerError> {
     if let Some(message) = body.message.as_deref() {
         if message.trim().is_empty() || message.contains('\0') {
             return Err(ServerError::bad_request(
@@ -295,14 +282,14 @@ pub async fn patch_queued_turn(
         .update_queued_turn(id, queued_id, body.message.as_deref(), body.position)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("queued turn {queued_id} not found")))?;
-    Ok(Json(QueuedCodeTurn::from(updated)))
+    Ok(Json(QueuedTurn::from(updated)))
 }
 
-/// `DELETE /code/sessions/{id}/queued/{queued_id}` — retract one queued
+/// `DELETE /sessions/{id}/queued/{queued_id}` — retract one queued
 /// message.
 pub async fn delete_queued_turn(
     code: ScopedCode,
-    Path((id, queued_id)): Path<(CodeSessionId, tidebreak_core::CodeTurnId)>,
+    Path((id, queued_id)): Path<(SessionId, tidebreak_core::TurnId)>,
 ) -> Result<StatusCode, ServerError> {
     if code.delete_queued_turn(id, queued_id).await? {
         Ok(StatusCode::NO_CONTENT)
@@ -313,31 +300,31 @@ pub async fn delete_queued_turn(
     }
 }
 
-/// `PUT /code/sessions/{id}/queue-paused` — pause or release promotion for
+/// `PUT /sessions/{id}/queue-paused` — pause or release promotion for
 /// this session; queued rows stay put while paused.
 pub async fn put_queue_paused(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<QueuePausedBody>,
 ) -> Result<StatusCode, ServerError> {
     code.set_queue_paused(id, body.paused).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// `POST /code/sessions/{id}/queued/send-now` — clear this session's pause
+/// `POST /sessions/{id}/queued/send-now` — clear this session's pause
 /// and wake the worker so the head row starts.
 ///
 /// The tray composes the full gesture client-side exactly as chat's does:
 /// pause, move the row first, stop the live turn, then this.
 pub async fn post_queue_send_now(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
 ) -> Result<StatusCode, ServerError> {
     code.send_queued_now(id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// `POST /code/sessions/{id}/fork` — write this session's handoff into
+/// `POST /sessions/{id}/fork` — write this session's handoff into
 /// private storage and report where it landed.
 ///
 /// Creating the child session is a separate call: forking is a file, and the
@@ -346,7 +333,7 @@ pub async fn post_queue_send_now(
 /// the newest turn.
 pub async fn fork_session(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     body: axum::body::Bytes,
 ) -> Result<(StatusCode, Json<CodeForkTranscript>), ServerError> {
     let at_turn = if body.is_empty() {
@@ -373,15 +360,15 @@ pub async fn fork_session(
 
 pub async fn get_session_debug(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
-) -> Result<Json<super::types::CodeSessionDebug>, ServerError> {
+    Path(id): Path<SessionId>,
+) -> Result<Json<super::types::SessionDebug>, ServerError> {
     let (session, turns, events) = code.session_debug(id).await?;
-    Ok(Json(super::types::CodeSessionDebug {
-        session: CodeSessionSnapshot::from(session),
-        turns: turns.into_iter().map(CodeTurnSnapshot::from).collect(),
+    Ok(Json(super::types::SessionDebug {
+        session: SessionSnapshot::from(session),
+        turns: turns.into_iter().map(TurnSnapshot::from).collect(),
         events: events
             .into_iter()
-            .map(|item| SequencedCodeEventFrame {
+            .map(|item| SequencedEventFrame {
                 seq: item.seq,
                 event: item.event,
                 replayed: None,
@@ -395,17 +382,15 @@ pub async fn get_session_debug(
 
 pub async fn list_session_turns(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
-) -> Result<Json<Vec<CodeTurnSnapshot>>, ServerError> {
+    Path(id): Path<SessionId>,
+) -> Result<Json<Vec<TurnSnapshot>>, ServerError> {
     let turns = code.list_session_turns(id).await?;
-    Ok(Json(
-        turns.into_iter().map(CodeTurnSnapshot::from).collect(),
-    ))
+    Ok(Json(turns.into_iter().map(TurnSnapshot::from).collect()))
 }
 
 pub async fn steer_session(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<SteerBody>,
 ) -> Result<StatusCode, ServerError> {
     let guidance = body.guidance.trim().to_owned();
@@ -423,7 +408,7 @@ pub async fn steer_session(
 
 pub async fn interrupt_session(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
 ) -> Result<StatusCode, ServerError> {
     code.interrupt(id).await?;
     Ok(StatusCode::ACCEPTED)
@@ -431,17 +416,17 @@ pub async fn interrupt_session(
 
 pub async fn set_attention(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<SetAttentionBody>,
-) -> Result<Json<CodeSessionSnapshot>, ServerError> {
+) -> Result<Json<SessionSnapshot>, ServerError> {
     let session = code.set_attention(id, body.clear, body.note).await?;
     Ok(Json(snapshot_with_origin(&code, session).await?))
 }
 
 pub async fn reap_session(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
-) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
+    Path(id): Path<SessionId>,
+) -> Result<(StatusCode, Json<SessionSnapshot>), ServerError> {
     let session = code.reap(id).await?;
     Ok((
         StatusCode::OK,
@@ -449,7 +434,7 @@ pub async fn reap_session(
     ))
 }
 
-/// `POST /code/sessions/{id}/mode` — change a session's permission mode.
+/// `POST /sessions/{id}/mode` — change a session's permission mode.
 ///
 /// The engine is relaunched against the new posture, so this is refused
 /// while a turn is running and while the session has ended. A mode the
@@ -458,9 +443,9 @@ pub async fn reap_session(
 pub async fn set_session_permission_mode(
     State(state): State<AppState>,
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<SetPermissionModeBody>,
-) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
+) -> Result<(StatusCode, Json<SessionSnapshot>), ServerError> {
     refuse_permission_mode_over_ceiling(&state, Some(body.permission_mode)).await?;
     let session = code.set_permission_mode(id, body.permission_mode).await?;
     Ok((
@@ -469,16 +454,16 @@ pub async fn set_session_permission_mode(
     ))
 }
 
-/// `POST /code/sessions/{id}/effort` — change a session's reasoning effort.
+/// `POST /sessions/{id}/effort` — change a session's reasoning effort.
 ///
 /// No relaunch: every adapter reads the level off the turn, so the next turn
 /// carries it. Refused while a turn is running and after the session ends, on
 /// the same rule the mode route applies.
 pub async fn set_session_reasoning_effort(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<SetReasoningEffortBody>,
-) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
+) -> Result<(StatusCode, Json<SessionSnapshot>), ServerError> {
     let session = code.set_reasoning_effort(id, body.reasoning_effort).await?;
     Ok((
         StatusCode::OK,
@@ -486,7 +471,7 @@ pub async fn set_session_reasoning_effort(
     ))
 }
 
-/// `POST /code/sessions/{id}/fast-mode` — arm or disarm the engine's fast mode.
+/// `POST /sessions/{id}/fast-mode` — arm or disarm the engine's fast mode.
 ///
 /// Fast mode buys output speed at a premium rate, so this is a spend switch
 /// rather than a quality one. Refused while a turn is running and after the
@@ -494,9 +479,9 @@ pub async fn set_session_reasoning_effort(
 /// when the session's model does not serve the tier.
 pub async fn set_session_fast_mode(
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<SetFastModeBody>,
-) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
+) -> Result<(StatusCode, Json<SessionSnapshot>), ServerError> {
     let session = code.set_fast_mode(id, body.fast_mode).await?;
     Ok((
         StatusCode::OK,
@@ -504,13 +489,13 @@ pub async fn set_session_fast_mode(
     ))
 }
 
-/// `POST /code/sessions/{id}/attachments/images` — publish pixels a later
+/// `POST /sessions/{id}/attachments/images` — publish pixels a later
 /// turn can reference. Same sniff-and-store path as chat; the turn row is
 /// what pins the blob.
 pub async fn publish_session_image(
     State(state): State<AppState>,
     code: ScopedCode,
-    Path(id): Path<CodeSessionId>,
+    Path(id): Path<SessionId>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
@@ -541,12 +526,12 @@ pub async fn publish_session_image(
     ))
 }
 
-/// `GET /code/sessions/{id}/attachments/images/{blob_id}` — pixels for an
+/// `GET /sessions/{id}/attachments/images/{blob_id}` — pixels for an
 /// image a turn on this session already referenced.
 pub async fn get_session_image(
     State(state): State<AppState>,
     code: ScopedCode,
-    Path((id, blob_id)): Path<(CodeSessionId, uuid::Uuid)>,
+    Path((id, blob_id)): Path<(SessionId, uuid::Uuid)>,
 ) -> Result<Response, ServerError> {
     let turns = code.list_session_turns(id).await?;
     let attachment = turns

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -4,13 +4,12 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use tidebreak_core::{
-    Attention, CapLevel, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
-    CodeEvent, CodePullRequestRelation, CodeRepo, CodeSession, CodeSessionKind,
-    CodeSessionLifecycle, CodeSubagentSummary, CodeTerminalId, CodeTrigger, CodeTriggerAction,
-    CodeTriggerCondition, CodeTriggerId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWatch,
-    CodeWatchId, CodeWatchState, CodeWorkspace, CodeWorkspaceStatus, Diffstat, FenceReason,
-    FileChangeKind, HarnessCaps, HarnessKind, HarnessTier, PermissionMode, PullRequestDigest,
-    QuickAction, ReasoningEffort, RepoId, WorkspaceId,
+    Approval, ApprovalId, ApprovalKind, ApprovalState, Attention, CapLevel,
+    CodePullRequestRelation, CodeRepo, CodeSubagentSummary, CodeTerminalId, CodeTrigger,
+    CodeTriggerAction, CodeTriggerCondition, CodeTriggerId, CodeWatch, CodeWatchId, CodeWatchState,
+    CodeWorkspace, CodeWorkspaceStatus, Diffstat, Event, FenceReason, FileChangeKind, HarnessCaps,
+    HarnessKind, HarnessTier, PermissionMode, PullRequestDigest, QuickAction, ReasoningEffort,
+    RepoId, Session, SessionKind, SessionLifecycle, Turn, TurnId, TurnStatus, WorkspaceId,
 };
 
 /// One adapter grant, as the desktop grants list renders it. Carries no
@@ -203,7 +202,7 @@ impl From<CodeWorkspace> for CodeWorkspaceSnapshot {
 /// as the provenance banner; a session the desktop created carries none.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
-pub struct CodeSessionExternalOrigin {
+pub struct SessionExternalOrigin {
     /// The channel family, for example `slack`.
     pub channel_kind: String,
     /// The channel's durable conversation identity, opaque to the server.
@@ -215,12 +214,12 @@ pub struct CodeSessionExternalOrigin {
 /// One durable conversation with an external agent engine.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
-pub struct CodeSessionSnapshot {
-    pub id: tidebreak_core::CodeSessionId,
+pub struct SessionSnapshot {
+    pub id: tidebreak_core::SessionId,
     /// `None` for a session that binds no workspace: the in-process
     /// engine's (decision 0048 step 5).
     pub workspace_id: Option<WorkspaceId>,
-    pub kind: CodeSessionKind,
+    pub kind: SessionKind,
     pub harness_kind: HarnessKind,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -239,7 +238,7 @@ pub struct CodeSessionSnapshot {
     /// Whether this session runs its turns in the engine's fast mode.
     #[serde(default)]
     pub fast_mode: bool,
-    pub lifecycle: CodeSessionLifecycle,
+    pub lifecycle: SessionLifecycle,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub fence_reason: Option<FenceReason>,
@@ -249,11 +248,11 @@ pub struct CodeSessionSnapshot {
     /// Present when an external channel created the session.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub external_origin: Option<CodeSessionExternalOrigin>,
+    pub external_origin: Option<SessionExternalOrigin>,
 }
 
-impl From<CodeSession> for CodeSessionSnapshot {
-    fn from(session: CodeSession) -> Self {
+impl From<Session> for SessionSnapshot {
+    fn from(session: Session) -> Self {
         Self {
             id: session.id,
             workspace_id: session.workspace_id,
@@ -280,11 +279,11 @@ impl From<CodeSession> for CodeSessionSnapshot {
 /// One user→engine turn.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
-pub struct CodeTurnSnapshot {
-    pub id: tidebreak_core::CodeTurnId,
-    pub session_id: tidebreak_core::CodeSessionId,
+pub struct TurnSnapshot {
+    pub id: tidebreak_core::TurnId,
+    pub session_id: tidebreak_core::SessionId,
     pub ordinal: i64,
-    pub status: CodeTurnStatus,
+    pub status: TurnStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub model: Option<String>,
@@ -294,7 +293,7 @@ pub struct CodeTurnSnapshot {
     pub attachments: Vec<tidebreak_core::ImageRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub usage: Option<tidebreak_core::CodeUsage>,
+    pub usage: Option<tidebreak_core::TurnUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub checkpoint_ref: Option<String>,
@@ -311,8 +310,8 @@ pub struct CodeTurnSnapshot {
     pub rewrite: Option<String>,
 }
 
-impl From<CodeTurn> for CodeTurnSnapshot {
-    fn from(turn: CodeTurn) -> Self {
+impl From<Turn> for TurnSnapshot {
+    fn from(turn: Turn) -> Self {
         Self {
             id: turn.id,
             session_id: turn.session_id,
@@ -450,12 +449,12 @@ pub struct CodeAnalyticsSnapshot {
 /// One event on the per-session WebSocket.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
-pub struct SequencedCodeEventFrame {
+pub struct SequencedEventFrame {
     /// Journal position. On a `transient` frame this is the cursor the event
     /// streamed behind, not a position the frame occupies — resume from it
     /// and you lose nothing, because no row holds this event.
     pub seq: i64,
-    pub event: CodeEvent,
+    pub event: Event,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub replayed: Option<bool>,
@@ -479,12 +478,12 @@ pub struct SequencedCodeEventFrame {
     pub truncated: Option<bool>,
 }
 
-/// `GET /code/sessions/{id}/debug` — journal plus turn rows for a bug report.
+/// `GET /sessions/{id}/debug` — journal plus turn rows for a bug report.
 #[derive(Debug, Clone, PartialEq, Serialize, TS)]
-pub struct CodeSessionDebug {
-    pub session: CodeSessionSnapshot,
-    pub turns: Vec<CodeTurnSnapshot>,
-    pub events: Vec<SequencedCodeEventFrame>,
+pub struct SessionDebug {
+    pub session: SessionSnapshot,
+    pub turns: Vec<TurnSnapshot>,
+    pub events: Vec<SequencedEventFrame>,
 }
 
 /// Doctor report for every registered engine adapter.
@@ -741,7 +740,7 @@ pub struct CodeRepoSource {
     pub remediation: Option<String>,
 }
 
-/// A written fork handoff: `POST /code/sessions/{id}/fork`.
+/// A written fork handoff: `POST /sessions/{id}/fork`.
 ///
 /// `path` is the condensed transcript, absolute under private storage so a
 /// child agent of any engine can read it without Git ever indexing it. `dir`
@@ -766,7 +765,7 @@ pub struct CodeForkTranscript {
     pub truncated: bool,
 }
 
-/// Body of `POST /code/sessions/{id}/fork`. An absent body forks at the
+/// Body of `POST /sessions/{id}/fork`. An absent body forks at the
 /// newest turn.
 #[derive(Debug, Default, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
@@ -774,7 +773,7 @@ pub struct CodeForkBody {
     /// Fork at the end of this turn; later turns stay out of the handoff.
     #[serde(default)]
     #[ts(optional)]
-    pub at_turn: Option<tidebreak_core::CodeTurnId>,
+    pub at_turn: Option<tidebreak_core::TurnId>,
 }
 
 /// Where new worktrees land: `GET`/`PUT /code/worktree-root`.
@@ -1021,7 +1020,7 @@ pub struct CodeWorkspacePullRequests {
 pub struct CodeWatchSnapshot {
     pub id: CodeWatchId,
     pub workspace_id: WorkspaceId,
-    pub session_id: tidebreak_core::CodeSessionId,
+    pub session_id: tidebreak_core::SessionId,
     pub pr_number: u64,
     pub state: CodeWatchState,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1761,7 +1760,7 @@ pub struct CodeActionSnapshot {
 }
 
 /// Body of `POST /code/workspaces/{id}/sessions`.
-/// `POST /code/sessions`: a conversation with no workspace, hosted by the
+/// `POST /sessions`: a conversation with no workspace, hosted by the
 /// in-process engine (decision 0048 step 5). The engine is implied.
 #[derive(Debug, Deserialize, TS)]
 pub struct CreateInternalSessionBody {
@@ -1801,14 +1800,14 @@ pub struct CreateRemoteSessionBody {
     pub reasoning_effort: Option<ReasoningEffort>,
 }
 
-/// Body of `POST /code/sessions/{id}/mode`.
+/// Body of `POST /sessions/{id}/mode`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SetPermissionModeBody {
     pub permission_mode: PermissionMode,
 }
 
-/// Body of `POST /code/sessions/{id}/effort`.
+/// Body of `POST /sessions/{id}/effort`.
 ///
 /// `null` is a choice, not an omission: it hands the level back to the
 /// engine's own default.
@@ -1818,14 +1817,14 @@ pub struct SetReasoningEffortBody {
     pub reasoning_effort: Option<ReasoningEffort>,
 }
 
-/// Body of `POST /code/sessions/{id}/fast-mode`.
+/// Body of `POST /sessions/{id}/fast-mode`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SetFastModeBody {
     pub fast_mode: bool,
 }
 
-/// Body of `POST /code/sessions/{id}/turns`.
+/// Body of `POST /sessions/{id}/turns`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SubmitTurnBody {
@@ -1850,11 +1849,11 @@ pub struct SubmitTurnAttachment {
     pub media_type: String,
 }
 
-/// Body of `POST /code/sessions/{id}/steer`.
+/// Body of `POST /sessions/{id}/steer`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SteerBody {
-    pub expected_turn_id: tidebreak_core::CodeTurnId,
+    pub expected_turn_id: tidebreak_core::TurnId,
     pub guidance: String,
 }
 
@@ -1866,17 +1865,17 @@ pub struct SteerBody {
 /// the session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
-pub struct QueuedCodeTurn {
-    pub id: tidebreak_core::CodeTurnId,
-    pub session_id: tidebreak_core::CodeSessionId,
+pub struct QueuedTurn {
+    pub id: tidebreak_core::TurnId,
+    pub session_id: tidebreak_core::SessionId,
     pub message: String,
     pub position: i32,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-impl From<tidebreak_core::CodeQueuedTurn> for QueuedCodeTurn {
-    fn from(row: tidebreak_core::CodeQueuedTurn) -> Self {
+impl From<tidebreak_core::code::QueuedTurn> for QueuedTurn {
+    fn from(row: tidebreak_core::code::QueuedTurn) -> Self {
         Self {
             id: row.id,
             session_id: row.session_id,
@@ -1888,25 +1887,25 @@ impl From<tidebreak_core::CodeQueuedTurn> for QueuedCodeTurn {
     }
 }
 
-/// Response of `GET /code/sessions/{id}/queued`.
+/// Response of `GET /sessions/{id}/queued`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct QueuedCodeTurnsSnapshot {
-    pub queued: Vec<QueuedCodeTurn>,
+pub struct QueuedTurnsSnapshot {
+    pub queued: Vec<QueuedTurn>,
     pub paused: bool,
 }
 
-/// Body of `PATCH /code/sessions/{id}/queued/{queued_id}`.
+/// Body of `PATCH /sessions/{id}/queued/{queued_id}`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct QueuedCodeTurnUpdate {
+pub struct QueuedTurnUpdate {
     #[serde(default)]
     pub message: Option<String>,
     #[serde(default)]
     pub position: Option<i32>,
 }
 
-/// Body of `PUT /code/sessions/{id}/queue-paused`.
+/// Body of `PUT /sessions/{id}/queue-paused`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct QueuePausedBody {
@@ -1974,10 +1973,10 @@ pub enum CodeWorkspaceHistorySearchSource {
 pub struct CodeWorkspaceHistorySearchMatch {
     pub workspace_id: WorkspaceId,
     pub workspace_title: String,
-    pub session_id: tidebreak_core::CodeSessionId,
+    pub session_id: tidebreak_core::SessionId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub turn_id: Option<CodeTurnId>,
+    pub turn_id: Option<TurnId>,
     pub source: CodeWorkspaceHistorySearchSource,
     pub preview: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
@@ -1996,7 +1995,7 @@ pub struct CodeWorkspaceSearch {
 #[derive(Debug, Deserialize)]
 pub struct WorkspaceFilesQuery {
     #[serde(default)]
-    pub turn: Option<CodeTurnId>,
+    pub turn: Option<TurnId>,
 }
 
 /// Query for `GET /code/workspaces/{id}/blob`.
@@ -2018,7 +2017,7 @@ pub struct CodeWorkspaceBlob {
 #[derive(Debug, Deserialize)]
 pub struct WorkspaceDiffQuery {
     #[serde(default)]
-    pub turn: Option<CodeTurnId>,
+    pub turn: Option<TurnId>,
     #[serde(default)]
     pub file: Option<String>,
 }
@@ -2045,7 +2044,7 @@ pub struct CodeWorkspaceFiles {
     pub stat: Diffstat,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub turn_id: Option<CodeTurnId>,
+    pub turn_id: Option<TurnId>,
 }
 
 /// Bounded unified diff for `GET /code/workspaces/{id}/diff`.
@@ -2057,7 +2056,7 @@ pub struct CodeWorkspaceDiff {
     pub stat: Diffstat,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub turn_id: Option<CodeTurnId>,
+    pub turn_id: Option<TurnId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub file: Option<String>,
@@ -2066,14 +2065,14 @@ pub struct CodeWorkspaceDiff {
 /// One parked or decided engine approval.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
-pub struct CodeApprovalSnapshot {
-    pub id: CodeApprovalId,
-    pub session_id: tidebreak_core::CodeSessionId,
-    pub turn_id: tidebreak_core::CodeTurnId,
-    pub kind: CodeApprovalKind,
+pub struct ApprovalSnapshot {
+    pub id: ApprovalId,
+    pub session_id: tidebreak_core::SessionId,
+    pub turn_id: tidebreak_core::TurnId,
+    pub kind: ApprovalKind,
     /// Exact JSON the engine sent, already size-capped. The card renders this.
     pub harness_raw_json: String,
-    pub state: CodeApprovalState,
+    pub state: ApprovalState,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub feedback: Option<String>,
@@ -2083,8 +2082,8 @@ pub struct CodeApprovalSnapshot {
     pub decided_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-impl From<CodeApproval> for CodeApprovalSnapshot {
-    fn from(approval: CodeApproval) -> Self {
+impl From<Approval> for ApprovalSnapshot {
+    fn from(approval: Approval) -> Self {
         Self {
             id: approval.id,
             session_id: approval.session_id,
@@ -2099,11 +2098,11 @@ impl From<CodeApproval> for CodeApprovalSnapshot {
     }
 }
 
-/// Body of `POST /code/approvals/{id}/decision`.
+/// Body of `POST /approvals/{id}/decision`.
 #[derive(Debug, Deserialize, Serialize, TS)]
 #[serde(deny_unknown_fields)]
-pub struct CodeApprovalDecisionBody {
-    pub decision: CodeApprovalDecision,
+pub struct ApprovalDecisionBody {
+    pub decision: ApprovalDecision,
     #[serde(default)]
     #[ts(optional)]
     pub feedback: Option<String>,
@@ -2117,7 +2116,7 @@ pub struct CodeApprovalDecisionBody {
 /// a client can pick a rung the card showed, never invent a scope.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, TS)]
 #[serde(rename_all = "snake_case")]
-pub enum CodeApprovalDecision {
+pub enum ApprovalDecision {
     Approve,
     Deny,
     ApproveWithGrant {
@@ -2142,16 +2141,16 @@ pub struct InstallHarnessQuery {
     pub deliberate: bool,
 }
 
-/// Query for `GET /code/approvals`.
+/// Query for `GET /approvals`.
 #[derive(Debug, Deserialize)]
 pub struct ListApprovalsQuery {
     #[serde(default)]
-    pub state: Option<CodeApprovalState>,
+    pub state: Option<ApprovalState>,
     #[serde(default)]
-    pub session_id: Option<tidebreak_core::CodeSessionId>,
+    pub session_id: Option<tidebreak_core::SessionId>,
 }
 
-/// Query for `GET /code/sessions/{id}/events`.
+/// Query for `GET /sessions/{id}/events`.
 #[derive(Debug, Deserialize)]
 pub struct SessionEventsQuery {
     #[serde(default)]
@@ -2185,21 +2184,31 @@ pub struct CodeTerminalRead {
     pub ended: bool,
 }
 
-/// Cheap per-session digest on `/code/updates`.
+/// Unsequenced activity notice published on the updates channel.
+///
+/// Never journaled. A client that missed one just pulls from its last cursor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[allow(dead_code)]
+pub struct CodeTerminalActivityNotice {
+    pub workspace_id: WorkspaceId,
+    pub terminal_id: CodeTerminalId,
+}
+
+/// Cheap per-session digest on `/updates`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
-pub struct CodeSessionDigest {
+pub struct SessionDigest {
     /// `None` for a session that binds no workspace.
     pub workspace: Option<WorkspaceId>,
-    pub session: tidebreak_core::CodeSessionId,
-    pub kind: CodeSessionKind,
+    pub session: tidebreak_core::SessionId,
+    pub kind: SessionKind,
     /// Engine identity for list surfaces that collapse several sessions into
     /// one workspace row. Optional on the wire so a desktop can still read a
     /// digest from an older server during an update.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub harness_kind: Option<HarnessKind>,
-    pub lifecycle: CodeSessionLifecycle,
+    pub lifecycle: SessionLifecycle,
     pub attention: Attention,
     pub title: String,
     pub turn_count: i64,
@@ -2212,7 +2221,7 @@ pub struct CodeSessionDigest {
     /// What the live turn is occupied with, while running.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub activity: Option<tidebreak_core::CodeSessionActivity>,
+    pub activity: Option<tidebreak_core::SessionActivity>,
     /// The subject of the tool the live turn is waiting on: the command,
     /// path, query, or task description. Present only while `activity`
     /// names a tool, and bounded to one line.
@@ -2254,7 +2263,7 @@ pub struct CodeSessionDigest {
     pub memory_proposal_count: Option<u64>,
 }
 
-impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
+impl From<crate::code::bus::SessionDigest> for SessionDigest {
     fn from(digest: crate::code::bus::SessionDigest) -> Self {
         Self {
             workspace: digest.workspace,
@@ -2280,27 +2289,27 @@ impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
     }
 }
 
-/// One unsequenced notice on `WS /code/updates`.
+/// One unsequenced notice on `WS /updates`.
 ///
 /// A connect is restated as [`Self::Snapshot`]; later notices are live only.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
-pub enum CodeUpdateNotice {
+pub enum UpdateNotice {
     /// Full current digest of every non-ended session.
     Snapshot {
         /// One row per live session.
-        sessions: Vec<CodeSessionDigest>,
+        sessions: Vec<SessionDigest>,
     },
     /// One session's current digest.
     Digest {
         workspace: Option<WorkspaceId>,
-        session: tidebreak_core::CodeSessionId,
-        kind: CodeSessionKind,
+        session: tidebreak_core::SessionId,
+        kind: SessionKind,
         /// Engine identity for the session represented by this digest.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         harness_kind: Option<HarnessKind>,
-        lifecycle: CodeSessionLifecycle,
+        lifecycle: SessionLifecycle,
         attention: Attention,
         title: String,
         turn_count: i64,
@@ -2311,7 +2320,7 @@ pub enum CodeUpdateNotice {
         /// What the live turn is occupied with, while running.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
-        activity: Option<tidebreak_core::CodeSessionActivity>,
+        activity: Option<tidebreak_core::SessionActivity>,
         /// The subject of the tool the live turn is waiting on, while
         /// `activity` names one.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -2391,9 +2400,9 @@ pub enum CodeUpdateNotice {
     /// Lucid rewrite of a completed turn's closing message. Not restated on
     /// connect: the turn snapshot carries the stored rewrite.
     TurnRewrite {
-        session: tidebreak_core::CodeSessionId,
-        turn_id: tidebreak_core::CodeTurnId,
-        state: CodeTurnRewriteState,
+        session: tidebreak_core::SessionId,
+        turn_id: tidebreak_core::TurnId,
+        state: TurnRewriteState,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         rewrite: Option<String>,
@@ -2403,13 +2412,13 @@ pub enum CodeUpdateNotice {
 /// Where one closing-message rewrite stands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
-pub enum CodeTurnRewriteState {
+pub enum TurnRewriteState {
     Rewriting,
     Rewritten,
     Failed,
 }
 
-impl CodeUpdateNotice {
+impl UpdateNotice {
     pub(crate) fn harness_install(progress: crate::code::bus::HarnessInstallProgress) -> Self {
         Self::HarnessInstall {
             kind: progress.kind,
@@ -2432,7 +2441,7 @@ impl CodeUpdateNotice {
     }
 
     pub(crate) fn digest(digest: crate::code::bus::SessionDigest) -> Self {
-        let wire = CodeSessionDigest::from(digest);
+        let wire = SessionDigest::from(digest);
         Self::Digest {
             workspace: wire.workspace,
             session: wire.session,
@@ -2461,16 +2470,16 @@ impl CodeUpdateNotice {
             session: notice.session,
             turn_id: notice.turn_id,
             state: match notice.state {
-                crate::code::bus::TurnRewriteState::Rewriting => CodeTurnRewriteState::Rewriting,
-                crate::code::bus::TurnRewriteState::Rewritten => CodeTurnRewriteState::Rewritten,
-                crate::code::bus::TurnRewriteState::Failed => CodeTurnRewriteState::Failed,
+                crate::code::bus::TurnRewriteState::Rewriting => TurnRewriteState::Rewriting,
+                crate::code::bus::TurnRewriteState::Rewritten => TurnRewriteState::Rewritten,
+                crate::code::bus::TurnRewriteState::Failed => TurnRewriteState::Failed,
             },
             rewrite: notice.rewrite,
         }
     }
 }
 
-/// Body of `POST /code/sessions/{id}/attention`.
+/// Body of `POST /sessions/{id}/attention`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SetAttentionBody {

--- a/crates/tidebreak-server/src/routes/code/updates.rs
+++ b/crates/tidebreak-server/src/routes/code/updates.rs
@@ -1,4 +1,4 @@
-//! `WS /code/updates` — the principal's digest channel, restated on connect.
+//! `WS /updates` — the principal's digest channel, restated on connect.
 //!
 //! The channel is partitioned by owner in the bus rather than filtered here:
 //! [`ScopedCode`] resolves the requesting principal before the upgrade, and
@@ -24,7 +24,7 @@ use crate::error::ServerError;
 use crate::routes::events::{gateway_auth_revalidation_timer, wait_for_gateway_auth_revalidation};
 use crate::state::AppState;
 
-use super::types::{CodeSessionDigest, CodeUpdateNotice};
+use super::types::{SessionDigest, UpdateNotice};
 
 pub async fn code_updates(
     State(state): State<AppState>,
@@ -57,8 +57,8 @@ async fn stream_updates(
     let mut terminals = state.terminals.subscribe(&owner);
     match list_digests(&runtime.db, &owner).await {
         Ok(sessions) => {
-            let notice = CodeUpdateNotice::Snapshot {
-                sessions: sessions.into_iter().map(CodeSessionDigest::from).collect(),
+            let notice = UpdateNotice::Snapshot {
+                sessions: sessions.into_iter().map(SessionDigest::from).collect(),
             };
             if send_notice(&mut socket, &notice).await.is_err() {
                 return;
@@ -84,7 +84,7 @@ async fn stream_updates(
             },
             update = live.recv() => match update {
                 Ok(CodeLiveUpdate::Digest(digest)) => {
-                    if send_notice(&mut socket, &CodeUpdateNotice::digest(*digest))
+                    if send_notice(&mut socket, &UpdateNotice::digest(*digest))
                         .await
                         .is_err()
                     {
@@ -92,7 +92,7 @@ async fn stream_updates(
                     }
                 }
                 Ok(CodeLiveUpdate::CloneProgress(progress)) => {
-                    if send_notice(&mut socket, &CodeUpdateNotice::clone_progress(progress))
+                    if send_notice(&mut socket, &UpdateNotice::clone_progress(progress))
                         .await
                         .is_err()
                     {
@@ -100,7 +100,7 @@ async fn stream_updates(
                     }
                 }
                 Ok(CodeLiveUpdate::HarnessInstall(progress)) => {
-                    if send_notice(&mut socket, &CodeUpdateNotice::harness_install(progress))
+                    if send_notice(&mut socket, &UpdateNotice::harness_install(progress))
                         .await
                         .is_err()
                     {
@@ -108,7 +108,7 @@ async fn stream_updates(
                     }
                 }
                 Ok(CodeLiveUpdate::Delivery) => {
-                    if send_notice(&mut socket, &CodeUpdateNotice::Delivery)
+                    if send_notice(&mut socket, &UpdateNotice::Delivery)
                         .await
                         .is_err()
                     {
@@ -116,7 +116,7 @@ async fn stream_updates(
                     }
                 }
                 Ok(CodeLiveUpdate::TurnRewrite(notice)) => {
-                    if send_notice(&mut socket, &CodeUpdateNotice::turn_rewrite(notice))
+                    if send_notice(&mut socket, &UpdateNotice::turn_rewrite(notice))
                         .await
                         .is_err()
                     {
@@ -126,10 +126,10 @@ async fn stream_updates(
                 Err(RecvError::Lagged(_)) => {
                     match list_digests(&runtime.db, &owner).await {
                         Ok(sessions) => {
-                            let notice = CodeUpdateNotice::Snapshot {
+                            let notice = UpdateNotice::Snapshot {
                                 sessions: sessions
                                     .into_iter()
-                                    .map(CodeSessionDigest::from)
+                                    .map(SessionDigest::from)
                                     .collect(),
                             };
                             if send_notice(&mut socket, &notice).await.is_err() {
@@ -145,7 +145,7 @@ async fn stream_updates(
                 Ok(notice) => {
                     if send_notice(
                         &mut socket,
-                        &CodeUpdateNotice::TerminalActivity {
+                        &UpdateNotice::TerminalActivity {
                             workspace_id: notice.workspace_id,
                             terminal_id: notice.terminal_id,
                         },
@@ -163,7 +163,7 @@ async fn stream_updates(
     }
 }
 
-async fn send_notice(socket: &mut WebSocket, notice: &CodeUpdateNotice) -> Result<(), axum::Error> {
+async fn send_notice(socket: &mut WebSocket, notice: &UpdateNotice) -> Result<(), axum::Error> {
     let Ok(json) = serde_json::to_string(notice) else {
         return Ok(());
     };

--- a/crates/tidebreak-server/src/routes/compaction.rs
+++ b/crates/tidebreak-server/src/routes/compaction.rs
@@ -12,7 +12,7 @@ use futures::channel::mpsc;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
-use tidebreak_core::{Agent, ChatId, SequencedEvent, ToolRegistry};
+use tidebreak_core::{Agent, SequencedAgentEvent, SessionId, ToolRegistry};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
@@ -61,7 +61,7 @@ pub struct CompactionRun {
 pub async fn post_compact(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<CompactChat>,
 ) -> Result<Json<CompactionRun>, ServerError> {
     let chat = store.require_chat(id).await?;
@@ -130,7 +130,10 @@ pub async fn post_compact(
     // allocated, which is what the live stream reconciles against.
     while let Some(event) = receiver.next().await {
         let seq = state.store.append_chat_event(id, &event).await?;
-        let _ = state.events.sender(id).send(SequencedEvent { seq, event });
+        let _ = state
+            .events
+            .sender(id)
+            .send(SequencedAgentEvent { seq, event });
     }
 
     Ok(Json(CompactionRun {

--- a/crates/tidebreak-server/src/routes/delegated_file_execution.rs
+++ b/crates/tidebreak-server/src/routes/delegated_file_execution.rs
@@ -45,7 +45,7 @@ pub struct ClaimDelegatedFileReadBody {
 pub struct ClaimedDelegatedFileRead {
     pub disposition: DelegatedFileClaimDisposition,
     pub call_id: CallId,
-    pub chat_id: tidebreak_core::ChatId,
+    pub chat_id: tidebreak_core::SessionId,
     pub root_id: HostRootId,
     pub relative_path: String,
 }

--- a/crates/tidebreak-server/src/routes/document.rs
+++ b/crates/tidebreak-server/src/routes/document.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use unicode_general_category::{get_general_category, GeneralCategory};
 
 use tidebreak_core::{
-    AgentError, ChatId, DocumentBlob, DocumentId, DocumentListCursor, DocumentReadiness,
-    DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, ProjectId,
+    AgentError, DocumentBlob, DocumentId, DocumentListCursor, DocumentReadiness, DocumentRecord,
+    DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, ProjectId, SessionId,
 };
 
 use crate::document_decode::decode_document;
@@ -41,7 +41,7 @@ pub struct IngestDocument {
 pub struct PromoteDocument {
     /// The conversation that owns the document being promoted. It must belong to
     /// the project in the path.
-    pub chat_id: ChatId,
+    pub chat_id: SessionId,
     /// The conversation-owned document to share with the project.
     pub document_id: DocumentId,
 }
@@ -97,7 +97,7 @@ pub struct DocumentSummary {
     /// Stable identifier shared with citations and delete/get routes.
     pub document_id: DocumentId,
     /// Owning conversation for conversation-scoped sources.
-    pub chat_id: Option<ChatId>,
+    pub chat_id: Option<SessionId>,
     /// Owning project, or `None` for a legacy unscoped source.
     pub project_id: Option<ProjectId>,
     /// Source path or URL, or `None` for inline content.
@@ -352,7 +352,7 @@ pub async fn promote_document_to_project(
 pub async fn ingest_chat_document(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
     Json(body): Json<IngestDocument>,
 ) -> Result<impl IntoResponse, ServerError> {
     store.require_chat(chat_id).await?;
@@ -362,7 +362,7 @@ pub async fn ingest_chat_document(
 async fn ingest_document_in_scope(
     state: &AppState,
     store: &ScopedStore,
-    chat_id: Option<ChatId>,
+    chat_id: Option<SessionId>,
     project_id: Option<ProjectId>,
     body: IngestDocument,
 ) -> Result<(StatusCode, Json<IngestResult>), ServerError> {
@@ -422,7 +422,7 @@ pub async fn ingest_raw_project_document(
 pub async fn ingest_raw_chat_document(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
     Query(query): Query<RawDocumentQuery>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
@@ -446,7 +446,7 @@ pub async fn ingest_raw_chat_document(
 pub async fn ingest_streamed_raw_chat_document(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
     Query(query): Query<StreamedRawDocumentQuery>,
     headers: HeaderMap,
     body: Body,
@@ -515,7 +515,7 @@ pub async fn ingest_streamed_raw_chat_document(
 async fn ingest_raw_document_in_scope(
     state: &AppState,
     store: &ScopedStore,
-    chat_id: Option<ChatId>,
+    chat_id: Option<SessionId>,
     project_id: Option<ProjectId>,
     query: RawDocumentQuery,
     headers: &HeaderMap,
@@ -542,7 +542,7 @@ async fn ingest_raw_document_in_scope(
 async fn publish_document_source(
     state: &AppState,
     store: &ScopedStore,
-    chat_id: Option<ChatId>,
+    chat_id: Option<SessionId>,
     project_id: Option<ProjectId>,
     origin_uri: Option<String>,
     title: Option<String>,
@@ -722,7 +722,7 @@ pub async fn list_project_documents(
 /// `GET /chats/{chat_id}/documents` — list only sources owned by one conversation.
 pub async fn list_chat_documents(
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
     Query(query): Query<DocumentListQuery>,
 ) -> Result<Json<DocumentListPage>, ServerError> {
     store.require_chat(chat_id).await?;
@@ -801,7 +801,7 @@ pub async fn get_project_document(
 /// the path conversation owns it.
 pub async fn get_chat_document(
     store: ScopedStore,
-    Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
+    Path((chat_id, document_id)): Path<(SessionId, DocumentId)>,
 ) -> Result<Json<ChatDocumentDetail>, ServerError> {
     store
         .get_document(document_id)
@@ -850,7 +850,7 @@ pub async fn get_project_document_file_content(
 pub async fn get_chat_document_file_content(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
+    Path((chat_id, document_id)): Path<(SessionId, DocumentId)>,
     method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
@@ -975,7 +975,7 @@ async fn serve_document_file_content(
     state: &AppState,
     store: &ScopedStore,
     document_id: DocumentId,
-    chat_id: Option<ChatId>,
+    chat_id: Option<SessionId>,
     project_id: Option<ProjectId>,
     method: Method,
     headers: &HeaderMap,
@@ -1245,7 +1245,7 @@ pub async fn delete_project_document(
 pub async fn delete_chat_document(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
+    Path((chat_id, document_id)): Path<(SessionId, DocumentId)>,
 ) -> Result<StatusCode, ServerError> {
     if store
         .get_document(document_id)

--- a/crates/tidebreak-server/src/routes/events.rs
+++ b/crates/tidebreak-server/src/routes/events.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::time::{Instant, Interval, MissedTickBehavior};
 
-use tidebreak_core::{AgentEvent, ChatId, SequencedEvent, Store, TurnId};
+use tidebreak_core::{AgentEvent, SequencedAgentEvent, SessionId, Store, TurnId};
 
 use crate::auth::{offered_handshake_subprotocol, GatewayAuthLease, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::error::ServerError;
@@ -70,7 +70,7 @@ pub struct EventsQuery {
 pub async fn chat_events(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
     Query(query): Query<EventsQuery>,
     headers: axum::http::HeaderMap,
     auth_lease: Option<Extension<GatewayAuthLease>>,
@@ -90,7 +90,7 @@ pub async fn chat_events(
 async fn stream_events(
     mut socket: WebSocket,
     state: AppState,
-    chat: ChatId,
+    chat: SessionId,
     after: i64,
     auth_lease: Option<GatewayAuthLease>,
 ) {
@@ -234,7 +234,7 @@ async fn stream_events(
 async fn replay_after(
     socket: &mut WebSocket,
     store: &dyn Store,
-    chat: ChatId,
+    chat: SessionId,
     last_seq: &mut i64,
     turn_models: &mut TurnModelCache,
 ) -> Result<(), ()> {
@@ -301,7 +301,7 @@ impl TurnModelCache {
         }
     }
 
-    async fn refresh(&mut self, store: &dyn Store, chat: ChatId) -> Result<(), ()> {
+    async fn refresh(&mut self, store: &dyn Store, chat: SessionId) -> Result<(), ()> {
         let turns = store.list_turns(chat).await.map_err(|_| ())?;
         self.replace_from_turns(
             turns
@@ -326,7 +326,7 @@ fn is_turn_boundary(event: &AgentEvent) -> bool {
 /// Send one journaled event as a frame.
 async fn send_event(
     socket: &mut WebSocket,
-    event: &SequencedEvent,
+    event: &SequencedAgentEvent,
     model: Option<&str>,
     replayed: bool,
 ) -> Result<(), axum::Error> {

--- a/crates/tidebreak-server/src/routes/image_attachment.rs
+++ b/crates/tidebreak-server/src/routes/image_attachment.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use tidebreak_core::{
-    ChatId, DocumentBlob, ImageMediaType, ImageRef, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION,
+    DocumentBlob, ImageMediaType, ImageRef, SessionId, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION,
 };
 
 use crate::error::ServerError;
@@ -84,7 +84,7 @@ impl From<ImageRef> for PublishedImageAttachment {
 pub async fn publish_chat_image_attachment(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
@@ -120,7 +120,7 @@ pub async fn publish_chat_image_attachment(
 pub async fn get_chat_image_attachment(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, attachment_id)): Path<(ChatId, Uuid)>,
+    Path((chat_id, attachment_id)): Path<(SessionId, Uuid)>,
 ) -> Result<Response, ServerError> {
     store.require_chat(chat_id).await?;
     let message_image = store

--- a/crates/tidebreak-server/src/routes/inbox.rs
+++ b/crates/tidebreak-server/src/routes/inbox.rs
@@ -10,10 +10,8 @@
 //!
 //! Decision 48 step 3 made this one queue over both surfaces. An entry is a
 //! conversation carrying an [`Attention`] in the shared vocabulary, with the
-//! parked items behind it for deep links. Chat and code still have separate
-//! id spaces, so the conversation reference is tagged; that tag is the seam
-//! step 5 removes when the entities merge, and it is deliberately the only
-//! place either surface's shape shows through.
+//! parked items behind it for deep links. Chat and code now share one session
+//! id space, so every entry names the same conversation shape.
 //!
 //! Entries stay as opaque as the per-conversation attention summary.
 //! Identity, kind, the title, and when it parked are enough to triage;
@@ -22,7 +20,7 @@
 
 use serde::Serialize;
 use tidebreak_core::{
-    Attention, AttentionState, CallId, ChatId, CodeSessionId, InboxItemKind, TurnId, WorkspaceId,
+    Attention, AttentionState, CallId, InboxItemKind, SessionId, TurnId, WorkspaceId,
 };
 
 use crate::error::ServerError;
@@ -31,24 +29,13 @@ use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 
 /// Which conversation an entry belongs to.
-///
-/// Tagged because chat ids and code session ids are still separate spaces
-/// (the repository check `chat_and_code_entities_do_not_cross_reference`
-/// enforces it). When step 5 merges the entities this collapses to one id.
 #[derive(Debug, Serialize, ts_rs::TS)]
-#[serde(tag = "surface", rename_all = "snake_case")]
-pub enum InboxConversation {
-    /// A conversation with the internal engine.
-    Chat { chat_id: ChatId },
-    /// A conversation with an external agent engine.
-    ///
-    /// Carries the workspace too: a code conversation is reached through its
-    /// workspace, so a session id alone is not a link the reader can follow.
-    Code {
-        session_id: CodeSessionId,
-        /// `None` for a session with no workspace: the in-process engine's.
-        workspace_id: Option<WorkspaceId>,
-    },
+pub struct InboxConversation {
+    pub session_id: SessionId,
+    /// Present when the conversation belongs to a repo-backed workspace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub workspace_id: Option<WorkspaceId>,
 }
 
 /// One item waiting on the reader, and where to go to answer it.
@@ -96,10 +83,12 @@ pub async fn list_inbox(
     let attention = store.chat_attention(&items).await?;
 
     let mut entries: Vec<InboxEntrySnapshot> = Vec::new();
-    let mut by_chat: std::collections::HashMap<ChatId, usize> = std::collections::HashMap::new();
+    let mut by_session: std::collections::HashMap<SessionId, usize> =
+        std::collections::HashMap::new();
 
     for item in items {
-        let index = match by_chat.get(&item.chat_id) {
+        let session_id = SessionId(item.chat_id.0);
+        let index = match by_session.get(&session_id) {
             Some(index) => *index,
             None => {
                 let attention = attention
@@ -115,15 +104,16 @@ pub async fn list_inbox(
                         )
                     });
                 entries.push(InboxEntrySnapshot {
-                    conversation: InboxConversation::Chat {
-                        chat_id: item.chat_id,
+                    conversation: InboxConversation {
+                        session_id,
+                        workspace_id: None,
                     },
                     title: item.chat_title.clone(),
                     attention,
                     items: Vec::new(),
                     waiting_since: item.requested_at,
                 });
-                by_chat.insert(item.chat_id, entries.len() - 1);
+                by_session.insert(session_id, entries.len() - 1);
                 entries.len() - 1
             }
         };
@@ -167,11 +157,15 @@ pub async fn list_inbox(
                 if !wants_the_reader(&session.attention.state) {
                     continue;
                 }
+                if let Some(index) = by_session.get(&session.id).copied() {
+                    entries[index].conversation.workspace_id = session.workspace_id;
+                    continue;
+                }
                 entries.push(InboxEntrySnapshot {
                     title: session
                         .workspace_id
                         .and_then(|workspace_id| titles.get(&workspace_id).cloned()),
-                    conversation: InboxConversation::Code {
+                    conversation: InboxConversation {
                         session_id: session.id,
                         workspace_id: session.workspace_id,
                     },
@@ -179,6 +173,7 @@ pub async fn list_inbox(
                     items: Vec::new(),
                     waiting_since: session.created_at,
                 });
+                by_session.insert(session.id, entries.len() - 1);
             }
         }
     }
@@ -187,7 +182,10 @@ pub async fn list_inbox(
     // needs to see, and it is what survives any cap a client applies.
     entries.sort_by(|left, right| {
         left.waiting_since.cmp(&right.waiting_since).then_with(|| {
-            format!("{:?}", left.conversation).cmp(&format!("{:?}", right.conversation))
+            left.conversation
+                .session_id
+                .to_string()
+                .cmp(&right.conversation.session_id.to_string())
         })
     });
     Ok(Json(entries))

--- a/crates/tidebreak-server/src/routes/mcp_gateway.rs
+++ b/crates/tidebreak-server/src/routes/mcp_gateway.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use tidebreak_core::id::{AppId, AppRevisionId};
 use tidebreak_core::local_app::app_revision_relative_path;
-use tidebreak_core::{AgentError, CallId, ChatId, SequencedEvent};
+use tidebreak_core::{AgentError, CallId, SequencedAgentEvent, SessionId};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
@@ -107,7 +107,7 @@ pub async fn put_mcp_servers(
 /// sandboxed frame — the transcript presentation itself never reads it.
 pub async fn get_mcp_app_payload(
     store: ScopedStore,
-    Path((chat_id, call_id)): Path<(ChatId, CallId)>,
+    Path((chat_id, call_id)): Path<(SessionId, CallId)>,
 ) -> Result<Json<McpAppPayload>, ServerError> {
     store.require_chat(chat_id).await?;
     let events = store.list_events_for_call(chat_id, call_id).await?;
@@ -135,7 +135,7 @@ pub struct McpAppPayload {
 }
 
 fn mcp_app_payload_from_events(
-    events: &[SequencedEvent],
+    events: &[SequencedAgentEvent],
     call_id: CallId,
 ) -> Option<McpAppPayload> {
     let mut fragments = String::new();
@@ -489,8 +489,8 @@ mod mcp_app_payload_tests {
 
     use super::*;
 
-    fn sequenced(seq: i64, event: AgentEvent) -> SequencedEvent {
-        SequencedEvent { seq, event }
+    fn sequenced(seq: i64, event: AgentEvent) -> SequencedAgentEvent {
+        SequencedAgentEvent { seq, event }
     }
 
     #[test]

--- a/crates/tidebreak-server/src/routes/notifications.rs
+++ b/crates/tidebreak-server/src/routes/notifications.rs
@@ -3,8 +3,8 @@
 
 use serde::{Deserialize, Serialize};
 use tidebreak_core::{
-    ChatId, CodeSessionId, Notification, NotificationContext, NotificationId, NotificationKind,
-    NotificationListCursor, WorkspaceId,
+    Notification, NotificationContext, NotificationId, NotificationKind, NotificationListCursor,
+    SessionId, WorkspaceId,
 };
 
 use crate::error::ServerError;
@@ -35,10 +35,10 @@ impl From<NotificationKind> for NotificationKindSnapshot {
 #[serde(tag = "surface", rename_all = "snake_case")]
 pub enum NotificationContextSnapshot {
     Chat {
-        chat_id: ChatId,
+        chat_id: SessionId,
     },
     Code {
-        session_id: CodeSessionId,
+        session_id: SessionId,
         workspace_id: WorkspaceId,
     },
 }

--- a/crates/tidebreak-server/src/routes/outputs.rs
+++ b/crates/tidebreak-server/src/routes/outputs.rs
@@ -28,8 +28,8 @@ use serde::{Deserialize, Serialize};
 
 use tidebreak_core::{
     deliverable_media_type, media_type_is_text, revision_byte_ceiling, AgentError,
-    AssistantCitationId, ChatId, ChatTranscriptSnapshot, CitationLocator, DocumentId, OutputId,
-    OutputRecord, OutputRevision, OutputRevisionId, ResultEntryKind, ToolCallRecord,
+    AssistantCitationId, ChatTranscriptSnapshot, CitationLocator, DocumentId, OutputId,
+    OutputRecord, OutputRevision, OutputRevisionId, ResultEntryKind, SessionId, ToolCallRecord,
     ToolCallStatus, ToolResultPreview, TurnId, WEB_SEARCH_TOOL,
 };
 
@@ -215,7 +215,7 @@ pub struct RevisionQuery {
 pub async fn list_chat_outputs(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
 ) -> Result<Json<DeliverablesCatalog>, ServerError> {
     store.require_chat(chat_id).await?;
     let mut outputs = state
@@ -244,7 +244,7 @@ pub async fn list_chat_outputs(
 pub async fn get_chat_output(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, output_id)): Path<(ChatId, OutputId)>,
+    Path((chat_id, output_id)): Path<(SessionId, OutputId)>,
 ) -> Result<Json<DeliverablePreview>, ServerError> {
     store.require_chat(chat_id).await?;
     let (output, revision) = require_live_output(&state.store, chat_id, output_id)
@@ -260,7 +260,7 @@ pub async fn get_chat_output(
 pub async fn get_chat_output_revision(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, output_id, revision_id)): Path<(ChatId, OutputId, OutputRevisionId)>,
+    Path((chat_id, output_id, revision_id)): Path<(SessionId, OutputId, OutputRevisionId)>,
 ) -> Result<Json<DeliverablePreview>, ServerError> {
     store.require_chat(chat_id).await?;
     let (output, revision) = require_output_revision(&state.store, chat_id, output_id, revision_id)
@@ -281,7 +281,7 @@ pub async fn get_chat_output_revision(
 pub async fn get_chat_output_content(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, output_id)): Path<(ChatId, OutputId)>,
+    Path((chat_id, output_id)): Path<(SessionId, OutputId)>,
     Query(query): Query<RevisionQuery>,
 ) -> Result<Response, ServerError> {
     store.require_chat(chat_id).await?;
@@ -321,7 +321,7 @@ pub async fn get_chat_output_content(
 pub async fn list_chat_output_revisions(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, output_id)): Path<(ChatId, OutputId)>,
+    Path((chat_id, output_id)): Path<(SessionId, OutputId)>,
 ) -> Result<Json<OutputRevisionsCatalog>, ServerError> {
     store.require_chat(chat_id).await?;
     let (output, _) = require_live_output(&state.store, chat_id, output_id)
@@ -462,7 +462,7 @@ fn web_domain(value: &str) -> Option<String> {
 pub async fn restore_chat_output_revision(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, output_id, revision_id)): Path<(ChatId, OutputId, OutputRevisionId)>,
+    Path((chat_id, output_id, revision_id)): Path<(SessionId, OutputId, OutputRevisionId)>,
 ) -> Result<Json<DeliverableSummary>, ServerError> {
     store.require_chat(chat_id).await?;
     let scratch = chat_scratch(&state, chat_id).await?;
@@ -486,7 +486,7 @@ pub async fn restore_chat_output_revision(
 pub async fn save_chat_output_revision(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, output_id)): Path<(ChatId, OutputId)>,
+    Path((chat_id, output_id)): Path<(SessionId, OutputId)>,
     Json(body): Json<SaveOutputRevisionBody>,
 ) -> Result<Json<SaveOutputRevisionResult>, ServerError> {
     store.require_chat(chat_id).await?;
@@ -525,7 +525,7 @@ pub async fn save_chat_output_revision(
 pub async fn delete_chat_output(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, output_id)): Path<(ChatId, OutputId)>,
+    Path((chat_id, output_id)): Path<(SessionId, OutputId)>,
 ) -> Result<Json<DeliverableSummary>, ServerError> {
     store.require_chat(chat_id).await?;
     let (output, revision) = require_live_output(&state.store, chat_id, output_id)
@@ -540,7 +540,7 @@ pub async fn delete_chat_output(
 pub async fn restore_chat_output(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, output_id)): Path<(ChatId, OutputId)>,
+    Path((chat_id, output_id)): Path<(SessionId, OutputId)>,
 ) -> Result<Json<DeliverableSummary>, ServerError> {
     store.require_chat(chat_id).await?;
     // A restore targets a soft-deleted output, so it cannot go through the
@@ -558,7 +558,7 @@ pub async fn restore_chat_output(
 
 async fn current_summary(
     state: &AppState,
-    chat_id: ChatId,
+    chat_id: SessionId,
     output_id: OutputId,
 ) -> Result<Json<DeliverableSummary>, ServerError> {
     let (output, revision) = require_live_output(&state.store, chat_id, output_id)
@@ -570,7 +570,10 @@ async fn current_summary(
 }
 
 /// Open the conversation's private scratch directory for an append-only write.
-async fn chat_scratch(state: &AppState, chat_id: ChatId) -> Result<cap_std::fs::Dir, ServerError> {
+async fn chat_scratch(
+    state: &AppState,
+    chat_id: SessionId,
+) -> Result<cap_std::fs::Dir, ServerError> {
     let scratch_root = state.config.data_dir.join("scratch");
     tokio::task::spawn_blocking(move || open_chat_scratch(&scratch_root, chat_id))
         .await
@@ -580,7 +583,7 @@ async fn chat_scratch(state: &AppState, chat_id: ChatId) -> Result<cap_std::fs::
 
 async fn revision_bytes(
     state: &AppState,
-    chat_id: ChatId,
+    chat_id: SessionId,
     output: &OutputRecord,
     revision: &OutputRevision,
 ) -> Result<Vec<u8>, ServerError> {
@@ -598,7 +601,7 @@ async fn revision_bytes(
 /// Build the bounded preview of one exact revision's content.
 async fn revision_preview(
     state: &AppState,
-    chat_id: ChatId,
+    chat_id: SessionId,
     output: &OutputRecord,
     revision: &OutputRevision,
 ) -> Result<DeliverablePreview, ServerError> {

--- a/crates/tidebreak-server/src/routes/plans.rs
+++ b/crates/tidebreak-server/src/routes/plans.rs
@@ -5,8 +5,8 @@ use chrono::Utc;
 use serde::Serialize;
 use tidebreak_core::storage::DecidePlanOutcome;
 use tidebreak_core::{
-    CallId, ChatId, CodeApprovalId, CodeSessionId, DecidePlanRequest, PendingPlanApproval,
-    PlanDecision, PlanDecisionChoice, TurnRunStatus, DEFAULT_ACCEPTED_PLAN_MODE,
+    ApprovalId, CallId, DecidePlanRequest, PendingPlanApproval, PlanDecision, PlanDecisionChoice,
+    SessionId, TurnRunStatus, DEFAULT_ACCEPTED_PLAN_MODE,
 };
 
 use crate::error::ServerError;
@@ -19,7 +19,7 @@ pub const MAX_PLAN_DECISION_BODY_BYTES: usize = 16 * 1024;
 
 pub async fn list_pending_plan_approvals(
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
 ) -> Result<Json<Vec<PendingPlanApproval>>, ServerError> {
     store.require_chat(chat_id).await?;
     Ok(Json(store.list_pending_plan_approvals(chat_id).await?))
@@ -40,7 +40,7 @@ pub struct DecidedPlan {
 pub async fn decide_plan(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, call_id)): Path<(ChatId, CallId)>,
+    Path((chat_id, call_id)): Path<(SessionId, CallId)>,
     Json(decision): Json<PlanDecision>,
 ) -> Result<Json<DecidedPlan>, ServerError> {
     store.require_chat(chat_id).await?;
@@ -53,11 +53,11 @@ pub async fn decide_plan(
         let proposed_mode = decision
             .permission_mode
             .is_none_or(|mode| mode == DEFAULT_ACCEPTED_PLAN_MODE);
-        if proposed_mode && code.has_worker(CodeSessionId(chat_id.0)) {
+        if proposed_mode && code.has_worker(SessionId(chat_id.0)) {
             match code
                 .decide_approval(
                     &store.owner_id(),
-                    CodeApprovalId(call_id.0),
+                    ApprovalId(call_id.0),
                     crate::code::runtime::ApprovalDecisionRequest::PlanDecision {
                         approve: matches!(decision.decision, PlanDecisionChoice::Accept),
                         feedback: decision.feedback.clone(),

--- a/crates/tidebreak-server/src/routes/projects_chats.rs
+++ b/crates/tidebreak-server/src/routes/projects_chats.rs
@@ -10,9 +10,10 @@ use serde::{Deserialize, Serialize};
 use std::path::Path as FsPath;
 
 use tidebreak_core::{
-    AgentRunId, Chat, ChatId, DeleteChatOutcome, DeleteProjectOutcome, DocumentId,
+    AgentRunId, Chat, DeleteChatOutcome, DeleteProjectOutcome, DocumentId,
     Message as StoredMessage, MessageId, MoveChatOutcome, PermissionMode, Project, ProjectId,
-    ReasoningEffort, Role, TurnId, CONTEXT_CHECKPOINT_FORMAT_V1, CONTEXT_CHECKPOINT_FORMAT_V2,
+    ReasoningEffort, Role, SessionId, TurnId, CONTEXT_CHECKPOINT_FORMAT_V1,
+    CONTEXT_CHECKPOINT_FORMAT_V2,
 };
 
 use crate::error::ServerError;
@@ -304,7 +305,7 @@ pub async fn create_chat(
         ));
     }
     let chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: body.project_id,
         title,
         model,
@@ -364,7 +365,7 @@ pub async fn patch_chat(
     State(state): State<AppState>,
     auth: AuthContext,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
     Json(mut body): Json<ChatUpdate>,
 ) -> Result<Json<Chat>, ServerError> {
     let owner = auth.principal.owner_id();
@@ -738,12 +739,12 @@ pub async fn list_chat_messages(
     State(state): State<AppState>,
     auth: AuthContext,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<Json<ChatTranscript>, ServerError> {
     if let Some(runtime) = state.code.as_ref() {
         if let Some(session) = tidebreak_core::db::code::get_session_all_owners(
             &runtime.db,
-            tidebreak_core::CodeSessionId(id.0),
+            tidebreak_core::SessionId(id.0),
         )
         .await?
         {
@@ -930,7 +931,7 @@ pub async fn list_chats(store: ScopedStore) -> Result<Json<Vec<Chat>>, ServerErr
 /// `GET /chats/{id}` — fetch one chat, or `404`.
 pub async fn get_chat(
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<Json<Chat>, ServerError> {
     Ok(Json(store.require_chat(id).await?))
 }
@@ -941,7 +942,7 @@ pub async fn get_chat(
 pub async fn delete_chat(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<StatusCode, ServerError> {
     match store.delete_chat(id).await? {
         DeleteChatOutcome::Deleted { background_run_ids } => {
@@ -992,7 +993,7 @@ pub async fn delete_chat(
 /// root or chat-directory symlink. Database deletion remains authoritative, so
 /// callers log cleanup failure rather than turning a committed delete into an
 /// ambiguous HTTP failure.
-fn remove_private_chat_scratch(root: &FsPath, id: ChatId) -> std::io::Result<()> {
+fn remove_private_chat_scratch(root: &FsPath, id: SessionId) -> std::io::Result<()> {
     let root_metadata = match std::fs::symlink_metadata(root) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -1040,7 +1041,7 @@ fn remove_private_chat_scratch(root: &FsPath, id: ChatId) -> std::io::Result<()>
 /// agent-run scratch reaper remains the backstop.
 async fn erase_deleted_chat_agent_run_workspaces(
     state: &AppState,
-    chat_id: ChatId,
+    chat_id: SessionId,
     run_ids: Vec<AgentRunId>,
 ) {
     let scratch_root = state.config.data_dir.join("scratch");

--- a/crates/tidebreak-server/src/routes/root_attachment.rs
+++ b/crates/tidebreak-server/src/routes/root_attachment.rs
@@ -7,11 +7,11 @@ use axum::extract::State;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tidebreak_core::{
-    BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, ChatId,
-    FinishRootAttachmentChangeOutcome, HostRootId, RootAttachmentChange,
-    RootAttachmentChangeAction, RootAttachmentChangeFailure, RootAttachmentChangeId,
-    RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
-    RootAttachmentSubjectKind, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+    BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, FinishRootAttachmentChangeOutcome,
+    HostRootId, RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
+    RootAttachmentChangeId, RootAttachmentChangePhase, RootAttachmentChangeTerminal,
+    RootAttachmentOrigin, RootAttachmentSubjectKind, SessionId,
+    MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 use uuid::Uuid;
 
@@ -65,7 +65,7 @@ pub enum FinishRootAttachmentChangeDisposition {
 #[derive(Debug, Serialize)]
 pub struct RootAttachmentChangeView {
     pub id: RootAttachmentChangeId,
-    pub chat_id: ChatId,
+    pub chat_id: SessionId,
     pub root_id: HostRootId,
     pub action: RootAttachmentChangeAction,
     pub subject_kind: RootAttachmentSubjectKind,
@@ -134,7 +134,7 @@ pub struct PendingRootAttachmentChanges {
 pub async fn begin_root_attachment_change(
     State(state): State<AppState>,
     _executor: ClientExecutor,
-    Path((chat_id, change_id)): Path<(ChatId, RootAttachmentChangeId)>,
+    Path((chat_id, change_id)): Path<(SessionId, RootAttachmentChangeId)>,
     Json(body): Json<BeginRootAttachmentChangeBody>,
 ) -> Result<Json<BegunRootAttachmentChange>, ServerError> {
     if chat_id.as_uuid().is_nil() {

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use tidebreak_core::{
-    AgentRun, ChatId, CompactionPolicy, OwnerId, PermissionMode, PromptCacheRetention,
-    ReasoningEffort, Store, TurnId, DEFAULT_COMPACTION_MIN_THRESHOLD_TOKENS,
+    AgentRun, CompactionPolicy, OwnerId, PermissionMode, PromptCacheRetention, ReasoningEffort,
+    SessionId, Store, TurnId, DEFAULT_COMPACTION_MIN_THRESHOLD_TOKENS,
     DEFAULT_COMPACTION_PROTECT_RECENT_MESSAGES, DEFAULT_COMPACTION_TARGET_FRACTION,
     DEFAULT_COMPACTION_THRESHOLD_FRACTION,
 };
@@ -920,7 +920,7 @@ pub async fn delete_code_execution_credential(
 pub async fn post_undo_turn_file_changes(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, turn_id)): Path<(ChatId, TurnId)>,
+    Path((chat_id, turn_id)): Path<(SessionId, TurnId)>,
 ) -> Result<Json<ExecTurnUndoOutcome>, ServerError> {
     store.require_chat(chat_id).await?;
     let outcome = undo_turn_file_changes(&*state.store, &*state.blobs, chat_id, turn_id).await?;
@@ -937,7 +937,7 @@ pub async fn post_undo_turn_file_changes(
 pub async fn post_undo_one_file_change(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, turn_id, snapshot_id)): Path<(ChatId, TurnId, uuid::Uuid)>,
+    Path((chat_id, turn_id, snapshot_id)): Path<(SessionId, TurnId, uuid::Uuid)>,
 ) -> Result<Json<ExecFileUndoOutcome>, ServerError> {
     store.require_chat(chat_id).await?;
     undo_one_file_change(&*state.store, &*state.blobs, chat_id, turn_id, snapshot_id)
@@ -953,7 +953,7 @@ pub async fn get_file_change_preview(
     State(state): State<AppState>,
     store: ScopedStore,
     Path((chat_id, turn_id, snapshot_id, revision)): Path<(
-        ChatId,
+        SessionId,
         TurnId,
         uuid::Uuid,
         ExecFilePreviewRevision,

--- a/crates/tidebreak-server/src/routes/task_plan.rs
+++ b/crates/tidebreak-server/src/routes/task_plan.rs
@@ -1,6 +1,6 @@
 //! Renderer-safe recovery of a conversation's task plan.
 
-use tidebreak_core::{ChatId, TaskPlan};
+use tidebreak_core::{SessionId, TaskPlan};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
@@ -13,7 +13,7 @@ use crate::scoped_store::ScopedStore;
 /// error; it answers `null`.
 pub async fn get_task_plan(
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
 ) -> Result<Json<Option<TaskPlan>>, ServerError> {
     store.require_chat(chat_id).await?;
     Ok(Json(store.get_task_plan(chat_id).await?))

--- a/crates/tidebreak-server/src/routes/turn_control.rs
+++ b/crates/tidebreak-server/src/routes/turn_control.rs
@@ -6,9 +6,9 @@ use chrono::Utc;
 use serde::Deserialize;
 
 use tidebreak_core::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, BeginTurnAdmissionOutcome, ChatId, DocumentId,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, BeginTurnAdmissionOutcome, DocumentId,
     PromoteQueuedTurnOutcome, RequestTurnCancellationOutcome, ReservedQueuedTurnOutcome,
-    ReservedTurnAcceptanceOutcome, TurnAdmissionRequest, TurnId, TurnSteer, TurnSteerId,
+    ReservedTurnAcceptanceOutcome, SessionId, TurnAdmissionRequest, TurnId, TurnSteer, TurnSteerId,
 };
 
 use crate::error::ServerError;
@@ -54,7 +54,7 @@ pub struct PostMessage {
     /// Queue instead of refusing when the chat has a live turn.
     ///
     /// With this set, `ChatBusy` durably parks the validated message as a
-    /// [`tidebreak_core::QueuedTurn`]; the promoter runs it as its own turn
+    /// [`tidebreak_core::QueuedAgentTurn`]; the promoter runs it as its own turn
     /// once the chat is free. An idle chat sends immediately either way.
     #[serde(default)]
     pub queue: bool,
@@ -117,7 +117,7 @@ async fn require_invocable_skills(state: &AppState, invoked: &[String]) -> Resul
 /// persisted with the turn describes the content that actually exists.
 async fn resolve_message_attachments(
     state: &AppState,
-    chat_id: ChatId,
+    chat_id: SessionId,
     ids: &[uuid::Uuid],
 ) -> Result<Vec<tidebreak_core::ImageRef>, ServerError> {
     if ids.is_empty() {
@@ -160,7 +160,7 @@ async fn resolve_message_attachments(
 
 async fn resolve_file_attachments(
     store: &ScopedStore,
-    chat_id: ChatId,
+    chat_id: SessionId,
     ids: &[DocumentId],
 ) -> Result<Vec<DocumentId>, ServerError> {
     if ids.is_empty() {
@@ -243,7 +243,7 @@ async fn require_image_capable_model(
     require_image_input(&policy)
 }
 
-fn turn_admission_from_message(chat_id: ChatId, body: &PostMessage) -> TurnAdmissionRequest {
+fn turn_admission_from_message(chat_id: SessionId, body: &PostMessage) -> TurnAdmissionRequest {
     TurnAdmissionRequest {
         id: body.turn_id,
         chat_id,
@@ -255,9 +255,12 @@ fn turn_admission_from_message(chat_id: ChatId, body: &PostMessage) -> TurnAdmis
     }
 }
 
-fn queued_turn_from_message(chat_id: ChatId, body: &PostMessage) -> tidebreak_core::QueuedTurn {
+fn queued_turn_from_message(
+    chat_id: SessionId,
+    body: &PostMessage,
+) -> tidebreak_core::QueuedAgentTurn {
     let now = Utc::now();
-    tidebreak_core::QueuedTurn {
+    tidebreak_core::QueuedAgentTurn {
         id: body.turn_id,
         chat_id,
         content: body.content.clone(),
@@ -340,7 +343,7 @@ mod image_capability_tests {
 pub async fn post_message(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<PostMessage>,
 ) -> Result<StatusCode, ServerError> {
     if body.turn_id.0.is_nil() {
@@ -472,17 +475,17 @@ pub async fn post_message(
 /// Response of `GET /chats/{chat_id}/queued`.
 #[derive(Debug, serde::Serialize)]
 pub struct QueuedTurnsSnapshot {
-    pub queued: Vec<tidebreak_core::QueuedTurn>,
+    pub queued: Vec<tidebreak_core::QueuedAgentTurn>,
     pub paused: bool,
 }
 
-fn queue_paused_setting(chat_id: ChatId) -> String {
-    format!("chats.{chat_id}.queue_paused")
+fn queue_paused_setting(chat_id: SessionId) -> String {
+    format!("sessions.{chat_id}.queue_paused")
 }
 
 pub(crate) async fn read_queue_paused(
     store: &dyn tidebreak_core::Store,
-    chat_id: ChatId,
+    chat_id: SessionId,
 ) -> tidebreak_core::Result<bool> {
     Ok(store
         .get_setting(&queue_paused_setting(chat_id))
@@ -495,7 +498,7 @@ pub(crate) async fn read_queue_paused(
 pub async fn list_queued_turns(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<Json<QueuedTurnsSnapshot>, ServerError> {
     store.require_chat(id).await?;
     Ok(Json(QueuedTurnsSnapshot {
@@ -518,9 +521,9 @@ pub struct QueuedTurnUpdate {
 pub async fn patch_queued_turn(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((id, turn_id)): Path<(ChatId, TurnId)>,
+    Path((id, turn_id)): Path<(SessionId, TurnId)>,
     Json(body): Json<QueuedTurnUpdate>,
-) -> Result<Json<tidebreak_core::QueuedTurn>, ServerError> {
+) -> Result<Json<tidebreak_core::QueuedAgentTurn>, ServerError> {
     store.require_chat(id).await?;
     match state
         .store
@@ -538,7 +541,7 @@ pub async fn patch_queued_turn(
 pub async fn delete_queued_turn(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((id, turn_id)): Path<(ChatId, TurnId)>,
+    Path((id, turn_id)): Path<(SessionId, TurnId)>,
 ) -> Result<StatusCode, ServerError> {
     store.require_chat(id).await?;
     if state.store.delete_queued_turn(id, turn_id).await? {
@@ -561,7 +564,7 @@ pub struct QueuePausedBody {
 pub async fn put_queue_paused(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<QueuePausedBody>,
 ) -> Result<StatusCode, ServerError> {
     store.require_chat(id).await?;
@@ -586,7 +589,7 @@ pub async fn put_queue_paused(
 pub async fn post_queue_send_now(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
 ) -> Result<StatusCode, ServerError> {
     store.require_chat(id).await?;
     state
@@ -629,7 +632,7 @@ pub struct SteerBody {
 pub async fn post_steer(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<SteerBody>,
 ) -> Result<StatusCode, ServerError> {
     if body.steer_id.0.is_nil() {
@@ -690,7 +693,7 @@ pub struct CancelBody {
 pub async fn post_cancel(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path(id): Path<ChatId>,
+    Path(id): Path<SessionId>,
     Json(body): Json<CancelBody>,
 ) -> Result<StatusCode, ServerError> {
     // Distinguish "unknown chat" (404) from "known chat, nothing running" (409).

--- a/crates/tidebreak-server/src/routes/user_questions.rs
+++ b/crates/tidebreak-server/src/routes/user_questions.rs
@@ -4,8 +4,8 @@ use axum::extract::State;
 use chrono::Utc;
 use serde::Serialize;
 use tidebreak_core::{
-    AnswerUserQuestions, AnswerUserQuestionsOutcome, AnswerUserQuestionsRequest, CallId, ChatId,
-    CodeApprovalId, CodeSessionId, PendingChatPrompt, PendingUserQuestions, TurnRunStatus,
+    AnswerUserQuestions, AnswerUserQuestionsOutcome, AnswerUserQuestionsRequest, ApprovalId,
+    CallId, PendingChatPrompt, PendingUserQuestions, SessionId, TurnRunStatus,
 };
 
 use crate::error::ServerError;
@@ -18,7 +18,7 @@ pub const MAX_USER_QUESTION_ANSWER_BODY_BYTES: usize = 8 * 1024;
 
 pub async fn list_pending_user_questions(
     store: ScopedStore,
-    Path(chat_id): Path<ChatId>,
+    Path(chat_id): Path<SessionId>,
 ) -> Result<Json<Vec<PendingUserQuestions>>, ServerError> {
     store.require_chat(chat_id).await?;
     Ok(Json(store.list_pending_user_questions(chat_id).await?))
@@ -64,7 +64,7 @@ pub struct AnsweredUserQuestions {
 pub async fn answer_user_questions(
     State(state): State<AppState>,
     store: ScopedStore,
-    Path((chat_id, call_id)): Path<(ChatId, CallId)>,
+    Path((chat_id, call_id)): Path<(SessionId, CallId)>,
     Json(answers): Json<AnswerUserQuestions>,
 ) -> Result<Json<AnsweredUserQuestions>, ServerError> {
     store.require_chat(chat_id).await?;
@@ -74,11 +74,11 @@ pub async fn answer_user_questions(
     // the engine contract carries; additional context has no field there
     // and settles the row directly, which the worker resumes from as well.
     if let Some(code) = state.code.as_ref() {
-        if answers.additional_user_context.is_none() && code.has_worker(CodeSessionId(chat_id.0)) {
+        if answers.additional_user_context.is_none() && code.has_worker(SessionId(chat_id.0)) {
             match code
                 .decide_approval(
                     &store.owner_id(),
-                    CodeApprovalId(call_id.0),
+                    ApprovalId(call_id.0),
                     crate::code::runtime::ApprovalDecisionRequest::Answers {
                         answers: answers.answers.clone(),
                     },

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/tests.rs
@@ -28,7 +28,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use futures::stream::{self, BoxStream};
 use tidebreak_core::{
-    Chat, ChatId, DbStore, ProviderId, ReasoningEffort, TurnCheckpointProgress, TurnId,
+    Chat, DbStore, ProviderId, ReasoningEffort, SessionId, TurnCheckpointProgress, TurnId,
     TurnRunStatus, Usage,
 };
 
@@ -526,7 +526,7 @@ where
 
 async fn admit_sandbox(
     store: &Arc<dyn Store>,
-    chat_id: tidebreak_core::ChatId,
+    chat_id: tidebreak_core::SessionId,
     call: CallId,
     input: &str,
 ) -> tidebreak_core::AgentRun {
@@ -635,7 +635,7 @@ async fn park_wait_set(
 
 async fn ready_wait_set_for_test(
     store: &Arc<dyn Store>,
-    chat_id: tidebreak_core::ChatId,
+    chat_id: tidebreak_core::SessionId,
 ) -> (TurnId, CallId) {
     let turn_id = TurnId::new();
     store
@@ -3092,7 +3092,7 @@ async fn delegated_file_advertisement_requires_exact_current_attachment() {
         });
     assert!(delegated_file_admission_matches(&run, &admission, &chat));
 
-    admission.chat_id = ChatId::new();
+    admission.chat_id = SessionId::new();
     assert!(!delegated_file_admission_matches(&run, &admission, &chat));
 }
 
@@ -3289,7 +3289,7 @@ async fn set_web_search_mode(store: &Arc<dyn Store>, mode: &str) {
 
 /// Freeze the origin turn on an exact model so admission carries it to the
 /// child, the way a real conversation's selection does.
-async fn running_turn_on_model(store: &Arc<dyn Store>, chat_id: ChatId, model: &str) {
+async fn running_turn_on_model(store: &Arc<dyn Store>, chat_id: SessionId, model: &str) {
     let turn_id = TurnId::new();
     store
         .accept_turn(turn_id, chat_id, model, "delegate this")
@@ -3509,7 +3509,7 @@ fn tool_capable_sandbox_prompt_includes_host_skills_summary() {
 
 fn sandbox_chat() -> Chat {
     Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: Some("sandbox".into()),
         model: Some("model".into()),
@@ -3814,7 +3814,7 @@ async fn a_run_at_its_last_step_submits_rather_than_being_reminded() {
 async fn spend_the_cadence(
     store: &Arc<dyn Store>,
     id: tidebreak_core::AgentRunId,
-    chat_id: ChatId,
+    chat_id: SessionId,
     steps: usize,
 ) {
     for step in 0..steps {

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
@@ -243,8 +243,8 @@ impl SandboxAgentRunWorker {
     fn publish_parent_wait_set_resume(
         &self,
         wait_id: CallId,
-        chat_id: tidebreak_core::ChatId,
-        event: tidebreak_core::SequencedEvent,
+        chat_id: tidebreak_core::SessionId,
+        event: tidebreak_core::SequencedAgentEvent,
     ) -> Result<SandboxAgentRunWorkerOutcome> {
         // The journal remains authoritative for replay. Publish its exact
         // committed event before shortening the ordinary turn worker's next

--- a/crates/tidebreak-server/src/sandbox_container_run/tests.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run/tests.rs
@@ -26,8 +26,8 @@ use futures::StreamExt;
 use sea_orm::ConnectOptions;
 use tidebreak_core::{
     AdmitSandboxAgentRunOutcome, AgentConfig, AgentError, AgentRun, AgentRunExecutionLocation,
-    AgentRunId, AgentRunStatus, CallId, CancelToken, Chat, ChatId, ChatRequest, DbStore,
-    ModelProvider, ProviderEvent, ProviderId, Result, StopReason, Store,
+    AgentRunId, AgentRunStatus, CallId, CancelToken, Chat, ChatRequest, DbStore, ModelProvider,
+    ProviderEvent, ProviderId, Result, SessionId, StopReason, Store,
 };
 use tidebreak_sandbox_agent::{run_agent, STEERING_PREFIX};
 use tidebreak_sandbox_protocol::{
@@ -472,7 +472,7 @@ impl Store for TerminalFaultStore {
         self.inner.create_chat_with_project_defaults(chat).await
     }
 
-    async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
+    async fn get_chat(&self, id: SessionId) -> Result<Option<Chat>> {
         if self.setup_fault == Some(SetupFault::ModelResolution) {
             self.setup.enter_and_wait().await;
             return Err(AgentError::Store(
@@ -488,26 +488,26 @@ impl Store for TerminalFaultStore {
 
     async fn get_chat_transcript(
         &self,
-        id: ChatId,
+        id: SessionId,
     ) -> Result<Option<tidebreak_core::ChatTranscriptSnapshot>> {
         self.inner.get_chat_transcript(id).await
     }
 
-    async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
+    async fn set_chat_model(&self, id: SessionId, model: Option<String>) -> Result<()> {
         self.inner.set_chat_model(id, model).await
     }
 
-    async fn set_chat_title(&self, id: ChatId, title: Option<String>) -> Result<()> {
+    async fn set_chat_title(&self, id: SessionId, title: Option<String>) -> Result<()> {
         self.inner.set_chat_title(id, title).await
     }
 
-    async fn set_chat_title_if_unset(&self, id: ChatId, title: &str) -> Result<bool> {
+    async fn set_chat_title_if_unset(&self, id: SessionId, title: &str) -> Result<bool> {
         self.inner.set_chat_title_if_unset(id, title).await
     }
 
     async fn update_chat_metadata(
         &self,
-        id: ChatId,
+        id: SessionId,
         title: Option<Option<String>>,
         model: Option<Option<String>>,
         reasoning_effort: Option<Option<tidebreak_core::ReasoningEffort>>,
@@ -525,7 +525,11 @@ impl Store for TerminalFaultStore {
             )
             .await
     }
-    async fn set_chat_memory_incognito(&self, id: ChatId, memory_incognito: bool) -> Result<bool> {
+    async fn set_chat_memory_incognito(
+        &self,
+        id: SessionId,
+        memory_incognito: bool,
+    ) -> Result<bool> {
         self.inner
             .set_chat_memory_incognito(id, memory_incognito)
             .await
@@ -711,7 +715,7 @@ impl Store for TerminalFaultStore {
         self.inner.append_message(message).await
     }
 
-    async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<tidebreak_core::Message>> {
+    async fn list_messages(&self, chat_id: SessionId) -> Result<Vec<tidebreak_core::Message>> {
         self.inner.list_messages(chat_id).await
     }
 
@@ -725,7 +729,7 @@ impl Store for TerminalFaultStore {
     async fn claim_client_tool_call(
         &self,
         id: CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         executor_id: Uuid,
         lease_token: Uuid,
         now: chrono::DateTime<chrono::Utc>,
@@ -739,7 +743,7 @@ impl Store for TerminalFaultStore {
     async fn heartbeat_client_tool_call(
         &self,
         id: CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         lease_token: Uuid,
         now: chrono::DateTime<chrono::Utc>,
         lease_expires_at: chrono::DateTime<chrono::Utc>,
@@ -763,7 +767,7 @@ impl Store for TerminalFaultStore {
     async fn resolve_client_tool_call_and_append_event(
         &self,
         id: CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         lease_token: Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &tidebreak_core::ToolCallResolution,
@@ -784,7 +788,7 @@ impl Store for TerminalFaultStore {
     async fn resolve_expired_client_tool_call_and_append_event(
         &self,
         id: CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         lease_token: Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &tidebreak_core::ToolCallResolution,
@@ -804,14 +808,14 @@ impl Store for TerminalFaultStore {
 
     async fn list_pending_client_tool_calls(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
     ) -> Result<Vec<tidebreak_core::ToolCallRecord>> {
         self.inner.list_pending_client_tool_calls(chat_id).await
     }
 
     async fn list_tool_calls(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
     ) -> Result<Vec<tidebreak_core::ToolCallRecord>> {
         self.inner.list_tool_calls(chat_id).await
     }
@@ -830,7 +834,7 @@ impl Store for TerminalFaultStore {
 
     async fn append_event(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         event: &tidebreak_core::AgentEvent,
     ) -> Result<i64> {
         self.inner.append_event(chat_id, event).await
@@ -838,9 +842,9 @@ impl Store for TerminalFaultStore {
 
     async fn list_events(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         after: i64,
-    ) -> Result<Vec<tidebreak_core::SequencedEvent>> {
+    ) -> Result<Vec<tidebreak_core::SequencedAgentEvent>> {
         self.inner.list_events(chat_id, after).await
     }
 }
@@ -1120,7 +1124,7 @@ async fn store_with_pool(
     }
     let store: Arc<dyn Store> = Arc::new(DbStore::connect_with_options(options).await.unwrap());
     let chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: Some("container".into()),
         model: Some("host-model".into()),
@@ -1139,7 +1143,7 @@ async fn store_with_pool(
 /// Admit one container-located sandbox child under the chat's running turn,
 /// mirroring how a foreground turn admits a sandbox child — but at the container
 /// execution location.
-async fn admit_container_run(store: &Arc<dyn Store>, chat_id: ChatId, task: &str) -> AgentRunId {
+async fn admit_container_run(store: &Arc<dyn Store>, chat_id: SessionId, task: &str) -> AgentRunId {
     let turn_id = tidebreak_core::TurnId::new();
     store
         .accept_turn(turn_id, chat_id, "host-model", "delegate a container run")
@@ -2849,7 +2853,7 @@ async fn the_container_claim_refuses_past_the_concurrency_cap() {
     // The cap is global across chats, so give each run its own chat (a chat
     // runs one turn at a time, and the admit helper claims the chat's turn).
     let other = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         title: Some("second container chat".into()),
         ..chat.clone()
     };

--- a/crates/tidebreak-server/src/sandbox_exec_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_exec_worker.rs
@@ -17,8 +17,8 @@ use tidebreak_code_execution::{
     OutputArtifactStatus,
 };
 use tidebreak_core::{
-    AgentError, AgentRunId, CallId, ChatId, ClaimSandboxToolCallOutcome, Result, SandboxExecArgs,
-    SandboxToolCall, Store, ToolCallResolution, SANDBOX_EXEC_TOOL,
+    AgentError, AgentRunId, CallId, ClaimSandboxToolCallOutcome, Result, SandboxExecArgs,
+    SandboxToolCall, SessionId, Store, ToolCallResolution, SANDBOX_EXEC_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -42,7 +42,7 @@ const TRUNCATION_MARKER: &str = "\n…[truncated]";
 pub(crate) struct SandboxExecJob {
     pub(crate) call_id: CallId,
     pub(crate) run_id: AgentRunId,
-    pub(crate) chat_id: ChatId,
+    pub(crate) chat_id: SessionId,
     pub(crate) arguments: SandboxExecArgs,
 }
 
@@ -626,7 +626,7 @@ mod tests {
     /// Park one exec checkpoint the way a background run's own loop does.
     async fn checkpoint(store: &Arc<DbStore>, arguments: serde_json::Value) -> CallId {
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("sandbox exec".into()),
             model: Some("model".into()),

--- a/crates/tidebreak-server/src/sandbox_web_search_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_web_search_worker.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 #[cfg(test)]
 use chrono::Utc;
 use tidebreak_core::{
-    AgentError, ChatId, ClaimSandboxToolCallOutcome, Result, SandboxToolCall, Store,
+    AgentError, ClaimSandboxToolCallOutcome, Result, SandboxToolCall, SessionId, Store,
     ToolCallResolution,
 };
 use tokio::sync::Notify;
@@ -40,7 +40,7 @@ pub(crate) trait SandboxWebSearch: Send + Sync {
     /// against the chat it belongs to rather than against host settings alone.
     async fn resolve(
         &self,
-        chat: ChatId,
+        chat: SessionId,
     ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>;
 }
 
@@ -63,7 +63,7 @@ struct HostSandboxWebSearch {
 impl SandboxWebSearch for HostSandboxWebSearch {
     async fn resolve(
         &self,
-        chat: ChatId,
+        chat: SessionId,
     ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError> {
         web_search::resolve_provider(
             &*self.store,
@@ -461,9 +461,9 @@ mod tests {
 
     use crate::web_search::{WebSearchProviderKind, WebSearchResult};
     use tidebreak_core::{
-        AgentRunStatus, CallId, Chat, ChatId, ClaimSandboxToolCallOutcome, DbStore,
+        AgentRunStatus, CallId, Chat, ClaimSandboxToolCallOutcome, DbStore,
         ParkSandboxToolCallOutcome, RequestAgentRunCancellationOutcome, SandboxToolCallRequest,
-        Store,
+        SessionId, Store,
     };
 
     use super::*;
@@ -520,7 +520,7 @@ mod tests {
     impl SandboxWebSearch for BlockingResolution {
         async fn resolve(
             &self,
-            _chat: ChatId,
+            _chat: SessionId,
         ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>
         {
             let _drop = DropMarker(self.dropped.clone());
@@ -569,7 +569,7 @@ mod tests {
     impl SandboxWebSearch for FakeSearch {
         async fn resolve(
             &self,
-            _chat: ChatId,
+            _chat: SessionId,
         ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>
         {
             self.resolution.clone()
@@ -595,7 +595,7 @@ mod tests {
         arguments: serde_json::Value,
     ) -> SandboxToolCallRequest {
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("sandbox web search".into()),
             model: Some("model".into()),

--- a/crates/tidebreak-server/src/scoped_store.rs
+++ b/crates/tidebreak-server/src/scoped_store.rs
@@ -33,14 +33,14 @@ use tidebreak_core::local_app::{AppGrant, AppRecord, AppRevision};
 use tidebreak_core::storage::DecidePlanOutcome;
 use tidebreak_core::{
     AcceptTurnSteerOutcome, AgentRun, AgentRunId, AgentRunResult, AnswerUserQuestionsOutcome,
-    AnswerUserQuestionsRequest, CallId, Chat, ChatId, ChatTranscriptSnapshot, DecidePlanRequest,
+    AnswerUserQuestionsRequest, CallId, Chat, ChatTranscriptSnapshot, DecidePlanRequest,
     DeleteChatOutcome, DeleteProjectOutcome, DocumentId, DocumentListCursor, DocumentRecord,
     DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, ImageRef, JournaledTurnOutcome,
     MessageAttachment, MoveChatOutcome, NetworkPolicy, OwnerId, PendingPlanApproval,
     PendingUserQuestions, PermissionMode, Project, ProjectId, ReasoningEffort,
     RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Result,
-    SandboxAgentAdmission, SandboxToolCall, SandboxToolCallReceipt, SequencedEvent, Store,
-    TaskPlan, ToolApproval, ToolCallRecord, TurnId, TurnRun, TurnSteerId,
+    SandboxAgentAdmission, SandboxToolCall, SandboxToolCallReceipt, SequencedAgentEvent, SessionId,
+    Store, TaskPlan, ToolApproval, ToolCallRecord, TurnId, TurnRun, TurnSteerId,
 };
 
 use crate::error::ServerError;
@@ -79,13 +79,13 @@ impl ScopedStore {
     // ------------------------------------------------------------------
 
     /// Fetch the principal's chat by id.
-    pub async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
+    pub async fn get_chat(&self, id: SessionId) -> Result<Option<Chat>> {
         self.store.get_chat_scoped(&self.owner, id).await
     }
 
     /// The recurring route gate: the principal's chat, or a `404` that does
     /// not reveal whether someone else's chat exists under that id.
-    pub async fn require_chat(&self, id: ChatId) -> std::result::Result<Chat, ServerError> {
+    pub async fn require_chat(&self, id: SessionId) -> std::result::Result<Chat, ServerError> {
         self.get_chat(id)
             .await?
             .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))
@@ -109,12 +109,15 @@ impl ScopedStore {
     }
 
     /// Delete the principal's chat.
-    pub async fn delete_chat(&self, id: ChatId) -> Result<DeleteChatOutcome> {
+    pub async fn delete_chat(&self, id: SessionId) -> Result<DeleteChatOutcome> {
         self.store.delete_chat_scoped(&self.owner, id).await
     }
 
     /// The principal's chat transcript snapshot.
-    pub async fn get_chat_transcript(&self, id: ChatId) -> Result<Option<ChatTranscriptSnapshot>> {
+    pub async fn get_chat_transcript(
+        &self,
+        id: SessionId,
+    ) -> Result<Option<ChatTranscriptSnapshot>> {
         self.store.get_chat_transcript_scoped(&self.owner, id).await
     }
 
@@ -122,7 +125,7 @@ impl ScopedStore {
     #[allow(clippy::too_many_arguments)]
     pub async fn update_chat_metadata(
         &self,
-        id: ChatId,
+        id: SessionId,
         title: Option<Option<String>>,
         model: Option<Option<String>>,
         reasoning_effort: Option<Option<ReasoningEffort>>,
@@ -145,7 +148,7 @@ impl ScopedStore {
     /// Flip the memory-incognito switch on the principal's chat.
     pub async fn set_chat_memory_incognito(
         &self,
-        id: ChatId,
+        id: SessionId,
         memory_incognito: bool,
     ) -> Result<bool> {
         self.store
@@ -194,7 +197,7 @@ impl ScopedStore {
     /// it back out with `None`.
     pub async fn move_chat_to_project(
         &self,
-        id: ChatId,
+        id: SessionId,
         project_id: Option<ProjectId>,
     ) -> Result<MoveChatOutcome> {
         self.store
@@ -301,7 +304,7 @@ impl ScopedStore {
         &self,
         id: TurnSteerId,
         turn_id: TurnId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         content: &str,
         invoked_skills: &[String],
         interrupt: bool,
@@ -332,7 +335,7 @@ impl ScopedStore {
     }
 
     /// [`Store::list_agent_runs`].
-    pub async fn list_agent_runs(&self, chat_id: ChatId) -> Result<Vec<AgentRun>> {
+    pub async fn list_agent_runs(&self, chat_id: SessionId) -> Result<Vec<AgentRun>> {
         self.store.list_agent_runs(chat_id).await
     }
 
@@ -412,7 +415,7 @@ impl ScopedStore {
     /// [`Store::list_pending_client_tool_calls`].
     pub async fn list_pending_client_tool_calls(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
     ) -> Result<Vec<ToolCallRecord>> {
         self.store.list_pending_client_tool_calls(chat_id).await
     }
@@ -420,7 +423,7 @@ impl ScopedStore {
     /// [`Store::list_pending_tool_call_approvals`].
     pub async fn list_pending_tool_call_approvals(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         limit: u64,
     ) -> Result<Vec<ToolApproval>> {
         self.store
@@ -479,7 +482,8 @@ impl ScopedStore {
     pub async fn chat_attention(
         &self,
         items: &[tidebreak_core::InboxItem],
-    ) -> Result<std::collections::HashMap<tidebreak_core::ChatId, tidebreak_core::Attention>> {
+    ) -> Result<std::collections::HashMap<tidebreak_core::SessionId, tidebreak_core::Attention>>
+    {
         self.store.chat_attention_scoped(&self.owner, items).await
     }
 
@@ -515,21 +519,21 @@ impl ScopedStore {
     /// [`Store::list_events_for_call`].
     pub async fn list_events_for_call(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         call_id: CallId,
-    ) -> Result<Vec<SequencedEvent>> {
+    ) -> Result<Vec<SequencedAgentEvent>> {
         self.store.list_events_for_call(chat_id, call_id).await
     }
 
     /// [`Store::get_task_plan`].
-    pub async fn get_task_plan(&self, chat_id: ChatId) -> Result<Option<TaskPlan>> {
+    pub async fn get_task_plan(&self, chat_id: SessionId) -> Result<Option<TaskPlan>> {
         self.store.get_task_plan(chat_id).await
     }
 
     /// [`Store::list_pending_plan_approvals`].
     pub async fn list_pending_plan_approvals(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
     ) -> Result<Vec<PendingPlanApproval>> {
         self.store.list_pending_plan_approvals(chat_id).await
     }
@@ -546,7 +550,7 @@ impl ScopedStore {
     /// [`Store::list_pending_user_questions`].
     pub async fn list_pending_user_questions(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
     ) -> Result<Vec<PendingUserQuestions>> {
         self.store.list_pending_user_questions(chat_id).await
     }
@@ -563,20 +567,20 @@ impl ScopedStore {
     /// [`Store::list_message_attachments`].
     pub async fn list_message_attachments(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
     ) -> Result<Vec<MessageAttachment>> {
         self.store.list_message_attachments(chat_id).await
     }
 
     /// Durably authorize this principal's chat to attach `image`.
-    pub async fn publish_chat_image(&self, chat_id: ChatId, image: &ImageRef) -> Result<bool> {
+    pub async fn publish_chat_image(&self, chat_id: SessionId, image: &ImageRef) -> Result<bool> {
         self.store
             .publish_chat_image_scoped(&self.owner, chat_id, image)
             .await
     }
 
     /// [`Store::list_tool_calls`].
-    pub async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
+    pub async fn list_tool_calls(&self, chat_id: SessionId) -> Result<Vec<ToolCallRecord>> {
         self.store.list_tool_calls(chat_id).await
     }
 }

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -940,7 +940,7 @@ pub(crate) fn plain_text_script() -> Vec<HarnessEvent> {
             text: "hello from the scripted engine".into(),
         },
         HarnessEvent::TurnCompleted {
-            usage: tidebreak_core::CodeUsage {
+            usage: tidebreak_core::TurnUsage {
                 input_tokens: 4,
                 output_tokens: 6,
                 cache_read_input_tokens: 0,
@@ -955,7 +955,7 @@ pub(crate) fn plain_text_script() -> Vec<HarnessEvent> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidebreak_core::{CodeUsage, PermissionMode};
+    use tidebreak_core::{PermissionMode, TurnUsage};
 
     /// Sink that collects every emitted event for assertions.
     #[derive(Default)]
@@ -973,7 +973,7 @@ mod tests {
     fn spec(sink: Arc<CollectingSink>, worktree: &Path) -> SessionSpec {
         SessionSpec {
             owner: tidebreak_core::OwnerId::local(),
-            session_id: tidebreak_core::CodeSessionId::new(),
+            session_id: tidebreak_core::SessionId::new(),
             worktree: worktree.to_path_buf(),
             allowed_read_roots: Vec::new(),
             permission_mode: PermissionMode::Ask,
@@ -1002,7 +1002,7 @@ mod tests {
                 text: "after the park".into(),
             },
             HarnessEvent::TurnCompleted {
-                usage: CodeUsage::default(),
+                usage: TurnUsage::default(),
             },
         ]
     }

--- a/crates/tidebreak-server/src/source_tools.rs
+++ b/crates/tidebreak-server/src/source_tools.rs
@@ -548,7 +548,7 @@ mod tests {
     use chrono::Utc;
     use serde_json::json;
     use tidebreak_core::{
-        Chat, ChatId, DbStore, DocumentUpsert, ReasoningEffort, Store, ToolCallRecord, TurnId,
+        Chat, DbStore, DocumentUpsert, ReasoningEffort, SessionId, Store, ToolCallRecord, TurnId,
     };
 
     use super::*;
@@ -564,7 +564,7 @@ mod tests {
             .unwrap(),
         );
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: Some("Workspace".into()),
             model: None,
@@ -635,7 +635,7 @@ mod tests {
     async fn a_truncated_result_can_be_read_past_the_cut_but_only_in_its_own_chat() {
         let (_directory, store, chat, _document_id) = source_fixture().await;
         let other_chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: None,
             model: None,
@@ -843,7 +843,7 @@ mod tests {
     async fn tools_are_exactly_conversation_scoped_and_reads_show_line_locators() {
         let (_directory, store, chat, document_id) = source_fixture().await;
         let other_chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: None,
             model: None,

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -8,8 +8,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, Weak};
 
 use tidebreak_core::{
-    AgentConfig, AgentError, AgentRunId, BlobStore, CallId, CancelToken, ChatId, Config, DbStore,
-    FsBlobStore, Profile, Result, SecretProvider, SteerInbox, Store, ToolRegistry, TurnId,
+    AgentConfig, AgentError, AgentRunId, BlobStore, CallId, CancelToken, Config, DbStore,
+    FsBlobStore, Profile, Result, SecretProvider, SessionId, SteerInbox, Store, ToolRegistry,
+    TurnId,
 };
 use tokio::sync::{mpsc, Notify, Semaphore};
 use uuid::Uuid;
@@ -922,7 +923,7 @@ struct TurnHandles {
 /// `(chat, turn, lease)` identity in this process.
 #[derive(Default)]
 pub struct TurnGuard {
-    active: Mutex<HashMap<ChatId, TurnHandles>>,
+    active: Mutex<HashMap<SessionId, TurnHandles>>,
     admissions: Mutex<HashMap<TurnId, Weak<tokio::sync::Mutex<()>>>>,
     released: tokio::sync::Notify,
 }
@@ -950,7 +951,7 @@ impl TurnGuard {
     /// Register one exact local attempt, or refuse a conflicting local worker.
     pub fn register(
         self: &Arc<Self>,
-        chat_id: ChatId,
+        chat_id: SessionId,
         turn_id: TurnId,
         lease_token: Uuid,
     ) -> Option<ActiveTurn> {
@@ -980,7 +981,7 @@ impl TurnGuard {
     }
 
     /// Wait until no local worker owns this chat.
-    pub async fn wait_until_vacant(&self, chat_id: ChatId) {
+    pub async fn wait_until_vacant(&self, chat_id: SessionId) {
         loop {
             let released = self.released.notified();
             if !self.active.lock().unwrap().contains_key(&chat_id) {
@@ -991,7 +992,7 @@ impl TurnGuard {
     }
 
     /// Trip cancellation only for the exact turn currently executing locally.
-    pub fn cancel(&self, chat_id: ChatId, turn_id: TurnId) -> bool {
+    pub fn cancel(&self, chat_id: SessionId, turn_id: TurnId) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {
             Some(handles) if handles.turn_id == turn_id => {
                 handles.cancel.cancel();
@@ -1005,7 +1006,7 @@ impl TurnGuard {
     ///
     /// The instruction remains in the store; this process-local signal only
     /// reduces delivery latency and optionally preempts the provider stream.
-    pub fn signal_steer(&self, chat_id: ChatId, turn_id: TurnId, interrupt: bool) -> bool {
+    pub fn signal_steer(&self, chat_id: SessionId, turn_id: TurnId, interrupt: bool) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {
             Some(handles) if handles.turn_id == turn_id => handles.steer.signal_durable(interrupt),
             _ => false,
@@ -1016,7 +1017,7 @@ impl TurnGuard {
 /// A held turn slot; releases the chat on drop.
 pub struct ActiveTurn {
     guard: Arc<TurnGuard>,
-    chat_id: ChatId,
+    chat_id: SessionId,
     turn_id: TurnId,
     lease_token: Uuid,
     cancel: CancelToken,
@@ -1056,7 +1057,7 @@ mod tests {
     #[test]
     fn one_local_attempt_per_chat_then_released_on_drop() {
         let guard = Arc::new(TurnGuard::default());
-        let chat = ChatId::new();
+        let chat = SessionId::new();
         let turn = TurnId::new();
 
         let held = guard
@@ -1069,7 +1070,7 @@ mod tests {
             "a conflicting local attempt is refused"
         );
         assert!(guard
-            .register(ChatId::new(), TurnId::new(), Uuid::new_v4())
+            .register(SessionId::new(), TurnId::new(), Uuid::new_v4())
             .is_some());
 
         drop(held);
@@ -1084,7 +1085,7 @@ mod tests {
     #[test]
     fn cancel_trips_the_held_token() {
         let guard = Arc::new(TurnGuard::default());
-        let chat = ChatId::new();
+        let chat = SessionId::new();
         let turn = TurnId::new();
 
         assert!(!guard.cancel(chat, turn), "nothing to cancel yet");
@@ -1101,7 +1102,7 @@ mod tests {
     #[test]
     fn stale_permit_cannot_remove_a_newer_attempt() {
         let guard = Arc::new(TurnGuard::default());
-        let chat = ChatId::new();
+        let chat = SessionId::new();
         let old_turn = TurnId::new();
         let old_token = Uuid::new_v4();
         let held = guard.register(chat, old_turn, old_token).expect("register");
@@ -1123,7 +1124,7 @@ mod tests {
     #[test]
     fn steer_signal_wakes_the_held_inbox() {
         let guard = Arc::new(TurnGuard::default());
-        let chat = ChatId::new();
+        let chat = SessionId::new();
         let turn = TurnId::new();
 
         assert!(!guard.signal_steer(chat, turn, false));

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -21,14 +21,14 @@ use sea_orm::ConnectionTrait;
 use serde::de::DeserializeOwned;
 use tidebreak_core::{
     AgentConfig, AgentErrorInfo, AgentEvent, AgentRunInboxStatus, AgentRunStatus, ApprovalClass,
-    BeginRootAttachmentChange, BlobMetadata, BlobStore, BlobStream, CallId, Chat, ChatId,
-    ChatRequest, ChatRootAttachment, ClientToolCallRequest, ContentBlock, DeleteProjectOutcome,
-    HostRootId, Message, MessageId, ModelProvider, ParkSandboxToolCallOutcome,
-    ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent, ProviderId, Role,
-    RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin,
-    SandboxToolCallRequest, SecretProvider, SequencedEvent, StopReason, Tool, ToolCallExecution,
-    ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput, ToolRegistry,
-    ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
+    BeginRootAttachmentChange, BlobMetadata, BlobStore, BlobStream, CallId, Chat, ChatRequest,
+    ChatRootAttachment, ClientToolCallRequest, ContentBlock, DeleteProjectOutcome, HostRootId,
+    Message, MessageId, ModelProvider, ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome,
+    Project, ProjectId, ProviderEvent, ProviderId, Role, RootAttachmentChangeAction,
+    RootAttachmentChangeId, RootAttachmentOrigin, SandboxToolCallRequest, SecretProvider,
+    SequencedAgentEvent, SessionId, StopReason, Tool, ToolCallExecution, ToolCallRecord,
+    ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput, ToolRegistry, ToolSpec,
+    TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
 };
 use tokio::sync::Notify;
 use tower::ServiceExt;
@@ -985,7 +985,7 @@ impl Store for PauseTerminalStore {
             .create_chat_with_project_defaults_and_settings_scoped(owner, chat, settings)
             .await
     }
-    async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
+    async fn get_chat(&self, id: SessionId) -> Result<Option<Chat>> {
         self.inner.get_chat(id).await
     }
     async fn list_chats(&self) -> Result<Vec<Chat>> {
@@ -993,22 +993,22 @@ impl Store for PauseTerminalStore {
     }
     async fn get_chat_transcript(
         &self,
-        id: ChatId,
+        id: SessionId,
     ) -> Result<Option<tidebreak_core::ChatTranscriptSnapshot>> {
         self.inner.get_chat_transcript(id).await
     }
-    async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
+    async fn set_chat_model(&self, id: SessionId, model: Option<String>) -> Result<()> {
         self.inner.set_chat_model(id, model).await
     }
-    async fn set_chat_title(&self, id: ChatId, title: Option<String>) -> Result<()> {
+    async fn set_chat_title(&self, id: SessionId, title: Option<String>) -> Result<()> {
         self.inner.set_chat_title(id, title).await
     }
-    async fn set_chat_title_if_unset(&self, id: ChatId, title: &str) -> Result<bool> {
+    async fn set_chat_title_if_unset(&self, id: SessionId, title: &str) -> Result<bool> {
         self.inner.set_chat_title_if_unset(id, title).await
     }
     async fn update_chat_metadata(
         &self,
-        id: ChatId,
+        id: SessionId,
         title: Option<Option<String>>,
         model: Option<Option<String>>,
         reasoning_effort: Option<Option<tidebreak_core::ReasoningEffort>>,
@@ -1026,7 +1026,11 @@ impl Store for PauseTerminalStore {
             )
             .await
     }
-    async fn set_chat_memory_incognito(&self, id: ChatId, memory_incognito: bool) -> Result<bool> {
+    async fn set_chat_memory_incognito(
+        &self,
+        id: SessionId,
+        memory_incognito: bool,
+    ) -> Result<bool> {
         self.inner
             .set_chat_memory_incognito(id, memory_incognito)
             .await
@@ -1034,7 +1038,7 @@ impl Store for PauseTerminalStore {
     async fn get_turn(&self, id: TurnId) -> Result<Option<tidebreak_core::TurnRun>> {
         self.inner.get_turn(id).await
     }
-    async fn list_turns(&self, chat_id: ChatId) -> Result<Vec<tidebreak_core::TurnRun>> {
+    async fn list_turns(&self, chat_id: SessionId) -> Result<Vec<tidebreak_core::TurnRun>> {
         self.inner.list_turns(chat_id).await
     }
     async fn begin_turn_admission(
@@ -1053,7 +1057,10 @@ impl Store for PauseTerminalStore {
     ) -> Result<bool> {
         self.inner.release_turn_admission(lease).await
     }
-    async fn list_queued_turns(&self, chat_id: ChatId) -> Result<Vec<tidebreak_core::QueuedTurn>> {
+    async fn list_queued_turns(
+        &self,
+        chat_id: SessionId,
+    ) -> Result<Vec<tidebreak_core::QueuedAgentTurn>> {
         self.inner.list_queued_turns(chat_id).await
     }
     // Hooked here rather than on `accept_turn`, because the trait's plain
@@ -1062,7 +1069,7 @@ impl Store for PauseTerminalStore {
     async fn accept_turn_with_attachments(
         &self,
         id: TurnId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         model: &str,
         content: &str,
         images: &[tidebreak_core::ImageRef],
@@ -1088,7 +1095,7 @@ impl Store for PauseTerminalStore {
     async fn accept_reserved_turn_with_message_context(
         &self,
         lease: tidebreak_core::TurnAdmissionLease,
-        chat_id: ChatId,
+        chat_id: SessionId,
         model: &str,
         content: &str,
         images: &[tidebreak_core::ImageRef],
@@ -1116,7 +1123,7 @@ impl Store for PauseTerminalStore {
     async fn enqueue_reserved_turn(
         &self,
         lease: tidebreak_core::TurnAdmissionLease,
-        queued: &tidebreak_core::QueuedTurn,
+        queued: &tidebreak_core::QueuedAgentTurn,
     ) -> Result<tidebreak_core::ReservedQueuedTurnOutcome> {
         self.inner.enqueue_reserved_turn(lease, queued).await
     }
@@ -1124,7 +1131,7 @@ impl Store for PauseTerminalStore {
         &self,
         id: TurnSteerId,
         turn_id: TurnId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         content: &str,
         interrupt: bool,
     ) -> Result<tidebreak_core::AcceptTurnSteerOutcome> {
@@ -1469,7 +1476,7 @@ impl Store for PauseTerminalStore {
     }
     async fn append_turn_event(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         attempt_event_ordinal: i32,
@@ -1496,7 +1503,7 @@ impl Store for PauseTerminalStore {
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         event: &AgentEvent,
-    ) -> Result<Option<SequencedEvent>> {
+    ) -> Result<Option<SequencedAgentEvent>> {
         self.terminal_recovery_calls.fetch_add(1, Ordering::SeqCst);
         if self.fail_terminal_recovery.swap(false, Ordering::SeqCst) {
             return Err(AgentError::Store(
@@ -1514,7 +1521,7 @@ impl Store for PauseTerminalStore {
         output: &Message,
         citations: &[tidebreak_core::AssistantCitationInput],
         event: &AgentEvent,
-    ) -> Result<Option<SequencedEvent>> {
+    ) -> Result<Option<SequencedAgentEvent>> {
         self.terminal_recovery_calls.fetch_add(1, Ordering::SeqCst);
         if self.fail_terminal_recovery.swap(false, Ordering::SeqCst) {
             return Err(AgentError::Store(
@@ -1548,7 +1555,7 @@ impl Store for PauseTerminalStore {
             .append_claimed_assistant_message_with_citations(message, citations, lease_token, now)
             .await
     }
-    async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
+    async fn list_messages(&self, chat_id: SessionId) -> Result<Vec<Message>> {
         self.inner.list_messages(chat_id).await
     }
     async fn accept_tool_call(
@@ -1594,7 +1601,7 @@ impl Store for PauseTerminalStore {
     }
     async fn decide_tool_call_approval(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         call_id: CallId,
         decision: &tidebreak_core::ApprovalDecision,
         decided_at: chrono::DateTime<chrono::Utc>,
@@ -1605,7 +1612,7 @@ impl Store for PauseTerminalStore {
     }
     async fn decide_tool_call_approval_with_grant(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         call_id: CallId,
         decision: &tidebreak_core::ApprovalDecision,
         grant: &tidebreak_core::StandingGrant,
@@ -1624,7 +1631,7 @@ impl Store for PauseTerminalStore {
     async fn claim_client_tool_call(
         &self,
         id: tidebreak_core::CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         executor_id: uuid::Uuid,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
@@ -1637,7 +1644,7 @@ impl Store for PauseTerminalStore {
     async fn heartbeat_client_tool_call(
         &self,
         id: tidebreak_core::CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         lease_expires_at: chrono::DateTime<chrono::Utc>,
@@ -1660,7 +1667,7 @@ impl Store for PauseTerminalStore {
     async fn abandon_inherited_server_tool_call(
         &self,
         id: tidebreak_core::CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
@@ -1682,7 +1689,7 @@ impl Store for PauseTerminalStore {
     async fn resolve_client_tool_call_and_append_event(
         &self,
         id: tidebreak_core::CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &tidebreak_core::ToolCallResolution,
@@ -1702,7 +1709,7 @@ impl Store for PauseTerminalStore {
     async fn resolve_expired_client_tool_call_and_append_event(
         &self,
         id: tidebreak_core::CallId,
-        chat_id: ChatId,
+        chat_id: SessionId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &tidebreak_core::ToolCallResolution,
@@ -1721,13 +1728,13 @@ impl Store for PauseTerminalStore {
     }
     async fn list_pending_client_tool_calls(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
     ) -> Result<Vec<tidebreak_core::ToolCallRecord>> {
         self.inner.list_pending_client_tool_calls(chat_id).await
     }
     async fn list_tool_calls(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
     ) -> Result<Vec<tidebreak_core::ToolCallRecord>> {
         self.inner.list_tool_calls(chat_id).await
     }
@@ -1740,7 +1747,7 @@ impl Store for PauseTerminalStore {
     async fn delete_setting(&self, key: &str) -> Result<()> {
         self.inner.delete_setting(key).await
     }
-    async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64> {
+    async fn append_event(&self, chat_id: SessionId, event: &AgentEvent) -> Result<i64> {
         if matches!(
             event,
             AgentEvent::TurnCompleted { .. }
@@ -1756,7 +1763,11 @@ impl Store for PauseTerminalStore {
         }
         self.inner.append_event(chat_id, event).await
     }
-    async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>> {
+    async fn list_events(
+        &self,
+        chat_id: SessionId,
+        after: i64,
+    ) -> Result<Vec<SequencedAgentEvent>> {
         self.inner.list_events(chat_id, after).await
     }
 }
@@ -1937,7 +1948,7 @@ async fn test_app_with_state() -> (
 /// a turn worker — see `test_app_without_turn_worker`.
 async fn admit_sandbox_for_test(
     store: &Arc<dyn Store>,
-    chat_id: ChatId,
+    chat_id: SessionId,
     input: &str,
 ) -> tidebreak_core::AgentRun {
     let turn_id = TurnId::new();
@@ -2125,14 +2136,14 @@ async fn make_chat(router: &Router, bearer: &str) -> Chat {
 }
 
 /// POST a message to a chat, returning the response status.
-async fn send_message(router: &Router, bearer: &str, chat: ChatId, content: &str) -> StatusCode {
+async fn send_message(router: &Router, bearer: &str, chat: SessionId, content: &str) -> StatusCode {
     send_message_with_id(router, bearer, chat, TurnId::new(), content).await
 }
 
 async fn send_message_with_id(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     turn_id: TurnId,
     content: &str,
 ) -> StatusCode {
@@ -2155,7 +2166,12 @@ async fn send_message_with_id(
 }
 
 /// POST `/chats/{id}/cancel`, returning the response status.
-async fn cancel_turn(router: &Router, bearer: &str, chat: ChatId, turn_id: TurnId) -> StatusCode {
+async fn cancel_turn(
+    router: &Router,
+    bearer: &str,
+    chat: SessionId,
+    turn_id: TurnId,
+) -> StatusCode {
     router
         .clone()
         .oneshot(
@@ -2176,7 +2192,7 @@ async fn cancel_turn(router: &Router, bearer: &str, chat: ChatId, turn_id: TurnI
 
 /// Poll the journal until the turn terminates (or time out), returning its
 /// events in sequence order.
-async fn wait_for_turn(store: &Arc<dyn Store>, chat: ChatId) -> Vec<SequencedEvent> {
+async fn wait_for_turn(store: &Arc<dyn Store>, chat: SessionId) -> Vec<SequencedAgentEvent> {
     for _ in 0..500 {
         let events = store.list_events(chat, 0).await.unwrap();
         if events.iter().any(|e| {

--- a/crates/tidebreak-server/src/tests/chat_titling.rs
+++ b/crates/tidebreak-server/src/tests/chat_titling.rs
@@ -193,7 +193,7 @@ async fn titling_app_with_answers(
 }
 
 /// The chat's title once the background titling call has stored one.
-async fn wait_for_title(store: &Arc<dyn Store>, chat: ChatId) -> Option<String> {
+async fn wait_for_title(store: &Arc<dyn Store>, chat: SessionId) -> Option<String> {
     for _ in 0..300 {
         let title = store.get_chat(chat).await.unwrap().unwrap().title;
         if title.is_some() {

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -25,8 +25,8 @@ use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
     BlobStore, BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
     BrowserScreenshotArgs, BrowserScreenshotResult, BrowserSnapshotArgs, BrowserWaitArgs,
-    BrowserWaitResult, CodeSessionId, CodeTurnId, CodeTurnStatus, CodeWorkspaceStatus, DbStore,
-    HarnessKind, PermissionMode, ReasoningEffort, RepoId, Store, WorkspaceId,
+    BrowserWaitResult, CodeWorkspaceStatus, DbStore, HarnessKind, PermissionMode, ReasoningEffort,
+    RepoId, SessionId, Store, TurnId, TurnStatus, WorkspaceId,
 };
 use tidebreak_harness::{AdapterRegistry, HarnessApprovalRef, HarnessEvent, ListedHarnessModel};
 
@@ -292,8 +292,8 @@ pub(super) fn write_approval_script(call_id: &str, content: &str) -> Vec<Harness
 /// Every event a session journaled, in order.
 pub(super) async fn journaled_events(
     db: &DbStore,
-    session_id: CodeSessionId,
-) -> Vec<tidebreak_core::SequencedCodeEvent> {
+    session_id: SessionId,
+) -> Vec<tidebreak_core::code::SequencedEvent> {
     tidebreak_core::db::code::list_events(
         db,
         &tidebreak_core::OwnerId::local(),
@@ -531,10 +531,7 @@ pub(super) async fn wait_until(mut ready: impl FnMut() -> bool) {
     .expect("condition never held");
 }
 
-pub(super) async fn wait_for_open_turn(
-    runtime: &CodeRuntime,
-    session_id: CodeSessionId,
-) -> CodeTurnId {
+pub(super) async fn wait_for_open_turn(runtime: &CodeRuntime, session_id: SessionId) -> TurnId {
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             if let Some(turn) = tidebreak_core::db::code::get_open_turn(
@@ -614,7 +611,7 @@ pub(super) async fn next_json(
 fn _types(
     _id: WorkspaceId,
     _status: CodeWorkspaceStatus,
-    _turn: CodeTurnStatus,
+    _turn: TurnStatus,
     _db: Option<DbStore>,
     _mode: PermissionMode,
     _kind: HarnessKind,

--- a/crates/tidebreak-server/src/tests/code_approvals.rs
+++ b/crates/tidebreak-server/src/tests/code_approvals.rs
@@ -12,8 +12,8 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
-    AttentionSource, AttentionState, CapLevel, CodeEvent, CodeSessionId, CodeSessionLifecycle,
-    CodeTurnId, DbStore, HarnessKind,
+    AttentionSource, AttentionState, CapLevel, DbStore, Event, HarnessKind, SessionId,
+    SessionLifecycle, TurnId,
 };
 use tidebreak_harness::{AdapterRegistry, ApprovalDecision, HarnessApprovalRef, HarnessEvent};
 
@@ -77,7 +77,7 @@ async fn ran_one_ask_turn(
     reqwest::Client,
     std::net::SocketAddr,
     Arc<str>,
-    CodeSessionId,
+    SessionId,
     Arc<CodeRuntime>,
     tempfile::TempDir,
 ) {
@@ -102,7 +102,7 @@ async fn ran_one_ask_turn(
         .json()
         .await
         .unwrap();
-    let session_id: CodeSessionId = json_id(&session).parse().unwrap();
+    let session_id: SessionId = json_id(&session).parse().unwrap();
     let turn = tokio::time::timeout(
         Duration::from_secs(10),
         client
@@ -123,7 +123,7 @@ async fn approvals_for(
     client: &reqwest::Client,
     addr: std::net::SocketAddr,
     token: &str,
-    session_id: CodeSessionId,
+    session_id: SessionId,
 ) -> Vec<serde_json::Value> {
     client
         .get(format!(
@@ -141,13 +141,13 @@ async fn approvals_for(
 /// The outcome carried on every `ApprovalResolved` the session journaled.
 async fn journaled_resolutions(
     db: &DbStore,
-    session_id: CodeSessionId,
+    session_id: SessionId,
 ) -> Vec<tidebreak_core::ApprovalDecisionKind> {
     journaled_events(db, session_id)
         .await
         .into_iter()
         .filter_map(|framed| match framed.event {
-            CodeEvent::ApprovalResolved { decision, .. } => Some(decision),
+            Event::ApprovalResolved { decision, .. } => Some(decision),
             _ => None,
         })
         .collect()
@@ -216,7 +216,7 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     .await
     .expect("pending approval never appeared");
 
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -225,7 +225,7 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     .await
     .unwrap()
     .unwrap();
-    assert_eq!(row.lifecycle, CodeSessionLifecycle::Running);
+    assert_eq!(row.lifecycle, SessionLifecycle::Running);
     assert!(!turn.is_finished(), "run_turn must still be executing");
 
     let decided = tokio::time::timeout(Duration::from_secs(2), async {
@@ -260,12 +260,12 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     let kinds: Vec<&str> = events
         .iter()
         .map(|framed| match &framed.event {
-            tidebreak_core::CodeEvent::ApprovalRequested { .. } => "requested",
-            tidebreak_core::CodeEvent::ApprovalResolved { .. } => "resolved",
+            tidebreak_core::Event::ApprovalRequested { .. } => "requested",
+            tidebreak_core::Event::ApprovalResolved { .. } => "resolved",
             // Deltas stream and are never journaled; the message that states
             // the same text is what the turn leaves behind (record 57).
-            tidebreak_core::CodeEvent::AssistantMessage { .. } => "message",
-            tidebreak_core::CodeEvent::TurnCompleted { .. } => "completed",
+            tidebreak_core::Event::AssistantMessage { .. } => "message",
+            tidebreak_core::Event::TurnCompleted { .. } => "completed",
             _ => "other",
         })
         .collect();
@@ -275,7 +275,7 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     assert!(kinds.contains(&"completed"));
     assert!(events.iter().any(|framed| matches!(
         &framed.event,
-        tidebreak_core::CodeEvent::AssistantMessage { text, .. } if text == "after the decision"
+        tidebreak_core::Event::AssistantMessage { text, .. } if text == "after the decision"
     )));
     let requested = kinds.iter().position(|k| *k == "requested").unwrap();
     let message = kinds.iter().position(|k| *k == "message").unwrap();
@@ -387,7 +387,7 @@ async fn concurrent_approval_decisions_deliver_exactly_once() {
         &client,
         addr,
         &token,
-        session_id.parse::<CodeSessionId>().unwrap(),
+        session_id.parse::<SessionId>().unwrap(),
     )
     .await;
     assert_eq!(rows.len(), 1);
@@ -396,7 +396,7 @@ async fn concurrent_approval_decisions_deliver_exactly_once() {
         Some("approved" | "denied")
     ));
     let resolutions =
-        journaled_resolutions(&runtime.db, session_id.parse::<CodeSessionId>().unwrap()).await;
+        journaled_resolutions(&runtime.db, session_id.parse::<SessionId>().unwrap()).await;
     assert_eq!(resolutions.len(), 1);
 }
 
@@ -477,7 +477,7 @@ async fn a_definite_native_approval_delivery_failure_is_abandoned() {
     assert_eq!(body["kind"], "approval_delivery_failed");
     assert!(observed.observed_decisions().is_empty());
 
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let rows = approvals_for(&client, addr, &token, parsed).await;
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["state"], "abandoned");
@@ -615,7 +615,7 @@ async fn shutdown_waits_for_an_accepted_approval_to_finish_durably() {
         .unwrap();
     assert_eq!(archived.status(), reqwest::StatusCode::OK);
 
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let rows = approvals_for(&client, addr, &token, parsed).await;
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["state"], "approved");
@@ -690,7 +690,7 @@ async fn an_unknown_approval_delivery_stays_claimed_until_restart_recovery() {
     let approval_id = approval["id"]
         .as_str()
         .unwrap()
-        .parse::<tidebreak_core::CodeApprovalId>()
+        .parse::<tidebreak_core::ApprovalId>()
         .unwrap();
 
     let unknown = client
@@ -719,7 +719,7 @@ async fn an_unknown_approval_delivery_stays_claimed_until_restart_recovery() {
     .await
     .unwrap()
     .unwrap();
-    assert_eq!(claimed.state, tidebreak_core::CodeApprovalState::Pending);
+    assert_eq!(claimed.state, tidebreak_core::ApprovalState::Pending);
     assert!(claimed.decision_claim.is_some());
     assert!(claimed.decided_at.is_none());
 
@@ -750,14 +750,11 @@ async fn an_unknown_approval_delivery_stays_claimed_until_restart_recovery() {
     .await
     .unwrap()
     .unwrap();
-    assert_eq!(
-        recovered.state,
-        tidebreak_core::CodeApprovalState::Abandoned
-    );
+    assert_eq!(recovered.state, tidebreak_core::ApprovalState::Abandoned);
     assert!(recovered.decision_claim.is_none());
     assert!(recovered.decided_at.is_some());
     assert_eq!(
-        journaled_resolutions(&runtime.db, session_id.parse::<CodeSessionId>().unwrap()).await,
+        journaled_resolutions(&runtime.db, session_id.parse::<SessionId>().unwrap()).await,
         vec![tidebreak_core::ApprovalDecisionKind::Abandoned]
     );
 }
@@ -813,7 +810,7 @@ async fn deny_feedback_reaches_the_scripted_engine() {
             assert_eq!(listed.status(), reqwest::StatusCode::OK);
             let body: Vec<serde_json::Value> = listed.json().await.unwrap();
             if let Some(row) = body.into_iter().next() {
-                let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+                let parsed: SessionId = json_id(&session).parse().unwrap();
                 let session = tidebreak_core::db::code::get_session(
                     &runtime.db,
                     &tidebreak_core::OwnerId::local(),
@@ -842,7 +839,7 @@ async fn deny_feedback_reaches_the_scripted_engine() {
         .unwrap_or("")
         .contains("Write"));
 
-    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+    let parsed: SessionId = json_id(&session).parse().unwrap();
     let row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -1002,7 +999,7 @@ async fn restart_abandons_an_approval_whose_native_waiter_was_lost() {
     assert_eq!(rows[0]["id"], approval["id"]);
     assert_eq!(rows[0]["state"], "abandoned");
 
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -1097,7 +1094,7 @@ async fn a_stale_worker_completion_cannot_abandon_a_reused_call_id() {
         .unwrap();
     assert_eq!(session.status(), reqwest::StatusCode::CREATED);
     let session = session.json::<serde_json::Value>().await.unwrap();
-    let session_id = json_id(&session).parse::<CodeSessionId>().unwrap();
+    let session_id = json_id(&session).parse::<SessionId>().unwrap();
     let turn = client
         .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
         .bearer_auth(&token)
@@ -1108,7 +1105,7 @@ async fn a_stale_worker_completion_cannot_abandon_a_reused_call_id() {
         .json::<serde_json::Value>()
         .await
         .unwrap();
-    let turn_id = json_id(&turn).parse::<CodeTurnId>().unwrap();
+    let turn_id = json_id(&turn).parse::<TurnId>().unwrap();
     let row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -1118,17 +1115,17 @@ async fn a_stale_worker_completion_cannot_abandon_a_reused_call_id() {
     .unwrap()
     .unwrap();
     let stale_epoch = row.spawn_epoch - 1;
-    let stale_id = tidebreak_core::CodeApprovalId::new();
-    let current_id = tidebreak_core::CodeApprovalId::new();
+    let stale_id = tidebreak_core::ApprovalId::new();
+    let current_id = tidebreak_core::ApprovalId::new();
     for (id, worker_epoch) in [(stale_id, stale_epoch), (current_id, row.spawn_epoch)] {
         tidebreak_core::db::code::insert_approval(
             &runtime.db,
             &row.owner,
-            &tidebreak_core::CodeApproval {
+            &tidebreak_core::Approval {
                 id,
                 session_id,
                 turn_id,
-                kind: tidebreak_core::CodeApprovalKind::Other {
+                kind: tidebreak_core::ApprovalKind::Other {
                     summary: "run command".into(),
                 },
                 harness_raw: serde_json::json!({"call_id":"toolu_reused"}),
@@ -1138,7 +1135,7 @@ async fn a_stale_worker_completion_cannot_abandon_a_reused_call_id() {
                 worker_epoch: Some(worker_epoch),
                 decision_claim: None,
                 claimed_at: None,
-                state: tidebreak_core::CodeApprovalState::Pending,
+                state: tidebreak_core::ApprovalState::Pending,
                 feedback: None,
                 requested_at: chrono::Utc::now(),
                 decided_at: None,
@@ -1165,7 +1162,7 @@ async fn a_stale_worker_completion_cannot_abandon_a_reused_call_id() {
             .unwrap()
             .unwrap()
             .state,
-        tidebreak_core::CodeApprovalState::Abandoned
+        tidebreak_core::ApprovalState::Abandoned
     );
     assert_eq!(
         tidebreak_core::db::code::get_approval(&runtime.db, &row.owner, current_id)
@@ -1173,7 +1170,7 @@ async fn a_stale_worker_completion_cannot_abandon_a_reused_call_id() {
             .unwrap()
             .unwrap()
             .state,
-        tidebreak_core::CodeApprovalState::Pending,
+        tidebreak_core::ApprovalState::Pending,
         "a stale completion must not settle the replacement worker's approval"
     );
 }
@@ -1381,7 +1378,7 @@ async fn attention_follows_approval_completion_and_view() {
         }
     });
 
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
@@ -1531,7 +1528,7 @@ async fn user_can_pin_and_clear_attention() {
     assert_eq!(body["attention"]["state"]["note"], "look at this later");
     assert_eq!(body["attention"]["source"], "user");
 
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let mut row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -1540,7 +1537,7 @@ async fn user_can_pin_and_clear_attention() {
     .await
     .unwrap()
     .unwrap();
-    row.lifecycle = CodeSessionLifecycle::Running;
+    row.lifecycle = SessionLifecycle::Running;
     tidebreak_core::db::code::save_session(&runtime.db, &row)
         .await
         .unwrap();

--- a/crates/tidebreak-server/src/tests/code_archive.rs
+++ b/crates/tidebreak-server/src/tests/code_archive.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
-use tidebreak_core::{CodeSessionId, CodeSessionLifecycle, CodeWorkspaceStatus, WorkspaceId};
+use tidebreak_core::{CodeWorkspaceStatus, SessionId, SessionLifecycle, WorkspaceId};
 use tidebreak_harness::HarnessEvent;
 
 #[tokio::test]
@@ -123,7 +123,7 @@ async fn no_force_archive_of_a_dirty_workspace_leaves_an_idle_session() {
     let body: serde_json::Value = refused.json().await.unwrap();
     assert_eq!(body["kind"], "uncommitted");
 
-    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+    let parsed: SessionId = json_id(&session).parse().unwrap();
     let row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -132,7 +132,7 @@ async fn no_force_archive_of_a_dirty_workspace_leaves_an_idle_session() {
     .await
     .unwrap()
     .unwrap();
-    assert_eq!(row.lifecycle, CodeSessionLifecycle::Idle);
+    assert_eq!(row.lifecycle, SessionLifecycle::Idle);
     assert!(std::path::Path::new(path).exists());
 
     let turn = client
@@ -565,7 +565,7 @@ async fn archive_ends_the_session_before_removing_the_worktree() {
         .unwrap();
     assert_eq!(archived.status(), reqwest::StatusCode::OK);
     assert!(!std::path::Path::new(&path).exists());
-    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+    let parsed: SessionId = json_id(&session).parse().unwrap();
     let row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -574,7 +574,7 @@ async fn archive_ends_the_session_before_removing_the_worktree() {
     .await
     .unwrap()
     .unwrap();
-    assert_eq!(row.lifecycle, CodeSessionLifecycle::Ended);
+    assert_eq!(row.lifecycle, SessionLifecycle::Ended);
 
     let again = client
         .post(format!(
@@ -632,7 +632,7 @@ async fn archive_refuses_a_running_session_without_force() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let turn = tokio::spawn({
         let client = client.clone();
         let token = token.clone();
@@ -656,7 +656,7 @@ async fn archive_refuses_a_running_session_without_force() {
             .await
             .unwrap()
             .unwrap();
-            if row.lifecycle == CodeSessionLifecycle::Running {
+            if row.lifecycle == SessionLifecycle::Running {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
@@ -699,7 +699,7 @@ async fn archive_refuses_a_running_session_without_force() {
     .await
     .unwrap()
     .unwrap();
-    assert_eq!(row.lifecycle, CodeSessionLifecycle::Ended);
+    assert_eq!(row.lifecycle, SessionLifecycle::Ended);
 }
 
 /// A freshly created workspace has a branch with no commits past its base.

--- a/crates/tidebreak-server/src/tests/code_attachments.rs
+++ b/crates/tidebreak-server/src/tests/code_attachments.rs
@@ -8,7 +8,7 @@ use axum::Router;
 
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
-use tidebreak_core::{CapLevel, CodeSessionId, CodeSessionLifecycle, Store};
+use tidebreak_core::{CapLevel, SessionId, SessionLifecycle, Store};
 
 async fn code_app_with_put_gate(
     adapter: ScriptedAdapter,
@@ -362,7 +362,7 @@ async fn a_live_session_image_upload_is_idempotently_published() {
         assert_eq!(body["attachment_id"], expected.blob_id.to_string());
     }
 
-    let session_id: CodeSessionId = session.parse().unwrap();
+    let session_id: SessionId = session.parse().unwrap();
     assert_eq!(
         runtime
             .db
@@ -392,7 +392,7 @@ async fn an_image_upload_losing_the_session_end_race_conflicts_and_queues_retire
     let session = create_sibling_sessions(&client, addr, &token, &workspace, 1)
         .await
         .remove(0);
-    let session_id: CodeSessionId = session.parse().unwrap();
+    let session_id: SessionId = session.parse().unwrap();
     let pixels = one_pixel_png();
     let image = crate::routes::image_attachment::inspect_image_bytes(&pixels).unwrap();
     let upload = tokio::spawn({
@@ -422,7 +422,7 @@ async fn an_image_upload_losing_the_session_end_race_conflicts_and_queues_retire
     .await
     .unwrap()
     .unwrap();
-    row.lifecycle = CodeSessionLifecycle::Ended;
+    row.lifecycle = SessionLifecycle::Ended;
     row.child_pid = None;
     assert!(tidebreak_core::db::code::save_session(&runtime.db, &row)
         .await

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -18,9 +18,9 @@ use tidebreak_core::{
     BrowserEngineDescriptor, BrowserEngineName, BrowserListResult, BrowserLoadState,
     BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot, BrowserScreenshotArgs,
     BrowserScreenshotResult, BrowserSessionSummary, BrowserSnapshotArgs, BrowserViewport,
-    BrowserWaitArgs, BrowserWaitResult, BrowserWaitStatus, CodeRepo, CodeSession, CodeSessionId,
-    CodeSessionKind, CodeSessionLifecycle, CodeWorkspace, CodeWorkspaceStatus, DbStore,
-    HarnessKind, OwnerId, PermissionMode, RepoId, Store, WorkspaceId,
+    BrowserWaitArgs, BrowserWaitResult, BrowserWaitStatus, CodeRepo, CodeWorkspace,
+    CodeWorkspaceStatus, DbStore, HarnessKind, OwnerId, PermissionMode, RepoId, Session, SessionId,
+    SessionKind, SessionLifecycle, Store, WorkspaceId,
 };
 use tidebreak_harness::AdapterRegistry;
 
@@ -270,7 +270,7 @@ async fn serve(router: Router) -> std::net::SocketAddr {
     a
 }
 
-async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, CodeSessionId) {
+async fn seed_session(db: &DbStore, lc: SessionLifecycle) -> (WorkspaceId, SessionId) {
     let repo_id = RepoId::new();
     db::code::insert_repo(
         db,
@@ -311,11 +311,11 @@ async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, C
         bundle_bytes: None,
     };
     db::code::insert_workspace(db, &ws).await.unwrap();
-    let s = CodeSession {
-        id: CodeSessionId::new(),
+    let s = Session {
+        id: SessionId::new(),
         owner: OwnerId::local(),
         workspace_id: Some(ws.id),
-        kind: CodeSessionKind::Interactive,
+        kind: SessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: None,
         harness_resume_ref: None,
@@ -337,7 +337,7 @@ async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, C
     (ws.id, s.id)
 }
 
-fn mint_token(code: &CodeRuntime, ws: WorkspaceId, s: CodeSessionId) -> String {
+fn mint_token(code: &CodeRuntime, ws: WorkspaceId, s: SessionId) -> String {
     let bridge = crate::code::browser_channel::test_bridge_command();
     let sp = code
         .browser_tokens
@@ -382,7 +382,7 @@ async fn get(addr: std::net::SocketAddr, rt: &str, tok: Option<&str>) -> reqwest
 #[tokio::test]
 async fn valid_token_lists() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = get(a.addr, "list", Some(&t)).await;
     assert_eq!(r.status(), reqwest::StatusCode::OK);
@@ -399,7 +399,7 @@ async fn valid_token_lists() {
 #[tokio::test]
 async fn missing_and_unknown_401() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let _ = mint_token(&a.code, ws, s);
     assert_eq!(
         get(a.addr, "list", None).await.status(),
@@ -415,7 +415,7 @@ async fn missing_and_unknown_401() {
 #[tokio::test]
 async fn app_token_not_browser() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let _ = mint_token(&a.code, ws, s);
     assert_eq!(
         get(
@@ -432,7 +432,7 @@ async fn app_token_not_browser() {
 #[tokio::test]
 async fn revoked_then_401() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     a.code.browser_tokens.revoke(s);
     let r = get(a.addr, "list", Some(&t)).await;
@@ -443,7 +443,7 @@ async fn revoked_then_401() {
 #[tokio::test]
 async fn ended_session_403() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Ended).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Ended).await;
     let t = mint_token(&a.code, ws, s);
     assert_eq!(
         get(a.addr, "list", Some(&t)).await.status(),
@@ -455,7 +455,7 @@ async fn ended_session_403() {
 #[tokio::test]
 async fn cross_workspace_404() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (_, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (_, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, WorkspaceId::new(), s);
     assert_eq!(
         get(a.addr, "list", Some(&t)).await.status(),
@@ -467,7 +467,7 @@ async fn cross_workspace_404() {
 #[tokio::test]
 async fn missing_runtime_501() {
     let a = browser_app(None).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = get(a.addr, "list", Some(&t)).await;
     assert_eq!(r.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
@@ -481,7 +481,7 @@ async fn missing_runtime_501() {
 #[tokio::test]
 async fn stale_snapshot_409() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::stale()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -500,7 +500,7 @@ async fn stale_snapshot_409() {
 #[tokio::test]
 async fn unshared_origin_403() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::not_authorized()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -518,7 +518,7 @@ async fn unshared_origin_403() {
 #[tokio::test]
 async fn navigate_roundtrip() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -544,7 +544,7 @@ async fn navigate_roundtrip() {
 #[tokio::test]
 async fn snapshot_roundtrip() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -563,7 +563,7 @@ async fn snapshot_roundtrip() {
 #[tokio::test]
 async fn navigate_refuses_non_http() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     for u in ["file:///etc/passwd", "https://user:secret@example.com"] {
         assert_eq!(
@@ -584,7 +584,7 @@ async fn navigate_refuses_non_http() {
 #[tokio::test]
 async fn wait_roundtrip() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -608,7 +608,7 @@ async fn wait_roundtrip() {
 #[tokio::test]
 async fn wait_refuses_missing_browser_id() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     assert_eq!(
         post(
@@ -631,7 +631,7 @@ async fn wait_refuses_missing_browser_id() {
 #[tokio::test]
 async fn wait_refuses_non_well_formed() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     assert_eq!(
         post(
@@ -649,7 +649,7 @@ async fn wait_refuses_non_well_formed() {
 #[tokio::test]
 async fn wait_stale_409() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::stale()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -669,7 +669,7 @@ async fn wait_stale_409() {
 #[tokio::test]
 async fn wait_missing_runtime_501() {
     let a = browser_app(None).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -689,7 +689,7 @@ async fn wait_missing_runtime_501() {
 #[tokio::test]
 async fn screenshot_roundtrip() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -711,7 +711,7 @@ async fn screenshot_roundtrip() {
 #[tokio::test]
 async fn screenshot_refuses_non_well_formed() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     assert_eq!(
         post(
@@ -729,7 +729,7 @@ async fn screenshot_refuses_non_well_formed() {
 #[tokio::test]
 async fn screenshot_stale_409() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::stale()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -748,7 +748,7 @@ async fn screenshot_stale_409() {
 #[tokio::test]
 async fn screenshot_missing_runtime_501() {
     let a = browser_app(None).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -767,7 +767,7 @@ async fn screenshot_missing_runtime_501() {
 #[tokio::test]
 async fn act_roundtrip() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -793,7 +793,7 @@ async fn act_roundtrip() {
 #[tokio::test]
 async fn act_refuses_non_well_formed_or_stale_requests() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     assert_eq!(
         post(
@@ -814,7 +814,7 @@ async fn act_refuses_non_well_formed_or_stale_requests() {
     );
 
     let stale = browser_app(Some(Arc::new(FakeBrowserRuntime::stale()))).await;
-    let (ws, s) = seed_session(&stale.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&stale.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&stale.code, ws, s);
     assert_eq!(
         post(
@@ -838,7 +838,7 @@ async fn act_refuses_non_well_formed_or_stale_requests() {
 #[tokio::test]
 async fn act_missing_runtime_501() {
     let a = browser_app(None).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     let r = post(
         a.addr,
@@ -859,7 +859,7 @@ async fn act_missing_runtime_501() {
 #[tokio::test]
 async fn new_routes_require_capability_token() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let _t = mint_token(&a.code, ws, s);
     for (rt, body) in [
         (
@@ -900,7 +900,7 @@ async fn new_routes_require_capability_token() {
 #[tokio::test]
 async fn new_routes_refuse_wrong_workspace_scope() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (_, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (_, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, WorkspaceId::new(), s);
     for (rt, body) in [
         (
@@ -927,7 +927,7 @@ async fn new_routes_refuse_wrong_workspace_scope() {
 #[tokio::test]
 async fn new_routes_refuse_ended_session() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Ended).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Ended).await;
     let t = mint_token(&a.code, ws, s);
     for (rt, body) in [
         (
@@ -954,7 +954,7 @@ async fn new_routes_refuse_ended_session() {
 #[tokio::test]
 async fn snapshot_needs_browser_id() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     assert_eq!(
         post(a.addr, "snapshot", Some(&t), serde_json::json!({}))
@@ -967,7 +967,7 @@ async fn snapshot_needs_browser_id() {
 #[tokio::test]
 async fn bodies_reject_subject_ids() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
-    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let (ws, s) = seed_session(&a.code.db, SessionLifecycle::Idle).await;
     let t = mint_token(&a.code, ws, s);
     for (rt, body) in [
         (

--- a/crates/tidebreak-server/src/tests/code_doctor.rs
+++ b/crates/tidebreak-server/src/tests/code_doctor.rs
@@ -11,8 +11,7 @@ use axum::Router;
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
-    AttentionState, CapLevel, CodeSessionId, CodeSessionLifecycle, HarnessKind, ReasoningEffort,
-    Store,
+    AttentionState, CapLevel, HarnessKind, ReasoningEffort, SessionId, SessionLifecycle, Store,
 };
 use tidebreak_harness::AdapterRegistry;
 
@@ -39,7 +38,7 @@ async fn stall_sweep_marks_a_silent_running_session() {
         .json::<serde_json::Value>()
         .await
         .unwrap();
-    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+    let parsed: SessionId = json_id(&session).parse().unwrap();
     let mut row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -48,7 +47,7 @@ async fn stall_sweep_marks_a_silent_running_session() {
     .await
     .unwrap()
     .unwrap();
-    row.lifecycle = CodeSessionLifecycle::Running;
+    row.lifecycle = SessionLifecycle::Running;
     tidebreak_core::db::code::save_session(&runtime.db, &row)
         .await
         .unwrap();
@@ -97,13 +96,13 @@ async fn stall_sweep_leaves_a_monitoring_session_working() {
         .json::<serde_json::Value>()
         .await
         .unwrap();
-    let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+    let parsed: SessionId = json_id(&session).parse().unwrap();
     let owner = tidebreak_core::OwnerId::local();
     let mut row = tidebreak_core::db::code::get_session(&runtime.db, &owner, parsed)
         .await
         .unwrap()
         .unwrap();
-    row.lifecycle = CodeSessionLifecycle::Running;
+    row.lifecycle = SessionLifecycle::Running;
     tidebreak_core::db::code::save_session(&runtime.db, &row)
         .await
         .unwrap();
@@ -121,7 +120,7 @@ async fn stall_sweep_leaves_a_monitoring_session_working() {
         &owner,
         parsed,
         row.spawn_epoch,
-        &tidebreak_core::CodeEvent::ToolStarted {
+        &tidebreak_core::Event::ToolStarted {
             call_id: "monitor-1".into(),
             name: "Monitor".into(),
             detail: tidebreak_core::ToolDetail::Other {
@@ -861,7 +860,7 @@ async fn a_lost_resume_fences_the_session_instead_of_failing_every_turn() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
 
     // The session carries a ref from an earlier engine process.
     let mut row = tidebreak_core::db::code::get_session(

--- a/crates/tidebreak-server/src/tests/code_external.rs
+++ b/crates/tidebreak-server/src/tests/code_external.rs
@@ -197,7 +197,7 @@ async fn bound_session_id(
     runtime: &CodeRuntime,
     owner: &OwnerId,
     external_key: &str,
-) -> tidebreak_core::CodeSessionId {
+) -> tidebreak_core::SessionId {
     tidebreak_core::db::code::get_external_binding(&runtime.db, owner, "slack", external_key)
         .await
         .unwrap()

--- a/crates/tidebreak-server/src/tests/code_internal.rs
+++ b/crates/tidebreak-server/src/tests/code_internal.rs
@@ -17,10 +17,9 @@ use axum::http::{header, Request, StatusCode};
 use tower::ServiceExt;
 
 use tidebreak_core::{
-    ApprovalClass, ChatRequest, CodeSessionId, CodeTurnStatus, ContentBlock, DbStore,
-    ModelProvider, OwnerId, ProviderEvent, ProviderId, StopReason, Store,
-    SubmitAgentRunResultOutcome, Tool, ToolCtx, ToolOutput, ToolRegistry, ToolSpec, TurnId,
-    TurnParkWait, TurnRunStatus,
+    ApprovalClass, ChatRequest, ContentBlock, DbStore, ModelProvider, OwnerId, ProviderEvent,
+    ProviderId, SessionId, StopReason, Store, SubmitAgentRunResultOutcome, Tool, ToolCtx,
+    ToolOutput, ToolRegistry, ToolSpec, TurnId, TurnParkWait, TurnRunStatus, TurnStatus,
 };
 use tidebreak_harness::AdapterRegistry;
 
@@ -282,7 +281,7 @@ async fn pending_approval_of_kind(
     client: &reqwest::Client,
     addr: std::net::SocketAddr,
     token: &str,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     kind: &str,
 ) -> serde_json::Value {
     tokio::time::timeout(Duration::from_secs(10), async {
@@ -316,7 +315,7 @@ async fn wait_for_turn_statuses(
     client: &reqwest::Client,
     addr: std::net::SocketAddr,
     token: &str,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     expected: &[&str],
 ) {
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
@@ -337,7 +336,7 @@ async fn turn_statuses(
     client: &reqwest::Client,
     addr: std::net::SocketAddr,
     token: &str,
-    session_id: CodeSessionId,
+    session_id: SessionId,
 ) -> Vec<String> {
     let turns: Vec<serde_json::Value> = client
         .get(format!("http://{addr}/sessions/{session_id}/turns"))
@@ -373,7 +372,7 @@ async fn decide(
     assert_eq!(status, reqwest::StatusCode::OK, "{text}");
 }
 
-fn event_types(events: &[tidebreak_core::SequencedCodeEvent]) -> Vec<String> {
+fn event_types(events: &[tidebreak_core::code::SequencedEvent]) -> Vec<String> {
     events
         .iter()
         .map(|event| {
@@ -399,7 +398,7 @@ async fn create_internal_session(
     router: &axum::Router,
     bearer: &str,
     permission_mode: &str,
-) -> CodeSessionId {
+) -> SessionId {
     let created = router
         .clone()
         .oneshot(
@@ -423,7 +422,7 @@ async fn create_internal_session(
 fn submit_internal_turn(
     router: &axum::Router,
     bearer: &str,
-    session_id: CodeSessionId,
+    session_id: SessionId,
     message: &str,
 ) -> tokio::task::JoinHandle<axum::response::Response> {
     let router = router.clone();
@@ -449,8 +448,8 @@ fn submit_internal_turn(
 
 async fn wait_for_durable_park(
     runtime: &CodeRuntime,
-    session_id: CodeSessionId,
-) -> tidebreak_core::CodeTurn {
+    session_id: SessionId,
+) -> tidebreak_core::Turn {
     let parked = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             if let Some(turn) =
@@ -458,7 +457,7 @@ async fn wait_for_durable_park(
                     .await
                     .unwrap()
             {
-                if turn.status == CodeTurnStatus::Waiting
+                if turn.status == TurnStatus::Waiting
                     && turn.park_ref.is_some()
                     && turn.park_wait.is_some()
                 {
@@ -478,7 +477,7 @@ async fn wait_for_durable_park(
                     .unwrap();
             let runs = runtime
                 .db
-                .list_agent_runs(tidebreak_core::ChatId(session_id.0))
+                .list_agent_runs(tidebreak_core::SessionId(session_id.0))
                 .await
                 .unwrap();
             let events = tidebreak_core::db::code::list_recent_events(
@@ -614,7 +613,7 @@ async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
     let session: serde_json::Value = created.json().await.unwrap();
     assert_eq!(session["harness_kind"], "internal");
     assert!(session["workspace_id"].is_null(), "{session}");
-    let session_id: CodeSessionId = session["id"].as_str().unwrap().parse().unwrap();
+    let session_id: SessionId = session["id"].as_str().unwrap().parse().unwrap();
 
     // The session row is the conversation row: the chat routes read the
     // same row by the same id.
@@ -831,7 +830,7 @@ async fn a_conversation_without_a_workspace_runs_on_the_code_wire() {
 /// always replayed that), one terminal row, and no `AssistantMessage`
 /// beside the deltas that carry the answer (the whole message lives on the
 /// transcript row, not a second journal row).
-fn assert_journaled_once(events: &[tidebreak_core::SequencedCodeEvent], legs: usize) {
+fn assert_journaled_once(events: &[tidebreak_core::code::SequencedEvent], legs: usize) {
     let types = event_types(events);
     let count = |kind: &str| types.iter().filter(|entry| entry.as_str() == kind).count();
     assert_eq!(count("turn_started"), legs, "{types:?}");
@@ -845,11 +844,11 @@ fn assert_journaled_once(events: &[tidebreak_core::SequencedCodeEvent], legs: us
 }
 
 /// The assistant text a journal streams, concatenated.
-fn streamed_text(events: &[tidebreak_core::SequencedCodeEvent]) -> String {
+fn streamed_text(events: &[tidebreak_core::code::SequencedEvent]) -> String {
     events
         .iter()
         .filter_map(|event| match &event.event {
-            tidebreak_core::CodeEvent::AssistantDelta { text } => Some(text.as_str()),
+            tidebreak_core::Event::AssistantDelta { text } => Some(text.as_str()),
             _ => None,
         })
         .collect()
@@ -860,12 +859,12 @@ fn streamed_text(events: &[tidebreak_core::SequencedCodeEvent]) -> String {
 /// reading of exactly that row.
 async fn assert_chat_replay_is_the_journal(
     db: &DbStore,
-    session_id: CodeSessionId,
-    journal: &[tidebreak_core::SequencedCodeEvent],
+    session_id: SessionId,
+    journal: &[tidebreak_core::code::SequencedEvent],
 ) {
     use tidebreak_core::Store as _;
     let replay = db
-        .list_events(tidebreak_core::ChatId(session_id.0), 0)
+        .list_events(tidebreak_core::SessionId(session_id.0), 0)
         .await
         .unwrap();
     assert!(!replay.is_empty());
@@ -896,6 +895,200 @@ async fn assert_chat_replay_is_the_journal(
         projected,
         "the chat replay skips only code-only rows"
     );
+}
+
+#[tokio::test]
+async fn canonical_and_compatibility_routes_share_conversation_rows() {
+    let (addr, token, _runtime, ran, _dir) = internal_engine_app(vec![
+        Step::Tool {
+            name: "exec",
+            input: serde_json::json!({"command": "echo", "args": ["hi"]}),
+        },
+        Step::Text("done"),
+    ])
+    .await;
+    let client = reqwest::Client::new();
+    let created = client
+        .post(format!("http://{addr}/sessions"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "permission_mode": "ask" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = created.json().await.unwrap();
+    let session_id: SessionId = session["id"].as_str().unwrap().parse().unwrap();
+
+    let canonical_session: serde_json::Value = client
+        .get(format!("http://{addr}/sessions/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let code_session: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(canonical_session, code_session);
+    let chat: serde_json::Value = client
+        .get(format!("http://{addr}/chats/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(chat["id"], session["id"]);
+
+    let running = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "run it" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let approval = pending_approval_of_kind(&client, addr, &token, session_id, "tool_use").await;
+    let approval_id = approval["id"].as_str().unwrap();
+
+    let code_approvals: Vec<serde_json::Value> = client
+        .get(format!(
+            "http://{addr}/code/approvals?session_id={session_id}&state=pending"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(code_approvals.len(), 1);
+    assert_eq!(code_approvals[0]["id"], approval["id"]);
+    let chat_approvals: Vec<serde_json::Value> = client
+        .get(format!("http://{addr}/chats/{session_id}/approvals"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(chat_approvals.len(), 1);
+    assert_eq!(chat_approvals[0]["call_id"], approval["id"]);
+
+    let canonical_turns: serde_json::Value = client
+        .get(format!("http://{addr}/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let code_turns: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(canonical_turns, code_turns);
+
+    let queued_id = TurnId::new();
+    let queued = client
+        .post(format!("http://{addr}/chats/{session_id}/messages"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "turn_id": queued_id,
+            "content": "follow up",
+            "queue": true,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(queued.status(), reqwest::StatusCode::ACCEPTED);
+
+    let canonical_queue: serde_json::Value = client
+        .get(format!("http://{addr}/sessions/{session_id}/queued"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let code_queue: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{session_id}/queued"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(canonical_queue, code_queue);
+    assert_eq!(canonical_queue["queued"][0]["id"], queued_id.to_string());
+    let chat_queue: serde_json::Value = client
+        .get(format!("http://{addr}/chats/{session_id}/queued"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(chat_queue["queued"][0]["id"], queued_id.to_string());
+
+    let deleted = client
+        .delete(format!(
+            "http://{addr}/sessions/{session_id}/queued/{queued_id}"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), reqwest::StatusCode::NO_CONTENT);
+    let chat_queue: serde_json::Value = client
+        .get(format!("http://{addr}/chats/{session_id}/queued"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(chat_queue["queued"], serde_json::json!([]));
+
+    decide(
+        &client,
+        addr,
+        &token,
+        approval_id,
+        serde_json::json!({ "decision": "approve" }),
+    )
+    .await;
+    let response = tokio::time::timeout(Duration::from_secs(20), running)
+        .await
+        .expect("the approved turn completes")
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::ACCEPTED);
+    assert_eq!(ran.load(Ordering::SeqCst), 1);
 }
 
 /// A questions park answered through the chat route resumes the session
@@ -933,7 +1126,7 @@ async fn a_questions_park_answered_from_the_chat_route_resumes_the_session() {
         .unwrap();
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let session: serde_json::Value = created.json().await.unwrap();
-    let hosted: CodeSessionId = session["id"].as_str().unwrap().parse().unwrap();
+    let hosted: SessionId = session["id"].as_str().unwrap().parse().unwrap();
     let turn = tokio::spawn({
         let client = client.clone();
         let token = token.clone();
@@ -1013,7 +1206,7 @@ async fn a_plan_accepted_from_the_chat_route_resumes_the_session() {
             .unwrap();
         assert_eq!(created.status(), reqwest::StatusCode::CREATED);
         let session: serde_json::Value = created.json().await.unwrap();
-        let hosted: CodeSessionId = session["id"].as_str().unwrap().parse().unwrap();
+        let hosted: SessionId = session["id"].as_str().unwrap().parse().unwrap();
         let turn = tokio::spawn({
             let client = client.clone();
             let token = token.clone();
@@ -1106,7 +1299,7 @@ async fn an_internal_client_wait_resumes_through_one_adapter_park() {
     let call_id: tidebreak_core::CallId = call_id.parse().unwrap();
     let pending = runtime
         .db
-        .list_pending_client_tool_calls(tidebreak_core::ChatId(session_id.0))
+        .list_pending_client_tool_calls(tidebreak_core::SessionId(session_id.0))
         .await
         .unwrap();
     assert_eq!(pending.len(), 1);
@@ -1177,7 +1370,7 @@ async fn an_internal_client_wait_resumes_through_one_adapter_park() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(completed.status, CodeTurnStatus::Completed);
+    assert_eq!(completed.status, TurnStatus::Completed);
     assert_eq!(completed.park_ref, None);
     assert_eq!(completed.park_wait, None);
     let after_resume = runtime
@@ -1228,7 +1421,7 @@ async fn an_internal_agent_wait_resumes_through_one_adapter_park() {
     let child_id: tidebreak_core::AgentRunId = run_ids[0].parse().unwrap();
     let children = runtime
         .db
-        .list_agent_runs(tidebreak_core::ChatId(session_id.0))
+        .list_agent_runs(tidebreak_core::SessionId(session_id.0))
         .await
         .unwrap()
         .into_iter()
@@ -1276,7 +1469,7 @@ async fn an_internal_agent_wait_resumes_through_one_adapter_park() {
     };
     let _ = state
         .events
-        .sender(tidebreak_core::ChatId(session_id.0))
+        .sender(tidebreak_core::SessionId(session_id.0))
         .send(event);
     state.turn_job_wake.notify_one();
 
@@ -1289,7 +1482,7 @@ async fn an_internal_agent_wait_resumes_through_one_adapter_park() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(completed.status, CodeTurnStatus::Completed);
+    assert_eq!(completed.status, TurnStatus::Completed);
     assert_eq!(completed.park_ref, None);
     assert_eq!(completed.park_wait, None);
     let after_resume = runtime
@@ -1344,11 +1537,11 @@ async fn interrupting_an_internal_client_park_closes_the_turn() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(closed.status, CodeTurnStatus::Interrupted);
+    assert_eq!(closed.status, TurnStatus::Interrupted);
     let call_id: tidebreak_core::CallId = call_id.parse().unwrap();
     let call = runtime
         .db
-        .list_tool_calls(tidebreak_core::ChatId(session_id.0))
+        .list_tool_calls(tidebreak_core::SessionId(session_id.0))
         .await
         .unwrap()
         .into_iter()
@@ -1374,7 +1567,7 @@ async fn a_plain_internal_turn_is_journaled_once() {
         .unwrap();
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let session: serde_json::Value = created.json().await.unwrap();
-    let hosted: CodeSessionId = session["id"].as_str().unwrap().parse().unwrap();
+    let hosted: SessionId = session["id"].as_str().unwrap().parse().unwrap();
 
     let response = tokio::time::timeout(Duration::from_secs(20), async {
         client
@@ -1480,7 +1673,7 @@ async fn deleting_a_hosted_session_through_the_chat_route_removes_it_from_both_s
         .unwrap();
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let session: serde_json::Value = created.json().await.unwrap();
-    let id: CodeSessionId = session["id"].as_str().unwrap().parse().unwrap();
+    let id: SessionId = session["id"].as_str().unwrap().parse().unwrap();
 
     // Creating the session attached the engine, which journaled
     // `SessionStarted` under this id; without the code-side cascade the

--- a/crates/tidebreak-server/src/tests/code_pr_facts.rs
+++ b/crates/tidebreak-server/src/tests/code_pr_facts.rs
@@ -15,10 +15,10 @@ use tidebreak_core::db::code::{
     save_turn,
 };
 use tidebreak_core::{
-    Attention, AttentionSource, CodeEvent, CodePullRequestRelation, CodePullRequestState, CodeRepo,
-    CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeTurn, CodeTurnId,
-    CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, Diffstat, HarnessKind, OwnerId,
-    PermissionMode, RepoId, ToolDetail, ToolOutcome, WorkspaceId,
+    Attention, AttentionSource, CodePullRequestRelation, CodePullRequestState, CodeRepo,
+    CodeWorkspace, CodeWorkspaceStatus, Diffstat, Event, HarnessKind, OwnerId, PermissionMode,
+    RepoId, Session, SessionId, SessionKind, SessionLifecycle, ToolDetail, ToolOutcome, Turn,
+    TurnId, TurnStatus, WorkspaceId,
 };
 
 use crate::code::pr_facts;
@@ -97,8 +97,8 @@ fn write_gh_shim_with_view(dir: &std::path::Path, log: &std::path::Path, view_js
 
 async fn mark_turn_checkout_changed(
     store: &tidebreak_core::DbStore,
-    session: &CodeSession,
-    turn_id: CodeTurnId,
+    session: &Session,
+    turn_id: TurnId,
 ) {
     let mut turn = get_turn(store, &session.owner, turn_id)
         .await
@@ -114,10 +114,7 @@ async fn mark_turn_checkout_changed(
     save_turn(store, &session.owner, &turn).await.unwrap();
 }
 
-async fn seeded(
-    store: &tidebreak_core::DbStore,
-    worktree: &std::path::Path,
-) -> (CodeSession, CodeTurnId) {
+async fn seeded(store: &tidebreak_core::DbStore, worktree: &std::path::Path) -> (Session, TurnId) {
     let owner = OwnerId::local();
     let repo_id = RepoId::new();
     insert_repo(
@@ -164,11 +161,11 @@ async fn seeded(
     )
     .await
     .unwrap();
-    let session = CodeSession {
-        id: CodeSessionId::new(),
+    let session = Session {
+        id: SessionId::new(),
         owner: owner.clone(),
         workspace_id: Some(workspace_id),
-        kind: CodeSessionKind::Interactive,
+        kind: SessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: Some("2.1.233".into()),
         harness_resume_ref: None,
@@ -176,7 +173,7 @@ async fn seeded(
         model: None,
         reasoning_effort: None,
         fast_mode: false,
-        lifecycle: CodeSessionLifecycle::Idle,
+        lifecycle: SessionLifecycle::Idle,
         fence_reason: None,
         child_pid: None,
         child_process_identity: None,
@@ -187,15 +184,15 @@ async fn seeded(
         created_at: chrono::Utc::now(),
     };
     insert_session(store, &session).await.unwrap();
-    let turn_id = CodeTurnId::new();
+    let turn_id = TurnId::new();
     insert_turn(
         store,
         &owner,
-        &CodeTurn {
+        &Turn {
             id: turn_id,
             session_id: session.id,
             ordinal: 1,
-            status: CodeTurnStatus::Completed,
+            status: TurnStatus::Completed,
             model: None,
             fast_mode: false,
             user_input: "ship it".into(),
@@ -219,7 +216,7 @@ async fn seeded(
         &owner,
         session.id,
         0,
-        &CodeEvent::TurnStarted { turn_id },
+        &Event::TurnStarted { turn_id },
     )
     .await
     .unwrap();
@@ -229,7 +226,7 @@ async fn seeded(
 #[allow(clippy::too_many_arguments)]
 async fn journal_command(
     store: &tidebreak_core::DbStore,
-    session: &CodeSession,
+    session: &Session,
     call_id: &str,
     cmd: &str,
     cwd: &std::path::Path,
@@ -242,7 +239,7 @@ async fn journal_command(
         &session.owner,
         session.id,
         0,
-        &CodeEvent::ToolStarted {
+        &Event::ToolStarted {
             call_id: call_id.into(),
             name: "Bash".into(),
             detail: ToolDetail::Command {
@@ -259,7 +256,7 @@ async fn journal_command(
         &session.owner,
         session.id,
         0,
-        &CodeEvent::ToolCompleted {
+        &Event::ToolCompleted {
             call_id: call_id.into(),
             outcome,
             preview: preview.into(),

--- a/crates/tidebreak-server/src/tests/code_recap.rs
+++ b/crates/tidebreak-server/src/tests/code_recap.rs
@@ -210,7 +210,7 @@ async fn start_turn(
     token: &str,
     dir: &std::path::Path,
     harness_kind: tidebreak_core::HarnessKind,
-) -> tidebreak_core::CodeSessionId {
+) -> tidebreak_core::SessionId {
     let repo = init_git_repo(dir);
     let registered = client
         .post(format!("http://{addr}/code/repos"))
@@ -247,9 +247,8 @@ async fn start_turn(
         .unwrap();
     assert_eq!(session.status(), reqwest::StatusCode::CREATED);
     let session: serde_json::Value = session.json().await.unwrap();
-    let session_id = tidebreak_core::CodeSessionId(
-        uuid::Uuid::parse_str(session["id"].as_str().unwrap()).unwrap(),
-    );
+    let session_id =
+        tidebreak_core::SessionId(uuid::Uuid::parse_str(session["id"].as_str().unwrap()).unwrap());
 
     let turn = client
         .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
@@ -266,8 +265,8 @@ async fn start_turn(
 
 async fn wait_for_completed_turn(
     runtime: &CodeRuntime,
-    session_id: tidebreak_core::CodeSessionId,
-) -> tidebreak_core::CodeTurn {
+    session_id: tidebreak_core::SessionId,
+) -> tidebreak_core::Turn {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
         let turns = tidebreak_core::db::code::list_turns(
@@ -279,7 +278,7 @@ async fn wait_for_completed_turn(
         .unwrap();
         if let Some(turn) = turns
             .last()
-            .filter(|turn| turn.status == tidebreak_core::CodeTurnStatus::Completed)
+            .filter(|turn| turn.status == tidebreak_core::TurnStatus::Completed)
         {
             return turn.clone();
         }
@@ -496,8 +495,8 @@ async fn a_machine_with_no_utility_model_stores_no_recap() {
     let outcome = recapper
         .derive(
             &tidebreak_core::OwnerId::local(),
-            tidebreak_core::CodeSessionId(uuid::Uuid::new_v4()),
-            tidebreak_core::CodeTurnId(uuid::Uuid::new_v4()),
+            tidebreak_core::SessionId(uuid::Uuid::new_v4()),
+            tidebreak_core::TurnId(uuid::Uuid::new_v4()),
         )
         .await
         .unwrap();

--- a/crates/tidebreak-server/src/tests/code_rewrite.rs
+++ b/crates/tidebreak-server/src/tests/code_rewrite.rs
@@ -312,7 +312,7 @@ async fn a_completed_turn_stores_the_derived_rewrite() {
     let turns = tidebreak_core::db::code::list_turns(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
-        tidebreak_core::CodeSessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
+        tidebreak_core::SessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
     )
     .await
     .unwrap();
@@ -324,13 +324,13 @@ async fn a_completed_turn_stores_the_derived_rewrite() {
     let events = tidebreak_core::db::code::list_recent_events(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
-        tidebreak_core::CodeSessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
+        tidebreak_core::SessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
         400,
     )
     .await
     .unwrap();
     let closing = events.iter().find_map(|sequenced| match &sequenced.event {
-        tidebreak_core::CodeEvent::AssistantMessage {
+        tidebreak_core::Event::AssistantMessage {
             text,
             parent_call_id: None,
         } => Some(text.as_str()),
@@ -404,8 +404,8 @@ async fn a_machine_with_no_utility_model_stores_no_rewrite() {
     let outcome = rewriter
         .derive(
             &tidebreak_core::OwnerId::local(),
-            tidebreak_core::CodeSessionId(uuid::Uuid::new_v4()),
-            tidebreak_core::CodeTurnId(uuid::Uuid::new_v4()),
+            tidebreak_core::SessionId(uuid::Uuid::new_v4()),
+            tidebreak_core::TurnId(uuid::Uuid::new_v4()),
         )
         .await
         .unwrap();
@@ -442,7 +442,7 @@ async fn a_failed_rewrite_leaves_the_original() {
     let turns = tidebreak_core::db::code::list_turns(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
-        tidebreak_core::CodeSessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
+        tidebreak_core::SessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
     )
     .await
     .unwrap();
@@ -451,13 +451,13 @@ async fn a_failed_rewrite_leaves_the_original() {
     let events = tidebreak_core::db::code::list_recent_events(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
-        tidebreak_core::CodeSessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
+        tidebreak_core::SessionId(uuid::Uuid::parse_str(&session_id).unwrap()),
         400,
     )
     .await
     .unwrap();
     let closing = events.iter().find_map(|sequenced| match &sequenced.event {
-        tidebreak_core::CodeEvent::AssistantMessage {
+        tidebreak_core::Event::AssistantMessage {
             text,
             parent_call_id: None,
         } => Some(text.as_str()),

--- a/crates/tidebreak-server/src/tests/code_settings.rs
+++ b/crates/tidebreak-server/src/tests/code_settings.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
-    CapLevel, CodeSessionId, CodeSessionLifecycle, FenceReason, HarnessKind, PermissionMode,
-    ReasoningEffort,
+    CapLevel, FenceReason, HarnessKind, PermissionMode, ReasoningEffort, SessionId,
+    SessionLifecycle,
 };
 
 async fn execute_code_db_unprepared(dir: &tempfile::TempDir, statement: &str) {
@@ -507,7 +507,7 @@ async fn a_queued_turn_receives_the_validated_effective_settings() {
         .unwrap();
     let session: serde_json::Value = created.json().await.unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
 
     let first = {
         let client = client.clone();
@@ -593,7 +593,7 @@ async fn a_live_setting_update_becomes_active_only_after_its_exact_write_commits
     execute_code_db_unprepared(
         &dir,
         "CREATE TRIGGER ignore_reasoning_effort_update
-         BEFORE UPDATE OF reasoning_effort ON session
+         BEFORE UPDATE OF reasoning_effort ON \"session\"
          WHEN NEW.reasoning_effort IS NOT OLD.reasoning_effort
          BEGIN
            SELECT RAISE(IGNORE);
@@ -730,7 +730,7 @@ async fn a_permission_mode_intent_persistence_failure_never_reaches_the_engine()
     execute_code_db_unprepared(
         &dir,
         "CREATE TRIGGER fail_permission_mode_intent
-         BEFORE UPDATE OF permission_mode_intent ON session
+         BEFORE UPDATE OF permission_mode_intent ON \"session\"
          WHEN NEW.permission_mode_intent IS NOT NULL
          BEGIN
            SELECT RAISE(FAIL, 'permission-mode intent write failed');
@@ -782,7 +782,7 @@ async fn a_permission_mode_confirmation_failure_terminates_and_fences_the_engine
     execute_code_db_unprepared(
         &dir,
         "CREATE TRIGGER ignore_permission_mode_confirmation
-         BEFORE UPDATE OF permission_mode ON session
+         BEFORE UPDATE OF permission_mode ON \"session\"
          WHEN NEW.permission_mode <> OLD.permission_mode
          BEGIN
            SELECT RAISE(IGNORE);
@@ -813,7 +813,7 @@ async fn a_permission_mode_confirmation_failure_terminates_and_fences_the_engine
     .unwrap()
     .unwrap();
     assert_eq!(stored.permission_mode, PermissionMode::Plan);
-    assert_eq!(stored.lifecycle, CodeSessionLifecycle::Fenced);
+    assert_eq!(stored.lifecycle, SessionLifecycle::Fenced);
     assert!(matches!(
         stored.fence_reason,
         Some(FenceReason::ProbeAmbiguous { .. })

--- a/crates/tidebreak-server/src/tests/code_steer.rs
+++ b/crates/tidebreak-server/src/tests/code_steer.rs
@@ -5,7 +5,7 @@ use super::code::*;
 use std::time::Duration;
 
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
-use tidebreak_core::{CapLevel, CodeEvent, CodeSessionId, CodeTurnId, CodeTurnStatus};
+use tidebreak_core::{CapLevel, Event, SessionId, TurnId, TurnStatus};
 
 #[tokio::test]
 async fn unsupported_explicit_steer_is_refused_without_queueing() {
@@ -34,7 +34,7 @@ async fn unsupported_explicit_steer_is_refused_without_queueing() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let turn = tokio::spawn({
         let client = client.clone();
         let token = token.clone();
@@ -97,7 +97,7 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let (mut events, _) = runtime.bus.attach(parsed);
 
     let turn = tokio::spawn({
@@ -116,7 +116,7 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
     });
     let active_turn_id = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
-            if let CodeEvent::TurnStarted { turn_id } = events.recv().await.unwrap().event {
+            if let Event::TurnStarted { turn_id } = events.recv().await.unwrap().event {
                 break turn_id;
             }
         }
@@ -190,10 +190,10 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let event = events.recv().await.unwrap().event;
-            if let CodeEvent::UserSteered { text, .. } = &event {
+            if let Event::UserSteered { text, .. } = &event {
                 steer_events.push(text.clone());
             }
-            if matches!(event, CodeEvent::TurnCompleted { .. }) {
+            if matches!(event, Event::TurnCompleted { .. }) {
                 break;
             }
         }
@@ -250,7 +250,7 @@ async fn supported_steer_requires_an_active_turn() {
         ))
         .bearer_auth(&token)
         .json(&serde_json::json!({
-            "expected_turn_id": CodeTurnId::new(),
+            "expected_turn_id": TurnId::new(),
             "guidance": "too late",
         }))
         .send()
@@ -299,7 +299,7 @@ async fn steer_rejects_blank_nul_and_oversized_guidance() {
             ))
             .bearer_auth(&token)
             .json(&serde_json::json!({
-                "expected_turn_id": CodeTurnId::new(),
+                "expected_turn_id": TurnId::new(),
                 "guidance": guidance,
             }))
             .send()
@@ -338,7 +338,7 @@ async fn stale_turn_steering_is_rejected_before_reaching_the_adapter() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let turn = tokio::spawn({
         let client = client.clone();
         let token = token.clone();
@@ -355,7 +355,7 @@ async fn stale_turn_steering_is_rejected_before_reaching_the_adapter() {
     });
     let active_turn_id = wait_for_open_turn(&runtime, parsed).await;
     let stale_turn_id = loop {
-        let candidate = CodeTurnId::new();
+        let candidate = TurnId::new();
         if candidate != active_turn_id {
             break candidate;
         }
@@ -380,7 +380,7 @@ async fn stale_turn_steering_is_rejected_before_reaching_the_adapter() {
     assert!(
         events
             .iter()
-            .all(|event| !matches!(event.event, CodeEvent::UserSteered { .. })),
+            .all(|event| !matches!(event.event, Event::UserSteered { .. })),
         "stale steering reached the adapter: {events:?}"
     );
 }
@@ -417,7 +417,7 @@ async fn stalled_native_steering_times_out_without_wedging_turn_completion() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let turn = tokio::spawn({
         let client = client.clone();
         let token = token.clone();
@@ -522,7 +522,7 @@ async fn terminal_turn_event_closes_steering_before_a_late_command_is_admitted()
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let (mut events, _) = runtime.bus.attach(parsed);
     let turn = tokio::spawn({
         let client = client.clone();
@@ -542,8 +542,8 @@ async fn terminal_turn_event_closes_steering_before_a_late_command_is_admitted()
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             match events.recv().await.unwrap().event {
-                CodeEvent::TurnStarted { turn_id } => active_turn_id = Some(turn_id),
-                CodeEvent::TurnCompleted { .. } => break,
+                Event::TurnStarted { turn_id } => active_turn_id = Some(turn_id),
+                Event::TurnCompleted { .. } => break,
                 _ => {}
             }
         }
@@ -596,7 +596,7 @@ async fn a_native_steer_rejection_does_not_fail_or_redirect_the_turn() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let (mut events, _) = runtime.bus.attach(parsed);
     let turn = tokio::spawn({
         let client = client.clone();
@@ -614,7 +614,7 @@ async fn a_native_steer_rejection_does_not_fail_or_redirect_the_turn() {
     });
     let active_turn_id = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            if let CodeEvent::TurnStarted { turn_id } = events.recv().await.unwrap().event {
+            if let Event::TurnStarted { turn_id } = events.recv().await.unwrap().event {
                 break turn_id;
             }
         }
@@ -645,5 +645,5 @@ async fn a_native_steer_rejection_does_not_fail_or_redirect_the_turn() {
     .await
     .unwrap();
     assert_eq!(turns.len(), 1);
-    assert_eq!(turns[0].status, CodeTurnStatus::Completed);
+    assert_eq!(turns[0].status, TurnStatus::Completed);
 }

--- a/crates/tidebreak-server/src/tests/code_turns.rs
+++ b/crates/tidebreak-server/src/tests/code_turns.rs
@@ -11,8 +11,8 @@ use axum::Router;
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
-    Attention, AttentionSource, AttentionState, CapLevel, CodeEvent, CodeSession, CodeSessionId,
-    CodeSessionLifecycle, CodeTurnStatus, FenceReason, HarnessKind, PermissionMode, WorkspaceId,
+    Attention, AttentionSource, AttentionState, CapLevel, Event, FenceReason, HarnessKind,
+    PermissionMode, Session, SessionId, SessionLifecycle, TurnStatus, WorkspaceId,
 };
 use tidebreak_harness::HarnessEvent;
 
@@ -23,7 +23,7 @@ async fn code_app_with_browser(
     code_app_with_optional_browser(adapter, Some(browser_runtime)).await
 }
 
-fn browser_token_for_session(runtime: &CodeRuntime, session_id: CodeSessionId) -> String {
+fn browser_token_for_session(runtime: &CodeRuntime, session_id: SessionId) -> String {
     for entry in std::fs::read_dir(runtime.browser_tokens.capfile_dir()).unwrap() {
         let path = entry.unwrap().path();
         if path.extension().and_then(|value| value.to_str()) != Some("json") {
@@ -43,8 +43,8 @@ fn browser_token_for_session(runtime: &CodeRuntime, session_id: CodeSessionId) -
     panic!("browser token for session {session_id} was not found")
 }
 
-fn mark_as_exited_orphan(session: &mut CodeSession) {
-    session.lifecycle = CodeSessionLifecycle::Fenced;
+fn mark_as_exited_orphan(session: &mut Session) {
+    session.lifecycle = SessionLifecycle::Fenced;
     session.fence_reason = Some(FenceReason::OrphanAlive);
     // A stale identity on a live PID models PID reuse. Reap treats that as
     // proof that the recorded process exited and never signals the new owner.
@@ -96,7 +96,7 @@ async fn interrupt_stops_a_running_turn_without_ending_its_browser_channel() {
         .await
         .unwrap();
 
-    let session_id: CodeSessionId = json_id(&session).parse().unwrap();
+    let session_id: SessionId = json_id(&session).parse().unwrap();
     let browser_token = browser_token_for_session(&runtime, session_id);
     let (mut events, _) = runtime.bus.attach(session_id);
 
@@ -113,7 +113,7 @@ async fn interrupt_stops_a_running_turn_without_ending_its_browser_channel() {
         // queuing on a slow CI runner.
         loop {
             let event = events.recv().await.unwrap();
-            if matches!(event.event, CodeEvent::TurnStarted { .. }) {
+            if matches!(event.event, Event::TurnStarted { .. }) {
                 break;
             }
         }
@@ -175,7 +175,7 @@ async fn reap_replaces_browser_authority_without_tombstoning_the_session() {
         .json::<serde_json::Value>()
         .await
         .unwrap();
-    let session_id: CodeSessionId = json_id(&session).parse().unwrap();
+    let session_id: SessionId = json_id(&session).parse().unwrap();
     let old_browser_token = browser_token_for_session(&runtime, session_id);
 
     let initial_list = client
@@ -287,7 +287,7 @@ async fn an_engine_that_dies_without_saying_so_journals_an_interrupted_turn() {
         .await
         .unwrap();
 
-    let session_id: CodeSessionId = json_id(&session).parse().unwrap();
+    let session_id: SessionId = json_id(&session).parse().unwrap();
     let (mut events, _) = runtime.bus.attach(session_id);
 
     let turn_req = client
@@ -303,7 +303,7 @@ async fn an_engine_that_dies_without_saying_so_journals_an_interrupted_turn() {
         // queuing on a slow CI runner.
         loop {
             let event = events.recv().await.unwrap();
-            if matches!(event.event, CodeEvent::TurnStarted { .. }) {
+            if matches!(event.event, Event::TurnStarted { .. }) {
                 break;
             }
         }
@@ -391,7 +391,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
 
     let first = tokio::spawn({
         let client = client.clone();
@@ -418,7 +418,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
             .await
             .unwrap()
             .unwrap();
-            if row.lifecycle == CodeSessionLifecycle::Running {
+            if row.lifecycle == SessionLifecycle::Running {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
@@ -517,11 +517,11 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
             .await
             .unwrap();
             if turns.len() >= 2
-                && turns[1].status == CodeTurnStatus::Completed
+                && turns[1].status == TurnStatus::Completed
                 && turns[1].user_input == "follow-up"
             {
                 assert_eq!(turns[0].user_input, "first");
-                assert_eq!(turns[0].status, CodeTurnStatus::Completed);
+                assert_eq!(turns[0].status, TurnStatus::Completed);
                 let first_end = turns[0].ended_at.expect("first turn ended");
                 assert!(
                     turns[1].started_at >= first_end,
@@ -657,7 +657,7 @@ async fn a_fenced_session_closes_its_whole_workspace_to_turns() {
     let ids = create_sibling_sessions(&client, addr, &token, &workspace, 2).await;
 
     let owner = tidebreak_core::OwnerId::local();
-    let fenced_id: CodeSessionId = ids[0].parse().unwrap();
+    let fenced_id: SessionId = ids[0].parse().unwrap();
     let mut row = tidebreak_core::db::code::get_session(&runtime.db, &owner, fenced_id)
         .await
         .unwrap()
@@ -718,7 +718,7 @@ async fn a_sibling_fenced_for_repeated_failures_does_not_close_the_workspace() {
     let ids = create_sibling_sessions(&client, addr, &token, &workspace, 2).await;
 
     let owner = tidebreak_core::OwnerId::local();
-    let fenced_id: CodeSessionId = ids[0].parse().unwrap();
+    let fenced_id: SessionId = ids[0].parse().unwrap();
     let reason = FenceReason::RepeatedTurnFailures {
         count: 3,
         detail: "the provider refused three turns in a row".into(),
@@ -727,7 +727,7 @@ async fn a_sibling_fenced_for_repeated_failures_does_not_close_the_workspace() {
         .await
         .unwrap()
         .unwrap();
-    row.lifecycle = CodeSessionLifecycle::Fenced;
+    row.lifecycle = SessionLifecycle::Fenced;
     row.fence_reason = Some(reason.clone());
     row.attention = Attention::new(
         AttentionState::Fenced { reason },
@@ -769,7 +769,7 @@ async fn a_workspace_still_holds_only_one_watch_session() {
         runtime.create_session_of_kind(
             &owner,
             workspace_id,
-            tidebreak_core::CodeSessionKind::Watch,
+            tidebreak_core::SessionKind::Watch,
             HarnessKind::ClaudeCode,
             crate::code::runtime::NewSessionSettings {
                 permission_mode: PermissionMode::Plan,
@@ -848,7 +848,7 @@ async fn a_recovered_session_accepts_a_turn() {
     assert_eq!(body["status"], "completed");
     assert_eq!(body["user_input"], "after restart");
 
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let mut row = tidebreak_core::db::code::get_session(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
@@ -955,7 +955,7 @@ async fn a_failed_checkpoint_does_not_fail_the_turn() {
         events.iter().any(|framed| {
             matches!(
                 framed.event,
-                tidebreak_core::CodeEvent::HarnessNotice {
+                tidebreak_core::Event::HarnessNotice {
                     level: tidebreak_core::HarnessNoticeLevel::Warning,
                     ..
                 }

--- a/crates/tidebreak-server/src/tests/code_ws.rs
+++ b/crates/tidebreak-server/src/tests/code_ws.rs
@@ -10,7 +10,7 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
-use tidebreak_core::{CodeEvent, CodeSessionId};
+use tidebreak_core::{Event, SessionId};
 use tidebreak_harness::HarnessEvent;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -103,14 +103,14 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
 
     // Concurrent write after connect: journal a notice and publish a later seq
     // first so the socket must fill the gap from the journal.
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let current = *seqs.last().unwrap();
     let _ = tidebreak_core::db::code::append_event(
         &runtime.db,
         &tidebreak_core::OwnerId::local(),
         parsed,
         1,
-        &tidebreak_core::CodeEvent::HarnessNotice {
+        &tidebreak_core::Event::HarnessNotice {
             level: tidebreak_core::HarnessNoticeLevel::Info,
             message: "gap-a".into(),
         },
@@ -122,7 +122,7 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
         &tidebreak_core::OwnerId::local(),
         parsed,
         1,
-        &tidebreak_core::CodeEvent::HarnessNotice {
+        &tidebreak_core::Event::HarnessNotice {
             level: tidebreak_core::HarnessNoticeLevel::Info,
             message: "gap-b".into(),
         },
@@ -131,9 +131,9 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
     .unwrap();
     runtime.bus.publish(
         parsed,
-        tidebreak_core::SequencedCodeEvent {
+        tidebreak_core::code::SequencedEvent {
             seq: seq_b,
-            event: tidebreak_core::CodeEvent::HarnessNotice {
+            event: tidebreak_core::Event::HarnessNotice {
                 level: tidebreak_core::HarnessNoticeLevel::Info,
                 message: "gap-b".into(),
             },
@@ -182,7 +182,7 @@ async fn ws_replay_emits_every_durable_sequence_after_the_cursor_in_order() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
     let replay_after_seq = journaled_events(&runtime.db, parsed)
         .await
         .last()
@@ -193,7 +193,7 @@ async fn ws_replay_emits_every_durable_sequence_after_the_cursor_in_order() {
         &tidebreak_core::OwnerId::local(),
         parsed,
         1,
-        &tidebreak_core::CodeEvent::AssistantDelta { text: "hel".into() },
+        &tidebreak_core::Event::AssistantDelta { text: "hel".into() },
     )
     .await
     .unwrap();
@@ -202,7 +202,7 @@ async fn ws_replay_emits_every_durable_sequence_after_the_cursor_in_order() {
         &tidebreak_core::OwnerId::local(),
         parsed,
         1,
-        &tidebreak_core::CodeEvent::AssistantDelta { text: "lo".into() },
+        &tidebreak_core::Event::AssistantDelta { text: "lo".into() },
     )
     .await
     .unwrap();
@@ -287,7 +287,7 @@ async fn a_turn_journals_its_message_and_none_of_the_deltas_that_built_it() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
 
     let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
         .into_client_request()
@@ -331,13 +331,13 @@ async fn a_turn_journals_its_message_and_none_of_the_deltas_that_built_it() {
     assert!(
         !journaled
             .iter()
-            .any(|framed| matches!(framed.event, CodeEvent::AssistantDelta { .. })),
+            .any(|framed| matches!(framed.event, Event::AssistantDelta { .. })),
         "a delta reached the journal: {journaled:?}"
     );
     let messages: Vec<&str> = journaled
         .iter()
         .filter_map(|framed| match &framed.event {
-            CodeEvent::AssistantMessage { text, .. } => Some(text.as_str()),
+            Event::AssistantMessage { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -370,7 +370,7 @@ async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
         .await
         .unwrap();
     let session_id = json_id(&session).to_owned();
-    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let parsed: SessionId = session_id.parse().unwrap();
 
     let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
         .into_client_request()
@@ -389,7 +389,7 @@ async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
     .unwrap()
     .unwrap()
     .spawn_epoch;
-    let marker = CodeEvent::HarnessNotice {
+    let marker = Event::HarnessNotice {
         level: tidebreak_core::HarnessNoticeLevel::Info,
         message: "reconnect cursor".into(),
     };
@@ -404,7 +404,7 @@ async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
     .unwrap();
     runtime.bus.publish(
         parsed,
-        tidebreak_core::SequencedCodeEvent {
+        tidebreak_core::code::SequencedEvent {
             seq: cursor,
             event: marker,
         },
@@ -426,13 +426,13 @@ async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
 
     runtime.bus.publish_transient(
         parsed,
-        CodeEvent::AssistantDelta {
+        Event::AssistantDelta {
             text: "first ".into(),
         },
     );
     runtime.bus.publish_transient(
         parsed,
-        CodeEvent::AssistantDelta {
+        Event::AssistantDelta {
             text: "second ".into(),
         },
     );
@@ -457,7 +457,7 @@ async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
 
     runtime.bus.publish_transient(
         parsed,
-        CodeEvent::AssistantDelta {
+        Event::AssistantDelta {
             text: "third".into(),
         },
     );
@@ -488,7 +488,7 @@ async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
 
     runtime.bus.publish_transient(
         parsed,
-        CodeEvent::AssistantDelta {
+        Event::AssistantDelta {
             text: " fourth".into(),
         },
     );
@@ -531,7 +531,7 @@ async fn superseded_worker_cannot_append_to_the_journal() {
         .json::<serde_json::Value>()
         .await
         .unwrap();
-    let session_id: CodeSessionId = json_id(&session).parse().unwrap();
+    let session_id: SessionId = json_id(&session).parse().unwrap();
     let current = session["lifecycle"].as_str().unwrap().to_owned();
     assert_eq!(current, "idle");
     let bumped = tidebreak_core::db::code::bump_spawn_epoch(&runtime.db, session_id, None)
@@ -542,12 +542,12 @@ async fn superseded_worker_cannot_append_to_the_journal() {
         &tidebreak_core::OwnerId::local(),
         session_id,
         bumped - 1,
-        &tidebreak_core::CodeEvent::TurnInterrupted { usage: None },
+        &tidebreak_core::Event::TurnInterrupted { usage: None },
     )
     .await
     .unwrap_err();
     match err {
-        tidebreak_core::db::code::CodeJournalError::StaleSpawnEpoch {
+        tidebreak_core::db::code::JournalError::StaleSpawnEpoch {
             attempted, current, ..
         } => {
             assert_eq!(attempted, bumped - 1);

--- a/crates/tidebreak-server/src/tests/compaction.rs
+++ b/crates/tidebreak-server/src/tests/compaction.rs
@@ -78,7 +78,7 @@ async fn compact_everything_but_the_last_message(router: &Router, bearer: &str) 
 /// `wait_for_turn` scans the journal from the start, so on a chat that has
 /// already finished one turn it returns on that turn's terminal event rather
 /// than the one just sent.
-async fn wait_until_idle(store: &Arc<dyn Store>, chat: ChatId) {
+async fn wait_until_idle(store: &Arc<dyn Store>, chat: SessionId) {
     for _ in 0..500 {
         let runs = store.list_turns(chat).await.unwrap();
         if !runs.is_empty() && runs.iter().all(|turn| turn.status.is_terminal()) {
@@ -383,7 +383,7 @@ async fn compaction_focus_is_bounded_and_the_chat_must_exist() {
     let response = post_json(
         &router,
         &bearer,
-        &format!("/chats/{}/compact", ChatId::new()),
+        &format!("/chats/{}/compact", SessionId::new()),
         serde_json::json!({}),
     )
     .await;

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -5380,7 +5380,7 @@ async fn the_catalog_lists_prompts_and_serves_their_bodies() {
 async fn send_message_invoking(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     invoked: &[&str],
 ) -> axum::response::Response {
     router
@@ -5467,7 +5467,7 @@ async fn an_invoked_skill_must_be_enabled_or_the_turn_is_refused() {
 async fn steer_invoking(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     turn: TurnId,
     steer_id: TurnSteerId,
     invoked: &[&str],

--- a/crates/tidebreak-server/src/tests/conversations.rs
+++ b/crates/tidebreak-server/src/tests/conversations.rs
@@ -545,7 +545,7 @@ async fn chat_created_with_empty_model_is_rejected() {
 pub(super) async fn patch_chat(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     body: serde_json::Value,
 ) -> axum::response::Response {
     router
@@ -1682,7 +1682,7 @@ async fn patch_chat_rejects_empty_model_and_unknown_chat() {
     let missing = patch_chat(
         &router,
         &bearer,
-        ChatId::new(),
+        SessionId::new(),
         serde_json::json!({"model": "m"}),
     )
     .await;

--- a/crates/tidebreak-server/src/tests/documents.rs
+++ b/crates/tidebreak-server/src/tests/documents.rs
@@ -1993,7 +1993,7 @@ async fn promoting_a_document_shares_it_with_the_project_and_keeps_the_original(
     let attached_id: tidebreak_core::DocumentId =
         attached["document_id"].as_str().unwrap().parse().unwrap();
 
-    let promote = |project_id: tidebreak_core::ProjectId, chat_id: tidebreak_core::ChatId| {
+    let promote = |project_id: tidebreak_core::ProjectId, chat_id: tidebreak_core::SessionId| {
         let router = router.clone();
         let bearer = bearer.clone();
         async move {

--- a/crates/tidebreak-server/src/tests/image_attachment.rs
+++ b/crates/tidebreak-server/src/tests/image_attachment.rs
@@ -4,11 +4,11 @@ use super::*;
 
 use crate::routes::image_attachment::{gif_with_screen_size, png_header};
 
-fn image_attachments_uri(chat: ChatId) -> String {
+fn image_attachments_uri(chat: SessionId) -> String {
     format!("/chats/{chat}/attachments/images")
 }
 
-fn transcript_image_uri(chat: ChatId, attachment_id: uuid::Uuid) -> String {
+fn transcript_image_uri(chat: SessionId, attachment_id: uuid::Uuid) -> String {
     format!("/chats/{chat}/attachments/images/{attachment_id}")
 }
 
@@ -16,7 +16,7 @@ fn transcript_image_uri(chat: ChatId, attachment_id: uuid::Uuid) -> String {
 async fn publish_image(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     declared: &str,
     bytes: Vec<u8>,
 ) -> axum::response::Response {
@@ -35,7 +35,7 @@ async fn publish_image(
         .unwrap()
 }
 
-async fn publish_png(router: &Router, bearer: &str, chat: ChatId, bytes: Vec<u8>) -> uuid::Uuid {
+async fn publish_png(router: &Router, bearer: &str, chat: SessionId, bytes: Vec<u8>) -> uuid::Uuid {
     let response = publish_image(router, bearer, chat, "image/png", bytes).await;
     assert_eq!(response.status(), StatusCode::CREATED);
     let published: serde_json::Value = json_body(response).await;
@@ -50,7 +50,7 @@ async fn publish_png(router: &Router, bearer: &str, chat: ChatId, bytes: Vec<u8>
 async fn send_message_with_attachments(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     turn_id: TurnId,
     content: &str,
     attachments: &[uuid::Uuid],
@@ -195,7 +195,7 @@ async fn publishing_returns_opaque_identity_and_bounded_metadata_only() {
     let missing = publish_image(
         &router,
         &bearer,
-        ChatId::new(),
+        SessionId::new(),
         "image/png",
         png_header(8, 8),
     )
@@ -388,7 +388,7 @@ async fn a_known_blob_id_requires_a_separate_publication_in_each_chat() {
     // row cannot bypass publication merely because it was already durable.
     let now = chrono::Utc::now();
     store
-        .enqueue_queued_turn(&tidebreak_core::QueuedTurn {
+        .enqueue_queued_turn(&tidebreak_core::QueuedAgentTurn {
             id: TurnId::new(),
             chat_id: second_chat.id,
             content: "queued cross-chat rebind".into(),

--- a/crates/tidebreak-server/src/tests/lifecycle.rs
+++ b/crates/tidebreak-server/src/tests/lifecycle.rs
@@ -146,7 +146,7 @@ async fn cancel_without_a_running_turn_is_a_conflict_and_unknown_chat_is_404() {
     );
     // Unknown chat → 404.
     assert_eq!(
-        cancel_turn(&router, &bearer, ChatId::new(), TurnId::new()).await,
+        cancel_turn(&router, &bearer, SessionId::new(), TurnId::new()).await,
         StatusCode::NOT_FOUND
     );
 }
@@ -183,7 +183,7 @@ async fn cancel_cannot_target_a_turn_through_another_chat() {
 pub(super) async fn steer_turn(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     turn_id: TurnId,
     content: &str,
     interrupt: bool,
@@ -203,7 +203,7 @@ pub(super) async fn steer_turn(
 pub(super) async fn steer_turn_with_id(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     steer_id: TurnSteerId,
     turn_id: TurnId,
     content: &str,
@@ -219,7 +219,7 @@ pub(super) async fn steer_turn_with_id(
 async fn steer_turn_with_id_and_voice(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     steer_id: TurnSteerId,
     turn_id: TurnId,
     content: &str,
@@ -262,7 +262,15 @@ async fn steer_without_a_running_turn_is_a_conflict_and_unknown_chat_is_404() {
         StatusCode::CONFLICT
     );
     assert_eq!(
-        steer_turn(&router, &bearer, ChatId::new(), TurnId::new(), "hi", false,).await,
+        steer_turn(
+            &router,
+            &bearer,
+            SessionId::new(),
+            TurnId::new(),
+            "hi",
+            false,
+        )
+        .await,
         StatusCode::NOT_FOUND
     );
     assert_eq!(
@@ -1101,7 +1109,7 @@ async fn post_executor_json(
 async fn accept_and_claim_turn_for_route_test(
     store: &dyn Store,
     turn_id: TurnId,
-    chat_id: ChatId,
+    chat_id: SessionId,
     content: &str,
 ) -> (uuid::Uuid, chrono::DateTime<chrono::Utc>) {
     let accepted = match store
@@ -1131,7 +1139,7 @@ async fn accept_and_claim_turn_for_route_test(
 
 async fn park_client_wait_for_route_test(
     store: &dyn Store,
-    chat_id: ChatId,
+    chat_id: SessionId,
     progress: TurnCheckpointProgress,
 ) -> (TurnId, ClientToolCallRequest) {
     let turn_id = TurnId::new();
@@ -1158,7 +1166,7 @@ async fn park_client_wait_for_route_test(
 
 async fn park_user_questions_for_route_test(
     store: &dyn Store,
-    chat_id: ChatId,
+    chat_id: SessionId,
 ) -> (TurnId, ClientToolCallRequest) {
     let turn_id = TurnId::new();
     let (turn_token, claimed_at) =
@@ -1225,7 +1233,7 @@ fn test_client_checkpoint_progress(model_steps: i32) -> TurnCheckpointProgress {
 
 async fn resolve_parked_client_call(
     store: &dyn Store,
-    chat_id: ChatId,
+    chat_id: SessionId,
     call: &ClientToolCallRequest,
 ) {
     let lease_token = uuid::Uuid::new_v4();
@@ -1991,13 +1999,12 @@ async fn the_inbox_lists_parked_work_until_its_own_route_resolves_it() {
 
     // An entry carries its conversation and the parked call, which is what a
     // deep link needs to reopen the transcript where it stopped. The
-    // conversation is tagged because chat and code ids are still separate
-    // spaces; step 5 collapses that.
+    // conversation uses the one session identity shared by chat and code.
     let approval_entry = listed
         .iter()
-        .find(|entry| entry["conversation"]["chat_id"] == approval_chat.id.to_string())
+        .find(|entry| entry["conversation"]["session_id"] == approval_chat.id.to_string())
         .expect("the parked approval is listed");
-    assert_eq!(approval_entry["conversation"]["surface"], "chat");
+    assert!(approval_entry["conversation"].get("surface").is_none());
     assert_eq!(
         approval_entry["items"][0]["call_id"],
         approval_call.to_string()
@@ -2105,7 +2112,7 @@ async fn list_inbox(router: &Router, bearer: &str) -> Vec<serde_json::Value> {
 
 async fn park_plan_for_route_test(
     store: &dyn Store,
-    chat_id: ChatId,
+    chat_id: SessionId,
 ) -> (TurnId, ClientToolCallRequest) {
     let turn_id = TurnId::new();
     let (turn_token, claimed_at) =
@@ -2138,7 +2145,7 @@ async fn park_plan_for_route_test(
 
 async fn park_folder_access_for_route_test(
     store: &dyn Store,
-    chat_id: ChatId,
+    chat_id: SessionId,
 ) -> ClientToolCallRequest {
     let turn_id = TurnId::new();
     let (turn_token, claimed_at) =
@@ -2170,7 +2177,7 @@ async fn park_folder_access_for_route_test(
     call
 }
 
-async fn park_tool_approval_for_route_test(store: &dyn Store, chat_id: ChatId) -> CallId {
+async fn park_tool_approval_for_route_test(store: &dyn Store, chat_id: SessionId) -> CallId {
     let turn_id = TurnId::new();
     store
         .accept_turn(turn_id, chat_id, "fake", "search the filings")
@@ -2202,7 +2209,7 @@ async fn park_tool_approval_for_route_test(store: &dyn Store, chat_id: ChatId) -
 
 async fn accept_server_tool_call_for_route_test(
     store: &dyn Store,
-    chat_id: ChatId,
+    chat_id: SessionId,
     turn_id: TurnId,
     call_id: CallId,
 ) {
@@ -2236,7 +2243,7 @@ async fn accept_server_tool_call_for_route_test(
 async fn answer_questions(
     router: &Router,
     bearer: &str,
-    chat_id: ChatId,
+    chat_id: SessionId,
     call_id: CallId,
 ) -> StatusCode {
     post_json(
@@ -2257,7 +2264,7 @@ async fn answer_questions(
 async fn decide_plan_request(
     router: &Router,
     bearer: &str,
-    chat_id: ChatId,
+    chat_id: SessionId,
     call_id: CallId,
 ) -> StatusCode {
     post_json(
@@ -2273,7 +2280,7 @@ async fn decide_plan_request(
 async fn decide_approval(
     router: &Router,
     bearer: &str,
-    chat_id: ChatId,
+    chat_id: SessionId,
     call_id: CallId,
     decision: &str,
 ) -> StatusCode {
@@ -3012,7 +3019,7 @@ async fn client_execution_api_validates_scope_identity_and_terminal_payloads() {
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
-    let missing_chat = ChatId::new();
+    let missing_chat = SessionId::new();
     let missing = router
         .clone()
         .oneshot(
@@ -3570,7 +3577,7 @@ async fn a_turn_replaces_its_task_plan_and_journals_only_a_refresh_hint() {
     );
 
     let events = wait_for_turn(&store, chat.id).await;
-    let hints: Vec<&SequencedEvent> = events
+    let hints: Vec<&SequencedAgentEvent> = events
         .iter()
         .filter(|event| matches!(event.event, AgentEvent::TaskPlanUpdated { .. }))
         .collect();
@@ -3830,7 +3837,7 @@ async fn send_now_releases_a_paused_queue() {
     // promoter claiming that same turn and read as a leak below.
     store
         .set_setting(
-            &format!("chats.{}.queue_paused", chat.id),
+            &format!("sessions.{}.queue_paused", chat.id),
             &serde_json::json!(true),
         )
         .await

--- a/crates/tidebreak-server/src/tests/memory.rs
+++ b/crates/tidebreak-server/src/tests/memory.rs
@@ -445,7 +445,7 @@ fn active_titled(id: MemoryRecordId, title: &str) -> MemoryRecord {
     record
 }
 
-async fn wait_for_turns(store: &Arc<dyn Store>, chat: ChatId, terminal: usize) {
+async fn wait_for_turns(store: &Arc<dyn Store>, chat: SessionId, terminal: usize) {
     for _ in 0..500 {
         let events = store.list_events(chat, 0).await.unwrap();
         let finished = events

--- a/crates/tidebreak-server/src/tests/sandbox.rs
+++ b/crates/tidebreak-server/src/tests/sandbox.rs
@@ -723,7 +723,7 @@ async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_auth
         relative_path: "reports/private-summary.md".into(),
     };
     let chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: Some("delegated read".into()),
         model: None,

--- a/crates/tidebreak-server/src/tests/websocket.rs
+++ b/crates/tidebreak-server/src/tests/websocket.rs
@@ -74,7 +74,12 @@ async fn make_chat_http(client: &reqwest::Client, addr: SocketAddr, token: &str)
         .unwrap()
 }
 
-async fn send_message_http(client: &reqwest::Client, addr: SocketAddr, token: &str, chat: ChatId) {
+async fn send_message_http(
+    client: &reqwest::Client,
+    addr: SocketAddr,
+    token: &str,
+    chat: SessionId,
+) {
     let response = client
         .post(format!("http://{addr}/chats/{chat}/messages"))
         .bearer_auth(token)
@@ -91,7 +96,7 @@ async fn send_message_http(client: &reqwest::Client, addr: SocketAddr, token: &s
 async fn read_until_turns_end(
     addr: SocketAddr,
     token: &str,
-    chat: ChatId,
+    chat: SessionId,
     after: i64,
     want: usize,
 ) -> Vec<RendererSequencedEvent> {
@@ -133,7 +138,7 @@ async fn read_until_turns_end(
 async fn read_until_turn_end(
     addr: SocketAddr,
     token: &str,
-    chat: ChatId,
+    chat: SessionId,
     after: i64,
 ) -> Vec<RendererSequencedEvent> {
     read_until_turns_end(addr, token, chat, after, 1).await
@@ -316,11 +321,11 @@ async fn ws_replays_a_journal_gap_before_accepting_a_later_live_event() {
     };
     assert_eq!(store.append_event(chat.id, &second).await.unwrap(), 2);
     assert_eq!(store.append_event(chat.id, &third).await.unwrap(), 3);
-    let _ = state.events.sender(chat.id).send(SequencedEvent {
+    let _ = state.events.sender(chat.id).send(SequencedAgentEvent {
         seq: 3,
         event: third,
     });
-    let _ = state.events.sender(chat.id).send(SequencedEvent {
+    let _ = state.events.sender(chat.id).send(SequencedAgentEvent {
         seq: 2,
         event: second.clone(),
     });
@@ -451,7 +456,7 @@ async fn ws_bad_after_cursor_is_a_json_400() {
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_without_a_token_is_rejected() {
     let (addr, _token, _store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;
-    let chat = ChatId::new();
+    let chat = SessionId::new();
     let request = format!("ws://{addr}/chats/{chat}/events")
         .into_client_request()
         .unwrap();
@@ -511,7 +516,7 @@ async fn ws_subprotocol_wrong_token_is_rejected() {
     use crate::auth::{WS_HANDSHAKE_SUBPROTOCOL, WS_TOKEN_SUBPROTOCOL_PREFIX};
 
     let (addr, _token, _store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;
-    let chat = ChatId::new();
+    let chat = SessionId::new();
     let mut request = format!("ws://{addr}/chats/{chat}/events")
         .into_client_request()
         .unwrap();

--- a/crates/tidebreak-server/src/tests/workers.rs
+++ b/crates/tidebreak-server/src/tests/workers.rs
@@ -16,7 +16,7 @@ impl ProviderResolver for RegistryEnforcingResolver {
 }
 
 /// Put a chat in `Allow` so a delegation runs without an approval card.
-async fn allow_delegation(store: &dyn Store, chat: ChatId) {
+async fn allow_delegation(store: &dyn Store, chat: SessionId) {
     store
         .update_chat_metadata(
             chat,
@@ -30,7 +30,7 @@ async fn allow_delegation(store: &dyn Store, chat: ChatId) {
         .unwrap();
 }
 
-async fn approval_call_ids(store: &Arc<dyn Store>, chat: ChatId) -> Vec<CallId> {
+async fn approval_call_ids(store: &Arc<dyn Store>, chat: SessionId) -> Vec<CallId> {
     store
         .list_events(chat, 0)
         .await
@@ -103,7 +103,7 @@ fn test_router_with_skills_from_store(
 async fn post_message_body(
     router: &Router,
     bearer: &str,
-    chat: ChatId,
+    chat: SessionId,
     body: serde_json::Value,
 ) -> axum::response::Response {
     router
@@ -191,7 +191,7 @@ async fn unknown_chat_is_404() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri(format!("/chats/{}", ChatId::new()))
+                .uri(format!("/chats/{}", SessionId::new()))
                 .header(header::AUTHORIZATION, format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
@@ -544,7 +544,7 @@ async fn worker_drains_a_turn_queued_before_startup() {
         .unwrap(),
     );
     let chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: None,
         model: None,
@@ -619,7 +619,7 @@ async fn worker_rejects_an_already_accepted_plain_gateway_model_before_egress() 
     .unwrap();
 
     let chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: None,
         model: None,
@@ -1099,7 +1099,7 @@ async fn queued_retry_compares_attachment_identity_before_blob_resolution() {
     let attachment_id = uuid::Uuid::new_v4();
     let now = chrono::Utc::now();
     store
-        .enqueue_queued_turn(&tidebreak_core::QueuedTurn {
+        .enqueue_queued_turn(&tidebreak_core::QueuedAgentTurn {
             id: queued_id,
             chat_id: chat.id,
             content: "queued image".into(),
@@ -1157,7 +1157,7 @@ async fn queued_turn_id_cannot_be_accepted_by_another_chat() {
     let first_chat = make_chat(&router, &bearer).await;
     let second_chat = make_chat(&router, &bearer).await;
     let queued_id = TurnId::new();
-    let queued = tidebreak_core::QueuedTurn {
+    let queued = tidebreak_core::QueuedAgentTurn {
         id: queued_id,
         chat_id: first_chat.id,
         content: "owned by the first chat".into(),
@@ -1275,7 +1275,7 @@ async fn sandbox_container_routing_preserves_in_process_task_and_deadline_shape(
     let (_reference_dir, reference_store) = temp_db_store("in-process-reference.db").await;
     let reference_store: Arc<dyn Store> = Arc::new(reference_store);
     let reference_chat = Chat {
-        id: ChatId::new(),
+        id: SessionId::new(),
         project_id: None,
         title: Some("in-process reference".into()),
         model: Some("fake".into()),
@@ -2046,7 +2046,7 @@ async fn post_message_rejects_blank_content_as_bad_request() {
 async fn message_to_unknown_chat_is_404() {
     let (router, token, _store, _dir) = test_app().await;
     assert_eq!(
-        send_message(&router, &format!("Bearer {token}"), ChatId::new(), "hi").await,
+        send_message(&router, &format!("Bearer {token}"), SessionId::new(), "hi").await,
         StatusCode::NOT_FOUND
     );
 }
@@ -2900,7 +2900,7 @@ struct FixedWebSearchResolver {
 impl WebSearchResolver for FixedWebSearchResolver {
     async fn resolve(
         &self,
-        _chat: Option<tidebreak_core::ChatId>,
+        _chat: Option<tidebreak_core::SessionId>,
     ) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
         Ok(Some(self.provider.clone()))
     }

--- a/crates/tidebreak-server/src/web_search/extract_source.rs
+++ b/crates/tidebreak-server/src/web_search/extract_source.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use tidebreak_core::{ChatId, DocumentId};
+use tidebreak_core::{DocumentId, SessionId};
 
 use crate::web_search::WebExtractResponse;
 
@@ -22,7 +22,7 @@ pub struct ExtractedPageSinkError;
 pub trait ExtractedPageSink: Send + Sync {
     async fn store_page(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         page: &WebExtractResponse,
         fetched_at: DateTime<Utc>,
     ) -> Result<StoredExtractedPage, ExtractedPageSinkError>;

--- a/crates/tidebreak-server/src/web_search/host.rs
+++ b/crates/tidebreak-server/src/web_search/host.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tidebreak_core::{
-    ApprovalClass, ChatId, DocumentId, DocumentUpsert, NetworkPolicy, Result, SecretProvider,
+    ApprovalClass, DocumentId, DocumentUpsert, NetworkPolicy, Result, SecretProvider, SessionId,
     Store, Tool, ToolCtx, ToolOutput, ToolSpec, TurnWebSearch, VendorWebSearch,
 };
 
@@ -581,7 +581,7 @@ async fn required_credential(
 /// so the search runs on the model the reader believes they are talking to.
 async fn chat_search_model(
     store: &dyn Store,
-    chat: ChatId,
+    chat: SessionId,
     default_model: &str,
 ) -> Option<SearchModel> {
     let selected = match store
@@ -637,7 +637,7 @@ async fn chat_search_model(
 pub async fn resolve_provider(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
-    chat: Option<ChatId>,
+    chat: Option<SessionId>,
     providers: Option<&Arc<dyn ProviderResolver>>,
     default_model: &str,
 ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, ServerError> {
@@ -741,7 +741,7 @@ struct HostWebSearchResolver {
 impl WebSearchResolver for HostWebSearchResolver {
     async fn resolve(
         &self,
-        chat: Option<ChatId>,
+        chat: Option<SessionId>,
     ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
         resolve_provider(
             &*self.store,
@@ -831,7 +831,7 @@ struct HostExtractedPageSink {
 impl ExtractedPageSink for HostExtractedPageSink {
     async fn store_page(
         &self,
-        chat_id: ChatId,
+        chat_id: SessionId,
         page: &WebExtractResponse,
         fetched_at: DateTime<Utc>,
     ) -> std::result::Result<StoredExtractedPage, ExtractedPageSinkError> {
@@ -968,9 +968,9 @@ mod tests {
     }
 
     /// Store a chat pinned to `model`, and return the router to resolve against.
-    async fn chat_on(store: &DbStore, model: &str) -> (ChatId, Arc<dyn ProviderResolver>) {
+    async fn chat_on(store: &DbStore, model: &str) -> (SessionId, Arc<dyn ProviderResolver>) {
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: None,
             model: Some(model.to_owned()),
@@ -1007,7 +1007,7 @@ mod tests {
     async fn offline_chat_network_denial_is_actionable_and_structured() {
         let (store, _dir) = test_store().await;
         let chat = Chat {
-            id: ChatId::new(),
+            id: SessionId::new(),
             project_id: None,
             title: None,
             model: None,

--- a/crates/tidebreak-server/src/web_search/tool.rs
+++ b/crates/tidebreak-server/src/web_search/tool.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use serde_json::Value;
 use thiserror::Error;
 use tidebreak_core::{
-    ApprovalClass, ChatId, ResultEntry, ResultEntryKind, Tool, ToolCtx, ToolErrorCategory,
+    ApprovalClass, ResultEntry, ResultEntryKind, SessionId, Tool, ToolCtx, ToolErrorCategory,
     ToolOutput, ToolSpec, WebExtractArgs, WebSearchArgs,
 };
 use url::Url;
@@ -39,7 +39,7 @@ pub struct WebSearchResolverError;
 pub trait WebSearchResolver: Send + Sync {
     async fn resolve(
         &self,
-        chat: Option<ChatId>,
+        chat: Option<SessionId>,
     ) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError>;
 }
 
@@ -318,7 +318,7 @@ fn page_entry(result: &WebSearchResult) -> ResultEntry {
 mod tests {
     use std::sync::Mutex;
 
-    use tidebreak_core::{ChatId, Tool};
+    use tidebreak_core::{SessionId, Tool};
 
     use super::*;
     use crate::web_search::{WebSearchProviderKind, WebSearchResponse};
@@ -332,7 +332,7 @@ mod tests {
     impl WebSearchResolver for FakeResolver {
         async fn resolve(
             &self,
-            _chat: Option<ChatId>,
+            _chat: Option<SessionId>,
         ) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
             if self.fail {
                 Err(WebSearchResolverError)
@@ -368,7 +368,7 @@ mod tests {
     }
 
     fn context() -> ToolCtx {
-        ToolCtx::without_private_scratch(ChatId::new(), None)
+        ToolCtx::without_private_scratch(SessionId::new(), None)
     }
 
     #[test]

--- a/crates/tidebreak-server/src/wire.rs
+++ b/crates/tidebreak-server/src/wire.rs
@@ -93,6 +93,16 @@ pub use crate::routes::code::types::{
     SessionExternalOrigin, SessionSnapshot, TurnRewriteState, TurnSnapshot, UpdateNotice,
 };
 
+// Keep the unchanged CLI compiling while the D6 rename lands in server and
+// client slices. The client slice removes these compatibility exports.
+pub use crate::routes::code::types::{
+    ApprovalSnapshot as CodeApprovalSnapshot, QueuedTurn as QueuedCodeTurn,
+    QueuedTurnsSnapshot as QueuedCodeTurnsSnapshot, SequencedEventFrame as SequencedCodeEventFrame,
+    SessionDigest as CodeSessionDigest, SessionExternalOrigin as CodeSessionExternalOrigin,
+    SessionSnapshot as CodeSessionSnapshot, TurnRewriteState as CodeTurnRewriteState,
+    TurnSnapshot as CodeTurnSnapshot, UpdateNotice as CodeUpdateNotice,
+};
+
 /// Guard sizes for the opaque strings a client draws from this surface.
 ///
 /// A renderer validates what it is about to draw rather than trusting that the

--- a/crates/tidebreak-server/src/wire.rs
+++ b/crates/tidebreak-server/src/wire.rs
@@ -44,10 +44,10 @@
 //!
 //! The same module carries the code-mode surface the CLI drives: repo,
 //! workspace, session, turn, approval, and delivery snapshots, the sequenced
-//! event frame on `/code/sessions/{id}/events`, and the notices on
-//! `/code/updates`. They follow the strictness above. The one shape a client
-//! composes itself is the response to `POST /code/sessions/{id}/turns`, which
-//! is a [`CodeTurnSnapshot`] on `200` and a [`QueuedCodeTurn`] on `202`.
+//! event frame on `/sessions/{id}/events`, and the notices on
+//! `/updates`. They follow the strictness above. The one shape a client
+//! composes itself is the response to `POST /sessions/{id}/turns`, which
+//! is a [`TurnSnapshot`] on `200` and a [`QueuedTurn`] on `202`.
 //!
 //! # Limits
 //!
@@ -81,17 +81,16 @@ pub use crate::routes::{
 };
 
 // Code mode: the snapshots the REST routes return, the per-session event
-// frame, and the notices on `/code/updates`. Same contract as the chat
+// frame, and the notices on `/updates`. Same contract as the chat
 // socket above: closed vocabularies, unknown keys rejected, an unknown notice
 // or event type failing its frame. The fixtures in `fixtures/code-frames.json`
 // are serialized from these types (see `wire_code_fixtures`).
 pub use crate::routes::code::types::{
-    CodeActionSnapshot, CodeApprovalSnapshot, CodeCommitSnapshot, CodeFileChange, CodePushSnapshot,
-    CodeRepoSnapshot, CodeSessionDigest, CodeSessionExternalOrigin, CodeSessionSnapshot,
-    CodeTurnRewriteState, CodeTurnSnapshot, CodeUpdateNotice, CodeWatchSnapshot, CodeWorkspaceDiff,
-    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot, HarnessAuthMode,
-    HarnessDoctorEntry, HarnessDoctorReport, QueuedCodeTurn, QueuedCodeTurnsSnapshot,
-    SequencedCodeEventFrame,
+    ApprovalSnapshot, CodeActionSnapshot, CodeCommitSnapshot, CodeFileChange, CodePushSnapshot,
+    CodeRepoSnapshot, CodeWatchSnapshot, CodeWorkspaceDiff, CodeWorkspaceFiles,
+    CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot, HarnessAuthMode, HarnessDoctorEntry,
+    HarnessDoctorReport, QueuedTurn, QueuedTurnsSnapshot, SequencedEventFrame, SessionDigest,
+    SessionExternalOrigin, SessionSnapshot, TurnRewriteState, TurnSnapshot, UpdateNotice,
 };
 
 /// Guard sizes for the opaque strings a client draws from this surface.

--- a/crates/tidebreak-server/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server/src/wire_code_fixtures.rs
@@ -1,7 +1,7 @@
 //! Shared fixtures for the code-mode wire surface.
 //!
 //! `fixtures/code-frames.json` holds one real value of every snapshot the code
-//! routes return, every notice on `/code/updates`, and every event the
+//! routes return, every notice on `/updates`, and every event the
 //! per-session socket can carry, serialized from the server's own types. Three
 //! decoders read the file: this crate's round trip, the CLI's
 //! `api::code` tests, and the renderer's `code/parsers.test.ts`. A shape
@@ -11,24 +11,23 @@
 //! same switch that rewrites `wire.ts`.
 
 use crate::wire::{
-    CodeActionSnapshot, CodeApprovalSnapshot, CodeCommitSnapshot, CodeFileChange, CodePushSnapshot,
-    CodeRepoSnapshot, CodeSessionDigest, CodeSessionExternalOrigin, CodeSessionSnapshot,
-    CodeTurnRewriteState, CodeTurnSnapshot, CodeUpdateNotice, CodeWatchSnapshot, CodeWorkspaceDiff,
-    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot, HarnessAuthMode,
-    HarnessDoctorEntry, HarnessDoctorReport, QueuedCodeTurn, QueuedCodeTurnsSnapshot,
-    SequencedCodeEventFrame,
+    ApprovalSnapshot, CodeActionSnapshot, CodeCommitSnapshot, CodeFileChange, CodePushSnapshot,
+    CodeRepoSnapshot, CodeWatchSnapshot, CodeWorkspaceDiff, CodeWorkspaceFiles,
+    CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot, HarnessAuthMode, HarnessDoctorEntry,
+    HarnessDoctorReport, QueuedTurn, QueuedTurnsSnapshot, SequencedEventFrame, SessionDigest,
+    SessionExternalOrigin, SessionSnapshot, TurnRewriteState, TurnSnapshot, UpdateNotice,
 };
 use crate::wire_types::generate;
 use tidebreak_core::{
-    ApprovalClass, ApprovalDecisionKind, Attention, AttentionSource, AttentionState, BoundedError,
-    CapLevel, CheckpointHint, CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent,
-    CodeSessionActivity, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentStatus,
-    CodeSubagentSummary, CodeTerminalId, CodeTurnId, CodeTurnStatus, CodeUsage, CodeWatchId,
-    CodeWatchState, CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, GrantScope,
-    HarnessCaps, HarnessCommand, HarnessKind, HarnessNoticeLevel, HarnessTier, ImageMediaType,
-    ImageRef, InternalApprovalRequest, PermissionMode, PullRequestCheckCounts, PullRequestDigest,
-    QuickAction, ReasoningEffort, RefusalOutcome, RepoId, ToolApprovalKind, ToolDetail,
-    ToolOutcome, WorkspaceId,
+    ApprovalClass, ApprovalDecisionKind, ApprovalId, ApprovalKind, ApprovalState, Attention,
+    AttentionSource, AttentionState, BoundedError, CapLevel, CheckpointHint, CodeSubagentStatus,
+    CodeSubagentSummary, CodeTerminalId, CodeWatchId, CodeWatchState, CodeWorkspaceStatus,
+    Diffstat, Event, FenceReason, FileChangeKind, GrantScope, HarnessCaps, HarnessCommand,
+    HarnessKind, HarnessNoticeLevel, HarnessTier, ImageMediaType, ImageRef,
+    InternalApprovalRequest, PermissionMode, PullRequestCheckCounts, PullRequestDigest,
+    QuickAction, ReasoningEffort, RefusalOutcome, RepoId, SessionActivity, SessionId, SessionKind,
+    SessionLifecycle, ToolApprovalKind, ToolDetail, ToolOutcome, TurnId, TurnStatus, TurnUsage,
+    WorkspaceId,
 };
 
 /// Path of the shared code-mode fixtures, relative to this crate.
@@ -68,16 +67,16 @@ fn workspace_id() -> WorkspaceId {
     WorkspaceId(id(0x02))
 }
 
-fn session_id() -> CodeSessionId {
-    CodeSessionId(id(0x03))
+fn session_id() -> SessionId {
+    SessionId(id(0x03))
 }
 
-fn turn_id() -> CodeTurnId {
-    CodeTurnId(id(0x04))
+fn turn_id() -> TurnId {
+    TurnId(id(0x04))
 }
 
-fn approval_id() -> CodeApprovalId {
-    CodeApprovalId(id(0x05))
+fn approval_id() -> ApprovalId {
+    ApprovalId(id(0x05))
 }
 
 fn diffstat() -> Diffstat {
@@ -89,8 +88,8 @@ fn diffstat() -> Diffstat {
     }
 }
 
-fn usage() -> CodeUsage {
-    CodeUsage {
+fn usage() -> TurnUsage {
+    TurnUsage {
         input_tokens: 1_200,
         output_tokens: 340,
         cache_read_input_tokens: 900,
@@ -157,11 +156,11 @@ fn caps() -> HarnessCaps {
     }
 }
 
-fn session() -> CodeSessionSnapshot {
-    CodeSessionSnapshot {
+fn session() -> SessionSnapshot {
+    SessionSnapshot {
         id: session_id(),
         workspace_id: Some(workspace_id()),
-        kind: CodeSessionKind::Interactive,
+        kind: SessionKind::Interactive,
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: Some("2.0.14".to_owned()),
         harness_resume_ref: Some("9f2c1d4e-resume".to_owned()),
@@ -169,24 +168,24 @@ fn session() -> CodeSessionSnapshot {
         model: Some("claude-opus-5".to_owned()),
         reasoning_effort: Some(ReasoningEffort::High),
         fast_mode: false,
-        lifecycle: CodeSessionLifecycle::Running,
+        lifecycle: SessionLifecycle::Running,
         fence_reason: None,
         attention: attention(),
         unrecognized_event_count: 0,
         created_at: at(1_756_700_000),
-        external_origin: Some(CodeSessionExternalOrigin {
+        external_origin: Some(SessionExternalOrigin {
             channel_kind: "slack".to_owned(),
             external_key: "T0/C1/1756700000.000100".to_owned(),
         }),
     }
 }
 
-fn turn() -> CodeTurnSnapshot {
-    CodeTurnSnapshot {
+fn turn() -> TurnSnapshot {
+    TurnSnapshot {
         id: turn_id(),
         session_id: session_id(),
         ordinal: 3,
-        status: CodeTurnStatus::Completed,
+        status: TurnStatus::Completed,
         model: Some("claude-opus-5".to_owned()),
         fast_mode: false,
         user_input: "Bound every string the code parser draws.".to_owned(),
@@ -206,9 +205,9 @@ fn turn() -> CodeTurnSnapshot {
     }
 }
 
-fn queued_turn() -> QueuedCodeTurn {
-    QueuedCodeTurn {
-        id: CodeTurnId(id(0x06)),
+fn queued_turn() -> QueuedTurn {
+    QueuedTurn {
+        id: TurnId(id(0x06)),
         session_id: session_id(),
         message: "Then add the fixture test.".to_owned(),
         position: 0,
@@ -217,18 +216,18 @@ fn queued_turn() -> QueuedCodeTurn {
     }
 }
 
-fn digest() -> CodeSessionDigest {
-    CodeSessionDigest {
+fn digest() -> SessionDigest {
+    SessionDigest {
         workspace: Some(workspace_id()),
         session: session_id(),
-        kind: CodeSessionKind::Interactive,
+        kind: SessionKind::Interactive,
         harness_kind: Some(HarnessKind::ClaudeCode),
-        lifecycle: CodeSessionLifecycle::Running,
+        lifecycle: SessionLifecycle::Running,
         attention: attention(),
         title: "Bound the code parser".to_owned(),
         turn_count: 3,
         trigger_target_at: Some(at(1_756_700_100)),
-        activity: Some(CodeSessionActivity::Shell),
+        activity: Some(SessionActivity::Shell),
         activity_detail: Some("cargo test -p tidebreak-server code_parser".to_owned()),
         pr_state: Some(pull_request()),
         pr_count: Some(1),
@@ -246,14 +245,14 @@ fn digest() -> CodeSessionDigest {
 }
 
 /// The in-process engine's session binds no workspace (decision 0048 step 5).
-fn internal_digest() -> CodeSessionDigest {
-    CodeSessionDigest {
+fn internal_digest() -> SessionDigest {
+    SessionDigest {
         workspace: None,
-        session: CodeSessionId(id(0x22)),
+        session: SessionId(id(0x22)),
         harness_kind: Some(HarnessKind::Internal),
         title: "Plan the memory substrate".to_owned(),
         turn_count: 1,
-        activity: Some(CodeSessionActivity::Agent),
+        activity: Some(SessionActivity::Agent),
         activity_detail: None,
         pr_state: None,
         pr_count: None,
@@ -263,8 +262,8 @@ fn internal_digest() -> CodeSessionDigest {
     }
 }
 
-fn digest_notice(d: CodeSessionDigest) -> CodeUpdateNotice {
-    CodeUpdateNotice::Digest {
+fn digest_notice(d: SessionDigest) -> UpdateNotice {
+    UpdateNotice::Digest {
         workspace: d.workspace,
         session: d.session,
         kind: d.kind,
@@ -287,8 +286,8 @@ fn digest_notice(d: CodeSessionDigest) -> CodeUpdateNotice {
     }
 }
 
-fn frame(seq: i64, event: CodeEvent) -> SequencedCodeEventFrame {
-    SequencedCodeEventFrame {
+fn frame(seq: i64, event: Event) -> SequencedEventFrame {
+    SequencedEventFrame {
         seq,
         event,
         replayed: None,
@@ -365,10 +364,10 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
         fixture(
             "fenced session",
             "session",
-            &CodeSessionSnapshot {
+            &SessionSnapshot {
                 workspace_id: None,
                 harness_kind: HarnessKind::Internal,
-                lifecycle: CodeSessionLifecycle::Fenced,
+                lifecycle: SessionLifecycle::Fenced,
                 fence_reason: Some(FenceReason::ResumeLost {
                     detail: "the engine forgot the resume ref".to_owned(),
                 }),
@@ -389,7 +388,7 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
         fixture(
             "queued turns",
             "queued_turns",
-            &QueuedCodeTurnsSnapshot {
+            &QueuedTurnsSnapshot {
                 queued: vec![queued_turn()],
                 paused: true,
             },
@@ -492,17 +491,17 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
         fixture(
             "pending approval",
             "approval",
-            &CodeApprovalSnapshot {
+            &ApprovalSnapshot {
                 id: approval_id(),
                 session_id: session_id(),
                 turn_id: turn_id(),
-                kind: CodeApprovalKind::Command {
+                kind: ApprovalKind::Command {
                     cmd: "cargo test -p tidebreak-cli".to_owned(),
                     cwd: Some("/Users/mara/code/tidebreak".to_owned()),
                 },
                 harness_raw_json: r#"{"tool":"Bash","command":"cargo test -p tidebreak-cli"}"#
                     .to_owned(),
-                state: CodeApprovalState::Pending,
+                state: ApprovalState::Pending,
                 feedback: None,
                 requested_at: at(1_756_700_120),
                 decided_at: None,
@@ -511,15 +510,15 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
         fixture(
             "denied approval",
             "approval",
-            &CodeApprovalSnapshot {
-                id: CodeApprovalId(id(0x15)),
+            &ApprovalSnapshot {
+                id: ApprovalId(id(0x15)),
                 session_id: session_id(),
                 turn_id: turn_id(),
-                kind: CodeApprovalKind::FileWrite {
+                kind: ApprovalKind::FileWrite {
                     paths: vec!["/etc/hosts".to_owned()],
                 },
                 harness_raw_json: r#"{"tool":"Write","path":"/etc/hosts"}"#.to_owned(),
-                state: CodeApprovalState::Denied,
+                state: ApprovalState::Denied,
                 feedback: Some("Not that file.".to_owned()),
                 requested_at: at(1_756_700_130),
                 decided_at: Some(at(1_756_700_140)),
@@ -560,7 +559,7 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
                 watch: Some(CodeWatchSnapshot {
                     id: CodeWatchId(id(0x20)),
                     workspace_id: workspace_id(),
-                    session_id: CodeSessionId(id(0x21)),
+                    session_id: SessionId(id(0x21)),
                     pr_number: 3006,
                     state: CodeWatchState::Watching,
                     detail: Some("waiting on the desktop UI lane".to_owned()),
@@ -586,9 +585,9 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
         fixture(
             "watch digest",
             "session_digest",
-            &CodeSessionDigest {
-                session: CodeSessionId(id(0x21)),
-                kind: CodeSessionKind::Watch,
+            &SessionDigest {
+                session: SessionId(id(0x21)),
+                kind: SessionKind::Watch,
                 title: "Watch #3006".to_owned(),
                 activity: None,
                 activity_detail: None,
@@ -612,13 +611,13 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
     out
 }
 
-/// One notice per variant of [`CodeUpdateNotice`].
+/// One notice per variant of [`UpdateNotice`].
 fn update_notices() -> Vec<Fixture> {
     vec![
         fixture(
             "updates: snapshot",
             "update_notice",
-            &CodeUpdateNotice::Snapshot {
+            &UpdateNotice::Snapshot {
                 sessions: vec![digest(), internal_digest()],
             },
         ),
@@ -631,7 +630,7 @@ fn update_notices() -> Vec<Fixture> {
         fixture(
             "updates: terminal activity",
             "update_notice",
-            &CodeUpdateNotice::TerminalActivity {
+            &UpdateNotice::TerminalActivity {
                 workspace_id: workspace_id(),
                 terminal_id: CodeTerminalId(id(0x40)),
             },
@@ -639,7 +638,7 @@ fn update_notices() -> Vec<Fixture> {
         fixture(
             "updates: clone progress",
             "update_notice",
-            &CodeUpdateNotice::CloneProgress {
+            &UpdateNotice::CloneProgress {
                 job: "clone-7".to_owned(),
                 phase: "receiving objects".to_owned(),
                 percent: Some(62),
@@ -651,7 +650,7 @@ fn update_notices() -> Vec<Fixture> {
         fixture(
             "updates: harness install",
             "update_notice",
-            &CodeUpdateNotice::HarnessInstall {
+            &UpdateNotice::HarnessInstall {
                 kind: HarnessKind::Codex,
                 version: Some("0.42.0".to_owned()),
                 phase: "failed".to_owned(),
@@ -662,25 +661,25 @@ fn update_notices() -> Vec<Fixture> {
         fixture(
             "updates: delivery",
             "update_notice",
-            &CodeUpdateNotice::Delivery,
+            &UpdateNotice::Delivery,
         ),
         fixture(
             "updates: turn rewrite",
             "update_notice",
-            &CodeUpdateNotice::TurnRewrite {
+            &UpdateNotice::TurnRewrite {
                 session: session_id(),
                 turn_id: turn_id(),
-                state: CodeTurnRewriteState::Rewritten,
+                state: TurnRewriteState::Rewritten,
                 rewrite: Some("Every code-mode string now has a bound.".to_owned()),
             },
         ),
     ]
 }
 
-/// One frame per variant of [`CodeEvent`], plus the frame flags a reader
+/// One frame per variant of [`Event`], plus the frame flags a reader
 /// has to honor: `replayed`, `transient` with `replacement`, and `truncated`.
 fn event_frames() -> Vec<Fixture> {
-    let started = CodeEvent::SessionStarted {
+    let started = Event::SessionStarted {
         harness_kind: HarnessKind::ClaudeCode,
         harness_version: "2.0.14".to_owned(),
         resume_ref: Some("9f2c1d4e-resume".to_owned()),
@@ -688,7 +687,7 @@ fn event_frames() -> Vec<Fixture> {
     let frames = vec![
         (
             "event: session_started (replayed, truncated)",
-            SequencedCodeEventFrame {
+            SequencedEventFrame {
                 replayed: Some(true),
                 truncated: Some(true),
                 ..frame(40, started)
@@ -696,23 +695,23 @@ fn event_frames() -> Vec<Fixture> {
         ),
         (
             "event: turn_started",
-            SequencedCodeEventFrame {
+            SequencedEventFrame {
                 replayed: Some(true),
-                ..frame(41, CodeEvent::TurnStarted { turn_id: turn_id() })
+                ..frame(41, Event::TurnStarted { turn_id: turn_id() })
             },
         ),
         (
             "event: turn_resumed",
-            frame(42, CodeEvent::TurnResumed { turn_id: turn_id() }),
+            frame(42, Event::TurnResumed { turn_id: turn_id() }),
         ),
         (
             "event: assistant_delta (transient replacement)",
-            SequencedCodeEventFrame {
+            SequencedEventFrame {
                 transient: Some(true),
                 replacement: Some(true),
                 ..frame(
                     41,
-                    CodeEvent::AssistantDelta {
+                    Event::AssistantDelta {
                         text: "Reading the parser".to_owned(),
                     },
                 )
@@ -722,7 +721,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: assistant_message",
             frame(
                 42,
-                CodeEvent::AssistantMessage {
+                Event::AssistantMessage {
                     text: "The parser checks presence only.".to_owned(),
                     parent_call_id: None,
                 },
@@ -732,7 +731,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: reasoning_delta",
             frame(
                 43,
-                CodeEvent::ReasoningDelta {
+                Event::ReasoningDelta {
                     text: "Which fields are drawn on one line?".to_owned(),
                 },
             ),
@@ -741,7 +740,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: tool_started",
             frame(
                 44,
-                CodeEvent::ToolStarted {
+                Event::ToolStarted {
                     call_id: "call-1".to_owned(),
                     name: "Bash".to_owned(),
                     detail: ToolDetail::Command {
@@ -756,7 +755,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: tool_completed",
             frame(
                 45,
-                CodeEvent::ToolCompleted {
+                Event::ToolCompleted {
                     call_id: "call-2".to_owned(),
                     outcome: ToolOutcome::Succeeded,
                     preview: "1 file changed".to_owned(),
@@ -774,7 +773,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: file_changed",
             frame(
                 46,
-                CodeEvent::FileChanged {
+                Event::FileChanged {
                     path: "crates/tidebreak-cli/src/api/code.rs".to_owned(),
                     kind: FileChangeKind::Modified,
                     diffstat: diffstat(),
@@ -785,7 +784,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: approval_requested",
             frame(
                 47,
-                CodeEvent::ApprovalRequested {
+                Event::ApprovalRequested {
                     approval_id: approval_id(),
                     request: None,
                 },
@@ -795,7 +794,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: approval_resolved",
             frame(
                 48,
-                CodeEvent::ApprovalResolved {
+                Event::ApprovalResolved {
                     approval_id: approval_id(),
                     decision: ApprovalDecisionKind::Deny {
                         feedback: Some("Not that file.".to_owned()),
@@ -807,7 +806,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: user_steered",
             frame(
                 49,
-                CodeEvent::UserSteered {
+                Event::UserSteered {
                     text: "Keep the raw tier for diffs.".to_owned(),
                     message_id: None,
                 },
@@ -817,7 +816,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: turn_completed",
             frame(
                 50,
-                CodeEvent::TurnCompleted {
+                Event::TurnCompleted {
                     usage: usage(),
                     checkpoint: Some(CheckpointHint {
                         checkpoint_ref: Some("refs/tidebreak/checkpoints/3".to_owned()),
@@ -831,7 +830,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: turn_failed",
             frame(
                 51,
-                CodeEvent::TurnFailed {
+                Event::TurnFailed {
                     error: BoundedError {
                         message: "the engine exited with status 1".to_owned(),
                     },
@@ -841,13 +840,13 @@ fn event_frames() -> Vec<Fixture> {
         ),
         (
             "event: turn_interrupted",
-            frame(52, CodeEvent::TurnInterrupted { usage: None }),
+            frame(52, Event::TurnInterrupted { usage: None }),
         ),
         (
             "event: checkpoint_recorded",
             frame(
                 53,
-                CodeEvent::CheckpointRecorded {
+                Event::CheckpointRecorded {
                     turn_id: turn_id(),
                     diffstat: diffstat(),
                 },
@@ -857,7 +856,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: harness_notice",
             frame(
                 54,
-                CodeEvent::HarnessNotice {
+                Event::HarnessNotice {
                     level: HarnessNoticeLevel::Warning,
                     message: "context is 80% full".to_owned(),
                 },
@@ -867,7 +866,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: attention_changed",
             frame(
                 55,
-                CodeEvent::AttentionChanged {
+                Event::AttentionChanged {
                     state: AttentionState::NeedsYou {
                         prompt: "Approve the write to /etc/hosts?".to_owned(),
                         source: AttentionSource::Structured,
@@ -882,7 +881,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: turn_refused (internal engine)",
             frame(
                 56,
-                CodeEvent::TurnRefused {
+                Event::TurnRefused {
                     usage: usage(),
                     refusal: RefusalOutcome::report_blocked(),
                 },
@@ -890,18 +889,18 @@ fn event_frames() -> Vec<Fixture> {
         ),
         (
             "event: stream_interrupted (internal engine)",
-            SequencedCodeEventFrame {
+            SequencedEventFrame {
                 transient: Some(true),
-                ..frame(57, CodeEvent::StreamInterrupted)
+                ..frame(57, Event::StreamInterrupted)
             },
         ),
         (
             "event: tool_args_delta (internal engine, transient)",
-            SequencedCodeEventFrame {
+            SequencedEventFrame {
                 transient: Some(true),
                 ..frame(
                     57,
-                    CodeEvent::ToolArgsDelta {
+                    Event::ToolArgsDelta {
                         call_id: "call_01".to_owned(),
                         fragment: "{\"command\":\"cargo\",".to_owned(),
                     },
@@ -912,7 +911,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: approval_requested (internal engine consent card)",
             frame(
                 58,
-                CodeEvent::ApprovalRequested {
+                Event::ApprovalRequested {
                     approval_id: approval_id(),
                     request: Some(InternalApprovalRequest::ToolUse {
                         auto_judging: false,
@@ -931,7 +930,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: approval_requested (internal engine questions park)",
             frame(
                 59,
-                CodeEvent::ApprovalRequested {
+                Event::ApprovalRequested {
                     approval_id: approval_id(),
                     request: Some(InternalApprovalRequest::Questions { turn_id: turn_id() }),
                 },
@@ -941,7 +940,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: approval_requested (internal engine plan park)",
             frame(
                 60,
-                CodeEvent::ApprovalRequested {
+                Event::ApprovalRequested {
                     approval_id: approval_id(),
                     request: Some(InternalApprovalRequest::Plan { turn_id: turn_id() }),
                 },
@@ -951,7 +950,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: task_plan_updated (internal engine)",
             frame(
                 62,
-                CodeEvent::TaskPlanUpdated {
+                Event::TaskPlanUpdated {
                     call_id: "call_04".to_owned(),
                     turn_id: turn_id(),
                 },
@@ -961,7 +960,7 @@ fn event_frames() -> Vec<Fixture> {
             "event: context_truncated (internal engine)",
             frame(
                 63,
-                CodeEvent::ContextTruncated {
+                Event::ContextTruncated {
                     original_tokens: 210_000,
                     fitted_tokens: 180_000,
                 },
@@ -969,11 +968,11 @@ fn event_frames() -> Vec<Fixture> {
         ),
         (
             "event: compaction_started (internal engine)",
-            frame(64, CodeEvent::CompactionStarted),
+            frame(64, Event::CompactionStarted),
         ),
         (
             "event: compaction_finished (internal engine)",
-            frame(65, CodeEvent::CompactionFinished { compacted: true }),
+            frame(65, Event::CompactionFinished { compacted: true }),
         ),
     ];
     frames
@@ -1050,7 +1049,7 @@ fn the_code_frame_fixtures_are_current() {
 /// new variant fails here until it has one.
 #[test]
 fn the_code_frame_fixtures_cover_every_event() {
-    let declared = declared_tags::<CodeEvent>("Event");
+    let declared = declared_tags::<Event>("Event");
     let covered = fixture_tags("event_frame", |value| value.get("event")?.get("type"));
     let missing: Vec<_> = declared.difference(&covered).collect();
     assert!(
@@ -1058,7 +1057,7 @@ fn the_code_frame_fixtures_cover_every_event() {
         "event types without a code-frame fixture: {missing:?}"
     );
 
-    let declared = declared_tags::<CodeUpdateNotice>("CodeUpdateNotice");
+    let declared = declared_tags::<UpdateNotice>("UpdateNotice");
     let covered = fixture_tags("update_notice", |value| value.get("type"));
     let missing: Vec<_> = declared.difference(&covered).collect();
     assert!(
@@ -1075,21 +1074,21 @@ fn every_code_frame_fixture_round_trips() {
         match entry.kind {
             "repo" => round_trip::<CodeRepoSnapshot>(entry),
             "workspace" => round_trip::<CodeWorkspaceSnapshot>(entry),
-            "session" => round_trip::<CodeSessionSnapshot>(entry),
-            "turn" => round_trip::<CodeTurnSnapshot>(entry),
-            "queued_turn" => round_trip::<QueuedCodeTurn>(entry),
-            "queued_turns" => round_trip::<QueuedCodeTurnsSnapshot>(entry),
+            "session" => round_trip::<SessionSnapshot>(entry),
+            "turn" => round_trip::<TurnSnapshot>(entry),
+            "queued_turn" => round_trip::<QueuedTurn>(entry),
+            "queued_turns" => round_trip::<QueuedTurnsSnapshot>(entry),
             "harness_doctor" => round_trip::<HarnessDoctorReport>(entry),
             "workspace_files" => round_trip::<CodeWorkspaceFiles>(entry),
             "workspace_diff" => round_trip::<CodeWorkspaceDiff>(entry),
-            "approval" => round_trip::<CodeApprovalSnapshot>(entry),
+            "approval" => round_trip::<ApprovalSnapshot>(entry),
             "commit" => round_trip::<CodeCommitSnapshot>(entry),
             "push" => round_trip::<CodePushSnapshot>(entry),
             "workspace_pr" => round_trip::<CodeWorkspacePrSnapshot>(entry),
             "action" => round_trip::<CodeActionSnapshot>(entry),
-            "session_digest" => round_trip::<CodeSessionDigest>(entry),
-            "update_notice" => round_trip::<CodeUpdateNotice>(entry),
-            "event_frame" => round_trip::<SequencedCodeEventFrame>(entry),
+            "session_digest" => round_trip::<SessionDigest>(entry),
+            "update_notice" => round_trip::<UpdateNotice>(entry),
+            "event_frame" => round_trip::<SequencedEventFrame>(entry),
             other => panic!("fixture {} has no decoder for kind {other}", entry.name),
         }
     }
@@ -1119,26 +1118,26 @@ fn code_values_reject_unknown_keys() {
         let rejected = match entry.kind {
             "repo" => serde_json::from_value::<CodeRepoSnapshot>(value).is_err(),
             "workspace" => serde_json::from_value::<CodeWorkspaceSnapshot>(value).is_err(),
-            "session" => serde_json::from_value::<CodeSessionSnapshot>(value).is_err(),
-            "turn" => serde_json::from_value::<CodeTurnSnapshot>(value).is_err(),
-            "queued_turn" => serde_json::from_value::<QueuedCodeTurn>(value).is_err(),
-            "queued_turns" => serde_json::from_value::<QueuedCodeTurnsSnapshot>(value).is_err(),
+            "session" => serde_json::from_value::<SessionSnapshot>(value).is_err(),
+            "turn" => serde_json::from_value::<TurnSnapshot>(value).is_err(),
+            "queued_turn" => serde_json::from_value::<QueuedTurn>(value).is_err(),
+            "queued_turns" => serde_json::from_value::<QueuedTurnsSnapshot>(value).is_err(),
             "harness_doctor" => serde_json::from_value::<HarnessDoctorReport>(value).is_err(),
             "workspace_files" => serde_json::from_value::<CodeWorkspaceFiles>(value).is_err(),
             "workspace_diff" => serde_json::from_value::<CodeWorkspaceDiff>(value).is_err(),
-            "approval" => serde_json::from_value::<CodeApprovalSnapshot>(value).is_err(),
+            "approval" => serde_json::from_value::<ApprovalSnapshot>(value).is_err(),
             "commit" => serde_json::from_value::<CodeCommitSnapshot>(value).is_err(),
             "push" => serde_json::from_value::<CodePushSnapshot>(value).is_err(),
             "workspace_pr" => serde_json::from_value::<CodeWorkspacePrSnapshot>(value).is_err(),
             "action" => serde_json::from_value::<CodeActionSnapshot>(value).is_err(),
-            "session_digest" => serde_json::from_value::<CodeSessionDigest>(value).is_err(),
-            "update_notice" => serde_json::from_value::<CodeUpdateNotice>(value).is_err(),
+            "session_digest" => serde_json::from_value::<SessionDigest>(value).is_err(),
+            "update_notice" => serde_json::from_value::<UpdateNotice>(value).is_err(),
             // The event union is `tidebreak_core`'s and tolerates extra keys
             // inside a variant; the frame around it does not.
             "event_frame" => {
                 let mut frame = entry.value.clone();
                 frame["extra"] = serde_json::Value::Bool(true);
-                serde_json::from_value::<SequencedCodeEventFrame>(frame).is_err()
+                serde_json::from_value::<SequencedEventFrame>(frame).is_err()
             }
             other => panic!("fixture {} has no decoder for kind {other}", entry.name),
         };
@@ -1151,7 +1150,7 @@ fn code_values_reject_unknown_keys() {
 #[test]
 fn unknown_update_notices_fail() {
     let unknown = r#"{"type":"some_future_notice","extra":true}"#;
-    assert!(serde_json::from_str::<CodeUpdateNotice>(unknown).is_err());
+    assert!(serde_json::from_str::<UpdateNotice>(unknown).is_err());
     let unknown_event = r#"{"seq":9,"event":{"type":"some_future_event"}}"#;
-    assert!(serde_json::from_str::<SequencedCodeEventFrame>(unknown_event).is_err());
+    assert!(serde_json::from_str::<SequencedEventFrame>(unknown_event).is_err());
 }

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -542,7 +542,20 @@ mod tests {
     }
 
     fn rendered_bindings() -> String {
-        let declarations = event_declarations();
+        let mut declarations = event_declarations();
+        let queued_turn = declarations
+            .remove("QueuedTurn")
+            .expect("the code queue row is a generated root");
+        let queued_code_turn = queued_turn.replacen(
+            "export type QueuedTurn =",
+            "export type QueuedCodeTurn =",
+            1,
+        );
+        assert_ne!(
+            queued_code_turn, queued_turn,
+            "the code queue declaration keeps its expected shape"
+        );
+        declarations.insert("QueuedCodeTurn".to_owned(), queued_code_turn);
         let union = declarations
             .get("RendererToolName")
             .expect("the vocabulary is reachable from the event root");
@@ -562,18 +575,28 @@ mod tests {
     fn conversation_compatibility_aliases() -> String {
         "// Compatibility aliases for clients that still use the earlier conversation names.\n\
          export type ChatId = SessionId;\n\
+         export type CodeApprovalDecision = ApprovalDecision;\n\
+         export type CodeApprovalDecisionBody = ApprovalDecisionBody;\n\
          export type CodeApprovalId = ApprovalId;\n\
          export type CodeApprovalKind = ApprovalKind;\n\
+         export type CodeApprovalSnapshot = ApprovalSnapshot;\n\
          export type CodeApprovalState = ApprovalState;\n\
          export type CodeEvent = Event;\n\
          export type CodeSessionActivity = SessionActivity;\n\
+         export type CodeSessionDigest = SessionDigest;\n\
+         export type CodeSessionExternalOrigin = SessionExternalOrigin;\n\
          export type CodeSessionId = SessionId;\n\
          export type CodeSessionKind = SessionKind;\n\
          export type CodeSessionLifecycle = SessionLifecycle;\n\
+         export type CodeSessionSnapshot = SessionSnapshot;\n\
          export type CodeTurnId = TurnId;\n\
+         export type CodeTurnRewriteState = TurnRewriteState;\n\
+         export type CodeTurnSnapshot = TurnSnapshot;\n\
          export type CodeTurnStatus = TurnStatus;\n\
+         export type CodeUpdateNotice = UpdateNotice;\n\
          export type CodeUsage = TurnUsage;\n\
-         export type QueuedTurn = QueuedAgentTurn;\n"
+         export type QueuedTurn = QueuedAgentTurn;\n\
+         export type SequencedCodeEventFrame = SequencedEventFrame;\n"
             .to_owned()
     }
 

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -389,7 +389,7 @@ mod tests {
         // types with the conversation path, but one generated module keeps the
         // renderer importing from a single place.
         generate::collect_from::<crate::routes::Settings>(&cfg, &mut out);
-        generate::collect_from::<tidebreak_core::QueuedTurn>(&cfg, &mut out);
+        generate::collect_from::<tidebreak_core::QueuedAgentTurn>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ModelInfo>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ModelRoleInfo>(&cfg, &mut out);
         // Memory: backend capabilities, records, search, context, revisions,
@@ -468,11 +468,11 @@ mod tests {
         generate::collect_from::<crate::routes::code::WorkspaceTitleProposal>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeConnectPage>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeGrantSnapshot>(&cfg, &mut out);
-        generate::collect_from::<crate::routes::code::CodeSessionSnapshot>(&cfg, &mut out);
-        generate::collect_from::<crate::routes::code::CodeTurnSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::SessionSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::TurnSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeAnalyticsSnapshot>(&cfg, &mut out);
-        generate::collect_from::<crate::routes::code::QueuedCodeTurn>(&cfg, &mut out);
-        generate::collect_from::<crate::routes::code::SequencedCodeEventFrame>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::QueuedTurn>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::SequencedEventFrame>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::HarnessDoctorReport>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::HarnessModelList>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeWorkspaceFiles>(&cfg, &mut out);
@@ -482,10 +482,11 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeWorkspaceDiff>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeTerminalSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeTerminalRead>(&cfg, &mut out);
-        generate::collect_from::<crate::routes::code::CodeSessionDigest>(&cfg, &mut out);
-        generate::collect_from::<crate::routes::code::CodeUpdateNotice>(&cfg, &mut out);
-        generate::collect_from::<crate::routes::code::CodeApprovalSnapshot>(&cfg, &mut out);
-        generate::collect_from::<crate::routes::code::CodeApprovalDecisionBody>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeTerminalActivityNotice>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::SessionDigest>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::UpdateNotice>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::ApprovalSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::ApprovalDecisionBody>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeCommitSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodePushSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeWorkspacePrSnapshot>(&cfg, &mut out);

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -506,6 +506,33 @@ export type AppViewSession = { frame_path: string, };
 export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 
 /**
+ * The decision on one approval.
+ *
+ * The richer variants are capability-gated: the server refuses them for an
+ * engine whose capability vector does not declare the channel, and a grant
+ * is named by its index into the rungs the approval's own kind offered —
+ * a client can pick a rung the card showed, never invent a scope.
+ */
+export type ApprovalDecision = "approve" | "deny" | { "approve_with_grant": {
+/**
+ * Index into the approval kind's `offered_grants`, narrowest first.
+ */
+grant_index: number, } } | { "answers": {
+/**
+ * Answers to a questions approval, validated server-side.
+ */
+answers: Array<UserQuestionAnswer>, } } | { "plan_decision": {
+/**
+ * Whether the proposed plan is accepted.
+ */
+approve: boolean, } };
+
+/**
+ * Body of `POST /approvals/{id}/decision`.
+ */
+export type ApprovalDecisionBody = { decision: ApprovalDecision, feedback?: string, };
+
+/**
  * Outcome recorded on [`Event::ApprovalResolved`].
  */
 export type ApprovalDecisionKind = { "type": "approve" } | { "type": "deny",
@@ -586,6 +613,15 @@ questions: Array<UserQuestion>, } | { "type": "plan",
  * accepted.
  */
 proposed_mode: PermissionMode, };
+
+/**
+ * One parked or decided engine approval.
+ */
+export type ApprovalSnapshot = { id: ApprovalId, session_id: SessionId, turn_id: TurnId, kind: ApprovalKind,
+/**
+ * Exact JSON the engine sent, already size-capped. The card renders this.
+ */
+harness_raw_json: string, state: ApprovalState, feedback?: string, requested_at: string, decided_at?: string, };
 
 /**
  * State of a persisted approval.
@@ -945,42 +981,6 @@ export type CodeAnalyticsSnapshot = { range: CodeAnalyticsRange, from?: string, 
 export type CodeAnalyticsTotals = { sessions: number, turns: number, completed_turns: number, failed_turns: number, interrupted_turns: number, running_turns: number, input_tokens: number, output_tokens: number, cache_read_tokens: number, cache_write_tokens: number, total_tokens: number, estimated_cost_microusd: number, pull_requests_opened: number, pull_requests_merged: number, };
 
 /**
- * The decision on one approval.
- *
- * The richer variants are capability-gated: the server refuses them for an
- * engine whose capability vector does not declare the channel, and a grant
- * is named by its index into the rungs the approval's own kind offered —
- * a client can pick a rung the card showed, never invent a scope.
- */
-export type CodeApprovalDecision = "approve" | "deny" | { "approve_with_grant": {
-/**
- * Index into the approval kind's `offered_grants`, narrowest first.
- */
-grant_index: number, } } | { "answers": {
-/**
- * Answers to a questions approval, validated server-side.
- */
-answers: Array<UserQuestionAnswer>, } } | { "plan_decision": {
-/**
- * Whether the proposed plan is accepted.
- */
-approve: boolean, } };
-
-/**
- * Body of `POST /code/approvals/{id}/decision`.
- */
-export type CodeApprovalDecisionBody = { decision: CodeApprovalDecision, feedback?: string, };
-
-/**
- * One parked or decided engine approval.
- */
-export type CodeApprovalSnapshot = { id: ApprovalId, session_id: SessionId, turn_id: TurnId, kind: ApprovalKind,
-/**
- * Exact JSON the engine sent, already size-capped. The card renders this.
- */
-harness_raw_json: string, state: ApprovalState, feedback?: string, requested_at: string, decided_at?: string, };
-
-/**
  * One failing check's downloaded job log:
  * `POST /code/workspaces/{id}/pr/check-logs`.
  *
@@ -1278,7 +1278,7 @@ relation?: CodePullRequestRelation, };
 export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: number, deletions: number, previous_path?: string, };
 
 /**
- * Body of `POST /code/sessions/{id}/fork`. An absent body forks at the
+ * Body of `POST /sessions/{id}/fork`. An absent body forks at the
  * newest turn.
  */
 export type CodeForkBody = {
@@ -1288,7 +1288,7 @@ export type CodeForkBody = {
 at_turn?: TurnId, };
 
 /**
- * A written fork handoff: `POST /code/sessions/{id}/fork`.
+ * A written fork handoff: `POST /sessions/{id}/fork`.
  *
  * `path` is the condensed transcript, absolute under private storage so a
  * child agent of any engine can read it without Git ever indexing it. `dir`
@@ -1477,99 +1477,6 @@ export type CodeRepoSource = { kind: string, available: boolean, remediation?: s
 export type CodeRepoSources = { sources: Array<CodeRepoSource>, chooses_destination: boolean, };
 
 /**
- * Cheap per-session digest on `/code/updates`.
- */
-export type CodeSessionDigest = {
-/**
- * `None` for a session that binds no workspace.
- */
-workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
-/**
- * Engine identity for list surfaces that collapse several sessions into
- * one workspace row. Optional on the wire so a desktop can still read a
- * digest from an older server during an update.
- */
-harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
-/**
- * Timestamp trigger delivery uses to rank candidate sessions: the newest
- * turn start, or session creation before the first turn. Optional so a
- * desktop can still read a digest from an older server during an update.
- */
-trigger_target_at?: string,
-/**
- * What the live turn is occupied with, while running.
- */
-activity?: SessionActivity,
-/**
- * The subject of the tool the live turn is waiting on: the command,
- * path, query, or task description. Present only while `activity`
- * names a tool, and bounded to one line.
- */
-activity_detail?: string, pr_state?: PullRequestDigest,
-/**
- * How many pull requests hold a durable attribution to this workspace
- * (decision 77). Absent when none do.
- */
-pr_count?: number,
-/**
- * Watch progress, present only on `kind: watch` digests.
- */
-watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
-/**
- * Harness subagents on this session, present only when any were
- * observed (decision 52).
- */
-subagents?: Array<CodeSubagentSummary>,
-/**
- * Where this session stands, in a sentence, derived from the newest turn
- * that carries one. Absent until a turn has been recapped, and on
- * machines with no utility model to derive one.
- */
-recap?: string,
-/**
- * Pending memory proposals that originated in this session.
- */
-memory_proposal_count?: number, };
-
-/**
- * Where an externally created session came from. The desktop renders it
- * as the provenance banner; a session the desktop created carries none.
- */
-export type CodeSessionExternalOrigin = {
-/**
- * The channel family, for example `slack`.
- */
-channel_kind: string,
-/**
- * The channel's durable conversation identity, opaque to the server.
- * For Slack this is `workspace/channel/thread_ts`, which the desktop
- * turns into a thread permalink.
- */
-external_key: string, };
-
-/**
- * One durable conversation with an external agent engine.
- */
-export type CodeSessionSnapshot = { id: SessionId,
-/**
- * `None` for a session that binds no workspace: the in-process
- * engine's (decision 0048 step 5).
- */
-workspace_id: WorkspaceId | null, kind: SessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
-/**
- * Absent means the engine's own default, which is not any level.
- */
-reasoning_effort?: ReasoningEffort,
-/**
- * Whether this session runs its turns in the engine's fast mode.
- */
-fast_mode: boolean, lifecycle: SessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string,
-/**
- * Present when an external channel created the session.
- */
-external_origin?: CodeSessionExternalOrigin, };
-
-/**
  * Status of a harness subagent, derived from its spanning `Task` call
  * (decision 52): the call's start is the subagent's start, its result is
  * the end and outcome.
@@ -1594,6 +1501,13 @@ name: string,
  * Status derived from the spanning call.
  */
 status: CodeSubagentStatus, };
+
+/**
+ * Unsequenced activity notice published on the updates channel.
+ *
+ * Never journaled. A client that missed one just pulls from its last cursor.
+ */
+export type CodeTerminalActivityNotice = { workspace_id: WorkspaceId, terminal_id: CodeTerminalId, };
 
 /**
  * Identifies one auxiliary terminal attached to a workspace.
@@ -1640,76 +1554,6 @@ export type CodeTriggerId = string;
  * One armed trigger, as the interface reads it.
  */
 export type CodeTriggerSnapshot = { id: CodeTriggerId, repo_id: RepoId, condition: CodeTriggerCondition, action: CodeTriggerAction, enabled: boolean, created_at: string, updated_at: string, };
-
-/**
- * Where one closing-message rewrite stands.
- */
-export type CodeTurnRewriteState = "rewriting" | "rewritten" | "failed";
-
-/**
- * One user→engine turn.
- */
-export type CodeTurnSnapshot = { id: TurnId, session_id: SessionId, ordinal: number, status: TurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: TurnUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string,
-/**
- * Lucid rewrite of the closing message. The journal keeps the original.
- */
-rewrite?: string, };
-
-/**
- * One unsequenced notice on `WS /code/updates`.
- *
- * A connect is restated as [`Self::Snapshot`]; later notices are live only.
- */
-export type CodeUpdateNotice = { "type": "snapshot",
-/**
- * One row per live session.
- */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
-/**
- * Engine identity for the session represented by this digest.
- */
-harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
-/**
- * Timestamp trigger delivery uses to rank candidate sessions.
- */
-trigger_target_at?: string,
-/**
- * What the live turn is occupied with, while running.
- */
-activity?: SessionActivity,
-/**
- * The subject of the tool the live turn is waiting on, while
- * `activity` names one.
- */
-activity_detail?: string,
-/**
- * Boxed to keep the notice enum's variants near one size; the wire
- * shape is unchanged.
- */
-pr_state?: PullRequestDigest,
-/**
- * How many pull requests hold a durable attribution to this
- * workspace (decision 77). Absent when none do.
- */
-pr_count?: number,
-/**
- * Watch progress, present only on `kind: watch` digests.
- */
-watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
-/**
- * Harness subagents on this session, present only when any were
- * observed (decision 52).
- */
-subagents?: Array<CodeSubagentSummary>,
-/**
- * Where this session stands, in a sentence, derived from the newest
- * turn that carries one.
- */
-recap?: string,
-/**
- * Pending memory proposals that originated in this session.
- */
-memory_proposal_count?: number, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, } | { "type": "harness_install", kind: HarnessKind, version?: string, phase: string, done: boolean, error?: string, } | { "type": "delivery" } | { "type": "turn_rewrite", session: SessionId, turn_id: TurnId, state: CodeTurnRewriteState, rewrite?: string, };
 
 /**
  * Identifies one durable watch task on a workspace's pull request.
@@ -3047,16 +2891,12 @@ byte_len: number, };
 
 /**
  * Which conversation an entry belongs to.
- *
- * Tagged because chat ids and code session ids are still separate spaces
- * (the repository check `chat_and_code_entities_do_not_cross_reference`
- * enforces it). When step 5 merges the entities this collapses to one id.
  */
-export type InboxConversation = { "surface": "chat", chat_id: SessionId, } | { "surface": "code", session_id: SessionId,
+export type InboxConversation = { session_id: SessionId,
 /**
- * `None` for a session with no workspace: the in-process engine's.
+ * Present when the conversation belongs to a repo-backed workspace.
  */
-workspace_id: WorkspaceId | null, };
+workspace_id?: WorkspaceId, };
 
 /**
  * One conversation that wants the reader, and why.
@@ -4840,7 +4680,7 @@ export type RootAttachmentOrigin = "project_default" | "conversation";
 /**
  * One event on the per-session WebSocket.
  */
-export type SequencedCodeEventFrame = {
+export type SequencedEventFrame = {
 /**
  * Journal position. On a `transient` frame this is the cursor the event
  * streamed behind, not a position the frame occupies — resume from it
@@ -4875,6 +4715,77 @@ truncated?: boolean, };
 export type SessionActivity = "agent" | "shell" | "monitor" | "subagents" | "file" | "search" | "tool";
 
 /**
+ * Cheap per-session digest on `/updates`.
+ */
+export type SessionDigest = {
+/**
+ * `None` for a session that binds no workspace.
+ */
+workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
+/**
+ * Engine identity for list surfaces that collapse several sessions into
+ * one workspace row. Optional on the wire so a desktop can still read a
+ * digest from an older server during an update.
+ */
+harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
+/**
+ * Timestamp trigger delivery uses to rank candidate sessions: the newest
+ * turn start, or session creation before the first turn. Optional so a
+ * desktop can still read a digest from an older server during an update.
+ */
+trigger_target_at?: string,
+/**
+ * What the live turn is occupied with, while running.
+ */
+activity?: SessionActivity,
+/**
+ * The subject of the tool the live turn is waiting on: the command,
+ * path, query, or task description. Present only while `activity`
+ * names a tool, and bounded to one line.
+ */
+activity_detail?: string, pr_state?: PullRequestDigest,
+/**
+ * How many pull requests hold a durable attribution to this workspace
+ * (decision 77). Absent when none do.
+ */
+pr_count?: number,
+/**
+ * Watch progress, present only on `kind: watch` digests.
+ */
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
+/**
+ * Harness subagents on this session, present only when any were
+ * observed (decision 52).
+ */
+subagents?: Array<CodeSubagentSummary>,
+/**
+ * Where this session stands, in a sentence, derived from the newest turn
+ * that carries one. Absent until a turn has been recapped, and on
+ * machines with no utility model to derive one.
+ */
+recap?: string,
+/**
+ * Pending memory proposals that originated in this session.
+ */
+memory_proposal_count?: number, };
+
+/**
+ * Where an externally created session came from. The desktop renders it
+ * as the provenance banner; a session the desktop created carries none.
+ */
+export type SessionExternalOrigin = {
+/**
+ * The channel family, for example `slack`.
+ */
+channel_kind: string,
+/**
+ * The channel's durable conversation identity, opaque to the server.
+ * For Slack this is `workspace/channel/thread_ts`, which the desktop
+ * turns into a thread permalink.
+ */
+external_key: string, };
+
+/**
  * Identifies a persistent conversation.
  */
 export type SessionId = string;
@@ -4888,6 +4799,28 @@ export type SessionKind = "interactive" | "watch";
  * Lifecycle of a persisted code session.
  */
 export type SessionLifecycle = "created" | "idle" | "running" | "fenced" | "ended";
+
+/**
+ * One durable conversation with an external agent engine.
+ */
+export type SessionSnapshot = { id: SessionId,
+/**
+ * `None` for a session that binds no workspace: the in-process
+ * engine's (decision 0048 step 5).
+ */
+workspace_id: WorkspaceId | null, kind: SessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: PermissionMode, model?: string,
+/**
+ * Absent means the engine's own default, which is not any level.
+ */
+reasoning_effort?: ReasoningEffort,
+/**
+ * Whether this session runs its turns in the engine's fast mode.
+ */
+fast_mode: boolean, lifecycle: SessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string,
+/**
+ * Present when an external channel created the session.
+ */
+external_origin?: SessionExternalOrigin, };
 
 /**
  * Body of `PUT /code/worktree-root`. A null or blank root clears the setting.
@@ -5508,6 +5441,20 @@ export type TurnFailureCategory = "rate_limited" | "auth" | "provider_access" | 
 export type TurnId = string;
 
 /**
+ * Where one closing-message rewrite stands.
+ */
+export type TurnRewriteState = "rewriting" | "rewritten" | "failed";
+
+/**
+ * One user→engine turn.
+ */
+export type TurnSnapshot = { id: TurnId, session_id: SessionId, ordinal: number, status: TurnStatus, model?: string, fast_mode: boolean, user_input: string, attachments: Array<ImageRef>, usage?: TurnUsage, checkpoint_ref?: string, diffstat?: Diffstat, started_at: string, ended_at?: string,
+/**
+ * Lucid rewrite of the closing message. The journal keeps the original.
+ */
+rewrite?: string, };
+
+/**
  * Status of one user→engine turn.
  *
  * Absorbs [`crate::model::TurnRunStatus`] one-for-one. Chat's `cancelled`
@@ -5588,6 +5535,62 @@ export type UpdateCodeTriggerBody = { enabled: boolean, };
  * Body of `PATCH /memory/records/{id}`.
  */
 export type UpdateMemoryRecordBody = { expected_revision: number, kind: MemoryKind, title: string, body: string, author: MemoryAuthor, origin: MemoryOrigin, evidence: Array<MemoryEvidence>, links: Array<MemoryLink>, expires_at: string | null, observation_count: number, };
+
+/**
+ * One unsequenced notice on `WS /updates`.
+ *
+ * A connect is restated as [`Self::Snapshot`]; later notices are live only.
+ */
+export type UpdateNotice = { "type": "snapshot",
+/**
+ * One row per live session.
+ */
+sessions: Array<SessionDigest>, } | { "type": "digest", workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
+/**
+ * Engine identity for the session represented by this digest.
+ */
+harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
+/**
+ * Timestamp trigger delivery uses to rank candidate sessions.
+ */
+trigger_target_at?: string,
+/**
+ * What the live turn is occupied with, while running.
+ */
+activity?: SessionActivity,
+/**
+ * The subject of the tool the live turn is waiting on, while
+ * `activity` names one.
+ */
+activity_detail?: string,
+/**
+ * Boxed to keep the notice enum's variants near one size; the wire
+ * shape is unchanged.
+ */
+pr_state?: PullRequestDigest,
+/**
+ * How many pull requests hold a durable attribution to this
+ * workspace (decision 77). Absent when none do.
+ */
+pr_count?: number,
+/**
+ * Watch progress, present only on `kind: watch` digests.
+ */
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
+/**
+ * Harness subagents on this session, present only when any were
+ * observed (decision 52).
+ */
+subagents?: Array<CodeSubagentSummary>,
+/**
+ * Where this session stands, in a sentence, derived from the newest
+ * turn that carries one.
+ */
+recap?: string,
+/**
+ * Pending memory proposals that originated in this session.
+ */
+memory_proposal_count?: number, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, } | { "type": "harness_install", kind: HarnessKind, version?: string, phase: string, done: boolean, error?: string, } | { "type": "delivery" } | { "type": "turn_rewrite", session: SessionId, turn_id: TurnId, state: TurnRewriteState, rewrite?: string, };
 
 /**
  * One bounded question shown to the user.
@@ -5768,15 +5771,25 @@ export const MAX_WIRE_CURSOR_CHARS = 256;
 
 // Compatibility aliases for clients that still use the earlier conversation names.
 export type ChatId = SessionId;
+export type CodeApprovalDecision = ApprovalDecision;
+export type CodeApprovalDecisionBody = ApprovalDecisionBody;
 export type CodeApprovalId = ApprovalId;
 export type CodeApprovalKind = ApprovalKind;
+export type CodeApprovalSnapshot = ApprovalSnapshot;
 export type CodeApprovalState = ApprovalState;
 export type CodeEvent = Event;
 export type CodeSessionActivity = SessionActivity;
+export type CodeSessionDigest = SessionDigest;
+export type CodeSessionExternalOrigin = SessionExternalOrigin;
 export type CodeSessionId = SessionId;
 export type CodeSessionKind = SessionKind;
 export type CodeSessionLifecycle = SessionLifecycle;
+export type CodeSessionSnapshot = SessionSnapshot;
 export type CodeTurnId = TurnId;
+export type CodeTurnRewriteState = TurnRewriteState;
+export type CodeTurnSnapshot = TurnSnapshot;
 export type CodeTurnStatus = TurnStatus;
+export type CodeUpdateNotice = UpdateNotice;
 export type CodeUsage = TurnUsage;
 export type QueuedTurn = QueuedAgentTurn;
+export type SequencedCodeEventFrame = SequencedEventFrame;


### PR DESCRIPTION
Part of #2313 and #2430. Follows D6 core in #3156.

This slice moves the server and `tidebreak-code-remote` crate from the temporary `Code*` and `ChatId` compatibility names to the canonical session, turn, event, and approval names. The rebase keeps the newer remote-session extraction and native client-execution authorization paths from `main`.

Validation:

- `cargo fmt --all -- --check`
- `cargo check -p tidebreak-code-remote -p tidebreak-server`
- `cargo test -p tidebreak-code-remote` — 37 passed
- `cargo test -p tidebreak-server wire_code_fixtures` — 5 passed
- `cargo test -p tidebreak-server client_execution` — 7 passed
- `cargo test -p tidebreak-server a_permission_mode` — 2 passed
- `cargo test -p tidebreak-server a_live_setting_update_becomes_active_only_after_its_exact_write_commits` — 1 passed
