### PR TITLE
ci(release): parallelize Windows preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1281,7 +1281,7 @@ jobs:
           [[ -z "${APPLE_CERTIFICATE_PATH:-}" ]] \
             || rm -f "$APPLE_CERTIFICATE_PATH"
 
-  prepare_windows_sidecars:
+  prepare_windows:
     name: prepare unsigned Windows sidecars · ${{ matrix.arch }}
     needs: [validate, inspect_hosted, notices]
     if: >-
@@ -1303,7 +1303,7 @@ jobs:
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: ${{ vars.RELEASE_WINDOWS_X64_RUNNER || 'windows-latest' }}
           - arch: aarch64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
@@ -1334,8 +1334,10 @@ jobs:
             target/${{ matrix.target }}/release/.fingerprint
             target/${{ matrix.target }}/release/build
             target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop.exe
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe
             target/${{ matrix.target }}/release/tidebreak.exe
+            target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
             crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
           key: windows-release-sidecars-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
@@ -1345,8 +1347,10 @@ jobs:
       - name: Discard restored sidecar product binaries
         run: |
           rm -rf \
+            target/${{ matrix.target }}/release/tidebreak-desktop.exe \
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe \
             target/${{ matrix.target }}/release/tidebreak.exe \
+            target/${{ matrix.target }}/release/tidebreak_desktop_lib.* \
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe \
             crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
 
@@ -1387,8 +1391,10 @@ jobs:
             target/${{ matrix.target }}/release/.fingerprint
             target/${{ matrix.target }}/release/build
             target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop.exe
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe
             target/${{ matrix.target }}/release/tidebreak.exe
+            target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
             crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
           key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
@@ -1470,7 +1476,7 @@ jobs:
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: ${{ vars.RELEASE_WINDOWS_X64_RUNNER || 'windows-latest' }}
           - arch: aarch64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
@@ -1656,7 +1662,7 @@ jobs:
 
   build_windows:
     name: Windows · ${{ matrix.arch }}
-    needs: [validate, inspect_hosted, notices, prepare_windows_sidecars, prepare_windows_desktop]
+    needs: [validate, inspect_hosted, notices, prepare_windows, prepare_windows_desktop]
     if: >-
       ${{
         always()
@@ -1665,7 +1671,7 @@ jobs:
         && needs.inspect_hosted.result == 'success'
         && needs.inspect_hosted.outputs.exists != 'true'
         && needs.notices.result == 'success'
-        && needs.prepare_windows_sidecars.result == 'success'
+        && needs.prepare_windows.result == 'success'
         && needs.prepare_windows_desktop.result == 'success'
       }}
     runs-on: ${{ matrix.runner }}
@@ -1682,7 +1688,7 @@ jobs:
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: ${{ vars.RELEASE_WINDOWS_X64_RUNNER || 'windows-latest' }}
           - arch: aarch64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
@@ -1772,14 +1778,14 @@ jobs:
           cp -p "$SIDECARS_ROOT/$cli_sidecar" "$cli_sidecar"
           cp "$DESKTOP_ROOT/release-config.json" "$RELEASE_CONFIG"
 
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-      - name: Enable pinned pnpm
-        run: |
-          corepack enable
-          corepack install --global pnpm@10.18.3
-          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
+          cache: pnpm
+          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
       - name: Install pinned Tauri bundler
         run: |
           pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1281,8 +1281,8 @@ jobs:
           [[ -z "${APPLE_CERTIFICATE_PATH:-}" ]] \
             || rm -f "$APPLE_CERTIFICATE_PATH"
 
-  prepare_windows:
-    name: prepare unsigned Windows · ${{ matrix.arch }}
+  prepare_windows_sidecars:
+    name: prepare unsigned Windows sidecars · ${{ matrix.arch }}
     needs: [validate, inspect_hosted, notices]
     if: >-
       ${{
@@ -1303,7 +1303,7 @@ jobs:
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
-            runner: ${{ vars.RELEASE_WINDOWS_X64_RUNNER || 'windows-latest' }}
+            runner: windows-latest
           - arch: aarch64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
@@ -1312,25 +1312,6 @@ jobs:
       RUSTC_WRAPPER: sccache
       TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
     steps:
-      # Generate this file before checking out the tag. Code from the release
-      # source cannot influence the command that creates the build configuration.
-      - name: Write tag-derived Tauri configuration
-        env:
-          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
-        run: |
-          node -e '
-            const fs = require("node:fs");
-            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
-              version: process.env.TIDEBREAK_VERSION,
-              // NSIS supports per-user installs without elevation and needs
-              // no WiX configuration.
-              bundle: { targets: ["nsis"] },
-              // Release bundles register only the real scheme. A release
-              // binary refuses tidebreak-dev:// links by design.
-              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
-            }));
-          '
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.validate.outputs.sha }}
@@ -1340,7 +1321,7 @@ jobs:
           rustup show
           rustup target add "${{ matrix.target }}"
 
-      - name: Restore unsigned Rust build cache
+      - name: Restore unsigned sidecar build cache
         id: rust-build-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -1353,23 +1334,19 @@ jobs:
             target/${{ matrix.target }}/release/.fingerprint
             target/${{ matrix.target }}/release/build
             target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop.exe
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe
             target/${{ matrix.target }}/release/tidebreak.exe
