### PR TITLE
improve(ui): the connect approval wears the machine's shell

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.tsx
@@ -3,6 +3,7 @@ import { useParams } from "@tanstack/react-router";
 
 import { useApp } from "./AppContext";
 import { HttpError, type CodeConnectPage } from "./api";
+import { Logomark } from "./Logomark";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
@@ -102,9 +103,16 @@ export function ConnectApprovalView({
   onApprove: () => void;
   onRetry: () => void;
 }) {
+  // The same shell as the hosted sign-in screen: a person arrives here
+  // from a Slack card, often on a machine they have never opened, and the
+  // page must say whose it is before it asks "is this you?".
   return (
-    <div className="flex min-h-full items-center justify-center p-6">
-      <Card className="w-full max-w-md p-6">
+    <div className="boot" aria-label="Connect approval">
+      <div className="boot-brand">
+        <Logomark />
+        <h1>Tidebreak</h1>
+      </div>
+      <Card className="w-full max-w-md p-6 text-left">
         {phase === "loading" ? (
           <p className="text-sm text-muted-foreground" role="status">
             Opening the connect request…


### PR DESCRIPTION
## Why

The connect approval a Slack card links to rendered as a bare card on an empty page. A person arrives there from Slack, often on a hosted machine they have never opened, and the page gave no sign of whose it was before asking "is this you?".

## Change

`ConnectApprovalRoute.tsx`: the view sits in the same `.boot` shell as the hosted sign-in screen, with the logomark and "Tidebreak" above the card; the card keeps its left-aligned copy. Nothing else on the page changes, so the existing DOM tests and the six Storybook states hold.

## Verified

- `vitest run ConnectApprovalRoute`: 4 passed; `tsc --noEmit`: clean; Biome formatted.
- Storybook `Code/Connect approval` stories captured in light and dark and looked at: brand, card, button, and the invalid-link state all read cleanly; contrast holds in both themes.