### PR TITLE
feat(code): a machine session's own git borrows the person's forge credential

### DIFF
--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -440,6 +440,14 @@ pub fn app(state: AppState) -> Router {
         .layer(DefaultBodyLimit::max(
             routes::code::MAX_HARNESS_LLM_BODY_BYTES,
         ))
+        // A machine session's own git borrows the person's forge credential
+        // here, under the same key; its body is a few description lines.
+        .route(
+            crate::code::harness_llm::GIT_CREDENTIAL_PATH,
+            post(routes::code::harness_git_credential).layer(DefaultBodyLimit::max(
+                routes::code::MAX_GIT_CREDENTIAL_BODY_BYTES,
+            )),
+        )
         .with_state(state.clone());
 
     // The channel-adapter surface (docs/slack-sessions.md, stage 2).

--- a/crates/tidebreak-server-api/src/routes/code/llm.rs
+++ b/crates/tidebreak-server-api/src/routes/code/llm.rs
@@ -7,10 +7,11 @@
 
 use axum::body::Body;
 use axum::extract::{RawQuery, State};
-use axum::http::{HeaderMap, StatusCode};
-use axum::response::Response;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
 
 use crate::code::harness_llm::RelayEndpoint;
+use crate::obo_gateway::GitForgeError;
 use crate::state::AppState;
 
 /// Body cap for one relayed inference request. A long session's request
@@ -82,4 +83,126 @@ async fn relay(
             "this machine has no harness inference relay",
         ),
     }
