### PR TITLE
docs(decisions): 0086 session access is separate from ownership; 0087 standalone browser sign-in

### DIFF
--- a/docs/decisions/0086-session-access-is-separate-from-ownership.md
+++ b/docs/decisions/0086-session-access-is-separate-from-ownership.md
@@ -1,0 +1,120 @@
+# 86. Session access is separate from ownership
+
+- Status: Accepted
+- Date: 2026-09-04
+- Owners: thet
+- Related: [0047](0047-gateway-linked-hosting.md) (amends its validation rule that a second user never sees another owner's events); [0049](0049-gateway-authenticated-hosted-machines.md); [0082](0082-the-hosted-machine-serves-the-renderer.md); `docs/slack-sessions.md`; tidebreak #3178 (track A), #3179, #3180
+- Supersedes: none
+
+## Context
+
+`ScopedCode` binds every `/code/*` read and write to the caller's owner key.
+Another owner's session is indistinguishable from one that does not exist,
+the updates channel fans out to the owner alone, and a turn records what was
+said but not who said it. That is the right floor for a machine one person
+uses. It is the wrong shape for what Slack asks of a machine: a thread in a
+channel is read by everyone in the room, several of them steer it, and a
+link in the thread should open the same session on the web for a teammate
+who never connected. Nothing in the model lets a session be seen by a
+second person, let alone driven by one, and nothing names who drove it.
+
+Two facts about the code are load-bearing. First, ownership is more than
+access: the owner's key is the execution identity (whose forge credential
+and inference the session spends) and the lifecycle authority (who may
+reap, delete, or change the permission mode). Second, the adapter already
+holds one external identity per person (`code_external_grant`), which is
+what the machine knows about a Slack user who has not signed in here.
+
+## Decision
+
+A session keeps exactly one owner, who remains its execution identity and
+lifecycle authority. Access is a separate, per-session list, and visibility
+is a per-session default.
+
+- `session_access (session_id, subject, level, granted_by, created_at)`,
+  `level` in `view` or `contribute`. A subject is a principal key
+  (`principal:<owner key>`) or an external identity
+  (`external:<channel_kind>:<user id>`), so the Slack adapter can mirror a
+  private channel's membership without the machine knowing those people.
+  An external-identity row resolves for a web caller only through a live
+  external grant that binds them to that identity; a revoked grant makes
+  the row inert.
+- `session.visibility` is `private` (the default) or `deployment`. A
+  `deployment` session may be read by any authenticated principal on the
+  machine. Visibility never grants writes.
+- Reads (the session, its workspace, turns, events, attention, artifacts,
+  approvals) resolve for the owner, any access row, or `deployment`
+  visibility. Submit, queue, steer, interrupt, and approval decisions need
+  `contribute` or ownership. Reap, permission mode, model, settings,
+  delete, and access management stay with the owner, or an admin where the
+  route already admits one.
+- The updates channel and the session event socket fan out to every
+  granted reader and sever a reader's stream the moment their row is
+  revoked or their grant is fenced.
+- Every turn and every approval, question, or plan decision records an
+  actor: the principal when there is one, the external identity and
+  display name when the input came through an adapter, the trigger when a
+  trigger fired it. Older rows stay null and render as the owner.
+
+A channel session (track D) does not enumerate its readers here: its
+contributor set is the channel's membership, resolved by the adapter at
+each turn under the shared identity that owns the session. This record
+covers DM sessions, web sharing, and private-channel membership the adapter
+mirrors into rows.
+
+Excluded: teams and roles (they wait on team ids from the gateway's
+principal read), transfer of ownership, and any access that outlives the
+session.
+
+## Alternatives Considered
+
+**Ownership as a set.** Several owners, each an execution identity. Rejected:
+the forge credential and the inference bill would have no single principal,
+and a reap by one owner would surprise another. One owner, many readers, a
+few contributors keeps every spend and every destructive action attributable
+to one person.
+
+**Visibility alone, no rows.** `private` or `deployment`, nothing per
+person. Rejected: a DM session shared with one teammate would have to become
+visible to the whole deployment, and a private channel's session could not
+be limited to the channel's members.
+
+**Rows keyed only by principal.** Rejected: a private channel's members are
+Slack identities, most of whom hold no principal on the machine until they
+connect, so the adapter could not mirror membership.
+
+**Do nothing.** Sessions stay single-reader; Slack threads would keep
+carrying a transcript the web cannot show and steering only the owner may
+do. Rejected; it is the reason for track A.
+
+## Consequences
+
+Two appended migrations (decision 61). Every read path in `ScopedCode`
+gains a second resolution step, so the owner-scope test suite grows a
+viewer, a contributor, a revoked reader, and a `deployment` reader, on both
+the desktop and the self-host profile. Decision 47's validation rule
+narrows from "a second user never sees another owner's events" to "a second
+user sees another owner's events only through an access row or `deployment`
+visibility, and never writes without `contribute`".
+
+The actor makes attribution a stored fact rather than an inference, which
+the adapter and the web both render. It also means a display name reaches
+the machine's database; it is the name the channel showed, nothing more.
+
+Revisit when the gateway's principal read carries team ids (rows keyed by
+team) or when a session needs to change owner.
+
+## Validation
+
+- A viewer reads the session, its turns, and its events, and every write
+  is refused; a contributor submits and steers and cannot reap or change
+  the permission mode.
+- Revoking a row closes that reader's open event socket within one event.
+- A `deployment` session is readable by a third principal that holds no
+  row; a `private` one answers not found to the same principal.
+- An external-identity row resolves through a live grant and stops
+  resolving when the grant is fenced, without the row changing.
+- A wrong implementation that passes the old suite and still fails this
+  one: resolving access by the workspace's owner instead of the session's,
+  or fanning out to viewers on the updates channel but not on the event
+  socket.

