### PR TITLE
feat(ui): send an expired hosted tab back through the console

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ComposerDrafts.ts
+++ b/crates/tidebreak-desktop/ui/src/ComposerDrafts.ts
@@ -24,7 +24,9 @@ function attachmentsStorageKeyFor(key: string): string {
   return `${ATTACHMENTS_PREFIX}${key}`;
 }
 
-function composerKeyForRoute(route: string): string | null {
+/** The composer a hash route's draft belongs to: a chat's id, the home
+ * composer's key, or `null` where no composer lives. */
+export function composerKeyForRoute(route: string): string | null {
   const chatMatch = /\/c\/([^/?]+)/.exec(route);
   if (chatMatch) return chatMatch[1];
   if (route === "/") return HOME_DRAFT_KEY;

--- a/crates/tidebreak-desktop/ui/src/ComposerDrafts.ts
+++ b/crates/tidebreak-desktop/ui/src/ComposerDrafts.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
 
+import {
+  hostedHashRoute,
+  type HostedLocationWin,
+  takeComposerDraftForReentry,
+} from "./hostedSession";
 import { isRecord } from "./lib/guards";
 import type { ImportedDocument } from "./documents";
 import type { ImageAttachment } from "./ImageAttachments";
@@ -17,6 +22,13 @@ function storageKeyFor(key: string): string {
 
 function attachmentsStorageKeyFor(key: string): string {
   return `${ATTACHMENTS_PREFIX}${key}`;
+}
+
+function composerKeyForRoute(route: string): string | null {
+  const chatMatch = /\/c\/([^/?]+)/.exec(route);
+  if (chatMatch) return chatMatch[1];
+  if (route === "/") return HOME_DRAFT_KEY;
+  return null;
 }
 
 function readStoredDrafts(): Record<string, string> {
@@ -281,6 +293,17 @@ export function createComposerDraftStore() {
 }
 
 export const useComposerDrafts = createComposerDraftStore();
+
+/** After a hosted console round trip: put the stashed draft back, once. */
+export function hydrateComposerDraftFromHostedReentry(
+  win: HostedLocationWin = window,
+  storage?: Storage | null,
+): void {
+  const route = hostedHashRoute(win);
+  const reentry = takeComposerDraftForReentry(route, storage);
+  const key = composerKeyForRoute(route);
+  if (reentry && key) useComposerDrafts.getState().setDraft(key, reentry);
+}
 
 /** This composer's unsent text, restored from a previous visit if there is one. */
 export function useComposerDraft(key: string): string {

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -4,6 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
 import { ManagedGate } from "./ManagedGate";
+import {
+  captureHandoffToken,
+  markHostedSession,
+  resetHostedSessionForTests,
+} from "./hostedSession";
 import { useManagedPolicy } from "./managedPolicy";
 
 // The policy stores its URL normalized with a trailing slash; the status
@@ -85,6 +90,7 @@ function HostedGatewayProbe() {
 afterEach(() => {
   cleanup();
   pairingNudge.fire = null;
+  resetHostedSessionForTests();
   vi.clearAllMocks();
   vi.useRealTimers();
   vi.unstubAllGlobals();
@@ -559,6 +565,43 @@ describe("ManagedGate", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText("https://next-gateway.example/"),
+    ).toBeInTheDocument();
+  });
+
+  it("a standalone hosted machine whose bearer died shows the session-ended screen", async () => {
+    markHostedSession({
+      baseUrl: "https://machine.example.test",
+      gatewayUrl: null,
+    });
+    const client = api({
+      getPolicy: vi.fn().mockRejectedValue(new Error("401: unauthorized")),
+    });
+    mount(client);
+    expect(
+      await screen.findByText("Your session on this machine ended"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+  });
+
+  it("a second refusal after a hand-off shows the session-ended screen", async () => {
+    captureHandoffToken({
+      location: {
+        hash: "#handoff=mg_at_abc.DEF-123~",
+        pathname: "/",
+        search: "",
+      },
+      history: { state: null, replaceState: () => undefined },
+    } as unknown as Window);
+    markHostedSession({
+      baseUrl: "https://machine.example.test",
+      gatewayUrl: "https://gateway.example.test",
+    });
+    const client = api({
+      getPolicy: vi.fn().mockRejectedValue(new Error("401: unauthorized")),
+    });
+    mount(client);
+    expect(
+      await screen.findByText("Your session on this machine ended"),
     ).toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
@@ -7,7 +7,13 @@ import { HostedSignIn } from "./HostedSignIn";
 import { Logomark } from "./Logomark";
 import { ManagedPolicyContext } from "./managedPolicy";
 import { hasNativeHost, onPairingChanged } from "./host";
-import { hostedSession } from "./hostedSession";
+import { HOME_DRAFT_KEY, useComposerDrafts } from "./ComposerDrafts";
+import {
+  hostedHashRoute,
+  hostedSession,
+  reenterExpiredHostedSession,
+  stashComposerDraftForReentry,
+} from "./hostedSession";
 import { openInBrowser } from "./openInBrowser";
 import { disconnectRemoteMachine, remoteMachineState } from "./remoteMachine";
 import { useVisibilityGatedPoll } from "./useVisibilityGatedPoll";
@@ -343,6 +349,21 @@ export function ManagedGate({
       policyState.kind === "blocked" &&
       (policyState.status === 401 || policyState.status === 403)
     ) {
+      const route = hostedHashRoute();
+      const chatMatch = /\/c\/([^/?]+)/.exec(route);
+      const composerKey = chatMatch
+        ? chatMatch[1]
+        : route === "/"
+          ? HOME_DRAFT_KEY
+          : null;
+      const draft =
+        composerKey === null
+          ? ""
+          : (useComposerDrafts.getState().drafts[composerKey] ?? "");
+      stashComposerDraftForReentry(route, draft);
+      if (reenterExpiredHostedSession(hosted) === "redirect") {
+        return null;
+      }
       return (
         <HostedSignIn
           reason="session_ended"

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
@@ -7,9 +7,10 @@ import { HostedSignIn } from "./HostedSignIn";
 import { Logomark } from "./Logomark";
 import { ManagedPolicyContext } from "./managedPolicy";
 import { hasNativeHost, onPairingChanged } from "./host";
-import { HOME_DRAFT_KEY, useComposerDrafts } from "./ComposerDrafts";
+import { composerKeyForRoute, useComposerDrafts } from "./ComposerDrafts";
 import {
   hostedHashRoute,
+  hostedReentryIsLooping,
   hostedSession,
   reenterExpiredHostedSession,
   stashComposerDraftForReentry,
@@ -349,18 +350,18 @@ export function ManagedGate({
       policyState.kind === "blocked" &&
       (policyState.status === 401 || policyState.status === 403)
     ) {
-      const route = hostedHashRoute();
-      const chatMatch = /\/c\/([^/?]+)/.exec(route);
-      const composerKey = chatMatch
-        ? chatMatch[1]
-        : route === "/"
-          ? HOME_DRAFT_KEY
-          : null;
-      const draft =
-        composerKey === null
-          ? ""
-          : (useComposerDrafts.getState().drafts[composerKey] ?? "");
-      stashComposerDraftForReentry(route, draft);
+      // Only a redirect needs the draft carried over; the dead-end screen
+      // keeps the page, and a draft written for nothing would resurface on
+      // some later boot.
+      if (hosted.gatewayUrl && !hostedReentryIsLooping()) {
+        const route = hostedHashRoute();
+        const composerKey = composerKeyForRoute(route);
+        const draft =
+          composerKey === null
+            ? ""
+            : (useComposerDrafts.getState().drafts[composerKey] ?? "");
+        stashComposerDraftForReentry(route, draft);
+      }
       if (reenterExpiredHostedSession(hosted) === "redirect") {
         return null;
       }

--- a/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
@@ -3,12 +3,20 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { HostedSignInRequired, hostedServerInfo } from "./boot";
 import {
+  HOME_DRAFT_KEY,
+  hydrateComposerDraftFromHostedReentry,
+  useComposerDrafts,
+} from "./ComposerDrafts";
+import {
   captureHandoffToken,
   consoleSignInUrl,
   handoffBearer,
   handoffFailure,
   hostedSession,
+  reenterExpiredHostedSession,
   resetHostedSessionForTests,
+  stashComposerDraftForReentry,
+  takeComposerDraftForReentry,
 } from "./hostedSession";
 import { remoteMachineState } from "./remoteMachine";
 
@@ -203,6 +211,47 @@ describe("the hosted boot branch", () => {
   });
 });
 
+function navWindow(hash: string): {
+  location: { hash: string; href: string };
+} {
+  let href = "https://machine.example.test/";
+  return {
+    location: {
+      hash,
+      get href() {
+        return href;
+      },
+      set href(next: string) {
+        href = next;
+      },
+    },
+  };
+}
+
+function memoryStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.get(key) ?? null;
+    },
+    key(index: number) {
+      return [...data.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    setItem(key: string, value: string) {
+      data.set(key, value);
+    },
+  };
+}
+
 describe("consoleSignInUrl", () => {
   it("sends the reader to the console's Tidebreak page with this page as the return path", () => {
     const win = {
@@ -224,5 +273,79 @@ describe("consoleSignInUrl", () => {
     expect(consoleSignInUrl("https://gateway.example.test", win)).toBe(
       "https://gateway.example.test/tidebreak",
     );
+  });
+});
+
+describe("reenterExpiredHostedSession", () => {
+  it("navigates a gateway machine to the console with the current hash route", () => {
+    const win = navWindow("#/c/chat-1");
+    const outcome = reenterExpiredHostedSession(
+      {
+        baseUrl: "https://machine.example.test",
+        gatewayUrl: "https://gateway.example.test",
+      },
+      win,
+    );
+    expect(outcome).toBe("redirect");
+    expect(win.location.href).toBe(
+      "https://gateway.example.test/tidebreak?return_to=%2Fc%2Fchat-1",
+    );
+  });
+
+  it("renders sign-in when a hand-off is refused again inside the loop window", () => {
+    captureHandoffToken(fakeWindow("#handoff=mg_at_abc.DEF-123~"));
+    const win = navWindow("#/c/chat-1");
+    const outcome = reenterExpiredHostedSession(
+      {
+        baseUrl: "https://machine.example.test",
+        gatewayUrl: "https://gateway.example.test",
+      },
+      win,
+    );
+    expect(outcome).toBe("sign_in");
+    expect(win.location.href).toBe("https://machine.example.test/");
+  });
+
+  it("renders sign-in on a standalone machine", () => {
+    const win = navWindow("#/c/chat-1");
+    const outcome = reenterExpiredHostedSession(
+      {
+        baseUrl: "https://machine.example.test",
+        gatewayUrl: null,
+      },
+      win,
+    );
+    expect(outcome).toBe("sign_in");
+    expect(win.location.href).toBe("https://machine.example.test/");
+  });
+});
+
+describe("hosted re-entry composer draft", () => {
+  afterEach(() => {
+    useComposerDrafts.getState().clearDraft("chat-1");
+    useComposerDrafts.getState().clearDraft(HOME_DRAFT_KEY);
+  });
+
+  it("survives the round trip and is deleted after it is read", () => {
+    const storage = memoryStorage();
+    const route = "/c/chat-1";
+    stashComposerDraftForReentry(route, "unsent hello", storage);
+    expect(storage.getItem(`tidebreak.hostedReentryDraft:${route}`)).toBe(
+      "unsent hello",
+    );
+    expect(takeComposerDraftForReentry(route, storage)).toBe("unsent hello");
+    expect(storage.getItem(`tidebreak.hostedReentryDraft:${route}`)).toBeNull();
+    expect(takeComposerDraftForReentry(route, storage)).toBeNull();
+  });
+
+  it("hydrates the composer from storage once on boot", () => {
+    const storage = memoryStorage();
+    const route = "/c/chat-1";
+    stashComposerDraftForReentry(route, "keep this", storage);
+    resetHostedSessionForTests();
+    const win = { location: { hash: `#${route}` } };
+    hydrateComposerDraftFromHostedReentry(win, storage);
+    expect(useComposerDrafts.getState().drafts["chat-1"]).toBe("keep this");
+    expect(storage.getItem(`tidebreak.hostedReentryDraft:${route}`)).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/hostedSession.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.ts
@@ -22,6 +22,11 @@ export type HostedSession = {
   gatewayUrl: string | null;
 };
 
+/** Enough of `window` for hash-route and navigation seams in tests. */
+export type HostedLocationWin = {
+  location: { hash: string; href?: string };
+};
+
 /**
  * The one carrier a bearer may arrive in. A fragment never reaches the
  * server or its access log, and the page clears it before anything else can
@@ -41,6 +46,16 @@ const HANDOFF_FAILURE_FRAGMENT =
 let handoffToken: string | null = null;
 let failure: HandoffFailure | null = null;
 let session: HostedSession | null = null;
+/** When this tab last landed through a hand-off. In memory only: a loop
+ * guard, not a session. */
+let handoffReturnedAt: number | null = null;
+/** Unsent composer text keyed by hash route, for a re-entry that stays in
+ * this document. A full-page navigation also writes it to sessionStorage. */
+const draftsByRoute = new Map<string, string>();
+
+const HOSTED_REENTRY_DRAFT_PREFIX = "tidebreak.hostedReentryDraft:";
+/** A second refusal this soon after a hand-off is a loop, not a new hour. */
+const REENTRY_LOOP_MS = 15_000;
 
 /**
  * Take the handoff bearer out of the page's fragment, if it arrived with one.
@@ -54,7 +69,10 @@ export function captureHandoffToken(win: Window = window): void {
   const failed = HANDOFF_FAILURE_FRAGMENT.exec(win.location.hash);
   if (!failed && !handoff) return;
   if (failed) failure = failed[1] as HandoffFailure;
-  if (handoff) handoffToken = handoff.token;
+  if (handoff) {
+    handoffToken = handoff.token;
+    handoffReturnedAt = Date.now();
+  }
   win.history.replaceState(
     win.history.state,
     "",
@@ -113,6 +131,90 @@ export function resetHostedSessionForTests(): void {
   handoffToken = null;
   failure = null;
   session = null;
+  handoffReturnedAt = null;
+  draftsByRoute.clear();
+}
+
+function sessionStorageOrNull(storage?: Storage | null): Storage | null {
+  if (storage !== undefined) return storage;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function draftStorageKey(route: string): string {
+  return `${HOSTED_REENTRY_DRAFT_PREFIX}${route}`;
+}
+
+/**
+ * Keep an unsent composer draft across hosted re-entry. Memory covers an
+ * in-page navigation; sessionStorage covers a full-page trip to the console
+ * and back. The bearer never goes here.
+ */
+export function stashComposerDraftForReentry(
+  route: string,
+  draft: string,
+  storage?: Storage | null,
+): void {
+  if (!draft) return;
+  draftsByRoute.set(route, draft);
+  try {
+    sessionStorageOrNull(storage)?.setItem(draftStorageKey(route), draft);
+  } catch {
+    // A lost draft is not a lost session.
+  }
+}
+
+/**
+ * Read the draft stashed for `route` once, then forget it. Memory wins when
+ * both are present.
+ */
+export function takeComposerDraftForReentry(
+  route: string,
+  storage?: Storage | null,
+): string | null {
+  const fromMemory = draftsByRoute.get(route) ?? null;
+  draftsByRoute.delete(route);
+  const store = sessionStorageOrNull(storage);
+  let fromStore: string | null = null;
+  try {
+    const key = draftStorageKey(route);
+    fromStore = store?.getItem(key) ?? null;
+    store?.removeItem(key);
+  } catch {
+    // Missing storage is the same as no draft.
+  }
+  return fromMemory || fromStore;
+}
+
+/** True when a hand-off just landed this tab and another refusal is a loop. */
+export function hostedReentryIsLooping(now: number = Date.now()): boolean {
+  return (
+    handoffReturnedAt !== null && now - handoffReturnedAt < REENTRY_LOOP_MS
+  );
+}
+
+/** This tab's hash-router path, or `/` when the fragment is not a route. */
+export function hostedHashRoute(win: HostedLocationWin = window): string {
+  return win.location.hash.startsWith("#/") ? win.location.hash.slice(1) : "/";
+}
+
+/**
+ * A gateway machine whose bearer died: send the tab to the console unless
+ * we just came back that way. Returns `"redirect"` after assigning
+ * `win.location.href`, or `"sign_in"` when the dead-end screen should
+ * render (standalone machine, or a loop).
+ */
+export function reenterExpiredHostedSession(
+  hosted: HostedSession,
+  win: HostedLocationWin = window,
+  now: number = Date.now(),
+): "redirect" | "sign_in" {
+  if (!hosted.gatewayUrl || hostedReentryIsLooping(now)) return "sign_in";
+  win.location.href = consoleSignInUrl(hosted.gatewayUrl, win);
+  return "redirect";
 }
 
 /**
@@ -124,7 +226,7 @@ export function resetHostedSessionForTests(): void {
  */
 export function consoleSignInUrl(
   gatewayUrl: string,
-  win: Pick<Window, "location"> = window,
+  win: HostedLocationWin = window,
 ): string {
   const base = `${gatewayUrl.replace(/\/+$/, "")}/tidebreak`;
   const here = win.location.hash.startsWith("#/")

--- a/crates/tidebreak-desktop/ui/src/main.tsx
+++ b/crates/tidebreak-desktop/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { Toaster } from "@/components/ui/sonner";
 import { restoreStoredAppMode } from "./appMode";
 import { ErrorBoundary } from "./ErrorBoundary";
+import { hydrateComposerDraftFromHostedReentry } from "./ComposerDrafts";
 import { captureHandoffToken } from "./hostedSession";
 import { refuseStrayFileDrops } from "./ImageAttachments";
 import { createAppRouter } from "./router";
@@ -16,6 +17,7 @@ refuseStrayFileDrops(window);
 // Before the router: it owns the fragment from here on, and a handoff bearer
 // left in it would be read as a route and stay in the address bar.
 captureHandoffToken();
+hydrateComposerDraftFromHostedReentry();
 const router = createAppRouter();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(


### PR DESCRIPTION
Closes #3183.

## What you get

When a hosted tab holds a bearer the machine answers 401 or 403 for, and the machine names a gateway, you go straight to `consoleSignInUrl` with `return_to` set to the current hash route. You do not see the session-ended screen first.

If you just landed through a hand-off and the machine refuses again within fifteen seconds, you see `HostedSignIn` with `reason="session_ended"` so a bad token cannot bounce you. That timestamp lives in memory only.

A standalone machine (`gatewayUrl` null) still renders `HostedSignIn`.

## What you keep

The route rides in `return_to`. An unsent composer draft is kept in a module map keyed by route, and also written to `sessionStorage` under `tidebreak.hostedReentryDraft:<route>` so a full-page trip to the console can restore it. Boot reads that value once and deletes it. The bearer never goes to storage.

## Verification

In `crates/tidebreak-desktop/ui`:

```
pnpm exec biome format --write src
Formatted 6 files in 12ms. No fixes applied.

pnpm exec biome check src
Checked 875 files in 1487ms. No fixes applied.

pnpm exec vitest run hostedSession ManagedGate HostedSignIn
 Test Files  2 passed (2)
      Tests  37 passed (37)

pnpm exec tsc --noEmit -p tsconfig.json
```

(`tsc` exits 0 with no output.)