-            target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
             crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
-          key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: windows-release-sidecars-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
 
       # The release version is a compile-time input. Rebuild every shipped
       # product even when an exact retry restores this release's cache.
-      - name: Discard restored product binaries
+      - name: Discard restored sidecar product binaries
         run: |
           rm -rf \
-            target/${{ matrix.target }}/release/tidebreak-desktop.exe \
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe \
             target/${{ matrix.target }}/release/tidebreak.exe \
-            target/${{ matrix.target }}/release/tidebreak_desktop_lib.* \
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe \
             crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
 
@@ -1390,19 +1367,213 @@ jobs:
           # A duplicate save against an existing key is skipped harmlessly.
           save-if: true
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - name: Compile sidecars without production credentials
+        id: compile
+        continue-on-error: true
+        env:
+          TAURI_ENV_TARGET_TRIPLE: ${{ matrix.target }}
+        run: node crates/tidebreak-desktop/scripts/prepare-sidecar.mjs --release
+
+      - name: Save release-specific unsigned sidecar build cache
+        if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          version: 10.18.3
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-host-broker.exe
+            target/${{ matrix.target }}/release/tidebreak.exe
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
+            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
+          key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
+
+      - name: Require successful sidecar compilation
+        if: ${{ steps.compile.outcome != 'success' }}
+        run: exit 1
+
+      - name: Archive prepared Windows sidecars
+        env:
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-windows-sidecars
+          RELEASE_TARGET: ${{ matrix.target }}
+        run: |
+          # GNU tar treats C:\path as a remote host and \ as escapes. Stay on
+          # POSIX paths for every tar argument.
+          PREPARED_ROOT="$(cygpath -u "$PREPARED_ROOT")"
+          workspace="$(cygpath -u "$GITHUB_WORKSPACE")"
+          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe"
+          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe"
+          for file in "$broker_sidecar" "$cli_sidecar"; do
+            [[ -s "$file" ]] || {
+              echo "Prepared Windows sidecar is missing or empty: $file" >&2
+              exit 1
+            }
+          done
+
+          rm -rf "$PREPARED_ROOT"
+          mkdir -p "$PREPARED_ROOT/crates/tidebreak-desktop/binaries"
+          cp -p "$broker_sidecar" "$PREPARED_ROOT/$broker_sidecar"
+          cp -p "$cli_sidecar" "$PREPARED_ROOT/$cli_sidecar"
+
+          (
+            cd "$PREPARED_ROOT"
+            sha256sum \
+              "$broker_sidecar" \
+              "$cli_sidecar" \
+              > SHA256SUMS
+          )
+          (
+            cd "$workspace"
+            tar -cf prepared-windows-sidecars.tar -C "$PREPARED_ROOT" \
+              SHA256SUMS \
+              crates
+            sha256sum prepared-windows-sidecars.tar \
+              > prepared-windows-sidecars.tar.sha256
+          )
+
+      - name: Upload prepared Windows sidecars
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-prepared-windows-sidecars-${{ matrix.arch }}-${{ github.run_id }}
+          path: |
+            prepared-windows-sidecars.tar
+            prepared-windows-sidecars.tar.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+  prepare_windows_desktop:
+    name: prepare unsigned Windows desktop · ${{ matrix.arch }}
+    needs: [validate, inspect_hosted, notices]
+    if: >-
+      ${{
+        needs.validate.outputs.draft == 'true'
+        && needs.inspect_hosted.outputs.exists != 'true'
+      }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-pc-windows-msvc
+            runner: windows-latest
+          - arch: aarch64
+            target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+      TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      # Generate this file before checking out the tag. Code from the release
+      # source cannot influence the command that creates the build configuration.
+      - name: Write tag-derived Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
+              version: process.env.TIDEBREAK_VERSION,
+              build: {
+                beforeBuildCommand: { script: "pnpm build", cwd: "ui" }
+              },
+              // NSIS supports per-user installs without elevation and needs
+              // no WiX configuration.
+              bundle: { targets: ["nsis"] },
+              // Release bundles register only the real scheme. A release
+              // binary refuses tidebreak-dev:// links by design.
+              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
+            }));
+          '
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      - name: Restore unsigned desktop build cache
+        id: rust-build-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop.exe
+            target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
+          key: windows-release-desktop-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+
+      - name: Discard restored desktop product binaries
+        run: |
+          rm -rf \
+            target/${{ matrix.target }}/release/tidebreak-desktop.exe \
+            target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
+
+      # The desktop build script requires target-named sidecars in release
+      # mode. The packaging job replaces these inert files with verified
+      # sidecars from the parallel preparation job.
+      - name: Stage inert sidecars for desktop compilation
+        env:
+          RELEASE_TARGET: ${{ matrix.target }}
+        run: |
+          mkdir -p crates/tidebreak-desktop/binaries
+          printf 'MZ' \
+            > "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe"
+          printf 'MZ' \
+            > "crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe"
+
+      - name: Set up compiler cache
+        uses: ./.github/actions/setup-sccache-s3
+        with:
+          access: write
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: true
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Enable pinned pnpm
+        run: |
+          corepack enable
+          corepack install --global pnpm@10.18.3
+          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
       - name: Install UI dependencies
         working-directory: crates/tidebreak-desktop/ui
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Compile without production credentials or bundles
+      - name: Compile desktop without production credentials or bundles
         id: compile
         continue-on-error: true
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
@@ -1414,7 +1585,7 @@ jobs:
             --no-bundle
             --ci
 
