### PR TITLE
feat: run hosted Slack sessions with isolated GitHub credentials

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -11,6 +11,10 @@ run-name: >-
 # to GHCR:
 #
 #   ghcr.io/brightwave-inc/tidebreak-server
+#   ghcr.io/brightwave-inc/tidebreak-supervised-agent
+#
+# Both images share verified tools and source. The supervised agent uses
+# Gateway's BYO startup contract and contains no server or renderer.
 #
 # The image is the same artifact deploy/self-host/docker-compose.yml builds
 # locally as `tidebreak-self-host:local`: the `tidebreak` binary with
@@ -95,9 +99,6 @@ concurrency:
   group: tidebreak-server-image-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag || 'latest-release' }}
   cancel-in-progress: false
 
-env:
-  SERVER_REPOSITORY: ghcr.io/${{ github.repository_owner }}/tidebreak-server
-
 jobs:
   resolve:
     name: resolve the release tag
@@ -110,6 +111,7 @@ jobs:
       build_sha: ${{ steps.decide.outputs.build_sha }}
       publish_latest: ${{ steps.decide.outputs.publish_latest }}
       immutable: ${{ steps.decide.outputs.immutable }}
+      images: ${{ steps.decide.outputs.images }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -211,6 +213,14 @@ jobs:
             exit 1
           }
 
+          # Older release tags predate the supervised target. Keep backfills
+          # on their original default server target.
+          git show "$build_sha:deploy/self-host/Dockerfile" > "$RUNNER_TEMP/tidebreak-release-Dockerfile"
+          images='[{"name":"server","target":""}]'
+          if grep -Eq '^FROM runtime-base AS supervised-agent$' "$RUNNER_TEMP/tidebreak-release-Dockerfile"; then
+            images='[{"name":"server","target":"server"},{"name":"supervised-agent","target":"supervised-agent"}]'
+          fi
+
           publish_latest=false
           if [[ "$tag" == "$latest_tag" ]]; then
             publish_latest=true
@@ -221,11 +231,12 @@ jobs:
             echo "build_sha=$build_sha"
             echo "publish_latest=$publish_latest"
             echo "immutable=$immutable"
+            echo "images=$images"
           } >> "$GITHUB_OUTPUT"
           echo "version=${tag#v} build_sha=$build_sha publish_latest=$publish_latest immutable=$immutable"
 
   build:
-    name: build and push · ${{ matrix.arch }}
+    name: build and push · ${{ matrix.artifact.name }} · ${{ matrix.arch }}
     needs: resolve
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
@@ -237,12 +248,16 @@ jobs:
       id-token: write
       attestations: write
     env:
+      SERVER_REPOSITORY: ghcr.io/${{ github.repository_owner }}/tidebreak-${{ matrix.artifact.name }}
+      IMAGE_TARGET: ${{ matrix.artifact.target }}
       BUILD_SHA: ${{ needs.resolve.outputs.build_sha }}
       IMMUTABLE: ${{ needs.resolve.outputs.immutable }}
       VERSION: ${{ needs.resolve.outputs.version }}
     strategy:
       fail-fast: true
       matrix:
+        artifact: ${{ fromJSON(needs.resolve.outputs.images) }}
+        arch: [amd64, arm64]
         include:
           - arch: amd64
             runner: ubuntu-latest
@@ -276,15 +291,23 @@ jobs:
       # --locked` has to see the whole workspace and the committed Cargo.lock.
       # BuildKit reads the sidecar deploy/self-host/Dockerfile.dockerignore,
       # which denies by default and admits only source paths.
-      - name: Build the server container
+      - name: Build the container
         run: |
-          docker build \
+          target=()
+          if [[ -n "$IMAGE_TARGET" ]]; then
+            target=(--target "$IMAGE_TARGET")
+          fi
+          if [[ "$IMAGE_TARGET" == "supervised-agent" ]]; then
+            target+=(--build-arg "TOOLCHAINS=rust,python")
+          fi
+          docker build "${target[@]}" \
             --file deploy/self-host/Dockerfile \
             --build-arg "TIDEBREAK_VERSION=$VERSION" \
             --tag "$SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}" \
             .
 
       - name: Smoke test the built binary
+        if: matrix.artifact.name == 'server'
         run: |
           # Proves the binary executes on this architecture, and that it
           # carries the release it claims to. A published image whose version
@@ -296,6 +319,12 @@ jobs:
             echo "Expected 'tidebreak $VERSION'." >&2
             exit 1
           }
+
+      - name: Smoke test the supervised workload
+        if: matrix.artifact.name == 'supervised-agent'
+        env:
+          TIDEBREAK_SUPERVISED_AGENT_IMAGE: ${{ env.SERVER_REPOSITORY }}:${{ env.VERSION }}-${{ matrix.arch }}
+        run: node --test scripts/supervised-agent-image.test.mjs
 
       - name: Push the per-architecture tag
         run: docker push "$SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}"
@@ -324,8 +353,11 @@ jobs:
   manifest:
     # Assembles the user-facing tags only after every architecture has built
     # and pushed.
-    name: assemble the multi-arch manifest
+    name: assemble the multi-arch manifest · ${{ matrix.artifact.name }}
     needs: [resolve, build]
