### PR TITLE
feat(self-host): a standalone machine signs a browser in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -3381,6 +3382,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,6 +3962,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.8",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -5137,7 +5173,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5308,7 +5344,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6018,6 +6054,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7521,7 +7566,9 @@ dependencies = [
  "image",
  "infer 0.22.0",
  "jsonschema",
+ "jsonwebtoken",
  "libc",
+ "oauth2",
  "plist",
  "portable-pty",
  "reqwest 0.12.28",
@@ -8227,6 +8274,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,8 @@ tokio-util = { version = "=0.7.19", features = ["io-util"] }
 # loopback chat socket itself is plain ws://.
 tokio-tungstenite = { version = "=0.30.0", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 reqwest = { version = "=0.12.28", default-features = false, features = ["json", "multipart", "stream", "rustls-tls"] }
+oauth2 = { version = "=5.0.0", default-features = false }
+jsonwebtoken = { version = "=11.0.0", default-features = false, features = ["aws_lc_rs"] }
 sha2 = "=0.11.0"
 symphonia = { version = "=0.6.0", default-features = false, features = ["aac", "alac", "isomp4", "mkv"] }
 opus-decoder = "=0.1.1"

--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -188,10 +188,11 @@ pub struct Config {
     pub auth_tokens_file: Option<PathBuf>,
     /// Model Gateway base URL used to authenticate self-hosted callers.
     ///
-    /// Mutually exclusive with [`Config::auth_tokens_file`]. The server sends
-    /// each presented `tidebreak` resource token to the Gateway's live
-    /// principal endpoint, so Gateway membership, deactivation, session
-    /// revocation, and administrator changes apply without a generated roster.
+    /// Mutually exclusive with [`Config::auth_tokens_file`] and with OpenID
+    /// Connect. The server sends each presented `tidebreak` resource token to
+    /// the Gateway's live principal endpoint, so Gateway membership,
+    /// deactivation, session revocation, and administrator changes apply
+    /// without a generated roster.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_gateway_url: Option<String>,
     /// Optional server-to-server Model Gateway URL used only for principal
@@ -200,6 +201,25 @@ pub struct Config {
     /// cannot hairpin through that public origin.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_gateway_verifier_url: Option<String>,
+    /// OpenID Connect issuer that signs browsers in to a standalone machine.
+    ///
+    /// The third exclusive authenticator (decision 0087). Mutually exclusive
+    /// with [`Config::auth_gateway_url`]; [`Config::auth_tokens_file`] may sit
+    /// beside it as the bootstrap for the first administrator and for CLI
+    /// access. Set together with the client id and secret below.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_oidc_issuer: Option<String>,
+    /// OpenID Connect client id this machine is registered with.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_oidc_client_id: Option<String>,
+    /// OpenID Connect client secret, used only for the server-to-server code
+    /// exchange. It stays in process memory and is never persisted or logged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_oidc_client_secret: Option<String>,
+    /// ID-token claim whose string value names the Tidebreak user. `sub` when
+    /// unset, which is the only claim an issuer always sends.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_oidc_claim: Option<String>,
     /// Canonical public base URL of this self-hosted Tidebreak machine.
     ///
     /// Gateway-backed authentication hashes this URL into the OAuth resource,
@@ -365,6 +385,10 @@ impl Config {
             auth_tokens_file: None,
             auth_gateway_url: None,
             auth_gateway_verifier_url: None,
+            auth_oidc_issuer: None,
+            auth_oidc_client_id: None,
+            auth_oidc_client_secret: None,
+            auth_oidc_claim: None,
             public_url: None,
             vault_secrets: None,
             listen_addr: None,
@@ -432,6 +456,12 @@ impl Config {
             std::env::var("TIDEBREAK_RUNTIME_ENDPOINT").ok(),
             std::env::var("TIDEBREAK_RUNTIME_PROFILE").ok(),
             vault_secrets,
+        )?
+        .with_oidc_vars(
+            std::env::var("TIDEBREAK_AUTH_OIDC_ISSUER").ok(),
+            std::env::var("TIDEBREAK_AUTH_OIDC_CLIENT_ID").ok(),
+            std::env::var("TIDEBREAK_AUTH_OIDC_CLIENT_SECRET").ok(),
+            std::env::var("TIDEBREAK_AUTH_OIDC_CLAIM").ok(),
         )?
         .with_runtime_limit_vars(
             std::env::var("TIDEBREAK_RUNTIME_CONCURRENCY_CAP").ok(),
@@ -553,6 +583,10 @@ impl Config {
             auth_tokens_file,
             auth_gateway_url,
             auth_gateway_verifier_url,
+            auth_oidc_issuer: None,
+            auth_oidc_client_id: None,
+            auth_oidc_client_secret: None,
+            auth_oidc_claim: None,
             public_url,
             vault_secrets,
             listen_addr,
@@ -565,6 +599,61 @@ impl Config {
             code_worktree_root_default: None,
             ui_dist: None,
         })
+    }
+
+    /// Apply the OpenID Connect variables of decision 0087. Split from
+    /// [`Config::from_env`] the way the runtime limits are, so the rules can be
+    /// tested without mutating process-global environment variables.
+    ///
+    /// The three credentials are one setting in three parts: two of them
+    /// describe a machine nobody can sign in to, so a partial set is a boot
+    /// error rather than a mode that half exists. The gateway is refused here
+    /// as well as at the authenticator, because this is where an operator's
+    /// environment is read and where the message can name both variables.
+    fn with_oidc_vars(
+        mut self,
+        issuer: Option<String>,
+        client_id: Option<String>,
+        client_secret: Option<String>,
+        claim: Option<String>,
+    ) -> Result<Self> {
+        fn present(value: Option<String>) -> Option<String> {
+            value
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+        }
+        let issuer = present(issuer);
+        let client_id = present(client_id);
+        let client_secret = present(client_secret);
+        let claim = present(claim);
+        let configured = [&issuer, &client_id, &client_secret]
+            .into_iter()
+            .filter(|value| value.is_some())
+            .count();
+        if configured != 0 && configured != 3 {
+            return Err(AgentError::config(
+                "TIDEBREAK_AUTH_OIDC_ISSUER, TIDEBREAK_AUTH_OIDC_CLIENT_ID, and \
+                 TIDEBREAK_AUTH_OIDC_CLIENT_SECRET are one setting: set all three or none",
+            ));
+        }
+        if configured == 3 && self.auth_gateway_url.is_some() {
+            return Err(AgentError::config(
+                "self-host authentication is ambiguous: TIDEBREAK_AUTH_OIDC_ISSUER cannot \
+                 be combined with TIDEBREAK_AUTH_GATEWAY_URL, because a machine signs \
+                 browsers in through one identity provider",
+            ));
+        }
+        if configured == 0 && claim.is_some() {
+            return Err(AgentError::config(
+                "TIDEBREAK_AUTH_OIDC_CLAIM names a claim in an ID token, so it requires \
+                 TIDEBREAK_AUTH_OIDC_ISSUER",
+            ));
+        }
+        self.auth_oidc_issuer = issuer.map(|value| value.trim_end_matches('/').to_owned());
+        self.auth_oidc_client_id = client_id;
+        self.auth_oidc_client_secret = client_secret;
+        self.auth_oidc_claim = claim;
+        Ok(self)
     }
 
     /// Apply the three operator-controlled remote runtime limits. Split from
@@ -1304,6 +1393,95 @@ mod tests {
         assert_ne!(
             tidebreak_machine_resource("https://tidebreak.example.test"),
             tidebreak_machine_resource("https://other.example.test")
+        );
+    }
+
+    /// The OIDC variables are one setting: all three or none, never beside
+    /// the gateway, and the claim override means nothing without them.
+    #[test]
+    fn the_oidc_variables_are_complete_and_exclusive_with_the_gateway() {
+        let configured = Config::desktop("/data")
+            .with_oidc_vars(
+                Some("  https://login.example.test/  ".into()),
+                Some(" client-id ".into()),
+                Some("client-secret".into()),
+                Some(" email ".into()),
+            )
+            .unwrap();
+        assert_eq!(
+            configured.auth_oidc_issuer.as_deref(),
+            Some("https://login.example.test"),
+            "a pasted issuer keeps neither its surrounding space nor its trailing slash"
+        );
+        assert_eq!(configured.auth_oidc_client_id.as_deref(), Some("client-id"));
+        assert_eq!(configured.auth_oidc_claim.as_deref(), Some("email"));
+
+        // An unset machine is not an OIDC machine, and a blank variable is
+        // unset — an empty client secret must not read as a configured one.
+        let none = Config::desktop("/data")
+            .with_oidc_vars(Some("   ".into()), None, None, Some("  ".into()))
+            .unwrap();
+        assert_eq!(none.auth_oidc_issuer, None);
+        assert_eq!(none.auth_oidc_claim, None);
+
+        for (issuer, client_id, client_secret, claim, why) in [
+            (
+                Some("https://login.example.test"),
+                None,
+                None,
+                None,
+                "an issuer with no client",
+            ),
+            (
+                Some("https://login.example.test"),
+                Some("client-id"),
+                None,
+                None,
+                "a client with no secret",
+            ),
+            (
+                None,
+                Some("client-id"),
+                Some("client-secret"),
+                None,
+                "a client with no issuer",
+            ),
+            (
+                None,
+                None,
+                None,
+                Some("email"),
+                "a login claim with no provider to read it from",
+            ),
+        ] {
+            assert!(
+                Config::desktop("/data")
+                    .with_oidc_vars(
+                        issuer.map(str::to_owned),
+                        client_id.map(str::to_owned),
+                        client_secret.map(str::to_owned),
+                        claim.map(str::to_owned),
+                    )
+                    .is_err(),
+                "{why} must fail boot"
+            );
+        }
+
+        let mut gateway = Config::desktop("/data");
+        gateway.auth_gateway_url = Some("https://gateway.example.test".into());
+        let error = gateway
+            .with_oidc_vars(
+                Some("https://login.example.test".into()),
+                Some("client-id".into()),
+                Some("client-secret".into()),
+                None,
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("TIDEBREAK_AUTH_OIDC_ISSUER")
+                && error.contains("TIDEBREAK_AUTH_GATEWAY_URL"),
+            "the refusal must name both variables: {error}"
         );
     }
 }

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -21,9 +21,13 @@ import {
 } from "./api";
 import { AppContextProvider, type AppContextValue } from "./AppContext";
 
-import { HostedSignInRequired, resolveServerInfo } from "./boot";
+import {
+  HostedSignInRequired,
+  acceptPastedToken,
+  resolveServerInfo,
+} from "./boot";
 import { HostedSignIn } from "./HostedSignIn";
-import type { HandoffFailure } from "./hostedSession";
+import type { AuthDiscovery, HandoffFailure } from "./hostedSession";
 import {
   BootFailure,
   type BootAttachment,
@@ -242,9 +246,9 @@ export function AppShell() {
     null,
   );
   // A hosted browser tab that holds no session. Not a failure: the machine
-  // answered, and the page knows which console can sign it in.
+  // answered, and its discovery document says how it signs a browser in.
   const [hostedSignIn, setHostedSignIn] = useState<{
-    gatewayUrl: string | null;
+    discovery: AuthDiscovery;
     failure: HandoffFailure | null;
   } | null>(null);
   const [appVersion, setAppVersion] = useState<string | null>(null);
@@ -516,7 +520,7 @@ export function AppShell() {
       } catch (err) {
         if (cancelled) return;
         if (err instanceof HostedSignInRequired) {
-          setHostedSignIn({ gatewayUrl: err.gatewayUrl, failure: err.failure });
+          setHostedSignIn({ discovery: err.discovery, failure: err.failure });
           return;
         }
         setBootFailure({ stage: "connect", error: err });
@@ -1083,13 +1087,22 @@ export function AppShell() {
     ],
   );
 
+  // A pasted token is probed against the machine before this tab holds it,
+  // and a held one only matters once boot runs again with it.
+  async function acceptHostedToken(token: string): Promise<boolean> {
+    const accepted = await acceptPastedToken(token);
+    if (accepted) retryBoot();
+    return accepted;
+  }
+
   if (hostedSignIn) {
     return (
       <HostedSignIn
         reason={hostedSignIn.failure ? "handoff_failed" : "no_session"}
         failure={hostedSignIn.failure}
         machineUrl={window.location.origin}
-        gatewayUrl={hostedSignIn.gatewayUrl}
+        discovery={hostedSignIn.discovery}
+        onToken={acceptHostedToken}
         onRetry={retryBoot}
       />
     );
@@ -1128,7 +1141,7 @@ export function AppShell() {
   const macOverlayTitlebar = hasMacOverlayTitlebar();
 
   return (
-    <ManagedGate client={client}>
+    <ManagedGate client={client} onHostedToken={acceptHostedToken}>
       <GatedShellHooks
         client={client}
         chatId={openChatId}

--- a/crates/tidebreak-desktop/ui/src/HostedSignIn.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/HostedSignIn.dom.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HostedSignIn } from "./HostedSignIn";
+
+afterEach(cleanup);
+
+describe("HostedSignIn", () => {
+  /**
+   * The token-paste path a standalone machine offers: the machine decides,
+   * the screen holds the refusal, and a token that is accepted leaves this
+   * screen to boot rather than saying anything more.
+   */
+  it("submits a pasted token and keeps a refusal on the sign-in screen", async () => {
+    const onToken = vi
+      .fn<(token: string) => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const user = userEvent.setup();
+
+    render(
+      <HostedSignIn
+        reason="no_session"
+        machineUrl="https://machine.example.test"
+        discovery={{ mode: "static_token" }}
+        onToken={onToken}
+      />,
+    );
+    // No console to send anyone to, and no OIDC button either.
+    expect(screen.queryByRole("link")).toBeNull();
+
+    const token = screen.getByLabelText("Token");
+    await user.type(token, "  wrong-token  ");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "This machine refused that token.",
+    );
+    // The pasted value is trimmed but otherwise untouched.
+    expect(onToken).toHaveBeenLastCalledWith("wrong-token");
+    expect(token).toHaveValue("  wrong-token  ");
+
+    await user.clear(token);
+    await user.type(token, "accepted-token");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(onToken).toHaveBeenLastCalledWith("accepted-token");
+    // Accepted: the screen stops saying it was refused and waits for boot.
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  /**
+   * A session link opened in a fresh browser has to survive the trip through
+   * the issuer, so the current hash route rides along as `return_to`.
+   */
+  it("keeps the current hash route in the OIDC start URL", () => {
+    window.history.replaceState({}, "", "/#/c/session-1");
+    render(
+      <HostedSignIn
+        reason="no_session"
+        machineUrl="https://machine.example.test"
+        discovery={{
+          mode: "oidc",
+          issuer_name: "login.example.test",
+          start_url: "/auth/oidc/start",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /Sign in with login\.example\.test/ }),
+    ).toHaveAttribute(
+      "href",
+      "http://localhost:3000/auth/oidc/start?return_to=%2Fc%2Fsession-1",
+    );
+    // An OIDC machine takes no pasted token.
+    expect(screen.queryByLabelText("Token")).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/HostedSignIn.tsx
+++ b/crates/tidebreak-desktop/ui/src/HostedSignIn.tsx
@@ -1,7 +1,14 @@
 import { ExternalLink, RotateCw } from "lucide-react";
+import { type FormEvent, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { consoleSignInUrl, type HandoffFailure } from "./hostedSession";
+import { Input } from "@/components/ui/input";
+import {
+  type AuthDiscovery,
+  type HandoffFailure,
+  consoleSignInUrl,
+  oidcSignInUrl,
+} from "./hostedSession";
 import { Logomark } from "./Logomark";
 import { WindowDragStrip } from "./WindowDragStrip";
 
@@ -12,7 +19,7 @@ import { WindowDragStrip } from "./WindowDragStrip";
  * machine's address, or reloaded a tab. `session_ended`: the bearer the page
  * held stopped being accepted, which after an hour is simply its lifetime.
  * `handoff_failed`: the page came from the machine's landing route and the
- * route could not turn the console's code into a bearer; `failure` says why.
+ * route could not turn a sign-in into a bearer; `failure` says why.
  */
 export type HostedSignInReason =
   | "no_session"
@@ -25,21 +32,18 @@ export type HostedSignInProps = {
   /** The machine this page is served by. */
   machineUrl: string;
   /**
-   * The console that can sign the reader in here. `null` when the machine
-   * has no gateway, in which case the page can only say where to go instead.
+   * How this machine signs a browser in, from its own discovery document.
+   * It decides which of the paths below the screen offers.
    */
-  gatewayUrl: string | null;
+  discovery: AuthDiscovery;
+  /**
+   * Probe a pasted token against the machine and, when it holds, keep it for
+   * this tab. `false` is the machine refusing it, which stays on this screen.
+   */
+  onToken?: (token: string) => Promise<boolean>;
   onRetry?: () => void;
 };
 
-/**
- * The screen a hosted browser tab shows until it holds a session.
- *
- * A browser tab cannot start the sign-in itself: the bearer it needs is
- * minted by the reader's Model Gateway console, which hands it to this page
- * once. So the screen names the console and sends the reader there; the
- * console's Manage Tidebreak action is what brings them back signed in.
- */
 function handoffFailureCopy(failure: HandoffFailure | null | undefined): {
   title: string;
   detail: string;
@@ -53,28 +57,108 @@ function handoffFailureCopy(failure: HandoffFailure | null | undefined): {
       };
     case "unavailable":
       return {
-        title: "This machine could not reach your gateway",
+        title: "This machine could not reach the provider that signs you in",
         detail:
-          "Sign-in needs the gateway to answer, and it did not. Nothing about your account has changed.",
+          "Sign-in needs that provider to answer, and it did not. Nothing about your account has changed.",
       };
     default:
       return {
-        title: "That sign-in link is not valid",
+        title: "That sign-in did not complete",
         detail:
-          "It did not come from the console, or it was changed on the way here.",
+          "The answer this machine got back was refused, or it was changed on the way here.",
       };
   }
 }
 
+/** The heading and the sentence under it: why this screen is here at all. */
+function reasonCopy(
+  reason: HostedSignInReason,
+  failure: HandoffFailure | null,
+  discovery: AuthDiscovery,
+): { title: string; detail: string } {
+  if (reason === "handoff_failed") return handoffFailureCopy(failure);
+  if (reason === "session_ended") {
+    return {
+      title: "Your session on this machine ended",
+      detail:
+        "Browser sessions last an hour. Work on this machine keeps running, and nothing you did here is lost.",
+    };
+  }
+  if (discovery.mode === "gateway") {
+    return {
+      title: "Sign in through your Model Gateway console",
+      detail:
+        "This machine runs Tidebreak for your organization. Its address alone does not sign you in.",
+    };
+  }
+  if (discovery.mode === "static_token" || discovery.mode === "oidc") {
+    return {
+      title: "Sign in to this machine",
+      detail:
+        "This machine runs Tidebreak for your organization. Its address alone does not sign you in.",
+    };
+  }
+  return {
+    title: "This machine does not sign browsers in",
+    detail: "Attach to it from the Tidebreak desktop app instead.",
+  };
+}
+
+/** What happens once the reader acts, worded for this machine's way in. */
+function nextStepCopy(discovery: AuthDiscovery): string | null {
+  switch (discovery.mode) {
+    case "gateway":
+      return "Open the console. It signs you in and brings you straight back to this page.";
+    case "static_token":
+      return "Paste the token your administrator gave you. This tab keeps it in memory alone and forgets it when you reload.";
+    case "oidc":
+      return `${discovery.issuer_name} signs you in and brings you straight back to this page.`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The screen a hosted browser tab shows until it holds a session.
+ *
+ * Which path it offers is the machine's to say, not the page's: a gateway
+ * machine sends the reader through the console that mints its bearers, a
+ * token-file machine takes the token their administrator gave them, and an
+ * OIDC machine starts the flow on the machine itself
+ * (`docs/decisions/0087-standalone-browser-sign-in.md`). Every path that
+ * works leaves the bearer in this tab's memory and nowhere else.
+ */
 export function HostedSignIn({
   reason,
   failure = null,
   machineUrl,
-  gatewayUrl,
+  discovery,
+  onToken,
   onRetry = () => window.location.reload(),
 }: HostedSignInProps) {
-  const failed =
-    reason === "handoff_failed" ? handoffFailureCopy(failure) : null;
+  const [token, setToken] = useState("");
+  const [refused, setRefused] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const { title, detail } = reasonCopy(reason, failure, discovery);
+  const nextStep = nextStepCopy(discovery);
+  const gatewayUrl =
+    discovery.mode === "gateway" ? discovery.gateway_url : null;
+  const takesToken = discovery.mode === "static_token" && onToken !== undefined;
+
+  async function submitToken(event: FormEvent) {
+    event.preventDefault();
+    const pasted = token.trim();
+    if (!onToken || !pasted || submitting) return;
+    setSubmitting(true);
+    setRefused(false);
+    // A held token unmounts this screen when boot runs again, so only the
+    // refusal has anything left to say.
+    const accepted = await onToken(pasted).catch(() => false);
+    if (accepted) return;
+    setRefused(true);
+    setSubmitting(false);
+  }
+
   return (
     <div className="boot" aria-label="Sign in required">
       <WindowDragStrip />
@@ -83,43 +167,41 @@ export function HostedSignIn({
         <h1>Tidebreak</h1>
       </div>
       <div className="welcome-copy">
-        {failed ? (
-          <>
-            <h2>{failed.title}</h2>
-            <p>{failed.detail}</p>
-          </>
-        ) : reason === "session_ended" ? (
-          <>
-            <h2>Your session on this machine ended</h2>
-            <p>
-              Browser sessions last an hour. Work on this machine keeps running,
-              and nothing you did here is lost.
-            </p>
-          </>
-        ) : (
-          <>
-            <h2>Sign in through your Model Gateway console</h2>
-            <p>
-              This machine runs Tidebreak for your organization. Its address
-              alone does not sign you in.
-            </p>
-          </>
-        )}
-        {gatewayUrl ? (
-          <p>
-            Open the console: it signs you in and brings you straight back to
-            this page.
-          </p>
-        ) : (
-          <p>
-            This machine does not sign browsers in. Attach to it from the
-            Tidebreak desktop app instead.
-          </p>
-        )}
+        <h2>{title}</h2>
+        <p>{detail}</p>
+        {nextStep && <p>{nextStep}</p>}
       </div>
       <p className="text-muted-foreground text-sm">
         Machine <code className="font-medium">{machineUrl}</code>
       </p>
+      {takesToken && (
+        <form className="boot-token-form" onSubmit={submitToken}>
+          <label className="text-sm font-medium" htmlFor="hosted-token">
+            Token
+          </label>
+          <Input
+            id="hosted-token"
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            value={token}
+            onChange={(event) => setToken(event.target.value)}
+          />
+          {refused && (
+            <p className="text-critical text-sm" role="alert">
+              This machine refused that token. Check it with whoever runs the
+              machine, then try again.
+            </p>
+          )}
+          <Button
+            size="sm"
+            type="submit"
+            disabled={submitting || !token.trim()}
+          >
+            {submitting ? "Signing in…" : "Sign in"}
+          </Button>
+        </form>
+      )}
       <div className="boot-actions">
         {gatewayUrl && (
           <Button size="sm" asChild>
@@ -129,9 +211,19 @@ export function HostedSignIn({
             </a>
           </Button>
         )}
+        {discovery.mode === "oidc" && (
+          <Button size="sm" asChild>
+            <a href={oidcSignInUrl(discovery.start_url)}>
+              <ExternalLink size={16} aria-hidden />
+              Sign in with {discovery.issuer_name}
+            </a>
+          </Button>
+        )}
         <Button
           size="sm"
-          variant={gatewayUrl ? "outline" : "default"}
+          variant={
+            gatewayUrl || discovery.mode === "oidc" ? "outline" : "default"
+          }
           onClick={onRetry}
         >
           <RotateCw size={16} aria-hidden />

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -572,6 +572,7 @@ describe("ManagedGate", () => {
     markHostedSession({
       baseUrl: "https://machine.example.test",
       gatewayUrl: null,
+      discovery: { mode: "static_token" },
     });
     const client = api({
       getPolicy: vi.fn().mockRejectedValue(new Error("401: unauthorized")),
@@ -595,6 +596,11 @@ describe("ManagedGate", () => {
     markHostedSession({
       baseUrl: "https://machine.example.test",
       gatewayUrl: "https://gateway.example.test",
+      discovery: {
+        mode: "gateway",
+        gateway_url: "https://gateway.example.test",
+        resource: "tidebreak:abc",
+      },
     });
     const client = api({
       getPolicy: vi.fn().mockRejectedValue(new Error("401: unauthorized")),

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
@@ -121,9 +121,14 @@ function samePolicy(a: ManagedPolicy, b: ManagedPolicy): boolean {
 export function ManagedGate({
   client,
   children,
+  onHostedToken,
 }: {
   client: ApiClient;
   children: ReactNode;
+  /** How a hosted tab whose bearer died signs in again on a token-file
+   * machine. Only that gate branch uses it; the desktop app never renders
+   * one, because it has a shell to refresh a bearer from. */
+  onHostedToken?: (token: string) => Promise<boolean>;
 }) {
   const [policyState, setPolicyState] = useState<PolicyState>({
     kind: "loading",
@@ -369,7 +374,8 @@ export function ManagedGate({
         <HostedSignIn
           reason="session_ended"
           machineUrl={hosted.baseUrl}
-          gatewayUrl={hosted.gatewayUrl}
+          discovery={hosted.discovery}
+          onToken={onHostedToken}
         />
       );
     }

--- a/crates/tidebreak-desktop/ui/src/boot.ts
+++ b/crates/tidebreak-desktop/ui/src/boot.ts
@@ -1,11 +1,14 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import type { RemoteMachineState, ServerInfo } from "./api";
 import {
+  type AuthDiscovery,
   type HandoffFailure,
   handoffBearer,
   handoffFailure,
   hostedSession,
+  isHostedBearerShape,
   markHostedSession,
+  rememberHostedBearer,
 } from "./hostedSession";
 
 /**
@@ -69,23 +72,59 @@ export async function remoteMachineState(): Promise<RemoteMachineState> {
  */
 export class HostedSignInRequired extends Error {
   constructor(
-    readonly gatewayUrl: string | null,
+    readonly discovery: AuthDiscovery,
     /** Set when the page came from the landing route and it could not
      * hand over a bearer; the sign-in screen words the reason. */
     readonly failure: HandoffFailure | null = null,
   ) {
-    super("This machine needs a session from your Model Gateway console.");
+    super("This machine needs you to sign in.");
     this.name = "HostedSignInRequired";
   }
 }
 
-/** What the machine's public discovery document says about signing in. */
-type AuthDiscovery =
-  | { mode: "gateway"; gateway_url: string; resource: string }
-  | { mode: "static_token" }
-  | { mode: "local" };
-
+/** The one public, JSON-answering route every machine has. */
 const DISCOVERY_PATH = "/auth/discovery";
+
+/**
+ * The authenticated read a pasted token has to pass before the tab holds it.
+ *
+ * `/models` is a member-plane capability read: every principal may make it,
+ * it names nobody, and it is the kind of request the shell makes with a
+ * bearer the moment boot finishes. A machine that refuses it refuses the
+ * token, which is the whole answer the sign-in screen needs.
+ */
+const PRINCIPAL_PROBE_PATH = "/models";
+
+/**
+ * Take a token the reader pasted and, if the machine accepts it, hold it for
+ * this tab's life exactly as a hand-off bearer is held (decision 0087).
+ *
+ * The token is probed first, so a wrong one never becomes the tab's session
+ * and the sign-in screen can word the refusal. Nothing is written to a
+ * cookie, to storage, or to disk on either path — and the token is not even
+ * sent when it could not be a bearer.
+ */
+export async function acceptPastedToken(
+  token: string,
+  {
+    origin = window.location.origin,
+    fetch = globalThis.fetch,
+  }: { origin?: string; fetch?: typeof globalThis.fetch } = {},
+): Promise<boolean> {
+  if (!isHostedBearerShape(token)) return false;
+  let response: Response;
+  try {
+    response = await fetch(`${origin}${PRINCIPAL_PROBE_PATH}`, {
+      cache: "no-store",
+      headers: { authorization: `Bearer ${token}`, accept: "application/json" },
+    });
+  } catch {
+    return false;
+  }
+  if (!response.ok) return false;
+  rememberHostedBearer(token);
+  return true;
+}
 
 /**
  * The hosted branch: a production bundle whose origin is a Tidebreak machine.
@@ -95,7 +134,8 @@ const DISCOVERY_PATH = "/auth/discovery";
  * document back is served by a machine, and one that does not — a static
  * preview of the bundle, say — is not, and boot goes on to say nothing is
  * reachable. A page served by a machine but holding no bearer throws
- * {@link HostedSignInRequired} with the console that can mint one.
+ * {@link HostedSignInRequired} carrying the mode the machine signs browsers
+ * in with, which is what the sign-in screen offers.
  */
 export async function hostedServerInfo({
   origin = window.location.origin,
@@ -119,8 +159,8 @@ export async function hostedServerInfo({
     discovery.mode === "gateway"
       ? discovery.gateway_url.replace(/\/$/, "")
       : null;
-  markHostedSession({ baseUrl: origin, gatewayUrl });
-  if (!bearer) throw new HostedSignInRequired(gatewayUrl, failure);
+  markHostedSession({ baseUrl: origin, gatewayUrl, discovery });
+  if (!bearer) throw new HostedSignInRequired(discovery, failure);
   return {
     baseUrl: origin,
     token: bearer,
@@ -145,6 +185,17 @@ async function readDiscovery(
     if (record.mode === "gateway") {
       return typeof record.gateway_url === "string" && record.gateway_url
         ? { mode: "gateway", gateway_url: record.gateway_url, resource: "" }
+        : null;
+    }
+    if (record.mode === "oidc") {
+      const oidc = record as { issuer_name?: unknown; start_url?: unknown };
+      return typeof oidc.issuer_name === "string" &&
+        typeof oidc.start_url === "string"
+        ? {
+            mode: "oidc",
+            issuer_name: oidc.issuer_name,
+            start_url: oidc.start_url,
+          }
         : null;
     }
     if (record.mode === "static_token" || record.mode === "local") {

--- a/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { HostedSignInRequired, hostedServerInfo } from "./boot";
+import {
+  HostedSignInRequired,
+  acceptPastedToken,
+  hostedServerInfo,
+} from "./boot";
 import {
   HOME_DRAFT_KEY,
   hydrateComposerDraftFromHostedReentry,
@@ -13,6 +17,7 @@ import {
   handoffBearer,
   handoffFailure,
   hostedSession,
+  oidcSignInUrl,
   reenterExpiredHostedSession,
   resetHostedSessionForTests,
   stashComposerDraftForReentry,
@@ -130,6 +135,11 @@ describe("the hosted boot branch", () => {
     expect(hostedSession()).toEqual({
       baseUrl: "https://tidebreak.example.com",
       gatewayUrl: "https://gateway.example.com",
+      discovery: {
+        mode: "gateway",
+        gateway_url: "https://gateway.example.com/",
+        resource: "",
+      },
     });
     // The gate and the Machine panel read the attachment from here, and a
     // browser tab has no shell to ask.
@@ -152,7 +162,10 @@ describe("the hosted boot branch", () => {
     });
     await expect(attempt).rejects.toBeInstanceOf(HostedSignInRequired);
     await attempt.catch((error: HostedSignInRequired) => {
-      expect(error.gatewayUrl).toBe("https://gateway.example.com");
+      expect(error.discovery).toMatchObject({
+        mode: "gateway",
+        gateway_url: "https://gateway.example.com",
+      });
       expect(error.failure).toBeNull();
     });
   });
@@ -173,7 +186,7 @@ describe("the hosted boot branch", () => {
     ).rejects.toMatchObject({ failure: "unavailable" });
   });
 
-  it("has no console to name for a machine on static tokens", async () => {
+  it("offers the token field, not a console, for a machine on a token file", async () => {
     const fetch = discovery({ mode: "static_token" });
     const attempt = hostedServerInfo({
       origin: "https://tidebreak.example.com",
@@ -181,7 +194,47 @@ describe("the hosted boot branch", () => {
       fetch,
       bearer: null,
     });
-    await expect(attempt).rejects.toMatchObject({ gatewayUrl: null });
+    await expect(attempt).rejects.toMatchObject({
+      discovery: { mode: "static_token" },
+    });
+    expect(hostedSession()).toMatchObject({
+      baseUrl: "https://tidebreak.example.com",
+      gatewayUrl: null,
+      discovery: { mode: "static_token" },
+    });
+  });
+
+  it("carries an OIDC machine's issuer and start URL to the sign-in screen", async () => {
+    const attempt = hostedServerInfo({
+      origin: "https://tidebreak.example.com",
+      dev: false,
+      fetch: discovery({
+        mode: "oidc",
+        issuer_name: "login.example.test",
+        start_url: "https://tidebreak.example.com/auth/oidc/start",
+      }),
+      bearer: null,
+    });
+    await expect(attempt).rejects.toMatchObject({
+      discovery: {
+        mode: "oidc",
+        issuer_name: "login.example.test",
+        start_url: "https://tidebreak.example.com/auth/oidc/start",
+      },
+    });
+    // An OIDC machine is standalone: there is no console to send anyone to.
+    expect(hostedSession()).toMatchObject({ gatewayUrl: null });
+  });
+
+  it("is not a machine when its discovery document names a mode it cannot read", async () => {
+    await expect(
+      hostedServerInfo({
+        origin: "https://tidebreak.example.com",
+        dev: false,
+        fetch: discovery({ mode: "oidc", issuer_name: "login.example.test" }),
+        bearer: null,
+      }),
+    ).resolves.toBeNull();
   });
 
   it("is not a machine when the origin answers no discovery document", async () => {
@@ -252,6 +305,72 @@ function memoryStorage(): Storage {
   };
 }
 
+describe("a pasted token", () => {
+  function probe(ok: boolean): typeof globalThis.fetch {
+    return vi.fn(async () => ({ ok })) as unknown as typeof globalThis.fetch;
+  }
+
+  it("is probed against the machine and then held in memory alone", async () => {
+    const fetch = probe(true);
+    await expect(
+      acceptPastedToken("alice-token-one-padded-to-thirty-two", {
+        origin: "https://tidebreak.example.com",
+        fetch,
+      }),
+    ).resolves.toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://tidebreak.example.com/models",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.objectContaining({
+          authorization: "Bearer alice-token-one-padded-to-thirty-two",
+        }),
+      }),
+    );
+    // The same slot the hand-off bearer lands in, and nowhere else.
+    expect(handoffBearer()).toBe("alice-token-one-padded-to-thirty-two");
+    expect(window.localStorage.length).toBe(0);
+    expect(window.sessionStorage.length).toBe(0);
+    expect(document.cookie).toBe("");
+  });
+
+  it("leaves the tab with no bearer when the machine refuses it", async () => {
+    await expect(
+      acceptPastedToken("wrong-token-padded-out-to-thirty-two", {
+        origin: "https://tidebreak.example.com",
+        fetch: probe(false),
+      }),
+    ).resolves.toBe(false);
+    expect(handoffBearer()).toBeNull();
+  });
+
+  it("is not sent at all when it could not be a bearer", async () => {
+    const fetch = probe(true);
+    for (const pasted of ["", "has spaces", "line\nbreak", "a".repeat(513)]) {
+      await expect(
+        acceptPastedToken(pasted, {
+          origin: "https://tidebreak.example.com",
+          fetch,
+        }),
+      ).resolves.toBe(false);
+    }
+    expect(fetch).not.toHaveBeenCalled();
+    expect(handoffBearer()).toBeNull();
+  });
+
+  it("is refused, not thrown, when the machine cannot be reached", async () => {
+    await expect(
+      acceptPastedToken("alice-token-one-padded-to-thirty-two", {
+        origin: "https://tidebreak.example.com",
+        fetch: vi.fn(async () => {
+          throw new TypeError("network down");
+        }) as unknown as typeof globalThis.fetch,
+      }),
+    ).resolves.toBe(false);
+    expect(handoffBearer()).toBeNull();
+  });
+});
+
 describe("consoleSignInUrl", () => {
   it("sends the reader to the console's Tidebreak page with this page as the return path", () => {
     const win = {
@@ -273,6 +392,35 @@ describe("consoleSignInUrl", () => {
     expect(consoleSignInUrl("https://gateway.example.test", win)).toBe(
       "https://gateway.example.test/tidebreak",
     );
+  });
+});
+
+/**
+ * The same return-path contract, on the machine's own start route: a Slack
+ * link to a session survives the trip through the issuer.
+ */
+describe("oidcSignInUrl", () => {
+  function win(hash: string): Pick<Window, "location"> {
+    return {
+      location: { origin: "https://machine.example.test", hash },
+    } as unknown as Pick<Window, "location">;
+  }
+
+  it("carries this page's hash route through the issuer", () => {
+    expect(
+      oidcSignInUrl("/auth/oidc/start", win("#/c/session-1?source=slack")),
+    ).toBe(
+      "https://machine.example.test/auth/oidc/start?return_to=%2Fc%2Fsession-1%3Fsource%3Dslack",
+    );
+  });
+
+  it("asks for no return path from the root, and keeps an absolute start URL", () => {
+    expect(
+      oidcSignInUrl(
+        "https://machine.example.test/tidebreak/auth/oidc/start",
+        win("#/"),
+      ),
+    ).toBe("https://machine.example.test/tidebreak/auth/oidc/start");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/hostedSession.ts
+++ b/crates/tidebreak-desktop/ui/src/hostedSession.ts
@@ -10,16 +10,25 @@
  * React (boot, the machine state read, the gate) agree.
  */
 
+/** What the machine's public discovery document says about signing in. */
+export type AuthDiscovery =
+  | { mode: "gateway"; gateway_url: string; resource: string }
+  | { mode: "static_token" }
+  | { mode: "oidc"; issuer_name: string; start_url: string }
+  | { mode: "local" };
+
 /** Where a page came from, once boot has confirmed the origin is a machine. */
 export type HostedSession = {
   /** The machine's origin, which is also this page's. */
   baseUrl: string;
   /**
    * The Model Gateway the machine authenticates against, from the machine's
-   * own discovery document. `null` for a machine on static tokens, which has
-   * no browser sign-in to send a reader to.
+   * own discovery document. `null` for standalone token and OIDC machines,
+   * whose browser sign-in starts on the machine itself.
    */
   gatewayUrl: string | null;
+  /** How this machine signs a browser in, so the gate can offer it again. */
+  discovery: AuthDiscovery;
 };
 
 /** Enough of `window` for hash-route and navigation seams in tests. */
@@ -104,6 +113,22 @@ function isHandoffReturnRoute(route: string): boolean {
       /[\u0000-\u001f\u007f]/.test(character),
     )
   );
+}
+
+/**
+ * Hold a bearer the reader pasted, in the same tab memory a hand-off bearer
+ * lives in: no cookie, no storage, gone on reload. Boot has already probed it
+ * against the machine, so this only records what was accepted.
+ */
+export function rememberHostedBearer(token: string): void {
+  handoffToken = token;
+  failure = null;
+}
+
+/** Whether a pasted value could be a bearer at all. Same alphabet a hand-off
+ * bearer arrives in, so a stray paste is refused before any request. */
+export function isHostedBearerShape(token: string): boolean {
+  return token.length <= 512 && HANDOFF_TOKEN.test(token);
 }
 
 /** The bearer the page arrived with, or `null` if it opened without one. */
@@ -208,7 +233,7 @@ export function hostedHashRoute(win: HostedLocationWin = window): string {
  * render (standalone machine, or a loop).
  */
 export function reenterExpiredHostedSession(
-  hosted: HostedSession,
+  hosted: Pick<HostedSession, "baseUrl" | "gatewayUrl">,
   win: HostedLocationWin = window,
   now: number = Date.now(),
 ): "redirect" | "sign_in" {
@@ -233,4 +258,21 @@ export function consoleSignInUrl(
     ? win.location.hash.slice(1)
     : "/";
   return here === "/" ? base : `${base}?return_to=${encodeURIComponent(here)}`;
+}
+
+/**
+ * Where a machine-owned OIDC sign-in starts, carrying this tab's route back.
+ *
+ * The machine publishes the start URL in its discovery document, and this
+ * adds `return_to` the way {@link consoleSignInUrl} does, so a session link
+ * opened in a fresh browser lands on the session rather than the root.
+ */
+export function oidcSignInUrl(
+  startUrl: string,
+  win: Pick<Window, "location"> = window,
+): string {
+  const url = new URL(startUrl, win.location.origin);
+  const here = hostedHashRoute(win);
+  if (here !== "/") url.searchParams.set("return_to", here);
+  return url.toString();
 }

--- a/crates/tidebreak-desktop/ui/src/stories/HostedSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HostedSession.stories.tsx
@@ -1,15 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { HostedSignIn } from "@/HostedSignIn";
 
 /**
  * A browser tab served by a hosted machine, before it holds a session.
  *
- * The machine serves the same renderer the desktop app runs, but a tab
- * cannot sign itself in: its bearer comes from the reader's Model Gateway
- * console, once. These are the screens between opening the address and
- * arriving signed in, and the one that follows an hour later.
+ * The machine serves the same renderer the desktop app runs, and how a tab
+ * signs in is the machine's to say: a gateway machine sends the reader to
+ * the console that mints its bearers, a token-file machine takes a pasted
+ * token, and an OIDC machine starts the flow on the machine itself. These
+ * are the screens between opening the address and arriving signed in, and
+ * the one that follows an hour later.
  */
 const meta = {
   title: "Shell/Hosted browser session",
@@ -18,7 +20,11 @@ const meta = {
   args: {
     reason: "no_session",
     machineUrl: "https://tidebreak.example.com",
-    gatewayUrl: "https://gateway.example.com",
+    discovery: {
+      mode: "gateway",
+      gateway_url: "https://gateway.example.com",
+      resource: "tidebreak",
+    },
     onRetry: fn(),
   },
 } satisfies Meta<typeof HostedSignIn>;
@@ -41,11 +47,45 @@ export const SessionEnded: Story = {
 };
 
 /**
- * A machine on static tokens has no console to send a browser to. The page
- * still says what to do instead of offering a link that goes nowhere.
+ * A machine on a token file takes the token its administrator handed out.
+ * The tab holds it in memory alone, and forgets it on reload.
  */
-export const NoBrowserSignIn: Story = {
-  args: { gatewayUrl: null },
+export const StaticToken: Story = {
+  args: {
+    discovery: { mode: "static_token" },
+    onToken: fn(async () => true),
+  },
+};
+
+/**
+ * The refusal a wrong token gets. It stays on this screen with the field
+ * still filled, because the next thing the reader does is fix the token.
+ */
+export const StaticTokenRefused: Story = {
+  args: {
+    discovery: { mode: "static_token" },
+    onToken: fn(async () => false),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText("Token"), "not-the-token");
+    await userEvent.click(canvas.getByRole("button", { name: "Sign in" }));
+    await expect(await canvas.findByRole("alert")).toBeVisible();
+  },
+};
+
+/**
+ * An OIDC machine offers one button, named for the issuer the operator
+ * configured. The flow starts and finishes on the machine.
+ */
+export const Oidc: Story = {
+  args: {
+    discovery: {
+      mode: "oidc",
+      issuer_name: "login.example.com",
+      start_url: "/auth/oidc/start",
+    },
+  },
 };
 
 /**
@@ -58,8 +98,8 @@ export const HandoffExpired: Story = {
 };
 
 /**
- * The machine could not reach the gateway to exchange the code. Nothing
- * about the reader's account is in question, and the copy says so.
+ * The machine could not reach the provider that signs the reader in. Nothing
+ * about their account is in question, and the copy says so.
  */
 export const HandoffUnavailable: Story = {
   args: { reason: "handoff_failed", failure: "unavailable" },

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -2102,6 +2102,22 @@ body {
     margin-top: 0.5rem;
   }
 
+  /* The token field a standalone machine signs a browser in with. Its own
+     block because the boot screen is centered copy and a field is not: the
+     label sits over the input, both left-aligned, at a width a token fits. */
+  .boot-token-form {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    width: min(24rem, 100%);
+    text-align: left;
+  }
+
+  .boot-token-form p {
+    text-align: left;
+  }
+
   /* A transcript phase whose row threw while rendering. Deliberately quiet: the
    conversation around it is intact, and the step itself is recoverable from the
    durable record. */

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -1148,6 +1148,8 @@ pub fn app(state: AppState) -> Router {
     let auth_discovery = Router::new()
         .route("/auth/discovery", get(auth::discovery))
         .route("/auth/handoff", get(auth::handoff))
+        .route("/auth/oidc/start", get(auth::oidc_start))
+        .route("/auth/oidc/callback", get(auth::oidc_callback))
         .with_state(state.clone());
 
     // Loopback-only + bearer token is the real gate. CORS names the origins

--- a/crates/tidebreak-server-api/src/tests.rs
+++ b/crates/tidebreak-server-api/src/tests.rs
@@ -3026,3 +3026,127 @@ async fn the_handoff_route_lands_the_page_with_the_bearer_in_the_fragment() {
         .unwrap();
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);
 }
+
+/// A self-host router whose authenticator the caller chooses.
+async fn standalone_app(configure: impl FnOnce(&mut Config)) -> (Router, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("t.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut config = Config::desktop(dir.path());
+    config.profile = Profile::SelfHost;
+    config.public_url = Some("https://machine.example.com/tidebreak/".to_owned());
+    configure(&mut config);
+    let state = AppState::new(
+        config,
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    (app(state), dir)
+}
+
+fn public_get(uri: &str) -> Request<Body> {
+    Request::builder().uri(uri).body(Body::empty()).unwrap()
+}
+
+/// What a standalone machine tells a browser it can do, and what it refuses.
+///
+/// The discovery document is the page's only input before it holds anything,
+/// so it stays readable without a bearer and names the one mode this machine
+/// booted with. The routes for the other modes do not exist here: a
+/// token-file machine has no OIDC flow to start, and neither standalone
+/// machine has a console hand-off to redeem (decision 0087).
+#[tokio::test]
+async fn a_standalone_machine_publishes_the_one_sign_in_it_can_run() {
+    let tokens = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        tokens.path(),
+        "alice alice-token-one-padded-to-thirty-two admin\n",
+    )
+    .unwrap();
+    let (static_token, _dir) = standalone_app(|config| {
+        config.auth_tokens_file = Some(tokens.path().to_owned());
+    })
+    .await;
+    let discovery: serde_json::Value = json_body(
+        static_token
+            .clone()
+            .oneshot(public_get("/auth/discovery"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(discovery, serde_json::json!({ "mode": "static_token" }));
+    for route in [
+        "/auth/oidc/start",
+        "/auth/oidc/callback?code=c&state=s",
+        "/auth/handoff?code=mg_ho_good",
+    ] {
+        let response = static_token
+            .clone()
+            .oneshot(public_get(route))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "{route} is not a route a token-file machine has"
+        );
+    }
+
+    let (oidc, _dir) = standalone_app(|config| {
+        config.auth_oidc_issuer = Some("https://login.example.test".to_owned());
+        config.auth_oidc_client_id = Some("client-id".to_owned());
+        config.auth_oidc_client_secret = Some("client-secret".to_owned());
+    })
+    .await;
+    let discovery: serde_json::Value = json_body(
+        oidc.clone()
+            .oneshot(public_get("/auth/discovery"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        discovery,
+        serde_json::json!({
+            "mode": "oidc",
+            "issuer_name": "login.example.test",
+            // The public URL's path prefix is kept, so the button works
+            // behind the operator's own ingress.
+            "start_url": "https://machine.example.com/tidebreak/auth/oidc/start",
+        })
+    );
+    let no_console = oidc
+        .clone()
+        .oneshot(public_get("/auth/handoff?code=mg_ho_good"))
+        .await
+        .unwrap();
+    assert_eq!(no_console.status(), StatusCode::NOT_FOUND);
+
+    // A callback this machine did not start is refused before the issuer is
+    // ever contacted, so a forged one costs nothing and admits nobody.
+    for query in [
+        "",
+        "?error=access_denied&state=s",
+        "?code=stolen-code&state=a-state-this-machine-never-issued",
+        "?code=stolen-code",
+    ] {
+        let response = oidc
+            .clone()
+            .oneshot(public_get(&format!("/auth/oidc/callback{query}")))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FOUND, "{query}");
+        assert_eq!(
+            response.headers()[header::LOCATION].to_str().unwrap(),
+            "https://machine.example.com/tidebreak/#handoff-failed=invalid",
+            "{query}"
+        );
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+    }
+}

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -56,6 +56,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 # The governed REST executor's pinned per-request egress client.
 reqwest = { workspace = true }
+oauth2 = { workspace = true }
+jsonwebtoken = { workspace = true }
 # Catalog-declared parameter and body schemas validated per request in the
 # governed REST executor.
 jsonschema = { workspace = true }

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -7,11 +7,12 @@
 //!   [`Principal::LocalOwner`]. It's the one thing standing between the agent
 //!   and any other local process that finds the port, so the check is
 //!   mandatory on every non-health route.
-//! - **Self-host** authenticates either with live Model Gateway identity or
-//!   static named bearer tokens from an operator-maintained file ([`TokenMap`]).
-//!   Both resolve to [`Principal::User`]. The per-launch token names nobody on
-//!   a shared deployment and is not accepted there — a credential that names
-//!   no one is rejected at this middleware (#853).
+//! - **Self-host** authenticates with live Model Gateway identity, with a
+//!   standalone OpenID Connect provider, or with static named bearer tokens
+//!   from an operator-maintained file ([`TokenMap`]). Each resolves to
+//!   [`Principal::User`]. The per-launch token names nobody on a shared
+//!   deployment and is not accepted there — a credential that names no one is
+//!   rejected at this middleware (#853).
 //!
 //! # Self-host token file
 //!
@@ -39,6 +40,22 @@
 //! bob    0123456789abcdef0123456789abcdef0123456789abcdef01234567
 //! ```
 //!
+//! # Self-host OpenID Connect
+//!
+//! `TIDEBREAK_AUTH_OIDC_ISSUER`, `TIDEBREAK_AUTH_OIDC_CLIENT_ID`, and
+//! `TIDEBREAK_AUTH_OIDC_CLIENT_SECRET` select a third exclusive mode
+//! ([`OidcAuthenticator`]) that signs a browser in without a gateway
+//! (`docs/decisions/0087-standalone-browser-sign-in.md`). Combining them with
+//! `TIDEBREAK_AUTH_GATEWAY_URL` is a boot error; a token file may sit beside
+//! them as the bootstrap for the first administrator and for CLI access,
+//! because OIDC itself only ever names a member.
+//!
+//! The machine runs the authorization-code flow with PKCE itself
+//! ([`oidc_start`] and [`oidc_callback`]), maps the login claim named by
+//! `TIDEBREAK_AUTH_OIDC_CLAIM` (`sub` by default) to a [`UserId`], and mints
+//! its own bearer for an hour. Every bearer it mints starts with
+//! `tb_oidc_`, so a mode confusion is a refusal rather than a coincidence.
+//!
 //! Browsers can't set an `Authorization` header on a WebSocket upgrade, so on
 //! upgrade requests the token is also accepted via `Sec-WebSocket-Protocol` as
 //! `tidebreak-token.<token>` (alongside the handshake subprotocol `tidebreak-v1`).
@@ -54,7 +71,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::extract::{FromRequestParts, Query, Request, State};
 use axum::http::{
@@ -189,10 +206,15 @@ impl FromRequestParts<AppState> for AdapterBootstrapAuth {
     }
 }
 
-/// Public, non-secret authentication metadata for native clients attaching to
-/// a hosted machine. A client uses this to discover that it should mint a
+/// Public, non-secret authentication metadata for clients attaching to a
+/// hosted machine. A native client uses it to discover that it should mint a
 /// Gateway `tidebreak` resource token instead of asking a person to paste a
-/// long-lived static bearer.
+/// long-lived static bearer; a browser tab uses it to pick which of the three
+/// sign-in screens it can offer (decision 0087).
+///
+/// The document is public and unauthenticated by design — a page has to read
+/// it before it holds any credential — so it names modes and public URLs and
+/// nothing else.
 #[derive(serde::Serialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum AuthDiscovery {
@@ -201,22 +223,32 @@ pub enum AuthDiscovery {
         resource: String,
     },
     StaticToken,
+    Oidc {
+        /// What the sign-in button names, taken from the issuer's host.
+        issuer_name: String,
+        /// Where the browser starts the authorization-code flow.
+        start_url: String,
+    },
     Local,
 }
 
 pub async fn discovery(State(state): State<AppState>) -> Json<AuthDiscovery> {
-    let discovery = match state.config.profile {
-        Profile::SelfHost => match state.config.auth_gateway_url.as_deref() {
-            Some(gateway_url) => AuthDiscovery::Gateway {
+    let discovery = match (
+        state.config.profile,
+        state.principal_authenticator.as_ref(),
+        state.config.auth_gateway_url.as_deref(),
+    ) {
+        (Profile::SelfHost, PrincipalAuthenticator::Gateway(gateway), Some(gateway_url)) => {
+            AuthDiscovery::Gateway {
                 gateway_url: gateway_url.trim_end_matches('/').to_owned(),
-                resource: state
-                    .principal_authenticator
-                    .gateway_resource()
-                    .expect("Gateway authenticator exposes its machine resource")
-                    .to_owned(),
-            },
-            None => AuthDiscovery::StaticToken,
+                resource: gateway.resource.clone(),
+            }
+        }
+        (Profile::SelfHost, PrincipalAuthenticator::Oidc(oidc), _) => AuthDiscovery::Oidc {
+            issuer_name: oidc.issuer_name(),
+            start_url: oidc.start_url.clone(),
         },
+        (Profile::SelfHost, PrincipalAuthenticator::Static(_), _) => AuthDiscovery::StaticToken,
         _ => AuthDiscovery::Local,
     };
     Json(discovery)
@@ -428,17 +460,64 @@ async fn resolve_principal(state: &AppState, presented: &str) -> Option<Principa
 
 /// The self-host credential-to-principal mechanism selected at boot.
 ///
-/// Gateway mode is the hosted default: every request is checked against the
-/// Gateway's live account and session state. Static tokens remain available
-/// for standalone self-host deployments with no Model Gateway.
+/// Gateway mode checks every request against the Gateway's live account and
+/// session state. Standalone machines use static tokens or OpenID Connect;
+/// OIDC may also load a token file for administrator bootstrap and CLI access.
 pub enum PrincipalAuthenticator {
     None,
     Static(TokenMap),
     Gateway(GatewayAuthenticator),
+    Oidc(OidcAuthenticator),
 }
 
 impl PrincipalAuthenticator {
     pub fn from_config(config: &tidebreak_core::Config) -> Result<Self> {
+        // OIDC is checked first because it is the one mode that may carry a
+        // token file alongside it, so the exclusivity table below would read
+        // an OIDC deployment's bootstrap file as static-token mode.
+        if let Some(issuer) = config.auth_oidc_issuer.as_deref() {
+            if config.auth_gateway_url.is_some() {
+                return Err(AgentError::config(
+                    "self-host authentication is ambiguous: TIDEBREAK_AUTH_OIDC_ISSUER \
+                     cannot be combined with TIDEBREAK_AUTH_GATEWAY_URL, because a machine \
+                     signs browsers in through one identity provider",
+                ));
+            }
+            let client_id = config.auth_oidc_client_id.as_deref().ok_or_else(|| {
+                AgentError::config(
+                    "TIDEBREAK_AUTH_OIDC_CLIENT_ID is required with TIDEBREAK_AUTH_OIDC_ISSUER",
+                )
+            })?;
+            let client_secret = config.auth_oidc_client_secret.as_deref().ok_or_else(|| {
+                AgentError::config(
+                    "TIDEBREAK_AUTH_OIDC_CLIENT_SECRET is required with TIDEBREAK_AUTH_OIDC_ISSUER",
+                )
+            })?;
+            let public_url = config.public_url.as_deref().ok_or_else(|| {
+                AgentError::config(
+                    "TIDEBREAK_PUBLIC_URL is required with TIDEBREAK_AUTH_OIDC_ISSUER so the \
+                     provider has a callback to return to",
+                )
+            })?;
+            // The token file stays the bootstrap for the first administrator
+            // and for CLI access; OIDC never mints an admin (decision 0087).
+            let bootstrap = config
+                .auth_tokens_file
+                .as_deref()
+                .map(TokenMap::load)
+                .transpose()?;
+            return Ok(Self::Oidc(OidcAuthenticator::new(
+                issuer,
+                client_id,
+                client_secret,
+                config
+                    .auth_oidc_claim
+                    .as_deref()
+                    .unwrap_or(DEFAULT_OIDC_CLAIM),
+                public_url,
+                bootstrap,
+            )?));
+        }
         match (
             config.auth_tokens_file.as_deref(),
             config.auth_gateway_url.as_deref(),
@@ -466,7 +545,8 @@ impl PrincipalAuthenticator {
             )),
             (None, None, None, _) => Err(AgentError::config(
                 "self-host requires a principal-naming authenticator: set \
-                 TIDEBREAK_AUTH_GATEWAY_URL for Model Gateway identity, or \
+                 TIDEBREAK_AUTH_GATEWAY_URL for Model Gateway identity, \
+                 TIDEBREAK_AUTH_OIDC_ISSUER for an OpenID Connect provider, or \
                  TIDEBREAK_AUTH_TOKENS_FILE for standalone static tokens",
             )),
         }
@@ -478,6 +558,7 @@ impl PrincipalAuthenticator {
             Self::Static(tokens) => tokens
                 .resolve(presented)
                 .map(|(id, role)| Principal::User { id, role }),
+            Self::Oidc(oidc) => oidc.resolve(presented),
             Self::Gateway(gateway) => match gateway.resolve(presented).await {
                 Ok(principal) => principal,
                 Err(error) => {
@@ -487,13 +568,564 @@ impl PrincipalAuthenticator {
             },
         }
     }
+}
 
-    fn gateway_resource(&self) -> Option<&str> {
-        match self {
-            Self::Gateway(gateway) => Some(&gateway.resource),
-            Self::None | Self::Static(_) => None,
+/// The ID-token claim whose string value names the Tidebreak user when the
+/// operator sets no override.
+const DEFAULT_OIDC_CLAIM: &str = "sub";
+
+/// Prefix on every bearer this machine mints for an OIDC sign-in. It is what
+/// makes a mode confusion visible: a static token never carries it, and a
+/// token-file machine holds no store that could ever answer for one.
+const OIDC_BEARER_PREFIX: &str = "tb_oidc_";
+
+/// How long a minted bearer names its principal. A browser tab holds no
+/// refreshable session, so this is the length of a hosted sign-in (decision
+/// 0082 defers the refresh path).
+const OIDC_BEARER_LIFETIME: Duration = Duration::from_secs(3600);
+
+/// How long a started authorization flow waits for its callback. Long enough
+/// for a password, a second factor, and a consent screen; short enough that an
+/// abandoned flow is not a lasting entry.
+const OIDC_FLOW_LIFETIME: Duration = Duration::from_secs(600);
+
+/// Ceilings on the two in-memory maps. `/auth/oidc/start` is public, so
+/// without a cap anyone could grow the pending map by asking; a start that
+/// would exceed the cap is refused rather than served, which is the
+/// fail-closed direction. Both are far above any real standalone deployment.
+const MAX_PENDING_OIDC_FLOWS: usize = 512;
+const MAX_OIDC_BEARERS: usize = 4096;
+
+/// Nothing an issuer legitimately answers with is this large. Discovery
+/// documents and key sets run to a few kilobytes.
+const OIDC_RESPONSE_LIMIT: usize = 64 * 1024;
+
+/// The subset of the issuer's discovery document this machine uses.
+#[derive(serde::Deserialize)]
+struct OidcMetadata {
+    issuer: String,
+    authorization_endpoint: String,
+    token_endpoint: String,
+    jwks_uri: String,
+}
+
+/// One authorization flow between `/auth/oidc/start` and its callback.
+///
+/// The verifier and the nonce never leave this process: the verifier proves
+/// the callback belongs to the browser that started the flow, and the nonce
+/// proves the ID token was minted for it.
+struct PendingOidc {
+    verifier: String,
+    nonce: String,
+    return_to: String,
+    created: Instant,
+}
+
+/// Standalone OpenID Connect authenticator (decision 0087).
+///
+/// The machine runs the authorization-code flow itself and mints its own
+/// bearer once the ID token verifies, so the issuer is on the path at sign-in
+/// and nowhere else. Bearers live in process memory: a restart signs everyone
+/// out, which is the same bound a hosted tab already has.
+pub struct OidcAuthenticator {
+    issuer: reqwest::Url,
+    client_id: String,
+    client_secret: String,
+    /// The ID-token claim mapped to the Tidebreak user id.
+    claim: String,
+    /// What the authorization request asks the issuer to release.
+    scope: &'static str,
+    callback_url: String,
+    /// Where the sign-in page sends the browser; published by discovery.
+    start_url: String,
+    client: reqwest::Client,
+    pending: std::sync::Mutex<HashMap<String, PendingOidc>>,
+    bearers: std::sync::Mutex<HashMap<String, (Principal, Instant)>>,
+    /// The token file an OIDC deployment may keep beside the provider, for the
+    /// first administrator and for CLI access. OIDC itself mints no admin.
+    bootstrap: Option<TokenMap>,
+}
+
+/// Claims an issuer releases only for the `profile` scope. Asking for the
+/// scope a login claim needs is the difference between a working mapping and
+/// a sign-in that fails closed on a claim the provider was never told to send.
+const OIDC_PROFILE_CLAIMS: &[&str] = &[
+    "name",
+    "preferred_username",
+    "nickname",
+    "given_name",
+    "family_name",
+    "profile",
+];
+
+impl OidcAuthenticator {
+    fn new(
+        issuer: &str,
+        client_id: &str,
+        client_secret: &str,
+        claim: &str,
+        public_url: &str,
+        bootstrap: Option<TokenMap>,
+    ) -> Result<Self> {
+        let issuer = reqwest::Url::parse(issuer.trim())
+            .map_err(|error| AgentError::config(format!("invalid OIDC issuer: {error}")))?;
+        require_https_or_loopback(&issuer, "TIDEBREAK_AUTH_OIDC_ISSUER")?;
+        if issuer.query().is_some()
+            || issuer.fragment().is_some()
+            || !issuer.username().is_empty()
+            || issuer.password().is_some()
+        {
+            return Err(AgentError::config(
+                "TIDEBREAK_AUTH_OIDC_ISSUER must not contain credentials, a query, or a fragment",
+            ));
         }
+        if claim.is_empty()
+            || claim.len() > 128
+            || !claim
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+        {
+            return Err(AgentError::config(
+                "TIDEBREAK_AUTH_OIDC_CLAIM must be a plain claim name of letters, digits, \
+                 `.`, `_`, or `-`",
+            ));
+        }
+        let scope = match claim {
+            "email" | "email_verified" => "openid email",
+            claim if OIDC_PROFILE_CLAIMS.contains(&claim) => "openid profile",
+            _ => "openid",
+        };
+        let public_url = canonical_public_url(public_url)?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| AgentError::config(format!("OIDC client: {error}")))?;
+        Ok(Self {
+            issuer,
+            client_id: client_id.to_owned(),
+            client_secret: client_secret.to_owned(),
+            claim: claim.to_owned(),
+            scope,
+            callback_url: format!("{public_url}/auth/oidc/callback"),
+            start_url: format!("{public_url}/auth/oidc/start"),
+            client,
+            pending: std::sync::Mutex::new(HashMap::new()),
+            bearers: std::sync::Mutex::new(HashMap::new()),
+            bootstrap,
+        })
     }
+
+    /// What the sign-in button names. The host alone, because an operator
+    /// reads "login.example.com", not a URL with a scheme and a path.
+    fn issuer_name(&self) -> String {
+        self.issuer
+            .host_str()
+            .unwrap_or(self.issuer.as_str())
+            .to_owned()
+    }
+
+    /// The bootstrap token file first, then this machine's own bearers.
+    ///
+    /// Anything else names nobody, which is how an OIDC machine refuses a
+    /// static token it was never given: there is no roster to find it in.
+    fn resolve(&self, presented: &str) -> Option<Principal> {
+        if let Some((id, role)) = self
+            .bootstrap
+            .as_ref()
+            .and_then(|tokens| tokens.resolve(presented))
+        {
+            return Some(Principal::User { id, role });
+        }
+        if !presented.starts_with(OIDC_BEARER_PREFIX) {
+            return None;
+        }
+        let mut bearers = self.bearers.lock().ok()?;
+        let now = Instant::now();
+        bearers.retain(|_, (_, expires)| *expires > now);
+        bearers
+            .get(presented)
+            .map(|(principal, _)| principal.clone())
+    }
+
+    /// Start a flow: remember what the callback must prove, and answer with
+    /// what the authorization request has to carry.
+    ///
+    /// `None` when the pending map is at its ceiling. A machine that cannot
+    /// remember a flow must not start one, because a callback it cannot check
+    /// is a callback it would have to trust.
+    fn begin(&self, return_to: &str) -> Option<(String, String, oauth2::PkceCodeChallenge)> {
+        let (challenge, verifier) = oauth2::PkceCodeChallenge::new_random_sha256();
+        // 256 bits from the OS generator, base64url — so both values are
+        // header- and fragment-safe as well as unguessable.
+        let state = oauth2::CsrfToken::new_random().secret().clone();
+        let nonce = oauth2::CsrfToken::new_random().secret().clone();
+        let mut pending = self.pending.lock().ok()?;
+        pending.retain(|_, flow| flow.created.elapsed() < OIDC_FLOW_LIFETIME);
+        if pending.len() >= MAX_PENDING_OIDC_FLOWS {
+            return None;
+        }
+        pending.insert(
+            state.clone(),
+            PendingOidc {
+                verifier: verifier.secret().clone(),
+                nonce: nonce.clone(),
+                return_to: return_to.to_owned(),
+                created: Instant::now(),
+            },
+        );
+        Some((state, nonce, challenge))
+    }
+
+    /// Take the flow this callback claims, if it is one this machine started
+    /// and has not already answered. Removing it is what makes a `state`
+    /// single-use.
+    fn claim_flow(&self, state: &str) -> Option<PendingOidc> {
+        self.pending
+            .lock()
+            .ok()?
+            .remove(state)
+            .filter(|flow| flow.created.elapsed() < OIDC_FLOW_LIFETIME)
+    }
+
+    /// The URL the browser is sent to, carrying everything the callback will
+    /// be checked against. Separate from [`OidcAuthenticator::begin`] so the
+    /// request this machine actually makes is readable on its own.
+    fn authorization_url(
+        &self,
+        endpoint: &str,
+        state: &str,
+        nonce: &str,
+        challenge: &oauth2::PkceCodeChallenge,
+    ) -> Option<reqwest::Url> {
+        let mut url = reqwest::Url::parse(endpoint).ok()?;
+        url.query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", &self.client_id)
+            .append_pair("redirect_uri", &self.callback_url)
+            .append_pair("scope", self.scope)
+            .append_pair("state", state)
+            .append_pair("nonce", nonce)
+            .append_pair("code_challenge", challenge.as_str())
+            .append_pair("code_challenge_method", challenge.method().as_str());
+        Some(url)
+    }
+
+    /// Mint a bearer for a verified principal and remember it for `lifetime`.
+    fn mint_bearer(&self, principal: Principal, lifetime: Duration) -> Option<String> {
+        let bearer = format!(
+            "{OIDC_BEARER_PREFIX}{}",
+            oauth2::CsrfToken::new_random().secret()
+        );
+        let mut bearers = self.bearers.lock().ok()?;
+        let now = Instant::now();
+        bearers.retain(|_, (_, expires)| *expires > now);
+        if bearers.len() >= MAX_OIDC_BEARERS {
+            return None;
+        }
+        bearers.insert(bearer.clone(), (principal, now + lifetime));
+        Some(bearer)
+    }
+
+    /// Read the issuer's discovery document and check it describes the issuer
+    /// this machine was configured with.
+    ///
+    /// Every endpoint it names is used to reach the provider, so each one is
+    /// held to the same transport rule as the issuer itself: an issuer that
+    /// answers with an `http://` token endpoint does not get the client
+    /// secret.
+    async fn metadata(&self) -> Result<OidcMetadata> {
+        let mut url = self.issuer.clone();
+        let base = url.path().trim_end_matches('/');
+        url.set_path(&format!("{base}/.well-known/openid-configuration"));
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|error| AgentError::msg(format!("OIDC discovery failed: {error}")))?
+            .error_for_status()
+            .map_err(|error| AgentError::msg(format!("OIDC discovery was refused: {error}")))?;
+        let metadata: OidcMetadata = bounded_oidc_json(response).await?;
+        if metadata.issuer.trim_end_matches('/') != self.issuer.as_str().trim_end_matches('/') {
+            return Err(AgentError::msg(
+                "OIDC discovery named a different issuer than the configured one",
+            ));
+        }
+        for (endpoint, what) in [
+            (&metadata.authorization_endpoint, "authorization_endpoint"),
+            (&metadata.token_endpoint, "token_endpoint"),
+            (&metadata.jwks_uri, "jwks_uri"),
+        ] {
+            let url = reqwest::Url::parse(endpoint).map_err(|error| {
+                AgentError::msg(format!("OIDC discovery {what} is not a URL: {error}"))
+            })?;
+            require_https_or_loopback(&url, &format!("the OIDC {what}"))?;
+        }
+        Ok(metadata)
+    }
+}
+
+/// Read a bounded JSON body. An issuer that answers with more than a key set
+/// is not one this machine reads into memory.
+async fn bounded_oidc_json<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > OIDC_RESPONSE_LIMIT as u64)
+    {
+        return Err(AgentError::msg("OIDC response exceeded the size limit"));
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|error| AgentError::msg(format!("OIDC response failed: {error}")))?;
+    if bytes.len() > OIDC_RESPONSE_LIMIT {
+        return Err(AgentError::msg("OIDC response exceeded the size limit"));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|error| AgentError::msg(format!("OIDC response was invalid: {error}")))
+}
+
+/// Require a URL this machine is willing to send a credential to. Plain HTTP
+/// is allowed only against loopback, where there is no network to read it off.
+fn require_https_or_loopback(url: &reqwest::Url, what: &str) -> Result<()> {
+    let loopback = url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    });
+    if url.scheme() == "https" || (url.scheme() == "http" && loopback) {
+        return Ok(());
+    }
+    Err(AgentError::config(format!(
+        "{what} must use https (http is allowed only for loopback development)"
+    )))
+}
+
+#[derive(serde::Deserialize)]
+pub struct OidcStartQuery {
+    /// Which UI route to open once the page is signed in, exactly as the
+    /// console hand-off carries it.
+    #[serde(default)]
+    return_to: Option<String>,
+}
+
+/// Start an OpenID Connect sign-in on this machine.
+///
+/// The browser arrives from the sign-in screen with no credential — the
+/// route is public for the same reason the discovery document is. It answers
+/// with a redirect to the issuer's authorization endpoint carrying a fresh
+/// `state`, `nonce`, and PKCE challenge; the secrets behind all three stay
+/// here. A machine that does not authenticate through OIDC has no such flow,
+/// so the route does not exist there.
+pub async fn oidc_start(
+    State(state): State<AppState>,
+    Query(query): Query<OidcStartQuery>,
+) -> Response {
+    let PrincipalAuthenticator::Oidc(oidc) = state.principal_authenticator.as_ref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let landing = handoff_landing(&state);
+    let metadata = match oidc.metadata().await {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            tracing::warn!(%error, "OIDC discovery could not be read");
+            return handoff_redirect(&landing, "handoff-failed", "unavailable", None);
+        }
+    };
+    let return_to = handoff_return_route(query.return_to.as_deref());
+    let Some((flow_state, nonce, challenge)) = oidc.begin(return_to) else {
+        tracing::warn!("refused an OIDC sign-in: too many flows are already waiting");
+        return handoff_redirect(&landing, "handoff-failed", "unavailable", None);
+    };
+    let Some(authorization) = oidc.authorization_url(
+        &metadata.authorization_endpoint,
+        &flow_state,
+        &nonce,
+        &challenge,
+    ) else {
+        return handoff_redirect(&landing, "handoff-failed", "unavailable", None);
+    };
+    (
+        StatusCode::FOUND,
+        [
+            (LOCATION, authorization.to_string()),
+            (CACHE_CONTROL, "no-store".to_owned()),
+            (REFERRER_POLICY, "no-referrer".to_owned()),
+        ],
+    )
+        .into_response()
+}
+
+#[derive(serde::Deserialize)]
+pub struct OidcCallbackQuery {
+    #[serde(default)]
+    code: String,
+    #[serde(default)]
+    state: String,
+    /// What the issuer sends instead of a code when it refused. A refusal
+    /// admits nobody, so it is only a reason for the page to word.
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct OidcTokenResponse {
+    id_token: String,
+}
+
+/// Finish an OpenID Connect sign-in and land the page holding a bearer.
+///
+/// Everything the issuer says is checked before anything is minted: the
+/// `state` names a flow this machine started and has not answered, the code
+/// is exchanged with that flow's PKCE verifier, and the ID token has to carry
+/// this client's audience, the configured issuer, a live expiry, and the
+/// flow's nonce. Only then does the machine mint a bearer of its own and hand
+/// it to the page through the fragment envelope the console hand-off uses
+/// (decision 0082), so the page needs no second way to receive one.
+///
+/// Nothing here is logged: not the code, not the ID token, not the bearer.
+pub async fn oidc_callback(
+    State(state): State<AppState>,
+    Query(query): Query<OidcCallbackQuery>,
+) -> Response {
+    let PrincipalAuthenticator::Oidc(oidc) = state.principal_authenticator.as_ref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let landing = handoff_landing(&state);
+    let refused = |reason| handoff_redirect(&landing, "handoff-failed", reason, None);
+    if query.error.is_some() || query.code.is_empty() || query.state.is_empty() {
+        return refused("invalid");
+    }
+    let Some(flow) = oidc.claim_flow(&query.state) else {
+        return refused("invalid");
+    };
+    let metadata = match oidc.metadata().await {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            tracing::warn!(%error, "OIDC discovery could not be read");
+            return refused("unavailable");
+        }
+    };
+    let exchange = oidc
+        .client
+        .post(&metadata.token_endpoint)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", query.code.as_str()),
+            ("redirect_uri", oidc.callback_url.as_str()),
+            ("client_id", oidc.client_id.as_str()),
+            ("client_secret", oidc.client_secret.as_str()),
+            ("code_verifier", flow.verifier.as_str()),
+        ])
+        .send()
+        .await;
+    let token: OidcTokenResponse = match exchange {
+        // A refused exchange is the provider saying no, which admits nobody.
+        Ok(response) if response.status().is_client_error() => return refused("invalid"),
+        Ok(response) if !response.status().is_success() => {
+            tracing::warn!(status = %response.status(), "OIDC token exchange returned an error status");
+            return refused("unavailable");
+        }
+        Ok(response) => match bounded_oidc_json(response).await {
+            Ok(token) => token,
+            Err(error) => {
+                tracing::warn!(%error, "OIDC token response was unusable");
+                return refused("unavailable");
+            }
+        },
+        Err(error) => {
+            tracing::warn!(%error, "OIDC token exchange failed");
+            return refused("unavailable");
+        }
+    };
+    let jwks: jsonwebtoken::jwk::JwkSet = match oidc.client.get(&metadata.jwks_uri).send().await {
+        Ok(response) if response.status().is_success() => match bounded_oidc_json(response).await {
+            Ok(jwks) => jwks,
+            Err(error) => {
+                tracing::warn!(%error, "OIDC key set was unusable");
+                return refused("unavailable");
+            }
+        },
+        _ => {
+            tracing::warn!("OIDC key set could not be read");
+            return refused("unavailable");
+        }
+    };
+    let Some(principal) =
+        validate_oidc_id_token(oidc, &metadata, &jwks, &token.id_token, &flow.nonce)
+    else {
+        return refused("invalid");
+    };
+    let Some(bearer) = oidc.mint_bearer(principal, OIDC_BEARER_LIFETIME) else {
+        tracing::warn!("refused an OIDC sign-in: too many bearers are already live");
+        return refused("unavailable");
+    };
+    handoff_redirect(&landing, "handoff", &bearer, Some(&flow.return_to))
+}
+
+/// Verify an ID token against the issuer's keys and map it to a principal.
+///
+/// `None` for every failure, deliberately without distinguishing them: the
+/// caller lands the page on one refusal either way, and a reason told apart
+/// here would only be told apart by whoever forged the token.
+///
+/// The role is always [`Role::Member`]. Decision 6 requires an external
+/// identity provider to supply a role or default everyone to member, and an
+/// ID token carries no Tidebreak role — the token file is where a standalone
+/// deployment names its administrators.
+fn validate_oidc_id_token(
+    oidc: &OidcAuthenticator,
+    metadata: &OidcMetadata,
+    jwks: &jsonwebtoken::jwk::JwkSet,
+    id_token: &str,
+    nonce: &str,
+) -> Option<Principal> {
+    let header = jsonwebtoken::decode_header(id_token).ok()?;
+    // The algorithm comes from the token, so the set it may name is fixed
+    // here: signing algorithms only. `none` and the HMAC family are excluded,
+    // the latter because their key would be the client secret rather than
+    // anything the issuer's key set publishes.
+    if !matches!(
+        header.alg,
+        jsonwebtoken::Algorithm::RS256
+            | jsonwebtoken::Algorithm::RS384
+            | jsonwebtoken::Algorithm::RS512
+            | jsonwebtoken::Algorithm::PS256
+            | jsonwebtoken::Algorithm::PS384
+            | jsonwebtoken::Algorithm::PS512
+            | jsonwebtoken::Algorithm::ES256
+            | jsonwebtoken::Algorithm::ES384
+            | jsonwebtoken::Algorithm::EdDSA
+    ) {
+        return None;
+    }
+    let key = jsonwebtoken::DecodingKey::from_jwk(jwks.find(header.kid.as_deref()?)?).ok()?;
+    let mut validation = jsonwebtoken::Validation::new(header.alg);
+    validation.set_audience(&[&oidc.client_id]);
+    validation.set_issuer(&[metadata.issuer.as_str()]);
+    validation.set_required_spec_claims(&["exp", "aud", "iss", "sub"]);
+    let claims = jsonwebtoken::decode::<serde_json::Value>(id_token, &key, &validation)
+        .ok()?
+        .claims;
+    // The nonce binds the token to the flow this browser started, which is
+    // what stops one replayed here from another.
+    if claims.get("nonce").and_then(serde_json::Value::as_str) != Some(nonce) {
+        return None;
+    }
+    let login = claims
+        .get(&oidc.claim)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())?;
+    Some(Principal::User {
+        id: UserId::new(login).ok()?,
+        role: Role::Member,
+    })
 }
 
 /// Live verifier for Gateway-issued `tidebreak` resource tokens.
@@ -1491,5 +2123,450 @@ mod tests {
             PrincipalAuthenticator::from_config(&config),
             Ok(PrincipalAuthenticator::Static(_))
         ));
+    }
+
+    /// A throwaway Ed25519 key pair for the ID tokens below. The private half
+    /// is spelled as DER bytes rather than a PEM block so the secret scanner
+    /// has nothing key-shaped to trip over; it signs nothing outside this
+    /// module.
+    const TEST_OIDC_PRIVATE_KEY: &[u8] = &[
+        48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32, 77, 131, 23, 2, 149, 50, 243,
+        210, 168, 16, 155, 75, 190, 114, 52, 174, 24, 147, 187, 163, 47, 207, 192, 156, 53, 223,
+        168, 73, 209, 213, 223, 139,
+    ];
+    const TEST_OIDC_PUBLIC_KEY: &str = "iCQjb0jIV9LwVk60OpxoyoYEtpKuMou948yRVjp6UEU";
+    const TEST_OIDC_ISSUER: &str = "http://127.0.0.1:12345";
+
+    fn unix_now() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    /// Sign an ID token the configured client would accept, with `overrides`
+    /// applied over the well-formed claims so each case says exactly what it
+    /// changed. A `null` override drops the claim entirely.
+    fn oidc_test_token(overrides: serde_json::Value) -> String {
+        let mut claims = serde_json::json!({
+            "iss": TEST_OIDC_ISSUER,
+            "sub": "oidc-user",
+            "aud": "client-id",
+            "exp": unix_now() + 300,
+            "nonce": "expected-nonce",
+            "email": "person@example.test",
+        });
+        let object = claims.as_object_mut().expect("the claims are an object");
+        for (name, value) in overrides.as_object().expect("overrides are an object") {
+            if value.is_null() {
+                object.remove(name);
+            } else {
+                object.insert(name.clone(), value.clone());
+            }
+        }
+        let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::EdDSA);
+        header.kid = Some("test-key".to_owned());
+        jsonwebtoken::encode(
+            &header,
+            &claims,
+            &jsonwebtoken::EncodingKey::from_ed_der(TEST_OIDC_PRIVATE_KEY),
+        )
+        .unwrap()
+    }
+
+    fn oidc_test_jwks() -> jsonwebtoken::jwk::JwkSet {
+        serde_json::from_value(serde_json::json!({
+            "keys": [{
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "kid": "test-key",
+                "use": "sig",
+                "alg": "EdDSA",
+                "x": TEST_OIDC_PUBLIC_KEY,
+            }]
+        }))
+        .unwrap()
+    }
+
+    fn oidc_test_metadata() -> OidcMetadata {
+        OidcMetadata {
+            issuer: TEST_OIDC_ISSUER.to_owned(),
+            authorization_endpoint: format!("{TEST_OIDC_ISSUER}/authorize"),
+            token_endpoint: format!("{TEST_OIDC_ISSUER}/token"),
+            jwks_uri: format!("{TEST_OIDC_ISSUER}/jwks"),
+        }
+    }
+
+    fn oidc_test_authenticator(claim: &str, bootstrap: Option<TokenMap>) -> OidcAuthenticator {
+        OidcAuthenticator::new(
+            TEST_OIDC_ISSUER,
+            "client-id",
+            "client-secret",
+            claim,
+            "http://127.0.0.1:8080",
+            bootstrap,
+        )
+        .unwrap()
+    }
+
+    /// The authorization request carries everything the callback is checked
+    /// against, and the flow behind it is single-use: a `state` answers once,
+    /// so a callback replayed after the browser landed finds nothing.
+    #[test]
+    fn a_started_flow_is_single_use_and_its_request_carries_the_whole_check() {
+        let oidc = oidc_test_authenticator(DEFAULT_OIDC_CLAIM, None);
+        let (state, nonce, challenge) = oidc.begin("/c/session-1").unwrap();
+        let url = oidc
+            .authorization_url(
+                &oidc_test_metadata().authorization_endpoint,
+                &state,
+                &nonce,
+                &challenge,
+            )
+            .unwrap();
+        let query: HashMap<String, String> = url.query_pairs().into_owned().collect();
+        assert_eq!(url.path(), "/authorize");
+        assert_eq!(query["response_type"], "code");
+        assert_eq!(query["client_id"], "client-id");
+        assert_eq!(
+            query["redirect_uri"],
+            "http://127.0.0.1:8080/auth/oidc/callback"
+        );
+        assert_eq!(query["scope"], "openid");
+        assert_eq!(query["state"], state);
+        assert_eq!(query["nonce"], nonce);
+        assert_eq!(query["code_challenge_method"], "S256");
+        assert_eq!(query["code_challenge"], challenge.as_str());
+        assert_ne!(
+            query["code_challenge"], "",
+            "the verifier never leaves this process, so the challenge must"
+        );
+        assert!(
+            !query.contains_key("code_verifier"),
+            "the verifier is the secret half and must not travel with the browser"
+        );
+
+        // The flow answers exactly one callback, and only its own state.
+        assert!(oidc.claim_flow("some-other-state").is_none());
+        let flow = oidc.claim_flow(&state).unwrap();
+        assert_eq!(flow.nonce, nonce);
+        assert_eq!(flow.return_to, "/c/session-1");
+        assert!(
+            oidc.claim_flow(&state).is_none(),
+            "a state that already landed a browser must not land another"
+        );
+    }
+
+    /// `/auth/oidc/start` is public, so the map behind it is bounded. A
+    /// machine that cannot remember a flow refuses to start one rather than
+    /// accepting a callback it could not check.
+    #[test]
+    fn the_number_of_waiting_sign_ins_is_bounded() {
+        let oidc = oidc_test_authenticator(DEFAULT_OIDC_CLAIM, None);
+        let started: Vec<_> = (0..MAX_PENDING_OIDC_FLOWS)
+            .filter_map(|_| oidc.begin("/"))
+            .collect();
+        assert_eq!(started.len(), MAX_PENDING_OIDC_FLOWS);
+        assert!(oidc.begin("/").is_none());
+        // Answering one makes room for the next reader.
+        oidc.claim_flow(&started[0].0).unwrap();
+        assert!(oidc.begin("/").is_some());
+    }
+
+    /// Every reason an ID token can fail is a refusal, and each one is a
+    /// separate way a forged or replayed token would otherwise get in: a
+    /// token minted for another client, one from another issuer, one from a
+    /// flow this machine did not start, one whose hour is up, and one signed
+    /// by a key the issuer does not publish.
+    #[test]
+    fn an_id_token_this_machine_did_not_ask_for_names_nobody() {
+        let oidc = oidc_test_authenticator(DEFAULT_OIDC_CLAIM, None);
+        let metadata = oidc_test_metadata();
+        let jwks = oidc_test_jwks();
+        let verify =
+            |token: &str| validate_oidc_id_token(&oidc, &metadata, &jwks, token, "expected-nonce");
+
+        assert_eq!(
+            verify(&oidc_test_token(serde_json::json!({}))),
+            Some(Principal::User {
+                id: UserId::new("oidc-user").unwrap(),
+                // OIDC names a member; the token file names administrators.
+                role: Role::Member,
+            }),
+            "a token for this client, from this issuer, in this flow, signs the person in"
+        );
+
+        for (token, why) in [
+            (
+                oidc_test_token(serde_json::json!({ "aud": "another-client" })),
+                "an audience that is not this client id",
+            ),
+            (
+                oidc_test_token(serde_json::json!({ "iss": "https://other.example.test" })),
+                "an issuer that is not the configured one",
+            ),
+            (
+                oidc_test_token(serde_json::json!({ "nonce": "some-other-flow" })),
+                "a nonce from a flow this machine did not start",
+            ),
+            (
+                oidc_test_token(serde_json::json!({ "nonce": null })),
+                "no nonce at all",
+            ),
+            (
+                oidc_test_token(serde_json::json!({ "exp": unix_now() - 3600 })),
+                "an expiry in the past",
+            ),
+            (
+                oidc_test_token(serde_json::json!({ "sub": null })),
+                "no subject",
+            ),
+        ] {
+            assert!(verify(&token).is_none(), "{why} must admit nobody");
+        }
+
+        // A key set that does not publish the signing key admits nobody
+        // either, however well-formed the token is.
+        let other_keys: jsonwebtoken::jwk::JwkSet = serde_json::from_value(serde_json::json!({
+            "keys": [{
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "kid": "another-key",
+                "use": "sig",
+                "alg": "EdDSA",
+                "x": TEST_OIDC_PUBLIC_KEY,
+            }]
+        }))
+        .unwrap();
+        assert!(validate_oidc_id_token(
+            &oidc,
+            &metadata,
+            &other_keys,
+            &oidc_test_token(serde_json::json!({})),
+            "expected-nonce",
+        )
+        .is_none());
+    }
+
+    /// The claim override picks which string names the user. A claim the
+    /// provider did not send, or sent as something other than a string, signs
+    /// nobody in — decision 0087's fail-closed outcome for a stale mapping.
+    #[test]
+    fn the_login_claim_override_names_the_user_or_nobody() {
+        let oidc = oidc_test_authenticator("email", None);
+        let metadata = oidc_test_metadata();
+        let jwks = oidc_test_jwks();
+        assert_eq!(
+            validate_oidc_id_token(
+                &oidc,
+                &metadata,
+                &jwks,
+                &oidc_test_token(serde_json::json!({})),
+                "expected-nonce",
+            ),
+            Some(Principal::User {
+                id: UserId::new("person@example.test").unwrap(),
+                role: Role::Member,
+            })
+        );
+        for overrides in [
+            serde_json::json!({ "email": null }),
+            serde_json::json!({ "email": "" }),
+            serde_json::json!({ "email": 42 }),
+            serde_json::json!({ "email": ["person@example.test"] }),
+        ] {
+            assert!(validate_oidc_id_token(
+                &oidc,
+                &metadata,
+                &jwks,
+                &oidc_test_token(overrides.clone()),
+                "expected-nonce",
+            )
+            .is_none());
+        }
+        // Asking for a claim means asking for the scope that releases it.
+        assert_eq!(oidc.scope, "openid email");
+        assert_eq!(oidc_test_authenticator("sub", None).scope, "openid");
+        assert_eq!(
+            oidc_test_authenticator("preferred_username", None).scope,
+            "openid profile"
+        );
+    }
+
+    /// A bearer this machine minted names its principal until its hour is up,
+    /// and never a moment longer. Nothing else is a bearer.
+    #[test]
+    fn a_minted_bearer_lasts_its_hour_and_then_names_nobody() {
+        let oidc = oidc_test_authenticator(DEFAULT_OIDC_CLAIM, None);
+        let principal = Principal::User {
+            id: UserId::new("oidc-user").unwrap(),
+            role: Role::Member,
+        };
+        let bearer = oidc
+            .mint_bearer(principal.clone(), OIDC_BEARER_LIFETIME)
+            .unwrap();
+        assert!(bearer.starts_with(OIDC_BEARER_PREFIX));
+        assert!(
+            bearer.bytes().all(is_token_byte),
+            "a bearer travels in a header and a subprotocol, so it stays in their alphabet"
+        );
+        assert_eq!(oidc.resolve(&bearer), Some(principal.clone()));
+        assert_eq!(oidc.resolve(&format!("{bearer}x")), None);
+
+        let expired = oidc.mint_bearer(principal, Duration::ZERO).unwrap();
+        assert_eq!(oidc.resolve(&expired), None);
+    }
+
+    /// Decision 0087's cross-mode rule, both directions. An OIDC machine has
+    /// no roster to find a static token in — except the bootstrap file it may
+    /// be given, which is exactly the tokens in that file and no others — and
+    /// a token-file machine holds nothing that could answer for a bearer only
+    /// an OIDC machine mints.
+    #[tokio::test]
+    async fn an_oidc_machine_refuses_a_static_token_and_a_token_file_machine_refuses_a_bearer() {
+        let bootstrap = TokenMap::parse(&format!("alice {ALICE_FIRST} admin\n")).unwrap();
+        let oidc = PrincipalAuthenticator::Oidc(oidc_test_authenticator(
+            DEFAULT_OIDC_CLAIM,
+            Some(bootstrap),
+        ));
+        // The bootstrap file is the first administrator and the CLI, and it
+        // is the only static credential an OIDC machine accepts.
+        assert_eq!(
+            oidc.resolve(ALICE_FIRST).await,
+            Some(Principal::User {
+                id: UserId::new("alice").unwrap(),
+                role: Role::Admin,
+            })
+        );
+        assert_eq!(oidc.resolve(BOB_TOKEN).await, None);
+        // Nor does a bearer shaped like one it mints but never minted.
+        assert_eq!(
+            oidc.resolve(&format!("{OIDC_BEARER_PREFIX}{}", "a".repeat(43)))
+                .await,
+            None
+        );
+
+        let tokens = PrincipalAuthenticator::Static(
+            TokenMap::parse(&format!("alice {ALICE_FIRST} admin\n")).unwrap(),
+        );
+        let bearer = oidc_test_authenticator(DEFAULT_OIDC_CLAIM, None)
+            .mint_bearer(
+                Principal::User {
+                    id: UserId::new("oidc-user").unwrap(),
+                    role: Role::Member,
+                },
+                OIDC_BEARER_LIFETIME,
+            )
+            .unwrap();
+        assert_eq!(tokens.resolve(&bearer).await, None);
+    }
+
+    /// The third mode's boot rules: it needs its client credentials and a
+    /// public URL to be returned to, it refuses to stand beside the gateway,
+    /// and it does stand beside a token file.
+    #[test]
+    fn oidc_is_a_third_exclusive_mode_that_keeps_its_bootstrap_token_file() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let tokens = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tokens.path(), format!("alice {ALICE_FIRST} admin\n")).unwrap();
+
+        let mut config = tidebreak_core::Config::desktop(data_dir.path());
+        config.profile = Profile::SelfHost;
+        config.auth_oidc_issuer = Some("https://login.example.test".to_owned());
+        // The issuer alone is not a configuration.
+        assert!(PrincipalAuthenticator::from_config(&config).is_err());
+        config.auth_oidc_client_id = Some("client-id".to_owned());
+        config.auth_oidc_client_secret = Some("client-secret".to_owned());
+        // Nowhere for the provider to return to.
+        assert!(PrincipalAuthenticator::from_config(&config).is_err());
+        config.public_url = Some("https://tidebreak.example.test".to_owned());
+        assert!(matches!(
+            PrincipalAuthenticator::from_config(&config),
+            Ok(PrincipalAuthenticator::Oidc(_))
+        ));
+
+        // The token file stays the bootstrap: still OIDC mode, not static.
+        config.auth_tokens_file = Some(tokens.path().to_owned());
+        assert!(matches!(
+            PrincipalAuthenticator::from_config(&config),
+            Ok(PrincipalAuthenticator::Oidc(_))
+        ));
+
+        // The gateway is the one thing it cannot share a machine with, and
+        // the refusal says which two variables to choose between.
+        config.auth_gateway_url = Some("https://gateway.example.test".to_owned());
+        let Err(refusal) = PrincipalAuthenticator::from_config(&config) else {
+            panic!("a machine cannot be both an OIDC and a gateway machine");
+        };
+        let refusal = refusal.to_string();
+        assert!(
+            refusal.contains("TIDEBREAK_AUTH_OIDC_ISSUER")
+                && refusal.contains("TIDEBREAK_AUTH_GATEWAY_URL"),
+            "the refusal must name both: {refusal}"
+        );
+    }
+
+    /// The issuer and every endpoint it names carry a credential, so plain
+    /// HTTP is refused off loopback. The login claim is a claim name, not a
+    /// path into one.
+    #[test]
+    fn an_oidc_provider_this_machine_would_not_trust_fails_boot() {
+        for (issuer, claim, why) in [
+            (
+                "http://login.example.test",
+                DEFAULT_OIDC_CLAIM,
+                "plain http",
+            ),
+            (
+                "ftp://login.example.test",
+                DEFAULT_OIDC_CLAIM,
+                "no scheme to speak",
+            ),
+            ("not a url", DEFAULT_OIDC_CLAIM, "not a URL"),
+            (
+                "https://user:pass@login.example.test",
+                DEFAULT_OIDC_CLAIM,
+                "credentials in the issuer",
+            ),
+            (
+                "https://login.example.test?tenant=a",
+                DEFAULT_OIDC_CLAIM,
+                "a query in the issuer",
+            ),
+            ("https://login.example.test", "", "an empty claim name"),
+            (
+                "https://login.example.test",
+                "profile/email",
+                "a path rather than a claim name",
+            ),
+        ] {
+            assert!(
+                OidcAuthenticator::new(
+                    issuer,
+                    "client-id",
+                    "client-secret",
+                    claim,
+                    "https://tidebreak.example.test",
+                    None,
+                )
+                .is_err(),
+                "{why} must fail boot"
+            );
+        }
+        // Loopback is the development exception, on both sides.
+        assert!(OidcAuthenticator::new(
+            "http://localhost:12345",
+            "client-id",
+            "client-secret",
+            DEFAULT_OIDC_CLAIM,
+            "http://127.0.0.1:8080",
+            None,
+        )
+        .is_ok());
+        assert!(require_https_or_loopback(
+            &reqwest::Url::parse("http://keys.example.test/jwks").unwrap(),
+            "the OIDC jwks_uri",
+        )
+        .is_err());
     }
 }

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -20,17 +20,19 @@ Selecting `TIDEBREAK_PROFILE=self_host` changes five things about the server:
   driver to exist at all.
 - **Every request must name a user.** The desktop profile's per-launch bearer
   token authenticates nobody here. A hosted deployment validates short-lived
-  Model Gateway `tidebreak` resource tokens; a standalone deployment can use
-  the operator-managed token file. Both resolve to a named principal carrying
-  a role. Chats, projects, documents, transcripts, code workspaces, and event
+  Model Gateway `tidebreak` resource tokens; a standalone deployment uses the
+  operator-managed token file, an OpenID Connect provider, or both. Each
+  resolves to a named principal carrying a role. Chats, projects, documents, transcripts, code workspaces, and event
   streams are owner-scoped to that principal.
 - **Blob bytes live in S3-compatible object storage**, selected by
   `TIDEBREAK_BLOB_STORE_URL`. PostgreSQL keeps the document catalog and
   references; the bucket keeps immutable source bytes, images, and artifacts.
 - **Boot fails closed.** The server refuses to open the shared store unless
-  exactly one of `TIDEBREAK_AUTH_GATEWAY_URL` or
-  `TIDEBREAK_AUTH_TOKENS_FILE` is valid — a shared database never comes up
-  behind an API that cannot tell its callers apart.
+  it has exactly one valid authenticator — a Model Gateway, an OpenID Connect
+  provider, or the token file — because a shared database never comes up
+  behind an API that cannot tell its callers apart. The token file may sit
+  beside OIDC as the bootstrap administrator and the CLI credential; the
+  gateway and OIDC may not sit together.
 - **Stored credentials use Vault KV v2.** The server never opens the desktop
   OS keychain. When Vault is not configured, provider environment variables
   remain available as read fallbacks, but deployment-plane credential writes
@@ -54,8 +56,9 @@ and for what is still integration work.
 
 - Docker with Compose v2.
 - A machine that can reach your model provider's API.
-- Somewhere private to keep the database password, plus either a Model Gateway
-  installation or a standalone tokens file.
+- Somewhere private to keep the database password, plus one way to name your
+  users: a Model Gateway installation, an OpenID Connect provider, or a
+  standalone tokens file.
 - A Vault KV v2 mount if administrators need to save shared credentials through
   Tidebreak. Provider environment variables remain available without Vault.
 
@@ -259,9 +262,13 @@ aspirational.
 | `TIDEBREAK_BLOB_STORE_URL` | yes (self-host) | — | S3 bucket and optional prefix, for example `s3://company-tidebreak/production`. Credentials, region, and an optional compatible endpoint come from standard `AWS_*` variables. |
 | `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_ENDPOINT_URL_S3`, `AWS_ALLOW_HTTP` | depends on provider | AWS defaults | Configure AWS S3 or an S3-compatible endpoint. Keep `AWS_ALLOW_HTTP=false` outside isolated development networks. Role, web-identity, and container credential variables are also accepted. |
 | `TIDEBREAK_AUTH_GATEWAY_URL` | one auth mode required | `GATEWAY_BASE_URL` | Public Model Gateway identity URL exposed to clients and, by default, used for live validation. HTTPS required except for loopback development. |
-| `TIDEBREAK_PUBLIC_URL` | with Gateway auth | `ADD_ON_PUBLIC_URL` | The machine's own public URL, which user credentials are bound to. On a Model Gateway managed machine the plane's `ADD_ON_PUBLIC_URL` stands in when this is unset (decision 0085). |
+| `TIDEBREAK_PUBLIC_URL` | with Gateway or OIDC auth | `ADD_ON_PUBLIC_URL` | The machine's own public URL. Gateway credentials are bound to it, and the OIDC callback returns to it. On a Model Gateway managed machine the plane's `ADD_ON_PUBLIC_URL` stands in when this is unset (decision 0085). |
 | `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` | no | `TIDEBREAK_AUTH_GATEWAY_URL` | Optional server-to-server Gateway URL for principal validation when the public origin is not cluster-routable. Requires Gateway auth. |
-| `TIDEBREAK_AUTH_TOKENS_FILE` | one auth mode required | — | Standalone compatibility: path to the static token file above. Mutually exclusive with Gateway auth. |
+| `TIDEBREAK_AUTH_TOKENS_FILE` | one auth mode required | — | Standalone: path to the static token file above. Mutually exclusive with Gateway auth. Set it beside OIDC to name the first administrator and keep CLI access. |
+| `TIDEBREAK_AUTH_OIDC_ISSUER` | one auth mode required | — | OpenID Connect issuer URL, whose `/.well-known/openid-configuration` the machine reads. HTTPS required except for loopback development. Mutually exclusive with Gateway auth; set all three OIDC variables or none. |
+| `TIDEBREAK_AUTH_OIDC_CLIENT_ID` | with OIDC | — | OIDC client id. Register `<TIDEBREAK_PUBLIC_URL>/auth/oidc/callback` as its redirect URI. |
+| `TIDEBREAK_AUTH_OIDC_CLIENT_SECRET` | with OIDC | — | OIDC client secret, used only for the server-to-server code exchange. It stays in process memory. |
+| `TIDEBREAK_AUTH_OIDC_CLAIM` | no | `sub` | ID-token claim whose string value becomes the Tidebreak user id. Requires OIDC. |
 | `TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS` | no | unset | Comma-separated service bearers allowed to start an external channel connect handshake. Each value must be 32–512 header-safe characters. Leave unset to disable connect start. To rotate without downtime, add the new value, move the adapter, then remove the old value. |
 | `TIDEBREAK_VAULT_ADDR` | required with Vault custody | — | Vault base URL. HTTPS is required except for literal loopback development. Setting any Vault option enables Vault configuration and requires this variable plus `TIDEBREAK_VAULT_TOKEN_FILE`. |
 | `TIDEBREAK_VAULT_TOKEN_FILE` | required with Vault custody | — | Mounted file containing the Vault token. Tidebreak reads it for every request so rotation does not require a restart. |
@@ -390,18 +397,55 @@ served for navigations only — a request for an unknown route with a JSON
 `Accept` still answers `404`, and every API route is matched ahead of the
 bundle — so the API contract does not change.
 
-A tab signs in the way the desktop does: with a short-lived Gateway bearer
-bound to this machine. The page holds that bearer in memory for the tab's
-life and never in a cookie or in storage. It arrives once, from the Model
-Gateway console's Manage action: the console sends the browser to the
-machine's `/auth/handoff` route with a one-time code, the machine exchanges
-the code with the gateway server to server, and the page receives the bearer
-in the URL fragment, which no server or access log sees. The bearer lasts
-its hour; a tab that opens the address directly, outlives its bearer, or
-arrives with a code that has already been used, shows a sign-in screen that
-sends the reader back through the console. A machine on static tokens
-(`TIDEBREAK_AUTH_TOKENS_FILE`) has no browser sign-in: the page says so, and
-the desktop app remains the client for it.
+However a tab signs in, it ends the same way: the bearer arrives in the URL
+fragment, which no server and no access log sees, and the page takes it out
+of the address before the router runs. It lives in that tab's memory for its
+hour and nowhere else — never a cookie, never localStorage, never disk. A
+link to a session keeps its route through sign-in, so you land on the session
+you opened rather than the root. Which path a machine offers is its own to
+say: the page reads `/auth/discovery`, which is public and needs no bearer,
+and shows the one screen that machine can act on. See
+[decision 0087](decisions/0087-standalone-browser-sign-in.md).
+
+**With a Model Gateway** (`TIDEBREAK_AUTH_GATEWAY_URL`), the bearer comes
+from the console's Manage action: the console sends the browser to the
+machine's `/auth/handoff` route with a one-time code, and the machine
+exchanges that code with the gateway server to server. A tab that opens the
+address directly, outlives its bearer, or arrives with a code that has
+already been used shows a sign-in screen that sends you back through the
+console.
+
+**With a token file** (`TIDEBREAK_AUTH_TOKENS_FILE`), the page asks you to
+paste your token. It probes the token against an authenticated read on the
+machine first, so a wrong one leaves you on the same screen with the
+refusal instead of a broken session. A token is as strong as the file it came
+from; whoever maintains the roster decides who holds one.
+
+**With an OpenID Connect provider**, set `TIDEBREAK_AUTH_OIDC_ISSUER`,
+`TIDEBREAK_AUTH_OIDC_CLIENT_ID`, and `TIDEBREAK_AUTH_OIDC_CLIENT_SECRET`, and
+register `<TIDEBREAK_PUBLIC_URL>/auth/oidc/callback` as the client's redirect
+URI. The page then shows one button. The machine runs authorization code with
+PKCE itself: it starts the flow at `/auth/oidc/start`, and at
+`/auth/oidc/callback` it checks the `state` against a flow it started,
+exchanges the code with the PKCE verifier, and validates the ID token against
+the issuer's discovery document and keys — signature, issuer, expiry, the
+client id as audience, and the flow's nonce. Only then does it mint its own
+bearer, good for one hour. Anything that does not check out signs nobody in.
+
+`TIDEBREAK_AUTH_OIDC_CLAIM` names the ID-token claim whose string value
+becomes the Tidebreak user id; it defaults to `sub`, the one claim every
+issuer sends. Point it at `email` or `preferred_username` when you want
+readable owner ids, and know that the mapping is the identity: a claim the
+provider stops sending, or a value that changes, signs that person in as
+nobody rather than as someone else. Tidebreak asks for the scope that claim
+needs (`email` or `profile`) alongside `openid`, so grant it to the client.
+
+OIDC never makes anyone an administrator. Keep `TIDEBREAK_AUTH_TOKENS_FILE`
+set beside it: that file is where the first administrator comes from, and it
+is what CLI and script access uses. What you cannot do is combine OIDC with
+`TIDEBREAK_AUTH_GATEWAY_URL` — a machine signs browsers in through one
+identity provider, and setting both is a boot error that names the two
+variables.
 
 Everything that reaches the reader's own computer — connected folders, tool
 calls on the local machine, saving files locally, computer use — is

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -27,9 +27,9 @@ a stale one.
 
 ## Summary
 
-- Rust crates: 849
+- Rust crates: 853
 - Desktop UI production packages: 535
-- Distinct license texts: 589
+- Distinct license texts: 591
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -2018,6 +2018,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/Stranger6667/jsonschema
 - License text: not distributed with this package
 
+### jsonwebtoken 11.0.0
+
+- License: `MIT`
+- Repository: https://github.com/Keats/jsonwebtoken
+- License text: `LICENSE` ([L-3a738a7fc361](#l-3a738a7fc361))
+
 ### keyboard-types 0.7.0
 
 - License: `MIT OR Apache-2.0`
@@ -2387,6 +2393,12 @@ License identifiers named across all declared expressions:
 - License: `BSD-3-Clause OR MIT OR Apache-2.0`
 - Repository: https://github.com/illicitonion/num_enum
 - License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-BSD` ([L-882b129495bc](#l-882b129495bc)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
+
+### oauth2 5.0.0
+
+- License: `MIT OR Apache-2.0`
+- Repository: https://github.com/ramosbugs/oauth2-rs
+- License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
 
 ### objc2 0.6.4
 
@@ -3480,6 +3492,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/vorner/signal-hook
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-aaac889d0a4a](#l-aaac889d0a4a))
 
+### signature 2.2.0
+
+- License: `Apache-2.0 OR MIT`
+- Repository: https://github.com/RustCrypto/traits/tree/master/signature
+- License text: `LICENSE-APACHE` ([L-59013a5c8d3a](#l-59013a5c8d3a)), `LICENSE-MIT` ([L-7d9f551458e8](#l-7d9f551458e8))
+
 ### simd-adler32 0.3.10
 
 - License: `MIT`
@@ -4276,6 +4294,12 @@ License identifiers named across all declared expressions:
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/unicode-rs/unicode-xid
 - License text: `COPYRIGHT` ([L-20cec30ad778](#l-20cec30ad778)), `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-033a9383ff21](#l-033a9383ff21))
+
+### untrusted 0.7.1
+
+- License: `ISC`
+- Repository: https://github.com/briansmith/untrusted
+- License text: `LICENSE.txt` ([L-a1fff3442978](#l-a1fff3442978))
 
 ### untrusted 0.9.0
 
@@ -13702,6 +13726,32 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
+```
+
+### L-3a738a7fc361
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Vincent Prouillet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### L-3a771adcf280
@@ -24534,6 +24584,36 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### L-7d9f551458e8
+
+```
+Copyright (c) 2018-2023 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ### L-7db0bcff78e7


### PR DESCRIPTION
Closes #3182. Implements [decision 0087](https://github.com/brightwave-inc/tidebreak/blob/main/docs/decisions/0087-standalone-browser-sign-in.md).

A machine on `TIDEBREAK_AUTH_TOKENS_FILE` had no browser sign-in at all: the page said so and sent the reader to the desktop app. A Slack link to a session on such a machine therefore landed on a screen nobody could pass, which quietly made every feature in this epic a gateway-only feature. This branch gives a standalone machine two ways to sign a browser in, and the page shows whichever one its machine can run.

## Token paste

When discovery reports `static_token`, the sign-in screen takes a token. On submit the page probes it against `/models` — the member-plane capability read every principal may make, and the kind of request the shell makes with a bearer the moment boot finishes — and only then holds it, in the same tab memory the hand-off bearer lives in: no cookie, no storage, gone on reload. A refusal stays on the same screen with the field still filled. A pasted value that could not be a bearer at all is refused without a request. `return_to` is honored the way `consoleSignInUrl` does it, so a session link lands on its route.

## OIDC authenticator

`TIDEBREAK_AUTH_OIDC_ISSUER`, `_CLIENT_ID`, and `_CLIENT_SECRET` select a third exclusive boot mode. Combining them with `TIDEBREAK_AUTH_GATEWAY_URL` is a boot error whose message names both variables; the token file may sit beside them, because OIDC only ever names a member and a standalone deployment still needs a first administrator and a CLI credential.

`/auth/oidc/start` redirects to the issuer's authorization endpoint with a fresh `state`, `nonce`, and PKCE challenge. `/auth/oidc/callback` takes the flow that `state` names — removing it, so a `state` answers once — exchanges the code with that flow's verifier, and validates the ID token against the issuer's discovery document and JWKS: signature by a published key, a signing algorithm from a fixed set, the configured issuer, a live expiry, this client id as the audience, and the flow's nonce. Only then does the machine mint its own bearer, good for an hour, and land the page through the same `#handoff=` envelope the console hand-off uses — so `captureHandoffToken` needed no change. Every failure lands the page with a reason and mints nothing. The code, the ID token, and the bearer are never logged.

`TIDEBREAK_AUTH_OIDC_CLAIM` overrides the login claim (`sub` by default), and the authorization request asks for the scope that claim needs (`email` or `profile`) alongside `openid` — otherwise pointing the override at `email` would fail closed on a claim the provider was never told to send. Discovery reports `mode: oidc` with the start URL, and the page shows one button named for the issuer.

### Which crate, and why

**`oauth2` 5.0.0 plus `jsonwebtoken` 11.0.0**, not `openidconnect`. `openidconnect` is not in the workspace lockfile, so it was not the cheaper option, and it brings a large generic client this code would use for two round trips. `oauth2` supplies the PKCE challenge and the CSPRNG behind `state`, `nonce`, and the minted bearer; `jsonwebtoken` supplies JWKS parsing and JWT validation, which is the part worth borrowing. Four packages join the lockfile (`oauth2`, `jsonwebtoken`, `signature`, `untrusted` 0.7.1), all under licenses `deny.toml` already allows.

## Fail-closed and hardening

- A provider refusal, an unreachable issuer, an oversized body, or a key set that does not publish the signing key all admit nobody.
- The issuer and every endpoint its discovery document names must be HTTPS, loopback excepted, so an issuer that answers with an `http://` token endpoint does not get the client secret. Discovery must also name the configured issuer.
- Both in-memory maps are capped. `/auth/oidc/start` is public, so a machine that cannot remember a flow refuses to start one rather than accepting a callback it could not check.
- `/auth/discovery` stays public and unauthenticated, and so do the two new routes, because a page reads all three before it holds any credential. They 404 on a machine in another mode.
- Cross-mode refusals are tests in both directions: an OIDC machine accepts only its bootstrap file's tokens and its own `tb_oidc_` bearers, and a token-file machine has nothing that could answer for one.

## Docs

`docs/self-hosting.md` loses the "has no browser sign-in" paragraph. In its place: what every path does with the bearer, the gateway console path kept, the two new paths, the four OIDC variables, the redirect URI to register, the claim mapping and what it costs when it drifts, and the corrected boot-fails-closed bullet, prerequisites, and variable table.

## Verification

Run locally on this branch; each block ends with the command's final line.

```
$ cargo fmt --all --check
(no output)

$ cargo clippy -p tidebreak-core -p tidebreak-server-core -p tidebreak-server --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 55.21s

$ cargo test -p tidebreak-server-core auth::tests
test result: FAILED. 22 passed; 1 failed; 0 ignored; 0 measured; 956 filtered out; finished in 5.01s

$ cargo test -p tidebreak-server-core -- an_id_token_this_machine_did_not_ask_for_names_nobody \
    the_login_claim_override_names_the_user_or_nobody \
    a_minted_bearer_lasts_its_hour_and_then_names_nobody \
    a_started_flow_is_single_use_and_its_request_carries_the_whole_check \
    the_number_of_waiting_sign_ins_is_bounded \
    an_oidc_machine_refuses_a_static_token_and_a_token_file_machine_refuses_a_bearer \
    oidc_is_a_third_exclusive_mode_that_keeps_its_bootstrap_token_file \
    an_oidc_provider_this_machine_would_not_trust_fails_boot
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 971 filtered out; finished in 0.03s

$ cargo test -p tidebreak-server auth
test result: FAILED. 11 passed; 2 failed; 0 ignored; 0 measured; 615 filtered out; finished in 127.48s

$ cargo test -p tidebreak-server a_standalone_machine_publishes_the_one_sign_in_it_can_run
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 627 filtered out; finished in 0.13s

$ cargo test -p tidebreak-core config
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 848 filtered out; finished in 0.01s
```

In `crates/tidebreak-desktop/ui`:

```
$ pnpm exec biome format --write src
Formatted 876 files in 964ms. No fixes applied.

$ pnpm exec vitest run HostedSignIn hostedSession boot
 Test Files  3 passed (3)
      Tests  37 passed (37)

$ pnpm exec tsc --noEmit -p tsconfig.json
(no output)
```

Also run, beyond what was asked: the whole UI suite (`267 files, 2306 tests passed`), `pnpm lint` (clean), and `pnpm storybook:build` (`Storybook build completed successfully`).

### The three Rust failures above are the sandbox, not this branch

This sandbox blocks loopback TCP, so every test that stands up a local HTTP server and connects to it fails here. The three are `auth::tests::gateway_auth_maps_live_identity_and_fails_closed`, `tests::websocket::ws_subprotocol_auth_succeeds`, and `tests::code_turns::reap_replaces_browser_authority_without_tombstoning_the_session` — none of them touched by this branch. Confirmed by running the same command in a clean worktree of unmodified `main`:

```
$ git worktree add /tmp/tb-main origin/main && cd /tmp/tb-main
$ cargo test -p tidebreak-server auth
test tests::websocket::ws_subprotocol_auth_succeeds ... FAILED
test tests::code_turns::reap_replaces_browser_authority_without_tombstoning_the_session ... FAILED
test result: FAILED. 11 passed; 2 failed; 0 ignored; 0 measured; 614 filtered out; finished in 127.96s
```

Same two, same counts. The same limitation is why the OIDC route tests here cover everything except the two HTTP round trips to the issuer: the wiring around them is covered by unit tests over `begin`, `claim_flow`, `authorization_url`, `mint_bearer`, and `validate_oidc_id_token`, and by route tests that reach the callback's refusal paths without a network. A reviewer with loopback available may want to exercise a real issuer once.

## Storybook

`Shell/Hosted browser session` gains `StaticToken`, `StaticTokenRefused` (with a play function that types a wrong token and asserts the refusal), and `Oidc`, and the existing gateway states are unchanged. `.boot-token-form` is a new block in `styles.css` because the boot screen is centered copy and a labelled field is not.
