### PR TITLE
ci: prevent UI timeouts and speed x64 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,20 +859,22 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.ui == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Keep enough headroom for a cold package install. A timeout reports as a
+    # cancelled job and makes an otherwise healthy main run red.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: crates/tidebreak-desktop/ui
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Enable pinned pnpm
+        run: |
+          corepack enable
+          corepack install --global pnpm@10.18.3
+          node -e 'const version = require("node:child_process").execFileSync("pnpm", ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
       - name: Install UI dependencies
         run: pnpm install --frozen-lockfile
       - name: Format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -990,14 +990,14 @@ jobs:
           install -m 755 "$PREPARED_ROOT/$cli_sidecar" "$cli_sidecar"
           install -m 644 "$PREPARED_ROOT/release-config.json" "$RELEASE_CONFIG"
 
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-      - name: Enable pinned pnpm
-        run: |
-          corepack enable
-          corepack install --global pnpm@10.18.3
-          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
+          cache: pnpm
+          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
       - name: Install pinned Tauri bundler
         run: |
           pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts
@@ -1588,14 +1588,14 @@ jobs:
           cp -p "$PREPARED_ROOT/$cli_sidecar" "$cli_sidecar"
           cp "$PREPARED_ROOT/release-config.json" "$RELEASE_CONFIG"
 
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-      - name: Enable pinned pnpm
-        run: |
-          corepack enable
-          corepack install --global pnpm@10.18.3
-          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
+          cache: pnpm
+          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
       - name: Install pinned Tauri bundler
         run: |
           pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,14 +248,17 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github/vercel-cli
           sparse-checkout-cone-mode: false
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: .github/vercel-cli/pnpm-lock.yaml
+      # pnpm/action-setup installs a bootstrap release and then self-updates it.
+      # That step has taken seven minutes on otherwise healthy hosted runners.
+      # Node 22's Corepack installs the exact project pin directly.
+      - name: Enable pinned pnpm
+        run: |
+          corepack enable
+          corepack install --global pnpm@10.18.3
+          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
       - name: Install the locked deployment client
         run: pnpm --dir .github/vercel-cli install --frozen-lockfile --ignore-scripts
       - name: Download the inert prebuilt documentation
@@ -987,14 +990,14 @@ jobs:
           install -m 755 "$PREPARED_ROOT/$cli_sidecar" "$cli_sidecar"
           install -m 644 "$PREPARED_ROOT/release-config.json" "$RELEASE_CONFIG"
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
+      - name: Enable pinned pnpm
+        run: |
+          corepack enable
+          corepack install --global pnpm@10.18.3
+          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
       - name: Install pinned Tauri bundler
         run: |
           pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts
@@ -1300,7 +1303,7 @@ jobs:
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: ${{ vars.RELEASE_WINDOWS_X64_RUNNER || 'windows-latest' }}
           - arch: aarch64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
@@ -1524,7 +1527,7 @@ jobs:
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: ${{ vars.RELEASE_WINDOWS_X64_RUNNER || 'windows-latest' }}
           - arch: aarch64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
@@ -1585,14 +1588,14 @@ jobs:
           cp -p "$PREPARED_ROOT/$cli_sidecar" "$cli_sidecar"
           cp "$PREPARED_ROOT/release-config.json" "$RELEASE_CONFIG"
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
+      - name: Enable pinned pnpm
+        run: |
+          corepack enable
+          corepack install --global pnpm@10.18.3
+          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
       - name: Install pinned Tauri bundler
         run: |
           pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -686,5 +686,10 @@ repository variable `CI_WINDOWS_RUNNER` to the provisioned x64 label. If you
 omit the variable, the job uses `windows-latest`. Do not point the variable at
 an ARM runner: the lane compiles `x86_64-pc-windows-msvc`.
 
