### PR TITLE
feat(self-host): publish a dev-profile end-to-end fixture image

### DIFF
--- a/.github/workflows/publish-e2e-image.yml
+++ b/.github/workflows/publish-e2e-image.yml
@@ -1,0 +1,84 @@
+# Publishes the end-to-end fixture image: the self-host server built with the
+# `dev` cargo profile, so the scripted harness
+# (`crates/tidebreak-server/src/scripted_harness.rs`, compiled only under
+# debug assertions) is present and a lane can drive a real machine without a
+# model. The Model Gateway repository's Slack adapter lane pulls
+# `ghcr.io/brightwave-inc/tidebreak-server-e2e:main` (issue
+# brightwave-inc/model-gateway#1865).
+#
+# This image is a test fixture. It is never attested, never tagged with a
+# release version, and never a candidate for the managed machine, which tracks
+# `tidebreak-server` releases (decision 0108).
+name: Publish e2e image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "crates/**"
+      - "deploy/self-host/**"
+      - ".github/workflows/publish-e2e-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tidebreak-e2e-image
+  cancel-in-progress: true
+
+env:
+  E2E_REPOSITORY: ghcr.io/${{ github.repository_owner }}/tidebreak-server-e2e
+
+jobs:
+  build:
+    name: build and push the dev-profile server
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+      - name: Build the fixture image
+        env:
+          VERSION: 0.0.0-e2e.${{ github.sha }}
+        run: |
+          docker build \
+            --file deploy/self-host/Dockerfile \
+            --build-arg CARGO_PROFILE=dev \
+            --build-arg "TIDEBREAK_VERSION=$VERSION" \
+            --tag "$E2E_REPOSITORY:sha-${GITHUB_SHA::12}" \
+            .
+      - name: Prove the scripted harness is compiled in
+        # A release binary ignores the variable. The dev binary refuses to
+        # boot on a script that does not parse, and names the variable while
+        # doing so, before it needs a database or a token file.
+        run: |
+          set +e
+          output="$(docker run --rm --entrypoint /usr/local/bin/tidebreak \
+            -e TIDEBREAK_PROFILE=desktop -e TIDEBREAK_LISTEN_ADDR= \
+            -e TIDEBREAK_SCRIPTED_HARNESS='{not json' \
+            "$E2E_REPOSITORY:sha-${GITHUB_SHA::12}" serve 2>&1)"
+          status=$?
+          set -e
+          echo "$output" | tail -5
+          [[ $status -ne 0 ]] || { echo "serve exited 0 with a broken script" >&2; exit 1; }
+          grep -q 'TIDEBREAK_SCRIPTED_HARNESS is not a valid script' <<<"$output" || {
+            echo "the binary did not reject the script: the scripted harness is not compiled in" >&2
+            exit 1
+          }
+      - name: Push the tags
+        run: |
+          docker tag "$E2E_REPOSITORY:sha-${GITHUB_SHA::12}" "$E2E_REPOSITORY:main"
+          docker push "$E2E_REPOSITORY:sha-${GITHUB_SHA::12}"
+          docker push "$E2E_REPOSITORY:main"

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -64,11 +64,26 @@ COPY . .
 # below as an environment variable, which is where `option_env!` reads it.
 ARG TIDEBREAK_VERSION="0.0.0-unreleased"
 
+# `release` is the image operators run. `dev` builds the same binary with debug
+# assertions on, which is the only build that carries the scripted harness
+# (`crates/tidebreak-server/src/scripted_harness.rs`); the end-to-end lane in
+# the Model Gateway repository drives a real machine through it. A `dev` image
+# is a test fixture: never deploy one.
+ARG CARGO_PROFILE=release
+# Debug info is dead weight in a container and triples the dev binary.
+ENV CARGO_PROFILE_DEV_DEBUG=0
+
 # `--features tidebreak-server/postgres` reaches through the CLI into the
 # server crate's feature, because the feature lives there and the CLI takes
 # tidebreak-server with default features. Without it the self-host boot has no
