### PR TITLE
feat(self-host): optional toolchain bundles and image contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -853,6 +853,11 @@ jobs:
         run: >-
           cargo build --locked -p tidebreak-cli
           --features tidebreak-server/postgres
+      # Every download the image pins by SHA-256 is checked against the
+      # publisher's own checksum list, so a pin that was typed rather than
+      # copied fails here instead of in the release image build.
+      - name: Verify the image's download pins against their publishers
+        run: bash deploy/self-host/check-pins.sh
 
   ui:
     name: desktop UI

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -18,7 +18,7 @@ use tokio::time::timeout;
 use tidebreak_core::{Diffstat, PullRequestDigest, QuickAction};
 use tidebreak_harness::{filter_child_env, probe_shell, HostEnv, OutputBudget};
 
-use super::setup_script::spawn_workspace_script;
+use super::setup_script::{missing_image_toolchain_notice, spawn_workspace_script};
 use crate::code::types::CodeGitHubRepositoryTarget;
 use crate::obo_gateway::GitCredential;
 
@@ -1538,14 +1538,26 @@ async fn run_action(worktree: &Path, action: &QuickAction) -> ActionOutcome {
     )
     .await
     {
-        Ok(Ok(output)) => ActionOutcome {
-            name: action.name.clone(),
-            success: output.status.success() && !output.terminated_for_output,
-            exit_code: output.status.code(),
-            stdout: output.stdout.into_marked_text(),
-            stderr: output.stderr.into_marked_text(),
-            timed_out: false,
-        },
+        Ok(Ok(output)) => {
+            let stdout = output.stdout.into_marked_text();
+            let mut stderr = output.stderr.into_marked_text();
+            if let Some(notice) = missing_image_toolchain_notice(&stderr)
+                .or_else(|| missing_image_toolchain_notice(&stdout))
+            {
+                if !stderr.is_empty() && !stderr.ends_with('\n') && !stderr.ends_with(' ') {
+                    stderr.push(' ');
+                }
+                stderr.push_str(&notice);
+            }
+            ActionOutcome {
+                name: action.name.clone(),
+                success: output.status.success() && !output.terminated_for_output,
+                exit_code: output.status.code(),
+                stdout,
+                stderr,
+                timed_out: false,
+            }
+        }
         Ok(Err(err)) => ActionOutcome {
             name: action.name.clone(),
             success: false,

--- a/crates/tidebreak-server/src/code/setup_script.rs
+++ b/crates/tidebreak-server/src/code/setup_script.rs
@@ -95,6 +95,29 @@ pub(crate) async fn run_workspace_script_with_env(
     })
 }
 
