### PR TITLE
feat(code): gh in a machine session borrows the person's forge credential per call

### DIFF
--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -38,6 +38,8 @@ use axum::response::Response;
 
 use tidebreak_core::{AgentError, HarnessKind, OwnerId, SessionId};
 
+use std::path::Path;
+
 use crate::obo_gateway::{GatewayCompatModel, OboGateway};
 
 /// Whose inference a relay key spends.
@@ -444,6 +446,33 @@ pub fn git_credential_wiring(loopback_base: &str) -> Vec<(String, String)> {
         ),
         ("GIT_CONFIG_VALUE_1".to_owned(), helper),
     ]
+}
+
+/// The `gh` a machine session runs: a wrapper that borrows the session's
+/// forge credential for one call through the same loopback route git uses,
+/// hands it to the real `gh` as `GH_TOKEN`, and never writes it anywhere.
+/// `gh auth status` reads signed in, `gh pr create` works against the
+/// workspace's own repository, and a token that dies within the hour is
+/// fetched fresh on the next call. With no relay key in the environment, or
+/// no credential lent, the real `gh` runs as it would have anyway.
+pub fn gh_shim_script(real_gh: &Path, loopback_base: &str, origin_host: &str) -> String {
+    let base = loopback_base.trim_end_matches('/');
+    let quote = |value: &str| format!("'{}'", value.replace('\'', "'\\''"));
+    format!(
+        "#!/bin/sh\n\
+         # Tidebreak: gh borrows this session's forge credential per call.\n\
+         if [ -n \"${RELAY_KEY_ENV}\" ]; then\n\
+         \x20 token=$(printf 'protocol=https\\nhost=%s\\n' {host} | \
+         curl -fsS -X POST --data-binary @- \
+         -H \"Authorization: Bearer ${RELAY_KEY_ENV}\" {route} 2>/dev/null | \
+         sed -n 's/^password=//p')\n\
+         \x20 if [ -n \"$token\" ]; then GH_TOKEN=\"$token\"; export GH_TOKEN; fi\n\
+         fi\n\
+         exec {real} \"$@\"\n",
+        host = quote(origin_host),
+        route = quote(&format!("{base}{GIT_CREDENTIAL_PATH}")),
+        real = quote(&real_gh.to_string_lossy()),
+    )
 }
 
 /// Whether the on-behalf-of relay can carry this engine's inference.
