### PR TITLE
fix(server): preserve hosted handoff routes

### DIFF
--- a/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
@@ -12,10 +12,14 @@ import {
 } from "./hostedSession";
 import { remoteMachineState } from "./remoteMachine";
 
-function fakeWindow(hash: string): Window & { replaced: string[] } {
+function fakeWindow(
+  hash: string,
+  pathname = "/",
+  search = "",
+): Window & { replaced: string[] } {
   const replaced: string[] = [];
   return {
-    location: { hash, pathname: "/", search: "" },
+    location: { hash, pathname, search },
     history: {
       state: null,
       replaceState: (_state: unknown, _title: string, url: string) => {
@@ -43,6 +47,16 @@ describe("the handoff fragment", () => {
     captureHandoffToken(win);
     expect(handoffBearer()).toBe("mg_at_abc.DEF-123~");
     expect(win.replaced).toEqual(["/"]);
+  });
+
+  it("restores a return route for the hash router while clearing the bearer", () => {
+    const win = fakeWindow(
+      "#handoff=mg_at_abc.DEF-123%7E&return_to=%2Fconnect%2Fnonce-1%3Fsource%3Dslack",
+      "/tidebreak/",
+    );
+    captureHandoffToken(win);
+    expect(handoffBearer()).toBe("mg_at_abc.DEF-123~");
+    expect(win.replaced).toEqual(["/tidebreak/#/connect/nonce-1?source=slack"]);
   });
 
   it("leaves a route fragment alone", () => {
@@ -192,7 +206,11 @@ describe("the hosted boot branch", () => {
 describe("consoleSignInUrl", () => {
   it("sends the reader to the console's Tidebreak page with this page as the return path", () => {
     const win = {
-      location: { pathname: "/connect/nonce-1", search: "?source=slack" },
+      location: {
+        pathname: "/tidebreak/",
+        search: "",
+        hash: "#/connect/nonce-1?source=slack",
+      },
     } as unknown as Window;
     expect(consoleSignInUrl("https://gateway.example.test/", win)).toBe(
       "https://gateway.example.test/tidebreak?return_to=%2Fconnect%2Fnonce-1%3Fsource%3Dslack",
@@ -201,7 +219,7 @@ describe("consoleSignInUrl", () => {
 
   it("asks for no return path from the root", () => {
     const win = {
-      location: { pathname: "/", search: "" },
+      location: { pathname: "/tidebreak/", search: "", hash: "#/" },
     } as unknown as Window;
     expect(consoleSignInUrl("https://gateway.example.test", win)).toBe(
       "https://gateway.example.test/tidebreak",

--- a/crates/tidebreak-desktop/ui/src/hostedSession.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.ts
@@ -27,7 +27,7 @@ export type HostedSession = {
  * server or its access log, and the page clears it before anything else can
  * read it. Tokens are URL-safe by construction; anything else is not a token.
  */
-const HANDOFF_FRAGMENT = /^#handoff=([A-Za-z0-9._~-]+)$/;
+const HANDOFF_TOKEN = /^[A-Za-z0-9._~-]+$/;
 
 /**
  * Why the machine's landing route could not hand the page a bearer. The
@@ -50,15 +50,41 @@ let session: HostedSession | null = null;
  * this page's life — long enough for boot to retry — and nowhere else.
  */
 export function captureHandoffToken(win: Window = window): void {
+  const handoff = handoffEnvelope(win.location.hash);
   const failed = HANDOFF_FAILURE_FRAGMENT.exec(win.location.hash);
-  const match = HANDOFF_FRAGMENT.exec(win.location.hash);
-  if (!failed && !match) return;
+  if (!failed && !handoff) return;
   if (failed) failure = failed[1] as HandoffFailure;
-  if (match) handoffToken = match[1];
+  if (handoff) handoffToken = handoff.token;
   win.history.replaceState(
     win.history.state,
     "",
-    `${win.location.pathname}${win.location.search}`,
+    `${win.location.pathname}${win.location.search}${handoff?.returnRoute ? `#${handoff.returnRoute}` : ""}`,
+  );
+}
+
+function handoffEnvelope(
+  hash: string,
+): { token: string; returnRoute: string | null } | null {
+  if (!hash.startsWith("#handoff=")) return null;
+  const params = new URLSearchParams(hash.slice(1));
+  const tokens = params.getAll("handoff");
+  if (tokens.length !== 1 || !HANDOFF_TOKEN.test(tokens[0])) return null;
+  const routes = params.getAll("return_to");
+  const returnRoute =
+    routes.length === 1 && isHandoffReturnRoute(routes[0]) ? routes[0] : null;
+  return { token: tokens[0], returnRoute };
+}
+
+function isHandoffReturnRoute(route: string): boolean {
+  return (
+    route.startsWith("/") &&
+    !route.startsWith("//") &&
+    !route.startsWith("/\\") &&
+    !route.includes("#") &&
+    route.length <= 4096 &&
+    !Array.from(route).some((character) =>
+      /[\u0000-\u001f\u007f]/.test(character),
+    )
   );
 }
 
@@ -91,18 +117,18 @@ export function resetHostedSessionForTests(): void {
 
 /**
  * Where the console signs a reader in and sends them back to this page:
- * the console's Tidebreak page with this page's path as `return_to`, which
- * the hand-off carries through to the landing route. A connect card's
- * approval page survives the round trip this way; the root asks for no
- * return path at all.
+ * the console's Tidebreak page with this page's hash-router route as
+ * `return_to`, which the hand-off carries through to the landing page. A
+ * connect card's approval page survives the round trip this way; the root
+ * asks for no return route at all.
  */
 export function consoleSignInUrl(
   gatewayUrl: string,
   win: Pick<Window, "location"> = window,
 ): string {
   const base = `${gatewayUrl.replace(/\/+$/, "")}/tidebreak`;
-  const here = `${win.location.pathname}${win.location.search}`;
-  return here === "/" || here === ""
-    ? base
-    : `${base}?return_to=${encodeURIComponent(here)}`;
+  const here = win.location.hash.startsWith("#/")
+    ? win.location.hash.slice(1)
+    : "/";
+  return here === "/" ? base : `${base}?return_to=${encodeURIComponent(here)}`;
 }

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -226,25 +226,25 @@ pub(crate) async fn discovery(State(state): State<AppState>) -> Json<AuthDiscove
 pub(crate) struct HandoffQuery {
     #[serde(default)]
     code: String,
-    /// Where on this machine the page should land once signed in — the
-    /// path a connect card or a deep link brought the reader to before the
-    /// console signed them in. Optional; the root when absent or refused.
+    /// Which UI route should open once the page is signed in — the hash-router
+    /// path a connect card or deep link opened before the console took over.
+    /// Optional; the root when absent or refused.
     #[serde(default)]
     return_to: Option<String>,
 }
 
-/// A return path is a same-origin path: it starts with one slash, carries no
-/// scheme or authority (so no `//host`), no fragment (the bearer rides
-/// there), and no control bytes. Anything else lands on the root instead of
-/// refusing the sign-in — the path is a convenience, the bearer is the point.
-fn handoff_return_path(raw: Option<&str>) -> &str {
-    raw.filter(|path| {
-        path.starts_with('/')
-            && !path.starts_with("//")
-            && !path.starts_with("/\\")
-            && path.len() <= 4096
-            && !path.contains('#')
-            && !path.bytes().any(|byte| byte.is_ascii_control())
+/// A return route is a hash-router path: it starts with one slash, carries no
+/// scheme or authority (so no `//host`), no nested fragment, and no control
+/// bytes. Anything else lands on the root instead of refusing the sign-in —
+/// the route is a convenience, and the bearer is the point.
+fn handoff_return_route(raw: Option<&str>) -> &str {
+    raw.filter(|route| {
+        route.starts_with('/')
+            && !route.starts_with("//")
+            && !route.starts_with("/\\")
+            && route.len() <= 4096
+            && !route.contains('#')
+            && !route.bytes().any(|byte| byte.is_ascii_control())
     })
     .unwrap_or("/")
 }
@@ -272,17 +272,27 @@ fn handoff_landing(state: &AppState) -> String {
         .unwrap_or_default()
 }
 
-/// A `302` to `path` on the landing origin carrying `fragment` after `#`.
+/// A `302` to the landing page carrying a handoff envelope after `#`.
 ///
-/// The fragment is the one carrier a bearer may ride in: a browser never
-/// sends it to a server, so it is in no access log, and the page clears it
-/// before the router sees it. `no-store` keeps the redirect itself out of a
-/// cache that could replay it.
-fn handoff_redirect(landing: &str, path: &str, fragment: &str) -> Response {
+/// The envelope carries the bearer and optional hash-router route. A browser
+/// never sends the fragment to a server, so it is in no access log, and the
+/// page clears the bearer before the router sees it. `no-store` keeps the
+/// redirect itself out of a cache that could replay it.
+fn handoff_redirect(
+    landing: &str,
+    handoff_key: &str,
+    handoff_value: &str,
+    return_route: Option<&str>,
+) -> Response {
+    let mut fragment = url::form_urlencoded::Serializer::new(String::new());
+    fragment.append_pair(handoff_key, handoff_value);
+    if let Some(route) = return_route.filter(|route| *route != "/") {
+        fragment.append_pair("return_to", route);
+    }
     (
         StatusCode::FOUND,
         [
-            (LOCATION, format!("{landing}{path}#{fragment}")),
+            (LOCATION, format!("{landing}/#{}", fragment.finish())),
             (CACHE_CONTROL, "no-store".to_owned()),
             (REFERRER_POLICY, "no-referrer".to_owned()),
         ],
@@ -312,18 +322,18 @@ pub(crate) async fn handoff(
     let landing = handoff_landing(&state);
     let code = query.code.trim();
     if !handoff_code_is_well_formed(code) {
-        return handoff_redirect(&landing, "/", "handoff-failed=invalid");
+        return handoff_redirect(&landing, "handoff-failed", "invalid", None);
     }
     // A granted bearer lands where the reader was headed; a failure lands
     // on the root, where the sign-in screen words it.
-    let return_path = handoff_return_path(query.return_to.as_deref());
+    let return_route = handoff_return_route(query.return_to.as_deref());
     match gateway.redeem_handoff(code).await {
         HandoffOutcome::Granted(bearer) => {
-            handoff_redirect(&landing, return_path, &format!("handoff={bearer}"))
+            handoff_redirect(&landing, "handoff", &bearer, Some(return_route))
         }
-        HandoffOutcome::Refused => handoff_redirect(&landing, "/", "handoff-failed=expired"),
+        HandoffOutcome::Refused => handoff_redirect(&landing, "handoff-failed", "expired", None),
         HandoffOutcome::Unavailable => {
-            handoff_redirect(&landing, "/", "handoff-failed=unavailable")
+            handoff_redirect(&landing, "handoff-failed", "unavailable", None)
         }
     }
 }

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -2959,7 +2959,7 @@ async fn the_handoff_route_lands_the_page_with_the_bearer_in_the_fragment() {
     // an authority-shaped or fragment-carrying value falls back to the root.
     assert_eq!(
         landed("?code=mg_ho_good&return_to=%2Fconnect%2Fnonce-1%3Fsource%3Dslack").await,
-        "https://machine.example.com/tidebreak/connect/nonce-1?source=slack#handoff=mg_at_minted"
+        "https://machine.example.com/tidebreak/#handoff=mg_at_minted&return_to=%2Fconnect%2Fnonce-1%3Fsource%3Dslack"
     );
     assert_eq!(
         landed("?code=mg_ho_good&return_to=%2F%2Fevil.example%2F").await,


### PR DESCRIPTION
## Why

Hosted Tidebreak uses hash history. The sign-in link sent the document path as `return_to`, and the handoff route redirected that value as a server path. Deep links therefore lost their UI route and could request a path that the hosted renderer did not serve.

## What changes

- Read `return_to` from the current `#/…` route instead of the document path.
- Keep the handoff redirect on the hosted document root.
- Carry the target route beside the bearer in the fragment, then restore it before TanStack Router starts.
- Cover path-prefixed hosted deployments and encoded bearer characters.

## Checks

- `cargo test -p tidebreak-server the_handoff_route_lands`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/hostedSession.test.ts` (`14 passed`)
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/hostedSession.ts src/hostedSession.test.ts`
- `cargo fmt --check`
- `git diff --check`