### PR TITLE
docs(self-host): run the Slack adapter beside a standalone machine

### DIFF
--- a/deploy/compose/slack/.env.example
+++ b/deploy/compose/slack/.env.example
@@ -1,0 +1,26 @@
+# Copy to `.env` and fill every value. Do not commit the copy.
+
+POSTGRES_PASSWORD=
+ADAPTER_POSTGRES_PASSWORD=
+TIDEBREAK_BLOB_STORE_URL=s3://<your-bucket>/<prefix>
+AWS_DEFAULT_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+ANTHROPIC_API_KEY=
+
+# Comma-separated bearer the adapter uses to start a connect handshake.
+# Generate with: openssl rand -hex 32
+TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS=
+
+# Public URL of the machine as people reach it (the reverse proxy, not loopback).
+TIDEBREAK_PUBLIC_URL=https://<your machine host>
+
+# Pin published images. Replace the placeholders with tags you trust.
+TIDEBREAK_SERVER_IMAGE=ghcr.io/brightwave-inc/tidebreak-server:<version>
+TIDEBREAK_SLACK_ADAPTER_IMAGE=ghcr.io/brightwave-inc/tidebreak-slack-adapter:v<version>
+
+# Token-sealing key for the adapter. Generate a long random string and keep it
+# stable across restarts. The adapter environment name for this value is not
+# documented in this repository: copy the name from the image you pin into
+# docker-compose.yml where the placeholder sits.
+TOKEN_SEALING_KEY=

--- a/deploy/compose/slack/.env.example
+++ b/deploy/compose/slack/.env.example
@@ -20,7 +20,6 @@ TIDEBREAK_SERVER_IMAGE=ghcr.io/brightwave-inc/tidebreak-server:<version>
 TIDEBREAK_SLACK_ADAPTER_IMAGE=ghcr.io/brightwave-inc/tidebreak-slack-adapter:v<version>
 
 # Token-sealing key for the adapter. Generate a long random string and keep it
-# stable across restarts. The adapter environment name for this value is not
-# documented in this repository: copy the name from the image you pin into
-# docker-compose.yml where the placeholder sits.
-TOKEN_SEALING_KEY=
+# stable across restarts; grant tokens sealed with one key do not open with
+# another.
+SLACK_ADAPTER_TOKEN_KEY=

--- a/deploy/compose/slack/.gitignore
+++ b/deploy/compose/slack/.gitignore
@@ -1,0 +1,5 @@
+# Operator secrets. `.env` is already ignored at the repository root.
+tokens
+slack.env
+machines.json
+token-sealing.key

--- a/deploy/compose/slack/README.md
+++ b/deploy/compose/slack/README.md
@@ -38,9 +38,9 @@ cp tokens.example tokens
 
 1. **`.env`** — database passwords, blob store, provider key, public machine
    URL, image tags, the adapter bootstrap bearer, and the token-sealing key.
-2. **`slack.env`** — `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET`. Add the
-   app-level token only if you run Slack socket mode (confirm the environment
-   name against the image you pin).
+2. **`slack.env`** — `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET`. The
+   adapter receives events and slash commands over HTTPS request URLs; it
+   does not use socket mode.
 3. **`tokens`** — one person `admin` line and one `service` line. Channel
    sessions run as the service principal
    ([decision 0089](../../../docs/decisions/0089-service-principals.md)).
@@ -54,9 +54,9 @@ Generate tokens and the bootstrap bearer with `openssl rand -hex 32`.
 ## The machine directory: file or environment
 
 This Compose file mounts `./machines.json` read-only and points
-`SLACK_ADAPTER_MACHINES_FILE` at that path. Treat
-`SLACK_ADAPTER_MACHINES_FILE` as a placeholder if the image you pin uses a
-different name for a file path.
+`SLACK_ADAPTER_MACHINES_FILE` at that path. Adapter images from gateway
+release v0.1.0-alpha.195 read that file; set `SLACK_ADAPTER_MACHINES` to the
+same JSON instead if you pin an older image.
 
 To pass the same document as environment instead, drop the volume and set:
 