@@ -876,6 +905,40 @@ mod tests {
         assert!(
             helper.contains("cat >/dev/null"),
             "store and erase swallow: {helper}"
+        );
+    }
+
+    #[test]
+    fn the_gh_shim_borrows_per_call_and_execs_the_real_binary() {
+        let script = gh_shim_script(
+            Path::new("/usr/bin/gh"),
+            "http://127.0.0.1:4321/",
+            "github.com",
+        );
+        assert!(script.starts_with("#!/bin/sh\n"), "{script}");
+        assert!(script.contains("host=%s"), "{script}");
+        assert!(
+            script.contains("'github.com'"),
+            "the origin host is pinned: {script}"
+        );
+        assert!(
+            script.contains("'http://127.0.0.1:4321/code/git/credential'"),
+            "{script}"
+        );
+        assert!(script.contains("Bearer $TIDEBREAK_LLM_KEY"), "{script}");
+        assert!(
+            script.contains("GH_TOKEN=\"$token\"; export GH_TOKEN"),
+            "{script}"
+        );
+        assert!(script.ends_with("exec '/usr/bin/gh' \"$@\"\n"), "{script}");
+        assert!(
+            !script.contains("gh auth login"),
+            "nothing durable is written: {script}"
+        );
+        let odd = gh_shim_script(Path::new("/opt/it's/gh"), "http://h", "GitHub.Example");
+        assert!(
+            odd.contains("exec '/opt/it'\\''s/gh'"),
+            "a quote in the path survives: {odd}"
         );
     }
 }

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -9,6 +9,57 @@ const DEFERRED_RESYNC_POLL: Duration = Duration::from_secs(2);
 const DEFERRED_RESYNC_DEADLINE: Duration = Duration::from_secs(2 * 60 * 60);
 
 impl CodeRuntime {
+    /// The `PATH` a machine session's child runs with when this machine
+    /// lends forge credentials: the session's private `bin` first, holding
+    /// a `gh` wrapper that borrows the credential per call, then the probe's
+    /// own path. Best effort: a machine without `gh`, a repository with no
+    /// origin, or a private root that refuses the write leaves the path
+    /// alone and the child's `gh` behaves as it always did.
+    async fn gh_shim_path(
+        &self,
+        private_root: &crate::code::scratch::ScratchRoot,
+        workspace: Option<&tidebreak_core::CodeWorkspace>,
+        probe_env: &[(std::ffi::OsString, std::ffi::OsString)],
+        loopback_base: &str,
+        owner: &OwnerId,
+    ) -> Option<String> {
+        let workspace = workspace?;
+        let repo = self.get_repo(owner, workspace.repo_id).await.ok()?;
+        let origin_host = repo.origin_host?;
+        let real = crate::code::gh::observe_gh(self.gh_search_path_owned().as_deref())
+            .await
+            .binary?;
+        let script = crate::code::harness_llm::gh_shim_script(&real, loopback_base, &origin_host);
+        let shim = match private_root
+            .publish_executable(
+                std::ffi::OsStr::new("bin"),
+                std::ffi::OsStr::new("gh"),
+                script.as_bytes(),
+            )
+            .await
+        {
+            Ok(path) => path,
+            Err(error) => {
+                tracing::warn!(%error, "the session's gh wrapper was not written");
+                return None;
+            }
+        };
+        let bin = shim.parent()?.to_path_buf();
+        let prior = probe_env
+            .iter()
+            .find(|(key, _)| key == "PATH")
+            .map(|(_, value)| value.clone())
+            .unwrap_or_default();
+        let mut paths = vec![bin];
+        paths.extend(std::env::split_paths(&prior));
+        Some(
+            std::env::join_paths(paths)
+                .ok()?
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+
     pub(super) fn wake_all_workers(&self) {
         for handle in self.workers.lock().expect("code workers").values() {
             wake_queue(handle);
@@ -196,6 +247,18 @@ impl CodeRuntime {
                 // that lends none leaves git as it found it.
                 if workspace.is_some() && self.git_credentials.is_some() {
                     env.extend(crate::code::harness_llm::git_credential_wiring(&base));
+                    if let Some(path) = self
+                        .gh_shim_path(
+                            &private_root,
+                            workspace.as_ref(),
+                            &probe.env,
+                            &base,
+                            &session.owner,
+                        )
+                        .await
+                    {
+                        env.push(("PATH".to_owned(), path));
+                    }
                 }
                 (
                     argv,

--- a/crates/tidebreak-server/src/code/scratch.rs
+++ b/crates/tidebreak-server/src/code/scratch.rs
@@ -36,6 +36,27 @@ impl ScratchRoot {
         &self.path
     }
 
+    /// Publish one owner-only executable in a child directory of this root:
+    /// the same atomic rename as any published file, then the mode that
+    /// lets its owner run it and nobody else read it. Returns the path an
+    /// engine reaches it by.
+    pub(crate) async fn publish_executable(
+        &self,
+        subdir: &OsStr,
+        name: &OsStr,
+        bytes: &[u8],
+    ) -> io::Result<PathBuf> {
+        let child = ensure_child_dir(&self.dir, subdir)?;
+        publish_file(&child, name, bytes).await?;
+        #[cfg(unix)]
+        {
+            use cap_std::fs::{Permissions, PermissionsExt as _};
+
+            child.set_permissions(name, Permissions::from_mode(0o700))?;
+        }
+        Ok(self.path.join(subdir).join(name))
+    }
+
     #[cfg(test)]
     pub(crate) fn open_for_test(path: &Path) -> io::Result<Self> {
         let path = absolute_path(path)?;
@@ -799,5 +820,28 @@ mod tests {
             .join("private.png");
         assert_eq!(std::fs::read(held.join(&relative)).unwrap(), b"private");
         assert!(!redirected.join(relative).exists());
+    }
+
+    #[tokio::test]
+    async fn a_published_executable_is_runnable_by_its_owner_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = ScratchRoot::open_for_test(tmp.path()).unwrap();
+        let path = root
+            .publish_executable(OsStr::new("bin"), OsStr::new("gh"), b"#!/bin/sh\nexit 0\n")
+            .await
+            .unwrap();
+        assert_eq!(path, tmp.path().join("bin").join("gh"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"#!/bin/sh\nexit 0\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "owner runs it, nobody else reads it");
+        }
+        // Publishing again replaces the file in place.
+        root.publish_executable(OsStr::new("bin"), OsStr::new("gh"), b"#!/bin/sh\nexit 1\n")
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"#!/bin/sh\nexit 1\n");
     }
 }


### PR DESCRIPTION
Follows #3209 (closes the `gh` half of #3207).

## What broke

With #3209 a machine session's `git push` works, but the agent's `gh pr create` still ended at "gh auth status shows logged out": `gh` reads no git credential helper, and a `GH_TOKEN` set once at launch would go stale inside the hour while the child lives across turns.

## Change

- `harness_llm::gh_shim_script`: a `/bin/sh` wrapper that posts `protocol=https`/`host=<origin host>` to `/code/git/credential` with the session's relay key, exports the answer as `GH_TOKEN` for that one call, and `exec`s the real `gh`. Without a key or a credential it runs the real `gh` unchanged. Nothing is written to `~/.config/gh` or any store.
- `ScratchRoot::publish_executable`: publishes an owner-only (0700) executable under a child directory of the session's private root, by the same atomic rename as any published file.
- `workers.rs`: for a machine session with a workspace on a machine that lends credentials, the launcher writes `<private root>/bin/gh` (real binary from the server's own `gh` probe, host from the repository's origin) and puts that directory first on the child's `PATH`, ahead of the probe's path. No `gh` on the machine, no origin on the repository, or a refused write leaves the path as it was.

The shell policy's refusal of the agent's own `credential.helper` and `GIT_ASKPASS` changes is unchanged; the wrapper only adds a credential the agent could already obtain through the route with its own key.

## Tests

- `the_gh_shim_borrows_per_call_and_execs_the_real_binary`: the script's shape, the pinned host and route, the `exec` line, and quoting of a path with a quote in it.
- `a_published_executable_is_runnable_by_its_owner_alone`: path, contents, mode 0700, and replacement in place.

## Verified

- `cargo test -p tidebreak-server-core --lib gh_shim` and `--lib a_published_executable`: pass.
- `cargo clippy -p tidebreak-server-core -p tidebreak-server --all-targets -- -D warnings`: clean.