-      - name: Save release-specific unsigned Rust build cache
+      - name: Save release-specific unsigned desktop build cache
         if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -1428,73 +1599,56 @@ jobs:
             target/${{ matrix.target }}/release/build
             target/${{ matrix.target }}/release/deps
             target/${{ matrix.target }}/release/tidebreak-desktop.exe
-            target/${{ matrix.target }}/release/tidebreak-host-broker.exe
-            target/${{ matrix.target }}/release/tidebreak.exe
             target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
-            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
           key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
 
-      - name: Require a successful unsigned compilation
+      - name: Require successful desktop compilation
         if: ${{ steps.compile.outcome != 'success' }}
         run: exit 1
 
-      - name: Archive prepared Windows inputs
+      - name: Archive prepared Windows desktop
         env:
-          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-windows
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-windows-desktop
           RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
           RELEASE_TARGET: ${{ matrix.target }}
         run: |
-          # GNU tar treats C:\path as a remote host and \ as escapes. Stay on
-          # POSIX paths for every tar argument.
           PREPARED_ROOT="$(cygpath -u "$PREPARED_ROOT")"
           RELEASE_CONFIG="$(cygpath -u "$RELEASE_CONFIG")"
           workspace="$(cygpath -u "$GITHUB_WORKSPACE")"
           app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop.exe"
-          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe"
-          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe"
-          for file in "$app_binary" "$broker_sidecar" "$cli_sidecar" "$RELEASE_CONFIG"; do
+          for file in "$app_binary" "$RELEASE_CONFIG"; do
             [[ -s "$file" ]] || {
-              echo "Prepared Windows input is missing or empty: $file" >&2
+              echo "Prepared Windows desktop input is missing or empty: $file" >&2
               exit 1
             }
           done
 
           rm -rf "$PREPARED_ROOT"
-          mkdir -p \
-            "$PREPARED_ROOT/target/$RELEASE_TARGET/release" \
-            "$PREPARED_ROOT/crates/tidebreak-desktop/binaries"
+          mkdir -p "$PREPARED_ROOT/target/$RELEASE_TARGET/release"
           cp -p "$app_binary" "$PREPARED_ROOT/$app_binary"
-          cp -p "$broker_sidecar" "$PREPARED_ROOT/$broker_sidecar"
-          cp -p "$cli_sidecar" "$PREPARED_ROOT/$cli_sidecar"
           cp "$RELEASE_CONFIG" "$PREPARED_ROOT/release-config.json"
 
           (
             cd "$PREPARED_ROOT"
-            sha256sum \
-              release-config.json \
-              "$app_binary" \
-              "$broker_sidecar" \
-              "$cli_sidecar" \
-              > SHA256SUMS
+            sha256sum release-config.json "$app_binary" > SHA256SUMS
           )
           (
             cd "$workspace"
-            tar -cf prepared-windows.tar -C "$PREPARED_ROOT" \
+            tar -cf prepared-windows-desktop.tar -C "$PREPARED_ROOT" \
               SHA256SUMS \
               release-config.json \
-              target \
-              crates
-            sha256sum prepared-windows.tar > prepared-windows.tar.sha256
+              target
+            sha256sum prepared-windows-desktop.tar \
+              > prepared-windows-desktop.tar.sha256
           )
 
-      - name: Upload prepared Windows inputs
+      - name: Upload prepared Windows desktop
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: tidebreak-prepared-windows-${{ matrix.arch }}-${{ github.run_id }}
+          name: tidebreak-prepared-windows-desktop-${{ matrix.arch }}-${{ github.run_id }}
           path: |
-            prepared-windows.tar
-            prepared-windows.tar.sha256
+            prepared-windows-desktop.tar
+            prepared-windows-desktop.tar.sha256
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
@@ -1502,7 +1656,7 @@ jobs:
 
   build_windows:
     name: Windows · ${{ matrix.arch }}
-    needs: [validate, inspect_hosted, notices, prepare_windows]
+    needs: [validate, inspect_hosted, notices, prepare_windows_sidecars, prepare_windows_desktop]
     if: >-
       ${{
         always()
@@ -1511,7 +1665,8 @@ jobs:
         && needs.inspect_hosted.result == 'success'
         && needs.inspect_hosted.outputs.exists != 'true'
         && needs.notices.result == 'success'
-        && needs.prepare_windows.result == 'success'
+        && needs.prepare_windows_sidecars.result == 'success'
+        && needs.prepare_windows_desktop.result == 'success'
       }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
@@ -1527,7 +1682,7 @@ jobs:
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
-            runner: ${{ vars.RELEASE_WINDOWS_X64_RUNNER || 'windows-latest' }}
+            runner: windows-latest
           - arch: aarch64
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
@@ -1538,42 +1693,71 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.sha }}
 