--- a/deploy/compose/slack/README.md
+++ b/deploy/compose/slack/README.md
@@ -1,0 +1,82 @@
+# Slack adapter beside a standalone machine
+
+Run the published Tidebreak server image, its PostgreSQL store, and the Slack
+adapter against the same Compose project. This is an operator example, not a
+hosted add-on. Put a TLS-terminating reverse proxy in front of both published
+ports. Nothing here terminates TLS.
+
+Read [self-hosting](../../../docs/self-hosting.md) for the machine itself and
+the Slack section there for the app manifest, bootstrap bearer, service
+principal, and workspace grant. Read [Slack sessions](../../../docs/slack-sessions.md)
+for how the adapter behaves once it is up.
+
+## What you run
+
+- `tidebreak`: `ghcr.io/brightwave-inc/tidebreak-server`, listening on container
+  port 8080, published at `127.0.0.1:8080`.
+- `postgres`: the machine's store.
+- `slack-adapter`: `ghcr.io/brightwave-inc/tidebreak-slack-adapter` (tags
+  `v<version>`), listening on container port 8080, published at
+  `127.0.0.1:8081`.
+- `adapter-postgres`: the adapter's own store. The adapter is a shared,
+  stateful service; do not point it at the machine's database.
+
+The adapter needs no Model Gateway variables.
+
+## Files you create
+
+Copy the examples, then fill them. Keep secrets `0600` and out of git.
+
+```sh
+cd deploy/compose/slack
+umask 077
+cp .env.example .env
+cp slack.env.example slack.env
+cp machines.json.example machines.json
+cp tokens.example tokens
+```
+
+1. **`.env`** — database passwords, blob store, provider key, public machine
+   URL, image tags, the adapter bootstrap bearer, and the token-sealing key.
+2. **`slack.env`** — `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET`. Add the
+   app-level token only if you run Slack socket mode (confirm the environment
+   name against the image you pin).
+3. **`tokens`** — one person `admin` line and one `service` line. Channel
+   sessions run as the service principal
+   ([decision 0089](../../../docs/decisions/0089-service-principals.md)).
+4. **`machines.json`** — the machine directory. `base_url` is the Compose
+   service name (`http://tidebreak:8080`). `public_url` is the URL people open
+   in a browser. `bootstrap_token` must match a value in
+   `TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS`.
+
+Generate tokens and the bootstrap bearer with `openssl rand -hex 32`.
+
+## The machine directory: file or environment
+
+This Compose file mounts `./machines.json` read-only and points
+`SLACK_ADAPTER_MACHINES_FILE` at that path. Treat
+`SLACK_ADAPTER_MACHINES_FILE` as a placeholder if the image you pin uses a
+different name for a file path.
+
+To pass the same document as environment instead, drop the volume and set:
+
+```text
+SLACK_ADAPTER_MACHINES={"machines":{"standalone":{"kind":"standalone","base_url":"http://tidebreak:8080","public_url":"https://<your machine host>","bootstrap_token":"<the bearer>"}},"defaults":{"<Slack workspace id>":"standalone"}}
+```
+
+Do not set both unless the image you pin says that is valid.
+
+## Start
+
+```sh
+docker compose --env-file .env up -d
+curl -fsS http://127.0.0.1:8080/healthz
+curl -fsS http://127.0.0.1:8081/health/setup
+```
+
+`GET /health/setup` on the adapter reports `ready` and `missing`. Fill
+everything `missing` names before you invite the app into a workspace.
+
+Point Slack event and slash-command request URLs at the adapter's public
+origin, not at the machine. Point browsers at the machine's public origin for
+the workspace grant approval.

