### PR TITLE
improve(ui): quiet notices and align journal widths

### DIFF
--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -258,3 +258,15 @@ A destructive action goes through `useConfirm`, which opens the shared
 consequence, a safe Cancel default, and the `destructive` action variant on
 the confirm button. `destructive` is the only chromatic button fill. Do not
 add type-to-confirm fields or a second confirmation shape.
+
+### Notices and errors
+
+Use `notice-surface` with `notice-info`, `notice-warning`, `notice-critical`,
+or `notice-success` for banners and notices. Keep the surface neutral and the
+body in normal ink. A thin leading edge carries the status color; icons may
+repeat it. Do not fill a notice with a status color. Keep its role, recovery
+actions, and error detail accessible.
+
+In chat and code journals, notices span the full message column regardless of
+text length or severity. Do not add a prose-width cap or size a notice to its
+content. Compaction stays a plain text event in the same column.

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -941,7 +941,7 @@ export function AppShell() {
             will close and reopen. Wait for active work to finish before
             restarting.
           </span>
-          <span className="border-warning-border bg-warning-background text-warning-foreground mt-3 block rounded-md border px-3 py-2.5">
+          <span className="notice-surface notice-warning mt-3 block rounded-md border px-3 py-2.5">
             <strong className="block font-medium">Pre-v1 data warning</strong>
             <span className="mt-0.5 block">
               Until Tidebreak reaches version 1.0, this update may wipe all

--- a/crates/tidebreak-desktop/ui/src/FoldersView.tsx
+++ b/crates/tidebreak-desktop/ui/src/FoldersView.tsx
@@ -278,7 +278,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto p-4">
         {error && (
           <div
-            className="shrink-0 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+            className="notice-surface notice-critical shrink-0 rounded-md px-3 py-2 text-sm"
             role="alert"
           >
             {error}

--- a/crates/tidebreak-desktop/ui/src/McpAppCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/McpAppCard.tsx
@@ -137,7 +137,7 @@ export function McpAppCard({
       <div className="border-t">
         {payloadState === "failed" && (
           <div
-            className="border-warning-border bg-warning-background text-warning-foreground flex min-w-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-2"
+            className="notice-surface notice-warning flex min-w-0 flex-wrap items-center justify-between gap-2 border-b px-2.5 py-2"
             role="alert"
           >
             <div className="flex min-w-0 items-center gap-1.5 text-xs">

--- a/crates/tidebreak-desktop/ui/src/apps/AppsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/apps/AppsView.tsx
@@ -94,7 +94,7 @@ export function AppsView({
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
           {error && hasApps && (
             <div
-              className="flex shrink-0 items-center justify-between gap-3 rounded-lg bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+              className="notice-surface notice-critical flex shrink-0 items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm"
               role="alert"
             >
               <span>{error}</span>

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -1714,7 +1714,7 @@ function ProbeFailure({
   onRetry: () => void;
 }) {
   return (
-    <div className="rounded-lg border border-warning-border bg-warning-background p-3">
+    <div className="notice-surface notice-warning rounded-lg border p-3">
       <p className={cn("text-sm", STATUS_TEXT.warning)}>{message}</p>
       <Button
         type="button"

--- a/crates/tidebreak-desktop/ui/src/code/CodeAnalyticsPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeAnalyticsPage.tsx
@@ -839,7 +839,7 @@ function AnalyticsRefreshError({
 }) {
   return (
     <div
-      className="mx-auto mb-4 flex w-full max-w-[1500px] items-center gap-2 rounded-lg border border-critical-border bg-critical-background px-3 py-2 text-xs text-critical-foreground"
+      className="notice-surface notice-critical mx-auto mb-4 flex w-full max-w-[1500px] items-center gap-2 rounded-lg border px-3 py-2 text-xs"
       role="alert"
     >
       <CircleAlert className="size-3.5 shrink-0" />

--- a/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
@@ -345,7 +345,7 @@ function CodeArchiveBody() {
         {!loaded ? (
           <ArchiveSkeleton />
         ) : error ? (
-          <div className="m-5 rounded-lg border border-critical-border bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted">
+          <div className="notice-surface notice-critical m-5 rounded-lg border px-3 py-2 text-sm">
             {error}
           </div>
         ) : totalArchived === 0 ? (

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -1012,13 +1012,10 @@ export function HarnessNotice({
       // the reader. A warning or an aside is announced when they get to it.
       role={level === "error" ? "alert" : "status"}
       className={cn(
-        "max-w-prose rounded-md border px-3 py-2 text-sm",
-        tone === "critical" &&
-          "border-critical-border bg-critical-background text-critical-foreground",
-        tone === "warning" &&
-          "border-warning-border bg-warning-background text-warning-foreground",
-        tone === "info" &&
-          "border-info-border bg-info-background text-info-foreground",
+        "notice-surface w-full self-stretch px-3 py-2 text-sm",
+        tone === "critical" && "notice-critical",
+        tone === "warning" && "notice-warning",
+        tone === "info" && "notice-info",
       )}
     >
       {level === "error" && onFileIssue ? (

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -559,7 +559,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             // including on an empty transcript.
             <div className="chat-pane" hidden={!visible || !showingChat}>
               {fenced && session?.fence_reason && (
-                <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
+                <div className="notice-surface notice-warning mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
                   <p>{fenceReasonText(session.fence_reason)}</p>
                   <Button
                     type="button"

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -2005,7 +2005,7 @@ function InlineDetailError({
   onRetry: () => void;
 }) {
   return (
-    <div className="m-5 flex items-center justify-between gap-3 rounded-lg border border-critical-border bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted">
+    <div className="notice-surface notice-critical m-5 flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm">
       <span>{message}</span>
       <Button type="button" size="xs" variant="outline" onClick={onRetry}>
         Try again

--- a/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
@@ -227,7 +227,7 @@ export function RepositorySettings({
         )}
       </div>
       {error && (
-        <div className="mb-4 flex flex-col items-stretch gap-2 rounded-md border border-critical-border bg-critical-background px-3 py-2 text-xs text-critical-foreground-muted min-[480px]:flex-row min-[480px]:items-center min-[480px]:justify-between">
+        <div className="notice-surface notice-critical mb-4 flex flex-col items-stretch gap-2 rounded-md border px-3 py-2 text-xs min-[480px]:flex-row min-[480px]:items-center min-[480px]:justify-between">
           <span className="flex min-w-0 items-start gap-2">
             <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
             <span className="min-w-0">{error}</span>

--- a/crates/tidebreak-desktop/ui/src/code/RepositoryTriggerRules.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositoryTriggerRules.tsx
@@ -150,7 +150,7 @@ export function RepositoryTriggerRules({
         {loading && <LoaderCircle className="size-4 animate-spin" />}
       </div>
       {error && (
-        <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-critical-border bg-critical-background px-3 py-2 text-xs text-critical-foreground-muted">
+        <div className="notice-surface notice-critical mb-4 flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs">
           <span className="flex items-start gap-2">
             <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
             {error}

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -812,7 +812,7 @@ export function TerminalPane({
       )}
       {writeFailure && (
         <div
-          className="flex shrink-0 flex-col gap-2 border-b border-critical-border bg-critical-background px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+          className="notice-surface notice-critical flex shrink-0 flex-col gap-2 border-b px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
           data-testid="terminal-write-failure"
           role="alert"
         >
@@ -852,7 +852,7 @@ export function TerminalPane({
       )}
       {terminalError && (
         <div
-          className="flex shrink-0 flex-col gap-2 border-b border-critical-border bg-critical-background px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+          className="notice-surface notice-critical flex shrink-0 flex-col gap-2 border-b px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
           data-testid={`terminal-${terminalError.kind}-error`}
           role="alert"
         >

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -108,7 +108,7 @@ export function TurnReviewCard({
     return (
       <div
         role="alert"
-        className="border-critical-border bg-critical-background text-critical-foreground flex flex-col gap-1.5 rounded-md border px-3 py-2 text-sm"
+        className="notice-surface notice-critical flex flex-col gap-1.5 rounded-md border px-3 py-2 text-sm"
       >
         <p className="flex items-center gap-1.5 font-medium">
           <TriangleAlert size={14} aria-hidden="true" />

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -499,7 +499,7 @@ export function BrowserToolbar({
         <p
           id={addressErrorId}
           role="alert"
-          className="border-t border-critical-border/45 bg-critical-background/55 px-3 py-1 text-xs text-critical-foreground"
+          className="notice-surface notice-critical border-t px-3 py-1 text-xs"
         >
           {addressError}
         </p>
@@ -516,7 +516,7 @@ export function BrowserToolbar({
         <div
           role="status"
           aria-live="polite"
-          className="border-t border-info-border bg-info-background px-3 py-1.5 text-xs text-info-foreground"
+          className="notice-surface notice-info border-t px-3 py-1.5 text-xs"
         >
           <span className="live-label-shimmer">
             {profileResetStatusMessage(lastResetPhaseRef.current)}
@@ -910,13 +910,10 @@ export function BrowserNoticeRow({
   return (
     <div
       className={cn(
-        "flex min-h-8 shrink-0 items-center gap-2 border-b px-3 py-1 text-xs",
-        tone === "info" &&
-          "border-info-border bg-info-background text-info-foreground",
-        tone === "warning" &&
-          "border-warning-border bg-warning-background text-warning-foreground",
-        tone === "critical" &&
-          "border-critical-border bg-critical-background text-critical-foreground",
+        "notice-surface flex min-h-8 shrink-0 items-center gap-2 border-b px-3 py-1 text-xs",
+        tone === "info" && "notice-info",
+        tone === "warning" && "notice-warning",
+        tone === "critical" && "notice-critical",
       )}
     >
       <Icon className="size-3.5 shrink-0" />

--- a/crates/tidebreak-desktop/ui/src/code/delivery/status.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/status.tsx
@@ -92,7 +92,7 @@ export function PartialErrorBanner({
     <div
       role="status"
       className={cn(
-        "flex shrink-0 items-start gap-2 border-b border-warning-border bg-warning-background px-5 py-2.5 text-xs text-warning-foreground-muted",
+        "notice-surface notice-warning flex shrink-0 items-start gap-2 border-b px-5 py-2.5 text-xs",
         compact && "border-t",
       )}
     >
@@ -110,7 +110,7 @@ export function RepositoryRefreshWarning({
   onRetry: () => void;
 }) {
   return (
-    <div className="flex shrink-0 items-center justify-between gap-3 border-b border-warning-border bg-warning-background px-5 py-2.5 text-xs text-warning-foreground-muted">
+    <div className="notice-surface notice-warning flex shrink-0 items-center justify-between gap-3 border-b px-5 py-2.5 text-xs">
       <span>GitHub repository discovery is stale: {message}</span>
       <Button type="button" size="xs" variant="outline" onClick={onRetry}>
         Try again
@@ -162,7 +162,7 @@ export function InlineLoadError({
   onRetry: () => void;
 }) {
   return (
-    <div className="m-4 flex items-center justify-between gap-3 rounded-lg border border-critical-border bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted">
+    <div className="notice-surface notice-critical m-4 flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm">
       <span>{message}</span>
       <Button type="button" size="xs" variant="outline" onClick={onRetry}>
         Try again

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.tsx
@@ -506,7 +506,7 @@ export function OutputDetailRoot({
       {confirmDialog}
       {previewRevision && (
         <div
-          className="mx-6 mt-3 flex shrink-0 flex-wrap items-center gap-2 rounded-md bg-info-background px-3 py-2 text-sm text-info-foreground-muted"
+          className="notice-surface notice-info mx-6 mt-3 flex shrink-0 flex-wrap items-center gap-2 rounded-md px-3 py-2 text-sm"
           role="status"
         >
           <HistoryIcon className="size-4 shrink-0" />
@@ -539,7 +539,7 @@ export function OutputDetailRoot({
       )}
       {editConflict && (
         <div
-          className="mx-6 mt-3 flex shrink-0 flex-wrap items-center gap-2 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+          className="notice-surface notice-critical mx-6 mt-3 flex shrink-0 flex-wrap items-center gap-2 rounded-md px-3 py-2 text-sm"
           role="alert"
         >
           <span className="min-w-0 flex-1">

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputsView.tsx
@@ -220,7 +220,7 @@ export function OutputsView({
       <div className="flex min-h-0 flex-1 flex-col gap-2 pt-4">
         {error && (
           <div
-            className="mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+            className="notice-surface notice-critical mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md px-3 py-2 text-sm"
             role="alert"
           >
             <span>{error}</span>

--- a/crates/tidebreak-desktop/ui/src/plugins/PluginsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/plugins/PluginsView.tsx
@@ -155,7 +155,7 @@ export function PluginsView({
 
           {error && (
             <div
-              className="flex shrink-0 items-center justify-between gap-3 rounded-lg bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+              className="notice-surface notice-critical flex shrink-0 items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm"
               role="alert"
             >
               <span>{error}</span>

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -829,7 +829,7 @@ export function ConnectedAppsPanel({
         </p>
       )}
       {loopbackHttpHost(draft.baseUrl) !== null && (
-        <div className="flex flex-col gap-2 rounded-xl border border-warning-border bg-warning-background px-3 py-2">
+        <div className="notice-surface notice-warning flex flex-col gap-2 rounded-xl border px-3 py-2">
           <p className="text-sm font-medium">
             Allow clear-text HTTP on this computer?
           </p>

--- a/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.tsx
@@ -65,7 +65,7 @@ export function UpdatesPanel({
       busy={busy}
     >
       <div
-        className="border-warning-border bg-warning-background text-warning-foreground flex items-start gap-3 rounded-md border px-4 py-3"
+        className="notice-surface notice-warning flex items-start gap-3 rounded-md border px-4 py-3"
         aria-label="Pre-v1 update warning"
       >
         <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />

--- a/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
@@ -362,3 +362,55 @@ const pastedTurn: CodeTranscriptItem[] = [
 export const PastedTextFolded: Story = {
   args: { items: pastedTurn },
 };
+
+export const Notices: Story = {
+  args: {
+    onFileIssue: fn(),
+    items: [
+      {
+        kind: "notice",
+        id: "notice-info",
+        level: "info",
+        message: "Session resumed.",
+      },
+      {
+        kind: "notice",
+        id: "notice-warning",
+        level: "warning",
+        message:
+          "The provider is busy. The session will retry when capacity is available.",
+      },
+      {
+        kind: "notice",
+        id: "notice-error",
+        level: "error",
+        message:
+          "The connection closed before the response completed. Check the connection and try again.",
+      },
+      {
+        kind: "notice",
+        id: "notice-path",
+        level: "error",
+        message:
+          "Unable to read /workspace/" +
+          "long-directory-name/".repeat(12) +
+          "output.log",
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const notices = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>(
+        ".message-notice, .message-turn-failure, .notice-surface",
+      ),
+    );
+    await expect(notices.length).toBeGreaterThan(2);
+    const first = notices[0].getBoundingClientRect();
+    for (const notice of notices) {
+      const rect = notice.getBoundingClientRect();
+      await expect(Math.abs(rect.width - first.width)).toBeLessThan(1);
+      await expect(Math.abs(rect.left - first.left)).toBeLessThan(1);
+      await expect(notice.scrollWidth).toBeLessThanOrEqual(notice.clientWidth);
+    }
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn } from "storybook/test";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -438,4 +438,35 @@ export const CompactWidth: Story = {
 
 export const TranscriptContents: Story = {
   args: { messages: denseMessages },
+};
+
+export const Notices: Story = {
+  args: {
+    messages: [
+      { id: "notice-system", role: "system", text: "Turn stopped." },
+      {
+        id: "notice-error",
+        role: "error",
+        text: "The connection closed before the response completed. Check the connection and try again.",
+      },
+      blockedMessages[2],
+      { id: "notice-compaction", role: "compaction" },
+      ...failureMessages,
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const notices = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>(
+        ".message-notice, .message-turn-failure, .notice-surface",
+      ),
+    );
+    await expect(notices.length).toBeGreaterThan(2);
+    const first = notices[0].getBoundingClientRect();
+    for (const notice of notices) {
+      const rect = notice.getBoundingClientRect();
+      await expect(Math.abs(rect.width - first.width)).toBeLessThan(1);
+      await expect(Math.abs(rect.left - first.left)).toBeLessThan(1);
+      await expect(notice.scrollWidth).toBeLessThanOrEqual(notice.clientWidth);
+    }
+  },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/Notices.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Notices.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { BrowserNoticeRow } from "@/code/browser/BrowserToolbar";
+
+const meta = {
+  title: "Foundations/Notices",
+  parameters: { layout: "padded" },
+} satisfies Meta;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Tones: Story = {
+  render: () => (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6">
+      <div className="space-y-2">
+        <h2 className="text-lg font-medium">Notices</h2>
+        <p className="text-sm text-muted-foreground">
+          Neutral surfaces keep the message readable. The leading edge marks its
+          status.
+        </p>
+      </div>
+      {(["info", "success", "warning", "critical"] as const).map((tone) => (
+        <div
+          key={tone}
+          className={
+            "notice-surface notice-" +
+            tone +
+            " rounded-md border px-3 py-2 text-sm"
+          }
+        >
+          <p className="font-medium">
+            {
+              {
+                info: "Session resumed",
+                success: "Changes saved",
+                warning: "Connection interrupted",
+                critical: "Could not save changes",
+              }[tone]
+            }
+          </p>
+          <p className="mt-1 text-muted-foreground">
+            {
+              {
+                info: "You can continue from the last message.",
+                success: "Your preferences apply to the next session.",
+                warning: "Check your connection before trying again.",
+                critical: "Your edits are still here. Reconnect and try again.",
+              }[tone]
+            }
+          </p>
+        </div>
+      ))}
+      <BrowserNoticeRow
+        tone="warning"
+        message="This page needs permission to open an external application."
+        actionLabel="Open"
+        onAction={fn()}
+        onDismiss={fn()}
+      />
+    </div>
+  ),
+};

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -1129,22 +1129,46 @@ body {
 
   /* ---------- Notices ---------- */
 
+  .notice-surface {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    border-color: var(--border);
+    border-inline-start: 2px solid var(--notice-tone, var(--border));
+    background: transparent;
+    color: var(--foreground);
+  }
+
+  .notice-critical {
+    --notice-tone: var(--critical);
+  }
+  .notice-warning {
+    --notice-tone: var(--warning);
+  }
+  .notice-info {
+    --notice-tone: var(--info);
+  }
+  .notice-success {
+    --notice-tone: var(--success);
+  }
+
   .message-notice {
-    align-self: center;
-    max-width: min(100%, 42rem);
+    align-self: stretch;
+    width: 100%;
+    min-width: 0;
+    overflow-wrap: anywhere;
     padding: 0.35rem 0.6rem;
     border-radius: 6px;
     color: var(--muted-foreground);
     font-size: 0.8rem;
-    text-align: center;
-    background: color-mix(in srgb, var(--muted) 68%, transparent);
+    text-align: left;
+    border-inline-start: 2px solid var(--border);
+    background: transparent;
   }
 
   .message-notice.is-error {
     align-self: stretch;
-    border: 1px solid color-mix(in srgb, var(--destructive) 35%, var(--line));
-    color: var(--destructive);
-    background: var(--critical-background);
+    border-inline-start-color: var(--critical);
+    color: var(--foreground);
     text-align: left;
   }
 
@@ -1155,13 +1179,11 @@ body {
     align-items: start;
     gap: 0.75rem;
     padding: 0.875rem;
-    border: 1px solid color-mix(in srgb, var(--destructive) 24%, var(--line));
-    border-radius: 8px;
-    background: color-mix(
-      in srgb,
-      var(--critical-background) 48%,
-      var(--background)
-    );
+    width: 100%;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    border-inline-start: 2px solid var(--critical);
+    background: transparent;
     color: var(--foreground);
     text-align: left;
   }
@@ -1230,13 +1252,13 @@ body {
 
   .message-notice.is-refusal {
     align-self: stretch;
-    border: 1px solid color-mix(in srgb, var(--warning) 42%, var(--line));
-    color: var(--warning-foreground);
-    background: var(--warning-background);
+    border-inline-start-color: var(--warning);
+    color: var(--foreground);
     text-align: left;
   }
 
   .message-notice.is-compaction {
+    border-inline-start: 0;
     padding: 0.15rem 0;
     background: transparent;
     color: var(--muted-foreground);


### PR DESCRIPTION
Notices and errors used large colored fills, and chat and code journals gave notices different widths based on their content and severity. Use neutral surfaces with a thin status-colored leading edge, and make journal notices fill the message column. Apply the shared notice style to app, settings, output, browser, and code banners, and document the pattern in DESIGN.md.

This changes presentation only. Existing alert roles, recovery actions, and error details remain available; no API, data, or dependency changes. The main risk is visual regression on less common banner layouts.

Validation: 92 focused tests passed; TypeScript, formatting, diff checks, and Storybook build passed. Added chat/code width regression stories and a notice palette. Browser checks at 420px and 1000px found aligned widths and no overflow across all four theme settings. Screenshots were captured; image inspection was unavailable in the agent session. The user reviewed and accepted the live preview.
