### PR TITLE
improve(slack): keep approval results on their connection page

### DIFF
--- a/.github/actions/setup-sccache-s3/action.yml
+++ b/.github/actions/setup-sccache-s3/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Configure compiler cache environment
-      if: ${{ inputs.remote-cache-enabled == 'true' }}
+      if: ${{ inputs.remote-cache-enabled == 'true' && (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
       shell: bash
       env:
         CACHE_ACCESS: ${{ inputs.access }}
@@ -36,7 +36,7 @@ runs:
         } >> "$GITHUB_ENV"
 
     - name: Authenticate to the compiler cache
-      if: ${{ inputs.remote-cache-enabled == 'true' }}
+      if: ${{ inputs.remote-cache-enabled == 'true' && (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
       uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
       with:
         role-to-assume: ${{ inputs.access == 'write' && 'arn:aws:iam::767397701846:role/bw-github-ci-sccache-write-role' || 'arn:aws:iam::767397701846:role/bw-github-ci-sccache-read-role' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1927,8 +1927,19 @@ jobs:
 
       - name: Install Linux packaging dependencies
         timeout-minutes: 8
+        env:
+          RELEASE_SHA: ${{ needs.validate.outputs.sha }}
+          RELEASE_WORKFLOW_SHA: ${{ github.sha }}
         run: |
-          scripts/install-linux-apt-packages.sh \
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || {
+            echo "Release checkout does not match the validated commit." >&2
+            exit 1
+          }
+          git fetch --no-tags --depth=1 origin "$RELEASE_WORKFLOW_SHA"
+          installer="$RUNNER_TEMP/tidebreak-install-linux-apt-packages.sh"
+          git show "$RELEASE_WORKFLOW_SHA:scripts/install-linux-apt-packages.sh" > "$installer"
+          bash "$installer" \
             build-essential \
             cmake \
             file \
@@ -1939,6 +1950,10 @@ jobs:
             libxdo-dev \
             patchelf \
             xdg-utils
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || {
+            echo "Dependency installation changed the release checkout." >&2
+            exit 1
+          }
 
       - name: Set up compiler cache
         uses: ./.github/actions/setup-sccache-s3

--- a/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.reuse.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.reuse.dom.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  createHashHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CodeConnectPage } from "./api";
+
+const mocks = vi.hoisted(() => ({
+  client: {
+    getCodeConnectPage: vi.fn(),
+    approveCodeConnect: vi.fn(),
+  },
+}));
+vi.mock("./AppContext", () => ({
+  useApp: () => ({ client: mocks.client }),
+}));
+
+import { ConnectApprovalRoute } from "./ConnectApprovalRoute";
+
+function routerAt(nonce: string) {
+  window.history.replaceState(null, "", "/#/connect/" + nonce);
+  const root = createRootRoute({ component: Outlet });
+  const approval = createRoute({
+    getParentRoute: () => root,
+    path: "/connect/$nonce",
+    component: ConnectApprovalRoute,
+  });
+  return createRouter({
+    routeTree: root.addChildren([approval]),
+    history: createHashHistory(),
+    defaultPreload: false,
+  });
+}
+
+function pendingApproval() {
+  let resolve!: () => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<void>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  mocks.client.approveCodeConnect.mockReturnValue(promise);
+  return { resolve, reject };
+}
+
+beforeEach(() => {
+  vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+  mocks.client.getCodeConnectPage.mockImplementation(
+    async (nonce: string): Promise<CodeConnectPage> => ({
+      channel_kind: "slack",
+      display_name: nonce,
+      workspace_name: "Test workspace",
+      state: "pending",
+      csrf: "csrf-" + nonce,
+      expires_at: "2026-09-06T00:00:00Z",
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  window.history.replaceState(null, "", "/");
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe.each([
+  { path: "A to B", intermediate: false, nonce: "nonce-b" },
+  { path: "A to B to A", intermediate: true, nonce: "nonce-a" },
+])("ConnectApprovalRoute navigating $path", ({ intermediate, nonce }) => {
+  it.each(["resolve", "reject"] as const)(
+    "keeps a replacement link ready when the previous approval later %ss",
+    async (outcome) => {
+      const pending = pendingApproval();
+      const router = routerAt("nonce-a");
+      await router.load();
+      render(<RouterProvider router={router} />);
+      await screen.findByRole("heading", { name: "nonce-a" });
+      await userEvent
+        .setup()
+        .click(screen.getByRole("button", { name: "Yes, this is me" }));
+      expect(mocks.client.approveCodeConnect).toHaveBeenCalledWith(
+        "nonce-a",
+        "csrf-nonce-a",
+      );
+
+      // Connect links differ only in their fragment when the tab is reused.
+      await act(async () => {
+        window.location.hash = "/connect/nonce-b";
+      });
+      await screen.findByRole("heading", { name: "nonce-b" });
+      if (intermediate) {
+        await act(async () => {
+          window.location.hash = "/connect/nonce-a";
+        });
+        await screen.findByRole("heading", { name: "nonce-a" });
+      }
+      await act(async () => {
+        if (outcome === "resolve") pending.resolve();
+        else pending.reject(new Error("The earlier approval failed"));
+      });
+
+      expect(screen.queryByText(/Approved\. To finish connecting/)).toBeNull();
+      expect(screen.queryByRole("alert")).toBeNull();
+      mocks.client.approveCodeConnect.mockResolvedValue(undefined);
+      await userEvent
+        .setup()
+        .click(screen.getByRole("button", { name: "Yes, this is me" }));
+      expect(mocks.client.approveCodeConnect).toHaveBeenLastCalledWith(
+        nonce,
+        "csrf-" + nonce,
+      );
+      expect(
+        await screen.findByText(/Approved\. To finish connecting/),
+      ).toBeTruthy();
+    },
+  );
+});

--- a/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ConnectApprovalRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams } from "@tanstack/react-router";
 
 import { useApp } from "./AppContext";
@@ -32,6 +32,7 @@ export function ConnectApprovalRoute() {
   const [phase, setPhase] = useState<ConnectApprovalPhase>("loading");
   const [error, setError] = useState<string | null>(null);
   const [loadAttempt, setLoadAttempt] = useState(0);
+  const approvalVersion = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -50,17 +51,21 @@ export function ConnectApprovalRoute() {
     })();
     return () => {
       cancelled = true;
+      approvalVersion.current += 1;
     };
   }, [client, loadAttempt, nonce]);
 
   async function approve() {
     if (!page) return;
+    const version = approvalVersion.current;
     setPhase("approving");
     setError(null);
     try {
       await client.approveCodeConnect(nonce, page.csrf);
+      if (approvalVersion.current !== version) return;
       setPhase("approved");
     } catch {
+      if (approvalVersion.current !== version) return;
       setError("The connect request could not be approved. Try again.");
       setPhase("ready");
     }

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -305,11 +305,14 @@ validated release tag before the updater private key enters the step
 environment, then signs and collects only the completed package bytes. The
 compile step can write S3 cache entries without receiving the updater key.
 
-Hosted `ubuntu-22.04` runners pin apt at `azure.archive.ubuntu.com`, which can
-stall on `apt-get update` for most of the 90-minute job. The packaging step
-rewrites that mirror to `archive.ubuntu.com` (or `ports.ubuntu.com` on ARM),
-sets short apt timeouts, and fails the step in eight minutes if the public
-archive is also unreachable.
+The Linux packaging step extracts its dependency installer from the dispatching
+workflow SHA while keeping application HEAD at the validated release SHA. Default
+amd64 downloads use HTTPS Ubuntu endpoints, then kernel.org if needed. Each
+mirror gets 60 seconds for indexes and 100 seconds for downloads, with a
+five-second termination grace per phase. The 340-second download bound leaves
+time for the final `--no-download` install within the eight-minute step. ARM and
+explicit endpoint overrides keep their existing installation path. APT signature
+checks stay enabled.
 
 The public download contract is rooted at:
 

--- a/scripts/install-linux-apt-packages.sh
+++ b/scripts/install-linux-apt-packages.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
-# Install Linux CI/release packages without stalling on a dead Azure mirror.
+# Use HTTPS Ubuntu archives for Linux CI and release dependencies.
 #
-# Hosted ubuntu-22.04 runners pin apt to azure.archive.ubuntu.com. That mirror
-# regularly returns Ign: for InRelease and package payloads and can hang far
-# longer than a healthy archive.ubuntu.com fetch. Point apt at the public
-# Ubuntu archive first, then install with short timeouts and a few retries.
+# Hosted runner mirrors can stall on HTTP requests. Normalize Ubuntu sources
+# to official HTTPS endpoints, then install with short timeouts and retries.
 set -euo pipefail
 
 if (($# == 0)); then
@@ -62,11 +60,11 @@ fi
 
 case "$arch" in
 amd64)
-  archive_url="${TIDEBREAK_APT_ARCHIVE_URL:-http://archive.ubuntu.com/ubuntu}"
-  security_url="${TIDEBREAK_APT_SECURITY_URL:-http://security.ubuntu.com/ubuntu}"
+  archive_url="${TIDEBREAK_APT_ARCHIVE_URL:-https://archive.ubuntu.com/ubuntu}"
+  security_url="${TIDEBREAK_APT_SECURITY_URL:-https://security.ubuntu.com/ubuntu}"
   ;;
 arm64)
-  archive_url="${TIDEBREAK_APT_ARCHIVE_URL:-http://ports.ubuntu.com/ubuntu-ports}"
+  archive_url="${TIDEBREAK_APT_ARCHIVE_URL:-https://ports.ubuntu.com/ubuntu-ports}"
   security_url="${TIDEBREAK_APT_SECURITY_URL:-$archive_url}"
   ;;
 *)
@@ -87,13 +85,16 @@ path = Path(sys.argv[1])
 archive_url = sys.argv[2]
 security_url = sys.argv[3]
 text = path.read_text()
-replacements = (
-    (r"https?://azure\.archive\.ubuntu\.com/ubuntu-ports", archive_url),
-    (r"https?://azure\.archive\.ubuntu\.com/ubuntu", archive_url),
-    (r"https?://security\.ubuntu\.com/ubuntu", security_url),
+ubuntu_source = re.compile(
+    r"https?://(?:(?P<security>security\.ubuntu\.com/ubuntu)"
+    r"|(?:azure\.)?archive\.ubuntu\.com/ubuntu(?:-ports)?"
+    r"|ports\.ubuntu\.com/ubuntu-ports)(?=/|\s|$)"
 )
-for pattern, replacement in replacements:
-    text = re.sub(pattern, replacement, text)
+# One pass preserves explicit overrides that name another Ubuntu endpoint.
+text = ubuntu_source.sub(
+    lambda match: security_url if match.group("security") else archive_url,
+    text,
+)
 path.write_text(text)
 ' "$file" "$archive_url" "$security_url"
 }

--- a/scripts/install-linux-apt-packages.sh
+++ b/scripts/install-linux-apt-packages.sh
@@ -2,7 +2,7 @@
 # Use HTTPS Ubuntu archives for Linux CI and release dependencies.
 #
 # Hosted runner mirrors can stall on HTTP requests. Normalize Ubuntu sources
-# to official HTTPS endpoints, then install with short timeouts and retries.
+# to HTTPS endpoints and use a second mirror when downloads stall.
 set -euo pipefail
 
 if (($# == 0)); then
@@ -101,9 +101,29 @@ path.write_text(text)
 
 run mkdir -p "$(dirname "$sources_list")" "$sources_dir" "$apt_conf_dir"
 
-if [[ -f "$sources_list" ]]; then
-  rewrite_ubuntu_sources "$sources_list"
-else
+shopt -s nullglob
+extra_sources=("$sources_dir"/*.list "$sources_dir"/*.sources)
+shopt -u nullglob
+
+has_ubuntu_source() {
+  python3 -c '
+from pathlib import Path
+import re
+import sys
+
+for name in sys.argv[3:]:
+    if not name:
+        continue
+    text = "\n".join(line for line in Path(name).read_text().splitlines()
+                     if not line.lstrip().startswith("#"))
+    if (re.search(r"https?://(?:[\w.-]+\.)?ubuntu\.com/ubuntu(?:-ports)?|mirror\+file:\S*/apt-mirrors\.txt", text)
+            or any(url in text for url in sys.argv[1:3])):
+        sys.exit(0)
+sys.exit(1)
+' "$archive_url" "$security_url" "${extra_sources[@]:-}"
+}
+
+if [[ ! -f "$sources_list" ]] && ! has_ubuntu_source; then
   cat <<SOURCES | run tee "$sources_list" >/dev/null
 deb $archive_url $codename main restricted universe multiverse
 deb $archive_url $codename-updates main restricted universe multiverse
@@ -112,15 +132,17 @@ deb $security_url $codename-security main restricted universe multiverse
 SOURCES
 fi
 
-shopt -s nullglob
-for file in "$sources_dir"/*.list "$sources_dir"/*.sources; do
-  rewrite_ubuntu_sources "$file"
-done
-shopt -u nullglob
+configure_sources() {
+  rewrite_ubuntu_sources "$sources_list"
+  for file in "${extra_sources[@]:-}"; do
+    rewrite_ubuntu_sources "$file"
+  done
+  if [[ -e "$mirrors_file" || -n "$root" ]]; then
+    printf '%s\tpriority:1\n' "$archive_url" | run tee "$mirrors_file" >/dev/null
+  fi
+}
 
-if [[ -e "$mirrors_file" || -n "$root" ]]; then
-  printf '%s\tpriority:1\n' "$archive_url" | run tee "$mirrors_file" >/dev/null
-fi
+configure_sources
 
 cat <<CONF | run tee "$apt_conf_dir/99tidebreak-ci" >/dev/null
 Acquire::Retries "3";
@@ -144,5 +166,30 @@ if [[ -n "${TIDEBREAK_APT_DRY_RUN:-}" ]]; then
   exit 0
 fi
 
-run apt-get "${apt_opts[@]}" update
-run apt-get "${apt_opts[@]}" install -y --no-install-recommends "$@"
+if [[ "$arch" != amd64 || -n "${TIDEBREAK_APT_ARCHIVE_URL+x}" || -n "${TIDEBREAK_APT_SECURITY_URL+x}" ]]; then
+  run apt-get "${apt_opts[@]}" update
+  run apt-get "${apt_opts[@]}" install -y --no-install-recommends "$@"
+  exit 0
+fi
+
+# Bound network work separately so a timeout never interrupts dpkg.
+# Both mirrors together use at most 340 seconds, leaving time to install.
+download_packages() {
+  run timeout --kill-after=5s 60s apt-get "${apt_opts[@]}" \
+    -o APT::Update::Error-Mode=any update &&
+    run timeout --kill-after=5s 100s apt-get "${apt_opts[@]}" \
+      install --download-only -y --no-install-recommends "$@"
+}
+
+if ! download_packages "$@"; then
+  echo "Ubuntu downloads did not finish; trying the HTTPS kernel.org mirror." >&2
+  archive_url=https://mirrors.edge.kernel.org/ubuntu
+  security_url="$archive_url"
+  configure_sources
+  if ! download_packages "$@"; then
+    echo "Ubuntu dependency downloads failed on both HTTPS mirrors." >&2
+    exit 1
+  fi
+fi
+
+run apt-get "${apt_opts[@]}" install --no-download -y --no-install-recommends "$@"

--- a/scripts/install-linux-apt-packages.test.mjs
+++ b/scripts/install-linux-apt-packages.test.mjs
@@ -94,15 +94,15 @@ test("rewrites the Azure Ubuntu mirror to archive.ubuntu.com on amd64", () => {
     mirrors: "http://azure.archive.ubuntu.com/ubuntu\tpriority:1\n",
   });
 
-  assert.match(result.sources, /deb http:\/\/archive\.ubuntu\.com\/ubuntu jammy main/);
+  assert.match(result.sources, /deb https:\/\/archive\.ubuntu\.com\/ubuntu jammy main/);
   assert.doesNotMatch(result.sources, /azure\.archive\.ubuntu\.com/);
   assert.match(
     result.extraLists["ubuntu.sources"],
-    /URIs: http:\/\/archive\.ubuntu\.com\/ubuntu/,
+    /URIs: https:\/\/archive\.ubuntu\.com\/ubuntu/,
   );
   assert.equal(
     result.mirrors,
-    "http://archive.ubuntu.com/ubuntu\tpriority:1\n",
+    "https://archive.ubuntu.com/ubuntu\tpriority:1\n",
   );
   assert.match(result.conf, /Acquire::Retries "3";/);
   assert.match(result.conf, /Acquire::http::Timeout "20";/);
@@ -125,14 +125,14 @@ test("rewrites ARM runners to ports.ubuntu.com", () => {
     },
   });
 
-  assert.match(result.sources, /deb http:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/);
+  assert.match(result.sources, /deb https:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/);
   assert.match(
     result.extraLists["ubuntu.list"],
-    /deb http:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/,
+    /deb https:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/,
   );
   assert.equal(
     result.mirrors,
-    "http://ports.ubuntu.com/ubuntu-ports\tpriority:1\n",
+    "https://ports.ubuntu.com/ubuntu-ports\tpriority:1\n",
   );
 });
 
@@ -145,10 +145,10 @@ test("writes a public archive sources.list when none exists", () => {
   assert.equal(
     result.sources,
     [
-      "deb http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse",
-      "deb http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse",
-      "deb http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse",
-      "deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse",
+      "deb https://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse",
+      "deb https://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse",
+      "deb https://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse",
+      "deb https://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse",
       "",
     ].join("\n"),
   );
@@ -164,4 +164,94 @@ test("the helper is executable", () => {
   chmodSync(script, 0o755);
   const result = spawnSync("test", ["-x", script]);
   assert.equal(result.status, 0);
+});
+
+test("normalizes existing official Ubuntu HTTP sources to HTTPS", () => {
+  const result = runFixture({
+    arch: "amd64",
+    sources: [
+      "deb http://archive.ubuntu.com/ubuntu jammy main",
+      "deb http://security.ubuntu.com/ubuntu jammy-security main",
+      "deb http://custom.example/ubuntu jammy main",
+      "",
+    ].join("\n"),
+    extraLists: {
+      "ubuntu.sources":
+        "URIs: http://archive.ubuntu.com/ubuntu\nSuites: jammy jammy-updates\n",
+      "security.list":
+        "deb http://security.ubuntu.com/ubuntu jammy-security main\n",
+    },
+    mirrors: "http://archive.ubuntu.com/ubuntu\tpriority:1\n",
+  });
+
+  assert.equal(
+    result.sources,
+    [
+      "deb https://archive.ubuntu.com/ubuntu jammy main",
+      "deb https://security.ubuntu.com/ubuntu jammy-security main",
+      "deb http://custom.example/ubuntu jammy main",
+      "",
+    ].join("\n"),
+  );
+  assert.equal(
+    result.extraLists["ubuntu.sources"],
+    "URIs: https://archive.ubuntu.com/ubuntu\nSuites: jammy jammy-updates\n",
+  );
+  assert.equal(
+    result.extraLists["security.list"],
+    "deb https://security.ubuntu.com/ubuntu jammy-security main\n",
+  );
+  assert.equal(result.mirrors, "https://archive.ubuntu.com/ubuntu\tpriority:1\n");
+});
+
+test("normalizes existing Ubuntu ports HTTP sources to HTTPS", () => {
+  const result = runFixture({
+    arch: "arm64",
+    sources: "deb http://ports.ubuntu.com/ubuntu-ports jammy main\n",
+    extraLists: {
+      "ubuntu.sources":
+        "URIs: http://ports.ubuntu.com/ubuntu-ports\nSuites: jammy\n",
+    },
+  });
+
+  assert.equal(
+    result.sources,
+    "deb https://ports.ubuntu.com/ubuntu-ports jammy main\n",
+  );
+  assert.equal(
+    result.extraLists["ubuntu.sources"],
+    "URIs: https://ports.ubuntu.com/ubuntu-ports\nSuites: jammy\n",
+  );
+  assert.equal(
+    result.mirrors,
+    "https://ports.ubuntu.com/ubuntu-ports\tpriority:1\n",
+  );
+});
+
+test("preserves explicit endpoint overrides without rewriting their output", () => {
+  const result = runFixture({
+    arch: "amd64",
+    sources: [
+      "deb http://archive.ubuntu.com/ubuntu jammy main",
+      "deb https://security.ubuntu.com/ubuntu jammy-security main",
+      "",
+    ].join("\n"),
+    extraEnv: {
+      TIDEBREAK_APT_ARCHIVE_URL: "http://security.ubuntu.com/ubuntu",
+      TIDEBREAK_APT_SECURITY_URL: "http://archive.ubuntu.com/ubuntu",
+    },
+  });
+
+  assert.equal(
+    result.sources,
+    [
+      "deb http://security.ubuntu.com/ubuntu jammy main",
+      "deb http://archive.ubuntu.com/ubuntu jammy-security main",
+      "",
+    ].join("\n"),
+  );
+  assert.equal(
+    result.mirrors,
+    "http://security.ubuntu.com/ubuntu\tpriority:1\n",
+  );
 });

--- a/scripts/install-linux-apt-packages.test.mjs
+++ b/scripts/install-linux-apt-packages.test.mjs
@@ -94,7 +94,10 @@ test("rewrites the Azure Ubuntu mirror to archive.ubuntu.com on amd64", () => {
     mirrors: "http://azure.archive.ubuntu.com/ubuntu\tpriority:1\n",
   });
 
-  assert.match(result.sources, /deb https:\/\/archive\.ubuntu\.com\/ubuntu jammy main/);
+  assert.match(
+    result.sources,
+    /deb https:\/\/archive\.ubuntu\.com\/ubuntu jammy main/,
+  );
   assert.doesNotMatch(result.sources, /azure\.archive\.ubuntu\.com/);
   assert.match(
     result.extraLists["ubuntu.sources"],
@@ -121,11 +124,15 @@ test("rewrites ARM runners to ports.ubuntu.com", () => {
     arch: "arm64",
     sources: "deb http://azure.archive.ubuntu.com/ubuntu jammy main\n",
     extraLists: {
-      "ubuntu.list": "deb http://azure.archive.ubuntu.com/ubuntu-ports jammy main\n",
+      "ubuntu.list":
+        "deb http://azure.archive.ubuntu.com/ubuntu-ports jammy main\n",
     },
   });
 
-  assert.match(result.sources, /deb https:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/);
+  assert.match(
+    result.sources,
+    /deb https:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/,
+  );
   assert.match(
     result.extraLists["ubuntu.list"],
     /deb https:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/,
@@ -201,7 +208,10 @@ test("normalizes existing official Ubuntu HTTP sources to HTTPS", () => {
     result.extraLists["security.list"],
     "deb https://security.ubuntu.com/ubuntu jammy-security main\n",
   );
-  assert.equal(result.mirrors, "https://archive.ubuntu.com/ubuntu\tpriority:1\n");
+  assert.equal(
+    result.mirrors,
+    "https://archive.ubuntu.com/ubuntu\tpriority:1\n",
+  );
 });
 
 test("normalizes existing Ubuntu ports HTTP sources to HTTPS", () => {
@@ -253,5 +263,178 @@ test("preserves explicit endpoint overrides without rewriting their output", () 
   assert.equal(
     result.mirrors,
     "http://security.ubuntu.com/ubuntu\tpriority:1\n",
+  );
+});
+
+test("keeps an existing Ubuntu deb822 source without adding sources.list", () => {
+  const result = runFixture({
+    arch: "amd64",
+    sources: null,
+    extraLists: {
+      "ubuntu.sources": [
+        "Types: deb",
+        "URIs: mirror+file:/etc/apt/apt-mirrors.txt",
+        "Suites: jammy jammy-updates jammy-security",
+        "Components: main restricted universe multiverse",
+        "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg",
+        "",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(result.sources, null);
+  assert.match(
+    result.extraLists["ubuntu.sources"],
+    /Signed-By: \/usr\/share\/keyrings\/ubuntu-archive-keyring\.gpg/,
+  );
+  assert.match(
+    result.extraLists["ubuntu.sources"],
+    /Suites: jammy jammy-updates jammy-security/,
+  );
+});
+
+function runCommandFixture({ plan = {}, extraEnv = {} } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "tidebreak-apt-commands-"));
+  try {
+    const bin = join(root, "bin");
+    const log = join(root, "commands.json");
+    mkdirSync(bin);
+    mkdirSync(join(root, "etc/apt/sources.list.d"), { recursive: true });
+    writeFileSync(
+      join(root, "etc/apt/sources.list"),
+      "deb http://archive.ubuntu.com/ubuntu jammy main\n",
+    );
+    writeFileSync(log, "[]");
+    const stub = [
+      "#!" + process.execPath,
+      'const fs = require("node:fs");',
+      'const mode = require("node:path").basename(process.argv[1]);',
+      'if (mode === "id") { console.log("0"); process.exit(0); }',
+      "const args = process.argv.slice(2);",
+      "const log = process.env.TIDEBREAK_APT_COMMAND_LOG;",
+      'const records = JSON.parse(fs.readFileSync(log, "utf8"));',
+      'const stage = args.includes("update") ? "update" : args.includes("--download-only") ? "download" : "install";',
+      'const attempt = records.filter(row => row.command === "apt-get" && row.stage === stage).length;',
+      'const mirrors = fs.readFileSync(process.env.TIDEBREAK_APT_ROOT + "/etc/apt/apt-mirrors.txt", "utf8");',
+      "records.push({ command: mode, args, stage, mirrors });",
+      "fs.writeFileSync(log, JSON.stringify(records));",
+      'if (mode === "timeout") {',
+      '  const child = require("node:child_process").spawnSync(args[2], args.slice(3), { stdio: "inherit", env: process.env });',
+      "  process.exit(child.status ?? 1);",
+      "}",
+      "const plan = JSON.parse(process.env.TIDEBREAK_APT_COMMAND_PLAN);",
+      "process.exit(plan[stage]?.[attempt] ?? 0);",
+      "",
+    ].join("\n");
+    for (const name of ["id", "timeout", "apt-get"]) {
+      writeFileSync(join(bin, name), stub, { mode: 0o755 });
+    }
+    const result = spawnSync(script, ["libwebkit2gtk-4.1-dev", "mold"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: bin + ":" + process.env.PATH,
+        TIDEBREAK_APT_ROOT: root,
+        TIDEBREAK_APT_ARCH: "amd64",
+        TIDEBREAK_APT_CODENAME: "jammy",
+        TIDEBREAK_APT_DRY_RUN: "",
+        TIDEBREAK_APT_COMMAND_LOG: log,
+        TIDEBREAK_APT_COMMAND_PLAN: JSON.stringify(plan),
+        ...extraEnv,
+      },
+    });
+    const commands = JSON.parse(readFileSync(log, "utf8"));
+    return {
+      ...result,
+      commands,
+      apt: commands.filter((row) => row.command === "apt-get"),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("uses the HTTPS fallback after an index refresh times out", () => {
+  const result = runCommandFixture({ plan: { update: [124, 0] } });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(
+    result.apt.map((row) => row.stage),
+    ["update", "update", "download", "install"],
+  );
+  assert.equal(
+    result.apt[0].mirrors,
+    "https://archive.ubuntu.com/ubuntu\tpriority:1\n",
+  );
+  assert.equal(
+    result.apt[1].mirrors,
+    "https://mirrors.edge.kernel.org/ubuntu\tpriority:1\n",
+  );
+  for (const row of result.apt.filter((row) => row.stage === "update")) {
+    assert.ok(row.args.includes("APT::Update::Error-Mode=any"));
+  }
+  assert.ok(result.apt.at(-1).args.includes("--no-download"));
+});
+
+test("bounds both mirror download phases and preserves the package arguments", () => {
+  const result = runCommandFixture({ plan: { download: [124, 0] } });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(
+    result.apt.map((row) => row.stage),
+    ["update", "download", "update", "download", "install"],
+  );
+  assert.deepEqual(
+    result.commands
+      .filter((row) => row.command === "timeout")
+      .map((row) => row.args.slice(0, 2)),
+    [
+      ["--kill-after=5s", "60s"],
+      ["--kill-after=5s", "100s"],
+      ["--kill-after=5s", "60s"],
+      ["--kill-after=5s", "100s"],
+    ],
+  );
+  for (const row of result.apt.filter((row) => row.stage !== "update")) {
+    assert.deepEqual(row.args.slice(-2), ["libwebkit2gtk-4.1-dev", "mold"]);
+  }
+  assert.ok(result.apt.at(-1).args.includes("--no-download"));
+  assert.equal(result.commands.at(-1).command, "apt-get");
+});
+
+test("fails after both mirror refreshes fail without installing packages", () => {
+  const result = runCommandFixture({ plan: { update: [124, 100] } });
+  assert.equal(result.status, 1);
+  assert.deepEqual(
+    result.apt.map((row) => row.stage),
+    ["update", "update"],
+  );
+  assert.match(result.stderr, /failed on both HTTPS mirrors/);
+});
+
+test("does not retry a local installation failure on another mirror", () => {
+  const result = runCommandFixture({ plan: { install: [100] } });
+  assert.equal(result.status, 100);
+  assert.deepEqual(
+    result.apt.map((row) => row.stage),
+    ["update", "download", "install"],
+  );
+  assert.ok(result.apt.every((row) => !row.mirrors.includes("kernel.org")));
+  assert.equal(result.commands.at(-1).command, "apt-get");
+});
+
+test("keeps explicit endpoint overrides outside automatic mirror fallback", () => {
+  const result = runCommandFixture({
+    plan: { install: [100] },
+    extraEnv: { TIDEBREAK_APT_ARCHIVE_URL: "https://custom.example/ubuntu" },
+  });
+  assert.equal(result.status, 100);
+  assert.deepEqual(
+    result.apt.map((row) => row.stage),
+    ["update", "install"],
+  );
+  assert.ok(result.commands.every((row) => row.command === "apt-get"));
+  assert.ok(
+    result.apt.every(
+      (row) => row.mirrors === "https://custom.example/ubuntu\tpriority:1\n",
+    ),
   );
 });

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -166,6 +166,16 @@ const mutations = [
       ),
   },
   {
+    name: "compiler cache feature-branch dispatch OIDC access",
+    file: ".github/actions/setup-sccache-s3/action.yml",
+    expected: "manual feature-branch validation keeps compiler cache local",
+    mutate: (source) =>
+      source.replaceAll(
+        " && (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))",
+        "",
+      ),
+  },
+  {
     name: "self-host mutable runtime packages",
     file: "deploy/self-host/Dockerfile",
     expected: "self-host runtime installs packages from an immutable Debian snapshot",

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -2809,3 +2809,69 @@ test("the packaged desktop activates the signed updater feed", () => {
     /const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs\(5 \* 60\)/,
   );
 });
+
+test("Linux release dependencies use the workflow helper without moving application HEAD", () => {
+  const buildJob = workflowJob(workflows["release.yml"], "build_linux");
+  assert.match(
+    buildJob,
+    /uses: actions\/checkout@[^\n]+\n\s+with:\n\s+ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/,
+  );
+  const step = buildJob.match(
+    /- name: Install Linux packaging dependencies\n[\s\S]*?(?=\n      - (?:name:|uses:))/,
+  )?.[0];
+  assert.ok(step, "Linux dependency installation step must exist");
+  assert.match(step, /timeout-minutes: 8/);
+  assert.match(step, /RELEASE_SHA: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
+  assert.match(step, /RELEASE_WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(
+    step,
+    /git fetch --no-tags --depth=1 origin "\$RELEASE_WORKFLOW_SHA"/,
+  );
+  assert.match(
+    step,
+    /installer="\$RUNNER_TEMP\/tidebreak-install-linux-apt-packages\.sh"/,
+  );
+  assert.match(
+    step,
+    /git show "\$RELEASE_WORKFLOW_SHA:scripts\/install-linux-apt-packages\.sh" > "\$installer"/,
+  );
+  assert.doesNotMatch(
+    step,
+    /\bgit\s+(?:checkout|switch|reset|restore|read-tree)\b/,
+  );
+  const install = step.indexOf('bash "$installer"');
+  assert.ok(
+    install > step.indexOf('git show "$RELEASE_WORKFLOW_SHA:'),
+    "Extract the helper before running it",
+  );
+  const guards = [
+    ...step.matchAll(
+      /\[\[ "\$\(git rev-parse HEAD\)" == "\$RELEASE_SHA" \]\] \|\| \{\n\s+echo [^\n]+\n\s+exit 1\n\s+\}/g,
+    ),
+  ];
+  assert.equal(
+    guards.length,
+    2,
+    "Guard application HEAD before and after dependency installation",
+  );
+  assert.ok(guards[0].index < step.indexOf("git fetch"));
+  assert.ok(guards[1].index > install);
+  const packages = step
+    .slice(install, guards[1].index)
+    .split("\n")
+    .slice(1)
+    .map((line) => line.trim().replace(/\s*\\$/, ""))
+    .filter(Boolean);
+  assert.deepEqual(packages, [
+    "build-essential",
+    "cmake",
+    "file",
+    "libayatana-appindicator3-dev",
+    "librsvg2-dev",
+    "libssl-dev",
+    "libwebkit2gtk-4.1-dev",
+    "libxdo-dev",
+    "patchelf",
+    "xdg-utils",
+  ]);
+});

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -846,6 +846,29 @@ test("compiler caches use OIDC-scoped S3 access", () => {
   }
 });
 
+test("manual feature-branch validation keeps compiler cache local", () => {
+  const remoteGuard =
+    "if: ${{ inputs.remote-cache-enabled == 'true' && (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}";
+  const steps = compilerCacheAction.split(/^    - name: /m).slice(1);
+  for (const name of [
+    "Configure compiler cache environment",
+    "Authenticate to the compiler cache",
+  ]) {
+    const step = steps.find((entry) => entry.startsWith(name + "\n"));
+    assert.ok(
+      step?.includes(remoteGuard),
+      name + " must exclude off-default manual runs",
+    );
+  }
+  const install = steps.find((entry) => entry.startsWith("Install sccache\n"));
+  assert.ok(install, "every run must install the local compiler cache");
+  assert.doesNotMatch(install, /^      if:/m);
+  assert.doesNotMatch(
+    install,
+    /SCCACHE_BUCKET|configure-aws-credentials|role-to-assume/,
+  );
+});
+
 test("production secrets remain isolated to the release workflow", () => {
   const secretConsumers = Object.entries(workflows)
     .filter(([, source]) => source.includes("secrets."))


### PR DESCRIPTION
When a pending connection approval finishes after the tab opens another connection link, its response can mark the replacement page approved or display an unrelated error. Ignore approval responses after the route reloads, including when navigation returns to the original nonce. The approval screen and API contract stay the same.

Manual feature-branch CI uses local sccache without configuring S3 or requesting the protected AWS write role. Linux CI and release dependency installation normalize official Ubuntu sources to HTTPS and reuse existing Ubuntu deb822 files without creating duplicate sources.list entries.

For default amd64 endpoints, dependency downloads try Ubuntu first and kernel.org if the first attempt fails or times out. Each mirror gets 60 seconds for an index refresh and 100 seconds for download-only work, with a 5-second termination grace per phase. The 340-second upper bound leaves about 140 seconds within the existing 8-minute step for local installation. The final install uses --no-download outside the timeout wrapper, so fallback never kills or retries dpkg. Explicit endpoint overrides and ARM retain their existing installation path. Package arguments, APT signature verification, source Signed-By fields, retry settings, and IAM policy remain intact.

A frozen release loads only the dependency installer from the trusted workflow commit into RUNNER_TEMP. The job checks that application HEAD matches the validated release commit before and after installation. It fetches the installer without checking out the workflow commit, so a release retry can use repaired build infrastructure while its application source stays pinned.

Validation:
- All 8 focused approval tests pass. The four navigation regressions fail without the response guard. TypeScript and Biome checks pass.
- All 14 apt-helper tests and 49 workflow-security tests pass. Five source-layout and fallback contracts fail against the previous helper, including stubbed timeout, download failure, exhausted fallback, and local installation failure paths.
- The release workflow regression enforces the helper SHA, both application HEAD guards, the unchanged package list, and extraction without checkout. It fails against the previous workflow.
- Bash syntax, JavaScript formatting, and diff checks pass.
- Automatic PR CI validates the published head; no duplicate manual CI run is dispatched.