-# PostgreSQL driver compiled in.
-RUN cargo build --release --locked -p tidebreak-cli --features tidebreak-server/postgres
+# PostgreSQL driver compiled in. The binary lands in `/out` so the runtime
+# stage copies one path whichever profile built it (cargo writes `dev` to
+# `target/debug`).
+RUN set -eu; \
+    cargo build --profile "${CARGO_PROFILE}" --locked -p tidebreak-cli \
+        --features tidebreak-server/postgres; \
+    case "${CARGO_PROFILE}" in dev) target_dir=debug ;; *) target_dir="${CARGO_PROFILE}" ;; esac; \
+    install -D "target/${target_dir}/tidebreak" /out/tidebreak
 
 # ---- runtime ---------------------------------------------------------------
 # Digest-pinned like the build stage: this is debian:bookworm-slim as of
@@ -170,7 +185,7 @@ RUN set -eu; \
     node --version; \
     npm --version
 
-COPY --from=build /src/target/release/tidebreak /usr/local/bin/tidebreak
+COPY --from=build /out/tidebreak /usr/local/bin/tidebreak
 COPY --from=renderer /src/crates/tidebreak-desktop/ui/dist /opt/tidebreak/ui
 COPY deploy/self-host/entrypoint.sh /usr/local/bin/tidebreak-entrypoint
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -370,6 +370,17 @@ Two things the image deliberately does not decide for you:
 The image ships no SSH client and no known-hosts file, so clone over HTTPS.
 An SSH clone URL fails.
 
+### The end-to-end fixture image
+
+`ghcr.io/brightwave-inc/tidebreak-server-e2e:main` is the same Dockerfile
+built with `--build-arg CARGO_PROFILE=dev`. That build carries the scripted
+harness, an engine that plays a JSON script of events from
+`TIDEBREAK_SCRIPTED_HARNESS` instead of running a model, so an integration
+lane can drive a real machine through connect, a turn, and an approval with
+nothing but the machine and a database. Model Gateway's Slack adapter lane is
+the consumer. The image is a test fixture: it is never attested, never
+versioned, and never a candidate for a managed machine. Do not deploy it.
+
 ## Opening the machine in a browser
 
 The image carries the Tidebreak desktop app's renderer, and the server serves


### PR DESCRIPTION
## Why

The Slack adapter's end-to-end lane (brightwave-inc/model-gateway#1865) needs a real machine it can drive without a model. The scripted harness (`crates/tidebreak-server/src/scripted_harness.rs`) is that engine, and it is compiled only under debug assertions, so no published image carries it today.

## What

- `deploy/self-host/Dockerfile` takes `CARGO_PROFILE` (default `release`). `dev` builds the same binary with debug assertions on; the binary lands in `/out` so the runtime stage copies one path whichever profile built it. `CARGO_PROFILE_DEV_DEBUG=0` keeps debug info out of the container.
- `.github/workflows/publish-e2e-image.yml` builds the `dev` image on every push to `main` that touches the workspace or the image, proves the scripted harness is compiled in (boots the binary against a script that does not parse and expects the `TIDEBREAK_SCRIPTED_HARNESS is not a valid script` refusal), and pushes `ghcr.io/brightwave-inc/tidebreak-server-e2e:main` and a `sha-` tag. No attestation, no version tag, not a release artifact.
- `docs/self-hosting.md` names the fixture image and says not to deploy it.

The release image is unchanged: the default profile is still `release`, and the publish workflow passes nothing new.

## Verification

Local, on arm64:

```
docker build --file deploy/self-host/Dockerfile --build-arg CARGO_PROFILE=dev --build-arg TIDEBREAK_VERSION=0.0.0-e2e.local --tag tidebreak-server-e2e:local .
# exit 0, 922MB
docker run --rm --entrypoint /usr/local/bin/tidebreak -e TIDEBREAK_PROFILE=desktop -e TIDEBREAK_LISTEN_ADDR= -e TIDEBREAK_SCRIPTED_HARNESS='{not json' tidebreak-server-e2e:local serve
# exit 1: tidebreak: configuration error: TIDEBREAK_SCRIPTED_HARNESS is not a valid script: key must be a string at line 1 column 2
docker run --rm --entrypoint /usr/local/bin/tidebreak tidebreak-server-e2e:local --version
# tidebreak 0.0.0-e2e.local
```

The workflow runs its first publish once this merges; the gateway lane pins the `:main` tag.