+    strategy:
+      matrix:
+        artifact: ${{ fromJSON(needs.resolve.outputs.images) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -334,6 +366,7 @@ jobs:
       id-token: write
       attestations: write
     env:
+      SERVER_REPOSITORY: ghcr.io/${{ github.repository_owner }}/tidebreak-${{ matrix.artifact.name }}
       VERSION: ${{ needs.resolve.outputs.version }}
     steps:
       - name: Log in to GHCR
@@ -375,7 +408,7 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
           echo "Published $SERVER_REPOSITORY:$VERSION at $digest"
           {
-            echo "## Published server image"
+            echo "## Published $SERVER_REPOSITORY"
             echo
             echo "- \`$SERVER_REPOSITORY:$VERSION\`"
             if [[ "$PUBLISH_LATEST" == "true" ]]; then

--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -46,6 +46,8 @@ const STALE_INTENT_AGE: chrono::Duration = chrono::Duration::minutes(10);
 pub struct RemoteSpawnSettings {
     /// Administrator-defined profile on the runtime endpoint.
     pub profile: String,
+    /// Engine and Allow mode supplied by the declared supervised image.
+    pub engine: Option<tidebreak_core::HarnessKind>,
     /// Concurrent live incarnations one owner may hold.
     pub incarnation_cap: usize,
     /// Per-spawn spend ceiling in micro-USD, when one is set.
@@ -53,6 +55,27 @@ pub struct RemoteSpawnSettings {
     /// Cumulative per-session spend ceiling in micro-USD, when one is set.
     /// Per-spawn ceilings multiply by reincarnation; this one does not.
     pub session_spend_ceiling_microusd: Option<i64>,
+}
+
+impl RemoteSpawnSettings {
+    /// Reject settings the declared supervised image cannot apply.
+    pub fn validate_execution(&self, session: &Session) -> Result<(), String> {
+        let Some(engine) = self.engine else {
+            return Ok(());
+        };
+        if session.harness_kind != engine {
+            return Err(format!(
+                "this sandbox profile runs {engine}; select that engine to start the session"
+            ));
+        }
+        if session.permission_mode != tidebreak_core::PermissionMode::Allow {
+            return Err("this sandbox profile supports Allow mode; Gateway still enforces repository and app access".into());
+        }
+        if session.fast_mode {
+            return Err("this sandbox profile does not support fast mode".into());
+        }
+        Ok(())
+    }
 }
 
 /// What one submitted turn became.
@@ -324,6 +347,9 @@ impl RemoteDriver<'_> {
         promoted: Option<&tidebreak_core::code::QueuedTurn>,
     ) -> Result<RemoteTurnOutcome, tidebreak_core::AgentError> {
         let (db, bus, provisioner, settings) = (self.db, self.bus, self.provisioner, self.settings);
+        settings
+            .validate_execution(session)
+            .map_err(tidebreak_core::AgentError::config)?;
         let owner = session.owner.clone();
         let last = latest_turn(db, &owner, session.id).await?;
         if last
@@ -348,7 +374,9 @@ impl RemoteDriver<'_> {
                     if row.state == IncarnationState::Active {
                         if let Some(sandbox_id) = row.sandbox_id.as_deref() {
                             releasing = true;
-                            if let Err(error) = provisioner.cancel(&owner, sandbox_id).await {
+                            if let Err(error) =
+                                provisioner.cancel(&owner, session.id, sandbox_id).await
+                            {
                                 warn!(
                                     session = %session.id,
                                     %error,
@@ -400,7 +428,10 @@ impl RemoteDriver<'_> {
                 message
                     .validate()
                     .map_err(tidebreak_core::AgentError::Store)?;
-                match provisioner.send(&owner, sandbox_id, &message).await {
+                match provisioner
+                    .send(&owner, session.id, sandbox_id, &message)
+                    .await
+                {
                     Ok(_) => {
                         let turn =
                             start_turn_row(db, bus, session, ordinal, text, promoted).await?;
@@ -492,7 +523,16 @@ impl RemoteDriver<'_> {
             profile: settings.profile.clone(),
             harness: "custom".to_owned(),
             mode: Some("turn".to_owned()),
-            task: text.to_owned(),
+            task: if settings.engine.is_some() {
+                tidebreak_core::code::RemoteWorkspaceTask::encode(text, &workspace.branch_name)
+                    .map_err(|error| {
+                        tidebreak_core::AgentError::config(format!(
+                            "the workspace task could not be encoded: {error}"
+                        ))
+                    })?
+            } else {
+                text.to_owned()
+            },
             repository: Some(repository_url(repo)?),
             repository_ref: Some(resume_ref.clone()),
             repositories: Vec::new(),
@@ -507,7 +547,7 @@ impl RemoteDriver<'_> {
             spend_ceiling_microusd: settings.spend_ceiling_microusd,
             max_turns: None,
         };
-        match provisioner.spawn(&owner, &arguments).await {
+        match provisioner.spawn(&owner, session.id, &arguments).await {
             Ok(lease) => {
                 if let Err(error) =
                     activate_incarnation(db, &owner, intent.id, &lease.sandbox_id).await
@@ -515,7 +555,10 @@ impl RemoteDriver<'_> {
                     // The protocol closed the row under us (the sweep, say).
                     // The sandbox this call holds is orphaned: cancel it, or
                     // a later turn provisions a second one for this session.
-                    if let Err(cancel_error) = provisioner.cancel(&owner, &lease.sandbox_id).await {
+                    if let Err(cancel_error) = provisioner
+                        .cancel(&owner, session.id, &lease.sandbox_id)
+                        .await
+                    {
                         warn!(
                             session = %session.id,
                             sandbox = %lease.sandbox_id,
@@ -607,6 +650,7 @@ impl RemoteDriver<'_> {
         let read = match provisioner
             .events(
                 &owner,
+                session.id,
                 &sandbox_id,
                 EventCursor {
                     after_seq: Some(row.events_cursor),
@@ -640,7 +684,8 @@ impl RemoteDriver<'_> {
                 // a refusal does not prove the workload is gone — then close
                 // the row and fence; reap waives the gate and the next turn
                 // reincarnates.
-                if let Err(cancel_error) = provisioner.cancel(&owner, &sandbox_id).await {
+                if let Err(cancel_error) = provisioner.cancel(&owner, session.id, &sandbox_id).await
+                {
                     warn!(
                         session = %session.id,
                         %cancel_error,
@@ -663,7 +708,7 @@ impl RemoteDriver<'_> {
         // Feed the spend ledger from the environment's own meter. Best
         // effort: a status fault costs one reading, and the terminal pump
         // records the final figure.
-        if let Ok(status) = provisioner.status(&owner, &sandbox_id).await {
+        if let Ok(status) = provisioner.status(&owner, session.id, &sandbox_id).await {
             if let Some(spend) = status.spend_microusd {
                 record_incarnation_spend(db, &owner, row.id, spend).await?;
             }
@@ -753,7 +798,7 @@ impl RemoteDriver<'_> {
                 if let Some(sandbox_id) = row.sandbox_id.as_deref() {
                     // Best effort: the reap must not hang on an environment
                     // that is already gone.
-                    if let Err(error) = provisioner.cancel(&owner, sandbox_id).await {
+                    if let Err(error) = provisioner.cancel(&owner, session.id, sandbox_id).await {
                         warn!(
                             session = %session.id,
                             %error,
@@ -972,6 +1017,7 @@ mod tests {
         async fn spawn(
             &self,
             _owner: &OwnerId,
+            _session: SessionId,
             arguments: &SpawnArguments,
         ) -> Result<SandboxLease, RemoteSandboxError> {
             let hook = self.on_spawn.lock().unwrap().take();
@@ -989,6 +1035,7 @@ mod tests {
         async fn status(
             &self,
             _owner: &OwnerId,
+            _session: SessionId,
             sandbox_id: &str,
         ) -> Result<SandboxStatus, RemoteSandboxError> {
             Ok(SandboxStatus {
@@ -1009,6 +1056,7 @@ mod tests {
         async fn events(
             &self,
             _owner: &OwnerId,
+            _session: SessionId,
             _sandbox_id: &str,
             _cursor: EventCursor,
         ) -> Result<SandboxEvents, RemoteSandboxError> {
@@ -1025,6 +1073,7 @@ mod tests {
         async fn send(
             &self,
             _owner: &OwnerId,
+            _session: SessionId,
             sandbox_id: &str,
             message: &SandboxMessage,
         ) -> Result<MessageReceipt, RemoteSandboxError> {
@@ -1042,6 +1091,7 @@ mod tests {
         async fn cancel(
             &self,
             _owner: &OwnerId,
+            _session: SessionId,
             sandbox_id: &str,
         ) -> Result<(), RemoteSandboxError> {
             self.cancels.lock().unwrap().push(sandbox_id.to_owned());
@@ -1052,6 +1102,7 @@ mod tests {
     fn settings() -> RemoteSpawnSettings {
         RemoteSpawnSettings {
             profile: "tidebreak-remote".to_owned(),
+            engine: None,
             incarnation_cap: 2,
             spend_ceiling_microusd: Some(5_000_000),
             session_spend_ceiling_microusd: None,
@@ -1067,6 +1118,52 @@ mod tests {
                 settings: $settings,
             }
         };
+    }
+
+    #[tokio::test]
+    async fn a_declared_engine_rejects_unsupported_settings_before_provisioning() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let mut settings = settings();
+        settings.engine = Some(tidebreak_core::HarnessKind::ClaudeCode);
+        let driver = driver!(&db, &bus, &fake, &settings);
+        for (harness, mode, fast) in [
+            (
+                tidebreak_core::HarnessKind::Codex,
+                tidebreak_core::PermissionMode::Allow,
+                false,
+            ),
+            (
+                tidebreak_core::HarnessKind::ClaudeCode,
+                tidebreak_core::PermissionMode::Ask,
+                false,
+            ),
+            (
+                tidebreak_core::HarnessKind::ClaudeCode,
+                tidebreak_core::PermissionMode::Allow,
+                true,
+            ),
+        ] {
+            let mut rejected = session.clone();
+            rejected.harness_kind = harness;
+            rejected.permission_mode = mode;
+            rejected.fast_mode = fast;
+            assert!(driver
+                .submit_turn(&mut rejected, &workspace, &repo, "start")
+                .await
+                .is_err());
+        }
+        assert!(fake.spawns.lock().unwrap().is_empty());
+        assert!(fake.sends.lock().unwrap().is_empty());
+        assert!(latest_incarnation(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(latest_turn(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     /// A first turn on a fresh remote session reserves, spawns from the
@@ -1103,6 +1200,26 @@ mod tests {
         assert_eq!(spawns[0].mode.as_deref(), Some("turn"));
         assert_eq!(spawns[0].spend_ceiling_microusd, Some(5_000_000));
         assert_eq!(session.lifecycle, SessionLifecycle::Running);
+    }
+
+    #[tokio::test]
+    async fn a_declared_supervisor_receives_the_workspace_branch_in_its_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let mut settings = settings();
+        settings.engine = Some(session.harness_kind);
+        let driver = driver!(&db, &bus, &fake, &settings);
+        driver
+            .submit_turn(&mut session, &workspace, &repo, "build it")
+            .await
+            .unwrap();
+        let spawns = fake.spawns.lock().unwrap();
+        let task = tidebreak_core::code::RemoteWorkspaceTask::parse(&spawns[0].task)
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.task, "build it");
+        assert_eq!(task.branch, workspace.branch_name);
     }
 
     /// A turn while the sandbox lives is an inbox message, not a spawn.
@@ -1888,20 +2005,23 @@ mod tests {
             async fn spawn(
                 &self,
                 owner: &OwnerId,
+                session: SessionId,
                 arguments: &SpawnArguments,
             ) -> Result<SandboxLease, RemoteSandboxError> {
-                self.0.spawn(owner, arguments).await
+                self.0.spawn(owner, session, arguments).await
             }
             async fn status(
                 &self,
                 owner: &OwnerId,
+                session: SessionId,
                 sandbox_id: &str,
             ) -> Result<SandboxStatus, RemoteSandboxError> {
-                self.0.status(owner, sandbox_id).await
+                self.0.status(owner, session, sandbox_id).await
             }
             async fn events(
                 &self,
                 _owner: &OwnerId,
+                _session: SessionId,
                 _sandbox_id: &str,
                 _cursor: EventCursor,
             ) -> Result<SandboxEvents, RemoteSandboxError> {
@@ -1914,17 +2034,19 @@ mod tests {
             async fn send(
                 &self,
                 owner: &OwnerId,
+                session: SessionId,
                 sandbox_id: &str,
                 message: &SandboxMessage,
             ) -> Result<MessageReceipt, RemoteSandboxError> {
-                self.0.send(owner, sandbox_id, message).await
+                self.0.send(owner, session, sandbox_id, message).await
             }
             async fn cancel(
                 &self,
                 owner: &OwnerId,
+                session: SessionId,
                 sandbox_id: &str,
             ) -> Result<(), RemoteSandboxError> {
-                self.0.cancel(owner, sandbox_id).await
+                self.0.cancel(owner, session, sandbox_id).await
             }
         }
         let refusing = RefusingReads(&fake);
@@ -1977,20 +2099,23 @@ mod tests {
             async fn spawn(
                 &self,
                 owner: &OwnerId,
+                session: SessionId,
                 arguments: &SpawnArguments,
             ) -> Result<SandboxLease, RemoteSandboxError> {
-                self.0.spawn(owner, arguments).await
+                self.0.spawn(owner, session, arguments).await
             }
             async fn status(
                 &self,
                 owner: &OwnerId,
+                session: SessionId,
                 sandbox_id: &str,
             ) -> Result<SandboxStatus, RemoteSandboxError> {
-                self.0.status(owner, sandbox_id).await
+                self.0.status(owner, session, sandbox_id).await
             }
             async fn events(
                 &self,
                 _owner: &OwnerId,
+                _session: SessionId,
                 _sandbox_id: &str,
                 _cursor: EventCursor,
             ) -> Result<SandboxEvents, RemoteSandboxError> {
@@ -2001,17 +2126,19 @@ mod tests {
             async fn send(
                 &self,
                 owner: &OwnerId,
+                session: SessionId,
                 sandbox_id: &str,
                 message: &SandboxMessage,
             ) -> Result<MessageReceipt, RemoteSandboxError> {
-                self.0.send(owner, sandbox_id, message).await
+                self.0.send(owner, session, sandbox_id, message).await
             }
             async fn cancel(
                 &self,
                 owner: &OwnerId,
+                session: SessionId,
                 sandbox_id: &str,
             ) -> Result<(), RemoteSandboxError> {
-                self.0.cancel(owner, sandbox_id).await
+                self.0.cancel(owner, session, sandbox_id).await
             }
         }
         let expired = ExpiredToken(&fake);

--- a/crates/tidebreak-code-remote/src/gateway.rs
+++ b/crates/tidebreak-code-remote/src/gateway.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tidebreak_core::OwnerId;
+use tidebreak_core::{OwnerId, SessionId};
 
 use super::wire::{
     EventCursor, MessageReceipt, RuntimeErrorBody, SandboxEvents, SandboxLease, SandboxMessage,
@@ -80,8 +80,9 @@ impl GatewayProvisioner {
         operation: &'static str,
         request: reqwest::RequestBuilder,
         owner: &OwnerId,
+        session: SessionId,
     ) -> Result<reqwest::Response, RemoteSandboxError> {
-        let token = self.tokens.runtime_token(owner).await?;
+        let token = self.tokens.runtime_token(owner, session).await?;
         let response = request
             .bearer_auth(&token.secret)
             .send()
@@ -141,6 +142,7 @@ impl SandboxProvisioner for GatewayProvisioner {
     async fn spawn(
         &self,
         owner: &OwnerId,
+        session: SessionId,
         arguments: &SpawnArguments,
     ) -> Result<SandboxLease, RemoteSandboxError> {
         let url = self.endpoint(&format!(
@@ -152,24 +154,26 @@ impl SandboxProvisioner for GatewayProvisioner {
             .post(url)
             .timeout(SPAWN_TIMEOUT)
             .json(&serde_json::json!({ "arguments": arguments }));
-        let response = self.dispatch("spawn", request, owner).await?;
+        let response = self.dispatch("spawn", request, owner, session).await?;
         Self::decode("spawn", response).await
     }
 
     async fn status(
         &self,
         owner: &OwnerId,
+        session: SessionId,
         sandbox_id: &str,
     ) -> Result<SandboxStatus, RemoteSandboxError> {
         let url = self.endpoint(&format!("api/v1/runtime/sandboxes/{sandbox_id}"))?;
         let request = self.http.get(url).timeout(CALL_TIMEOUT);
-        let response = self.dispatch("status", request, owner).await?;
+        let response = self.dispatch("status", request, owner, session).await?;
         Self::decode("status", response).await
     }
 
     async fn events(
         &self,
         owner: &OwnerId,
+        session: SessionId,
         sandbox_id: &str,
         cursor: EventCursor,
     ) -> Result<SandboxEvents, RemoteSandboxError> {
@@ -186,13 +190,14 @@ impl SandboxProvisioner for GatewayProvisioner {
                 wait_seconds: (wait > 0).then_some(wait),
                 ..cursor
             });
-        let response = self.dispatch("events", request, owner).await?;
+        let response = self.dispatch("events", request, owner, session).await?;
         Self::decode("events", response).await
     }
 
     async fn send(
         &self,
         owner: &OwnerId,
+        session: SessionId,
         sandbox_id: &str,
         message: &SandboxMessage,
     ) -> Result<MessageReceipt, RemoteSandboxError> {
@@ -201,14 +206,19 @@ impl SandboxProvisioner for GatewayProvisioner {
             .map_err(RemoteSandboxError::InvalidRequest)?;
         let url = self.endpoint(&format!("api/v1/runtime/sandboxes/{sandbox_id}/messages"))?;
         let request = self.http.post(url).timeout(CALL_TIMEOUT).json(message);
-        let response = self.dispatch("send", request, owner).await?;
+        let response = self.dispatch("send", request, owner, session).await?;
         Self::decode("send", response).await
     }
 
-    async fn cancel(&self, owner: &OwnerId, sandbox_id: &str) -> Result<(), RemoteSandboxError> {
+    async fn cancel(
+        &self,
+        owner: &OwnerId,
+        session: SessionId,
+        sandbox_id: &str,
+    ) -> Result<(), RemoteSandboxError> {
         let url = self.endpoint(&format!("api/v1/runtime/sandboxes/{sandbox_id}/cancel"))?;
         let request = self.http.post(url).timeout(CALL_TIMEOUT);
-        self.dispatch("cancel", request, owner).await?;
+        self.dispatch("cancel", request, owner, session).await?;
         Ok(())
     }
 }
@@ -406,7 +416,11 @@ mod tests {
 
     #[async_trait]
     impl RuntimeTokenSource for StaticTokens {
-        async fn runtime_token(&self, _: &OwnerId) -> Result<RuntimeToken, RemoteSandboxError> {
+        async fn runtime_token(
+            &self,
+            _: &OwnerId,
+            _: SessionId,
+        ) -> Result<RuntimeToken, RemoteSandboxError> {
             Ok(RuntimeToken {
                 secret: "mg_at_test".to_owned(),
             })
@@ -429,6 +443,7 @@ mod tests {
         let lease = provisioner
             .spawn(
                 &owner(),
+                SessionId::new(),
                 &SpawnArguments {
                     profile: "default".to_owned(),
                     harness: "claude_code".to_owned(),
@@ -459,7 +474,11 @@ mod tests {
         let runtime = Arc::new(FakeRuntime::default());
         let provisioner = client(runtime).await;
         let status = provisioner
-            .status(&owner(), "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f")
+            .status(
+                &owner(),
+                SessionId::new(),
+                "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f",
+            )
             .await
             .unwrap();
         assert_eq!(status.sandbox_id, "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f");
@@ -493,6 +512,7 @@ mod tests {
         let error = provisioner
             .spawn(
                 &owner(),
+                SessionId::new(),
                 &SpawnArguments {
                     profile: "default".to_owned(),
                     harness: "claude_code".to_owned(),
@@ -526,7 +546,11 @@ mod tests {
         });
         let provisioner = client(runtime).await;
         let error = provisioner
-            .status(&owner(), "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f")
+            .status(
+                &owner(),
+                SessionId::new(),
+                "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f",
+            )
             .await
             .unwrap_err();
         assert!(matches!(error, RemoteSandboxError::SignInRequired(_)));
@@ -540,7 +564,11 @@ mod tests {
         });
         let provisioner = client(runtime).await;
         let error = provisioner
-            .status(&owner(), "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f")
+            .status(
+                &owner(),
+                SessionId::new(),
+                "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f",
+            )
             .await
             .unwrap_err();
         assert!(error.is_retryable());
@@ -553,6 +581,7 @@ mod tests {
         let events = provisioner
             .events(
                 &owner(),
+                SessionId::new(),
                 "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f",
                 EventCursor {
                     after_seq: Some(2),
@@ -590,6 +619,7 @@ mod tests {
         let error = provisioner
             .send(
                 &owner(),
+                SessionId::new(),
                 "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f",
                 &SandboxMessage {
                     body: "  ".to_owned(),
@@ -610,6 +640,7 @@ mod tests {
         let receipt = provisioner
             .send(
                 &owner(),
+                SessionId::new(),
                 sandbox,
                 &SandboxMessage {
                     body: "also check the retry path".to_owned(),
@@ -621,7 +652,10 @@ mod tests {
         assert_eq!(receipt.seq, 7);
         assert!(!receipt.interrupt);
         assert_eq!(receipt.pending_messages, 0);
-        provisioner.cancel(&owner(), sandbox).await.unwrap();
+        provisioner
+            .cancel(&owner(), SessionId::new(), sandbox)
+            .await
+            .unwrap();
         let captured = runtime.captured.lock().unwrap();
         assert_eq!(captured.len(), 2);
         assert!(captured[0].body.get("interrupt").is_none());
@@ -633,5 +667,49 @@ mod tests {
             secret: "mg_at_secret".to_owned(),
         };
         assert!(!format!("{token:?}").contains("mg_at_secret"));
+    }
+    #[tokio::test]
+    async fn every_operation_uses_the_original_session_authority() {
+        struct RecordingTokens(Mutex<Vec<(OwnerId, SessionId)>>);
+        #[async_trait]
+        impl RuntimeTokenSource for RecordingTokens {
+            async fn runtime_token(
+                &self,
+                owner: &OwnerId,
+                session: SessionId,
+            ) -> Result<RuntimeToken, RemoteSandboxError> {
+                self.0.lock().unwrap().push((owner.clone(), session));
+                Ok(RuntimeToken {
+                    secret: "fixture-token".into(),
+                })
+            }
+        }
+        let runtime = Arc::new(FakeRuntime::default());
+        let base = serve(runtime).await;
+        let tokens = Arc::new(RecordingTokens(Mutex::new(Vec::new())));
+        let provisioner = GatewayProvisioner::new(&base, "primary", tokens.clone()).unwrap();
+        let session = SessionId::new();
+        let owner = owner();
+        let sandbox = "6b8e7f2c-1d0a-4b3c-9e5f-2a1b3c4d5e6f";
+        let _ = provisioner
+            .spawn(&owner, session, &SpawnArguments::default())
+            .await;
+        let _ = provisioner.status(&owner, session, sandbox).await;
+        let _ = provisioner
+            .events(&owner, session, sandbox, EventCursor::default())
+            .await;
+        let _ = provisioner
+            .send(
+                &owner,
+                session,
+                sandbox,
+                &SandboxMessage {
+                    body: "continue".into(),
+                    interrupt: false,
+                },
+            )
+            .await;
+        let _ = provisioner.cancel(&owner, session, sandbox).await;
+        assert_eq!(*tokens.0.lock().unwrap(), vec![(owner, session); 5]);
     }
 }

--- a/crates/tidebreak-code-remote/src/lib.rs
+++ b/crates/tidebreak-code-remote/src/lib.rs
@@ -111,13 +111,17 @@ impl std::fmt::Debug for RuntimeToken {
 /// provisioned as its owner, never as a shared machine identity.
 #[async_trait]
 pub trait RuntimeTokenSource: Send + Sync {
-    /// A live token for `owner`, minted or refreshed as needed.
+    /// A live token for this session, using its original external grant when bound.
     ///
     /// # Errors
     ///
     /// [`RemoteSandboxError::SignInRequired`] when no credential for this
     /// owner can mint one.
-    async fn runtime_token(&self, owner: &OwnerId) -> Result<RuntimeToken, RemoteSandboxError>;
+    async fn runtime_token(
+        &self,
+        owner: &OwnerId,
+        session: SessionId,
+    ) -> Result<RuntimeToken, RemoteSandboxError>;
 }
 
 /// The provisioning client a remote session drives its sandbox through.
@@ -134,6 +138,7 @@ pub trait SandboxProvisioner: Send + Sync {
     async fn spawn(
         &self,
         owner: &OwnerId,
+        session: SessionId,
         arguments: &SpawnArguments,
     ) -> Result<SandboxLease, RemoteSandboxError>;
 
@@ -141,6 +146,7 @@ pub trait SandboxProvisioner: Send + Sync {
     async fn status(
         &self,
         owner: &OwnerId,
+        session: SessionId,
         sandbox_id: &str,
     ) -> Result<SandboxStatus, RemoteSandboxError>;
 
@@ -151,6 +157,7 @@ pub trait SandboxProvisioner: Send + Sync {
     async fn events(
         &self,
         owner: &OwnerId,
+        session: SessionId,
         sandbox_id: &str,
         cursor: EventCursor,
     ) -> Result<SandboxEvents, RemoteSandboxError>;
@@ -159,13 +166,19 @@ pub trait SandboxProvisioner: Send + Sync {
     async fn send(
         &self,
         owner: &OwnerId,
+        session: SessionId,
         sandbox_id: &str,
         message: &SandboxMessage,
     ) -> Result<MessageReceipt, RemoteSandboxError>;
 
     /// Asks the environment to stop the sandbox. Idempotent server-side; a
     /// running sandbox keeps a short grace so its terminal checkpoint lands.
-    async fn cancel(&self, owner: &OwnerId, sandbox_id: &str) -> Result<(), RemoteSandboxError>;
+    async fn cancel(
+        &self,
+        owner: &OwnerId,
+        session: SessionId,
+        sandbox_id: &str,
+    ) -> Result<(), RemoteSandboxError>;
 }
 
 /// Supplies the session operations that stay owned by the embedding server.

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -5,6 +5,9 @@
 
 mod caps;
 mod event;
+mod remote_task;
+
+pub use remote_task::RemoteWorkspaceTask;
 
 pub use caps::{CapLevel, HarnessCaps, HarnessCommand, HarnessTier};
 pub use event::{

--- a/crates/tidebreak-core/src/code/remote_task.rs
+++ b/crates/tidebreak-core/src/code/remote_task.rs
@@ -1,0 +1,81 @@
+//! Versioned workspace metadata carried through the runtime's task string.
+
+use serde::{Deserialize, Serialize};
+
+const PREFIX: &str = "tidebreak-workspace-task\n";
+const VERSION: u8 = 1;
+
+/// A Tidebreak workspace's first task and the branch its remote checkout uses.
+/// The supervisor consumes the metadata before handing the task to the engine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteWorkspaceTask {
+    version: u8,
+    pub task: String,
+    pub branch: String,
+}
+
+impl RemoteWorkspaceTask {
+    /// Wrap a task for a Tidebreak supervisor without changing its text.
+    pub fn encode(task: &str, branch: &str) -> Result<String, serde_json::Error> {
+        let envelope = Self {
+            version: VERSION,
+            task: task.to_owned(),
+            branch: branch.to_owned(),
+        };
+        Ok(format!("{PREFIX}{}", serde_json::to_string(&envelope)?))
+    }
+
+    /// Decode Tidebreak metadata, leaving ordinary custom tasks untouched.
+    pub fn parse(value: &str) -> Result<Option<Self>, String> {
+        let Some(json) = value.strip_prefix(PREFIX) else {
+            return Ok(None);
+        };
+        let envelope: Self = serde_json::from_str(json)
+            .map_err(|error| format!("the workspace task envelope is invalid: {error}"))?;
+        if envelope.version != VERSION {
+            return Err("the workspace task envelope version is unsupported".into());
+        }
+        if envelope.task.trim().is_empty() {
+            return Err("the workspace task is empty".into());
+        }
+        if envelope.branch.is_empty()
+            || envelope.branch.len() > 1024
+            || envelope.branch != envelope.branch.trim()
+            || envelope.branch.starts_with('-')
+            || envelope.branch.contains("@{")
+        {
+            return Err("the workspace branch is invalid".into());
+        }
+        Ok(Some(envelope))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_envelope_preserves_task_text_and_branch() {
+        let task = "  Keep \"this\" text.\nThen test it.\n";
+        let encoded = RemoteWorkspaceTask::encode(task, "thet/slack-pr").unwrap();
+        let parsed = RemoteWorkspaceTask::parse(&encoded).unwrap().unwrap();
+        assert_eq!(parsed.task, task);
+        assert_eq!(parsed.branch, "thet/slack-pr");
+        assert_eq!(RemoteWorkspaceTask::parse(task).unwrap(), None);
+    }
+
+    #[test]
+    fn invalid_envelopes_fail_instead_of_becoming_engine_instructions() {
+        for body in [
+            r#"{"version":2,"task":"work","branch":"task"}"#,
+            r#"{"version":1,"task":"work","branch":"task","extra":true}"#,
+            r#"{"version":1,"task":" ","branch":"task"}"#,
+            r#"{"version":1,"task":"work","branch":"-reset"}"#,
+            r#"{"version":1,"task":"work","branch":"@{-1}"}"#,
+            "not json",
+        ] {
+            assert!(RemoteWorkspaceTask::parse(&format!("{PREFIX}{body}")).is_err());
+        }
+    }
+}

--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -255,6 +255,8 @@ pub struct Config {
     /// Required together with [`Config::runtime_endpoint`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_profile: Option<String>,
+    /// Engine packaged in a supervised sandbox profile, when explicitly declared.
+    pub runtime_engine: Option<crate::HarnessKind>,
     /// Concurrent remote sandboxes one owner may hold. The reservation is
     /// atomic, so competing starts cannot exceed this cap.
     #[serde(
@@ -394,6 +396,7 @@ impl Config {
             listen_addr: None,
             runtime_endpoint: None,
             runtime_profile: None,
+            runtime_engine: None,
             runtime_concurrency_cap: default_runtime_concurrency_cap(),
             runtime_spawn_spend_ceiling_microusd: default_runtime_spawn_spend_ceiling_microusd(),
             runtime_session_spend_ceiling_microusd: default_runtime_session_spend_ceiling_microusd(
@@ -468,7 +471,29 @@ impl Config {
             std::env::var("TIDEBREAK_RUNTIME_SPAWN_SPEND_CEILING_MICROUSD").ok(),
             std::env::var("TIDEBREAK_RUNTIME_SESSION_SPEND_CEILING_MICROUSD").ok(),
         )
+        .and_then(|config| {
+            config.with_runtime_engine_var(std::env::var("TIDEBREAK_RUNTIME_ENGINE").ok())
+        })
         .map(|config| config.with_ui_dist_var(std::env::var_os("TIDEBREAK_UI_DIST")))
+    }
+
+    /// Declare the engine in the remote profile without changing existing sessions.
+    pub fn with_runtime_engine_var(mut self, value: Option<String>) -> Result<Self> {
+        let Some(value) = value.filter(|value| !value.trim().is_empty()) else {
+            return Ok(self);
+        };
+        if self.runtime_profile.is_none() {
+            return Err(AgentError::config(
+                "TIDEBREAK_RUNTIME_ENGINE requires a sandbox runtime profile",
+            ));
+        }
+        let engine = crate::HarnessKind::from_str(value.trim())
+            .filter(|kind| !kind.is_in_process())
+            .ok_or_else(|| {
+                AgentError::config("TIDEBREAK_RUNTIME_ENGINE must name a supported external engine")
+            })?;
+        self.runtime_engine = Some(engine);
+        Ok(self)
     }
 
     /// Apply `TIDEBREAK_UI_DIST`. Split from [`Config::from_env`] like the
@@ -592,6 +617,7 @@ impl Config {
             listen_addr,
             runtime_endpoint,
             runtime_profile,
+            runtime_engine: None,
             runtime_concurrency_cap: default_runtime_concurrency_cap(),
             runtime_spawn_spend_ceiling_microusd: default_runtime_spawn_spend_ceiling_microusd(),
             runtime_session_spend_ceiling_microusd: default_runtime_session_spend_ceiling_microusd(
@@ -969,6 +995,40 @@ mod tests {
         .unwrap();
         assert_eq!(config.runtime_endpoint.as_deref(), Some("primary"));
         assert_eq!(config.runtime_profile.as_deref(), Some("tidebreak-remote"));
+    }
+
+    #[test]
+    fn runtime_engine_requires_a_profile_and_an_external_engine() {
+        let config = Config::desktop("/data");
+        assert!(config
+            .clone()
+            .with_runtime_engine_var(Some("claude_code".into()))
+            .is_err());
+        assert_eq!(
+            config
+                .clone()
+                .with_runtime_engine_var(Some("  ".into()))
+                .unwrap()
+                .runtime_engine,
+            None
+        );
+        let mut configured = config;
+        configured.runtime_endpoint = Some("tidebreak".into());
+        configured.runtime_profile = Some("tidebreak-supervised".into());
+        assert_eq!(
+            configured
+                .clone()
+                .with_runtime_engine_var(Some(" claude_code ".into()))
+                .unwrap()
+                .runtime_engine,
+            Some(crate::HarnessKind::ClaudeCode)
+        );
+        for engine in ["tidebreak", "missing-engine"] {
+            assert!(configured
+                .clone()
+                .with_runtime_engine_var(Some(engine.into()))
+                .is_err());
+        }
     }
 
     #[test]

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -572,9 +572,11 @@ export function WorkspaceWorkflowControl({
               />
             </div>
             <div className="flex flex-wrap gap-1 border-t border-border-subtle p-1.5">
-              <Button variant="ghost" size="sm" onClick={onOpenSourceControl}>
-                Source control
-              </Button>
+              {!model.remote && (
+                <Button variant="ghost" size="sm" onClick={onOpenSourceControl}>
+                  Source control
+                </Button>
+              )}
               {model.pr?.url && (
                 <Button
                   variant="ghost"

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -794,6 +794,12 @@ describe("parseCodeWorkspacePr", () => {
     },
   };
 
+  it("preserves the remote flag without accepting a non-boolean flag", () => {
+    const remote = { ...pr, remote: true };
+    expect(parseCodeWorkspacePr(remote)).toEqual(remote);
+    expect(parseCodeWorkspacePr({ ...pr, remote: "true" })).toBeNull();
+  });
+
   it("accepts GET /code/workspaces/{id}/pr", () => {
     expect(parseCodeWorkspacePr(pr)).toEqual(pr);
   });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2319,6 +2319,7 @@ export function parseCodeWorkspacePr(
   if (
     !isRecord(value) ||
     !onlyKeys<WireCodeWorkspacePrSnapshot>(value, [
+      "remote",
       "dirty",
       "unpushed",
       "ahead",
@@ -2333,6 +2334,7 @@ export function parseCodeWorkspacePr(
       "pushes_as_self",
       "watch",
     ]) ||
+    (value.remote !== undefined && typeof value.remote !== "boolean") ||
     typeof value.dirty !== "boolean" ||
     typeof value.unpushed !== "boolean" ||
     !isFiniteNumber(value.ahead) ||
@@ -2349,6 +2351,7 @@ export function parseCodeWorkspacePr(
     return null;
   }
   const parsed: CodeWorkspacePrSnapshot = {
+    ...(value.remote !== undefined ? { remote: value.remote } : {}),
     dirty: value.dirty,
     unpushed: value.unpushed,
     ahead: value.ahead,

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -580,3 +580,50 @@ describe("combined local and PR states", () => {
     expect(model.pr?.number).toBe(41);
   });
 });
+
+describe("remote workspace workflow", () => {
+  const remote: CodeWorkspacePrSnapshot = { ...CLEAN, remote: true };
+
+  it("does not report a remote checkout as clean or offer local changes", () => {
+    const model = workspaceWorkflowModel(remote);
+    expect(model.stage).toBe("remote");
+    expect(model.summary).toBe("Sandbox workspace");
+    expect(model.primary).toBeUndefined();
+    expect(model.secondary).toEqual([]);
+  });
+
+  it.each<Partial<PullRequestDigest>>([
+    { state: "open", draft: true },
+    { state: "open", mergeable: "mergeable", merge_state_status: "clean" },
+    { state: "open", checks: [{ name: "CI", bucket: "fail" }] },
+    { state: "merged", merged: true },
+  ])("keeps PR facts and navigation for %j", (facts) => {
+    const digest = pr(facts);
+    const model = workspaceWorkflowModel({ ...remote, pr: digest });
+    expect(model.pr).toEqual(digest);
+    expect(model.primary).toBe("open_pr");
+    expect(model.secondary).toEqual([]);
+    for (const shortcut of [
+      "merge",
+      "watch",
+      "update_branch",
+      "source_control",
+    ] as const) {
+      expect(resolveWorkflowShortcut(shortcut, model, false)).toHaveProperty(
+        "blocked",
+      );
+    }
+    expect(resolveWorkflowShortcut("view_pr", model, false)).toEqual({
+      run: "open_pr",
+    });
+    expect(resolveWorkflowShortcut("pull_request", model, false)).toEqual({
+      run: "open_pr",
+    });
+  });
+
+  it("preserves local behavior for older responses without a Git snapshot", () => {
+    expect(workspaceWorkflowModel({ ...CLEAN, dirty: true }).primary).toBe(
+      "compose_pr",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -43,7 +43,9 @@ export type WorkspaceWorkflowTone =
   | "merged";
 
 export type WorkspaceWorkflowModel = {
+  remote?: boolean;
   stage:
+    | "remote"
     | "detached"
     | "sync_needed"
     | "diverged"
@@ -229,6 +231,28 @@ export function workspaceWorkflowModel(
       detail: "Reading local changes and pull request status.",
       secondary: pr?.url ? ["open_pr", "open_source"] : ["open_source"],
     };
+  if (snapshot.remote) {
+    return hosted
+      ? {
+          ...hosted,
+          ...common,
+          remote: true,
+          detail:
+            "This checkout runs in a sandbox. Review its pull request on GitHub or continue the task in chat.",
+          primary: pr?.url ? "open_pr" : undefined,
+          secondary: [],
+        }
+      : {
+          remote: true,
+          stage: "remote",
+          tone: "neutral",
+          summary: "Sandbox workspace",
+          title: "Checkout runs in a sandbox",
+          detail:
+            "Continue the task in chat to commit, push, or create a pull request. Its status appears here once published.",
+          secondary: [],
+        };
+  }
   const git = snapshot.git;
   const localSummary = git?.changed_files
     ? `${git.changed_files} changed ${git.changed_files === 1 ? "file" : "files"}`
@@ -558,6 +582,18 @@ export function resolveWorkflowShortcut(
   model: WorkspaceWorkflowModel,
   watching: boolean,
 ): WorkflowShortcutResolution {
+  if (model.remote) {
+    if (
+      ["view_pr", "pull_request", "next"].includes(shortcut) &&
+      model.pr?.url
+    ) {
+      return { run: "open_pr" };
+    }
+    return {
+      blocked:
+        "This checkout runs in a sandbox. Continue the task in chat or open its pull request on GitHub.",
+    };
+  }
   // The review rail is chrome, not a Git operation: it opens whatever else is
   // going on, including while the status is still loading.
   if (shortcut === "source_control") return { run: "open_source" };

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1607,7 +1607,11 @@ export type CodeWorkspaceHistorySearchSource = "turn_user_input" | "turn_narrati
 /**
  * PR + checks digest plus the local git facts the PR card needs.
  */
-export type CodeWorkspacePrSnapshot = { git?: CodeWorkspaceGitState, dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string,
+export type CodeWorkspacePrSnapshot = {
+/**
+ * The checkout lives in a remote runtime; local git mutations are unavailable.
+ */
+remote?: boolean, git?: CodeWorkspaceGitState, dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string,
 /**
  * The identity a push from this machine acts as: the deployment's
  * GitHub App bot account (decision 63) or the caller's own login

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import { HttpError, type CodeWorkspacePrSnapshot } from "@/api";
 import { WorkspaceWorkflowControl } from "@/code/WorkspaceWorkflowControl";
 import type {
@@ -223,4 +223,61 @@ export const PersistentRefreshError: Story = {
  */
 export const ReadingCheckLogs: Story = {
   args: { snapshot: failingChecksPrGit, checkLogsHang: true },
+};
+
+export const SandboxWithoutPullRequest: Story = {
+  args: {
+    snapshot: { ...readyForPrGit, remote: true, git: undefined, pr: undefined },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: "Workspace status: Sandbox workspace",
+      }),
+    );
+    await expect(
+      within(document.body).getByText("Checkout runs in a sandbox"),
+    ).toBeVisible();
+    await expect(
+      within(document.body).queryByRole("button", {
+        name: /^Source control$/,
+      }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const SandboxPullRequest: Story = {
+  args: { snapshot: { ...openPrGit, remote: true, git: undefined } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", { name: /^View PR$/ }),
+    ).toBeVisible();
+    await userEvent.click(
+      canvas.getByRole("button", { name: /Workspace status:/ }),
+    );
+    await expect(
+      within(document.body).getByRole("button", { name: "Open on GitHub" }),
+    ).toBeVisible();
+    await expect(
+      within(document.body).queryByRole("button", {
+        name: /^Source control$/,
+      }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const SandboxRefreshFailed: Story = {
+  args: {
+    snapshot: { ...failingChecksPrGit, remote: true, git: undefined },
+    error:
+      "Your GitHub connection is unavailable. Reconnect it to refresh this pull request.",
+  },
+  play: async ({ canvasElement }) => {
+    await userEvent.click(
+      within(canvasElement).getByRole("button", { name: /Workspace status:/ }),
+    );
+    await expect(within(document.body).getByRole("alert")).toBeVisible();
+  },
 };

--- a/crates/tidebreak-server-api/src/routes/code/git.rs
+++ b/crates/tidebreak-server-api/src/routes/code/git.rs
@@ -223,7 +223,8 @@ fn pr_snapshot(
     watch: Option<tidebreak_core::CodeWatch>,
 ) -> CodeWorkspacePrSnapshot {
     CodeWorkspacePrSnapshot {
-        git: Some(status.git),
+        git: status.git,
+        remote: status.remote.then_some(true),
         dirty: status.dirty,
         unpushed: status.unpushed,
         ahead: status.ahead,

--- a/crates/tidebreak-server-api/src/routes/code/terminals.rs
+++ b/crates/tidebreak-server-api/src/routes/code/terminals.rs
@@ -8,7 +8,7 @@ use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
-use tidebreak_core::{CodeWorkspaceStatus, WorkspaceId};
+use tidebreak_core::WorkspaceId;
 
 use super::types::{
     CodeTerminalRead, CodeTerminalSnapshot, CreateTerminalBody, TerminalReadQuery,
@@ -21,12 +21,10 @@ pub async fn create_terminal(
     Path(id): Path<WorkspaceId>,
     Json(body): Json<CreateTerminalBody>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let workspace = code.get_workspace(id).await?;
-    require_active(&workspace.status)?;
+    code.require_live_workspace(id).await?;
     let write = code.workspace_write_lock(id);
     let _write_guard = write.lock().await;
-    let workspace = code.get_workspace(id).await?;
-    require_active(&workspace.status)?;
+    let workspace = code.require_live_workspace(id).await?;
     let snap = state
         .terminals
         .open(
@@ -99,12 +97,10 @@ pub async fn write_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalWriteBody>,
 ) -> Result<StatusCode, ServerError> {
-    let workspace = code.get_workspace(path.id).await?;
-    require_active(&workspace.status)?;
+    code.require_live_workspace(path.id).await?;
     let write = code.workspace_write_lock(path.id);
     let _write_guard = write.lock().await;
-    let workspace = code.get_workspace(path.id).await?;
-    require_active(&workspace.status)?;
+    code.require_live_workspace(path.id).await?;
     let bytes = decode_write(&body.bytes)?;
     state
         .terminals
@@ -119,27 +115,15 @@ pub async fn resize_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalResizeBody>,
 ) -> Result<Json<CodeTerminalSnapshot>, ServerError> {
-    let workspace = code.get_workspace(path.id).await?;
-    require_active(&workspace.status)?;
+    code.require_live_workspace(path.id).await?;
     let write = code.workspace_write_lock(path.id);
     let _write_guard = write.lock().await;
-    let workspace = code.get_workspace(path.id).await?;
-    require_active(&workspace.status)?;
+    code.require_live_workspace(path.id).await?;
     let snap = state
         .terminals
         .resize(path.id, path.tid, body.cols, body.rows)
         .map_err(map_terminal)?;
     Ok(Json(snapshot_wire(snap)))
-}
-
-fn require_active(status: &CodeWorkspaceStatus) -> Result<(), ServerError> {
-    if *status != CodeWorkspaceStatus::Active {
-        return Err(ServerError::conflict_kind(
-            "workspace_not_ready",
-            format!("workspace is {}", status.as_str()),
-        ));
-    }
-    Ok(())
 }
 
 fn decode_write(encoded: &str) -> Result<Vec<u8>, ServerError> {

--- a/crates/tidebreak-server-api/src/tests.rs
+++ b/crates/tidebreak-server-api/src/tests.rs
@@ -52,6 +52,7 @@ mod code_doctor;
 mod code_external;
 #[cfg(unix)]
 mod code_git;
+mod code_hosted_execution;
 mod code_internal;
 mod code_owner_scope;
 mod code_policy;

--- a/crates/tidebreak-server-api/src/tests/code.rs
+++ b/crates/tidebreak-server-api/src/tests/code.rs
@@ -117,6 +117,7 @@ impl SandboxProvisioner for UnusedRemoteProvisioner {
     async fn spawn(
         &self,
         _owner: &tidebreak_core::OwnerId,
+        _session: tidebreak_core::SessionId,
         _arguments: &SpawnArguments,
     ) -> Result<SandboxLease, RemoteSandboxError> {
         panic!("remote create-route tests must not provision a sandbox")
@@ -125,6 +126,7 @@ impl SandboxProvisioner for UnusedRemoteProvisioner {
     async fn status(
         &self,
         _owner: &tidebreak_core::OwnerId,
+        _session: tidebreak_core::SessionId,
         _sandbox_id: &str,
     ) -> Result<SandboxStatus, RemoteSandboxError> {
         panic!("remote create-route tests must not read sandbox status")
@@ -133,6 +135,7 @@ impl SandboxProvisioner for UnusedRemoteProvisioner {
     async fn events(
         &self,
         _owner: &tidebreak_core::OwnerId,
+        _session: tidebreak_core::SessionId,
         _sandbox_id: &str,
         _cursor: EventCursor,
     ) -> Result<SandboxEvents, RemoteSandboxError> {
@@ -142,6 +145,7 @@ impl SandboxProvisioner for UnusedRemoteProvisioner {
     async fn send(
         &self,
         _owner: &tidebreak_core::OwnerId,
+        _session: tidebreak_core::SessionId,
         _sandbox_id: &str,
         _message: &SandboxMessage,
     ) -> Result<MessageReceipt, RemoteSandboxError> {
@@ -151,6 +155,7 @@ impl SandboxProvisioner for UnusedRemoteProvisioner {
     async fn cancel(
         &self,
         _owner: &tidebreak_core::OwnerId,
+        _session: tidebreak_core::SessionId,
         _sandbox_id: &str,
     ) -> Result<(), RemoteSandboxError> {
         panic!("remote create-route tests must not cancel a sandbox")
@@ -225,6 +230,7 @@ pub(super) async fn code_app_with_options(
             Arc::new(UnusedRemoteProvisioner),
             RemoteSpawnSettings {
                 profile: "test-remote".to_owned(),
+                engine: None,
                 incarnation_cap: 2,
                 spend_ceiling_microusd: None,
                 session_spend_ceiling_microusd: None,

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -39,6 +39,7 @@ impl SandboxProvisioner for FakeProvisioner {
     async fn spawn(
         &self,
         _owner: &OwnerId,
+        _session: tidebreak_core::SessionId,
         arguments: &SpawnArguments,
     ) -> Result<SandboxLease, RemoteSandboxError> {
         self.spawns.lock().unwrap().push(arguments.clone());
@@ -53,6 +54,7 @@ impl SandboxProvisioner for FakeProvisioner {
     async fn status(
         &self,
         _owner: &OwnerId,
+        _session: tidebreak_core::SessionId,
         sandbox_id: &str,
     ) -> Result<SandboxStatus, RemoteSandboxError> {
         Ok(SandboxStatus {
@@ -73,6 +75,7 @@ impl SandboxProvisioner for FakeProvisioner {
     async fn events(
         &self,
         _owner: &OwnerId,
+        _session: tidebreak_core::SessionId,
         _sandbox_id: &str,
         _cursor: EventCursor,
     ) -> Result<SandboxEvents, RemoteSandboxError> {
@@ -89,6 +92,7 @@ impl SandboxProvisioner for FakeProvisioner {
     async fn send(
         &self,
         _owner: &OwnerId,
+        _session: tidebreak_core::SessionId,
         _sandbox_id: &str,
         message: &SandboxMessage,
     ) -> Result<MessageReceipt, RemoteSandboxError> {
@@ -100,7 +104,12 @@ impl SandboxProvisioner for FakeProvisioner {
         })
     }
 
-    async fn cancel(&self, _owner: &OwnerId, _sandbox_id: &str) -> Result<(), RemoteSandboxError> {
+    async fn cancel(
+        &self,
+        _owner: &OwnerId,
+        _session: tidebreak_core::SessionId,
+        _sandbox_id: &str,
+    ) -> Result<(), RemoteSandboxError> {
         Ok(())
     }
 }
@@ -108,6 +117,7 @@ impl SandboxProvisioner for FakeProvisioner {
 fn remote_settings() -> crate::code::remote::driver::RemoteSpawnSettings {
     crate::code::remote::driver::RemoteSpawnSettings {
         profile: "tidebreak-remote".to_owned(),
+        engine: None,
         incarnation_cap: 2,
         spend_ceiling_microusd: None,
         session_spend_ceiling_microusd: None,
@@ -411,6 +421,158 @@ async fn a_sessions_git_borrows_the_persons_credential_from_the_loopback_route()
         .await
         .unwrap();
     assert_eq!(wrong.status(), reqwest::StatusCode::UNAUTHORIZED);
+}
+
+/// A Slack sandbox stays remote when a browser follows the link, queues a
+/// turn, and the hosted process recovers its session rows.
+#[tokio::test]
+async fn web_follow_ups_and_recovery_keep_a_slack_session_in_its_sandbox() {
+    let (router, fake, runtime, repo_id, token, _dir) = external_app_built(|mut runtime| {
+        runtime
+            .adapters
+            .register(Arc::new(crate::scripted_harness::ScriptedAdapter::new(
+                crate::scripted_harness::plain_text_script(),
+            )));
+        runtime.with_sandbox_only_execution()
+    })
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C-web/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session_id = bound_session_id(&runtime, &owner, "T1/C-web/1.1").await;
+    let session = runtime.get_session(&owner, session_id).await.unwrap();
+    assert_eq!(
+        session.execution_location,
+        tidebreak_core::ExecutionLocation::Sandbox
+    );
+    assert!(!runtime.has_worker(session_id));
+    let error = runtime
+        .attach_and_spawn_worker(session.clone())
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "session_remote");
+
+    // The session location remains authoritative if old workspace metadata
+    // still names a local path after recovery or an upgrade.
+    let mut workspace = runtime
+        .get_workspace(&owner, session.workspace_id.unwrap())
+        .await
+        .unwrap();
+    workspace.worktree_path = _dir
+        .path()
+        .join("obsolete-local-path")
+        .display()
+        .to_string();
+    tidebreak_core::db::code::save_workspace(&runtime.db, &workspace)
+        .await
+        .unwrap();
+
+    let first = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/messages"
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "text": "start in Slack", "event_id": "Ev-web", "channel_ts": "1700000001.000100"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+    assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+
+    let queued = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "continue from the browser" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(queued.status(), reqwest::StatusCode::ACCEPTED);
+    let queued: serde_json::Value = queued.json().await.unwrap();
+    assert_eq!(queued["message"], "continue from the browser");
+    runtime.recover().await.unwrap();
+    assert!(!runtime.has_worker(session_id));
+    assert_eq!(
+        runtime
+            .get_session(&owner, session_id)
+            .await
+            .unwrap()
+            .lifecycle,
+        tidebreak_core::SessionLifecycle::Running
+    );
+
+    fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+        sandbox_id: "sb-ext".into(),
+        state: SandboxState::Running,
+        latest_event_seq: 2,
+        events: vec![
+            SandboxEvent {
+                seq: 1,
+                kind: "turn_started".into(),
+                payload: serde_json::json!({ "turn": 1 }),
+                created_at: String::new(),
+            },
+            SandboxEvent {
+                seq: 2,
+                kind: "turn_completed".into(),
+                payload: serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                created_at: String::new(),
+            },
+        ],
+    });
+    let mut live = runtime.get_session(&owner, session_id).await.unwrap();
+    runtime
+        .remote_sessions()
+        .unwrap()
+        .driver(&runtime.db, runtime.bus.as_ref())
+        .pump(&mut live, 0)
+        .await
+        .unwrap();
+    runtime.start(format!("http://{addr}")).await.unwrap();
+    super::code::wait_until(|| {
+        fake.sends
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|message| message.body == "continue from the browser")
+    })
+    .await;
+    assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+    assert!(!runtime.has_worker(session_id));
+    assert!(
+        tidebreak_core::db::code::list_queued_turns(&runtime.db, &owner, session_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    let interrupted = client
+        .post(format!(
+            "http://{addr}/code/sessions/{session_id}/interrupt"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(interrupted.status(), reqwest::StatusCode::ACCEPTED);
+    assert!(fake
+        .sends
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|message| message.interrupt));
 }
 
 /// The whole adapter surface over HTTP: bad tokens refuse, get-or-create

--- a/crates/tidebreak-server-api/src/tests/code_hosted_execution.rs
+++ b/crates/tidebreak-server-api/src/tests/code_hosted_execution.rs
@@ -1,0 +1,305 @@
+//! Hosted deployments refuse host scripts and terminals before side effects.
+
+use super::code::{init_git_repo, serve};
+use super::*;
+
+use crate::code::CodeRuntime;
+use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+use tidebreak_core::db::code::{insert_repo, list_workspaces, save_repo, save_workspace};
+use tidebreak_core::{CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId, QuickAction, RepoId};
+use tidebreak_harness::AdapterRegistry;
+
+async fn hosted_fixture() -> (
+    AppState,
+    Arc<CodeRuntime>,
+    CodeRepo,
+    CodeWorkspace,
+    tempfile::TempDir,
+) {
+    let (dir, db) = temp_db_store("hosted-execution.db").await;
+    let db = Arc::new(db);
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    let runtime = CodeRuntime::with_registry(db.clone(), dir.path().to_path_buf(), registry);
+    let owner = OwnerId::local();
+    let mut repo = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: init_git_repo(dir.path()).display().to_string(),
+        display_name: "hosted".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "tidebreak/".into(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: chrono::Utc::now(),
+        removed_at: None,
+        cloned_from: None,
+        origin_host: None,
+        origin_owner: None,
+        origin_name: None,
+    };
+    insert_repo(&db, &repo).await.unwrap();
+    let workspace = runtime
+        .create_workspace(&owner, repo.id, Some("existing".into()), None, None)
+        .await
+        .unwrap();
+    repo.setup_script = Some("echo setup > hosted-script-ran".into());
+    repo.archive_script = Some("echo archive > hosted-script-ran".into());
+    repo.quick_actions = vec![QuickAction {
+        name: "probe".into(),
+        command: "echo action > hosted-script-ran".into(),
+        auto_run_on_create: true,
+    }];
+    save_repo(&db, &repo).await.unwrap();
+    let runtime = Arc::new(runtime.with_sandbox_only_execution());
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        db,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime.clone());
+    (state, runtime, repo, workspace, dir)
+}
+
+async fn assert_hosted_refusal(response: reqwest::Response) {
+    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["kind"], "sandbox_session_required");
+}
+
+#[tokio::test]
+async fn sandbox_only_workspace_lifecycle_refuses_before_scripts_or_checkout_changes() {
+    let (state, runtime, repo, mut workspace, _dir) = hosted_fixture().await;
+    let token = state.token.clone();
+    let addr = serve(app(state)).await;
+    let client = reqwest::Client::new();
+    let path = std::path::PathBuf::from(&workspace.worktree_path);
+    let marker = path.join("hosted-script-ran");
+    let rows_before = list_workspaces(&runtime.db, &workspace.owner, Some(repo.id))
+        .await
+        .unwrap();
+    assert_hosted_refusal(
+        client
+            .post(format!("http://{addr}/code/workspaces"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({"repo_id": repo.id, "title": "forbidden"}))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        list_workspaces(&runtime.db, &workspace.owner, Some(repo.id))
+            .await
+            .unwrap()
+            .len(),
+        rows_before.len()
+    );
+    for action in ["archive", "actions/probe"] {
+        assert_hosted_refusal(
+            client
+                .post(format!(
+                    "http://{addr}/code/workspaces/{}/{action}",
+                    workspace.id
+                ))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({"force": true}))
+                .send()
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            runtime
+                .get_workspace(&workspace.owner, workspace.id)
+                .await
+                .unwrap()
+                .status,
+            CodeWorkspaceStatus::Active
+        );
+        assert!(path.join("README.md").exists());
+        assert!(!marker.exists());
+    }
+    workspace.status = CodeWorkspaceStatus::SetupFailed;
+    save_workspace(&runtime.db, &workspace).await.unwrap();
+    assert_hosted_refusal(
+        client
+            .post(format!(
+                "http://{addr}/code/workspaces/{}/retry-setup",
+                workspace.id
+            ))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        runtime
+            .get_workspace(&workspace.owner, workspace.id)
+            .await
+            .unwrap()
+            .status,
+        CodeWorkspaceStatus::SetupFailed
+    );
+    assert!(!marker.exists());
+
+    assert!(std::process::Command::new("git")
+        .args(["worktree", "remove", "--force", &workspace.worktree_path])
+        .current_dir(&repo.root_path)
+        .status()
+        .unwrap()
+        .success());
+    workspace.status = CodeWorkspaceStatus::Archived;
+    workspace.archived_at = Some(chrono::Utc::now());
+    save_workspace(&runtime.db, &workspace).await.unwrap();
+    assert_hosted_refusal(
+        client
+            .post(format!(
+                "http://{addr}/code/workspaces/{}/restore",
+                workspace.id
+            ))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        runtime
+            .get_workspace(&workspace.owner, workspace.id)
+            .await
+            .unwrap()
+            .status,
+        CodeWorkspaceStatus::Archived
+    );
+    assert!(!path.exists());
+}
+
+#[tokio::test]
+async fn sandbox_only_terminals_refuse_execution_but_allow_read_and_close() {
+    let (state, _runtime, _repo, workspace, _dir) = hosted_fixture().await;
+    let token = state.token.clone();
+    let terminal = state
+        .terminals
+        .open(
+            &workspace.owner,
+            workspace.id,
+            std::path::Path::new(&workspace.worktree_path),
+            Some(80),
+            Some(24),
+        )
+        .unwrap();
+    let addr = serve(app(state.clone())).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://{addr}/code/workspaces/{}/terminals", workspace.id);
+    assert_hosted_refusal(
+        client
+            .post(&base)
+            .bearer_auth(&token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(state.terminals.list(workspace.id).len(), 1);
+    use base64::Engine;
+    let bytes =
+        base64::engine::general_purpose::STANDARD.encode("echo terminal > hosted-terminal-ran\n");
+    assert_hosted_refusal(
+        client
+            .post(format!("{base}/{}/write", terminal.id))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({"bytes": bytes}))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_hosted_refusal(
+        client
+            .post(format!("{base}/{}/resize", terminal.id))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({"cols": 100, "rows": 30}))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    let unchanged = state.terminals.list(workspace.id);
+    assert_eq!((unchanged[0].cols, unchanged[0].rows), (80, 24));
+    assert_eq!(
+        client
+            .get(format!("{base}/{}/read?cursor=0", terminal.id))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::OK
+    );
+    assert_eq!(
+        client
+            .delete(format!("{base}/{}", terminal.id))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::NO_CONTENT
+    );
+    assert!(state.terminals.close_workspace_and_wait(workspace.id).await);
+    assert!(!std::path::Path::new(&workspace.worktree_path)
+        .join("hosted-terminal-ran")
+        .exists());
+}
+
+#[tokio::test]
+async fn sandbox_only_remote_archive_stays_available_without_host_restore_or_retry() {
+    let (state, runtime, _repo, mut workspace, _dir) = hosted_fixture().await;
+    workspace.worktree_path = CodeWorkspace::remote_worktree_marker(workspace.id);
+    save_workspace(&runtime.db, &workspace).await.unwrap();
+    let token = state.token.clone();
+    let addr = serve(app(state)).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://{addr}/code/workspaces/{}", workspace.id);
+    let archived = client
+        .post(format!("{base}/archive"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        runtime
+            .get_workspace(&workspace.owner, workspace.id)
+            .await
+            .unwrap()
+            .status,
+        CodeWorkspaceStatus::Archived
+    );
+    for action in ["restore", "retry-setup"] {
+        let response = client
+            .post(format!("{base}/{action}"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(body["kind"], "workspace_remote");
+    }
+    assert!(!std::path::Path::new(&workspace.worktree_path).exists());
+}

--- a/crates/tidebreak-server-api/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server-api/src/wire_code_fixtures.rs
@@ -556,6 +556,7 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
             "workspace pr",
             "workspace_pr",
             &CodeWorkspacePrSnapshot {
+                remote: None,
                 git: Some(CodeWorkspaceGitState {
                     branch: Some("mara/code-parsers-bounded".to_owned()),
                     head_sha: "cec166ffc1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6".to_owned(),

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -189,7 +189,8 @@ pub async fn configure_workspace_identity(
 /// Live git + `gh` observation for the workspace PR card.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceGitStatus {
-    pub git: super::types::CodeWorkspaceGitState,
+    pub git: Option<super::types::CodeWorkspaceGitState>,
+    pub remote: bool,
     pub dirty: bool,
     pub unpushed: bool,
     pub ahead: u64,
@@ -361,7 +362,8 @@ pub async fn workspace_git_status(
     // which the runtime drives with the fact row's ETags; this observation
     // only carries the persisted copy and the local git state.
     Ok(WorkspaceGitStatus {
-        git: inspect.git,
+        git: Some(inspect.git),
+        remote: false,
         dirty: inspect.dirty,
         unpushed: inspect.unpushed,
         ahead: inspect.ahead,
@@ -699,8 +701,8 @@ pub fn require_gh_binary(gh: &GhObservation) -> Result<PathBuf, GhError> {
     })
 }
 
-/// Parse `gh pr view --json number,comments,reviews`: issue comments plus
-/// review bodies. Missing or malformed entries are skipped, never fatal.
+/// Parse issue comments and review bodies from the `gh pr view` or REST vocabulary.
+/// Missing or malformed entries are skipped, never fatal.
 pub fn parse_pr_view_comments(
     json: &str,
 ) -> (Option<u64>, Vec<tidebreak_core::PullRequestComment>) {
@@ -719,6 +721,7 @@ pub fn parse_pr_view_comments(
     let login = |value: &serde_json::Value| {
         value
             .get("author")
+            .or_else(|| value.get("user"))
             .and_then(|author| author.get("login"))
             .and_then(|inner| inner.as_str())
             .filter(|inner| !inner.is_empty())
@@ -727,6 +730,7 @@ pub fn parse_pr_view_comments(
     let avatar = |value: &serde_json::Value| {
         value
             .get("author")
+            .or_else(|| value.get("user"))
             .and_then(|author| author.get("avatarUrl").or_else(|| author.get("avatar_url")))
             .and_then(|inner| inner.as_str())
             .filter(|inner| !inner.is_empty())
@@ -747,8 +751,8 @@ pub fn parse_pr_view_comments(
             id: id(item),
             author: login(item),
             avatar_url: avatar(item),
-            url: text(item, "url"),
-            created_at: text(item, "createdAt"),
+            url: text(item, "url").or_else(|| text(item, "html_url")),
+            created_at: text(item, "createdAt").or_else(|| text(item, "created_at")),
             body,
             review_state: None,
             path: None,
@@ -771,8 +775,11 @@ pub fn parse_pr_view_comments(
             id: id(item),
             author: login(item),
             avatar_url: avatar(item),
-            url: text(item, "url"),
-            created_at: text(item, "submittedAt").or_else(|| text(item, "createdAt")),
+            url: text(item, "url").or_else(|| text(item, "html_url")),
+            created_at: text(item, "submittedAt")
+                .or_else(|| text(item, "submitted_at"))
+                .or_else(|| text(item, "createdAt"))
+                .or_else(|| text(item, "created_at")),
             body,
             review_state: text(item, "state").map(|state| state.to_ascii_lowercase()),
             path: None,

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -93,10 +93,8 @@ pub(crate) async fn recover_running_sessions_with_caps(
         // Running with no pid is its normal shape, and interrupting it here
         // would abandon a lease that is still spending. Its own lifecycle
         // (the pump, the stale-intent sweep, reap) settles it.
-        if let Some(workspace) = super::session_workspace(store, &session).await? {
-            if workspace.is_remote() {
-                continue;
-            }
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
+            continue;
         }
         let parks = durable_parks(&session);
         if let Some(action) = recover_one(store, bus, session, &probe, parks).await? {
@@ -107,10 +105,8 @@ pub(crate) async fn recover_running_sessions_with_caps(
         if !matches!(session.fence_reason, Some(FenceReason::OrphanAlive)) {
             continue;
         }
-        if let Some(workspace) = super::session_workspace(store, &session).await? {
-            if workspace.is_remote() {
-                continue;
-            }
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
+            continue;
         }
         let Some(pid) = session.child_pid else {
             continue;
@@ -670,7 +666,15 @@ mod tests {
     }
 
     async fn seeded_running(pid: Option<i64>) -> (tempfile::TempDir, DbStore, SessionId, TurnId) {
-        let (directory, store, session_id) = seeded_session(pid, SessionLifecycle::Running).await;
+        seeded_running_at(pid, tidebreak_core::ExecutionLocation::Machine).await
+    }
+
+    async fn seeded_running_at(
+        pid: Option<i64>,
+        location: tidebreak_core::ExecutionLocation,
+    ) -> (tempfile::TempDir, DbStore, SessionId, TurnId) {
+        let (directory, store, session_id) =
+            seeded_session_at(pid, SessionLifecycle::Running, location).await;
         let turn_id = TurnId::new();
         insert_turn(
             &store,
@@ -705,6 +709,14 @@ mod tests {
     async fn seeded_session(
         pid: Option<i64>,
         lifecycle: SessionLifecycle,
+    ) -> (tempfile::TempDir, DbStore, SessionId) {
+        seeded_session_at(pid, lifecycle, tidebreak_core::ExecutionLocation::Machine).await
+    }
+
+    async fn seeded_session_at(
+        pid: Option<i64>,
+        lifecycle: SessionLifecycle,
+        location: tidebreak_core::ExecutionLocation,
     ) -> (tempfile::TempDir, DbStore, SessionId) {
         let directory = tempfile::tempdir().unwrap();
         let store = DbStore::connect(&format!(
@@ -783,7 +795,7 @@ mod tests {
                 unrecognized_event_count: 0,
                 subagents: Vec::new(),
                 created_at: now(),
-                execution_location: tidebreak_core::ExecutionLocation::Machine,
+                execution_location: location,
             },
         )
         .await
@@ -796,24 +808,10 @@ mod tests {
     /// still working.
     #[tokio::test]
     async fn boot_recovery_leaves_remote_sessions_running() {
-        let (_directory, store, session_id, _turn) = seeded_running(None).await;
+        let (_directory, store, session_id, _turn) =
+            seeded_running_at(None, tidebreak_core::ExecutionLocation::Sandbox).await;
         let owner = tidebreak_core::OwnerId::local();
-        let session = get_session(&store, &owner, session_id)
-            .await
-            .unwrap()
-            .unwrap();
-        let mut workspace = tidebreak_core::db::code::get_workspace(
-            &store,
-            &owner,
-            session.workspace_id.expect("workspace"),
-        )
-        .await
-        .unwrap()
-        .unwrap();
-        workspace.worktree_path = String::new();
-        tidebreak_core::db::code::save_workspace(&store, &workspace)
-            .await
-            .unwrap();
+        // Even an obsolete local workspace path must not select local recovery.
 
         let bus = CodeEventBus::default();
         let actions = recover_running_sessions_with(&store, &bus, |_, _| PidLiveness::Dead)

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -63,6 +63,7 @@ pub(crate) fn configured_settings(
 ) -> RemoteSpawnSettings {
     RemoteSpawnSettings {
         profile,
+        engine: config.runtime_engine,
         incarnation_cap: config.runtime_concurrency_cap,
         spend_ceiling_microusd: config.runtime_spawn_spend_ceiling_microusd,
         session_spend_ceiling_microusd: config.runtime_session_spend_ceiling_microusd,
@@ -389,6 +390,7 @@ mod tests {
         async fn spawn(
             &self,
             _owner: &OwnerId,
+            _session: tidebreak_core::SessionId,
             arguments: &SpawnArguments,
         ) -> Result<SandboxLease, RemoteSandboxError> {
             self.spawns.lock().unwrap().push(arguments.clone());
@@ -403,6 +405,7 @@ mod tests {
         async fn status(
             &self,
             _owner: &OwnerId,
+            _session: tidebreak_core::SessionId,
             sandbox_id: &str,
         ) -> Result<SandboxStatus, RemoteSandboxError> {
             Ok(SandboxStatus {
@@ -423,6 +426,7 @@ mod tests {
         async fn events(
             &self,
             _owner: &OwnerId,
+            _session: tidebreak_core::SessionId,
             _sandbox_id: &str,
             _cursor: EventCursor,
         ) -> Result<SandboxEvents, RemoteSandboxError> {
@@ -440,6 +444,7 @@ mod tests {
         async fn send(
             &self,
             _owner: &OwnerId,
+            _session: tidebreak_core::SessionId,
             _sandbox_id: &str,
             message: &SandboxMessage,
         ) -> Result<MessageReceipt, RemoteSandboxError> {
@@ -454,6 +459,7 @@ mod tests {
         async fn cancel(
             &self,
             _owner: &OwnerId,
+            _session: tidebreak_core::SessionId,
             sandbox_id: &str,
         ) -> Result<(), RemoteSandboxError> {
             self.cancels.lock().unwrap().push(sandbox_id.to_owned());
@@ -464,6 +470,7 @@ mod tests {
     fn settings() -> RemoteSpawnSettings {
         RemoteSpawnSettings {
             profile: "tidebreak-remote".to_owned(),
+            engine: None,
             incarnation_cap: 2,
             spend_ceiling_microusd: None,
             session_spend_ceiling_microusd: None,
@@ -474,11 +481,13 @@ mod tests {
     fn configured_settings_use_operator_limits() {
         let mut config = tidebreak_core::Config::desktop("/data");
         config.runtime_concurrency_cap = 7;
+        config.runtime_engine = Some(HarnessKind::ClaudeCode);
         config.runtime_spawn_spend_ceiling_microusd = Some(9_000_000);
         config.runtime_session_spend_ceiling_microusd = None;
 
         let settings = configured_settings("remote-large".to_owned(), &config);
         assert_eq!(settings.profile, "remote-large");
+        assert_eq!(settings.engine, Some(HarnessKind::ClaudeCode));
         assert_eq!(settings.incarnation_cap, 7);
         assert_eq!(settings.spend_ceiling_microusd, Some(9_000_000));
         assert_eq!(settings.session_spend_ceiling_microusd, None);
@@ -486,6 +495,13 @@ mod tests {
 
     async fn runtime_with_remote(
         root: &std::path::Path,
+    ) -> (Arc<CodeRuntime>, Arc<FakeProvisioner>, OwnerId, CodeRepo) {
+        runtime_with_remote_settings(root, settings()).await
+    }
+
+    async fn runtime_with_remote_settings(
+        root: &std::path::Path,
+        spawn_settings: RemoteSpawnSettings,
     ) -> (Arc<CodeRuntime>, Arc<FakeProvisioner>, OwnerId, CodeRepo) {
         let db = tidebreak_core::DbStore::connect(&format!(
             "sqlite://{}?mode=rwc",
@@ -504,7 +520,7 @@ mod tests {
             None,
             None,
         )
-        .with_remote_sessions(RemoteSessions::new(fake.clone(), settings()));
+        .with_remote_sessions(RemoteSessions::new(fake.clone(), spawn_settings));
         let runtime = Arc::new(runtime);
         let owner = OwnerId::local();
         let repo = CodeRepo {
@@ -545,6 +561,106 @@ mod tests {
             payload,
             created_at: String::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn a_declared_profile_rejects_settings_before_saving_or_queueing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spawn_settings = settings();
+        spawn_settings.engine = Some(HarnessKind::ClaudeCode);
+        let (runtime, fake, owner, repo) =
+            runtime_with_remote_settings(dir.path(), spawn_settings).await;
+        let workspace = runtime
+            .create_remote_workspace(&owner, repo.id, Some("declared".into()))
+            .await
+            .unwrap();
+        let mut unsupported = session_settings();
+        unsupported.permission_mode = PermissionMode::Ask;
+        assert!(runtime
+            .create_remote_session(&owner, workspace.id, HarnessKind::ClaudeCode, unsupported)
+            .await
+            .is_err());
+        let mut fast = session_settings();
+        fast.fast_mode = true;
+        assert!(runtime
+            .create_remote_session(&owner, workspace.id, HarnessKind::ClaudeCode, fast)
+            .await
+            .is_err());
+        let session = runtime
+            .create_remote_session(
+                &owner,
+                workspace.id,
+                HarnessKind::ClaudeCode,
+                session_settings(),
+            )
+            .await
+            .unwrap();
+        assert!(runtime
+            .set_permission_mode(&owner, session.id, PermissionMode::Ask)
+            .await
+            .is_err());
+        assert!(runtime
+            .set_fast_mode(&owner, session.id, true)
+            .await
+            .is_err());
+        assert!(runtime
+            .set_reasoning_effort(
+                &owner,
+                session.id,
+                Some(tidebreak_core::ReasoningEffort::High)
+            )
+            .await
+            .is_err());
+        runtime
+            .submit_turn(
+                &owner,
+                session.id,
+                "start".into(),
+                None,
+                None,
+                Vec::new(),
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(runtime
+            .submit_turn(
+                &owner,
+                session.id,
+                "changed model".into(),
+                Some("another-model".into()),
+                None,
+                Vec::new(),
+                None
+            )
+            .await
+            .is_err());
+        let stored = runtime.get_session(&owner, session.id).await.unwrap();
+        assert_eq!(stored.permission_mode, PermissionMode::Allow);
+        assert!(!stored.fast_mode);
+        assert_eq!(stored.model, None);
+        assert_eq!(stored.reasoning_effort, None);
+        let mut incompatible = stored;
+        incompatible.harness_kind = HarnessKind::Codex;
+        tidebreak_core::db::code::save_session(&runtime.db, &incompatible)
+            .await
+            .unwrap();
+        assert!(runtime
+            .submit_turn(
+                &owner,
+                session.id,
+                "unsupported queued engine".into(),
+                None,
+                None,
+                Vec::new(),
+                None
+            )
+            .await
+            .is_err());
+        let (queue, _) = runtime.list_queued_turns(&owner, session.id).await.unwrap();
+        assert!(queue.is_empty());
+        assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+        assert!(fake.sends.lock().unwrap().is_empty());
     }
 
     /// The runtime carries a turn to a sandbox with no local harness: create

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -205,6 +205,8 @@ pub struct CodeRuntime {
     /// runtime endpoint (`docs/slack-sessions.md`). `None` everywhere else;
     /// remote workspaces then refuse turns rather than half-running.
     remote: Option<Arc<super::remote::service::RemoteSessions>>,
+    /// Hosted execution keeps untrusted engines outside this server process.
+    sandbox_only_execution: bool,
     /// Live fan-out for adapter-grant revocations, so an event stream
     /// holding a revoked grant drops immediately (docs/slack-sessions.md).
     pub grant_revocations: Arc<super::grants::GrantRevocations>,
@@ -450,6 +452,7 @@ impl CodeRuntime {
             harness_llm,
             gateway_runtime: None,
             remote: None,
+            sandbox_only_execution: false,
             grant_revocations: Arc::new(super::grants::GrantRevocations::default()),
             loopback_base: Mutex::new(None),
             probes: Mutex::new(HashMap::new()),
@@ -610,6 +613,7 @@ impl CodeRuntime {
             harness_llm: None,
             gateway_runtime: None,
             remote: None,
+            sandbox_only_execution: false,
             grant_revocations: Arc::new(super::grants::GrantRevocations::default()),
             loopback_base: Mutex::new(None),
             probes: Mutex::new(HashMap::new()),
@@ -695,6 +699,22 @@ impl CodeRuntime {
     ) -> Self {
         self.remote = Some(remote);
         self
+    }
+
+    /// Refuse local engines on a hosted deployment that requires isolation.
+    pub fn with_sandbox_only_execution(mut self) -> Self {
+        self.sandbox_only_execution = true;
+        self
+    }
+
+    fn require_machine_execution(&self) -> Result<(), ServerError> {
+        if self.sandbox_only_execution {
+            return Err(ServerError::conflict_kind(
+                "sandbox_session_required",
+                "this hosted deployment runs agents in isolated sandboxes; start a new sandbox session",
+            ));
+        }
+        Ok(())
     }
 
     /// The remote-session context, when this deployment configured one.

--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -216,25 +216,14 @@ impl CodeRuntime {
         // Remote sessions have no local worker to re-attach: their engine
         // lives in a sandbox, and spawning a host harness against the empty
         // worktree path would fail loudly for a session that is healthy.
-        let mut remote_workspaces = std::collections::HashSet::new();
-        let mut checked_workspaces = std::collections::HashSet::new();
-        for session in &recovered_sessions {
-            if !checked_workspaces.insert(session.workspace_id) {
-                continue;
-            }
-            if let Ok(Some(workspace)) = self.session_workspace(session).await {
-                if workspace.is_remote() {
-                    remote_workspaces.insert(session.workspace_id);
-                }
-            }
-        }
         let resumable: Vec<Session> = recovered_sessions
             .into_iter()
             .filter(|session| {
                 !matches!(
                     session.lifecycle,
                     SessionLifecycle::Ended | SessionLifecycle::Fenced
-                ) && !remote_workspaces.contains(&session.workspace_id)
+                ) && !self.sandbox_only_execution
+                    && session.execution_location == tidebreak_core::ExecutionLocation::Machine
                     && !self
                         .workers
                         .lock()
@@ -253,7 +242,8 @@ impl CodeRuntime {
                         if !matches!(
                             latest.lifecycle,
                             SessionLifecycle::Ended | SessionLifecycle::Fenced
-                        ) && !self
+                        ) && latest.execution_location == tidebreak_core::ExecutionLocation::Machine
+                            && !self
                             .workers
                             .lock()
                             .expect("code workers")

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -93,6 +93,36 @@ impl CodeRuntime {
         })
     }
 
+    pub(super) fn validate_remote_execution(&self, session: &Session) -> Result<(), ServerError> {
+        if let Some(remote) = self.remote_sessions() {
+            remote
+                .settings
+                .validate_execution(session)
+                .map_err(|message| {
+                    ServerError::unprocessable_kind("sandbox_settings_unavailable", message)
+                })?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_remote_settings_change(
+        &self,
+        session: &Session,
+        next: &SessionExecutionSettings,
+    ) -> Result<(), ServerError> {
+        if self
+            .remote_sessions()
+            .is_some_and(|remote| remote.settings.engine.is_some())
+            && *next != SessionExecutionSettings::from(session)
+        {
+            return Err(ServerError::conflict_kind(
+                "sandbox_settings_fixed",
+                "choose the model and reasoning effort when starting a new sandbox session; this profile cannot change them during a session",
+            ));
+        }
+        Ok(())
+    }
+
     /// Shape a remote session value bound to `workspace`, uninserted.
     pub(super) fn remote_session_value(
         owner: &OwnerId,
@@ -112,7 +142,7 @@ impl CodeRuntime {
             permission_mode: settings.permission_mode,
             model: normalize_model(settings.model),
             reasoning_effort: settings.reasoning_effort,
-            fast_mode: false,
+            fast_mode: settings.fast_mode,
             lifecycle: SessionLifecycle::Idle,
             fence_reason: None,
             child_pid: None,
@@ -207,6 +237,7 @@ impl CodeRuntime {
                 }
                 let workspace = self.build_remote_workspace(owner, &repo, title).await?;
                 let session = Self::remote_session_value(owner, workspace.id, harness, settings);
+                self.validate_remote_execution(&session)?;
                 Ok(tidebreak_core::db::code::resolve_external_session(
                     &self.db,
                     owner,
@@ -321,6 +352,7 @@ impl CodeRuntime {
             ));
         }
         let session = Self::remote_session_value(owner, workspace_id, harness, settings);
+        self.validate_remote_execution(&session)?;
         insert_session(&self.db, &session).await?;
         Ok(session)
     }
@@ -364,9 +396,9 @@ impl CodeRuntime {
                 "remote sessions cannot stage attachment bytes because the sandbox message contract carries text only; send the turn without attachments",
             ));
         }
-        // Settings stick without local capability validation: the sandbox
-        // engine reads them off the spawn, and no local harness answers for
-        // a remote one.
+        self.validate_remote_execution(&session)?;
+        // The declared supervised image reads settings only at spawn. Inbox
+        // messages cannot change them, so preserve the session contract.
         let mut next = SessionExecutionSettings::from(&session);
         if let Some(model) = normalize_model(model) {
             next.model = Some(model);
@@ -374,6 +406,7 @@ impl CodeRuntime {
         if let Some(effort) = reasoning_effort {
             next.reasoning_effort = effort;
         }
+        self.validate_remote_settings_change(&session, &next)?;
         if next != SessionExecutionSettings::from(&session) {
             session = replace_session_execution_settings(&self.db, owner, &session, &next)
                 .await?
@@ -472,6 +505,7 @@ impl CodeRuntime {
         message: String,
         actor: Option<tidebreak_core::TurnActor>,
     ) -> Result<SubmitTurnOutcome, ServerError> {
+        self.validate_remote_execution(session)?;
         let queued = tidebreak_core::db::code::list_queued_turns(&self.db, owner, session.id)
             .await
             .map_err(ServerError::from)?;
@@ -571,15 +605,14 @@ impl CodeRuntime {
         let Some(remote) = self.remote_sessions() else {
             return Ok(());
         };
-        if session.lifecycle != SessionLifecycle::Idle {
+        if session.execution_location != ExecutionLocation::Sandbox
+            || session.lifecycle != SessionLifecycle::Idle
+        {
             return Ok(());
         }
         let Ok(Some(workspace)) = self.session_workspace(&session).await else {
             return Ok(());
         };
-        if !workspace.is_remote() {
-            return Ok(());
-        }
         if tidebreak_core::db::code::queue_paused(&self.db, &session.owner, session.id).await? {
             return Ok(());
         }
@@ -671,6 +704,7 @@ impl CodeRuntime {
         }
         let session = self.get_session(owner, session_id).await?;
         if session.execution_location == ExecutionLocation::Machine {
+            self.require_machine_execution()?;
             if let Some(external) = self
                 .harness_llm
                 .as_ref()
@@ -770,7 +804,7 @@ impl CodeRuntime {
         };
         match remote
             .provisioner
-            .send(&session.owner, sandbox_id, &message)
+            .send(&session.owner, session.id, sandbox_id, &message)
             .await
         {
             Ok(_) => Ok(()),
@@ -797,7 +831,11 @@ impl CodeRuntime {
             return;
         };
         if let Some(sandbox_id) = row.sandbox_id.as_deref() {
-            if let Err(error) = remote.provisioner.cancel(&session.owner, sandbox_id).await {
+            if let Err(error) = remote
+                .provisioner
+                .cancel(&session.owner, session.id, sandbox_id)
+                .await
+            {
                 tracing::warn!(
                     session = %session.id,
                     %error,

--- a/crates/tidebreak-server/src/code/runtime/settings.rs
+++ b/crates/tidebreak-server/src/code/runtime/settings.rs
@@ -179,15 +179,12 @@ impl CodeRuntime {
             _ => {}
         }
 
-        let workspace = self.session_workspace(&session).await?;
-        if workspace
-            .as_ref()
-            .is_some_and(|workspace| workspace.is_remote())
-        {
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
             // The sandbox carries the engine. Persist the mode on the row and
             // do not relaunch a host harness against the empty worktree.
             let mut session = session;
             session.permission_mode = mode;
+            self.validate_remote_execution(&session)?;
             crate::code::attention::persist_session(&self.db, &self.bus, &session).await?;
             return Ok(session);
         }
@@ -579,6 +576,15 @@ impl CodeRuntime {
         effort: Option<ReasoningEffort>,
     ) -> Result<Session, ServerError> {
         let session = self.get_session(owner, id).await?;
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
+            let mut next = SessionExecutionSettings::from(&session);
+            next.reasoning_effort = effort;
+            self.validate_remote_execution(&session)?;
+            self.validate_remote_settings_change(&session, &next)?;
+            if next == SessionExecutionSettings::from(&session) {
+                return Ok(session);
+            }
+        }
         match session.lifecycle {
             SessionLifecycle::Running => {
                 return Err(ServerError::conflict_kind(
@@ -635,6 +641,14 @@ impl CodeRuntime {
         fast_mode: bool,
     ) -> Result<Session, ServerError> {
         let session = self.get_session(owner, id).await?;
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
+            let mut requested = session.clone();
+            requested.fast_mode = fast_mode;
+            self.validate_remote_execution(&requested)?;
+            if session.fast_mode == fast_mode {
+                return Ok(session);
+            }
+        }
         match session.lifecycle {
             SessionLifecycle::Running => {
                 return Err(ServerError::conflict_kind(

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -177,10 +177,15 @@ impl CodeRuntime {
                 "session has ended",
             ));
         }
-        if let Some(workspace) = workspace.as_ref().filter(|workspace| workspace.is_remote()) {
-            // The sandbox path: no local worker, no worktree lock, no
-            // harness probe. Everything below this branch assumes a checkout
-            // on this machine.
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
+            let workspace = workspace.as_ref().ok_or_else(|| {
+                ServerError::conflict_kind(
+                    "remote_workspace_missing",
+                    "this sandbox session has no workspace",
+                )
+            })?;
+            // The stored session location owns dispatch. A workspace marker
+            // must never turn a sandbox session into a local engine.
             return self
                 .submit_remote_turn(
                     owner,
@@ -195,6 +200,16 @@ impl CodeRuntime {
                     queue_if_busy,
                 )
                 .await;
+        }
+        self.require_machine_execution()?;
+        if workspace
+            .as_ref()
+            .is_some_and(|workspace| workspace.is_remote())
+        {
+            return Err(ServerError::conflict_kind(
+                "session_location_mismatch",
+                "the machine session has a sandbox workspace and cannot run locally",
+            ));
         }
         // No capability gate on attachments. An engine that states image input
         // is handed the bytes on its own protocol; every other one is handed a
@@ -449,6 +464,12 @@ impl CodeRuntime {
     }
 
     pub async fn interrupt(&self, id: SessionId) -> Result<(), ServerError> {
+        let session = tidebreak_core::db::code::get_session_all_owners(&self.db, id)
+            .await?
+            .ok_or_else(|| ServerError::not_found("session not found"))?;
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
+            return self.interrupt_remote(&session).await;
+        }
         // Interrupt stops only the active turn. The worker and logical code
         // session continue, so its browser capfile and native capability must
         // remain live for later turns.
@@ -465,22 +486,10 @@ impl CodeRuntime {
                 .map_err(|_| ServerError::internal("session worker dropped the interrupt"))?
                 .map_err(map_worker);
         }
-        // No host worker: a remote session's engine lives in a sandbox.
-        let sessions = list_sessions_all_owners(&self.db).await?;
-        let Some(session) = sessions.into_iter().find(|session| session.id == id) else {
-            return Err(ServerError::conflict_kind(
-                "session_worker_missing",
-                "session worker is not running",
-            ));
-        };
-        let workspace = self.session_workspace(&session).await?;
-        if !workspace.is_some_and(|workspace| workspace.is_remote()) {
-            return Err(ServerError::conflict_kind(
-                "session_worker_missing",
-                "session worker is not running",
-            ));
-        }
-        self.interrupt_remote(&session).await
+        Err(ServerError::conflict_kind(
+            "session_worker_missing",
+            "session worker is not running",
+        ))
     }
 
     /// Retract one queued message. `false` when the row is gone.
@@ -502,10 +511,13 @@ impl CodeRuntime {
         id: SessionId,
         paused: bool,
     ) -> Result<(), ServerError> {
-        let _ = self.get_session(owner, id).await?;
+        let session = self.get_session(owner, id).await?;
+        if !paused && session.execution_location == tidebreak_core::ExecutionLocation::Machine {
+            self.require_machine_execution()?;
+        }
         tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, paused).await?;
         if !paused {
-            self.wake_session_queue(id);
+            self.wake_queue_for_location(&session);
         }
         Ok(())
     }
@@ -514,10 +526,24 @@ impl CodeRuntime {
     /// head row. The tray composes send-now client-side exactly as chat does:
     /// pause, move the row first, stop the live turn, then this.
     pub async fn send_queued_now(&self, owner: &OwnerId, id: SessionId) -> Result<(), ServerError> {
-        let _ = self.get_session(owner, id).await?;
+        let session = self.get_session(owner, id).await?;
+        if session.execution_location == tidebreak_core::ExecutionLocation::Machine {
+            self.require_machine_execution()?;
+        }
         tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, false).await?;
-        self.wake_session_queue(id);
+        self.wake_queue_for_location(&session);
         Ok(())
+    }
+
+    fn wake_queue_for_location(&self, session: &Session) {
+        match session.execution_location {
+            tidebreak_core::ExecutionLocation::Sandbox => {
+                if let Some(remote) = self.remote_sessions() {
+                    remote.wake_sweep();
+                }
+            }
+            tidebreak_core::ExecutionLocation::Machine => self.wake_session_queue(session.id),
+        }
     }
 
     /// Nudge a live worker to re-read its queue. A session with no worker has
@@ -717,11 +743,7 @@ impl CodeRuntime {
                 "only a fenced session can be reaped",
             ));
         }
-        let workspace = self.session_workspace(&session).await?;
-        if workspace
-            .as_ref()
-            .is_some_and(|workspace| workspace.is_remote())
-        {
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
             // No worker to shut down and nothing to relaunch: the driver
             // cancels whatever the environment still holds, closes the
             // incarnation, and resolves the fence. The next turn

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -99,8 +99,24 @@ impl CodeRuntime {
     }
 
     pub async fn attach_and_spawn_worker(&self, session: Session) -> Result<Session, ServerError> {
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
+            return Err(ServerError::conflict_kind(
+                "session_remote",
+                "this session runs in a sandbox and cannot attach a local worker",
+            ));
+        }
+        self.require_machine_execution()?;
         let mut session = session;
         let workspace = self.session_workspace(&session).await?;
+        if workspace
+            .as_ref()
+            .is_some_and(|workspace| workspace.is_remote())
+        {
+            return Err(ServerError::conflict_kind(
+                "session_location_mismatch",
+                "the machine session has a sandbox workspace and cannot attach a local worker",
+            ));
+        }
         let adapter = self.adapter(session.harness_kind)?;
         // Cached, so the probe `create_session` already paid for is not paid
         // again on the way into the worker.
@@ -589,6 +605,73 @@ mod tests {
             created_at: Utc::now(),
             execution_location: tidebreak_core::ExecutionLocation::Machine,
         }
+    }
+
+    #[tokio::test]
+    async fn a_sandbox_session_never_attaches_or_recovers_a_local_worker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime = scripted_runtime(tmp.path()).await;
+        let owner = OwnerId::local();
+        let mut session = workspaceless_session(&owner, HarnessKind::ClaudeCode);
+        session.execution_location = tidebreak_core::ExecutionLocation::Sandbox;
+        session.lifecycle = SessionLifecycle::Idle;
+        insert_session(&runtime.db, &session).await.unwrap();
+
+        let error = runtime
+            .attach_and_spawn_worker(session.clone())
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), "session_remote");
+        assert!(!runtime.has_worker(session.id));
+        runtime.recover().await.unwrap();
+        assert!(!runtime.has_worker(session.id));
+        let recovered = runtime.get_session(&owner, session.id).await.unwrap();
+        assert_eq!(recovered.spawn_epoch, session.spawn_epoch);
+        assert_eq!(recovered.lifecycle, SessionLifecycle::Idle);
+    }
+
+    #[tokio::test]
+    async fn sandbox_only_execution_refuses_existing_machine_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime = scripted_runtime(tmp.path())
+            .await
+            .with_sandbox_only_execution();
+        let owner = OwnerId::local();
+        let mut session = workspaceless_session(&owner, HarnessKind::ClaudeCode);
+        session.lifecycle = SessionLifecycle::Idle;
+        insert_session(&runtime.db, &session).await.unwrap();
+
+        let error = runtime
+            .attach_and_spawn_worker(session.clone())
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), "sandbox_session_required");
+        let outcome = runtime
+            .submit_turn(
+                &owner,
+                session.id,
+                "run locally".into(),
+                None,
+                None,
+                Vec::new(),
+                None,
+            )
+            .await;
+        let error = match outcome {
+            Err(error) => error,
+            Ok(_) => panic!("a hosted machine session accepted local execution"),
+        };
+        assert_eq!(error.kind(), "sandbox_session_required");
+        runtime.recover().await.unwrap();
+        assert!(!runtime.has_worker(session.id));
+        assert_eq!(
+            runtime
+                .get_session(&owner, session.id)
+                .await
+                .unwrap()
+                .execution_location,
+            tidebreak_core::ExecutionLocation::Machine
+        );
     }
 
     /// A worker still on another file than the channel selects is respawned

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -290,6 +290,161 @@ impl CodeRuntime {
         Ok(Some((target, credential)))
     }
 
+    /// Resolve the connection that created this workspace before borrowing authority.
+    /// An external workspace never falls back to a browser caller after revocation.
+    async fn workspace_git_lender(
+        &self,
+        owner: &OwnerId,
+        workspace: &CodeWorkspace,
+    ) -> Result<
+        (
+            Option<Arc<dyn crate::obo_gateway::GitCredentialLender>>,
+            bool,
+        ),
+        ServerError,
+    > {
+        let sessions = list_sessions_for_workspace(&self.db, owner, workspace.id).await?;
+        let ids: Vec<_> = sessions.iter().map(|session| session.id).collect();
+        let bindings =
+            tidebreak_core::db::code::list_external_bindings_for_sessions(&self.db, owner, &ids)
+                .await?;
+        let Some(first) = bindings.first() else {
+            return Ok((self.git_credentials().cloned(), false));
+        };
+        if bindings
+            .iter()
+            .any(|binding| binding.grant_id != first.grant_id)
+        {
+            return Err(ServerError::conflict_kind(
+                "external_connection_conflict",
+                "This workspace has conflicting external connections.",
+            ));
+        }
+        let external = self
+            .harness_llm
+            .as_ref()
+            .and_then(|relay| relay.external_delegations())
+            .ok_or_else(|| {
+                ServerError::conflict_kind(
+                    "external_reconnect_required",
+                    "The connection that created this workspace is unavailable.",
+                )
+            })?;
+        let gateway = external
+            .for_session(owner, first.session_id)
+            .await?
+            .ok_or_else(|| {
+                ServerError::conflict_kind(
+                    "external_reconnect_required",
+                    "The connection that created this workspace is unavailable.",
+                )
+            })?;
+        Ok((Some(gateway), true))
+    }
+
+    /// A remote checkout has no host path. Its registered origin and original
+    /// session connection provide the same repository-scoped REST authority.
+    async fn workspace_forge_rest_context(
+        &self,
+        owner: &OwnerId,
+        workspace: &CodeWorkspace,
+        lender: Option<&Arc<dyn crate::obo_gateway::GitCredentialLender>>,
+    ) -> Result<
+        Option<(
+            CodeGitHubRepositoryTarget,
+            crate::obo_gateway::GitCredential,
+        )>,
+        ServerError,
+    > {
+        let Some(lender) = lender else {
+            return Ok(None);
+        };
+        let target = if workspace.is_remote() {
+            self.workspace_repository_target(owner, workspace).await
+        } else {
+            forge_lending_target(std::path::Path::new(&workspace.worktree_path)).await
+        };
+        let Some(target) = target.filter(|target| {
+            target
+                .host
+                .eq_ignore_ascii_case(gh::GIT_CREDENTIAL_FORGE_HOST)
+        }) else {
+            return Err(ServerError::unprocessable_kind(
+                "git_forge_refused",
+                "This workspace has no supported forge repository.",
+            ));
+        };
+        if let Some(pr) = workspace.pr.as_ref() {
+            if let Some((host, repo_owner, repo_name, number)) = pr
+                .url
+                .as_deref()
+                .and_then(crate::code::pr_facts::pull_request_identity_from_url)
+            {
+                let identity = CodeGitHubRepositoryTarget {
+                    host,
+                    owner: repo_owner,
+                    name: repo_name,
+                };
+                if !same_repository(&target, &identity) || number != pr.number {
+                    return Err(ServerError::conflict_kind(
+                        "workspace_pr_target_changed",
+                        "The pull request does not match this workspace repository.",
+                    ));
+                }
+            }
+        }
+        let credential = lender
+            .git_credential(owner, &format!("{}/{}", target.owner, target.name))
+            .await
+            .map_err(|error| {
+                ServerError::unprocessable_kind(
+                    "git_forge_refused",
+                    crate::code::clone::git_forge_refusal_message(&error),
+                )
+            })?;
+        Ok(Some((target, credential)))
+    }
+
+    async fn remote_workspace_pr(
+        &self,
+        owner: &OwnerId,
+        workspace: &CodeWorkspace,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        let (lender, _) = self.workspace_git_lender(owner, workspace).await?;
+        let identity = match lender {
+            Some(lender) => lender.git_forge_identity(owner).await.ok(),
+            None => None,
+        };
+        let (pushes_as, pushes_as_self) = match identity {
+            Some(identity) => match identity.attribution {
+                crate::obo_gateway::GitForgeAttribution::Person { login, .. } => {
+                    (Some(login), Some(true))
+                }
+                crate::obo_gateway::GitForgeAttribution::Bot { bot_login } => {
+                    (Some(bot_login.unwrap_or(identity.app_name)), Some(false))
+                }
+            },
+            None => (None, None),
+        };
+        Ok(WorkspaceGitStatus {
+            remote: true,
+            git: None,
+            dirty: false,
+            unpushed: false,
+            ahead: 0,
+            has_upstream: false,
+            suggested_commit_message: String::new(),
+            pr: workspace.pr.clone(),
+            gh_found: false,
+            gh_authenticated: None,
+            remediation:
+                "Git changes run in the remote runtime. Pull request status comes from GitHub."
+                    .into(),
+            pushes_as,
+            pushes_as_self,
+        })
+    }
+
     pub async fn workspace_pr(
         &self,
         owner: &OwnerId,
@@ -300,6 +455,9 @@ impl CodeRuntime {
         // path reads local git plus the stored row, and the hot refresher
         // this mark feeds is what keeps the row current while anyone reads.
         self.mark_workspace_pr_hot(owner, workspace.id);
+        if workspace.is_remote() {
+            return self.remote_workspace_pr(owner, &workspace).await;
+        }
         let gh_path = self.gh_search_path_owned();
         let mut status = gh::workspace_git_status(
             std::path::Path::new(&workspace.worktree_path),
@@ -389,7 +547,16 @@ impl CodeRuntime {
         }
         let gh_path = self.gh_search_path_owned();
         let worktree = std::path::PathBuf::from(&workspace.worktree_path);
-        let digest = match gh::authenticated_gh_binary(gh_path.as_deref()).await {
+        let (lender, external) = self
+            .workspace_git_lender(owner, &workspace)
+            .await
+            .map_err(|error| error.message().to_owned())?;
+        let binary = if workspace.is_remote() || external {
+            None
+        } else {
+            gh::authenticated_gh_binary(gh_path.as_deref()).await
+        };
+        let digest = match binary {
             Some(binary) => {
                 let transport = crate::code::pr_fetch::FetchTransport::Gh {
                     cwd: &worktree,
@@ -400,7 +567,7 @@ impl CodeRuntime {
             }
             None => {
                 let (target, credential) = self
-                    .forge_rest_context(owner, &worktree)
+                    .workspace_forge_rest_context(owner, &workspace, lender.as_ref())
                     .await
                     .map_err(|error| error.message().to_owned())?
                     .ok_or_else(|| {
@@ -411,8 +578,22 @@ impl CodeRuntime {
                     api_base: &api_base,
                     credential: &credential,
                 };
-                self.fetched_workspace_digest(owner, &workspace, transport)
-                    .await
+                let digest = self
+                    .fetched_workspace_digest(owner, &workspace, transport)
+                    .await?;
+                if workspace.is_remote() {
+                    if let Some(digest) = digest.as_ref() {
+                        self.record_remote_workspace_pr(
+                            owner,
+                            &workspace,
+                            &target,
+                            &credential,
+                            digest,
+                        )
+                        .await?;
+                    }
+                }
+                Ok(digest)
             }
         };
         let Some(digest) = digest? else {
@@ -435,6 +616,85 @@ impl CodeRuntime {
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Attribute a remote PR only after GitHub confirms the assigned workspace branch.
+    async fn record_remote_workspace_pr(
+        &self,
+        owner: &OwnerId,
+        workspace: &CodeWorkspace,
+        target: &CodeGitHubRepositoryTarget,
+        credential: &crate::obo_gateway::GitCredential,
+        digest: &PullRequestDigest,
+    ) -> Result<(), String> {
+        if digest.head_branch.as_deref() != Some(workspace.branch_name.as_str()) {
+            return Ok(());
+        }
+        let attributed = self
+            .workspace_pull_requests(owner, workspace.id)
+            .await
+            .map_err(|error| error.message().to_owned())?;
+        if attributed.iter().any(|(fact, _)| {
+            fact.number == digest.number
+                && fact.host.eq_ignore_ascii_case(&target.host)
+                && fact.repo_owner.eq_ignore_ascii_case(&target.owner)
+                && fact.repo_name.eq_ignore_ascii_case(&target.name)
+        }) {
+            return Ok(());
+        }
+        let endpoint = format!(
+            "repos/{}/{}/pulls/{}",
+            target.owner, target.name, digest.number
+        );
+        let raw = crate::code::forge_rest::api_get(
+            &self.forge_api_base_for(&target.host),
+            credential,
+            &endpoint,
+        )
+        .await?;
+        let value = crate::code::forge_rest::fact_value(&raw);
+        if value["number"].as_u64() != Some(digest.number)
+            || value["headRefName"].as_str() != Some(workspace.branch_name.as_str())
+            || value["headRefOid"].as_str() != digest.head_sha.as_deref()
+        {
+            return Err("The pull request changed during refresh. Retry the refresh.".into());
+        }
+        let Some((host, repo_owner, repo_name, number)) = value["url"]
+            .as_str()
+            .and_then(crate::code::pr_facts::pull_request_identity_from_url)
+        else {
+            return Err("The pull request response has no repository identity.".into());
+        };
+        if number != digest.number
+            || !same_repository(
+                target,
+                &CodeGitHubRepositoryTarget {
+                    host,
+                    owner: repo_owner,
+                    name: repo_name,
+                },
+            )
+        {
+            return Err(
+                "The pull request response does not match the workspace repository.".into(),
+            );
+        }
+        crate::code::pr_facts::record_confirmed_fact(
+            &self.db,
+            owner,
+            workspace.id,
+            None,
+            None,
+            target,
+            &value,
+            tidebreak_core::CodePullRequestRelation::Contributed,
+            tidebreak_core::CodePullRequestDiscovery::Reconcile,
+        )
+        .await
+        .ok_or_else(|| "The confirmed pull request could not be saved.".to_owned())?;
+        self.record_pull_request_live_state(owner, Some(workspace.id), digest)
+            .await;
         Ok(())
     }
 
@@ -490,6 +750,9 @@ impl CodeRuntime {
                 owner: repo_owner,
                 name,
             });
+        }
+        if workspace.is_remote() {
+            return None;
         }
         crate::code::delivery::repository_target_from_local(&repo)
             .await
@@ -618,7 +881,7 @@ impl CodeRuntime {
                 false,
             ),
             Ok(EndpointRead::Missing) => {
-                return Err("The pull request is unavailable on GitHub.".to_owned())
+                return Err("The pull request is unavailable on GitHub.".to_owned());
             }
             Err(failure) => {
                 tracing::debug!(error = %failure, "code-mode: pull-request read skipped");
@@ -986,13 +1249,66 @@ impl CodeRuntime {
         id: WorkspaceId,
     ) -> Result<gh::PrComments, ServerError> {
         let workspace = self.get_workspace(owner, id).await?;
-        let gh_path = self.gh_search_path_owned();
-        gh::load_pr_comments(
-            std::path::Path::new(&workspace.worktree_path),
-            gh_path.as_deref(),
+        let (lender, external) = self.workspace_git_lender(owner, &workspace).await?;
+        if !workspace.is_remote() && !external && lender.is_none() {
+            let gh_path = self.gh_search_path_owned();
+            return gh::load_pr_comments(
+                std::path::Path::new(&workspace.worktree_path),
+                gh_path.as_deref(),
+            )
+            .await
+            .map_err(map_gh);
+        }
+        let (target, credential) = self
+            .workspace_forge_rest_context(owner, &workspace, lender.as_ref())
+            .await?
+            .ok_or_else(|| {
+                ServerError::unprocessable_kind(
+                    "git_forge_refused",
+                    "Connect GitHub before reading pull request comments.",
+                )
+            })?;
+        let api_base = self.forge_api_base_for(&target.host);
+        let number = match workspace.pr.as_ref() {
+            Some(pr) => pr.number,
+            None => {
+                let values = crate::code::forge_rest::list_pull_requests_for_head(
+                    &api_base,
+                    &target,
+                    &credential,
+                    &workspace.branch_name,
+                )
+                .await
+                .map_err(|error| ServerError::unprocessable_kind("pr_comments_failed", error))?;
+                let pull = values
+                    .iter()
+                    .find(|value| value["state"].as_str() == Some("open"))
+                    .or_else(|| values.first());
+                pull.and_then(|value| value["number"].as_u64())
+                    .ok_or_else(|| {
+                        ServerError::not_found("No pull request exists for this branch.")
+                    })?
+            }
+        };
+        let prefix = format!("repos/{}/{}", target.owner, target.name);
+        let issue_endpoint = format!("{prefix}/issues/{number}/comments?per_page=100");
+        let reviews_endpoint = format!("{prefix}/pulls/{number}/reviews?per_page=100");
+        let inline_endpoint = format!("{prefix}/pulls/{number}/comments?per_page=100");
+        let (issues, reviews, inline) = tokio::try_join!(
+            crate::code::forge_rest::api_get(&api_base, &credential, &issue_endpoint),
+            crate::code::forge_rest::api_get(&api_base, &credential, &reviews_endpoint),
+            crate::code::forge_rest::api_get(&api_base, &credential, &inline_endpoint),
         )
-        .await
-        .map_err(map_gh)
+        .map_err(|error| ServerError::unprocessable_kind("pr_comments_failed", error))?;
+        let view = serde_json::json!({
+            "number": number,
+            "comments": issues,
+            "reviews": reviews,
+        });
+        let (_, mut comments) = gh::parse_pr_view_comments(&view.to_string());
+        comments.extend(gh::parse_review_comments(&inline.to_string()));
+        comments.sort_by(|left, right| left.created_at.cmp(&right.created_at));
+        Ok(gh::PrComments { number, comments })
     }
 
     /// Every pull request attributed to the workspace, from the durable fact
@@ -1332,7 +1648,7 @@ impl CodeRuntime {
         .map_err(map_gh)
     }
 
-    pub(super) async fn require_live_workspace(
+    pub(crate) async fn require_live_workspace(
         &self,
         owner: &OwnerId,
         id: WorkspaceId,
@@ -1350,6 +1666,7 @@ impl CodeRuntime {
                 "this workspace's engine runs in a remote sandbox; there is no host worktree",
             ));
         }
+        self.require_machine_execution()?;
         if !std::path::Path::new(&workspace.worktree_path).exists() {
             return Err(ServerError::not_found("workspace worktree is gone"));
         }
@@ -1363,5 +1680,318 @@ impl CodeRuntime {
         }
         #[cfg(not(any(test, feature = "test-support")))]
         None
+    }
+}
+
+#[cfg(test)]
+mod remote_pr_tests {
+    use super::*;
+    use crate::obo_gateway::test_support::FakeLender;
+    use tidebreak_core::db::code::resolve_external_machine_session;
+
+    async fn fixture(root: &Path) -> (CodeRuntime, Arc<FakeLender>, OwnerId, CodeWorkspace) {
+        fixture_with_host(root, Some("github.com")).await
+    }
+
+    async fn fixture_with_host(
+        root: &Path,
+        host: Option<&str>,
+    ) -> (CodeRuntime, Arc<FakeLender>, OwnerId, CodeWorkspace) {
+        let db = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            root.join("remote-pr.db").display()
+        ))
+        .await
+        .unwrap();
+        let lender = Arc::new(FakeLender::offering("forge[bot]"));
+        let runtime = CodeRuntime::new(
+            Arc::new(db),
+            root.to_owned(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .with_git_credentials(lender.clone());
+        runtime.set_gh_search_path(Some(root.join("no-gh").display().to_string()));
+        let owner = OwnerId::local();
+        let repo = CodeRepo {
+            id: RepoId::new(),
+            owner: owner.clone(),
+            root_path: root.join("missing-repository").display().to_string(),
+            display_name: "tools".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: Vec::new(),
+            created_at: Utc::now(),
+            removed_at: None,
+            cloned_from: None,
+            origin_host: host.map(str::to_owned),
+            origin_owner: Some("acme".into()),
+            origin_name: Some("tools".into()),
+        };
+        insert_repo(&runtime.db, &repo).await.unwrap();
+        let mut workspace = runtime
+            .build_remote_workspace(&owner, &repo, Some("Remote delivery".into()))
+            .await
+            .unwrap();
+        workspace.pr = Some(
+            serde_json::from_value(serde_json::json!({
+                "number": 17,
+                "url": "https://github.com/acme/tools/pull/17",
+                "state": "open",
+                "title": "Stored title"
+            }))
+            .unwrap(),
+        );
+        insert_workspace(&runtime.db, &workspace).await.unwrap();
+        (runtime, lender, owner, workspace)
+    }
+
+    async fn bind(runtime: &CodeRuntime, owner: &OwnerId, workspace: WorkspaceId, identity: &str) {
+        let (grant, _) = runtime
+            .mint_adapter_grant(owner, "slack", identity, "T-TEST")
+            .await
+            .unwrap();
+        let session = CodeRuntime::remote_session_value(
+            owner,
+            workspace,
+            HarnessKind::Codex,
+            NewSessionSettings::default(),
+        );
+        resolve_external_machine_session(&runtime.db, owner, grant.id, "slack", identity, &session)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn remote_status_preserves_the_pr_without_inventing_local_git_facts() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, lender, owner, workspace) = fixture(dir.path()).await;
+        assert!(!Path::new(&workspace.worktree_path).exists());
+        let status = runtime.workspace_pr(&owner, workspace.id).await.unwrap();
+        assert!(status.remote);
+        assert!(status.git.is_none());
+        assert_eq!(status.pr, workspace.pr);
+        assert_eq!(status.pushes_as.as_deref(), Some("forge[bot]"));
+        assert_eq!(status.pushes_as_self, Some(false));
+        assert!(lender.minted().is_empty());
+    }
+
+    #[tokio::test]
+    async fn remote_reads_refuse_a_missing_original_connection_without_browser_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, lender, owner, workspace) = fixture(dir.path()).await;
+        bind(&runtime, &owner, workspace.id, "U-ONE").await;
+        let error = runtime
+            .workspace_pr(&owner, workspace.id)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), "external_reconnect_required");
+        let error = runtime
+            .workspace_pr_comments(&owner, workspace.id)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), "external_reconnect_required");
+        assert!(runtime
+            .refresh_workspace_pr(&owner, workspace.id)
+            .await
+            .is_err());
+        assert!(lender.minted().is_empty());
+    }
+
+    #[tokio::test]
+    async fn remote_reads_refuse_conflicting_original_connections() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, lender, owner, workspace) = fixture(dir.path()).await;
+        bind(&runtime, &owner, workspace.id, "U-ONE").await;
+        bind(&runtime, &owner, workspace.id, "U-TWO").await;
+        let error = runtime
+            .workspace_pr(&owner, workspace.id)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), "external_connection_conflict");
+        let error = runtime
+            .workspace_pr_comments(&owner, workspace.id)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), "external_connection_conflict");
+        assert!(lender.minted().is_empty());
+    }
+
+    #[tokio::test]
+    async fn remote_refresh_refuses_unknown_or_unsupported_origins_before_lending() {
+        for host in [Some("evil.example"), None] {
+            let dir = tempfile::tempdir().unwrap();
+            let (runtime, lender, owner, workspace) = fixture_with_host(dir.path(), host).await;
+            assert!(runtime
+                .refresh_workspace_pr(&owner, workspace.id)
+                .await
+                .is_err());
+            assert!(runtime
+                .workspace_pr_comments(&owner, workspace.id)
+                .await
+                .is_err());
+            assert!(lender.minted().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn remote_reads_refuse_a_pr_outside_the_registered_repository_before_lending() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, lender, owner, mut workspace) = fixture(dir.path()).await;
+        workspace.pr.as_mut().unwrap().url =
+            Some("https://github.com/other/repository/pull/17".into());
+        save_workspace(&runtime.db, &workspace).await.unwrap();
+        assert!(runtime
+            .refresh_workspace_pr(&owner, workspace.id)
+            .await
+            .is_err());
+        let error = runtime
+            .workspace_pr_comments(&owner, workspace.id)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), "workspace_pr_target_changed");
+        assert!(lender.minted().is_empty());
+    }
+
+    #[tokio::test]
+    async fn remote_refresh_and_discussion_use_the_registered_repository_over_rest() {
+        use axum::extract::State;
+        use axum::http::{HeaderMap, Uri};
+        use tidebreak_core::PullRequestCommentKind;
+        type Seen = Arc<Mutex<Vec<String>>>;
+        async fn forge(
+            State(seen): State<Seen>,
+            uri: Uri,
+            headers: HeaderMap,
+        ) -> axum::Json<serde_json::Value> {
+            assert_eq!(
+                headers.get("authorization").unwrap(),
+                "Bearer ghs_fake_borrowed"
+            );
+            let path = uri.path();
+            seen.lock().unwrap().push(path.to_owned());
+            let value = match path {
+                "/repos/acme/tools/pulls" => {
+                    assert!(uri
+                        .query()
+                        .unwrap_or_default()
+                        .contains("head=acme:tidebreak/remote-delivery"));
+                    serde_json::json!([{
+                        "number": 17,
+                        "html_url": "https://github.com/acme/tools/pull/17",
+                        "title": "Fresh title",
+                        "state": "open",
+                        "head": {"ref": "tidebreak/remote-delivery", "sha": "feedfeed"},
+                        "base": {"ref": "main"}
+                    }])
+                }
+                "/repos/acme/tools/pulls/17" => serde_json::json!({
+                    "number": 17,
+                    "html_url": "https://github.com/acme/tools/pull/17",
+                    "title": "Fresh title",
+                    "state": "open",
+                    "draft": false,
+                    "user": {"login": "author"},
+                    "head": {"ref": "tidebreak/remote-delivery", "sha": "feedfeed"},
+                    "base": {"ref": "main"},
+                    "merged": false,
+                    "mergeable": true,
+                    "mergeable_state": "clean",
+                    "created_at": "2026-09-04T10:00:00Z",
+                    "updated_at": "2026-09-04T10:00:00Z"
+                }),
+                "/repos/acme/tools/commits/feedfeed/check-runs" => {
+                    serde_json::json!({"check_runs": []})
+                }
+                "/repos/acme/tools/issues/17/comments" => serde_json::json!([{
+                    "id": 1, "body": "Issue comment", "user": {"login": "issue-author", "avatar_url": "https://avatars.example/1"},
+                    "html_url": "https://github.com/acme/tools/pull/17#issuecomment-1",
+                    "created_at": "2026-09-04T11:00:00Z"
+                }]),
+                "/repos/acme/tools/pulls/17/reviews" => serde_json::json!([{
+                    "id": 2, "body": "Review body", "state": "CHANGES_REQUESTED", "user": {"login": "review-author"},
+                    "html_url": "https://github.com/acme/tools/pull/17#pullrequestreview-2",
+                    "submitted_at": "2026-09-04T10:00:00Z"
+                }]),
+                "/repos/acme/tools/pulls/17/comments" => serde_json::json!([{
+                    "id": 3, "body": "Inline comment", "user": {"login": "inline-author"},
+                    "html_url": "https://github.com/acme/tools/pull/17#discussion_r3",
+                    "created_at": "2026-09-04T12:00:00Z", "path": "src/lib.rs", "line": 4
+                }]),
+                "/repos/acme/tools/issues/17/timeline"
+                | "/repos/acme/tools/rules/branches/main" => serde_json::json!([]),
+                other => panic!("unexpected forge request: {other}"),
+            };
+            axum::Json(value)
+        }
+        let seen: Seen = Arc::default();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let app = axum::Router::new().fallback(forge).with_state(seen.clone());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, lender, owner, mut workspace) = fixture(dir.path()).await;
+        workspace.pr = None;
+        save_workspace(&runtime.db, &workspace).await.unwrap();
+        runtime.set_forge_api_base(Some(base));
+        let refreshed = runtime
+            .refresh_workspace_pr(&owner, workspace.id)
+            .await
+            .unwrap();
+        assert!(refreshed.remote);
+        assert!(refreshed.git.is_none());
+        assert_eq!(refreshed.pr.unwrap().title.as_deref(), Some("Fresh title"));
+        let attributed = runtime
+            .workspace_pull_requests(&owner, workspace.id)
+            .await
+            .unwrap();
+        assert_eq!(attributed.len(), 1);
+        assert_eq!(attributed[0].0.number, 17);
+        assert_eq!(attributed[0].0.head_branch, workspace.branch_name);
+        assert_eq!(
+            attributed[0].1,
+            tidebreak_core::CodePullRequestRelation::Contributed
+        );
+        let comments = runtime
+            .workspace_pr_comments(&owner, workspace.id)
+            .await
+            .unwrap();
+        assert_eq!(comments.number, 17);
+        assert_eq!(comments.comments.len(), 3);
+        assert_eq!(comments.comments[0].kind, PullRequestCommentKind::Review);
+        assert_eq!(
+            comments.comments[0].author.as_deref(),
+            Some("review-author")
+        );
+        assert_eq!(
+            comments.comments[0].review_state.as_deref(),
+            Some("changes_requested")
+        );
+        assert_eq!(comments.comments[1].kind, PullRequestCommentKind::Issue);
+        assert_eq!(comments.comments[1].author.as_deref(), Some("issue-author"));
+        assert_eq!(
+            comments.comments[1].avatar_url.as_deref(),
+            Some("https://avatars.example/1")
+        );
+        assert_eq!(comments.comments[2].kind, PullRequestCommentKind::Inline);
+        assert_eq!(comments.comments[2].path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(comments.comments[2].line, Some(4));
+        assert!(comments
+            .comments
+            .iter()
+            .all(|comment| comment.url.is_some() && comment.created_at.is_some()));
+        assert_eq!(lender.minted(), ["acme/tools", "acme/tools"]);
+        assert!(seen
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|path| path.starts_with("/repos/acme/tools/")));
+        server.abort();
     }
 }

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -48,6 +48,7 @@ impl CodeRuntime {
         base_ref: Option<String>,
         lender: Option<&dyn crate::obo_gateway::GitCredentialLender>,
     ) -> Result<CodeWorkspace, ServerError> {
+        self.require_machine_execution()?;
         let repo = self.get_repo(owner, repo_id).await?;
         Self::refuse_removed_repo(&repo)?;
         let explicit_title = title
@@ -293,6 +294,9 @@ impl CodeRuntime {
         terminals: &crate::code::terminal::TerminalHub,
     ) -> Result<CodeWorkspace, ServerError> {
         let mut workspace = self.get_workspace(owner, id).await?;
+        if !workspace.is_remote() {
+            self.require_machine_execution()?;
+        }
         if workspace.status == CodeWorkspaceStatus::Archived {
             return Ok(workspace);
         }
@@ -395,6 +399,9 @@ impl CodeRuntime {
         force: bool,
         terminals: &crate::code::terminal::TerminalHub,
     ) -> Result<CodeWorkspace, ServerError> {
+        if !workspace.is_remote() {
+            self.require_machine_execution()?;
+        }
         if !terminals.close_workspace_and_wait(workspace.id).await {
             return Err(ServerError::conflict_kind(
                 "terminal_shutdown_timeout",
@@ -669,8 +676,17 @@ impl CodeRuntime {
         let lifecycle = self.workspace_lifecycle_lock(id);
         let _lifecycle_guard = lifecycle.lock().await;
         let mut workspace = self.get_workspace(owner, id).await?;
+        if !workspace.is_remote() {
+            self.require_machine_execution()?;
+        }
         if workspace.status == CodeWorkspaceStatus::Active {
             return Ok(workspace);
+        }
+        if workspace.is_remote() {
+            return Err(ServerError::conflict_kind(
+                "workspace_remote",
+                "this workspace runs in a remote sandbox; there is no host checkout to restore",
+            ));
         }
         let released = workspace.status == CodeWorkspaceStatus::Released;
         if !released && workspace.status != CodeWorkspaceStatus::Archived {
@@ -793,8 +809,17 @@ impl CodeRuntime {
         let lifecycle = self.workspace_lifecycle_lock(id);
         let _lifecycle_guard = lifecycle.lock().await;
         let mut workspace = self.get_workspace(owner, id).await?;
+        if !workspace.is_remote() {
+            self.require_machine_execution()?;
+        }
         if workspace.status == CodeWorkspaceStatus::Active {
             return Ok(workspace);
+        }
+        if workspace.is_remote() {
+            return Err(ServerError::conflict_kind(
+                "workspace_remote",
+                "this workspace runs in a remote sandbox; there is no host checkout to restore",
+            ));
         }
         if workspace.status != CodeWorkspaceStatus::SetupFailed {
             return Err(ServerError::conflict_kind(

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -362,6 +362,14 @@ impl ScopedCode {
         self.runtime.get_workspace(&self.owner, id).await
     }
 
+    /// Require a writable workspace whose commands may run on this machine.
+    pub async fn require_live_workspace(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<CodeWorkspace, ServerError> {
+        self.runtime.require_live_workspace(&self.owner, id).await
+    }
+
     pub async fn save_workspace(&self, workspace: &CodeWorkspace) -> Result<(), ServerError> {
         self.runtime.save_workspace(workspace).await
     }

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -2540,6 +2540,17 @@ async fn drive_turn_inner(
 ) -> Result<Turn, WorkerError> {
     let db = &sink.db;
     let bus = &sink.bus;
+    let current = get_session(db, &session.owner, session.id)
+        .await
+        .map_err(|error| WorkerError::Failed(error.to_string()))?
+        .ok_or_else(|| WorkerError::Conflict("session no longer exists".into()))?;
+    if session.execution_location != tidebreak_core::ExecutionLocation::Machine
+        || current.execution_location != tidebreak_core::ExecutionLocation::Machine
+    {
+        return Err(WorkerError::Conflict(
+            "this session runs in a sandbox; its queued messages stay with the sandbox".into(),
+        ));
+    }
     if session.lifecycle == SessionLifecycle::Running {
         return Err(WorkerError::Conflict(
             "a turn is already running on this session".into(),
@@ -2562,10 +2573,6 @@ async fn drive_turn_inner(
     // that wait then update this same session copy, so the turn sees the last
     // committed settings when the lock becomes available.
     if matches!(worktree.wait, TurnWait::Queued) {
-        let current = get_session(db, &session.owner, session.id)
-            .await
-            .map_err(|err| WorkerError::Failed(err.to_string()))?
-            .ok_or_else(|| WorkerError::Failed(format!("session {} not found", session.id)))?;
         if current.spawn_epoch != session.spawn_epoch {
             return Err(WorkerError::Conflict(
                 "the session worker was superseded before the turn started".into(),
@@ -2619,6 +2626,11 @@ async fn drive_turn_inner(
             .await
             .map_err(|error| WorkerError::Failed(error.to_string()))?
             .ok_or_else(|| WorkerError::Conflict("workspace no longer exists".into()))?;
+        if workspace.is_remote() {
+            return Err(WorkerError::Conflict(
+                "a local worker cannot run in a sandbox workspace".into(),
+            ));
+        }
         if workspace.status != CodeWorkspaceStatus::Active {
             return Err(WorkerError::Conflict(format!(
                 "workspace is {}",

--- a/crates/tidebreak-server/src/code/session_worker/tests.rs
+++ b/crates/tidebreak-server/src/code/session_worker/tests.rs
@@ -86,6 +86,24 @@ async fn seeded_session(
     Arc<CodeEventBus>,
     SessionId,
 ) {
+    seeded_session_at(
+        harness_kind,
+        harness_version,
+        tidebreak_core::ExecutionLocation::Machine,
+    )
+    .await
+}
+
+async fn seeded_session_at(
+    harness_kind: HarnessKind,
+    harness_version: Option<&str>,
+    location: tidebreak_core::ExecutionLocation,
+) -> (
+    tempfile::TempDir,
+    Arc<DbStore>,
+    Arc<CodeEventBus>,
+    SessionId,
+) {
     let directory = tempfile::tempdir().unwrap();
     let store = Arc::new(
         DbStore::connect(&format!(
@@ -166,7 +184,7 @@ async fn seeded_session(
             unrecognized_event_count: 0,
             subagents: Vec::new(),
             created_at: Utc::now(),
-            execution_location: tidebreak_core::ExecutionLocation::Machine,
+            execution_location: location,
         },
     )
     .await
@@ -180,8 +198,14 @@ async fn seeded_session(
 }
 
 async fn seeded_sink() -> (tempfile::TempDir, Arc<DbStore>, Arc<LiveSink>, SessionId) {
+    seeded_sink_at(tidebreak_core::ExecutionLocation::Machine).await
+}
+
+async fn seeded_sink_at(
+    location: tidebreak_core::ExecutionLocation,
+) -> (tempfile::TempDir, Arc<DbStore>, Arc<LiveSink>, SessionId) {
     let (directory, store, bus, session_id) =
-        seeded_session(HarnessKind::ClaudeCode, Some("2.1.237")).await;
+        seeded_session_at(HarnessKind::ClaudeCode, Some("2.1.237"), location).await;
     let sink = sink_for(
         store.clone(),
         bus,
@@ -199,6 +223,94 @@ async fn seeded_sink() -> (tempfile::TempDir, Arc<DbStore>, Arc<LiveSink>, Sessi
         crate::code::pr_refresh::HotPullRequests::default(),
     );
     (directory, store, sink, session_id)
+}
+
+#[tokio::test]
+async fn a_stale_local_worker_leaves_sandbox_queue_rows_for_the_remote_driver() {
+    let (directory, db, sink, session_id) =
+        seeded_sink_at(tidebreak_core::ExecutionLocation::Sandbox).await;
+    let owner = OwnerId::local();
+    let mut session = get_session(&db, &owner, session_id).await.unwrap().unwrap();
+    session.lifecycle = SessionLifecycle::Idle;
+    assert!(save_session(&db, &session).await.unwrap());
+    // A stale worker copy says Machine while the durable session says Sandbox.
+    session.execution_location = tidebreak_core::ExecutionLocation::Machine;
+    let worktree = directory.path().join("wt");
+    std::fs::create_dir_all(&worktree).unwrap();
+    let private = directory.path().join("private");
+    std::fs::create_dir(&private).unwrap();
+    let adapter = ScriptedAdapter::new(plain_text_script());
+    let engine = adapter
+        .launch(SessionSpec {
+            owner: owner.clone(),
+            session_id,
+            worktree,
+            allowed_read_roots: Vec::new(),
+            permission_mode: session.permission_mode,
+            model: None,
+            reasoning_effort: None,
+            fast_mode: false,
+            resume_ref: None,
+            extra_argv: Vec::new(),
+            extra_env: Vec::new(),
+            relay_key_env: None,
+            env: Vec::new(),
+            approval: None,
+            binary: Some(std::path::PathBuf::from("/scripted/engine")),
+            sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+            browser: None,
+        })
+        .await
+        .unwrap();
+    let now = Utc::now();
+    let queued = enqueue_queued_turn(
+        &db,
+        &owner,
+        &QueuedTurn {
+            actor: None,
+            id: TurnId::new(),
+            session_id,
+            message: "stay in the sandbox".into(),
+            attachments: Vec::new(),
+            position: 0,
+            created_at: now,
+            updated_at: now,
+        },
+    )
+    .await
+    .unwrap();
+    let store = AttachmentStore {
+        blobs: None,
+        private_root: super::super::scratch::ScratchRoot::open_for_test(&private).unwrap(),
+        engine_reads_images: false,
+    };
+    let queue = TurnQueue {
+        worktree: Arc::new(tokio::sync::Mutex::new(())),
+        wake: Arc::new(tokio::sync::Notify::new()),
+        quiesce: tokio::sync::watch::channel(false).1,
+    };
+    let (_sender, mut commands) = mpsc::channel(1);
+    drain_queued(
+        &mut session,
+        engine.as_ref(),
+        &sink,
+        &queue,
+        &store,
+        &mut commands,
+    )
+    .await;
+    assert_eq!(
+        queued_turn_head(&db, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        queued.id
+    );
+    assert!(list_turns(&db, &owner, session_id)
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 /// An engine that answers its own approval — a standing grant, an

--- a/crates/tidebreak-server/src/code/types.rs
+++ b/crates/tidebreak-server/src/code/types.rs
@@ -1002,6 +1002,10 @@ pub struct CodePushSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
 pub struct CodeWorkspacePrSnapshot {
+    /// The checkout lives in a remote runtime; local git mutations are unavailable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub remote: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub git: Option<CodeWorkspaceGitState>,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1337,9 +1337,16 @@ async fn bind_inner(
             let provisioner = code::remote::gateway::GatewayProvisioner::new(
                 gateway.gateway_base_url(),
                 &endpoint,
-                gateway.runtime_tokens(&endpoint),
+                gateway
+                    .runtime_tokens(&endpoint)
+                    .with_external_delegations(db.clone()),
             )
             .map_err(|error| AgentError::config(format!("sandbox runtime client: {error}")))?;
+            let runtime = if state.config.profile == Profile::SelfHost {
+                runtime.with_sandbox_only_execution()
+            } else {
+                runtime
+            };
             runtime.with_remote_sessions(code::remote::service::RemoteSessions::new(
                 Arc::new(provisioner),
                 code::remote::service::configured_settings(profile, &state.config),

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::StreamExt as _;
 
-use tidebreak_core::{AgentError, OwnerId, Profile, Result};
+use tidebreak_core::{AgentError, OwnerId, Profile, Result, SessionId};
 use tidebreak_router::BearerTokenSource;
 
 /// Mint a replacement this close to expiry instead of using the cached token.
@@ -465,6 +465,7 @@ impl OboGateway {
         Arc::new(RuntimeTokens {
             gateway: self.clone(),
             audience: format!("runtime:{endpoint_slug}"),
+            external: None,
             slots: std::sync::Mutex::new(HashMap::new()),
         })
     }
@@ -1206,13 +1207,54 @@ fn git_refusal(status: reqwest::StatusCode, body: &[u8]) -> GitForgeError {
 
 /// [`OboGateway`]-backed source of runtime bearers for one endpoint.
 ///
-/// Tokens are cached per owner and re-exchanged near expiry. Each owner
-/// has their own mutex, so one hung mint does not block another owner's
-/// spawn or pump.
+/// Tokens are cached per session and re-exchanged near expiry. External
+/// sessions validate their original grant before every operation.
+type RuntimeTokenSlot = Arc<tokio::sync::Mutex<Option<SessionRuntimeToken>>>;
+
+struct SessionRuntimeToken {
+    gateway: Arc<OboGateway>,
+    token: CachedToken,
+}
+
 pub struct RuntimeTokens {
     gateway: Arc<OboGateway>,
     audience: String,
-    slots: std::sync::Mutex<HashMap<OwnerId, Arc<tokio::sync::Mutex<Option<CachedToken>>>>>,
+    external: Option<Arc<external::ExternalDelegations>>,
+    slots: std::sync::Mutex<HashMap<(OwnerId, SessionId), RuntimeTokenSlot>>,
+}
+
+impl RuntimeTokens {
+    /// Resolve external sessions through their durable consent on every call.
+    pub fn with_external_delegations(
+        self: Arc<Self>,
+        db: Arc<tidebreak_core::DbStore>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            gateway: self.gateway.clone(),
+            audience: self.audience.clone(),
+            external: Some(Arc::new(external::ExternalDelegations::new(
+                self.gateway.clone(),
+                db,
+            ))),
+            slots: std::sync::Mutex::new(HashMap::new()),
+        })
+    }
+}
+
+fn runtime_token_error(error: AgentError) -> crate::code::remote::RemoteSandboxError {
+    use crate::code::remote::RemoteSandboxError;
+    match error {
+        AgentError::SignInRequired(detail) => RemoteSandboxError::SignInRequired(detail),
+        AgentError::InvalidTarget(detail) => RemoteSandboxError::Refused {
+            operation: "token",
+            code: "external_connection_conflict".into(),
+            message: detail,
+        },
+        other => RemoteSandboxError::Unavailable {
+            operation: "token",
+            detail: other.to_string(),
+        },
+    }
 }
 
 #[async_trait]
@@ -1220,6 +1262,7 @@ impl crate::code::remote::RuntimeTokenSource for RuntimeTokens {
     async fn runtime_token(
         &self,
         owner: &OwnerId,
+        session: SessionId,
     ) -> std::result::Result<
         crate::code::remote::RuntimeToken,
         crate::code::remote::RemoteSandboxError,
@@ -1234,39 +1277,56 @@ impl crate::code::remote::RuntimeTokenSource for RuntimeTokens {
                     detail: "runtime token state is unavailable in this process".into(),
                 })?;
             slots
-                .entry(owner.clone())
+                .entry((owner.clone(), session))
                 .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(None)))
                 .clone()
         };
-        // Holding this owner's slot across the exchange is the single-flight
-        // gate: a second call for the same owner waits and then finds a fresh
-        // token. Other owners are not blocked.
         let mut cached = slot.lock().await;
+        // Recheck the grant before reading a cached runtime token. A browser
+        // sign-in must never replace a revoked Slack connection's authority.
+        let gateway = match &self.external {
+            Some(external) => external
+                .for_session(owner, session)
+                .await
+                .map_err(runtime_token_error)?
+                .unwrap_or_else(|| self.gateway.clone()),
+            None => self.gateway.clone(),
+        };
         if let Some(current) = cached.as_ref() {
-            if current.is_fresh() {
+            if Arc::ptr_eq(&current.gateway, &gateway) && current.token.is_fresh() {
                 return Ok(RuntimeToken {
-                    secret: current.token.to_string(),
+                    secret: current.token.token.to_string(),
                 });
             }
         }
-        let Some(subject) = self.gateway.subject_for(owner) else {
+        let Some(subject) = gateway.subject_for(owner) else {
             return Err(RemoteSandboxError::SignInRequired(
                 "this machine holds no live Model Gateway session for you; sign in again".into(),
             ));
         };
-        let minted = self
-            .gateway
+        let minted = gateway
             .exchange(&subject, &self.audience)
             .await
-            .map_err(|error| match error {
-                AgentError::SignInRequired(detail) => RemoteSandboxError::SignInRequired(detail),
-                other => RemoteSandboxError::Unavailable {
-                    operation: "token",
-                    detail: other.to_string(),
-                },
-            })?;
+            .map_err(runtime_token_error)?;
+        // Revocation may commit while the exchange is in flight.
+        if let Some(external) = &self.external {
+            let confirmed = external
+                .for_session(owner, session)
+                .await
+                .map_err(runtime_token_error)?;
+            let confirmed = confirmed.unwrap_or_else(|| self.gateway.clone());
+            if !Arc::ptr_eq(&confirmed, &gateway) {
+                return Err(RemoteSandboxError::SignInRequired(
+                    "your external connection changed during the runtime request; retry the turn"
+                        .into(),
+                ));
+            }
+        }
         let secret = minted.token.to_string();
-        *cached = Some(minted);
+        *cached = Some(SessionRuntimeToken {
+            gateway,
+            token: minted,
+        });
         Ok(RuntimeToken { secret })
     }
 }
@@ -1979,12 +2039,13 @@ mod tests {
         inference.record_caller(&alice, "mg_at_alice".into());
 
         let tokens = inference.runtime_tokens("primary");
-        let token = tokens.runtime_token(&alice).await.unwrap();
+        let session = SessionId::new();
+        let token = tokens.runtime_token(&alice, session).await.unwrap();
         assert!(token.secret.starts_with("mg_at_runtime_"));
         assert!(token.secret.ends_with("mg_at_alice"));
         assert_eq!(gateway.served(), 1);
         // A second call inside the lifetime reuses the cached token.
-        let again = tokens.runtime_token(&alice).await.unwrap();
+        let again = tokens.runtime_token(&alice, session).await.unwrap();
         assert_eq!(again.secret, token.secret);
         assert_eq!(gateway.served(), 1);
         server.abort();

--- a/crates/tidebreak-server/src/obo_gateway/external.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external.rs
@@ -166,7 +166,7 @@ impl ExternalDelegations {
 
     /// Validate durable consent before serving even a fresh cached token.
     pub async fn for_grant(&self, owner: &OwnerId, grant: CodeGrantId) -> Result<Arc<OboGateway>> {
-        let handshake = self.live_handshake(owner, grant).await?;
+        self.live_handshake(owner, grant).await?;
         let slot = {
             let mut slots = self
                 .slots
@@ -178,6 +178,8 @@ impl ExternalDelegations {
                 .clone()
         };
         let mut held = slot.lock().await;
+        // Consent may change while another request holds this slot.
+        let handshake = self.live_handshake(owner, grant).await?;
         if let Some(current) = held.as_ref() {
             if current.expires_at > unix_time().saturating_add(EXPIRY_LEEWAY_SECONDS) {
                 return Ok(current.gateway.clone());
@@ -240,6 +242,9 @@ impl ExternalDelegations {
         owner: &OwnerId,
         session: SessionId,
     ) -> Result<Option<Arc<OboGateway>>> {
+        tidebreak_core::db::code::get_session(&self.db, owner, session)
+            .await?
+            .ok_or_else(|| AgentError::InvalidTarget("code session not found".into()))?;
         let bindings =
             tidebreak_core::db::code::list_bindings_for_session(&self.db, owner, session).await?;
         let Some(first) = bindings.first() else {

--- a/crates/tidebreak-server/src/obo_gateway/external/tests.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external/tests.rs
@@ -15,6 +15,7 @@ const RESOURCE: &str = "tidebreak:test-machine";
 #[derive(Clone, Default)]
 struct Gateway {
     approvals: Arc<AtomicUsize>,
+    exchanges: Arc<std::sync::Mutex<Vec<(String, String)>>>,
     mints: Arc<AtomicUsize>,
     revokes: Arc<AtomicUsize>,
     failed: Arc<AtomicBool>,
@@ -52,9 +53,11 @@ async fn gateway() -> (String, Gateway) {
             state.enrolled.lock().unwrap().remove(&id);
             StatusCode::NO_CONTENT
         }))
-        .route("/oauth/token", post(|axum::Form(body): axum::Form<HashMap<String, String>>| async move {
+        .route("/oauth/token", post(|State(state): State<Gateway>, axum::Form(body): axum::Form<HashMap<String, String>>| async move {
             assert!(body["subject_token"].starts_with("delegated-"), "a browser token must never supply external inference");
-            Json(serde_json::json!({"access_token": format!("llm-{}", body["subject_token"]), "expires_in": 600}))
+            state.exchanges.lock().unwrap().push((body["subject_token"].clone(), body["audience"].clone()));
+            let prefix = if body["audience"].starts_with("runtime:") { "runtime" } else { "llm" };
+            Json(serde_json::json!({"access_token": format!("{prefix}-{}", body["subject_token"]), "expires_in": 600}))
         }))
         .route("/compat/openai/v1/responses", post(|headers: HeaderMap| async move {
             headers.get("authorization").unwrap().to_str().unwrap().to_owned()
@@ -521,4 +524,293 @@ async fn first_external_worker_after_restart_names_the_owner_before_workspace_se
         author.starts_with("Slack Owner <owner@example.com>"),
         "the setup script must run with delegated Git identity: {author}"
     );
+}
+
+async fn bind_runtime_session(
+    db: &DbStore,
+    owner: &OwnerId,
+    grant: CodeGrantId,
+    workspace: Option<tidebreak_core::WorkspaceId>,
+) -> SessionId {
+    use tidebreak_core::{
+        Attention, AttentionSource, ExecutionLocation, HarnessKind, PermissionMode, Session,
+        SessionKind, SessionLifecycle, SessionVisibility,
+    };
+    let session = Session {
+        id: SessionId::new(),
+        owner: owner.clone(),
+        workspace_id: workspace,
+        kind: SessionKind::Interactive,
+        harness_kind: HarnessKind::ClaudeCode,
+        harness_version: None,
+        harness_resume_ref: None,
+        permission_mode: PermissionMode::Ask,
+        model: None,
+        reasoning_effort: None,
+        fast_mode: false,
+        lifecycle: SessionLifecycle::Idle,
+        fence_reason: None,
+        child_pid: None,
+        child_process_identity: None,
+        spawn_epoch: 1,
+        attention: Attention::working(AttentionSource::Lifecycle),
+        unrecognized_event_count: 0,
+        subagents: Vec::new(),
+        created_at: chrono::Utc::now(),
+        visibility: SessionVisibility::Private,
+        execution_location: if workspace.is_some() {
+            ExecutionLocation::Sandbox
+        } else {
+            ExecutionLocation::Machine
+        },
+    };
+    tidebreak_core::db::code::resolve_external_machine_session(
+        db,
+        owner,
+        grant,
+        "slack",
+        "T1/C1/runtime",
+        &session,
+    )
+    .await
+    .unwrap();
+    session.id
+}
+
+#[tokio::test]
+async fn runtime_tokens_follow_the_session_grant_after_restart_refresh_and_revocation() {
+    use crate::code::remote::{RemoteSandboxError, RuntimeTokenSource};
+    let (_dir, db, runtime, _browser, base, state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let session = bind_runtime_session(&db, &owner, grant.id, None).await;
+    let restarted_gateway = obo(&base);
+    let tokens = restarted_gateway
+        .runtime_tokens("tidebreak")
+        .with_external_delegations(db.clone());
+    let first = tokens.runtime_token(&owner, session).await.unwrap();
+    assert_eq!(first.secret, "runtime-delegated-1");
+    assert_eq!(
+        tokens.runtime_token(&owner, session).await.unwrap().secret,
+        first.secret
+    );
+    assert_eq!(
+        state.exchanges.lock().unwrap().as_slice(),
+        &[("delegated-1".into(), "runtime:tidebreak".into())]
+    );
+    // A refreshed delegation invalidates the cached runtime token even while
+    // that runtime token is fresh.
+    let slot = tokens
+        .external
+        .as_ref()
+        .unwrap()
+        .slots
+        .lock()
+        .unwrap()
+        .get(&grant.id)
+        .unwrap()
+        .clone();
+    slot.lock().await.as_mut().unwrap().expires_at = 0;
+    assert_eq!(
+        tokens.runtime_token(&owner, session).await.unwrap().secret,
+        "runtime-delegated-2"
+    );
+    // A browser sign-in cannot mask a revoked connection or replace its grant.
+    restarted_gateway.record_caller(&owner, "replacement-browser-session".into());
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "disconnect")
+        .await
+        .unwrap();
+    let _replacement = connect(&runtime, &owner).await;
+    assert!(matches!(
+        tokens.runtime_token(&owner, session).await,
+        Err(RemoteSandboxError::SignInRequired(_))
+    ));
+    assert_eq!(state.exchanges.lock().unwrap().len(), 2);
+}
+
+// The map and this test own two references. A third means the request has
+// cloned the slot and is waiting for the lock that the test holds.
+async fn wait_for_slot_waiter<T>(slot: &Arc<T>) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while Arc::strong_count(slot) < 3 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the request must reach the held credential slot");
+}
+
+#[tokio::test]
+async fn runtime_tokens_refuse_missing_and_wrong_owner_sessions_before_browser_fallback() {
+    use crate::code::remote::{RemoteSandboxError, RuntimeTokenSource};
+    let (_dir, db, runtime, browser, _base, state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let session = bind_runtime_session(&db, &owner, grant.id, None).await;
+    let other = OwnerId::new("user:another-owner").unwrap();
+    browser.record_caller(&other, "another-browser-session".into());
+    let tokens = browser
+        .runtime_tokens("tidebreak")
+        .with_external_delegations(db);
+    for (caller, target) in [(&owner, SessionId::new()), (&other, session)] {
+        assert!(matches!(
+            tokens.runtime_token(caller, target).await,
+            Err(RemoteSandboxError::Refused {
+                operation: "token",
+                ..
+            })
+        ));
+    }
+    assert_eq!(state.mints.load(Ordering::SeqCst), 0);
+    assert!(state.exchanges.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn cached_delegation_refuses_revocation_while_waiting_for_its_slot() {
+    let (_dir, db, runtime, _browser, base, state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let delegations = Arc::new(ExternalDelegations::new(obo(&base), db));
+    delegations.for_grant(&owner, grant.id).await.unwrap();
+    let slot = delegations
+        .slots
+        .lock()
+        .unwrap()
+        .get(&grant.id)
+        .unwrap()
+        .clone();
+    let held = slot.lock().await;
+    let caller = owner.clone();
+    let waiting = {
+        let delegations = delegations.clone();
+        tokio::spawn(async move { delegations.for_grant(&caller, grant.id).await })
+    };
+    wait_for_slot_waiter(&slot).await;
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "disconnect")
+        .await
+        .unwrap();
+    drop(held);
+    assert!(matches!(
+        waiting.await.unwrap(),
+        Err(AgentError::SignInRequired(_))
+    ));
+    assert_eq!(state.mints.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn cached_runtime_token_refuses_revocation_while_waiting_for_its_slot() {
+    use crate::code::remote::{RemoteSandboxError, RuntimeTokenSource};
+    let (_dir, db, runtime, _browser, base, state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let session = bind_runtime_session(&db, &owner, grant.id, None).await;
+    let tokens = obo(&base)
+        .runtime_tokens("tidebreak")
+        .with_external_delegations(db);
+    tokens.runtime_token(&owner, session).await.unwrap();
+    let slot = tokens
+        .slots
+        .lock()
+        .unwrap()
+        .get(&(owner.clone(), session))
+        .unwrap()
+        .clone();
+    let held = slot.lock().await;
+    let caller = owner.clone();
+    let waiting = {
+        let tokens = tokens.clone();
+        tokio::spawn(async move { tokens.runtime_token(&caller, session).await })
+    };
+    wait_for_slot_waiter(&slot).await;
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "disconnect")
+        .await
+        .unwrap();
+    drop(held);
+    assert!(matches!(
+        waiting.await.unwrap(),
+        Err(RemoteSandboxError::SignInRequired(_))
+    ));
+    assert_eq!(state.exchanges.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn remote_workspace_status_keeps_the_original_grant_after_restart_and_revocation() {
+    use tidebreak_core::{CodeRepo, CodeWorkspace, CodeWorkspaceStatus, RepoId, WorkspaceId};
+    let (dir, db, runtime, browser, base, state, owner) = setup().await;
+    let grant = connect(&runtime, &owner).await;
+    let repo = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: String::new(),
+        display_name: "Tools".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "thet/".into(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: chrono::Utc::now(),
+        removed_at: None,
+        cloned_from: Some("https://github.com/acme/tools".into()),
+        origin_host: Some("github.com".into()),
+        origin_owner: Some("acme".into()),
+        origin_name: Some("tools".into()),
+    };
+    tidebreak_core::db::code::insert_repo(&db, &repo)
+        .await
+        .unwrap();
+    let id = WorkspaceId::new();
+    let workspace = CodeWorkspace {
+        id,
+        owner: owner.clone(),
+        repo_id: repo.id,
+        title: "Slack work".into(),
+        worktree_path: CodeWorkspace::remote_worktree_marker(id),
+        branch_name: "thet/slack-work".into(),
+        base_ref: "main".into(),
+        status: CodeWorkspaceStatus::Active,
+        pr: None,
+        created_at: chrono::Utc::now(),
+        archived_at: None,
+        released_at: None,
+        released_tip: None,
+        bundle_bytes: None,
+    };
+    tidebreak_core::db::code::insert_workspace(&db, &workspace)
+        .await
+        .unwrap();
+    bind_runtime_session(&db, &owner, grant.id, Some(id)).await;
+    let relay = Arc::new(HarnessLlmRelay::new(obo(&base)).with_external_delegations(db.clone()));
+    let restarted = CodeRuntime::new(
+        db,
+        dir.path().to_path_buf(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(relay),
+    )
+    .with_git_credentials(browser.clone());
+    let status = restarted.workspace_pr(&owner, id).await.unwrap();
+    assert_eq!(status.pushes_as.as_deref(), Some("slack-owner"));
+    assert_eq!(status.pushes_as_self, Some(true));
+    assert_eq!(state.mints.load(Ordering::SeqCst), 1);
+    browser.record_caller(&owner, "replacement-browser-session".into());
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "disconnect")
+        .await
+        .unwrap();
+    let _replacement = connect(&runtime, &owner).await;
+    assert!(
+        restarted.workspace_pr(&owner, id).await.is_err(),
+        "status must refuse the original revoked grant"
+    );
+    assert!(
+        restarted.refresh_workspace_pr(&owner, id).await.is_err(),
+        "refresh must refuse before borrowing browser credentials"
+    );
+    assert!(
+        restarted.workspace_pr_comments(&owner, id).await.is_err(),
+        "comments must refuse before borrowing browser credentials"
+    );
+    assert_eq!(state.mints.load(Ordering::SeqCst), 1);
 }

--- a/crates/tidebreak-supervised-agent/src/bootstrap.rs
+++ b/crates/tidebreak-supervised-agent/src/bootstrap.rs
@@ -122,6 +122,16 @@ pub fn run(
                     stage: "repository_clone_failed",
                     message,
                 })?;
+            if position == 0 {
+                if let Some(branch) = inputs.workspace_branch.as_deref() {
+                    checkout_workspace_branch(&target, branch, &trust).map_err(|message| {
+                        BootstrapError {
+                            stage: "workspace_branch_failed",
+                            message,
+                        }
+                    })?;
+                }
+            }
             push(
                 "repository_cloned",
                 serde_json::json!({
@@ -129,6 +139,7 @@ pub fn run(
                     "ref": repository.repository_ref,
                     "directory": target.display().to_string(),
                     "position": position,
+                    "workspace_branch": (position == 0).then_some(inputs.workspace_branch.as_deref()).flatten(),
                 }),
             );
             clones.push(ClonedRepository {
@@ -272,6 +283,25 @@ fn clone_repository(
         }
     }
     Ok(target)
+}
+
+/// Start the assigned branch at the selected base or WIP commit in the fresh clone.
+fn checkout_workspace_branch(target: &Path, branch: &str, trust: &Trust) -> Result<(), String> {
+    if branch.is_empty() || branch.starts_with('-') || branch.contains("@{") {
+        return Err("the workspace branch is invalid".into());
+    }
+    run_git(
+        target,
+        trust,
+        &["check-ref-format", &format!("refs/heads/{branch}")],
+    )
+    .map_err(|error| format!("the workspace branch is invalid: {error}"))?;
+    run_git(
+        target,
+        trust,
+        &["checkout", "--no-track", "-B", branch, "HEAD"],
+    )
+    .map_err(|error| format!("the workspace branch could not be checked out: {error}"))
 }
 
 /// Runs one git command with the trust environment, output inherited so it
@@ -451,6 +481,102 @@ mod tests {
             .unwrap();
         assert_eq!(cloned.1["position"], 0);
         assert_eq!(cloned.1["ref"], "feature");
+    }
+
+    #[test]
+    fn a_workspace_task_starts_its_assigned_branch_at_the_selected_base_or_wip() {
+        let root = tempfile::tempdir().unwrap();
+        let remote = fixture_remote(root.path());
+        let trust = trust::prepare(&trust_options(root.path())).unwrap();
+        run_git(&remote, &trust, &["checkout", "-b", "mg-wip/sandbox-1"]).unwrap();
+        std::fs::write(remote.join("checkpoint.txt"), "saved work\n").unwrap();
+        run_git(&remote, &trust, &["add", "checkpoint.txt"]).unwrap();
+        run_git(
+            &remote,
+            &trust,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "checkpoint",
+            ],
+        )
+        .unwrap();
+        for (index, reference) in ["main", "mg-wip/sandbox-1"].iter().enumerate() {
+            let workspace = root.path().join(format!("workspace-{index}"));
+            let task = "Fix the bug.\nKeep this task text.\n";
+            let inputs = resolve(RawInputs {
+                task: Some(
+                    tidebreak_core::code::RemoteWorkspaceTask::encode(task, "thet/slack-pr")
+                        .unwrap(),
+                ),
+                workspace: Some(workspace.display().to_string()),
+                repository_url: Some(remote.display().to_string()),
+                repository_ref: Some((*reference).into()),
+                ..RawInputs::default()
+            })
+            .unwrap();
+            let bootstrap = run(&inputs, &trust_options(root.path()), None).unwrap();
+            let output = |directory: &Path, arguments: &[&str]| {
+                let output = Command::new("git")
+                    .args(arguments)
+                    .current_dir(directory)
+                    .output()
+                    .unwrap();
+                assert!(output.status.success());
+                String::from_utf8(output.stdout).unwrap().trim().to_owned()
+            };
+            assert_eq!(
+                output(&bootstrap.workdir, &["branch", "--show-current"]),
+                "thet/slack-pr"
+            );
+            assert_eq!(
+                output(&bootstrap.workdir, &["rev-parse", "HEAD"]),
+                output(&remote, &["rev-parse", reference])
+            );
+            assert_eq!(
+                bootstrap.workdir.join("checkpoint.txt").exists(),
+                index == 1
+            );
+            assert_eq!(inputs.task, task);
+            let cloned = bootstrap
+                .events
+                .iter()
+                .find(|(kind, _)| kind == "repository_cloned")
+                .unwrap();
+            assert_eq!(cloned.1["workspace_branch"], "thet/slack-pr");
+        }
+    }
+
+    #[test]
+    fn a_workspace_branch_cannot_be_a_revision_or_checkout_option() {
+        let root = tempfile::tempdir().unwrap();
+        let repository = fixture_remote(root.path());
+        let trust = trust::prepare(&trust_options(root.path())).unwrap();
+        for branch in [
+            "@{-1}",
+            "--orphan",
+            "bad..branch",
+            "bad.lock",
+            "HEAD",
+            "main~1",
+        ] {
+            assert!(
+                checkout_workspace_branch(&repository, branch, &trust).is_err(),
+                "accepted {branch}"
+            );
+        }
+        let head = Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&repository)
+            .output()
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&head.stdout).trim(), "main");
     }
 
     #[test]

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -54,6 +54,8 @@ use crate::engine::{
 /// such an environment and no wiring is applied.
 pub const PLACEHOLDER_TOKEN_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_PLACEHOLDER_TOKEN";
 
+const SANDBOX_PLACEHOLDER_TOKEN: &str = "mg-sandbox-placeholder";
+
 /// The gateway base URL the environment writes on every sandboxed pod.
 ///
 /// The confinement boundary recognizes gateway traffic by authority:
@@ -94,6 +96,11 @@ fn resolve_gateway_inference(
     let Some(placeholder_credential) = placeholder else {
         return Ok(None);
     };
+    if placeholder_credential != SANDBOX_PLACEHOLDER_TOKEN {
+        return Err(format!(
+            "{PLACEHOLDER_TOKEN_VARIABLE} must contain the public sandbox placeholder"
+        ));
+    }
     let Some(gateway_url) = gateway_url else {
         return Err(format!(
             "{PLACEHOLDER_TOKEN_VARIABLE} is set but {GATEWAY_URL_VARIABLE} is missing or empty; \
@@ -185,7 +192,7 @@ impl HarnessEngine {
                 let root = inference.gateway_url.trim_end_matches('/');
                 let anthropic_base = format!("{root}/compat/anthropic");
                 let openai_base = format!("{root}/compat/openai");
-                let (argv, env) = spawn_wiring(
+                let (argv, mut env) = spawn_wiring(
                     self.kind,
                     &InferenceWiring {
                         anthropic_base: &anthropic_base,
@@ -194,6 +201,24 @@ impl HarnessEngine {
                         key: &inference.placeholder_credential,
                     },
                 );
+                // gh requires a token to issue requests. Only the public dummy
+                // enters the engine; Gateway injects the connected app credential.
+                env.push(("GH_TOKEN".to_owned(), SANDBOX_PLACEHOLDER_TOKEN.to_owned()));
+                // Gateway resolves this public author metadata from the connected
+                // GitHub identity. Keep it across the harness environment filter.
+                for (name, value) in &probe.env {
+                    if let (Some(name), Some(value)) = (name.to_str(), value.to_str()) {
+                        if matches!(
+                            name,
+                            "GIT_AUTHOR_NAME"
+                                | "GIT_AUTHOR_EMAIL"
+                                | "GIT_COMMITTER_NAME"
+                                | "GIT_COMMITTER_EMAIL"
+                        ) {
+                            env.push((name.to_owned(), value.to_owned()));
+                        }
+                    }
+                }
                 (argv, env, Some(RELAY_KEY_ENV.to_owned()))
             }
             None => (Vec::new(), Vec::new(), None),
@@ -908,8 +933,22 @@ mod tests {
         let captured = adapter.captured.clone();
         let mut engine = engine_over(adapter, probe(true));
         // The trailing slash must not double up in the derived roots.
+        engine.spec.probe.env.extend([
+            ("GIT_AUTHOR_NAME".into(), "fixture-app[bot]".into()),
+            (
+                "GIT_AUTHOR_EMAIL".into(),
+                "fixture-app[bot]@users.noreply.github.com".into(),
+            ),
+            ("GIT_COMMITTER_NAME".into(), "fixture-app[bot]".into()),
+            (
+                "GIT_COMMITTER_EMAIL".into(),
+                "fixture-app[bot]@users.noreply.github.com".into(),
+            ),
+            ("GH_TOKEN".into(), "fixture-secret-must-not-pass".into()),
+            ("GITHUB_TOKEN".into(), "another-fixture-secret".into()),
+        ]);
         engine.spec.gateway_inference = Some(GatewayInference {
-            placeholder_credential: "placeholder".to_owned(),
+            placeholder_credential: SANDBOX_PLACEHOLDER_TOKEN.to_owned(),
             gateway_url: "https://gateway.internal:8443/".to_owned(),
         });
         engine.start_turn(request("go")).await.unwrap();
@@ -923,7 +962,49 @@ mod tests {
         assert!(captured
             .extra_env
             .iter()
-            .any(|(name, value)| name == "ANTHROPIC_AUTH_TOKEN" && value == "placeholder"));
+            .any(|(name, value)| name == "ANTHROPIC_AUTH_TOKEN"
+                && value == SANDBOX_PLACEHOLDER_TOKEN));
+        let mut effective: std::collections::HashMap<OsString, OsString> =
+            tidebreak_harness::filter_child_env(captured.env.clone())
+                .into_iter()
+                .collect();
+        effective.extend(
+            captured
+                .extra_env
+                .iter()
+                .map(|(name, value)| (name.into(), value.into())),
+        );
+        assert_eq!(
+            effective.get(std::ffi::OsStr::new("GH_TOKEN")).unwrap(),
+            SANDBOX_PLACEHOLDER_TOKEN
+        );
+        assert_eq!(
+            effective
+                .get(std::ffi::OsStr::new("GIT_AUTHOR_NAME"))
+                .unwrap(),
+            "fixture-app[bot]"
+        );
+        assert_eq!(
+            effective
+                .get(std::ffi::OsStr::new("GIT_COMMITTER_EMAIL"))
+                .unwrap(),
+            "fixture-app[bot]@users.noreply.github.com"
+        );
+        assert!(!effective.contains_key(std::ffi::OsStr::new("GITHUB_TOKEN")));
+        assert!(effective
+            .values()
+            .all(|value| !value.to_string_lossy().contains("fixture-secret")));
+    }
+
+    #[test]
+    fn real_credentials_cannot_replace_the_public_placeholder() {
+        let error = resolve_gateway_inference(
+            Some("fixture-real-secret".into()),
+            Some("https://gateway.invalid".into()),
+        )
+        .unwrap_err();
+        assert!(error.contains("public sandbox placeholder"));
+        assert!(!error.contains("fixture-real-secret"));
     }
 
     /// The placeholder never stands alone: without a gateway URL the pod
@@ -931,10 +1012,11 @@ mod tests {
     /// at a destination the confinement boundary refuses.
     #[test]
     fn a_placeholder_without_a_gateway_url_is_refused() {
-        let error = resolve_gateway_inference(Some("placeholder".to_owned()), None).unwrap_err();
+        let error = resolve_gateway_inference(Some(SANDBOX_PLACEHOLDER_TOKEN.to_owned()), None)
+            .unwrap_err();
         assert!(error.contains(GATEWAY_URL_VARIABLE));
         let error = resolve_gateway_inference(
-            Some("placeholder".to_owned()),
+            Some(SANDBOX_PLACEHOLDER_TOKEN.to_owned()),
             Some("gateway.internal:8443".to_owned()),
         )
         .unwrap_err();

--- a/crates/tidebreak-supervised-agent/src/inputs.rs
+++ b/crates/tidebreak-supervised-agent/src/inputs.rs
@@ -87,6 +87,8 @@ pub struct Repository {
 pub struct Inputs {
     /// Task text for the first turn.
     pub task: String,
+    /// Branch assigned by Tidebreak for the primary repository.
+    pub workspace_branch: Option<String>,
     /// Absolute URL of the control endpoint's poll route base.
     pub control_url: String,
     /// Directory the engine runs in.
@@ -193,7 +195,13 @@ fn optional(value: Option<String>) -> Option<String> {
 
 /// Resolves every input, naming the first one that is absent or unusable.
 pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
-    let task = optional(raw.task).ok_or_else(|| InputError::missing(TASK_VARIABLE))?;
+    let raw_task = optional(raw.task).ok_or_else(|| InputError::missing(TASK_VARIABLE))?;
+    let envelope = tidebreak_core::code::RemoteWorkspaceTask::parse(&raw_task)
+        .map_err(|message| InputError::unusable(TASK_VARIABLE, &message))?;
+    let (task, workspace_branch) = match envelope {
+        Some(envelope) => (envelope.task, Some(envelope.branch)),
+        None => (raw_task, None),
+    };
 
     let endpoint =
         optional(raw.supervisor_endpoint).unwrap_or_else(|| DEFAULT_SUPERVISOR_ENDPOINT.to_owned());
@@ -262,6 +270,13 @@ pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
             }
         });
 
+    if workspace_branch.is_some() && repositories.is_empty() {
+        return Err(InputError::unusable(
+            TASK_VARIABLE,
+            "a workspace task requires a repository",
+        ));
+    }
+
     let forge_push_denied = optional(raw.forge_push).as_deref() == Some("denied");
 
     let incarnation = optional(raw.incarnation)
@@ -285,6 +300,7 @@ pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
 
     Ok(Inputs {
         task,
+        workspace_branch,
         control_url,
         workspace,
         mode,
@@ -348,6 +364,7 @@ mod tests {
     fn defaults_cover_every_optional_variable() {
         let inputs = resolve(minimal()).unwrap();
         assert_eq!(inputs.control_url, "http://127.0.0.1:15003");
+        assert_eq!(inputs.workspace_branch, None);
         assert_eq!(inputs.mode, RunMode::Goal);
         assert_eq!(inputs.max_turns, None);
         assert_eq!(inputs.starting_turn, 1);
@@ -358,8 +375,32 @@ mod tests {
         assert_eq!(inputs.incarnation, 1);
     }
 
-    /// The environment writes empty strings for undeclared fields; they must
-    /// read the same as absent ones.
+    #[test]
+    fn a_workspace_envelope_hands_only_the_original_task_to_the_engine() {
+        let task = "Do this.\nKeep the exact text.\n";
+        let mut raw = minimal();
+        raw.task = Some(
+            tidebreak_core::code::RemoteWorkspaceTask::encode(task, "thet/remote-work").unwrap(),
+        );
+        raw.repository_url = Some("https://github.com/acme/tools".into());
+        let inputs = resolve(raw).unwrap();
+        assert_eq!(inputs.task, task);
+        assert_eq!(inputs.workspace_branch.as_deref(), Some("thet/remote-work"));
+    }
+
+    #[test]
+    fn a_workspace_envelope_requires_a_repository() {
+        let mut raw = minimal();
+        raw.task = Some(
+            tidebreak_core::code::RemoteWorkspaceTask::encode("work", "thet/remote-work").unwrap(),
+        );
+        assert!(resolve(raw)
+            .unwrap_err()
+            .message
+            .contains("requires a repository"));
+    }
+
+    /// Empty environment values must read the same as absent ones.
     #[test]
     fn empty_values_read_as_absent() {
         let raw = RawInputs {

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -80,15 +80,16 @@ ENV CARGO_PROFILE_DEV_DEBUG=0
 # stage copies one path whichever profile built it (cargo writes `dev` to
 # `target/debug`).
 RUN set -eu; \
-    cargo build --profile "${CARGO_PROFILE}" --locked -p tidebreak-cli \
+    cargo build --profile "${CARGO_PROFILE}" --locked -p tidebreak-cli -p tidebreak-supervised-agent \
         --features tidebreak-server/postgres; \
     case "${CARGO_PROFILE}" in dev) target_dir=debug ;; *) target_dir="${CARGO_PROFILE}" ;; esac; \
-    install -D "target/${target_dir}/tidebreak" /out/tidebreak
+    install -D "target/${target_dir}/tidebreak" /out/tidebreak; \
+    install -D "target/${target_dir}/tidebreak-supervised-agent" /out/tidebreak-supervised-agent
 
 # ---- runtime ---------------------------------------------------------------
 # Digest-pinned like the build stage: this is debian:bookworm-slim as of
 # 2026-08-10.
-FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS runtime-base
 
 # ca-certificates: the binary's TLS stack is rustls (no OpenSSL anywhere in
 # the lockfile), but parts of the graph resolve platform roots, so the system
@@ -184,20 +185,6 @@ RUN set -eu; \
     export PATH="/opt/tidebreak/node/${version}/bin:${PATH}"; \
     node --version; \
     npm --version
-
-COPY --from=build /out/tidebreak /usr/local/bin/tidebreak
-COPY --from=renderer /src/crates/tidebreak-desktop/ui/dist /opt/tidebreak/ui
-COPY deploy/self-host/entrypoint.sh /usr/local/bin/tidebreak-entrypoint
-
-# The server runs unprivileged. The uid is fixed rather than assigned by
-# adduser so a data volume initialized from this layer carries an ownership
-# the running user actually matches.
-RUN groupadd --gid 10001 tidebreak \
-    && useradd --uid 10001 --gid 10001 --home-dir /home/tidebreak --create-home \
-       --shell /usr/sbin/nologin tidebreak \
-    && chmod 0755 /usr/local/bin/tidebreak-entrypoint \
-    && mkdir -p /var/lib/tidebreak \
-    && chown -R tidebreak:tidebreak /var/lib/tidebreak /home/tidebreak
 
 # Optional toolchain bundles. Empty (the default) installs nothing, so this
 # RUN is a no-op and the image stays the size of git, gh, and managed Node.
@@ -299,6 +286,46 @@ RUN set -eu; \
           ;; \
       esac; \
     done
+
+# The supervised workload reuses the server's verified tools and runs behind
+# Gateway's sidecar. It carries no server, renderer, or authentication store.
+FROM runtime-base AS supervised-agent
+COPY --from=build /out/tidebreak-supervised-agent /usr/local/bin/tidebreak-supervised-agent
+COPY crates/tidebreak-harness/src/pin.rs /tmp/harness-pins.rs
+COPY deploy/supervised-agent/install-harness.mjs /tmp/install-harness.mjs
+COPY deploy/supervised-agent/entrypoint.sh /usr/local/bin/sandbox-agent
+RUN set -eu; \
+    node_root="$(find /opt/tidebreak/node -mindepth 1 -maxdepth 1 -type d)"; \
+    test -x "$node_root/bin/node"; \
+    for executable in node npm npx; do \
+        ln -s "$node_root/bin/$executable" "/usr/local/bin/$executable"; \
+    done; \
+    "$node_root/bin/node" /tmp/install-harness.mjs /tmp/harness-pins.rs "$node_root/bin/npm"; \
+    rm -f /tmp/harness-pins.rs /tmp/install-harness.mjs; \
+    chmod 0755 /usr/local/bin/sandbox-agent
+ENV HOME=/workspace \
+    SHELL=/bin/sh \
+    TIDEBREAK_AGENT_ENGINE=claude_code \
+    RUSTUP_HOME=/usr/local/rustup
+WORKDIR /workspace
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/sandbox-agent"]
+
+# Keep the server as the default target for existing local and release builds.
+FROM runtime-base AS server
+COPY --from=build /out/tidebreak /usr/local/bin/tidebreak
+COPY --from=renderer /src/crates/tidebreak-desktop/ui/dist /opt/tidebreak/ui
+COPY deploy/self-host/entrypoint.sh /usr/local/bin/tidebreak-entrypoint
+
+# The server runs unprivileged. The uid is fixed rather than assigned by
+# adduser so a data volume initialized from this layer carries an ownership
+# the running user actually matches.
+RUN groupadd --gid 10001 tidebreak \
+    && useradd --uid 10001 --gid 10001 --home-dir /home/tidebreak --create-home \
+       --shell /usr/sbin/nologin tidebreak \
+    && chmod 0755 /usr/local/bin/tidebreak-entrypoint \
+    && mkdir -p /var/lib/tidebreak \
+    && chown -R tidebreak:tidebreak /var/lib/tidebreak /home/tidebreak
 
 # The self-host profile. `TIDEBREAK_DATABASE_URL` and `TIDEBREAK_AUTH_TOKENS_FILE`
 # have no defaults and must be supplied — the server refuses to open a shared

--- a/deploy/self-host/Dockerfile.dockerignore
+++ b/deploy/self-host/Dockerfile.dockerignore
@@ -56,6 +56,9 @@
 !deploy/
 !deploy/self-host/
 !deploy/self-host/entrypoint.sh
+!deploy/supervised-agent/
+!deploy/supervised-agent/entrypoint.sh
+!deploy/supervised-agent/install-harness.mjs
 
 # Never admit hidden files or common credential files, even below an allowed
 # source directory. Keep these after the allow rules so they win. The explicit

--- a/deploy/supervised-agent/entrypoint.sh
+++ b/deploy/supervised-agent/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Start only inside Gateway's credential-free workload contract.
+set -eu
+
+: "${MODEL_GATEWAY_SANDBOX_ID:?Gateway must provide a sandbox identity}"
+: "${MODEL_GATEWAY_SANDBOX_SUPERVISOR_ENDPOINT:?Gateway must provide its supervisor endpoint}"
+: "${MODEL_GATEWAY_SANDBOX_GATEWAY_URL:?Gateway must provide its inference origin}"
+: "${MODEL_GATEWAY_SANDBOX_PLACEHOLDER_TOKEN:?Gateway must provide its placeholder}"
+
+if [ "$MODEL_GATEWAY_SANDBOX_PLACEHOLDER_TOKEN" != mg-sandbox-placeholder ]; then
+    echo "Gateway's public workload placeholder is required." >&2
+    exit 2
+fi
+if [ "${TIDEBREAK_AGENT_ENGINE:-claude_code}" != claude_code ]; then
+    echo "This image supports the pinned Claude Code engine." >&2
+    exit 2
+fi
+if [ -n "${GH_TOKEN:-}" ] && [ "$GH_TOKEN" != "$MODEL_GATEWAY_SANDBOX_PLACEHOLDER_TOKEN" ]; then
+    echo "The GitHub CLI must use Gateway's public workload placeholder." >&2
+    exit 2
+fi
+mkdir -p "$HOME"
+exec /usr/local/bin/tidebreak-supervised-agent "$@"

--- a/deploy/supervised-agent/install-harness.mjs
+++ b/deploy/supervised-agent/install-harness.mjs
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+// Read the same exact version that Tidebreak probes and tests.
+const [pinsPath, npmPath] = process.argv.slice(2);
+const pins = readFileSync(pinsPath, "utf8");
+const pin = pins.match(/kind: HarnessKind::ClaudeCode,\s*version: "([0-9]+\.[0-9]+\.[0-9]+)",\s*package: "(@anthropic-ai\/claude-code)"/);
+if (!pin) throw new Error("The Claude Code package pin is missing or malformed.");
+const [, version, name] = pin;
+execFileSync(npmPath, ["install", "--global", "--prefix", "/usr/local", "--omit=dev", "--no-fund", "--no-audit", "--no-progress", name + "@" + version], { stdio: "inherit" });
+const actual = execFileSync("/usr/local/bin/claude", ["--version"], { encoding: "utf8" }).trim();
+if (!actual.startsWith(version + " ")) throw new Error("The installed Claude Code version does not match Tidebreak's pin.");

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -398,6 +398,50 @@ Changing the repository means a new thread. The first status message
 carries the recovery inline: "Wrong repo? Reply `stop`, then start a new
 thread with `repo:owner/name`."
 
+## Packaged sandbox runtime
+
+The `supervised-agent` target in `deploy/self-host/Dockerfile` shares the
+server image's verified tools and packages Tidebreak's pinned Claude Code
+engine. The release workflow publishes `tidebreak-supervised-agent` beside
+`tidebreak-server` for both Linux architectures. It includes the existing
+Rust and Python bundles, git, and the GitHub CLI. The supervised image carries
+no server, renderer, or machine authentication store.
+
+Gateway starts the image through its BYO contract at
+`/usr/local/bin/sandbox-agent`. The workload runs as UID 65532 and receives
+only the public `mg-sandbox-placeholder` value. Gateway's sidecar holds the
+execution credentials under a different UID and process namespace. Tidebreak
+reuses its existing certificate wait, trust bundle, harness adapter, and
+`assistant_record` journal ingestion. The browser and desktop therefore
+render the same session without a separate Slack transcript UI.
+
+The machine declares its endpoint and profile through
+`TIDEBREAK_RUNTIME_ENDPOINT` and `TIDEBREAK_RUNTIME_PROFILE`, plus
+`TIDEBREAK_RUNTIME_ENGINE=claude_code` for this image. The configured engine
+uses Allow permissions inside Gateway's confinement. Unsupported engine,
+permission, or fast-mode settings are refused before a remote turn starts.
+The custom-harness contract does not transport tool approvals.
+Choose the model and reasoning level when you create the session. This
+profile cannot change either setting between messages.
+
+The Gateway deployment declaration attaches the existing general GitHub app
+to a dedicated Direct endpoint and grants only the
+`runtime:tidebreak` audience and resource with `runtime:execute`. Git and
+PR API requests use that app's existing identity and policy. A DM does not
+change installation-only credentials into a personal GitHub identity.
+Channel contribution remains owner-only until explicit sharing is enabled.
+
+A custom harness uses Gateway's generic client identity. Anthropic and OpenAI
+consumer subscriptions cannot fund it; a permitted API-funded route must be
+available. The profile uses one pod incarnation because the image does not
+restore the harness conversation across pod replacement.
+
+The profile pins a supervised-agent digest; it does not track server releases.
+For an upgrade, publish both images from the same release, update the profile
+first, and then update the server. The supervised image must accept the prior
+task format during this transition. If the server tracks releases, coordinate
+its update or pin it until the matching supervised image is ready.
+
 ## Execution
 
 The session's engine runs in a per-session confined sandbox driven by

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -1607,7 +1607,11 @@ export type CodeWorkspaceHistorySearchSource = "turn_user_input" | "turn_narrati
 /**
  * PR + checks digest plus the local git facts the PR card needs.
  */
-export type CodeWorkspacePrSnapshot = { git?: CodeWorkspaceGitState, dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string,
+export type CodeWorkspacePrSnapshot = {
+/**
+ * The checkout lives in a remote runtime; local git mutations are unavailable.
+ */
+remote?: boolean, git?: CodeWorkspaceGitState, dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string,
 /**
  * The identity a push from this machine acts as: the deployment's
  * GitHub App bot account (decision 63) or the caller's own login

--- a/scripts/supervised-agent-image.test.mjs
+++ b/scripts/supervised-agent-image.test.mjs
@@ -95,6 +95,14 @@ test("the built workload starts as UID 65532 with pinned tools and no server", {
   ], { encoding: "utf8", timeout: 60000 });
   assert.equal(inspect.status, 0, inspect.stderr);
   assert.match(inspect.stdout, new RegExp(claudeVersion.replaceAll(".", "\\.") + " "));
+  const committed = spawnSync("docker", ["run", "--rm", "--network=none", "--entrypoint", "/bin/sh",
+    "--env", "GIT_AUTHOR_NAME=fixture[bot]", "--env", "GIT_COMMITTER_NAME=fixture[bot]",
+    "--env", "GIT_AUTHOR_EMAIL=8675309+fixture[bot]@users.noreply.github.com",
+    "--env", "GIT_COMMITTER_EMAIL=8675309+fixture[bot]@users.noreply.github.com",
+    image, "-ec", 'directory=$(mktemp -d); cd "$directory"; git init -q; touch change; git add change; git commit -qm "Verify sandbox authorship"; git show -s --format="%an <%ae> | %cn <%ce>"',
+  ], { encoding: "utf8", timeout: 60000 });
+  assert.equal(committed.status, 0, committed.stderr);
+  assert.equal(committed.stdout.trim(), "fixture[bot] <8675309+fixture[bot]@users.noreply.github.com> | fixture[bot] <8675309+fixture[bot]@users.noreply.github.com>");
   const missingContract = spawnSync("docker", ["run", "--rm", "--network=none", image], { encoding: "utf8", timeout: 60000 });
   assert.notEqual(missingContract.status, 0);
   assert.match(missingContract.stderr, /Gateway must provide a sandbox identity/);

--- a/scripts/supervised-agent-image.test.mjs
+++ b/scripts/supervised-agent-image.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const root = new URL("../", import.meta.url);
+const dockerfile = readFileSync(new URL("deploy/self-host/Dockerfile", root), "utf8");
+const wrapper = readFileSync(new URL("deploy/supervised-agent/entrypoint.sh", root), "utf8");
+const workflow = readFileSync(new URL(".github/workflows/publish-server-image.yml", root), "utf8");
+const pins = readFileSync(new URL("crates/tidebreak-harness/src/pin.rs", root), "utf8");
+const claudeVersion = pins.match(/kind: HarnessKind::ClaudeCode,\s*version: "([^"]+)"/)[1];
+
+function runWrapper(overrides = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "tidebreak-workload-"));
+  try {
+    const path = join(directory, "entrypoint.sh");
+    // Keep the guard under test; replace only the final binary with a witness.
+    writeFileSync(path, wrapper.replace(
+      "exec /usr/local/bin/tidebreak-supervised-agent",
+      "exec /bin/echo agent-started",
+    ));
+    return spawnSync("/bin/sh", [path], {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH,
+        HOME: directory,
+        MODEL_GATEWAY_SANDBOX_ID: "fixture",
+        MODEL_GATEWAY_SANDBOX_SUPERVISOR_ENDPOINT: "127.0.0.1:15002",
+        MODEL_GATEWAY_SANDBOX_GATEWAY_URL: "https://gateway.example.test",
+        MODEL_GATEWAY_SANDBOX_PLACEHOLDER_TOKEN: "mg-sandbox-placeholder",
+        GH_TOKEN: "mg-sandbox-placeholder",
+        ...overrides,
+      },
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("the workload guards accept only the public placeholder and supported engine", () => {
+  const valid = runWrapper();
+  assert.equal(valid.status, 0, valid.stderr);
+  assert.equal(valid.stdout.trim(), "agent-started");
+  for (const override of [
+    { MODEL_GATEWAY_SANDBOX_ID: "" },
+    { MODEL_GATEWAY_SANDBOX_SUPERVISOR_ENDPOINT: "" },
+    { MODEL_GATEWAY_SANDBOX_GATEWAY_URL: "" },
+    { MODEL_GATEWAY_SANDBOX_PLACEHOLDER_TOKEN: "private-fixture" },
+    { GH_TOKEN: "private-fixture" },
+    { TIDEBREAK_AGENT_ENGINE: "codex" },
+  ]) {
+    const refused = runWrapper(override);
+    assert.notEqual(refused.status, 0, JSON.stringify(override));
+    assert.equal(refused.stdout, "");
+    assert.doesNotMatch(refused.stderr, /private-fixture/);
+  }
+});
+
+test("the BYO image installs Gateway's fixed command and keeps the server as default", () => {
+  const workload = dockerfile.split("FROM runtime-base AS supervised-agent\n")[1].split("FROM runtime-base AS server\n")[0];
+  assert.match(workload, /COPY --from=build \/out\/tidebreak-supervised-agent \/usr\/local\/bin\/tidebreak-supervised-agent/);
+  assert.match(workload, /COPY deploy\/supervised-agent\/entrypoint.sh \/usr\/local\/bin\/sandbox-agent/);
+  assert.match(workload, /USER 65532:65532/);
+  assert.match(workload, /ENTRYPOINT \["\/usr\/local\/bin\/sandbox-agent"\]/);
+  assert.doesNotMatch(workload, /COPY .*\/out\/tidebreak\s|COPY --from=renderer/);
+  assert.equal(dockerfile.match(/^FROM .+$/gm).at(-1), "FROM runtime-base AS server");
+});
+
+test("release publication builds both images and preserves older server backfills", () => {
+  assert.match(workflow, /images='\[{"name":"server","target":""}\]'/);
+  assert.match(workflow, /{"name":"supervised-agent","target":"supervised-agent"}/);
+  assert.match(workflow, /git show "\$build_sha:deploy\/self-host\/Dockerfile"/);
+  assert.match(workflow, /artifact: \$\{\{ fromJSON\(needs.resolve.outputs.images\) \}\}/);
+  assert.match(workflow, /TIDEBREAK_SUPERVISED_AGENT_IMAGE:/);
+  assert.match(workflow, /node --test scripts\/supervised-agent-image.test.mjs/);
+});
+
+test("the shared publication workflow has one job per stage and valid shell blocks", () => {
+  for (const job of ["resolve", "build", "manifest"]) {
+    assert.equal(workflow.match(new RegExp("^  " + job + ":$", "gm"))?.length, 1);
+  }
+  for (const block of workflow.matchAll(/^        run: \|\n((?:^          .*\n|^\n)+)/gm)) {
+    const script = block[1].replace(/^          /gm, "").replace(/\$\{\{[^\n]*?\}\}/g, "fixture");
+    const parsed = spawnSync("bash", ["-n"], { input: script, encoding: "utf8" });
+    assert.equal(parsed.status, 0, parsed.stderr);
+  }
+});
+
+const image = process.env.TIDEBREAK_SUPERVISED_AGENT_IMAGE;
+test("the built workload starts as UID 65532 with pinned tools and no server", { skip: !image }, () => {
+  const inspect = spawnSync("docker", ["run", "--rm", "--network=none", "--entrypoint", "/bin/sh", image, "-ec",
+    'test "$(id -u)" = 65532; test -x /usr/local/bin/sandbox-agent; test -x /usr/local/bin/tidebreak-supervised-agent; test ! -e /usr/local/bin/tidebreak; test ! -e /opt/tidebreak/ui; git --version; gh --version; node --version; npm --version; npx --version; rustc --version; cargo --version; python3 --version; claude --version',
+  ], { encoding: "utf8", timeout: 60000 });
+  assert.equal(inspect.status, 0, inspect.stderr);
+  assert.match(inspect.stdout, new RegExp(claudeVersion.replaceAll(".", "\\.") + " "));
+  const missingContract = spawnSync("docker", ["run", "--rm", "--network=none", image], { encoding: "utf8", timeout: 60000 });
+  assert.notEqual(missingContract.status, 0);
+  assert.match(missingContract.stderr, /Gateway must provide a sandbox identity/);
+  const missingInput = spawnSync("docker", ["run", "--rm", "--network=none", "--entrypoint", "/usr/local/bin/tidebreak-supervised-agent", image], { encoding: "utf8", timeout: 60000 });
+  assert.equal(missingInput.status, 64, missingInput.stderr);
+  assert.match(missingInput.stderr, /MODEL_GATEWAY_SANDBOX_TASK/);
+});


### PR DESCRIPTION
Hosted Slack sessions can create a conversation, but the machine execution path fails to push a branch or open a pull request with the connected GitHub app. This change runs configured hosted sessions in Gateway sandboxes through Tidebreak's existing supervised agent. Agents receive dummy credentials. Gateway injects the connected app credential outside the workload.

This PR is published for review and is not deployed. The hosted execution policy needs a product decision before rollout: configuring this runtime on a SelfHost server enables sandbox-only execution across that server, including sessions outside Slack. Terminal, file editing, local diffs, setup scripts, and previews do not yet have full remote workspace support. Do not treat this change as complete hosted utility parity.

Runtime operations retain the session's original Slack delegation. Renewals use that grant, and a later browser sign-in cannot replace revoked authority. Stored execution location controls dispatch, queue promotion, recovery, interruption, and cleanup. Sandbox-only hosting rejects local workers, workspace scripts, and terminal create/write/resize operations.

The supervised image shares the server's pinned toolchains and release workflow. A versioned first-task envelope starts the checkout on the assigned workspace branch before the engine runs. Public Git author metadata and a dummy GH_TOKEN survive the engine environment filter. The declared image supports Claude Code in Allow mode, with model and reasoning chosen when the session starts. Unsupported settings fail before persistence or execution.

The existing Tidebreak workspace control renders sandbox status and PR checks. Remote PR refresh and comments use repository-scoped REST through the original connected app. Confirmed PRs populate the existing workspace PR list. Arbitrary branch changes made by the remote agent are not attributed from remote tool events.

Compatibility: undeclared remote profiles keep the plain task format. The remote snapshot field is optional and stays synchronized across desktop and mobile. Existing sessions retain their execution location and never migrate silently. Hosts without a configured sandbox runtime retain machine execution and its utilities; this patch does not give machine execution the same credential-isolation guarantee. Deploy the matching supervised image before enabling the declared profile. Custom harnesses require an API-funded model route and do not restore native harness state after pod replacement.

Validation: focused remote driver/service, delegation revocation, PR discovery, host execution refusal, supervised-agent, and wire contract tests; TypeScript and UI contracts; Storybook build; container startup, toolchain, and workflow-security tests; formatting and clippy. The final real container smoke passes all five tests, including ordinary git commit with public author metadata. Desktop/mobile wire files match byte-for-byte. Storybook captures cover desktop/mobile in four themes; DOM checks show no overflow. Image pixels have not been inspected, so visual review is incomplete. CI runs on the published head.

Risk and rollout: this changes hosted execution and credential authority. It depends on brightwave-inc/model-gateway#1920. The runtime manifest is not applied and the supervised image is not published. A real Slack push/PR/notification canary, original-grant revocation, session renewal, restart, and browser/native continuation remain unverified for this sandbox version. DM personal identity, shared channel participation, and DM/channel workspace separation remain separate unresolved product requirements.