--- a/docs/decisions/0087-standalone-browser-sign-in.md
+++ b/docs/decisions/0087-standalone-browser-sign-in.md
@@ -1,0 +1,98 @@
+# 87. Standalone browser sign-in
+
+- Status: Accepted
+- Date: 2026-09-04
+- Owners: thet
+- Related: [0006](0006-self-host-deployment-plane-authorization.md) (sequences roster-provisioned tokens before an authenticator); [0049](0049-gateway-authenticated-hosted-machines.md) (fail-closed rules); [0082](0082-the-hosted-machine-serves-the-renderer.md) (the machine serves the page; a bearer arrives in the fragment); `docs/self-hosting.md`; tidebreak #3178 (track B), #3182
+- Supersedes: none
+
+## Context
+
+A gateway-authenticated machine signs a browser in through the console's
+hand-off: the console mints a one-time code, the machine redeems it, and
+the page receives a bearer in the URL fragment. A standalone machine, one
+on `TIDEBREAK_AUTH_TOKENS_FILE`, has no console and therefore no browser
+sign-in at all. The page says so and the desktop app stays its only client.
+A Slack link to a session on such a machine lands on a screen that cannot
+be passed, which makes every Slack feature this epic builds a
+gateway-only feature by accident.
+
+Decision 6 already sequences the end state: tokens provisioned from a
+roster first, then an authenticator behind the seam that turns a credential
+into a principal. What is missing is the browser half of both.
+
+## Decision
+
+A standalone machine signs a browser in by one of two paths, chosen by the
+machine's boot mode and reported in its discovery document.
+
+- **Token paste.** In `static_token` mode the sign-in page takes a token,
+  probes the principal read with it, and on success holds it in memory for
+  the tab's life exactly as the hand-off bearer is held: no cookie, no
+  storage, gone on reload. The page honors `return_to`, so a session link
+  lands on its route after sign-in. This is the bootstrap path and the CLI
+  path; it is not retired by the second.
+- **OIDC.** A third exclusive boot mode, selected by
+  `TIDEBREAK_AUTH_OIDC_ISSUER`, client id, and client secret, with an
+  optional login claim override. The machine starts an authorization-code
+  flow with PKCE, verifies the callback's state and nonce, validates the ID
+  token against the issuer's discovery document and keys, maps the login
+  claim to a principal, mints a machine-issued bearer bound to that
+  principal for one hour, and lands the page through the same fragment
+  envelope the hand-off uses. Discovery reports `mode: oidc` and the start
+  URL; the page shows one button.
+- **Exclusivity and refusals.** A machine is gateway, static-token, or
+  OIDC; combining the gateway URL with OIDC is a boot error. The token file
+  may sit beside OIDC as the bootstrap for the first admin and for CLI
+  access. An OIDC machine refuses a static token; a token-file machine
+  refuses an OIDC bearer; a provider refusal admits nobody.
+
+Everything above the credential-to-principal seam stays unaware of which
+mode is in use, which is decision 6's requirement.
+
+## Alternatives Considered
+
+**Require a gateway.** Every Slack feature would need a gateway
+installation. Rejected: the plan's premise is that Tidebreak works without
+one, and the machine engine is the floor.
+
+**A machine-local password login.** Rejected: it creates a second identity
+store to provision, rotate, and audit. The token file already is the local
+roster; OIDC is where real identity lives.
+
+**A bearer in a cookie.** Rejected for the same reasons decision 82 gave:
+a fragment never reaches a server or its logs, and the page clears it before
+the router runs.
+
+**Only OIDC, no token paste.** Rejected: the first admin of a standalone
+machine has no OIDC principal yet, and a CLI session needs a token either
+way.
+
+## Consequences
+
+`auth.rs` gains a third authenticator and two routes; the discovery
+document gains a mode and a start URL; `docs/self-hosting.md` loses its
+"no browser sign-in" paragraph. The OIDC path adds a dependency on the
+issuer's availability at sign-in time and nothing else, because the bearer
+is machine-issued once the ID token is verified.
+
+A pasted token is as strong as the file it came from; the roster owner
+decides who holds one. A stale OIDC mapping (a login claim that changes)
+signs a person in as nobody, which is the fail-closed outcome.
+
+Revisit when the gateway's principal read grows team ids and the standalone
+roster wants the same shape, or when a refresh flow is wanted for browsers
+kept open past an hour (tracked separately as hosted tab re-entry).
+
+## Validation
+
+- A fresh browser opening a session link on a static-token machine is
+  asked for a token and lands on the session; a wrong token stays on the
+  screen with the refusal.
+- On an OIDC machine the same link goes through the issuer and lands on
+  the session; a callback with a mismatched state, nonce, or audience is
+  refused and nothing is minted.
+- An OIDC machine refuses a static token; a token-file machine refuses an
+  OIDC bearer.
+- Nothing about a bearer or a token is written to storage, a cookie, or a
+  log line; the discovery document is readable without a bearer.

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -94,3 +94,5 @@
 0083  0083-portable-workspace-configuration-export.md
 0084  0084-the-server-image-carries-github-build-provenance.md
 0085  0085-the-server-honors-the-model-gateway-add-on-plane-s-environment-contract.md
+0086  0086-session-access-is-separate-from-ownership.md
+0087  0087-standalone-browser-sign-in.md


### PR DESCRIPTION
Part of #3178. Tracks A and B each start with their decision record, as the epic's order says.

- **0086, session access is separate from ownership** (tracks A: #3179, #3180). One owner stays the execution identity and lifecycle authority; a per-session access list (`view`, `contribute`) keyed by principal or external identity; `private` or `deployment` visibility; every turn and decision records an actor. Amends decision 47's validation rule to admit reads through a row or `deployment` visibility.
- **0087, standalone browser sign-in** (track B: #3182). Token paste in `static_token` mode, held in memory like the hand-off bearer; an OIDC boot mode with PKCE, machine-issued bearers, and the same fragment envelope; exclusivity and cross-mode refusals per decision 49.

`python3 scripts/adr.py check` passes; the manifest is regenerated by the tool.