-      - name: Download prepared Windows inputs
+      - name: Download prepared Windows sidecars
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: tidebreak-prepared-windows-${{ matrix.arch }}-${{ github.run_id }}
-          path: ${{ runner.temp }}/prepared-windows-download
+          name: tidebreak-prepared-windows-sidecars-${{ matrix.arch }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-windows-sidecars-download
+
+      - name: Download prepared Windows desktop
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-prepared-windows-desktop-${{ matrix.arch }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-windows-desktop-download
 
       - name: Verify prepared Windows inputs
         env:
-          PREPARED_DOWNLOAD: ${{ runner.temp }}/prepared-windows-download
-          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-windows
+          DESKTOP_DOWNLOAD: ${{ runner.temp }}/prepared-windows-desktop-download
+          DESKTOP_ROOT: ${{ runner.temp }}/tidebreak-prepared-windows-desktop
           RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
           RELEASE_TARGET: ${{ matrix.target }}
+          SIDECARS_DOWNLOAD: ${{ runner.temp }}/prepared-windows-sidecars-download
+          SIDECARS_ROOT: ${{ runner.temp }}/tidebreak-prepared-windows-sidecars
         run: |
-          PREPARED_ROOT="$(cygpath -u "$PREPARED_ROOT")"
-          PREPARED_DOWNLOAD="$(cygpath -u "$PREPARED_DOWNLOAD")"
+          DESKTOP_DOWNLOAD="$(cygpath -u "$DESKTOP_DOWNLOAD")"
+          DESKTOP_ROOT="$(cygpath -u "$DESKTOP_ROOT")"
           RELEASE_CONFIG="$(cygpath -u "$RELEASE_CONFIG")"
-          rm -rf "$PREPARED_ROOT"
-          mkdir -p "$PREPARED_ROOT"
+          SIDECARS_DOWNLOAD="$(cygpath -u "$SIDECARS_DOWNLOAD")"
+          SIDECARS_ROOT="$(cygpath -u "$SIDECARS_ROOT")"
+
+          rm -rf "$DESKTOP_ROOT" "$SIDECARS_ROOT"
+          mkdir -p "$DESKTOP_ROOT" "$SIDECARS_ROOT"
           (
-            cd "$PREPARED_DOWNLOAD"
-            sha256sum --check --strict prepared-windows.tar.sha256
-            tar -xf prepared-windows.tar -C "$PREPARED_ROOT"
+            cd "$DESKTOP_DOWNLOAD"
+            sha256sum --check --strict prepared-windows-desktop.tar.sha256
+            tar -xf prepared-windows-desktop.tar -C "$DESKTOP_ROOT"
           )
           (
-            cd "$PREPARED_ROOT"
+            cd "$DESKTOP_ROOT"
             sha256sum --check --strict SHA256SUMS
             expected_files="$(printf '%s\n' \
               "./SHA256SUMS" \
-              "./crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe" \
-              "./crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe" \
               "./release-config.json" \
               "./target/$RELEASE_TARGET/release/tidebreak-desktop.exe" \
               | LC_ALL=C sort)"
             actual_files="$(find . -type f -print | LC_ALL=C sort)"
             [[ "$actual_files" = "$expected_files" ]] || {
-              echo "Prepared Windows archive contains an unexpected file set" >&2
+              echo "Prepared Windows desktop archive contains an unexpected file set" >&2
+              printf '%s\n' "$actual_files" >&2
+              exit 1
+            }
+          )
+          (
+            cd "$SIDECARS_DOWNLOAD"
+            sha256sum --check --strict prepared-windows-sidecars.tar.sha256
+            tar -xf prepared-windows-sidecars.tar -C "$SIDECARS_ROOT"
+          )
+          (
+            cd "$SIDECARS_ROOT"
+            sha256sum --check --strict SHA256SUMS
+            expected_files="$(printf '%s\n' \
+              "./SHA256SUMS" \
+              "./crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe" \
+              "./crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe" \
+              | LC_ALL=C sort)"
+            actual_files="$(find . -type f -print | LC_ALL=C sort)"
+            [[ "$actual_files" = "$expected_files" ]] || {
+              echo "Prepared Windows sidecar archive contains an unexpected file set" >&2
               printf '%s\n' "$actual_files" >&2
               exit 1
             }
@@ -1583,19 +1767,19 @@ jobs:
           broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe"
           cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe"
           mkdir -p "$(dirname "$app_binary")" "$(dirname "$broker_sidecar")"
-          cp -p "$PREPARED_ROOT/$app_binary" "$app_binary"
-          cp -p "$PREPARED_ROOT/$broker_sidecar" "$broker_sidecar"
-          cp -p "$PREPARED_ROOT/$cli_sidecar" "$cli_sidecar"
-          cp "$PREPARED_ROOT/release-config.json" "$RELEASE_CONFIG"
+          cp -p "$DESKTOP_ROOT/$app_binary" "$app_binary"
+          cp -p "$SIDECARS_ROOT/$broker_sidecar" "$broker_sidecar"
+          cp -p "$SIDECARS_ROOT/$cli_sidecar" "$cli_sidecar"
+          cp "$DESKTOP_ROOT/release-config.json" "$RELEASE_CONFIG"
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
+      - name: Enable pinned pnpm
+        run: |
+          corepack enable
+          corepack install --global pnpm@10.18.3
+          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
       - name: Install pinned Tauri bundler
         run: |
           pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -264,15 +264,16 @@ installer itself, so no separate updater archive exists on Windows. Release
 builds check that authenticated feed and ask before restarting into the new
 installer.
 
-The credential-free `prepare_windows` job reuses compiler outputs directly
-from the shared S3 `sccache` backend. It compiles the exact release tag and
-product version, then saves a release-specific prepared archive for the
-credentialed packaging job. The Windows ARM job keeps the
-`aarch64-pc-windows-msvc` Rust target and compiles whisper.cpp with Ninja plus
+The credential-free `prepare_windows_sidecars` and
+`prepare_windows_desktop` jobs reuse compiler outputs directly from the shared
+S3 `sccache` backend. They compile the sidecars and desktop in parallel for the
+exact release tag and product version, then save separate prepared archives for
+the credentialed packaging job. The Windows ARM jobs keep the
+`aarch64-pc-windows-msvc` Rust target and compile whisper.cpp with Ninja plus
 `clang-cl`, because ggml refuses MSVC on ARM. After the compile, each job
-transfers only the final binary, sidecars, and Tauri configuration to the
-production job. The production job verifies and bundles those files without
-installing a compiler or rebuilding the frontend.
+transfers only its final binaries and Tauri configuration to the production
+job. The production job verifies and bundles those files without installing a
+compiler or rebuilding the frontend.
 
 Windows code mode uses the desktop's digest-verified managed Node ZIP and
 pinned harness packages. Setup, archive, and quick-action commands run through
@@ -686,10 +687,9 @@ repository variable `CI_WINDOWS_RUNNER` to the provisioned x64 label. If you
 omit the variable, the job uses `windows-latest`. Do not point the variable at
 an ARM runner: the lane compiles `x86_64-pc-windows-msvc`.
 
-To run the x86_64 Windows release compile and packaging jobs on the same larger
-runner, set `RELEASE_WINDOWS_X64_RUNNER` to the provisioned x64 label. If you
-omit the variable, both jobs use `windows-latest`. Windows ARM64 stays on the
-native `windows-11-arm` runner required by decision 43.
+The x86_64 Windows release compile and packaging jobs use `windows-latest`.
+Windows ARM64 stays on the native `windows-11-arm` runner required by decision
+43.
 
 The release-draft workflow uses the built-in `GITHUB_TOKEN`; it does not require
 a personal access token.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -264,9 +264,9 @@ installer itself, so no separate updater archive exists on Windows. Release
 builds check that authenticated feed and ask before restarting into the new
 installer.
 
-The credential-free `prepare_windows_sidecars` and
-`prepare_windows_desktop` jobs reuse compiler outputs directly from the shared
-S3 `sccache` backend. They compile the sidecars and desktop in parallel for the
+The credential-free `prepare_windows` and `prepare_windows_desktop` jobs reuse
+compiler outputs directly from the shared S3 `sccache` backend. They compile
+the sidecars and desktop in parallel for the
 exact release tag and product version, then save separate prepared archives for
 the credentialed packaging job. The Windows ARM jobs keep the
 `aarch64-pc-windows-msvc` Rust target and compile whisper.cpp with Ninja plus
@@ -687,9 +687,10 @@ repository variable `CI_WINDOWS_RUNNER` to the provisioned x64 label. If you
 omit the variable, the job uses `windows-latest`. Do not point the variable at
 an ARM runner: the lane compiles `x86_64-pc-windows-msvc`.
 
-The x86_64 Windows release compile and packaging jobs use `windows-latest`.
-Windows ARM64 stays on the native `windows-11-arm` runner required by decision
-43.
+The x86_64 Windows release compile and packaging jobs use the runner named by
+`RELEASE_WINDOWS_X64_RUNNER`. The repository sets this variable to
+`windows-latest`. Windows ARM64 stays on the native `windows-11-arm` runner
+required by decision 43.
 
 The release-draft workflow uses the built-in `GITHUB_TOKEN`; it does not require
 a personal access token.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -825,7 +825,8 @@ test("compiler caches use OIDC-scoped S3 access", () => {
 
   for (const [file, name] of [
     ["release.yml", "prepare_macos"],
-    ["release.yml", "prepare_windows"],
+    ["release.yml", "prepare_windows_sidecars"],
+    ["release.yml", "prepare_windows_desktop"],
     ["release.yml", "build_linux"],
     ["staging-publish.yml", "prepare_macos_staging"],
   ]) {
@@ -1676,21 +1677,45 @@ test("release compilation uses S3 without cache warmer workflows", () => {
   assert.doesNotMatch(release, /^  warm-macos-cache:/m);
 
   const prepareMacos = workflowJob(release, "prepare_macos");
-  const prepareWindows = workflowJob(release, "prepare_windows");
+  const prepareWindowsSidecars = workflowJob(
+    release,
+    "prepare_windows_sidecars",
+  );
+  const prepareWindowsDesktop = workflowJob(
+    release,
+    "prepare_windows_desktop",
+  );
+  const buildWindows = workflowJob(release, "build_windows");
   const buildLinux = workflowJob(release, "build_linux");
   assert.doesNotMatch(prepareMacos, /restore-keys:/);
-  assert.doesNotMatch(prepareWindows, /restore-keys:/);
-  assert.doesNotMatch(prepareWindows, /windows-release-target-v1-/);
+  assert.doesNotMatch(prepareWindowsSidecars, /restore-keys:/);
+  assert.doesNotMatch(prepareWindowsDesktop, /restore-keys:/);
+  assert.doesNotMatch(prepareWindowsSidecars, /windows-release-target-v1-/);
+  assert.doesNotMatch(prepareWindowsDesktop, /windows-release-target-v1-/);
   assert.doesNotMatch(buildLinux, /actions\/cache\/restore@/);
   assert.doesNotMatch(buildLinux, /linux-release-target-v1-/);
+  assert.doesNotMatch(release, /RELEASE_WINDOWS_X64_RUNNER/);
+  for (const job of [prepareWindowsSidecars, prepareWindowsDesktop, buildWindows]) {
+    assert.match(job, /target: x86_64-pc-windows-msvc\n\s+runner: windows-latest/);
+  }
   assert.match(
-    prepareWindows,
-    /vars\.RELEASE_WINDOWS_X64_RUNNER \|\| 'windows-latest'/,
+    buildWindows,
+    /needs: \[validate, inspect_hosted, notices, prepare_windows_sidecars, prepare_windows_desktop\]/,
   );
+  assert.match(prepareWindowsSidecars, /prepare-sidecar\.mjs --release/);
   assert.match(
-    workflowJob(release, "build_windows"),
-    /vars\.RELEASE_WINDOWS_X64_RUNNER \|\| 'windows-latest'/,
+    prepareWindowsDesktop,
+    /beforeBuildCommand: \{ script: "pnpm build", cwd: "ui" \}/,
   );
+  assert.match(prepareWindowsDesktop, /Stage inert sidecars for desktop compilation/);
+  assert.match(buildWindows, /tidebreak-prepared-windows-sidecars-/);
+  assert.match(buildWindows, /tidebreak-prepared-windows-desktop-/);
+  assert.match(buildWindows, /Prepared Windows sidecar archive contains an unexpected file set/);
+  assert.match(buildWindows, /Prepared Windows desktop archive contains an unexpected file set/);
+  for (const job of [prepareWindowsDesktop, buildWindows]) {
+    assert.match(job, /corepack install --global pnpm@10\.18\.3/);
+    assert.doesNotMatch(job, /uses: pnpm\/action-setup/);
+  }
 
   for (const workflow of [release]) {
     const downloadCaches = [
@@ -1727,7 +1752,12 @@ function stepNames(job) {
 
 test("credential-free compile jobs never load production secrets", () => {
   const release = workflows["release.yml"];
-  for (const jobName of ["prepare_macos", "combine_macos", "prepare_windows"]) {
+  for (const jobName of [
+    "prepare_macos",
+    "combine_macos",
+    "prepare_windows_sidecars",
+    "prepare_windows_desktop",
+  ]) {
     const job = workflowJob(release, jobName);
     assert.doesNotMatch(job, /^    environment:/m);
     assert.doesNotMatch(job, /secrets\./);
@@ -1735,7 +1765,11 @@ test("credential-free compile jobs never load production secrets", () => {
   }
   // The credential-free compile must save its cache before reporting a
   // failed compile, so partial work is reusable.
-  for (const jobName of ["prepare_macos", "prepare_windows"]) {
+  for (const jobName of [
+    "prepare_macos",
+    "prepare_windows_sidecars",
+    "prepare_windows_desktop",
+  ]) {
     const job = workflowJob(release, jobName);
     const names = stepNames(job);
     const saveIdx = names.findIndex((n) => /Save.*cache/i.test(n));
@@ -1772,7 +1806,11 @@ test("credentialed packaging policy rejects cache restores after signing materia
 
 test("the updater private key is isolated from compilation", () => {
   const release = workflows["release.yml"];
-  for (const jobName of ["prepare_macos", "prepare_windows"]) {
+  for (const jobName of [
+    "prepare_macos",
+    "prepare_windows_sidecars",
+    "prepare_windows_desktop",
+  ]) {
     assert.doesNotMatch(
       workflowJob(release, jobName),
       /TAURI_SIGNING_PRIVATE_KEY/,
@@ -1801,7 +1839,9 @@ test("signing jobs run installers before loading signing material", () => {
     const label = `${name} (${file})`;
     const secretsAt = firstSigningMaterialIndex(job, validate);
     assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
-    const pnpmAt = job.search(/pnpm\/action-setup@[0-9a-f]{40}/);
+    const pnpmAt = job.search(
+      /pnpm\/action-setup@[0-9a-f]{40}|- name: Enable pinned pnpm/,
+    );
     const nodeAt = job.search(/actions\/setup-node@[0-9a-f]{40}/);
     assert.ok(pnpmAt !== -1, `${label} must set up pnpm`);
     assert.ok(nodeAt !== -1, `${label} must set up Node`);
@@ -1815,7 +1855,11 @@ test("signing jobs run installers before loading signing material", () => {
     assert.ok(installAt !== -1, `${label} must have a frozen-lockfile install step`);
     assert.ok(installAt < secretsAt, `${label} must install dependencies before signing material`);
     // pnpm must be pinned to an exact version, not floating.
-    assert.match(job, /version: 10\.18\.3\n/, `${label} must pin pnpm 10.18.3`);
+    assert.match(
+      job,
+      /version: 10\.18\.3\n|corepack install --global pnpm@10\.18\.3/,
+      `${label} must pin pnpm 10.18.3`,
+    );
     // Installs must be frozen-lockfile with lifecycle scripts disabled.
     assert.match(
       job,
@@ -1850,7 +1894,48 @@ test("prepared binaries are checksum-verified before signing material loads", ()
 
 test("restored product binaries are discarded before the packaging build", () => {
   const release = workflows["release.yml"];
-  for (const name of ["build_macos", "prepare_windows", "build_windows", "build_linux"]) {
+  const expectedProducts = new Map([
+    [
+      "build_macos",
+      [
+        /release\/tidebreak-desktop/,
+        /release\/tidebreak-host-broker/,
+        /release\/tidebreak\b/,
+        /binaries\/tidebreak-host-broker/,
+        /binaries\/tidebreak\b/,
+      ],
+    ],
+    [
+      "prepare_windows_sidecars",
+      [
+        /release\/tidebreak-host-broker/,
+        /release\/tidebreak\b/,
+        /binaries\/tidebreak-host-broker/,
+        /binaries\/tidebreak\b/,
+      ],
+    ],
+    [
+      "prepare_windows_desktop",
+      [/release\/tidebreak-desktop/, /release\/tidebreak_desktop_lib/],
+    ],
+    [
+      "build_linux",
+      [
+        /release\/tidebreak-desktop/,
+        /release\/tidebreak-host-broker/,
+        /release\/tidebreak(?:\s|$)/m,
+        /binaries\/tidebreak-host-broker/,
+        /binaries\/tidebreak-\$\{\{ matrix\.target \}\}(?:\s|$)/m,
+      ],
+    ],
+  ]);
+  for (const name of [
+    "build_macos",
+    "prepare_windows_sidecars",
+    "prepare_windows_desktop",
+    "build_windows",
+    "build_linux",
+  ]) {
     const job = workflowJob(release, name);
     const names = stepNames(job);
     const restoreIdx = names.findIndex((n) => /Restore.*cache/i.test(n));
@@ -1872,17 +1957,7 @@ test("restored product binaries are discarded before the packaging build", () =>
       new RegExp(`- name: ${names[discardIdx].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\s\\S]*?(?=\\n\\s+- name:)`),
     )?.[0];
     assert.ok(discardStep, `${name}: discard step content not found`);
-    const products = [
-      /release\/tidebreak-desktop/,
-      /release\/tidebreak-host-broker/,
-      name === "build_linux"
-        ? /release\/tidebreak(?:\s|$)/m
-        : /release\/tidebreak\b/,
-      /binaries\/tidebreak-host-broker/,
-      name === "build_linux"
-        ? /binaries\/tidebreak-\$\{\{ matrix\.target \}\}(?:\s|$)/m
-        : /binaries\/tidebreak\b/,
-    ];
+    const products = expectedProducts.get(name) ?? [];
     for (const product of products) {
       assert.match(discardStep, product, `${name}: discard must remove ${product}`);
     }
@@ -2033,7 +2108,11 @@ test("an existing immutable release resumes without rebuilding or overwriting", 
     /needs\.inspect_hosted\.outputs\.exists != 'true'/,
   );
   assert.match(
-    workflowJob(release, "prepare_windows"),
+    workflowJob(release, "prepare_windows_sidecars"),
+    /needs\.inspect_hosted\.outputs\.exists != 'true'/,
+  );
+  assert.match(
+    workflowJob(release, "prepare_windows_desktop"),
     /needs\.inspect_hosted\.outputs\.exists != 'true'/,
   );
   assert.match(
@@ -2353,7 +2432,8 @@ test("release and staging share one third-party notices implementation", () => {
       platformJobs: [
         "prepare_macos",
         "build_macos",
-        "prepare_windows",
+        "prepare_windows_sidecars",
+        "prepare_windows_desktop",
         "build_windows",
         "build_linux",
       ],

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -825,7 +825,7 @@ test("compiler caches use OIDC-scoped S3 access", () => {
 
   for (const [file, name] of [
     ["release.yml", "prepare_macos"],
-    ["release.yml", "prepare_windows_sidecars"],
+    ["release.yml", "prepare_windows"],
     ["release.yml", "prepare_windows_desktop"],
     ["release.yml", "build_linux"],
     ["staging-publish.yml", "prepare_macos_staging"],
@@ -1677,10 +1677,7 @@ test("release compilation uses S3 without cache warmer workflows", () => {
   assert.doesNotMatch(release, /^  warm-macos-cache:/m);
 
   const prepareMacos = workflowJob(release, "prepare_macos");
-  const prepareWindowsSidecars = workflowJob(
-    release,
-    "prepare_windows_sidecars",
-  );
+  const prepareWindowsSidecars = workflowJob(release, "prepare_windows");
   const prepareWindowsDesktop = workflowJob(
     release,
     "prepare_windows_desktop",
@@ -1694,13 +1691,15 @@ test("release compilation uses S3 without cache warmer workflows", () => {
   assert.doesNotMatch(prepareWindowsDesktop, /windows-release-target-v1-/);
   assert.doesNotMatch(buildLinux, /actions\/cache\/restore@/);
   assert.doesNotMatch(buildLinux, /linux-release-target-v1-/);
-  assert.doesNotMatch(release, /RELEASE_WINDOWS_X64_RUNNER/);
   for (const job of [prepareWindowsSidecars, prepareWindowsDesktop, buildWindows]) {
-    assert.match(job, /target: x86_64-pc-windows-msvc\n\s+runner: windows-latest/);
+    assert.match(
+      job,
+      /target: x86_64-pc-windows-msvc\n\s+runner: \$\{\{ vars\.RELEASE_WINDOWS_X64_RUNNER \|\| 'windows-latest' \}\}/,
+    );
   }
   assert.match(
     buildWindows,
-    /needs: \[validate, inspect_hosted, notices, prepare_windows_sidecars, prepare_windows_desktop\]/,
+    /needs: \[validate, inspect_hosted, notices, prepare_windows, prepare_windows_desktop\]/,
   );
   assert.match(prepareWindowsSidecars, /prepare-sidecar\.mjs --release/);
   assert.match(
@@ -1712,10 +1711,8 @@ test("release compilation uses S3 without cache warmer workflows", () => {
   assert.match(buildWindows, /tidebreak-prepared-windows-desktop-/);
   assert.match(buildWindows, /Prepared Windows sidecar archive contains an unexpected file set/);
   assert.match(buildWindows, /Prepared Windows desktop archive contains an unexpected file set/);
-  for (const job of [prepareWindowsDesktop, buildWindows]) {
-    assert.match(job, /corepack install --global pnpm@10\.18\.3/);
-    assert.doesNotMatch(job, /uses: pnpm\/action-setup/);
-  }
+  assert.match(prepareWindowsDesktop, /corepack install --global pnpm@10\.18\.3/);
+  assert.doesNotMatch(prepareWindowsDesktop, /uses: pnpm\/action-setup/);
 
   for (const workflow of [release]) {
     const downloadCaches = [
@@ -1755,7 +1752,7 @@ test("credential-free compile jobs never load production secrets", () => {
   for (const jobName of [
     "prepare_macos",
     "combine_macos",
-    "prepare_windows_sidecars",
+    "prepare_windows",
     "prepare_windows_desktop",
   ]) {
     const job = workflowJob(release, jobName);
@@ -1767,7 +1764,7 @@ test("credential-free compile jobs never load production secrets", () => {
   // failed compile, so partial work is reusable.
   for (const jobName of [
     "prepare_macos",
-    "prepare_windows_sidecars",
+    "prepare_windows",
     "prepare_windows_desktop",
   ]) {
     const job = workflowJob(release, jobName);
@@ -1808,7 +1805,7 @@ test("the updater private key is isolated from compilation", () => {
   const release = workflows["release.yml"];
   for (const jobName of [
     "prepare_macos",
-    "prepare_windows_sidecars",
+    "prepare_windows",
     "prepare_windows_desktop",
   ]) {
     assert.doesNotMatch(
@@ -1906,7 +1903,7 @@ test("restored product binaries are discarded before the packaging build", () =>
       ],
     ],
     [
-      "prepare_windows_sidecars",
+      "prepare_windows",
       [
         /release\/tidebreak-host-broker/,
         /release\/tidebreak\b/,
@@ -1931,7 +1928,7 @@ test("restored product binaries are discarded before the packaging build", () =>
   ]);
   for (const name of [
     "build_macos",
-    "prepare_windows_sidecars",
+    "prepare_windows",
     "prepare_windows_desktop",
     "build_windows",
     "build_linux",
@@ -2108,7 +2105,7 @@ test("an existing immutable release resumes without rebuilding or overwriting", 
     /needs\.inspect_hosted\.outputs\.exists != 'true'/,
   );
   assert.match(
-    workflowJob(release, "prepare_windows_sidecars"),
+    workflowJob(release, "prepare_windows"),
     /needs\.inspect_hosted\.outputs\.exists != 'true'/,
   );
   assert.match(
@@ -2432,7 +2429,7 @@ test("release and staging share one third-party notices implementation", () => {
       platformJobs: [
         "prepare_macos",
         "build_macos",
-        "prepare_windows_sidecars",
+        "prepare_windows",
         "prepare_windows_desktop",
         "build_windows",
         "build_linux",


### PR DESCRIPTION
Windows release preparation remains the critical path even with strong S3 compiler-cache hits. The x64 jobs also queue on the unreliable large-runner label.

This change:
- runs Windows sidecar and desktop compilation in parallel
- routes x64 preparation and packaging through `RELEASE_WINDOWS_X64_RUNNER`, now set to `windows-latest`
- transfers and verifies separate prepared artifacts before loading signing material
- replaces the slow pnpm action in the desktop compile job with pinned Corepack setup
- updates release documentation and workflow security coverage

Validation:
- `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs` (94 passed)
- trusted `main` workflow-security policy (47 passed)
- release workflow YAML parse
- `actionlint -ignore 'SC2016' .github/workflows/release.yml`
- `git diff --check`