### PR TITLE
ci: spawn pnpm.cmd through the shell on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
         run: |
           corepack enable
           corepack install --global pnpm@10.18.3
-          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
+          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
       - name: Install the locked deployment client
         run: pnpm --dir .github/vercel-cli install --frozen-lockfile --ignore-scripts
       - name: Download the inert prebuilt documentation
@@ -1574,7 +1574,7 @@ jobs:
         run: |
           corepack enable
           corepack install --global pnpm@10.18.3
-          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
+          node -e 'const bin = process.platform === "win32" ? "pnpm.cmd" : "pnpm"; const version = require("node:child_process").execFileSync(bin, ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim(); if (version !== "10.18.3") throw new Error("Expected pnpm 10.18.3, got " + version)'
       - name: Install UI dependencies
         working-directory: crates/tidebreak-desktop/ui
         run: pnpm install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
The v0.90.0 release run failed both Windows desktop jobs at "Enable pinned pnpm":

```
Error: spawnSync pnpm.cmd EINVAL
```

Node refuses to spawn a `.cmd` file without a shell since its batch-file hardening (CVE-2024-27980), and the refreshed `windows-latest` image carries such a Node. The version check in the three `Enable pinned pnpm` steps now passes `shell: true` on Windows only; the version it compares (`10.18.3`) and every other platform are unchanged.

After this merges, the v0.90.0 release is retried with `release_tag=v0.90.0` and then the v0.91.0 draft (which carries #3218) is published.