### PR TITLE
improve(server): the console hand-off lands where the reader was headed

### DIFF
--- a/crates/tidebreak-desktop/ui/src/HostedSignIn.tsx
+++ b/crates/tidebreak-desktop/ui/src/HostedSignIn.tsx
@@ -1,7 +1,7 @@
 import { ExternalLink, RotateCw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import type { HandoffFailure } from "./hostedSession";
+import { consoleSignInUrl, type HandoffFailure } from "./hostedSession";
 import { Logomark } from "./Logomark";
 import { WindowDragStrip } from "./WindowDragStrip";
 
@@ -107,8 +107,8 @@ export function HostedSignIn({
         )}
         {gatewayUrl ? (
           <p>
-            Open the console and choose <strong>Manage Tidebreak</strong> to
-            come back here signed in.
+            Open the console: it signs you in and brings you straight back to
+            this page.
           </p>
         ) : (
           <p>
@@ -123,7 +123,7 @@ export function HostedSignIn({
       <div className="boot-actions">
         {gatewayUrl && (
           <Button size="sm" asChild>
-            <a href={gatewayUrl} rel="noreferrer">
+            <a href={consoleSignInUrl(gatewayUrl)} rel="noreferrer">
               <ExternalLink size={16} aria-hidden />
               Open the console
             </a>

--- a/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { HostedSignInRequired, hostedServerInfo } from "./boot";
 import {
   captureHandoffToken,
+  consoleSignInUrl,
   handoffBearer,
   handoffFailure,
   hostedSession,
@@ -187,3 +188,22 @@ describe("the hosted boot branch", () => {
     });
   });
 });
+
+describe("consoleSignInUrl", () => {
+  it("sends the reader to the console's Tidebreak page with this page as the return path", () => {
+    const win = {
+      location: { pathname: "/connect/nonce-1", search: "?source=slack" },
+    } as unknown as Window;
+    expect(consoleSignInUrl("https://gateway.example.test/", win)).toBe(
+      "https://gateway.example.test/tidebreak?return_to=%2Fconnect%2Fnonce-1%3Fsource%3Dslack",
+    );
+  });
+
+  it("asks for no return path from the root", () => {
+    const win = { location: { pathname: "/", search: "" } } as unknown as Window;
+    expect(consoleSignInUrl("https://gateway.example.test", win)).toBe(
+      "https://gateway.example.test/tidebreak",
+    );
+  });
+});
+

--- a/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
@@ -200,10 +200,11 @@ describe("consoleSignInUrl", () => {
   });
 
   it("asks for no return path from the root", () => {
-    const win = { location: { pathname: "/", search: "" } } as unknown as Window;
+    const win = {
+      location: { pathname: "/", search: "" },
+    } as unknown as Window;
     expect(consoleSignInUrl("https://gateway.example.test", win)).toBe(
       "https://gateway.example.test/tidebreak",
     );
   });
 });
-

--- a/crates/tidebreak-desktop/ui/src/hostedSession.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.ts
@@ -106,4 +106,3 @@ export function consoleSignInUrl(
     ? base
     : `${base}?return_to=${encodeURIComponent(here)}`;
 }
-

--- a/crates/tidebreak-desktop/ui/src/hostedSession.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.ts
@@ -88,3 +88,22 @@ export function resetHostedSessionForTests(): void {
   failure = null;
   session = null;
 }
+
+/**
+ * Where the console signs a reader in and sends them back to this page:
+ * the console's Tidebreak page with this page's path as `return_to`, which
+ * the hand-off carries through to the landing route. A connect card's
+ * approval page survives the round trip this way; the root asks for no
+ * return path at all.
+ */
+export function consoleSignInUrl(
+  gatewayUrl: string,
+  win: Pick<Window, "location"> = window,
+): string {
+  const base = `${gatewayUrl.replace(/\/+$/, "")}/tidebreak`;
+  const here = `${win.location.pathname}${win.location.search}`;
+  return here === "/" || here === ""
+    ? base
+    : `${base}?return_to=${encodeURIComponent(here)}`;
+}
+

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -226,6 +226,27 @@ pub(crate) async fn discovery(State(state): State<AppState>) -> Json<AuthDiscove
 pub(crate) struct HandoffQuery {
     #[serde(default)]
     code: String,
+    /// Where on this machine the page should land once signed in — the
+    /// path a connect card or a deep link brought the reader to before the
+    /// console signed them in. Optional; the root when absent or refused.
+    #[serde(default)]
+    return_to: Option<String>,
+}
+
+/// A return path is a same-origin path: it starts with one slash, carries no
+/// scheme or authority (so no `//host`), no fragment (the bearer rides
+/// there), and no control bytes. Anything else lands on the root instead of
+/// refusing the sign-in — the path is a convenience, the bearer is the point.
+fn handoff_return_path(raw: Option<&str>) -> &str {
+    raw.filter(|path| {
+        path.starts_with('/')
+            && !path.starts_with("//")
+            && !path.starts_with("/\\")
+            && path.len() <= 4096
+            && !path.contains('#')
+            && !path.bytes().any(|byte| byte.is_ascii_control())
+    })
+    .unwrap_or("/")
 }
 
 /// The URL-safe alphabet both a handoff code and a bearer are drawn from.
@@ -251,17 +272,17 @@ fn handoff_landing(state: &AppState) -> String {
         .unwrap_or_default()
 }
 
-/// A `302` to the landing page carrying `fragment` after `#`.
+/// A `302` to `path` on the landing origin carrying `fragment` after `#`.
 ///
 /// The fragment is the one carrier a bearer may ride in: a browser never
 /// sends it to a server, so it is in no access log, and the page clears it
 /// before the router sees it. `no-store` keeps the redirect itself out of a
 /// cache that could replay it.
-fn handoff_redirect(landing: &str, fragment: &str) -> Response {
+fn handoff_redirect(landing: &str, path: &str, fragment: &str) -> Response {
     (
         StatusCode::FOUND,
         [
-            (LOCATION, format!("{landing}/#{fragment}")),
+            (LOCATION, format!("{landing}{path}#{fragment}")),
             (CACHE_CONTROL, "no-store".to_owned()),
             (REFERRER_POLICY, "no-referrer".to_owned()),
         ],
@@ -291,12 +312,19 @@ pub(crate) async fn handoff(
     let landing = handoff_landing(&state);
     let code = query.code.trim();
     if !handoff_code_is_well_formed(code) {
-        return handoff_redirect(&landing, "handoff-failed=invalid");
+        return handoff_redirect(&landing, "/", "handoff-failed=invalid");
     }
+    // A granted bearer lands where the reader was headed; a failure lands
+    // on the root, where the sign-in screen words it.
+    let return_path = handoff_return_path(query.return_to.as_deref());
     match gateway.redeem_handoff(code).await {
-        HandoffOutcome::Granted(bearer) => handoff_redirect(&landing, &format!("handoff={bearer}")),
-        HandoffOutcome::Refused => handoff_redirect(&landing, "handoff-failed=expired"),
-        HandoffOutcome::Unavailable => handoff_redirect(&landing, "handoff-failed=unavailable"),
+        HandoffOutcome::Granted(bearer) => {
+            handoff_redirect(&landing, return_path, &format!("handoff={bearer}"))
+        }
+        HandoffOutcome::Refused => handoff_redirect(&landing, "/", "handoff-failed=expired"),
+        HandoffOutcome::Unavailable => {
+            handoff_redirect(&landing, "/", "handoff-failed=unavailable")
+        }
     }
 }
 

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -2953,6 +2953,25 @@ async fn the_handoff_route_lands_the_page_with_the_bearer_in_the_fragment() {
         landed("?code=mg_ho_good").await,
         "https://machine.example.com/tidebreak/#handoff=mg_at_minted"
     );
+    // A return path lands the signed-in page where the reader was headed —
+    // a connect card's approval page — and only a same-origin path counts:
+    // an authority-shaped or fragment-carrying value falls back to the root.
+    assert_eq!(
+        landed("?code=mg_ho_good&return_to=%2Fconnect%2Fnonce-1%3Fsource%3Dslack").await,
+        "https://machine.example.com/tidebreak/connect/nonce-1?source=slack#handoff=mg_at_minted"
+    );
+    assert_eq!(
+        landed("?code=mg_ho_good&return_to=%2F%2Fevil.example%2F").await,
+        "https://machine.example.com/tidebreak/#handoff=mg_at_minted"
+    );
+    assert_eq!(
+        landed("?code=mg_ho_good&return_to=%2Fconnect%2Fn%23x").await,
+        "https://machine.example.com/tidebreak/#handoff=mg_at_minted"
+    );
+    assert_eq!(
+        landed("?code=mg_ho_stale&return_to=%2Fconnect%2Fnonce-1").await,
+        "https://machine.example.com/tidebreak/#handoff-failed=expired"
+    );
     assert_eq!(
         landed("?code=mg_ho_stale").await,
         "https://machine.example.com/tidebreak/#handoff-failed=expired"
@@ -2980,9 +2999,20 @@ async fn the_handoff_route_lands_the_page_with_the_bearer_in_the_fragment() {
         landed("?code=mg_ho_%3Cscript%3E").await,
         "https://machine.example.com/tidebreak/#handoff-failed=invalid"
     );
+    // Every well-formed code reached the gateway exactly once per landing,
+    // the return-path landings included; the malformed ones never did.
     assert_eq!(
         *seen.lock().unwrap(),
-        vec!["mg_ho_good", "mg_ho_stale", "mg_ho_down", "mg_ho_odd"]
+        vec![
+            "mg_ho_good",
+            "mg_ho_good",
+            "mg_ho_good",
+            "mg_ho_good",
+            "mg_ho_stale",
+            "mg_ho_stale",
+            "mg_ho_down",
+            "mg_ho_odd"
+        ]
     );
 
     // No gateway, no route.


### PR DESCRIPTION
## Why

A hosted machine's browser session lives in the tab the console's Manage Tidebreak action opened (the bearer rides the URL fragment and stays in memory). A link that reaches the machine first, such as the connect approval a Slack card points at, lands on the sign-in screen, and after signing in through the console the reader is on the machine's root with no way back to that page.

## What changes

- `GET /auth/handoff` takes an optional `return_to`: a same-origin path (one leading slash, no authority, no fragment, no control bytes). A granted bearer lands on `<public_url><return_to>#handoff=…`; anything else lands on the root as before. A value that is not a same-origin path falls back to the root rather than refusing the sign-in.
- The hosted sign-in screen's "Open the console" link now goes to the console's `/tidebreak?return_to=<current path>`; that page mints the hand-off with the path and returns the tab (model-gateway side, paired change).

## Checks

- `cargo test -p tidebreak-server the_handoff_route_lands` (return-path landings, the authority-shaped and fragment-carrying refusals, the failure landing)
- `pnpm exec vitest run src/hostedSession.test.ts` (13 passed, two new for `consoleSignInUrl`)
- `tsc --noEmit`, `cargo fmt --check`