+}
+
+/// Body cap for one git credential description: a handful of `key=value`
+/// lines.
+pub(crate) const MAX_GIT_CREDENTIAL_BODY_BYTES: usize = 16 * 1024;
+
+/// `POST /code/git/credential` — git's credential protocol for a machine
+/// session's own `git`, authenticated by the session's relay key.
+///
+/// The body is the description git hands a helper (`protocol=`, `host=`,
+/// `path=`, one per line). A credential is lent only for `https` against
+/// the exact host the session's repository was cloned from, minted through
+/// the same person path the server's own git uses (decision 63), and
+/// answered as `username=` and `password=` lines. Any other description
+/// gets an empty answer, which git reads as "no credential", never as an
+/// error; so does a session with no repository.
+pub async fn harness_git_credential(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: String,
+) -> Response {
+    let Some(code) = state.code.as_ref() else {
+        return plain(StatusCode::NOT_FOUND, "this machine runs no code sessions");
+    };
+    let Some(relay) = code.harness_llm() else {
+        return plain(
+            StatusCode::NOT_FOUND,
+            "this machine lends no git credentials",
+        );
+    };
+    let Some(subject) = relay.subject_for_headers(&headers) else {
+        return plain(
+            StatusCode::UNAUTHORIZED,
+            "unknown or revoked harness relay key",
+        );
+    };
+    let Some(lender) = code.git_credentials() else {
+        return plain(
+            StatusCode::NOT_FOUND,
+            "this machine lends no git credentials",
+        );
+    };
+    let session = match code.get_session(&subject.owner, subject.session).await {
+        Ok(session) => session,
+        Err(_) => return plain(StatusCode::NOT_FOUND, "session not found"),
+    };
+    let Some(workspace_id) = session.workspace_id else {
+        return plain(StatusCode::OK, "");
+    };
+    let repo = match code.get_workspace(&subject.owner, workspace_id).await {
+        Ok(workspace) => match code.get_repo(&subject.owner, workspace.repo_id).await {
+            Ok(repo) => repo,
+            Err(_) => return plain(StatusCode::NOT_FOUND, "repository not found"),
+        },
+        Err(_) => return plain(StatusCode::NOT_FOUND, "workspace not found"),
+    };
+    let (Some(origin_host), Some(origin_owner), Some(origin_name)) =
+        (repo.origin_host, repo.origin_owner, repo.origin_name)
+    else {
+        return plain(StatusCode::OK, "");
+    };
+    let asked = GitCredentialAsk::parse(&body);
+    if asked.protocol.as_deref() != Some("https")
+        || !asked
+            .host
+            .as_deref()
+            .is_some_and(|host| host.eq_ignore_ascii_case(&origin_host))
+    {
+        return plain(StatusCode::OK, "");
+    }
+    match lender
+        .git_credential(&subject.owner, &format!("{origin_owner}/{origin_name}"))
+        .await
+    {
+        Ok(credential) => plain(
+            StatusCode::OK,
+            &format!(
+                "username={}\npassword={}\n",
+                credential.username, credential.secret
+            ),
+        ),
+        Err(GitForgeError::SignInRequired(message)) => plain(StatusCode::UNAUTHORIZED, &message),
+        Err(error) => plain(
+            StatusCode::BAD_GATEWAY,
+            &crate::code::clone::git_forge_refusal_message(&error),
+        ),
+    }
+}
+
+/// What git asked for, from the description lines a helper receives.
+#[derive(Default)]
+struct GitCredentialAsk {
+    protocol: Option<String>,
+    host: Option<String>,
+}
+
+impl GitCredentialAsk {
+    fn parse(body: &str) -> Self {
+        let mut asked = Self::default();
+        for line in body.lines() {
+            match line.split_once('=') {
+                Some(("protocol", value)) => asked.protocol = Some(value.trim().to_owned()),
+                // A `host` may carry a port; git compares the whole value,
+                // and so does the origin pin.
+                Some(("host", value)) => asked.host = Some(value.trim().to_owned()),
+                _ => {}
+            }
+        }
+        asked
+    }
+}
+
+fn plain(status: StatusCode, body: &str) -> Response {
+    (
+        status,
+        [
+            (header::CONTENT_TYPE, "text/plain; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-store"),
+        ],
+        body.to_owned(),
+    )
+        .into_response()
 }

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -64,8 +64,8 @@ pub(crate) use harnesses::{
     check_harness_updates, install_harness, list_harness_models, list_harnesses, refresh_harnesses,
 };
 pub(crate) use llm::{
-    harness_llm_anthropic_messages, harness_llm_openai_models, harness_llm_openai_responses,
-    MAX_HARNESS_LLM_BODY_BYTES,
+    harness_git_credential, harness_llm_anthropic_messages, harness_llm_openai_models,
+    harness_llm_openai_responses, MAX_GIT_CREDENTIAL_BODY_BYTES, MAX_HARNESS_LLM_BODY_BYTES,
 };
 pub(crate) use repos::{
     clone_defaults, create_repo, delete_repo, get_clone_job, get_repo, list_github_repositories,

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -137,11 +137,26 @@ async fn external_app_with_token() -> (
     Arc<str>,
     tempfile::TempDir,
 ) {
+    external_app_built(|runtime| runtime).await
+}
+
+/// [`external_app_with_token`] with the runtime shaped by the caller before
+/// the app is built: a lender or a relay a test needs wired in.
+async fn external_app_built(
+    customize: impl FnOnce(CodeRuntime) -> CodeRuntime,
+) -> (
+    Router,
+    Arc<FakeProvisioner>,
+    Arc<CodeRuntime>,
+    RepoId,
+    Arc<str>,
+    tempfile::TempDir,
+) {
     let (dir, store) = temp_db_store("code.db").await;
     let db = Arc::new(store);
     let store_trait: Arc<dyn Store> = db.clone();
     let fake = Arc::new(FakeProvisioner::default());
-    let runtime = Arc::new(
+    let runtime = Arc::new(customize(
         CodeRuntime::new(
             db,
             dir.path().to_path_buf(),
@@ -153,7 +168,7 @@ async fn external_app_with_token() -> (
             None,
         )
         .with_remote_sessions(RemoteSessions::new(fake.clone(), remote_settings())),
-    );
+    ));
     let owner = OwnerId::local();
     let repo = CodeRepo {
         id: RepoId::new(),
@@ -263,6 +278,139 @@ async fn an_external_session_names_its_repository_by_origin() {
         .await
         .unwrap();
     assert_eq!(nameless.status(), reqwest::StatusCode::BAD_REQUEST);
+}
+
+/// A fake forge that lends one fixed credential for whichever repository is
+/// asked, recording the ask.
+struct LendingFake(StdMutex<Vec<String>>);
+
+#[async_trait::async_trait]
+impl crate::obo_gateway::GitCredentialLender for LendingFake {
+    async fn git_forge_identity(
+        &self,
+        _owner: &OwnerId,
+    ) -> Result<crate::obo_gateway::GitForgeIdentity, crate::obo_gateway::GitForgeError> {
+        Err(crate::obo_gateway::GitForgeError::NoGitForge)
+    }
+
+    async fn git_credential(
+        &self,
+        _owner: &OwnerId,
+        repository: &str,
+    ) -> Result<crate::obo_gateway::GitCredential, crate::obo_gateway::GitForgeError> {
+        self.0.lock().unwrap().push(repository.to_owned());
+        Ok(crate::obo_gateway::GitCredential {
+            username: "x-access-token".to_owned(),
+            secret: "lent-secret".to_owned(),
+        })
+    }
+
+    async fn list_repositories(
+        &self,
+        _owner: &OwnerId,
+    ) -> Result<Vec<crate::obo_gateway::GitHubRepository>, crate::obo_gateway::GitForgeError> {
+        Ok(Vec::new())
+    }
+}
+
+/// A machine session's own git borrows the person's forge credential from
+/// the loopback route under the session's relay key: `https` against the
+/// repository's origin host answers a credential minted for that
+/// repository, any other host or protocol answers nothing, and a missing or
+/// unknown key is refused before anything is looked up.
+#[tokio::test]
+async fn a_sessions_git_borrows_the_persons_credential_from_the_loopback_route() {
+    let lender = Arc::new(LendingFake(StdMutex::new(Vec::new())));
+    let gateway = Arc::new(
+        crate::obo_gateway::OboGateway::new(
+            "https://gateway.example",
+            "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed".to_owned(),
+        )
+        .unwrap(),
+    );
+    let relay = Arc::new(crate::code::harness_llm::HarnessLlmRelay::new(gateway));
+    let (router, _fake, runtime, repo_id, _token, _dir) = external_app_built({
+        let lender = lender.clone();
+        let relay = relay.clone();
+        move |runtime| runtime.with_git_credentials(lender).with_harness_llm(relay)
+    })
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C7/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session_id = bound_session_id(&runtime, &owner, "T1/C7/1.1").await;
+    let key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
+        owner: owner.clone(),
+        session: session_id,
+    });
+    let route = format!(
+        "http://{addr}{}",
+        crate::code::harness_llm::GIT_CREDENTIAL_PATH
+    );
+    let ask = |body: &'static str, key: Option<&str>| {
+        let mut request = client.post(&route).body(body);
+        if let Some(key) = key {
+            request = request.bearer_auth(key);
+        }
+        request.send()
+    };
+
+    let lent = ask(
+        "protocol=https\nhost=github.com\npath=acme/tools.git\n",
+        Some(&key),
+    )
+    .await
+    .unwrap();
+    assert_eq!(lent.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        lent.text().await.unwrap(),
+        "username=x-access-token\npassword=lent-secret\n"
+    );
+    assert_eq!(
+        lender.0.lock().unwrap().as_slice(),
+        ["acme/tools"],
+        "minted for the workspace's own repository"
+    );
+
+    for other in [
+        "protocol=https\nhost=evil.example\n",
+        "protocol=http\nhost=github.com\n",
+        "protocol=ssh\nhost=github.com\n",
+    ] {
+        let nothing = ask(other, Some(&key)).await.unwrap();
+        assert_eq!(nothing.status(), reqwest::StatusCode::OK, "{other:?}");
+        assert_eq!(
+            nothing.text().await.unwrap(),
+            "",
+            "{other:?} gets no credential"
+        );
+    }
+    assert_eq!(
+        lender.0.lock().unwrap().len(),
+        1,
+        "no mint for a host that is not the origin"
+    );
+
+    let unkeyed = ask("protocol=https\nhost=github.com\n", None)
+        .await
+        .unwrap();
+    assert_eq!(unkeyed.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let wrong = ask("protocol=https\nhost=github.com\n", Some("not-a-key"))
+        .await
+        .unwrap();
+    assert_eq!(wrong.status(), reqwest::StatusCode::UNAUTHORIZED);
 }
 
 /// The whole adapter surface over HTTP: bad tokens refuse, get-or-create

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -161,6 +161,13 @@ impl HarnessLlmRelay {
         }
     }
 
+    /// Whose session a relayed request speaks for, from the same key the
+    /// inference routes accept. `None` for a missing, unknown, or revoked
+    /// key; the caller words the refusal for its own protocol.
+    pub fn subject_for_headers(&self, headers: &HeaderMap) -> Option<HarnessLlmSubject> {
+        relay_key(headers).and_then(|key| self.subject_for_key(key))
+    }
+
     fn subject_for_key(&self, key: &str) -> Option<HarnessLlmSubject> {
         self.state
             .lock()
@@ -400,6 +407,43 @@ pub fn spawn_wiring(
             key,
         },
     )
+}
+
+/// The loopback route a machine session's git asks for a credential.
+pub const GIT_CREDENTIAL_PATH: &str = "/code/git/credential";
+
+/// The environment that points a machine session's own `git` at the
+/// loopback credential route, so the harness's shell can push the branch it
+/// made without the person holding a token on the machine.
+///
+/// Two helper entries: the first empty one clears any helper the machine's
+/// git config names, the second answers `get` by posting git's description
+/// to the route with the session's relay key and passing the answer back.
+/// `store` and `erase` swallow their input, so a dying credential is never
+/// written by another helper. The route pins the host to the workspace's
+/// origin, so a rewritten remote gets no credential. The shell policy
+/// refuses the agent's own `credential.helper` changes, which keeps this
+/// the only helper the session ever runs.
+pub fn git_credential_wiring(loopback_base: &str) -> Vec<(String, String)> {
+    let base = loopback_base.trim_end_matches('/');
+    let helper = format!(
+        "!f() {{ if [ \"$1\" = get ]; then curl -fsS -X POST --data-binary @- \
+         -H \"Authorization: Bearer ${RELAY_KEY_ENV}\" \"{base}{GIT_CREDENTIAL_PATH}\"; \
+         else cat >/dev/null; fi; }}; f"
+    );
+    vec![
+        ("GIT_CONFIG_COUNT".to_owned(), "2".to_owned()),
+        (
+            "GIT_CONFIG_KEY_0".to_owned(),
+            "credential.helper".to_owned(),
+        ),
+        ("GIT_CONFIG_VALUE_0".to_owned(), String::new()),
+        (
+            "GIT_CONFIG_KEY_1".to_owned(),
+            "credential.helper".to_owned(),
+        ),
+        ("GIT_CONFIG_VALUE_1".to_owned(), helper),
+    ]
 }
 
 /// Whether the on-behalf-of relay can carry this engine's inference.