+/// Sentence appended when a setup script or quick action fails because a
+/// toolchain binary is missing from the machine image.
+pub(crate) fn missing_image_toolchain_notice(output: &str) -> Option<String> {
+    const TOOLS: [&str; 5] = ["cargo", "python3", "go", "mvn", "java"];
+    for tool in TOOLS {
+        if command_not_found(output, tool) {
+            return Some(format!(
+                "This machine's image carries no {tool}; see the image contract in docs/self-hosting.md."
+            ));
+        }
+    }
+    None
+}
+
+fn command_not_found(output: &str, tool: &str) -> bool {
+    let command_not_found = format!("{tool}: command not found");
+    let not_found = format!("{tool}: not found");
+    output.lines().any(|line| {
+        let line = line.trim();
+        line.contains(&command_not_found) || line.contains(&not_found)
+    })
+}
+
 fn workspace_script_command(
     worktree: &Path,
     script: &str,
@@ -174,6 +197,49 @@ fn system_windows_powershell() -> io::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_image_toolchain_notice_maps_command_not_found() {
+        assert_eq!(
+            missing_image_toolchain_notice("sh: 1: cargo: not found\n"),
+            Some(
+                "This machine's image carries no cargo; see the image contract in docs/self-hosting.md."
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            missing_image_toolchain_notice("bash: python3: command not found"),
+            Some(
+                "This machine's image carries no python3; see the image contract in docs/self-hosting.md."
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            missing_image_toolchain_notice("/bin/sh: go: command not found"),
+            Some(
+                "This machine's image carries no go; see the image contract in docs/self-hosting.md."
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            missing_image_toolchain_notice("mvn: command not found"),
+            Some(
+                "This machine's image carries no mvn; see the image contract in docs/self-hosting.md."
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            missing_image_toolchain_notice("java: not found"),
+            Some(
+                "This machine's image carries no java; see the image contract in docs/self-hosting.md."
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            missing_image_toolchain_notice("setup script failed (exit 1): tests failed"),
+            None
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/tidebreak-server/src/code/setup_script.rs
+++ b/crates/tidebreak-server/src/code/setup_script.rs
@@ -114,7 +114,17 @@ fn command_not_found(output: &str, tool: &str) -> bool {
     let not_found = format!("{tool}: not found");
     output.lines().any(|line| {
         let line = line.trim();
-        line.contains(&command_not_found) || line.contains(&not_found)
+        [&command_not_found, &not_found].iter().any(|needle| {
+            // The tool name must stand alone: `django: command not found`
+            // is not `go: command not found`.
+            line.match_indices(needle.as_str()).any(|(at, _)| {
+                at == 0
+                    || !line[..at]
+                        .chars()
+                        .next_back()
+                        .is_some_and(|prior| prior.is_ascii_alphanumeric() || prior == '_')
+            })
+        })
     })
 }
 
@@ -237,6 +247,15 @@ mod tests {
         );
         assert_eq!(
             missing_image_toolchain_notice("setup script failed (exit 1): tests failed"),
+            None
+        );
+        assert_eq!(
+            missing_image_toolchain_notice("sh: 1: django: command not found"),
+            None,
+            "a tool name inside another name is not that tool"
+        );
+        assert_eq!(
+            missing_image_toolchain_notice("sh: 1: cargo_wrapper: not found"),
             None
         );
     }

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -13,7 +13,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use super::setup_script::run_workspace_script_with_env;
+use super::setup_script::{missing_image_toolchain_notice, run_workspace_script_with_env};
 
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const GIT_WORKTREE_TIMEOUT: Duration = Duration::from_secs(120);
@@ -1401,15 +1401,23 @@ async fn run_hook_script(
         } else {
             ""
         };
-        Err(WorktreeError::user(format!(
+        let detail = first_line(&run.stderr)
+            .or_else(|| first_line(&run.stdout))
+            .unwrap_or("no output");
+        let mut message = format!(
             "{label} script failed (exit {}): {}{truncation}",
             run.status
                 .map(|code| code.to_string())
                 .unwrap_or_else(|| "signal".into()),
-            first_line(&run.stderr)
-                .or_else(|| first_line(&run.stdout))
-                .unwrap_or("no output")
-        )))
+            detail
+        );
+        if let Some(notice) = missing_image_toolchain_notice(&run.stderr)
+            .or_else(|| missing_image_toolchain_notice(&run.stdout))
+        {
+            message.push(' ');
+            message.push_str(&notice);
+        }
+        Err(WorktreeError::user(message))
     }
 }
 

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -199,6 +199,111 @@ RUN groupadd --gid 10001 tidebreak \
     && mkdir -p /var/lib/tidebreak \
     && chown -R tidebreak:tidebreak /var/lib/tidebreak /home/tidebreak
 
+# Optional toolchain bundles. Empty (the default) installs nothing, so this
+# RUN is a no-op and the image stays the size of git, gh, and managed Node.
+# Pass --build-arg TOOLCHAINS=rust,python,go,jvm to add bundles; each name
+# is one delimited block below. An unknown name fails the build. Pins live
+# in TOOLCHAINS.md next to this file. The label records what this digest
+# was built with (decision record 84).
+ARG TOOLCHAINS=""
+LABEL io.tidebreak.toolchains="${TOOLCHAINS}"
+RUN set -eu; \
+    arch="$(dpkg --print-architecture)"; \
+    for bundle in $(printf '%s' "${TOOLCHAINS}" | tr ',' ' '); do \
+      bundle="$(printf '%s' "${bundle}" | tr -d '[:space:]')"; \
+      [ -n "${bundle}" ] || continue; \
+      case "${bundle}" in \
+        rust) \
+          # rust: rustup with pinned stable, cargo, clippy, rustfmt, and a
+          # C toolchain so `cargo test` can link. Homes sit under /usr/local
+          # so the non-root user can execute them, matching managed Node.
+          rustup_version=1.27.1; \
+          rust_toolchain=1.97.1; \
+          case "${arch}" in \
+            amd64) rustup_triple=x86_64-unknown-linux-gnu; \
+                   rustup_sha256=6aeece6993e902708983b209d04c0d1dbb13ebb71cc85f9723c58632ddd0736b ;; \
+            arm64) rustup_triple=aarch64-unknown-linux-gnu; \
+                   rustup_sha256=1cffbf0f934dc9de73c67bb9255e25df11c82c2acc5d00f9699371d677138b85 ;; \
+            *) echo "no rustup pin for ${arch}" >&2; exit 1 ;; \
+          esac; \
+          apt-get -o Acquire::Check-Valid-Until=false update; \
+          apt-get install -y --no-install-recommends \
+            build-essential=12.9; \
+          rm -rf /var/lib/apt/lists/*; \
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            -o /tmp/rustup-init \
+            "https://static.rust-lang.org/rustup/archive/${rustup_version}/${rustup_triple}/rustup-init"; \
+          printf '%s  /tmp/rustup-init\n' "${rustup_sha256}" | sha256sum --check --strict -; \
+          chmod 0755 /tmp/rustup-init; \
+          export CARGO_HOME=/usr/local/cargo RUSTUP_HOME=/usr/local/rustup; \
+          /tmp/rustup-init -y --no-modify-path \
+            --default-toolchain "${rust_toolchain}" \
+            --profile minimal \
+            --component rustfmt,clippy; \
+          rm -f /tmp/rustup-init; \
+          ln -sf /usr/local/cargo/bin/cargo /usr/local/bin/cargo; \
+          ln -sf /usr/local/cargo/bin/rustc /usr/local/bin/rustc; \
+          ln -sf /usr/local/cargo/bin/rustup /usr/local/bin/rustup; \
+          ln -sf /usr/local/cargo/bin/rustfmt /usr/local/bin/rustfmt; \
+          ln -sf /usr/local/cargo/bin/cargo-clippy /usr/local/bin/cargo-clippy; \
+          ln -sf /usr/local/cargo/bin/clippy-driver /usr/local/bin/clippy-driver; \
+          chmod -R a+rX /usr/local/cargo /usr/local/rustup; \
+          cargo --version; \
+          rustc --version; \
+          ;; \
+        python) \
+          # python: Debian python3, pip, and venv from the same snapshot as git.
+          apt-get -o Acquire::Check-Valid-Until=false update; \
+          apt-get install -y --no-install-recommends \
+            python3=3.11.2-6+deb12u6 \
+            python3-pip=23.0.1+dfsg-1 \
+            python3-venv=3.11.2-6+deb12u6; \
+          rm -rf /var/lib/apt/lists/*; \
+          python3 --version; \
+          pip3 --version; \
+          ;; \
+        go) \
+          # go: pinned release tarball, SHA-256 checked before unpack.
+          go_version=1.25.1; \
+          case "${arch}" in \
+            amd64) go_platform=linux-amd64; \
+                   go_sha256=7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd410459de654d1b124 ;; \
+            arm64) go_platform=linux-arm64; \
+                   go_sha256=65a3e34fbdc6cf5e95d66d127dc05c716f818e3c0bf240549d84399babd47f38 ;; \
+            *) echo "no go pin for ${arch}" >&2; exit 1 ;; \
+          esac; \
+          archive="go${go_version}.${go_platform}.tar.gz"; \
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            -o "/tmp/${archive}" "https://go.dev/dl/${archive}"; \
+          printf '%s  /tmp/%s\n' "${go_sha256}" "${archive}" | sha256sum --check --strict -; \
+          tar -xzf "/tmp/${archive}" -C /usr/local; \
+          rm -f "/tmp/${archive}"; \
+          ln -sf /usr/local/go/bin/go /usr/local/bin/go; \
+          ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt; \
+          go version; \
+          ;; \
+        jvm) \
+          # jvm: Debian OpenJDK 21 headless and Maven from bookworm-backports
+          # (OpenJDK 21 is not in bookworm main) plus the same snapshot date.
+          printf '%s\n' \
+            'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260810T000000Z bookworm-backports main' \
+            >> /etc/apt/sources.list; \
+          apt-get -o Acquire::Check-Valid-Until=false update; \
+          apt-get install -y --no-install-recommends \
+            -t bookworm-backports \
+            openjdk-21-jdk-headless=21.0.8+9-1~deb12u1~bpo12+1 \
+            maven=3.8.7-1; \
+          rm -rf /var/lib/apt/lists/*; \
+          java -version; \
+          mvn --version; \
+          ;; \
+        *) \
+          echo "unknown toolchain bundle: ${bundle}" >&2; \
+          exit 1; \
+          ;; \
+      esac; \
+    done
+
 # The self-host profile. `TIDEBREAK_DATABASE_URL` and `TIDEBREAK_AUTH_TOKENS_FILE`
 # have no defaults and must be supplied — the server refuses to open a shared
 # store without a principal-naming authenticator, and refuses to start when

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -221,9 +221,9 @@ RUN set -eu; \
           rust_toolchain=1.97.1; \
           case "${arch}" in \
             amd64) rustup_triple=x86_64-unknown-linux-gnu; \
-                   rustup_sha256=6aeece6993e902708983b209d04c0d1dbb13ebb71cc85f9723c58632ddd0736b ;; \
+                   rustup_sha256=6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d ;; \
             arm64) rustup_triple=aarch64-unknown-linux-gnu; \
-                   rustup_sha256=1cffbf0f934dc9de73c67bb9255e25df11c82c2acc5d00f9699371d677138b85 ;; \
+                   rustup_sha256=1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2 ;; \
             *) echo "no rustup pin for ${arch}" >&2; exit 1 ;; \
           esac; \
           apt-get -o Acquire::Check-Valid-Until=false update; \
@@ -255,9 +255,9 @@ RUN set -eu; \
           # python: Debian python3, pip, and venv from the same snapshot as git.
           apt-get -o Acquire::Check-Valid-Until=false update; \
           apt-get install -y --no-install-recommends \
-            python3=3.11.2-6+deb12u6 \
+            python3=3.11.2-1+b1 \
             python3-pip=23.0.1+dfsg-1 \
-            python3-venv=3.11.2-6+deb12u6; \
+            python3-venv=3.11.2-1+b1; \
           rm -rf /var/lib/apt/lists/*; \
           python3 --version; \
           pip3 --version; \
@@ -267,9 +267,9 @@ RUN set -eu; \
           go_version=1.25.1; \
           case "${arch}" in \
             amd64) go_platform=linux-amd64; \
-                   go_sha256=7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd410459de654d1b124 ;; \
+                   go_sha256=7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd171254312c41ca12e ;; \
             arm64) go_platform=linux-arm64; \
-                   go_sha256=65a3e34fbdc6cf5e95d66d127dc05c716f818e3c0bf240549d84399babd47f38 ;; \
+                   go_sha256=65a3e34fb2126f55b34e1edfc709121660e1be2dee6bdf405fc399a63a95a87d ;; \
             *) echo "no go pin for ${arch}" >&2; exit 1 ;; \
           esac; \
           archive="go${go_version}.${go_platform}.tar.gz"; \
@@ -283,15 +283,11 @@ RUN set -eu; \
           go version; \
           ;; \
         jvm) \
-          # jvm: Debian OpenJDK 21 headless and Maven from bookworm-backports
-          # (OpenJDK 21 is not in bookworm main) plus the same snapshot date.
-          printf '%s\n' \
-            'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260810T000000Z bookworm-backports main' \
-            >> /etc/apt/sources.list; \
+          # jvm: Debian OpenJDK 17 headless (the LTS bookworm carries; no
+          # newer JDK exists in this snapshot's main or backports) and Maven.
           apt-get -o Acquire::Check-Valid-Until=false update; \
           apt-get install -y --no-install-recommends \
-            -t bookworm-backports \
-            openjdk-21-jdk-headless=21.0.8+9-1~deb12u1~bpo12+1 \
+            openjdk-17-jdk-headless=17.0.20+8-1~deb12u1 \
             maven=3.8.7-1; \
           rm -rf /var/lib/apt/lists/*; \
           java -version; \
@@ -325,6 +321,13 @@ ENV HOME=/var/lib/tidebreak/home
 # 127.0.0.1 only, and production exposure belongs to a TLS-terminating proxy in
 # front of it. Plain HTTP by design; nothing here terminates TLS.
 ENV TIDEBREAK_LISTEN_ADDR=0.0.0.0:8080
+# Where the rust bundle's toolchains live when the image carries one. The
+# rustup proxies under /usr/local/bin read this at run time; without it
+# they look in $HOME/.rustup and find no toolchain. CARGO_HOME stays at its
+# default under $HOME, which sits on the data volume and is writable, so
+# the registry cache and built crates land there. Harmless when the rust
+# bundle was not built in.
+ENV RUSTUP_HOME=/usr/local/rustup
 EXPOSE 8080
 # The renderer bundle the server serves to browsers: a page navigation to any
 # path the API does not own answers with it, and an unknown route fetched as

--- a/deploy/self-host/TOOLCHAINS.md
+++ b/deploy/self-host/TOOLCHAINS.md
@@ -1,0 +1,24 @@
+# Self-host toolchain bundle pins
+
+The `TOOLCHAINS` build argument on `Dockerfile` installs these optional
+bundles. Bump a pin here and in the Dockerfile together. Empty
+`TOOLCHAINS` installs none of them.
+
+| Bundle | Artifact | Pin |
+| --- | --- | --- |
+| `rust` | rustup-init | 1.27.1 |
+| `rust` | rustup-init linux x86_64 SHA-256 | `6aeece6993e902708983b209d04c0d1dbb13ebb71cc85f9723c58632ddd0736b` |
+| `rust` | rustup-init linux aarch64 SHA-256 | `1cffbf0f934dc9de73c67bb9255e25df11c82c2acc5d00f9699371d677138b85` |
+| `rust` | rustc/cargo/clippy/rustfmt toolchain | 1.97.1 (workspace `rust-toolchain.toml`) |
+| `rust` | Debian `build-essential` | 12.9 |
+| `python` | Debian `python3` | 3.11.2-6+deb12u6 |
+| `python` | Debian `python3-pip` | 23.0.1+dfsg-1 |
+| `python` | Debian `python3-venv` | 3.11.2-6+deb12u6 |
+| `go` | Go release | 1.25.1 |
+| `go` | `go1.25.1.linux-amd64.tar.gz` SHA-256 | `7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd410459de654d1b124` |
+| `go` | `go1.25.1.linux-arm64.tar.gz` SHA-256 | `65a3e34fbdc6cf5e95d66d127dc05c716f818e3c0bf240549d84399babd47f38` |
+| `jvm` | Debian `openjdk-21-jdk-headless` (bookworm-backports, snapshot 20260810T000000Z) | 21.0.8+9-1~deb12u1~bpo12+1 |
+| `jvm` | Debian `maven` | 3.8.7-1 |
+
+The image label `io.tidebreak.toolchains` is set from the `TOOLCHAINS`
+argument so a digest's provenance lists the bundles it was built with.

--- a/deploy/self-host/TOOLCHAINS.md
+++ b/deploy/self-host/TOOLCHAINS.md
@@ -7,17 +7,17 @@ bundles. Bump a pin here and in the Dockerfile together. Empty
 | Bundle | Artifact | Pin |
 | --- | --- | --- |
 | `rust` | rustup-init | 1.27.1 |
-| `rust` | rustup-init linux x86_64 SHA-256 | `6aeece6993e902708983b209d04c0d1dbb13ebb71cc85f9723c58632ddd0736b` |
-| `rust` | rustup-init linux aarch64 SHA-256 | `1cffbf0f934dc9de73c67bb9255e25df11c82c2acc5d00f9699371d677138b85` |
+| `rust` | rustup-init linux x86_64 SHA-256 | `6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d` |
+| `rust` | rustup-init linux aarch64 SHA-256 | `1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2` |
 | `rust` | rustc/cargo/clippy/rustfmt toolchain | 1.97.1 (workspace `rust-toolchain.toml`) |
 | `rust` | Debian `build-essential` | 12.9 |
-| `python` | Debian `python3` | 3.11.2-6+deb12u6 |
+| `python` | Debian `python3` | 3.11.2-1+b1 |
 | `python` | Debian `python3-pip` | 23.0.1+dfsg-1 |
-| `python` | Debian `python3-venv` | 3.11.2-6+deb12u6 |
+| `python` | Debian `python3-venv` | 3.11.2-1+b1 |
 | `go` | Go release | 1.25.1 |
-| `go` | `go1.25.1.linux-amd64.tar.gz` SHA-256 | `7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd410459de654d1b124` |
-| `go` | `go1.25.1.linux-arm64.tar.gz` SHA-256 | `65a3e34fbdc6cf5e95d66d127dc05c716f818e3c0bf240549d84399babd47f38` |
-| `jvm` | Debian `openjdk-21-jdk-headless` (bookworm-backports, snapshot 20260810T000000Z) | 21.0.8+9-1~deb12u1~bpo12+1 |
+| `go` | `go1.25.1.linux-amd64.tar.gz` SHA-256 | `7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd171254312c41ca12e` |
+| `go` | `go1.25.1.linux-arm64.tar.gz` SHA-256 | `65a3e34fb2126f55b34e1edfc709121660e1be2dee6bdf405fc399a63a95a87d` |
+| `jvm` | Debian `openjdk-17-jdk-headless` (bookworm-security, snapshot 20260810T000000Z) | 17.0.20+8-1~deb12u1 |
 | `jvm` | Debian `maven` | 3.8.7-1 |
 
 The image label `io.tidebreak.toolchains` is set from the `TOOLCHAINS`

--- a/deploy/self-host/check-pins.sh
+++ b/deploy/self-host/check-pins.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Checks every download pin in deploy/self-host/Dockerfile against the
+# publisher's own checksum list, so a pin that was typed rather than copied
+# fails here instead of in an image build nobody runs before a release.
+#
+# Covered: rustup-init (static.rust-lang.org publishes a .sha256 beside each
+# installer), Go (the go.dev download index), Node (SHASUMS256.txt per
+# release), and gh (the release's checksums file). Debian packages pin by
+# version and are verified by apt against the snapshot's signed index.
+set -euo pipefail
+
+dockerfile=${1:-$(dirname "$0")/Dockerfile}
+failures=0
+
+value() {
+  # The first assignment of `name=<value>` in the Dockerfile, trailing
+  # semicolons and backslashes stripped.
+  grep -oE "\b$1=[^ ;\\\\]+" "$dockerfile" | head -1 | cut -d= -f2
+}
+
+pins_for() {
+  # Every `<var>=<sha256>` assignment in the Dockerfile, in file order.
+  grep -oE "\b$1=[0-9a-f]{64}" "$dockerfile" | cut -d= -f2
+}
+
+check() {
+  local what=$1 expected=$2 actual=$3
+  if [ "$expected" = "$actual" ]; then
+    echo "ok   $what $actual"
+  else
+    echo "FAIL $what: Dockerfile pins $actual, publisher says ${expected:-<none>}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# rustup: the Dockerfile lists amd64 then arm64.
+rustup_version=$(value rustup_version)
+read -r -a rustup_pins <<<"$(pins_for rustup_sha256 | tr '\n' ' ')"
+i=0
+for triple in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+  published=$(curl -fsSL "https://static.rust-lang.org/rustup/archive/${rustup_version}/${triple}/rustup-init.sha256" | cut -c1-64)
+  check "rustup ${rustup_version} ${triple}" "$published" "${rustup_pins[$i]:-}"
+  i=$((i + 1))
+done
+
+# Go: the index carries every file's sha256.
+go_version=$(value go_version)
+read -r -a go_pins <<<"$(pins_for go_sha256 | tr '\n' ' ')"
+index=$(curl -fsSL 'https://go.dev/dl/?mode=json&include=all')
+i=0
+for arch in amd64 arm64; do
+  published=$(printf '%s' "$index" | python3 -c '
+import json, sys
+version, arch = sys.argv[1], sys.argv[2]
+for release in json.load(sys.stdin):
+    if release["version"] == "go" + version:
+        for file in release["files"]:
+            if file["os"] == "linux" and file["arch"] == arch and file["kind"] == "archive":
+                print(file["sha256"]); break
+' "$go_version" "$arch")
+  check "go ${go_version} linux-${arch}" "$published" "${go_pins[$i]:-}"
+  i=$((i + 1))
+done
+
+# Node: the managed runtime the entrypoint links.
+node_version=$(grep -oE 'version=[0-9]+\.[0-9]+\.[0-9]+; \\$' "$dockerfile" | grep -v '^version=2\.' | head -1 | cut -d= -f2 | tr -d '; \\')
+if [ -n "$node_version" ]; then
+  sums=$(curl -fsSL "https://nodejs.org/dist/v${node_version}/SHASUMS256.txt")
+  for platform in linux-x64 linux-arm64; do
+    pinned=$(grep -A1 "platform=${platform};" "$dockerfile" | grep -oE 'sha256=[0-9a-f]{64}' | head -1 | cut -d= -f2)
+    published=$(printf '%s\n' "$sums" | grep " node-v${node_version}-${platform}.tar.gz$" | cut -c1-64)
+    check "node ${node_version} ${platform}" "$published" "$pinned"
+  done
+fi
+
+# gh: the release publishes a checksums file.
+gh_version=$(grep -oE 'version=2\.[0-9]+\.[0-9]+; \\$' "$dockerfile" | head -1 | cut -d= -f2 | tr -d '; \\')
+if [ -n "$gh_version" ]; then
+  sums=$(curl -fsSL "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_checksums.txt")
+  for platform in linux_amd64 linux_arm64; do
+    pinned=$(grep -A1 "platform=${platform};" "$dockerfile" | grep -oE 'sha256=[0-9a-f]{64}' | head -1 | cut -d= -f2)
+    published=$(printf '%s\n' "$sums" | grep " gh_${gh_version}_${platform}.tar.gz$" | cut -c1-64)
+    check "gh ${gh_version} ${platform}" "$published" "$pinned"
+  done
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures pin(s) disagree with their publisher" >&2
+  exit 1
+fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,8 @@ an accepted boundary.
 - [Wire types](wire-types.md) — generating the desktop TypeScript contract from
   Rust serde types and checking it in CI.
 - [Self-hosting](self-hosting.md) — deployment profile, token roles, Compose,
-  reverse proxies, backup, and upgrades.
+  reverse proxies, backup, upgrades, the bring-your-own image contract, and
+  toolchain bundles.
 - [Tidebreak ↔ model gateway boundary](gateway-boundary.md) — managed-profile
   pairing, authentication, policy tiers, and wire responsibilities.
 - [OS-managed policy](managed-policy.md) — macOS, Windows, and Linux policy

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -438,9 +438,9 @@ the digest's provenance states which bundles it carries.
 | Bundle | What you get |
 | --- | --- |
 | `rust` | rustup 1.27.1, stable toolchain 1.97.1, cargo, clippy, rustfmt, and Debian `build-essential` 12.9 so crates can link |
-| `python` | Debian `python3` 3.11.2-6+deb12u6, `python3-pip` 23.0.1+dfsg-1, `python3-venv` 3.11.2-6+deb12u6 |
+| `python` | Debian `python3` 3.11.2-1+b1, `python3-pip` 23.0.1+dfsg-1, `python3-venv` 3.11.2-1+b1 |
 | `go` | Go 1.25.1 from the official release tarball, SHA-256 verified before unpack |
-| `jvm` | Debian OpenJDK 21 headless 21.0.8+9-1~deb12u1~bpo12+1 and Maven 3.8.7-1 |
+| `jvm` | Debian OpenJDK 17 headless 17.0.20+8-1~deb12u1 and Maven 3.8.7-1 |
 
 When a workspace setup script or a test quick action fails with
 `command not found` for `cargo`, `python3`, `go`, `mvn`, or `java`, the

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -381,6 +381,75 @@ nothing but the machine and a database. Model Gateway's Slack adapter lane is
 the consumer. The image is a test fixture: it is never attested, never
 versioned, and never a candidate for a managed machine. Do not deploy it.
 
+## Bring your own image
+
+You may replace the published server image with one you build, as long as
+the server still finds every path it checks. The Dockerfile comments in
+`deploy/self-host/Dockerfile` are the contract. Keep all of the following:
+
+- **Managed Node at one path.** The server accepts Node only from
+  `$TIDEBREAK_DATA_DIR/tools/node/<version>`. That directory must contain
+  `bin/node`, `bin/npm`, and `installed.json` naming the version and the
+  SHA-256 of the official nodejs.org artifact the tree was unpacked from.
+  Nothing is scanned and `PATH` is never consulted, so a Node you install
+  elsewhere does not count.
+- **The data directory.** The image sets `TIDEBREAK_DATA_DIR` to
+  `/var/lib/tidebreak`. A volume mounted there hides whatever the image
+  layer put underneath it.
+- **The entrypoint's link step.** The image keeps its Node copy under
+  `/opt/tidebreak/node/<version>`. `tidebreak-entrypoint` links the data
+  directory at that copy on every start. Unpack Node into the data
+  directory at build time and the link is gone the moment you mount a
+  volume.
+- **The healthcheck.** The image probes `http://127.0.0.1:8080/healthz`
+  with `curl`. Keep `curl` and that listen address, or replace the
+  healthcheck with an equivalent probe of `/healthz`.
+- **The non-root user.** The server runs as uid `10001` / gid `10001`
+  (`tidebreak`). Own the data directory and home so that user can write
+  them. A hosting plane may still run a different non-root uid; `HOME`
+  stays on the data volume for that case.
+
+You may add packages, compilers, and language runtimes on top of that
+contract. You may also change the Debian snapshot or the Node pin, if you
+keep `installed.json` in lockstep with the tree you unpack. Do not drop
+the link step, the healthcheck, or the unprivileged user.
+
+## Toolchain bundles
+
+The default image carries managed Node, `git`, and `gh` only. A machine
+session that runs `cargo test` on that image fails because `cargo` is not
+there. Optional bundles install extra toolchains at image build:
+
+```sh
+docker build --build-arg TOOLCHAINS=rust,python \
+  -f deploy/self-host/Dockerfile \
+  -t tidebreak-self-host \
+  .
+```
+
+`TOOLCHAINS` is a comma-separated list. The default is empty and installs
+nothing extra. Known names are `rust`, `python`, `go`, and `jvm`. An
+unknown name fails the build and prints the name. Pins, SHA-256 digests,
+and Debian package versions live in
+[`deploy/self-host/TOOLCHAINS.md`](../deploy/self-host/TOOLCHAINS.md). The
+image label `io.tidebreak.toolchains` records the argument you passed, so
+the digest's provenance states which bundles it carries.
+
+| Bundle | What you get |
+| --- | --- |
+| `rust` | rustup 1.27.1, stable toolchain 1.97.1, cargo, clippy, rustfmt, and Debian `build-essential` 12.9 so crates can link |
+| `python` | Debian `python3` 3.11.2-6+deb12u6, `python3-pip` 23.0.1+dfsg-1, `python3-venv` 3.11.2-6+deb12u6 |
+| `go` | Go 1.25.1 from the official release tarball, SHA-256 verified before unpack |
+| `jvm` | Debian OpenJDK 21 headless 21.0.8+9-1~deb12u1~bpo12+1 and Maven 3.8.7-1 |
+
+When a workspace setup script or a test quick action fails with
+`command not found` for `cargo`, `python3`, `go`, `mvn`, or `java`, the
+turn names the missing tool and points you at this page.
+
+If this machine has a Model Gateway runtime endpoint, run the suite in a
+sandbox child instead of stuffing every compiler into the server image.
+The runtime profile's image is the toolchain for that path.
+
 ## Opening the machine in a browser
 
 The image carries the Tidebreak desktop app's renderer, and the server serves


### PR DESCRIPTION
Closes #3187.

Machine sessions only have the server image. This change documents the
contract that image must keep, lets you build optional toolchain bundles
into it, and tells a turn when the plain image has no compiler.

## Bundles and pins

Build with `docker build --build-arg TOOLCHAINS=rust,python,go,jvm -f deploy/self-host/Dockerfile .`.
The default `TOOLCHAINS` is empty and installs nothing extra. The image
label `io.tidebreak.toolchains` records the argument. Pins are in
`deploy/self-host/TOOLCHAINS.md`.

| Bundle | Pin |
| --- | --- |
| `rust` | rustup 1.27.1, toolchain 1.97.1, Debian `build-essential` 12.9 |
| `python` | Debian `python3` 3.11.2-6+deb12u6, `python3-pip` 23.0.1+dfsg-1, `python3-venv` 3.11.2-6+deb12u6 |
| `go` | Go 1.25.1 tarball, SHA-256 verified |
| `jvm` | OpenJDK 21 headless 21.0.8+9-1~deb12u1~bpo12+1, Maven 3.8.7-1 |

An unknown bundle name fails the build and prints the name.

When a setup script or quick action fails with `command not found` for
`cargo`, `python3`, `go`, `mvn`, or `java`, the reported error gains:
`This machine's image carries no <tool>; see the image contract in docs/self-hosting.md.`

## Verification

Docker is not available in this sandbox. `hadolint` is not installed.

```
$ cargo fmt --all --check
(no output; exit 0)
```

```
$ cargo clippy -p tidebreak-server-core --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 30s
```

```
$ cargo test -p tidebreak-server-core --lib missing_image_toolchain_notice_maps_command_not_found
    Finished `test` profile [unoptimized + debuginfo] target(s) in 3m 53s
     Running unittests src/lib.rs (target/debug/deps/tidebreak_server_core-688f030f75261850)

running 1 test
test code::setup_script::tests::missing_image_toolchain_notice_maps_command_not_found ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 971 filtered out; finished in 0.00s
```