### PR TITLE
ci: accept extracted server API dependency

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -627,7 +627,7 @@ test("PR lanes are scope-gated, never label-gated", () => {
   }
   assert.match(
     desktopCargo,
-    /tidebreak-server = \{ path = "\.\.\/tidebreak-server" \}/,
+    /tidebreak-server = \{ path = "\.\.\/tidebreak-server(?:-api)?" \}/,
   );
   assert.doesNotMatch(desktopCargo, /document-parsers/);
 });


### PR DESCRIPTION
Updates the trusted release-policy test to accept the existing server crate path and the extracted server API crate path. The test still requires the desktop to depend directly on the `tidebreak-server` package.

Validation:
- `node --test scripts/workflow-security.test.mjs`
- Ran the updated trusted policy against the #3174 worktree; all 47 tests passed.