@@ -795,6 +839,43 @@ mod tests {
         assert!(
             text.contains("authentication_error") && text.contains("\"error\""),
             "the OpenAI error shape: {text}"
+        );
+    }
+
+    #[test]
+    fn git_wiring_clears_inherited_helpers_and_posts_to_the_loopback_route() {
+        let env = git_credential_wiring("http://127.0.0.1:4321/");
+        let value = |key: &str| {
+            env.iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.as_str())
+                .unwrap_or_default()
+        };
+        assert_eq!(value("GIT_CONFIG_COUNT"), "2");
+        assert_eq!(value("GIT_CONFIG_KEY_0"), "credential.helper");
+        assert_eq!(
+            value("GIT_CONFIG_VALUE_0"),
+            "",
+            "the first entry clears every configured helper"
+        );
+        assert_eq!(value("GIT_CONFIG_KEY_1"), "credential.helper");
+        let helper = value("GIT_CONFIG_VALUE_1");
+        assert!(helper.starts_with("!f() {"), "{helper}");
+        assert!(
+            helper.contains("http://127.0.0.1:4321/code/git/credential"),
+            "{helper}"
+        );
+        assert!(
+            helper.contains("Bearer $TIDEBREAK_LLM_KEY"),
+            "the session's own key: {helper}"
+        );
+        assert!(
+            helper.contains("= get ]"),
+            "only `get` reaches the route: {helper}"
+        );
+        assert!(
+            helper.contains("cat >/dev/null"),
+            "store and erase swallow: {helper}"
         );
     }
 }

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -188,8 +188,15 @@ impl CodeRuntime {
                     owner: session.owner.clone(),
                     session: session.id,
                 });
