### PR TITLE
feat(slack): retain hosted session authorization

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/binding.rs
+++ b/crates/tidebreak-core/src/db/ops/code/binding.rs
@@ -138,6 +138,49 @@ pub async fn resolve_external_session(
     workspace: &CodeWorkspace,
     session: &Session,
 ) -> Result<ExternalSessionResolution> {
+    resolve_external_session_inner(
+        store,
+        owner,
+        grant_id,
+        channel_kind,
+        external_key,
+        Some(workspace),
+        session,
+    )
+    .await
+}
+
+/// Insert a machine session and its external binding atomically. Recovery
+/// cannot observe the session before its grant is known.
+pub async fn resolve_external_machine_session(
+    store: &DbStore,
+    owner: &OwnerId,
+    grant_id: CodeGrantId,
+    channel_kind: &str,
+    external_key: &str,
+    session: &Session,
+) -> Result<ExternalSessionResolution> {
+    resolve_external_session_inner(
+        store,
+        owner,
+        grant_id,
+        channel_kind,
+        external_key,
+        None,
+        session,
+    )
+    .await
+}
+
+async fn resolve_external_session_inner(
+    store: &DbStore,
+    owner: &OwnerId,
+    grant_id: CodeGrantId,
+    channel_kind: &str,
+    external_key: &str,
+    workspace: Option<&CodeWorkspace>,
+    session: &Session,
+) -> Result<ExternalSessionResolution> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
     if let Some(hit) = entities::code_external_binding::Entity::find()
         .filter(entities::code_external_binding::Column::Owner.eq(owner.as_str()))
@@ -151,7 +194,9 @@ pub async fn resolve_external_session(
         transaction.commit().await.map_err(store_err)?;
         return Ok(resolution);
     }
-    super::workspace::insert_workspace_on(&transaction, workspace).await?;
+    if let Some(workspace) = workspace {
+        super::workspace::insert_workspace_on(&transaction, workspace).await?;
+    }
     super::session::insert_session_on(&transaction, session).await?;
     let now = database_now(&transaction).await?;
     let binding = CodeExternalBinding {

--- a/crates/tidebreak-core/src/db/ops/code/connect.rs
+++ b/crates/tidebreak-core/src/db/ops/code/connect.rs
@@ -9,7 +9,8 @@
 //! transaction that consumes the handshake.
 
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait,
+    Set, TransactionTrait,
 };
 
 use crate::code::{
@@ -441,4 +442,47 @@ pub async fn list_connect_grant_profiles(
             })
         })
         .collect())
+}
+
+/// The completed consent that owns one grant's gateway delegation.
+pub async fn completed_connect_handshake_for_grant(
+    store: &DbStore,
+    owner: &OwnerId,
+    grant_id: CodeGrantId,
+) -> Result<Option<CodeConnectHandshake>> {
+    entities::code_connect_handshake::Entity::find()
+        .filter(entities::code_connect_handshake::Column::ApprovalOwner.eq(owner.as_str()))
+        .filter(entities::code_connect_handshake::Column::GrantId.eq(grant_id.0))
+        .filter(
+            entities::code_connect_handshake::Column::State
+                .eq(CodeConnectState::Completed.as_str()),
+        )
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(handshake_from_model)
+        .transpose()
+}
+
+/// Revoked external consent retained for retrying gateway revocation after a restart.
+pub async fn revoked_connect_handshakes_all_owners(
+    store: &DbStore,
+) -> Result<Vec<CodeConnectHandshake>> {
+    let revoked = entities::code_external_grant::Entity::find()
+        .select_only()
+        .column(entities::code_external_grant::Column::Id)
+        .filter(entities::code_external_grant::Column::RevokedAt.is_not_null())
+        .into_query();
+    entities::code_connect_handshake::Entity::find()
+        .filter(entities::code_connect_handshake::Column::GrantId.in_subquery(revoked))
+        .filter(
+            entities::code_connect_handshake::Column::State
+                .eq(CodeConnectState::Completed.as_str()),
+        )
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(handshake_from_model)
+        .collect()
 }

--- a/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.dom.test.tsx
@@ -72,7 +72,9 @@ describe("ConnectApprovalView", () => {
         onRetry={() => {}}
       />,
     );
-    expect(screen.getByText(/return to Slack and confirm there/)).toBeTruthy();
+    expect(
+      screen.getByText(/return to the Slack conversation where you started/),
+    ).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: "Yes, this is me" }),
     ).toBeNull();