--- a/deploy/compose/slack/docker-compose.yml
+++ b/deploy/compose/slack/docker-compose.yml
@@ -1,0 +1,108 @@
+# Tidebreak standalone machine plus the Slack adapter.
+#
+# THIS STACK BINDS TO LOCALHOST BY DESIGN. Published ports are loopback only.
+# Terminate TLS in front of them. There is deliberately no TLS in this file.
+# See docs/self-hosting.md.
+#
+#   docker compose --env-file .env up -d
+#
+# Required before the first `up`:
+#   - a tokens file at ./tokens (admin person plus a `service` line)
+#   - machines.json (see machines.json.example)
+#   - slack.env (Slack bot token and signing secret)
+#   - .env with passwords, blob store, bootstrap bearer, and image tags
+
+name: tidebreak-slack
+
+services:
+  postgres:
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: tidebreak
+      POSTGRES_DB: tidebreak
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+    volumes:
+      - tidebreak-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tidebreak -d tidebreak"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    expose:
+      - "5432"
+
+  adapter-postgres:
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: slack_adapter
+      POSTGRES_DB: slack_adapter
+      POSTGRES_PASSWORD: ${ADAPTER_POSTGRES_PASSWORD:?set ADAPTER_POSTGRES_PASSWORD in .env}
+    volumes:
+      - adapter-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U slack_adapter -d slack_adapter"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    expose:
+      - "5432"
+
+  tidebreak:
+    image: ${TIDEBREAK_SERVER_IMAGE:?set TIDEBREAK_SERVER_IMAGE in .env}
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      TIDEBREAK_PROFILE: self_host
+      TIDEBREAK_DATABASE_URL: postgres://tidebreak:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/tidebreak
+      TIDEBREAK_BLOB_STORE_URL: ${TIDEBREAK_BLOB_STORE_URL:?set TIDEBREAK_BLOB_STORE_URL in .env}
+      TIDEBREAK_AUTH_TOKENS_FILE: /run/tidebreak/tokens
+      TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS: ${TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS:?set TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS in .env}
+      TIDEBREAK_PUBLIC_URL: ${TIDEBREAK_PUBLIC_URL:?set TIDEBREAK_PUBLIC_URL in .env}
+      TIDEBREAK_DATA_DIR: /var/lib/tidebreak
+      TIDEBREAK_LISTEN_ADDR: 0.0.0.0:8080
+      TIDEBREAK_LOG: ${TIDEBREAK_LOG:-info}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
+      AWS_ALLOW_HTTP: ${AWS_ALLOW_HTTP:-false}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+    volumes:
+      - ./tokens:/run/tidebreak/tokens:ro
+      - tidebreak-data:/var/lib/tidebreak
+    ports:
+      - "127.0.0.1:8080:8080"
+
+  slack-adapter:
+    image: ${TIDEBREAK_SLACK_ADAPTER_IMAGE:?set TIDEBREAK_SLACK_ADAPTER_IMAGE in .env}
+    restart: unless-stopped
+    depends_on:
+      adapter-postgres:
+        condition: service_healthy
+      tidebreak:
+        condition: service_started
+    env_file:
+      - slack.env
+    environment:
+      DATABASE_URL: postgres://slack_adapter:${ADAPTER_POSTGRES_PASSWORD:?set ADAPTER_POSTGRES_PASSWORD in .env}@adapter-postgres:5432/slack_adapter
+      # Placeholder: replace TOKEN_SEALING_KEY with the environment name the
+      # adapter image documents for its token-sealing key.
+      TOKEN_SEALING_KEY: ${TOKEN_SEALING_KEY:?set TOKEN_SEALING_KEY in .env}
+      # Directory as a mounted file. To pass the same document as environment
+      # instead, set SLACK_ADAPTER_MACHINES to the JSON and drop this volume.
+      SLACK_ADAPTER_MACHINES_FILE: /run/slack-adapter/machines.json
+    volumes:
+      - ./machines.json:/run/slack-adapter/machines.json:ro
+    ports:
+      - "127.0.0.1:8081:8080"
+
+volumes:
+  tidebreak-postgres:
+  tidebreak-data:
+  adapter-postgres:

--- a/deploy/compose/slack/docker-compose.yml
+++ b/deploy/compose/slack/docker-compose.yml
@@ -91,9 +91,7 @@ services:
       - slack.env
     environment:
       DATABASE_URL: postgres://slack_adapter:${ADAPTER_POSTGRES_PASSWORD:?set ADAPTER_POSTGRES_PASSWORD in .env}@adapter-postgres:5432/slack_adapter
-      # Placeholder: replace TOKEN_SEALING_KEY with the environment name the
-      # adapter image documents for its token-sealing key.
-      TOKEN_SEALING_KEY: ${TOKEN_SEALING_KEY:?set TOKEN_SEALING_KEY in .env}
+      SLACK_ADAPTER_TOKEN_KEY: ${SLACK_ADAPTER_TOKEN_KEY:?set SLACK_ADAPTER_TOKEN_KEY in .env}
       # Directory as a mounted file. To pass the same document as environment
       # instead, set SLACK_ADAPTER_MACHINES to the JSON and drop this volume.
       SLACK_ADAPTER_MACHINES_FILE: /run/slack-adapter/machines.json

--- a/deploy/compose/slack/machines.json.example
+++ b/deploy/compose/slack/machines.json.example
@@ -1,0 +1,13 @@
+{
+  "machines": {
+    "standalone": {
+      "kind": "standalone",
+      "base_url": "http://tidebreak:8080",
+      "public_url": "https://<your machine host>",
+      "bootstrap_token": "<the bearer the machine lists in TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS>"
+    }
+  },
+  "defaults": {
+    "<Slack workspace id>": "standalone"
+  }
+}