-                let (argv, env) =
+                let (argv, mut env) =
                     crate::code::harness_llm::spawn_wiring(session.harness_kind, &base, &key);
+                // A repository session's own git borrows the person's forge
+                // credential through the loopback route under the same key,
+                // so the harness's shell can push what it made. A machine
+                // that lends none leaves git as it found it.
+                if workspace.is_some() && self.git_credentials.is_some() {
+                    env.extend(crate::code::harness_llm::git_credential_wiring(&base));
+                }
                 (
                     argv,
                     env,


### PR DESCRIPTION
Closes #3207.

## What broke

On the hosted devops machine, a session on the machine's own engine committed a change and then reported "GitHub authentication is unavailable (`gh auth status` shows logged out, and push failed)". Tidebreak's own git borrows a short-lived person credential from the gateway (`gh.rs`, host-pinned one-shot helper) and sandbox children get `/ambient/askpass`; the harness child a machine session launches got neither.

## Change

- `POST /code/git/credential` (`routes/code/llm.rs`), registered beside the inference relay and authenticated by the same per-session relay key. The body is git's credential description. A credential is lent only for `https` against the exact host the session's repository was cloned from, minted through `GitCredentialLender::git_credential` for `owner/name`, and answered as `username=`/`password=` lines. Any other host or protocol, or a session with no repository, gets an empty answer, which git reads as "no credential". A missing or unknown key is 401 before anything is looked up.
- `harness_llm::git_credential_wiring`: `GIT_CONFIG_COUNT=2` with an empty `credential.helper` that clears whatever the machine's git config names, then a helper that posts `get` to the route with `$TIDEBREAK_LLM_KEY` and swallows `store`/`erase`, so no other helper ever sees the dying token. `workers.rs` adds it to the child's environment when the session has a workspace and the machine lends credentials.
- The shell policy already lists `credential.helper` and `GIT_ASKPASS` as things the agent may not set, which keeps this the only helper a session runs.

Not in this change: `gh` itself. It reads no git helper, and a long-lived `GH_TOKEN` is the wrong shape for a dying credential; Tidebreak's delivery verbs open the pull request today, and a `gh`-side answer is a follow-up.

## Tests

- `a_sessions_git_borrows_the_persons_credential_from_the_loopback_route`: lends for the origin host, records the mint for `acme/tools`, answers nothing for another host or for `http`/`ssh`, refuses a missing or wrong key.
- `git_wiring_clears_inherited_helpers_and_posts_to_the_loopback_route`: the environment's shape.

## Verified

- `cargo test -p tidebreak-server a_sessions_git_borrows` and `cargo test -p tidebreak-server-core --lib git_wiring`: pass.
- `cargo clippy -p tidebreak-server-core -p tidebreak-server --all-targets -- -D warnings`: clean.