--- a/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.tsx
@@ -155,10 +155,10 @@ export function ConnectApprovalView({
             </div>
             {phase === "approved" ? (
               <p className="text-sm leading-relaxed">
-                Approved. To finish connecting, return to{" "}
-                {channelLabel(page.channel_kind)} and confirm there — the direct
-                message proves the account is yours, and nothing is linked until
-                it lands.
+                Approved. To finish connecting, return to the{" "}
+                {channelLabel(page.channel_kind)} conversation where you started
+                and select Confirm connection. This confirms that you control
+                the account.
               </p>
             ) : (
               <>

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -469,6 +469,97 @@ describe("ManagedGate", () => {
     expect(screen.queryByText("the open product")).not.toBeInTheDocument();
   });
 
+  it.each([502, 503, 504])(
+    "a %s policy response holds boot closed and retries until the machine returns",
+    async (status) => {
+      const getPolicy = vi
+        .fn()
+        .mockRejectedValueOnce(new Error(`${status}: machine restarting`))
+        .mockRejectedValueOnce(new Error(`${status}: machine restarting`))
+        .mockResolvedValue(managed);
+      vi.useFakeTimers();
+      mount(api({ getPolicy }));
+      await act(async () => {});
+      expect(screen.getByText("starting…")).toBeInTheDocument();
+      expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_100);
+      });
+      expect(getPolicy).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("starting…")).toBeInTheDocument();
+      expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_100);
+      });
+      expect(getPolicy).toHaveBeenCalledTimes(3);
+      expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
+      expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+    },
+  );
+
+  it.each([502, 503, 504])(
+    "a %s policy watch response preserves the last policy and keeps watching",
+    async (status) => {
+      const getPolicy = vi
+        .fn()
+        .mockResolvedValueOnce(managed)
+        .mockRejectedValueOnce(new Error(`${status}: machine restarting`))
+        .mockResolvedValue({
+          ...managed,
+          gateway_url: "https://next-gateway.example/",
+        });
+      vi.useFakeTimers();
+      mount(
+        api({
+          getPolicy,
+          getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        }),
+      );
+      await act(async () => {});
+      await act(async () => {});
+      expect(screen.getByText("the open product")).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_100);
+      });
+      expect(getPolicy).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("the open product")).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_100);
+      });
+      expect(getPolicy).toHaveBeenCalledTimes(3);
+      expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
+      expect(
+        screen.getByText("https://next-gateway.example/"),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+    },
+  );
+
+  it.each([401, 403, 500])(
+    "a %s policy refusal does not retry or open the app",
+    async (status) => {
+      const getPolicy = vi
+        .fn()
+        .mockRejectedValue(new Error(`${status}: refused`));
+      vi.useFakeTimers();
+      mount(api({ getPolicy }));
+      await act(async () => {});
+      expect(
+        screen.getByText(/Contact your administrator/),
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_100);
+      });
+      expect(getPolicy).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+    },
+  );
+
   it("a managed policy without a gateway URL blocks instead of lifting on any session", async () => {
     const client = api({
       getPolicy: vi.fn().mockResolvedValue({ managed: true, source: "os" }),

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
@@ -51,6 +51,11 @@ function httpStatusOf(err: unknown): number | null {
   return match ? Number(match[1]) : null;
 }
 
+/** A proxy or restarting machine has not answered the policy question yet. */
+function isTransientPolicyStatus(status: number): boolean {
+  return status === 502 || status === 503 || status === 504;
+}
+
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = window.setTimeout(
@@ -115,8 +120,9 @@ function samePolicy(a: ManagedPolicy, b: ManagedPolicy): boolean {
  *
  * The policy read fails closed. A transport failure (server not up yet,
  * request timed out) retries silently behind the boot screen — an
- * unreachable server is not an unmanaged profile. An error response blocks
- * the app outright: the server actively said the policy is unreadable.
+ * unreachable server is not an unmanaged profile. Temporary proxy failures
+ * retry the same way. Other error responses block the app because the server
+ * actively said the policy is unreadable.
  */
 export function ManagedGate({
   client,
@@ -207,7 +213,7 @@ export function ManagedGate({
           });
           return;
         }
-        if (httpStatus !== null) {
+        if (httpStatus !== null && !isTransientPolicyStatus(httpStatus)) {
           setPolicyState({ kind: "blocked", status: httpStatus });
           return;
         }
@@ -242,11 +248,15 @@ export function ManagedGate({
         );
       })
       .catch((err) => {
-        // An error *response* means the server says the policy is
-        // unreadable, which fails closed exactly as it does on first read.
-        // A transport failure says nothing, so the last answer stands.
+        // Transport and temporary proxy failures leave the last policy in
+        // force while the watch keeps running. Other HTTP errors fail closed
+        // exactly as they do on the first read.
         const httpStatus = httpStatusOf(err);
-        if (httpStatus !== null && httpStatus !== 404) {
+        if (
+          httpStatus !== null &&
+          httpStatus !== 404 &&
+          !isTransientPolicyStatus(httpStatus)
+        ) {
           setPolicyState({ kind: "blocked", status: httpStatus });
         }
       });

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.dom.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SessionOriginBanner } from "./SessionOriginBanner";
+
+const origin = {
+  channel_kind: "slack",
+  external_key: "T0400000:C0812345:1724900000.123456",
+};
+
+afterEach(cleanup);
+
+describe("SessionOriginBanner", () => {
+  it("describes the session's execution location", () => {
+    const { rerender } = render(
+      <SessionOriginBanner origin={origin} executionLocation="machine" />,
+    );
+    expect(screen.getByTestId("session-origin-banner")).toHaveTextContent(
+      "Started from Slack; runs on this machine.",
+    );
+    expect(
+      screen.getByRole("button", { name: "Open the thread" }),
+    ).toBeTruthy();
+
+    rerender(
+      <SessionOriginBanner origin={origin} executionLocation="sandbox" />,
+    );
+    expect(screen.getByTestId("session-origin-banner")).toHaveTextContent(
+      "Started from Slack; runs in a sandbox.",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.test.ts
@@ -7,7 +7,7 @@ describe("externalThreadUrl", () => {
     expect(
       externalThreadUrl({
         channel_kind: "slack",
-        external_key: "T0400000/C0812345/1724900000.123456",
+        external_key: "T0400000:C0812345:1724900000.123456",
       }),
     ).toBe("https://slack.com/archives/C0812345/p1724900000123456");
     expect(
@@ -24,8 +24,19 @@ describe("externalThreadUrl", () => {
     expect(
       externalThreadUrl({
         channel_kind: "slack",
-        external_key: "T0400000/D0898765/dm/2",
+        external_key: "T0400000:D0898765:dm2",
       }),
+    ).toBeNull();
+  });
+
+  it.each([
+    "T1:C1:not-a-timestamp",
+    "T1:C1:171.5:extra",
+    "T1:C1/redirect:171.5",
+    "T1:C1:171.5?redirect=elsewhere",
+  ])("rejects malformed thread key %s", (external_key) => {
+    expect(
+      externalThreadUrl({ channel_kind: "slack", external_key }),
     ).toBeNull();
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
@@ -1,34 +1,28 @@
-/**
- * The provenance banner for a session an external channel created
- * (docs/slack-sessions.md, desktop pickup).
- *
- * The journal such a session shows is coarse on purpose — turns, per-turn
- * assistant records, artifacts, never tool activity. Without the banner a
- * thin journal reads as corruption; with it, as provenance. One line, one
- * link back to the thread, no further channel UI.
- */
+/** Identifies the channel that started the session and links back to its thread. */
 
 import { MessageCircle } from "lucide-react";
 
 import { openExternal } from "@/host";
-import type { SessionExternalOrigin as CodeSessionExternalOrigin } from "../generated/wire";
+import type {
+  ExecutionLocation,
+  SessionExternalOrigin as CodeSessionExternalOrigin,
+} from "../generated/wire";
 
 function channelLabel(kind: string): string {
   return kind === "slack" ? "Slack" : kind;
 }
 
 /**
- * The thread permalink for a Slack origin, when the key carries one.
- *
- * The adapter's durable key is `workspace/channel/thread_ts`. A key in any
- * other shape — a DM generation key, another channel family — yields no
- * link, and the banner renders without one rather than guessing.
+ * Slack keys carry `workspace:channel:thread_ts`. Preserve links for legacy
+ * slash-delimited keys; DM generations have no thread timestamp.
  */
 export function externalThreadUrl(
   origin: CodeSessionExternalOrigin,
 ): string | null {
   if (origin.channel_kind !== "slack") return null;
-  const parts = origin.external_key.split("/");
+  const parts = origin.external_key.split(
+    origin.external_key.includes(":") ? ":" : "/",
+  );
   if (parts.length !== 3) return null;
   const [, channel, ts] = parts;
   if (!/^[A-Z0-9]+$/i.test(channel) || !/^\d+\.\d+$/.test(ts)) return null;
@@ -37,22 +31,24 @@ export function externalThreadUrl(
 
 export function SessionOriginBanner({
   origin,
+  executionLocation,
 }: {
   origin: CodeSessionExternalOrigin;
+  executionLocation: ExecutionLocation;
 }) {
   const url = externalThreadUrl(origin);
   return (
     <div
-      className="border-border-subtle bg-background/85 mx-auto mt-3 flex w-[calc(100%-2rem)] max-w-3xl items-center gap-2 rounded-lg border px-3 py-2"
+      className="border-border-subtle bg-background/85 mx-auto mt-3 flex w-[calc(100%-2rem)] max-w-3xl items-start gap-2 rounded-lg border px-3 py-2"
       data-testid="session-origin-banner"
     >
       <MessageCircle
-        className="text-muted-foreground size-3.5 shrink-0"
+        className="text-muted-foreground mt-px size-3.5 shrink-0"
         aria-hidden
       />
-      <p className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
-        Started from {channelLabel(origin.channel_kind)}; engine activity stays
-        in the sandbox.
+      <p className="text-muted-foreground min-w-0 flex-1 text-xs">
+        Started from {channelLabel(origin.channel_kind)}; runs{" "}
+        {executionLocation === "machine" ? "on this machine" : "in a sandbox"}.
       </p>
       {url && (
         <button

--- a/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
@@ -545,7 +545,10 @@ export function CodeSessionPane({
         />
       )}
       {!subagentCallId && session.external_origin && (
-        <SessionOriginBanner origin={session.external_origin} />
+        <SessionOriginBanner
+          origin={session.external_origin}
+          executionLocation={session.execution_location}
+        />
       )}
       <div className={cn("message-view", follow.fadeClass)}>
         {connectionState === "reconnecting" && (

--- a/crates/tidebreak-desktop/ui/src/stories/SessionOriginBanner.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SessionOriginBanner.stories.tsx
@@ -2,15 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { SessionOriginBanner } from "@/code/SessionOriginBanner";
 
-/**
- * The provenance banner for a session an external channel created. Its
- * journal is coarse on purpose — the banner says why, and links back to the
- * thread when the origin key carries one. A key without a derivable
- * permalink still gets the banner, just without the link.
- */
+/** Reuse the session banner for both machine and sandbox execution. */
 const meta = {
   title: "Code/Session origin banner",
   component: SessionOriginBanner,
+  args: { executionLocation: "machine" },
   decorators: [
     (Story) => (
       <div className="bg-background w-[42rem] max-w-full pb-4">
@@ -28,7 +24,7 @@ export const SlackThread: Story = {
   args: {
     origin: {
       channel_kind: "slack",
-      external_key: "T0400000/C0812345/1724900000.123456",
+      external_key: "T0400000:C0812345:1724900000.123456",
     },
   },
 };
@@ -38,7 +34,7 @@ export const SlackDirectMessage: Story = {
   args: {
     origin: {
       channel_kind: "slack",
-      external_key: "T0400000/D0898765/dm/2",
+      external_key: "T0400000:D0898765:dm2",
     },
   },
 };
@@ -51,4 +47,8 @@ export const OtherChannel: Story = {
       external_key: "!room:example.org",
     },
   },
+};
+
+export const SandboxThread: Story = {
+  args: { ...SlackThread.args, executionLocation: "sandbox" },
 };

--- a/crates/tidebreak-server-api/src/routes/code/grants.rs
+++ b/crates/tidebreak-server-api/src/routes/code/grants.rs
@@ -204,9 +204,10 @@ pub struct ConnectApproveBody {
 pub async fn connect_approve(
     code: ScopedCode,
     Path(nonce): Path<String>,
+    lease: Option<axum::Extension<crate::auth::GatewayAuthLease>>,
     Json(body): Json<ConnectApproveBody>,
 ) -> Result<StatusCode, ServerError> {
-    code.approve_connect_handshake(&nonce, &body.csrf)
+    code.approve_connect_handshake(&nonce, &body.csrf, lease.as_ref().map(|lease| &lease.0))
         .await?
         .ok_or_else(|| ServerError::not_found("this connect link is no longer valid"))?;
     Ok(StatusCode::NO_CONTENT)

--- a/crates/tidebreak-server-api/src/routes/code/llm.rs
+++ b/crates/tidebreak-server-api/src/routes/code/llm.rs
@@ -153,6 +153,21 @@ pub async fn harness_git_credential(
     {
         return plain(StatusCode::OK, "");
     }
+    let delegated = match relay
+        .external_gateway_for_session(&subject.owner, subject.session)
+        .await
+    {
+        Ok(gateway) => gateway,
+        Err(
+            error @ (tidebreak_core::AgentError::SignInRequired(_)
+            | tidebreak_core::AgentError::InvalidTarget(_)),
+        ) => return plain(StatusCode::UNAUTHORIZED, &error.to_string()),
+        Err(error) => return plain(StatusCode::BAD_GATEWAY, &error.to_string()),
+    };
+    let lender: &dyn crate::obo_gateway::GitCredentialLender = match delegated.as_ref() {
+        Some(gateway) => gateway.as_ref(),
+        None => lender.as_ref(),
+    };
     match lender
         .git_credential(&subject.owner, &format!("{origin_owner}/{origin_name}"))
         .await

--- a/crates/tidebreak-server-api/src/tests.rs
+++ b/crates/tidebreak-server-api/src/tests.rs
@@ -2875,6 +2875,83 @@ async fn handoff_app(gateway_url: &str) -> (Router, tempfile::TempDir) {
     (app(state), dir)
 }
 
+/// A verifier outage admits nobody but preserves the caller's session. Once
+/// the gateway returns, the same bearer works without another sign-in.
+#[tokio::test]
+async fn gateway_verifier_outage_is_retryable_without_ending_the_session() {
+    use axum::response::IntoResponse as _;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let seen = attempts.clone();
+    let gateway = Router::new().route(
+        "/api/v1/tidebreak/principal",
+        axum::routing::get(move |headers: axum::http::HeaderMap| {
+            let seen = seen.clone();
+            async move {
+                match headers
+                    .get(header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                {
+                    Some("Bearer mg_at_retry") => {
+                        let attempt = seen.fetch_add(1, Ordering::SeqCst);
+                        match attempt {
+                            0 => StatusCode::BAD_GATEWAY.into_response(),
+                            1 => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+                            2 => StatusCode::GATEWAY_TIMEOUT.into_response(),
+                            _ => axum::Json(serde_json::json!({
+                                "user_id": "73eaa9e8-f60a-4f84-96cf-6a9d2bbd6d55",
+                                "is_admin": true,
+                            }))
+                            .into_response(),
+                        }
+                    }
+                    _ => StatusCode::UNAUTHORIZED.into_response(),
+                }
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, gateway).await.unwrap() });
+    let (machine, _directory) = handoff_app(&format!("http://{address}")).await;
+    let request = |token: &str| {
+        Request::builder()
+            .uri("/policy")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    };
+
+    for _ in 0..3 {
+        let response = machine
+            .clone()
+            .oneshot(request("mg_at_retry"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+    assert_eq!(
+        machine
+            .clone()
+            .oneshot(request("mg_at_retry"))
+            .await
+            .unwrap()
+            .status(),
+        StatusCode::OK,
+    );
+    assert_eq!(
+        machine
+            .oneshot(request("mg_at_revoked"))
+            .await
+            .unwrap()
+            .status(),
+        StatusCode::UNAUTHORIZED,
+    );
+    assert_eq!(attempts.load(Ordering::SeqCst), 4);
+    server.abort();
+}
+
 fn handoff_request(query: &str) -> Request<Body> {
     Request::builder()
         .uri(format!("/auth/handoff{query}"))

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -380,7 +380,13 @@ pub async fn require_token(
 ) -> Response {
     let presented = extract_token(request.headers()).map(str::to_owned);
     let resolved = match presented.as_deref() {
-        Some(presented) => resolve_principal(&state, presented).await,
+        Some(presented) => match resolve_principal(&state, presented).await {
+            Ok(principal) => principal,
+            Err(error) => {
+                tracing::warn!(%error, "model-gateway could not validate Tidebreak caller");
+                return StatusCode::SERVICE_UNAVAILABLE.into_response();
+            }
+        },
         None => None,
     };
 
@@ -415,11 +421,12 @@ pub async fn require_token(
     }
 }
 
-/// Process-memory lease retained by Gateway-authenticated WebSocket tasks.
+/// Process-memory lease retained by gateway-authenticated request tasks.
 ///
 /// The bearer is intentionally private and this type deliberately implements
-/// neither `Debug` nor serialization. Socket loops use it only to re-check the
-/// live Gateway principal; static-token and local sockets receive no lease.
+/// neither `Debug` nor serialization. Socket loops re-check its principal;
+/// external consent uses its exact credential. Static-token and local
+/// requests receive no lease.
 #[derive(Clone)]
 pub struct GatewayAuthLease {
     bearer: std::sync::Arc<str>,
@@ -427,6 +434,26 @@ pub struct GatewayAuthLease {
 }
 
 impl GatewayAuthLease {
+    /// Bind consent to the exact request credential that approved it.
+    pub(crate) async fn enroll_external_delegation(
+        &self,
+        external: &crate::obo_gateway::external::ExternalDelegations,
+        owner: &tidebreak_core::OwnerId,
+        handshake: tidebreak_core::CodeHandshakeId,
+    ) -> Result<()> {
+        if &self.principal.owner_id() != owner {
+            return Err(AgentError::SignInRequired(
+                "the approval credential belongs to another account".into(),
+            ));
+        }
+        external.enroll(owner, handshake, &self.bearer).await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(principal: Principal, bearer: std::sync::Arc<str>) -> Self {
+        Self { principal, bearer }
+    }
+
     /// Revalidate the original credential and require identity and role to be
     /// unchanged. Refusal, expiry, deactivation, demotion/promotion, and
     /// verifier outages all fail closed.
@@ -444,17 +471,19 @@ impl GatewayAuthLease {
 /// `None` is a 401: a token that names no one admits no one. Unknown future
 /// profiles resolve nobody until they choose an authenticator — fail closed,
 /// never defaulted to the local owner.
-async fn resolve_principal(state: &AppState, presented: &str) -> Option<Principal> {
+async fn resolve_principal(state: &AppState, presented: &str) -> Result<Option<Principal>> {
     match state.config.profile {
         // The per-launch bearer is loopback-only and handed to one client, so
         // the verified caller *is* the local owner.
-        Profile::Desktop => constant_time_eq(presented.as_bytes(), state.token.as_bytes())
-            .then_some(Principal::LocalOwner),
+        Profile::Desktop => Ok(
+            constant_time_eq(presented.as_bytes(), state.token.as_bytes())
+                .then_some(Principal::LocalOwner),
+        ),
         // Every self-host credential names a configured user. The per-launch
         // bearer is deliberately not consulted: on a shared deployment it
         // names nobody, so it authenticates nobody.
-        Profile::SelfHost => state.principal_authenticator.resolve(presented).await,
-        _ => None,
+        Profile::SelfHost => state.principal_authenticator.try_resolve(presented).await,
+        _ => Ok(None),
     }
 }
 
@@ -553,19 +582,25 @@ impl PrincipalAuthenticator {
     }
 
     async fn resolve(&self, presented: &str) -> Option<Principal> {
+        match self.try_resolve(presented).await {
+            Ok(principal) => principal,
+            Err(error) => {
+                tracing::warn!(%error, "model-gateway could not validate Tidebreak caller");
+                None
+            }
+        }
+    }
+
+    /// Preserve verifier failures so HTTP requests can retry without treating
+    /// an unavailable identity service as an expired or revoked credential.
+    async fn try_resolve(&self, presented: &str) -> Result<Option<Principal>> {
         match self {
-            Self::None => None,
-            Self::Static(tokens) => tokens
+            Self::None => Ok(None),
+            Self::Static(tokens) => Ok(tokens
                 .resolve(presented)
-                .map(|(id, role)| Principal::User { id, role }),
-            Self::Oidc(oidc) => oidc.resolve(presented),
-            Self::Gateway(gateway) => match gateway.resolve(presented).await {
-                Ok(principal) => principal,
-                Err(error) => {
-                    tracing::warn!(%error, "model-gateway could not validate Tidebreak caller");
-                    None
-                }
-            },
+                .map(|(id, role)| Principal::User { id, role })),
+            Self::Oidc(oidc) => Ok(oidc.resolve(presented)),
+            Self::Gateway(gateway) => gateway.resolve(presented).await,
         }
     }
 }

--- a/crates/tidebreak-server/src/code/grants.rs
+++ b/crates/tidebreak-server/src/code/grants.rs
@@ -221,6 +221,7 @@ impl super::runtime::CodeRuntime {
                     "a rotated refresh token was replayed; the grant is revoked"
                 );
                 self.grant_revocations().publish(grant.id);
+                self.revoke_gateway_delegation(&grant.owner, grant.id).await;
                 Ok((outcome, None))
             }
             GrantRotation::Unknown => Ok((outcome, None)),
@@ -240,7 +241,19 @@ impl super::runtime::CodeRuntime {
         if revoked.is_some() {
             self.grant_revocations().publish(grant_id);
         }
+        self.revoke_gateway_delegation(owner, grant_id).await;
         Ok(revoked)
+    }
+
+    async fn revoke_gateway_delegation(&self, owner: &OwnerId, grant: CodeGrantId) {
+        if let Some(external) = self
+            .harness_llm()
+            .and_then(|relay| relay.external_delegations().cloned())
+        {
+            if let Err(error) = external.revoke(owner, grant).await {
+                tracing::warn!(%grant, %error, "external access is revoked locally; gateway revocation will retry");
+            }
+        }
     }
 
     pub fn grant_revocations(&self) -> Arc<GrantRevocations> {
@@ -342,7 +355,28 @@ impl super::runtime::CodeRuntime {
         owner: &OwnerId,
         nonce: &str,
         csrf: &str,
+        lease: Option<&crate::auth::GatewayAuthLease>,
     ) -> Result<Option<tidebreak_core::CodeConnectHandshake>, ServerError> {
+        if let Some(external) = self
+            .harness_llm()
+            .and_then(|relay| relay.external_delegations().cloned())
+        {
+            let Some((handshake, expected_csrf)) =
+                self.view_connect_handshake(owner, nonce).await?
+            else {
+                return Ok(None);
+            };
+            if handshake.state != tidebreak_core::CodeConnectState::Pending || expected_csrf != csrf
+            {
+                return Ok(None);
+            }
+            let lease = lease.ok_or_else(|| {
+                ServerError::unauthorized("sign in again to approve this external connection")
+            })?;
+            lease
+                .enroll_external_delegation(&external, owner, handshake.id)
+                .await?;
+        }
         Ok(
             tidebreak_core::db::code::approve_connect_handshake_all_owners(
                 &self.db,
@@ -379,6 +413,7 @@ impl super::runtime::CodeRuntime {
         };
         for grant_id in replaced {
             self.grant_revocations().publish(grant_id);
+            self.revoke_gateway_delegation(&grant.owner, grant_id).await;
         }
         Ok(Some((grant, pair)))
     }
@@ -419,6 +454,7 @@ impl super::runtime::CodeRuntime {
         .await?;
         for grant in &revoked {
             self.grant_revocations().publish(grant.id);
+            self.revoke_gateway_delegation(owner, grant.id).await;
         }
         Ok(revoked)
     }

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -95,6 +95,7 @@ pub struct HarnessLlmRelay {
     obo: Arc<OboGateway>,
     client: reqwest::Client,
     state: Mutex<RelayState>,
+    external: Option<Arc<crate::obo_gateway::external::ExternalDelegations>>,
 }
 
 #[derive(Default)]
@@ -117,7 +118,72 @@ impl HarnessLlmRelay {
             obo,
             client,
             state: Mutex::new(RelayState::default()),
+            external: None,
         }
+    }
+
+    /// Attach durable external consent before any worker can use this relay.
+    pub fn with_external_delegations(mut self, db: Arc<tidebreak_core::db::DbStore>) -> Self {
+        self.external = Some(Arc::new(
+            crate::obo_gateway::external::ExternalDelegations::new(self.obo.clone(), db),
+        ));
+        self
+    }
+
+    pub fn external_delegations(
+        &self,
+    ) -> Option<&Arc<crate::obo_gateway::external::ExternalDelegations>> {
+        self.external.as_ref()
+    }
+
+    pub async fn gateway_for_session(
+        &self,
+        owner: &OwnerId,
+        session: SessionId,
+    ) -> tidebreak_core::Result<Arc<OboGateway>> {
+        match self.external.as_ref() {
+            Some(external) => Ok(external
+                .for_session(owner, session)
+                .await?
+                .unwrap_or_else(|| self.obo.clone())),
+            None => Ok(self.obo.clone()),
+        }
+    }
+
+    pub async fn external_gateway_for_session(
+        &self,
+        owner: &OwnerId,
+        session: SessionId,
+    ) -> tidebreak_core::Result<Option<Arc<OboGateway>>> {
+        match self.external.as_ref() {
+            Some(external) => external.for_session(owner, session).await,
+            None => Ok(None),
+        }
+    }
+
+    pub async fn catalog_for_session(
+        &self,
+        owner: &OwnerId,
+        session: SessionId,
+    ) -> tidebreak_core::Result<Option<crate::providers::GatewayModelSnapshot>> {
+        self.gateway_for_session(owner, session)
+            .await?
+            .snapshot_for(owner)
+            .await
+    }
+
+    pub async fn catalog_for_grant(
+        &self,
+        owner: &OwnerId,
+        grant: tidebreak_core::CodeGrantId,
+    ) -> tidebreak_core::Result<Option<crate::providers::GatewayModelSnapshot>> {
+        self.external
+            .as_ref()
+            .ok_or_else(|| AgentError::SignInRequired("reconnect this external connection".into()))?
+            .for_grant(owner, grant)
+            .await?
+            .snapshot_for(owner)
+            .await
     }
 
     /// Both of the caller's compat listings. Keeping the read behind the
@@ -205,7 +271,14 @@ impl HarnessLlmRelay {
                 "unknown or revoked harness relay key",
             ));
         };
-        match self.obo.bearer_for(&subject.owner).await {
+        let bearer = async {
+            self.gateway_for_session(&subject.owner, subject.session)
+                .await?
+                .bearer_for(&subject.owner)
+                .await
+        }
+        .await;
+        match bearer {
             Ok(token) => Ok(token),
             Err(error @ (AgentError::SignInRequired(_) | AgentError::InvalidTarget(_))) => {
                 Err(endpoint.error_response(

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -551,6 +551,13 @@ impl CodeRuntime {
         let runtime = self.clone();
         Box::pin(async move {
             cleanup.map_err(ServerError::internal)?;
+            if let Some(external) = runtime
+                .harness_llm
+                .as_ref()
+                .and_then(|relay| relay.external_delegations())
+            {
+                external.start_revocation_sweep();
+            }
             let actions = runtime.recover().await;
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -8,6 +8,16 @@ use tidebreak_core::ExecutionLocation;
 const MACHINE_PROMOTION_POLL: std::time::Duration = std::time::Duration::from_millis(50);
 const MACHINE_PROMOTION_POLLS: usize = 40;
 
+fn external_delegation_error(error: tidebreak_core::AgentError) -> ServerError {
+    match error {
+        tidebreak_core::AgentError::SignInRequired(_) | tidebreak_core::AgentError::InvalidTarget(_) => ServerError::conflict_kind(
+            "external_reconnect_required",
+            "Your Slack connection needs approval again. Send `reconnect` to Tidebreak, then approve the connection.",
+        ),
+        error => ServerError::from(error),
+    }
+}
+
 impl CodeRuntime {
     /// Create a workspace whose checkout lives in a sandbox, not on this
     /// machine. A per-workspace `remote:<id>` worktree marker records that
@@ -143,6 +153,23 @@ impl CodeRuntime {
                 "a binding needs a channel kind and a conversation key",
             ));
         }
+        let delegated = if self.external_execution_location() == ExecutionLocation::Machine {
+            match self
+                .harness_llm
+                .as_ref()
+                .and_then(|relay| relay.external_delegations())
+            {
+                Some(external) => Some(
+                    external
+                        .for_grant(owner, grant_id)
+                        .await
+                        .map_err(external_delegation_error)?,
+                ),
+                None => None,
+            }
+        } else {
+            None
+        };
         // The fast path costs one read and builds nothing.
         if let Some(binding) = tidebreak_core::db::code::get_external_binding(
             &self.db,
@@ -203,20 +230,46 @@ impl CodeRuntime {
                     ..settings
                 };
                 let workspace = self
-                    .create_workspace(owner, repo_id, title, None, None)
+                    .create_workspace_with_git_credentials(
+                        owner,
+                        repo_id,
+                        title,
+                        None,
+                        None,
+                        delegated
+                            .as_ref()
+                            .map(|gateway| {
+                                gateway.as_ref() as &dyn crate::obo_gateway::GitCredentialLender
+                            })
+                            .or_else(|| self.git_credentials().map(|lender| lender.as_ref())),
+                    )
                     .await?;
                 let session = self
-                    .create_session(owner, workspace.id, harness, settings)
+                    .create_session_of_kind_unattached(
+                        owner,
+                        workspace.id,
+                        SessionKind::Interactive,
+                        harness,
+                        settings,
+                        Some(grant_id),
+                    )
                     .await?;
-                Ok(tidebreak_core::db::code::bind_external_session(
+                let resolution = tidebreak_core::db::code::resolve_external_machine_session(
                     &self.db,
                     owner,
                     grant_id,
                     channel_kind,
                     external_key,
-                    session.id,
+                    &session,
                 )
-                .await?)
+                .await?;
+                if matches!(
+                    resolution,
+                    tidebreak_core::ExternalSessionResolution::Created(_)
+                ) {
+                    self.attach_and_spawn_worker(session).await?;
+                }
+                Ok(resolution)
             }
         }
     }
@@ -617,6 +670,18 @@ impl CodeRuntime {
             ));
         }
         let session = self.get_session(owner, session_id).await?;
+        if session.execution_location == ExecutionLocation::Machine {
+            if let Some(external) = self
+                .harness_llm
+                .as_ref()
+                .and_then(|relay| relay.external_delegations())
+            {
+                external
+                    .for_grant(owner, grant_id)
+                    .await
+                    .map_err(external_delegation_error)?;
+            }
+        }
         match session.lifecycle {
             SessionLifecycle::Ended => {
                 return Err(ServerError::conflict_kind(

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -32,6 +32,21 @@ impl CodeRuntime {
         workspace_id: WorkspaceId,
         kind: SessionKind,
         harness: HarnessKind,
+        settings: NewSessionSettings,
+    ) -> Result<Session, ServerError> {
+        let session = self
+            .create_session_of_kind_unattached(owner, workspace_id, kind, harness, settings, None)
+            .await?;
+        self.attach_and_spawn_worker(session).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn create_session_of_kind_unattached(
+        &self,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+        kind: SessionKind,
+        harness: HarnessKind,
         NewSessionSettings {
             permission_mode,
             model,
@@ -39,6 +54,7 @@ impl CodeRuntime {
             fast_mode,
             permission_mode_ceiling,
         }: NewSessionSettings,
+        external_grant: Option<tidebreak_core::CodeGrantId>,
     ) -> Result<Session, ServerError> {
         if harness.is_in_process() {
             return Err(ServerError::conflict_kind(
@@ -150,8 +166,9 @@ impl CodeRuntime {
         };
         if execution_settings.reasoning_effort.is_some() || execution_settings.fast_mode {
             let selected = self
-                .selected_model_capabilities_for_owner(
+                .selected_model_capabilities_for_scope(
                     owner,
+                    external_grant.map(super::settings::ModelCredentialScope::Grant),
                     adapter.as_ref(),
                     &probe,
                     execution_settings.model.as_deref(),
@@ -183,7 +200,9 @@ impl CodeRuntime {
             created_at: Utc::now(),
             execution_location: tidebreak_core::ExecutionLocation::Machine,
         };
-        insert_session(&self.db, &session).await?;
+        if external_grant.is_none() {
+            insert_session(&self.db, &session).await?;
+        }
         // Pin where this session starts, before it can take a turn. Sessions
         // share the worktree (record 55), so without a baseline the first
         // turn's diff is the whole worktree against the base branch — a
@@ -202,7 +221,7 @@ impl CodeRuntime {
                 "could not record the session baseline; its first turn diffs against the base ref"
             );
         }
-        self.attach_and_spawn_worker(session).await
+        Ok(session)
     }
 
     /// Create a conversation with no workspace, hosted by the in-process

--- a/crates/tidebreak-server/src/code/runtime/settings.rs
+++ b/crates/tidebreak-server/src/code/runtime/settings.rs
@@ -136,6 +136,12 @@ pub(super) fn permission_mode_fence_reason(intent: &PermissionModeChangeIntent) 
     }
 }
 
+#[derive(Clone, Copy)]
+pub(super) enum ModelCredentialScope {
+    Session(SessionId),
+    Grant(tidebreak_core::CodeGrantId),
+}
+
 impl CodeRuntime {
     /// Change a session's permission mode through one durable intent.
     ///
@@ -597,8 +603,9 @@ impl CodeRuntime {
         let adapter = self.adapter(session.harness_kind)?;
         let probe = self.probe(adapter.as_ref()).await;
         let selected = self
-            .selected_model_capabilities_for_owner(
+            .selected_model_capabilities_for_scope(
                 owner,
+                Some(ModelCredentialScope::Session(session.id)),
                 adapter.as_ref(),
                 &probe,
                 session.model.as_deref(),
@@ -652,8 +659,9 @@ impl CodeRuntime {
         let adapter = self.adapter(session.harness_kind)?;
         let probe = self.probe(adapter.as_ref()).await;
         let selected = self
-            .selected_model_capabilities_for_owner(
+            .selected_model_capabilities_for_scope(
                 owner,
+                Some(ModelCredentialScope::Session(session.id)),
                 adapter.as_ref(),
                 &probe,
                 session.model.as_deref(),
@@ -714,9 +722,10 @@ impl CodeRuntime {
         }
     }
 
-    pub(super) async fn selected_model_capabilities_for_owner(
+    pub(super) async fn selected_model_capabilities_for_scope(
         &self,
         owner: &OwnerId,
+        scope: Option<ModelCredentialScope>,
         adapter: &dyn HarnessAdapter,
         probe: &HarnessProbe,
         selected: Option<&str>,
@@ -728,7 +737,16 @@ impl CodeRuntime {
         if adapter.capabilities(probe).reasoning_levels != CapLevel::Supported {
             return capabilities;
         }
-        let Some(snapshot) = self.gateway_model_snapshot(owner).await else {
+        let snapshot = match (self.harness_llm.as_ref(), scope) {
+            (Some(relay), Some(ModelCredentialScope::Session(id))) => {
+                relay.catalog_for_session(owner, id).await.ok().flatten()
+            }
+            (Some(relay), Some(ModelCredentialScope::Grant(id))) => {
+                relay.catalog_for_grant(owner, id).await.ok().flatten()
+            }
+            _ => self.gateway_model_snapshot(owner).await,
+        };
+        let Some(snapshot) = snapshot else {
             return capabilities;
         };
         let Some(model_efforts) =
@@ -942,8 +960,9 @@ mod selected_model_capabilities_tests {
             ScriptedAdapter::new(plain_text_script()).with_reasoning_levels(CapLevel::Supported);
 
         let capabilities = runtime
-            .selected_model_capabilities_for_owner(
+            .selected_model_capabilities_for_scope(
                 &OwnerId::new("alice").unwrap(),
+                None,
                 &adapter,
                 &scripted_probe(),
                 Some("model-gateway-model-gateway/glm-5.3"),
@@ -982,8 +1001,9 @@ mod selected_model_capabilities_tests {
             }]);
 
         let capabilities = runtime
-            .selected_model_capabilities_for_owner(
+            .selected_model_capabilities_for_scope(
                 &OwnerId::new("alice").unwrap(),
+                None,
                 &adapter,
                 &scripted_probe(),
                 Some("model-gateway-model-gateway/glm-5.3"),
@@ -1007,8 +1027,9 @@ mod selected_model_capabilities_tests {
             ScriptedAdapter::new(plain_text_script()).with_reasoning_levels(CapLevel::Supported);
 
         let capabilities = runtime
-            .selected_model_capabilities_for_owner(
+            .selected_model_capabilities_for_scope(
                 &OwnerId::new("alice").unwrap(),
+                None,
                 &adapter,
                 &scripted_probe(),
                 Some("model-gateway-model-gateway/glm-5.3"),

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -224,8 +224,9 @@ impl CodeRuntime {
             let adapter = self.adapter(session.harness_kind)?;
             let probe = self.probe(adapter.as_ref()).await;
             let selected = self
-                .selected_model_capabilities_for_owner(
+                .selected_model_capabilities_for_scope(
                     owner,
+                    Some(super::settings::ModelCredentialScope::Session(session.id)),
                     adapter.as_ref(),
                     &probe,
                     next.model.as_deref(),

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -113,8 +113,9 @@ impl CodeRuntime {
         }
         if session.reasoning_effort.is_some() || session.fast_mode {
             let selected = self
-                .selected_model_capabilities_for_owner(
+                .selected_model_capabilities_for_scope(
                     &session.owner,
+                    Some(super::settings::ModelCredentialScope::Session(session.id)),
                     adapter.as_ref(),
                     &probe,
                     session.model.as_deref(),

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -169,8 +169,13 @@ impl CodeRuntime {
     /// failures. An identity the gateway states without a commit email is
     /// incomplete and configures nothing — half an identity would be worse
     /// than the checkout's own.
-    pub(super) async fn name_workspace_author(&self, owner: &OwnerId, worktree: &std::path::Path) {
-        let Some(lender) = self.git_credentials() else {
+    pub(super) async fn name_workspace_author_with_lender(
+        &self,
+        owner: &OwnerId,
+        worktree: &std::path::Path,
+        lender: Option<&dyn crate::obo_gateway::GitCredentialLender>,
+    ) {
+        let Some(lender) = lender else {
             return;
         };
         let Ok(identity) = lender.git_forge_identity(owner).await else {

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -27,6 +27,27 @@ impl CodeRuntime {
         suggested_title: Option<String>,
         base_ref: Option<String>,
     ) -> Result<CodeWorkspace, ServerError> {
+        self.create_workspace_with_git_credentials(
+            owner,
+            repo_id,
+            title,
+            suggested_title,
+            base_ref,
+            self.git_credentials().map(|lender| lender.as_ref()),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn create_workspace_with_git_credentials(
+        &self,
+        owner: &OwnerId,
+        repo_id: RepoId,
+        title: Option<String>,
+        suggested_title: Option<String>,
+        base_ref: Option<String>,
+        lender: Option<&dyn crate::obo_gateway::GitCredentialLender>,
+    ) -> Result<CodeWorkspace, ServerError> {
         let repo = self.get_repo(owner, repo_id).await?;
         Self::refuse_removed_repo(&repo)?;
         let explicit_title = title
@@ -154,7 +175,8 @@ impl CodeRuntime {
         // Before the setup script, which may itself commit: from here on,
         // anything this workspace commits should already carry the right
         // name.
-        self.name_workspace_author(owner, &path).await;
+        self.name_workspace_author_with_lender(owner, &path, lender)
+            .await;
         match run_setup_script(
             &path,
             std::path::Path::new(&repo.root_path),

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -986,9 +986,10 @@ impl ScopedCode {
         &self,
         nonce: &str,
         csrf: &str,
+        lease: Option<&crate::auth::GatewayAuthLease>,
     ) -> Result<Option<tidebreak_core::CodeConnectHandshake>, ServerError> {
         self.runtime
-            .approve_connect_handshake(&self.owner, nonce, csrf)
+            .approve_connect_handshake(&self.owner, nonce, csrf, lease)
             .await
     }
 

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1290,10 +1290,12 @@ async fn bind_inner(
         // And engine inference rides the caller's gateway grant through the
         // relay, since the hosted image has no provider credentials of its
         // own (decision 71).
-        state
-            .on_behalf_of_gateway
-            .clone()
-            .map(|gateway| Arc::new(code::harness_llm::HarnessLlmRelay::new(gateway))),
+        state.on_behalf_of_gateway.clone().map(|gateway| {
+            Arc::new(
+                code::harness_llm::HarnessLlmRelay::new(gateway)
+                    .with_external_delegations(db.clone()),
+            )
+        }),
     )
     .with_gateway_runtime(state.gateway.clone());
     // A self-host machine owns its filesystem. Clones land under the data

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -33,6 +33,8 @@
 //!   router only where the deployment states no other inference path; see
 //!   [`crate::providers::collect_routes`].
 
+pub mod external;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -305,6 +307,7 @@ pub struct OboGateway {
     gateway_base_url: String,
     client: reqwest::Client,
     users: std::sync::Mutex<HashMap<OwnerId, Arc<UserSlot>>>,
+    machine_credentials: Option<(String, String)>,
 }
 
 impl OboGateway {
@@ -344,7 +347,12 @@ impl OboGateway {
             .auth_gateway_verifier_url
             .as_deref()
             .unwrap_or(gateway_url);
-        Ok(Some(Arc::new(Self::new(base, resource)?)))
+        let mut gateway = Self::new(base, resource)?;
+        gateway.machine_credentials = std::env::var("GATEWAY_CLIENT_ID")
+            .ok()
+            .zip(std::env::var("GATEWAY_CLIENT_SECRET").ok())
+            .filter(|(id, secret)| !id.is_empty() && !secret.is_empty());
+        Ok(Some(Arc::new(gateway)))
     }
 
     /// Build an exchange client against `base_url`, acting as the machine
@@ -382,6 +390,7 @@ impl OboGateway {
             gateway_base_url,
             client,
             users: std::sync::Mutex::new(HashMap::new()),
+            machine_credentials: None,
         })
     }
 

--- a/crates/tidebreak-server/src/obo_gateway/external.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external.rs
@@ -1,0 +1,302 @@
+//! Gateway delegation for confirmed external connections.
+//!
+//! The store retains consent identifiers, never gateway tokens. Each grant
+//! has a separate in-memory gateway client so browser credentials cannot
+//! supply or replace its authority.
+
+use super::*;
+use tidebreak_core::db::DbStore;
+use tidebreak_core::{CodeGrantId, CodeHandshakeId, SessionId};
+
+struct DelegatedGateway {
+    expires_at: u64,
+    gateway: Arc<OboGateway>,
+}
+
+type DelegationSlot = Arc<tokio::sync::Mutex<Option<DelegatedGateway>>>;
+
+pub struct ExternalDelegations {
+    gateway: Arc<OboGateway>,
+    db: Arc<DbStore>,
+    slots: std::sync::Mutex<HashMap<CodeGrantId, DelegationSlot>>,
+    sweep_started: std::sync::atomic::AtomicBool,
+    revoked: std::sync::Mutex<std::collections::HashSet<CodeGrantId>>,
+}
+
+#[derive(serde::Deserialize)]
+struct DelegationIdentity {
+    delegation_id: String,
+    resource: String,
+    user_id: String,
+}
+
+#[derive(serde::Deserialize)]
+struct DelegationToken {
+    access_token: String,
+    token_type: String,
+    expires_in: u64,
+    resource: String,
+    user_id: String,
+}
+
+fn reconnect() -> AgentError {
+    AgentError::SignInRequired(
+        "this external connection has no live gateway delegation; reconnect it from Slack".into(),
+    )
+}
+
+impl ExternalDelegations {
+    pub fn new(gateway: Arc<OboGateway>, db: Arc<DbStore>) -> Self {
+        Self {
+            gateway,
+            db,
+            slots: std::sync::Mutex::new(HashMap::new()),
+            sweep_started: std::sync::atomic::AtomicBool::new(false),
+            revoked: std::sync::Mutex::new(std::collections::HashSet::new()),
+        }
+    }
+
+    /// Reconcile durable revocations after restart and retry transport failures.
+    pub fn start_revocation_sweep(self: &Arc<Self>) {
+        if self
+            .sweep_started
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+        {
+            return;
+        }
+        let weak = Arc::downgrade(self);
+        tokio::spawn(async move {
+            loop {
+                let Some(this) = weak.upgrade() else {
+                    return;
+                };
+                if let Err(error) = this.reconcile_revocations().await {
+                    tracing::warn!(%error, "could not reconcile external gateway revocations");
+                }
+                drop(this);
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            }
+        });
+    }
+
+    async fn reconcile_revocations(&self) -> Result<()> {
+        for handshake in
+            tidebreak_core::db::code::revoked_connect_handshakes_all_owners(&self.db).await?
+        {
+            if let (Some(owner), Some(grant)) = (handshake.approval_owner, handshake.grant_id) {
+                self.revoke(&owner, grant).await?;
+            }
+        }
+        Ok(())
+    }
+
+    fn endpoint(&self, suffix: &str) -> Result<reqwest::Url> {
+        let base = normalized_gateway_base(&self.gateway.gateway_base_url)?;
+        join_below(
+            &base,
+            &format!("api/v1/tidebreak/external-delegations{suffix}"),
+        )
+    }
+
+    fn machine_auth(&self) -> Result<serde_json::Value> {
+        let (client_id, client_secret) =
+            self.gateway.machine_credentials.as_ref().ok_or_else(|| {
+                AgentError::config("this machine has no gateway identity for external connections")
+            })?;
+        Ok(serde_json::json!({
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "resource": self.gateway.resource,
+        }))
+    }
+
+    /// Enroll only after the approval route validates the owner and CSRF.
+    /// The adapter still needs to confirm before any grant can use this ID.
+    pub(crate) async fn enroll(
+        &self,
+        owner: &OwnerId,
+        id: CodeHandshakeId,
+        subject: &str,
+    ) -> Result<()> {
+        let _ = self.machine_auth()?;
+        let response = self.gateway.client.post(self.endpoint("")?)
+            .bearer_auth(subject)
+            .json(&serde_json::json!({"delegation_id": id.to_string(), "resource": self.gateway.resource}))
+            .send().await.map_err(|error| AgentError::msg(format!("gateway delegation approval failed: {error}")))?;
+        let status = response.status();
+        let body = read_bounded(response, RESPONSE_LIMIT).await?;
+        if !status.is_success() {
+            return Err(if status.is_client_error() {
+                reconnect()
+            } else {
+                AgentError::msg("the gateway could not approve this external connection; try again")
+            });
+        }
+        let identity: DelegationIdentity = serde_json::from_slice(&body).map_err(|_| {
+            AgentError::msg("the gateway returned an unreadable delegation approval")
+        })?;
+        if identity.delegation_id != id.to_string()
+            || identity.resource != self.gateway.resource
+            || owner.as_str().strip_prefix("user:") != Some(identity.user_id.as_str())
+        {
+            return Err(AgentError::InvalidTarget(
+                "the gateway approved a different external connection".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn live_handshake(&self, owner: &OwnerId, grant: CodeGrantId) -> Result<CodeHandshakeId> {
+        let row = tidebreak_core::db::code::get_external_grant(&self.db, owner, grant)
+            .await?
+            .ok_or_else(reconnect)?;
+        if row.revoked_at.is_some() {
+            // The durable local refusal applies even when the gateway is down.
+            if let Err(error) = self.revoke(owner, grant).await {
+                tracing::warn!(%grant, %error, "gateway delegation revocation will retry on the next request");
+            }
+            return Err(reconnect());
+        }
+        let handshake =
+            tidebreak_core::db::code::completed_connect_handshake_for_grant(&self.db, owner, grant)
+                .await?
+                .ok_or_else(reconnect)?;
+        Ok(handshake.id)
+    }
+
+    /// Validate durable consent before serving even a fresh cached token.
+    pub async fn for_grant(&self, owner: &OwnerId, grant: CodeGrantId) -> Result<Arc<OboGateway>> {
+        let handshake = self.live_handshake(owner, grant).await?;
+        let slot = {
+            let mut slots = self
+                .slots
+                .lock()
+                .map_err(|_| AgentError::msg("external delegation state is unavailable"))?;
+            slots
+                .entry(grant)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(None)))
+                .clone()
+        };
+        let mut held = slot.lock().await;
+        if let Some(current) = held.as_ref() {
+            if current.expires_at > unix_time().saturating_add(EXPIRY_LEEWAY_SECONDS) {
+                return Ok(current.gateway.clone());
+            }
+        }
+        let response = self
+            .gateway
+            .client
+            .post(self.endpoint(&format!("/{handshake}/token"))?)
+            .json(&self.machine_auth()?)
+            .send()
+            .await
+            .map_err(|error| {
+                AgentError::msg(format!("gateway delegation token request failed: {error}"))
+            })?;
+        let status = response.status();
+        let body = read_bounded(response, RESPONSE_LIMIT).await?;
+        if !status.is_success() {
+            *held = None;
+            return Err(if status.is_client_error() {
+                reconnect()
+            } else {
+                AgentError::msg(
+                    "the gateway could not issue an external connection token; try again",
+                )
+            });
+        }
+        let token: DelegationToken = serde_json::from_slice(&body).map_err(|_| {
+            AgentError::msg("the gateway returned an unreadable external connection token")
+        })?;
+        if owner.as_str().strip_prefix("user:") != Some(token.user_id.as_str())
+            || token.resource != self.gateway.resource
+            || token.token_type != "Bearer"
+            || token.access_token.is_empty()
+            || token.expires_in == 0
+        {
+            return Err(AgentError::InvalidTarget(
+                "the gateway issued a token for a different external connection".into(),
+            ));
+        }
+        // A revoke may commit while the mint is in flight. Recheck before
+        // publishing its result into the slot or using it for an exchange.
+        self.live_handshake(owner, grant).await?;
+        let gateway = Arc::new(OboGateway::new(
+            &self.gateway.gateway_base_url,
+            self.gateway.resource.clone(),
+        )?);
+        gateway.record_caller(owner, token.access_token.into());
+        *held = Some(DelegatedGateway {
+            expires_at: unix_time().saturating_add(token.expires_in),
+            gateway: gateway.clone(),
+        });
+        Ok(gateway)
+    }
+
+    /// Bound sessions always use their grant; an ordinary session retains
+    /// its browser credential path. Multiple grants never choose by order.
+    pub async fn for_session(
+        &self,
+        owner: &OwnerId,
+        session: SessionId,
+    ) -> Result<Option<Arc<OboGateway>>> {
+        let bindings =
+            tidebreak_core::db::code::list_bindings_for_session(&self.db, owner, session).await?;
+        let Some(first) = bindings.first() else {
+            return Ok(None);
+        };
+        if bindings
+            .iter()
+            .any(|binding| binding.grant_id != first.grant_id)
+        {
+            return Err(AgentError::InvalidTarget(
+                "this session has conflicting external connections".into(),
+            ));
+        }
+        self.for_grant(owner, first.grant_id).await.map(Some)
+    }
+
+    /// Local revocation commits first. This removes cached authority and
+    /// revokes the gateway's delegation with the machine identity.
+    pub async fn revoke(&self, owner: &OwnerId, grant: CodeGrantId) -> Result<()> {
+        if let Ok(mut slots) = self.slots.lock() {
+            slots.remove(&grant);
+        }
+        if self
+            .revoked
+            .lock()
+            .is_ok_and(|revoked| revoked.contains(&grant))
+        {
+            return Ok(());
+        }
+        let Some(handshake) =
+            tidebreak_core::db::code::completed_connect_handshake_for_grant(&self.db, owner, grant)
+                .await?
+        else {
+            return Ok(());
+        };
+        let response = self
+            .gateway
+            .client
+            .post(self.endpoint(&format!("/{}/revoke", handshake.id))?)
+            .json(&self.machine_auth()?)
+            .send()
+            .await
+            .map_err(|error| {
+                AgentError::msg(format!("gateway delegation revocation failed: {error}"))
+            })?;
+        if response.status().is_success() {
+            if let Ok(mut revoked) = self.revoked.lock() {
+                revoked.insert(grant);
+            }
+            Ok(())
+        } else {
+            Err(AgentError::msg(
+                "the gateway could not revoke this external connection",
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tidebreak-server/src/obo_gateway/external/tests.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external/tests.rs
@@ -1,0 +1,524 @@
+use super::*;
+use crate::code::{harness_llm::HarnessLlmRelay, runtime::CodeRuntime};
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Json, Router,
+};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+const USER: &str = "26fecc98-0998-4f3b-a302-cafce9b8dd68";
+const RESOURCE: &str = "tidebreak:test-machine";
+
+#[derive(Clone, Default)]
+struct Gateway {
+    approvals: Arc<AtomicUsize>,
+    mints: Arc<AtomicUsize>,
+    revokes: Arc<AtomicUsize>,
+    failed: Arc<AtomicBool>,
+    wrong_owner: Arc<AtomicBool>,
+    wrong_machine: Arc<AtomicBool>,
+    enrolled: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+}
+
+async fn gateway() -> (String, Gateway) {
+    let state = Gateway::default();
+    let router = Router::new()
+        .route("/api/v1/tidebreak/external-delegations", post(|State(state): State<Gateway>, headers: HeaderMap, Json(body): Json<serde_json::Value>| async move {
+            assert_eq!(headers.get("authorization").unwrap(), "Bearer browser-owner");
+            assert_eq!(body["resource"], RESOURCE);
+            state.approvals.fetch_add(1, Ordering::SeqCst);
+            state.enrolled.lock().unwrap().insert(body["delegation_id"].as_str().unwrap().to_owned());
+            Json(serde_json::json!({"delegation_id": body["delegation_id"], "resource": RESOURCE, "user_id": USER}))
+        }))
+        .route("/api/v1/tidebreak/external-delegations/{id}/token", post(|State(state): State<Gateway>, Path(id): Path<String>, Json(body): Json<serde_json::Value>| async move {
+            assert_eq!(body["client_id"], "tidebreak");
+            assert_eq!(body["client_secret"], "test-machine-secret");
+            assert_eq!(body["resource"], RESOURCE);
+            if !state.enrolled.lock().unwrap().contains(&id) { return StatusCode::NOT_FOUND.into_response(); }
+            let minted = state.mints.fetch_add(1, Ordering::SeqCst) + 1;
+            Json(serde_json::json!({
+                "access_token": format!("delegated-{minted}"), "token_type": "Bearer", "expires_in": 600,
+                "user_id": if state.wrong_owner.load(Ordering::SeqCst) { "someone-else" } else { USER },
+                "resource": if state.wrong_machine.load(Ordering::SeqCst) { "tidebreak:another-machine" } else { RESOURCE },
+            })).into_response()
+        }))
+        .route("/api/v1/tidebreak/external-delegations/{id}/revoke", post(|State(state): State<Gateway>, Path(id): Path<String>, Json(body): Json<serde_json::Value>| async move {
+            assert_eq!(body["client_secret"], "test-machine-secret");
+            if state.failed.load(Ordering::SeqCst) { return StatusCode::SERVICE_UNAVAILABLE; }
+            state.revokes.fetch_add(1, Ordering::SeqCst);
+            state.enrolled.lock().unwrap().remove(&id);
+            StatusCode::NO_CONTENT
+        }))
+        .route("/oauth/token", post(|axum::Form(body): axum::Form<HashMap<String, String>>| async move {
+            assert!(body["subject_token"].starts_with("delegated-"), "a browser token must never supply external inference");
+            Json(serde_json::json!({"access_token": format!("llm-{}", body["subject_token"]), "expires_in": 600}))
+        }))
+        .route("/compat/openai/v1/responses", post(|headers: HeaderMap| async move {
+            headers.get("authorization").unwrap().to_str().unwrap().to_owned()
+        }))
+        .route("/api/v1/tidebreak/git-forge", axum::routing::get(|headers: HeaderMap| async move {
+            assert!(headers.get("authorization").unwrap().to_str().unwrap().starts_with("Bearer delegated-"));
+            Json(serde_json::json!({"app_name":"forge", "attribution":"person", "acts_as":"slack-owner", "display_name":"Slack Owner", "commit_email":"owner@example.com"}))
+        }))
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    (base, state)
+}
+
+fn obo(base: &str) -> Arc<OboGateway> {
+    let mut gateway = OboGateway::new(base, RESOURCE.into()).unwrap();
+    gateway.machine_credentials = Some(("tidebreak".into(), "test-machine-secret".into()));
+    Arc::new(gateway)
+}
+
+async fn setup() -> (
+    tempfile::TempDir,
+    Arc<DbStore>,
+    CodeRuntime,
+    Arc<OboGateway>,
+    String,
+    Gateway,
+    OwnerId,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("code.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let (base, state) = gateway().await;
+    let gateway = obo(&base);
+    let owner = OwnerId::new(&format!("user:{USER}")).unwrap();
+    gateway.record_caller(&owner, "browser-owner".into());
+    let relay =
+        Arc::new(HarnessLlmRelay::new(gateway.clone()).with_external_delegations(db.clone()));
+    let runtime = CodeRuntime::new(
+        db.clone(),
+        dir.path().to_path_buf(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(relay),
+    );
+    (dir, db, runtime, gateway, base, state, owner)
+}
+
+fn approval_lease() -> crate::auth::GatewayAuthLease {
+    crate::auth::GatewayAuthLease::for_test(
+        crate::principal::Principal::User {
+            id: crate::principal::UserId::new(USER).unwrap(),
+            role: crate::principal::Role::Member,
+        },
+        "browser-owner".into(),
+    )
+}
+
+async fn connect(runtime: &CodeRuntime, owner: &OwnerId) -> tidebreak_core::CodeExternalGrant {
+    let (_, nonce, confirm) = runtime
+        .start_connect_handshake("slack", "U1", "T1", "Thet", "Workspace", None)
+        .await
+        .unwrap();
+    let (_, csrf) = runtime
+        .view_connect_handshake(owner, &nonce)
+        .await
+        .unwrap()
+        .unwrap();
+    runtime
+        .approve_connect_handshake(owner, &nonce, &csrf, Some(&approval_lease()))
+        .await
+        .unwrap()
+        .unwrap();
+    runtime
+        .complete_connect_handshake(&nonce, &confirm)
+        .await
+        .unwrap()
+        .unwrap()
+        .0
+}
+
+#[tokio::test]
+async fn completed_connection_survives_restart_and_refreshes_without_browser_credentials() {
+    let (_dir, db, runtime, _browser, base, state, owner) = setup().await;
+    _browser.record_caller(&owner, "second-browser-session".into());
+    let grant = connect(&runtime, &owner).await;
+    let restarted = ExternalDelegations::new(obo(&base), db);
+    let first = restarted.for_grant(&owner, grant.id).await.unwrap();
+    assert_eq!(first.bearer_for(&owner).await.unwrap(), "llm-delegated-1");
+    assert_eq!(
+        restarted
+            .for_grant(&owner, grant.id)
+            .await
+            .unwrap()
+            .bearer_for(&owner)
+            .await
+            .unwrap(),
+        "llm-delegated-1"
+    );
+    assert_eq!(state.mints.load(Ordering::SeqCst), 1);
+    let slot = restarted
+        .slots
+        .lock()
+        .unwrap()
+        .get(&grant.id)
+        .unwrap()
+        .clone();
+    slot.lock().await.as_mut().unwrap().expires_at = 0;
+    assert_eq!(
+        restarted
+            .for_grant(&owner, grant.id)
+            .await
+            .unwrap()
+            .bearer_for(&owner)
+            .await
+            .unwrap(),
+        "llm-delegated-2"
+    );
+}
+
+#[tokio::test]
+async fn browser_credentials_cannot_mask_missing_or_unconfirmed_delegation() {
+    let (_dir, db, runtime, browser, _base, state, owner) = setup().await;
+    let (unconfirmed, nonce, _) = runtime
+        .start_connect_handshake("slack", "U1", "T1", "Thet", "Workspace", None)
+        .await
+        .unwrap();
+    let (_, csrf) = runtime
+        .view_connect_handshake(&owner, &nonce)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(runtime
+        .approve_connect_handshake(&owner, &nonce, "wrong csrf", Some(&approval_lease()))
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(state.approvals.load(Ordering::SeqCst), 0);
+    assert!(runtime
+        .approve_connect_handshake(&owner, &nonce, &csrf, None)
+        .await
+        .is_err());
+    let wrong_owner = crate::auth::GatewayAuthLease::for_test(
+        crate::principal::Principal::LocalOwner,
+        "browser-owner".into(),
+    );
+    assert!(runtime
+        .approve_connect_handshake(&owner, &nonce, &csrf, Some(&wrong_owner))
+        .await
+        .is_err());
+    assert_eq!(state.approvals.load(Ordering::SeqCst), 0);
+    runtime
+        .approve_connect_handshake(&owner, &nonce, &csrf, Some(&approval_lease()))
+        .await
+        .unwrap()
+        .unwrap();
+    let (grant, _) = runtime
+        .mint_adapter_grant(&owner, "slack", "U2", "T1")
+        .await
+        .unwrap();
+    let error = runtime
+        .external_get_or_create(
+            &owner,
+            grant.id,
+            "slack",
+            "T1/C1/legacy",
+            tidebreak_core::RepoId::new(),
+            None,
+            tidebreak_core::HarnessKind::ClaudeCode,
+            crate::code::runtime::NewSessionSettings::default(),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "external_reconnect_required");
+    assert!(error.message().contains("reconnect"));
+    assert_eq!(error.into_response().status(), StatusCode::CONFLICT);
+    let delegated = ExternalDelegations::new(browser, db);
+    assert!(matches!(
+        delegated.for_grant(&owner, grant.id).await,
+        Err(AgentError::SignInRequired(_))
+    ));
+    assert_eq!(state.mints.load(Ordering::SeqCst), 0);
+    assert!(unconfirmed.grant_id.is_none());
+    let completed = connect(&runtime, &owner).await;
+    state.enrolled.lock().unwrap().clear();
+    assert!(matches!(
+        delegated.for_grant(&owner, completed.id).await,
+        Err(AgentError::SignInRequired(_))
+    ));
+}
+
+#[tokio::test]
+async fn revocation_denies_cached_authority_and_retries_after_restart() {
+    let (_dir, db, runtime, browser, base, state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let delegated = ExternalDelegations::new(browser, db.clone());
+    delegated
+        .for_grant(&owner, grant.id)
+        .await
+        .unwrap()
+        .bearer_for(&owner)
+        .await
+        .unwrap();
+    state.failed.store(true, Ordering::SeqCst);
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "owner disconnected Slack")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        delegated.for_grant(&owner, grant.id).await,
+        Err(AgentError::SignInRequired(_))
+    ));
+    assert_eq!(state.revokes.load(Ordering::SeqCst), 0);
+    state.failed.store(false, Ordering::SeqCst);
+    let restarted = ExternalDelegations::new(obo(&base), db);
+    restarted.reconcile_revocations().await.unwrap();
+    assert_eq!(state.revokes.load(Ordering::SeqCst), 1);
+    restarted.reconcile_revocations().await.unwrap();
+    assert_eq!(state.revokes.load(Ordering::SeqCst), 1);
+    assert!(matches!(
+        restarted.for_grant(&owner, grant.id).await,
+        Err(AgentError::SignInRequired(_))
+    ));
+}
+
+#[tokio::test]
+async fn grant_and_gateway_responses_cannot_cross_owner_or_machine() {
+    let (_dir, db, runtime, browser, _base, state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let delegated = ExternalDelegations::new(browser, db);
+    assert!(matches!(
+        delegated.for_grant(&OwnerId::local(), grant.id).await,
+        Err(AgentError::SignInRequired(_))
+    ));
+    assert_eq!(state.mints.load(Ordering::SeqCst), 0);
+    state.wrong_owner.store(true, Ordering::SeqCst);
+    assert!(matches!(
+        delegated.for_grant(&owner, grant.id).await,
+        Err(AgentError::InvalidTarget(_))
+    ));
+    state.wrong_owner.store(false, Ordering::SeqCst);
+    state.wrong_machine.store(true, Ordering::SeqCst);
+    assert!(matches!(
+        delegated.for_grant(&owner, grant.id).await,
+        Err(AgentError::InvalidTarget(_))
+    ));
+}
+
+#[tokio::test]
+async fn first_relay_request_after_restart_uses_the_persisted_session_grant() {
+    use crate::code::harness_llm::{HarnessLlmSubject, RelayEndpoint};
+    use tidebreak_core::{
+        Attention, AttentionSource, ExecutionLocation, HarnessKind, PermissionMode, Session,
+        SessionKind, SessionLifecycle, SessionVisibility,
+    };
+    let (_dir, db, runtime, _browser, base, state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let session = Session {
+        id: SessionId::new(),
+        owner: owner.clone(),
+        workspace_id: None,
+        kind: SessionKind::Interactive,
+        harness_kind: HarnessKind::ClaudeCode,
+        harness_version: None,
+        harness_resume_ref: None,
+        permission_mode: PermissionMode::default(),
+        model: None,
+        reasoning_effort: None,
+        fast_mode: false,
+        lifecycle: SessionLifecycle::Idle,
+        fence_reason: None,
+        child_pid: None,
+        child_process_identity: None,
+        spawn_epoch: 1,
+        attention: Attention::working(AttentionSource::Lifecycle),
+        unrecognized_event_count: 0,
+        subagents: Vec::new(),
+        created_at: chrono::Utc::now(),
+        visibility: SessionVisibility::Private,
+        execution_location: ExecutionLocation::Machine,
+    };
+    let resolution = tidebreak_core::db::code::resolve_external_machine_session(
+        &db,
+        &owner,
+        grant.id,
+        "slack",
+        "T1/C1/1.1",
+        &session,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        resolution,
+        tidebreak_core::ExternalSessionResolution::Created(_)
+    ));
+    let loser = Session {
+        id: SessionId::new(),
+        ..session.clone()
+    };
+    let resolution = tidebreak_core::db::code::resolve_external_machine_session(
+        &db,
+        &owner,
+        grant.id,
+        "slack",
+        "T1/C1/1.1",
+        &loser,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        resolution,
+        tidebreak_core::ExternalSessionResolution::Existing(_)
+    ));
+    assert!(tidebreak_core::db::code::get_session(&db, &owner, loser.id)
+        .await
+        .unwrap()
+        .is_none());
+    let restarted = HarnessLlmRelay::new(obo(&base)).with_external_delegations(db.clone());
+    let key = restarted.issue(HarnessLlmSubject {
+        owner: owner.clone(),
+        session: session.id,
+    });
+    let mut headers = HeaderMap::new();
+    headers.insert("authorization", format!("Bearer {key}").parse().unwrap());
+    let response = restarted
+        .forward(
+            RelayEndpoint::OpenAiResponses,
+            &headers,
+            None,
+            axum::body::Body::empty(),
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 4096)
+        .await
+        .unwrap();
+    assert_eq!(body.as_ref(), b"Bearer llm-delegated-1");
+    assert_eq!(state.mints.load(Ordering::SeqCst), 1);
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "disconnect")
+        .await
+        .unwrap();
+    let response = restarted
+        .forward(
+            RelayEndpoint::OpenAiResponses,
+            &headers,
+            None,
+            axum::body::Body::empty(),
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn first_external_worker_after_restart_names_the_owner_before_workspace_setup() {
+    use tidebreak_core::{CodeRepo, HarnessKind, RepoId};
+    use tidebreak_harness::AdapterRegistry;
+    let (dir, db, runtime, _browser, base, _state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let repo_root = dir.path().join("source");
+    std::fs::create_dir_all(&repo_root).unwrap();
+    for args in [
+        vec!["init", "-b", "main"],
+        vec![
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+    ] {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo_root)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let repo = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: repo_root.display().to_string(),
+        display_name: "Source".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "test/".into(),
+        setup_script: Some("git var GIT_AUTHOR_IDENT > setup-author.txt".into()),
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: chrono::Utc::now(),
+        removed_at: None,
+        cloned_from: None,
+        origin_host: Some("github.com".into()),
+        origin_owner: Some("example".into()),
+        origin_name: Some("source".into()),
+    };
+    tidebreak_core::db::code::insert_repo(&db, &repo)
+        .await
+        .unwrap();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(
+        crate::scripted_harness::ScriptedAdapter::new(crate::scripted_harness::plain_text_script())
+            .with_approvals(tidebreak_core::CapLevel::Supported),
+    ));
+    let relay = Arc::new(HarnessLlmRelay::new(obo(&base)).with_external_delegations(db.clone()));
+    let restarted = Arc::new(
+        CodeRuntime::with_registry(db, dir.path().to_path_buf(), registry).with_harness_llm(relay),
+    );
+    restarted.start("http://127.0.0.1:1".into()).await.unwrap();
+    let result = restarted
+        .external_get_or_create(
+            &owner,
+            grant.id,
+            "slack",
+            "T1/C1/restarted",
+            repo.id,
+            Some("From Slack".into()),
+            HarnessKind::ClaudeCode,
+            crate::code::runtime::NewSessionSettings::default(),
+        )
+        .await
+        .unwrap();
+    let tidebreak_core::ExternalSessionResolution::Created(binding) = result else {
+        panic!("expected a new external session");
+    };
+    let session = restarted
+        .get_session(&owner, binding.session_id)
+        .await
+        .unwrap();
+    assert!(
+        session.spawn_epoch > 0,
+        "the worker must attach after the binding commits"
+    );
+    let workspace = restarted
+        .get_workspace(&owner, session.workspace_id.unwrap())
+        .await
+        .unwrap();
+    let author = std::fs::read_to_string(
+        std::path::Path::new(&workspace.worktree_path).join("setup-author.txt"),
+    )
+    .unwrap();
+    assert!(
+        author.starts_with("Slack Owner <owner@example.com>"),
+        "the setup script must run with delegated Git identity: {author}"
+    );
+}

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -68,6 +68,24 @@ criteria" and "Stage: scratch workspaces").
   requests ceilings at spawn; it does not own enforcement of them. Naming
   and versioning that contract is a dependency of stage 1, not a detail.
 
+## Hosted machine connections
+
+On a gateway-managed machine, a confirmed Slack connection retains a gateway
+delegation. The gateway stores the consent. Tidebreak stores the connection
+identifier and uses the machine's existing gateway identity to request
+short-lived tokens. Browser closure, browser token expiry, and a machine
+restart do not require another sign-in for the connection's machine sessions.
+Tidebreak checks the live local grant before each delegated inference, catalog,
+and Git credential request. Revoking or replacing the connection denies local
+access immediately. A retry sweep completes gateway revocation after an outage
+or restart. Revoking the source gateway sign-in also ends its delegation.
+
+Connections approved before gateway delegation support need approval again.
+A live browser sign-in cannot supply credentials for those old connections.
+When Slack reports that approval is required, send "reconnect" to Tidebreak and
+approve the connection. This replaces the old grant; existing sessions keep
+their original grant and do not acquire the replacement's authority.
+
 ## Bets and exit criteria
 
 Slack as a channel is a product conviction, not a bet under test: people


### PR DESCRIPTION
Slack sessions can lose gateway authorization after the approving browser closes, its token expires, or the machine restarts. A temporary gateway verifier failure also appears as a permanent sign-in failure.

This change enrolls gateway-owned consent during the existing connection approval flow and gives each external grant its own renewable gateway client. Session bindings are recorded before worker startup; inference, model discovery, and Git credentials check the live grant. Revocation retries after outages. Temporary 502/503/504 policy failures retry through the existing boot screen, while invalid credentials still fail closed.

The approval screen and session banner reuse Tidebreak's existing components and tokens. Approval directs you back to the initiating Slack conversation. The banner reports the actual execution location and links real Slack thread keys correctly.

Compatibility and rollout: deploy the companion Model Gateway delegation endpoints before this Tidebreak build. Existing Slack grants need one reconnect; old sessions retain their original grant and never inherit replacement authority. No owner refresh token or new machine secret is stored.

Validation: 41 focused Rust regressions passed, including first external worker startup without browser credentials and delegated Git identity during setup. Server/API Clippy, formatting, and diff checks pass. 42 focused UI tests, TypeScript, Biome, and Storybook build pass. Storybook captures cover four themes at desktop and narrow widths; DOM overflow checks pass. Image inspection is unavailable in this session, so visual review is not claimed. Changed-source secret scan passes.

Companion gateway change: brightwave-inc/model-gateway#1909. Live hosted rollout and Slack canary follow after both releases deploy.