### PR TITLE
feat(models): add OpenAI Astra support

### DIFF
--- a/crates/tidebreak-server-api/src/routes/code/analytics.rs
+++ b/crates/tidebreak-server-api/src/routes/code/analytics.rs
@@ -21,7 +21,7 @@ use super::types::{
     CodeAnalyticsRange, CodeAnalyticsRepository, CodeAnalyticsSnapshot, CodeAnalyticsTotals,
 };
 
-const PRICES_AS_OF: &str = "2026-08-21";
+const PRICES_AS_OF: &str = "2026-09-03";
 
 #[derive(Debug, Default, Deserialize)]
 pub(crate) struct CodeAnalyticsQuery {
@@ -465,6 +465,7 @@ fn canonical_model_id(model: &str) -> Option<&'static str> {
     // Longer ids first: a bare `claude-fable-5` must not claim the 5.1 row,
     // and Flash-Lite must not read as Flash.
     [
+        "gpt-6-astra",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
         "gpt-5.5",
@@ -512,9 +513,16 @@ fn model_has_dated_suffix(value: &str, id: &str) -> bool {
 
 fn price_for_canonical(model: &str) -> Option<PriceRate> {
     match model {
-        // OpenAI short-context (under 272K) rates. The GPT-5.6 rows are the
-        // only OpenAI models that bill cache writes. Sol's rate is promotional,
-        // published as holding at least through 2026-11-21.
+        // OpenAI short-context (up to 272K) rates. Longer Astra prompts use
+        // multipliers that this canonical table does not model. The GPT-5.6
+        // rows also bill cache writes; Sol's rate is promotional, published as
+        // holding at least through 2026-11-21.
+        "gpt-6-astra" => Some(PriceRate {
+            input: 10_000,
+            output: 50_000,
+            cache_read: 1_000,
+            cache_write: 12_500,
+        }),
         "gpt-5.6-sol" => Some(PriceRate {
             input: 4_000,
             output: 20_000,
@@ -718,6 +726,14 @@ mod tests {
     #[test]
     fn canonical_prices_cover_curated_gateway_ids() {
         assert_eq!(
+            canonical_model_id("model_gateway::gpt-6-astra"),
+            Some("gpt-6-astra")
+        );
+        assert_eq!(
+            canonical_model_id("openai/gpt-6-astra"),
+            Some("gpt-6-astra")
+        );
+        assert_eq!(
             canonical_model_id("model_gateway::gpt-5.6"),
             Some("gpt-5.6-sol")
         );
@@ -801,5 +817,28 @@ mod tests {
             total: 1_610_000,
         });
         assert_eq!(microusd(cost), 3_125_000);
+    }
+
+    #[test]
+    fn gpt_6_astra_uses_the_published_short_context_rates() {
+        let rate = price_for_canonical("gpt-6-astra").unwrap();
+        assert_eq!(
+            rate,
+            PriceRate {
+                input: 10_000,
+                output: 50_000,
+                cache_read: 1_000,
+                cache_write: 12_500,
+            }
+        );
+
+        let cost = rate.cost_millimicrousd(UsageTotals {
+            input: 1_000_000,
+            output: 1_000_000,
+            cache_read: 1_000_000,
+            cache_write: 1_000_000,
+            total: 4_000_000,
+        });
+        assert_eq!(microusd(cost), 73_500_000);
     }
 }

--- a/crates/tidebreak-server/src/model_registry.rs
+++ b/crates/tidebreak-server/src/model_registry.rs
@@ -441,6 +441,23 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         // `max_completion_tokens`. Only the 5.6 generation added `max`.
         reasoning_efforts: EFFORT_NONE_TO_MAX,
     },
+    // Astra is the current flagship, but OpenAI is still rolling access out
+    // and provider discovery does not expose it on the installation used for
+    // verification. Keep it selectable without making an unavailable row the
+    // default-visible recommendation; revisit after rollout and a live turn.
+    ModelSpec {
+        id: "gpt-6-astra",
+        display_name: "GPT-6 Astra",
+        provider: ProviderKind::Openai,
+        verification: VerificationTier::Unverified,
+        recommended: false,
+        context_window: 1_050_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        supports_vendor_web_search: false,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
+    },
     ModelSpec {
         id: "gpt-5.6-terra",
         display_name: "GPT-5.6 Terra",
@@ -1282,10 +1299,12 @@ mod tests {
     }
 
     #[test]
-    fn every_openai_entry_reasons_on_a_caller_selected_effort() {
-        let openai: Vec<_> = models_for(ProviderKind::Openai).collect();
-        assert!(!openai.is_empty());
-        for spec in openai {
+    fn every_gpt_5_entry_reasons_on_a_caller_selected_effort() {
+        let gpt_5: Vec<_> = models_for(ProviderKind::Openai)
+            .filter(|spec| spec.id.starts_with("gpt-5"))
+            .collect();
+        assert!(!gpt_5.is_empty());
+        for spec in gpt_5 {
             assert!(
                 spec.supports_reasoning && spec.supports_reasoning_effort(),
                 "{} is curated on the OpenAI route without the reasoning shape that route sends",
@@ -1320,6 +1339,22 @@ mod tests {
             find("gpt-5.4-nano").unwrap().reasoning_efforts,
             EFFORT_NONE_TO_XHIGH
         );
+    }
+
+    #[test]
+    fn gpt_6_astra_rejects_none_and_exposes_its_documented_contract() {
+        let astra = find_for(ProviderKind::Openai, "gpt-6-astra").unwrap();
+
+        assert_eq!(astra.verification, VerificationTier::Unverified);
+        assert!(!astra.recommended);
+        assert_eq!(astra.context_window, 1_050_000);
+        assert_eq!(astra.max_output_tokens, 128_000);
+        assert!(astra.accepts(InputModality::Text));
+        assert!(astra.accepts(InputModality::Image));
+        assert!(astra.supports_reasoning);
+        assert!(astra.supports_tools());
+        assert_eq!(astra.reasoning_efforts, EFFORT_LOW_TO_MAX);
+        assert!(!astra.reasoning_efforts.contains(&ReasoningEffort::None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add the direct OpenAI `gpt-6-astra` row with a 1,050,000-token context window, 128,000-token output ceiling, text and image input, text output, structured-output/function-tool support, and the `low` through `max` reasoning ladder.
- Keep the existing GPT-5 `none` contracts intact while explicitly pinning that Astra rejects `none`.
- Canonicalize Astra in code-session analytics and add its short-context rates: $10 input, $1 cached input, $12.50 cache write, and $50 output per million tokens. Prompts above 272K input tokens use the published multipliers; the current analytics table intentionally documents only short-context rates.

## Rollout and recommendation

OpenAI documents `gpt-6-astra` as the current snapshot and supports it through Responses, Chat Completions, and Batch. Tidebreak continues to use Responses for native OpenAI tool turns. Custom temperature, `top_p`, and logprobs are unsupported.

API-account rollout is occurring over the coming days, and this installation's live OpenAI provider discovery does not list Astra yet. The exact direct row is therefore `Unverified`; this PR does not claim live end-to-end verification. It is also temporarily `recommended: false`: the curated-model policy makes recommendations default-visible, while the staged rollout would expose a selection that this account cannot currently discover. The row remains selectable from the full catalog. Recommendation can be revisited after rollout and a live direct-route turn.

The native request path required no change: it already posts tool turns to `/responses`, removes temperature for every registry-declared reasoning model, and has no `top_p` or logprobs request fields.

## Checks

- `cargo fmt --all --check`
- `CARGO_NET_OFFLINE=false cargo test --locked -p tidebreak-server --lib model_registry`
- `CARGO_NET_OFFLINE=false CARGO_BUILD_JOBS=1 cargo test --locked -p tidebreak-server --lib routes::code::analytics::tests`
- `CARGO_NET_OFFLINE=false CARGO_BUILD_JOBS=1 cargo test --locked -p tidebreak-server --lib providers::tests::every_curated_model_applies_its_exact_runtime_contract`
- `CARGO_NET_OFFLINE=false CARGO_BUILD_JOBS=1 cargo test --locked -p tidebreak-router --lib openai::tests::tools_and_reasoning_use_responses_shape_together`
- `CARGO_NET_OFFLINE=false CARGO_BUILD_JOBS=1 cargo check --locked -p tidebreak-server`