+To run the x86_64 Windows release compile and packaging jobs on the same larger
+runner, set `RELEASE_WINDOWS_X64_RUNNER` to the provisioned x64 label. If you
+omit the variable, both jobs use `windows-latest`. Windows ARM64 stays on the
+native `windows-11-arm` runner required by decision 43.
+
 The release-draft workflow uses the built-in `GITHUB_TOKEN`; it does not require
 a personal access token.

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -497,10 +497,7 @@ const mutations = [
     expected: "signing jobs run installers before loading signing material",
     mutate: (source) =>
       editWorkflowJob(source, "build_macos", (job) =>
-        job.replace(
-          "corepack install --global pnpm@10.18.3",
-          "corepack install --global pnpm@latest",
-        ),
+        job.replace(/version: 10(?:\.18\.3)?\n/, "version: latest\n"),
       ),
   },
   {
@@ -528,10 +525,7 @@ const mutations = [
     expected: "signing jobs run installers before loading signing material",
     mutate: (source) =>
       editWorkflowJob(source, "build_macos", (job) =>
-        job.replace(
-          "corepack install --global pnpm@10.18.3",
-          "corepack install --global pnpm@10",
-        ),
+        job.replace(/version: 10\.18\.3\n/, "version: 10\n"),
       ),
   },
   {

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -497,7 +497,10 @@ const mutations = [
     expected: "signing jobs run installers before loading signing material",
     mutate: (source) =>
       editWorkflowJob(source, "build_macos", (job) =>
-        job.replace(/version: 10(?:\.18\.3)?\n/, "version: latest\n"),
+        job.replace(
+          "corepack install --global pnpm@10.18.3",
+          "corepack install --global pnpm@latest",
+        ),
       ),
   },
   {
@@ -525,7 +528,10 @@ const mutations = [
     expected: "signing jobs run installers before loading signing material",
     mutate: (source) =>
       editWorkflowJob(source, "build_macos", (job) =>
-        job.replace(/version: 10\.18\.3\n/, "version: 10\n"),
+        job.replace(
+          "corepack install --global pnpm@10.18.3",
+          "corepack install --global pnpm@10",
+        ),
       ),
   },
   {

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -757,6 +757,9 @@ test("UI tests and production build each gate the UI lane", () => {
   const ui = workflowJob(ci, "ui");
 
   assert.match(ui, /if:.*needs\.changes\.outputs\.ui == 'true'/);
+  assert.match(ui, /timeout-minutes: 20/);
+  assert.match(ui, /corepack install --global pnpm@10\.18\.3/);
+  assert.doesNotMatch(ui, /uses: pnpm\/action-setup/);
   assert.match(ui, /run: pnpm install --frozen-lockfile/);
   // Sequential steps, one command each: a backgrounded `a & b & wait` swallows
   // the children's exit codes, so a failing test or build reported success
@@ -1587,6 +1590,8 @@ test("release documentation is built from the validated tag and promoted only af
   assert.equal(vercelCliPackage.dependencies.vercel, "59.0.0");
   assert.match(publish, /sparse-checkout: \.github\/vercel-cli/);
   assert.match(publish, /persist-credentials: false/);
+  assert.match(publish, /corepack install --global pnpm@10\.18\.3/);
+  assert.doesNotMatch(publish, /uses: pnpm\/action-setup/);
   assert.match(
     publish,
     /pnpm --dir \.github\/vercel-cli install --frozen-lockfile --ignore-scripts/,
@@ -1672,12 +1677,26 @@ test("release compilation uses S3 without cache warmer workflows", () => {
 
   const prepareMacos = workflowJob(release, "prepare_macos");
   const prepareWindows = workflowJob(release, "prepare_windows");
+  const buildMacos = workflowJob(release, "build_macos");
+  const buildWindows = workflowJob(release, "build_windows");
   const buildLinux = workflowJob(release, "build_linux");
   assert.doesNotMatch(prepareMacos, /restore-keys:/);
   assert.doesNotMatch(prepareWindows, /restore-keys:/);
   assert.doesNotMatch(prepareWindows, /windows-release-target-v1-/);
   assert.doesNotMatch(buildLinux, /actions\/cache\/restore@/);
   assert.doesNotMatch(buildLinux, /linux-release-target-v1-/);
+  assert.match(
+    prepareWindows,
+    /vars\.RELEASE_WINDOWS_X64_RUNNER \|\| 'windows-latest'/,
+  );
+  assert.match(
+    buildWindows,
+    /vars\.RELEASE_WINDOWS_X64_RUNNER \|\| 'windows-latest'/,
+  );
+  for (const job of [buildMacos, buildWindows]) {
+    assert.match(job, /corepack install --global pnpm@10\.18\.3/);
+    assert.doesNotMatch(job, /uses: pnpm\/action-setup/);
+  }
 
   for (const workflow of [release]) {
     const downloadCaches = [
@@ -1788,7 +1807,9 @@ test("signing jobs run installers before loading signing material", () => {
     const label = `${name} (${file})`;
     const secretsAt = firstSigningMaterialIndex(job, validate);
     assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
-    const pnpmAt = job.search(/pnpm\/action-setup@[0-9a-f]{40}/);
+    const pnpmAt = job.search(
+      /(?:pnpm\/action-setup@[0-9a-f]{40}|corepack install --global pnpm@10\.18\.3)/,
+    );
     const nodeAt = job.search(/actions\/setup-node@[0-9a-f]{40}/);
     assert.ok(pnpmAt !== -1, `${label} must set up pnpm`);
     assert.ok(nodeAt !== -1, `${label} must set up Node`);
@@ -1802,7 +1823,11 @@ test("signing jobs run installers before loading signing material", () => {
     assert.ok(installAt !== -1, `${label} must have a frozen-lockfile install step`);
     assert.ok(installAt < secretsAt, `${label} must install dependencies before signing material`);
     // pnpm must be pinned to an exact version, not floating.
-    assert.match(job, /version: 10\.18\.3\n/, `${label} must pin pnpm 10.18.3`);
+    assert.match(
+      job,
+      /(?:version: 10\.18\.3\n|corepack install --global pnpm@10\.18\.3)/,
+      `${label} must pin pnpm 10.18.3`,
+    );
     // Installs must be frozen-lockfile with lifecycle scripts disabled.
     assert.match(
       job,

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1677,8 +1677,6 @@ test("release compilation uses S3 without cache warmer workflows", () => {
 
   const prepareMacos = workflowJob(release, "prepare_macos");
   const prepareWindows = workflowJob(release, "prepare_windows");
-  const buildMacos = workflowJob(release, "build_macos");
-  const buildWindows = workflowJob(release, "build_windows");
   const buildLinux = workflowJob(release, "build_linux");
   assert.doesNotMatch(prepareMacos, /restore-keys:/);
   assert.doesNotMatch(prepareWindows, /restore-keys:/);
@@ -1690,13 +1688,9 @@ test("release compilation uses S3 without cache warmer workflows", () => {
     /vars\.RELEASE_WINDOWS_X64_RUNNER \|\| 'windows-latest'/,
   );
   assert.match(
-    buildWindows,
+    workflowJob(release, "build_windows"),
     /vars\.RELEASE_WINDOWS_X64_RUNNER \|\| 'windows-latest'/,
   );
-  for (const job of [buildMacos, buildWindows]) {
-    assert.match(job, /corepack install --global pnpm@10\.18\.3/);
-    assert.doesNotMatch(job, /uses: pnpm\/action-setup/);
-  }
 
   for (const workflow of [release]) {
     const downloadCaches = [
@@ -1807,9 +1801,7 @@ test("signing jobs run installers before loading signing material", () => {
     const label = `${name} (${file})`;
     const secretsAt = firstSigningMaterialIndex(job, validate);
     assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
-    const pnpmAt = job.search(
-      /(?:pnpm\/action-setup@[0-9a-f]{40}|corepack install --global pnpm@10\.18\.3)/,
-    );
+    const pnpmAt = job.search(/pnpm\/action-setup@[0-9a-f]{40}/);
     const nodeAt = job.search(/actions\/setup-node@[0-9a-f]{40}/);
     assert.ok(pnpmAt !== -1, `${label} must set up pnpm`);
     assert.ok(nodeAt !== -1, `${label} must set up Node`);
@@ -1823,11 +1815,7 @@ test("signing jobs run installers before loading signing material", () => {
     assert.ok(installAt !== -1, `${label} must have a frozen-lockfile install step`);
     assert.ok(installAt < secretsAt, `${label} must install dependencies before signing material`);
     // pnpm must be pinned to an exact version, not floating.
-    assert.match(
-      job,
-      /(?:version: 10\.18\.3\n|corepack install --global pnpm@10\.18\.3)/,
-      `${label} must pin pnpm 10.18.3`,
-    );
+    assert.match(job, /version: 10\.18\.3\n/, `${label} must pin pnpm 10.18.3`);
     // Installs must be frozen-lockfile with lifecycle scripts disabled.
     assert.match(
       job,


### PR DESCRIPTION
The desktop UI job timed out after pnpm/action-setup consumed most of its 10-minute limit. The last desktop release also spent about 39 minutes compiling each Windows target despite real S3 compiler-cache hits.

This change installs the exact pnpm pin through Node 22 Corepack in the UI job and release documentation publisher, raises the UI timeout to 20 minutes for cold installs, and runs x86_64 Windows release compilation and packaging on the existing 8-core larger runner. Windows ARM64 remains on its required native runner.

The repository variable `RELEASE_WINDOWS_X64_RUNNER` is set to `windows-latest-l`.

Validation:
- `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs` (94 passed)
- `git diff --check`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml` (one existing SC2016 at release.yml:2199)