### PR TITLE
improve(code): an external session may name its repository as the forge does

### DIFF
--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -90,8 +90,15 @@ async fn require_bound(
 pub struct ExternalSessionBody {
     /// The channel's durable conversation identity, opaque here.
     pub external_key: String,
-    /// The repository the sandbox clones. Required in v1.
-    pub repo_id: RepoId,
+    /// The repository the sandbox clones, by record id. One of `repo_id`
+    /// and `repository` is required; `repo_id` wins when both are sent.
+    #[serde(default)]
+    pub repo_id: Option<RepoId>,
+    /// The repository by its origin, `owner/name`, resolved against the
+    /// grant owner's registered repositories. This is how a channel names
+    /// its default: the adapter never learns record ids.
+    #[serde(default)]
+    pub repository: Option<String>,
     #[serde(default)]
     pub title: Option<String>,
     #[serde(default)]
@@ -118,13 +125,23 @@ pub async fn external_get_or_create(
         .code
         .clone()
         .ok_or_else(|| ServerError::unauthorized("adapter access is not configured"))?;
+    let repo_id = match (body.repo_id, body.repository.as_deref()) {
+        (Some(id), _) => id,
+        (None, Some(origin)) => runtime.repo_by_origin(&grant.owner, origin).await?.id,
+        (None, None) => {
+            return Err(ServerError::bad_request_kind(
+                "repo_required",
+                "name the repository by `repo_id` or as `repository: owner/name`",
+            ));
+        }
+    };
     let resolution = runtime
         .external_get_or_create(
             &grant.owner,
             grant.id,
             &grant.channel_kind,
             &body.external_key,
-            body.repo_id,
+            repo_id,
             body.title,
             body.harness.unwrap_or(HarnessKind::ClaudeCode),
             NewSessionSettings {

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -231,10 +231,18 @@ async fn an_external_session_names_its_repository_by_origin() {
     let session_id = bound_session_id(&runtime, &owner, "T1/C9/1.1").await;
     let session = runtime.get_session(&owner, session_id).await.unwrap();
     let workspace = runtime
-        .get_workspace(&owner, session.workspace_id.expect("a repository session has a workspace"))
+        .get_workspace(
+            &owner,
+            session
+                .workspace_id
+                .expect("a repository session has a workspace"),
+        )
         .await
         .unwrap();
-    assert_eq!(workspace.repo_id, repo_id, "the origin resolved to the registered checkout");
+    assert_eq!(
+        workspace.repo_id, repo_id,
+        "the origin resolved to the registered checkout"
+    );
 
     let unknown = client
         .post(format!("http://{addr}/external/code/sessions"))

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -205,6 +205,58 @@ async fn bound_session_id(
         .session_id
 }
 
+/// A channel names its repository the way a forge does. `repository:
+/// owner/name` resolves to the owner's registered checkout regardless of
+/// case, a name nobody registered is a typed conflict the adapter can word,
+/// and a request naming no repository at all is a bad request.
+#[tokio::test]
+async fn an_external_session_names_its_repository_by_origin() {
+    let (router, _fake, runtime, repo_id, _dir) = external_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C9/1.1", "repository": "ACME/Tools" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session_id = bound_session_id(&runtime, &owner, "T1/C9/1.1").await;
+    let session = runtime.get_session(&owner, session_id).await.unwrap();
+    let workspace = runtime
+        .get_workspace(&owner, session.workspace_id.expect("a repository session has a workspace"))
+        .await
+        .unwrap();
+    assert_eq!(workspace.repo_id, repo_id, "the origin resolved to the registered checkout");
+
+    let unknown = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C9/2.1", "repository": "acme/other" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unknown.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = unknown.json().await.unwrap();
+    assert_eq!(body["kind"], "repo_unknown");
+
+    let nameless = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C9/3.1" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(nameless.status(), reqwest::StatusCode::BAD_REQUEST);
+}
+
 /// The whole adapter surface over HTTP: bad tokens refuse, get-or-create
 /// is idempotent, messages are idempotent on the event id, a foreign grant
 /// sees "not found", interrupt reaches the sandbox, and rotation with a

--- a/crates/tidebreak-server/src/code/runtime/repos.rs
+++ b/crates/tidebreak-server/src/code/runtime/repos.rs
@@ -102,7 +102,11 @@ impl CodeRuntime {
     /// does not count. A repository that is not registered is a conflict
     /// the caller can word, not a not-found: the name may be right and the
     /// clone simply missing.
-    pub async fn repo_by_origin(&self, owner: &OwnerId, origin: &str) -> Result<CodeRepo, ServerError> {
+    pub async fn repo_by_origin(
+        &self,
+        owner: &OwnerId,
+        origin: &str,
+    ) -> Result<CodeRepo, ServerError> {
         let Some((origin_owner, origin_name)) = parse_repository_origin(origin) else {
             return Err(ServerError::bad_request_kind(
                 "repo_origin_invalid",
@@ -260,9 +264,9 @@ fn parse_repository_origin(raw: &str) -> Option<(&str, &str)> {
     let (owner, name) = rest.split_once('/')?;
     let valid = |part: &str| {
         !part.is_empty()
-            && part
-                .chars()
-                .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+            && part.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+            })
     };
     (valid(owner) && valid(name)).then_some((owner, name))
 }
@@ -281,9 +285,20 @@ mod origin_tests {
             "https://github.com/acme/tools",
             "https://github.com/acme/tools.git/",
         ] {
-            assert_eq!(parse_repository_origin(raw), Some(("acme", "tools")), "{raw:?}");
+            assert_eq!(
+                parse_repository_origin(raw),
+                Some(("acme", "tools")),
+                "{raw:?}"
+            );
         }
-        for raw in ["tools", "acme/", "/tools", "acme/tools/extra", "acme tools/x", ""] {
+        for raw in [
+            "tools",
+            "acme/",
+            "/tools",
+            "acme/tools/extra",
+            "acme tools/x",
+            "",
+        ] {
             assert_eq!(parse_repository_origin(raw), None, "{raw:?}");
         }
     }

--- a/crates/tidebreak-server/src/code/runtime/repos.rs
+++ b/crates/tidebreak-server/src/code/runtime/repos.rs
@@ -96,6 +96,43 @@ impl CodeRuntime {
         Ok(list_repos(&self.db, owner).await?)
     }
 
+    /// The owner's registered repository whose origin is `owner/name`, for
+    /// callers that name repositories the way a forge does. Both parts
+    /// compare case-insensitively, as GitHub does; a removed registration
+    /// does not count. A repository that is not registered is a conflict
+    /// the caller can word, not a not-found: the name may be right and the
+    /// clone simply missing.
+    pub async fn repo_by_origin(&self, owner: &OwnerId, origin: &str) -> Result<CodeRepo, ServerError> {
+        let Some((origin_owner, origin_name)) = parse_repository_origin(origin) else {
+            return Err(ServerError::bad_request_kind(
+                "repo_origin_invalid",
+                format!("{origin:?} is not a repository as owner/name"),
+            ));
+        };
+        self.list_repos(owner)
+            .await?
+            .into_iter()
+            .filter(|repo| repo.removed_at.is_none())
+            .find(|repo| {
+                repo.origin_owner
+                    .as_deref()
+                    .is_some_and(|value| value.eq_ignore_ascii_case(origin_owner))
+                    && repo
+                        .origin_name
+                        .as_deref()
+                        .is_some_and(|value| value.eq_ignore_ascii_case(origin_name))
+            })
+            .ok_or_else(|| {
+                ServerError::conflict_kind(
+                    "repo_unknown",
+                    format!(
+                        "{origin_owner}/{origin_name} is not registered on this machine; \
+                         clone it in Tidebreak first"
+                    ),
+                )
+            })
+    }
+
     pub async fn get_repo(&self, owner: &OwnerId, id: RepoId) -> Result<CodeRepo, ServerError> {
         get_repo(&self.db, owner, id)
             .await?
@@ -203,5 +240,51 @@ impl CodeRuntime {
         }
         self.delivery_cache.invalidate_owner(owner);
         Ok(())
+    }
+}
+
+/// `owner/name` out of the shapes people paste: the bare pair, the pair
+/// with a `.git` suffix, or a GitHub URL or host-prefixed path. Anything
+/// with more or fewer segments, an empty segment, or whitespace is not a
+/// repository name.
+fn parse_repository_origin(raw: &str) -> Option<(&str, &str)> {
+    let mut rest = raw.trim();
+    for prefix in ["https://github.com/", "http://github.com/", "github.com/"] {
+        if let Some(stripped) = rest.strip_prefix(prefix) {
+            rest = stripped;
+            break;
+        }
+    }
+    let rest = rest.trim_end_matches('/');
+    let rest = rest.strip_suffix(".git").unwrap_or(rest);
+    let (owner, name) = rest.split_once('/')?;
+    let valid = |part: &str| {
+        !part.is_empty()
+            && part
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+    };
+    (valid(owner) && valid(name)).then_some((owner, name))
+}
+
+#[cfg(test)]
+mod origin_tests {
+    use super::parse_repository_origin;
+
+    #[test]
+    fn every_pasted_shape_of_a_repository_name_resolves_to_owner_and_name() {
+        for raw in [
+            "acme/tools",
+            " acme/tools ",
+            "acme/tools.git",
+            "github.com/acme/tools",
+            "https://github.com/acme/tools",
+            "https://github.com/acme/tools.git/",
+        ] {
+            assert_eq!(parse_repository_origin(raw), Some(("acme", "tools")), "{raw:?}");
+        }
+        for raw in ["tools", "acme/", "/tools", "acme/tools/extra", "acme tools/x", ""] {
+            assert_eq!(parse_repository_origin(raw), None, "{raw:?}");
+        }
     }
 }


### PR DESCRIPTION
## What broke

On the hosted devops machine, a Slack connect completed, then every first turn was refused: `POST /external/code/sessions` took `repo_id` as a record id, and the adapter sent the setup page's `owner/name`. The adapter never learns record ids, and the design (`docs/slack-sessions.md`, "Choosing the repository") names repositories as `owner/name`.

## Change

- `ExternalSessionBody` takes `repository: owner/name` (also a GitHub URL or `.git` suffix) as an alternative to `repo_id`; `repo_id` wins when both are sent, and a body naming neither is a `400 repo_required`.
- `CodeRuntime::repo_by_origin` resolves the name against the grant owner's registered, non-removed checkouts by `origin_owner`/`origin_name`, case-insensitively as GitHub does. A name nobody registered answers `409 repo_unknown` with "clone it in Tidebreak first", so the adapter renders it in the thread instead of the person seeing silence.
- Tests: `an_external_session_names_its_repository_by_origin` (resolves `ACME/Tools` to the fixture's `acme/tools`, refuses `acme/other`, refuses a nameless body) and the origin parser's accepted and rejected shapes.

Pairs with brightwave-inc/model-gateway#1870, which sends the field.

## Verified

- `cargo test -p tidebreak-server an_external_session_names_its_repository_by_origin` and `cargo test -p tidebreak-server-core --lib every_pasted_shape`: pass.
- `cargo clippy` on both crates with `-D warnings`: clean.