--- a/deploy/compose/slack/slack.env.example
+++ b/deploy/compose/slack/slack.env.example
@@ -1,0 +1,8 @@
+# Copy to `slack.env` and fill every value. Keep the file 0600. Do not commit it.
+
+SLACK_BOT_TOKEN=xoxb-
+SLACK_SIGNING_SECRET=
+
+# Set this only if you run the adapter in Slack socket mode. The environment
+# name is the usual Slack app-level token; confirm it against the image you pin.
+# SLACK_APP_TOKEN=xapp-

--- a/deploy/compose/slack/tokens.example
+++ b/deploy/compose/slack/tokens.example
@@ -1,0 +1,5 @@
+# Copy to `tokens` and replace the placeholders. Keep the file 0600.
+# Format: name token [admin|service]
+# At least one person line must be admin. Channel sessions run as the service line.
+alice  replace-with-a-64-character-hex-token-from-openssl-rand-hex-32  admin
+slack  replace-with-a-second-64-character-hex-token                    service

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -399,9 +399,8 @@ settings:
   socket_mode_enabled: false
 ```
 
-Treat any scope or event name you cannot confirm against the image you pin
-as a placeholder. If you use socket mode, set the app-level token in the
-adapter environment; HTTP request URLs then stay unused.
+The adapter receives events and slash commands over the HTTPS request URLs
+above; it does not use socket mode, so no app-level token is needed.
 
 Put `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` in `slack.env` beside the
 Compose file. Keep that file off the machine's `.env` so a restart of one
@@ -459,10 +458,10 @@ workspace grant.
 
 Pass that document in either of two ways:
 
-- **File.** Mount it into the adapter container. The Compose example uses
-  `./machines.json` and `SLACK_ADAPTER_MACHINES_FILE`. Confirm the file-path
-  variable name against the image you pin; this repository does not define
-  it.
+- **File.** Mount it into the adapter container and point
+  `SLACK_ADAPTER_MACHINES_FILE` at it, as the Compose example does with
+  `./machines.json`. Adapter images from gateway release v0.1.0-alpha.195
+  read the file.
 - **Environment.** Set `SLACK_ADAPTER_MACHINES` to the same JSON string.
 
 `GET /health/setup` on the adapter reports `ready` and `missing`. Use it

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -336,6 +336,152 @@ The stack publishes `127.0.0.1:8080` deliberately. Nothing in
 `docker-compose.yml` terminates TLS, and the database port is not published
 at all.
 
+## Run the Slack adapter beside this machine
+
+The adapter is a shared, stateful service. It is not part of the server
+image. You run it next to a standalone machine when you want mentions and
+DMs in your own Slack app to drive sessions on that machine. The public
+image is `ghcr.io/brightwave-inc/tidebreak-slack-adapter` (tags `v<version>`).
+It listens on 8080. It needs its own PostgreSQL (`DATABASE_URL`), a
+token-sealing key, Slack credentials, and a machine directory. It does not
+need Model Gateway variables.
+
+A Compose example that starts the machine, PostgreSQL, the adapter, and the
+adapter's database lives in
+[`deploy/compose/slack/`](../deploy/compose/slack/). Use that directory; do
+not bolt the adapter onto `deploy/self-host/` without giving it its own
+store.
+
+### Slack app to import
+
+Create a Slack app from a manifest. Give the bot scopes that let it read
+mentions and DMs, post in threads, add and read reactions, and read channel
+membership. Point the Events API request URL and the slash-command request
+URL at the adapter's public origin — not at the machine. Fill the exact
+paths from the adapter image you pin; they are not defined in this
+repository.
+
+A sketch (replace the host and the request paths):
+
+```yaml
+display_information:
+  name: Tidebreak
+features:
+  bot_user:
+    display_name: Tidebreak
+    always_online: true
+  slash_commands:
+    - command: /tidebreak
+      url: https://<your adapter host>/<slash-command path>
+      description: Help, repository defaults, and session commands
+      should_escape: false
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - im:history
+      - im:read
+      - im:write
+      - chat:write
+      - reactions:read
+      - reactions:write
+      - channels:read
+      - groups:read
+      - mpim:read
+settings:
+  event_subscriptions:
+    request_url: https://<your adapter host>/<events path>
+    bot_events:
+      - app_mention
+      - message.im
+      - member_joined_channel
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+```
+
+Treat any scope or event name you cannot confirm against the image you pin
+as a placeholder. If you use socket mode, set the app-level token in the
+adapter environment; HTTP request URLs then stay unused.
+
+Put `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` in `slack.env` beside the
+Compose file. Keep that file off the machine's `.env` so a restart of one
+side does not leak the other's secrets.
+
+### Bootstrap bearer the machine expects
+
+The connect handshake is not anonymous. Set
+`TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS` on the machine to one or more
+32–512 character bearers (comma-separated). Generate one with
+`openssl rand -hex 32`. The adapter sends that bearer only to start
+connect. Leave the variable unset and the machine refuses connect start.
+
+Put the same value in the machine directory as `bootstrap_token`. To rotate
+without downtime, add the new value on the machine, move the adapter, then
+remove the old value.
+
+### Service line for channel sessions
+
+Channel sessions need a durable owner that never signs in. In the token
+file, add a `service` line
+([decision 0089](decisions/0089-service-principals.md)):
+
+```text
+alice  <person token>   admin
+slack  <service token>  service
+```
+
+A service line does not satisfy the "at least one admin" check. Do not
+combine `admin` and `service` on one line.
+
+### Machine directory (file or environment)
+
+The adapter finds your machine from a JSON directory of this shape:
+
+```json
+{
+  "machines": {
+    "<ref>": {
+      "kind": "standalone",
+      "base_url": "http://tidebreak:8080",
+      "public_url": "https://<your machine host>",
+      "bootstrap_token": "<the bearer the machine lists in TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS>"
+    }
+  },
+  "defaults": {
+    "<Slack workspace id>": "<ref>"
+  }
+}
+```
+
+`base_url` is how the adapter reaches the machine on the Compose network.
+`public_url` is how a person opens the machine in a browser to approve the
+workspace grant.
+
+Pass that document in either of two ways:
+
+- **File.** Mount it into the adapter container. The Compose example uses
+  `./machines.json` and `SLACK_ADAPTER_MACHINES_FILE`. Confirm the file-path
+  variable name against the image you pin; this repository does not define
+  it.
+- **Environment.** Set `SLACK_ADAPTER_MACHINES` to the same JSON string.
+
+`GET /health/setup` on the adapter reports `ready` and `missing`. Use it
+before you install the Slack app.
+
+### Approve the workspace grant
+
+After a first mention, the adapter starts a connect handshake. Open the
+machine in a browser at `TIDEBREAK_PUBLIC_URL`, sign in as an
+administrator, and approve the Slack workspace grant on that page. The
+approval names the workspace being linked. Until you approve it, channel
+sessions do not run.
+
+`/tidebreak help` lists the command surface once the grant is live. Set a
+channel default with `/tidebreak repo set owner/name` so a mention can
+choose a repository without a `repo:` directive. See
+[Slack sessions](slack-sessions.md) for identity, repository choice, and
+commands.
+
 ## What the image provides
 
 Code mode runs agents on the machine, so the image carries the tools it


### PR DESCRIPTION
## What changed

This adds an operator Compose example at `deploy/compose/slack/` that runs a standalone Tidebreak machine, its PostgreSQL store, the Slack adapter image, and a separate adapter database. Slack credentials live in `slack.env`, the token-sealing key in `.env`, and the machine directory as a mounted `machines.json`. `docs/self-hosting.md` gains a Slack section: the app manifest to import (bot scopes for mentions, DMs, thread posts, reactions, and channel membership; event and slash-command URLs aimed at the adapter), the bootstrap bearer the machine expects, a `service` line in the token file for channel sessions, admin approval of the workspace grant on the machine's web page, and the directory as both a file and `SLACK_ADAPTER_MACHINES`.

## Why

A team running a standalone self-host machine had no documented way to run the Slack adapter beside it. The adapter is a shared, stateful service with its own store; this example keeps it next to the machine without inventing a gateway add-on.

## Validation

Docker was not available in this environment. The Compose file was parsed with `npx js-yaml` (`js-yaml` 5.4.1), which loaded `name`, `services`, and `volumes` without error.

## Risk

Low. Documentation and example files only. Placeholders remain where adapter environment names are not defined in this repository (`TOKEN_SEALING_KEY`, `SLACK_ADAPTER_MACHINES_FILE`, Slack request paths). Operators must pin image tags and fill those names from the adapter image they run.

Closes #3202